### PR TITLE
docs(utils): file headers

### DIFF
--- a/packages/utils/src/arrays.bench.ts
+++ b/packages/utils/src/arrays.bench.ts
@@ -1,6 +1,4 @@
 /**
- * Array-predicate Performance Benchmarks
- *
  * `isInertArray()` is called once per array node by the fabric membership,
  * cloning, and conversion walks, so its cost is paid per container rather than
  * once per operation; `isArrayWithOnlyIndexProperties()` is its cheaper

--- a/packages/utils/src/buffers.bench.ts
+++ b/packages/utils/src/buffers.bench.ts
@@ -1,6 +1,4 @@
 /**
- * Byte-Ownership Performance Benchmarks
- *
  * `toOwnedUint8Array()` is how a value that promises an immutable byte
  * sequence gets bytes it can rely on, so its cost is paid once per such value
  * constructed. Each size runs three arms side by side, and it is the spread

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -1,6 +1,8 @@
-// Predicates for the JavaScript environment the calling code finds itself in.
-// Each is a feature test, not a build-time constant, so a single bundle can
-// ask at runtime which of its supported hosts it landed in.
+/**
+ * Predicates for the JavaScript environment the calling code finds itself in.
+ * Each is a feature test, not a build-time constant, so a single bundle can
+ * ask at runtime which of its supported hosts it landed in.
+ */
 
 /** Indicates whether the current environment is Deno. */
 export function isDeno(): boolean {

--- a/packages/utils/src/sandbox-contract.ts
+++ b/packages/utils/src/sandbox-contract.ts
@@ -1,8 +1,10 @@
-// The contract between the pattern toolchain and the sandbox compartment a
-// pattern runs in: the globals a compartment withholds, the builder and
-// data-helper names that are trusted, the identifiers reserved within a
-// factory's scope, and the source text of the helpers that carry the
-// value-side parts of the contract.
+/**
+ * The contract between the pattern toolchain and the sandbox compartment a
+ * pattern runs in: the globals a compartment withholds, the builder and
+ * data-helper names that are trusted, the identifiers reserved within a
+ * factory's scope, and the source text of the helpers that carry the
+ * value-side parts of the contract.
+ */
 
 /**
  * Names that a factory's scope shadows, so that authored code reaching for one

--- a/packages/utils/test/arrays.test.ts
+++ b/packages/utils/test/arrays.test.ts
@@ -1,3 +1,15 @@
+/**
+ * Three predicates that form a ladder, tested together because what matters
+ * about each is where it stops. `isArrayIndexPropertyName()` judges a single
+ * key, `isArrayWithOnlyIndexProperties()` judges an array's key shape, and
+ * `isInertArray()` adds a per-index descriptor walk on top of that.
+ *
+ * The last rung is the expensive one, and the cases here are what say whether
+ * a caller needs it: a value can have nothing but index keys and still not be
+ * inert, because a key's descriptor can make it something other than a plain
+ * element.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {

--- a/packages/utils/test/buffers.test.ts
+++ b/packages/utils/test/buffers.test.ts
@@ -1,3 +1,13 @@
+/**
+ * The two questions a byte holder has to answer before it can promise
+ * anything about the bytes it was handed: whether the buffer underneath has
+ * been detached, and how to obtain an array it is allowed to rely on.
+ *
+ * `toOwnedUint8Array()` is where the promise is actually made, so its cases
+ * are about what a caller may still do to the source afterwards. A holder
+ * that skips it is holding a view someone else can mutate or transfer away.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/utils/test/deep-equal.bench.ts
+++ b/packages/utils/test/deep-equal.bench.ts
@@ -1,3 +1,14 @@
+/**
+ * `deepEqual()` over 1000-element arrays, in the two arrangements that bound
+ * its cost: a pair that is equal, so every element is visited, and a pair
+ * differing only at the last element, so the walk runs to the end before it
+ * can say no.
+ *
+ * Number arrays and object arrays are run separately because the per-element
+ * work differs between them, and the fixtures are built once outside the
+ * measured region so that array construction is not part of what is timed.
+ */
+
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 
 // Create test fixtures once, outside the benchmarks

--- a/packages/utils/test/deep-equal.bench.ts
+++ b/packages/utils/test/deep-equal.bench.ts
@@ -1,8 +1,10 @@
 /**
- * `deepEqual()` over 1000-element arrays, in the two arrangements that bound
- * its cost: a pair that is equal, so every element is visited, and a pair
- * differing only at the last element, so the walk runs to the end before it
- * can say no.
+ * `deepEqual()` over 1000-element arrays, at the three points that bound its
+ * cost: two arrays that are equal, so every element is visited; two differing
+ * only at the last element, so the walk runs to the end before it can say no;
+ * and one array against itself, which short-circuits on identity and is the
+ * floor. That floor is what says how much of any measured difference is
+ * dispatch rather than comparison.
  *
  * Number arrays and object arrays are run separately because the per-element
  * work differs between them, and the fixtures are built once outside the

--- a/packages/utils/test/deep-equal.test.ts
+++ b/packages/utils/test/deep-equal.test.ts
@@ -1,3 +1,15 @@
+/**
+ * `deepEqual()` against the shapes where a plausible implementation quietly
+ * gives the wrong answer rather than throwing.
+ *
+ * The value model treats `-0` and `0` as distinct and `NaN` as equal to
+ * itself, which is the opposite of `===` on both counts, so the special-number
+ * cases are the ones that decide whether this function belongs to the value
+ * model or to JavaScript. A sparse array and an array carrying named
+ * properties are the other two: both compare equal to an ordinary array under
+ * any comparison that walks indices alone.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { deepEqual } from "@commonfabric/utils/deep-equal";

--- a/packages/utils/test/hashtags.test.ts
+++ b/packages/utils/test/hashtags.test.ts
@@ -1,3 +1,15 @@
+/**
+ * The tokenizer boundaries behind `#hashtag` extraction, which is program
+ * output rather than a convenience: `schema-generator`'s doc-comment handling
+ * and the runner's wish builtin both read what this function returns, so a
+ * hashtag written as an aside in a doc comment becomes data downstream.
+ *
+ * Each case fixes a decision the name does not carry -- a token takes in an
+ * underscore but ends at a hyphen, letters outside Latin and their diacritics
+ * count, and results come back lowercased and deduplicated in
+ * first-appearance order.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/utils/test/markdown.test.ts
+++ b/packages/utils/test/markdown.test.ts
@@ -1,3 +1,14 @@
+/**
+ * `backtickQuote()` has to produce a span that survives being read back, and
+ * the two rules that achieve it are independent.
+ *
+ * Choosing a delimiter longer than the longest backtick run inside is the
+ * obvious half. The padding rule is the half that is easy to omit: text
+ * beginning or ending with a backtick, or with a space at both ends, needs a
+ * space inserted or the span closes early or loses a character. The cases here
+ * cover both, including the ones where padding must NOT be added.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/utils/test/narrowing.test.ts
+++ b/packages/utils/test/narrowing.test.ts
@@ -1,3 +1,14 @@
+/**
+ * These assert at the type level, not the value level: what the predicates
+ * narrow to in each branch, for callers that start from `unknown`, from
+ * `object`, and from a type they already know.
+ *
+ * The `false` branch is the half worth the effort. A predicate written as a
+ * lone signature strips `readonly` and other detail from the caller's original
+ * type when the check fails, which costs a caller that already knew the shape
+ * more than the narrowing gains them.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {

--- a/packages/utils/test/objects.test.ts
+++ b/packages/utils/test/objects.test.ts
@@ -1,3 +1,14 @@
+/**
+ * What `isInertPlainObject()` accepts, and the accepting cases are the
+ * surprising ones. A frozen object qualifies, and so does a key whose value is
+ * `undefined` and one whose name is index-shaped -- none of those disturbs the
+ * property that the predicate is actually about.
+ *
+ * Inertness is about how the properties are defined rather than what they
+ * hold, which is the distinction a caller has to get right before trusting the
+ * answer to bound anything.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { isInertPlainObject } from "@commonfabric/utils/objects";

--- a/packages/utils/test/path-key-map.test.ts
+++ b/packages/utils/test/path-key-map.test.ts
@@ -1,3 +1,14 @@
+/**
+ * `PathKeyMap` keyed by path rather than by a single value, so the cases that
+ * matter are the ones where paths relate to each other: a nested path under a
+ * set one, overwriting at the same path, and invalidating a chain.
+ *
+ * The distinction between a present-but-`undefined` value and an absent key is
+ * pinned deliberately. A map that collapses the two cannot be used to cache
+ * anything whose legitimate value is `undefined`, which is most of what a
+ * reactive read returns.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { PathKeyMap } from "../src/path-key-map.ts";

--- a/packages/utils/test/strip-undefined-props.test.ts
+++ b/packages/utils/test/strip-undefined-props.test.ts
@@ -1,3 +1,14 @@
+/**
+ * `stripUndefinedProps()` removes `undefined`-valued properties, and the cases
+ * that say what it is are the things it leaves alone: a `null` property, an
+ * empty nested object, and an array holding `undefined` elements.
+ *
+ * That last one is the boundary a caller is most likely to assume wrongly.
+ * Dropping an element from an array would renumber the rest, so array contents
+ * pass through untouched however much they look like the properties being
+ * stripped.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { stripUndefinedProps } from "@commonfabric/utils/strip-undefined-props";

--- a/packages/utils/test/utf8.test.ts
+++ b/packages/utils/test/utf8.test.ts
@@ -1,3 +1,14 @@
+/**
+ * `utf8Compare()` exists because JavaScript's own string comparison is not
+ * UTF-8 order, and these cases are where the two disagree.
+ *
+ * Ordinary strings and prefixes are the easy half. The astral-plane cases are
+ * the reason the function is not `a < b`: those characters are stored as
+ * surrogate pairs, whose UTF-16 code units sort differently from the UTF-8
+ * bytes any other implementation would compare, so a sort that crosses a
+ * process boundary needs this one to agree with itself on both sides.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { utf8Compare, utf8SortedKeysOf } from "@commonfabric/utils/utf8";


### PR DESCRIPTION
Third in the series conforming files to the file-header rule added in #5647,
covering the violations attributable to @danfuzz. This one is all of
`packages/utils`. Independent of the merged #5653 and #5659; branched from
`main`.

## What changed

Fifteen files, in three commits.

| kind | files | what |
| --- | ---: | --- |
| form | 2 | header written as a `//` block, now a doc comment |
| title card | 2 | header opened by restating the filename |
| missing | 11 | no header at all, now written |

The two form conversions carry their prose across byte for byte — `// ` and
` * ` are both three characters — verified by extracting the prose from each
side of the diff and comparing, with the check confirmed able to fail on a
control first. The two title cards lose only their first line; the prose
underneath already opened with the claim.

## What the new headers say

Each names the cases that decide something, which the `it()` descriptions do
not. A recurring shape is that the interesting boundary is in the **accepting**
direction:

- `objects.test.ts` accepts a frozen object and an `undefined`-valued key,
  because inertness is about how properties are defined rather than what they
  hold.
- `strip-undefined-props.test.ts` leaves an array's `undefined` elements alone,
  since dropping one would renumber the rest.
- `path-key-map.test.ts` keeps a present-but-`undefined` value distinct from an
  absent key, without which the map could not cache a reactive read.
- `arrays.test.ts` covers three predicates forming a ladder, where the point is
  that a value can have nothing but index keys and still not be inert.

Two headers name which comparison their subject belongs to: `utf8.test.ts` to
UTF-8 byte order rather than UTF-16 code units, and `deep-equal.test.ts` to the
value model's `-0`-and-`NaN` semantics rather than `===`.

`hashtags.test.ts` names its downstream — `schema-generator/src/doc-utils.ts`
and `runner/src/builtins/wish.ts` both consume what the function returns,
verified by grep rather than assumed, so a hashtag written as an aside in a doc
comment becomes data.

## Two files deliberately untouched

Both were false positives in my classifier, and finding them is why the set is
15 rather than 17:

- **`test/bigint.test.ts`** was flagged as a misplaced header. What sits below
  its imports is a **section marker** — the `//` / text / `//` form this
  repo defines — not a header. My detector's banner filter only skipped
  `---`/`===` runs, which is backwards, since those are the forbidden form. A
  script promoted `// Reference encoder` to a file header before the check
  caught it; reverted. Exactly 1 of 255 placement candidates repo-wide has this
  shape.
- **`test/path-key-map.bench.ts`** was flagged as a title card. Its first line
  is a wrapped sentence that happens to break before a period.

## Checks

`deno fmt` and `deno lint` clean over the package. `deno task test` in
`packages/utils`: `ok | 99 passed (660 steps) | 0 failed`.

Every header verified to be followed by a blank line, so none binds to the
declaration below it — 11 of 11 on the last commit.

Two claims were spot-checked against the assertions rather than written from
the file's shape: that `deep-equal.test.ts` really pins `NaN === NaN` and
`-0` vs `+0`, and that `arrays.test.ts` really has an index-keys-but-not-inert
case. Both hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWSRsoxPqARrkCgLz5Smww


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

