### PR TITLE
refactor(tasks): share the LCOV parser and directory walker

### DIFF
--- a/tasks/ci-check-lib.ts
+++ b/tasks/ci-check-lib.ts
@@ -270,10 +270,18 @@ function retryAfterDelayMs(value: string | null): number | undefined {
   return undefined;
 }
 
-function githubRetryDelayMs(resp: Response, attempt: number): number {
+/**
+ * How long to wait before the attempt after `attempt`. A `Retry-After` header
+ * on the response that failed sets the delay when GitHub sends one; without a
+ * response, or without that header, the delay doubles with each attempt. Both
+ * are capped.
+ */
+function githubRetryDelayMs(attempt: number, resp?: Response): number {
+  const retryAfter = resp
+    ? retryAfterDelayMs(resp.headers.get("retry-after"))
+    : undefined;
   return Math.min(
-    retryAfterDelayMs(resp.headers.get("retry-after")) ??
-      GITHUB_GET_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
+    retryAfter ?? GITHUB_GET_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
     GITHUB_GET_RETRY_MAX_DELAY_MS,
   );
 }
@@ -309,32 +317,22 @@ export async function githubGet<T>(path: string): Promise<T> {
     try {
       resp = await fetch(url, { headers: apiHeaders() });
     } catch (error) {
-      if (attempt === GITHUB_GET_MAX_ATTEMPTS) {
-        throw error;
-      }
-      await sleep(
-        Math.min(
-          GITHUB_GET_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
-          GITHUB_GET_RETRY_MAX_DELAY_MS,
-        ),
-      );
+      if (attempt === GITHUB_GET_MAX_ATTEMPTS) throw error;
+      await sleep(githubRetryDelayMs(attempt));
       continue;
     }
 
-    if (resp.ok) {
-      return resp.json();
-    }
+    if (resp.ok) return resp.json();
 
+    await cancelResponseBody(resp);
     if (
       !RETRYABLE_GITHUB_STATUSES.has(resp.status) ||
       attempt === GITHUB_GET_MAX_ATTEMPTS
     ) {
-      await cancelResponseBody(resp);
       throw githubApiError(resp, path, "GET");
     }
 
-    await cancelResponseBody(resp);
-    await sleep(githubRetryDelayMs(resp, attempt));
+    await sleep(githubRetryDelayMs(attempt, resp));
   }
 
   throw new Error(`GitHub API GET retry loop exhausted unexpectedly: ${path}`);
@@ -536,6 +534,53 @@ export async function writeCoverageBaselineFile(
   );
 }
 
+/** What extracting one downloaded artifact zip produced. */
+type ArtifactExtraction =
+  | { extracted: true; tmpDir: string }
+  | { extracted: false; error: string };
+
+/**
+ * Write the artifact zip carried by `resp` into a fresh temporary directory and
+ * unzip it there, returning the directory. When either step fails the directory
+ * is removed again and the failure is described for the caller's attempt log.
+ */
+async function extractArtifactZip(
+  resp: Response,
+  tmpPrefix: string,
+): Promise<ArtifactExtraction> {
+  const tmpDir = await Deno.makeTempDir({ prefix: tmpPrefix });
+  const zipPath = `${tmpDir}/artifact.zip`;
+
+  let error: string;
+  try {
+    const data = new Uint8Array(await resp.arrayBuffer());
+    await Deno.writeFile(zipPath, data);
+
+    const unzip = new Deno.Command("unzip", {
+      args: ["-o", zipPath, "-d", tmpDir],
+      stdout: "null",
+      stderr: "piped",
+    });
+    const result = await unzip.output();
+    if (result.success) {
+      return { extracted: true, tmpDir };
+    }
+
+    const stderr = new TextDecoder().decode(result.stderr).trim();
+    error = `unzip failed with exit code ${result.code}${
+      stderr ? `: ${stderr}` : ""
+    }`;
+  } catch (caught) {
+    error = `${caught}`;
+  }
+
+  try {
+    await Deno.remove(tmpDir, { recursive: true });
+  } catch { /* ignore cleanup errors */ }
+
+  return { extracted: false, error };
+}
+
 export async function downloadAndExtractArtifact(
   artifactId: number,
   tmpPrefix: string,
@@ -544,79 +589,45 @@ export async function downloadAndExtractArtifact(
   const url = `https://api.github.com${artifactPath}`;
   let lastError = "unknown error";
   const attemptErrors: string[] = [];
+  const recordFailure = (attempt: number, message: string) => {
+    lastError = message;
+    attemptErrors.push(`attempt ${attempt}: ${message}`);
+  };
 
   for (let attempt = 1; attempt <= GITHUB_GET_MAX_ATTEMPTS; attempt++) {
     let resp: Response;
     try {
       resp = await fetch(url, { headers: apiHeaders() });
     } catch (error) {
-      lastError = `fetch failed: ${error}`;
-      attemptErrors.push(`attempt ${attempt}: ${lastError}`);
-      if (attempt < GITHUB_GET_MAX_ATTEMPTS) {
-        await sleep(
-          Math.min(
-            GITHUB_GET_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
-            GITHUB_GET_RETRY_MAX_DELAY_MS,
-          ),
-        );
-        continue;
-      }
-      break;
+      recordFailure(attempt, `fetch failed: ${error}`);
+      if (attempt === GITHUB_GET_MAX_ATTEMPTS) break;
+      await sleep(githubRetryDelayMs(attempt));
+      continue;
     }
 
     if (!resp.ok) {
       const statusText = resp.statusText ? ` ${resp.statusText}` : "";
-      lastError =
-        `GitHub artifact download ${resp.status}${statusText}: ${artifactPath}`;
-      attemptErrors.push(`attempt ${attempt}: ${lastError}`);
+      recordFailure(
+        attempt,
+        `GitHub artifact download ${resp.status}${statusText}: ${artifactPath}`,
+      );
       await cancelResponseBody(resp);
       if (
-        attempt < GITHUB_GET_MAX_ATTEMPTS &&
-        RETRYABLE_ARTIFACT_DOWNLOAD_STATUSES.has(resp.status)
+        attempt === GITHUB_GET_MAX_ATTEMPTS ||
+        !RETRYABLE_ARTIFACT_DOWNLOAD_STATUSES.has(resp.status)
       ) {
-        await sleep(githubRetryDelayMs(resp, attempt));
-        continue;
+        break;
       }
-      break;
+      await sleep(githubRetryDelayMs(attempt, resp));
+      continue;
     }
 
-    const tmpDir = await Deno.makeTempDir({ prefix: tmpPrefix });
-    const zipPath = `${tmpDir}/artifact.zip`;
-
-    try {
-      const data = new Uint8Array(await resp.arrayBuffer());
-      await Deno.writeFile(zipPath, data);
-
-      const unzip = new Deno.Command("unzip", {
-        args: ["-o", zipPath, "-d", tmpDir],
-        stdout: "null",
-        stderr: "piped",
-      });
-      const result = await unzip.output();
-      if (result.success) {
-        return tmpDir;
-      }
-
-      const stderr = new TextDecoder().decode(result.stderr).trim();
-      lastError = `unzip failed with exit code ${result.code}${
-        stderr ? `: ${stderr}` : ""
-      }`;
-    } catch (error) {
-      lastError = `${error}`;
-    }
-    attemptErrors.push(`attempt ${attempt}: ${lastError}`);
-
-    try {
-      await Deno.remove(tmpDir, { recursive: true });
-    } catch { /* ignore cleanup errors */ }
+    const extraction = await extractArtifactZip(resp, tmpPrefix);
+    if (extraction.extracted) return extraction.tmpDir;
+    recordFailure(attempt, extraction.error);
 
     if (attempt < GITHUB_GET_MAX_ATTEMPTS) {
-      await sleep(
-        Math.min(
-          GITHUB_GET_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
-          GITHUB_GET_RETRY_MAX_DELAY_MS,
-        ),
-      );
+      await sleep(githubRetryDelayMs(attempt));
     }
   }
 
@@ -648,14 +659,6 @@ export async function downloadAndParseCoverageBaseline(
     try {
       await Deno.remove(tmpDir, { recursive: true });
     } catch { /* ignore cleanup errors */ }
-  }
-}
-
-export async function* walkFiles(dir: string): AsyncGenerator<string> {
-  for await (const entry of Deno.readDir(dir)) {
-    const full = `${dir}/${entry.name}`;
-    if (entry.isDirectory) yield* walkFiles(full);
-    else yield full;
   }
 }
 

--- a/tasks/combine-coverage-lcov.ts
+++ b/tasks/combine-coverage-lcov.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write
+import { walk } from "@std/fs/walk";
 import * as path from "@std/path";
+import { type LcovFileCoverage, parseLcovReports } from "./lcov.ts";
 
 /**
  * Rewrite an LCOV `SF:` source path to a repository-relative POSIX path.
@@ -31,73 +33,23 @@ export function normalizeSourcePath(
   return posix;
 }
 
-interface FileCoverage {
-  testName?: string;
-  lineHits: Map<number, number>;
-}
-
 /**
- * Parse one or more LCOV reports, normalize their source paths, and merge every
- * record that refers to the same source file into a single line-coverage
- * record. Per-line execution counts are summed, matching how the repository's
- * own coverage tooling (tasks/coverage-metrics.ts) accumulates hits, so a file
- * exercised by several test jobs is reported once with its combined coverage
- * rather than as repeated records that some LCOV consumers keep only the last
- * of.
+ * Merge one or more LCOV reports into a single report whose source paths are
+ * repository-relative. Records that refer to the same source file collapse into
+ * one, with per-line execution counts summed, so a file exercised by several
+ * test jobs is reported once with its combined coverage rather than as repeated
+ * records that some LCOV consumers keep only the last of.
  *
- * Only line coverage (`DA`/`LF`/`LH`) is carried through. Function (`FN`) and
- * branch (`BRDA`) records are dropped: LCOV keys function hits by name, and a
- * single source file can declare several functions with the same name (for
- * example a free function and a method), so merging them faithfully is not
- * possible from the report alone. Line coverage is what IDEs use to colour the
- * gutter and is the signal the combined report exists to provide.
+ * Only line coverage (`DA`/`LF`/`LH`) is carried through; `parseLcovReports`
+ * explains what the other record kinds cost to merge.
  */
 export function mergeLcovReports(
   reports: string[],
   repoName: string,
 ): { lcov: string; fileCount: number; rewritten: number; unchanged: number } {
-  const files = new Map<string, FileCoverage>();
-  const anchored = new Set<string>();
-
-  for (const report of reports) {
-    let current: FileCoverage | undefined;
-    // An LCOV record opens with an optional `TN:` test-name line before its
-    // `SF:` line, so a test name is held until the source path is known.
-    let pendingTestName: string | undefined;
-    for (const line of report.split(/\r?\n/)) {
-      if (line.startsWith("TN:")) {
-        pendingTestName = line.slice(3) || undefined;
-      } else if (line.startsWith("SF:")) {
-        const original = line.slice(3);
-        const normalized = normalizeSourcePath(original, repoName);
-        current = files.get(normalized);
-        if (!current) {
-          current = { lineHits: new Map() };
-          files.set(normalized, current);
-          if (normalized !== original) anchored.add(normalized);
-        }
-        if (pendingTestName && !current.testName) {
-          current.testName = pendingTestName;
-        }
-        pendingTestName = undefined;
-      } else if (!current) {
-        continue;
-      } else if (line.startsWith("DA:")) {
-        const [lineNumber, hits] = line.slice(3).split(",");
-        const parsedLine = Number(lineNumber);
-        const parsedHits = Number(hits);
-        if (Number.isInteger(parsedLine) && Number.isFinite(parsedHits)) {
-          current.lineHits.set(
-            parsedLine,
-            (current.lineHits.get(parsedLine) ?? 0) + parsedHits,
-          );
-        }
-      } else if (line === "end_of_record") {
-        current = undefined;
-        pendingTestName = undefined;
-      }
-    }
-  }
+  const files = parseLcovReports(reports, {
+    mapPath: (sourcePath) => normalizeSourcePath(sourcePath, repoName),
+  });
 
   const paths = [...files.keys()].sort();
   const blocks = paths.map((sourcePath) =>
@@ -105,17 +57,22 @@ export function mergeLcovReports(
   );
   const lcov = blocks.length === 0 ? "" : `${blocks.join("\n")}\n`;
 
+  let rewritten = 0;
+  for (const [normalized, file] of files) {
+    if (normalized !== file.sourcePath) rewritten++;
+  }
+
   return {
     lcov,
     fileCount: files.size,
-    rewritten: anchored.size,
-    unchanged: files.size - anchored.size,
+    rewritten,
+    unchanged: files.size - rewritten,
   };
 }
 
 function serializeFileCoverage(
   sourcePath: string,
-  file: FileCoverage,
+  file: LcovFileCoverage,
 ): string {
   const lines: string[] = [];
   if (file.testName) lines.push(`TN:${file.testName}`);
@@ -134,23 +91,27 @@ function serializeFileCoverage(
   return lines.join("\n");
 }
 
-async function* collectLcovFiles(dir: string): AsyncGenerator<string> {
-  let entries: Deno.DirEntry[];
+/**
+ * Every `.lcov` report under `dir`. A missing input directory means no coverage
+ * was downloaded and yields no files; anything that goes wrong once the walk is
+ * under way is reported, so a report that is present but unreadable cannot
+ * shorten the merged output unnoticed.
+ */
+async function collectLcovFiles(dir: string): Promise<string[]> {
   try {
-    entries = await Array.fromAsync(Deno.readDir(dir));
+    await Deno.stat(dir);
   } catch (error) {
-    // A missing input directory (no coverage was downloaded) yields no files.
-    if (error instanceof Deno.errors.NotFound) return;
+    if (error instanceof Deno.errors.NotFound) return [];
     throw error;
   }
-  for (const entry of entries) {
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory) {
-      yield* collectLcovFiles(full);
-    } else if (entry.name.endsWith(".lcov")) {
-      yield full;
-    }
+
+  const files: string[] = [];
+  for await (
+    const entry of walk(dir, { includeDirs: false, exts: [".lcov"] })
+  ) {
+    files.push(entry.path);
   }
+  return files;
 }
 
 /**
@@ -163,9 +124,7 @@ export async function combineCoverageLcov(
 ): Promise<
   { lcov: string; fileCount: number; rewritten: number; unchanged: number }
 > {
-  const files: string[] = [];
-  for await (const file of collectLcovFiles(inputDir)) files.push(file);
-  files.sort();
+  const files = (await collectLcovFiles(inputDir)).sort();
 
   const reports: string[] = [];
   for (const file of files) {

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -57,7 +57,6 @@ import {
   readAndParseEvent,
   REPO,
   shouldGateCoverageDebtMetric,
-  walkFiles,
   WORKFLOW_FILE,
   type WorkflowRun,
   writeCoverageBaselineFile,
@@ -67,6 +66,7 @@ import {
   inferCurrentRunFallbackState,
   recordUnstampedBaselineRunState,
 } from "./compile-cache-state.ts";
+import { walk } from "@std/fs/walk";
 import * as path from "@std/path";
 import {
   collectCoverageDebtMetricsFromLcov,
@@ -861,10 +861,10 @@ async function downloadCacheStateFiles(
   if (!tmpDir) return null;
   try {
     const contents: string[] = [];
-    for await (const file of walkFiles(tmpDir)) {
-      if (file.endsWith(".json")) {
-        contents.push(await Deno.readTextFile(file));
-      }
+    for await (
+      const entry of walk(tmpDir, { includeDirs: false, exts: [".json"] })
+    ) {
+      contents.push(await Deno.readTextFile(entry.path));
     }
     return contents;
   } finally {
@@ -1000,17 +1000,20 @@ export async function copyCoverageArtifactFiles(
   let profileFiles = 0;
   let lcovFiles = 0;
   try {
-    for await (const file of walkFiles(sourceDir)) {
-      const isProfile = file.endsWith(".json");
-      const isLcov = file.endsWith(".lcov");
-      if (!isProfile && !isLcov) continue;
+    for await (
+      const entry of walk(sourceDir, {
+        includeDirs: false,
+        exts: [".json", ".lcov"],
+      })
+    ) {
+      const isLcov = entry.path.endsWith(".lcov");
       const count = isLcov ? lcovFiles : profileFiles;
       const destDir = isLcov ? lcovDir : profileDir;
       const dest = path.join(
         destDir,
-        `${artifact.id}-${count}-${path.basename(file)}`,
+        `${artifact.id}-${count}-${path.basename(entry.path)}`,
       );
-      await Deno.copyFile(file, dest);
+      await Deno.copyFile(entry.path, dest);
       if (isLcov) lcovFiles++;
       else profileFiles++;
     }
@@ -1033,9 +1036,10 @@ export async function copyCoverageArtifactFiles(
 
 async function readCombinedLcov(lcovDir: string): Promise<string> {
   const chunks: string[] = [];
-  for await (const file of walkFiles(lcovDir)) {
-    if (!file.endsWith(".lcov")) continue;
-    chunks.push(await Deno.readTextFile(file));
+  for await (
+    const entry of walk(lcovDir, { includeDirs: false, exts: [".lcov"] })
+  ) {
+    chunks.push(await Deno.readTextFile(entry.path));
   }
   return chunks.join("\n");
 }

--- a/tasks/coverage-metrics.ts
+++ b/tasks/coverage-metrics.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write --allow-run --allow-env
 import * as path from "@std/path";
 import { hasExecutableCode } from "./executable-source.ts";
+import { type LcovFileCoverage, parseLcovReports } from "./lcov.ts";
 import { normalizeLcovInstancePaths } from "./write-coverage-lcov.ts";
 
 export const COVERAGE_PROFILE_ARTIFACT_PREFIX = "coverage-profile-";
@@ -57,10 +58,6 @@ interface SourceFile {
   relativePath: string;
   metricGroup: string;
   trackedLineCount: number;
-}
-
-interface LcovFileCoverage {
-  lineHits: Map<number, number>;
 }
 
 export async function collectCoverageDebtMetrics(
@@ -305,44 +302,17 @@ export function trackedSourceLineNumbers(content: string): number[] {
   return lineNumbers;
 }
 
+/**
+ * Read one `deno coverage --lcov` report, keyed by normalized source path.
+ *
+ * Per-instance suffixes (`?testRun=<uuid>` cache-busting imports) are
+ * normalized away at LCOV GENERATION (write-coverage-lcov.ts,
+ * `normalizeLcovInstancePaths` — CT-1861), so records arriving here already
+ * share one path per physical file; duplicate `SF:` sections accumulate into
+ * the same entry.
+ */
 export function parseLcov(lcov: string): Map<string, LcovFileCoverage> {
-  const files = new Map<string, LcovFileCoverage>();
-  let currentPath: string | undefined;
-
-  for (const line of lcov.split(/\r?\n/)) {
-    if (line.startsWith("SF:")) {
-      // Per-instance suffixes (`?testRun=<uuid>` cache-busting imports) are
-      // normalized away at LCOV GENERATION (write-coverage-lcov.ts,
-      // `normalizeLcovInstancePaths` — CT-1861), so records arriving here
-      // already share one path per physical file; duplicate `SF:` sections
-      // accumulate into the same entry below.
-      currentPath = path.normalize(line.slice(3));
-      if (!files.has(currentPath)) {
-        files.set(currentPath, { lineHits: new Map() });
-      }
-      continue;
-    }
-
-    if (line.startsWith("DA:") && currentPath) {
-      const [lineNumberRaw, hitsRaw] = line.slice(3).split(",");
-      const lineNumber = Number(lineNumberRaw);
-      const hits = Number(hitsRaw);
-      if (Number.isFinite(lineNumber) && Number.isFinite(hits)) {
-        const file = files.get(currentPath)!;
-        file.lineHits.set(
-          lineNumber,
-          (file.lineHits.get(lineNumber) ?? 0) + hits,
-        );
-      }
-      continue;
-    }
-
-    if (line === "end_of_record") {
-      currentPath = undefined;
-    }
-  }
-
-  return files;
+  return parseLcovReports([lcov], { mapPath: path.normalize });
 }
 
 export function countUncoveredProfileLines(coverage: LcovFileCoverage): number {

--- a/tasks/integration.ts
+++ b/tasks/integration.ts
@@ -16,6 +16,7 @@
  *                 If not set, picks a random offset and cleans up after.
  */
 
+import { walk } from "@std/fs/walk";
 import * as path from "@std/path";
 import ports from "@commonfabric/ports" with { type: "json" };
 
@@ -169,12 +170,15 @@ async function findPatternTests(
 
   // Find all .test.tsx files
   const testFiles: string[] = [];
-  for await (const entry of walkDir(patternsDir)) {
-    if (entry.endsWith(".test.tsx")) {
-      const relative = path.relative(rootDir, entry);
-      if (!nameFilter || relative.includes(nameFilter)) {
-        testFiles.push(relative);
-      }
+  for await (
+    const entry of walk(patternsDir, {
+      includeDirs: false,
+      exts: [".test.tsx"],
+    })
+  ) {
+    const relative = path.relative(rootDir, entry.path);
+    if (!nameFilter || relative.includes(nameFilter)) {
+      testFiles.push(relative);
     }
   }
 
@@ -496,18 +500,6 @@ export async function runFilteredIntegration(
     env,
     inheritStdio: true,
   });
-}
-
-/** Recursively walk a directory yielding file paths. */
-async function* walkDir(dir: string): AsyncGenerator<string> {
-  for await (const entry of Deno.readDir(dir)) {
-    const fullPath = path.join(dir, entry.name);
-    if (entry.isDirectory) {
-      yield* walkDir(fullPath);
-    } else {
-      yield fullPath;
-    }
-  }
 }
 
 export async function runPackageIntegration(

--- a/tasks/lcov.test.ts
+++ b/tasks/lcov.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Covers the shared LCOV reader on the reports that are not a straightforward
+ * list of records: coverage for one file spread over several reports, several
+ * source paths that map to a single key, and records carrying counts that do
+ * not parse. Those are the cases where a reader can quietly lose coverage
+ * rather than fail.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { parseLcovReports } from "./lcov.ts";
+
+describe("lcov", () => {
+  describe("parseLcovReports()", () => {
+    it("sums the hits for a file split across several reports", () => {
+      const files = parseLcovReports([
+        ["SF:/repo/a.ts", "DA:1,1", "DA:2,0", "end_of_record"].join("\n"),
+        ["SF:/repo/a.ts", "DA:1,4", "DA:2,0", "end_of_record"].join("\n"),
+      ]);
+
+      expect([...files.keys()]).toEqual(["/repo/a.ts"]);
+      const file = files.get("/repo/a.ts")!;
+      expect(file.sourcePath).toBe("/repo/a.ts");
+      expect([...file.lineHits]).toEqual([[1, 5], [2, 0]]);
+    });
+
+    it("merges the source paths `mapPath` sends to one key", () => {
+      const files = parseLcovReports([
+        [
+          "SF:/runner-a/repo/a.ts",
+          "DA:1,1",
+          "end_of_record",
+          "SF:/runner-b/repo/a.ts",
+          "DA:2,1",
+          "end_of_record",
+        ].join("\n"),
+      ], { mapPath: (sourcePath) => sourcePath.replace(/^\/runner-[ab]/, "") });
+
+      expect([...files.keys()]).toEqual(["/repo/a.ts"]);
+      expect([...files.get("/repo/a.ts")!.lineHits]).toEqual([[1, 1], [2, 1]]);
+    });
+
+    it("returns the path carried by the record that opened an entry", () => {
+      const files = parseLcovReports([
+        [
+          "SF:/runner-a/repo/a.ts",
+          "DA:1,1",
+          "end_of_record",
+          "SF:/runner-b/repo/a.ts",
+          "DA:2,1",
+          "end_of_record",
+        ].join("\n"),
+      ], { mapPath: (sourcePath) => sourcePath.replace(/^\/runner-[ab]/, "") });
+
+      expect(files.get("/repo/a.ts")!.sourcePath).toBe("/runner-a/repo/a.ts");
+    });
+
+    it("returns the first test name a file is given", () => {
+      const files = parseLcovReports([
+        [
+          "TN:first",
+          "SF:/repo/a.ts",
+          "DA:1,1",
+          "end_of_record",
+          "TN:second",
+          "SF:/repo/a.ts",
+          "DA:2,1",
+          "end_of_record",
+          "SF:/repo/b.ts",
+          "DA:1,1",
+          "end_of_record",
+        ].join("\n"),
+      ]);
+
+      expect(files.get("/repo/a.ts")!.testName).toBe("first");
+      expect(files.get("/repo/b.ts")!.testName).toBeUndefined();
+    });
+
+    it("omits records and counts it cannot read", () => {
+      const files = parseLcovReports([
+        [
+          // A `DA:` line outside any record has no file to charge.
+          "DA:9,1",
+          "SF:/repo/a.ts",
+          "FN:1,add",
+          "BRDA:2,0,0,1",
+          "DA:1.5,1",
+          "DA:2,not-a-number",
+          "DA:3,7",
+          "LF:1",
+          "LH:1",
+          "end_of_record",
+          "DA:9,1",
+        ].join("\n"),
+      ]);
+
+      expect([...files.keys()]).toEqual(["/repo/a.ts"]);
+      expect([...files.get("/repo/a.ts")!.lineHits]).toEqual([[3, 7]]);
+    });
+
+    it("reads reports with carriage returns", () => {
+      const files = parseLcovReports([
+        "SF:/repo/a.ts\r\nDA:1,1\r\nend_of_record\r\n",
+      ]);
+
+      expect([...files.get("/repo/a.ts")!.lineHits]).toEqual([[1, 1]]);
+    });
+  });
+});

--- a/tasks/lcov.test.ts
+++ b/tasks/lcov.test.ts
@@ -98,6 +98,37 @@ describe("lcov", () => {
       expect([...files.get("/repo/a.ts")!.lineHits]).toEqual([[3, 7]]);
     });
 
+    it("omits records with a blank line number or count", () => {
+      const files = parseLcovReports([
+        [
+          "SF:/repo/a.ts",
+          "DA:,0",
+          "DA:1,",
+          "DA:,",
+          "DA: , ",
+          "DA:3",
+          "DA:4,2",
+          "end_of_record",
+        ].join("\n"),
+      ]);
+
+      expect([...files.get("/repo/a.ts")!.lineHits]).toEqual([[4, 2]]);
+    });
+
+    it("omits records numbering a line at or below zero", () => {
+      const files = parseLcovReports([
+        [
+          "SF:/repo/a.ts",
+          "DA:0,5",
+          "DA:-1,5",
+          "DA:2,5",
+          "end_of_record",
+        ].join("\n"),
+      ]);
+
+      expect([...files.get("/repo/a.ts")!.lineHits]).toEqual([[2, 5]]);
+    });
+
     it("reads reports with carriage returns", () => {
       const files = parseLcovReports([
         "SF:/repo/a.ts\r\nDA:1,1\r\nend_of_record\r\n",

--- a/tasks/lcov.ts
+++ b/tasks/lcov.ts
@@ -75,9 +75,17 @@ export function parseLcovReports(
         continue;
       } else if (line.startsWith("DA:")) {
         const [lineNumberText, hitsText] = line.slice(3).split(",");
-        const lineNumber = Number(lineNumberText);
-        const hits = Number(hitsText);
-        if (Number.isInteger(lineNumber) && Number.isFinite(hits)) {
+        // Both fields have to carry something. `Number("")` is 0, so a record
+        // missing its line number reads as line 0 and one missing its count
+        // reads as a line nobody ran.
+        const lineNumber = lineNumberText?.trim()
+          ? Number(lineNumberText)
+          : NaN;
+        const hits = hitsText?.trim() ? Number(hitsText) : NaN;
+        if (
+          Number.isInteger(lineNumber) && lineNumber > 0 &&
+          Number.isFinite(hits)
+        ) {
           current.lineHits.set(
             lineNumber,
             (current.lineHits.get(lineNumber) ?? 0) + hits,

--- a/tasks/lcov.ts
+++ b/tasks/lcov.ts
@@ -1,0 +1,94 @@
+/**
+ * Reads line coverage out of LCOV reports. One reader serves both the
+ * coverage-debt gate and the combined report published for IDEs, so the two
+ * cannot come to different conclusions about the same report. Line coverage is
+ * all it reads: function and branch records are dropped, and the summary
+ * counters are left to whoever writes a report back out.
+ */
+
+/** The line coverage one source file accumulated across the records read. */
+export interface LcovFileCoverage {
+  /**
+   * The `SF:` path as the record that introduced this file wrote it, before
+   * `mapPath` turned it into the key this entry is stored under.
+   */
+  sourcePath: string;
+  /** The `TN:` name from the first record for this file that carried one. */
+  testName?: string;
+  /** Execution count per line number, summed over every record read. */
+  lineHits: Map<number, number>;
+}
+
+/** Options for {@linkcode parseLcovReports}. */
+export interface ParseLcovOptions {
+  /**
+   * Turns each `SF:` path into the key its coverage is stored under. Records
+   * whose paths map to the same key merge into one entry. The path is used
+   * unchanged when this is not given.
+   */
+  mapPath?: (sourcePath: string) => string;
+}
+
+/**
+ * Read the line coverage out of LCOV reports, merging every record that refers
+ * to the same source file into a single entry whose per-line execution counts
+ * are summed. Reports are read in the order given, and the records for one file
+ * may be spread over several of them.
+ *
+ * Only `TN:`, `SF:` and `DA:` are read. The summary counters (`LF:`, `LH:`) are
+ * recomputed by whoever writes a report back out. Function (`FN:`) and branch
+ * (`BRDA:`) records are dropped: LCOV keys function hits by name, and a single
+ * source file can declare several functions with the same name (for example a
+ * free function and a method), so merging them faithfully is not possible from
+ * the report alone. Line coverage is what IDEs use to colour the gutter and
+ * what the coverage-debt metric counts.
+ */
+export function parseLcovReports(
+  reports: readonly string[],
+  options: ParseLcovOptions = {},
+): Map<string, LcovFileCoverage> {
+  const mapPath = options.mapPath ?? ((sourcePath: string) => sourcePath);
+  const files = new Map<string, LcovFileCoverage>();
+
+  for (const report of reports) {
+    let current: LcovFileCoverage | undefined;
+    // A record opens with an optional `TN:` test-name line before its `SF:`
+    // line, so a test name is held until the source path is known.
+    let pendingTestName: string | undefined;
+
+    for (const line of report.split(/\r?\n/)) {
+      if (line.startsWith("TN:")) {
+        pendingTestName = line.slice(3) || undefined;
+      } else if (line.startsWith("SF:")) {
+        const sourcePath = line.slice(3);
+        const key = mapPath(sourcePath);
+        current = files.get(key);
+        if (!current) {
+          current = { sourcePath, lineHits: new Map() };
+          files.set(key, current);
+        }
+        if (pendingTestName && !current.testName) {
+          current.testName = pendingTestName;
+        }
+        pendingTestName = undefined;
+      } else if (!current) {
+        continue;
+      } else if (line.startsWith("DA:")) {
+        const [lineNumberText, hitsText] = line.slice(3).split(",");
+        const lineNumber = Number(lineNumberText);
+        const hits = Number(hitsText);
+        if (Number.isInteger(lineNumber) && Number.isFinite(hits)) {
+          current.lineHits.set(
+            lineNumber,
+            (current.lineHits.get(lineNumber) ?? 0) + hits,
+          );
+        }
+      } else if (line === "end_of_record") {
+        current = undefined;
+        pendingTestName = undefined;
+      }
+    }
+  }
+
+  return files;
+}


### PR DESCRIPTION
The tasks/ directory grew several families of hand-rolled platform code, each written out more than once.

Two independent LCOV parsers of about forty lines each walked SF:, DA: and end_of_record lines into a map from source path to per-line hit counts. One merges the reports the test jobs upload into the combined report published for IDEs; the other feeds the coverage-debt gate. They had already drifted: the combined-report parser required a DA: line number to be an integer, while the gate's parser accepted any finite number. A further divergence in how a hit count is read would have made the gate and the published report disagree about the same checkout.

tasks/lcov.ts now holds the single parser. The two differences between the callers become options rather than separate code. mapPath rewrites each SF: path into the key its coverage is filed under, which is path.normalize for the gate and the repository-relative rewrite for the combined report. Each entry also records the SF: path that the first record for that file carried, which is what lets the combined report count how many paths its rewrite actually changed; that count previously needed a separate set built inside the parser. The stricter integer test for a DA: line number is the one that survives, so only a malformed report, which deno coverage does not emit, can tell the difference.

Its tests cover the reports that are not a straightforward list of records, those being the ones where a reader can lose coverage without failing: one file's coverage spread over several reports, several source paths mapping to a single key, and records carrying counts that do not parse.

Five recursive directory walkers each re-implemented "yield every file under this directory". Three of them take no exclusions at all, so walk from @std/fs covers them exactly, with its exts option doing the extension filtering each call site did by hand: the artifact walker shared by the coverage gate, the LCOV collector in the combined-report task, and the pattern-test finder in the integration runner.

The LCOV collector tolerates a missing input directory, because a run that downloaded no coverage has nothing to merge and that is not an error. That tolerance belongs to the input directory itself, so it is a stat of that directory before walking rather than a catch for Deno.errors.NotFound around the walk. Caught around the walk, it would also swallow a NotFound raised once the walk was under way, ending the walk and merging however many reports had been reached by then; the task would write a combined report missing every file the walk had not yet visited and exit successfully, with the shortfall depending on the order the filesystem listed directories in. A directory that is really there but cannot be read through now fails loudly instead.

Two walkers stay hand-rolled. collectCoverageProfileFiles in tasks/write-coverage-lcov.ts takes an injectable readDir that a test uses to present a directory holding several hundred thousand entries, and it tolerates a directory that disappears mid-walk. The source walk in tasks/coverage-metrics.ts prunes directories by name, and the names it prunes are generic ones such as build, test and coverage; walk matches its skip patterns against the whole path including the root it was handed, so a checkout whose own path contained one of those segments would silently walk nothing and report zero coverage debt. tasks/check-unused-deps.ts already records that same reasoning for the names it declines to skip.

The four-attempt retry loops in the GitHub API helper and the artifact downloader stay written out separately, having been tried the other way and measured. The two differ in which statuses they retry, in throwing against returning null, and in whether they keep a per-attempt error log, and routing each of those through one shared runner added more lines than the second copy of the loop costs. A named runner would also present retrying as a facility to reach for, and retry loops are disfavoured here.

Two smaller pieces of that attempt are kept, because each stands on its own rather than existing to unify the two callers. githubRetryDelayMs computes the capped delay, taking the response as an optional argument so that one function serves both the case that reads a Retry-After header and the case where a failed fetch left no response to read one from; the arithmetic it replaces was written out four times. extractArtifactZip holds the write-and-unzip step, which lets the downloader's loop body read as one step per outcome. Attempt counts, delays, retryable status sets, and which failures are retried at all are unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

