### PR TITLE
docs(runner): convert thirteen `//` file headers to doc comments

### DIFF
--- a/packages/runner/test/convert-cells-to-links-annotations.test.ts
+++ b/packages/runner/test/convert-cells-to-links-annotations.test.ts
@@ -1,7 +1,9 @@
-// A schema-bearing read attaches a non-enumerable `toCell` symbol to the
-// values it returns (see `schema.ts`). That annotation is not content, so it
-// must not reach -- and be rejected by -- the fabric-conversion gate inside
-// `convertCellsToLinks()`.
+/**
+ * A schema-bearing read attaches a non-enumerable `toCell` symbol to the
+ * values it returns (see `schema.ts`). That annotation is not content, so it
+ * must not reach -- and be rejected by -- the fabric-conversion gate inside
+ * `convertCellsToLinks()`.
+ */
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";

--- a/packages/runner/test/convert-cells-to-links-sharing.test.ts
+++ b/packages/runner/test/convert-cells-to-links-sharing.test.ts
@@ -1,7 +1,9 @@
-// A value reachable twice by different paths is SHARED, not circular. The
-// conversion answers an ancestor with a back-link -- that is what makes a cycle
-// representable -- and must not answer a sibling the same way, which would
-// rewrite one of the two positions into a pointer at the other.
+/**
+ * A value reachable twice by different paths is SHARED, not circular. The
+ * conversion answers an ancestor with a back-link -- that is what makes a cycle
+ * representable -- and must not answer a sibling the same way, which would
+ * rewrite one of the two positions into a pointer at the other.
+ */
 
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";

--- a/packages/runner/test/convert-cells-to-links-special-objects.test.ts
+++ b/packages/runner/test/convert-cells-to-links-special-objects.test.ts
@@ -1,8 +1,10 @@
-// The two special-object kinds get opposite treatment, and neither is the
-// object branch. A `FabricPrimitive` is a leaf and stands whole, where a walk
-// that rebuilt it from its entries would give a bare `{}`. A `FabricInstance`
-// is a container reached by its codec contents, which this walk cannot do, so
-// it refuses rather than converting one wrongly.
+/**
+ * The two special-object kinds get opposite treatment, and neither is the
+ * object branch. A `FabricPrimitive` is a leaf and stands whole, where a walk
+ * that rebuilt it from its entries would give a bare `{}`. A `FabricInstance`
+ * is a container reached by its codec contents, which this walk cannot do, so
+ * it refuses rather than converting one wrongly.
+ */
 
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";

--- a/packages/runner/test/fabric-special-object.test.ts
+++ b/packages/runner/test/fabric-special-object.test.ts
@@ -1,8 +1,10 @@
-// The refusal a `FabricInstance` gets from a walk that cannot descend one.
-// Several walks share it so that they refuse in one wording; these pin that
-// wording, since a caller asserting on the message has no other guarantee of
-// it -- and pin that reaching for it throws, rather than handing back
-// something a caller could drop.
+/**
+ * The refusal a `FabricInstance` gets from a walk that cannot descend one.
+ * Several walks share it so that they refuse in one wording; these pin that
+ * wording, since a caller asserting on the message has no other guarantee of
+ * it -- and pin that reaching for it throws, rather than handing back
+ * something a caller could drop.
+ */
 
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";

--- a/packages/runner/test/llm-dialog-error-messages.test.ts
+++ b/packages/runner/test/llm-dialog-error-messages.test.ts
@@ -1,8 +1,10 @@
-// The dialog's error paths substitute an assistant message when a turn cannot
-// produce a real reply. None of them had end-to-end coverage, so nothing pinned
-// either the message reaching `messages` or its landing in a document of its
-// own -- the latter being what the LlmDerived stamping downstream depends on,
-// and what keeps the array from mixing bare values with links.
+/**
+ * The dialog's error paths substitute an assistant message when a turn cannot
+ * produce a real reply. None of them had end-to-end coverage, so nothing pinned
+ * either the message reaching `messages` or its landing in a document of its
+ * own -- the latter being what the LlmDerived stamping downstream depends on,
+ * and what keeps the array from mixing bare values with links.
+ */
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";

--- a/packages/runner/test/llm-dialog-message-scope.test.ts
+++ b/packages/runner/test/llm-dialog-message-scope.test.ts
@@ -1,11 +1,13 @@
-// The dialog's per-message documents must land in the same partition as the
-// messages array itself. An element anchored by `Cell.push` inherits the
-// array's scope; a document the dialog creates explicitly has to be given that
-// scope, or the document and the readers of its link disagree about the
-// partition: the stored element link is bare, a reader resolves it against the
-// array's scope, and a document minted at the default `"space"` scope is
-// simply not there. A session-scoped messages cell is what makes the
-// difference observable at all -- at `"space"` scope every choice coincides.
+/**
+ * The dialog's per-message documents must land in the same partition as the
+ * messages array itself. An element anchored by `Cell.push` inherits the
+ * array's scope; a document the dialog creates explicitly has to be given that
+ * scope, or the document and the readers of its link disagree about the
+ * partition: the stored element link is bare, a reader resolves it against the
+ * array's scope, and a document minted at the default `"space"` scope is
+ * simply not there. A session-scoped messages cell is what makes the
+ * difference observable at all -- at `"space"` scope every choice coincides.
+ */
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";

--- a/packages/runner/test/llm-dialog-special-objects.test.ts
+++ b/packages/runner/test/llm-dialog-special-objects.test.ts
@@ -1,9 +1,11 @@
-// The two walks in `llm-dialog.ts` that carry a `FabricValue` give the two
-// special-object kinds opposite treatment, and neither is the object branch. A
-// `FabricPrimitive` is a leaf and stands whole, where a walk that rebuilt it
-// from its entries would hand the model a bare `{}`. A `FabricInstance` is a
-// container reached by its codec contents, which neither walk can do, so each
-// refuses rather than flattening one.
+/**
+ * The two walks in `llm-dialog.ts` that carry a `FabricValue` give the two
+ * special-object kinds opposite treatment, and neither is the object branch. A
+ * `FabricPrimitive` is a leaf and stands whole, where a walk that rebuilt it
+ * from its entries would hand the model a bare `{}`. A `FabricInstance` is a
+ * container reached by its codec contents, which neither walk can do, so each
+ * refuses rather than flattening one.
+ */
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";

--- a/packages/runner/test/merge-defaults.test.ts
+++ b/packages/runner/test/merge-defaults.test.ts
@@ -1,5 +1,7 @@
-// Unit tests for mergeDefaults — the internal helper that builds a schema with
-// a merged `.default` property for use by processDefaultValue/createCell.
+/**
+ * Unit tests for mergeDefaults — the internal helper that builds a schema with
+ * a merged `.default` property for use by processDefaultValue/createCell.
+ */
 
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";

--- a/packages/runner/test/node-utils.test.ts
+++ b/packages/runner/test/node-utils.test.ts
@@ -1,8 +1,10 @@
-// What the CFC output-labelling walk does with a `FabricSpecialObject`. Such a
-// value has zero enumerable own properties, so the walk's `Object.entries()`
-// descent ends at it. That costs a `FabricPrimitive` nothing -- a leaf holds no
-// cell to label -- but for a `FabricInstance` it means a cell in its codec
-// contents goes _unlabelled_, so the walk refuses one instead.
+/**
+ * What the CFC output-labelling walk does with a `FabricSpecialObject`. Such a
+ * value has zero enumerable own properties, so the walk's `Object.entries()`
+ * descent ends at it. That costs a `FabricPrimitive` nothing -- a leaf holds no
+ * cell to label -- but for a `FabricInstance` it means a cell in its codec
+ * contents goes _unlabelled_, so the walk refuses one instead.
+ */
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";

--- a/packages/runner/test/pattern-binding.bench.ts
+++ b/packages/runner/test/pattern-binding.bench.ts
@@ -1,27 +1,29 @@
-// Micro-benchmark for `unwrapOneLevelAndBindToDoc`.
-//
-// CONTEXT / CONCLUSION: reload profiling showed `bindNodeIO` is ~90% of per-node
-// instantiation cost during the `raw:map` notes-list reconcile (~3ms/node, up to
-// ~52ms for one node). `bindNodeIO` = unwrapOneLevelAndBindToDoc(in/out) +
-// findAllWriteRedirectCells(in/out). This bench was written to study the unwrap
-// part — and it PROVED unwrap is NOT the bottleneck:
-//   * unwrap is ~1.9µs/alias (5.2µs with $ref/$defs schemas) and linear — a real
-//     UI node (~30 aliases) is sub-millisecond.
-//   * A browser split-probe confirmed it: per reload, bio/unwrap = 6ms total
-//     across 133 nodes, while bio/findRedir (findAllWriteRedirectCells) = 356ms.
-// So the real cost is `findAllWriteRedirectCells`, which is NOT a pure transform:
-// it follows every write-redirect link via
-// `parseLink -> runtime.getCellFromLink -> linkCell.getRaw() -> recurse`, i.e.
-// recursive cell/storage resolution per node. That part needs a Runtime, so it
-// isn't covered by this pure micro-bench (TODO: add an emulate-runtime bench for
-// findAllWriteRedirectCells to study/optimize the actual hotspot).
-//
-// unwrapOneLevelAndBindToDoc itself is PURE (CFC schema traversal + deep
-// clone/rebind of the binding tree; no storage/tx), studied in isolation below.
-//
-// Run as a bench:        deno bench -A packages/runner/test/pattern-binding.bench.ts
-// Run directly (study):  deno run  -A packages/runner/test/pattern-binding.bench.ts
-//                        deno run  -A packages/runner/test/pattern-binding.bench.ts 2000   # custom size
+/**
+ * Micro-benchmark for `unwrapOneLevelAndBindToDoc`.
+ *
+ * CONTEXT / CONCLUSION: reload profiling showed `bindNodeIO` is ~90% of per-node
+ * instantiation cost during the `raw:map` notes-list reconcile (~3ms/node, up to
+ * ~52ms for one node). `bindNodeIO` = unwrapOneLevelAndBindToDoc(in/out) +
+ * findAllWriteRedirectCells(in/out). This bench was written to study the unwrap
+ * part — and it PROVED unwrap is NOT the bottleneck:
+ *   * unwrap is ~1.9µs/alias (5.2µs with $ref/$defs schemas) and linear — a real
+ *     UI node (~30 aliases) is sub-millisecond.
+ *   * A browser split-probe confirmed it: per reload, bio/unwrap = 6ms total
+ *     across 133 nodes, while bio/findRedir (findAllWriteRedirectCells) = 356ms.
+ * So the real cost is `findAllWriteRedirectCells`, which is NOT a pure transform:
+ * it follows every write-redirect link via
+ * `parseLink -> runtime.getCellFromLink -> linkCell.getRaw() -> recurse`, i.e.
+ * recursive cell/storage resolution per node. That part needs a Runtime, so it
+ * isn't covered by this pure micro-bench (TODO: add an emulate-runtime bench for
+ * findAllWriteRedirectCells to study/optimize the actual hotspot).
+ *
+ * unwrapOneLevelAndBindToDoc itself is PURE (CFC schema traversal + deep
+ * clone/rebind of the binding tree; no storage/tx), studied in isolation below.
+ *
+ * Run as a bench:        deno bench -A packages/runner/test/pattern-binding.bench.ts
+ * Run directly (study):  deno run  -A packages/runner/test/pattern-binding.bench.ts
+ *                        deno run  -A packages/runner/test/pattern-binding.bench.ts 2000   # custom size
+ */
 
 import { unwrapOneLevelAndBindToDoc } from "../src/pattern-binding.ts";
 import type { AnyCell } from "../src/cell.ts";

--- a/packages/runner/test/query-result-proxy-array-key-order.test.ts
+++ b/packages/runner/test/query-result-proxy-array-key-order.test.ts
@@ -1,7 +1,9 @@
-// The `ownKeys` trap supplies a `length` key when the underlying value has
-// none of its own. Where it puts that key matters: own-key order is what
-// distinguishes an index-only array from one carrying named properties, and
-// `isArrayWithOnlyIndexProperties()` reads exactly that.
+/**
+ * The `ownKeys` trap supplies a `length` key when the underlying value has
+ * none of its own. Where it puts that key matters: own-key order is what
+ * distinguishes an index-only array from one carrying named properties, and
+ * `isArrayWithOnlyIndexProperties()` reads exactly that.
+ */
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";

--- a/packages/runner/test/resolve-schema.test.ts
+++ b/packages/runner/test/resolve-schema.test.ts
@@ -1,6 +1,8 @@
-// Unit tests for resolveSchema — basic resolution behavior.
-// Note: Robin's #3118 removed the filterAsCell parameter from resolveSchema,
-// so these tests only cover the single-argument form.
+/**
+ * Unit tests for resolveSchema — basic resolution behavior.
+ * Note: Robin's #3118 removed the filterAsCell parameter from resolveSchema,
+ * so these tests only cover the single-argument form.
+ */
 
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";

--- a/packages/runner/test/runner-argument-walks.test.ts
+++ b/packages/runner/test/runner-argument-walks.test.ts
@@ -1,17 +1,19 @@
-// What the two schema-guided argument walks in `runner.ts` do with a
-// `FabricSpecialObject`. Both collect links out of a live action argument, and
-// both are security-relevant: what they find becomes scheduler read tracking
-// and write-policy input.
-//
-// Neither walk rebuilds anything -- each INDEXES the value at the position its
-// schema names (`currentValue[key]`). So a `FabricPrimitive` standing where the
-// schema expects a container yields `undefined` per key and contributes
-// nothing, which is the right answer: a leaf holds no link to find.
-//
-// A `FabricInstance` is a different case and both walks refuse one. A link in
-// its codec contents is unreachable by property name, so passing it through
-// _misses_ that link -- and over-collection is these walkers' safe direction,
-// which makes a miss the unsafe one.
+/**
+ * What the two schema-guided argument walks in `runner.ts` do with a
+ * `FabricSpecialObject`. Both collect links out of a live action argument, and
+ * both are security-relevant: what they find becomes scheduler read tracking
+ * and write-policy input.
+ *
+ * Neither walk rebuilds anything -- each INDEXES the value at the position its
+ * schema names (`currentValue[key]`). So a `FabricPrimitive` standing where the
+ * schema expects a container yields `undefined` per key and contributes
+ * nothing, which is the right answer: a leaf holds no link to find.
+ *
+ * A `FabricInstance` is a different case and both walks refuse one. A link in
+ * its codec contents is unreachable by property name, so passing it through
+ * _misses_ that link -- and over-collection is these walkers' safe direction,
+ * which makes a miss the unsafe one.
+ */
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";


### PR DESCRIPTION
Fourth in the series conforming files to the file-header rule added in #5647,
covering the violations attributable to @danfuzz. `runner` is split into three
PRs by kind rather than by directory, so the mechanical work can be reviewed as
mechanical. This is the mechanical one: **thirteen headers, form only, no
prose changed anywhere.**

Branched from `main`, independent of #5687 (`utils`).

## Why this is safe to skim

`// ` and ` * ` are both three characters, so every line of prose keeps its
exact wrapping and the text crosses byte for byte. A script did the conversion
and refuses anything it does not recognize; separately, I extracted the prose
from each side of the diff, stripped the markers, and compared — **13 of 13
identical**, with the comparison confirmed able to fail on a control first.

So every hunk in this PR should read as the same words with a different comment
delimiter. Anything else is a bug.

Files: the three `convert-cells-to-links-*` tests, `fabric-special-object`,
the three `llm-dialog-*` tests, `merge-defaults`, `node-utils`,
`pattern-binding.bench`, `query-result-proxy-array-key-order`,
`resolve-schema`, and `runner-argument-walks`.

## Checks

`deno fmt` and `deno lint` clean on all thirteen. Full `deno task test` in
`packages/runner`: `ok | 1189 passed (6302 steps) | 0 failed`.

Every converted header verified to be followed by a blank line, so none binds
to the declaration below it as its doc comment.

## Still to come for this package

Two more PRs: the five misplaced headers plus two title cards and two `src/`
files, then nineteen files that need a header written from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWSRsoxPqARrkCgLz5Smww


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

