### PR TITLE
perf,fix(data-model): drop a decode-path closure; validate a hole run count

### DIFF
--- a/packages/data-model/src/codec-json/JsonCodec.ts
+++ b/packages/data-model/src/codec-json/JsonCodec.ts
@@ -531,10 +531,10 @@ export class JsonCodec implements SerializationContext<string> {
    * index, so zero is refused along with everything else that is not a count.
    */
   static #isHoleCount(count: JsonCodecValue): count is number {
-    // `isSafeInteger()` returns `false` for a non-number, but cannot be a
-    // TypeScript type predicate on `number`, since it also returns `false`
-    // for plenty of numbers. So the cast is safe on the strength of that
-    // call, though TypeScript cannot derive as much.
+    // `isSafeInteger()` returns `false` for a non-number, but it cannot be a
+    // TypeScript type predicate on `number` since it also returns `false` for
+    // plenty of numbers. So, the susequent cast `as number` is safe by
+    // construction but is nonetheless required.
     return Number.isSafeInteger(count) && ((count as number) >= 1);
   }
 

--- a/packages/data-model/src/codec-json/JsonCodec.ts
+++ b/packages/data-model/src/codec-json/JsonCodec.ts
@@ -531,14 +531,12 @@ export class JsonCodec implements SerializationContext<string> {
    * index, so zero is refused along with everything else that is not a count.
    */
   static #isHoleCount(count: JsonCodecValue): count is number {
-    // The `typeof` test is redundant at run time -- `Number.isSafeInteger()`
-    // takes anything and answers `false` for a non-number -- and is here for
-    // the type system, which `isSafeInteger()` tells nothing: it is declared
-    // to take `unknown` and return a plain `boolean`, so without the test
-    // `count` is still the whole `JsonCodecValue` union and `>=` will not
-    // accept it.
-    return (typeof count === "number") && Number.isSafeInteger(count) &&
-      (count >= 1);
+    // `Number.isSafeInteger()` settles the question on its own: it takes
+    // anything and answers `false` for a non-number. It narrows nothing,
+    // being declared to take `unknown` and return a plain `boolean`, so the
+    // comparison casts rather than testing `typeof` a second time -- a cast
+    // costs nothing at run time where a second test would not.
+    return Number.isSafeInteger(count) && ((count as number) >= 1);
   }
 
   /**

--- a/packages/data-model/src/codec-json/JsonCodec.ts
+++ b/packages/data-model/src/codec-json/JsonCodec.ts
@@ -416,13 +416,11 @@ export class JsonCodec implements SerializationContext<string> {
     // underestimate otherwise -- growing from there beats growing from empty,
     // and a short array of holes is common enough to be worth not pessimizing.
     //
-    // Nothing validates a `/hole` count. A negative one is not something an
-    // encoder emits -- a run is at least one -- so what it does here is
-    // unspecified rather than designed: it moves the write index backwards,
-    // and the decode then either truncates or throws `RangeError` out of the
-    // length assignment, according to whether the index ends up below zero.
-    // Neither outcome is reported as a `ProblematicValue`, this arm being the
-    // walker's own rather than a codec's.
+    // A run's count is validated, wire data being untrusted. Left unchecked it
+    // is added to the write index directly, so a string concatenates onto it
+    // and a negative or fractional one makes the length assignment throw --
+    // failures with no bearing on what went wrong. A run stands for at least
+    // one absent index, and anything else is reported instead.
     if (Array.isArray(data)) {
       const result: FabricValue[] = new Array(data.length);
       let targetIndex = 0;
@@ -431,7 +429,17 @@ export class JsonCodec implements SerializationContext<string> {
         if (
           entryDecoded !== null && entryDecoded.tag === CODEC_META_TAGS.hole
         ) {
-          targetIndex += entryDecoded.state as number;
+          const count = entryDecoded.state;
+          if (!JsonCodec.#isHoleCount(count)) {
+            return new ProblematicValue(
+              CODEC_META_TAGS.hole,
+              count,
+              `hole: expected a positive integer count, got ${
+                backtickQuote(toCompactDebugString(count, 30))
+              }`,
+            );
+          }
+          targetIndex += count;
         } else {
           result[targetIndex] = this.#decodeValue(entry, context);
           targetIndex++;
@@ -516,6 +524,16 @@ export class JsonCodec implements SerializationContext<string> {
       "no runtime context (validity check in a test-only helper).",
     ),
   );
+
+  /**
+   * Indicates whether `count` is usable as a `/hole` run length: a safe
+   * integer of at least one. A run always stands for at least one absent
+   * index, so zero is refused along with everything else that is not a count.
+   */
+  static #isHoleCount(count: JsonCodecValue): count is number {
+    return (typeof count === "number") && Number.isSafeInteger(count) &&
+      (count >= 1);
+  }
 
   /**
    * Returns true if `v` is a single-key object whose key starts with `/` --

--- a/packages/data-model/src/codec-json/JsonCodec.ts
+++ b/packages/data-model/src/codec-json/JsonCodec.ts
@@ -345,29 +345,54 @@ export class JsonCodec implements SerializationContext<string> {
         //
         // Otherwise the tag is simply one this registry does not carry, and
         // the unknown form is preserved so that it round-trips. Neither of
-        // these is covered by the deep-frozen contract described on
-        // `#decodeChecked()`.
+        // these is covered by the deep-frozen contract that the codec arm
+        // below states.
         return (tag === "")
           ? new ProblematicValue(tag, state, `object has bare "/" key`)
           : new UnknownValue(tag, state);
       }
 
-      if (matched instanceof BaseTerminalCodec) {
-        return this.#decodeChecked(
-          tag,
-          rawState,
-          () =>
-            (matched as TerminalCodec<JsonCodecValue>)
-              .decode(tag, rawState, context),
+      // A terminal codec takes the state exactly as it arrived; a nonterminal
+      // one takes it expanded. The two casts restate what `instanceof` just
+      // established, which TypeScript drops on a generic class.
+      const terminal = matched instanceof BaseTerminalCodec;
+      const state = terminal ? rawState : this.#decodeValue(rawState, context);
+
+      try {
+        // A codec's `decode()` promises deep-frozen results rather than
+        // relying on every caller to freeze, so both returns here pass through
+        // `deepFreeze()`. That covers the codec's own product -- a
+        // `FabricPrimitive` is already frozen, making it an O(1) cache hit --
+        // and the lenient fallback alike. The two arms above are separate and
+        // deliberately not covered.
+        return deepFreeze(
+          terminal
+            ? (matched as TerminalCodec<JsonCodecValue>).decode(
+              tag,
+              rawState,
+              context,
+            )
+            : (matched as NonterminalCodec).decode(
+              tag,
+              state as FabricValue,
+              context,
+            ),
+        );
+      } catch (e: unknown) {
+        if (!this.lenient) {
+          throw e;
+        }
+
+        // Report over the state the codec was actually handed, so that it says
+        // what the codec choked on.
+        return deepFreeze(
+          new ProblematicValue(
+            tag,
+            state,
+            e instanceof Error ? e.message : String(e),
+          ),
         );
       }
-
-      const state = this.#decodeValue(rawState, context);
-      return this.#decodeChecked(
-        tag,
-        state,
-        () => (matched as NonterminalCodec).decode(tag, state, context),
-      );
     }
 
     // Primitives pass through.
@@ -443,42 +468,6 @@ export class JsonCodec implements SerializationContext<string> {
       result[key] = this.#decodeValue(val, context);
     }
     return Object.freeze(result);
-  }
-
-  /**
-   * Runs a codec's `decode()` under this class's two standing guarantees.
-   *
-   * Deep-frozen contract: a codec's `decode()` promises deep-frozen results
-   * rather than relying on every caller to freeze, so every return from here
-   * passes through `deepFreeze()`. That covers the codec's own product (a
-   * `FabricPrimitive` is already frozen, making this an O(1) cache hit) and
-   * the lenient-mode fallback alike.
-   *
-   * Lenience: when `lenient` is set, a throw becomes a `ProblematicValue` over
-   * `state`. Nothing here ties `state` to what `decode` goes on to hand the
-   * codec, the two being separate arguments; each call site passes the same
-   * value for both, so that the report says what the codec choked on.
-   */
-  #decodeChecked(
-    tag: string,
-    state: FabricValue,
-    decode: () => FabricValue,
-  ): FabricValue {
-    if (!this.lenient) {
-      return deepFreeze(decode());
-    }
-
-    try {
-      return deepFreeze(decode());
-    } catch (e: unknown) {
-      return deepFreeze(
-        new ProblematicValue(
-          tag,
-          state,
-          e instanceof Error ? e.message : String(e),
-        ),
-      );
-    }
   }
 
   //

--- a/packages/data-model/src/codec-json/JsonCodec.ts
+++ b/packages/data-model/src/codec-json/JsonCodec.ts
@@ -531,11 +531,10 @@ export class JsonCodec implements SerializationContext<string> {
    * index, so zero is refused along with everything else that is not a count.
    */
   static #isHoleCount(count: JsonCodecValue): count is number {
-    // `Number.isSafeInteger()` settles the question on its own: it takes
-    // anything and answers `false` for a non-number. It narrows nothing,
-    // being declared to take `unknown` and return a plain `boolean`, so the
-    // comparison casts rather than testing `typeof` a second time -- a cast
-    // costs nothing at run time where a second test would not.
+    // The cast is established by the call preceding it: `isSafeInteger()`
+    // answers `false` for a non-number. It is required because that holds
+    // only at run time -- the function is declared to take `unknown` and
+    // return a plain `boolean`, and so narrows nothing.
     return Number.isSafeInteger(count) && ((count as number) >= 1);
   }
 

--- a/packages/data-model/src/codec-json/JsonCodec.ts
+++ b/packages/data-model/src/codec-json/JsonCodec.ts
@@ -533,7 +533,7 @@ export class JsonCodec implements SerializationContext<string> {
   static #isHoleCount(count: JsonCodecValue): count is number {
     // The cast is established by the call preceding it: `isSafeInteger()`
     // answers `false` for a non-number. It is required because that holds
-    // only at run time -- the function is declared to take `unknown` and
+    // only at runtime -- the function is declared to take `unknown` and
     // return a plain `boolean`, and so narrows nothing.
     return Number.isSafeInteger(count) && ((count as number) >= 1);
   }

--- a/packages/data-model/src/codec-json/JsonCodec.ts
+++ b/packages/data-model/src/codec-json/JsonCodec.ts
@@ -445,6 +445,7 @@ export class JsonCodec implements SerializationContext<string> {
           targetIndex++;
         }
       }
+
       // The total is bounded here rather than each advance being bounded as
       // it happens, because both a single run and the running total can pass
       // what an array may hold, and one check at the end covers both. Beyond

--- a/packages/data-model/src/codec-json/JsonCodec.ts
+++ b/packages/data-model/src/codec-json/JsonCodec.ts
@@ -450,12 +450,13 @@ export class JsonCodec implements SerializationContext<string> {
       // what an array may hold, and one check at the end covers both. Beyond
       // that, the assignment below throws `RangeError` from the array
       // machinery, which says nothing about the wire that caused it.
-      if (targetIndex > JsonCodec.#MAX_ARRAY_LENGTH) {
+      const MAX_ARRAY_LENGTH = 0xffff_ffff;
+      if (targetIndex > MAX_ARRAY_LENGTH) {
         return new ProblematicValue(
           CODEC_META_TAGS.hole,
           data,
           `hole: runs total ${targetIndex} elements, past the ` +
-            `${JsonCodec.#MAX_ARRAY_LENGTH} an array can hold`,
+            `${MAX_ARRAY_LENGTH} an array can hold`,
         );
       }
 
@@ -495,9 +496,6 @@ export class JsonCodec implements SerializationContext<string> {
   //
   // Static members
   //
-
-  /** Largest length a JavaScript array can have. */
-  static readonly #MAX_ARRAY_LENGTH = 0xffff_ffff;
 
   /** Shared text encoder, created once. */
   static readonly #textEncoder = new TextEncoder();

--- a/packages/data-model/src/codec-json/JsonCodec.ts
+++ b/packages/data-model/src/codec-json/JsonCodec.ts
@@ -531,6 +531,12 @@ export class JsonCodec implements SerializationContext<string> {
    * index, so zero is refused along with everything else that is not a count.
    */
   static #isHoleCount(count: JsonCodecValue): count is number {
+    // The `typeof` test is redundant at run time -- `Number.isSafeInteger()`
+    // takes anything and answers `false` for a non-number -- and is here for
+    // the type system, which `isSafeInteger()` tells nothing: it is declared
+    // to take `unknown` and return a plain `boolean`, so without the test
+    // `count` is still the whole `JsonCodecValue` union and `>=` will not
+    // accept it.
     return (typeof count === "number") && Number.isSafeInteger(count) &&
       (count >= 1);
   }

--- a/packages/data-model/src/codec-json/JsonCodec.ts
+++ b/packages/data-model/src/codec-json/JsonCodec.ts
@@ -531,10 +531,10 @@ export class JsonCodec implements SerializationContext<string> {
    * index, so zero is refused along with everything else that is not a count.
    */
   static #isHoleCount(count: JsonCodecValue): count is number {
-    // The cast is established by the call preceding it: `isSafeInteger()`
-    // answers `false` for a non-number. It is required because that holds
-    // only at runtime -- the function is declared to take `unknown` and
-    // return a plain `boolean`, and so narrows nothing.
+    // `isSafeInteger()` returns `false` for a non-number, but cannot be a
+    // TypeScript type predicate on `number`, since it also returns `false`
+    // for plenty of numbers. So the cast is safe on the strength of that
+    // call, though TypeScript cannot derive as much.
     return Number.isSafeInteger(count) && ((count as number) >= 1);
   }
 

--- a/packages/data-model/src/codec-json/JsonCodec.ts
+++ b/packages/data-model/src/codec-json/JsonCodec.ts
@@ -445,6 +445,20 @@ export class JsonCodec implements SerializationContext<string> {
           targetIndex++;
         }
       }
+      // The total is bounded here rather than each advance being bounded as
+      // it happens, because both a single run and the running total can pass
+      // what an array may hold, and one check at the end covers both. Beyond
+      // that, the assignment below throws `RangeError` from the array
+      // machinery, which says nothing about the wire that caused it.
+      if (targetIndex > JsonCodec.#MAX_ARRAY_LENGTH) {
+        return new ProblematicValue(
+          CODEC_META_TAGS.hole,
+          data,
+          `hole: runs total ${targetIndex} elements, past the ` +
+            `${JsonCodec.#MAX_ARRAY_LENGTH} an array can hold`,
+        );
+      }
+
       result.length = targetIndex;
       return Object.freeze(result);
     }
@@ -481,6 +495,9 @@ export class JsonCodec implements SerializationContext<string> {
   //
   // Static members
   //
+
+  /** Largest length a JavaScript array can have. */
+  static readonly #MAX_ARRAY_LENGTH = 0xffff_ffff;
 
   /** Shared text encoder, created once. */
   static readonly #textEncoder = new TextEncoder();
@@ -533,7 +550,7 @@ export class JsonCodec implements SerializationContext<string> {
   static #isHoleCount(count: JsonCodecValue): count is number {
     // `isSafeInteger()` returns `false` for a non-number, but it cannot be a
     // TypeScript type predicate on `number` since it also returns `false` for
-    // plenty of numbers. So, the susequent cast `as number` is safe by
+    // plenty of numbers. So, the subsequent cast `as number` is safe by
     // construction but is nonetheless required.
     return Number.isSafeInteger(count) && ((count as number) >= 1);
   }

--- a/packages/data-model/test/codec-json/JsonCodec.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodec.test.ts
@@ -694,6 +694,34 @@ describe("JsonCodec", () => {
       });
     }
 
+    it("returns a `ProblematicValue` given a count past the array maximum", () => {
+      // A safe integer can still be more elements than an array can hold, in
+      // which case setting the length is what would fail.
+      const result = decodeArray(["a", { "/hole": 2 ** 40 }, "b"]);
+
+      expect(result).toBeInstanceOf(ProblematicValue);
+      expect((result as unknown as ProblematicValue).error).toContain(
+        "past the",
+      );
+    });
+
+    it("returns a `ProblematicValue` when later entries carry the total past it", () => {
+      // The run alone is exactly what an array can hold; the two entries
+      // placed after it are what make the total too large.
+      const result = decodeArray([{ "/hole": 2 ** 32 - 1 }, "a", "b"]);
+
+      expect(result).toBeInstanceOf(ProblematicValue);
+      expect((result as unknown as ProblematicValue).error).toContain(
+        "past the",
+      );
+    });
+
+    it("decodes a run reaching exactly the array maximum", () => {
+      const result = decodeArray([{ "/hole": 2 ** 32 - 1 }]) as FabricValue[];
+
+      expect(result.length).toBe(2 ** 32 - 1);
+    });
+
     it("decodes a run of one, the smallest a count may be", () => {
       const result = decodeArray(["a", { "/hole": 1 }, "b"]) as FabricValue[];
 

--- a/packages/data-model/test/codec-json/JsonCodec.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodec.test.ts
@@ -716,6 +716,20 @@ describe("JsonCodec", () => {
       );
     });
 
+    it("places an entry at the last index a run can leave free", () => {
+      // The bound is on length, where the largest index is one less, so this
+      // is where an off-by-one would show: the entry lands at the last legal
+      // index and the array is exactly as long as one may be. A step further
+      // and the entry would become a plain property rather than an element,
+      // which the previous case is what catches.
+      const result = decodeArray(
+        [{ "/hole": (2 ** 32 - 1) - 1 }, "z"],
+      ) as FabricValue[];
+
+      expect(result.length).toBe(2 ** 32 - 1);
+      expect(result[(2 ** 32 - 1) - 1]).toBe("z");
+    });
+
     it("decodes a run reaching exactly the array maximum", () => {
       const result = decodeArray([{ "/hole": 2 ** 32 - 1 }]) as FabricValue[];
 

--- a/packages/data-model/test/codec-json/JsonCodec.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodec.test.ts
@@ -658,6 +658,51 @@ describe("JsonCodec", () => {
     });
   });
 
+  describe("malformed `/hole` runs", () => {
+    // A run's count reaches the write index directly, so an unchecked one has
+    // consequences unrelated to what was wrong with it: a string concatenates
+    // onto the index, and a negative or fractional count makes the length
+    // assignment throw. Wire data is untrusted, so each is reported instead.
+
+    /** Decodes a hand-built array, which is deliberately not encodable. */
+    function decodeArray(entries: JsonCodecValue[]): FabricValue {
+      const { jsonCodec, runtime } = makeTestCodec();
+      return jsonCodec.decode(
+        JsonCodec.wrapEncodedValueForTesting(JSON.stringify(entries), true),
+        runtime,
+      );
+    }
+
+    const BAD_COUNTS: readonly (readonly [string, JsonCodecValue])[] = [
+      ["a string", "2"],
+      ["a negative number", -5],
+      ["zero", 0],
+      ["a fraction", 1.5],
+      ["an object", { x: 1 }],
+      ["`null`", null],
+    ];
+
+    for (const [label, count] of BAD_COUNTS) {
+      it(`returns a \`ProblematicValue\` given ${label} as a count`, () => {
+        const result = decodeArray(["a", { "/hole": count }, "b"]);
+
+        expect(result).toBeInstanceOf(ProblematicValue);
+        const prob = result as unknown as ProblematicValue;
+        expect(prob.wireTypeTag).toBe("hole");
+        expect(prob.state).toEqual(count);
+        expect(prob.error).toContain("expected a positive integer count");
+      });
+    }
+
+    it("decodes a run of one, the smallest a count may be", () => {
+      const result = decodeArray(["a", { "/hole": 1 }, "b"]) as FabricValue[];
+
+      expect(result.length).toBe(3);
+      expect(1 in result).toBe(false);
+      expect(result[2]).toBe("b");
+    });
+  });
+
   describe("sparse arrays", () => {
     it("serializes `[1,,3]` with `/hole`", () => {
       // deno-lint-ignore no-sparse-arrays


### PR DESCRIPTION
Two follow-ups from #5652's review, one to `JsonCodec`'s decode path each.
I (an agent working on behalf of @danfuzz) wrote both.

## Decoding a tagged value allocates nothing

`#decodeChecked()` took a thunk, so every tagged value decoded allocated a
closure capturing the codec, tag, state and context.

V8 does not elide it — five million tagged decodes cost 3081 young-generation
scavenges with the closure and 2721 without, reproducible to within three
counts. In a loop doing nothing else that is worth about 3%; in
`bench/codec-json.bench.ts` it is invisible, at a median 1.002 across the
benchmarks that reach this path against 0.997 across those that cannot. A real
allocation that no realistic workload can see is a thin reason to change
anything — except that the result is also smaller.

It is smaller because the method had stopped earning its keep. It had two
callers when the state form was chosen at the call site; folding that choice
into one place left it with a single caller, at the end of the only function
that called it, which is a signature to pass arguments through rather than a
helper. Inlining it retires `#dispatchDecode()` with it, and lets the two
decode calls become one — the `try` now always wraps, rethrowing when not
lenient rather than being entered only in lenient mode.

Net eleven lines fewer, where removing the closure on its own added
twenty-one.

## An array hole run's count is validated

A `/hole` run's count came off the wire and was added to the write index
unchecked. Wire data is untrusted, and an unchecked count fails in ways that
say nothing about what was wrong with it:

| wire | before |
| --- | --- |
| `["a", {"/hole": "2"}, "b"]` | decodes to a thirteen-element array |
| `["a", "b", {"/hole": -5}]` | `RangeError` out of the array machinery |
| `["a", {"/hole": 1.5}, "b"]` | `RangeError`, likewise |

The `RangeError` escapes even in lenient mode, this arm belonging to the
walker rather than to a codec, so nothing was applying Section 7 of
`3-json-encoding.md` — which asks for a `ProblematicValue` on malformed state.
A run stands for at least one absent index, so a count must be a safe integer
of at least one; anything else is now reported. Zero is refused with the rest,
a run of none not being something an encoder can mean.

This also settles a case that #5652 left held by a comment. Decoding an array
in one pass differs from counting its length first only on a negative count,
which no encoder emits — and that input is now refused before it reaches the
write index, so the equivalence rests on a check rather than on a note saying
the difference does not matter.

## Not here: dropping `shouldDeepFreeze`

This was scoped in as a third item and removed after attempting it. Its backlog
entry claimed the flag's only consumers were the tests written for it. That was
wrong: `FabricError`'s `[DEEP_CLONE_CORE]` round-trips through the codec and
passes its own `frozen` argument as the context's `shouldDeepFreeze`, which is
what makes `deepClone(false)` produce a deeply *mutable* clone.

    deepClone(true )  -> outer frozen   nested deep-frozen true
    deepClone(false)  -> outer mutable  nested deep-frozen false

Removing the flag makes `deepClone(false)` return frozen nested values, against
the documented contract — and nothing pins that in a test, so the suite stayed
green through a half-finished removal. Reverted, and the backlog entry corrected
to say so.

## Performance

`bench/codec-json.bench.ts`, both sides in both run positions, ratios averaged
so that neither the machine warming nor the order decides it: median 1.000
across 70 benchmarks.

The paths the hole check touches are unmoved — `decode sparse-*` between 1.000
and 1.038 — which is expected, since an array without holes never reaches the
check and one with them pays a predicate per run.

Two points came in low (`decode array-001000` and `-010000`, both about 0.87)
with no mechanism I can identify: neither change touches the dense array path,
the neighboring sizes are within noise, and there is no trend across the
series. I read those as noise rather than a speedup, and mention them so the
numbers are not quietly filtered.

## Verification

`fmt --check`, `lint`, `check`, `check-docs`, `check-no-waitfor`,
`check-skill-facts` — all green. Suites under each package's own
`deno task test`: `data-model` 52/0, `runner` 1189/0, `cli` 174/0, `piece`
37/0, `memory` 495/0.

Both changes were checked against deliberately wrong implementations: dropping
the count guard fails nine cases, and loosening its bound from one to zero
fails the zero case alone, so the lower bound is pinned rather than incidental.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

