### PR TITLE
Report what the write benchmarks actually wrote

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -116,7 +116,10 @@
         "no-explicit-any",
         "require-yield"
       ]
-    }
+    },
+    "plugins": [
+      "./tasks/lint-bench-console.ts"
+    ]
   },
   "fmt": {
     "indentWidth": 2,

--- a/docs/development/BENCHMARKS.md
+++ b/docs/development/BENCHMARKS.md
@@ -48,6 +48,30 @@ stderr to `diagnostics.log` in the uploaded artifact and also shows it in the
 workflow log. A stray diagnostic once corrupted every benchmark artifact for
 five weeks before anyone noticed.
 
+The `cf-bench/no-lost-diagnostics` lint rule (`tasks/lint-bench-console.ts`,
+registered in the root `deno.jsonc`) holds both halves of that in place, so a
+plain `deno lint` catches either mistake. In a `*.bench.ts` file it rejects a
+`console` method that writes to stdout wherever it appears, and any `console`
+call at all that runs in a benchmark body — written there, or in a helper of
+the same file that a body calls, however many hops away. A helper in another
+module is past what one file's syntax tree shows, so write those with
+`Deno.stderr` too. The runner's benchmarks do that through `benchDiagnostic()`
+in `packages/runner/test/bench-diagnostics.ts`.
+
+**Read a transaction's journal before it commits.** A benchmark that reports
+what it wrote reads `tx.journal.novelty(space)`, and a transaction holds that
+journal only while it is open: `commit()` releases it on the way to settling,
+and the same call afterwards reports nothing. A benchmark that times the commit
+cannot afford the read inside its timed window either.
+`packages/runner/test/cell-set-flat-index-list.bench.ts` shows the arrangement.
+Each of its write scenarios takes a callback and hands it the transaction just
+before committing; the benchmark itself passes no callback, and instead runs the
+same scenario once more, untimed, to fill in a report it writes once.
+`packages/runner/test/bench-write-accounting.ts` turns those attestations into a
+document count and a byte count — one attestation per written path is not one
+document and not one value, so adding them up directly counts some bytes twice
+and misses others.
+
 **Names identify chart series.** The dashboard tracks each benchmark by its
 origin file, group, and verbatim name. Renaming a bench or its group breaks
 the series: history stays under the old name and the renamed bench starts

--- a/docs/development/BENCHMARKS.md
+++ b/docs/development/BENCHMARKS.md
@@ -50,13 +50,17 @@ five weeks before anyone noticed.
 
 The `cf-bench/no-lost-diagnostics` lint rule (`tasks/lint-bench-console.ts`,
 registered in the root `deno.jsonc`) holds both halves of that in place, so a
-plain `deno lint` catches either mistake. In a `*.bench.ts` file it rejects a
-`console` method that writes to stdout wherever it appears, and any `console`
-call at all that runs in a benchmark body — written there, or in a helper of
-the same file that a body calls, however many hops away. A helper in another
-module is past what one file's syntax tree shows, so write those with
-`Deno.stderr` too. The runner's benchmarks do that through `benchDiagnostic()`
-in `packages/runner/test/bench-diagnostics.ts`.
+plain `deno lint` catches either mistake. In a `*.bench.ts` file, outside a
+benchmark body, the four `console` methods that write to stderr — `error`,
+`warn`, `trace`, `assert` — are the whole of what it allows, and every other one
+is rejected. Naming the permitted four rather than enumerating the ones that
+write to stdout is what makes that safe: a method nobody thought of, `dirxml`
+say, is rejected rather than let through. Inside a benchmark body it rejects any
+`console` call at all, written there or in a helper of the same file that a body
+calls, however many hops away. A helper in another module is past what one
+file's syntax tree shows, so write those with `Deno.stderr` too. The runner's
+benchmarks do that through `benchDiagnostic()` in
+`packages/runner/test/bench-diagnostics.ts`.
 
 **Read a transaction's journal before it commits.** A benchmark that reports
 what it wrote reads `tx.journal.novelty(space)`, and a transaction holds that

--- a/packages/runner/test/bench-diagnostics.ts
+++ b/packages/runner/test/bench-diagnostics.ts
@@ -1,0 +1,25 @@
+/**
+ * Writes a benchmark diagnostic line to stderr.
+ *
+ * `deno bench --json` puts its report on stdout and captures whatever a
+ * benchmark body writes through `console`, on either stream. A body diagnostic
+ * written with `console.error` therefore reaches nothing: not the report, not
+ * stderr, not the workflow log. A write straight to `Deno.stderr` passes
+ * through, and the Benchmarks workflow tees stderr into `diagnostics.log` in
+ * the results artifact.
+ *
+ * See docs/development/BENCHMARKS.md.
+ */
+
+const encoder = new TextEncoder();
+
+/** Writes `line` and a newline to stderr, whole. */
+export function benchDiagnostic(line: string): void {
+  const bytes = encoder.encode(`${line}\n`);
+  // `writeSync` reports how much of the buffer it took, which on a pipe can be
+  // less than all of it. Resume from there until the line is out.
+  let written = 0;
+  while (written < bytes.length) {
+    written += Deno.stderr.writeSync(bytes.subarray(written));
+  }
+}

--- a/packages/runner/test/bench-write-accounting.test.ts
+++ b/packages/runner/test/bench-write-accounting.test.ts
@@ -14,6 +14,7 @@ import type { IAttestation } from "../src/storage/interface.ts";
 import {
   accountNovelty,
   addAccounts,
+  jsonBytes,
   noveltyWrites,
 } from "./bench-write-accounting.ts";
 
@@ -100,6 +101,23 @@ describe("bench-write-accounting", () => {
     });
   });
 
+  describe("jsonBytes", () => {
+    it("counts an ASCII value at one byte per character", () => {
+      expect(jsonBytes({ a: 1 })).toBe('{"a":1}'.length);
+    });
+
+    it("counts a character that encodes wide at its encoded width", () => {
+      // "é" is one UTF-16 code unit and two UTF-8 bytes; "🍩" is two code
+      // units and four bytes. The quotes account for the other two.
+      expect(jsonBytes("é")).toBe(4);
+      expect(jsonBytes("🍩")).toBe(6);
+    });
+
+    it("returns zero for a value JSON does not represent", () => {
+      expect(jsonBytes(undefined)).toBe(0);
+    });
+  });
+
   describe("accountNovelty", () => {
     it("counts the JSON bytes of each top-level write", () => {
       expect(accountNovelty([
@@ -113,6 +131,11 @@ describe("bench-write-accounting", () => {
     it("counts a removed slot as no bytes", () => {
       expect(accountNovelty([attestation("a", ["value", "n"], undefined)]))
         .toEqual({ docs: 1, bytes: 0 });
+    });
+
+    it("counts a wide character at its encoded width", () => {
+      expect(accountNovelty([attestation("a", ["value", "s"], "é")]))
+        .toEqual({ docs: 1, bytes: 4 });
     });
 
     it("returns nothing for a transaction that wrote nothing", () => {

--- a/packages/runner/test/bench-write-accounting.test.ts
+++ b/packages/runner/test/bench-write-accounting.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Checks the write accounting on both the shapes the journal produces and on a
+ * live transaction. The synthetic cases fix what each shape means; the live
+ * ones check that the shapes are the ones the runner actually records, and that
+ * a reconstructed value is the value that went in.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { IAttestation } from "../src/storage/interface.ts";
+import {
+  accountNovelty,
+  addAccounts,
+  noveltyWrites,
+} from "./bench-write-accounting.ts";
+
+const signer = await Identity.fromPassphrase("bench write accounting test");
+const space = signer.did();
+
+function attestation(
+  id: string,
+  path: string[],
+  value: unknown,
+): IAttestation {
+  return {
+    address: { id: `of:${id}`, type: "application/json", path },
+    value: value as IAttestation["value"],
+  };
+}
+
+/** A runtime over its own emulated storage, plus the way to shut it down. */
+function runtimeFixture() {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const close = async () => {
+    await runtime.dispose();
+    await storageManager.close();
+  };
+  return { runtime, close };
+}
+
+describe("bench-write-accounting", () => {
+  describe("noveltyWrites", () => {
+    it("returns the value of a write with nothing below it", () => {
+      expect(noveltyWrites([attestation("a", ["value", "n"], 7)])).toEqual([
+        { id: "of:a", path: ["value", "n"], value: 7 },
+      ]);
+    });
+
+    it("folds the paths below a whole-document write into one write", () => {
+      const writes = noveltyWrites([
+        attestation("a", [], { value: { n: 7, s: "x" } }),
+        attestation("a", ["value", "n"], 7),
+        attestation("a", ["value", "s"], "x"),
+      ]);
+      expect(writes).toEqual([
+        { id: "of:a", path: [], value: { value: { n: 7, s: "x" } } },
+      ]);
+    });
+
+    it("rebuilds a value from the paths a nested write recorded", () => {
+      // A write below the root records each container empty, with its contents
+      // on the paths below it.
+      const writes = noveltyWrites([
+        attestation("a", ["value", "1"], {}),
+        attestation("a", ["value", "1", "label"], "Z"),
+        attestation("a", ["value", "1", "aliases"], []),
+        attestation("a", ["value", "1", "aliases", "0"], "w"),
+      ]);
+      expect(writes).toEqual([{
+        id: "of:a",
+        path: ["value", "1"],
+        value: { label: "Z", aliases: ["w"] },
+      }]);
+    });
+
+    it("keeps one write per document", () => {
+      const writes = noveltyWrites([
+        attestation("a", [], { value: 1 }),
+        attestation("b", [], { value: 2 }),
+      ]);
+      expect(writes.map((write) => write.id)).toEqual(["of:a", "of:b"]);
+    });
+
+    it("keeps sibling writes in one document apart", () => {
+      const writes = noveltyWrites([
+        attestation("a", ["value", "0"], "x"),
+        attestation("a", ["value", "1"], "y"),
+      ]);
+      expect(writes).toEqual([
+        { id: "of:a", path: ["value", "0"], value: "x" },
+        { id: "of:a", path: ["value", "1"], value: "y" },
+      ]);
+    });
+  });
+
+  describe("accountNovelty", () => {
+    it("counts the JSON bytes of each top-level write", () => {
+      expect(accountNovelty([
+        attestation("a", [], { value: [1, 2, 3] }),
+        attestation("a", ["value", "0"], 1),
+        attestation("a", ["value", "1"], 2),
+        attestation("a", ["value", "2"], 3),
+      ])).toEqual({ docs: 1, bytes: '{"value":[1,2,3]}'.length });
+    });
+
+    it("counts a removed slot as no bytes", () => {
+      expect(accountNovelty([attestation("a", ["value", "n"], undefined)]))
+        .toEqual({ docs: 1, bytes: 0 });
+    });
+
+    it("returns nothing for a transaction that wrote nothing", () => {
+      expect(accountNovelty([])).toEqual({ docs: 0, bytes: 0 });
+    });
+  });
+
+  describe("addAccounts", () => {
+    it("adds both fields", () => {
+      expect(addAccounts({ docs: 1, bytes: 20 }, { docs: 2, bytes: 5 }))
+        .toEqual({ docs: 3, bytes: 25 });
+    });
+  });
+
+  describe("over a live transaction", () => {
+    it("counts the bytes a scalar list put in its document", async () => {
+      const { runtime, close } = runtimeFixture();
+      try {
+        const tx = runtime.edit();
+        const cell = runtime.getCell<number[]>(
+          space,
+          "accounting-scalars",
+          undefined,
+          tx,
+        );
+        cell.set([1, 2, 3]);
+        expect(accountNovelty(tx.journal.novelty(space)))
+          .toEqual({ docs: 1, bytes: '{"value":[1,2,3]}'.length });
+        await tx.commit();
+      } finally {
+        await close();
+      }
+    });
+
+    it("counts one document per object element of a list", async () => {
+      const { runtime, close } = runtimeFixture();
+      try {
+        const tx = runtime.edit();
+        const cell = runtime.getCell<{ n: number }[]>(
+          space,
+          "accounting-elements",
+          undefined,
+          tx,
+        );
+        cell.set([{ n: 1 }, { n: 2 }, { n: 3 }]);
+        // The parent array holds a link per element, and each element is a
+        // document of its own.
+        expect(accountNovelty(tx.journal.novelty(space)).docs).toBe(4);
+        await tx.commit();
+      } finally {
+        await close();
+      }
+    });
+
+    it("returns the item a targeted write stored", async () => {
+      const { runtime, close } = runtimeFixture();
+      try {
+        const setupTx = runtime.edit();
+        const seed = runtime.getCell<{ label: string; tags: string[] }[]>(
+          space,
+          "accounting-targeted",
+          undefined,
+          setupTx,
+        );
+        seed.set([
+          { label: "a", tags: ["one"] },
+          { label: "b", tags: ["two"] },
+        ]);
+        await setupTx.commit();
+
+        const tx = runtime.edit();
+        const cell = runtime.getCell<{ label: string; tags: string[] }[]>(
+          space,
+          "accounting-targeted",
+          undefined,
+          tx,
+        );
+        const replacement = { label: "c", tags: ["three"] };
+        cell.key(1).set(replacement);
+        expect(noveltyWrites(tx.journal.novelty(space))).toEqual([{
+          id: seed.getAsNormalizedFullLink().id,
+          path: ["value", "1"],
+          value: replacement,
+        }]);
+        expect(accountNovelty(tx.journal.novelty(space))).toEqual({
+          docs: 1,
+          bytes: JSON.stringify(replacement).length,
+        });
+        await tx.commit();
+      } finally {
+        await close();
+      }
+    });
+
+    it("returns nothing once the transaction has committed", async () => {
+      const { runtime, close } = runtimeFixture();
+      try {
+        const tx = runtime.edit();
+        const cell = runtime.getCell<number[]>(
+          space,
+          "accounting-settled",
+          undefined,
+          tx,
+        );
+        cell.set([1, 2, 3]);
+        await tx.commit();
+        // A settled transaction releases its journal, which is why the
+        // benchmarks read these numbers before they commit.
+        expect(accountNovelty(tx.journal.novelty(space)))
+          .toEqual({ docs: 0, bytes: 0 });
+      } finally {
+        await close();
+      }
+    });
+  });
+});

--- a/packages/runner/test/bench-write-accounting.ts
+++ b/packages/runner/test/bench-write-accounting.ts
@@ -1,0 +1,160 @@
+/**
+ * Counts what a storage transaction wrote: how many documents it touched, and
+ * how many JSON bytes it put into them.
+ *
+ * `tx.journal.novelty(space)` yields one attestation per written path, and a
+ * single `cell.set()` produces many: the path the write was made at, and a path
+ * for each slot below it that changed. Each value is a snapshot taken as its
+ * own part of the write landed, so a write below the root shows up as a
+ * container recorded empty with its contents on the paths under it, while a
+ * write of a whole document shows up as the document value with its parts
+ * repeated under it. Adding up every attestation counts the same bytes several
+ * times over in the second shape, and drops the key names in the first.
+ *
+ * These functions read the attestations as what they are: a set of writes, some
+ * of which sit inside others. For each document they keep the writes no other
+ * write encloses, and rebuild each one's value from the writes below it. What
+ * comes back is one value per top-level write, which is what that transaction
+ * put into storage.
+ *
+ * The journal a transaction wrote is only readable while the transaction is
+ * open. `commit()` releases it on the way to settling, so a caller that wants
+ * these numbers reads them before it commits.
+ */
+
+import type { IAttestation } from "../src/storage/interface.ts";
+
+/** One top-level write: a document, a path in it, and the value written. */
+export interface WrittenValue {
+  /** The document the write landed in. */
+  id: string;
+  /** Where in the document it landed. */
+  path: readonly string[];
+  /** What it put there; undefined when the write removed the slot. */
+  value: unknown;
+}
+
+/** How much a transaction wrote. */
+export interface WriteAccount {
+  /** Documents the transaction wrote to. */
+  docs: number;
+  /** JSON bytes it wrote into them. */
+  bytes: number;
+}
+
+interface PathNode {
+  /** True when an attestation named this exact path. */
+  written: boolean;
+  value: unknown;
+  children: Map<string, PathNode>;
+}
+
+function emptyNode(): PathNode {
+  return { written: false, value: undefined, children: new Map() };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Builds the container the keys of `children` describe. */
+function containerFor(children: Map<string, PathNode>): unknown {
+  for (const key of children.keys()) {
+    if (!/^(0|[1-9][0-9]*)$/.test(key)) return {};
+  }
+  return [];
+}
+
+/**
+ * Rebuilds the value a write put at `node`'s path, replacing each slot that a
+ * write below it named. `inherited` is what the enclosing value holds at this
+ * path, which stands where no attestation named the path itself. A slot with no
+ * write below it keeps what it already held, which is how a value written whole
+ * survives intact.
+ */
+function materialize(node: PathNode, inherited: unknown): unknown {
+  const base = node.written ? node.value : inherited;
+  if (node.children.size === 0) return base;
+  const container = Array.isArray(base) || isRecord(base)
+    ? base
+    : containerFor(node.children);
+  if (Array.isArray(container)) {
+    const out = [...container];
+    for (const [index, child] of node.children) {
+      const slot = Number(index);
+      out[slot] = materialize(child, out[slot]);
+    }
+    return out;
+  }
+  const out = { ...container as Record<string, unknown> };
+  for (const [key, child] of node.children) {
+    out[key] = materialize(child, out[key]);
+  }
+  return out;
+}
+
+/** Collects the top-level writes under `node`, whose path is `prefix`. */
+function collect(
+  id: string,
+  prefix: readonly string[],
+  node: PathNode,
+  out: WrittenValue[],
+): void {
+  if (node.written) {
+    out.push({ id, path: prefix, value: materialize(node, undefined) });
+    return;
+  }
+  for (const [key, child] of node.children) {
+    collect(id, [...prefix, key], child, out);
+  }
+}
+
+/**
+ * Returns the top-level writes a transaction's novelty describes, one per
+ * document path that no other written path encloses.
+ */
+export function noveltyWrites(
+  novelty: Iterable<IAttestation>,
+): WrittenValue[] {
+  const docs = new Map<string, PathNode>();
+  for (const attestation of novelty) {
+    const { id, path } = attestation.address;
+    let node: PathNode | undefined = docs.get(id);
+    if (node === undefined) {
+      node = emptyNode();
+      docs.set(id, node);
+    }
+    for (const segment of path) {
+      let child: PathNode | undefined = node.children.get(segment);
+      if (child === undefined) {
+        child = emptyNode();
+        node.children.set(segment, child);
+      }
+      node = child;
+    }
+    node.written = true;
+    node.value = attestation.value;
+  }
+  const writes: WrittenValue[] = [];
+  for (const [id, root] of docs) collect(id, [], root, writes);
+  return writes;
+}
+
+/** Counts the documents a transaction wrote and the JSON bytes it wrote. */
+export function accountNovelty(
+  novelty: Iterable<IAttestation>,
+): WriteAccount {
+  const writes = noveltyWrites(novelty);
+  const ids = new Set(writes.map((write) => write.id));
+  let bytes = 0;
+  for (const { value } of writes) {
+    if (value === undefined) continue;
+    bytes += JSON.stringify(value).length;
+  }
+  return { docs: ids.size, bytes };
+}
+
+/** Adds two accounts, for totalling across transactions. */
+export function addAccounts(a: WriteAccount, b: WriteAccount): WriteAccount {
+  return { docs: a.docs + b.docs, bytes: a.bytes + b.bytes };
+}

--- a/packages/runner/test/bench-write-accounting.ts
+++ b/packages/runner/test/bench-write-accounting.ts
@@ -42,6 +42,20 @@ export interface WriteAccount {
   bytes: number;
 }
 
+const encoder = new TextEncoder();
+
+/**
+ * The number of bytes `value` occupies as JSON, and zero for a value JSON does
+ * not represent. Counted as encoded bytes rather than as string length, which
+ * counts UTF-16 code units and so reads one byte for a character that takes
+ * two, three, or four.
+ */
+export function jsonBytes(value: unknown): number {
+  const json = JSON.stringify(value);
+  if (json === undefined) return 0;
+  return encoder.encode(json).byteLength;
+}
+
 interface PathNode {
   /** True when an attestation named this exact path. */
   written: boolean;
@@ -147,10 +161,7 @@ export function accountNovelty(
   const writes = noveltyWrites(novelty);
   const ids = new Set(writes.map((write) => write.id));
   let bytes = 0;
-  for (const { value } of writes) {
-    if (value === undefined) continue;
-    bytes += JSON.stringify(value).length;
-  }
+  for (const { value } of writes) bytes += jsonBytes(value);
   return { docs: ids.size, bytes };
 }
 

--- a/packages/runner/test/cell-set-flat-index-list.bench.ts
+++ b/packages/runner/test/cell-set-flat-index-list.bench.ts
@@ -52,6 +52,7 @@ import { benchDiagnostic } from "./bench-diagnostics.ts";
 import {
   accountNovelty,
   addAccounts,
+  jsonBytes,
   type WriteAccount,
 } from "./bench-write-accounting.ts";
 
@@ -204,7 +205,7 @@ function creationLine(
 function updateLine({ docs, bytes }: WriteAccount): string {
   return `txs=${UPDATE_TXS} avgBytes/tx=${Math.round(bytes / UPDATE_TXS)} ` +
     `avgDocs/tx=${(docs / UPDATE_TXS).toFixed(1)} ` +
-    `(one raw item≈${JSON.stringify(makeItem(0)).length}B)`;
+    `(one raw item≈${jsonBytes(makeItem(0))}B)`;
 }
 
 // =============================================================================
@@ -273,7 +274,7 @@ async function writePerItem(
 }
 
 for (const N of SIZES) {
-  const rawBytes = JSON.stringify(makeList(N)).length;
+  const rawBytes = jsonBytes(makeList(N));
 
   Deno.bench({
     name: `flat list ONE doc - cell.set(${N} items) + commit`,

--- a/packages/runner/test/cell-set-flat-index-list.bench.ts
+++ b/packages/runner/test/cell-set-flat-index-list.bench.ts
@@ -18,6 +18,11 @@
  *   3. update cost: whole-array re-set with one item changed vs a targeted
  *      per-index write — bytes written per transaction (history growth)
  *
+ * The first two group names say how the write is issued, not how many
+ * documents it makes. Both report N+1: the runtime gives every object element
+ * of an array a document of its own, and the parent array holds a link per
+ * element.
+ *
  * Interpretation guide: if stored bytes ≈ raw JSON and per-tx update bytes
  * ≈ one item, the runtime is efficient for this shape and the production
  * bloat is usage (item shape redundancy + per-instance copies). Superlinear
@@ -28,7 +33,8 @@
  * - FLAT_INDEX_LIST_SIZES: comma-separated Ns, default "100,1000,3000"
  * - FLAT_INDEX_LIST_UPDATE_TXS: update transactions per bench, default 20
  * - FLAT_INDEX_LIST_REPORT: "1" (default) prints a one-line stored-bytes/doc
- *   accounting per bench+N to stderr (outside the timed window); "0" silences
+ *   accounting per bench+N to stderr, from one extra untimed run of that
+ *   benchmark's scenario; "0" silences the reports and skips those runs
  */
 
 import { Identity } from "@commonfabric/identity";
@@ -42,6 +48,12 @@ import {
   type JSONSchema,
 } from "../src/builder/types.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { benchDiagnostic } from "./bench-diagnostics.ts";
+import {
+  accountNovelty,
+  addAccounts,
+  type WriteAccount,
+} from "./bench-write-accounting.ts";
 
 const signer = await Identity.fromPassphrase("bench flat index list");
 const space = signer.did();
@@ -145,106 +157,148 @@ async function cleanup(
   await storageManager.close();
 }
 
-// --- write accounting (outside timed windows) -------------------------------
-// tx.journal.novelty(space) yields the attestations a commit wrote. Count
-// distinct doc ids and JSON bytes so each bench can report stored size vs the
-// raw-JSON floor. Printed once per bench name.
+// --- write accounting -------------------------------------------------------
+// A transaction holds its journal only while it is open: commit() releases it
+// on the way to settling, so tx.journal.novelty(space) is empty afterwards.
+// Each write scenario below therefore takes an `account` callback and hands it
+// the transaction while the writes are still on it, just before committing.
+//
+// A benchmark cannot afford that call inside its timed window, so it does not
+// pass one. Instead it runs the same scenario once more, untimed and with the
+// callback, and reports what came back. The reports are per bench name, once.
+type Account = (tx: IExtendedStorageTransaction) => void;
+
 const reported = new Set<string>();
-function accountNovelty(tx: IExtendedStorageTransaction): {
-  docs: number;
-  bytes: number;
-} {
-  const ids = new Set<string>();
-  let bytes = 0;
-  for (const att of tx.journal.novelty(space)) {
-    ids.add(String((att.address as { id?: unknown }).id ?? "?"));
-    if (att.value !== undefined) bytes += JSON.stringify(att.value).length;
-  }
-  return { docs: ids.size, bytes };
-}
-function reportOnce(name: string, detail: string) {
+
+/**
+ * Runs `scenario` once with an accounting callback and writes one line for
+ * `name`. Repeat calls for the same name do nothing, so a benchmark can ask on
+ * every iteration and pay for one run.
+ */
+async function reportOnce(
+  name: string,
+  scenario: (account: Account) => Promise<void>,
+  format: (account: WriteAccount) => string,
+): Promise<void> {
   if (!REPORT || reported.has(name)) return;
   reported.add(name);
-  console.error(`[flat-index-list] ${name}: ${detail}`);
+  let total: WriteAccount = { docs: 0, bytes: 0 };
+  await scenario((tx) => {
+    total = addAccounts(total, accountNovelty(tx.journal.novelty(space)));
+  });
+  benchDiagnostic(`[flat-index-list] ${name}: ${format(total)}`);
+}
+
+/** The accounting line for a scenario that stores a list from nothing. */
+function creationLine(
+  N: number,
+  rawBytes: number,
+): (a: WriteAccount) => string {
+  return ({ docs, bytes }) =>
+    `docs=${docs} storedBytes=${bytes} rawJSON=${rawBytes} ` +
+    `overhead=${(bytes / rawBytes).toFixed(2)}x ` +
+    `perItem=${Math.round(bytes / N)}B`;
+}
+
+/** The accounting line for a scenario that runs UPDATE_TXS transactions. */
+function updateLine({ docs, bytes }: WriteAccount): string {
+  return `txs=${UPDATE_TXS} avgBytes/tx=${Math.round(bytes / UPDATE_TXS)} ` +
+    `avgDocs/tx=${(docs / UPDATE_TXS).toFixed(1)} ` +
+    `(one raw item≈${JSON.stringify(makeItem(0)).length}B)`;
 }
 
 // =============================================================================
 // 1. WRITE: one flat array in ONE doc, via a single Cell.set()
 // =============================================================================
+async function writeOneDoc(
+  N: number,
+  b?: Deno.BenchContext,
+  account?: Account,
+): Promise<void> {
+  const { runtime, storageManager, tx } = setup();
+  const cell = runtime.getCell<IndexItem[]>(
+    space,
+    `bench-flat-index-one-doc-${N}`,
+    undefined,
+    tx,
+  );
+  const list = makeList(N);
+  try {
+    b?.start();
+    cell.set(list);
+    account?.(tx);
+    await tx.commit();
+    b?.end();
+  } finally {
+    await cleanup(runtime, storageManager, tx);
+  }
+}
+
+// =============================================================================
+// 2. WRITE: one doc PER ITEM (parent array holds cell links)
+// =============================================================================
+async function writePerItem(
+  N: number,
+  b?: Deno.BenchContext,
+  account?: Account,
+): Promise<void> {
+  const { runtime, storageManager, tx } = setup();
+  const frame: Frame = pushFrame({
+    cause: { type: "bench-flat-index-per-item", n: N },
+    runtime,
+    tx,
+    space,
+    inHandler: true,
+  });
+  const parent = runtime.getCell<Cell<IndexItem>[]>(
+    space,
+    `bench-flat-index-per-item-${N}`,
+    undefined,
+    tx,
+  );
+  try {
+    b?.start();
+    const cells = makeList(N).map((item, i) =>
+      Writable.for<IndexItem>(`bench-flat-index-item-${N}-${i}`)
+        .set(item) as unknown as Cell<IndexItem>
+    );
+    parent.set(cells);
+    account?.(tx);
+    await tx.commit();
+    b?.end();
+  } finally {
+    popFrame(frame);
+    await cleanup(runtime, storageManager, tx);
+  }
+}
+
 for (const N of SIZES) {
   const rawBytes = JSON.stringify(makeList(N)).length;
+
   Deno.bench({
     name: `flat list ONE doc - cell.set(${N} items) + commit`,
     group: `write-${N}`,
     baseline: true,
     async fn(b) {
-      const { runtime, storageManager, tx } = setup();
-      const cell = runtime.getCell<IndexItem[]>(
-        space,
-        `bench-flat-index-one-doc-${N}`,
-        undefined,
-        tx,
+      await reportOnce(
+        `one-doc write N=${N}`,
+        (account) => writeOneDoc(N, undefined, account),
+        creationLine(N, rawBytes),
       );
-      const list = makeList(N);
-      try {
-        b.start();
-        cell.set(list);
-        await tx.commit();
-        b.end();
-        const { docs, bytes } = accountNovelty(tx);
-        reportOnce(
-          `one-doc write N=${N}`,
-          `docs=${docs} storedBytes=${bytes} rawJSON=${rawBytes} ` +
-            `overhead=${(bytes / rawBytes).toFixed(2)}x ` +
-            `perItem=${Math.round(bytes / N)}B`,
-        );
-      } finally {
-        await cleanup(runtime, storageManager, tx);
-      }
+      await writeOneDoc(N, b);
     },
   });
 
-  // ===========================================================================
-  // 2. WRITE: one doc PER ITEM (parent array holds cell links)
-  // ===========================================================================
   Deno.bench({
     name: `flat list PER-ITEM docs - ${N} Writable.set + parent set + commit`,
     group: `write-${N}`,
     async fn(b) {
-      const { runtime, storageManager, tx } = setup();
-      const frame: Frame = pushFrame({
-        cause: { type: "bench-flat-index-per-item", n: N },
-        runtime,
-        tx,
-        space,
-        inHandler: true,
-      });
-      const parent = runtime.getCell<Cell<IndexItem>[]>(
-        space,
-        `bench-flat-index-per-item-${N}`,
-        undefined,
-        tx,
+      await reportOnce(
+        `per-item write N=${N}`,
+        (account) => writePerItem(N, undefined, account),
+        creationLine(N, rawBytes),
       );
-      try {
-        b.start();
-        const cells = makeList(N).map((item, i) =>
-          Writable.for<IndexItem>(`bench-flat-index-item-${N}-${i}`)
-            .set(item) as unknown as Cell<IndexItem>
-        );
-        parent.set(cells);
-        await tx.commit();
-        b.end();
-        const { docs, bytes } = accountNovelty(tx);
-        reportOnce(
-          `per-item write N=${N}`,
-          `docs=${docs} storedBytes=${bytes} rawJSON=${rawBytes} ` +
-            `overhead=${(bytes / rawBytes).toFixed(2)}x ` +
-            `perItem=${Math.round(bytes / N)}B`,
-        );
-      } finally {
-        popFrame(frame);
-        await cleanup(runtime, storageManager, tx);
-      }
+      await writePerItem(N, b);
     },
   });
 }
@@ -361,8 +415,7 @@ for (const N of SIZES) {
 
 // =============================================================================
 // 4. UPDATE: three writer profiles for "one item changed", distinguished
-//    because they have wildly different write footprints (novelty accounting
-//    runs AFTER b.end(), on the retained per-tx journals):
+//    because they have wildly different write footprints:
 //      a. REGENERATE from scratch (what a derivation/lift recompute does):
 //         fresh objects carry no doc identity → every element re-minted.
 //      b. READ-MODIFY-WRITE (the idiomatic handler edit): objects returned
@@ -370,26 +423,107 @@ for (const N of SIZES) {
 //         the parent write.
 //      c. TARGETED key(i).set: bypasses the array diff entirely.
 // =============================================================================
-type UpdateAccount = { docs: number; bytes: number };
+async function updateRegenerate(
+  N: number,
+  b?: Deno.BenchContext,
+  account?: Account,
+): Promise<void> {
+  const { runtime, storageManager, tx: setupTx } = setup();
+  const cell0 = runtime.getCell<IndexItem[]>(
+    space,
+    `bench-flat-index-update-set-${N}`,
+    undefined,
+    setupTx,
+  );
+  cell0.set(makeList(N));
+  await setupTx.commit();
 
-function accountAll(txs: IExtendedStorageTransaction[]): UpdateAccount {
-  let docs = 0;
-  let bytes = 0;
-  for (const tx of txs) {
-    const a = accountNovelty(tx);
-    docs += a.docs;
-    bytes += a.bytes;
+  b?.start();
+  for (let t = 0; t < UPDATE_TXS; t++) {
+    const tx = runtime.edit();
+    const cell = runtime.getCell<IndexItem[]>(
+      space,
+      `bench-flat-index-update-set-${N}`,
+      undefined,
+      tx,
+    );
+    const list = makeList(N);
+    list[t % N] = makeItem(t % N, `-mut${t}`);
+    cell.set(list);
+    account?.(tx);
+    await tx.commit();
   }
-  return { docs, bytes };
+  b?.end();
+  await cleanup(runtime, storageManager);
 }
 
-function reportUpdate(label: string, N: number, acc: UpdateAccount) {
-  reportOnce(
-    `${label} N=${N}`,
-    `txs=${UPDATE_TXS} avgBytes/tx=${Math.round(acc.bytes / UPDATE_TXS)} ` +
-      `avgDocs/tx=${(acc.docs / UPDATE_TXS).toFixed(1)} ` +
-      `(one raw item≈${JSON.stringify(makeItem(0)).length}B)`,
+async function updateReadModifyWrite(
+  N: number,
+  b?: Deno.BenchContext,
+  account?: Account,
+): Promise<void> {
+  const { runtime, storageManager, tx: setupTx } = setup();
+  const cell0 = runtime.getCell<IndexItem[]>(
+    space,
+    `bench-flat-index-update-rmw-${N}`,
+    undefined,
+    setupTx,
   );
+  cell0.set(makeList(N));
+  await setupTx.commit();
+
+  b?.start();
+  for (let t = 0; t < UPDATE_TXS; t++) {
+    const tx = runtime.edit();
+    const cell = runtime.getCell<IndexItem[]>(
+      space,
+      `bench-flat-index-update-rmw-${N}`,
+      undefined,
+      tx,
+    );
+    // Idiomatic edit: read the current array (elements carry their doc
+    // identity), replace ONE element, write the array back.
+    const current = cell.get();
+    const list = [...current];
+    list[t % N] = makeItem(t % N, `-mut${t}`);
+    cell.set(list);
+    account?.(tx);
+    await tx.commit();
+  }
+  b?.end();
+  await cleanup(runtime, storageManager);
+}
+
+async function updateTargeted(
+  N: number,
+  b?: Deno.BenchContext,
+  account?: Account,
+): Promise<void> {
+  const { runtime, storageManager, tx: setupTx } = setup();
+  const cell0 = runtime.getCell<IndexItem[]>(
+    space,
+    `bench-flat-index-update-key-${N}`,
+    undefined,
+    setupTx,
+  );
+  cell0.set(makeList(N));
+  await setupTx.commit();
+
+  b?.start();
+  for (let t = 0; t < UPDATE_TXS; t++) {
+    const tx = runtime.edit();
+    const cell = runtime.getCell<IndexItem[]>(
+      space,
+      `bench-flat-index-update-key-${N}`,
+      undefined,
+      tx,
+    );
+    cell.key(t % N).set(makeItem(t % N, `-mut${t}`));
+    account?.(tx);
+    await tx.commit();
+  }
+  b?.end();
+  await cleanup(runtime, storageManager);
 }
 
 for (const N of SIZES) {
@@ -399,35 +533,12 @@ for (const N of SIZES) {
     group: `update-${N}`,
     baseline: true,
     async fn(b) {
-      const { runtime, storageManager, tx: setupTx } = setup();
-      const cell0 = runtime.getCell<IndexItem[]>(
-        space,
-        `bench-flat-index-update-set-${N}`,
-        undefined,
-        setupTx,
+      await reportOnce(
+        `update regenerate N=${N}`,
+        (account) => updateRegenerate(N, undefined, account),
+        updateLine,
       );
-      cell0.set(makeList(N));
-      await setupTx.commit();
-
-      const txs: IExtendedStorageTransaction[] = [];
-      b.start();
-      for (let t = 0; t < UPDATE_TXS; t++) {
-        const tx = runtime.edit();
-        const cell = runtime.getCell<IndexItem[]>(
-          space,
-          `bench-flat-index-update-set-${N}`,
-          undefined,
-          tx,
-        );
-        const list = makeList(N);
-        list[t % N] = makeItem(t % N, `-mut${t}`);
-        cell.set(list);
-        await tx.commit();
-        txs.push(tx);
-      }
-      b.end();
-      reportUpdate("update regenerate", N, accountAll(txs));
-      await cleanup(runtime, storageManager);
+      await updateRegenerate(N, b);
     },
   });
 
@@ -435,38 +546,12 @@ for (const N of SIZES) {
     name: `flat list update - READ-MODIFY-WRITE, 1 item changed (${N} items)`,
     group: `update-${N}`,
     async fn(b) {
-      const { runtime, storageManager, tx: setupTx } = setup();
-      const cell0 = runtime.getCell<IndexItem[]>(
-        space,
-        `bench-flat-index-update-rmw-${N}`,
-        undefined,
-        setupTx,
+      await reportOnce(
+        `update read-modify-write N=${N}`,
+        (account) => updateReadModifyWrite(N, undefined, account),
+        updateLine,
       );
-      cell0.set(makeList(N));
-      await setupTx.commit();
-
-      const txs: IExtendedStorageTransaction[] = [];
-      b.start();
-      for (let t = 0; t < UPDATE_TXS; t++) {
-        const tx = runtime.edit();
-        const cell = runtime.getCell<IndexItem[]>(
-          space,
-          `bench-flat-index-update-rmw-${N}`,
-          undefined,
-          tx,
-        );
-        // Idiomatic edit: read the current array (elements carry their doc
-        // identity), replace ONE element, write the array back.
-        const current = cell.get();
-        const list = [...current];
-        list[t % N] = makeItem(t % N, `-mut${t}`);
-        cell.set(list);
-        await tx.commit();
-        txs.push(tx);
-      }
-      b.end();
-      reportUpdate("update read-modify-write", N, accountAll(txs));
-      await cleanup(runtime, storageManager);
+      await updateReadModifyWrite(N, b);
     },
   });
 
@@ -474,33 +559,12 @@ for (const N of SIZES) {
     name: `flat list update - targeted key(i).set, 1 item changed (${N} items)`,
     group: `update-${N}`,
     async fn(b) {
-      const { runtime, storageManager, tx: setupTx } = setup();
-      const cell0 = runtime.getCell<IndexItem[]>(
-        space,
-        `bench-flat-index-update-key-${N}`,
-        undefined,
-        setupTx,
+      await reportOnce(
+        `update targeted N=${N}`,
+        (account) => updateTargeted(N, undefined, account),
+        updateLine,
       );
-      cell0.set(makeList(N));
-      await setupTx.commit();
-
-      const txs: IExtendedStorageTransaction[] = [];
-      b.start();
-      for (let t = 0; t < UPDATE_TXS; t++) {
-        const tx = runtime.edit();
-        const cell = runtime.getCell<IndexItem[]>(
-          space,
-          `bench-flat-index-update-key-${N}`,
-          undefined,
-          tx,
-        );
-        cell.key(t % N).set(makeItem(t % N, `-mut${t}`));
-        await tx.commit();
-        txs.push(tx);
-      }
-      b.end();
-      reportUpdate("update targeted", N, accountAll(txs));
-      await cleanup(runtime, storageManager);
+      await updateTargeted(N, b);
     },
   });
 }

--- a/packages/runner/test/scheduler-materializer-fanout.bench.ts
+++ b/packages/runner/test/scheduler-materializer-fanout.bench.ts
@@ -12,6 +12,7 @@ import {
   runWithSchedulerTiming,
   type SchedulerBenchEnv,
 } from "./scheduler-bench-helpers.ts";
+import { benchDiagnostic } from "./bench-diagnostics.ts";
 
 const benchDiagnosticsEnabled = Deno.env.get("BENCH_DIAGNOSTICS") === "1";
 
@@ -195,7 +196,7 @@ for (const fanout of FANOUT_SIZES) {
             0,
           );
           if (benchDiagnosticsEnabled) {
-            console.error(
+            benchDiagnostic(
               `materializer fanout ${fanout}: materializerRuns=${graph.getMaterializerRuns()}, readerRuns=${totalReaderRuns}`,
             );
           }
@@ -222,7 +223,7 @@ Deno.bench(
         await graph.env.runtime.scheduler.idle();
 
         if (benchDiagnosticsEnabled) {
-          console.error(
+          benchDiagnostic(
             `static declared write: computationRuns=${graph.getComputationRuns()}, effectRuns=${graph.effectRuns.value}`,
           );
         }

--- a/packages/runner/test/scheduler.bench.ts
+++ b/packages/runner/test/scheduler.bench.ts
@@ -15,6 +15,7 @@ import {
   sortAndCompactPaths,
 } from "../src/reactive-dependencies.ts";
 import { toMemorySpaceAddress } from "../src/link-utils.ts";
+import { benchDiagnostic } from "./bench-diagnostics.ts";
 
 const signer = await Identity.fromPassphrase("bench operator");
 const space = signer.did();
@@ -651,9 +652,8 @@ Deno.bench(
     await tx.commit();
     const commitTime = performance.now() - start;
 
-    // Log commit time (won't show in bench output but useful for debugging)
     if (commitTime > 100 && Deno.env.get("BENCH_DIAGNOSTICS") === "1") {
-      console.error(`Commit took ${commitTime.toFixed(1)}ms`);
+      benchDiagnostic(`Commit took ${commitTime.toFixed(1)}ms`);
     }
 
     await runtime.dispose();

--- a/tasks/lint-bench-console.test.ts
+++ b/tasks/lint-bench-console.test.ts
@@ -17,7 +17,7 @@ function diagnose(source: string, fileName = "sample.bench.ts"): string[] {
 
 /** The distinguishing phrase of each of the rule's two messages. */
 const LOST = "never reaches stderr";
-const STDOUT = "writes to stdout";
+const STDOUT = "may use only the `console` methods that write to stderr";
 
 describe("lint-bench-console", () => {
   it("reports a console call written in a benchmark body", () => {
@@ -92,6 +92,29 @@ describe("lint-bench-console", () => {
     `);
     expect(messages.length).toBe(1);
     expect(messages[0]).toContain(STDOUT);
+  });
+
+  it("reports every console method outside the four stderr ones", () => {
+    // `dirxml` and `table` write to stdout; `time` writes nothing but is not
+    // one of the four, and the rule turns on the permitted list rather than on
+    // an enumeration of the ways a method can reach stdout.
+    for (const method of ["dirxml", "table", "count", "group", "time"]) {
+      const messages = diagnose(`
+        console.${method}("x");
+        Deno.bench("a", () => {});
+      `);
+      expect(messages.length).toBe(1);
+      expect(messages[0]).toContain(STDOUT);
+    }
+  });
+
+  it("returns nothing for the four console methods that reach stderr", () => {
+    for (const method of ["assert", "error", "trace", "warn"]) {
+      expect(diagnose(`
+        console.${method}("x");
+        Deno.bench("a", () => {});
+      `)).toEqual([]);
+    }
   });
 
   it("returns nothing for a module-scope console.error", () => {

--- a/tasks/lint-bench-console.test.ts
+++ b/tasks/lint-bench-console.test.ts
@@ -1,0 +1,152 @@
+/// <reference lib="deno.unstable" />
+
+/**
+ * Runs the `cf-bench/no-lost-diagnostics` rule over short benchmark files and
+ * checks which of the two messages, if either, it reports. `Deno.lint.runPlugin`
+ * takes the file name, so a case names one ending in `.bench.ts` to put the rule
+ * in scope.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import plugin from "./lint-bench-console.ts";
+
+function diagnose(source: string, fileName = "sample.bench.ts"): string[] {
+  return Deno.lint.runPlugin(plugin, fileName, source).map((d) => d.message);
+}
+
+/** The distinguishing phrase of each of the rule's two messages. */
+const LOST = "never reaches stderr";
+const STDOUT = "writes to stdout";
+
+describe("lint-bench-console", () => {
+  it("reports a console call written in a benchmark body", () => {
+    const messages = diagnose(`
+      Deno.bench("a", () => {
+        console.error("how big");
+      });
+    `);
+    expect(messages.length).toBe(1);
+    expect(messages[0]).toContain(LOST);
+  });
+
+  it("reports a console call in the object form of Deno.bench", () => {
+    const messages = diagnose(`
+      Deno.bench({
+        name: "a",
+        fn(b) {
+          b.start();
+          b.end();
+          console.error("how big");
+        },
+      });
+    `);
+    expect(messages.length).toBe(1);
+    expect(messages[0]).toContain(LOST);
+  });
+
+  it("reports a console call in a helper a body calls", () => {
+    const messages = diagnose(`
+      function report(detail) {
+        console.error(detail);
+      }
+      Deno.bench("a", () => {
+        report("how big");
+      });
+    `);
+    expect(messages.length).toBe(1);
+    expect(messages[0]).toContain(LOST);
+  });
+
+  it("follows helper calls through more than one hop", () => {
+    const messages = diagnose(`
+      const emit = (line) => {
+        console.error(line);
+      };
+      function report(detail) {
+        emit(detail);
+      }
+      Deno.bench("a", async (b) => {
+        await Promise.resolve();
+        report("how big");
+      });
+    `);
+    expect(messages.length).toBe(1);
+    expect(messages[0]).toContain(LOST);
+  });
+
+  it("reports a stdout method in a body as a lost diagnostic", () => {
+    const messages = diagnose(`
+      Deno.bench("a", () => {
+        console.log("how big");
+      });
+    `);
+    expect(messages.length).toBe(1);
+    expect(messages[0]).toContain(LOST);
+  });
+
+  it("reports a module-scope console method that writes to stdout", () => {
+    const messages = diagnose(`
+      console.log("program size: 4");
+      Deno.bench("a", () => {});
+    `);
+    expect(messages.length).toBe(1);
+    expect(messages[0]).toContain(STDOUT);
+  });
+
+  it("returns nothing for a module-scope console.error", () => {
+    expect(diagnose(`
+      console.error("program size: 4");
+      Deno.bench("a", () => {});
+    `)).toEqual([]);
+  });
+
+  it("returns nothing for a console.error in an unload handler", () => {
+    expect(diagnose(`
+      addEventListener("unload", () => {
+        console.error("summary");
+      });
+      Deno.bench("a", () => {});
+    `)).toEqual([]);
+  });
+
+  it("returns nothing for a helper only module scope calls", () => {
+    expect(diagnose(`
+      function report(detail) {
+        console.error(detail);
+      }
+      report("program size: 4");
+      Deno.bench("a", () => {});
+    `)).toEqual([]);
+  });
+
+  it("returns nothing for a Deno.stderr write in a body", () => {
+    expect(diagnose(`
+      const encoder = new TextEncoder();
+      Deno.bench("a", () => {
+        Deno.stderr.writeSync(encoder.encode("how big\\n"));
+      });
+    `)).toEqual([]);
+  });
+
+  it("returns nothing for a member call that is not on console", () => {
+    expect(diagnose(`
+      const logger = { log: (line) => line };
+      Deno.bench("a", () => {
+        logger.log("how big");
+      });
+    `)).toEqual([]);
+  });
+
+  it("returns nothing for a file that is not a benchmark", () => {
+    expect(diagnose(
+      `
+      console.log("hello");
+      Deno.bench("a", () => {
+        console.error("how big");
+      });
+    `,
+      "sample.ts",
+    )).toEqual([]);
+  });
+});

--- a/tasks/lint-bench-console.ts
+++ b/tasks/lint-bench-console.ts
@@ -1,0 +1,229 @@
+/// <reference lib="deno.unstable" />
+
+/**
+ * A lint rule that keeps the diagnostics a `*.bench.ts` file prints on a stream
+ * that survives a `deno bench --json` run.
+ *
+ * The Benchmarks workflow sends stdout to `bench-results/results.json` and tees
+ * stderr to `bench-results/diagnostics.log`. Two things follow, and this rule
+ * enforces both:
+ *
+ *   - A `console` method that writes to stdout puts non-JSON text into
+ *     `results.json`, which invalidates the artifact for every benchmark in the
+ *     run, not just the file that printed it.
+ *   - The JSON reporter captures whatever a benchmark body writes through
+ *     `console`, on either stream, and drops it. A diagnostic written that way
+ *     reaches neither the artifact nor the workflow log. A write straight to
+ *     `Deno.stderr` inside a body passes through.
+ *
+ * A `console` call counts as a body diagnostic when it sits inside a
+ * `Deno.bench(...)` argument, and also when it sits in a function of the same
+ * file that a benchmark body calls, however many hops away. That second form is
+ * how the rule reads a file whose bodies print through a shared reporting
+ * helper. A helper in another module is beyond what one file's syntax tree
+ * shows; write those with `Deno.stderr` too.
+ *
+ * See docs/development/BENCHMARKS.md.
+ */
+
+/**
+ * The `console` methods that write to stdout. The rest — `error`, `warn`,
+ * `trace`, `assert` — write to stderr.
+ */
+const STDOUT_METHODS: ReadonlySet<string> = new Set([
+  "count",
+  "debug",
+  "dir",
+  "group",
+  "groupCollapsed",
+  "groupEnd",
+  "info",
+  "log",
+  "table",
+  "timeEnd",
+  "timeLog",
+]);
+
+const BODY_MESSAGE =
+  "A `console` call that runs in a benchmark body is captured by the `deno " +
+  "bench --json` reporter and never reaches stderr. Write the diagnostic with " +
+  "`Deno.stderr.writeSync(...)` instead. See docs/development/BENCHMARKS.md.";
+
+const STDOUT_MESSAGE =
+  "This `console` method writes to stdout, which carries the `deno bench " +
+  "--json` report. One stray line invalidates the results artifact for every " +
+  "benchmark in the run. Use `console.error` at module scope, or " +
+  "`Deno.stderr.writeSync(...)`. See docs/development/BENCHMARKS.md.";
+
+const FUNCTION_TYPES: ReadonlySet<string> = new Set([
+  "ArrowFunctionExpression",
+  "FunctionDeclaration",
+  "FunctionExpression",
+]);
+
+/** The shape this rule reads off a node, on top of the type tag. */
+interface BenchNode {
+  readonly type: string;
+  readonly range: readonly [number, number];
+  readonly id?: { readonly type: string; readonly name?: string };
+  readonly init?: BenchNode | null;
+  readonly callee: {
+    readonly type: string;
+    readonly name?: string;
+    readonly computed?: boolean;
+    readonly object?: { readonly type: string; readonly name?: string };
+    readonly property?: { readonly type: string; readonly name?: string };
+  };
+}
+
+/**
+ * Returns the method name when `node` is a call on the `console` global, and
+ * undefined otherwise. A local binding named `console` would read the same way;
+ * no benchmark file shadows the global.
+ */
+function consoleMethod(node: BenchNode): string | undefined {
+  const { callee } = node;
+  if (callee.type !== "MemberExpression" || callee.computed) return undefined;
+  if (callee.object?.type !== "Identifier") return undefined;
+  if (callee.object.name !== "console") return undefined;
+  if (callee.property?.type !== "Identifier") return undefined;
+  return callee.property.name;
+}
+
+/** Returns true when `node` is a `Deno.bench(...)` call. */
+function isBenchCall(node: BenchNode): boolean {
+  const { callee } = node;
+  return callee.type === "MemberExpression" && !callee.computed &&
+    callee.object?.type === "Identifier" && callee.object.name === "Deno" &&
+    callee.property?.type === "Identifier" && callee.property.name === "bench";
+}
+
+/** The name a plain `name(...)` call names, if the call has that form. */
+function calledName(node: BenchNode): string | undefined {
+  const { callee } = node;
+  return callee.type === "Identifier" ? callee.name : undefined;
+}
+
+/** One function body, plus the module body, which the rule treats as one. */
+interface Scope {
+  /** Names this body calls as plain `name(...)` calls. */
+  readonly calls: Set<string>;
+  /** The `console` calls written directly in this body. */
+  readonly consoleCalls: { node: Deno.lint.Node; method: string }[];
+  /** True when this function was written inside a `Deno.bench(...)` call. */
+  readonly inBench: boolean;
+}
+
+export default {
+  name: "cf-bench",
+  rules: {
+    "no-lost-diagnostics": {
+      create(context) {
+        if (!context.filename.endsWith(".bench.ts")) return {};
+
+        const moduleScope: Scope = {
+          calls: new Set(),
+          consoleCalls: [],
+          inBench: false,
+        };
+        const scopes: Scope[] = [moduleScope];
+        const stack: Scope[] = [moduleScope];
+        // Functions reachable by name from a benchmark body. A function
+        // expression bound to a variable takes that variable's name, which the
+        // declarator records before the traversal descends into the function.
+        const byName = new Map<string, Scope>();
+        const pendingNames = new Map<string, string>();
+        // Counts the `Deno.bench(...)` calls the traversal is currently inside.
+        let benchDepth = 0;
+
+        const rangeKey = (node: BenchNode) => node.range.join(":");
+
+        return {
+          VariableDeclarator(node) {
+            const declarator = node as unknown as BenchNode;
+            const init = declarator.init;
+            if (!init || !FUNCTION_TYPES.has(init.type)) return;
+            if (declarator.id?.type !== "Identifier") return;
+            const name = declarator.id.name;
+            if (name !== undefined) pendingNames.set(rangeKey(init), name);
+          },
+
+          ArrowFunctionExpression: enterFunction,
+          FunctionDeclaration: enterFunction,
+          FunctionExpression: enterFunction,
+          "ArrowFunctionExpression:exit": exitFunction,
+          "FunctionDeclaration:exit": exitFunction,
+          "FunctionExpression:exit": exitFunction,
+
+          CallExpression(node) {
+            const call = node as unknown as BenchNode;
+            if (isBenchCall(call)) {
+              benchDepth += 1;
+              return;
+            }
+            const scope = stack[stack.length - 1];
+            const name = calledName(call);
+            if (name !== undefined) scope.calls.add(name);
+            const method = consoleMethod(call);
+            if (method === undefined) return;
+            if (benchDepth > 0) {
+              // Written inside the `Deno.bench(...)` call itself, whether or
+              // not a nested function encloses it.
+              context.report({ node, message: BODY_MESSAGE });
+              return;
+            }
+            scope.consoleCalls.push({ node, method });
+          },
+
+          "CallExpression:exit"(node) {
+            if (isBenchCall(node as unknown as BenchNode)) benchDepth -= 1;
+          },
+
+          "Program:exit"() {
+            // Walk out from the bodies, through the names they call, to every
+            // function of this file that a body can reach.
+            const reached = new Set<Scope>();
+            const queue = scopes.filter((scope) => scope.inBench);
+            while (queue.length > 0) {
+              const scope = queue.pop()!;
+              for (const name of scope.calls) {
+                const target = byName.get(name);
+                if (target === undefined || reached.has(target)) continue;
+                reached.add(target);
+                queue.push(target);
+              }
+            }
+            for (const scope of scopes) {
+              for (const { node, method } of scope.consoleCalls) {
+                if (reached.has(scope)) {
+                  context.report({ node, message: BODY_MESSAGE });
+                } else if (STDOUT_METHODS.has(method)) {
+                  context.report({ node, message: STDOUT_MESSAGE });
+                }
+              }
+            }
+          },
+        };
+
+        function enterFunction(node: Deno.lint.Node) {
+          const fn = node as unknown as BenchNode;
+          const scope: Scope = {
+            calls: new Set(),
+            consoleCalls: [],
+            inBench: benchDepth > 0,
+          };
+          scopes.push(scope);
+          stack.push(scope);
+          const name = fn.id?.type === "Identifier"
+            ? fn.id.name
+            : pendingNames.get(rangeKey(fn));
+          if (name !== undefined) byName.set(name, scope);
+        }
+
+        function exitFunction() {
+          stack.pop();
+        }
+      },
+    },
+  },
+} satisfies Deno.lint.Plugin;

--- a/tasks/lint-bench-console.ts
+++ b/tasks/lint-bench-console.ts
@@ -10,7 +10,9 @@
  *
  *   - A `console` method that writes to stdout puts non-JSON text into
  *     `results.json`, which invalidates the artifact for every benchmark in the
- *     run, not just the file that printed it.
+ *     run, not just the file that printed it. Only `error`, `warn`, `trace`,
+ *     and `assert` write to stderr, so those four are the whole of what a
+ *     benchmark file may call outside a body.
  *   - The JSON reporter captures whatever a benchmark body writes through
  *     `console`, on either stream, and drops it. A diagnostic written that way
  *     reaches neither the artifact nor the workflow log. A write straight to
@@ -27,21 +29,16 @@
  */
 
 /**
- * The `console` methods that write to stdout. The rest — `error`, `warn`,
- * `trace`, `assert` — write to stderr.
+ * The `console` methods that write to stderr. Everything else on `console`
+ * either writes to stdout or writes nothing, and naming the short list this way
+ * round is what makes the rule safe: a method nobody here has heard of is
+ * rejected rather than allowed through.
  */
-const STDOUT_METHODS: ReadonlySet<string> = new Set([
-  "count",
-  "debug",
-  "dir",
-  "group",
-  "groupCollapsed",
-  "groupEnd",
-  "info",
-  "log",
-  "table",
-  "timeEnd",
-  "timeLog",
+const STDERR_METHODS: ReadonlySet<string> = new Set([
+  "assert",
+  "error",
+  "trace",
+  "warn",
 ]);
 
 const BODY_MESSAGE =
@@ -50,10 +47,12 @@ const BODY_MESSAGE =
   "`Deno.stderr.writeSync(...)` instead. See docs/development/BENCHMARKS.md.";
 
 const STDOUT_MESSAGE =
-  "This `console` method writes to stdout, which carries the `deno bench " +
-  "--json` report. One stray line invalidates the results artifact for every " +
-  "benchmark in the run. Use `console.error` at module scope, or " +
-  "`Deno.stderr.writeSync(...)`. See docs/development/BENCHMARKS.md.";
+  "A benchmark file may use only the `console` methods that write to stderr: " +
+  "`error`, `warn`, `trace`, `assert`. Any other one risks a line on stdout, " +
+  "which carries the `deno bench --json` report, where one stray line " +
+  "invalidates the results artifact for every benchmark in the run. Use " +
+  "`console.error`, or `Deno.stderr.writeSync(...)`. See " +
+  "docs/development/BENCHMARKS.md.";
 
 const FUNCTION_TYPES: ReadonlySet<string> = new Set([
   "ArrowFunctionExpression",
@@ -197,7 +196,7 @@ export default {
               for (const { node, method } of scope.consoleCalls) {
                 if (reached.has(scope)) {
                   context.report({ node, message: BODY_MESSAGE });
-                } else if (STDOUT_METHODS.has(method)) {
+                } else if (!STDERR_METHODS.has(method)) {
                   context.report({ node, message: STDOUT_MESSAGE });
                 }
               }


### PR DESCRIPTION
Two defects kept the storage benchmarks from answering the questions they exist to answer.

The first is in cell-set-flat-index-list.bench.ts, whose header says it measures stored bytes per item and documents written per transaction. It read tx.journal.novelty(space) after the transaction had committed, and a transaction releases its journal on the way to settling, so every report in the file read docs=0 storedBytes=0 and avgBytes/tx=0 avgDocs/tx=0.0. Each write scenario is now a function that takes a callback and hands it the transaction just before committing. A benchmark passes no callback, so its timed window is unchanged; it runs the same scenario once more, untimed, to fill in the report it writes once.

Summing the attestations that come back would still have been wrong. The journal records one attestation per written path, not one per document and not one per value: a write of a whole document repeats its parts on the paths below it, and a write below the root records each container empty with its contents on the paths under it. Adding them all up counts the same bytes several times over in the first shape and drops the key names in the second. The new bench-write-accounting.ts reads the attestations as a set of writes, keeps the ones no other write encloses, and rebuilds each one's value from the writes below it. Its tests check that reconstruction against a live transaction: a targeted key(i).set comes back as exactly the item it stored, and a list of scalars comes back as exactly the JSON its document holds.

What the reports now say also names something the group names do not. A single cell.set of an array of objects makes N+1 documents, one per element plus the parent holding a link each, so the "ONE doc" and "PER-ITEM docs" groups both report N+1. The file's header now says so.

The second defect is that none of those reports could have reached continuous integration in any case. They went out through console.error from inside a benchmark body, and the deno bench --json reporter captures a body's console output and drops it, on either stream. Two more files had the same mistake: scheduler.bench.ts and scheduler-materializer-fanout.bench.ts, both behind BENCH_DIAGNOSTICS. All three now write through benchDiagnostic() in bench-diagnostics.ts, which writes to Deno.stderr directly. The Benchmarks workflow already tees stderr into diagnostics.log, so the reports land in the uploaded artifact.

BENCHMARKS.md already stated the rule that was broken, so stating it again would not have fixed anything. A lint plugin now enforces it. In a *.bench.ts file, cf-bench/no-lost-diagnostics rejects a console method that writes to stdout wherever it appears, and any console call at all that runs in a benchmark body. The second half follows helper calls within the file, which is what a purely lexical rule would have missed: the report in cell-set-flat-index-list.bench.ts went out through a helper, so a rule that only looked inside Deno.bench arguments would have passed the very file that motivated the check.

The rest of the benchmarks the workflow runs were read for both mistakes. Their remaining console.error calls sit at module scope or in unload handlers, where the reporter is not listening and the output passes through.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

