### PR TITLE
feat(cli): add piece CFC label commands

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -115,6 +115,39 @@ as `cf piece ls`. Human-readable output uses the same columns as `piece ls`.
 matches. If part of a piece cannot be read, the command reports a warning on
 standard error and continues searching that piece and the rest of the space.
 
+## Piece CFC labels
+
+`cf piece get-label` returns the effective CFC label view for a result path.
+Pass `--input` to select the input cell. The paths in the returned view are
+relative to the selected path, and the view includes declared, derived, and
+link-carried labels. An unlabeled value returns JSON `null`.
+
+```bash
+cf piece get-label --piece ID messages/0/body
+cf piece get-label --piece ID credentials --input
+```
+
+`cf piece set-label` reads a declared label update from standard input and
+returns the updated effective view. The input is an object with a
+`confidentiality` array, an `integrity` array, or both. An optional `observes`
+field selects `value`, `shape`, `enumerate`, or `followRef` consumption.
+
+```bash
+echo '{"confidentiality":["team"]}' \
+  | cf piece set-label --piece ID notes
+echo '{"integrity":[],"observes":"value"}' \
+  | cf piece set-label --piece ID draft --input
+```
+
+The command updates the label through the same checked write path used by
+ordinary runtime operations. It does not edit raw CFC metadata. The
+stored-schema rules reject a confidentiality update that would make data less
+restricted and an integrity update that would silently make data more trusted.
+An absent path is also rejected rather than creating policy metadata without a
+value. An `observes` update is rejected when it would combine with an existing
+observation class instead of preserving the requested class. Omitting `observes`
+from a later update preserves an existing unambiguous class.
+
 ## Output Conventions
 
 - stdout carries command output only; hints and diagnostics go to stderr.

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -8,6 +8,7 @@ import {
   executePieceCallable,
   formatViewTree,
   generateSpaceMap,
+  getCellCfcLabel,
   getCellValue,
   getPieceView,
   inspectPiece,
@@ -27,6 +28,7 @@ import {
   resetHomePattern,
   savePiecePattern,
   searchPieces,
+  setCellCfcLabel,
   setCellValue,
   setHomePattern,
   setPiecePattern,
@@ -1614,6 +1616,92 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
       if (report) exitWithDataError(report);
       throw error;
     }
+  })
+  /* piece get-label */
+  .command(
+    "get-label",
+    `Get the effective CFC label view for a piece data path.
+
+The returned paths are relative to the selected path. The view includes
+declared, derived, and link-carried labels. Omit path to inspect the root.`,
+  )
+  .usage(`${pieceUsage} [path]`)
+  .example(
+    cliText(`cf piece get-label ${EX_ID} ${EX_COMP_PIECE} messages/0/body`),
+    "Get the effective label on a nested result value.",
+  )
+  .example(
+    cliText(`cf piece get-label ${EX_ID} ${EX_COMP_PIECE} secret --input`),
+    "Get the effective label on an input value.",
+  )
+  .option("-c,--piece <piece:string>", "The target piece ID.")
+  .option("--input", "Read from the piece's input cell instead of result cell")
+  .option(
+    "--json",
+    "Select JSON output explicitly. This command always outputs JSON.",
+  )
+  .arguments("[path:string]")
+  .action(async (options, pathString) => {
+    setQuietMode(!!options.quiet);
+    const pieceConfig = {
+      ...parsePieceOptions(options),
+      jsonOutput: true,
+    };
+    const pathSegments = pathString ? parseCellPath(pathString) : [];
+    const label = await getCellCfcLabel(pieceConfig, pathSegments, {
+      input: options.input,
+    });
+    render(label, { json: true });
+  })
+  /* piece set-label */
+  .command(
+    "set-label",
+    cliText(`Set the declared CFC label at a piece data path from JSON on stdin.
+
+INPUT: An object with confidentiality and/or integrity arrays, plus an optional
+observes value: value, shape, enumerate, or followRef.
+
+The update uses the stored schema and CFC transaction rules. Confidentiality
+can only become stricter, and integrity cannot be silently strengthened. Raw
+CFC metadata is never edited. Conflicting observation classes are rejected.
+Omitting observes preserves an existing class. The updated effective label view
+is returned.`),
+  )
+  .usage(`${pieceUsage} [path]`)
+  .example(
+    cliText(
+      `echo '{"confidentiality":["team"]}' | cf piece set-label ${EX_ID} ${EX_COMP_PIECE} notes`,
+    ),
+    "Add a confidentiality requirement to a result value.",
+  )
+  .example(
+    cliText(
+      `echo '{"integrity":[],"observes":"value"}' | cf piece set-label ${EX_ID} ${EX_COMP_PIECE} draft --input`,
+    ),
+    "Remove declared integrity claims from an input value.",
+  )
+  .option("-c,--piece <piece:string>", "The target piece ID.")
+  .option("--input", "Write to the piece's input cell instead of result cell")
+  .option(
+    "--json",
+    "Select JSON output explicitly. This command always outputs JSON.",
+  )
+  .arguments("[path:string]")
+  .action(async (options, pathString) => {
+    setQuietMode(!!options.quiet);
+    const pieceConfig = {
+      ...parsePieceOptions(options),
+      jsonOutput: true,
+    };
+    const pathSegments = pathString ? parseCellPath(pathString) : [];
+    const update = await drainStdin();
+    const label = await setCellCfcLabel(
+      pieceConfig,
+      pathSegments,
+      update,
+      { input: options.input },
+    );
+    render(label, { json: true });
   })
   /* piece set */
   .command(

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1650,11 +1650,12 @@ declared, derived, and link-carried labels. Omit path to inspect the root.`,
 INPUT: An object with confidentiality and/or integrity arrays, plus an optional
 observes value: value, shape, enumerate, or followRef.
 
-The update uses the stored schema and CFC transaction rules. Confidentiality
-can only become stricter, and integrity cannot be silently strengthened. Raw
-CFC metadata is never edited. Conflicting observation classes are rejected.
-Omitting observes preserves an existing class. The updated effective label view
-is returned.`),
+The command records the label through the same checked write operation used for
+piece data. It never changes raw CFC metadata. Confidentiality may only become
+more restrictive. An integrity update may keep or remove existing claims, but
+cannot add trust. Conflicting observation classes are rejected. If observes is
+omitted, an existing unambiguous class is preserved. The command returns the
+updated effective label view.`),
   )
   .usage(`${pieceUsage} [path]`)
   .example(

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1641,18 +1641,7 @@ declared, derived, and link-carried labels. Omit path to inspect the root.`,
     "Select JSON output explicitly. This command always outputs JSON.",
   )
   .arguments("[path:string]")
-  .action(async (options, pathString) => {
-    setQuietMode(!!options.quiet);
-    const pieceConfig = {
-      ...parsePieceOptions(options),
-      jsonOutput: true,
-    };
-    const pathSegments = pathString ? parseCellPath(pathString) : [];
-    const label = await getCellCfcLabel(pieceConfig, pathSegments, {
-      input: options.input,
-    });
-    render(label, { json: true });
-  })
+  .action(getCellCfcLabelFromCommand)
   /* piece set-label */
   .command(
     "set-label",
@@ -1687,22 +1676,7 @@ is returned.`),
     "Select JSON output explicitly. This command always outputs JSON.",
   )
   .arguments("[path:string]")
-  .action(async (options, pathString) => {
-    setQuietMode(!!options.quiet);
-    const pieceConfig = {
-      ...parsePieceOptions(options),
-      jsonOutput: true,
-    };
-    const pathSegments = pathString ? parseCellPath(pathString) : [];
-    const update = await drainStdin();
-    const label = await setCellCfcLabel(
-      pieceConfig,
-      pathSegments,
-      update,
-      { input: options.input },
-    );
-    render(label, { json: true });
-  })
+  .action(setCellCfcLabelFromCommand)
   /* piece set */
   .command(
     "set",
@@ -2227,6 +2201,58 @@ export interface PieceCLIOptions {
 
 export interface PieceSummaryCLIOptions extends PieceCLIOptions {
   json?: boolean;
+}
+
+export interface PieceLabelCLIOptions extends PieceCLIOptions {
+  input?: boolean;
+  quiet?: boolean;
+}
+
+export interface PieceLabelCommandDependencies {
+  getCellCfcLabel?: typeof getCellCfcLabel;
+  setCellCfcLabel?: typeof setCellCfcLabel;
+  drainStdin?: typeof drainStdin;
+  render?: typeof render;
+}
+
+export async function getCellCfcLabelFromCommand(
+  options: PieceLabelCLIOptions,
+  pathString?: string,
+  deps: PieceLabelCommandDependencies = {},
+): Promise<void> {
+  setQuietMode(!!options.quiet);
+  const pieceConfig = {
+    ...parsePieceOptions(options),
+    jsonOutput: true,
+  };
+  const pathSegments = pathString ? parseCellPath(pathString) : [];
+  const label = await (deps.getCellCfcLabel ?? getCellCfcLabel)(
+    pieceConfig,
+    pathSegments,
+    { input: options.input },
+  );
+  (deps.render ?? render)(label, { json: true });
+}
+
+export async function setCellCfcLabelFromCommand(
+  options: PieceLabelCLIOptions,
+  pathString?: string,
+  deps: PieceLabelCommandDependencies = {},
+): Promise<void> {
+  setQuietMode(!!options.quiet);
+  const pieceConfig = {
+    ...parsePieceOptions(options),
+    jsonOutput: true,
+  };
+  const pathSegments = pathString ? parseCellPath(pathString) : [];
+  const update = await (deps.drainStdin ?? drainStdin)();
+  const label = await (deps.setCellCfcLabel ?? setCellCfcLabel)(
+    pieceConfig,
+    pathSegments,
+    update,
+    { input: options.input },
+  );
+  (deps.render ?? render)(label, { json: true });
 }
 
 export interface PieceListCommandDependencies {

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -351,7 +351,9 @@ const ARGUMENT_PROVIDERS: Readonly<
 > = {
   "piece call:callable": callableCandidates,
   "piece get:path": cellPathCandidates,
+  "piece get-label:path": cellPathCandidates,
   "piece set:path": cellPathCandidates,
+  "piece set-label:path": cellPathCandidates,
   "piece link:source": linkEndpointCandidates,
   "piece link:target": linkEndpointCandidates,
   "piece new:main": patternFiles,

--- a/packages/cli/lib/json-output.ts
+++ b/packages/cli/lib/json-output.ts
@@ -78,7 +78,8 @@ export function reservesStdoutForCommandOutput(
   if (args[0] === "exec") return true;
   if (args[0] === "wish") return true;
   const subcommand = pieceSubcommand(args);
-  return subcommand === "get" || subcommand === "call";
+  return subcommand === "get" || subcommand === "get-label" ||
+    subcommand === "set-label" || subcommand === "call";
 }
 
 export const stderrConsoleHandler: ConsoleHandler = ({ method, args }) => ({

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -2699,7 +2699,7 @@ export async function setCellCfcLabel(
       ...label,
       ...(observes !== undefined ? { observes } : {}),
     },
-  }).set(value);
+  }).applyCfcSchemaToExistingValue();
   pieces.runtime.prepareTxForCommit(tx);
   const committed = await tx.commit();
   if (committed.error !== undefined) {

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -23,7 +23,14 @@ import {
   UI,
   VNode,
 } from "@commonfabric/runner";
-import { validateSchemaValue } from "@commonfabric/runner/cfc";
+import {
+  type CfcLabelView,
+  cfcLabelViewForCellWithStatus,
+  getCarriedCfcLabelView,
+  type IFCLabel,
+  redactCaveatSourcesForDisplay,
+  validateSchemaValue,
+} from "@commonfabric/runner/cfc";
 import type { CellScope, JSONSchema } from "@commonfabric/api";
 import { utf8Compare } from "@commonfabric/utils/utf8";
 import { StorageManager } from "@commonfabric/runner/storage/cache";
@@ -49,7 +56,6 @@ import {
 } from "@commonfabric/data-model/fabric-value";
 import { codecOf } from "@commonfabric/data-model/codec-common";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
-import { getCarriedCfcLabelView } from "@commonfabric/runner/cfc";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { isPlainObject, isRecord } from "@commonfabric/utils/types";
 import { pinProgramFabricImports, renderPinRewrite } from "./fabric-deps.ts";
@@ -121,6 +127,95 @@ export interface GetCellValueOptions {
   input?: boolean;
   step?: boolean;
   selection?: CellSelection;
+}
+
+/** A declared CFC label update accepted by `cf piece set-label`. */
+export type CellCfcLabelUpdate = IFCLabel & {
+  observes?: LabelObservationClass;
+};
+
+type LabelObservationClass = NonNullable<
+  CfcLabelView["entries"][number]["observes"]
+>;
+
+const CFC_LABEL_OBSERVATION_CLASSES = new Set<LabelObservationClass>([
+  "value",
+  "shape",
+  "enumerate",
+  "followRef",
+]);
+
+/**
+ * Validate the JSON object accepted by `cf piece set-label`.
+ *
+ * The command exposes the two stored label families and their observation
+ * class. Policy claims such as `requiredIntegrity` remain pattern-schema
+ * authoring concerns rather than label metadata.
+ */
+export function parseCellCfcLabelUpdate(
+  input: unknown,
+): CellCfcLabelUpdate {
+  if (!isPlainObject(input)) {
+    throw new Error("CFC label input must be a JSON object.");
+  }
+
+  const supported = new Set(["confidentiality", "integrity", "observes"]);
+  const unsupported = Object.keys(input).filter((key) => !supported.has(key));
+  if (unsupported.length > 0) {
+    throw new Error(
+      `Unknown CFC label field${unsupported.length === 1 ? "" : "s"}: ` +
+        unsupported.join(", ") +
+        ". Expected confidentiality, integrity, or observes.",
+    );
+  }
+
+  const confidentiality = input.confidentiality;
+  const integrity = input.integrity;
+  if (confidentiality === undefined && integrity === undefined) {
+    throw new Error(
+      "CFC label input must include confidentiality or integrity.",
+    );
+  }
+  if (confidentiality !== undefined && !Array.isArray(confidentiality)) {
+    throw new Error("CFC label confidentiality must be a JSON array.");
+  }
+  if (integrity !== undefined && !Array.isArray(integrity)) {
+    throw new Error("CFC label integrity must be a JSON array.");
+  }
+
+  const observes = input.observes;
+  if (
+    observes !== undefined &&
+    !CFC_LABEL_OBSERVATION_CLASSES.has(
+      observes as LabelObservationClass,
+    )
+  ) {
+    throw new Error(
+      "CFC label observes must be value, shape, enumerate, or followRef.",
+    );
+  }
+
+  return {
+    ...(confidentiality !== undefined
+      ? { confidentiality: [...confidentiality] }
+      : {}),
+    ...(integrity !== undefined ? { integrity: [...integrity] } : {}),
+    ...(observes !== undefined
+      ? { observes: observes as LabelObservationClass }
+      : {}),
+  } as CellCfcLabelUpdate;
+}
+
+function cfcLabelViewForCommand(
+  cell: unknown,
+  path: readonly (string | number)[],
+): CfcLabelView | null {
+  const { view, readFailed } = cfcLabelViewForCellWithStatus(cell);
+  if (readFailed) {
+    const location = path.length === 0 ? "<root>" : path.join("/");
+    throw new Error(`Could not read CFC labels at "${location}".`);
+  }
+  return view === undefined ? null : redactCaveatSourcesForDisplay(view);
 }
 
 /** A `cf piece get` path that lands ON a verb. Reading a verb returns the
@@ -2476,6 +2571,147 @@ async function verbReadRefusalOrNull(
   return verb
     ? new PieceVerbReadError(verb.verb, pieceId, verb.callable)
     : null;
+}
+
+/**
+ * Return the effective CFC label view at one piece data path.
+ *
+ * Paths in the returned view are relative to the selected cell. The view
+ * includes stored declared, derived, and link-carried labels and uses the same
+ * display redaction as the runtime-client boundary.
+ */
+export async function getCellCfcLabel(
+  config: PieceConfig,
+  path: (string | number)[],
+  options: { input?: boolean } = {},
+  deps: PieceOperationDependencies = {},
+): Promise<CfcLabelView | null> {
+  const pieces = await (deps.loadPieces ?? loadPieces)(config);
+  const resolvedConfig = await resolvePieceConfigWithPieces(
+    config,
+    pieces,
+    deps.resolvePieceAddress,
+  );
+  const piece = await pieces.get(
+    resolvedConfig.piece,
+    false,
+    undefined,
+    resolvedConfig.pieceScope,
+  );
+  const rootCell =
+    await (options.input ? piece.input.getCell() : piece.result.getCell());
+  const targetCell = rootCell.key(...path);
+  await targetCell.pull();
+  return cfcLabelViewForCommand(targetCell, path);
+}
+
+/**
+ * Update the declared CFC label at one piece data path.
+ *
+ * This updates the label through the same checked write path used by ordinary
+ * runtime operations. The stored schema merge and CFC preparation rules
+ * therefore reject changes that weaken confidentiality or strengthen
+ * integrity. Raw label-map metadata is never written by the CLI.
+ */
+export async function setCellCfcLabel(
+  config: PieceConfig,
+  path: (string | number)[],
+  input: unknown,
+  options: { input?: boolean } = {},
+  deps: PieceOperationDependencies = {},
+): Promise<CfcLabelView | null> {
+  const update = parseCellCfcLabelUpdate(input);
+  const pieces = await (deps.loadPieces ?? loadPieces)(config);
+  const resolvedConfig = await resolvePieceConfigWithPieces(
+    config,
+    pieces,
+    deps.resolvePieceAddress,
+  );
+  const piece = await pieces.get(
+    resolvedConfig.piece,
+    false,
+    undefined,
+    resolvedConfig.pieceScope,
+  );
+  const rootCell =
+    await (options.input ? piece.input.getCell() : piece.result.getCell());
+  const targetCell = rootCell.key(...path);
+  await targetCell.pull();
+  const currentView = cfcLabelViewForCommand(targetCell, path);
+  const value = targetCell.getRaw();
+  if (value === undefined) {
+    const location = path.length === 0 ? "<root>" : path.join("/");
+    throw new Error(`Cannot set a CFC label on absent path "${location}".`);
+  }
+
+  const { observes: requestedObserves, ...label } = update;
+  const schemaIfc = isRecord(targetCell.schema) &&
+      isRecord(targetCell.schema.ifc)
+    ? targetCell.schema.ifc
+    : undefined;
+  const existingObservationClasses = new Set<
+    LabelObservationClass | undefined
+  >(
+    currentView?.entries
+      .filter((entry) => entry.path.length === 0)
+      .map((entry) => entry.observes) ?? [],
+  );
+  if (schemaIfc !== undefined) {
+    existingObservationClasses.add(
+      CFC_LABEL_OBSERVATION_CLASSES.has(
+          schemaIfc.observes as LabelObservationClass,
+        )
+        ? schemaIfc.observes as LabelObservationClass
+        : undefined,
+    );
+  }
+  if (
+    requestedObserves === undefined && existingObservationClasses.size > 1
+  ) {
+    const location = path.length === 0 ? "<root>" : path.join("/");
+    throw new Error(
+      `Cannot preserve observes at "${location}": ` +
+        "the effective label uses multiple observation classes.",
+    );
+  }
+  const observes = requestedObserves ??
+    (existingObservationClasses.size === 1
+      ? existingObservationClasses.values().next().value
+      : undefined);
+  if (
+    observes !== undefined &&
+    (
+      (schemaIfc !== undefined && schemaIfc.observes !== observes) ||
+      currentView?.entries.some((entry) =>
+        entry.path.length === 0 && entry.observes !== observes
+      )
+    )
+  ) {
+    const location = path.length === 0 ? "<root>" : path.join("/");
+    throw new Error(
+      `Cannot set observes to "${observes}" at "${location}": ` +
+        "the effective label already uses a different observation class.",
+    );
+  }
+  const tx = pieces.runtime.edit();
+  targetCell.withTx(tx).asSchema({
+    ifc: {
+      ...label,
+      ...(observes !== undefined ? { observes } : {}),
+    },
+  }).set(value);
+  pieces.runtime.prepareTxForCommit(tx);
+  const committed = await tx.commit();
+  if (committed.error !== undefined) {
+    throw new Error(
+      `Could not set the CFC label at ${
+        path.length === 0 ? "<root>" : path.join("/")
+      }: ${committed.error.message}`,
+    );
+  }
+  await pieces.synced();
+
+  return cfcLabelViewForCommand(targetCell, path);
 }
 
 export async function getCellValue(

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -159,6 +159,8 @@ Deno.test("live candidates: a fabric slot without context degrades to empty", as
       const text of [
         "cf piece call --piece x ",
         "cf piece get --piece x ",
+        "cf piece get-label --piece x ",
+        "cf piece set-label --piece x ",
         "cf piece link ",
         "cf piece ls --piece ",
       ]

--- a/packages/cli/test/json-command.test.ts
+++ b/packages/cli/test/json-command.test.ts
@@ -41,6 +41,10 @@ describe("JSON command contracts", () => {
     ).toBe(true);
     expect(reservesStdoutForCommandOutput(["piece", "get", "path"]))
       .toBe(true);
+    expect(reservesStdoutForCommandOutput(["piece", "get-label", "path"]))
+      .toBe(true);
+    expect(reservesStdoutForCommandOutput(["piece", "set-label", "path"]))
+      .toBe(true);
     expect(
       reservesStdoutForCommandOutput([
         "piece",
@@ -106,6 +110,8 @@ describe("JSON command contracts", () => {
       const command of [
         "check --pattern-json --bogus fixtures/pow-5.tsx",
         "piece get --bogus",
+        "piece get-label --bogus",
+        "piece set-label --bogus",
         "piece --bogus get",
         "piece --bogus call",
         "wish --bogus #profile",

--- a/packages/cli/test/piece-label.test.ts
+++ b/packages/cli/test/piece-label.test.ts
@@ -650,7 +650,9 @@ describe("cf piece CFC labels", () => {
     expect(setHelp.code).toBe(0);
     const text = stripAnsi(setHelp.stdout.join("\n"));
     expect(text).toContain("from JSON on stdin");
-    expect(text).toMatch(/Confidentiality\s+can only become stricter/);
+    expect(text).toMatch(
+      /Confidentiality\s+may only become\s+more restrictive/,
+    );
     expect(text).toContain("--json");
   });
 });

--- a/packages/cli/test/piece-label.test.ts
+++ b/packages/cli/test/piece-label.test.ts
@@ -2,7 +2,13 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import { valueEqual } from "@commonfabric/data-model/fabric-value";
+import {
+  FabricBytes,
+  FabricEpochNsec,
+} from "@commonfabric/data-model/fabric-primitives";
 import { type Cell, Runtime } from "@commonfabric/runner";
+import { cfcLabelViewForCell } from "@commonfabric/runner/cfc";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import {
   getCellCfcLabel,
@@ -123,6 +129,150 @@ describe("cf piece CFC labels", () => {
     expect(
       await getCellCfcLabel(pieceConfig, ["body"], {}, deps as never),
     ).toEqual(updated);
+  });
+
+  it("requires a transaction and an existing value for a CFC schema update", async () => {
+    expect(() =>
+      root.key("body").asSchema({
+        ifc: { confidentiality: ["team"] },
+      }).applyCfcSchemaToExistingValue()
+    ).toThrow("Transaction required");
+
+    const absent = runtime.getCell<string>(
+      signer.did(),
+      "cf-piece-label-absent-schema-target",
+      { type: "string" },
+    );
+    await absent.pull();
+    const tx = runtime.edit();
+    expect(() =>
+      absent.withTx(tx).asSchema({
+        ifc: { confidentiality: ["team"] },
+      }).applyCfcSchemaToExistingValue()
+    ).toThrow("absent value");
+    tx.abort();
+  });
+
+  it("labels a link slot without moving the label to its target", async () => {
+    const linked = runtime.getCell<string>(
+      signer.did(),
+      "cf-piece-label-linked-target",
+      { type: "string" },
+    );
+    const seed = runtime.edit();
+    linked.withTx(seed).set("linked value");
+    const storedLink = linked.getAsLink();
+    root.withTx(seed).key("body").setRawUntyped(storedLink);
+    runtime.prepareTxForCommit(seed);
+    expect((await seed.commit()).error).toBeUndefined();
+
+    const updated = await setCellCfcLabel(
+      pieceConfig,
+      ["body"],
+      { confidentiality: ["team"] },
+      {},
+      deps as never,
+    );
+
+    await root.pull();
+    await linked.pull();
+    expect(root.key("body").getRaw()).toEqual(storedLink);
+    expect(linked.getRaw()).toBe("linked value");
+    expect(cfcLabelViewForCell(linked)).toBeUndefined();
+    expect(updated?.entries[0].label.confidentiality).toEqual(["team"]);
+  });
+
+  it("applies a label through a schema-bearing write redirect", async () => {
+    const linked = runtime.getCell<string>(
+      signer.did(),
+      "cf-piece-label-write-redirect-target",
+      { type: "string" },
+    );
+    const seed = runtime.edit();
+    linked.withTx(seed).set("redirected value");
+    const storedRedirect = linked.getAsWriteRedirectLink({
+      includeSchema: true,
+    });
+    root.withTx(seed).key("body").setRawUntyped(storedRedirect);
+    runtime.prepareTxForCommit(seed);
+    expect((await seed.commit()).error).toBeUndefined();
+
+    const updated = await setCellCfcLabel(
+      pieceConfig,
+      ["body"],
+      { confidentiality: ["team"] },
+      {},
+      deps as never,
+    );
+
+    await root.pull();
+    await linked.pull();
+    expect(root.key("body").getRaw()).toEqual(storedRedirect);
+    expect(linked.getRaw()).toBe("redirected value");
+    expect(cfcLabelViewForCell(linked)?.entries[0].label.confidentiality)
+      .toEqual(["team"]);
+    expect(updated?.entries[0].label.confidentiality).toEqual(["team"]);
+  });
+
+  it("preserves raw Fabric values while adding a label", async () => {
+    const original = {
+      bytes: new FabricBytes(new Uint8Array([1, 2, 3])),
+      timestamp: new FabricEpochNsec(1_725_000_000_000_000_000n),
+    };
+    const fabricRoot = runtime.getCell<{ body: typeof original }>(
+      signer.did(),
+      "cf-piece-label-fabric-root",
+      {
+        type: "object",
+        properties: {
+          body: {
+            type: "object",
+            properties: {
+              bytes: { type: "FabricBytes" },
+              timestamp: { type: "FabricEpochNsec" },
+            },
+            required: ["bytes", "timestamp"],
+          },
+        },
+        required: ["body"],
+      },
+    );
+    const seed = runtime.edit();
+    fabricRoot.withTx(seed).set({ body: original });
+    runtime.prepareTxForCommit(seed);
+    expect((await seed.commit()).error).toBeUndefined();
+    await fabricRoot.pull();
+    const before = fabricRoot.key("body").getRawUntyped();
+    const piece = {
+      input: { getCell: () => Promise.resolve(fabricRoot) },
+      result: { getCell: () => Promise.resolve(fabricRoot) },
+    };
+    const fabricDeps = {
+      ...deps,
+      loadPieces: () =>
+        Promise.resolve({
+          runtime,
+          get: () => Promise.resolve(piece),
+          synced: () => Promise.resolve(),
+        }),
+    };
+
+    const updated = await setCellCfcLabel(
+      pieceConfig,
+      ["body"],
+      { confidentiality: ["team"] },
+      {},
+      fabricDeps as never,
+    );
+
+    await fabricRoot.pull();
+    const after = fabricRoot.key("body").getRawUntyped() as typeof original;
+    expect(valueEqual(after, before)).toBe(true);
+    expect(after.bytes).toBeInstanceOf(FabricBytes);
+    expect(Array.from(after.bytes.slice())).toEqual([1, 2, 3]);
+    expect(after.timestamp).toBeInstanceOf(FabricEpochNsec);
+    expect(after.timestamp.value).toBe(1_725_000_000_000_000_000n);
+    expect(updated?.entries[0].label.confidentiality).toEqual(["team"]);
   });
 
   it("allows integrity to become less trusted", async () => {

--- a/packages/cli/test/piece-label.test.ts
+++ b/packages/cli/test/piece-label.test.ts
@@ -15,6 +15,12 @@ import {
   parseCellCfcLabelUpdate,
   setCellCfcLabel,
 } from "../lib/piece.ts";
+import {
+  getCellCfcLabelFromCommand,
+  piece,
+  setCellCfcLabelFromCommand,
+  setQuietMode,
+} from "../commands/piece.ts";
 import { cf, stripAnsi } from "./utils.ts";
 
 const signer = await Identity.fromPassphrase("cf-piece-label");
@@ -72,6 +78,7 @@ describe("cf piece CFC labels", () => {
   });
 
   afterEach(async () => {
+    setQuietMode(false);
     await runtime.dispose();
     await storageManager.close();
   });
@@ -95,11 +102,77 @@ describe("cf piece CFC labels", () => {
     expect(() => parseCellCfcLabelUpdate({ confidentiality: "team" })).toThrow(
       "confidentiality must be a JSON array",
     );
+    expect(() => parseCellCfcLabelUpdate({ integrity: "reviewed" })).toThrow(
+      "integrity must be a JSON array",
+    );
     expect(() => parseCellCfcLabelUpdate({ integrity: [], extra: true }))
       .toThrow("Unknown CFC label field: extra");
     expect(() =>
       parseCellCfcLabelUpdate({ integrity: [], observes: "content" })
     ).toThrow("value, shape, enumerate, or followRef");
+  });
+
+  it("routes both command actions through their JSON boundaries", async () => {
+    const actionHandler = (name: string): unknown =>
+      (piece.getCommand(name) as unknown as
+        | { actionHandler?: unknown }
+        | undefined)?.actionHandler;
+    expect(actionHandler("get-label")).toBe(getCellCfcLabelFromCommand);
+    expect(actionHandler("set-label")).toBe(setCellCfcLabelFromCommand);
+
+    const options = {
+      apiUrl: "https://example.com",
+      identity: "/identity.key",
+      space: signer.did(),
+      piece: "piece",
+      input: true,
+      quiet: true,
+    };
+    const rendered: Array<{ value: unknown; json: boolean | undefined }> = [];
+    const getCalls: unknown[][] = [];
+    const setCalls: unknown[][] = [];
+    const label = { version: 1 as const, entries: [] };
+    const renderOutput = (value: unknown, config?: { json?: boolean }) => {
+      rendered.push({ value, json: config?.json });
+    };
+
+    await getCellCfcLabelFromCommand(options, "messages/0/body", {
+      getCellCfcLabel: ((...args: unknown[]) => {
+        getCalls.push(args);
+        return Promise.resolve(label);
+      }) as never,
+      render: renderOutput,
+    });
+    await setCellCfcLabelFromCommand(options, undefined, {
+      drainStdin: () => Promise.resolve({ integrity: [] }),
+      setCellCfcLabel: ((...args: unknown[]) => {
+        setCalls.push(args);
+        return Promise.resolve(null);
+      }) as never,
+      render: renderOutput,
+    });
+
+    expect(getCalls[0]?.[0]).toEqual({
+      apiUrl: "https://example.com",
+      identity: "/identity.key",
+      space: signer.did(),
+      piece: "piece",
+      jsonOutput: true,
+    });
+    expect(getCalls[0]?.slice(1)).toEqual([
+      ["messages", 0, "body"],
+      { input: true },
+    ]);
+    expect(setCalls[0]?.[0]).toEqual(getCalls[0]?.[0]);
+    expect(setCalls[0]?.slice(1)).toEqual([
+      [],
+      { integrity: [] },
+      { input: true },
+    ]);
+    expect(rendered).toEqual([
+      { value: label, json: true },
+      { value: null, json: true },
+    ]);
   });
 
   it("sets a declared label and returns its effective view", async () => {
@@ -373,6 +446,111 @@ describe("cf piece CFC labels", () => {
         observes: "value",
       }],
     });
+  });
+
+  it("preserves an observation class declared by the stored schema", async () => {
+    const schemaRoot = runtime.getCell<{ body: string }>(
+      signer.did(),
+      "cf-piece-label-schema-observes",
+      {
+        type: "object",
+        properties: {
+          body: {
+            type: "string",
+            ifc: {
+              confidentiality: ["team"],
+              observes: "value",
+            },
+          },
+        },
+        required: ["body"],
+      },
+    );
+    const tx = runtime.edit();
+    schemaRoot.withTx(tx).set({ body: "hello" });
+    runtime.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+
+    const schemaDeps = {
+      ...deps,
+      loadPieces: () =>
+        Promise.resolve({
+          runtime,
+          get: () =>
+            Promise.resolve({
+              input: { getCell: () => Promise.resolve(schemaRoot) },
+              result: { getCell: () => Promise.resolve(schemaRoot) },
+            }),
+          synced: () => Promise.resolve(),
+        }),
+    };
+    const updated = await setCellCfcLabel(
+      pieceConfig,
+      ["body"],
+      { confidentiality: ["team", "legal"] },
+      {},
+      schemaDeps as never,
+    );
+
+    expect(updated).toEqual({
+      version: 1,
+      entries: [{
+        path: [],
+        label: { confidentiality: ["team", "legal"] },
+        observes: "value",
+      }],
+    });
+  });
+
+  it("rejects an ambiguous observation class instead of choosing one", async () => {
+    const labelSymbol = Object.getOwnPropertySymbols(
+      Object.getPrototypeOf(root),
+    ).find((symbol) => symbol.description === "cfcLabelView");
+    expect(labelSymbol).toBeDefined();
+    if (labelSymbol === undefined) throw new Error("Missing CFC label carrier");
+
+    const ambiguousCell = {
+      key: () => ambiguousCell,
+      pull: () => Promise.resolve(),
+      getRaw: () => "hello",
+      schema: {},
+      [labelSymbol]: () => ({
+        version: 1,
+        entries: [
+          {
+            path: [],
+            label: { confidentiality: ["team"] },
+            observes: "value",
+          },
+          {
+            path: [],
+            label: { integrity: ["reviewed"] },
+            observes: "shape",
+          },
+        ],
+      }),
+    };
+    const ambiguousDeps = {
+      ...deps,
+      loadPieces: () =>
+        Promise.resolve({
+          runtime,
+          get: () =>
+            Promise.resolve({
+              input: { getCell: () => Promise.resolve(ambiguousCell) },
+              result: { getCell: () => Promise.resolve(ambiguousCell) },
+            }),
+          synced: () => Promise.resolve(),
+        }),
+    };
+
+    await expect(setCellCfcLabel(
+      pieceConfig,
+      [],
+      { confidentiality: ["team", "legal"] },
+      {},
+      ambiguousDeps as never,
+    )).rejects.toThrow("effective label uses multiple observation classes");
   });
 
   it("redacts caveat sources from command-facing label views", async () => {

--- a/packages/cli/test/piece-label.test.ts
+++ b/packages/cli/test/piece-label.test.ts
@@ -1,0 +1,328 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import { type Cell, Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import {
+  getCellCfcLabel,
+  parseCellCfcLabelUpdate,
+  setCellCfcLabel,
+} from "../lib/piece.ts";
+import { cf, stripAnsi } from "./utils.ts";
+
+const signer = await Identity.fromPassphrase("cf-piece-label");
+const pieceConfig = {
+  apiUrl: "https://example.com",
+  identity: "/unused.key",
+  space: signer.did(),
+  piece: "piece",
+};
+
+describe("cf piece CFC labels", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let root: Cell<{ body: string }>;
+  let deps: {
+    loadPieces: () => Promise<unknown>;
+    resolvePieceAddress: (_pieces: unknown, token: string) => Promise<string>;
+  };
+
+  beforeEach(async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+      cfcDeclaredMonotonicity: "enforce",
+    });
+    root = runtime.getCell<{ body: string }>(
+      signer.did(),
+      "cf-piece-label-root",
+      {
+        type: "object",
+        properties: { body: { type: "string" } },
+        required: ["body"],
+      },
+    );
+    const tx = runtime.edit();
+    root.withTx(tx).set({ body: "hello" });
+    runtime.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+
+    const piece = {
+      input: { getCell: () => Promise.resolve(root) },
+      result: { getCell: () => Promise.resolve(root) },
+    };
+    const pieces = {
+      runtime,
+      get: () => Promise.resolve(piece),
+      synced: () => Promise.resolve(),
+    };
+    deps = {
+      loadPieces: () => Promise.resolve(pieces),
+      resolvePieceAddress: (_pieces, token) => Promise.resolve(token),
+    };
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  it("validates the declared-label JSON shape", () => {
+    expect(parseCellCfcLabelUpdate({
+      confidentiality: ["team"],
+      integrity: [],
+      observes: "value",
+    })).toEqual({
+      confidentiality: ["team"],
+      integrity: [],
+      observes: "value",
+    });
+    expect(() => parseCellCfcLabelUpdate(null)).toThrow(
+      "must be a JSON object",
+    );
+    expect(() => parseCellCfcLabelUpdate({ observes: "value" })).toThrow(
+      "must include confidentiality or integrity",
+    );
+    expect(() => parseCellCfcLabelUpdate({ confidentiality: "team" })).toThrow(
+      "confidentiality must be a JSON array",
+    );
+    expect(() => parseCellCfcLabelUpdate({ integrity: [], extra: true }))
+      .toThrow("Unknown CFC label field: extra");
+    expect(() =>
+      parseCellCfcLabelUpdate({ integrity: [], observes: "content" })
+    ).toThrow("value, shape, enumerate, or followRef");
+  });
+
+  it("sets a declared label and returns its effective view", async () => {
+    const updated = await setCellCfcLabel(
+      pieceConfig,
+      ["body"],
+      {
+        confidentiality: ["team"],
+        integrity: ["reviewed", "authored"],
+        observes: "value",
+      },
+      {},
+      deps as never,
+    );
+
+    expect(updated).toEqual({
+      version: 1,
+      entries: [{
+        path: [],
+        label: {
+          confidentiality: ["team"],
+          integrity: ["reviewed", "authored"],
+        },
+        observes: "value",
+      }],
+    });
+    expect(
+      await getCellCfcLabel(pieceConfig, ["body"], {}, deps as never),
+    ).toEqual(updated);
+  });
+
+  it("allows integrity to become less trusted", async () => {
+    await setCellCfcLabel(
+      pieceConfig,
+      ["body"],
+      { integrity: ["reviewed", "authored"] },
+      {},
+      deps as never,
+    );
+    const updated = await setCellCfcLabel(
+      pieceConfig,
+      ["body"],
+      { integrity: ["reviewed"] },
+      {},
+      deps as never,
+    );
+
+    expect(updated?.entries[0].label.integrity).toEqual(["reviewed"]);
+
+    const cleared = await setCellCfcLabel(
+      pieceConfig,
+      ["body"],
+      { integrity: [] },
+      {},
+      deps as never,
+    );
+    expect(cleared).toBeNull();
+  });
+
+  it("rejects weaker confidentiality", async () => {
+    await setCellCfcLabel(
+      pieceConfig,
+      ["body"],
+      { confidentiality: ["team"] },
+      {},
+      deps as never,
+    );
+
+    await expect(setCellCfcLabel(
+      pieceConfig,
+      ["body"],
+      { confidentiality: [] },
+      {},
+      deps as never,
+    )).rejects.toThrow("confidentiality cannot be weakened");
+  });
+
+  it("rejects a conflicting observation class", async () => {
+    await setCellCfcLabel(
+      pieceConfig,
+      ["body"],
+      { confidentiality: ["team"], observes: "value" },
+      {},
+      deps as never,
+    );
+
+    await expect(setCellCfcLabel(
+      pieceConfig,
+      ["body"],
+      { confidentiality: ["team"], observes: "shape" },
+      {},
+      deps as never,
+    )).rejects.toThrow("effective label already uses a different");
+    expect(
+      await getCellCfcLabel(pieceConfig, ["body"], {}, deps as never),
+    ).toEqual({
+      version: 1,
+      entries: [{
+        path: [],
+        label: { confidentiality: ["team"] },
+        observes: "value",
+      }],
+    });
+  });
+
+  it("preserves an observation class when a later update omits it", async () => {
+    await setCellCfcLabel(
+      pieceConfig,
+      ["body"],
+      { confidentiality: ["team"], observes: "value" },
+      {},
+      deps as never,
+    );
+
+    const updated = await setCellCfcLabel(
+      pieceConfig,
+      ["body"],
+      { confidentiality: ["team", "legal"] },
+      {},
+      deps as never,
+    );
+    expect(updated).toEqual({
+      version: 1,
+      entries: [{
+        path: [],
+        label: { confidentiality: ["team", "legal"] },
+        observes: "value",
+      }],
+    });
+  });
+
+  it("redacts caveat sources from command-facing label views", async () => {
+    const updated = await setCellCfcLabel(
+      pieceConfig,
+      ["body"],
+      {
+        confidentiality: [{
+          type: CFC_ATOM_TYPE.Caveat,
+          kind: "derived-from",
+          source: "did:key:private-source",
+        }],
+      },
+      {},
+      deps as never,
+    );
+
+    expect(updated?.entries[0].label.confidentiality).toEqual([{
+      type: CFC_ATOM_TYPE.Caveat,
+      kind: "derived-from",
+    }]);
+  });
+
+  it("returns null for unlabeled values and rejects absent paths", async () => {
+    expect(
+      await getCellCfcLabel(pieceConfig, ["body"], {}, deps as never),
+    ).toBeNull();
+    await expect(setCellCfcLabel(
+      pieceConfig,
+      ["missing"],
+      { confidentiality: ["team"] },
+      {},
+      deps as never,
+    )).rejects.toThrow('absent path "missing"');
+  });
+
+  it("fails when label metadata cannot be read", async () => {
+    const failingCell = {
+      pull: () => Promise.resolve(),
+      key: () => failingCell,
+      getAsNormalizedFullLink: () => ({
+        space: signer.did(),
+        id: "unreadable-labels",
+        path: [],
+      }),
+      runtime: {
+        readTx: () => {
+          throw new Error("metadata unavailable");
+        },
+      },
+    };
+    let editCalled = false;
+    const failingPieces = {
+      runtime: {
+        edit: () => {
+          editCalled = true;
+          throw new Error("edit must not start");
+        },
+      },
+      get: () =>
+        Promise.resolve({
+          input: { getCell: () => Promise.resolve(failingCell) },
+          result: { getCell: () => Promise.resolve(failingCell) },
+        }),
+    };
+    const failingDeps = {
+      loadPieces: () => Promise.resolve(failingPieces),
+      resolvePieceAddress: (_pieces: unknown, token: string) =>
+        Promise.resolve(token),
+    };
+
+    await expect(getCellCfcLabel(
+      pieceConfig,
+      [],
+      {},
+      failingDeps as never,
+    )).rejects.toThrow('Could not read CFC labels at "<root>"');
+    await expect(setCellCfcLabel(
+      pieceConfig,
+      [],
+      { confidentiality: ["team"] },
+      {},
+      failingDeps as never,
+    )).rejects.toThrow('Could not read CFC labels at "<root>"');
+    expect(editCalled).toBe(false);
+  });
+
+  it("documents JSON input and output on both commands", async () => {
+    const getHelp = await cf("piece get-label --help");
+    expect(getHelp.code).toBe(0);
+    expect(stripAnsi(getHelp.stdout.join("\n"))).toContain(
+      "effective CFC label view",
+    );
+    expect(getHelp.stdout.join("\n")).toContain("--json");
+
+    const setHelp = await cf("piece set-label --help");
+    expect(setHelp.code).toBe(0);
+    const text = stripAnsi(setHelp.stdout.join("\n"));
+    expect(text).toContain("from JSON on stdin");
+    expect(text).toMatch(/Confidentiality\s+can only become stricter/);
+    expect(text).toContain("--json");
+  });
+});

--- a/packages/cli/test/piece-label.test.ts
+++ b/packages/cli/test/piece-label.test.ts
@@ -546,11 +546,14 @@ describe("cf piece CFC labels", () => {
 
     await expect(setCellCfcLabel(
       pieceConfig,
-      [],
+      ["body"],
       { confidentiality: ["team", "legal"] },
       {},
       ambiguousDeps as never,
-    )).rejects.toThrow("effective label uses multiple observation classes");
+    )).rejects.toThrow(
+      'Cannot preserve observes at "body": ' +
+        "the effective label uses multiple observation classes.",
+    );
   });
 
   it("redacts caveat sources from command-facing label views", async () => {

--- a/packages/integration/page.ts
+++ b/packages/integration/page.ts
@@ -4,7 +4,6 @@ import {
   ElementHandle as AstralElementHandle,
   EvaluateFunction,
   EvaluateOptions,
-  GoToOptions,
   Keyboard,
   KeyboardTypeOptions,
   Page as AstralPage,
@@ -29,6 +28,11 @@ import { Mutable } from "@commonfabric/utils/types";
 import * as path from "@std/path";
 import { ensureDirSync } from "@std/fs";
 import { ConsoleMethod } from "./console.ts";
+
+export interface NavigationOptions {
+  waitUntil?: "load" | "none";
+  referrer?: string;
+}
 
 // To handle `console` events from `Page`, logging to outer context:
 //
@@ -71,6 +75,7 @@ export class Page extends EventTarget {
   private decoratedElements = new WeakSet<AstralElementHandle>();
   private patchedKeyboard?: Keyboard;
   private originalKeyboardType?: Keyboard["type"];
+  private navigationQueue: Promise<void> = Promise.resolve();
 
   constructor(page: AstralPage, options: { timeout: number }) {
     super();
@@ -326,18 +331,145 @@ export class Page extends EventTarget {
     return await this.page!.evaluate(evaluate, evaluateOptions);
   }
 
-  // Passthru of `@astral/astral`'s `Page#goto`
-  async goto(url: string, options?: GoToOptions): Promise<void> {
+  // Navigates through the browser protocol and waits for the requested
+  // lifecycle event.
+  async goto(url: string, options?: NavigationOptions): Promise<void> {
     this.checkIsOk();
-    await this.page!.goto(url, options);
+    await this.runNavigation(() => this.navigate(url, options));
+  }
+
+  private async runNavigation(operation: () => Promise<void>): Promise<void> {
+    const previousNavigation = this.navigationQueue;
+    let releaseNavigation!: () => void;
+    this.navigationQueue = new Promise((resolve) => {
+      releaseNavigation = resolve;
+    });
+    await previousNavigation;
+    try {
+      await operation();
+    } finally {
+      releaseNavigation();
+    }
+  }
+
+  private async navigate(
+    url: string,
+    options?: NavigationOptions,
+  ): Promise<void> {
+    const waitUntil = options?.waitUntil;
+    const navigateOptions = options?.referrer === undefined
+      ? { url }
+      : { url, referrer: options.referrer };
+
+    const celestial = this.page!.unsafelyGetCelestialBindings();
+    if (waitUntil === "none") {
+      const result = await celestial.Page.navigate(navigateOptions);
+      if (result.errorText) throw new Error(result.errorText);
+      await this.afterNavigation?.();
+      return;
+    }
+    const lifecycleNames = waitUntil === "load"
+      ? new Set(["load"])
+      : new Set(["DOMContentLoaded", "networkAlmostIdle"]);
+    const lifecycleEvents: Array<{ loaderId: string; name: string }> = [];
+    const detachedFrames: string[] = [];
+    let terminalError: Error | undefined;
+    let inspectorDetached = false;
+    let resolveLifecycle!: () => void;
+    const lifecycleReady = new Promise<void>((resolve) => {
+      resolveLifecycle = resolve;
+    });
+    let loaderId: string | undefined;
+    let frameId: string | undefined;
+    const lifecycleListener = (event: Event) => {
+      const detail = (event as CustomEvent<{
+        loaderId: string;
+        name: string;
+      }>).detail;
+      lifecycleEvents.push(detail);
+      if (detail.loaderId === loaderId && lifecycleNames.has(detail.name)) {
+        resolveLifecycle();
+      }
+    };
+    const frameDetachedListener = (event: Event) => {
+      const detail = (event as CustomEvent<{ frameId: string }>).detail;
+      detachedFrames.push(detail.frameId);
+      if (detail.frameId === frameId) {
+        terminalError = new Error("Navigation frame was detached.");
+        resolveLifecycle();
+      }
+    };
+    const inspectorDetachedListener = (event: Event) => {
+      const detail = (event as CustomEvent<{ reason: string }>).detail;
+      inspectorDetached = true;
+      terminalError = new Error(
+        `Browser session detached during navigation: ${detail.reason}`,
+      );
+      resolveLifecycle();
+    };
+
+    await celestial.Page.setLifecycleEventsEnabled({ enabled: true });
+    celestial.addEventListener("Page.lifecycleEvent", lifecycleListener);
+    celestial.addEventListener("Page.frameDetached", frameDetachedListener);
+    celestial.addEventListener("Inspector.detached", inspectorDetachedListener);
+    let navigationFailed = false;
+    let navigationError: unknown;
+    try {
+      const result = await celestial.Page.navigate(navigateOptions);
+      if (result.errorText) throw new Error(result.errorText);
+      loaderId = result.loaderId;
+      frameId = result.frameId;
+      if (terminalError) throw terminalError;
+      if (frameId !== undefined && detachedFrames.includes(frameId)) {
+        throw new Error("Navigation frame was detached.");
+      }
+      if (loaderId !== undefined) {
+        if (
+          lifecycleEvents.some((event) =>
+            event.loaderId === loaderId && lifecycleNames.has(event.name)
+          )
+        ) {
+          resolveLifecycle();
+        }
+        await lifecycleReady;
+        if (terminalError) throw terminalError;
+      }
+    } catch (error) {
+      navigationFailed = true;
+      navigationError = error;
+    } finally {
+      celestial.removeEventListener("Page.lifecycleEvent", lifecycleListener);
+      celestial.removeEventListener(
+        "Page.frameDetached",
+        frameDetachedListener,
+      );
+      celestial.removeEventListener(
+        "Inspector.detached",
+        inspectorDetachedListener,
+      );
+    }
+    let cleanupFailed = false;
+    let cleanupError: unknown;
+    if (!inspectorDetached) {
+      try {
+        await celestial.Page.setLifecycleEventsEnabled({ enabled: false });
+      } catch (error) {
+        cleanupFailed = true;
+        cleanupError = error;
+      }
+    }
+    if (navigationFailed) throw navigationError;
+    if (cleanupFailed) throw cleanupError;
     await this.afterNavigation?.();
   }
 
   // Passthru of `@astral/astral`'s `Page#reload`
   async reload(options?: WaitForOptions): Promise<void> {
     this.checkIsOk();
-    await this.page!.reload(options);
-    await this.afterNavigation?.();
+    await this.runNavigation(async () => {
+      await this.page!.reload(options);
+      await this.afterNavigation?.();
+    });
   }
 
   // Passthru of `@astral/astral`'s `Page#waitForSelector`.

--- a/packages/integration/page.ts
+++ b/packages/integration/page.ts
@@ -371,46 +371,119 @@ export class Page extends EventTarget {
     const lifecycleNames = waitUntil === "load"
       ? new Set(["load"])
       : new Set(["DOMContentLoaded", "networkAlmostIdle"]);
-    const lifecycleEvents: Array<{ loaderId: string; name: string }> = [];
-    const detachedFrames: string[] = [];
+    type NavigationSignal =
+      | { type: "lifecycle"; loaderId: string; name: string }
+      | { type: "frame-detached"; frameId: string }
+      | { type: "frame-stopped"; frameId: string }
+      | {
+        type: "frame-navigated";
+        frameId: string;
+        loaderId: string;
+      }
+      | { type: "inspector-detached"; reason: string };
+    const navigationSignals: NavigationSignal[] = [];
     let terminalError: Error | undefined;
     let inspectorDetached = false;
+    let loaderEstablished = false;
+    let lifecycleAccepted = false;
     let resolveLifecycle!: () => void;
     const lifecycleReady = new Promise<void>((resolve) => {
       resolveLifecycle = resolve;
     });
     let loaderId: string | undefined;
     let frameId: string | undefined;
+    const handleNavigationSignal = (signal: NavigationSignal) => {
+      switch (signal.type) {
+        case "lifecycle":
+          if (signal.loaderId === loaderId) {
+            loaderEstablished = true;
+            if (
+              terminalError === undefined && lifecycleNames.has(signal.name)
+            ) {
+              lifecycleAccepted = true;
+              resolveLifecycle();
+            }
+          }
+          break;
+        case "frame-detached":
+          if (signal.frameId === frameId) {
+            terminalError = new Error("Navigation frame was detached.");
+            resolveLifecycle();
+          }
+          break;
+        case "frame-stopped":
+          if (
+            signal.frameId === frameId && loaderEstablished &&
+            !lifecycleAccepted
+          ) {
+            terminalError = new Error(
+              "Navigation frame stopped loading before it became ready.",
+            );
+            resolveLifecycle();
+          }
+          break;
+        case "frame-navigated":
+          if (signal.frameId !== frameId) break;
+          if (signal.loaderId === loaderId) {
+            loaderEstablished = true;
+          } else if (loaderEstablished && !lifecycleAccepted) {
+            terminalError = new Error(
+              "Navigation was superseded by another document.",
+            );
+            resolveLifecycle();
+          }
+          break;
+        case "inspector-detached":
+          inspectorDetached = true;
+          terminalError = new Error(
+            `Browser session detached during navigation: ${signal.reason}`,
+          );
+          resolveLifecycle();
+          break;
+      }
+    };
+    const recordNavigationSignal = (signal: NavigationSignal) => {
+      navigationSignals.push(signal);
+      handleNavigationSignal(signal);
+    };
     const lifecycleListener = (event: Event) => {
       const detail = (event as CustomEvent<{
         loaderId: string;
         name: string;
       }>).detail;
-      lifecycleEvents.push(detail);
-      if (detail.loaderId === loaderId && lifecycleNames.has(detail.name)) {
-        resolveLifecycle();
-      }
+      recordNavigationSignal({ type: "lifecycle", ...detail });
     };
     const frameDetachedListener = (event: Event) => {
       const detail = (event as CustomEvent<{ frameId: string }>).detail;
-      detachedFrames.push(detail.frameId);
-      if (detail.frameId === frameId) {
-        terminalError = new Error("Navigation frame was detached.");
-        resolveLifecycle();
-      }
+      recordNavigationSignal({ type: "frame-detached", ...detail });
+    };
+    const frameStoppedListener = (event: Event) => {
+      const detail = (event as CustomEvent<{ frameId: string }>).detail;
+      recordNavigationSignal({ type: "frame-stopped", ...detail });
+    };
+    const frameNavigatedListener = (event: Event) => {
+      const detail = (event as CustomEvent<{
+        frame: { id: string; loaderId: string };
+      }>).detail;
+      recordNavigationSignal({
+        type: "frame-navigated",
+        frameId: detail.frame.id,
+        loaderId: detail.frame.loaderId,
+      });
     };
     const inspectorDetachedListener = (event: Event) => {
       const detail = (event as CustomEvent<{ reason: string }>).detail;
-      inspectorDetached = true;
-      terminalError = new Error(
-        `Browser session detached during navigation: ${detail.reason}`,
-      );
-      resolveLifecycle();
+      recordNavigationSignal({ type: "inspector-detached", ...detail });
     };
 
     await celestial.Page.setLifecycleEventsEnabled({ enabled: true });
     celestial.addEventListener("Page.lifecycleEvent", lifecycleListener);
     celestial.addEventListener("Page.frameDetached", frameDetachedListener);
+    celestial.addEventListener(
+      "Page.frameStoppedLoading",
+      frameStoppedListener,
+    );
+    celestial.addEventListener("Page.frameNavigated", frameNavigatedListener);
     celestial.addEventListener("Inspector.detached", inspectorDetachedListener);
     let navigationFailed = false;
     let navigationError: unknown;
@@ -419,18 +492,9 @@ export class Page extends EventTarget {
       if (result.errorText) throw new Error(result.errorText);
       loaderId = result.loaderId;
       frameId = result.frameId;
+      for (const signal of navigationSignals) handleNavigationSignal(signal);
       if (terminalError) throw terminalError;
-      if (frameId !== undefined && detachedFrames.includes(frameId)) {
-        throw new Error("Navigation frame was detached.");
-      }
       if (loaderId !== undefined) {
-        if (
-          lifecycleEvents.some((event) =>
-            event.loaderId === loaderId && lifecycleNames.has(event.name)
-          )
-        ) {
-          resolveLifecycle();
-        }
         await lifecycleReady;
         if (terminalError) throw terminalError;
       }
@@ -442,6 +506,14 @@ export class Page extends EventTarget {
       celestial.removeEventListener(
         "Page.frameDetached",
         frameDetachedListener,
+      );
+      celestial.removeEventListener(
+        "Page.frameStoppedLoading",
+        frameStoppedListener,
+      );
+      celestial.removeEventListener(
+        "Page.frameNavigated",
+        frameNavigatedListener,
       );
       celestial.removeEventListener(
         "Inspector.detached",

--- a/packages/integration/test/presentation.test.ts
+++ b/packages/integration/test/presentation.test.ts
@@ -50,18 +50,31 @@ Deno.test("Page runs the navigation hook after goto and reload", async () => {
 
 Deno.test("Page navigation does not depend on Astral's retry wrapper", async () => {
   const navigationCalls: unknown[] = [];
+  const lifecycleCalls: unknown[] = [];
   const celestial = new EventTarget() as EventTarget & {
     Page: {
-      navigate(options: unknown): Promise<{ loaderId: string }>;
+      setLifecycleEventsEnabled(options: unknown): Promise<Record<string, never>>;
+      navigate(options: unknown): Promise<{ frameId: string; loaderId: string }>;
     };
   };
   celestial.Page = {
+    setLifecycleEventsEnabled(options) {
+      lifecycleCalls.push(options);
+      return Promise.resolve({});
+    },
     navigate(options) {
       navigationCalls.push(options);
       queueMicrotask(() => {
-        celestial.dispatchEvent(new Event("Page.domContentEventFired"));
+        celestial.dispatchEvent(new CustomEvent("Page.lifecycleEvent", {
+          detail: {
+            frameId: "frame",
+            loaderId: "loader",
+            name: "DOMContentLoaded",
+            timestamp: 0,
+          },
+        }));
       });
-      return Promise.resolve({ loaderId: "loader" });
+      return Promise.resolve({ frameId: "frame", loaderId: "loader" });
     },
   };
   const astralPage = {
@@ -88,6 +101,7 @@ Deno.test("Page navigation does not depend on Astral's retry wrapper", async () 
     url: "https://example.test/next",
     referrer: "https://example.test/previous",
   }]);
+  assertEquals(lifecycleCalls, [{ enabled: true }, { enabled: false }]);
   assertEquals(hookCalls, 1);
 });
 

--- a/packages/integration/test/presentation.test.ts
+++ b/packages/integration/test/presentation.test.ts
@@ -329,6 +329,8 @@ Deno.test("Page navigation cleans up after its frame detaches", async () => {
   assertEquals(removedListeners, [
     "Page.lifecycleEvent",
     "Page.frameDetached",
+    "Page.frameStoppedLoading",
+    "Page.frameNavigated",
     "Inspector.detached",
   ]);
 });
@@ -377,6 +379,11 @@ Deno.test("Page rejects when its frame stops before becoming ready", async () =>
     setLifecycleEventsEnabled: () => Promise.resolve({}),
     navigate: () => {
       celestial.dispatchEvent(
+        new CustomEvent("Page.lifecycleEvent", {
+          detail: { loaderId: "loader", name: "init" },
+        }),
+      );
+      celestial.dispatchEvent(
         new CustomEvent("Page.frameStoppedLoading", {
           detail: { frameId: "frame" },
         }),
@@ -414,6 +421,14 @@ Deno.test("Page rejects when another loader supersedes navigation", async () => 
   celestial.Page = {
     setLifecycleEventsEnabled: () => Promise.resolve({}),
     navigate: () => {
+      celestial.dispatchEvent(
+        new CustomEvent("Page.frameNavigated", {
+          detail: {
+            frame: { id: "frame", loaderId: "loader" },
+            type: "Navigation",
+          },
+        }),
+      );
       celestial.dispatchEvent(
         new CustomEvent("Page.frameNavigated", {
           detail: {
@@ -463,6 +478,53 @@ Deno.test("Page accepts readiness before its frame stops", async () => {
       celestial.dispatchEvent(
         new CustomEvent("Page.frameStoppedLoading", {
           detail: { frameId: "frame" },
+        }),
+      );
+      return Promise.resolve({ frameId: "frame", loaderId: "loader" });
+    },
+  };
+  const page = new Page(
+    {
+      timeout: 0,
+      unsafelyGetCelestialBindings: () => celestial,
+    } as unknown as ConstructorParameters<typeof Page>[0],
+    { timeout: 10 },
+  );
+
+  await page.goto("https://example.test/");
+});
+
+Deno.test("Page ignores terminal signals from the previous document", async () => {
+  const celestial = new EventTarget() as EventTarget & {
+    Page: {
+      setLifecycleEventsEnabled(): Promise<Record<string, never>>;
+      navigate(): Promise<{ frameId: string; loaderId: string }>;
+    };
+  };
+  celestial.Page = {
+    setLifecycleEventsEnabled: () => Promise.resolve({}),
+    navigate: () => {
+      celestial.dispatchEvent(
+        new CustomEvent("Page.frameStoppedLoading", {
+          detail: { frameId: "frame" },
+        }),
+      );
+      celestial.dispatchEvent(
+        new CustomEvent("Page.frameNavigated", {
+          detail: {
+            frame: { id: "frame", loaderId: "previous" },
+            type: "Navigation",
+          },
+        }),
+      );
+      celestial.dispatchEvent(
+        new CustomEvent("Page.lifecycleEvent", {
+          detail: { loaderId: "loader", name: "init" },
+        }),
+      );
+      celestial.dispatchEvent(
+        new CustomEvent("Page.lifecycleEvent", {
+          detail: { loaderId: "loader", name: "DOMContentLoaded" },
         }),
       );
       return Promise.resolve({ frameId: "frame", loaderId: "loader" });

--- a/packages/integration/test/presentation.test.ts
+++ b/packages/integration/test/presentation.test.ts
@@ -21,16 +21,26 @@ Deno.test("parsePresentationConfig stays disabled without an output directory", 
 
 Deno.test("Page runs the navigation hook after goto and reload", async () => {
   const navigations: string[] = [];
+  const celestial = new EventTarget() as EventTarget & {
+    Page: {
+      setLifecycleEventsEnabled(): Promise<Record<string, never>>;
+      navigate(options: { url: string }): Promise<{ loaderId?: string }>;
+    };
+  };
+  celestial.Page = {
+    setLifecycleEventsEnabled: () => Promise.resolve({}),
+    navigate: ({ url }) => {
+      navigations.push(url);
+      return Promise.resolve({});
+    },
+  };
   const astralPage = {
     timeout: 0,
-    goto: (url: string) => {
-      navigations.push(url);
-      return Promise.resolve();
-    },
     reload: () => {
       navigations.push("reload");
       return Promise.resolve();
     },
+    unsafelyGetCelestialBindings: () => celestial,
   };
   const page = new Page(
     astralPage as unknown as ConstructorParameters<typeof Page>[0],
@@ -107,6 +117,437 @@ Deno.test("Page navigation does not depend on Astral's retry wrapper", async () 
   }]);
   assertEquals(lifecycleCalls, [{ enabled: true }, { enabled: false }]);
   assertEquals(hookCalls, 1);
+});
+
+Deno.test("Page navigation ignores unrelated lifecycle events", async () => {
+  let navigationStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    navigationStarted = resolve;
+  });
+  const celestial = new EventTarget() as EventTarget & {
+    Page: {
+      setLifecycleEventsEnabled(): Promise<Record<string, never>>;
+      navigate(): Promise<{ frameId: string; loaderId: string }>;
+    };
+  };
+  celestial.Page = {
+    setLifecycleEventsEnabled: () => Promise.resolve({}),
+    navigate: () => {
+      navigationStarted();
+      return Promise.resolve({ frameId: "frame", loaderId: "target" });
+    },
+  };
+  const page = new Page(
+    {
+      timeout: 0,
+      unsafelyGetCelestialBindings: () => celestial,
+    } as unknown as ConstructorParameters<typeof Page>[0],
+    { timeout: 10 },
+  );
+  let completed = false;
+  const navigation = page.goto("https://example.test/").then(() => {
+    completed = true;
+  });
+  await started;
+
+  celestial.dispatchEvent(
+    new CustomEvent("Page.lifecycleEvent", {
+      detail: { loaderId: "other", name: "networkAlmostIdle" },
+    }),
+  );
+  celestial.dispatchEvent(
+    new CustomEvent("Page.lifecycleEvent", {
+      detail: { loaderId: "target", name: "load" },
+    }),
+  );
+  await Promise.resolve();
+  await Promise.resolve();
+  assertEquals(completed, false);
+
+  celestial.dispatchEvent(
+    new CustomEvent("Page.lifecycleEvent", {
+      detail: { loaderId: "target", name: "networkAlmostIdle" },
+    }),
+  );
+  await navigation;
+  assertEquals(completed, true);
+});
+
+Deno.test("Page navigation maps the explicit load option", async () => {
+  const lifecycleNames: string[] = [];
+  const celestial = new EventTarget() as EventTarget & {
+    Page: {
+      setLifecycleEventsEnabled(): Promise<Record<string, never>>;
+      navigate(): Promise<{ frameId: string; loaderId: string }>;
+    };
+  };
+  celestial.Page = {
+    setLifecycleEventsEnabled: () => Promise.resolve({}),
+    navigate: () => {
+      lifecycleNames.push("load");
+      celestial.dispatchEvent(
+        new CustomEvent("Page.lifecycleEvent", {
+          detail: { loaderId: "loader", name: "load" },
+        }),
+      );
+      return Promise.resolve({ frameId: "frame", loaderId: "loader" });
+    },
+  };
+  const page = new Page(
+    {
+      timeout: 0,
+      unsafelyGetCelestialBindings: () => celestial,
+    } as unknown as ConstructorParameters<typeof Page>[0],
+    { timeout: 10 },
+  );
+
+  await page.goto("https://example.test/load", { waitUntil: "load" });
+
+  assertEquals(lifecycleNames, ["load"]);
+});
+
+Deno.test("Page navigation accepts DOMContentLoaded by default", async () => {
+  const celestial = new EventTarget() as EventTarget & {
+    Page: {
+      setLifecycleEventsEnabled(): Promise<Record<string, never>>;
+      navigate(): Promise<{ frameId: string; loaderId: string }>;
+    };
+  };
+  celestial.Page = {
+    setLifecycleEventsEnabled: () => Promise.resolve({}),
+    navigate: () => {
+      celestial.dispatchEvent(
+        new CustomEvent("Page.lifecycleEvent", {
+          detail: { loaderId: "loader", name: "DOMContentLoaded" },
+        }),
+      );
+      return Promise.resolve({ frameId: "frame", loaderId: "loader" });
+    },
+  };
+  const page = new Page(
+    {
+      timeout: 0,
+      unsafelyGetCelestialBindings: () => celestial,
+    } as unknown as ConstructorParameters<typeof Page>[0],
+    { timeout: 10 },
+  );
+
+  await page.goto("https://example.test/");
+});
+
+Deno.test("Page navigation rejects when its browser session detaches", async () => {
+  let navigationStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    navigationStarted = resolve;
+  });
+  const celestial = new EventTarget() as EventTarget & {
+    Page: {
+      setLifecycleEventsEnabled(): Promise<Record<string, never>>;
+      navigate(): Promise<{ frameId: string; loaderId: string }>;
+    };
+  };
+  celestial.Page = {
+    setLifecycleEventsEnabled: () => Promise.resolve({}),
+    navigate: () => {
+      navigationStarted();
+      return Promise.resolve({ frameId: "frame", loaderId: "loader" });
+    },
+  };
+  const page = new Page(
+    {
+      timeout: 0,
+      unsafelyGetCelestialBindings: () => celestial,
+    } as unknown as ConstructorParameters<typeof Page>[0],
+    { timeout: 10 },
+  );
+  const navigation = page.goto("https://example.test/");
+  await started;
+  celestial.dispatchEvent(
+    new CustomEvent("Inspector.detached", {
+      detail: { reason: "target closed" },
+    }),
+  );
+
+  await assertRejects(
+    () => navigation,
+    Error,
+    "Browser session detached during navigation: target closed",
+  );
+});
+
+Deno.test("Page navigation cleans up after its frame detaches", async () => {
+  let navigationStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    navigationStarted = resolve;
+  });
+  const lifecycleStates: boolean[] = [];
+  const removedListeners: string[] = [];
+  const celestial = new EventTarget() as EventTarget & {
+    Page: {
+      setLifecycleEventsEnabled(
+        options: { enabled: boolean },
+      ): Promise<Record<string, never>>;
+      navigate(): Promise<{ frameId: string; loaderId: string }>;
+    };
+  };
+  const removeEventListener = celestial.removeEventListener.bind(celestial);
+  celestial.removeEventListener = (type, callback, options) => {
+    removedListeners.push(type);
+    removeEventListener(type, callback, options);
+  };
+  celestial.Page = {
+    setLifecycleEventsEnabled: ({ enabled }) => {
+      lifecycleStates.push(enabled);
+      return Promise.resolve({});
+    },
+    navigate: () => {
+      navigationStarted();
+      return Promise.resolve({ frameId: "frame", loaderId: "loader" });
+    },
+  };
+  const page = new Page(
+    {
+      timeout: 0,
+      unsafelyGetCelestialBindings: () => celestial,
+    } as unknown as ConstructorParameters<typeof Page>[0],
+    { timeout: 10 },
+  );
+  const navigation = page.goto("https://example.test/");
+  await started;
+  celestial.dispatchEvent(
+    new CustomEvent("Page.frameDetached", {
+      detail: { frameId: "frame" },
+    }),
+  );
+
+  await assertRejects(
+    () => navigation,
+    Error,
+    "Navigation frame was detached.",
+  );
+  assertEquals(lifecycleStates, [true, false]);
+  assertEquals(removedListeners, [
+    "Page.lifecycleEvent",
+    "Page.frameDetached",
+    "Inspector.detached",
+  ]);
+});
+
+Deno.test("Page detects an early frame detachment without a loader", async () => {
+  const celestial = new EventTarget() as EventTarget & {
+    Page: {
+      setLifecycleEventsEnabled(): Promise<Record<string, never>>;
+      navigate(): Promise<{ frameId: string }>;
+    };
+  };
+  celestial.Page = {
+    setLifecycleEventsEnabled: () => Promise.resolve({}),
+    navigate: () => {
+      celestial.dispatchEvent(
+        new CustomEvent("Page.frameDetached", {
+          detail: { frameId: "frame" },
+        }),
+      );
+      return Promise.resolve({ frameId: "frame" });
+    },
+  };
+  const page = new Page(
+    {
+      timeout: 0,
+      unsafelyGetCelestialBindings: () => celestial,
+    } as unknown as ConstructorParameters<typeof Page>[0],
+    { timeout: 10 },
+  );
+
+  await assertRejects(
+    () => page.goto("https://example.test/"),
+    Error,
+    "Navigation frame was detached.",
+  );
+});
+
+Deno.test("Page preserves a navigation command failure after detachment", async () => {
+  let navigationStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    navigationStarted = resolve;
+  });
+  let rejectNavigation!: (error: Error) => void;
+  const navigationResult = new Promise<never>((_resolve, reject) => {
+    rejectNavigation = reject;
+  });
+  const celestial = new EventTarget() as EventTarget & {
+    Page: {
+      setLifecycleEventsEnabled(): Promise<Record<string, never>>;
+      navigate(): Promise<never>;
+    };
+  };
+  celestial.Page = {
+    setLifecycleEventsEnabled: () => Promise.resolve({}),
+    navigate: () => {
+      navigationStarted();
+      return navigationResult;
+    },
+  };
+  const page = new Page(
+    {
+      timeout: 0,
+      unsafelyGetCelestialBindings: () => celestial,
+    } as unknown as ConstructorParameters<typeof Page>[0],
+    { timeout: 10 },
+  );
+  const navigation = page.goto("https://example.test/");
+  await started;
+  celestial.dispatchEvent(
+    new CustomEvent("Inspector.detached", {
+      detail: { reason: "target closed" },
+    }),
+  );
+  rejectNavigation(new Error("Navigation command disconnected."));
+
+  await assertRejects(
+    () => navigation,
+    Error,
+    "Navigation command disconnected.",
+  );
+});
+
+Deno.test("Page preserves navigation failures when cleanup fails", async () => {
+  let lifecycleCall = 0;
+  const celestial = new EventTarget() as EventTarget & {
+    Page: {
+      setLifecycleEventsEnabled(): Promise<Record<string, never>>;
+      navigate(): Promise<never>;
+    };
+  };
+  celestial.Page = {
+    setLifecycleEventsEnabled: () => {
+      lifecycleCall++;
+      return lifecycleCall === 1
+        ? Promise.resolve({})
+        : Promise.reject(new Error("Lifecycle cleanup failed."));
+    },
+    navigate: () => Promise.reject(new Error("Navigation failed.")),
+  };
+  const page = new Page(
+    {
+      timeout: 0,
+      unsafelyGetCelestialBindings: () => celestial,
+    } as unknown as ConstructorParameters<typeof Page>[0],
+    { timeout: 10 },
+  );
+
+  await assertRejects(
+    () => page.goto("https://example.test/"),
+    Error,
+    "Navigation failed.",
+  );
+});
+
+Deno.test("Page serializes overlapping navigation calls", async () => {
+  const loaderIds = ["first", "second"];
+  const navigationCalls: string[] = [];
+  let firstNavigationStarted!: () => void;
+  const firstStarted = new Promise<void>((resolve) => {
+    firstNavigationStarted = resolve;
+  });
+  let secondNavigationStarted!: () => void;
+  const secondStarted = new Promise<void>((resolve) => {
+    secondNavigationStarted = resolve;
+  });
+  const celestial = new EventTarget() as EventTarget & {
+    Page: {
+      setLifecycleEventsEnabled(): Promise<Record<string, never>>;
+      navigate(): Promise<{ frameId: string; loaderId: string }>;
+    };
+  };
+  celestial.Page = {
+    setLifecycleEventsEnabled: () => Promise.resolve({}),
+    navigate: () => {
+      const loaderId = loaderIds[navigationCalls.length];
+      navigationCalls.push(loaderId);
+      if (loaderId === "first") firstNavigationStarted();
+      if (loaderId === "second") secondNavigationStarted();
+      return Promise.resolve({ frameId: "frame", loaderId });
+    },
+  };
+  const page = new Page(
+    {
+      timeout: 0,
+      unsafelyGetCelestialBindings: () => celestial,
+    } as unknown as ConstructorParameters<typeof Page>[0],
+    { timeout: 10 },
+  );
+
+  const first = page.goto("https://example.test/first");
+  const second = page.goto("https://example.test/second");
+  await firstStarted;
+  celestial.dispatchEvent(
+    new CustomEvent("Page.lifecycleEvent", {
+      detail: { loaderId: "first", name: "networkAlmostIdle" },
+    }),
+  );
+  await first;
+  await secondStarted;
+  celestial.dispatchEvent(
+    new CustomEvent("Page.lifecycleEvent", {
+      detail: { loaderId: "second", name: "networkAlmostIdle" },
+    }),
+  );
+  await second;
+
+  assertEquals(navigationCalls, ["first", "second"]);
+});
+
+Deno.test("Page serializes reload behind navigation", async () => {
+  const operations: string[] = [];
+  let navigationStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    navigationStarted = resolve;
+  });
+  let reloadStarted!: () => void;
+  const reloading = new Promise<void>((resolve) => {
+    reloadStarted = resolve;
+  });
+  const celestial = new EventTarget() as EventTarget & {
+    Page: {
+      setLifecycleEventsEnabled(): Promise<Record<string, never>>;
+      navigate(): Promise<{ frameId: string; loaderId: string }>;
+    };
+  };
+  celestial.Page = {
+    setLifecycleEventsEnabled: () => Promise.resolve({}),
+    navigate: () => {
+      operations.push("goto");
+      navigationStarted();
+      return Promise.resolve({ frameId: "frame", loaderId: "loader" });
+    },
+  };
+  const page = new Page(
+    {
+      timeout: 0,
+      reload: () => {
+        operations.push("reload");
+        reloadStarted();
+        return Promise.resolve();
+      },
+      unsafelyGetCelestialBindings: () => celestial,
+    } as unknown as ConstructorParameters<typeof Page>[0],
+    { timeout: 10 },
+  );
+
+  const navigation = page.goto("https://example.test/");
+  const reload = page.reload();
+  await started;
+  celestial.dispatchEvent(
+    new CustomEvent("Page.lifecycleEvent", {
+      detail: { loaderId: "loader", name: "networkAlmostIdle" },
+    }),
+  );
+  await navigation;
+  await reloading;
+  await reload;
+
+  assertEquals(operations, ["goto", "reload"]);
 });
 
 Deno.test("parsePresentationConfig supplies deterministic defaults", () => {

--- a/packages/integration/test/presentation.test.ts
+++ b/packages/integration/test/presentation.test.ts
@@ -366,6 +366,119 @@ Deno.test("Page detects an early frame detachment without a loader", async () =>
   );
 });
 
+Deno.test("Page rejects when its frame stops before becoming ready", async () => {
+  const celestial = new EventTarget() as EventTarget & {
+    Page: {
+      setLifecycleEventsEnabled(): Promise<Record<string, never>>;
+      navigate(): Promise<{ frameId: string; loaderId: string }>;
+    };
+  };
+  celestial.Page = {
+    setLifecycleEventsEnabled: () => Promise.resolve({}),
+    navigate: () => {
+      celestial.dispatchEvent(
+        new CustomEvent("Page.frameStoppedLoading", {
+          detail: { frameId: "frame" },
+        }),
+      );
+      celestial.dispatchEvent(
+        new CustomEvent("Page.lifecycleEvent", {
+          detail: { loaderId: "loader", name: "DOMContentLoaded" },
+        }),
+      );
+      return Promise.resolve({ frameId: "frame", loaderId: "loader" });
+    },
+  };
+  const page = new Page(
+    {
+      timeout: 0,
+      unsafelyGetCelestialBindings: () => celestial,
+    } as unknown as ConstructorParameters<typeof Page>[0],
+    { timeout: 10 },
+  );
+
+  await assertRejects(
+    () => page.goto("https://example.test/"),
+    Error,
+    "Navigation frame stopped loading before it became ready.",
+  );
+});
+
+Deno.test("Page rejects when another loader supersedes navigation", async () => {
+  const celestial = new EventTarget() as EventTarget & {
+    Page: {
+      setLifecycleEventsEnabled(): Promise<Record<string, never>>;
+      navigate(): Promise<{ frameId: string; loaderId: string }>;
+    };
+  };
+  celestial.Page = {
+    setLifecycleEventsEnabled: () => Promise.resolve({}),
+    navigate: () => {
+      celestial.dispatchEvent(
+        new CustomEvent("Page.frameNavigated", {
+          detail: {
+            frame: { id: "frame", loaderId: "replacement" },
+            type: "Navigation",
+          },
+        }),
+      );
+      celestial.dispatchEvent(
+        new CustomEvent("Page.lifecycleEvent", {
+          detail: { loaderId: "loader", name: "DOMContentLoaded" },
+        }),
+      );
+      return Promise.resolve({ frameId: "frame", loaderId: "loader" });
+    },
+  };
+  const page = new Page(
+    {
+      timeout: 0,
+      unsafelyGetCelestialBindings: () => celestial,
+    } as unknown as ConstructorParameters<typeof Page>[0],
+    { timeout: 10 },
+  );
+
+  await assertRejects(
+    () => page.goto("https://example.test/"),
+    Error,
+    "Navigation was superseded by another document.",
+  );
+});
+
+Deno.test("Page accepts readiness before its frame stops", async () => {
+  const celestial = new EventTarget() as EventTarget & {
+    Page: {
+      setLifecycleEventsEnabled(): Promise<Record<string, never>>;
+      navigate(): Promise<{ frameId: string; loaderId: string }>;
+    };
+  };
+  celestial.Page = {
+    setLifecycleEventsEnabled: () => Promise.resolve({}),
+    navigate: () => {
+      celestial.dispatchEvent(
+        new CustomEvent("Page.lifecycleEvent", {
+          detail: { loaderId: "loader", name: "DOMContentLoaded" },
+        }),
+      );
+      celestial.dispatchEvent(
+        new CustomEvent("Page.frameStoppedLoading", {
+          detail: { frameId: "frame" },
+        }),
+      );
+      return Promise.resolve({ frameId: "frame", loaderId: "loader" });
+    },
+  };
+  const page = new Page(
+    {
+      timeout: 0,
+      unsafelyGetCelestialBindings: () => celestial,
+    } as unknown as ConstructorParameters<typeof Page>[0],
+    { timeout: 10 },
+  );
+
+  await page.goto("https://example.test/");
+});
+
 Deno.test("Page preserves a navigation command failure after detachment", async () => {
   let navigationStarted!: () => void;
   const started = new Promise<void>((resolve) => {

--- a/packages/integration/test/presentation.test.ts
+++ b/packages/integration/test/presentation.test.ts
@@ -53,8 +53,12 @@ Deno.test("Page navigation does not depend on Astral's retry wrapper", async () 
   const lifecycleCalls: unknown[] = [];
   const celestial = new EventTarget() as EventTarget & {
     Page: {
-      setLifecycleEventsEnabled(options: unknown): Promise<Record<string, never>>;
-      navigate(options: unknown): Promise<{ frameId: string; loaderId: string }>;
+      setLifecycleEventsEnabled(
+        options: unknown,
+      ): Promise<Record<string, never>>;
+      navigate(
+        options: unknown,
+      ): Promise<{ frameId: string; loaderId: string }>;
     };
   };
   celestial.Page = {
@@ -64,16 +68,16 @@ Deno.test("Page navigation does not depend on Astral's retry wrapper", async () 
     },
     navigate(options) {
       navigationCalls.push(options);
-      queueMicrotask(() => {
-        celestial.dispatchEvent(new CustomEvent("Page.lifecycleEvent", {
+      celestial.dispatchEvent(
+        new CustomEvent("Page.lifecycleEvent", {
           detail: {
             frameId: "frame",
             loaderId: "loader",
-            name: "DOMContentLoaded",
+            name: "networkAlmostIdle",
             timestamp: 0,
           },
-        }));
-      });
+        }),
+      );
       return Promise.resolve({ frameId: "frame", loaderId: "loader" });
     },
   };

--- a/packages/integration/test/presentation.test.ts
+++ b/packages/integration/test/presentation.test.ts
@@ -48,6 +48,49 @@ Deno.test("Page runs the navigation hook after goto and reload", async () => {
   assertEquals(hookCalls, 2);
 });
 
+Deno.test("Page navigation does not depend on Astral's retry wrapper", async () => {
+  const navigationCalls: unknown[] = [];
+  const celestial = new EventTarget() as EventTarget & {
+    Page: {
+      navigate(options: unknown): Promise<{ loaderId: string }>;
+    };
+  };
+  celestial.Page = {
+    navigate(options) {
+      navigationCalls.push(options);
+      queueMicrotask(() => {
+        celestial.dispatchEvent(new Event("Page.domContentEventFired"));
+      });
+      return Promise.resolve({ loaderId: "loader" });
+    },
+  };
+  const astralPage = {
+    timeout: 0,
+    goto: () => {
+      throw new Error("RetryError: Retrying exceeded the maxAttempts (5).");
+    },
+    unsafelyGetCelestialBindings: () => celestial,
+  };
+  const page = new Page(
+    astralPage as unknown as ConstructorParameters<typeof Page>[0],
+    { timeout: 10 },
+  );
+  let hookCalls = 0;
+  page.setAfterNavigationHook(() => {
+    hookCalls++;
+  });
+
+  await page.goto("https://example.test/next", {
+    referrer: "https://example.test/previous",
+  });
+
+  assertEquals(navigationCalls, [{
+    url: "https://example.test/next",
+    referrer: "https://example.test/previous",
+  }]);
+  assertEquals(hookCalls, 1);
+});
+
 Deno.test("parsePresentationConfig supplies deterministic defaults", () => {
   const config = parsePresentationConfig({
     CF_DEMO_OUTPUT_DIR: "/tmp/demo",

--- a/packages/patterns/integration/cf-code-editor.test.ts
+++ b/packages/patterns/integration/cf-code-editor.test.ts
@@ -45,6 +45,7 @@ const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
 // Debounce delay configured in cf-code-editor (default timingDelay)
 const DEBOUNCE_DELAY = 500;
 const DEBOUNCE_BUFFER = 100; // Extra time for processing
+const HELD_DEBOUNCE_DELAY = 2_147_483_647;
 
 // In-page predicate for waitForCondition: the editor document text equals
 // `expected`. `probe.collect` pierces shadow roots to find the editor host.
@@ -811,63 +812,71 @@ describe("cf-code-editor cursor stability", () => {
     );
   });
 
-  it("ADVERSARIAL: Multiple Cell updates while user is continuously typing", async () => {
-    // User types continuously (letters every 50ms) while external updates
-    // bombard the Cell. The editor should not corrupt or crash.
-    //
-    // CORRECT BEHAVIOR: the pending local edit wins over the bombarding
-    // deliveries for as long as its write has not settled, so the typed
-    // characters accumulate and commit as one debounced write.
+  it("keeps one debounced edit over multiple interleaved Cell updates", async () => {
+    // Hold the debounce callback until blur so each external delivery can be
+    // observed before the local edit commits.
     const page = shell.page();
 
     await resetEditorState(page);
+    await configureTiming(page, {
+      strategy: "debounce",
+      delay: HELD_DEBOUNCE_DELAY,
+    });
     await focusEditor(page);
 
-    // Interleave keystrokes and external updates on their own clocks; the
-    // pauses shape the interleaving.
-    const typingPromise = (async () => {
+    try {
+      let typed = "";
       for (let i = 0; i < 10; i++) {
-        await page.keyboard.type(String.fromCharCode(65 + i)); // A, B, C...
-        await new Promise((r) => setTimeout(r, 50));
+        const character = String.fromCharCode(65 + i); // A, B, C...
+        typed += character;
+        await page.keyboard.type(character);
+        if (i % 2 === 1) {
+          await piece.result.set(`Bombard-${(i - 1) / 2}`, ["content"]);
+          await waitForRuntimeSynced(page);
+          await awaitViewSettled(page);
+          assertEquals(
+            await getEditorContent(page),
+            typed,
+            "Pending local edit should remain visible after an external update",
+          );
+        }
       }
-    })();
 
-    const cellBombardPromise = (async () => {
-      for (let i = 0; i < 5; i++) {
-        await new Promise((r) => setTimeout(r, 80));
-        await piece.result.set(`Bombard-${i}`, ["content"]);
-      }
-    })();
+      // Blurring commits the complete local edit after every external update.
+      await blurEditor(page);
+      await awaitCellContent("ABCDEFGHIJ");
+      await awaitEchoDelivered(page);
 
-    await Promise.all([typingPromise, cellBombardPromise]);
+      // Final state should be consistent
+      const content = await getEditorContent(page);
+      const cursor = await getCursorPosition(page);
+      const cellValue = await piece.result.get(["content"]) as string;
 
-    // The typed characters commit as one debounced write over the bombards.
-    await awaitCellContent("ABCDEFGHIJ");
-    await awaitEchoDelivered(page);
+      // Cursor must be valid
+      assert(
+        cursor >= 0 && cursor <= content.length,
+        `Cursor ${cursor} should be valid for content length ${content.length}`,
+      );
 
-    // Final state should be consistent
-    const content = await getEditorContent(page);
-    const cursor = await getCursorPosition(page);
-    const cellValue = await piece.result.get(["content"]) as string;
+      // Editor and Cell should be in sync
+      assertEquals(
+        content,
+        cellValue,
+        "Editor and Cell should match after the local edit commits",
+      );
 
-    // Cursor must be valid
-    assert(
-      cursor >= 0 && cursor <= content.length,
-      `Cursor ${cursor} should be valid for content length ${content.length}`,
-    );
-
-    // Editor and Cell should be in sync
-    assertEquals(
-      content,
-      cellValue,
-      "Editor and Cell should be in sync after chaos",
-    );
-
-    assertEquals(
-      content,
-      "ABCDEFGHIJ",
-      "Typed content should win over the bombarding external updates",
-    );
+      assertEquals(
+        content,
+        "ABCDEFGHIJ",
+        "Pending local edit should survive all external updates",
+      );
+    } finally {
+      await cancelPendingEditorEdit(page);
+      await configureTiming(page, {
+        strategy: "debounce",
+        delay: DEBOUNCE_DELAY,
+      });
+    }
   });
 
   it("ADVERSARIAL: Empty string Cell update during typing", async () => {
@@ -1482,6 +1491,31 @@ async function focusEditor(page: Page): Promise<void> {
       if (cfEditor && cfEditor._editorView) {
         cfEditor._editorView.focus();
       }
+    })()
+  `);
+}
+
+/** Abandon the editor's pending local edit and scheduled write. */
+async function cancelPendingEditorEdit(page: Page): Promise<void> {
+  await page.evaluate(`
+    (() => {
+      function findCfCodeEditor(root) {
+        if (!root) return null;
+        const editor = root.querySelector?.('cf-code-editor');
+        if (editor) return editor;
+        const allElements = root.querySelectorAll?.('*') || [];
+        for (const el of allElements) {
+          if (el.shadowRoot) {
+            const found = findCfCodeEditor(el.shadowRoot);
+            if (found) return found;
+          }
+        }
+        return null;
+      }
+
+      const cfEditor = findCfCodeEditor(document);
+      if (!cfEditor) throw new Error('cf-code-editor not found');
+      cfEditor._cellController.cancel();
     })()
   `);
 }

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -88,7 +88,9 @@ import {
   txToReactivityLog,
 } from "./scheduler.ts";
 import {
+  allowMutableTransactionRead,
   internalVerifierRead,
+  markReadAsAttemptedWrite,
   mergeableOpRead,
 } from "./storage/reactivity-log.ts";
 import { type Cancel, isCancel, useCancelGroup } from "./cancel.ts";
@@ -479,6 +481,11 @@ declare module "@commonfabric/api" {
       onlyIfDifferent?: boolean,
       schemaRole?: "output",
     ): void;
+    /**
+     * Applies this cell's CFC schema to its existing stored value without
+     * rewriting that value.
+     */
+    applyCfcSchemaToExistingValue(): void;
     setSchema(newSchema: JSONSchema): void;
     connect(node: NodeRef): void;
     export(): {
@@ -2550,6 +2557,33 @@ export class CellImpl<T extends FabricValue>
     // ever recorded, so this is inert; it is here so the rule stays true if that
     // changes.
     this.tx.poisonMergeableOp?.(this.link);
+  }
+
+  applyCfcSchemaToExistingValue(): void {
+    if (!this.tx) {
+      throw new Error(
+        "Transaction required for applyCfcSchemaToExistingValue",
+      );
+    }
+    if (!this.synced) this.sync();
+
+    const writeLink = resolveLink(
+      this.runtime,
+      this.tx,
+      this.link,
+      "writeRedirect",
+    );
+    const value = this.tx.readValueOrThrow(writeLink, {
+      meta: { ...markReadAsAttemptedWrite, ...allowMutableTransactionRead },
+    });
+    if (value === undefined) {
+      throw new Error("Cannot apply a CFC schema to an absent value");
+    }
+    recordRelevantSchemaWritePolicyInput(
+      this.tx,
+      writeLink,
+      this.schema,
+    );
   }
 
   getArgumentCell<U>(schema?: JSONSchema): Cell<U> | undefined {

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -1,4 +1,8 @@
-export type { CfcLabelView, CfcLabelViewEntry } from "./label-view.ts";
+export type {
+  CfcLabelView,
+  CfcLabelViewEntry,
+  CfcLabelViewStatus,
+} from "./label-view.ts";
 export {
   type CfcCellLinkRefPayload,
   linkCfcLabelView,
@@ -26,6 +30,7 @@ export {
 export {
   cfcLabelViewForCell,
   cfcLabelViewForCellFailClosed,
+  cfcLabelViewForCellWithStatus,
   cfcLabelViewForDereference,
   cfcLabelViewForDereferenceTraces,
   cfcLabelViewFromMetadata,

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -5697,6 +5697,7 @@ export const prepareBoundaryCommit = (
     // When an ingest target failed verification we keep the runtime's mark
     // (appended below) but drop the payload's declared policy label — a
     // non-rejecting commit must not store claims that didn't verify.
+    const remintedDeclaredPaths = new Map<string, readonly string[]>();
     const persistedLabelEntries: LabelMapEntry[] = ingestVerificationFailed
       ? []
       : mergedSchemaEntries
@@ -5711,6 +5712,16 @@ export const prepareBoundaryCommit = (
             )
           ) {
             return [];
+          }
+          const ifc = isRecord(entry.schema) && isRecord(entry.schema.ifc)
+            ? entry.schema.ifc
+            : undefined;
+          if (
+            ifc !== undefined &&
+            (Object.hasOwn(ifc, "confidentiality") ||
+              Object.hasOwn(ifc, "integrity"))
+          ) {
+            remintedDeclaredPaths.set(pathKey(entry.path), entry.path);
           }
           const derived = gateRuntimeMintedIntegrity(
             derivePersistedLabel(
@@ -5767,11 +5778,24 @@ export const prepareBoundaryCommit = (
     // an ingest target keeps only the runtime's mark); under `observe` it
     // diagnoses and persists today's bytes; `off` runs nothing.
     if (state.declaredMonotonicityMode !== "off" && existing !== undefined) {
+      const proposedDeclaredPathKeys = new Set(
+        persistedLabelEntries
+          .filter((entry) => entry.origin === "declared")
+          .map((entry) => pathKey(entry.path)),
+      );
+      const proposedEntries = [
+        ...persistedLabelEntries,
+        ...[...remintedDeclaredPaths.entries()].flatMap(([key, path]) =>
+          proposedDeclaredPathKeys.has(key)
+            ? []
+            : [{ path, label: {}, origin: "declared" as const }]
+        ),
+      ];
       const monotonicityViolations = collectDeclaredMonotonicityViolations({
         space,
         docId: id,
         storedEntries: existing.labelMap.entries,
-        proposedEntries: persistedLabelEntries,
+        proposedEntries,
         exemption: state.declaredWideningExemption,
       });
       if (monotonicityViolations.length > 0) {
@@ -5782,6 +5806,7 @@ export const prepareBoundaryCommit = (
           // (appended below) still persists in non-rejecting modes, but the
           // non-monotone declared claims must not.
           persistedLabelEntries.length = 0;
+          remintedDeclaredPaths.clear();
         } else {
           for (const violation of monotonicityViolations) {
             tx.noteCfcDiagnostic(
@@ -5798,6 +5823,7 @@ export const prepareBoundaryCommit = (
       linkWriteInputs.map((input) => pathKey(input.target.path)),
     );
     let flowCleared = false;
+    let remintCleared = false;
     // Stage B: stored label-metadata templates this persist drops (they are
     // re-derived from the FINAL payload entry set below). Tracked so a
     // TEMPLATE-ONLY stale envelope — a mixed-version writer cleared the
@@ -5949,7 +5975,16 @@ export const prepareBoundaryCommit = (
           continue;
         }
       }
-      if (persistedLabelEntryKeys.has(key) || currentLinkWritePaths.has(key)) {
+      if (
+        persistedLabelEntryKeys.has(key) || remintedDeclaredPaths.has(key) ||
+        currentLinkWritePaths.has(key)
+      ) {
+        if (
+          remintedDeclaredPaths.has(key) &&
+          !persistedLabelEntryKeys.has(key)
+        ) {
+          remintCleared = true;
+        }
         // A link write replacing a previously content-labeled path — or a
         // declared entry re-minting at the same path — drops the old
         // derived entries here, through a different skip than the
@@ -6646,7 +6681,7 @@ export const prepareBoundaryCommit = (
     const coalescedLabelEntries = coalesceLabelEntries(persistedLabelEntries);
 
     if (
-      coalescedLabelEntries.length === 0 && !flowCleared &&
+      coalescedLabelEntries.length === 0 && !flowCleared && !remintCleared &&
       !droppedLabelMetadataTemplates
     ) {
       continue;

--- a/packages/runner/test/cfc-declared-monotonicity.test.ts
+++ b/packages/runner/test/cfc-declared-monotonicity.test.ts
@@ -89,6 +89,22 @@ const SCHEMA_MINT_XY = {
   required: ["out"],
 } as const satisfies JSONSchema;
 
+const SCHEMA_INTEGRITY_X = {
+  type: "object",
+  properties: {
+    out: { type: "string", ifc: { integrity: [ATOM_X] } },
+  },
+  required: ["out"],
+} as const satisfies JSONSchema;
+
+const SCHEMA_EMPTY_INTEGRITY = {
+  type: "object",
+  properties: {
+    out: { type: "string", ifc: { integrity: [] } },
+  },
+  required: ["out"],
+} as const satisfies JSONSchema;
+
 type PersistedEntry = {
   path: string[];
   origin?: string;
@@ -1053,6 +1069,39 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
       expect(result.error).toBeUndefined();
       const entry = declaredEntryAt(result.entries, ["out"]);
       expect(entry?.label.integrity).toEqual([ATOM_X]);
+    });
+
+    it("removing the final integrity atom clears the declared entry", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({
+        storageManager,
+        cfcDeclaredMonotonicity: "enforce",
+      });
+      try {
+        const first = await commitWrite(
+          runtime,
+          "dm-tight-empty-integ",
+          SCHEMA_INTEGRITY_X,
+          { out: "v1" },
+        );
+        expect(first.error).toBeUndefined();
+        const second = await commitWrite(
+          runtime,
+          "dm-tight-empty-integ",
+          SCHEMA_EMPTY_INTEGRITY,
+          { out: "v2" },
+        );
+        expect(second.error).toBeUndefined();
+        expect(
+          declaredEntryAt(
+            persistedEntriesFor(storageManager, second.docId),
+            ["out"],
+          ),
+        ).toBeUndefined();
+      } finally {
+        await runtime.dispose({ closeStorage: false });
+        await storageManager.close();
+      }
     });
 
     it("multiple stored declared entries at one path are joined before the integrity check", async () => {

--- a/packages/runner/test/cfc-declared-monotonicity.test.ts
+++ b/packages/runner/test/cfc-declared-monotonicity.test.ts
@@ -1085,6 +1085,16 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
           { out: "v1" },
         );
         expect(first.error).toBeUndefined();
+        expect(
+          declaredEntryAt(
+            persistedEntriesFor(storageManager, first.docId),
+            ["out"],
+          ),
+        ).toEqual({
+          path: ["out"],
+          label: { integrity: [ATOM_X] },
+          origin: "declared",
+        });
         const second = await commitWrite(
           runtime,
           "dm-tight-empty-integ",
@@ -1092,6 +1102,7 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
           { out: "v2" },
         );
         expect(second.error).toBeUndefined();
+        expect(second.docId).toBe(first.docId);
         expect(
           declaredEntryAt(
             persistedEntriesFor(storageManager, second.docId),


### PR DESCRIPTION
Add piece commands for reading effective CFC label views and updating declared confidentiality and integrity labels through JSON input. Route updates through the same checked write path as ordinary runtime operations so stored monotonicity and policy checks remain authoritative.

Reject unreadable metadata, absent values, and observation-class changes that would broaden silently. Preserve an existing observation class for partial updates, redact caveat sources from output, and reserve stdout for machine-readable results.

Treat explicitly empty declared labels as real re-mints in CFC preparation. This lets an integrity claim shrink to empty without stale carry-forward while confidentiality weakening still fails the declared monotonicity check.

Add runtime-backed CLI coverage, CFC persistence coverage, shell completion, and user documentation.

Verified with the full runner and CLI test suites, repository type checking, formatting, and linting.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

