### PR TITLE
feat(patterns): render mentions written in reference form

### DIFF
--- a/docs/plans/editor-mention-references.md
+++ b/docs/plans/editor-mention-references.md
@@ -116,7 +116,7 @@ reference form.
 
 ## Stage 1 — the editor
 
-- [ ] `packages/ui/src/v2/core/mention-refs.ts`: `MentionRef`,
+- [x] `packages/ui/src/v2/core/mention-refs.ts`: `MentionRef`,
       `MentionRefMap`, their schemas, and `mintRefKey`.
 
   ```typescript
@@ -142,37 +142,37 @@ reference form.
   than a fixed six: a key the mint can produce and the parser would not accept
   is a mention that reads as ordinary text.
 
-- [ ] `features/mention-refs.ts`: the structural twin of `backlinks.ts` —
+- [x] `features/mention-refs.ts`: the structural twin of `backlinks.ts` —
       `parseMentionRefs`, a `mentionRefField` that recomputes on `docChanged`
       **or** a `setKnownRefKeys` effect, `atomicMentionRefRanges` and
       `mentionRefEditFilter` over the `][key]` suffix, and a decoration plugin
       that renders a pill and reveals `[Label]` under the cursor. The label
       pattern excludes newlines, so a mention is a single-line range by
       construction rather than by a guard.
-- [ ] `cf-code-editor.ts`: the `references` property (`$references`), wrapped
+- [x] `cf-code-editor.ts`: the `references` property (`$references`), wrapped
       with `asSchema(MentionRefMapSchema)` and subscribed on change like
       `mentionable`; completion and novel-mention creation minting reference
       form when the map is present; `$mentioned` drawn from the union of both
       forms; label edits setting `modifiedTitle` instead of renaming;
       destination-title subscriptions honoring the flag.
-- [ ] Garbage collection: a map entry whose key has left the document is
+- [x] Garbage collection: a map entry whose key has left the document is
       removed — conservatively (see risks) and never against a document that
       has not loaded.
-- [ ] `packages/html/src/jsx.d.ts`: `$references` and the label-change event on
+- [x] `packages/html/src/jsx.d.ts`: `$references` and the label-change event on
       `CFCodeEditorAttributes`.
-- [ ] Unit tests mirroring `features/backlinks.test.ts`, plus key minting, plus
+- [x] Unit tests mirroring `features/backlinks.test.ts`, plus key minting, plus
       an integration case pinning that **no map means wiki-link output,
       unchanged**.
-- [ ] `components/cf-code-editor/docs/mention-refs.md`, and a pointer from
+- [x] `components/cf-code-editor/docs/mention-refs.md`, and a pointer from
       `docs/backlinks.md` naming the two coexisting forms.
 
 ## Stage 2 — the renderer
 
-- [ ] `note-md.tsx` takes the map as an input and extends `processedContent` to
+- [x] `note-md.tsx` takes the map as an input and extends `processedContent` to
       rewrite `[Label][key]` alongside the wiki-link form. A key with no entry
       keeps its literal text, so a broken reference degrades where a reader can
       see it.
-- [ ] Derive the link scheme from the resolved destination rather than
+- [x] Derive the link scheme from the resolved destination rather than
       prefixing `/of:`. That prefix is sound today only because the embed
       format rejects every other scheme; a cell-valued destination removes the
       guarantee along with the limitation.

--- a/packages/patterns/baselines/notes/note-md.tsx/20260812T165045Z-EHXA5z1fb-gGonJK.json
+++ b/packages/patterns/baselines/notes/note-md.tsx/20260812T165045Z-EHXA5z1fb-gGonJK.json
@@ -1,0 +1,520 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "AnonymousType_1": {
+        "items": {
+          "$ref": "#/$defs/MentionablePiece"
+        },
+        "type": "array"
+      },
+      "MentionRef": {
+        "properties": {
+          "destination": {
+            "type": "unknown"
+          },
+          "modifiedTitle": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "destination",
+          "modifiedTitle"
+        ],
+        "type": "object"
+      },
+      "MentionRefMap": {
+        "additionalProperties": {
+          "$ref": "#/$defs/MentionRef"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "MentionablePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "mentioned": {
+            "$ref": "#/$defs/AnonymousType_1"
+          }
+        },
+        "required": [
+          "mentioned",
+          "backlinks"
+        ],
+        "type": "object"
+      },
+      "NotePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "content": {
+            "type": "string"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "parentNotebook": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/NotebookPiece"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "setTitle": {
+            "asCell": [
+              "stream"
+            ],
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "NotebookPiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "createNote": {
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "navigate": {
+                "type": "boolean"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title",
+              "content"
+            ],
+            "type": "object"
+          },
+          "createNotebook": {
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notesData": {
+                "items": {
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "content"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          },
+          "createNotes": {
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notesData": {
+                "items": {
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "content"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "notesData"
+            ],
+            "type": "object"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "isNotebook": {
+            "type": "boolean"
+          },
+          "notes": {
+            "items": {
+              "$ref": "#/$defs/NotePiece"
+            },
+            "type": "array"
+          },
+          "setTitle": {
+            "asCell": [
+              "stream"
+            ],
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "createNote",
+          "createNotes",
+          "setTitle",
+          "createNotebook"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "content": {
+        "asCell": [
+          "cell"
+        ],
+        "description": "Writable content cell for checkbox updates",
+        "type": "string"
+      },
+      "note": {
+        "$ref": "#/$defs/NotePiece",
+        "default": {
+          "backlinks": [],
+          "content": "",
+          "title": ""
+        },
+        "description": "Cell reference to note data (title + content + backlinks)"
+      },
+      "references": {
+        "$ref": "#/$defs/MentionRefMap",
+        "asCell": [
+          "cell"
+        ],
+        "description": "The note's mentions, for resolving `[Label][key]` in its content"
+      },
+      "sourceNoteRef": {
+        "$ref": "#/$defs/NotePiece",
+        "description": "Direct reference to source note for Edit navigation"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "notes/note-md.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AnonymousType_1": {
+        "items": {
+          "$ref": "#/$defs/MentionablePiece"
+        },
+        "type": "array"
+      },
+      "MentionablePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "mentioned": {
+            "$ref": "#/$defs/AnonymousType_1"
+          }
+        },
+        "required": [
+          "mentioned",
+          "backlinks"
+        ],
+        "type": "object"
+      },
+      "NotePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "content": {
+            "type": "string"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "parentNotebook": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/NotebookPiece"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "setTitle": {
+            "asCell": [
+              "stream"
+            ],
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "NotebookPiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "createNote": {
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "navigate": {
+                "type": "boolean"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title",
+              "content"
+            ],
+            "type": "object"
+          },
+          "createNotebook": {
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notesData": {
+                "items": {
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "content"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          },
+          "createNotes": {
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notesData": {
+                "items": {
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "content"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "notesData"
+            ],
+            "type": "object"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "isNotebook": {
+            "type": "boolean"
+          },
+          "notes": {
+            "items": {
+              "$ref": "#/$defs/NotePiece"
+            },
+            "type": "array"
+          },
+          "setTitle": {
+            "asCell": [
+              "stream"
+            ],
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "createNote",
+          "createNotes",
+          "setTitle",
+          "createNotebook"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$TILE_UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json",
+        "description": "Tile variant (CT-1764): minimal embedded UI for `<cf-render variant=\"tile\">`."
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "checkboxToggle": {
+        "asCell": [
+          "stream"
+        ],
+        "description": "Stream to toggle checkboxes in content",
+        "properties": {
+          "detail": {
+            "properties": {
+              "checked": {
+                "type": "boolean"
+              },
+              "index": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "index",
+              "checked"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "type": "object"
+      },
+      "goToEdit": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "Stream to navigate back to source note for editing"
+      },
+      "hasBacklinks": {
+        "description": "Whether backlinks section should be visible",
+        "type": "boolean"
+      },
+      "isHidden": {
+        "description": "Hidden from default-app piece list",
+        "enum": [
+          true
+        ],
+        "type": "boolean"
+      },
+      "isMentionable": {
+        "description": "Excluded from mentions autocomplete (notes in notebooks may be hidden but still mentionable)",
+        "enum": [
+          false
+        ],
+        "type": "boolean"
+      },
+      "note": {
+        "$ref": "#/$defs/NotePiece",
+        "description": "Passthrough note reference"
+      },
+      "processedContent": {
+        "description": "Processed content with wiki-links converted to markdown links",
+        "type": "string"
+      }
+    },
+    "required": [
+      "note",
+      "isHidden",
+      "isMentionable",
+      "processedContent",
+      "checkboxToggle",
+      "hasBacklinks",
+      "goToEdit",
+      "$NAME",
+      "$UI",
+      "$TILE_UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/notes/note-md.test.tsx
+++ b/packages/patterns/notes/note-md.test.tsx
@@ -15,6 +15,22 @@
 import { action, assert, NAME, pattern, TESTS, Writable } from "commonfabric";
 import NoteMd from "./note-md.tsx";
 import Note from "./note.tsx";
+import { type MentionRefMap } from "./schemas.tsx";
+
+/**
+ * The address the renderer should produce for a reference, read back the way
+ * the renderer reads it. A destination's address is a content hash, so it
+ * cannot be spelled out in an expectation. Module scope is required: an
+ * assertion callback may not capture a callable from an enclosing function.
+ */
+const referenceAddress = (
+  references: Writable<MentionRefMap>,
+  key: string,
+): string => {
+  const uri = ((references as any).key(key).key("destination"))
+    ?.resolveAsCell?.()?.sourceURI;
+  return uri ? `/${uri}` : "";
+};
 
 export default pattern(() => {
   // Writable content cell for basic testing
@@ -145,6 +161,54 @@ export default pattern(() => {
     content: whitespaceContent,
   });
 
+  // === Instance with mentions in reference form ===
+  // `[Label][key]` resolves through the note's reference map. The destination
+  // is a live piece, so its address is content-derived and cannot be spelled
+  // out here; the assertions read it back the way the renderer does.
+  const alice = Note({ title: "Alice", content: "", isHidden: false });
+
+  // Seeded by an action rather than inline: a Writable initializer takes
+  // static data, and a destination is a live piece.
+  const references = new Writable<MentionRefMap>({});
+
+  const refContent = new Writable("See [Alice][a3f9zz] for details");
+
+  const mdRefs = NoteMd({
+    note: { title: "Ref Note", content: "Fallback", backlinks: [] },
+    content: refContent,
+    references,
+  });
+
+  // A key the map does not hold, and a hand-written reference link that
+  // happens to fit the key shape. Neither is a mention.
+  const unknownRefContent = new Writable(
+    "See [Bob][zzzz99] and [the docs][readme] here",
+  );
+
+  const mdUnknownRefs = NoteMd({
+    note: { title: "Unknown Ref Note", content: "Fallback", backlinks: [] },
+    content: unknownRefContent,
+    references,
+  });
+
+  // Reference-form content reaching a viewer given no map at all.
+  const mdRefsNoMap = NoteMd({
+    note: { title: "No Map Note", content: "Fallback", backlinks: [] },
+    content: new Writable("See [Alice][a3f9zz] for details"),
+  });
+
+  // Both mention forms in one document, which is what a note part-way through
+  // a migration looks like.
+  const mixedFormsContent = new Writable(
+    "Old [[Bob (def456)]] and new [Alice][a3f9zz]",
+  );
+
+  const mdMixedForms = NoteMd({
+    note: { title: "Mixed Forms Note", content: "Fallback", backlinks: [] },
+    content: mixedFormsContent,
+    references,
+  });
+
   // === Instance with sourceNoteRef for Edit navigation ===
   const sourceNote = Note({
     title: "Source Note",
@@ -191,6 +255,18 @@ export default pattern(() => {
   // Toggle third checkbox (index 2) to checked
   const action_check_third = action(() => {
     mdCheckbox.checkboxToggle.send({ detail: { index: 2, checked: true } });
+  });
+
+  const action_seed_reference = action(() => {
+    references.key("a3f9zz").set({ destination: alice, modifiedTitle: false });
+  });
+
+  // Add an entry for a key already sitting in a document, which is the order
+  // a mention pasted before its map arrives comes in.
+  const bob = Note({ title: "Bob", content: "", isHidden: false });
+
+  const action_add_reference = action(() => {
+    references.key("zzzz99").set({ destination: bob, modifiedTitle: false });
   });
 
   // Update wiki content to have multiple links
@@ -262,6 +338,57 @@ export default pattern(() => {
   // Content without wiki-links passes through unchanged
   const assert_plain_passthrough = assert(
     () => mdPlain.processedContent === "No links here, just plain text.",
+  );
+
+  // ==========================================================================
+  // Assertions - Reference-form mentions
+  // ==========================================================================
+
+  const assert_reference_before_entry_untouched = assert(
+    () => mdRefs.processedContent === "See [Alice][a3f9zz] for details",
+  );
+
+  const assert_reference_converted = assert(
+    () =>
+      mdRefs.processedContent ===
+        `See [Alice](${referenceAddress(references, "a3f9zz")}) for details`,
+  );
+
+  // The address carries the destination's own scheme rather than a prepended
+  // one, which for a piece is `of:`.
+  const assert_reference_address_schemed = assert(
+    () => referenceAddress(references, "a3f9zz").startsWith("/of:"),
+  );
+
+  // A key with no entry, and a hand-written reference link, both stay as
+  // written — the label survives and nothing points at nothing.
+  const assert_unknown_reference_untouched = assert(
+    () =>
+      mdUnknownRefs.processedContent ===
+        "See [Bob][zzzz99] and [the docs][readme] here",
+  );
+
+  // With no map, reference-form text is text.
+  const assert_reference_without_map_untouched = assert(
+    () => mdRefsNoMap.processedContent === "See [Alice][a3f9zz] for details",
+  );
+
+  // A note holding both forms converts both.
+  const assert_mixed_forms_converted = assert(
+    () =>
+      mdMixedForms.processedContent ===
+        `Old [Bob](/of:def456) and new [Alice](${
+          referenceAddress(references, "a3f9zz")
+        })`,
+  );
+
+  // An entry added after the fact resolves the token that was waiting for it.
+  const assert_late_reference_converted = assert(
+    () =>
+      mdUnknownRefs.processedContent ===
+        `See [Bob](${
+          referenceAddress(references, "zzzz99")
+        }) and [the docs][readme] here`,
   );
 
   // After updating wiki content, new links should be converted
@@ -411,6 +538,21 @@ export default pattern(() => {
       // === Wiki-link conversion ===
       { assertion: assert_wiki_links_converted },
       { assertion: assert_plain_passthrough },
+
+      // === Reference-form mentions ===
+      // Before its entry exists, a token is text — which is also what a
+      // document whose map has not arrived yet looks like.
+      { assertion: assert_reference_before_entry_untouched },
+      { action: action_seed_reference },
+      { assertion: assert_reference_converted },
+      { assertion: assert_reference_address_schemed },
+      { assertion: assert_unknown_reference_untouched },
+      { assertion: assert_reference_without_map_untouched },
+      { assertion: assert_mixed_forms_converted },
+
+      // === An entry arriving after the token ===
+      { action: action_add_reference },
+      { assertion: assert_late_reference_converted },
 
       // === Update wiki content and verify ===
       { action: action_set_multi_wiki },

--- a/packages/patterns/notes/note-md.test.tsx
+++ b/packages/patterns/notes/note-md.test.tsx
@@ -15,20 +15,23 @@
 import { action, assert, NAME, pattern, TESTS, Writable } from "commonfabric";
 import NoteMd from "./note-md.tsx";
 import Note from "./note.tsx";
-import { type MentionRefMap } from "./schemas.tsx";
+import { type MentionRefMap, type NotePiece } from "./schemas.tsx";
 
 /**
- * The address the renderer should produce for a reference, read back the way
- * the renderer reads it. A destination's address is a content hash, so it
- * cannot be spelled out in an expectation. Module scope is required: an
- * assertion callback may not capture a callable from an enclosing function.
+ * The address of the piece a cell holds.
+ *
+ * A destination's address is a content hash, so an expectation cannot spell it
+ * out. It is read here from a cell that holds the destination DIRECTLY, never
+ * from the reference map: walking the map the way the renderer walks it would
+ * make expected and actual agree by construction, and the test would still
+ * pass if the renderer resolved the wrong key. Two independent paths to the
+ * same piece is what pins which destination the rendered link names.
+ *
+ * Module scope is required: an assertion callback may not capture a callable
+ * from an enclosing function.
  */
-const referenceAddress = (
-  references: Writable<MentionRefMap>,
-  key: string,
-): string => {
-  const uri = ((references as any).key(key).key("destination"))
-    ?.resolveAsCell?.()?.sourceURI;
+const heldPieceAddress = (held: unknown): string => {
+  const uri = (held as any)?.resolveAsCell?.()?.sourceURI;
   return uri ? `/${uri}` : "";
 };
 
@@ -163,9 +166,11 @@ export default pattern(() => {
 
   // === Instance with mentions in reference form ===
   // `[Label][key]` resolves through the note's reference map. The destination
-  // is a live piece, so its address is content-derived and cannot be spelled
-  // out here; the assertions read it back the way the renderer does.
+  // is a live piece, so its address is content-derived; the assertions ask the
+  // piece for its own address rather than re-walking the map.
   const alice = Note({ title: "Alice", content: "", isHidden: false });
+  // The same destination, reachable without going through the map.
+  const aliceHeld = new Writable<NotePiece | null>(null);
 
   // Seeded by an action rather than inline: a Writable initializer takes
   // static data, and a destination is a live piece.
@@ -259,14 +264,17 @@ export default pattern(() => {
 
   const action_seed_reference = action(() => {
     references.key("a3f9zz").set({ destination: alice, modifiedTitle: false });
+    aliceHeld.set(alice as NotePiece);
   });
 
   // Add an entry for a key already sitting in a document, which is the order
   // a mention pasted before its map arrives comes in.
   const bob = Note({ title: "Bob", content: "", isHidden: false });
+  const bobHeld = new Writable<NotePiece | null>(null);
 
   const action_add_reference = action(() => {
     references.key("zzzz99").set({ destination: bob, modifiedTitle: false });
+    bobHeld.set(bob as NotePiece);
   });
 
   // Update wiki content to have multiple links
@@ -351,13 +359,13 @@ export default pattern(() => {
   const assert_reference_converted = assert(
     () =>
       mdRefs.processedContent ===
-        `See [Alice](${referenceAddress(references, "a3f9zz")}) for details`,
+        `See [Alice](${heldPieceAddress(aliceHeld)}) for details`,
   );
 
   // The address carries the destination's own scheme rather than a prepended
   // one, which for a piece is `of:`.
   const assert_reference_address_schemed = assert(
-    () => referenceAddress(references, "a3f9zz").startsWith("/of:"),
+    () => heldPieceAddress(aliceHeld).startsWith("/of:"),
   );
 
   // A key with no entry, and a hand-written reference link, both stay as
@@ -377,18 +385,14 @@ export default pattern(() => {
   const assert_mixed_forms_converted = assert(
     () =>
       mdMixedForms.processedContent ===
-        `Old [Bob](/of:def456) and new [Alice](${
-          referenceAddress(references, "a3f9zz")
-        })`,
+        `Old [Bob](/of:def456) and new [Alice](${heldPieceAddress(aliceHeld)})`,
   );
 
   // An entry added after the fact resolves the token that was waiting for it.
   const assert_late_reference_converted = assert(
     () =>
       mdUnknownRefs.processedContent ===
-        `See [Bob](${
-          referenceAddress(references, "zzzz99")
-        }) and [the docs][readme] here`,
+        `See [Bob](${heldPieceAddress(bobHeld)}) and [the docs][readme] here`,
   );
 
   // After updating wiki content, new links should be converted

--- a/packages/patterns/notes/note-md.tsx
+++ b/packages/patterns/notes/note-md.tsx
@@ -15,6 +15,7 @@ import {
 } from "commonfabric";
 import {
   type MentionablePiece,
+  type MentionRefMap,
   type NoteMdInput,
   type NotePiece,
 } from "./schemas.tsx";
@@ -24,6 +25,44 @@ const handleBacklinkClick = handler<
   void,
   { piece: Writable<MentionablePiece> }
 >((_, { piece }) => navigateTo(piece));
+
+/**
+ * The address of a reference's destination, or undefined when the map does not
+ * hold the key.
+ *
+ * The scheme comes from the destination rather than being prepended. A
+ * wiki-link's embedded id is bare and provably `of:`, because the embed format
+ * rejects every other scheme, so the renderer can put `of:` back. A
+ * reference's destination is a cell carrying whatever scheme it has, and
+ * assuming `of:` for it would address a different entity than the one meant.
+ *
+ * `resolveAsCell` and `sourceURI` are cell-runtime surface rather than the
+ * pattern Writable type, hence the cast — the same one notes' `appendLink`
+ * makes.
+ */
+const referenceAddresses = (
+  references: Writable<MentionRefMap> | undefined,
+): Record<string, string> => {
+  const addresses: Record<string, string> = {};
+  // `.get()` here is also what subscribes the caller to the map, which is why
+  // this runs in the computed's own body rather than inside the replacement
+  // callback below it: a read from a nested callback resolves the address
+  // correctly and registers no dependency, so the rendered content would be
+  // right once and then never again.
+  const map = references?.get?.();
+  if (!map) return addresses;
+
+  for (const key of Object.keys(map)) {
+    // `destination` is typed unknown and so reads back undefined, but the
+    // ENTRY still materializes — `modifiedTitle` is a boolean — and the
+    // address comes from the path to the destination, not from its value.
+    const destination = (references as any).key(key).key("destination");
+    const uri: string | undefined = destination?.resolveAsCell?.()?.sourceURI;
+    if (uri) addresses[key] = `/${uri}`;
+  }
+
+  return addresses;
+};
 
 // ===== Output Type =====
 
@@ -49,7 +88,7 @@ export interface NoteMdOutput {
 }
 
 export default pattern<NoteMdInput, NoteMdOutput>(
-  ({ note, sourceNoteRef, content }) => {
+  ({ note, sourceNoteRef, content, references }) => {
     const displayName = computed(() => {
       const title = note?.title || "Untitled";
       return `📖 ${title}`;
@@ -57,22 +96,37 @@ export default pattern<NoteMdInput, NoteMdOutput>(
 
     const hasBacklinks = computed(() => (note?.backlinks?.length ?? 0) > 0);
 
-    // Convert [[Name (id)]] wiki-links to markdown links [Name](/of:id)
-    // cf-markdown will then convert these to clickable cf-cell-link components
-    // Use content prop if provided, otherwise fall back to note.content
+    // Convert both mention forms to markdown links, which cf-markdown then
+    // turns into clickable cf-cell-link components. Use the content prop if
+    // provided, otherwise fall back to note.content.
     //
-    // The embedded id is the BARE tagged hash by contract: the editor strips
-    // `of:` at embed time (mentionIdFromCellId in packages/ui) and REJECTS
-    // `computed:` ids, so prepending `/of:` here is always correct. If
-    // mentionable cells ever include computed ones, the embed format must
-    // carry the scheme instead — the bare form cannot, because the scheme is
-    // part of the identity and `/of:` would address the wrong entity.
+    // A wiki-link's embedded id is the BARE tagged hash by contract: the
+    // editor strips `of:` at embed time (mentionIdFromCellId in packages/ui)
+    // and REJECTS `computed:` ids, so prepending `/of:` is always correct for
+    // that form. A reference's destination carries its own scheme, so that
+    // form reads the address off the destination instead.
     const processedContent = computed(() => {
       const raw = content?.get?.() ?? note?.content ?? "";
-      // Match [[Name (id)]] pattern and convert to [Name](/of:id)
-      return raw.replace(
+      const withWikiLinks = raw.replace(
         /\[\[([^\]]*?)\s*\(([^)]+)\)\]\]/g,
         (_match, name, id) => `[${name.trim()}](/of:${id})`,
+      );
+      const addresses = referenceAddresses(references);
+
+      // Match `[Label][key]`, the reference form. The key shape matches what
+      // the editor mints (`mintRefKey`, `packages/ui/src/v2/core/mention-refs.ts`);
+      // a pattern cannot import from the UI package, so the two are held in
+      // step by hand. The literal is built here rather than at module scope,
+      // where a stateful RegExp is not allowed.
+      //
+      // A key with no address is left exactly as written. It may be a
+      // hand-written reference link, or a mention pasted out of a note whose
+      // map is elsewhere; either way the label survives and the reader sees
+      // what the author typed rather than a link to nothing.
+      return withWikiLinks.replace(
+        /\[([^\]\n]*)\]\[([0-9a-z]{6,10})\]/g,
+        (match: string, label: string, key: string) =>
+          addresses[key] ? `[${label}](${addresses[key]})` : match,
       );
     });
 

--- a/packages/patterns/notes/note-md.tsx
+++ b/packages/patterns/notes/note-md.tsx
@@ -26,9 +26,48 @@ const handleBacklinkClick = handler<
   { piece: Writable<MentionablePiece> }
 >((_, { piece }) => navigateTo(piece));
 
+/** The shape `getAsNormalizedFullLink()` returns, as much of it as is used. */
+interface NormalizedLink {
+  id?: string;
+  path?: readonly PropertyKey[];
+  space?: string;
+  scope?: string;
+}
+
 /**
- * The address of a reference's destination, or undefined when the map does not
- * hold the key.
+ * A resolved cell's address, in the form `cf-markdown` turns into a cell link.
+ *
+ * This mirrors `createLLMFriendlyLink` (`packages/runner/src/link-types.ts`),
+ * which a pattern cannot import. Reproducing it rather than using the id alone
+ * is what keeps a destination that is a nested cell, or one in another space,
+ * addressable: an id on its own names the document root in the reader's own
+ * space, which for those destinations is a different cell than the one meant.
+ * Segments are escaped per RFC 6901, as `encodeJsonPointer` does.
+ */
+const linkAddress = (
+  link: NormalizedLink,
+  contextSpace: string | undefined,
+): string | undefined => {
+  if (!link.id) return undefined;
+
+  const id = link.scope && link.scope !== "space"
+    ? `${link.id}@${link.scope}`
+    : link.id;
+  const segments = contextSpace && link.space && link.space !== contextSpace
+    ? [`@${link.space}`, id, ...(link.path ?? [])]
+    : [id, ...(link.path ?? [])];
+
+  return `/${
+    segments
+      .map((segment) =>
+        String(segment).replace(/~/g, "~0").replace(/\//g, "~1")
+      )
+      .join("/")
+  }`;
+};
+
+/**
+ * Every reference key the map resolves, paired with its destination's address.
  *
  * The scheme comes from the destination rather than being prepended. A
  * wiki-link's embedded id is bare and provably `of:`, because the embed format
@@ -36,9 +75,9 @@ const handleBacklinkClick = handler<
  * reference's destination is a cell carrying whatever scheme it has, and
  * assuming `of:` for it would address a different entity than the one meant.
  *
- * `resolveAsCell` and `sourceURI` are cell-runtime surface rather than the
- * pattern Writable type, hence the cast — the same one notes' `appendLink`
- * makes.
+ * `resolveAsCell` and `getAsNormalizedFullLink` are cell-runtime surface
+ * rather than the pattern Writable type, hence the casts — the same one notes'
+ * `appendLink` makes.
  */
 const referenceAddresses = (
   references: Writable<MentionRefMap> | undefined,
@@ -52,13 +91,20 @@ const referenceAddresses = (
   const map = references?.get?.();
   if (!map) return addresses;
 
+  // The space the note itself lives in. A destination in the same space is
+  // addressed without one, which is what every mention made today looks like.
+  const contextSpace: string | undefined = (references as any)
+    ?.getAsNormalizedFullLink?.()?.space;
+
   for (const key of Object.keys(map)) {
     // `destination` is typed unknown and so reads back undefined, but the
     // ENTRY still materializes — `modifiedTitle` is a boolean — and the
     // address comes from the path to the destination, not from its value.
     const destination = (references as any).key(key).key("destination");
-    const uri: string | undefined = destination?.resolveAsCell?.()?.sourceURI;
-    if (uri) addresses[key] = `/${uri}`;
+    const link: NormalizedLink | undefined = destination?.resolveAsCell?.()
+      ?.getAsNormalizedFullLink?.();
+    const address = link ? linkAddress(link, contextSpace) : undefined;
+    if (address) addresses[key] = address;
   }
 
   return addresses;

--- a/packages/patterns/notes/schemas.tsx
+++ b/packages/patterns/notes/schemas.tsx
@@ -112,6 +112,26 @@ export interface NotebookInput {
   parentNotebook?: Writable<NotebookPiece | null | Default<null>>;
 }
 
+/**
+ * One mention in reference form: where it points, and whether the label
+ * carrying it in the text is the user's own wording rather than the
+ * destination's name.
+ *
+ * `destination` is typed `unknown` because a mention may address any piece,
+ * and a read of it comes back undefined for that reason. An address is taken
+ * from the path to it instead, which survives where the value does not.
+ */
+export interface MentionRef {
+  destination: unknown;
+  modifiedTitle: boolean;
+}
+
+/**
+ * A note's mentions, keyed by the token that appears in its text. The keys are
+ * local to one note and mean nothing anywhere else.
+ */
+export type MentionRefMap = Record<string, MentionRef>;
+
 export interface NoteMdInput {
   /** Cell reference to note data (title + content + backlinks) */
   note?: NotePiece | Default<{ title: ""; content: ""; backlinks: [] }>;
@@ -119,6 +139,8 @@ export interface NoteMdInput {
   sourceNoteRef?: NotePiece;
   /** Writable content cell for checkbox updates */
   content?: Writable<string>;
+  /** The note's mentions, for resolving `[Label][key]` in its content */
+  references?: Writable<MentionRefMap>;
 }
 
 // ===== Utility Functions =====

--- a/packages/ui/docs/mentionable-internals.md
+++ b/packages/ui/docs/mentionable-internals.md
@@ -130,7 +130,7 @@ wish("#mentionable")  ──►  $mentionable prop    ──►  @link array
                     │             │              destination in that cell
                     ▼             ▼
              LLM sees links   note-md.tsx converts
-             in user message  a wiki-link to [Name](/of:id)
+             in user message  either form to [Name](/of:id)
                                   │
                                   ▼
                               cf-markdown renders

--- a/packages/ui/src/v2/components/cf-markdown/cf-markdown.test.ts
+++ b/packages/ui/src/v2/components/cf-markdown/cf-markdown.test.ts
@@ -52,6 +52,20 @@ describe("cf-markdown", () => {
     );
   });
 
+  it("should replace a cross-space LLM-friendly link with cf-cell-link", () => {
+    const el = new CFMarkdown();
+    // What `createLLMFriendlyLink` writes when the destination's space differs
+    // from the reader's: the space leads, prefixed with `@`.
+    const link = "/@did:key:z6MkpXpe/of:bafyabc123/path";
+    const markdown = `Check this [Link](${link})`;
+
+    const rendered = (el as any)._renderMarkdown(markdown);
+
+    expect(rendered).toContain(
+      `<cf-cell-link link="${link}" label="Link"></cf-cell-link>`,
+    );
+  });
+
   it("should wrap code blocks with copy buttons", () => {
     const el = new CFMarkdown();
     const markdown = "```js\nconsole.log('hello');\n```";

--- a/packages/ui/src/v2/components/cf-markdown/cf-markdown.ts
+++ b/packages/ui/src/v2/components/cf-markdown/cf-markdown.ts
@@ -481,10 +481,13 @@ export class CFMarkdown extends BaseElement {
   }
 
   private _replaceCellLinks(html: string): string {
-    // Matches <a href="/of:...">Name</a>
-    // Supports LLM-friendly links starting with /of: or similar schemes
+    // Matches <a href="/of:...">Name</a>, and the cross-space form the
+    // LLM-friendly link writes as /@did:key:.../of:... — a link whose space
+    // differs from the reader's leads with `@space`, and a matcher requiring
+    // an alphanumeric first character would leave it an ordinary relative
+    // anchor pointing at a path the shell does not serve.
     return html.replace(
-      /<a href="(\/[a-zA-Z0-9]+:[^"]+)">([^<]*)<\/a>/g,
+      /<a href="(\/@?[a-zA-Z0-9]+:[^"]+)">([^<]*)<\/a>/g,
       (_match, link, text) => {
         return `<cf-cell-link link="${link}" label="${
           this._escapeForAttribute(text)


### PR DESCRIPTION
## Why

Stage 2 of #5658, stacked on #5660. The editor can mint `[Label][key]`, but
nothing renders it — a note holding one shows the raw token — so the form is
unusable end to end until this lands.

`note-md` resolves the key through the note's reference map and emits the
markdown link `cf-markdown` turns into a `cf-cell-link`.

**The address comes from the destination rather than being prepended.** A
wiki-link's embedded id is bare and provably `of:`, because the embed format
rejects every other scheme, so the renderer can put `of:` back. A reference's
destination is a cell carrying whatever scheme it has, and assuming `of:` for
it would address a different entity than the one meant. `cf-markdown` already
matches any `/<scheme>:` href, so nothing downstream needed widening.

## What Changed

- `schemas.tsx` — `MentionRef` / `MentionRefMap`, and `references` on
  `NoteMdInput`.
- `note-md.tsx` — `processedContent` converts both mention forms. A key the map
  does not hold is left exactly as written: it may be a hand-written reference
  link, or a mention pasted out of a note whose map is elsewhere, and either way
  the label survives and nothing points at nothing.
- `note-md.test.tsx` — six cases (below).
- A recorded contract baseline for the changed input schema, added via
  `deno task pattern-compat --update` as the gate instructs.

Two things this cost, both worth a reviewer's eye:

1. **The map is read in the computed's own body, not from the replacement
   callback.** A read from the callback resolves the address correctly and
   registers no dependency, so the content renders right once and then goes
   stale. I hit exactly that: the first run of the tests showed unconverted
   tokens while a probe proved the resolution worked. The late-entry test is
   what pins it.
2. **The regex literal is built inside the callback**, not at module scope,
   where the pattern sandbox refuses a stateful RegExp. The key shape is
   duplicated from `mintRefKey` in `packages/ui`, since a pattern cannot import
   from the UI package — held in step by a comment on both sides.

## Test plan

`deno task cf test packages/patterns/notes/note-md.test.tsx` — 33 passed, 0
failed. New cases:

- a token with no entry yet is text (what an unloaded map looks like)
- once seeded, it renders as a link to the destination's own address
- that address carries the destination's scheme (`/of:` for a piece)
- an unknown key and a hand-written `[the docs][readme]` are both left alone
- with no map at all, reference-form text stays text
- both forms in one note convert together
- an entry arriving *after* the token resolves it — the reactivity guard

Also green: `deno task check`, `pattern-compat` (327 patterns update from every
recorded contract), `check-docs`, `check-baselines-append-only`,
`check-conflict-markers`, `deno fmt`, `deno lint`.

Pre-existing and untouched by this change: `note.test.tsx` and
`notebook-drop.test.tsx` fail under a per-file `cf test` invocation with
`realpath '.../notes/test/vnode-helpers.ts'` — the helper lives at
`packages/patterns/test/`. Both fail identically with this branch's changes
stashed.

The plan's Stage 1 and Stage 2 boxes are ticked here, since the stack carries
both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

