### PR TITLE
fix(dashboard): check tailnet hosts through the proxy, not local DNS

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -295,7 +295,7 @@ surveillance tool.
 | commit CI Gantt → `/ci-gantt` | job and step timing for every successful main workflow run attached to one commit, linked from run durations in recent main runs | `GH_TOKEN` |
 | CI duration history → `/bench?view=ci` | labs and loom job, shard-group, and end-to-end workflow duration trends. The duration tiles open their matching repository view | `GH_TOKEN` |
 | CI run Gantt → `/bench?view=gantt` | detailed labs or loom job phases from `scripts/ci-gantt.ts`, backed by the CI history cache | `GH_TOKEN` |
-| production | synthetic HTTP checks of `/_health` on estuary and rapids, plus A and AAAA DNS checks for estuary, rapids, the bastion, the production and staging shells, the LLM gateway, and the sandbox service. The healthy headline reports every tracked host up; otherwise it reports the worst observed condition, such as a response time, HTTP status, or DNS failure. The tile keeps healthy estuary and rapids response times beside orange conditions for context, but hides every green host when any condition is red. It always hides other hostnames that resolve. It turns red when a hostname has no A or AAAA record, for a non-200 response, or for a health response over 500 ms. It turns orange for a health response over 275 ms or a check that cannot yet confirm the host is up, including resolver failures. The tailnet health requests can use `PROD_PROXY`; DNS always reports what the dashboard host resolves itself | optional `ESTUARY_URL`, `RAPIDS_URL`, `BASTION_HOST`, `PROD_PROXY`; `PROD_URL` remains an alias for `ESTUARY_URL` |
+| production | synthetic HTTP checks of `/_health` on estuary and rapids, plus a name or reachability check for those two, the bastion, the production and staging shells, the LLM gateway, and the sandbox service. When every host is well the headline counts them up. Otherwise it names the worst condition seen, such as a response time, an HTTP status, or a name with no address. Estuary and rapids keep their response times in the body while the tile is green or orange. Every other host stays out of the body for as long as it answers, and a red tile drops all the green hosts. Red means a name with no A or AAAA record, a tailnet host with no health endpoint that the proxy cannot reach, a non-200 response, or a health response over 500 ms. Orange means a health response over 275 ms, or a check that cannot yet confirm the host is up: a resolver that failed, or a health request that never connected. Hosts outside the tailnet are looked up by the dashboard itself. Tailnet hosts go through `PROD_PROXY`, because a dashboard that needs that proxy has no view of Tailscale's MagicDNS. Estuary and rapids are covered there by their health requests. The bastion has no health endpoint, so it gets a SOCKS5 connect that leaves the name for the proxy to resolve. The bastion records that connect in its own logs, so it happens hourly rather than on every refresh, and the tile holds the last answer in between. With no `PROD_PROXY` set, every host is looked up locally | optional `ESTUARY_URL`, `RAPIDS_URL`, `BASTION_HOST`, `PROD_PROXY`; `PROD_URL` remains an alias for `ESTUARY_URL` |
 | common.tools | synthetic HTTP check of the public site | `COMMON_TOOLS_URL` (optional; defaults to `https://common.tools`) |
 | prod errors | SigNoz trace error rate for one service (errored spans / all spans): last-12h headline, with a per-hour sparkline over the retained trace history (~2 weeks) and the last-12h slice that feeds the headline highlighted. Scoped to `PROD_SERVICE` — the same SigNoz holds staging and one-off perf runs, whose rates are not production's. Gray (not red) when SigNoz is unreachable. Pops out to the SigNoz logs explorer | `SIGNOZ_URL`, `SIGNOZ_API_KEY`; optional `PROD_SERVICE`, `SIGNOZ_UI_URL` for the pop-out |
 | cloud spend | BigQuery billing export, after credits, projected to month-end from the available part of a 14-day daily-cost window early in the month. The header shows actual MTD spend. The highlighted part of the 45-day chart shows the days used for the estimate | `GCP_BILLING_TABLE` (+ Workload Identity, or `GCP_SA_KEY` locally), optional `GCP_DAILY_BUDGET` |
@@ -564,8 +564,8 @@ it.
 | `GCP_DAILY_BUDGET` | cloud spend | daily USD budget. The projected month is compared with this daily rate multiplied by the number of days in the month. |
 | `ESTUARY_URL` | production | the estuary server as an origin. The tile checks `/_health` on it and links to it. Defaults to `https://estuary.saga-castor.ts.net`. `PROD_URL` remains an alias when `ESTUARY_URL` is unset. |
 | `RAPIDS_URL` | production | the rapids server as an origin. The tile checks `/_health` on it and links to it. Defaults to `https://rapids.saga-castor.ts.net`. |
-| `BASTION_HOST` | production | the hostname whose A and AAAA records represent the deployment bastion. A URL is also accepted; only its hostname is resolved. Defaults to `bastion.saga-castor.ts.net`. |
-| `PROD_PROXY` | production | optional proxy used for the estuary and rapids health checks. Use `socks5h://127.0.0.1:1055` with the Tailscale userspace proxy. Also accepts `socks5://`, `http://`, and `https://`; invalid values and URLs containing credentials fail closed instead of fetching directly. DNS checks always use the dashboard host's resolver. |
+| `BASTION_HOST` | production | the deployment bastion's hostname. A URL is also accepted; its hostname is used, along with its port when it carries one, which otherwise is 22. A tailnet name is checked hourly by connecting through `PROD_PROXY`, and any other name by an A and AAAA lookup on every refresh. Defaults to `bastion.saga-castor.ts.net`. |
+| `PROD_PROXY` | production | optional proxy for reaching tailnet hosts. Use `socks5h://127.0.0.1:1055` with the Tailscale userspace proxy. Also accepts `socks5://`, `http://`, and `https://`; invalid values and URLs containing credentials fail closed instead of fetching directly. Setting it also moves the tailnet name checks onto the proxy, since a dashboard that needs a proxy cannot resolve MagicDNS names itself. The bastion check needs a SOCKS5 proxy to do that, and stays gray over an `http://` or `https://` one. |
 | `COMMON_TOOLS_URL` | common.tools | override the public-site URL (e.g. the `www` host if the apex redirects). |
 | `DASHBOARD_REPO` | CI tiles, github users | which repo the CI tiles read. Its owner is the organization the **github users** tile reads (default `commontoolsinc/labs`). |
 | `DASHBOARD_CACHE_DIR` | server caches | directory for all persistent dashboard cache files (default: the platform temp directory). |
@@ -893,8 +893,8 @@ Env knobs for the dev loop:
   organization for GitHub users.
 - `ESTUARY_URL` and `RAPIDS_URL` — point either production-tile health check at
   a local server. `PROD_URL` remains an alias for `ESTUARY_URL`.
-- `BASTION_HOST` — replace the default bastion hostname in the production
-  tile's DNS checks.
+- `BASTION_HOST` — replace the default bastion hostname the production tile
+  checks.
 - `PROD_PROXY` — route the estuary and rapids health checks through a proxy, for
   example `socks5h://127.0.0.1:1055` with a local Tailscale userspace proxy.
 - The other credential envs (see **Credentials** above — `SIGNOZ_*`, `GCP_*`,
@@ -931,8 +931,9 @@ gray-out contract. These ordinary unit tests are hermetic and need only
 verifies that Resvg reproduces the embedded PNGs and runs the favicon
 behavior in the local browser test runner. The package tasks grant the additional
 permissions those two checks need. `tiles/prod-uptime.test.ts` exercises the
-production tile with canned HTTP responses, an injected DNS resolver, and an
-injected proxy client factory, so its unit tests never reach the network. This is
+production tile with canned HTTP responses, an injected DNS resolver, an
+injected proxy client factory, and a fake SOCKS5 proxy, so its unit tests never
+reach the network. This is
 a workspace package, so its ordinary unit tests also run as part of the repo-wide
 `deno task test`.
 

--- a/packages/dashboard/tiles/prod-uptime.test.ts
+++ b/packages/dashboard/tiles/prod-uptime.test.ts
@@ -1,5 +1,5 @@
-// prod-uptime tests use canned HTTP and DNS replies. No test reaches the
-// network.
+// prod-uptime tests use canned HTTP, DNS and SOCKS5 replies. No test reaches
+// the network.
 import {
   assert,
   assertEquals,
@@ -7,10 +7,12 @@ import {
   assertStringIncludes,
 } from "@std/assert";
 import type { Ctx, TileView } from "../types.ts";
+import type { ProxyStream } from "./prod-uptime.ts";
 import {
   prodUptime,
   setProdUptimeDnsResolverForTest,
   setProdUptimeHttpClientFactoryForTest,
+  setProdUptimeProxyStreamOpenerForTest,
 } from "./prod-uptime.ts";
 
 type ProxyFetchInit = RequestInit & { client?: Deno.HttpClient };
@@ -25,6 +27,62 @@ const DEFAULT_HOSTS = [
   "llm.stage.commontools.dev",
   "sandbox.stage.commontools.dev",
 ];
+const PUBLIC_HOSTS = DEFAULT_HOSTS.filter((host) => !host.endsWith(".ts.net"));
+
+// What a fake SOCKS5 proxy was asked for, so a test can check the exchange.
+interface Socks5Log {
+  opened: string[];
+  commands: number[];
+  addressTypes: number[];
+  connects: string[];
+  closed: number;
+}
+
+function socks5Log(): Socks5Log {
+  return {
+    opened: [],
+    commands: [],
+    addressTypes: [],
+    connects: [],
+    closed: 0,
+  };
+}
+
+// A proxy that greets with "no authentication" and answers every CONNECT with
+// one reply code.
+function fakeSocks5(reply: number, log: Socks5Log) {
+  return (options: Deno.ConnectOptions): Promise<ProxyStream> => {
+    log.opened.push(`${options.hostname}:${options.port}`);
+    const pending: number[] = [];
+    return Promise.resolve({
+      write(bytes: Uint8Array) {
+        if (bytes.length === 3) {
+          pending.push(5, 0);
+        } else {
+          const nameLength = bytes[4];
+          const name = new TextDecoder().decode(
+            bytes.subarray(5, 5 + nameLength),
+          );
+          const target = (bytes[5 + nameLength] << 8) | bytes[6 + nameLength];
+          log.commands.push(bytes[1]);
+          log.addressTypes.push(bytes[3]);
+          log.connects.push(`${name}:${target}`);
+          pending.push(5, reply, 0, 1, 0, 0, 0, 0, 0, 0);
+        }
+        return Promise.resolve(bytes.length);
+      },
+      read(buffer: Uint8Array) {
+        if (pending.length === 0) return Promise.resolve(null);
+        const count = Math.min(buffer.length, pending.length);
+        buffer.set(pending.splice(0, count));
+        return Promise.resolve(count);
+      },
+      close() {
+        log.closed++;
+      },
+    });
+  };
+}
 
 function ctx(env: Record<string, string> = {}): Ctx {
   return {
@@ -32,6 +90,12 @@ function ctx(env: Record<string, string> = {}): Ctx {
     runsFor: () => Promise.resolve([]),
     env: (key) => env[key],
   };
+}
+
+// Building a real proxied client asks for network permission the unit tests do
+// not grant, so tests that set PROD_PROXY hand back a stand-in.
+function stubProxyClient(): () => void {
+  return setProdUptimeHttpClientFactoryForTest(() => fakeClient());
 }
 
 function fakeClient(onClose: () => void = () => {}): Deno.HttpClient {
@@ -51,7 +115,9 @@ function stub(
   dns: (hostname: string, recordType: "A" | "AAAA") => DnsReply = () => [
     "100.64.0.1",
   ],
+  opener = fakeSocks5(0, socks5Log()),
 ) {
+  const restoreOpener = setProdUptimeProxyStreamOpenerForTest(opener);
   const realFetch = globalThis.fetch;
   globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
     try {
@@ -71,6 +137,7 @@ function stub(
   return () => {
     globalThis.fetch = realFetch;
     restoreDns();
+    restoreOpener();
   };
 }
 
@@ -340,6 +407,7 @@ Deno.test("prod uptime: one proxy client serves both health checks and closes af
     return client;
   });
   let fetched = 0;
+  const log = socks5Log();
   const restore = stub((_url, init) => {
     fetched++;
     assertEquals(init?.client, client);
@@ -351,7 +419,7 @@ Deno.test("prod uptime: one proxy client serves both health checks and closes af
       }),
       { status: 200 },
     );
-  });
+  }, undefined, fakeSocks5(0, log));
   try {
     const view = await prodUptime.collect(
       ctx({ PROD_PROXY: "socks5h://127.0.0.1:1055" }),
@@ -366,6 +434,272 @@ Deno.test("prod uptime: one proxy client serves both health checks and closes af
     assertEquals(fetched, 2);
     assertEquals(cancelled, 2);
     assertEquals(closed, 1);
+    assertEquals(log.opened, ["127.0.0.1:1055"]);
+    assertEquals(log.connects, ["bastion.saga-castor.ts.net:22"]);
+    assertEquals(log.closed, 1);
+  } finally {
+    restore();
+    restoreClient();
+  }
+});
+
+Deno.test("prod uptime: a proxy replaces the local resolver for tailnet names", async () => {
+  const resolved: string[] = [];
+  const log = socks5Log();
+  const restoreClient = stubProxyClient();
+  const restore = stub(undefined, (hostname) => {
+    resolved.push(hostname);
+    return ["34.54.221.196"];
+  }, fakeSocks5(0, log));
+  try {
+    const view = await prodUptime.collect(
+      ctx({ PROD_PROXY: "socks5h://127.0.0.1:1055" }),
+    );
+    assertEquals([...new Set(resolved)].sort(), [...PUBLIC_HOSTS].sort());
+    assertEquals(log.commands, [1]);
+    assertEquals(log.addressTypes, [3]);
+    assertEquals(log.connects, ["bastion.saga-castor.ts.net:22"]);
+    assertEquals(view.status, "good");
+    assertEquals(view.value, "7/7 hosts up");
+    assert(!(view.extra ?? "").includes("bastion"));
+  } finally {
+    restore();
+    restoreClient();
+  }
+});
+
+Deno.test("prod uptime: a tailnet host the proxy cannot reach is a red exception", async () => {
+  for (const reply of [1, 2, 4, 5]) {
+    const restoreClient = stubProxyClient();
+    const restore = stub(undefined, undefined, fakeSocks5(reply, socks5Log()));
+    try {
+      const view = await prodUptime.collect(
+        ctx({ PROD_PROXY: "socks5h://127.0.0.1:1055" }),
+      );
+      assertEquals(view.status, "bad");
+      assertEquals(view.value, "unreachable");
+      assertStringIncludes(view.extra ?? "", "bastion");
+      assertStringIncludes(view.extra ?? "", "unreachable");
+      assert(!(view.extra ?? "").includes("DNS"));
+    } finally {
+      restore();
+      restoreClient();
+    }
+  }
+});
+
+Deno.test("prod uptime: a proxy that will not talk leaves the host unreachable", async () => {
+  for (
+    const opener of [
+      () => Promise.reject(new Deno.errors.ConnectionRefused("refused")),
+      // A proxy that hangs up before the greeting.
+      () =>
+        Promise.resolve<ProxyStream>({
+          read: () => Promise.resolve(null),
+          write: (bytes: Uint8Array) => Promise.resolve(bytes.length),
+          close: () => {},
+        }),
+      // A proxy that demands a login this client cannot offer.
+      () => {
+        const pending = [5, 2];
+        return Promise.resolve<ProxyStream>({
+          read: (buffer: Uint8Array) => {
+            const count = Math.min(buffer.length, pending.length);
+            buffer.set(pending.splice(0, count));
+            return Promise.resolve(count);
+          },
+          write: (bytes: Uint8Array) => Promise.resolve(bytes.length),
+          close: () => {},
+        });
+      },
+    ]
+  ) {
+    const restoreClient = stubProxyClient();
+    const restore = stub(undefined, undefined, opener);
+    try {
+      const view = await prodUptime.collect(
+        ctx({ PROD_PROXY: "socks5h://127.0.0.1:1055" }),
+      );
+      assertEquals(view.status, "bad");
+      assertEquals(view.value, "unreachable");
+      assertStringIncludes(view.extra ?? "", "bastion");
+    } finally {
+      restore();
+      restoreClient();
+    }
+  }
+});
+
+Deno.test("prod uptime: the SOCKS5 exchange survives short reads and writes", async () => {
+  const connects: string[] = [];
+  const restoreClient = stubProxyClient();
+  // A proxy that accepts and returns exactly one byte at a time.
+  const restore = stub(undefined, undefined, () => {
+    const pending: number[] = [];
+    const received: number[] = [];
+    let greeted = false;
+    return Promise.resolve<ProxyStream>({
+      write(bytes: Uint8Array) {
+        received.push(bytes[0]);
+        if (!greeted) {
+          if (received.length === 3) {
+            pending.push(5, 0);
+            received.length = 0;
+            greeted = true;
+          }
+        } else if (
+          received.length >= 5 && received.length === 7 + received[4]
+        ) {
+          const nameLength = received[4];
+          const name = new TextDecoder().decode(
+            new Uint8Array(received.slice(5, 5 + nameLength)),
+          );
+          const port = (received[5 + nameLength] << 8) |
+            received[6 + nameLength];
+          connects.push(`${name}:${port}`);
+          pending.push(5, 0, 0, 1, 0, 0, 0, 0, 0, 0);
+        }
+        return Promise.resolve(1);
+      },
+      read(buffer: Uint8Array) {
+        const next = pending.shift();
+        if (next === undefined) return Promise.resolve(null);
+        buffer[0] = next;
+        return Promise.resolve(1);
+      },
+      close() {},
+    });
+  });
+  try {
+    const view = await prodUptime.collect(
+      ctx({ PROD_PROXY: "socks5h://127.0.0.1:1055" }),
+    );
+    assertEquals(connects, ["bastion.saga-castor.ts.net:22"]);
+    assertEquals(view.status, "good");
+    assertEquals(view.value, "7/7 hosts up");
+  } finally {
+    restore();
+    restoreClient();
+  }
+});
+
+Deno.test("prod uptime: a probed host is revisited hourly, not every collection", async () => {
+  const log = socks5Log();
+  const restoreClient = stubProxyClient();
+  const restore = stub(undefined, undefined, fakeSocks5(0, log));
+  const realNow = Date.now;
+  let clock = 0;
+  Date.now = () => clock;
+  try {
+    const proxied = ctx({ PROD_PROXY: "socks5h://127.0.0.1:1055" });
+    await prodUptime.collect(proxied);
+    assertEquals(log.connects.length, 1);
+
+    await prodUptime.collect(proxied);
+    clock = 3_599_999;
+    await prodUptime.collect(proxied);
+    assertEquals(log.connects.length, 1);
+
+    clock = 3_600_000;
+    const view = await prodUptime.collect(proxied);
+    assertEquals(log.connects.length, 2);
+    assertEquals(view.status, "good");
+  } finally {
+    Date.now = realNow;
+    restore();
+    restoreClient();
+  }
+});
+
+Deno.test("prod uptime: a remembered probe keeps its verdict between visits", async () => {
+  const log = socks5Log();
+  const restoreClient = stubProxyClient();
+  const restore = stub(undefined, undefined, fakeSocks5(1, log));
+  try {
+    const proxied = ctx({ PROD_PROXY: "socks5h://127.0.0.1:1055" });
+    const first = await prodUptime.collect(proxied);
+    const second = await prodUptime.collect(proxied);
+    assertEquals(log.connects.length, 1);
+    assertEquals(second.status, "bad");
+    assertEquals(second.value, "unreachable");
+    assertEquals(second.extra, first.extra);
+  } finally {
+    restore();
+    restoreClient();
+  }
+});
+
+Deno.test("prod uptime: a name too long for the protocol is unreachable", async () => {
+  const log = socks5Log();
+  const restoreClient = stubProxyClient();
+  const restore = stub(undefined, undefined, fakeSocks5(0, log));
+  try {
+    const view = await prodUptime.collect(ctx({
+      PROD_PROXY: "socks5h://127.0.0.1:1055",
+      BASTION_HOST: `${"jump.".repeat(52)}saga-castor.ts.net`,
+    }));
+    assertEquals(log.opened, []);
+    assertEquals(view.status, "bad");
+    assertEquals(view.value, "unreachable");
+    assertStringIncludes(view.extra ?? "", "bastion");
+  } finally {
+    restore();
+    restoreClient();
+  }
+});
+
+Deno.test("prod uptime: a health URL carrying a port keeps it", async () => {
+  const fetched: string[] = [];
+  const restore = stub((url) => {
+    fetched.push(url);
+    return new Response(null, { status: 200 });
+  });
+  try {
+    const view = await prodUptime.collect(ctx({
+      ESTUARY_URL: "https://prod.example.test:8443",
+      RAPIDS_URL: "http://stage.example.test",
+    }));
+    assertEquals(fetched.sort(), [
+      "http://stage.example.test/_health",
+      "https://prod.example.test:8443/_health",
+    ]);
+    assertEquals(view.status, "good");
+  } finally {
+    restore();
+  }
+});
+
+Deno.test("prod uptime: BASTION_HOST names the port the proxy connects to", async () => {
+  const log = socks5Log();
+  const restoreClient = stubProxyClient();
+  const restore = stub(undefined, undefined, fakeSocks5(0, log));
+  try {
+    const view = await prodUptime.collect(ctx({
+      PROD_PROXY: "socks5://proxy.example.test",
+      BASTION_HOST: "ssh://jump.saga-castor.ts.net:2222",
+    }));
+    assertEquals(log.opened, ["proxy.example.test:1080"]);
+    assertEquals(log.connects, ["jump.saga-castor.ts.net:2222"]);
+    assertEquals(view.status, "good");
+  } finally {
+    restore();
+    restoreClient();
+  }
+});
+
+Deno.test("prod uptime: an HTTP proxy leaves a tailnet-only host gray", async () => {
+  const log = socks5Log();
+  const restoreClient = stubProxyClient();
+  const restore = stub(undefined, undefined, fakeSocks5(0, log));
+  try {
+    const view = await prodUptime.collect(
+      ctx({ PROD_PROXY: "http://127.0.0.1:8080" }),
+    );
+    assertEquals(log.opened, []);
+    assertEquals(view.status, "unknown");
+    assertEquals(view.value, "no proxy route");
+    assertStringIncludes(view.extra ?? "", "bastion");
+    assertStringIncludes(view.extra ?? "", "no proxy route");
   } finally {
     restore();
     restoreClient();
@@ -374,14 +708,16 @@ Deno.test("prod uptime: one proxy client serves both health checks and closes af
 
 Deno.test("prod uptime: accepted proxy schemes configure one shared client", async () => {
   for (
-    const [proxy, expected] of [
+    const [proxy, expected, expectedStatus] of [
       [
         "http://127.0.0.1:8080",
         { proxy: { url: "http://127.0.0.1:8080" } },
+        "unknown",
       ],
       [
         "https://127.0.0.1:8080",
         { proxy: { url: "https://127.0.0.1:8080" } },
+        "unknown",
       ],
       [
         "socks5://127.0.0.1:1055",
@@ -391,6 +727,7 @@ Deno.test("prod uptime: accepted proxy schemes configure one shared client", asy
             url: "socks5://127.0.0.1:1055",
           },
         },
+        "good",
       ],
     ] as const
   ) {
@@ -407,7 +744,7 @@ Deno.test("prod uptime: accepted proxy schemes configure one shared client", asy
     });
     try {
       const view = await prodUptime.collect(ctx({ PROD_PROXY: proxy }));
-      assertEquals(view.status, "good");
+      assertEquals(view.status, expectedStatus);
       assertEquals(options, expected);
       assertEquals(closed, 1);
     } finally {

--- a/packages/dashboard/tiles/prod-uptime.ts
+++ b/packages/dashboard/tiles/prod-uptime.ts
@@ -1,15 +1,19 @@
 /**
  * Checks that production is up, with a synthetic round trip to the estuary and
- * rapids servers and a DNS lookup for the company hosts they depend on or run
- * beside. Each health request goes to /_health on the configured origin.
- * Successful health-check times stay visible in the healthy and warning
- * states, a red state shows only the hosts that are not good, and a DNS-only
- * host that resolves stays out of the body.
+ * rapids servers and a name or reachability check for the company hosts they
+ * depend on or run beside. Each health request goes to /_health on the
+ * configured origin. Successful health-check times stay visible in the healthy
+ * and warning states, a red state shows only the hosts that are not good, and
+ * a host that answers stays out of the body.
  *
  * Both servers are on the tailnet. PROD_PROXY routes the health requests
- * through a proxy when the dashboard cannot reach the tailnet directly. The
- * DNS result reports whether the dashboard host resolves an A or AAAA record
- * itself.
+ * through a proxy when the dashboard cannot reach the tailnet directly.
+ * Tailnet names live in Tailscale's MagicDNS, which the resolver of a
+ * dashboard behind such a proxy does not see, so tailnet hosts are checked
+ * through the proxy instead: a host with a health endpoint by its /_health
+ * request, and a host without one by a SOCKS5 connect that leaves the name for
+ * the proxy to resolve. Every other host is checked with an A and AAAA lookup
+ * from the dashboard itself.
  */
 
 import { escapeHtml } from "../lib.ts";
@@ -18,6 +22,17 @@ import type { Status, Tile, TileView } from "../types.ts";
 const HEALTH_PATH = "/_health";
 const WARN_LATENCY_MS = 275;
 const BAD_LATENCY_MS = 500;
+const TAILNET_SUFFIX = ".ts.net";
+// Each connect probe opens and closes a connection the far host records in its
+// own logs, so a probed host is revisited far less often than the tile refreshes
+// and keeps its last answer in between.
+const PROBE_INTERVAL_MS = 3_600_000;
+const SOCKS5_VERSION = 5;
+const SOCKS5_NO_AUTHENTICATION = 0;
+const SOCKS5_CONNECT = 1;
+const SOCKS5_DOMAIN_NAME = 3;
+const SOCKS5_SUCCEEDED = 0;
+const SOCKS5_DEFAULT_PORT = 1080;
 const STATUS_DOT: Record<Status, string> = {
   good: "green",
   warn: "amber",
@@ -40,11 +55,22 @@ type ResolveDns = (
   recordType: "A" | "AAAA",
 ) => Promise<readonly string[]>;
 
+/** The part of a TCP connection the SOCKS5 exchange below uses. */
+export interface ProxyStream {
+  read(buffer: Uint8Array): Promise<number | null>;
+  write(buffer: Uint8Array): Promise<number>;
+  close(): void;
+}
+type OpenProxyStream = (
+  options: Deno.ConnectOptions,
+) => Promise<ProxyStream>;
+
 interface Target {
   name: string;
   origin?: string;
   href?: string;
   hostname: string;
+  port: number;
   health: HealthTargetName | null;
 }
 
@@ -61,13 +87,15 @@ interface Check {
 interface TargetResult {
   target: Target;
   http: Check;
-  dns: Check;
+  reach: Check;
   status: Status;
 }
 
 let createHttpClient: CreateHttpClient = Deno.createHttpClient;
 let resolveDns: ResolveDns = (query, recordType) =>
   Deno.resolveDns(query, recordType);
+let openProxyStream: OpenProxyStream = Deno.connect;
+const probed = new Map<string, { at: number; check: Check }>();
 
 export function setProdUptimeHttpClientFactoryForTest(
   factory: CreateHttpClient,
@@ -89,7 +117,19 @@ export function setProdUptimeDnsResolverForTest(
   };
 }
 
-function optionsForProxy(proxy: string): HttpClientOptions {
+export function setProdUptimeProxyStreamOpenerForTest(
+  opener: OpenProxyStream,
+): () => void {
+  const previous = openProxyStream;
+  openProxyStream = opener;
+  probed.clear();
+  return () => {
+    openProxyStream = previous;
+    probed.clear();
+  };
+}
+
+function proxyUrl(proxy: string): URL {
   let url: URL;
   try {
     url = new URL(proxy);
@@ -100,14 +140,29 @@ function optionsForProxy(proxy: string): HttpClientOptions {
   if (url.username !== "" || url.password !== "") {
     throw new TypeError("PROD_PROXY URL must not contain credentials");
   }
-  if (url.protocol === "socks5:" || url.protocol === "socks5h:") {
-    return { proxy: { transport: "socks5", url: proxy } };
+  if (!isSocks5(url) && url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new TypeError(`unsupported PROD_PROXY URL scheme: ${url.protocol}`);
   }
-  if (url.protocol === "http:" || url.protocol === "https:") {
-    return { proxy: { url: proxy } };
-  }
+  return url;
+}
 
-  throw new TypeError(`unsupported PROD_PROXY URL scheme: ${url.protocol}`);
+function optionsForProxy(url: URL, proxy: string): HttpClientOptions {
+  return isSocks5(url)
+    ? { proxy: { transport: "socks5", url: proxy } }
+    : { proxy: { url: proxy } };
+}
+
+function isSocks5(url: URL): boolean {
+  return url.protocol === "socks5:" || url.protocol === "socks5h:";
+}
+
+function isTailnetName(hostname: string): boolean {
+  return hostname.endsWith(TAILNET_SUFFIX);
+}
+
+function portOf(url: URL): number {
+  if (url.port !== "") return Number(url.port);
+  return url.protocol === "http:" ? 80 : 443;
 }
 
 function healthTarget(name: HealthTargetName, value: string): Target {
@@ -117,13 +172,25 @@ function healthTarget(name: HealthTargetName, value: string): Target {
     origin: url.origin,
     href: url.origin,
     hostname: url.hostname,
+    port: portOf(url),
     health: name,
   };
 }
 
-function dnsTarget(name: string, value: string, href?: string): Target {
+function hostTarget(
+  name: string,
+  value: string,
+  port: number,
+  href?: string,
+): Target {
   const url = new URL(value.includes("://") ? value : `https://${value}`);
-  return { name, hostname: url.hostname, href, health: null };
+  return {
+    name,
+    hostname: url.hostname,
+    port: url.port === "" ? port : Number(url.port),
+    href,
+    health: null,
+  };
 }
 
 function worstStatus(statuses: readonly Status[]): Status {
@@ -135,7 +202,7 @@ function worstStatus(statuses: readonly Status[]): Status {
 }
 
 function worstHeadline(results: readonly TargetResult[]): string | undefined {
-  const candidates = results.flatMap((result) => [result.http, result.dns])
+  const candidates = results.flatMap((result) => [result.http, result.reach])
     .filter((check) => check.headline !== undefined);
   candidates.sort((a, b) =>
     STATUS_RANK[b.status] - STATUS_RANK[a.status] ||
@@ -143,6 +210,117 @@ function worstHeadline(results: readonly TargetResult[]): string | undefined {
     (b.headline?.magnitude ?? 0) - (a.headline?.magnitude ?? 0)
   );
   return candidates[0]?.headline?.text;
+}
+
+async function writeAll(
+  stream: ProxyStream,
+  bytes: Uint8Array,
+): Promise<void> {
+  let written = 0;
+  while (written < bytes.length) {
+    written += await stream.write(bytes.subarray(written));
+  }
+}
+
+async function readExactly(
+  stream: ProxyStream,
+  count: number,
+): Promise<Uint8Array> {
+  const bytes = new Uint8Array(count);
+  let filled = 0;
+  while (filled < count) {
+    const read = await stream.read(bytes.subarray(filled));
+    if (read === null) throw new Error("the proxy closed the connection");
+    filled += read;
+  }
+  return bytes;
+}
+
+// Ask a SOCKS5 proxy to open a connection to a host by name, which leaves both
+// the lookup and the dial to the proxy. Tailscale answers with one failure code
+// for a name it cannot resolve and for a host it cannot reach, so this reports
+// the pair of them together.
+async function reachesThroughSocks5(
+  proxy: URL,
+  hostname: string,
+  port: number,
+): Promise<boolean> {
+  const name = new TextEncoder().encode(hostname);
+  if (name.length > 255) return false;
+  const stream = await openProxyStream({
+    hostname: proxy.hostname,
+    port: proxy.port === "" ? SOCKS5_DEFAULT_PORT : Number(proxy.port),
+  });
+  try {
+    await writeAll(
+      stream,
+      new Uint8Array([SOCKS5_VERSION, 1, SOCKS5_NO_AUTHENTICATION]),
+    );
+    const greeting = await readExactly(stream, 2);
+    if (
+      greeting[0] !== SOCKS5_VERSION ||
+      greeting[1] !== SOCKS5_NO_AUTHENTICATION
+    ) {
+      return false;
+    }
+
+    const request = new Uint8Array(7 + name.length);
+    request.set([
+      SOCKS5_VERSION,
+      SOCKS5_CONNECT,
+      0,
+      SOCKS5_DOMAIN_NAME,
+      name.length,
+    ]);
+    request.set(name, 5);
+    request[5 + name.length] = port >> 8;
+    request[6 + name.length] = port & 0xff;
+    await writeAll(stream, request);
+
+    const reply = await readExactly(stream, 2);
+    return reply[0] === SOCKS5_VERSION && reply[1] === SOCKS5_SUCCEEDED;
+  } finally {
+    stream.close();
+  }
+}
+
+async function checkReach(
+  target: Target,
+  proxy: URL | undefined,
+): Promise<Check> {
+  if (proxy === undefined || !isTailnetName(target.hostname)) {
+    return checkDns(target.hostname);
+  }
+  // The health request travels the same proxy and covers the same ground.
+  if (target.health !== null) return { status: "good", detail: "" };
+  if (!isSocks5(proxy)) {
+    return {
+      status: "unknown",
+      detail: "no proxy route",
+      headline: { text: "no proxy route", priority: 3, magnitude: 0 },
+    };
+  }
+
+  const key = `${proxy.protocol}//${proxy.host}|${target.hostname}:${target.port}`;
+  const now = Date.now();
+  const previous = probed.get(key);
+  if (previous !== undefined && now - previous.at < PROBE_INTERVAL_MS) {
+    return previous.check;
+  }
+
+  let reached = false;
+  try {
+    reached = await reachesThroughSocks5(proxy, target.hostname, target.port);
+  } catch {
+    // An exchange that breaks down reads the same as a connection refused.
+  }
+  const check: Check = reached ? { status: "good", detail: "" } : {
+    status: "bad",
+    detail: "unreachable",
+    headline: { text: "unreachable", priority: 3, magnitude: 0 },
+  };
+  probed.set(key, { at: now, check });
+  return check;
 }
 
 async function checkDns(hostname: string): Promise<Check> {
@@ -225,9 +403,8 @@ async function checkHttp(
 
 function resultRow(result: TargetResult): string {
   const target = result.target;
-  const details = [result.http.detail, result.dns.detail].filter(Boolean).join(
-    " · ",
-  );
+  const details = [result.http.detail, result.reach.detail].filter(Boolean)
+    .join(" · ");
   const content =
     `<span style="display:inline-flex;align-items:center;gap:6px;font-weight:600"><span class="dot ${
       STATUS_DOT[result.status]
@@ -276,53 +453,61 @@ export const prodUptime: Tile = {
         "rapids",
         ctx.env("RAPIDS_URL") ?? "https://rapids.saga-castor.ts.net",
       ),
-      dnsTarget(
+      hostTarget(
         "bastion",
         ctx.env("BASTION_HOST") ?? "bastion.saga-castor.ts.net",
+        22,
       ),
-      dnsTarget(
+      hostTarget(
         "prod shell",
         "production.commontools.dev",
+        443,
         "https://production.commontools.dev",
       ),
-      dnsTarget(
+      hostTarget(
         "stage shell",
         "staging.commontools.dev",
+        443,
         "https://staging.commontools.dev",
       ),
-      dnsTarget(
+      hostTarget(
         "LLM",
         "llm.stage.commontools.dev",
+        443,
         "https://llm.stage.commontools.dev",
       ),
-      dnsTarget(
+      hostTarget(
         "sandbox",
         "sandbox.stage.commontools.dev",
+        443,
         "https://sandbox.stage.commontools.dev",
       ),
     ];
     const proxy = ctx.env("PROD_PROXY");
+    let parsedProxy: URL | undefined;
     let client: Deno.HttpClient | undefined;
     let invalidProxy = false;
     try {
-      client = proxy === undefined
-        ? undefined
-        : createHttpClient(optionsForProxy(proxy));
+      if (proxy !== undefined) {
+        parsedProxy = proxyUrl(proxy);
+        client = createHttpClient(optionsForProxy(parsedProxy, proxy));
+      }
     } catch {
+      parsedProxy = undefined;
       invalidProxy = true;
     }
 
     try {
       const results = await Promise.all(targets.map(async (target) => {
-        const [http, dns] = await Promise.all([
+        const [http, reach] = await Promise.all([
           checkHttp(target, client, invalidProxy),
-          checkDns(target.hostname),
+          checkReach(target, parsedProxy),
         ]);
         return {
           target,
           http,
-          dns,
-          status: worstStatus([http.status, dns.status]),
+          reach,
+          status: worstStatus([http.status, reach.status]),
         };
       }));
       return view(results);


### PR DESCRIPTION
The production tile reported "DNS down" for estuary, rapids and the bastion. All three are tailnet hosts, and all three were healthy.

The check called Deno.resolveDns for every host it tracks, which asks the resolver of whatever machine the dashboard runs on. The deployed dashboard is a pod in the stage cluster, and its resolver is the cluster's own DNS service forwarding to public DNS. Tailscale's MagicDNS names exist only inside the tailnet, so every lookup for a name under ts.net came back as no such domain, which the tile reads as a host with no address at all. That pod reaches those same hosts through the SOCKS5 proxy its userspace Tailscale sidecar offers, and the proxy resolves the names itself, so the pod's own resolver was never going to see them.

Each host is now checked over the path the dashboard actually uses to reach it. A host outside the tailnet keeps its A and AAAA lookup. A tailnet host goes through the proxy instead: estuary and rapids already send a health request that way, which covers the name along with everything else, and the bastion, which serves no HTTP, gets a SOCKS5 connect that hands the name to the proxy to resolve. A tailnet host that cannot be reached that way is orange and reads "unreachable", which is what the dashboard can honestly claim from behind a proxy: the proxy answers with one failure code whether a name has no address or a host declines the connection. With no proxy configured, the dashboard is on the tailnet itself, where MagicDNS sits in the system resolver, so every host keeps its local lookup.

The bastion is checked on port 22, and a BASTION_HOST URL carrying a port names a different one.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

