### PR TITLE
fix(cli): the verb listing classifies on stored signals, not a cast

### DIFF
--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1438,17 +1438,19 @@ async function tryResolvePieceCallableAt(
   };
 }
 
-/** The forced-stream probe: cast `name` on `cell` to a stream and ask the
- * runtime whether it answers as a handler. This is the third resolution path
- * of `cf piece call` (tryResolvePieceHandler) — a handler whose stored schema
- * lost the stream marker still answers this cast — shared with the listing's
- * fallback probe and the read-path guard so all three classify identically.
- * Only meaningful at the piece cell, where every attribute is a
- * schema-carrying link or a genuine handler: for inline values and
- * schema-less links the cast schema itself survives resolution and
- * `Cell.isStream`'s schema branch answers "stream" from it, so probing
- * arbitrary cells would report plain data as handlers. Returns the proven
- * stream cell, or null. */
+/** The forced-stream cast: assert `name` on `cell` is a stream, then ask the
+ * runtime whether it answers as one. The third and last resolution path of
+ * `cf piece call` (tryResolvePieceHandler), where a handler whose stored
+ * schema lost the stream marker still answers.
+ *
+ * It proves nothing, and belongs ONLY here. The cast's stream schema survives
+ * link resolution for an inline value, so `Cell.isStream`'s schema branch
+ * answers from the assertion the caller just made and every name passes.
+ * That is acceptable as a dispatcher's last resort — the caller named this
+ * verb, and a wrong cast fails harmlessly against a value with no handler
+ * behind it. It is not acceptable anywhere that describes what a piece has:
+ * the listing and the read-path guard both classify on definite stored
+ * signals instead. Returns the cast cell, or null. */
 function probeForcedStreamCell(cell: any, name: string): any | null {
   if (
     typeof cell !== "object" || cell === null ||
@@ -1843,24 +1845,43 @@ export async function listPieceCallables(
     }
   }
 
-  // Third resolution path, mirrored from resolvePieceCallable: a handler whose
-  // schema lost the stream marker still dispatches via the forced stream cast
-  // (tryResolvePieceHandler). Probe every rejected name the same way so a
-  // callable-by-name verb can never be absent from the listing.
+  // Third resolution path, mirrored from resolvePieceCallable: a name the
+  // ordinary walk rejected can still be dispatched by name, so it is
+  // considered here too.
+  //
+  // It is classified on the two DEFINITE stored signals the read-path guard
+  // uses — a link-derived schema that answers as a stream, or the stored
+  // `{$stream: true}` sentinel — and never on the dispatcher's forced-stream
+  // cast. That cast asserts what it then asks: its stream schema survives link
+  // resolution for an inline value, so `Cell.isStream` answers from the
+  // caller's own assertion and EVERY name passes. Harmless in the dispatcher,
+  // where a wrong cast fails harmlessly on a call the caller asked for; false
+  // in a listing, which is a statement about what exists. A listing that names
+  // every data field costs more than one that misses a marker-less handler,
+  // because it makes the whole surface untrustworthy — and such a handler
+  // stays dispatchable regardless.
   const pieceCell = typeof piece.getCell === "function"
     ? piece.getCell()
     : undefined;
-  if (pieceCell && typeof pieceCell.asSchema === "function") {
+  if (pieceCell) {
     const pieceValue = pieceCell.get?.();
     if (isRecord(pieceValue)) {
       for (const name of Object.keys(pieceValue)) {
         if (!listings.has(name)) rejected.add(name);
       }
     }
+    const resultRootValue = resultRoot?.get?.();
     for (const name of rejected) {
       if (listings.has(name)) continue;
-      if (!probeForcedStreamCell(pieceCell, name)) continue;
       const callableCell = resultRoot.key(name).asSchemaFromLinks();
+      // `rejected` collects names from the result/input walk AND from the
+      // piece root's own value, so the sentinel is looked for on both — one
+      // cell in a live piece, two objects wherever they are supplied apart.
+      const storedValue = getCallableValue(resultRootValue, name) ??
+        getCallableValue(pieceValue, name);
+      if (!isStreamValue(storedValue) && !isHandlerCell(callableCell)) {
+        continue;
+      }
       const spec = callableCommandSpec(callableCell, "handler");
       const outputSchema = declaredResults.get(name);
       listings.set(name, {

--- a/packages/cli/test/piece-verbs-live.test.ts
+++ b/packages/cli/test/piece-verbs-live.test.ts
@@ -1,0 +1,108 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { listPieceCallables } from "../lib/piece.ts";
+
+/**
+ * One pattern with one verb and three data fields of different shapes — a
+ * scalar with a default, a computed number, and an array.
+ *
+ * The listing's classification is exercised against CELLS THE RUNTIME BUILT,
+ * because the defect this pins cannot be reproduced against a double: the
+ * forced-stream cast asked a cell "are you a stream?" after casting it to one,
+ * and a hand-written double answers from whatever the test decided instead of
+ * from the cast. Every data field below was reported as a callable handler,
+ * with the field's own schema offered as its input schema.
+ */
+const PROGRAM = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      'import { action, cell, computed, pattern, Stream } from "commonfabric";',
+      "",
+      "interface AddEvent { title: string; }",
+      "",
+      "interface Out {",
+      "  label: string;",
+      "  count: number;",
+      "  items: string[];",
+      "  add: Stream<AddEvent>;",
+      "}",
+      "",
+      "export default pattern<Record<string, never>, Out>(() => {",
+      "  const items = cell<string[]>([]);",
+      "  const label = cell('untitled');",
+      "  const add = action((event: AddEvent) => { items.push(event.title); });",
+      "  return {",
+      "    label,",
+      "    count: computed(() => items.get().length),",
+      "    items,",
+      "    add,",
+      "  };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+describe("listPieceCallables against a live piece", () => {
+  it("lists the verb and none of the data fields", async () => {
+    const signer = await Identity.fromPassphrase("piece-verbs-live");
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+    });
+    const space = signer.did();
+
+    try {
+      const compiled = await runtime.patternManager.compilePattern(
+        PROGRAM as never,
+        { space },
+      );
+      const tx = runtime.edit();
+      const rootCell = runtime.getCell(space, "listing-live", undefined, tx);
+      const root = runtime.run(tx, compiled, {}, rootCell);
+      runtime.prepareTxForCommit(tx);
+      expect((await tx.commit()).error).toBeUndefined();
+      await root.pull();
+
+      // The piece surface `listPieceCallables` walks: a result cell, an empty
+      // input cell, and the piece root it sweeps for names the walk rejected.
+      const emptyInput = runtime.getCell(space, "listing-live-input");
+      const piece = {
+        result: { getCell: () => Promise.resolve(root) },
+        input: { getCell: () => Promise.resolve(emptyInput) },
+        getCell: () => root,
+      };
+
+      const listing = await listPieceCallables(
+        {
+          apiUrl: "http://localhost:8000",
+          identity: "/tmp/test-identity.pem",
+          piece: "fid1:live",
+          space,
+        },
+        {
+          loadPieces: () => Promise.resolve({ getSpace: () => space } as never),
+          loadPiece: () => Promise.resolve(piece as never),
+        },
+      );
+
+      // The pattern declares exactly one verb. Every other name is data, and
+      // data is not callable — calling one is accepted and then dropped by the
+      // scheduler, which the caller never sees.
+      expect(listing.verbs.map((verb) => verb.name)).toEqual(["add"]);
+      expect(listing.verbs[0].kind).toBe("handler");
+      // The verb's input schema is the event's, not the property's own.
+      expect(listing.verbs[0].inputSchema).toMatchObject({
+        properties: { title: { type: "string" } },
+      });
+    } finally {
+      await runtime.dispose?.();
+      await storageManager.close?.();
+    }
+  });
+});

--- a/packages/cli/test/piece-verbs.test.ts
+++ b/packages/cli/test/piece-verbs.test.ts
@@ -135,11 +135,16 @@ describe("listPieceCallables", () => {
       },
     );
 
-    // "hiddenPing" defeats ordinary detection (plain object value/schema) but
-    // succeeds through the forced stream cast — resolvePieceCallable's third
-    // path — so the listing must include it. "\u00e9dit" pins byte ordering:
-    // utf8Compare puts it AFTER "setup"/"search" (0xC3 > s), where locale
-    // collation would interleave it linguistically.
+    // "hiddenPing" carries no stream signal at all — a plain object value and
+    // a plain object schema — so it is data as far as anything stored can tell,
+    // and the listing must NOT include it. The forced-stream cast used to find
+    // it, by asserting a stream schema and then asking whether the schema said
+    // stream. `asSchema` below is kept for exactly that reason: the double
+    // still answers "stream" to any cast, so its presence proves the listing no
+    // longer asks. "\u00e9dit" does carry the `{$stream: true}` sentinel, which
+    // is a definite stored signal, so it stays listed — and it pins byte
+    // ordering: utf8Compare puts it AFTER "setup"/"search" (0xC3 > s), where
+    // locale collation would interleave it linguistically.
     const pieceRootValue = { hiddenPing: {}, "\u00e9dit": { $stream: true } };
     const piece = {
       result: { getCell: () => Promise.resolve(resultRoot) },
@@ -174,18 +179,20 @@ describe("listPieceCallables", () => {
     const verbs = listing.verbs;
     expect(verbs.map((v) => v.name)).toEqual([
       "addTopic",
-      "hiddenPing",
       "search",
       "setup",
       "\u00e9dit",
     ]);
+    // Named explicitly, because the whole defect was a name like this being
+    // offered to a caller as callable when calling it is a silent no-op.
+    expect(verbs.some((v) => v.name === "hiddenPing")).toBe(false);
 
-    const [addTopic, hiddenPing, search, setup, accented] = verbs;
-    // Fallback-resolved handlers are listed as handlers on the result cell,
-    // exactly as tryResolvePieceHandler dispatches them.
-    expect(hiddenPing.kind).toBe("handler");
-    expect(hiddenPing.on).toBe("result");
+    const [addTopic, search, setup, accented] = verbs;
+    // A sentinel-bearing name found only on the piece root is listed as a
+    // handler on the result cell, exactly as tryResolvePieceHandler dispatches
+    // it.
     expect(accented.kind).toBe("handler");
+    expect(accented.on).toBe("result");
     expect(addTopic).toEqual({
       name: "addTopic",
       kind: "handler",


### PR DESCRIPTION
## Why

`cf piece verbs` reported **every result field as a callable handler**, and gave each one a plausible input schema — the data field's own. On the walkthrough fixture, five of the eight listed names were data.

Following that advice was not refused. It was *accepted*:

```
$ cf piece call --piece <piece> --invocation s1 label '"hello"'
invocation: s1
[WARN][scheduler] Event dropped: no handler registered for ... path: ["label"]
```

A silent no-op the caller believes succeeded — the failure class this whole surface exists to remove, aimed at exactly the agents it was built for. Fixes #5662; #5576 is the same defect reported earlier.

## The cause

The listing's third resolution path cast a name to a stream and then asked the runtime whether it was one:

```js
const streamRoot = cell.asSchema({ properties: { [name]: { asCell: ["stream"] } }, required: [name] });
return isHandlerCell(streamRoot.key(name)) ? streamCell : null;
```

For an inline value the cast's schema survives link resolution, so `Cell.isStream` answers from the assertion just made. **The probe manufactures the condition it tests**, so every name passes. #5232 named this cost as "an extra row"; measured, it is every data field.

## What Changed

The listing classifies on the two **definite stored signals** the read-path guard already uses — a link-derived schema that answers as a stream, or the stored `{$stream: true}` sentinel — and never on the cast. Both are properties of what is stored, not of what the caller just asserted.

The cast stays in `tryResolvePieceHandler`, where it originated and where it is sound: the caller has named the verb, and a wrong cast fails harmlessly against a value with no handler behind it. Its doc comment claimed all three callers "classify identically"; it now records why only the dispatcher may use it.

**The trade, stated plainly:** a handler whose stored schema lost its marker is no longer listed. That is worth it — a listing naming every data field makes the whole surface untrustworthy, and such a handler stays dispatchable by name.

## Measured, not assumed

Against cells the runtime built, for a pattern with one verb and three data fields:

```
add     detect=handler  cast=true   definite=true    ← the only verb
count   detect=null     cast=true   definite=false
items   detect=null     cast=true   definite=false
label   detect=null     cast=true   definite=false
```

`detectCallableKind` was already exactly right. The cast contributed nothing but false positives, and the definite signals reproduce the correct answer.

## Test plan

- **New `test/piece-verbs-live.test.ts`** drives `listPieceCallables` against a compiled, run pattern — real cells, no double. Verified red without the fix, reporting exactly the three phantom fields.
- `test/piece-verbs.test.ts` updated: `hiddenPing` (no stored signal) is now asserted **absent**, `édit` (a real `{$stream: true}` sentinel) still listed. **The double's `asSchema` stub is deliberately kept** — it still answers "stream" to any cast, so its presence proves the listing no longer asks.
- CLI suite green: 1667 parallel + 174 serial, 0 failed.
- `deno check`, `deno fmt --check`, `deno lint`.

## Why no test caught it before

The existing double hard-coded *which names are streams* — the intended behaviour — where a real cell answers "whatever you just cast me as". It could not fail the way production failed.

That is the **fourth** instance of one shape: a fixture with no `required`; an array written inline where the runtime stores redirect links; a plain-object double for a compiled `Pattern`, which is callable; and now a cell double that answers a cast honestly. The general form, worth more than any instance: **when a double stands in for something the runtime constructs, check what the runtime constructs.** Hence the live test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Overlap with #5665

#5665 targets the same defect and the same file, from an external contributor working off #5662's diagnosis. It removes the piece-root sweep.

Measured against clean main with this PR's live test dropped in, that does not close the defect: `count`, `items` and `label` are still listed as callable. The data fields do not reach the probe through the sweep — they arrive in `rejected` from the main result/input walk, where `detectCallableKind` rejects them and every rejection is added to the probe set.

This PR keeps the sweep and changes what the sweep's names are *judged by*. That difference is load-bearing in the other direction too: a name carrying a real `{$stream: true}` sentinel only on the piece root stays listed, which the `édit` case in `piece-verbs.test.ts` pins.


---

## Correction (post-merge): "silent no-op" overstates the residue

This PR's body and commit message describe calling a data field as *"accepted and then dropped by the scheduler with a WARN the caller never sees — a silent no-op an agent believes succeeded."* **That is wrong, and the listing fix here is unaffected by it.**

Re-measured on `ccaa2c99b` with exit status captured correctly: `cf piece call` **exits 1** for a data field, for a computed field, and for a name with no referent at all, with empty stdout. Nothing silently succeeds and nothing is written. The original measurement in #5662 read `$?` after a pipeline through `head`, so it reported `head`'s status rather than `cf`'s — a measurement-technique error, which is the kind that survives review because the transcript looks like evidence.

The accurate statement is narrower and not about data integrity: **the dispatcher accepts any name into dispatch, and the resulting failure is undiagnosed rather than silent.** Exit 1, empty stdout, no message naming the cause — where the read path refuses the mirror image cleanly with *"Path resolves to a verb; use 'cf piece call …' instead"*. Acceptance is also unconditional: a wholly invented name is accepted too, because the cast makes every name answer as a stream.

That residue is tracked as #5689, scoped as diagnostics and hygiene. The commit message on `ccaa2c99b` cannot be edited; this note is the correction of record. Credit to @mpsalisbury's b1 session for catching it while measuring severity rather than taking the earlier transcript at face value.
