### PR TITLE
docs(plans): designing verbs so they can change — problem, requirements, design, tooling

### DIFF
--- a/docs/common/concepts/self-reference.md
+++ b/docs/common/concepts/self-reference.md
@@ -70,6 +70,9 @@ interface Input { title: string | Default<"Untitled">; }
   answered by naming what you want (`--select 'title,status'`), not by
   narrowing the type; the measurement is in
   [What you are driving](../verb-session-walkthrough.md#what-you-are-driving).
+  Adding a verb to such a type later is refused on update —
+  [designing verbs so they can change](../../plans/verb-evolution.md) has the
+  mechanism and the open options.
 
 ## See Also
 

--- a/docs/common/concepts/self-reference.md
+++ b/docs/common/concepts/self-reference.md
@@ -72,7 +72,7 @@ interface Input { title: string | Default<"Untitled">; }
   [What you are driving](../verb-session-walkthrough.md#what-you-are-driving).
   Adding a verb to such a type later is refused on update —
   [designing verbs so they can change](../../plans/verb-evolution.md) has the
-  mechanism and the open options.
+  mechanism, and the holder-side rule that removes the refusal.
 
 ## See Also
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -71,14 +71,16 @@ a record: archive it to `docs/history/plans/` following the procedure in
   already diverged. It carries the measurement, the size, and the gate-by-gate
   evidence that the refusal is drift rather than policy — the dispatch gate
   already accepts link values; the outer gates never got the option.
-- [Designing verbs so they can change](verb-evolution.md) frames one decision
-  for the pattern owners: how verbs should be declared so that adding to and
-  changing them later is possible. It states what the update gate enforces
-  today, names the five dimensions any answer has to settle, weighs five
-  candidate designs (one considered and set aside), and records the longer
-  arc — versioned interfaces, per-piece upgrade policy, migrations that run
-  code — with the prior art for each. Written to be followable by anyone on
-  the team, not only by pattern authors.
+- [Designing verbs so they can change](verb-evolution.md) records how verbs are
+  declared so that adding to and changing them later is possible: verbs are
+  promises and their names are permanent, a holder declares only what it uses,
+  an optional member's maybe is resolved once at binding, and an output change
+  gets a new verb name. It states what the update gate enforces today, what
+  the transformer and authoring tools should carry so a one-off author never
+  has to learn a rule, and the open stream — named versioned interfaces,
+  per-piece upgrade policy, migrations that run code — that everything else
+  stands as the interim for. Written to be followable by anyone on the team,
+  not only by pattern authors.
 - [Verb calls: working notes](verb-result-selection.md) holds the call-specific
   investigation those documents do not carry: what produces a receipt and what
   its existence proves, how a receipt's address is derived, and the error and

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -71,6 +71,14 @@ a record: archive it to `docs/history/plans/` following the procedure in
   already diverged. It carries the measurement, the size, and the gate-by-gate
   evidence that the refusal is drift rather than policy — the dispatch gate
   already accepts link values; the outer gates never got the option.
+- [Designing verbs so they can change](verb-evolution.md) frames one decision
+  for the pattern owners: how verbs should be declared so that adding to and
+  changing them later is possible. It states what the update gate enforces
+  today, names the five dimensions any answer has to settle, weighs five
+  candidate designs (one considered and set aside), and records the longer
+  arc — versioned interfaces, per-piece upgrade policy, migrations that run
+  code — with the prior art for each. Written to be followable by anyone on
+  the team, not only by pattern authors.
 - [Verb calls: working notes](verb-result-selection.md) holds the call-specific
   investigation those documents do not carry: what produces a receipt and what
   its existence proves, how a receipt's address is derived, and the error and

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -435,6 +435,17 @@ break stays possible with impact and recourse visible. Generated migrations
 and adapters — applied eagerly, or lazily when a piece is next touched — are
 the recourse this grows into.
 
+The count has a horizon, and the report has to name it. References cross
+spaces — a stored link carries its target's space (`NormalizedFullLink`,
+`packages/runner/src/link-types.ts`) — and links are one-directional,
+recorded in the holder's space, with no reverse index anywhere. So the
+report enumerates in rings: the workspace's recorded demands, completely;
+spaces the deployment can read, by scan; and beyond that nothing, because a
+consumer in a space nobody here can read is invisible in principle. That
+invisible ring is also the sharpest argument for versioned interfaces: a
+registry consumers declare against is the only mechanism that makes foreign
+demands discoverable at all.
+
 ### A break is acknowledged one at a time
 
 The only override today turns the entire gate off, so accepting one
@@ -448,8 +459,13 @@ and what eventually lets a dead verb be removed rather than hidden.
 
 Retirement policy is guesswork without usage data; deprecation windows work
 in other systems because usage is observable. The planned invocation-record
-work is the natural place for this to ride, and the blast-radius report is
-far more useful when it can say which contracts are live.
+work is the natural place for this to ride. Counting also sees past the
+blast-radius horizon: a call executes against the provider's piece, in the
+provider's space, so invocation records catch the cross-space and
+third-party callers no static enumeration can reach. The two signals are
+complementary and both partial — enumeration sees recorded demands within
+its horizon, dormant holders included; counting sees live callers beyond
+it, and misses anyone who has not called lately.
 
 ## The longer arc
 

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -304,17 +304,8 @@ rather than silent.
 
 The default is still to stay compatible. Most patterns are updated by models
 that will cheerfully jump through hoops to avoid a break, and a compatible
-update needs none of this machinery.
-
-**Redeploying as a new pattern is the special case, not the answer.** A
-redeploy mints a new piece with a new identity. What it buys is coexistence
-— the old piece keeps working for its callers — and unmanaged coexistence is
-the measured failure mode in the longer arc, not a free good. What it costs
-is every stored reference: boards hold notes, topics hold cross-references,
-and nothing re-points them at the successor. There is no forwarding
-mechanism, and building one has not been scheduled. That cost belongs to
-choosing a redeploy — a deliberately new thing, or a move across spaces,
-where identity genuinely cannot follow — not to every incompatible change.
+update needs none of this machinery. Deploying the successor as a *new*
+pattern instead is considered and set aside below.
 
 ## How the design holds up
 
@@ -535,6 +526,20 @@ binding. They are not an evolution device.
 `append_v1` taxes every verb forever to serve the few that ever need a
 second generation. The suffix appears when the second generation does.
 
+**Redeploying a new pattern to escape a true break.** Deploying the
+successor as a new pattern looks like the safe way out of an incompatible
+change: the old piece keeps working, the new one starts clean. It is set
+aside because it forks the piece's identity. Every stored reference — boards
+holding notes, topics holding cross-references — keeps pointing at the old
+piece, and no forwarding mechanism exists or is scheduled; the data forks
+with it, and the two populations coexist unmanaged, which is the measured
+write-storm failure in the longer arc. Everything it seems to offer arrives
+better in place: migration handles the shape, versioned interfaces handle
+the callers, per-piece upgrade policy handles the rollout. What remains
+legitimate is creation — a genuinely new pattern, owing nothing to the old
+one's callers — and a move across spaces, where identity cannot follow.
+Neither is evolution, so neither is governed by this design.
+
 ## What is not settled here
 
 One question is open by design, and it is the one the cross product exposes:
@@ -545,12 +550,6 @@ or a migration that rewrites holders. Which carries it — and whether the
 gate should learn that removal beneath a demand marker is narrowing rather
 than breakage — decides how much of this design applies to what is already
 running.
-
-One mechanism is missing and unscheduled: **reference forwarding.** A
-redeploy mints a new piece identity, and nothing re-points stored references
-to the successor; until something does, a redeploy means re-pointing them by
-hand. The migration-in-place path makes this rarer, not moot: anything that
-is genuinely a new pattern still forks its references.
 
 Three smaller calls belong to whoever does the work:
 

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -1,14 +1,12 @@
 # Designing verbs so they can change
 
-This document exists so the team can make one decision together: **how should
-verbs be designed, so that changing them later is possible?**
+This document records how verbs are designed so that changing them later is
+possible: what a verb promises, what an author may change about one, what a
+holder of a piece has to write down, and what the tooling does about it.
 
-The decision belongs to the pattern owners. The argument should be followable
-by anyone on the team, so this starts from first principles and avoids
-shorthand. It frames the problem, names the dimensions the answer has to
-settle, weighs the candidate designs — including one considered and set
-aside — and records the longer arc of versioned interfaces and managed
-upgrades that any near-term choice is an interim for.
+Two audiences share it. Pattern authors need the rules. Everybody else needs
+the argument to be checkable, so it starts from first principles and avoids
+shorthand.
 
 ## The vocabulary, briefly
 
@@ -22,12 +20,11 @@ do exactly that, and so do `cf piece set` and the filesystem mount. A piece's
 interface is its fields and its verbs together, the same way an object's
 interface is its public fields and its methods.
 
-This document is about the verb half, because that is where the open design
-questions are. The field half is already governed by the same update gate —
-its accept-more/provide-more rules below are field rules — and a writable
-field is the tightest contract of the lot, because it is promised in both
-directions at once: writers rely on what it accepts, readers on what it
-holds.
+This document is about the verb half, because that is where the design
+questions are. The field half is governed by the same update gate — its
+accept-more/provide-more rules below are field rules — and a writable field is
+the tightest contract of the lot, because it is promised in both directions at
+once: writers rely on what it accepts, readers on what it holds.
 
 The runtime writes down the **shape** of every pattern automatically, from the
 TypeScript types the author wrote. The shape records what a pattern accepts,
@@ -38,7 +35,37 @@ exist and already hold data. That is the whole source of the problem: the new
 code has to keep working for everything that was already talking to the old
 code.
 
-## The problem
+## Two kinds of pattern
+
+Two populations share this runtime, and the rules have to serve both without
+charging both the same price.
+
+Most patterns are **one-offs**. Somebody wanted a thing, worked with a model
+for an afternoon, and now has it. That author will not read a compatibility
+rule, and will not be around to debug a refused update six months later. For
+these, the right rule is the one nobody has to learn — applied by the
+transformer and the authoring tools, so the ordinary way to write a pattern is
+already the compatible way.
+
+Some patterns are **long-lived and shared**: made deliberately, depended on by
+people the author has never met, expected to keep working for years. Their
+authors are motivated to get it right and will spend time on it. For these,
+the right rule is the complete one — named interfaces, declared versions,
+explicit compatibility boundaries — and those tools have to exist even though
+most patterns never reach for them.
+
+The two are served by one substrate, not two systems. The default path is the
+simple one; the deliberate path adds machinery on top of it and never
+contradicts it.
+
+That ordering carries a constraint worth stating plainly: **prefer the simple
+rule to the precise one.** Most of the code around these patterns is written
+by models, including inexpensive ones, and an elaborate rule is one more thing
+to get subtly wrong at a moment when nobody is watching. A rule that is
+slightly less precise and considerably easier to follow is the better rule
+here.
+
+## The problem this answers
 
 When a pattern is updated, the runtime compares the old shape to the new one
 and **refuses the update** if the new shape would break something relying on
@@ -74,8 +101,8 @@ This one is a straightforward defect, filed with its fix decided
 here because it shapes how much the gate can be trusted while it is open.
 
 So the gate refuses changes that are safe, and permits at least one that is
-not. Pattern authors will learn to work around it either way. The question is
-what we want them working around.
+not. Pattern authors will learn to work around it either way. The design below
+settles what they should be working around.
 
 ## What is true today
 
@@ -96,24 +123,22 @@ Measured against the current runtime, not inferred:
 Two entries deserve emphasis.
 
 **A verb's name is permanent.** Removal and renaming are both refused, and
-that is unlikely to change — it is the one rule genuinely protecting callers.
-Retiring a verb therefore means adding its replacement and marking the old one
-`@deprecated`, which hides it from listings while keeping it callable.
+that is not going to change — it is the one rule genuinely protecting callers.
 
 **A verb's output is completely unprotected.** The shape the runtime writes
 down records a verb's input and discards its output. Renaming a field of what
 a verb hands back passes every check and breaks callers silently. This is a
-known, deliberate deferral — recording outputs would commit us to a format
-that the planned Fabric-types work is expected to replace — but it means
-output changes are governed by care alone.
+deliberate deferral — recording outputs would commit us to a format that the
+planned Fabric-types work is expected to replace — and it means output changes
+are governed by convention alone.
 
 ## What a piece promises
 
 In ordinary object-oriented programming, an object promises an interface:
 these fields, these methods. Code that holds the object leans on that promise
-without checking. Take the promise away and every caller turns defensive —
-if this method exists use it, otherwise try that one, otherwise fall back.
-Agents can cope with code like that. People maintaining it are miserable.
+without checking. Take the promise away and every caller turns defensive — if
+this method exists use it, otherwise try that one, otherwise fall back. Agents
+can cope with code like that. People maintaining it are miserable.
 
 The promise is worth keeping. What makes keeping it hard here is that pieces
 are persistent: each one carries the interface it was created with, and keeps
@@ -123,10 +148,9 @@ impossible.
 
 So the uncertainty cannot be removed — but it can be **placed**. The livable
 designs concentrate it at one moment: when a caller first takes hold of a
-piece, it establishes what it is holding, and relies on a guaranteed
-interface from then on. The miserable designs spread it across every call.
-That is the standard to hold each option below against: after the first
-check, does the caller hold a promise or a maybe?
+piece, it establishes what it is holding, and relies on a guaranteed interface
+from then on. The miserable designs spread it across every call. That standard
+decides most of what follows.
 
 Who is doing the calling matters too, because the callers are not alike:
 
@@ -137,254 +161,248 @@ Who is doing the calling matters too, because the callers are not alike:
   piece — bind when the code is written. They are exactly what the interface
   promise exists for.
 - **Stored references** — a board holding a list of notes — are bindings
-  that persist. What a pattern demands of the pieces it stores is written
-  into its own shape and outlives everyone's code. These are the hardest
-  case, and they are where today's refusal comes from.
+  that persist. What a pattern demands of the pieces it stores is written into
+  its own shape and outlives everyone's code. These are the hardest case, and
+  they are where today's refusal comes from.
 
-## The dimensions
+## The design
 
-Any answer has to settle five things. They are listed in order of leverage:
-the first one changes how much the others matter.
+### Verbs are promises, and names are permanent
 
-### 1. How much do we want to depend on updating in place?
+A verb is declared as something a piece definitely has, not something it may
+have. Code that holds a piece and calls a verb holds a guarantee, and does not
+check first.
 
-This is the real question, and the others are downstream of it.
+Names never change. A verb is never removed and never renamed. Retiring one
+means adding its replacement and marking the old one `@deprecated`, which
+hides it from listings while keeping it callable. A verb whose contract must
+change incompatibly gets a new name, spelled `append_v2`, introduced when the
+second generation actually appears rather than reserved on day one.
 
-If updating a running piece is the normal way patterns change, then the shape
-rules are a permanent design constraint and type design has to bend around
-them. If deploying a new pattern and migrating the data is normal, the gate is
-a safety net for small changes and stops driving design at all.
+This is the floor. Everything below stands on it.
 
-This is a product-stage question more than a technical one. Today nothing
-outside the team holds a piece running our patterns, and migrating data
-between shapes is something we control end to end. That will not always be
-true.
+### A holder demands only what it uses
 
-### 2. Should a verb promise that it exists?
+When one pattern stores another, it writes down what it *uses*, not what the
+other pattern *is*: the fields it reads or writes, the verbs it calls, and the
+reference itself. A board that keeps notes but never appends to them does not
+mention `append`.
 
-A verb can be declared as something a piece definitely has, or as something it
-may have. That single choice decides the refusal above: a verb declared as
-"definitely has" must be present everywhere the type is used, including inside
-patterns that merely store it — which is why adding one is refused. A verb
-declared as "may have" can be added anywhere, at any time.
+The refusal that motivated this document then disappears at its root. Adding
+`append` to notes no longer changes the board's shape, because the board never
+demanded `append`. Nobody's promise weakens: a holder that *does* call a verb
+declares it, and holds a guarantee for exactly what it declared.
 
-In the source this is one character. The verb an author writes today:
+The principle is old — declare what you need, not what they are. It is how Go
+interfaces work: declared by the consumer, satisfied by shape, and best kept
+tiny ("the bigger the interface, the weaker the abstraction"). Pattern code
+already lives this way at compile time, because TypeScript types structurally;
+this extends the same discipline to the stored contract. The difference from
+Go is that a demand here is durable — written into the holder's shape and
+proved again at link time, against a provider that evolves independently.
 
-```tsx
-// Shown as interface or class members.
-/** Append a line to the body. */
-append: Stream<{ text: string }>;
-```
+Most of the machinery already exists: the runtime already proves that a stored
+link satisfies the shape its holder demands, and shared narrow projections — a
+board-facing view of a topic — are already in use across patterns. What is new
+is that holder-side types are *demands*, written that way on purpose, and that
+the tooling says so.
 
-and the same verb declared as "may have":
-
-```tsx
-// Shown as interface or class members.
-/** Append a line to the body. */
-append?: Stream<{ text: string }>;
-```
-
-The cost is what a caller can assume. If verbs may be absent, every piece of
-TypeScript that reads one off another piece has to cope with it not being
-there — and most of that code is our own tests. Option B below carries the
-measurement.
-
-### 3. How does a changed contract get a name?
-
-Since names are permanent, a verb whose contract must change incompatibly
-needs a new name. Two spellings are available: a name that describes the
-difference (`appendFormatted`), or a version suffix (`append_v2`).
-
-A related question is whether to version from the start — `append_v1` on day
-one — or only when a second generation appears. Versioning from the start is
-uniform but taxes every verb forever to serve the few that ever change.
-
-### 4. What should the gate protect?
-
-Today it protects names and inputs, and ignores outputs. It could protect
-outputs too, at the cost of committing to a format now rather than after the
-Fabric-types work. Or output safety could stay a matter of convention and
-review.
-
-### 5. What does a holder of a piece have to declare about it?
-
-When one pattern stores another — the board holding notes — today it embeds
-the note's whole shape, verbs included, into its own. That is why adding a
-verb to notes is refused as an update to the *board*: the board's shape
-changed, even though the board never calls the new verb.
-
-The alternative is for a holder to declare only what it actually uses: the
-fields it reads or writes, the verbs it calls, and the reference itself.
-Then a provider growing a new verb never touches its holders. Option D below is
-this choice taken deliberately.
-
-## The options
-
-These are coherent packages, not a menu — each settles the dimensions
-together.
-
-### Option A — Verbs are permanent public contracts
-
-Declare every verb as something a piece definitely has. Never remove or
-rename. Version by new name when a contract must change. Accept that adding a
-verb to a stored type requires a redeploy rather than an update.
-
-**Good when** things outside our control call our verbs, and stability matters
-more than iteration speed.
-
-**Costs** the most common evolution step — adding an action — becomes a
-migration event whenever the type is stored elsewhere. Option D removes
-exactly this cost, and composes with A.
-
-### Option B — All verbs optional (considered, and set aside)
-
-Declare every verb as something a piece may have. Adding a verb is then
-always allowed, anywhere, including on types other patterns store. Names
-stay permanent and retirement still goes through `@deprecated`.
-
-This buys the most evolution for the least machinery, and it is set aside
-anyway, for the reason the promise section gives: it moves the maybe into
-every call site, permanently. An interface whose every member is optional is
-not a contract, it is a suggestion — and code consuming a suggestion turns
-defensive. It is convenient for probing callers and for data upgrades, and
-wrong for everything the promise exists to serve. Every system in the longer
-arc bought the same evolution while keeping the promise.
-
-The measurements are recorded because they locate who actually depends on
-verb declarations:
-
-- **8 call sites** in shipped pattern code read a verb off another piece,
-  across four files.
-- **396 call sites across 50 test files** do the same, every one of the form
-  `instance.verb.send(...)` — the documented way to test a pattern.
-
-Making verbs optional turns each of those into a possibly-absent value, and
-the obvious rewrite, `instance.verb?.send(...)`, **does nothing at all when
-the verb is absent** — in a test, a real failure becomes a pass. Whether the
-compiler would even catch a missed rewrite is unestablished: pattern
-`*.test.tsx` files are excluded from `deno task test` in `packages/patterns`
-and run through the `cf` binary instead.
-
-Optional declaration stays legitimate where absence is a real state of the
-piece — a capability present by configuration, not by version. Even then,
-the right shape for it is a separate small contract a caller probes for once
-at binding (Go spells this `if f, ok := w.(http.Flusher)`), not optional
-members scattered through the primary interface. What it must not become is
-an evolution device.
-
-### Option C — Redeploy first
-
-Treat a significant pattern change as a new deployment plus a data migration,
-rather than an in-place update. Do not bend type design around the gate at
-all; let it catch what it catches.
-
-**Good when** we are still learning what these patterns should be, and the
-data we would migrate is ours.
-
-**Costs** it needs migration to be genuinely easy, and it stops being
-available the moment someone outside the team holds a piece we cannot
-redeploy for them.
-
-It also has a hole. A redeploy mints a
-**new piece with a new identity**, and other pieces hold references to the
-old one — boards hold notes, topics hold cross-references. Those stored
-references keep pointing at the old piece; nothing re-points them. In-place
-update exists precisely because identity persists through it. A
-redeploy-first posture is therefore incomplete without a re-pointing or
-forwarding story — a way for an old identity to hand its callers on to its
-successor — and that is a mechanism someone has to design, not a workflow
-note.
-
-### Option D — Holders demand only what they use
-
-Keep every verb a promise, and change what a *holder* writes down. Today a
-board storing notes embeds the note's whole shape in its own; under this
-option it declares only its demand: the fields it reads or writes, the verbs
-it actually calls, and the reference itself. A note is still everything its own
-pattern says it is — this changes the consumer's declaration, not the
-provider's.
-
-The measured refusal disappears at the root: adding `append` to notes never
-changes the board's shape, because the board never demanded `append`. And
-the promise survives, because a holder that *does* call a verb declares it —
-and then holds a guarantee for exactly what it declared.
-
-The principle is old — declare what you need, not what they are. It is how
-Go interfaces work: declared by the consumer, satisfied by shape, and best
-kept tiny ("the bigger the interface, the weaker the abstraction"). Our
-pattern code already lives this way at compile time, because TypeScript
-types structurally; this option extends the same discipline to the stored
-contract. The difference from Go is that a demand here is durable — it is
-written into the holder's shape and proved again at link time, against a
-provider that evolves independently.
-
-Most of the machinery already exists: the runtime already proves that a
-stored link satisfies the shape its holder demands, and shared narrow
-projections (a board-facing view of a topic) are already in use across
-patterns. What is missing is the decision that holder-side types are
-*demands*, written that way on purpose, and the authoring guidance to match.
+The cost is that an author writes two kinds of type: a pattern's own full
+truth, and its demands on others. A demand is a real contract and has to stay
+as small as it claims.
 
 One limit to know about: shape carries no meaning. A demand can say "has a
 verb named `append` taking text"; it cannot say "and `append` means what I
 think it does". Small demands keep that gap harmless, the same way small Go
-interfaces do — and closing it properly is what Option E's names and
-versions are for.
+interfaces do. Closing it properly is what names and versions are for.
 
-**Costs** an author writes two kinds of type — a pattern's own full truth,
-and its demands on others — and a demand is a real contract that must stay
-as small as it claims. It does nothing for the other evolution problems:
-changing an existing verb still means a new name, and outputs are still
-unprotected.
+### Named, versioned interfaces are where this goes
 
-### Option E — Named, versioned interfaces
+An interface gets a name and a version of its own, separate from any one
+pattern: "Notes, version 2" is a first-class thing, patterns declare which
+interfaces they provide, and consumers declare the minimum version they
+accept. Binding checks once; after that the caller holds a guarantee.
 
-Give interfaces names and versions of their own, separate from any one
-pattern: a "Notes, version 2" interface exists as a first-class thing,
-patterns declare which interfaces they provide, and consumers declare the
-minimum version they accept. Binding checks once; after that the caller
-holds a guarantee.
+This is the mechanism that survives contact with **patterns owned by different
+people**, and that is why it is scheduled rather than left in the distance.
+Holder-side demands answer the shape question, and shape carries no meaning; a
+name and a version are what let one author rely on another author's contract
+and know when it has moved. Without it, the honest advice to somebody building
+on a pattern they do not own is to fork it, which forfeits the substrate.
 
-This is the full form of the longer arc's first mechanism, and the only
-option here that still works when pieces and callers are owned by different
-people. It is also the most machinery: an interface needs an identity, a
-registry, a compatibility rule of its own, and a place to live in the shape
-— the planned Fabric-types work is the natural vehicle. A nominal interface
-mechanism was considered once before and deliberately deferred; this option
-is the argument for scheduling that work rather than rediscovering it.
+It is also the most machinery of anything here: an interface needs an
+identity, a registry, a compatibility rule of its own, and a place to live in
+the shape. The planned Fabric-types work is the natural vehicle. This is a
+design stream of its own — see [the longer arc](#the-longer-arc) — and it is
+open, with everything else in this document standing as the interim until it
+lands.
 
-### How they compose
+### A maybe is resolved once, at binding
 
-A is the floor everything else stands on: names permanent, contracts kept.
-D removes the one measured refusal without weakening anyone's promise, and
-can be adopted pattern by pattern. C handles the true breaks D cannot — but
-it is incomplete until redeploy has a re-pointing story. E is the
-destination the longer arc describes, and the only complete answer once
-outside callers exist. B is set aside as a posture; optional declaration
-remains a scalpel for verbs whose absence is a real state.
+A published interface may carry optional members, because a piece deployed
+under an earlier generation genuinely does not have the later generation's
+verbs. Absence there is a fact about the piece, not a hedge — and an interface
+that is handed to consumers has to cover every generation still running,
+including where the pattern's own declaration marks the member required.
 
-Sequencing matters more than the labels: D and the three items under "Worth
-doing under any posture" are compatible with every posture, so they need not
-wait on the larger decision.
+What an optional member does not license is a maybe at every call site. A
+caller resolves it **once, when it takes hold of the piece**, into a real
+fallback or a real failure, and holds a promise from then on:
 
-## The longer arc: versioned interfaces and managed upgrades
+```tsx
+// Shown at module scope.
+declare const activityLog: { logEvent?: Stream<{ text: string }> };
 
-Whichever posture wins now, the pressure behind this document does not go
-away: pieces live a long time, they carry their interface with them, and the
-code around them keeps changing. Other systems have faced exactly this —
-long-lived stateful things, evolving interfaces, no way to update everything
-at once — and they converged on the same small set of mechanisms. None of
-them solved it by making the interface uncertain. They kept the promise,
-versioned it, and built machinery for old and new to live side by side.
+// Resolve once. Every later call site holds a guarantee.
+const logEvent = activityLog.logEvent;
+if (logEvent !== undefined) logEvent.send({ text: "started" });
 
-Four mechanisms recur, and ours will likely need a form of each:
+// Never this. When the verb is absent, nothing happens and nothing says so.
+activityLog.logEvent?.send({ text: "started" });
+```
+
+The second form is the tempting rewrite and the one to refuse. It is not the
+resolution of a maybe, it is the deferral of one, and it fails silently: no
+error, no log, no signal. In a test, a real failure becomes a pass.
+
+And when a caller cannot proceed without the member at all, an optional is the
+wrong tool. The answer is a new interface version, and a caller that declares
+it requires that version. "This needs Notes v2, and the piece provides v1" is
+a failure someone can act on; a skipped `send` is not.
+
+### A verb's output changes by getting a new name
+
+Nothing checks outputs, so the convention has to do the work: **a change to
+what a verb hands back is treated exactly like a rename, and gets a new verb
+name.** Adding to an output is safe; changing or removing anything in one is
+not, and there is no gate to catch it.
+
+This costs nothing to adopt and is the only protection available until outputs
+are recorded in the shape. Recording them is Fabric-types' job, and when it
+lands the convention is replaced by a check rather than supplemented by one.
+
+### A true break is a redeploy
+
+Some changes are genuinely incompatible, and no declaration discipline makes
+them compatible. Those are handled by deploying a new pattern and migrating
+the data, rather than by updating in place.
+
+Migration is a good bet to get cheaper: migrating data from an old shape to a
+new one is work a model can do, and the useful form of that is generated
+migration logic rather than per-piece hand-holding. It is still the exception,
+not the path. The default is to stay compatible, because most patterns are
+updated by models that will cheerfully jump through hoops to avoid a break,
+and because a compatible update keeps the piece's identity.
+
+That last part is the gap to know about. A redeploy mints a **new piece with a
+new identity**, and other pieces hold references to the old one — boards hold
+notes, topics hold cross-references. Those stored references keep pointing at
+the old piece, and nothing re-points them; migrating the data does not move
+the references. Anyone redeploying a pattern whose pieces are referenced
+elsewhere has to re-point those references themselves. There is no general
+forwarding mechanism — no way for an old identity to hand its callers on to
+its successor — and building one has not been scheduled.
+
+## What the tooling does
+
+The rules above are only as good as the number of authors who never have to
+learn them. These are the mechanisms that carry them.
+
+### A pattern exports interfaces, not the type it returns
+
+Exporting the type a pattern declares its own output with is the fast route
+into the incompatibility this document exists to remove: every consumer that
+imports it embeds the provider's whole shape, and every addition to the
+provider becomes a change to each consumer.
+
+A pattern exports **interfaces describing how to use it** instead. Those grow
+by optional member, by version, or by both — an optional member covering the
+deployed generations that lack it, a version for the consumer that requires
+what the new generation added. The pattern's own declaration is free to mark
+the same member required; the two are different artifacts with different jobs.
+
+The transformer is the natural place to enforce this, and it is the highest
+leverage item here, because it is a rule the one-off author never has to know.
+
+Landing it has a known cost: compatibility baselines involving re-exports need
+resetting, because a pattern that today returns `B[]` will afterwards return
+considerably less. That is a deliberate one-time break of the recorded
+baselines, not a regression, and it interacts with the append-only baselines
+gate — so it needs planning rather than a quiet edit.
+
+### A holder declares what it uses
+
+The consumer half of the same rule: a pattern does not import a provider's
+type in order to store or call it. It declares the fields and verbs it
+actually uses, which is usually a title and a single verb.
+
+Importing the provider's type stays right in two cases. One is legitimate: the
+holder genuinely means "that interface, at that version, with those required
+verbs". The other is practical rather than principled — the type is large and
+restating it is redundant — and it is the case worth designing away.
+
+Nothing checks this today. `skills/pattern-critic/SKILL.md` has no rule for it,
+and adding one is the cheapest first step, ahead of anything in the
+transformer.
+
+### Authoring time shows the blast radius
+
+Compatibility is discovered today by having an update refused. The same
+comparison the gate runs can run before anything deploys, over two versions of
+a pattern — and, because holders record what they demand, it can go further
+than pass or fail and report what a change would actually hit:
+
+```
+This update breaks 14 recorded consumer contracts across 6 patterns:
+- 9 are owned by you
+- 3 appear automatically adaptable
+- 2 belong to other authors
+
+Choose: revise the change, generate migrations or adapters, or proceed and
+mark affected consumers incompatible.
+```
+
+This is the shape that lets nobody classify a pattern's permanence up front.
+An author does not declare whether a pattern is a one-off or a long-lived
+contract; its dependencies say so, and the report is where they say it.
+Compatibility stays the default, and an intentional break stays possible with
+its impact and its recourse both visible. Generated migrations and adapters —
+applied eagerly, or lazily when a piece is next touched — are the recourse
+this grows into.
+
+### A break is acknowledged one at a time
+
+The only override today turns the entire gate off at once, which makes
+accepting one deliberate break silence every other protection. A break should
+be acknowledgeable by name — this field, this verb — which is also what
+"proceed and mark affected consumers incompatible" needs underneath it.
+
+### Verb calls are counted
+
+Retirement policy is guesswork without usage data; deprecation windows work in
+other systems because usage is observable. The planned invocation-record work
+is the natural place for this to ride, and the blast-radius report is a good
+deal more useful when it can say which of those contracts is live.
+
+## The longer arc
+
+The pressure behind this document does not go away: pieces live a long time,
+they carry their interface with them, and the code around them keeps changing.
+Other systems have faced exactly this — long-lived stateful things, evolving
+interfaces, no way to update everything at once — and they converged on the
+same small set of mechanisms. None of them solved it by making the interface
+uncertain. They kept the promise, versioned it, and built machinery for old
+and new to live side by side.
+
+This is an open design stream, and four mechanisms recur in it:
 
 **1. Interfaces carry versions, and consumers name the minimum they accept.**
-COM froze every published interface permanently: you never changed `IFoo`,
-you published `IFoo2`, and an object implemented both. A caller asked once —
-"do you support `IFoo2`?" — and held a guaranteed interface from then on.
-OSGi modules import each other at "version 1.2 or newer". Kubernetes serves
-the same API at several versions at the same time. The planned Fabric-types
-shape for verbs is the natural place a declared version would ride.
+COM froze every published interface permanently: you never changed `IFoo`, you
+published `IFoo2`, and an object implemented both. A caller asked once — "do
+you support `IFoo2`?" — and held a guaranteed interface from then on. OSGi
+modules import each other at "version 1.2 or newer". Kubernetes serves the
+same API at several versions at the same time. The planned Fabric-types shape
+for verbs is the natural place a declared version would ride.
 
 **2. Compatibility has declared boundaries, and breaking one is a decision.**
 Semantic versioning is the everyday form: additions are minor, breaks are
@@ -415,60 +433,58 @@ through a hook the author writes. Rails migrations and event-sourcing
 upcasters are the same idea for databases and event logs. Kubernetes converts
 stored objects between API versions through registered conversion code. The
 recurring design fork is eager (upgrade everything now) against lazy (upgrade
-each piece when next touched); systems with many small stateful things
-mostly chose lazy.
+each piece when next touched); systems with many small stateful things mostly
+chose lazy.
 
 Two of the rules recorded above were derived by measurement against our own
-runtime and then turned out to be classical results — which suggests the
-rest of this map is worth reading before we draw more of it ourselves. "A published interface only grows" is COM's frozen
-interfaces and protobuf's permanent field numbers. "A newly required input
-breaks callers" is so well established that proto3 removed the `required`
-keyword from the language entirely.
+runtime and then turned out to be classical results — which suggests the rest
+of this map is worth reading before we draw more of it ourselves. "A published
+interface only grows" is COM's frozen interfaces and protobuf's permanent
+field numbers. "A newly required input breaks callers" is so well established
+that proto3 removed the `required` keyword from the language entirely.
 
-None of this machinery is designed here. It is recorded so the near-term
-choice is made knowing where the road leads, and so the owners can decide
-whether to open it as its own design stream.
+## Considered and set aside
 
-## Worth doing under any posture
+**All verbs optional, as the default.** Declaring every verb as something a
+piece may have buys the most evolution for the least machinery: adding a verb
+is then always allowed, anywhere, including on types other patterns store. It
+is set aside because it moves the maybe into every call site, permanently. An
+interface whose every member is optional is not a contract, it is a
+suggestion, and code consuming a suggestion turns defensive. Every system in
+the longer arc bought the same evolution while keeping the promise.
 
-Three items fall out of this analysis that no option contradicts:
+The measurements are kept because they locate who depends on verb
+declarations:
 
-- **Move compatibility discovery to authoring time.** Today an author learns
-  the rules when an update is refused. The same comparison the gate runs can
-  run as a `cf` command over two versions of a pattern before anything
-  deploys — the difference between a published contract and a wall you find
-  by walking into it.
-- **Make deliberate breaks scoped.** The only override today turns off the
-  entire gate at once. A deliberate break should be acknowledgeable by name
-  — this field, this verb — so accepting one break does not silence every
-  other protection.
-- **Count verb calls.** Retirement policy is guesswork without usage data:
-  deprecation windows work in other systems because usage is observable. The
-  planned invocation-record work is the natural place for this to ride.
+- **8 call sites** in shipped pattern code read a verb off another piece,
+  across four files.
+- **396 call sites across 50 test files** do the same, every one of the form
+  `instance.verb.send(...)` — the documented way to test a pattern.
 
-## What this document asks the owners to decide
+Making verbs optional turns each of those into a possibly-absent value, and
+the obvious rewrite, `instance.verb?.send(...)`, does nothing at all when the
+verb is absent. Whether the compiler would even catch a missed rewrite is
+unestablished: pattern `*.test.tsx` files are excluded from `deno task test`
+in `packages/patterns` and run through the `cf` binary instead. This is the
+measurement behind the call-site rule above.
 
-1. **The posture**: A alone, A+D, or A+D with C for true breaks — and
-   whether to schedule E now or leave it in the longer arc.
-2. **Whether optional verbs remain permitted as a targeted tool** — for
-   absence that is a real state of the piece — now that they are set aside
-   as a default.
-3. **Whether output shape protection waits for Fabric-types** or gets an
-   interim, given that nothing checks outputs at all right now.
-4. **Whether to open the longer arc as its own design stream** — versioned
-   interfaces, declared compatibility boundaries, per-piece upgrade policy
-   and ownership, and upgrades that run code — with today's choice named
-   explicitly as the interim until that stream lands.
+Optional members survive where absence is a real state — a generation that
+lacks a verb, or a capability present by configuration — resolved once at
+binding. What they are not is an evolution device applied across the board.
 
-Two questions are already settled and are recorded here so they do not get
-reopened: verb names are permanent and retirement runs through `@deprecated`;
-and a version suffix is spelled `append_v2`, introduced only when a second
-generation is needed.
+**Versioning every verb from day one.** Spelling the first generation
+`append_v1` is uniform, and it taxes every verb forever to serve the few that
+ever need a second generation. A version suffix appears when the second
+generation does.
 
-## The one thing that is not optional
+## What is not settled here
 
-Whatever posture we take, **a verb's output needs a convention**, because
-nothing enforces one. The cheapest version: treat a change to what a verb
-hands back exactly like a rename, and give it a new verb name. That costs
-nothing to adopt and is the only protection available until outputs are
-recorded in the shape.
+Three implementation calls belong to whoever does the work, not to this
+document:
+
+- Whether the holder-demand rule is a transformer error, a lint, or authoring
+  guidance backed by `pattern-critic` — and in what order those arrive.
+- How wide the re-export baseline reset has to be, and how it is sequenced
+  against the append-only baselines gate.
+- Whether an interim output check is possible before Fabric-types, given that
+  the shape discards verb outputs today.

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -2,11 +2,9 @@
 
 This document records how verbs are designed so that changing them later is
 possible: what a verb promises, what an author may change about one, what a
-holder of a piece has to write down, and what the tooling does about it.
-
-Two audiences share it. Pattern authors need the rules. Everybody else needs
-the argument to be checkable, so it starts from first principles and avoids
-shorthand.
+holder of a piece writes down, and what the tooling does about it. It is
+written for the whole team, not only pattern authors — the argument avoids
+shorthand so a reader outside this part of the system can still check it.
 
 ## The vocabulary, briefly
 
@@ -14,99 +12,36 @@ A **pattern** is a program someone writes. A **piece** is a running copy of
 that pattern that holds real data — a specific notebook, a specific board.
 
 A **verb** is a named action a pattern offers to the outside world: `addItem`,
-`setLabel`, `archive`. Verbs are not the only way in: a caller with write
-permission can also set a piece's fields directly — the UI's editing controls
-do exactly that, and so do `cf piece set` and the filesystem mount. A piece's
-interface is its fields and its verbs together, the same way an object's
-interface is its public fields and its methods.
+`setLabel`, `archive`. Verbs are not the only way in — a caller with write
+permission can also set a piece's fields directly, as the UI's editing
+controls, `cf piece set`, and the filesystem mount all do. A piece's
+interface is its fields and its verbs together, the way an object's interface
+is its public fields and its methods. This document is about the verb half,
+where the design questions are; fields go through the same update gate, and
+the accept-more and provide-more rules below are field rules.
 
-This document is about the verb half, because that is where the design
-questions are. The field half is governed by the same update gate — its
-accept-more/provide-more rules below are field rules — and a writable field is
-the tightest contract of the lot, because it is promised in both directions at
-once: writers rely on what it accepts, readers on what it holds.
+The **shape** of a pattern is the runtime's record of what it accepts, what
+it provides, and which of its fields are verbs. A build step — the
+**transformer** — derives it automatically from the TypeScript types the
+author wrote.
 
-The runtime writes down the **shape** of every pattern automatically, from the
-TypeScript types the author wrote. The shape records what a pattern accepts,
-what it provides, and which of its fields are verbs.
+Patterns are **updated in place**: new code is pushed onto pieces that
+already exist and already hold data, and it has to keep working for
+everything that was already talking to the old code.
 
-Patterns are **updated in place**. You push new code onto pieces that already
-exist and already hold data. That is the whole source of the problem: the new
-code has to keep working for everything that was already talking to the old
-code.
-
-## Two kinds of pattern
-
-Two populations share this runtime, and the rules have to serve both without
-charging both the same price.
-
-Most patterns are **one-offs**. Somebody wanted a thing, worked with a model
-for an afternoon, and now has it. That author will not read a compatibility
-rule, and will not be around to debug a refused update six months later. For
-these, the right rule is the one nobody has to learn — applied by the
-transformer and the authoring tools, so the ordinary way to write a pattern is
-already the compatible way.
-
-Some patterns are **long-lived and shared**: made deliberately, depended on by
-people the author has never met, expected to keep working for years. Their
-authors are motivated to get it right and will spend time on it. For these,
-the right rule is the complete one — named interfaces, declared versions,
-explicit compatibility boundaries — and those tools have to exist even though
-most patterns never reach for them.
-
-The two are served by one substrate, not two systems. The default path is the
-simple one; the deliberate path adds machinery on top of it and never
-contradicts it.
-
-That ordering carries a constraint worth stating plainly: **prefer the simple
-rule to the precise one.** Most of the code around these patterns is written
-by models, including inexpensive ones, and an elaborate rule is one more thing
-to get subtly wrong at a moment when nobody is watching. A rule that is
-slightly less precise and considerably easier to follow is the better rule
-here.
-
-## The problem this answers
+## The problem
 
 When a pattern is updated, the runtime compares the old shape to the new one
 and **refuses the update** if the new shape would break something relying on
-the old one. Two rules drive that comparison, and they run in opposite
-directions:
+the old one. Two rules drive that comparison, in opposite directions:
 
-- For things a pattern **accepts**, it may accept more than before, never
-  less. Accepting less breaks whoever was sending the thing you dropped.
-- For things a pattern **provides**, it may provide more than before, never
-  less. Providing less breaks whoever was reading the thing you dropped.
+- What a pattern **accepts**, it may accept more of, never less. Accepting
+  less breaks whoever was sending the thing you dropped.
+- What a pattern **provides**, it may provide more of, never less. Providing
+  less breaks whoever was reading the thing you dropped.
 
-That is sound in principle. In practice it produces two bad outcomes today,
-pulling in opposite directions.
-
-**Ordinary changes are refused.** Adding a new verb to a type that another
-pattern stores fails the check. If a board keeps a list of notes, and you add
-one new action to notes, updating the board is refused outright:
-
-```
-argument.notes[].append: newly required argument field has no default
-```
-
-Nothing is wrong with that change. It adds an action; it takes nothing away.
-It is refused because of how verbs are declared, not because of what the
-change does.
-
-**And some genuinely breaking changes pass.** Adding a newly required field to
-a verb's input passes the check and then fails every existing caller at the
-moment they call it. The check treats a verb's input as though it were an
-output — the one place the two rules above get applied the wrong way round.
-This one is a straightforward defect, filed with its fix decided
-([#5663](https://github.com/commontoolsinc/labs/issues/5663)); it is listed
-here because it shapes how much the gate can be trusted while it is open.
-
-So the gate refuses changes that are safe, and permits at least one that is
-not. Pattern authors will learn to work around it either way. The design below
-settles what they should be working around.
-
-## What is true today
-
-Measured against the current runtime, not inferred:
+Sound in principle. Measured against the current runtime — not inferred —
+here is what it does to a verb's author:
 
 | Change to a verb | Result |
 | --- | --- |
@@ -120,20 +55,36 @@ Measured against the current runtime, not inferred:
 | Remove or retype a field of a verb's input | refused |
 | Change anything about a verb's **output** | allowed, and nothing checks it |
 
-Two entries deserve emphasis.
+Three rows are bad outcomes, and they pull in different directions.
 
-**A verb's name is permanent.** Removal and renaming are both refused, and
-that is not going to change — it is the one rule genuinely protecting callers.
+**Ordinary changes are refused.** If a board keeps a list of notes and you
+add one new action to notes, updating the board is refused outright:
 
-**A verb's output is completely unprotected.** The shape the runtime writes
-down records a verb's input and discards its output. Renaming a field of what
-a verb hands back passes every check and breaks callers silently. This is a
-deliberate deferral — recording outputs would commit us to a format that the
-planned Fabric-types work is expected to replace — and it means output changes
-are governed by convention alone.
+```
+argument.notes[].append: newly required argument field has no default
+```
 
-The same gate governs what a *holder* may change about what it demands, and
-there the rules are considerably tighter than they look:
+Nothing is wrong with that change — it adds an action and takes nothing
+away. It is refused because of how verbs are declared, not because of what
+the change does.
+
+**Some genuinely breaking changes pass.** Adding a newly required field to a
+verb's input passes the check, then fails every existing caller the moment
+they call. A straightforward defect — the one place the two rules above get
+applied the wrong way round — filed with its fix decided ([#5663]), and
+listed here because it shapes how much the gate can be trusted while open.
+
+**A verb's output is not checked at all.** The shape records a verb's input
+and discards its output, so renaming a field of what a verb hands back
+passes every check and breaks callers silently. This is a deliberate
+deferral: recording outputs now would commit to a format that
+**Fabric-types** — the planned design stream that gives verbs declared,
+checkable result types in the shape — is expected to replace. Until it
+lands, output changes are governed by convention alone.
+
+The same gate also governs the *holder* — what a pattern may change about
+what it demands from the pieces it stores — and there is the fourth bad
+outcome:
 
 | Change a holder makes to its own demand | Result |
 | --- | --- |
@@ -142,106 +93,129 @@ there the rules are considerably tighter than they look:
 | Demand a new **required verb** | **refused** |
 | Stop demanding a field or verb it no longer uses | **refused** |
 
-Both refusals come from `packages/piece/src/schema-compatibility.ts`. Dropping
-a named field is rejected outright as `existing argument field was removed` —
-the gate has no notion of narrowing, so giving up a demand looks exactly like
-breaking one. Raising a demand hits `newly required argument field has no
-default`, and a verb is a stream, which cannot carry a default; that message is
-the very refusal this document opens with, arriving from the other direction.
+Both refusals come from `packages/piece/src/schema-compatibility.ts`.
+Dropping a named field is rejected as `existing argument field was removed`
+— the gate has no notion of narrowing, so giving up a demand looks exactly
+like breaking one. Raising one hits `newly required argument field has no
+default`, and a verb is a stream, which cannot carry a default: the refusal
+above, arriving from the other direction.
 
-The consequence is worth stating plainly, because most of the design rests on
-it: **a deployed holder's required demands are write-once.** They cannot be
-added to and cannot be given up. Only optional demands can evolve at all, and
-only by growing.
+Stated plainly, because much of the design rests on it: **a deployed
+holder's required demands are write-once.** They cannot be added to and
+cannot be given up; only optional demands can evolve, and only by growing.
+(The provider side is looser on purpose: a pattern may add a newly required
+field to its own *result*, because the new code materializes it when it
+runs. A demand has no such escape — the piece it points at already exists.)
 
-Note the asymmetry with the provider side, which is deliberate and correct: a
-pattern may add a newly required field to its own *result*, because the new
-graph materializes it when it runs. Nobody is left holding a gap. A demand has
-no such escape, because the piece it points at already exists.
+Behind all four outcomes is the fact that makes this hard: **pieces
+persist.** Each carries the interface it was created with while the code
+around it moves on. Sooner or later some caller holds a piece older than the
+interface it wants, and no declaration style makes that impossible.
 
-## What a piece promises
-
-In ordinary object-oriented programming, an object promises an interface:
-these fields, these methods. Code that holds the object leans on that promise
-without checking. Take the promise away and every caller turns defensive — if
-this method exists use it, otherwise try that one, otherwise fall back. Agents
-can cope with code like that. People maintaining it are miserable.
-
-The promise is worth keeping. What makes keeping it hard here is that pieces
-are persistent: each one carries the interface it was created with, and keeps
-it while the code around it moves on. Sooner or later some caller holds a
-piece older than the interface it wants, and no declaration style makes that
-impossible.
-
-So the uncertainty cannot be removed — but it can be **placed**. The livable
-designs concentrate it at one moment: when a caller first takes hold of a
-piece, it establishes what it is holding, and relies on a guaranteed interface
-from then on. The miserable designs spread it across every call. That standard
-decides most of what follows.
-
-Who is doing the calling matters too, because the callers are not alike:
+The callers are not alike, and the difference matters throughout:
 
 - **Probing callers** — the CLI, the UI, an agent — ask a piece what it has
-  before acting. They bind late, so a missing verb costs them a listing
-  lookup, not a crash. Flexibility is cheap here.
+  before acting. They bind late; a missing verb costs a listing lookup, not
+  a crash. (True only while listings tell the truth: [#5662], open, has the
+  CLI listing data fields as callable and dropping calls on them silently.)
 - **Compiled callers** — TypeScript in one pattern calling a verb on another
-  piece — bind when the code is written. They are exactly what the interface
-  promise exists for.
+  piece — bind when the code is written. They are what an interface promise
+  exists for.
 - **Stored references** — a board holding a list of notes — are bindings
-  that persist. What a pattern demands of the pieces it stores is written into
-  its own shape and outlives everyone's code. These are the hardest case, and
-  they are where today's refusal comes from.
+  that persist: what a pattern demands of the pieces it stores is written
+  into its own shape and outlives everyone's code. The hardest case, and
+  where the refusal above comes from.
+
+## What a solution must satisfy
+
+Six requirements, each load-bearing in the design that follows.
+
+1. **Serve both populations, without charging both the same price.** Most
+   patterns are one-offs — somebody worked with a model for an afternoon and
+   now has a thing. That author will never read a compatibility rule, so the
+   default rules must be applied by tooling rather than learned. Some
+   patterns are long-lived and shared, depended on by people the author has
+   never met; the complete machinery must exist for them. One substrate
+   serves both: the deliberate path adds to the simple one, never
+   contradicts it.
+
+2. **Prefer the simple rule to the precise one.** Most code around these
+   patterns is written by models, including inexpensive ones, and an
+   elaborate rule is one more thing to get subtly wrong while nobody is
+   watching.
+
+3. **Keep the interface a promise.** Code that holds an object leans on its
+   interface without checking. Take that away and every caller turns
+   defensive — if this method exists use it, otherwise try that one,
+   otherwise fall back. Agents can cope with such code; people maintaining
+   it are miserable.
+
+4. **Put the uncertainty in one place.** Old pieces make uncertainty
+   unavoidable, but it can be placed. The livable designs concentrate it at
+   the moment a caller first takes hold of a piece — establish what it is
+   holding once, rely on a guarantee from then on. The miserable designs
+   spread it across every call site.
+
+5. **Hold across authors.** Patterns by one party will depend on contracts
+   offered by another's, and those contracts must be clear, reliable, and
+   enforceable. If a stranger can break the shape your mechanism depends on,
+   the rational move is to fork — forfeiting exactly the composition the
+   substrate exists for.
+
+6. **Reach what is already deployed.** The pieces and holders that exist
+   today are the ones with real data. A design reachable only by patterns
+   not yet written has to say how the installed base gets there.
 
 ## The design
 
 ### Verbs are promises, and names are permanent
 
 A verb is declared as something a piece definitely has, not something it may
-have. Code that holds a piece and calls a verb holds a guarantee, and does not
-check first.
+have. Code that holds a piece and calls a verb holds a guarantee, and does
+not check first.
 
-Names never change. A verb is never removed and never renamed. Retiring one
-means adding its replacement and marking the old one `@deprecated`, which
-hides it from listings while keeping it callable. A verb whose contract must
-change incompatibly gets a new name, spelled `append_v2`, introduced when the
-second generation actually appears rather than reserved on day one.
+Names never change: a verb is never removed and never renamed. That refusal
+is the one rule in today's gate genuinely protecting callers, and it stays.
+Retiring a verb means adding its replacement and marking the old one
+`@deprecated`, which hides it from listings while keeping it callable. A
+verb whose contract must change incompatibly gets a new name, spelled
+`append_v2`, introduced when the second generation actually appears.
+
+Retirement currently ends there — a deprecated verb stays callable forever,
+implementation and all. Actually removing one is a deliberate break, taken
+when usage data says nobody calls it, and needs the scoped acknowledgment
+and call counting described under tooling. Until both exist, accumulation is
+the price of permanence.
 
 This is the floor. Everything below stands on it.
 
 ### A holder demands only what it uses
 
 When one pattern stores another, it writes down what it *uses*, not what the
-other pattern *is*: the fields it reads or writes, the verbs it calls, and the
-reference itself. A board that keeps notes but never appends to them does not
-mention `append`.
+other pattern *is*: the fields it reads or writes, the verbs it calls, the
+reference itself. A board that keeps notes but never appends to them does
+not mention `append`.
 
 The refusal that motivated this document then disappears at its root. Adding
-`append` to notes no longer changes the board's shape, because the board never
-demanded `append`. Nobody's promise weakens: a holder that *does* call a verb
-declares it, and holds a guarantee for exactly what it declared.
+`append` to notes no longer changes the board's shape, because the board
+never demanded `append`. Nobody's promise weakens: a holder that *does* call
+a verb declares it, and holds a guarantee for exactly what it declared.
 
-The principle is old — declare what you need, not what they are. It is how Go
-interfaces work: declared by the consumer, satisfied by shape, and best kept
-tiny ("the bigger the interface, the weaker the abstraction"). Pattern code
-already lives this way at compile time, because TypeScript types structurally;
-this extends the same discipline to the stored contract. The difference from
-Go is that a demand here is durable — written into the holder's shape and
-proved again at link time, against a provider that evolves independently.
+The principle is old — declare what you need, not what they are — and it is
+how Go interfaces work: declared by the consumer, satisfied by shape, best
+kept tiny. TypeScript already types pattern code structurally at compile
+time; the difference is that a demand is durable, written into the holder's
+shape and proved again at link time against a provider that evolves
+independently. The runtime already proves that a stored link satisfies the
+shape its holder demands. What is new is that holder-side types are
+*demands*, written that way on purpose, and that the tooling says so.
 
-Most of the machinery already exists: the runtime already proves that a stored
-link satisfies the shape its holder demands, and shared narrow projections — a
-board-facing view of a topic — are already in use across patterns. What is new
-is that holder-side types are *demands*, written that way on purpose, and that
-the tooling says so.
-
-The cost is that an author writes two kinds of type: a pattern's own full
-truth, and its demands on others. A demand is a real contract and has to stay
-as small as it claims.
-
-One limit to know about: shape carries no meaning. A demand can say "has a
-verb named `append` taking text"; it cannot say "and `append` means what I
-think it does". Small demands keep that gap harmless, the same way small Go
-interfaces do. Closing it properly is what names and versions are for.
+Two honest costs. An author now writes two kinds of type — a pattern's own
+full truth, and its demands on others — and a demand is a real contract that
+must stay as small as it claims. And shape carries no meaning: a demand can
+say "has a verb named `append` taking text," never "and `append` means what
+I think it does." Small demands keep that gap harmless; closing it properly
+is what names and versions are for.
 
 ### Named, versioned interfaces are where this goes
 
@@ -250,95 +224,93 @@ pattern: "Notes, version 2" is a first-class thing, patterns declare which
 interfaces they provide, and consumers declare the minimum version they
 accept. Binding checks once; after that the caller holds a guarantee.
 
-This is the mechanism that survives contact with **patterns owned by different
-people**, and that is why it is scheduled rather than left in the distance.
-Holder-side demands answer the shape question, and shape carries no meaning; a
-name and a version are what let one author rely on another author's contract
-and know when it has moved. Without it, the honest advice to somebody building
-on a pattern they do not own is to fork it, which forfeits the substrate.
+This is what satisfies the across-authors requirement, and why it is
+scheduled rather than left in the distance: a name and a version are what
+let one author rely on another author's contract and know when it has moved.
+Without them, the honest advice to somebody building on a pattern they do
+not own is to fork it.
 
-It is also the most machinery of anything here: an interface needs an
-identity, a registry, a compatibility rule of its own, and a place to live in
-the shape. The planned Fabric-types work is the natural vehicle. This is a
-design stream of its own — see [the longer arc](#the-longer-arc) — and it is
-open, with everything else in this document standing as the interim until it
-lands.
+It is also the most machinery of anything here — an identity, a registry, a
+compatibility rule of its own, a place in the shape — and Fabric-types is
+the natural vehicle. It is a design stream of its own (see
+[the longer arc](#the-longer-arc)), with everything else in this document
+standing as the interim until it lands.
 
 ### A maybe is resolved once, at binding
 
 A published interface may carry optional members, because a piece deployed
-under an earlier generation genuinely does not have the later generation's
-verbs. Absence there is a fact about the piece, not a hedge — and an interface
-that is handed to consumers has to cover every generation still running,
-including where the pattern's own declaration marks the member required.
+under an earlier generation genuinely lacks the later generation's verbs.
+Absence there is a fact about the piece, not a hedge — an interface handed
+to consumers covers every generation still running, even where the pattern's
+own declaration marks the member required.
 
 What an optional member does not license is a maybe at every call site. A
-caller resolves it **once, when it takes hold of the piece**, into a real
-fallback or a real failure, and holds a promise from then on:
+caller resolves it **once, when it takes hold of the piece** — into a real
+fallback or a real failure — and holds a promise from then on:
 
 ```tsx
 // Shown at module scope.
 declare const activityLog: { logEvent?: Stream<{ text: string }> };
 
-// Resolve once. Every later call site holds a guarantee.
-const logEvent = activityLog.logEvent;
-if (logEvent !== undefined) logEvent.send({ text: "started" });
-
-// Never this. When the verb is absent, nothing happens and nothing says so.
+// Never this: when the verb is absent, nothing happens and nothing says so.
 activityLog.logEvent?.send({ text: "started" });
+
+// Resolve once, into a guarantee or a failure someone can act on.
+const logEvent = activityLog.logEvent;
+if (logEvent === undefined) {
+  throw new Error("activity log predates logEvent; Notes v2 required");
+}
+logEvent.send({ text: "started" });
 ```
 
-The second form is the tempting rewrite and the one to refuse. It is not the
-resolution of a maybe, it is the deferral of one, and it fails silently: no
-error, no log, no signal. In a test, a real failure becomes a pass.
+The first form is the tempting rewrite and the one to refuse: it does not
+resolve the maybe, it defers it to every call site, and it fails silently —
+no error, no log, no signal; in a test, a real failure becomes a pass. The
+second turns absence into something a person can act on. A real fallback —
+another way to get the work done — resolves it just as well; what is not
+acceptable is nothing.
 
-And when a caller cannot proceed without the member at all, an optional is the
-wrong tool. The answer is a new interface version, and a caller that declares
-it requires that version. "This needs Notes v2, and the piece provides v1" is
-a failure someone can act on; a skipped `send` is not.
+And when a caller cannot proceed without the member at all, an optional is
+the wrong tool. The answer is an interface version the caller requires:
+"this needs Notes v2, and the piece provides v1" is a failure someone can
+act on; a skipped `send` is not.
 
 ### A verb's output changes by getting a new name
 
-Nothing checks outputs, so the convention has to do the work: **a change to
+Nothing checks outputs, so a convention has to do the work: **a change to
 what a verb hands back is treated exactly like a rename, and gets a new verb
 name.** Adding to an output is safe; changing or removing anything in one is
-not, and there is no gate to catch it.
-
-This costs nothing to adopt and is the only protection available until outputs
-are recorded in the shape. Recording them is Fabric-types' job, and when it
-lands the convention is replaced by a check rather than supplemented by one.
+not, and no gate catches it. This costs nothing to adopt and is the only
+protection available until Fabric-types records outputs in the shape — at
+which point the convention is replaced by a check.
 
 ### A true break is a redeploy
 
 Some changes are genuinely incompatible, and no declaration discipline makes
 them compatible. Those are handled by deploying a new pattern and migrating
-the data, rather than by updating in place.
-
-Migration is a good bet to get cheaper: migrating data from an old shape to a
-new one is work a model can do, and the useful form of that is generated
-migration logic rather than per-piece hand-holding. It is still the exception,
-not the path. The default is to stay compatible, because most patterns are
+the data, not by updating in place. Migration is a good bet to get cheaper —
+moving data between shapes is work a model can do, and the useful form is
+generated migration logic, not per-piece hand-holding — but it stays the
+exception. The default is to stay compatible, because most patterns are
 updated by models that will cheerfully jump through hoops to avoid a break,
 and because a compatible update keeps the piece's identity.
 
-That last part is the gap to know about. A redeploy mints a **new piece with a
-new identity**, and other pieces hold references to the old one — boards hold
-notes, topics hold cross-references. Those stored references keep pointing at
-the old piece, and nothing re-points them; migrating the data does not move
-the references. Anyone redeploying a pattern whose pieces are referenced
-elsewhere has to re-point those references themselves. There is no general
-forwarding mechanism — no way for an old identity to hand its callers on to
-its successor — and building one has not been scheduled.
+Identity is the gap to know about. A redeploy mints a **new piece with a new
+identity**, and other pieces hold references to the old one — boards hold
+notes, topics hold cross-references. Nothing re-points those references;
+migrating the data does not move them. There is no forwarding mechanism — no
+way for an old identity to hand its callers on to its successor — and
+building one has not been scheduled. Until it exists, whoever redeploys a
+referenced pattern re-points the references themselves.
 
 ## How the design holds up
 
-The way to evaluate any of this is to cross what a provider might do to its
-interface against what a holder wrote down, and read the cells. Five kinds of
-demand are reachable: embedding the provider's whole **Output** type (today's
-default), a narrow demand naming **fields only**, a narrow demand naming a
-**required verb**, one naming an **optional verb**, and a **versioned**
-interface demand. Probing callers are omitted because they bind late and
-survive every row.
+Cross what a provider might do to its interface against what a holder wrote
+down, and read the cells. Five kinds of demand are reachable: embedding the
+provider's whole **Output** type (today's default), a narrow demand naming
+**fields only**, one naming a **required verb**, one naming an **optional
+verb**, and a **versioned** interface demand. Probing callers are omitted —
+they bind late and survive every row.
 
 | Provider evolution | Full Output | Fields only | Req. verb | Opt. verb | Versioned |
 | --- | --- | --- | --- | --- | --- |
@@ -351,43 +323,40 @@ survive every row.
 | Rename or remove a verb | provider refused | provider refused | provider refused | provider refused | provider refused |
 | Retire: add the replacement, deprecate the old | **holder refused** | ok | ok | ok | ok |
 
-"Holder refused" means the gate stops the *holder's* next update, so nothing
-breaks at runtime but the holder is stuck. "Breaks at call" means every gate
-passes and the failure arrives when someone calls the verb.
+"Holder refused" means the gate stops the *holder's* next update: nothing
+breaks at runtime, but the holder is stuck. "Breaks at call" means every
+gate passes and the failure arrives when someone calls the verb.
 
 Four things fall out of it.
 
-**Every refusal lives in one column.** The whole cost of today's default is the
-Full Output column, and both of its refusals are the same event — a provider
-adding an action. That is the argument for holder-side demands in one column,
-and it is why the mechanical check belongs where embedding happens.
+**Every refusal lives in one column.** The whole cost of today's default is
+the Full Output column, and both of its refusals are the same event — a
+provider adding an action. That is the argument for holder-side demands, and
+why the mechanical check belongs where embedding happens.
 
-**Two rows are red everywhere.** Requiring more of a verb's input and changing
-a verb's output break every demand shape equally, because neither is recorded
-where a gate can see it. No declaration discipline helps: the first is a filed
-defect ([#5663](https://github.com/commontoolsinc/labs/issues/5663)) and the
-second is the naming convention above, and until they are closed a holder's
-care buys nothing on those two rows. Versioning does not rescue them either
-until outputs are in the shape and a provider actually bumps.
+**Two rows are red everywhere.** Requiring more of a verb's input and
+changing a verb's output break every demand shape equally, because neither
+is recorded where a gate can see it. The first is the filed defect
+([#5663]), the second the naming convention above; until they close, a
+holder's care buys nothing on those rows, and versioning does not rescue
+them until outputs are in the shape and a provider actually bumps.
 
-**The optional-verb and versioned columns are identical.** Every cell agrees,
-which says the choice between them is not about what can evolve — it is about
-what a reader can tell. `BackwardsCompatibleProfile` in
-`packages/patterns/system/profile-home.tsx` is the exhibit: a `PartialBy` over
-the full Output that records its vintages in a comment ("setBio/addPiece
-2026-06-17, toggleEditing 2026-06-16") because the type cannot say them, and
-carries a hand-maintained instruction to add every future stream to the list.
-The optionality *is* a version boundary with its name erased. Versioning names
-the vintage, and moves the maybe from every seam to bind time.
+**The optional-verb and versioned columns are identical.** So the choice
+between them is not about what can evolve but about what a reader can tell.
+`BackwardsCompatibleProfile` in `packages/patterns/system/profile-home.tsx`
+is the exhibit: a `PartialBy` over the full Output that records its vintages
+in a comment, because the type cannot say them, plus a hand-maintained
+instruction to add every future stream to the list. The optionality *is* a
+version boundary with its name erased; versioning names the vintage, and
+moves the maybe from every seam to bind time.
 
-**The columns are not reachable from one another.** This is the finding that
-changes what happens next. A deployed holder cannot move rightward: it cannot
-add a required verb demand, because that is a newly required field with no
-default, and it cannot drop what it no longer needs, because removal reads as a
-break. Escalating a versioned demand from v1 to v2 hits the identical wall. So
-the design is complete for holders that do not exist yet, and inert for every
-holder already deployed — which puts scoped acknowledgment and migration on
-the critical path for adoption rather than in the nice-to-have pile.
+**The columns are not reachable from one another.** A deployed holder cannot
+move rightward — every such move hits the write-once wall in the holder
+table, and escalating a versioned demand from v1 to v2 is the same event. So
+the design is complete for holders that do not exist yet and inert for every
+holder already deployed: on its own it fails the reach-what-is-deployed
+requirement, which puts scoped acknowledgment and migration on the critical
+path for adoption.
 
 ## What the tooling does
 
@@ -396,59 +365,54 @@ learn them. These are the mechanisms that carry them.
 
 ### The rule is about embedding, not exporting
 
-A pattern's output type has to be **exported**: TypeScript cannot otherwise
+A pattern's output type has to be **exported** — TypeScript cannot otherwise
 name the factory's return type, which
-[composition](../common/patterns/composition.md) requires and most shipped
-patterns do. Export is not the vector either — the refusal reproduces inside a
-single file with no import anywhere in it, when a board stores `NoteOutput[]`
-declared in the same module.
+[composition](../common/patterns/composition.md) requires. Export is not the
+vector anyway: the refusal reproduces in a single file with no imports, when
+a board stores `NoteOutput[]` declared in the same module.
 
-The enforceable joint is **embedding**: a holder does not put another pattern's
-Output type into its own schema. It declares the fields and verbs it uses,
-which is usually a title and a single verb. The transformer already has the
+The enforceable joint is **embedding**: a holder does not put another
+pattern's Output type into its own schema; it declares the fields and verbs
+it uses, usually a title and a single verb. The transformer already has the
 resolved type at every `pattern<I, O>` call, so it can check this where it
-happens — including the aliases that sound narrow and are not, where a name
-like `EventPiece` turns out to be a whole Output.
-
-Embedding the provider's type stays right in one legitimate case: the holder
-genuinely means "that interface, with those required verbs". The other reason
-it happens — the type is large and restating it is redundant — is practical
-rather than principled, and it is the case worth designing away.
+happens — including aliases that sound narrow and are not, where a name like
+`EventPiece` turns out to be a whole Output. Embedding stays right in one
+case: the holder genuinely means "that interface, with those required
+verbs." The other reason it happens — the type is large and restating it is
+redundant — is practical rather than principled, and worth designing away.
 
 `skills/pattern-critic/SKILL.md` already asks for this direction under
 "oversized cross-pattern contracts" (critique-guide category 17): prefer a
 consumer-owned minimal structural type over the full pattern schema and over
-`Pick`/`Omit` coupling. What a critique cannot do is enforce the rule or record
-which demands exist, which is what everything below needs.
+`Pick`/`Omit` coupling. What a critique cannot do is enforce the rule or
+record which demands exist, which is what everything below needs.
 
 ### Demands are recorded as demands
 
-Today a holder's demand is indistinguishable from its own state: the refusal
-path `argument.notes[].append` *is* the demand subtree, unmarked. That single
-gap is why the impact report below cannot count anything, why the gate treats
-giving up a demand as a break rather than the safe narrowing it is, and why a
-deliberate break can only be acknowledged by turning the whole gate off.
+Today a holder's demand is indistinguishable from its own state — the
+refusal path `argument.notes[].append` *is* the demand subtree, unmarked.
+That single gap is why the impact report below cannot count anything, why
+the gate treats giving up a demand as a break rather than the safe narrowing
+it is, and why a deliberate break can only be acknowledged by turning the
+whole gate off. Marking demands is the substrate the rest of the tooling
+stands on.
 
-Marking demands is therefore the substrate the rest of the tooling stands on,
-not a nicety.
-[#5746](https://github.com/commontoolsinc/labs/pull/5746) prototypes both
-halves — a `Demand<T>` marker whose stamp rides the referencing node so a
-shared definition stays neutral and each use site declares its own
-demand-ness, and an advisory warning when a contract embeds a foreign Output
-type, with self-reference still legal and `@sharedContract` opting a genuine
-protocol type out.
+[#5746] prototypes both halves: a `Demand<T>` marker whose stamp rides the
+referencing node — a shared definition stays neutral; each use site declares
+its own demand-ness — and an advisory warning when a contract embeds a
+foreign Output type, with self-reference still legal and `@sharedContract`
+opting a genuine protocol type out.
 
 Adopting narrow demands across already-deployed patterns is itself a break,
-and on both sides: a deployed holder cannot drop the fields it stopped needing
-(see the holder table above), so the migration needs the scoped acknowledgment
+on both sides: a deployed holder cannot drop the fields it stopped needing
+(the holder table above), so the migration needs the scoped acknowledgment
 below rather than a quiet edit.
 
 ### Authoring time shows the blast radius
 
 Compatibility is discovered today by having an update refused. The same
-comparison the gate runs can run before anything deploys, over two versions of
-a pattern — and, because holders record what they demand, it can go further
-than pass or fail and report what a change would actually hit:
+comparison the gate runs can run before anything deploys — and, because
+holders record what they demand, it can report what a change would hit:
 
 ```
 This update breaks 14 recorded consumer contracts across 6 patterns:
@@ -460,98 +424,83 @@ Choose: revise the change, generate migrations or adapters, or proceed and
 mark affected consumers incompatible.
 ```
 
-This is the shape that lets nobody classify a pattern's permanence up front.
-An author does not declare whether a pattern is a one-off or a long-lived
-contract; its dependencies say so, and the report is where they say it.
-Compatibility stays the default, and an intentional break stays possible with
-its impact and its recourse both visible. Generated migrations and adapters —
-applied eagerly, or lazily when a piece is next touched — are the recourse
-this grows into.
+This is what lets nobody classify a pattern's permanence up front: its
+dependencies say whether it is a one-off or a load-bearing contract, and the
+report is where they say it. Compatibility stays the default; an intentional
+break stays possible with impact and recourse visible. Generated migrations
+and adapters — applied eagerly, or lazily when a piece is next touched — are
+the recourse this grows into.
 
 ### A break is acknowledged one at a time
 
-The only override today turns the entire gate off at once, which makes
-accepting one deliberate break silence every other protection. A break should
-be acknowledgeable by name — this field, this verb — which is also what
-"proceed and mark affected consumers incompatible" needs underneath it.
+The only override today turns the entire gate off, so accepting one
+deliberate break silences every other protection. A break should be
+acknowledgeable by name — this field, this verb, this consumer. That
+**scoped acknowledgment** is what "proceed and mark affected consumers
+incompatible" needs underneath it, what the demand migration above rides on,
+and what eventually lets a dead verb be removed rather than hidden.
 
 ### Verb calls are counted
 
-Retirement policy is guesswork without usage data; deprecation windows work in
-other systems because usage is observable. The planned invocation-record work
-is the natural place for this to ride, and the blast-radius report is a good
-deal more useful when it can say which of those contracts is live.
+Retirement policy is guesswork without usage data; deprecation windows work
+in other systems because usage is observable. The planned invocation-record
+work is the natural place for this to ride, and the blast-radius report is
+far more useful when it can say which contracts are live.
 
 ## The longer arc
 
 The pressure behind this document does not go away: pieces live a long time,
-they carry their interface with them, and the code around them keeps changing.
-Other systems have faced exactly this — long-lived stateful things, evolving
-interfaces, no way to update everything at once — and they converged on the
-same small set of mechanisms. None of them solved it by making the interface
-uncertain. They kept the promise, versioned it, and built machinery for old
-and new to live side by side.
+carry their interface with them, and the code around them keeps changing.
+Other systems have faced exactly this and converged on the same small set of
+mechanisms — none of them by making the interface uncertain. They kept the
+promise, versioned it, and built machinery for old and new to live side by
+side. Four mechanisms recur; this is an open design stream.
 
-This is an open design stream, and four mechanisms recur in it:
+**1. Interfaces carry versions, and consumers name the minimum they
+accept.** COM froze every published interface: you never changed `IFoo`, you
+published `IFoo2`, an object implemented both, and a caller asked once. OSGi
+imports at "version 1.2 or newer"; Kubernetes serves several API versions at
+once. Fabric-types is where a declared version would ride here.
 
-**1. Interfaces carry versions, and consumers name the minimum they accept.**
-COM froze every published interface permanently: you never changed `IFoo`, you
-published `IFoo2`, and an object implemented both. A caller asked once — "do
-you support `IFoo2`?" — and held a guaranteed interface from then on. OSGi
-modules import each other at "version 1.2 or newer". Kubernetes serves the
-same API at several versions at the same time. The planned Fabric-types shape
-for verbs is the natural place a declared version would ride.
+**2. Compatibility has declared boundaries, and breaking one is a
+decision.** Semantic versioning is the everyday form — a break is a major
+version, chosen on purpose, never a side effect of an edit. Avro checks
+compatibility pairwise, structurally what our update gate does; the
+difference is that Avro's rules are a published contract authors design
+against, while ours are discovered at refusal time.
 
-**2. Compatibility has declared boundaries, and breaking one is a decision.**
-Semantic versioning is the everyday form: additions are minor, breaks are
-major, and a major is a choice someone makes on purpose, never a side effect
-of an edit. Avro checks compatibility pairwise — the shape data was written
-with against the shape the reader expects — which is structurally what our
-update gate already does. The difference is that Avro's rules are a published
-contract authors design against, while ours are discovered at refusal time.
+**3. Upgrades are per-piece, and every piece has an upgrade policy.** Erlang
+runs at most two versions of a module and migrates each process
+individually; Orleans routes each call to a host compatible with that
+actor's version; upgradeable smart contracts record who may upgrade as
+state. We ran the unmanaged experiment ourselves: a board update left old
+and new pattern versions writing to the same space, and the write storm
+measured 96% of all commits there. Coexistence without management is a
+failure mode we have met, not a hypothesis.
 
-**3. Upgrades are per-piece, and every piece has an upgrade policy.**
-Erlang, the canonical hot-upgrade system, runs at most two versions of a
-module at once and migrates each process individually. Orleans upgrades
-long-lived actors during rolling deployments by routing each call to a host
-compatible with that actor's version. Upgradeable smart contracts make the
-policy explicit: who may upgrade a given contract is itself recorded state.
-We have already run the unmanaged version of this experiment: a prior board
-update left old and new pattern versions writing to the same space, and the
-resulting write storm was measured at 96% of all commits in that space.
-Coexistence without management is a failure mode we have met, not a
-hypothesis.
+**4. Upgrades can run code.** Sooner or later a new shape needs data the old
+shape did not store. Erlang gives every process a state-transform callback;
+Common Lisp's object system migrates each instance lazily, when next
+touched; Rails migrations and event-sourcing upcasters are the same idea for
+databases and logs. The recurring fork is eager against lazy, and systems
+with many small stateful things mostly chose lazy.
 
-**4. Upgrades can run code.**
-Sooner or later a new shape needs data the old shape did not store, and the
-upgrade has to compute it. Erlang gives every process a state-transform
-callback that runs during upgrade. Common Lisp's object system migrates each
-instance lazily — the first time it is touched after its class changes —
-through a hook the author writes. Rails migrations and event-sourcing
-upcasters are the same idea for databases and event logs. Kubernetes converts
-stored objects between API versions through registered conversion code. The
-recurring design fork is eager (upgrade everything now) against lazy (upgrade
-each piece when next touched); systems with many small stateful things mostly
-chose lazy.
-
-Two of the rules recorded above were derived by measurement against our own
-runtime and then turned out to be classical results — which suggests the rest
-of this map is worth reading before we draw more of it ourselves. "A published
-interface only grows" is COM's frozen interfaces and protobuf's permanent
-field numbers. "A newly required input breaks callers" is so well established
-that proto3 removed the `required` keyword from the language entirely.
+Two of the rules above were derived by measurement against our own runtime
+and turned out to be classical results: "a published interface only grows"
+is COM's frozen interfaces and protobuf's permanent field numbers, and "a
+newly required input breaks callers" is so well established that proto3
+removed `required` from the language. The rest of this map is worth reading
+before we draw more of it ourselves.
 
 ## Considered and set aside
 
 **All verbs optional, as the default.** Declaring every verb as something a
-piece may have buys the most evolution for the least machinery: adding a verb
-is then always allowed, anywhere, including on types other patterns store. It
-is set aside because it moves the maybe into every call site, permanently. An
-interface whose every member is optional is not a contract, it is a
-suggestion, and code consuming a suggestion turns defensive. Every system in
-the longer arc bought the same evolution while keeping the promise.
-
-The measurements are kept because they locate who depends on verb
+piece may have buys the most evolution for the least machinery — adding a
+verb is then always allowed, anywhere. It is set aside because it moves the
+maybe into every call site, permanently, failing the promise requirement: an
+interface whose every member is optional is not a contract but a suggestion.
+Every system in the longer arc bought the same evolution while keeping the
+promise. The measurements are kept because they locate who depends on verb
 declarations:
 
 - **8 call sites** in shipped pattern code read a verb off another piece,
@@ -559,39 +508,47 @@ declarations:
 - **396 call sites across 50 test files** do the same, every one of the form
   `instance.verb.send(...)` — the documented way to test a pattern.
 
-Making verbs optional turns each of those into a possibly-absent value, and
-the obvious rewrite, `instance.verb?.send(...)`, does nothing at all when the
+Optional verbs turn each of those into a possibly-absent value, and the
+obvious rewrite, `instance.verb?.send(...)`, does nothing at all when the
 verb is absent. Whether the compiler would even catch a missed rewrite is
 unestablished: pattern `*.test.tsx` files are excluded from `deno task test`
-in `packages/patterns` and run through the `cf` binary instead. This is the
-measurement behind the call-site rule above.
+in `packages/patterns` and run through the `cf` binary instead.
 
 Optional members survive where absence is a real state — a generation that
-lacks a verb, or a capability present by configuration — resolved once at
-binding. What they are not is an evolution device applied across the board.
+lacks a verb, a capability present by configuration — resolved once at
+binding. They are not an evolution device.
 
 **Versioning every verb from day one.** Spelling the first generation
-`append_v1` is uniform, and it taxes every verb forever to serve the few that
-ever need a second generation. A version suffix appears when the second
-generation does.
+`append_v1` taxes every verb forever to serve the few that ever need a
+second generation. The suffix appears when the second generation does.
 
 ## What is not settled here
 
 One question is open by design, and it is the one the cross product exposes:
 **how a deployed holder moves.** Narrow demands, required-verb demands and
-versioned demands are all reachable when a holder is written and none of them
-are reachable afterwards, so every adoption path runs through either a scoped
-acknowledgment or a migration that rewrites holders. Which of those carries it
-— and whether the gate should learn that removal beneath a demand marker is
-narrowing rather than breakage — decides how much of this design applies to
-what is already running.
+versioned demands are all reachable when a holder is written and none of
+them afterwards, so every adoption path runs through a scoped acknowledgment
+or a migration that rewrites holders. Which carries it — and whether the
+gate should learn that removal beneath a demand marker is narrowing rather
+than breakage — decides how much of this design applies to what is already
+running.
+
+One mechanism is missing and unscheduled: **reference forwarding.** A true
+break mints a new piece identity, and nothing re-points stored references to
+the successor; until something does, a redeploy means re-pointing them by
+hand.
 
 Three smaller calls belong to whoever does the work:
 
 - Whether the embedding rule warns, lints, or fails, and in what order those
-  arrive; [#5746](https://github.com/commontoolsinc/labs/pull/5746) starts at
-  advisory on purpose.
-- How wide the baseline reset has to be once narrow demands land, and how it
-  is sequenced against the append-only baselines gate.
-- Whether an interim output check is possible before Fabric-types, given that
-  the shape discards verb outputs today.
+  arrive; [#5746] starts at advisory on purpose.
+- How wide the baseline reset has to be once narrow demands land (the
+  recorded shapes under `packages/patterns/baselines/` that updates are
+  checked against), and how it is sequenced against the append-only
+  baselines gate.
+- Whether an interim output check is possible before Fabric-types, given
+  that the shape discards verb outputs today.
+
+[#5662]: https://github.com/commontoolsinc/labs/issues/5662
+[#5663]: https://github.com/commontoolsinc/labs/issues/5663
+[#5746]: https://github.com/commontoolsinc/labs/pull/5746

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -514,47 +514,26 @@ before we draw more of it ourselves.
 
 ## Considered and set aside
 
-**All verbs optional, as the default.** Declaring every verb as something a
-piece may have buys the most evolution for the least machinery — adding a
-verb is then always allowed, anywhere. It is set aside because it moves the
-maybe into every call site, permanently, failing the promise requirement: an
-interface whose every member is optional is not a contract but a suggestion.
-Every system in the longer arc bought the same evolution while keeping the
-promise. The measurements are kept because they locate who depends on verb
-declarations:
-
-- **8 call sites** in shipped pattern code read a verb off another piece,
-  across four files.
-- **396 call sites across 50 test files** do the same, every one of the form
-  `instance.verb.send(...)` — the documented way to test a pattern.
-
-Optional verbs turn each of those into a possibly-absent value, and the
-obvious rewrite, `instance.verb?.send(...)`, does nothing at all when the
-verb is absent. Whether the compiler would even catch a missed rewrite is
-unestablished: pattern `*.test.tsx` files are excluded from `deno task test`
-in `packages/patterns` and run through the `cf` binary instead.
-
-Optional members survive where absence is a real state — a generation that
-lacks a verb, a capability present by configuration — resolved once at
-binding. They are not an evolution device.
+**All verbs optional, as the default.** The cheapest evolution — adding a
+verb is then always allowed, anywhere — at the cost of a maybe at every
+call site, permanently: an interface whose every member is optional is not
+a contract but a suggestion, which fails the promise requirement. The 8
+cross-piece verb call sites in shipped patterns and the 396 across the
+tests would each become a possibly-absent value whose obvious rewrite,
+`instance.verb?.send(...)`, skips silently. Where absence is a real state,
+the design already admits an optional member, resolved once at binding.
 
 **Versioning every verb from day one.** Spelling the first generation
-`append_v1` taxes every verb forever to serve the few that ever need a
-second generation. The suffix appears when the second generation does.
+`append_v1` taxes every verb forever to serve the few that ever get a
+second. The suffix appears when the second generation does.
 
-**Redeploying a new pattern to escape a true break.** Deploying the
-successor as a new pattern looks like the safe way out of an incompatible
-change: the old piece keeps working, the new one starts clean. It is set
-aside because it forks the piece's identity. Every stored reference — boards
-holding notes, topics holding cross-references — keeps pointing at the old
-piece, and no forwarding mechanism exists or is scheduled; the data forks
-with it, and the two populations coexist unmanaged, which is the measured
-write-storm failure in the longer arc. Everything it seems to offer arrives
-better in place: migration handles the shape, versioned interfaces handle
-the callers, per-piece upgrade policy handles the rollout. What remains
-legitimate is creation — a genuinely new pattern, owing nothing to the old
-one's callers — and a move across spaces, where identity cannot follow.
-Neither is evolution, so neither is governed by this design.
+**Redeploying a new pattern to escape a true break.** It forks the piece's
+identity: every stored reference keeps pointing at the old piece, with no
+forwarding mechanism, and the two populations coexist unmanaged — the
+measured write-storm failure in the longer arc. Everything it offers
+arrives better in place: migration handles the shape, versioned interfaces
+the callers, upgrade policy the rollout. What remains — a genuinely new
+pattern, a move across spaces — is creation, not evolution.
 
 ## What is not settled here
 

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -224,6 +224,14 @@ pattern: "Notes, version 2" is a first-class thing, patterns declare which
 interfaces they provide, and consumers declare the minimum version they
 accept. Binding checks once; after that the caller holds a guarantee.
 
+Interface versions layer over new verb names; they do not replace them. A
+piece's shape is one namespace, so when two generations coexist on one
+piece the incompatible verb still lives under a fresh name — `append`
+beside `append_v2`. The interface version is the name a consumer binds
+against, and it maps to whichever spelling its generation carries: the
+suffix is bookkeeping inside the piece, the version is the contract outside
+it. Consumers reason in versions; pieces store names.
+
 This is what satisfies the across-authors requirement, and why it is
 scheduled rather than left in the distance: a name and a version are what
 let one author rely on another author's contract and know when it has moved.

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -132,6 +132,33 @@ deliberate deferral — recording outputs would commit us to a format that the
 planned Fabric-types work is expected to replace — and it means output changes
 are governed by convention alone.
 
+The same gate governs what a *holder* may change about what it demands, and
+there the rules are considerably tighter than they look:
+
+| Change a holder makes to its own demand | Result |
+| --- | --- |
+| Demand a new optional field or verb | allowed |
+| Demand a new required field that carries a default | allowed |
+| Demand a new **required verb** | **refused** |
+| Stop demanding a field or verb it no longer uses | **refused** |
+
+Both refusals come from `packages/piece/src/schema-compatibility.ts`. Dropping
+a named field is rejected outright as `existing argument field was removed` —
+the gate has no notion of narrowing, so giving up a demand looks exactly like
+breaking one. Raising a demand hits `newly required argument field has no
+default`, and a verb is a stream, which cannot carry a default; that message is
+the very refusal this document opens with, arriving from the other direction.
+
+The consequence is worth stating plainly, because most of the design rests on
+it: **a deployed holder's required demands are write-once.** They cannot be
+added to and cannot be given up. Only optional demands can evolve at all, and
+only by growing.
+
+Note the asymmetry with the provider side, which is deliberate and correct: a
+pattern may add a newly required field to its own *result*, because the new
+graph materializes it when it runs. Nobody is left holding a gap. A demand has
+no such escape, because the piece it points at already exists.
+
 ## What a piece promises
 
 In ordinary object-oriented programming, an object promises an interface:
@@ -303,47 +330,118 @@ elsewhere has to re-point those references themselves. There is no general
 forwarding mechanism — no way for an old identity to hand its callers on to
 its successor — and building one has not been scheduled.
 
+## How the design holds up
+
+The way to evaluate any of this is to cross what a provider might do to its
+interface against what a holder wrote down, and read the cells. Five kinds of
+demand are reachable: embedding the provider's whole **Output** type (today's
+default), a narrow demand naming **fields only**, a narrow demand naming a
+**required verb**, one naming an **optional verb**, and a **versioned**
+interface demand. Probing callers are omitted because they bind late and
+survive every row.
+
+| Provider evolution | Full Output | Fields only | Req. verb | Opt. verb | Versioned |
+| --- | --- | --- | --- | --- | --- |
+| Add a verb | **holder refused** | ok | ok | ok | ok |
+| Add an optional field | ok | ok | ok | ok | ok |
+| Add a required field carrying a default | ok | ok | ok | ok | ok |
+| Widen a verb's input with an optional field | ok | ok | ok | ok | ok |
+| Require more of a verb's input | **breaks at call** | **breaks at call** | **breaks at call** | **breaks at call** | **breaks at call** |
+| Change a verb's output | **breaks at call** | **breaks at call** | **breaks at call** | **breaks at call** | **breaks at call** |
+| Rename or remove a verb | provider refused | provider refused | provider refused | provider refused | provider refused |
+| Retire: add the replacement, deprecate the old | **holder refused** | ok | ok | ok | ok |
+
+"Holder refused" means the gate stops the *holder's* next update, so nothing
+breaks at runtime but the holder is stuck. "Breaks at call" means every gate
+passes and the failure arrives when someone calls the verb.
+
+Four things fall out of it.
+
+**Every refusal lives in one column.** The whole cost of today's default is the
+Full Output column, and both of its refusals are the same event — a provider
+adding an action. That is the argument for holder-side demands in one column,
+and it is why the mechanical check belongs where embedding happens.
+
+**Two rows are red everywhere.** Requiring more of a verb's input and changing
+a verb's output break every demand shape equally, because neither is recorded
+where a gate can see it. No declaration discipline helps: the first is a filed
+defect ([#5663](https://github.com/commontoolsinc/labs/issues/5663)) and the
+second is the naming convention above, and until they are closed a holder's
+care buys nothing on those two rows. Versioning does not rescue them either
+until outputs are in the shape and a provider actually bumps.
+
+**The optional-verb and versioned columns are identical.** Every cell agrees,
+which says the choice between them is not about what can evolve — it is about
+what a reader can tell. `BackwardsCompatibleProfile` in
+`packages/patterns/system/profile-home.tsx` is the exhibit: a `PartialBy` over
+the full Output that records its vintages in a comment ("setBio/addPiece
+2026-06-17, toggleEditing 2026-06-16") because the type cannot say them, and
+carries a hand-maintained instruction to add every future stream to the list.
+The optionality *is* a version boundary with its name erased. Versioning names
+the vintage, and moves the maybe from every seam to bind time.
+
+**The columns are not reachable from one another.** This is the finding that
+changes what happens next. A deployed holder cannot move rightward: it cannot
+add a required verb demand, because that is a newly required field with no
+default, and it cannot drop what it no longer needs, because removal reads as a
+break. Escalating a versioned demand from v1 to v2 hits the identical wall. So
+the design is complete for holders that do not exist yet, and inert for every
+holder already deployed — which puts scoped acknowledgment and migration on
+the critical path for adoption rather than in the nice-to-have pile.
+
 ## What the tooling does
 
 The rules above are only as good as the number of authors who never have to
 learn them. These are the mechanisms that carry them.
 
-### A pattern exports interfaces, not the type it returns
+### The rule is about embedding, not exporting
 
-Exporting the type a pattern declares its own output with is the fast route
-into the incompatibility this document exists to remove: every consumer that
-imports it embeds the provider's whole shape, and every addition to the
-provider becomes a change to each consumer.
+A pattern's output type has to be **exported**: TypeScript cannot otherwise
+name the factory's return type, which
+[composition](../common/patterns/composition.md) requires and most shipped
+patterns do. Export is not the vector either — the refusal reproduces inside a
+single file with no import anywhere in it, when a board stores `NoteOutput[]`
+declared in the same module.
 
-A pattern exports **interfaces describing how to use it** instead. Those grow
-by optional member, by version, or by both — an optional member covering the
-deployed generations that lack it, a version for the consumer that requires
-what the new generation added. The pattern's own declaration is free to mark
-the same member required; the two are different artifacts with different jobs.
+The enforceable joint is **embedding**: a holder does not put another pattern's
+Output type into its own schema. It declares the fields and verbs it uses,
+which is usually a title and a single verb. The transformer already has the
+resolved type at every `pattern<I, O>` call, so it can check this where it
+happens — including the aliases that sound narrow and are not, where a name
+like `EventPiece` turns out to be a whole Output.
 
-The transformer is the natural place to enforce this, and it is the highest
-leverage item here, because it is a rule the one-off author never has to know.
+Embedding the provider's type stays right in one legitimate case: the holder
+genuinely means "that interface, with those required verbs". The other reason
+it happens — the type is large and restating it is redundant — is practical
+rather than principled, and it is the case worth designing away.
 
-Landing it has a known cost: compatibility baselines involving re-exports need
-resetting, because a pattern that today returns `B[]` will afterwards return
-considerably less. That is a deliberate one-time break of the recorded
-baselines, not a regression, and it interacts with the append-only baselines
-gate — so it needs planning rather than a quiet edit.
+`skills/pattern-critic/SKILL.md` already asks for this direction under
+"oversized cross-pattern contracts" (critique-guide category 17): prefer a
+consumer-owned minimal structural type over the full pattern schema and over
+`Pick`/`Omit` coupling. What a critique cannot do is enforce the rule or record
+which demands exist, which is what everything below needs.
 
-### A holder declares what it uses
+### Demands are recorded as demands
 
-The consumer half of the same rule: a pattern does not import a provider's
-type in order to store or call it. It declares the fields and verbs it
-actually uses, which is usually a title and a single verb.
+Today a holder's demand is indistinguishable from its own state: the refusal
+path `argument.notes[].append` *is* the demand subtree, unmarked. That single
+gap is why the impact report below cannot count anything, why the gate treats
+giving up a demand as a break rather than the safe narrowing it is, and why a
+deliberate break can only be acknowledged by turning the whole gate off.
 
-Importing the provider's type stays right in two cases. One is legitimate: the
-holder genuinely means "that interface, at that version, with those required
-verbs". The other is practical rather than principled — the type is large and
-restating it is redundant — and it is the case worth designing away.
+Marking demands is therefore the substrate the rest of the tooling stands on,
+not a nicety.
+[#5746](https://github.com/commontoolsinc/labs/pull/5746) prototypes both
+halves — a `Demand<T>` marker whose stamp rides the referencing node so a
+shared definition stays neutral and each use site declares its own
+demand-ness, and an advisory warning when a contract embeds a foreign Output
+type, with self-reference still legal and `@sharedContract` opting a genuine
+protocol type out.
 
-Nothing checks this today. `skills/pattern-critic/SKILL.md` has no rule for it,
-and adding one is the cheapest first step, ahead of anything in the
-transformer.
+Adopting narrow demands across already-deployed patterns is itself a break,
+and on both sides: a deployed holder cannot drop the fields it stopped needing
+(see the holder table above), so the migration needs the scoped acknowledgment
+below rather than a quiet edit.
 
 ### Authoring time shows the blast radius
 
@@ -479,12 +577,21 @@ generation does.
 
 ## What is not settled here
 
-Three implementation calls belong to whoever does the work, not to this
-document:
+One question is open by design, and it is the one the cross product exposes:
+**how a deployed holder moves.** Narrow demands, required-verb demands and
+versioned demands are all reachable when a holder is written and none of them
+are reachable afterwards, so every adoption path runs through either a scoped
+acknowledgment or a migration that rewrites holders. Which of those carries it
+— and whether the gate should learn that removal beneath a demand marker is
+narrowing rather than breakage — decides how much of this design applies to
+what is already running.
 
-- Whether the holder-demand rule is a transformer error, a lint, or authoring
-  guidance backed by `pattern-critic` — and in what order those arrive.
-- How wide the re-export baseline reset has to be, and how it is sequenced
-  against the append-only baselines gate.
+Three smaller calls belong to whoever does the work:
+
+- Whether the embedding rule warns, lints, or fails, and in what order those
+  arrive; [#5746](https://github.com/commontoolsinc/labs/pull/5746) starts at
+  advisory on purpose.
+- How wide the baseline reset has to be once narrow demands land, and how it
+  is sequenced against the append-only baselines gate.
 - Whether an interim output check is possible before Fabric-types, given that
   the shape discards verb outputs today.

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -69,7 +69,7 @@ change does.
 a verb's input passes the check and then fails every existing caller at the
 moment they call it. The check treats a verb's input as though it were an
 output — the one place the two rules above get applied the wrong way round.
-This one is a straightforward defect and is being fixed
+This one is a straightforward defect, filed with its fix decided
 ([#5663](https://github.com/commontoolsinc/labs/issues/5663)); it is listed
 here because it shapes how much the gate can be trusted while it is open.
 

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -219,10 +219,14 @@ is what names and versions are for.
 
 ### Named, versioned interfaces are where this goes
 
-An interface gets a name and a version of its own, separate from any one
-pattern: "Notes, version 2" is a first-class thing, patterns declare which
-interfaces they provide, and consumers declare the minimum version they
-accept. Binding checks once; after that the caller holds a guarantee.
+An interface here is a named set of field and verb contracts, carrying a
+version, separate from any one pattern: "Notes, version 2" is a
+first-class thing. A pattern declares which interfaces it provides —
+usually several, none of them the whole of its shape — and consumers
+declare the minimum version they accept. Binding checks once; after that
+the caller holds a guarantee. The name is what shape cannot be: a claim
+about meaning. Declaring "Notes v2" says `append` does what Notes means by
+it, which no structural demand can say.
 
 Interface versions layer over new verb names; they do not replace them. A
 piece's shape is one namespace, so when two generations coexist on one
@@ -238,9 +242,11 @@ let one author rely on another author's contract and know when it has moved.
 Without them, the honest advice to somebody building on a pattern they do
 not own is to fork it.
 
-It is also the most machinery of anything here — an identity, a registry, a
-compatibility rule of its own, a place in the shape — and Fabric-types is
-the natural vehicle. It is a design stream of its own (see
+It is also the most machinery of anything here — an identity, a registry,
+a place in the shape, and a compatibility rule of its own: what a version
+bump means, and how a declared minimum resolves against what a piece
+provides, are both still to be designed. Fabric-types is the natural
+vehicle. It is a design stream of its own (see
 [the longer arc](#the-longer-arc)), with everything else in this document
 standing as the interim until it lands.
 

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -212,10 +212,9 @@ shape its holder demands. What is new is that holder-side types are
 
 Two honest costs. An author now writes two kinds of type — a pattern's own
 full truth, and its demands on others — and a demand is a real contract that
-must stay as small as it claims. And shape carries no meaning: a demand can
-say "has a verb named `append` taking text," never "and `append` means what
-I think it does." Small demands keep that gap harmless; closing it properly
-is what names and versions are for.
+must stay as small as it claims. And shape carries no meaning; small demands
+keep that gap harmless, and closing it properly is what names and versions
+are for.
 
 ### Named, versioned interfaces are where this goes
 
@@ -229,9 +228,9 @@ about meaning. Declaring "Notes v2" says `append` does what Notes means by
 it, which no structural demand can say.
 
 Who defines one is worth pinning down, because it is the consumer who
-knows what it needs. A demand stays the consumer's tool — structural,
-anonymous, needing nothing from the provider — and stays the default. A
-named interface is not an enumeration of consumers' subsets; it is a
+knows what it needs — and that knowledge stays where it is: the structural
+demand remains the default. A named interface is not an enumeration of
+consumers' subsets; it is a
 promise the provider opts into: the contract it commits to keeping stable
 and meaningful. The definition itself can come from either side, because
 an interface is separate from any pattern — a consumer, a community, or a
@@ -251,19 +250,15 @@ against, and it maps to whichever spelling its generation carries: the
 suffix is bookkeeping inside the piece, the version is the contract outside
 it. Consumers reason in versions; pieces store names.
 
-This is what satisfies the across-authors requirement, and why it is
-scheduled rather than left in the distance: a name and a version are what
-let one author rely on another author's contract and know when it has moved.
-Without them, the honest advice to somebody building on a pattern they do
-not own is to fork it.
-
-It is also the most machinery of anything here — an identity, a registry,
-a place in the shape, and a compatibility rule of its own: what a version
-bump means, and how a declared minimum resolves against what a piece
-provides, are both still to be designed. Fabric-types is the natural
-vehicle. It is a design stream of its own (see
-[the longer arc](#the-longer-arc)), with everything else in this document
-standing as the interim until it lands.
+This is what satisfies the across-authors requirement: a name and a version
+are what let one author rely on another's contract and know when it has
+moved. It is also the most machinery of anything here — an identity, a
+registry, a place in the shape, and a compatibility rule of its own, where
+what a version bump means and how a declared minimum resolves against what
+a piece provides are both still to be designed. Fabric-types is the natural
+vehicle, the work is a design stream of its own (see
+[the longer arc](#the-longer-arc)), and everything else in this document
+stands as the interim until it lands.
 
 ### A maybe is resolved once, at binding
 
@@ -292,12 +287,10 @@ if (logEvent === undefined) {
 logEvent.send({ text: "started" });
 ```
 
-The first form is the tempting rewrite and the one to refuse: it does not
-resolve the maybe, it defers it to every call site, and it fails silently —
-no error, no log, no signal; in a test, a real failure becomes a pass. The
-second turns absence into something a person can act on. A real fallback —
-another way to get the work done — resolves it just as well; what is not
-acceptable is nothing.
+The first form defers the maybe to every call site and fails silently — in
+a test, a real failure becomes a pass. The second turns absence into
+something a person can act on; a real fallback resolves it just as well.
+What is not acceptable is nothing.
 
 And when a caller cannot proceed without the member at all, an optional is
 the wrong tool. The answer is an interface version the caller requires:
@@ -327,9 +320,8 @@ is our own check, with an all-or-nothing bypass
 the machinery that makes the break safe rather than nuclear: the scoped
 acknowledgment and blast-radius report under tooling, and the upgrade
 mechanisms of [the longer arc](#the-longer-arc). A migration still breaks
-callers whose expectations no longer hold — but because demands are
-recorded, that breakage is enumerable and answerable, migrated or adapted,
-rather than silent.
+callers whose expectations no longer hold; the blast-radius report is what
+makes that breakage enumerable and answerable rather than silent.
 
 The default is still to stay compatible. Most patterns are updated by models
 that will cheerfully jump through hoops to avoid a break, and a compatible
@@ -436,10 +428,9 @@ its own demand-ness — and an advisory warning when a contract embeds a
 foreign Output type, with self-reference still legal and `@sharedContract`
 opting a genuine protocol type out.
 
-Adopting narrow demands across already-deployed patterns is itself a break,
-on both sides: a deployed holder cannot drop the fields it stopped needing
-(the holder table above), so the migration needs the scoped acknowledgment
-below rather than a quiet edit.
+Adopting narrow demands across already-deployed patterns is itself a break
+— a deployed holder cannot drop what it stopped needing — so that migration
+rides the scoped acknowledgment below, not a quiet edit.
 
 ### Authoring time shows the blast radius
 
@@ -506,17 +497,14 @@ promise, versioned it, and built machinery for old and new to live side by
 side. Four mechanisms recur; this is an open design stream.
 
 **1. Interfaces carry versions, and consumers name the minimum they
-accept.** COM froze every published interface: you never changed `IFoo`, you
-published `IFoo2`, an object implemented both, and a caller asked once. OSGi
-imports at "version 1.2 or newer"; Kubernetes serves several API versions at
-once. Fabric-types is where a declared version would ride here.
+accept.** COM froze `IFoo` and published `IFoo2` beside it; OSGi imports at
+"version 1.2 or newer"; Kubernetes serves several API versions at once. The
+named-interfaces section above is this mechanism, scheduled.
 
 **2. Compatibility has declared boundaries, and breaking one is a
-decision.** Semantic versioning is the everyday form — a break is a major
-version, chosen on purpose, never a side effect of an edit. Avro checks
-compatibility pairwise, structurally what our update gate does; the
-difference is that Avro's rules are a published contract authors design
-against, while ours are discovered at refusal time.
+decision.** Semver's major version is a choice, never a side effect of an
+edit; Avro publishes rules authors design against, where ours are
+discovered at refusal time. Scoped acknowledgment is this mechanism's seed.
 
 **3. Upgrades are per-piece, and every piece has an upgrade policy.** Erlang
 runs at most two versions of a module and migrates each process
@@ -527,12 +515,12 @@ and new pattern versions writing to the same space, and the write storm
 measured 96% of all commits there. Coexistence without management is a
 failure mode we have met, not a hypothesis.
 
-**4. Upgrades can run code.** Sooner or later a new shape needs data the old
-shape did not store. Erlang gives every process a state-transform callback;
-Common Lisp's object system migrates each instance lazily, when next
-touched; Rails migrations and event-sourcing upcasters are the same idea for
-databases and logs. The recurring fork is eager against lazy, and systems
-with many small stateful things mostly chose lazy.
+**4. Upgrades can run code.** Sooner or later a new shape needs data the
+old shape did not store. Erlang's state-transform callbacks, Common Lisp's
+instances migrating when next touched, Rails migrations and event-sourcing
+upcasters are all this mechanism; systems with many small stateful things
+mostly chose lazy over eager — the fork the migration-in-place path
+inherits.
 
 Two of the rules above were derived by measurement against our own runtime
 and turned out to be classical results: "a published interface only grows"
@@ -582,11 +570,10 @@ about it, and it can ship that with the new generation — prose for a
 person, a recipe for a tool. Where it lives matters most: askable of the
 piece itself, so an agent watching a holding piece's errors can ask the
 held piece for upgrade instructions and decide whether to apply them. The
-shape already carries deprecation out of JSDoc and into listings; guidance
-addressed to machines is the same channel carrying more. The classical
-anchor is the deprecation that ships its own rewrite — Kotlin's
-`ReplaceWith`, a library's published codemods — applied by tooling the
-consumer chooses to run. Scoped acknowledgment is the natural place to
+channel exists — the shape already lifts deprecation out of JSDoc into
+listings — and the classical anchor is the deprecation that ships its own
+rewrite: Kotlin's `ReplaceWith`, a library's codemods, applied by tooling
+the consumer chooses to run. Scoped acknowledgment is the natural place to
 demand it: a deliberate break proceeds when it says what those it breaks
 should do instead. A break stays a break, but no holder is left out in the
 cold.

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -228,6 +228,21 @@ the caller holds a guarantee. The name is what shape cannot be: a claim
 about meaning. Declaring "Notes v2" says `append` does what Notes means by
 it, which no structural demand can say.
 
+Who defines one is worth pinning down, because it is the consumer who
+knows what it needs. A demand stays the consumer's tool — structural,
+anonymous, needing nothing from the provider — and stays the default. A
+named interface is not an enumeration of consumers' subsets; it is a
+promise the provider opts into: the contract it commits to keeping stable
+and meaningful. The definition itself can come from either side, because
+an interface is separate from any pattern — a consumer, a community, or a
+provider may coin one, and providers adopt it by declaring they provide
+it. Go's `io.Reader` is the exhibit: defined once, owned by neither side,
+satisfied everywhere. Nor is the boundary guesswork here: demands are
+recorded, so a provider factors its interfaces from the clusters consumers
+actually demand. The demands are the evidence, the interface is the
+crystallization, and the registry is what carries it past the visibility
+horizon.
+
 Interface versions layer over new verb names; they do not replace them. A
 piece's shape is one namespace, so when two generations coexist on one
 piece the incompatible verb still lives under a fresh name — `append`

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -1,0 +1,474 @@
+# Designing verbs so they can change
+
+This document exists so the team can make one decision together: **how should
+verbs be designed, so that changing them later is possible?**
+
+The decision belongs to the pattern owners. The argument should be followable
+by anyone on the team, so this starts from first principles and avoids
+shorthand. It frames the problem, names the dimensions the answer has to
+settle, weighs the candidate designs — including one considered and set
+aside — and records the longer arc of versioned interfaces and managed
+upgrades that any near-term choice is an interim for.
+
+## The vocabulary, briefly
+
+A **pattern** is a program someone writes. A **piece** is a running copy of
+that pattern that holds real data — a specific notebook, a specific board.
+
+A **verb** is a named action a pattern offers to the outside world: `addItem`,
+`setLabel`, `archive`. Verbs are not the only way in: a caller with write
+permission can also set a piece's fields directly — the UI's editing controls
+do exactly that, and so do `cf piece set` and the filesystem mount. A piece's
+interface is its fields and its verbs together, the same way an object's
+interface is its public fields and its methods.
+
+This document is about the verb half, because that is where the open design
+questions are. The field half is already governed by the same update gate —
+its accept-more/provide-more rules below are field rules — and a writable
+field is the tightest contract of the lot, because it is promised in both
+directions at once: writers rely on what it accepts, readers on what it
+holds.
+
+The runtime writes down the **shape** of every pattern automatically, from the
+TypeScript types the author wrote. The shape records what a pattern accepts,
+what it provides, and which of its fields are verbs.
+
+Patterns are **updated in place**. You push new code onto pieces that already
+exist and already hold data. That is the whole source of the problem: the new
+code has to keep working for everything that was already talking to the old
+code.
+
+## The problem
+
+When a pattern is updated, the runtime compares the old shape to the new one
+and **refuses the update** if the new shape would break something relying on
+the old one. Two rules drive that comparison, and they run in opposite
+directions:
+
+- For things a pattern **accepts**, it may accept more than before, never
+  less. Accepting less breaks whoever was sending the thing you dropped.
+- For things a pattern **provides**, it may provide more than before, never
+  less. Providing less breaks whoever was reading the thing you dropped.
+
+That is sound in principle. In practice it produces two bad outcomes today,
+pulling in opposite directions.
+
+**Ordinary changes are refused.** Adding a new verb to a type that another
+pattern stores fails the check. If a board keeps a list of notes, and you add
+one new action to notes, updating the board is refused outright:
+
+```
+argument.notes[].append: newly required argument field has no default
+```
+
+Nothing is wrong with that change. It adds an action; it takes nothing away.
+It is refused because of how verbs are declared, not because of what the
+change does.
+
+**And some genuinely breaking changes pass.** Adding a newly required field to
+a verb's input passes the check and then fails every existing caller at the
+moment they call it. The check treats a verb's input as though it were an
+output — the one place the two rules above get applied the wrong way round.
+This one is a straightforward defect and is being fixed
+([#5663](https://github.com/commontoolsinc/labs/issues/5663)); it is listed
+here because it shapes how much the gate can be trusted while it is open.
+
+So the gate refuses changes that are safe, and permits at least one that is
+not. Pattern authors will learn to work around it either way. The question is
+what we want them working around.
+
+## What is true today
+
+Measured against the current runtime, not inferred:
+
+| Change to a verb | Result |
+| --- | --- |
+| Add a verb | allowed |
+| Add a verb to a type another pattern stores | **refused** |
+| Remove or rename a verb | refused |
+| Mark a verb `@deprecated` | allowed, and it disappears from listings |
+| Turn a verb into data, or data into a verb | refused |
+| Add an optional field to a verb's input | allowed |
+| Add a required field to a verb's input | allowed, **and breaks callers** |
+| Remove or retype a field of a verb's input | refused |
+| Change anything about a verb's **output** | allowed, and nothing checks it |
+
+Two entries deserve emphasis.
+
+**A verb's name is permanent.** Removal and renaming are both refused, and
+that is unlikely to change — it is the one rule genuinely protecting callers.
+Retiring a verb therefore means adding its replacement and marking the old one
+`@deprecated`, which hides it from listings while keeping it callable.
+
+**A verb's output is completely unprotected.** The shape the runtime writes
+down records a verb's input and discards its output. Renaming a field of what
+a verb hands back passes every check and breaks callers silently. This is a
+known, deliberate deferral — recording outputs would commit us to a format
+that the planned Fabric-types work is expected to replace — but it means
+output changes are governed by care alone.
+
+## What a piece promises
+
+In ordinary object-oriented programming, an object promises an interface:
+these fields, these methods. Code that holds the object leans on that promise
+without checking. Take the promise away and every caller turns defensive —
+if this method exists use it, otherwise try that one, otherwise fall back.
+Agents can cope with code like that. People maintaining it are miserable.
+
+The promise is worth keeping. What makes keeping it hard here is that pieces
+are persistent: each one carries the interface it was created with, and keeps
+it while the code around it moves on. Sooner or later some caller holds a
+piece older than the interface it wants, and no declaration style makes that
+impossible.
+
+So the uncertainty cannot be removed — but it can be **placed**. The livable
+designs concentrate it at one moment: when a caller first takes hold of a
+piece, it establishes what it is holding, and relies on a guaranteed
+interface from then on. The miserable designs spread it across every call.
+That is the standard to hold each option below against: after the first
+check, does the caller hold a promise or a maybe?
+
+Who is doing the calling matters too, because the callers are not alike:
+
+- **Probing callers** — the CLI, the UI, an agent — ask a piece what it has
+  before acting. They bind late, so a missing verb costs them a listing
+  lookup, not a crash. Flexibility is cheap here.
+- **Compiled callers** — TypeScript in one pattern calling a verb on another
+  piece — bind when the code is written. They are exactly what the interface
+  promise exists for.
+- **Stored references** — a board holding a list of notes — are bindings
+  that persist. What a pattern demands of the pieces it stores is written
+  into its own shape and outlives everyone's code. These are the hardest
+  case, and they are where today's refusal comes from.
+
+## The dimensions
+
+Any answer has to settle five things. They are listed in order of leverage:
+the first one changes how much the others matter.
+
+### 1. How much do we want to depend on updating in place?
+
+This is the real question, and the others are downstream of it.
+
+If updating a running piece is the normal way patterns change, then the shape
+rules are a permanent design constraint and type design has to bend around
+them. If deploying a new pattern and migrating the data is normal, the gate is
+a safety net for small changes and stops driving design at all.
+
+This is a product-stage question more than a technical one. Today nothing
+outside the team holds a piece running our patterns, and migrating data
+between shapes is something we control end to end. That will not always be
+true.
+
+### 2. Should a verb promise that it exists?
+
+A verb can be declared as something a piece definitely has, or as something it
+may have. That single choice decides the refusal above: a verb declared as
+"definitely has" must be present everywhere the type is used, including inside
+patterns that merely store it — which is why adding one is refused. A verb
+declared as "may have" can be added anywhere, at any time.
+
+In the source this is one character. The verb an author writes today:
+
+```tsx
+// Shown as interface or class members.
+/** Append a line to the body. */
+append: Stream<{ text: string }>;
+```
+
+and the same verb declared as "may have":
+
+```tsx
+// Shown as interface or class members.
+/** Append a line to the body. */
+append?: Stream<{ text: string }>;
+```
+
+The cost is what a caller can assume. If verbs may be absent, every piece of
+TypeScript that reads one off another piece has to cope with it not being
+there — and most of that code is our own tests. Option B below carries the
+measurement.
+
+### 3. How does a changed contract get a name?
+
+Since names are permanent, a verb whose contract must change incompatibly
+needs a new name. Two spellings are available: a name that describes the
+difference (`appendFormatted`), or a version suffix (`append_v2`).
+
+A related question is whether to version from the start — `append_v1` on day
+one — or only when a second generation appears. Versioning from the start is
+uniform but taxes every verb forever to serve the few that ever change.
+
+### 4. What should the gate protect?
+
+Today it protects names and inputs, and ignores outputs. It could protect
+outputs too, at the cost of committing to a format now rather than after the
+Fabric-types work. Or output safety could stay a matter of convention and
+review.
+
+### 5. What does a holder of a piece have to declare about it?
+
+When one pattern stores another — the board holding notes — today it embeds
+the note's whole shape, verbs included, into its own. That is why adding a
+verb to notes is refused as an update to the *board*: the board's shape
+changed, even though the board never calls the new verb.
+
+The alternative is for a holder to declare only what it actually uses: the
+fields it reads or writes, the verbs it calls, and the reference itself.
+Then a provider growing a new verb never touches its holders. Option D below is
+this choice taken deliberately.
+
+## The options
+
+These are coherent packages, not a menu — each settles the dimensions
+together.
+
+### Option A — Verbs are permanent public contracts
+
+Declare every verb as something a piece definitely has. Never remove or
+rename. Version by new name when a contract must change. Accept that adding a
+verb to a stored type requires a redeploy rather than an update.
+
+**Good when** things outside our control call our verbs, and stability matters
+more than iteration speed.
+
+**Costs** the most common evolution step — adding an action — becomes a
+migration event whenever the type is stored elsewhere. Option D removes
+exactly this cost, and composes with A.
+
+### Option B — All verbs optional (considered, and set aside)
+
+Declare every verb as something a piece may have. Adding a verb is then
+always allowed, anywhere, including on types other patterns store. Names
+stay permanent and retirement still goes through `@deprecated`.
+
+This buys the most evolution for the least machinery, and it is set aside
+anyway, for the reason the promise section gives: it moves the maybe into
+every call site, permanently. An interface whose every member is optional is
+not a contract, it is a suggestion — and code consuming a suggestion turns
+defensive. It is convenient for probing callers and for data upgrades, and
+wrong for everything the promise exists to serve. Every system in the longer
+arc bought the same evolution while keeping the promise.
+
+The measurements are recorded because they locate who actually depends on
+verb declarations:
+
+- **8 call sites** in shipped pattern code read a verb off another piece,
+  across four files.
+- **396 call sites across 50 test files** do the same, every one of the form
+  `instance.verb.send(...)` — the documented way to test a pattern.
+
+Making verbs optional turns each of those into a possibly-absent value, and
+the obvious rewrite, `instance.verb?.send(...)`, **does nothing at all when
+the verb is absent** — in a test, a real failure becomes a pass. Whether the
+compiler would even catch a missed rewrite is unestablished: pattern
+`*.test.tsx` files are excluded from `deno task test` in `packages/patterns`
+and run through the `cf` binary instead.
+
+Optional declaration stays legitimate where absence is a real state of the
+piece — a capability present by configuration, not by version. Even then,
+the right shape for it is a separate small contract a caller probes for once
+at binding (Go spells this `if f, ok := w.(http.Flusher)`), not optional
+members scattered through the primary interface. What it must not become is
+an evolution device.
+
+### Option C — Redeploy first
+
+Treat a significant pattern change as a new deployment plus a data migration,
+rather than an in-place update. Do not bend type design around the gate at
+all; let it catch what it catches.
+
+**Good when** we are still learning what these patterns should be, and the
+data we would migrate is ours.
+
+**Costs** it needs migration to be genuinely easy, and it stops being
+available the moment someone outside the team holds a piece we cannot
+redeploy for them.
+
+It also has a hole. A redeploy mints a
+**new piece with a new identity**, and other pieces hold references to the
+old one — boards hold notes, topics hold cross-references. Those stored
+references keep pointing at the old piece; nothing re-points them. In-place
+update exists precisely because identity persists through it. A
+redeploy-first posture is therefore incomplete without a re-pointing or
+forwarding story — a way for an old identity to hand its callers on to its
+successor — and that is a mechanism someone has to design, not a workflow
+note.
+
+### Option D — Holders demand only what they use
+
+Keep every verb a promise, and change what a *holder* writes down. Today a
+board storing notes embeds the note's whole shape in its own; under this
+option it declares only its demand: the fields it reads or writes, the verbs
+it actually calls, and the reference itself. A note is still everything its own
+pattern says it is — this changes the consumer's declaration, not the
+provider's.
+
+The measured refusal disappears at the root: adding `append` to notes never
+changes the board's shape, because the board never demanded `append`. And
+the promise survives, because a holder that *does* call a verb declares it —
+and then holds a guarantee for exactly what it declared.
+
+The principle is old — declare what you need, not what they are. It is how
+Go interfaces work: declared by the consumer, satisfied by shape, and best
+kept tiny ("the bigger the interface, the weaker the abstraction"). Our
+pattern code already lives this way at compile time, because TypeScript
+types structurally; this option extends the same discipline to the stored
+contract. The difference from Go is that a demand here is durable — it is
+written into the holder's shape and proved again at link time, against a
+provider that evolves independently.
+
+Most of the machinery already exists: the runtime already proves that a
+stored link satisfies the shape its holder demands, and shared narrow
+projections (a board-facing view of a topic) are already in use across
+patterns. What is missing is the decision that holder-side types are
+*demands*, written that way on purpose, and the authoring guidance to match.
+
+One limit to know about: shape carries no meaning. A demand can say "has a
+verb named `append` taking text"; it cannot say "and `append` means what I
+think it does". Small demands keep that gap harmless, the same way small Go
+interfaces do — and closing it properly is what Option E's names and
+versions are for.
+
+**Costs** an author writes two kinds of type — a pattern's own full truth,
+and its demands on others — and a demand is a real contract that must stay
+as small as it claims. It does nothing for the other evolution problems:
+changing an existing verb still means a new name, and outputs are still
+unprotected.
+
+### Option E — Named, versioned interfaces
+
+Give interfaces names and versions of their own, separate from any one
+pattern: a "Notes, version 2" interface exists as a first-class thing,
+patterns declare which interfaces they provide, and consumers declare the
+minimum version they accept. Binding checks once; after that the caller
+holds a guarantee.
+
+This is the full form of the longer arc's first mechanism, and the only
+option here that still works when pieces and callers are owned by different
+people. It is also the most machinery: an interface needs an identity, a
+registry, a compatibility rule of its own, and a place to live in the shape
+— the planned Fabric-types work is the natural vehicle. A nominal interface
+mechanism was considered once before and deliberately deferred; this option
+is the argument for scheduling that work rather than rediscovering it.
+
+### How they compose
+
+A is the floor everything else stands on: names permanent, contracts kept.
+D removes the one measured refusal without weakening anyone's promise, and
+can be adopted pattern by pattern. C handles the true breaks D cannot — but
+it is incomplete until redeploy has a re-pointing story. E is the
+destination the longer arc describes, and the only complete answer once
+outside callers exist. B is set aside as a posture; optional declaration
+remains a scalpel for verbs whose absence is a real state.
+
+Sequencing matters more than the labels: D and the three items under "Worth
+doing under any posture" are compatible with every posture, so they need not
+wait on the larger decision.
+
+## The longer arc: versioned interfaces and managed upgrades
+
+Whichever posture wins now, the pressure behind this document does not go
+away: pieces live a long time, they carry their interface with them, and the
+code around them keeps changing. Other systems have faced exactly this —
+long-lived stateful things, evolving interfaces, no way to update everything
+at once — and they converged on the same small set of mechanisms. None of
+them solved it by making the interface uncertain. They kept the promise,
+versioned it, and built machinery for old and new to live side by side.
+
+Four mechanisms recur, and ours will likely need a form of each:
+
+**1. Interfaces carry versions, and consumers name the minimum they accept.**
+COM froze every published interface permanently: you never changed `IFoo`,
+you published `IFoo2`, and an object implemented both. A caller asked once —
+"do you support `IFoo2`?" — and held a guaranteed interface from then on.
+OSGi modules import each other at "version 1.2 or newer". Kubernetes serves
+the same API at several versions at the same time. The planned Fabric-types
+shape for verbs is the natural place a declared version would ride.
+
+**2. Compatibility has declared boundaries, and breaking one is a decision.**
+Semantic versioning is the everyday form: additions are minor, breaks are
+major, and a major is a choice someone makes on purpose, never a side effect
+of an edit. Avro checks compatibility pairwise — the shape data was written
+with against the shape the reader expects — which is structurally what our
+update gate already does. The difference is that Avro's rules are a published
+contract authors design against, while ours are discovered at refusal time.
+
+**3. Upgrades are per-piece, and every piece has an upgrade policy.**
+Erlang, the canonical hot-upgrade system, runs at most two versions of a
+module at once and migrates each process individually. Orleans upgrades
+long-lived actors during rolling deployments by routing each call to a host
+compatible with that actor's version. Upgradeable smart contracts make the
+policy explicit: who may upgrade a given contract is itself recorded state.
+We have already run the unmanaged version of this experiment: a prior board
+update left old and new pattern versions writing to the same space, and the
+resulting write storm was measured at 96% of all commits in that space.
+Coexistence without management is a failure mode we have met, not a
+hypothesis.
+
+**4. Upgrades can run code.**
+Sooner or later a new shape needs data the old shape did not store, and the
+upgrade has to compute it. Erlang gives every process a state-transform
+callback that runs during upgrade. Common Lisp's object system migrates each
+instance lazily — the first time it is touched after its class changes —
+through a hook the author writes. Rails migrations and event-sourcing
+upcasters are the same idea for databases and event logs. Kubernetes converts
+stored objects between API versions through registered conversion code. The
+recurring design fork is eager (upgrade everything now) against lazy (upgrade
+each piece when next touched); systems with many small stateful things
+mostly chose lazy.
+
+Two of the rules recorded above were derived by measurement against our own
+runtime and then turned out to be classical results — which suggests the
+rest of this map is worth reading before we draw more of it ourselves. "A published interface only grows" is COM's frozen
+interfaces and protobuf's permanent field numbers. "A newly required input
+breaks callers" is so well established that proto3 removed the `required`
+keyword from the language entirely.
+
+None of this machinery is designed here. It is recorded so the near-term
+choice is made knowing where the road leads, and so the owners can decide
+whether to open it as its own design stream.
+
+## Worth doing under any posture
+
+Three items fall out of this analysis that no option contradicts:
+
+- **Move compatibility discovery to authoring time.** Today an author learns
+  the rules when an update is refused. The same comparison the gate runs can
+  run as a `cf` command over two versions of a pattern before anything
+  deploys — the difference between a published contract and a wall you find
+  by walking into it.
+- **Make deliberate breaks scoped.** The only override today turns off the
+  entire gate at once. A deliberate break should be acknowledgeable by name
+  — this field, this verb — so accepting one break does not silence every
+  other protection.
+- **Count verb calls.** Retirement policy is guesswork without usage data:
+  deprecation windows work in other systems because usage is observable. The
+  planned invocation-record work is the natural place for this to ride.
+
+## What this document asks the owners to decide
+
+1. **The posture**: A alone, A+D, or A+D with C for true breaks — and
+   whether to schedule E now or leave it in the longer arc.
+2. **Whether optional verbs remain permitted as a targeted tool** — for
+   absence that is a real state of the piece — now that they are set aside
+   as a default.
+3. **Whether output shape protection waits for Fabric-types** or gets an
+   interim, given that nothing checks outputs at all right now.
+4. **Whether to open the longer arc as its own design stream** — versioned
+   interfaces, declared compatibility boundaries, per-piece upgrade policy
+   and ownership, and upgrades that run code — with today's choice named
+   explicitly as the interim until that stream lands.
+
+Two questions are already settled and are recorded here so they do not get
+reopened: verb names are permanent and retirement runs through `@deprecated`;
+and a version suffix is spelled `append_v2`, introduced only when a second
+generation is needed.
+
+## The one thing that is not optional
+
+Whatever posture we take, **a verb's output needs a convention**, because
+nothing enforces one. The cheapest version: treat a change to what a verb
+hands back exactly like a rename, and give it a new verb name. That costs
+nothing to adopt and is the only protection available until outputs are
+recorded in the shape.

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -284,24 +284,37 @@ not, and no gate catches it. This costs nothing to adopt and is the only
 protection available until Fabric-types records outputs in the shape — at
 which point the convention is replaced by a check.
 
-### A true break is a redeploy
+### A true break is a migration in place
 
 Some changes are genuinely incompatible, and no declaration discipline makes
-them compatible. Those are handled by deploying a new pattern and migrating
-the data, not by updating in place. Migration is a good bet to get cheaper —
-moving data between shapes is work a model can do, and the useful form is
-generated migration logic, not per-piece hand-holding — but it stays the
-exception. The default is to stay compatible, because most patterns are
-updated by models that will cheerfully jump through hoops to avoid a break,
-and because a compatible update keeps the piece's identity.
+them compatible. What handles them is a **migration**: the same piece,
+updated in place to the new shape, its stored data transformed by migration
+code — work a model can do, and the useful form is generated migration
+logic, not per-piece hand-holding. Nothing structural stands in the way. The
+update path already applies new source to an existing piece while keeping
+its identity and its state, and the gate that refuses an incompatible shape
+is our own check, with an all-or-nothing bypass
+(`dangerouslyAllowIncompatibleSchema`) that exists today. What is missing is
+the machinery that makes the break safe rather than nuclear: the scoped
+acknowledgment and blast-radius report under tooling, and the upgrade
+mechanisms of [the longer arc](#the-longer-arc). A migration still breaks
+callers whose expectations no longer hold — but because demands are
+recorded, that breakage is enumerable and answerable, migrated or adapted,
+rather than silent.
 
-Identity is the gap to know about. A redeploy mints a **new piece with a new
-identity**, and other pieces hold references to the old one — boards hold
-notes, topics hold cross-references. Nothing re-points those references;
-migrating the data does not move them. There is no forwarding mechanism — no
-way for an old identity to hand its callers on to its successor — and
-building one has not been scheduled. Until it exists, whoever redeploys a
-referenced pattern re-points the references themselves.
+The default is still to stay compatible. Most patterns are updated by models
+that will cheerfully jump through hoops to avoid a break, and a compatible
+update needs none of this machinery.
+
+**Redeploying as a new pattern is the special case, not the answer.** A
+redeploy mints a new piece with a new identity. What it buys is coexistence
+— the old piece keeps working for its callers — and unmanaged coexistence is
+the measured failure mode in the longer arc, not a free good. What it costs
+is every stored reference: boards hold notes, topics hold cross-references,
+and nothing re-points them at the successor. There is no forwarding
+mechanism, and building one has not been scheduled. That cost belongs to
+choosing a redeploy — a deliberately new thing, or a move across spaces,
+where identity genuinely cannot follow — not to every incompatible change.
 
 ## How the design holds up
 
@@ -533,10 +546,11 @@ gate should learn that removal beneath a demand marker is narrowing rather
 than breakage — decides how much of this design applies to what is already
 running.
 
-One mechanism is missing and unscheduled: **reference forwarding.** A true
-break mints a new piece identity, and nothing re-points stored references to
-the successor; until something does, a redeploy means re-pointing them by
-hand.
+One mechanism is missing and unscheduled: **reference forwarding.** A
+redeploy mints a new piece identity, and nothing re-points stored references
+to the successor; until something does, a redeploy means re-pointing them by
+hand. The migration-in-place path makes this rarer, not moot: anything that
+is genuinely a new pattern still forks its references.
 
 Three smaller calls belong to whoever does the work:
 

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -567,6 +567,22 @@ gate should learn that removal beneath a demand marker is narrowing rather
 than breakage — decides how much of this design applies to what is already
 running.
 
+One direction belongs in that conversation, recorded as intent rather than
+mechanism: **the provider tells holders how to move.** A pattern that
+breaks its interface knows what changed and what it expects holders to do
+about it, and it can ship that with the new generation — prose for a
+person, a recipe for a tool. Where it lives matters most: askable of the
+piece itself, so an agent watching a holding piece's errors can ask the
+held piece for upgrade instructions and decide whether to apply them. The
+shape already carries deprecation out of JSDoc and into listings; guidance
+addressed to machines is the same channel carrying more. The classical
+anchor is the deprecation that ships its own rewrite — Kotlin's
+`ReplaceWith`, a library's published codemods — applied by tooling the
+consumer chooses to run. Scoped acknowledgment is the natural place to
+demand it: a deliberate break proceeds when it says what those it breaks
+should do instead. A break stays a break, but no holder is left out in the
+cold.
+
 Three smaller calls belong to whoever does the work:
 
 - Whether the embedding rule warns, lints, or fails, and in what order those

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -116,8 +116,7 @@ The callers are not alike, and the difference matters throughout:
 
 - **Probing callers** — the CLI, the UI, an agent — ask a piece what it has
   before acting. They bind late; a missing verb costs a listing lookup, not
-  a crash. (True only while listings tell the truth: [#5662], open, has the
-  CLI listing data fields as callable and dropping calls on them silently.)
+  a crash.
 - **Compiled callers** — TypeScript in one pattern calling a verb on another
   piece — bind when the code is written. They are what an interface promise
   exists for.
@@ -239,8 +238,8 @@ it. Go's `io.Reader` is the exhibit: defined once, owned by neither side,
 satisfied everywhere. Nor is the boundary guesswork here: demands are
 recorded, so a provider factors its interfaces from the clusters consumers
 actually demand. The demands are the evidence, the interface is the
-crystallization, and the registry is what carries it past the visibility
-horizon.
+crystallization — that is the build order, not only a composition — and
+the registry is what carries it past the visibility horizon.
 
 Interface versions layer over new verb names; they do not replace them. A
 piece's shape is one namespace, so when two generations coexist on one
@@ -253,9 +252,10 @@ it. Consumers reason in versions; pieces store names.
 This is what satisfies the across-authors requirement: a name and a version
 are what let one author rely on another's contract and know when it has
 moved. It is also the most machinery of anything here — an identity, a
-registry, a place in the shape, and a compatibility rule of its own, where
-what a version bump means and how a declared minimum resolves against what
-a piece provides are both still to be designed. Fabric-types is the natural
+registry, a place in the shape, the member-to-field mapping the layering
+above implies, and a compatibility rule of its own, where what a version
+bump means and how a declared minimum resolves against what a piece
+provides are both still to be designed. Fabric-types is the natural
 vehicle, the work is a design stream of its own (see
 [the longer arc](#the-longer-arc)), and everything else in this document
 stands as the interim until it lands.
@@ -321,7 +321,11 @@ the machinery that makes the break safe rather than nuclear: the scoped
 acknowledgment and blast-radius report under tooling, and the upgrade
 mechanisms of [the longer arc](#the-longer-arc). A migration still breaks
 callers whose expectations no longer hold; the blast-radius report is what
-makes that breakage enumerable and answerable rather than silent.
+makes that breakage enumerable and answerable rather than silent. The one
+measured failure on this path is the rollout window — an update once left
+old and new versions writing to the same space at 96% of commits — which
+is why [space-clone rehearsal](../development/space-clone-rehearsal.md)
+precedes any update against real data.
 
 The default is still to stay compatible. Most patterns are updated by models
 that will cheerfully jump through hoops to avoid a break, and a compatible
@@ -359,12 +363,13 @@ the Full Output column, and both of its refusals are the same event — a
 provider adding an action. That is the argument for holder-side demands, and
 why the mechanical check belongs where embedding happens.
 
-**Two rows are red everywhere.** Requiring more of a verb's input and
-changing a verb's output break every demand shape equally, because neither
-is recorded where a gate can see it. The first is the filed defect
-([#5663]), the second the naming convention above; until they close, a
-holder's care buys nothing on those rows, and versioning does not rescue
-them until outputs are in the shape and a provider actually bumps.
+**Two rows are red everywhere, for different reasons.** A verb's output is
+not in the shape, so no gate can see an output change until Fabric-types
+records one; only the naming convention above stands in front of it. A
+verb's input *is* in the shape — that row is red only while [#5663] stays
+open, and a version bump would move its failure from call time to bind
+time. The Versioned column is scored as today's behavior throughout: what
+a bump means is still undesigned, so its cells are contingent.
 
 **The optional-verb and versioned columns are identical.** So the choice
 between them is not about what can evolve but about what a reader can tell.
@@ -378,10 +383,17 @@ moves the maybe from every seam to bind time.
 **The columns are not reachable from one another.** A deployed holder cannot
 move rightward — every such move hits the write-once wall in the holder
 table, and escalating a versioned demand from v1 to v2 is the same event. So
-the design is complete for holders that do not exist yet and inert for every
-holder already deployed: on its own it fails the reach-what-is-deployed
-requirement, which puts scoped acknowledgment and migration on the critical
-path for adoption.
+the design is complete for holders that do not exist yet and — until scoped
+acknowledgment and migration exist — inert for every holder already
+deployed: requirement 6 unmet, and both mechanisms on the critical path for
+adoption.
+
+The table scores breakage only. Two requirements it cannot see: simplicity
+(requirement 2) is met the way requirement 1 demands — the machinery here
+belongs to the deliberate path, and the tooling below exists so the default
+author never meets it; across-authors (requirement 5) is carried by the
+blast-radius horizon under tooling, where a registry is what makes a
+foreign author's demands discoverable at all.
 
 ## What the tooling does
 
@@ -546,8 +558,8 @@ second. The suffix appears when the second generation does.
 
 **Redeploying a new pattern to escape a true break.** It forks the piece's
 identity: every stored reference keeps pointing at the old piece, with no
-forwarding mechanism, and the two populations coexist unmanaged — the
-measured write-storm failure in the longer arc. Everything it offers
+forwarding mechanism, and the two populations coexist unmanaged.
+Everything it offers
 arrives better in place: migration handles the shape, versioned interfaces
 the callers, upgrade policy the rollout. What remains — a genuinely new
 pattern, a move across spaces — is creation, not evolution.
@@ -578,7 +590,7 @@ demand it: a deliberate break proceeds when it says what those it breaks
 should do instead. A break stays a break, but no holder is left out in the
 cold.
 
-Three smaller calls belong to whoever does the work:
+Five smaller calls belong to whoever does the work:
 
 - Whether the embedding rule warns, lints, or fails, and in what order those
   arrive; [#5746] starts at advisory on purpose.
@@ -588,7 +600,12 @@ Three smaller calls belong to whoever does the work:
   baselines gate.
 - Whether an interim output check is possible before Fabric-types, given
   that the shape discards verb outputs today.
+- Whether a version bump is author-declared or derived from the shape diff;
+  the Versioned column's red rows depend on the answer.
+- When the `Demand<T>` marker grows interface and version fields: the
+  growth is free — annotation values are never compared across updates —
+  but only until a binding check reads them, at which point the key stops
+  being annotation-neutral. A real design step, not an extension.
 
-[#5662]: https://github.com/commontoolsinc/labs/issues/5662
 [#5663]: https://github.com/commontoolsinc/labs/issues/5663
 [#5746]: https://github.com/commontoolsinc/labs/pull/5746

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -156,10 +156,13 @@ Six requirements, each load-bearing in the design that follows.
    spread it across every call site.
 
 5. **Hold across authors.** Patterns by one party will depend on contracts
-   offered by another's, and those contracts must be clear, reliable, and
-   enforceable. If a stranger can break the shape your mechanism depends on,
-   the rational move is to fork — forfeiting exactly the composition the
-   substrate exists for.
+   offered by another's. Those contracts cannot be made unbreakable — an
+   owner may break their own pattern — so what the substrate owes a consumer
+   is the means to judge instead: contracts stated clearly, breakage made
+   visible, and both attributable to whoever is responsible. If a stranger
+   can break the shape your mechanism depends on *and* you could neither see
+   it coming nor tell whose doing it was, the rational move is to fork —
+   forfeiting exactly the composition the substrate exists for.
 
 6. **Reach what is already deployed.** The pieces and holders that exist
    today are the ones with real data. A design reachable only by patterns
@@ -167,24 +170,35 @@ Six requirements, each load-bearing in the design that follows.
 
 ## The design
 
-### Verbs are promises, and names are permanent
+### Verbs are promises, and names are stable
 
 A verb is declared as something a piece definitely has, not something it may
-have. Code that holds a piece and calls a verb holds a guarantee, and does
-not check first.
+have. Code that holds a piece and calls a verb writes no check: the
+declaration says the verb is there, and the compiler agrees.
 
-Names never change: a verb is never removed and never renamed. That refusal
-is the one rule in today's gate genuinely protecting callers, and it stays.
-Retiring a verb means adding its replacement and marking the old one
-`@deprecated`, which hides it from listings while keeping it callable. A
-verb whose contract must change incompatibly gets a new name, spelled
-`append_v2`, introduced when the second generation actually appears.
+Names are stable by default. The gate refuses a shape that removes or renames
+a verb — the one rule in today's gate genuinely protecting callers, and it
+stays — so a verb does not vanish by accident. The ordinary way to retire one
+is to add its replacement and mark the old one `@deprecated`, which hides it
+from listings while keeping it callable. A verb whose contract must change
+incompatibly gets a new name, spelled `append_v2`, introduced when the second
+generation actually appears.
 
-Retirement currently ends there — a deprecated verb stays callable forever,
-implementation and all. Actually removing one is a deliberate break, taken
-when usage data says nobody calls it, and needs the scoped acknowledgment
-and call counting described under tooling. Until both exist, accumulation is
-the price of permanence.
+What this is not is an invariant. A pattern's owner may deliberately break
+their own pattern — retire a verb for real, change what one means — and the
+design permits it. Requiring permanent compatibility would tax every author
+forever to serve the cases that never arise, and it would not survive contact
+with an author who has good reason to move on. So a break is made deliberate,
+visible, and attributable rather than impossible, which is what the tooling
+below is for. Removing a deprecated verb outright is a break of exactly this
+kind, taken when call counting says nobody calls it — which makes
+accumulation a choice rather than a sentence.
+
+What a caller holds is therefore a commitment rather than a guarantee, and
+its strength is a property of whoever wrote the pattern. Reputation is the
+discipline, as it is for anyone else running a service other people build on,
+and it is why the tooling below aims at making breakage legible rather than
+at preventing it.
 
 This is the floor. Everything below stands on it.
 
@@ -198,7 +212,8 @@ not mention `append`.
 The refusal that motivated this document then disappears at its root. Adding
 `append` to notes no longer changes the board's shape, because the board
 never demanded `append`. Nobody's promise weakens: a holder that *does* call
-a verb declares it, and holds a guarantee for exactly what it declared.
+a verb declares it, and holds a checked contract for exactly what it
+declared.
 
 The principle is old — declare what you need, not what they are — and it is
 how Go interfaces work: declared by the consumer, satisfied by shape, best
@@ -354,7 +369,9 @@ they bind late and survive every row.
 
 "Holder refused" means the gate stops the *holder's* next update: nothing
 breaks at runtime, but the holder is stuck. "Breaks at call" means every
-gate passes and the failure arrives when someone calls the verb.
+gate passes and the failure arrives when someone calls the verb. "Provider
+refused" means the gate stops the provider by default — an owner may
+deliberately override it, forfeiting what the row protects.
 
 Four things fall out of it.
 
@@ -487,6 +504,12 @@ acknowledgeable by name — this field, this verb, this consumer. That
 incompatible" needs underneath it, what the demand migration above rides on,
 and what eventually lets a dead verb be removed rather than hidden.
 
+Because a break is permitted rather than prevented, this is also where one
+becomes a record. The acknowledgment is the moment what broke is known
+precisely, and the only place that information exists before it is lost.
+Whether making that record is obligatory — and what an obligation would mean
+in practice — is for whoever builds it to settle.
+
 ### Verb calls are counted
 
 Retirement policy is guesswork without usage data; deprecation windows work
@@ -534,12 +557,13 @@ upcasters are all this mechanism; systems with many small stateful things
 mostly chose lazy over eager — the fork the migration-in-place path
 inherits.
 
-Two of the rules above were derived by measurement against our own runtime
-and turned out to be classical results: "a published interface only grows"
-is COM's frozen interfaces and protobuf's permanent field numbers, and "a
-newly required input breaks callers" is so well established that proto3
-removed `required` from the language. The rest of this map is worth reading
-before we draw more of it ourselves.
+Two of the rules the gate enforces were derived by measurement against our
+own runtime and turned out to be classical results: "a published interface
+only grows" is COM's frozen interfaces and protobuf's permanent field
+numbers — here it is a default an owner may leave rather than a law, but the
+shape is theirs — and "a newly required input breaks callers" is so well
+established that proto3 removed `required` from the language. The rest of
+this map is worth reading before we draw more of it ourselves.
 
 ## Considered and set aside
 
@@ -583,12 +607,23 @@ person, a recipe for a tool. Where it lives matters most: askable of the
 piece itself, so an agent watching a holding piece's errors can ask the
 held piece for upgrade instructions and decide whether to apply them. The
 channel exists — the shape already lifts deprecation out of JSDoc into
-listings — and the classical anchor is the deprecation that ships its own
-rewrite: Kotlin's `ReplaceWith`, a library's codemods, applied by tooling
-the consumer chooses to run. Scoped acknowledgment is the natural place to
-demand it: a deliberate break proceeds when it says what those it breaks
-should do instead. A break stays a break, but no holder is left out in the
-cold.
+listings. Scoped acknowledgment is the natural place to ask for it: a
+deliberate break proceeds when it says what those it breaks should do
+instead.
+
+The anchors are the systems that permit breakage and manage it rather than
+forbid it. Kubernetes deprecates an API, keeps serving it for a published
+number of releases, then removes it. Chrome measures how much of the web
+uses a feature, announces an intent to remove, publishes the migration path,
+and removes it anyway — usage data and the ecosystem's reaction are the
+check, not a rule against removing. Both leave anyone who ignored the notice
+broken, and both are judged on how well they gave it.
+
+This is a partial answer, and worth saying so. Instructions help a holder
+that is watched, maintained, or agent-tended, and do nothing for one whose
+author has moved on. They are the difference between a break that can be
+recovered from and one that cannot, which is worth a great deal and is not
+the same thing as safety.
 
 Five smaller calls belong to whoever does the work:
 


### PR DESCRIPTION
## Why

The rules for how a verb may change were discovered by collision, not
designed: #5643 hit the storer-refusal, probing the compat checker surfaced
#5662 and #5663, and #5307 parked on a semantics ruling in the same territory.
Each finding was handled locally; nobody had put the whole picture in front of
the pattern owners so the design could be decided once. Every pattern that
ships meanwhile accumulates under rules nobody chose.

This lands that design as a live plan document, written for the whole team
rather than only pattern authors — the argument avoids shorthand so a reader
outside this part of the system can still check it.

## What Changed

**`docs/plans/verb-evolution.md`** (new):

- **The problem**, with the evolution tables as its evidence: what the update
  gate does to a verb's author, and what it does to a *holder*. The holder half
  is measured against `packages/piece/src/schema-compatibility.ts` and yields
  the fact much of the design rests on — a deployed holder's required demands
  are write-once, addable and droppable neither one.
- **What a solution must satisfy** — six requirements, including serving
  one-off and long-lived patterns without charging both the same price,
  preferring the simple rule to the precise one, and reaching what is already
  deployed.
- **The design.** Verbs are promises and names are stable by default, but not
  an invariant: an owner may deliberately break their own pattern, and the
  substrate's job is to make that break visible and attributable rather than
  impossible. A holder declares only what it uses. Named, versioned interfaces
  are scheduled, defined, and separated from verb-name suffixes — consumers
  reason in versions, pieces store names. An optional member's maybe resolves
  once at binding. An output change gets a new verb name. A true break is a
  migration in place.
- **How the design holds up** — provider evolutions crossed against the five
  reachable demand kinds. It produces the finding that sets the adoption path:
  the demand columns are not reachable from one another, so the design is
  complete for holders not yet written and, until scoped acknowledgment and
  migration exist, inert for those already deployed.
- **What the tooling does** — the rule is about embedding, not exporting;
  demands recorded as demands (#5746); a blast-radius report that enumerates in
  rings, because links are one-directional and cross spaces; breaks
  acknowledged one at a time; verb calls counted, which reaches past the
  enumeration horizon.
- **The longer arc** — versioned interfaces, declared compatibility boundaries,
  per-piece upgrade policy, upgrades that run code, each anchored to the systems
  that proved it.
- **Considered and set aside** — all-verbs-optional as a default, with the
  measurements that rule it out; versioning every verb from day one; and
  redeploying a new pattern to escape a break.
- **What is not settled** — how a deployed holder moves, the provider telling
  holders how to move, and five implementation calls.

**`docs/common/concepts/self-reference.md`**: the Key Rule from #5643 gains a
pointer to the document.

**`docs/plans/README.md`**: index entry.

## Test plan

- `deno task check-docs plans` — passes; the document's TSX block is one of the
  two blocks that directory checks.
- `deno task check-skill-facts`, `check-conflict-markers`,
  `docs-links --orphan` — green; the document is indexed, not orphaned.
- `deno fmt --check` — clean across 4378 files.
- All added prose lines wrap at 80 columns.
- Load-bearing claims were verified against source rather than inferred:
  the two holder-side refusals and the provider/result asymmetry against
  `packages/piece/src/schema-compatibility.ts`; the bypass against
  `packages/cli/commands/piece.ts`; `NormalizedFullLink` carrying its target's
  space against `packages/runner/src/link-types.ts`; the export requirement
  against `docs/common/patterns/composition.md`; the write-storm exhibit
  against `docs/history/plans/pattern-verb-contract-implementation.md`.

Thread review from @Hixie, @seefeldb, @bfollington and @mathpirate is folded in.
Related: #5746 prototypes the demand marking and embedding check this document
says the tooling needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
