### PR TITLE
fix(cli): a handler's help stops claiming the verb returns nothing

### DIFF
--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -229,7 +229,7 @@ The renderer is ready for two of the three: `specificFlagLines` reads a
 were given one, and a listing row would carry one as soon as it were supplied.
 The verb's *purpose* needs a second change on top, because
 `renderPieceCallHelp` has nowhere to put it — the page runs Usage, JSON input,
-Flags, Output, with no summary line.
+Flags, with no summary line.
 
 So the help page shows `--title <string>  Required.` and stops.
 

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -192,13 +192,12 @@ JSON input:
 
 Flags after `--`:
   --title <string>    Required.
-
-Output:
-  No output on success.
 ```
 
-**Structure is published; prose is not.** That line is the whole of what `cf`
-can currently say about a verb, and the split is worth holding onto:
+**Structure is published; prose is not.** The flags are the whole of what `cf`
+can currently say about a verb — there is no `Output:` section, because this
+page cannot see a declared result and a fixed claim about output would be false
+for every verb that declares one. The split is worth holding onto:
 
 | | Where it comes from | Survives? |
 | --- | --- | --- |

--- a/packages/cli/integration/fuse-exec.sh
+++ b/packages/cli/integration/fuse-exec.sh
@@ -136,6 +136,16 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local message="$3"
+
+  if [[ "$haystack" == *"$needle"* ]]; then
+    error "$message"
+  fi
+}
+
 assert_not_exists() {
   local path="$1"
   local message="$2"
@@ -813,7 +823,10 @@ assert_contains "$HANDLER_HELP" "cf exec" "cf exec help should describe the cf e
 assert_contains "$HANDLER_HELP" "[invoke] --message <string>" "Handler help should show the optional invoke verb."
 assert_contains "$HANDLER_HELP" "--message <string>" "Handler help should expand schema-derived flags."
 assert_contains "$HANDLER_HELP" "Required." "Handler help should mark required flags."
-assert_contains "$HANDLER_HELP" "No output on success." "Handler help should describe handler output."
+# A handler's help says nothing about output rather than asserting there is
+# none: a verb declared `Stream<E, R>` does return a result, and this page
+# cannot see the declaration.
+assert_not_contains "$HANDLER_HELP" "Output:" "Handler help should carry no Output section."
 assert_contains "$HANDLER_HELP" "Alternatively, write JSON to this file to invoke the handler." "Handler help should mention write-through invocation."
 assert_contains "$TOOL_HELP" "[run] --query <string>" "Tool help should show the optional run verb."
 assert_contains "$TOOL_HELP" "--query <string>" "Tool help should expand schema-derived flags."

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -1011,9 +1011,11 @@ export function renderExecHelp(
   ];
 
   if (spec.callableKind === "handler") {
-    lines.push("");
-    lines.push("Output:");
-    lines.push("  No output on success.");
+    // No `Output:` section. A verb declared `Stream<E, R>` returns a result and
+    // the caller reads it off the invocation, so claiming there is none is
+    // false for exactly the verbs a caller most wants described. Saying nothing
+    // is the honest position until a handler's declared result reaches this
+    // path; the listing already carries it (`cf piece verbs --json`).
     lines.push("");
     lines.push("Alternatively, write JSON to this file to invoke the handler.");
     if (handlerAllowsInvokeWithoutInputs(spec.inputSchema)) {
@@ -1110,9 +1112,11 @@ export function renderPieceCallHelp(
   }
 
   if (spec.callableKind === "handler") {
-    lines.push("");
-    lines.push("Output:");
-    lines.push("  No output on success.");
+    // No `Output:` section. A verb declared `Stream<E, R>` returns a result and
+    // the caller reads it off the invocation, so claiming there is none is
+    // false for exactly the verbs a caller most wants described. Saying nothing
+    // is the honest position until a handler's declared result reaches this
+    // path; the listing already carries it (`cf piece verbs --json`).
     lines.push("");
     lines.push("Alternatively, write JSON to this file to invoke the handler.");
     if (handlerAllowsInvokeWithoutInputs(spec.inputSchema)) {

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -835,7 +835,10 @@ describe("renderExecHelp", () => {
     expect(help).toContain("./legacyWrite.handler [invoke] --message <string>");
     expect(help).toContain("./legacyWrite.handler [invoke] --help");
     expect(help).not.toContain("cf exec ./legacyWrite.handler");
-    expect(help).toContain("No output on success.");
+    // A handler's help carries no `Output:` section at all: it cannot see a
+    // declared result from here, and a verb that declares one does return it,
+    // so any fixed claim about output would be false for half the verbs.
+    expect(help).not.toContain("Output:");
     expect(help).toContain(
       "Alternatively, write JSON to this file to invoke the handler.",
     );


### PR DESCRIPTION
## Why

`cf piece call <verb> --help` and `cf exec <handler> --help` printed a fixed section for every handler:

```text
Output:
  No output on success.
```

That is false for a verb declared `Stream<E, R>`. It runs, returns a value, and the value arrives on `invocation.result`. The help page a caller reads *before* calling tells them the opposite — and it does so for exactly the verbs whose result a caller most wants described.

The line was accurate when handlers returned nothing. It became wrong rather than ever having been wrong, which is why it survived review. #5558, first half; verbs plan step 5.

## What Changed

- **`renderPieceCallHelp` and `renderExecHelp`** (`packages/cli/lib/exec-schema.ts`) no longer emit an `Output:` section for a handler. The page cannot tell a value-less verb from one that declares a result — a handler's declared result does not reach this path, only the listing carries it (`cf piece verbs --json`, #5629) — so saying nothing is the honest position. The write-through invocation lines are unchanged.
- `fuse-exec.sh` asserted the claim. It now asserts the **property** — that a handler's help carries no `Output:` section — and gains the `assert_not_contains` helper that needs.
- `docs/common/verb-session-walkthrough.md` showed the section in its rendered help and built a sentence on it; both updated.

## What this deliberately does not do

Enumerate the result's fields. That is the other half of #5558 and it needs the declared result at `resolvePieceCallable`, which is real plumbing rather than a one-line correction. Splitting them is the point: **stopping a false claim needs no decision from anyone, and should not wait behind work that does.**

## Test plan

- `packages/cli` — 174 passed, 0 failed.
- **Verified red without the fix:** reverting only `exec-schema.ts` and keeping the test turns `renderExecHelp` red. (My first attempt at this check stashed both and proved nothing — recording that because a green "verified" is worse than no check.)
- `deno fmt --check`, `deno lint`, `bash -n` on the changed script, `deno task check-docs` (547 blocks).
- `fuse-exec.sh` runs in CI as the `fuse` suite, so the changed assertion is actually gated.

## Adjacent, not fixed here

`renderPieceCallHelp` also prints *"Alternatively, write JSON to this file to invoke the handler."* There is no file in a `cf piece call` — that text belongs to the `cf exec` path it was shared from. A second false statement on the same page, left alone to keep this change to one claim. Happy to take it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

