### PR TITLE
docs(data-model): file headers for the package's `src` tree

### DIFF
--- a/packages/data-model/src/codec-common/CodecRegistry.ts
+++ b/packages/data-model/src/codec-common/CodecRegistry.ts
@@ -1,3 +1,17 @@
+/**
+ * The registry a wire format's walker consults: tag to codec on the way in,
+ * value to codec on the way out. On the encode side the match is by class
+ * where a value has a useful one and by primitive type otherwise, with a value
+ * that is already its own wire form answering to neither and getting a
+ * sentinel in place of a codec.
+ *
+ * A registry is mutable while it is being assembled and immutable once frozen,
+ * and that is a safety property rather than a convenience. A codec holds the
+ * registry it was constructed with, so one handed out unfrozen could gain a
+ * registration underneath a codec already relying on it. Building further on a
+ * frozen registry means extending it into a new one.
+ */
+
 import type { FabricValue } from "@/interface.ts";
 import { CODEC, type CodecForFormat, type WireFormat } from "./interface.ts";
 import { BaseNonterminalCodec } from "./BaseNonterminalCodec.ts";

--- a/packages/data-model/src/codec-common/interface.ts
+++ b/packages/data-model/src/codec-common/interface.ts
@@ -1,3 +1,16 @@
+/**
+ * The codec layer's contracts, written without naming any wire format: what a
+ * codec is, the two things its state can mean to a walker, and the context
+ * objects carried through an encode or a decode.
+ *
+ * The distinction running through all of it is that a codec's type does not
+ * say what its state is for. Every codec has the same members whatever domain
+ * it works in, and the domains overlap, so which kind a codec is has to be
+ * declared by the base class it extends rather than inferred from its
+ * signature. Everything downstream -- what a registry will accept, how a
+ * walker dispatches -- reads that declaration.
+ */
+
 import type { Constructor } from "@commonfabric/utils/types";
 
 import type { FabricInstance, FabricValue } from "@/interface.ts";

--- a/packages/data-model/src/codec-json/interface.ts
+++ b/packages/data-model/src/codec-json/interface.ts
@@ -1,3 +1,14 @@
+/**
+ * The JSON wire format's declarations: the tag its encoded text carries, the
+ * intermediate tree type built while walking a value, and the format value a
+ * `CodecRegistry` is constructed over.
+ *
+ * The tree type is not the serialized form -- that is a string -- and the two
+ * are easy to conflate. Which of those trees are deep-frozen is a real
+ * distinction rather than an incidental one, and it is recorded on the type
+ * itself rather than restated here.
+ */
+
 import type { WireFormat } from "@/codec-common/interface.ts";
 import { JSON_CODEC } from "@/interface.ts";
 

--- a/packages/data-model/src/codecs.ts
+++ b/packages/data-model/src/codecs.ts
@@ -1,16 +1,18 @@
-// The package's ready-to-use codec defaults: entry points that encode and
-// decode with this package's own set of fabric classes, for callers that want
-// the standard answer rather than a configured one.
-//
-// This sits above `codec-json` and `codec-common`, which carry the format and
-// the mechanism and know nothing about which classes participate. Nothing in
-// either of those directories may import from here; the dependency runs one
-// way, and a convenience import in the other direction would make it a cycle.
-//
-// Both class rosters are imported at module scope and the registry is built at
-// first import, so this module pulls in every class that participates in the
-// wire format. That is the shape a cycle would be most costly in, which is the
-// other half of why the rule above is absolute rather than stylistic.
+/**
+ * The package's ready-to-use codec defaults: entry points that encode and
+ * decode with this package's own set of fabric classes, for callers that want
+ * the standard answer rather than a configured one.
+ *
+ * This sits above `codec-json` and `codec-common`, which carry the format and
+ * the mechanism and know nothing about which classes participate. Nothing in
+ * either of those directories may import from here; the dependency runs one
+ * way, and a convenience import in the other direction would make it a cycle.
+ *
+ * Both class rosters are imported at module scope and the registry is built at
+ * first import, so this module pulls in every class that participates in the
+ * wire format. That is the shape a cycle would be most costly in, which is the
+ * other half of why the rule above is absolute rather than stylistic.
+ */
 
 import { isInstance } from "@commonfabric/utils/types";
 

--- a/packages/data-model/src/deep-freeze.ts
+++ b/packages/data-model/src/deep-freeze.ts
@@ -1,3 +1,17 @@
+/**
+ * Freezing a value all the way down, and asking whether it already is.
+ *
+ * Both walks are memoized in a `WeakSet`, which is what makes the ordinary
+ * case cheap: a value frozen once answers in constant time ever after, and a
+ * primitive never needs asking at all. Those answers are given before any
+ * per-walk state is allocated, so the cheap path costs nothing.
+ *
+ * A fabric instance keeps its contents private, so neither walk can descend
+ * into one directly. Each calls the instance's own protocol member and passes
+ * recursion back in, which is what keeps the cycle tracking and the cache
+ * shared across that boundary instead of restarting inside it.
+ */
+
 import type { FabricValue } from "./interface.ts";
 import {
   BaseFabricInstance,

--- a/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
+++ b/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
@@ -1,3 +1,20 @@
+/**
+ * The implementation side of the instance hierarchy: the base class that
+ * concrete fabric instances extend, and the symbol-keyed protocol members by
+ * which the generic freeze and clone utilities reach an instance's interior.
+ *
+ * An instance holds its contents in private fields, so no walker can descend
+ * into one by enumerating properties. The protocols invert that: the utility
+ * calls the member and hands recursion back in as a callback, so its cycle
+ * tracking and its cache carry across the boundary rather than restarting
+ * inside it. Dispatch is generic in the base class, so nothing here enumerates
+ * concrete subclasses.
+ *
+ * This module and the freeze utility import each other. The cycle is
+ * deliberate, and is safe only because each side reaches the other from inside
+ * a function body; a dereference during module evaluation would break it.
+ */
+
 import { FabricInstance, type FabricValue } from "@/interface.ts";
 import { toCompactDebugString } from "@/value-debug.ts";
 // Used only inside method bodies: this import participates in a module cycle

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -1,3 +1,18 @@
+/**
+ * `Error` as a fabric value: the wrapper class, and the shape it is built
+ * from.
+ *
+ * A native error is the wild west -- any property, any prototype -- while the
+ * fabric layer needs a value whose observable state is entirely typed. The
+ * useful parts therefore become fixed slots and everything else goes to an
+ * extras bag reached by map-like methods, with the slot names reserved so that
+ * an extra cannot shadow one. The native form is not retained at all; it is
+ * rebuilt on demand.
+ *
+ * Mutability follows the usual instance rule: writable until the instance is
+ * frozen, and every mutator refuses from then on.
+ */
+
 import type {
   FabricError as ApiFabricError,
   FabricErrorConstructor as ApiFabricErrorConstructor,

--- a/packages/data-model/src/fabric-primitives/BaseFabricPrimitive.ts
+++ b/packages/data-model/src/fabric-primitives/BaseFabricPrimitive.ts
@@ -1,3 +1,15 @@
+/**
+ * The implementation side of the primitive hierarchy: the base class that
+ * concrete primitives extend, the interface by which one advertises a JSON
+ * codec, and the symbol seeding its plumbing members.
+ *
+ * `FabricPrimitive` is the contract external code is written against, and this
+ * is where the shared implementation behind it lives. The split is held by
+ * convention rather than by the type system -- nothing stops a subclass from
+ * extending the contract directly -- so the invariant is enforced at runtime
+ * instead of being assumed.
+ */
+
 import type { CodecForFormat } from "@/codec-common/interface.ts";
 import type { JsonCodecValue } from "@/codec-json/interface.ts";
 import { FabricPrimitive, JSON_CODEC } from "@/interface.ts";

--- a/packages/data-model/src/fabric-primitives/index.ts
+++ b/packages/data-model/src/fabric-primitives/index.ts
@@ -1,3 +1,16 @@
+/**
+ * The primitive classes' entry point, and the two answers that have to be kept
+ * in step with the set of them: which classes travel over the wire, and what
+ * each one is called in the schema dialect.
+ *
+ * Both lists are written out by hand rather than derived, because neither can
+ * be discovered by reflection. A class binds its codec under a wire format's
+ * own symbol, so nothing here can name the symbol to look for without naming a
+ * format; and the constructor name a lookup would otherwise key on does not
+ * survive a minified build. Adding a primitive therefore means editing this
+ * file, and both lists are built to fail loudly when it has not been.
+ */
+
 import { backtickQuote } from "@commonfabric/utils/markdown";
 import type { Constructor } from "@commonfabric/utils/types";
 import type { FabricPrimitiveSchemaType } from "@commonfabric/api";

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -1,3 +1,21 @@
+/**
+ * The boundary between native JS values and fabric values, in both
+ * directions, along with the predicate saying in advance whether a value can
+ * cross it.
+ *
+ * Inbound, anything not representable is refused rather than approximated: a
+ * `Map`, a class instance, an unrecognized type all throw, on the principle
+ * that a wrong value is worse than none. A value that is already a deep-frozen
+ * fabric value crosses by identity instead of being rebuilt, and a cycle is
+ * detected rather than followed.
+ *
+ * Outbound, a wrapper is unwrapped to the native type it stands for, while a
+ * fabric instance with no native counterpart passes through untouched. Both
+ * directions take the result's freeze state as an argument; on the way out, a
+ * class defined to be always frozen comes back frozen regardless of what was
+ * asked for.
+ */
+
 import { backtickQuote } from "@commonfabric/utils/markdown";
 import {
   isInstance,

--- a/packages/data-model/src/native-type-tags.ts
+++ b/packages/data-model/src/native-type-tags.ts
@@ -1,3 +1,18 @@
+/**
+ * Answering what a JS value already is, so that conversion can decide what to
+ * make of it. These tags name the value's own class, and are unrelated to the
+ * tags a wire format writes, which say what it became.
+ *
+ * The question is harder than an `instanceof` because the answer must not be
+ * forgeable, and must still be reachable for a value that did not come from
+ * here. A class is read off the prototype rather than off the value, since an
+ * own `constructor` property is ordinary data that would otherwise let a plain
+ * record present itself as an `Error`. A value from another realm, or one
+ * whose prototype has been severed, has to be recognized regardless, which is
+ * why the constructor switch has fallbacks beneath it rather than standing
+ * alone.
+ */
+
 import { FabricEpochDays } from "@/fabric-primitives/FabricEpochDays.ts";
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
 import { FabricHash } from "@/fabric-primitives/FabricHash.ts";

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -1,3 +1,19 @@
+/**
+ * The predicates deciding whether a value belongs to the `FabricValue` type,
+ * and the narrowings that ask a shape question about one that already does.
+ *
+ * Membership turns on inertness: a fabric value is data, so anything that is
+ * live code is refused -- a function, an accessor-backed property, the
+ * prototype of an `Array` subclass, a symbol that was never registry-interned.
+ * Frozen-ness is a separate question and deliberately not asked here, so a
+ * structurally-valid unfrozen value is a member.
+ *
+ * The narrowings are looser than membership on purpose. They are asked of a
+ * value whose type already claims to be a `FabricValue`, and answer only
+ * whether it may be read by name; where one accepts something membership
+ * refuses, the difference is stated on that narrowing rather than here.
+ */
+
 import { isInertArray } from "@commonfabric/utils/arrays";
 import { isInertPlainObject } from "@commonfabric/utils/objects";
 import { isPlainObject, unsafeObjectKeyIn } from "@commonfabric/utils/types";

--- a/packages/data-model/src/value-clone.ts
+++ b/packages/data-model/src/value-clone.ts
@@ -1,3 +1,20 @@
+/**
+ * Cloning a value that is already a `FabricValue`, in order to change how
+ * frozen it is. This is not conversion: the input is taken as valid, and what
+ * varies is frozenness, depth, and whether a copy is forced rather than
+ * elided.
+ *
+ * The more involved job is preparing a value for a structured mutation, which
+ * is a copy-on-write descent. Only the containers along the path being mutated
+ * are thawed and spliced back in, and every subtree off that path keeps its
+ * identity. That identity is the point rather than an incidental saving: an
+ * untouched subtree stays in the deep-frozen cache, so re-freezing the result
+ * short-circuits on it instead of walking it again.
+ *
+ * Cycles are refused rather than accommodated, on the deep paths that would
+ * otherwise recurse forever.
+ */
+
 import { backtickQuote } from "@commonfabric/utils/markdown";
 import { type Immutable, isPlainContainer } from "@commonfabric/utils/types";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) am extending the file-header
conformance work to `packages/data-model`, against the "File headers" section
of `docs/development/code-comment-style.md`. This covers the package's `src`
tree; its `test` tree follows separately.

Twelve files gain a header, and `codecs.ts` converts its `//` block to a doc
comment with its prose crossing unchanged.

### What the headers say

Each states what its module is for at an altitude its declarations do not
reach, rather than summarizing them:

- `type-check.ts` — membership turns on inertness (a fabric value is data, so a
  function, an accessor, or an `Array` subclass's prototype is refused), and
  frozen-ness is a separate question it deliberately does not ask.
- `native-type-tags.ts` — identity has to be unforgeable, which is why a class
  is read off the prototype rather than off a value whose own `constructor`
  property is ordinary data.
- `codec-common/interface.ts` — a codec's type does not say what its state is
  for, the domains overlapping, so the kind is declared by the base class
  extended rather than inferred from a signature.
- `CodecRegistry.ts` — freezing is a safety property, not a convenience: a
  codec holds the registry it was built with, so one handed out unfrozen could
  gain a registration underneath a codec already relying on it.
- `BaseFabricInstance.ts` and `deep-freeze.ts` import each other. The header on
  the former records that the cycle is deliberate and survives only because
  each side reaches the other from inside a function body.

### Nothing here is a relocation

Unlike the `runner` chunks, no file in this tree had a header sitting in the
wrong place. Every doc comment below an import block was read and found to
document the declaration under it — including the ones in
`create-ref-cell-routes.test.ts`-shaped positions that a detector flags and a
reader dismisses.

### Three files a mechanical pass would have damaged

These are deliberately untouched, and the reasons generalize:

- `codec-meta-tags.ts` and `codec-type-tags.ts` each define exactly one thing,
  so the doc comment sitting tight against that declaration is what a correct
  file looks like. Adding the blank line a header wants would have converted it
  into a file header and left the declaration undocumented.
- `codecOf.ts` writes `export function` three times for one overloaded
  declaration. It is still a single-declaration file and takes no header;
  counting `export` lines rather than exported names is what makes it look
  plural.

### Testing

`deno task test` in `packages/data-model`: `ok | 52 passed (2340 steps) |
0 failed`. Note that `deno task check` does not cover this package, so that
suite is the gate. `deno fmt --check` and `deno lint` are clean over the
thirteen files, and no added line exceeds 80 characters measured in characters
rather than bytes.

Merged with `main` after the recent `codec-json` work landed. That change
rewrote `JsonCodec.ts`; its sibling `interface.ts` keeps a header here that
defers to a doc comment in that file rather than restating it, and both that
comment and `JsonCodec.ts`'s single-export shape survive the merge intact.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

