### PR TITLE
feat(cli): a call publishes the address of the outcome it filed

### DIFF
--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -113,6 +113,7 @@ cf piece call --piece <board> addTopic \
 {
   "invocation": "0f4c…",
   "status": "settled",
+  "receipt": { "space": "did:key:…", "id": "of:fid1:…", "scope": "space" },
   "result": { "topic": { "$NAME": "Ship the thing", "…": "…" } }
 }
 ```
@@ -125,6 +126,19 @@ callers file concurrently.
 Anything the *pattern* resolved comes back too. A verb that stamps a write time
 or derives structured authorship from the event returns those in its record;
 the caller could not have computed them.
+
+The `receipt` is where that outcome lives: the address of the cell this
+handling wrote it to. Keep it and the result is re-readable without calling
+anything again —
+
+```bash
+cf piece get --piece <the receipt id>
+```
+
+— which is an ordinary read, so the verb's body does not run a second time.
+The address is known at commit rather than at readback, so it rides every
+envelope, including `--no-wait`'s. It is absent only where the runtime wrote no
+receipt to name.
 
 ### Asking for a smaller result
 
@@ -239,6 +253,25 @@ timing: readback → settled 72.8ms
 `--await` and `--no-wait` control whether the call waits for settlement and
 readback or exits once the commit is acknowledged.
 
+### Dispatching now, collecting later
+
+`--no-wait` returns at `"committed"`: the handler has run and its write is
+durable, and only the readback is skipped. The envelope still carries the
+`receipt`, so a detached call is a handle rather than a dead end —
+
+```json
+{
+  "invocation": "add-1",
+  "status": "committed",
+  "receipt": { "space": "did:key:…", "id": "of:fid1:…", "scope": "space" }
+}
+```
+
+— and collecting the outcome later is `cf piece get --piece <the receipt id>`.
+Replaying the same id and session recovers it too, but that re-runs the handler
+body: a verb that sends mail or spends a model call does it again. Reading the
+address does not.
+
 ## Which results arrive, and when
 
 Two paths deliver a result, and both arrive by default:
@@ -333,6 +366,11 @@ one, so a chain of references annotates each hop exactly once. The walk stops at
 any non-plain object: a live runtime object reached through a result gets its
 own entry and nothing below it, because its properties belong to the runtime
 rather than to the result.
+
+`links` answers a different question from the envelope's `receipt`: `"/"` names
+whatever document backs the result **value**, which is the receipt only when the
+result is not itself a reference, while `receipt` always names the handling's
+own receipt and needs no flag to appear.
 
 The links describe whatever result you were handed, so a projection composes
 with them: a path `--select` or `--schema` dropped simply gets no entry.

--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -187,7 +187,8 @@ stranger, and a command's arguments are readable in a process listing where its
 environment is not. `--invocation-session <id>` overrides it for one call.
 
 The pair is what names an invocation. Replaying a settled id **from the session
-that chose it** returns the **original** result rather than re-executing:
+that chose it** hands back the **original** result, and nothing is written a
+second time:
 
 ```bash
 cf piece call --piece <topic> --invocation add-comment-1 \
@@ -201,6 +202,16 @@ cf piece call --piece <topic> --invocation add-comment-1 \
 
 That is the property an agent depends on when it retries a call whose response
 it never saw.
+
+**A receipt witnesses the commit, not the execution.** The replay above does run
+the handler body again; it then loses the race for the create-only receipt, so
+its commit is refused and no second comment is recorded. What it cannot undo is
+anything the body did *outside* that transaction: a verb that sends mail or
+spends a model call does it twice, and a write it made into another space
+commits before the receipt is contested and is not rolled back when the receipt
+is lost. So retry freely for a verb that only writes its own space, and prefer
+reading the `receipt` address for a verb that reaches beyond it — that collects
+the same outcome without running anything.
 
 That same id under a **different** session is a different invocation: it
 executes, and returns its own result. So two agents that pick the same word are
@@ -370,7 +381,10 @@ rather than to the result.
 `links` answers a different question from the envelope's `receipt`: `"/"` names
 whatever document backs the result **value**, which is the receipt only when the
 result is not itself a reference, while `receipt` always names the handling's
-own receipt and needs no flag to appear.
+own receipt and needs no flag to appear. Where the two describe the same thing
+they carry the same address — the receipt appears in `links` as `"/"`, or under
+the reserved bare `receipt` key when `"/"` had to name something else — so under
+`--show-links` the address is simply present twice.
 
 The links describe whatever result you were handed, so a projection composes
 with them: a path `--select` or `--schema` dropped simply gets no entry.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -353,7 +353,9 @@ Three cases follow from that:
 - **`--no-wait` refuses all three flags.** That mode exits once the commit is
   acknowledged and skips the receipt readback, so there is no result to shape.
   The refusal names the flags that need the readback, alongside `--show-links`
-  for the same reason.
+  for the same reason. What it still returns is the envelope's `receipt` — the
+  address of the cell holding the outcome, known at commit — so the shaping
+  flags apply to the `cf piece get` that collects it.
 - **`--show-links` composes with a projection, not with `--filter`.** Links are
   collected after the selection, over exactly the value the caller is holding: a
   projection leaves every surviving path where it was, so each address still

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -339,8 +339,11 @@ export function exitPieceCallFailure(
   const exit = deps?.exit ?? Deno.exit;
   printError(error instanceof Error ? error.message : String(error));
   // Where the invocation stopped decides retry semantics: anything at or
-  // past "dispatched" retries SAFELY ONLY with this same id (same-id
-  // retries deduplicate; a fresh id would re-execute).
+  // past "dispatched" retries SAFELY ONLY with this same id. At-most-once
+  // is per COMMIT, not per execution: a same-id retry runs the handler
+  // body again and then loses the race for the receipt, so nothing
+  // commits twice but effects outside the transaction repeat. A fresh id
+  // loses nothing and commits a second time.
   printError(`invocation: ${invocationId} phase: ${phase}`);
   return exit(1);
 }
@@ -480,8 +483,10 @@ export function resolveInvocationIdentity(
  * Build the phase observer for a handler invocation. Its whole job is to put
  * the invocation id on stderr at the moment the event is about to dispatch —
  * BEFORE any network work — so a caller whose process dies past that line
- * still holds the exact id to retry with, and the retry deduplicates instead
- * of executing a second time. Announcing once matters: a caller scraping
+ * still holds the exact id to retry with. At-most-once is per COMMIT, not per
+ * execution: the retry runs the handler body again and loses the race for the
+ * receipt, so nothing commits twice while effects outside the transaction
+ * repeat. Announcing once matters: a caller scraping
  * stderr for its id should not have to decide which of several to trust.
  *
  * The id is half of what a retry names: it deduplicates only under the session
@@ -1796,9 +1801,10 @@ after --. Handlers interpret piped input when no input argument is present.`,
     "Bound the settlement wait by a chosen patience, in seconds (before " +
       "the callable name). On expiry the exit is nonzero with the " +
       "invocation id and furthest phase on stderr; the invocation may not " +
-      "have executed or committed, and re-invoking under the same id and " +
-      "session is safe in every phase — it finishes the work or reads the " +
-      "outcome back.",
+      "have executed or committed. Re-invoking under the same id and " +
+      "session cannot commit twice — but it runs the handler body again, " +
+      "so effects outside the transaction repeat. An expiry is exactly the " +
+      "case where you cannot tell whether it committed.",
   )
   .option(
     "--no-wait",
@@ -1922,8 +1928,11 @@ after --. Handlers interpret piped input when no input argument is present.`,
       console.error(message);
       observer.finish("failed");
       // Where the invocation stopped decides retry semantics: anything at or
-      // past "dispatched" retries SAFELY ONLY with this same id (same-id
-      // retries deduplicate; a fresh id would re-execute).
+      // past "dispatched" retries SAFELY ONLY with this same id. At-most-once
+      // is per COMMIT, not per execution: a same-id retry runs the handler
+      // body again and then loses the race for the receipt, so nothing
+      // commits twice but effects outside the transaction repeat. A fresh id
+      // loses nothing and commits a second time.
       console.error(`invocation: ${invocationId} phase: ${phase}`);
       if (error instanceof WaitBoundExpired) {
         // The caller's patience expired. The handler runs in this process,

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -625,27 +625,33 @@ export function renderPieceCallOutcome(
     renderOut(JSON.stringify(invocationJson(result.invocation), null, 2));
     // The address the envelope published, when the runtime wrote a receipt.
     // It leads the detached next steps because it collects the outcome
-    // without running the verb again — a same-id replay returns the original
-    // outcome but re-executes the handler body, so a verb with effects
-    // outside its transaction repeats them.
+    // without running the verb again.
     const receiptId = result.invocation.receipt?.id;
     hintOut(
-      // The replay names its session through the environment rather than
-      // `--invocation-session`, because a session is what keeps an outcome's
-      // address out of reach of anyone who can guess a piece, a verb and an
-      // id — and an argument is readable in a process listing where an
-      // environment variable is not.
       opts.detached
-        ? cliText(`NEXT STEPS:${
-          receiptId === undefined ? "" : `
-  → Read the outcome: cf piece get --piece ${receiptId} (this call's receipt, an ordinary read — the handler does not run again)`
-        }
+        ? cliText(
+          receiptId === undefined
+            // No receipt means receipts are not being written here, and that
+            // is exactly the configuration in which a same-id call does NOT
+            // deduplicate — it executes AND commits a second time. Offering
+            // the replay as a recovery would be offering a duplicate.
+            ? `NEXT STEPS:
+  → Nothing to collect: this handling wrote no receipt, so the outcome has no address and a call naming the same pair executes and commits AGAIN rather than deduplicating.
+  → Verify state:     cf piece get --piece ${piece} <path> ...`
+            // The replay names its session through the environment rather
+            // than `--invocation-session`, because a session is what keeps an
+            // outcome's address out of reach of anyone who can guess a piece,
+            // a verb and an id — and an argument is readable in a process
+            // listing where an environment variable is not.
+            : `NEXT STEPS:
+  → Read the outcome: cf piece get --piece ${receiptId} (this call's receipt, an ordinary read — the handler does not run again)
   → Or replay it:     CF_INVOCATION_SESSION=${
-          opts.invocation?.session ?? "<session>"
-        } cf piece call --piece ${piece} --invocation ${
-          opts.invocation?.id ?? "<id>"
-        } ${callableName} ... (the commit is durable; a call naming this same pair deduplicates and returns the settled outcome)
-  → Verify state:     cf piece get --piece ${piece} <path> ...`)
+              opts.invocation?.session ?? "<session>"
+            } cf piece call --piece ${piece} --invocation ${
+              opts.invocation?.id ?? "<id>"
+            } ${callableName} ... (the commit is durable and the replay loses the race for the receipt, so nothing commits twice — but the handler body RUNS AGAIN, repeating effects outside its transaction, and any write it made into another space)
+  → Verify state:     cf piece get --piece ${piece} <path> ...`,
+        )
         : nextSteps,
     );
     return;
@@ -1800,9 +1806,9 @@ after --. Handlers interpret piped input when no input argument is present.`,
       "name), skipping only the receipt readback: stdout reports status " +
       '"committed" plus the receipt address, so `cf piece get --piece <that ' +
       "id>` collects the outcome later without re-running the handler; a " +
-      "later call naming the same invocation session and --invocation " +
-      "recovers it too. The handler still executes here and its commit is " +
-      "durable. Handler invocations only.",
+      "call naming the same session and --invocation recovers it too, but " +
+      "runs the handler body again. The handler still executes here and its " +
+      "commit is durable. Handler invocations only.",
   )
   .option(
     "--show-links",

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -623,15 +623,24 @@ export function renderPieceCallOutcome(
     // Invocation JSON — settled, or stopped at "committed" under --no-wait —
     // prose stays on stderr via hint().
     renderOut(JSON.stringify(invocationJson(result.invocation), null, 2));
+    // The address the envelope published, when the runtime wrote a receipt.
+    // It leads the detached next steps because it collects the outcome
+    // without running the verb again — a same-id replay returns the original
+    // outcome but re-executes the handler body, so a verb with effects
+    // outside its transaction repeats them.
+    const receiptId = result.invocation.receipt?.id;
     hintOut(
-      // The readback names its session through the environment rather than
+      // The replay names its session through the environment rather than
       // `--invocation-session`, because a session is what keeps an outcome's
       // address out of reach of anyone who can guess a piece, a verb and an
       // id — and an argument is readable in a process listing where an
       // environment variable is not.
       opts.detached
-        ? cliText(`NEXT STEPS:
-  → Read the outcome: CF_INVOCATION_SESSION=${
+        ? cliText(`NEXT STEPS:${
+          receiptId === undefined ? "" : `
+  → Read the outcome: cf piece get --piece ${receiptId} (this call's receipt, an ordinary read — the handler does not run again)`
+        }
+  → Or replay it:     CF_INVOCATION_SESSION=${
           opts.invocation?.session ?? "<session>"
         } cf piece call --piece ${piece} --invocation ${
           opts.invocation?.id ?? "<id>"
@@ -658,6 +667,11 @@ export function renderPieceCallOutcome(
  * `null`, which would be indistinguishable from a verb that returned null.
  * `links` appears only under --show-links: provenance beside the value,
  * never inline in it.
+ *
+ * `receipt` is the one key that does not depend on a readback or a flag: it
+ * is the address of the cell holding this outcome, known at commit, so it
+ * rides a `--no-wait` envelope as well as a settled one. It is absent only
+ * where the runtime wrote no receipt to address.
  */
 export function invocationJson(
   outcome: InvocationOutcome,
@@ -666,6 +680,7 @@ export function invocationJson(
     invocation: outcome.id,
     status: outcome.status,
     ...(outcome.deduplicated ? { deduplicated: true } : {}),
+    ...(outcome.receipt !== undefined ? { receipt: outcome.receipt } : {}),
     ...("result" in outcome && outcome.result !== undefined
       ? { result: outcome.result }
       : {}),
@@ -1783,9 +1798,11 @@ after --. Handlers interpret piped input when no input argument is present.`,
     "--no-wait",
     "Exit once this handling's commit is acknowledged (before the callable " +
       "name), skipping only the receipt readback: stdout reports status " +
-      '"committed", and a later call naming the same invocation session and ' +
-      "--invocation reads the outcome back. The handler still executes here " +
-      "and its commit is durable. Handler invocations only.",
+      '"committed" plus the receipt address, so `cf piece get --piece <that ' +
+      "id>` collects the outcome later without re-running the handler; a " +
+      "later call naming the same invocation session and --invocation " +
+      "recovers it too. The handler still executes here and its commit is " +
+      "durable. Handler invocations only.",
   )
   .option(
     "--show-links",

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -89,10 +89,11 @@ export interface CallableExecutionDeps {
    * THIS process's runtime, so exiting before the commit is acknowledged
    * would abandon the invocation un-executed — nothing durable would have
    * happened — not leave it settling elsewhere. What CAN be skipped is
-   * fetching the outcome back, because a caller-supplied id keeps that
-   * fetch available forever: a later same-id call deduplicates against the
-   * create-only receipt and returns the original outcome (verb contract
-   * D1/D3). Requires an `invocationId` — without one there is no receipt to
+   * fetching the outcome back, because the exit publishes the receipt's
+   * address (`InvocationOutcome.receipt`), so collecting it later is an
+   * ordinary read; a same-id replay recovers it too, deduplicating against
+   * the create-only receipt (verb contract D1/D3), but re-runs the handler
+   * body. Requires an `invocationId` — without one there is no receipt to
    * come back for — and only the handler send path supports it (a tool's
    * result is delivered by this process, not read back from a receipt). */
   skipReadback?: boolean;
@@ -134,6 +135,24 @@ export interface InvocationOutcome {
    * (commit acknowledged, readback skipped), and a caller-bounded wait
    * reports the phase its bound expired in. */
   status: "settled" | InvocationPhase;
+  /** Durable address of this handling's receipt — the cell the outcome is
+   * written to, and the one `result` is read from.
+   *
+   * Published from the transaction's handling receipt link, which the commit
+   * callback carries, so the address is known BEFORE the outcome is read.
+   * That is what makes it available under `--no-wait`: a caller that chose
+   * not to wait still holds the address to collect from, and reads it back
+   * with `cf piece get --piece <id>` rather than re-invoking the verb — a
+   * same-id replay returns the original outcome but re-runs the handler
+   * body, so a verb with effects outside its transaction repeats them.
+   *
+   * On a create-only collision this addresses the ORIGINAL handling's
+   * receipt, which is the outcome a caller wants either way.
+   *
+   * Absent when the runtime published no link: with `commitPreconditions`
+   * off nothing writes a receipt, and an address naming a cell that does not
+   * exist is worse than no address. */
+  receipt?: InvocationResultLink;
   /** The verb's result read back from the handling's receipt, when the
    * receipt carried one (a reactive-bearing return, or a plain return under
    * the plainResultReceipts flag). Absent for value-less verbs. */
@@ -695,17 +714,28 @@ export async function executeResolvedCallable(
 
     if (invocationId === undefined) return {};
 
+    // The handling's receipt address, taken off the transaction the commit
+    // callback handed back (verb contract WS-D). It is known HERE — at
+    // commit, before anything is read — which is what lets the detached exit
+    // below publish an address for an outcome nobody waited for.
+    const link = tx.handlingReceiptLink;
+    const receiptAddress = link === undefined
+      ? undefined
+      : toInvocationResultLink(link);
+
     if (deps.skipReadback) {
       // --no-wait's exit point: the commit is acknowledged, so the
       // handling — and on a collision, the original one — is durable on
       // the server and survives this process. Only the readback
-      // (sync + read of the outcome) is skipped; a later same-id call
-      // retrieves it by deduplicating against the create-only receipt.
+      // (sync + read of the outcome) is skipped; the address of the outcome
+      // rides out regardless, so collecting it later is an ordinary read
+      // rather than a same-id replay that re-runs the handler body.
       return {
         invocation: {
           id: invocationId,
           status: "committed",
           ...(deduplicated ? { deduplicated: true } : {}),
+          ...(receiptAddress !== undefined ? { receipt: receiptAddress } : {}),
         },
       };
     }
@@ -716,7 +746,6 @@ export async function executeResolvedCallable(
     deps.onPhase?.("readback");
     let result: unknown;
     let links: Record<string, InvocationResultLink> | undefined;
-    const link = tx.handlingReceiptLink;
     if (link) {
       const receipt = resolved.pieces.runtime.getCellFromLink<any>(link);
       const value = await receipt.pull();
@@ -754,6 +783,7 @@ export async function executeResolvedCallable(
         id: invocationId,
         status: "settled",
         ...(deduplicated ? { deduplicated: true } : {}),
+        ...(receiptAddress !== undefined ? { receipt: receiptAddress } : {}),
         ...(result !== undefined ? { result } : {}),
         ...(links !== undefined ? { links } : {}),
       },

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -142,12 +142,17 @@ export interface InvocationOutcome {
    * callback carries, so the address is known BEFORE the outcome is read.
    * That is what makes it available under `--no-wait`: a caller that chose
    * not to wait still holds the address to collect from, and reads it back
-   * with `cf piece get --piece <id>` rather than re-invoking the verb — a
-   * same-id replay returns the original outcome but re-runs the handler
-   * body, so a verb with effects outside its transaction repeats them.
+   * with `cf piece get --piece <id>` rather than re-invoking the verb. The
+   * receipt is a COMMIT witness, not an execution witness — a same-id replay
+   * runs the handler body again and then loses the race, so effects outside
+   * the transaction repeat.
    *
    * On a create-only collision this addresses the ORIGINAL handling's
-   * receipt, which is the outcome a caller wants either way.
+   * receipt: the loser's commit callback carries the winner's address. That
+   * is the runner's guarantee, asserted where it is implemented
+   * (`packages/runner/test/scheduler-event-receipts.test.ts`, "cell.send
+   * carries a caller-supplied eventId and exposes the receipt link") — the
+   * CLI's own tests drive a single address and cannot witness it.
    *
    * Absent when the runtime published no link: with `commitPreconditions`
    * off nothing writes a receipt, and an address naming a cell that does not
@@ -742,7 +747,10 @@ export async function executeResolvedCallable(
 
     // Read the handling's outcome back off its receipt. On a receipt-exists
     // collision this is the ORIGINAL handling's receipt — same id, same
-    // outcome, no re-execution — so a retry settles as a success.
+    // outcome — so a retry settles as a success. The receipt is a COMMIT
+    // witness, not an execution witness: the redelivered event still ran the
+    // handler body and then lost the race, so nothing committed twice while
+    // effects outside the transaction repeated.
     deps.onPhase?.("readback");
     let result: unknown;
     let links: Record<string, InvocationResultLink> | undefined;

--- a/packages/cli/test/main-command.test.ts
+++ b/packages/cli/test/main-command.test.ts
@@ -82,6 +82,26 @@ describe("main command", () => {
     expect(mismatchedUsage).toEqual([]);
   });
 
+  it("tells a caller what a same-id retry costs, on every waiting flag", async () => {
+    // Both waiting flags invite a retry, and a retry runs the handler body
+    // again — at-most-once is per commit, not per execution. `--wait` is the
+    // sharper case: an expiry is exactly when the caller cannot tell whether
+    // the handling committed. The two sit adjacent in `--help`, so a caveat
+    // on one and silence on the other reads as a real difference between
+    // them.
+    const { code, stdout, stderr } = await cf("piece call --help");
+    checkStderr(stderr);
+    const help = stripAnsi(stdout.join("\n")).replaceAll(/\s+/g, " ");
+    expect(help).toContain(
+      "Re-invoking under the same id and session cannot commit twice — but " +
+        "it runs the handler body again",
+    );
+    expect(help).toContain(
+      "recovers it too, but runs the handler body again",
+    );
+    expect(code).toBe(0);
+  });
+
   it("describes and parses piece call's accepted input forms", async () => {
     const { piece } = await import(
       "../commands/piece.ts?piece-call-usage-test"

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -5,6 +5,8 @@ import type { JSONSchema } from "@commonfabric/api";
 import { Identity } from "@commonfabric/identity";
 import {
   type Cell,
+  entityIdFrom,
+  type MemorySpace,
   type NormalizedFullLink,
   Runtime,
 } from "@commonfabric/runner";
@@ -384,6 +386,7 @@ describe("executePieceCallable", () => {
     expect(result.invocation).toEqual({
       id: "inv-defaulted",
       status: "settled",
+      receipt: harnessReceipt,
     });
   });
 
@@ -962,6 +965,7 @@ describe("executePieceCallable", () => {
     expect(result.invocation).toEqual({
       id: "inv-123",
       status: "settled",
+      receipt: harnessReceipt,
       result: { commentId: "c-1" },
     });
     expect(phases).toEqual(["dispatched", "committed", "readback"]);
@@ -1013,6 +1017,7 @@ describe("executePieceCallable", () => {
     expect(result.invocation).toEqual({
       id: "inv-123",
       status: "settled",
+      receipt: harnessReceipt,
       result: { commentId: "c-1" },
     });
   });
@@ -1087,8 +1092,47 @@ describe("executePieceCallable", () => {
       id: "inv-dup",
       status: "settled",
       deduplicated: true,
+      receipt: harnessReceipt,
       result: { commentId: "c-original" },
     });
+  });
+
+  it("names the receipt the settled result was read out of", async () => {
+    // One envelope shape whether or not the caller waited: the address is
+    // published on both exits, and on the settled one it is demonstrably the
+    // document the readback opened — not a second address for the same
+    // outcome.
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "addComment",
+      inputSchema: {
+        type: "object",
+        properties: { message: { type: "string" } },
+        required: ["message"],
+      },
+      receiptValue: { commentId: "c-1" },
+    });
+
+    const result = await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-123",
+        space: "home",
+      },
+      "addComment",
+      ["--message", "milk"],
+      {
+        loadPieces: () => Promise.resolve(harness.pieces),
+        loadPiece: () => Promise.resolve(harness.piece),
+        invocation: { id: "inv-settled-address", session: callerSession },
+      },
+    );
+
+    expect(result.invocation?.receipt).toEqual(harnessReceipt);
+    expect(harness.tracker.receiptLinkRequested?.id).toBe(
+      result.invocation?.receipt?.id,
+    );
   });
 
   it("settles a value-less verb with no result key (existence-only receipt)", async () => {
@@ -1116,7 +1160,11 @@ describe("executePieceCallable", () => {
       },
     );
 
-    expect(result.invocation).toEqual({ id: "inv-empty", status: "settled" });
+    expect(result.invocation).toEqual({
+      id: "inv-empty",
+      status: "settled",
+      receipt: harnessReceipt,
+    });
   });
 
   it("sends without options and returns no invocation when no id is supplied", async () => {
@@ -1149,6 +1197,17 @@ describe("executePieceCallable", () => {
   });
 });
 
+/** The address the harness's handling files its receipt under: the link its
+ * `send` hands the commit callback, in the serialized form the envelope
+ * publishes. Every settled or committed invocation the harness produces
+ * carries it, because the runtime hands the address over at commit rather
+ * than at readback. */
+const harnessReceipt = {
+  space: "did:key:test-home",
+  id: "of:receipt-1",
+  scope: "space",
+};
+
 function createPieceCallableHarness(options: {
   callableKind: "handler" | "tool";
   cellKey: string;
@@ -1173,6 +1232,11 @@ function createPieceCallableHarness(options: {
    * completes anyway — or exercises a wait bound against a call that can
    * never beat it. */
   neverCommit?: boolean;
+  /** Commit with no `handlingReceiptLink` on the transaction, which is what
+   * the runner leaves behind when receipts are not being written
+   * (`commitPreconditions` off): it stashes the link only when it will
+   * create the cell. */
+  noReceiptLink?: boolean;
   /** Replace the readback receipt cell wholesale — for --show-links tests,
    * whose receipt must support key()/resolveAsCell link traversal. */
   receiptCell?: Cell<any>;
@@ -1259,9 +1323,11 @@ function createPieceCallableHarness(options: {
                     ),
                   }
                   : { status: "done" },
-              handlingReceiptLink: mockLink({
-                id: "of:receipt-1",
-                space: "did:key:test-home",
+              ...(options.noReceiptLink ? {} : {
+                handlingReceiptLink: mockLink({
+                  id: "of:receipt-1",
+                  space: "did:key:test-home",
+                }),
               }),
             });
           },
@@ -2012,6 +2078,34 @@ describe("piece call stdin payloads", () => {
     ).not.toHaveProperty("result");
   });
 
+  it("carries the receipt address as a top-level envelope key", () => {
+    // Beside the id and the status, not inside the result: it addresses the
+    // outcome rather than being part of one, and a value-less verb has an
+    // address just the same.
+    const receipt = {
+      space: "did:key:s",
+      id: "of:receipt-1",
+      scope: "space" as const,
+    };
+    expect(
+      invocationJson({
+        id: "inv-1",
+        status: "settled",
+        receipt,
+        result: { commentId: "c-1" },
+      }),
+    ).toEqual({
+      invocation: "inv-1",
+      status: "settled",
+      receipt,
+      result: { commentId: "c-1" },
+    });
+    expect(invocationJson({ id: "inv-1", status: "committed", receipt }))
+      .toEqual({ invocation: "inv-1", status: "committed", receipt });
+    expect(invocationJson({ id: "inv-1", status: "settled" }))
+      .not.toHaveProperty("receipt");
+  });
+
   it('maps a bare "-" payload onto the --json-file stdin path', () => {
     expect(pieceCallRawArgs(["-"], [])).toEqual(["--json-file", "-"]);
   });
@@ -2283,6 +2377,7 @@ describe("piece call wait control", () => {
     expect(result.invocation).toEqual({
       id: "inv-no-readback",
       status: "committed",
+      receipt: harnessReceipt,
     });
     expect(phases).toEqual(["dispatched", "committed"]);
     expect(harness.tracker.sendOptions).toEqual([
@@ -2293,6 +2388,95 @@ describe("piece call wait control", () => {
     expect(harness.tracker.receiptLinkRequested).toBeUndefined();
     expect(harness.tracker.idleCalls).toBe(0);
     expect(harness.tracker.syncedCalls).toBe(0);
+  });
+
+  it("publishes the receipt address a detached call has to collect with", async () => {
+    // Without it --no-wait is a dead end: the caller holds an id whose only
+    // use is re-invoking the verb. The address is known at commit, so it
+    // costs nothing the mode skips — and it reaches stdout as a top-level
+    // envelope key, beside the id rather than inside the result.
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "addComment",
+      inputSchema: {
+        type: "object",
+        properties: { message: { type: "string" } },
+        required: ["message"],
+      },
+      receiptValue: { commentId: "c-1" },
+    });
+
+    const result = await executePieceCallable(
+      config,
+      "addComment",
+      ["--message", "milk"],
+      {
+        loadPieces: () => Promise.resolve(harness.pieces),
+        loadPiece: () => Promise.resolve(harness.piece),
+        invocation: { id: "inv-detached-address", session: callerSession },
+        skipReadback: true,
+      },
+    );
+
+    expect(result.invocation?.receipt).toEqual(harnessReceipt);
+    // Published from the commit, not from a readback: the receipt cell is
+    // never opened on this path.
+    expect(harness.tracker.receiptLinkRequested).toBeUndefined();
+    expect(invocationJson(result.invocation!)).toEqual({
+      invocation: "inv-detached-address",
+      status: "committed",
+      receipt: harnessReceipt,
+    });
+  });
+
+  it("omits the receipt when the runtime published no address", async () => {
+    // With receipts off nothing is created for the link to name. An address
+    // that resolves to no cell would invite a readback against a document
+    // that does not exist, so absent beats fabricated.
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "addComment",
+      inputSchema: {
+        type: "object",
+        properties: { message: { type: "string" } },
+        required: ["message"],
+      },
+      noReceiptLink: true,
+    });
+
+    const detached = await executePieceCallable(
+      config,
+      "addComment",
+      ["--message", "milk"],
+      {
+        loadPieces: () => Promise.resolve(harness.pieces),
+        loadPiece: () => Promise.resolve(harness.piece),
+        invocation: { id: "inv-no-receipt", session: callerSession },
+        skipReadback: true,
+      },
+    );
+
+    expect(detached.invocation).toEqual({
+      id: "inv-no-receipt",
+      status: "committed",
+    });
+    expect(invocationJson(detached.invocation!)).not.toHaveProperty("receipt");
+
+    const settled = await executePieceCallable(
+      config,
+      "addComment",
+      ["--message", "milk"],
+      {
+        loadPieces: () => Promise.resolve(harness.pieces),
+        loadPiece: () => Promise.resolve(harness.piece),
+        invocation: { id: "inv-no-receipt-settled", session: callerSession },
+      },
+    );
+
+    expect(settled.invocation).toEqual({
+      id: "inv-no-receipt-settled",
+      status: "settled",
+    });
   });
 
   it("still awaits the commit acknowledgement under --no-wait", async () => {
@@ -2365,6 +2549,7 @@ describe("piece call wait control", () => {
       id: "inv-dup-no-readback",
       status: "committed",
       deduplicated: true,
+      receipt: harnessReceipt,
     });
     expect(harness.tracker.receiptLinkRequested).toBeUndefined();
   });
@@ -2992,6 +3177,7 @@ describe("piece call --show-links", () => {
     expect(result.invocation).toEqual({
       id: "inv-links",
       status: "settled",
+      receipt: harnessReceipt,
       result: commentValue,
       links: {
         "/": { space: "did:key:test-home", id: "of:receipt-1", scope: "space" },
@@ -3008,6 +3194,7 @@ describe("piece call --show-links", () => {
     expect(Object.keys(json)).toEqual([
       "invocation",
       "status",
+      "receipt",
       "result",
       "links",
     ]);
@@ -3033,6 +3220,7 @@ describe("piece call --show-links", () => {
     expect(result.invocation).toEqual({
       id: "inv-no-links",
       status: "settled",
+      receipt: harnessReceipt,
       result: commentValue,
     });
     expect(invocationJson(result.invocation!)).not.toHaveProperty("links");
@@ -3063,6 +3251,7 @@ describe("piece call --show-links", () => {
     expect(result.invocation).toEqual({
       id: "inv-void-links",
       status: "settled",
+      receipt: harnessReceipt,
       links: {
         "/": { space: "did:key:test-home", id: "of:receipt-1", scope: "space" },
       },
@@ -3201,6 +3390,7 @@ describe("piece call selection", () => {
     expect(result.invocation).toEqual({
       id: "inv-select",
       status: "settled",
+      receipt: harnessReceipt,
       result: { topic: { title: "Ship it" } },
     });
     expect(selector.calls).toHaveLength(1);
@@ -3231,6 +3421,7 @@ describe("piece call selection", () => {
     expect(result.invocation).toEqual({
       id: "inv-plain",
       status: "settled",
+      receipt: harnessReceipt,
       result: topicResult,
     });
     expect(selector.calls).toEqual([]);
@@ -3260,6 +3451,7 @@ describe("piece call selection", () => {
     expect(result.invocation).toEqual({
       id: "inv-void-select",
       status: "settled",
+      receipt: harnessReceipt,
     });
     expect(invocationJson(result.invocation!)).not.toHaveProperty("result");
     expect(selector.calls).toEqual([]);
@@ -3368,6 +3560,7 @@ describe("piece call selection", () => {
     expect(result.invocation).toEqual({
       id: "inv-select-links",
       status: "settled",
+      receipt: harnessReceipt,
       result: { count: 1 },
       links: {
         "/": { space: "did:key:test-home", id: "of:receipt-1", scope: "space" },
@@ -3465,7 +3658,7 @@ const selectionSigner = await Identity.fromPassphrase(
   "cf-piece-call-selection",
 );
 
-describe("piece call selection over a live runtime", () => {
+describe("piece call over a live runtime", () => {
   const signer = selectionSigner;
   const space = signer.did();
   let storageManager: ReturnType<typeof StorageManager.emulate>;
@@ -3530,6 +3723,16 @@ describe("piece call selection over a live runtime", () => {
     };
   }
 
+  /** The serialized address of the receipt `settleWith` commits — what the
+   * envelope publishes, read off the same real cell the handling hands the
+   * commit callback. */
+  function receiptAddress(): Record<string, unknown> {
+    const link = runtime
+      .getCell(space, "handling-receipt")
+      .getAsNormalizedFullLink();
+    return { space: link.space, id: link.id, scope: link.scope };
+  }
+
   it("projects a settled result through the real selection step", async () => {
     const resolved = await settleWith({
       topics: [
@@ -3550,6 +3753,7 @@ describe("piece call selection over a live runtime", () => {
     expect(executed.invocation).toEqual({
       id: "inv-live",
       status: "settled",
+      receipt: receiptAddress(),
       result: { topics: [{ title: "First" }, { title: "Second" }] },
     });
   });
@@ -3628,6 +3832,45 @@ describe("piece call selection over a live runtime", () => {
     ).rejects.toThrow(
       /Cannot shape the result of "addTopic".*did not materialize/s,
     );
+  });
+
+  it("hands a detached call an address that reads the outcome back", async () => {
+    // The whole of `receipt`: a caller that skipped the readback holds an
+    // address, and that address resolves to the outcome it named. Reading it
+    // is an ordinary read — no second dispatch, so a verb whose body has
+    // effects outside its transaction does not repeat them.
+    const outcome = { topic: { title: "Ship it", body: "the document" } };
+    const resolved = await settleWith(outcome);
+
+    const executed = await executeResolvedCallable(
+      resolved,
+      { title: "Ship it" },
+      {
+        invocation: { id: "inv-live-detached", session: callerSession },
+        skipReadback: true,
+      },
+    );
+
+    // Nothing was read back — the envelope carries no result — and the
+    // address is still there to collect with.
+    expect(executed.invocation).toEqual({
+      id: "inv-live-detached",
+      status: "committed",
+      receipt: receiptAddress(),
+    });
+
+    // Resolve it exactly as `cf piece get --piece <id>` does: the id through
+    // the entity-URI intake, then the cell it names (a piece's result cell
+    // IS that cell, `PiecesController.getResult`).
+    const published = executed.invocation!.receipt!;
+    const collected = runtime.getCellFromEntityId(
+      published.space as MemorySpace,
+      entityIdFrom(published.id),
+      [],
+      undefined,
+    );
+    await collected.sync();
+    expect(collected.get()).toEqual(outcome);
   });
 });
 
@@ -4254,6 +4497,40 @@ describe("renderPieceCallOutcome", () => {
       "CF_INVOCATION_SESSION=ses-7 cf piece call",
     );
     assertStringIncludes(hinted[0], "--invocation inv-1");
+  });
+
+  it("leads the detached next steps with the address it published", () => {
+    const { observer } = observerRecorder();
+    const { deps, hinted } = sinkRecorder();
+    renderPieceCallOutcome(
+      observer,
+      {
+        ...base,
+        invocation: {
+          id: "inv-1",
+          status: "committed",
+          receipt: {
+            space: "did:key:s",
+            id: "of:receipt-1",
+            scope: "space",
+          },
+        },
+      } as unknown as ExecutedPieceCallable,
+      "addTopic",
+      "fid1:piece",
+      deps,
+      { detached: true, invocation: { id: "inv-1", session: "ses-7" } },
+    );
+    // Collecting the outcome is a read of the address this call published,
+    // and it comes first because it does not run the verb again. The replay
+    // stays on offer below it — it is the recovery when the address is lost.
+    assertStringIncludes(hinted[0], "cf piece get --piece of:receipt-1");
+    assertStringIncludes(
+      hinted[0],
+      "CF_INVOCATION_SESSION=ses-7 cf piece call",
+    );
+    expect(hinted[0].indexOf("cf piece get --piece of:receipt-1"))
+      .toBeLessThan(hinted[0].indexOf("CF_INVOCATION_SESSION"));
   });
 
   it("confirmations route to stderr under JSON input, stdout otherwise", () => {

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -1088,6 +1088,11 @@ describe("executePieceCallable", () => {
       },
     );
 
+    // The `receipt` here says only that the address survives a collision.
+    // That it is the WINNER's address is the runner's guarantee and needs
+    // two competing handlings to witness, which this harness does not have —
+    // see "cell.send carries a caller-supplied eventId and exposes the
+    // receipt link" in packages/runner/test/scheduler-event-receipts.test.ts.
     expect(result.invocation).toEqual({
       id: "inv-dup",
       status: "settled",
@@ -2543,8 +2548,10 @@ describe("piece call wait control", () => {
     );
 
     // The collision is still a success — the ORIGINAL commit stands and is
-    // durable — but the original outcome is not fetched; a later same-id
-    // call reads it back.
+    // durable — but the original outcome is not fetched; the address it
+    // published is what reads it back. Which handling's address that is, on
+    // a real collision, is the runner's guarantee rather than this harness's
+    // (see the settled collision case above).
     expect(result.invocation).toEqual({
       id: "inv-dup-no-readback",
       status: "committed",
@@ -3859,9 +3866,11 @@ describe("piece call over a live runtime", () => {
       receipt: receiptAddress(),
     });
 
-    // Resolve it exactly as `cf piece get --piece <id>` does: the id through
-    // the entity-URI intake, then the cell it names (a piece's result cell
-    // IS that cell, `PiecesController.getResult`).
+    // Resolve the published id through the entity-URI intake `--piece` runs
+    // it through, and read the cell it names. This covers the address and
+    // the intake; it stops short of the whole `cf piece get` route, which
+    // also runs slug resolution (a pass-through for a token carrying a
+    // colon) and the read-path guards before reaching the same cell.
     const published = executed.invocation!.receipt!;
     const collected = runtime.getCellFromEntityId(
       published.space as MemorySpace,
@@ -4480,14 +4489,18 @@ describe("renderPieceCallOutcome", () => {
       observer,
       {
         ...base,
-        invocation: { id: "inv-1", status: "committed" },
+        invocation: {
+          id: "inv-1",
+          status: "committed",
+          receipt: { space: "did:key:s", id: "of:receipt-1", scope: "space" },
+        },
       } as unknown as ExecutedPieceCallable,
       "addTopic",
       "fid1:piece",
       deps,
       { detached: true, invocation: { id: "inv-1", session: "ses-7" } },
     );
-    // The hint is a command the caller runs to collect the outcome it chose
+    // The replay is a command the caller runs against the outcome it chose
     // not to wait for, and an id reaches that outcome only within the
     // session it was chosen in — so the hint has to carry both. The session
     // travels in the environment because it is what makes that outcome's
@@ -4497,6 +4510,35 @@ describe("renderPieceCallOutcome", () => {
       "CF_INVOCATION_SESSION=ses-7 cf piece call",
     );
     assertStringIncludes(hinted[0], "--invocation inv-1");
+    // And it says what the replay costs: the receipt witnesses the commit,
+    // not the execution, so the body runs a second time.
+    assertStringIncludes(hinted[0], "RUNS AGAIN");
+  });
+
+  it("offers no replay in the detached step that published no address", () => {
+    // No receipt means receipts are not being written, and that is exactly
+    // when a same-pair call does NOT deduplicate: it executes and commits
+    // again ("allows redelivered events to commit twice while receipts are
+    // disabled", packages/runner/test/scheduler-event-receipts.test.ts).
+    // Offering the replay here would be offering a duplicate.
+    const { observer } = observerRecorder();
+    const { deps, hinted } = sinkRecorder();
+    renderPieceCallOutcome(
+      observer,
+      {
+        ...base,
+        invocation: { id: "inv-1", status: "committed" },
+      } as unknown as ExecutedPieceCallable,
+      "addTopic",
+      "fid1:piece",
+      deps,
+      { detached: true, invocation: { id: "inv-1", session: "ses-7" } },
+    );
+    expect(hinted[0]).not.toContain("CF_INVOCATION_SESSION");
+    assertStringIncludes(hinted[0], "executes and commits AGAIN");
+    // And no dangling alternative: there is nothing for an "Or" to be or to.
+    expect(hinted[0]).not.toContain("Or replay");
+    assertStringIncludes(hinted[0], "cf piece get --piece fid1:piece");
   });
 
   it("leads the detached next steps with the address it published", () => {
@@ -4523,7 +4565,7 @@ describe("renderPieceCallOutcome", () => {
     );
     // Collecting the outcome is a read of the address this call published,
     // and it comes first because it does not run the verb again. The replay
-    // stays on offer below it — it is the recovery when the address is lost.
+    // stays on offer below it, for a caller that lost the address.
     assertStringIncludes(hinted[0], "cf piece get --piece of:receipt-1");
     assertStringIncludes(
       hinted[0],


### PR DESCRIPTION
## Why

A detached call had no way back. `cf piece call --no-wait` returned `{invocation: {id, status: "committed"}}` and nothing else — no address — so a caller that chose not to wait could reach its own outcome only by replaying the same id. That is a dead end for collecting work later, and worse than it looks: **a replay re-runs the handler body.**

Item 4 of [the verbs plan](https://github.com/commontoolsinc/labs/blob/main/docs/plans/verbs-implementation.md). It is also what gives items 8 and 9 a consumer — a receipt's schema is read by `piece get` against the address this publishes, not by the call path.

## What Changed

**`InvocationOutcome` gains `receipt`**, published from `tx.handlingReceiptLink` on **both** exits of `executeResolvedCallable`. The link is read at commit — before anything is fetched back — which is exactly what lets the detached exit publish an address for an outcome nobody waited for. It is normalized through the existing `toInvocationResultLink`, and omitted rather than fabricated when the runtime published no link.

**`commands/piece.ts`** emits `receipt` as a top-level envelope key and rewrites the detached NEXT STEPS to lead with `cf piece get --piece <receipt id>` — an ordinary read, where the handler does not run again.

## The correction this carries

The tree said replay was free. It is not, and the runtime already knew:

> `packages/runner/src/cell.ts` — *"The receipt is a **COMMIT witness, not an execution witness** — the redelivered event still runs the handler body and then loses the race, so effects outside the transaction repeat."*

`scheduler-event-receipts.test.ts` proves it: two sends on one `{eventId, session}` pair assert `handlerInvocations === 2` with `precondition === "receipt-exists"`. Meanwhile `callable.ts` said *"no re-execution"* and `verbs-over-the-cli.md` said replay *"returns the original result rather than re-executing"* — and the one string a user actually reads promised deduplication with no caveat at all.

All of those now agree, and keep the half that was true: **nothing commits twice; the body runs again.** The cost is stated where it lands — effects outside the transaction repeat, *and so does any write into another space*, because cross-space commits are ordered child-before-parent and earlier spaces are not rolled back when the parent loses the receipt race.

**The sharpest fix is the branch where no receipt exists.** With `commitPreconditions` off nothing deduplicates — a same-pair call executes and commits *again*. The old text offered replay there as the recovery. It now says so plainly instead.

## Test plan

- `packages/cli` suite green on the rebased tree: **1667 + 174 passed, 0 failed**, exit 0.
- `deno fmt --check`, `deno lint`, `deno check`, `check-docs` (547 blocks), `check-no-waitfor`, `check-skill-facts`, `check-conflict-markers`.
- Red-first verified by reverting **only** the source and keeping the tests — five of six new tests fail. The sixth guards the absent-receipt branch and passes without the change; that is stated rather than counted as evidence.
- The exit-criterion test runs against a real `Runtime`, takes the **published** id string, and resolves it through `entityIdFrom` → `getCellFromEntityId` → `sync` → `get`, asserting the value equals the outcome. It would fail if the address were mangled, mis-spaced, or lost its `of:` prefix.

## Reviewed

An adversarial `cf-review` returned *land with named changes*; all six findings are applied. Two of them were mine to own: the tree carrying two accounts of replay, and the terminal string omitting the caveat every other surface had. It also caught that two dedup assertions in the CLI tests cannot fail — the harness returns the same link regardless — so the JSDoc now cites the runner test as the authority instead of implying local proof.

`links["receipt"]` already reserved the same address, so under `--show-links` it now appears twice. Documented rather than retired; retiring it is a `--show-links` behaviour change and does not belong here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

