### PR TITLE
docs(runner): twelve file headers, ten of them already written

### DIFF
--- a/packages/runner/test/array-write-guards.test.ts
+++ b/packages/runner/test/array-write-guards.test.ts
@@ -1,3 +1,10 @@
+/**
+ * The three states `Cell.push()` and `Cell.addUnique()` can find the stored
+ * value in: absent, an array, or something else. Each method decides between
+ * them before it has an array to work with, so all three are covered here for
+ * both.
+ */
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
@@ -7,12 +14,6 @@ import { Runtime } from "../src/runtime.ts";
 import type { Cell } from "../src/cell.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
-/**
- * The three states `Cell.push()` and `Cell.addUnique()` can find the stored
- * value in: absent, an array, or something else. Each method decides between
- * them before it has an array to work with, so all three are covered here for
- * both.
- */
 const signer = await Identity.fromPassphrase("array write guards");
 const space = signer.did();
 

--- a/packages/runner/test/attestation-data-uri.test.ts
+++ b/packages/runner/test/attestation-data-uri.test.ts
@@ -1,3 +1,10 @@
+/**
+ * `load()` is the storage-transaction-side reader of `data:` URI documents,
+ * separate from `data-uri.ts`'s `valueFromDataUri()`. Both route payload
+ * text through `valueFromDataUriPayloadText()`, so the two readers cannot
+ * silently diverge on what a payload means.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { JsonCodec } from "@commonfabric/data-model/codec-json";
@@ -13,10 +20,6 @@ const uriOf = (payload: string): URI =>
     toUnpaddedBase64url(new TextEncoder().encode(payload))
   }` as URI;
 
-// `load()` is the storage-transaction-side reader of `data:` URI documents,
-// separate from `data-uri.ts`'s `valueFromDataUri()`. Both route payload
-// text through `valueFromDataUriPayloadText()`, so the two readers cannot
-// silently diverge on what a payload means.
 describe("attestation `load()` of `data:` URIs", () => {
   it("errors on a historical bare-JSON payload", () => {
     const { ok, error } = load({ id: uriOf('{"value":{"x":1}}') });

--- a/packages/runner/test/builder-fabric-classes.test.ts
+++ b/packages/runner/test/builder-fabric-classes.test.ts
@@ -1,3 +1,17 @@
+/**
+ * The Fabric value classes reach pattern code as `export declare const`s in
+ * `api/index.ts`, but the runtime values behind those declarations are bound
+ * separately, in `builder/factory.ts`. The two sides are maintained by hand, so
+ * a class can be declared without being bound -- which type-checks when the
+ * pattern is compiled and then fails once it actually runs. These tests pin the
+ * runtime half against the declared half.
+ *
+ * `types/commonfabric.d.ts` is a symlink to `api/index.ts`, and is the exact
+ * artifact the sandbox hands a pattern as its view of `commonfabric`. Deriving
+ * the expected names from it means this test tracks the real declarations
+ * rather than a hand-copied list that someone has to remember to extend.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { StaticCache } from "@commonfabric/static";
@@ -20,17 +34,6 @@ import {
 import { createBuilder } from "../src/builder/factory.ts";
 import { getRuntimeModuleExports } from "../src/sandbox/runtime-modules.ts";
 
-// The Fabric value classes reach pattern code as `export declare const`s in
-// `api/index.ts`, but the runtime values behind those declarations are bound
-// separately, in `builder/factory.ts`. The two sides are maintained by hand, so
-// a class can be declared without being bound -- which type-checks when the
-// pattern is compiled and then fails once it actually runs. These tests pin the
-// runtime half against the declared half.
-//
-// `types/commonfabric.d.ts` is a symlink to `api/index.ts`, and is the exact
-// artifact the sandbox hands a pattern as its view of `commonfabric`. Deriving
-// the expected names from it means this test tracks the real declarations
-// rather than a hand-copied list that someone has to remember to extend.
 const patternVisibleTypes = await StaticCache.fromFileSystem().getText(
   "types/commonfabric.d.ts",
 );

--- a/packages/runner/test/builder-value-equal.test.ts
+++ b/packages/runner/test/builder-value-equal.test.ts
@@ -1,11 +1,14 @@
+/**
+ * `valueEqual` is exposed to pattern code through the `commonfabric` builder
+ * surface (declared in `api/index.ts`, bound in `builder/factory.ts`). These
+ * tests pin that it is present and is the real `data-model` `valueEqual` — the
+ * `Object.is`-leading, content-hash comparison — rather than a stand-in.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createBuilder } from "../src/builder/factory.ts";
 
-// `valueEqual` is exposed to pattern code through the `commonfabric` builder
-// surface (declared in `api/index.ts`, bound in `builder/factory.ts`). These
-// tests pin that it is present and is the real `data-model` `valueEqual` — the
-// `Object.is`-leading, content-hash comparison — rather than a stand-in.
 describe("commonfabric valueEqual builtin", () => {
   const { valueEqual } = createBuilder().commonfabric;
 

--- a/packages/runner/test/cell-rep-wedge.test.ts
+++ b/packages/runner/test/cell-rep-wedge.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Exercises the modern-cell-rep flag end to end at the `Cell.entityId` →
+ * `createRef`/`hashOf` boundary that the `map`/`filter`/`flatMap` builtins use
+ * to derive result-cell addresses. The serialized entity-id reference's shape
+ * is itself a hash input, so flipping the flag re-points those derived
+ * addresses — the storage-affecting change the flag gates.
+ */
+
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
@@ -14,13 +22,6 @@ import { createRef } from "../src/create-ref.ts";
 const signer = await Identity.fromPassphrase("cell-rep wedge");
 const space = signer.did();
 
-/**
- * Exercises the modern-cell-rep flag end to end at the `Cell.entityId` →
- * `createRef`/`hashOf` boundary that the `map`/`filter`/`flatMap` builtins use
- * to derive result-cell addresses. The serialized entity-id reference's shape
- * is itself a hash input, so flipping the flag re-points those derived
- * addresses — the storage-affecting change the flag gates.
- */
 describe("modern-cell-rep wedge", () => {
   afterEach(() => {
     resetModernCellRepConfig();

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests for the `ExperimentalOptions` feature-flag system: verifies that
+ * `Runtime` construction/disposal correctly resolves flags and propagates the
+ * flags whose consumers are ambient.
+ */
+
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
@@ -16,11 +22,6 @@ import {
 
 const signer = await Identity.fromPassphrase("test experimental");
 
-/**
- * Tests for the `ExperimentalOptions` feature-flag system: verifies that
- * `Runtime` construction/disposal correctly resolves flags and propagates the
- * flags whose consumers are ambient.
- */
 describe("ExperimentalOptions", () => {
   afterEach(() => {
     resetModernCellRepConfig();

--- a/packages/runner/test/fetch-utils.test.ts
+++ b/packages/runner/test/fetch-utils.test.ts
@@ -1,3 +1,16 @@
+/**
+ * What `computeInputHashFromValue()` deliberately ignores, which is most of
+ * its contract: two inputs that differ only in ways carrying no request
+ * content must hash the same.
+ *
+ * Three kinds of difference are erased -- the top-level `result` field, which
+ * is a type hint rather than part of the request; a property that is present
+ * but `undefined` against one simply omitted, at the top level and nested;
+ * and an absent input against an empty object. The remaining case is the
+ * counterweight, since erasing differences is only safe if a difference in
+ * real content still changes the hash.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { computeInputHashFromValue } from "../src/builtins/fetch-utils.ts";

--- a/packages/runner/test/link-rep-wedge.test.ts
+++ b/packages/runner/test/link-rep-wedge.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Exercises the modern-cell-rep flag end to end at the link boundary: the
+ * representation a `Cell` hands out for `getAsLink`, and — crucially — that a
+ * link written into storage round-trips and still resolves. In modern mode a
+ * link is a {@link FabricLink} instance stored as one atomic leaf, so the
+ * storage path-walk that link resolution relies on must find it without the
+ * legacy `{ "/": { "link@1": … } }` sub-tree to descend into.
+ */
+
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
@@ -13,14 +22,6 @@ import { Runtime } from "../src/runtime.ts";
 const signer = await Identity.fromPassphrase("link-rep wedge");
 const space = signer.did();
 
-/**
- * Exercises the modern-cell-rep flag end to end at the link boundary: the
- * representation a `Cell` hands out for `getAsLink`, and — crucially — that a
- * link written into storage round-trips and still resolves. In modern mode a
- * link is a {@link FabricLink} instance stored as one atomic leaf, so the
- * storage path-walk that link resolution relies on must find it without the
- * legacy `{ "/": { "link@1": … } }` sub-tree to descend into.
- */
 describe("modern-cell-rep link wedge", () => {
   afterEach(() => {
     // Runtime.dispose already resets, but guard against an early failure that

--- a/packages/runner/test/query-result-proxy-fabric-instance.test.ts
+++ b/packages/runner/test/query-result-proxy-fabric-instance.test.ts
@@ -1,3 +1,16 @@
+/**
+ * A `FabricInstance` holds all of its state in private fields and exposes it
+ * through accessors on its prototype. Reading one through the query-result
+ * proxy has to evaluate the accessor against the instance itself: a private
+ * field is unreachable from the proxy, which does not declare it, so an
+ * accessor run with the proxy as receiver throws outright rather than
+ * returning a wrong answer.
+ *
+ * `FabricError` stands in for the whole tree here because it is the instance a
+ * cell write actually produces -- `Cell.set()` of a native `Error` wraps one --
+ * and it is the state-heaviest of the concrete classes.
+ */
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
@@ -8,16 +21,6 @@ import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 const signer = await Identity.fromPassphrase("test proxy fabric instance");
 const space = signer.did();
 
-// A `FabricInstance` holds all of its state in private fields and exposes it
-// through accessors on its prototype. Reading one through the query-result
-// proxy has to evaluate the accessor against the instance itself: a private
-// field is unreachable from the proxy, which does not declare it, so an
-// accessor run with the proxy as receiver throws outright rather than
-// returning a wrong answer.
-//
-// `FabricError` stands in for the whole tree here because it is the instance a
-// cell write actually produces -- `Cell.set()` of a native `Error` wraps one --
-// and it is the state-heaviest of the concrete classes.
 describe("query-result proxy: FabricInstance accessors read through to the instance", () => {
   let runtime: Runtime;
   let storageManager: ReturnType<typeof StorageManager.emulate>;

--- a/packages/runner/test/query-result-proxy-fabric-primitive.test.ts
+++ b/packages/runner/test/query-result-proxy-fabric-primitive.test.ts
@@ -1,3 +1,12 @@
+/**
+ * A `FabricPrimitive` (byte sequence, temporal value, hash, ...) is an
+ * immutable leaf. The query-result proxy must hand it back raw rather than
+ * wrapping it in a live proxy: a wrapped primitive leaks the proxy into any
+ * consumer that deep-clones or freezes the surrounding value -- notably schema
+ * interning, which deep-freezes its argument and trips the proxy's
+ * structural-mutation guard.
+ */
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
@@ -11,12 +20,6 @@ import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 const signer = await Identity.fromPassphrase("test proxy fabric primitive");
 const space = signer.did();
 
-// A `FabricPrimitive` (byte sequence, temporal value, hash, ...) is an
-// immutable leaf. The query-result proxy must hand it back raw rather than
-// wrapping it in a live proxy: a wrapped primitive leaks the proxy into any
-// consumer that deep-clones or freezes the surrounding value -- notably schema
-// interning, which deep-freezes its argument and trips the proxy's
-// structural-mutation guard.
 describe("query-result proxy: FabricPrimitive leaves are not proxy-wrapped", () => {
   let runtime: Runtime;
   let storageManager: ReturnType<typeof StorageManager.emulate>;

--- a/packages/runner/test/query-result-proxy-mutation-guard.test.ts
+++ b/packages/runner/test/query-result-proxy-mutation-guard.test.ts
@@ -1,3 +1,11 @@
+/**
+ * A query-result proxy is a live, transaction-backed view. Structural
+ * mutations (freeze/seal/defineProperty/delete) cannot be honored without
+ * either corrupting the backing store or defeating live read-resolution, so
+ * the proxy refuses them outright -- callers must snapshot to a plain value
+ * first. These tests lock in that refusal.
+ */
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
@@ -8,11 +16,6 @@ import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 const signer = await Identity.fromPassphrase("test proxy mutation guard");
 const space = signer.did();
 
-// A query-result proxy is a live, transaction-backed view. Structural
-// mutations (freeze/seal/defineProperty/delete) cannot be honored without
-// either corrupting the backing store or defeating live read-resolution, so
-// the proxy refuses them outright -- callers must snapshot to a plain value
-// first. These tests lock in that refusal.
 describe("query-result proxy structural-mutation guard", () => {
   let runtime: Runtime;
   let storageManager: ReturnType<typeof StorageManager.emulate>;

--- a/packages/runner/test/sigil-types.test.ts
+++ b/packages/runner/test/sigil-types.test.ts
@@ -1,3 +1,16 @@
+/**
+ * `assertWebhookCellLinkRefPayload()` guards a cell-link payload arriving from
+ * outside the runtime, so what it refuses carries more weight here than what
+ * it accepts.
+ *
+ * Every field is optional, which makes the empty payload valid and means the
+ * assertion cannot lean on presence at all. What it does instead is refuse
+ * anything unrecognized -- an extra field is how a schema would ride in
+ * alongside an addressing payload -- and refuse a malformed value in any field
+ * it does know, since an assertion that admits a bad `scope` hands its caller
+ * a type that lies.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { assertWebhookCellLinkRefPayload } from "../src/sigil-types.ts";


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) am continuing the file-header
conformance work in `packages/runner`, against the "File headers" section of
`docs/development/code-comment-style.md`.

Twelve files. Ten already had a header written — it just sat below the import
block, where the rule says it reads as the doc comment of the first declaration
under it rather than as a statement about the file. Those move to the top with
their prose unchanged. The other two, `fetch-utils.test.ts` and
`sigil-types.test.ts`, had none and gain one.

### Why so many were filed as having no header

A stranded header can only be found by looking for a comment that talks about
the whole file rather than about the declaration beneath it, and two different
mechanical tests for that each have a blind spot:

- Requiring a blank line after the comment — which is what stops a declaration's
  own doc comment from being mistaken for a header — also hides a real header
  that happens to sit flush against the first `describe()`.
- Scanning for a `//` run cannot see a stranded header that is already a doc
  comment, which is indistinguishable in form from a well-placed one.

Four of the eight in the second commit fall in that second category. Every
candidate was read rather than classified: the doc comments that look identical
in `encodable-form.ts` and `create-ref-cell-routes.test.ts` describe the
declaration they sit on, and stay where they are.

### Checking that a move stayed a move

A hoist that quietly rewrites its prose is worse than no hoist, so each moved
comment is checked by reducing the comments on both sides of the change to a
bag of words and requiring the two to match. That catches a swapped word and,
more to the point, a dropped qualifier — the failure where tightening prose in
transit deletes the clause that made it true. The check was run first against
deliberately corrupted copies, to confirm it fails when it should.

### Testing

`deno task test` in `packages/runner` at `d4b9965be`, which is where the four
headers in the first commit landed and had not yet been exercised:
`ok | 1189 passed (6302 steps) | 0 failed`. The eight hoisted files were then
run again after the hoist: `ok | 9 passed (86 steps) | 0 failed`.

`deno fmt --check` and `deno lint` are clean over the twelve files, and no
added line exceeds 80 characters measured in characters rather than bytes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

