### PR TITLE
fix(cli): a rejection propagates up through what holds it

### DIFF
--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -467,8 +467,8 @@ A marked position is not fetched — the address is stored in the document that
 contains it, so a marked collection of a hundred notes costs the one read that
 document already needed. It costs the same whether the marker sits on the link
 or below it: a position that asks for nothing but addresses is not read either,
-and `notes.title@` reads the board alone. Where the marker is the whole
-selection, nothing behind it is read at all.
+so `notes.title@` reads what holds the collection and none of the notes. Where
+the marker is the whole selection, nothing behind it is read at all.
 
 The address a marked read returns is one `cf piece call` accepts, minus the
 `of:` prefix, which is the reason to ask for it.

--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -465,8 +465,10 @@ title.
 
 A marked position is not fetched — the address is stored in the document that
 contains it, so a marked collection of a hundred notes costs the one read that
-document already needed. Where the marker is the whole selection, nothing
-behind it is read at all.
+document already needed. It costs the same whether the marker sits on the link
+or below it: a position that asks for nothing but addresses is not read either,
+and `notes.title@` reads the board alone. Where the marker is the whole
+selection, nothing behind it is read at all.
 
 The address a marked read returns is one `cf piece call` accepts, minus the
 `of:` prefix, which is the reason to ask for it.

--- a/docs/plans/shaped-reads-and-verb-results.md
+++ b/docs/plans/shaped-reads-and-verb-results.md
@@ -469,12 +469,13 @@ result holding anything reactive does not have one at the moment the receipt is
 written. So a verb returning a child piece — the case this design exists to
 serve — gets a receipt with no schema, and a selection over it matches a runtime
 value rather than a declaration. What that costs is bounded: a `$link` marker
-*on a link position* still renders an address and still suppresses the fetch,
-because a rejecting selector short-circuits before a source schema is consulted.
-A marker below a link is a separate matter — the rejection has to propagate up
-through the containers holding it, which is its own piece of work. What is lost is
-narrowing on field selection, and any check of a selection before the call. The
-open question below is how that gap closes.
+renders an address and suppresses the fetch wherever it sits, because a
+rejecting selector short-circuits before a source schema is consulted, and a
+container whose every position rejects rejects in turn — so a marker below a
+link carries its rejection up to the position holding that link and costs the
+same one read as a marker on it. What is lost is narrowing on field selection,
+and any check of a selection before the call. The open question below is how
+that gap closes.
 
 It records nothing about which positions hold links. A link position in a source
 schema is spelled `asCell`, and `["cell"]` asserts a writable handle; writing

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -172,10 +172,12 @@ keyword is accepted and ignored. A command that ran only because a key was
 silently dropped now fails loudly, which is the point rather than a regression.
 
 **3. A rejection propagates up through what holds it.** *(S)* The projection
-mask reduces an array whose items reject to `false`, but leaves an object whose
-every property rejects as a live selector. So marking a field below a link loads
-every element document — measured at four reads where one would do. The fix is
-the symmetric reduction, which then cascades to the array above it.
+mask reduces either container whose whole selection rejects — an array whose
+items reject, and an object whose every named property rejects — to `false`. A
+rejection below a link therefore cascades up to the position holding that link,
+which is where a rejecting selector suppresses the fetch, so marking a field
+below a link costs the read that document already needed rather than one per
+element.
 
 *Exit:* a marked collection is one document read whether the marker sits on the
 link or below it.

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -1183,6 +1183,20 @@ interface ObjectProjectionMask extends ObjectMask<ProjectionMask> {}
  * Which positions a selection reads. `false` is the rejecting one: the
  * position contributes nothing to the read, and the runner never loads what
  * is behind it.
+ *
+ * **A rejecting position is always a marked one.**
+ * {@link normalizeProjectionSchema} refuses a bare `false` in a projection
+ * schema, so `false` enters a mask only where a `$link` marker took the whole
+ * selection at that position, and only ever spreads upward from there. A mask
+ * that rejects therefore always has markers to answer with, and a selection
+ * whose root mask is `false` selects no value anywhere.
+ *
+ * Two things rest on that. {@link deriveSelectedValue}'s whole-selection
+ * short-circuit answers from the stored links alone, which is a wrong answer
+ * rather than an empty one if a rejection ever arrives without a marker. And
+ * the item masks it dereferences beside a `--filter` are reachable only
+ * because a marker and a filter are refused together. Admitting `false` by
+ * any other route breaks both, silently.
  */
 type ProjectionMask =
   | true
@@ -1326,16 +1340,14 @@ function alignConciseProjectionMask(
 
   if (schemaMayBeArray(source, flag)) {
     const sourceItem = schemaAtArrayItem(source);
-    return {
-      type: "array",
-      items: alignConciseProjectionMask(sourceItem, mask, flag),
-    };
+    return arrayProjectionMask(
+      alignConciseProjectionMask(sourceItem, mask, flag),
+    );
   }
 
   const objectMask = mask as ObjectProjectionMask;
-  return {
-    ...objectMask,
-    properties: Object.fromEntries(
+  return objectProjectionMask(
+    Object.fromEntries(
       Object.entries(objectMask.properties).map(([key, childMask]) => {
         const child = ContextualFlowControl.schemaAtPath(source, [key]);
         return [
@@ -1348,7 +1360,7 @@ function alignConciseProjectionMask(
         ];
       }),
     ),
-  };
+  );
 }
 
 /**
@@ -1473,10 +1485,7 @@ export function mergeMasks(
   // predicate observes it.
   if (right === false) return left;
   if (right.type === "array") {
-    return {
-      type: "array",
-      items: mergeMasks(left, right.items),
-    };
+    return arrayProjectionMask(mergeMasks(left, right.items));
   }
   const properties: Record<string, ProjectionMask> = {};
   for (
@@ -1493,7 +1502,7 @@ export function mergeMasks(
       ? leftChild
       : mergeMasks(leftChild, rightChild);
   }
-  return { type: "object", properties, additionalProperties: false };
+  return objectProjectionMask(properties);
 }
 
 /** @internal Exported for focused source-schema selection tests. */
@@ -1916,6 +1925,18 @@ async function composeLinkAddresses(
     : address;
 }
 
+/**
+ * The refusal a projection over array items earns when the value it meets is
+ * not an array. Both roads to that mismatch answer with it: the pattern graph
+ * reaches it through the map builtin, and a selection that is entirely
+ * addresses reaches it through the walk, which never runs one.
+ */
+function arrayItemProjectionError(flag: ProjectionFlag): CellSelectionError {
+  return new CellSelectionError(
+    `${flag} can only project array items from an array value`,
+  );
+}
+
 /** Optional hooks into {@link deriveSelectedValue}'s internals. */
 export interface DeriveSelectedValueDependencies {
   /** Called with the cell the returned value was read from. */
@@ -2002,9 +2023,27 @@ export async function deriveSelectedValue(
     // The whole selection was addresses. There is no value to compute, so the
     // pattern graph would run over the rejecting selector and produce nothing
     // for the composition to join. Read the stored links and answer.
-    await sourceValueCell.asSchema(false).pull();
+    //
+    // One cell reads and is walked: a sync is recorded on the cell it was
+    // asked of, so walking any other instance of the same position kicks a
+    // second sync of the document just loaded. The rejecting schema is what
+    // holds that load to the one document, because a sync selector carries
+    // the cell's schema.
+    const walked = sourceValueCell.asSchema(false);
+    await walked.pull();
+    const position = sourcePosition(walked);
+    // The graph path refuses a projection over array items that meets a value
+    // which is not an array, and the answer to a marked one is the same
+    // refusal: a walk over a non-array simply finds no elements to address,
+    // which renders as an absent value rather than as the mismatch it is.
+    if (
+      projection.projectsArrayItems &&
+      !Array.isArray(await storedContainer(position))
+    ) {
+      throw arrayItemProjectionError(selection.projection!.flag);
+    }
     return await composeLinkAddresses(
-      sourcePosition(sourceValueCell),
+      position,
       markers,
       undefined,
       implicitArrayTraversal,
@@ -2242,10 +2281,7 @@ export async function deriveSelectedValue(
           error.message === "map currently only supports arrays"
         )
       ) {
-        throw new CellSelectionError(
-          `${selection.projection!.flag} can only project array items from ` +
-            "an array value",
-        );
+        throw arrayItemProjectionError(selection.projection!.flag);
       }
       const lastError = recorded.at(-1)!;
       throw new CellSelectionError(

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -1192,20 +1192,51 @@ type ProjectionMask =
 interface ObjectPredicateMask extends ObjectMask<PredicateMask> {}
 type PredicateMask = true | ObjectPredicateMask;
 
+/**
+ * The mask for an array whose elements `items` selects.
+ *
+ * An array whose elements are not read is not read. The rejecting selector has
+ * to sit at the array itself to suppress the fetch: array traversal follows
+ * each element's link before it consults the item schema, so a rejection one
+ * level down arrives after the load it was meant to prevent.
+ */
+function arrayProjectionMask(items: ProjectionMask): ProjectionMask {
+  return items === false ? false : { type: "array", items };
+}
+
+/**
+ * The mask for an object whose named positions `properties` selects.
+ *
+ * An object whose every named position rejects is not read, by the same rule
+ * {@link arrayProjectionMask} applies one level up: a rejection reaches the
+ * fetch it suppresses only from the position that holds the link. Reducing
+ * here is what carries a rejection below a link up to the array holding it, so
+ * a marker below a link costs the same one read as a marker on it.
+ *
+ * Callers filter out the object that admits keys it does not name, which
+ * cannot be narrowed and so is never all-rejecting. An object naming no
+ * positions rejects nothing and stays a selector for the empty object it
+ * describes.
+ */
+function objectProjectionMask(
+  properties: Record<string, ProjectionMask>,
+): ProjectionMask {
+  const children = Object.values(properties);
+  return children.length > 0 && children.every((child) => child === false)
+    ? false
+    : { type: "object", properties, additionalProperties: false };
+}
+
 function projectionMask(schema: JSONSchema): ProjectionMask {
   if (schema === true) return true;
   if (schema === false) return false;
   const objectSchema = schema as Exclude<JSONSchema, boolean>;
   if (objectSchema.type === "array" || objectSchema.items !== undefined) {
-    const items = objectSchema.items === undefined
-      ? true
-      : projectionMask(objectSchema.items);
-    // An array whose elements are not read is not read. The rejecting
-    // selector has to sit at the array itself to suppress the fetch: array
-    // traversal follows each element's link before it consults the item
-    // schema, so a rejection one level down arrives after the load it was
-    // meant to prevent.
-    return items === false ? false : { type: "array", items };
+    return arrayProjectionMask(
+      objectSchema.items === undefined
+        ? true
+        : projectionMask(objectSchema.items),
+    );
   }
   // An object that admits keys it does not name cannot be narrowed: the
   // selector has to read whatever is there. The array branch above takes a
@@ -1222,16 +1253,14 @@ function projectionMask(schema: JSONSchema): ProjectionMask {
   if (
     objectSchema.type === "object" || objectSchema.properties !== undefined
   ) {
-    return {
-      type: "object",
-      properties: Object.fromEntries(
+    return objectProjectionMask(
+      Object.fromEntries(
         Object.entries(objectSchema.properties ?? {}).map(([key, child]) => [
           key,
           projectionMask(child),
         ]),
       ),
-      additionalProperties: false,
-    };
+    );
   }
   return true;
 }
@@ -1627,7 +1656,10 @@ function resolveProjection(
           type: "array",
           items: projectionSchema,
         },
-        mask: { type: "array", items: mask },
+        // A field list read element-wise selects the array through its
+        // elements, so an element the list rejects entirely rejects the array
+        // the same way an item schema does.
+        mask: arrayProjectionMask(mask),
         projectsArrayItems: true,
         itemOutputSchema: outputSchema,
         itemProjectionSchema: projectionSchema,

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -2036,10 +2036,21 @@ export async function deriveSelectedValue(
     // which is not an array, and the answer to a marked one is the same
     // refusal: a walk over a non-array simply finds no elements to address,
     // which renders as an absent value rather than as the mismatch it is.
-    if (
-      projection.projectsArrayItems &&
-      !Array.isArray(await storedContainer(position))
-    ) {
+    //
+    // `undefined` is not a mismatch. An unset declared array is the empty
+    // array under the runner's map semantics, so the unmarked spelling
+    // answers `[]` — and a marked one has to answer `[]` too, or the two
+    // disagree about a piece that simply has nothing in it yet. A stored
+    // `null` or object still is a mismatch and still refuses.
+    const storedValue = await storedContainer(position);
+    if (projection.projectsArrayItems && !Array.isArray(storedValue)) {
+      // An unset declared array is the empty array under the runner's map
+      // semantics, which is why the unmarked spelling answers `[]`. A marked
+      // one answers `[]` as well rather than refusing or going absent: the
+      // piece is not malformed, it simply holds nothing yet, and that is the
+      // state every collection starts in. A stored `null` or object IS a
+      // mismatch and still refuses.
+      if (storedValue === undefined) return [];
       throw arrayItemProjectionError(selection.projection!.flag);
     }
     return await composeLinkAddresses(

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -1950,6 +1950,43 @@ describe("cf piece get transforms", () => {
     );
   });
 
+  it("answers an unset declared array with no addresses rather than a refusal", async () => {
+    // An unset declared array is the empty array under the runner's map
+    // semantics, and the unmarked spelling already answers `[]`. A marked one
+    // must agree: refusing here would tell a caller its piece is malformed
+    // when it merely has nothing in it yet — the state every collection
+    // starts in.
+    const tx = runtime.edit();
+    const unsetSource = runtime.getCell(
+      space,
+      "declared-array-unset-source",
+      { type: "array", items: { type: "object" } },
+      tx,
+    );
+    expect((await tx.commit()).ok).toBeDefined();
+
+    // All three spellings agree, which is the property: an unmarked
+    // projection, a concise marker, and the JSON-schema marker each answer
+    // with no elements rather than one refusing and another going absent.
+    expect(
+      await deriveSelectedValue(runtime, space, unsetSource, {
+        projection: parseSelectProjection("id"),
+      }),
+    ).toEqual([]);
+    expect(
+      await deriveSelectedValue(runtime, space, unsetSource, {
+        projection: parseSelectProjection("id@"),
+      }),
+    ).toEqual([]);
+    expect(
+      await deriveSelectedValue(runtime, space, unsetSource, {
+        projection: await parseSelectionProjection(
+          '{"type":"array","items":{"properties":{"id":{"$link":true}}}}',
+        ),
+      }),
+    ).toEqual([]);
+  });
+
   it("reports runtime predicate failures as transform errors", async () => {
     const tx = runtime.edit();
     const source = runtime.getCell(

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -2190,6 +2190,40 @@ describe("cf piece get transforms", () => {
       };
     }
 
+    const uriOf = (cell: Cell<unknown>) => cell.getAsNormalizedFullLink().id;
+
+    /**
+     * Which of `cells`' documents `read` reaches, in the order the provider
+     * first synced each. Answering a read from a document that is not loaded
+     * has to reach storage, so a document seeded unwritten is one whose read is
+     * observable here.
+     *
+     * Only the documents named are counted: a read of the transform's own
+     * session documents says nothing about which of the source's data the
+     * selection reached. Each is counted once, because a document consulted
+     * twice is still one document read, and the syncs run concurrently, so a
+     * caller comparing more than one sorts.
+     */
+    async function documentsRead(
+      cells: Cell<unknown>[],
+      read: () => Promise<unknown>,
+    ): Promise<string[]> {
+      const provider = storageManager.open(space);
+      const originalSync = provider.sync.bind(provider);
+      const named = cells.map(uriOf);
+      const reached: string[] = [];
+      provider.sync = ((uri, selector, scope) => {
+        if (named.includes(uri) && !reached.includes(uri)) reached.push(uri);
+        return originalSync(uri, selector, scope);
+      }) as typeof provider.sync;
+      try {
+        await read();
+      } finally {
+        provider.sync = originalSync;
+      }
+      return reached;
+    }
+
     it("returns a marked position's address instead of its contents", async () => {
       const { board, notes } = await seedBoard("link-marker-instead", true);
       expect(
@@ -2339,52 +2373,142 @@ describe("cf piece get transforms", () => {
       });
     });
 
-    it("reads one document for a marked collection, not one per element", async () => {
+    it("reads one document for a marked collection, whether the marker sits on the link or below it", async () => {
       const { board, notes } = await seedBoard("link-marker-reads", false);
-      const provider = storageManager.open(space);
-      const originalSync = provider.sync.bind(provider);
-      let syncedUris: string[] = [];
-      provider.sync = ((uri, selector, scope) => {
-        syncedUris.push(uri);
-        return originalSync(uri, selector, scope);
-      }) as typeof provider.sync;
-      const boardUri = board.getAsNormalizedFullLink().id;
-      const noteUris: string[] = notes.map((note) =>
-        note.getAsNormalizedFullLink().id
+      const documents = [board, ...notes];
+      const reopened = () =>
+        runtime.getCell(space, "link-marker-reads-board", boardSchema);
+      const onTheLink = await parseSelectionProjection(
+        '{"properties":{"notes":{"type":"array","items":{"$link":true}}}}',
       );
-      // A read of the transform's own session documents says nothing about
-      // which of the board's data this selection reached.
-      const boardDocuments = (uris: string[]) =>
-        uris.filter((uri) => uri === boardUri || noteUris.includes(uri));
+      const belowTheLink = await parseSelectionProjection(
+        '{"properties":{"notes":{"type":"array","items":' +
+          '{"type":"object","properties":{"title":{"$link":true}}}}}}',
+      );
+      const unmarked = await parseSelectionProjection(
+        '{"properties":{"notes":{"type":"array","items":' +
+          '{"type":"object","properties":{"title":true}}}}}',
+      );
 
-      syncedUris = [];
-      await deriveSelectedValue(runtime, space, board, {
-        projection: await parseSelectionProjection(
-          '{"properties":{"notes":{"type":"array","items":{"$link":true}}}}',
+      expect(
+        await documentsRead(
+          documents,
+          () =>
+            deriveSelectedValue(runtime, space, board, {
+              projection: onTheLink,
+            }),
         ),
-      });
-      const marked = boardDocuments(syncedUris);
+      ).toEqual([uriOf(board)]);
+      expect(
+        await documentsRead(
+          documents,
+          () =>
+            deriveSelectedValue(runtime, space, reopened(), {
+              projection: belowTheLink,
+            }),
+        ),
+      ).toEqual([uriOf(board)]);
 
-      syncedUris = [];
-      await deriveSelectedValue(
-        runtime,
+      // The control: the same collection asked for its contents does load
+      // every element, which is what makes the two reads above evidence of a
+      // suppressed fetch rather than of a harness that observes nothing. The
+      // board itself is already loaded by here, so this read has no reason to
+      // reach for it again.
+      expect(
+        (await documentsRead(
+          documents,
+          () =>
+            deriveSelectedValue(runtime, space, reopened(), {
+              projection: unmarked,
+            }),
+        )).toSorted(),
+      ).toEqual(notes.map(uriOf).toSorted());
+    });
+
+    it("reads one document for a marker below a link, not the document the link names", async () => {
+      const { board, notes } = await seedBoard(
+        "link-marker-below-reads",
+        false,
+      );
+      const belowTheLink = await parseSelectionProjection(
+        '{"properties":{"topic":{"properties":{"title":{"$link":true}}}}}',
+      );
+
+      expect(
+        await documentsRead(
+          [board, ...notes],
+          () =>
+            deriveSelectedValue(runtime, space, board, {
+              projection: belowTheLink,
+            }),
+        ),
+      ).toEqual([uriOf(board)]);
+    });
+
+    /**
+     * A board whose `notes` is itself a link to the document holding the
+     * array, which is the shape a value assembled elsewhere arrives in — a
+     * collection the source names but does not contain. The elements are the
+     * links `seedBoard` writes, and the note documents stay unwritten.
+     */
+    async function seedLinkedCollection(
+      cause: string,
+    ): Promise<{
+      board: Cell<unknown>;
+      holder: Cell<unknown>;
+      notes: Cell<unknown>[];
+    }> {
+      const tx = runtime.edit();
+      const notes = ["a", "b", "c"].map((suffix) =>
+        runtime.getCell(space, `${cause}-note-${suffix}`, noteSchema, tx)
+      );
+      const holderSchema = {
+        type: "object",
+        properties: { notes: { type: "array", items: noteSchema } },
+      } as const satisfies JSONSchema;
+      const holder = runtime.getCell(
         space,
-        runtime.getCell(space, "link-marker-reads-board", boardSchema),
-        {
-          projection: await parseSelectionProjection(
-            '{"properties":{"notes":{"type":"array","items":' +
-              '{"type":"object","properties":{"title":true}}}}}',
-          ),
-        },
+        `${cause}-holder`,
+        holderSchema,
+        tx,
       );
+      holder.setRaw({ notes: notes.map((note) => note.getAsLink()) } as never);
+      const board = runtime.getCell(space, `${cause}-board`, boardSchema, tx);
+      board.setRaw({
+        notes: holder.key("notes").getAsLink(),
+        topic: notes[0].getAsLink(),
+        label: "Field notes",
+      } as never);
+      expect((await tx.commit()).ok).toBeDefined();
+      return {
+        board: runtime.getCell(space, `${cause}-board`, boardSchema),
+        holder,
+        notes,
+      };
+    }
 
-      expect(marked).toEqual([boardUri]);
-      // `syncedUris` is a push-order log of concurrent syncs, so which
-      // documents were reached is the fact here and the order they resolved
-      // in is not.
-      expect(boardDocuments(syncedUris).toSorted()).toEqual(
-        noteUris.toSorted(),
+    it("reads the document holding a linked collection, and none of its elements", async () => {
+      const { board, holder, notes } = await seedLinkedCollection(
+        "link-marker-linked-collection",
       );
+      const titleAddresses = notes.map((note) => ({
+        title: { $link: { ...addressOf(note), path: ["title"] } },
+      }));
+      let value: unknown;
+
+      // The element documents are the fact here: the holder is written by the
+      // fixture, so enumerating the collection out of it reaches no storage
+      // and says nothing either way. What the read must not reach is the
+      // document each element links to, since every position asked for below
+      // there is an address the element's own slot already holds.
+      expect(
+        await documentsRead([board, holder, ...notes], async () => {
+          value = await deriveSelectedValue(runtime, space, board, {
+            projection: parseSelectProjection("notes.title@"),
+          });
+        }),
+      ).toEqual([uriOf(board)]);
+      expect(value).toEqual({ notes: titleAddresses });
     });
 
     it("returns the address of the position it was read at for a marked root", async () => {
@@ -2748,38 +2872,56 @@ describe("cf piece get transforms", () => {
         });
       });
 
-      it("reads one document for a marked collection, not one per element", async () => {
+      it("reads one document for a marked collection, whether the marker sits on the link or below it", async () => {
         const { board, notes } = await seedBoard("at-suffix-reads", false);
-        const provider = storageManager.open(space);
-        const originalSync = provider.sync.bind(provider);
-        let syncedUris: string[] = [];
-        provider.sync = ((uri, selector, scope) => {
-          syncedUris.push(uri);
-          return originalSync(uri, selector, scope);
-        }) as typeof provider.sync;
-        const boardUri = board.getAsNormalizedFullLink().id;
-        const noteUris: string[] = notes.map((note) =>
-          note.getAsNormalizedFullLink().id
-        );
-        const boardDocuments = (uris: string[]) =>
-          uris.filter((uri) => uri === boardUri || noteUris.includes(uri));
+        const documents = [board, ...notes];
+        const reopened = () =>
+          runtime.getCell(space, "at-suffix-reads-board", boardSchema);
 
-        syncedUris = [];
-        await deriveSelectedValue(runtime, space, board, {
-          projection: parseSelectProjection("notes@"),
-        });
-        const marked = boardDocuments(syncedUris);
+        expect(
+          await documentsRead(
+            documents,
+            () =>
+              deriveSelectedValue(runtime, space, board, {
+                projection: parseSelectProjection("notes@"),
+              }),
+          ),
+        ).toEqual([uriOf(board)]);
+        expect(
+          await documentsRead(
+            documents,
+            () =>
+              deriveSelectedValue(runtime, space, reopened(), {
+                projection: parseSelectProjection("notes.title@"),
+              }),
+          ),
+        ).toEqual([uriOf(board)]);
 
-        syncedUris = [];
-        await deriveSelectedValue(
-          runtime,
-          space,
-          runtime.getCell(space, "at-suffix-reads-board", boardSchema),
-          { projection: parseSelectProjection("notes.title") },
-        );
+        // The control, as in the JSON spelling above: the unmarked field list
+        // loads every element.
+        expect(
+          (await documentsRead(
+            documents,
+            () =>
+              deriveSelectedValue(runtime, space, reopened(), {
+                projection: parseSelectProjection("notes.title"),
+              }),
+          )).toSorted(),
+        ).toEqual(notes.map(uriOf).toSorted());
+      });
 
-        expect(marked).toEqual([boardUri]);
-        expect(boardDocuments(syncedUris)).toEqual(noteUris);
+      it("reads one document for a marked field below the array the read starts at", async () => {
+        const { board, notes } = await seedBoard("at-suffix-root-reads", false);
+
+        expect(
+          await documentsRead(
+            [board, ...notes],
+            () =>
+              deriveSelectedValue(runtime, space, board.key("notes"), {
+                projection: parseSelectProjection("title@"),
+              }),
+          ),
+        ).toEqual([uriOf(board)]);
       });
 
       it("reaches a field whose name holds an `@` of its own", async () => {

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -1932,6 +1932,22 @@ describe("cf piece get transforms", () => {
     })).rejects.toThrow(
       /^--schema can only project array items from an array value$/,
     );
+    // A selection that is entirely addresses meets the mismatch on the walk
+    // rather than through the map builtin, and answers with the same refusal:
+    // a walk over a value that is not an array finds no elements to address,
+    // which would otherwise render as an absent value.
+    await expect(deriveSelectedValue(runtime, space, objectSource, {
+      projection: await parseSelectionProjection(
+        '{"type":"array","items":{"properties":{"id":{"$link":true}}}}',
+      ),
+    })).rejects.toThrow(
+      /^--schema can only project array items from an array value$/,
+    );
+    await expect(deriveSelectedValue(runtime, space, objectSource, {
+      projection: parseSelectProjection("id@"),
+    })).rejects.toThrow(
+      /^--select can only project array items from an array value$/,
+    );
   });
 
   it("reports runtime predicate failures as transform errors", async () => {
@@ -2200,11 +2216,16 @@ describe("cf piece get transforms", () => {
      *
      * Only the documents named are counted: a read of the transform's own
      * session documents says nothing about which of the source's data the
-     * selection reached. Each is counted once, because a document consulted
-     * twice is still one document read, and the syncs run concurrently, so a
-     * caller comparing more than one sorts.
+     * selection reached. Each is counted once — a document consulted twice is
+     * still one document read — so this bounds the documents a selection
+     * reaches rather than the syncs it issues, and the syncs run
+     * concurrently, so a caller comparing more than one sorts.
+     *
+     * A document already resident is reached without a sync, so absence from
+     * this list is evidence only for a document the fixture left unwritten.
+     * Name those, rather than asserting over documents the fixture wrote.
      */
-    async function documentsRead(
+    async function distinctDocumentsRead(
       cells: Cell<unknown>[],
       read: () => Promise<unknown>,
     ): Promise<string[]> {
@@ -2222,6 +2243,34 @@ describe("cf piece get transforms", () => {
         provider.sync = originalSync;
       }
       return reached;
+    }
+
+    /**
+     * How many times `read` syncs `cell`'s document.
+     * {@link distinctDocumentsRead} bounds which documents a selection
+     * reaches; this bounds how often it asks for one, which is what asking
+     * twice costs a caller across a real link. A sync is requested
+     * synchronously even where its result is not awaited, so a second request
+     * lands inside the window rather than racing it.
+     */
+    async function documentSyncs(
+      cell: Cell<unknown>,
+      read: () => Promise<unknown>,
+    ): Promise<number> {
+      const provider = storageManager.open(space);
+      const originalSync = provider.sync.bind(provider);
+      const uri = uriOf(cell);
+      let syncs = 0;
+      provider.sync = ((requested, selector, scope) => {
+        if (requested === uri) syncs++;
+        return originalSync(requested, selector, scope);
+      }) as typeof provider.sync;
+      try {
+        await read();
+      } finally {
+        provider.sync = originalSync;
+      }
+      return syncs;
     }
 
     it("returns a marked position's address instead of its contents", async () => {
@@ -2391,7 +2440,7 @@ describe("cf piece get transforms", () => {
       );
 
       expect(
-        await documentsRead(
+        await distinctDocumentsRead(
           documents,
           () =>
             deriveSelectedValue(runtime, space, board, {
@@ -2400,7 +2449,7 @@ describe("cf piece get transforms", () => {
         ),
       ).toEqual([uriOf(board)]);
       expect(
-        await documentsRead(
+        await distinctDocumentsRead(
           documents,
           () =>
             deriveSelectedValue(runtime, space, reopened(), {
@@ -2411,18 +2460,45 @@ describe("cf piece get transforms", () => {
 
       // The control: the same collection asked for its contents does load
       // every element, which is what makes the two reads above evidence of a
-      // suppressed fetch rather than of a harness that observes nothing. The
-      // board itself is already loaded by here, so this read has no reason to
-      // reach for it again.
+      // suppressed fetch rather than of a harness that observes nothing. It
+      // counts the element documents alone, so what it asserts does not depend
+      // on the reads above having warmed the board.
       expect(
-        (await documentsRead(
-          documents,
+        (await distinctDocumentsRead(
+          notes,
           () =>
             deriveSelectedValue(runtime, space, reopened(), {
               projection: unmarked,
             }),
         )).toSorted(),
       ).toEqual(notes.map(uriOf).toSorted());
+    });
+
+    it("loads the source document once for a selection that is entirely addresses", async () => {
+      const { board } = await seedBoard("link-marker-source-syncs", false);
+      const reopened = () =>
+        runtime.getCell(space, "link-marker-source-syncs-board", boardSchema);
+
+      // The read and the walk that composes the addresses are one cell, so
+      // the walk does not ask for the document the read just loaded.
+      expect(
+        await documentSyncs(
+          board,
+          () =>
+            deriveSelectedValue(runtime, space, board, {
+              projection: parseSelectProjection("notes@"),
+            }),
+        ),
+      ).toBe(1);
+      expect(
+        await documentSyncs(
+          board,
+          () =>
+            deriveSelectedValue(runtime, space, reopened(), {
+              projection: parseSelectProjection("notes.title@"),
+            }),
+        ),
+      ).toBe(1);
     });
 
     it("reads one document for a marker below a link, not the document the link names", async () => {
@@ -2435,7 +2511,7 @@ describe("cf piece get transforms", () => {
       );
 
       expect(
-        await documentsRead(
+        await distinctDocumentsRead(
           [board, ...notes],
           () =>
             deriveSelectedValue(runtime, space, board, {
@@ -2487,8 +2563,8 @@ describe("cf piece get transforms", () => {
       };
     }
 
-    it("reads the document holding a linked collection, and none of its elements", async () => {
-      const { board, holder, notes } = await seedLinkedCollection(
+    it("reads no element document for a marker below a linked collection", async () => {
+      const { board, notes } = await seedLinkedCollection(
         "link-marker-linked-collection",
       );
       const titleAddresses = notes.map((note) => ({
@@ -2496,18 +2572,18 @@ describe("cf piece get transforms", () => {
       }));
       let value: unknown;
 
-      // The element documents are the fact here: the holder is written by the
-      // fixture, so enumerating the collection out of it reaches no storage
-      // and says nothing either way. What the read must not reach is the
-      // document each element links to, since every position asked for below
-      // there is an address the element's own slot already holds.
+      // The element documents are what this asserts over. Enumerating the
+      // collection reaches the document holding it — which a reader that did
+      // not write it fetches, and this one already holds — while the document
+      // each element links to is never reached, because every position asked
+      // for below there is an address the element's own slot already holds.
       expect(
-        await documentsRead([board, holder, ...notes], async () => {
+        await distinctDocumentsRead(notes, async () => {
           value = await deriveSelectedValue(runtime, space, board, {
             projection: parseSelectProjection("notes.title@"),
           });
         }),
-      ).toEqual([uriOf(board)]);
+      ).toEqual([]);
       expect(value).toEqual({ notes: titleAddresses });
     });
 
@@ -2879,7 +2955,7 @@ describe("cf piece get transforms", () => {
           runtime.getCell(space, "at-suffix-reads-board", boardSchema);
 
         expect(
-          await documentsRead(
+          await distinctDocumentsRead(
             documents,
             () =>
               deriveSelectedValue(runtime, space, board, {
@@ -2888,7 +2964,7 @@ describe("cf piece get transforms", () => {
           ),
         ).toEqual([uriOf(board)]);
         expect(
-          await documentsRead(
+          await distinctDocumentsRead(
             documents,
             () =>
               deriveSelectedValue(runtime, space, reopened(), {
@@ -2898,10 +2974,11 @@ describe("cf piece get transforms", () => {
         ).toEqual([uriOf(board)]);
 
         // The control, as in the JSON spelling above: the unmarked field list
-        // loads every element.
+        // loads every element, counted over the element documents alone so
+        // the board's residency does not decide it.
         expect(
-          (await documentsRead(
-            documents,
+          (await distinctDocumentsRead(
+            notes,
             () =>
               deriveSelectedValue(runtime, space, reopened(), {
                 projection: parseSelectProjection("notes.title"),
@@ -2914,7 +2991,7 @@ describe("cf piece get transforms", () => {
         const { board, notes } = await seedBoard("at-suffix-root-reads", false);
 
         expect(
-          await documentsRead(
+          await distinctDocumentsRead(
             [board, ...notes],
             () =>
               deriveSelectedValue(runtime, space, board.key("notes"), {


### PR DESCRIPTION
## Why

Marking a field below a link read every element document. The projection mask reduced an array whose items reject to `false` — the rejecting selector has to sit at the array itself, because traversal follows each element's link *before* it consults the item schema — but left an object whose every property rejects as a live selector. So a rejection one level down arrived after the load it was meant to prevent.

Measured: **4 documents read where 1 would do.** Item 3 of [the verbs plan](https://github.com/commontoolsinc/labs/blob/main/docs/plans/verbs-implementation.md).

## What Changed

Two mask constructors replace the inline literals. `arrayProjectionMask` carries the existing array rule; `objectProjectionMask` adds the symmetric one — an object whose every *named* position rejects reduces to `false`, so a rejection below a link cascades to the position holding it.

A second site needed it: `resolveProjection`'s concise branch hand-built `{type: "array", items: mask}`, reconstituting a live array mask around a rejecting element list, so `--select 'title@'` on an array-rooted read still loaded every element.

`alignConciseProjectionMask` and `mergeMasks` now go through the constructors too — both are provably safe today, which is the identical reasoning that made the third site look safe until it wasn't. `maskFromPaths` is deliberately left: it builds a `PredicateMask`, a different type whose leaves are always `true`.

## Read counts, measured

| Selection | Before → after |
| --- | --- |
| `{"properties":{"notes":{"items":{"properties":{"title":{"$link":true}}}}}}` | 4 → 1 |
| `--select 'notes.title@'` | 4 → 1 |
| `{"properties":{"topic":{"properties":{"title":{"$link":true}}}}}` (object, no array) | 2 → 1 |
| `--select 'title@'` read at `board.notes` (array-rooted) | 4 → 1 |
| `notes.title@` where `notes` is itself behind a link | 4 → 1 |

## The invariant this rests on, now written down

`normalizeProjectionSchema` refuses a bare `false`, so `false` enters a projection schema by exactly one route: a bare `$link` marker. Therefore an all-rejecting mask **always has markers to answer with**, and the value the graph would have produced is an empty shell — every key overwritten by `composeLinkAddresses`. That is what makes the short-circuit safe, and two separate things now depend on it, so it is recorded on the `ProjectionMask` type rather than left to be re-derived.

## Reviewed, and it changed the branch

An adversarial `cf-review` returned *land with named changes*, and closed the risk this change could not close on its own — 22 selections plus 12 adversarial edge cases, **values byte-identical** to main in every case. Three findings changed the code:

- **A test asserted something the system does not do.** It expected the holder document to be absent from the reads; against a genuinely cold reader it *is* read, and the test passed only because the fixture wrote the holder in its own transaction. It now asserts the property that survives — no element document is read — and the cold numbers are in the test.
- **This change introduced a doubled source-document sync**, which the new distinct-document metric could not see. Fixed at the source rather than accepted: one cell is now read *and* walked, since a sync is recorded per `CellImpl`. A sync-counting test guards it, because the distinct metric stays green either way.
- **The array-shape refusal is preserved.** Reducing to `false` would have turned a precise error into a generic "did not materialize" message. ~12 lines keep the diagnostic while the two spellings still agree.

The metric is renamed `distinctDocumentsRead`, and its doc comment now says what it cannot see: a resident document is reached without a sync, so absence is evidence only for a document the fixture left unwritten.

## Test plan

- `packages/cli` suite green, exit 0. `piece-get-transform.test.ts` 103 steps on the rebased tree.
- `deno fmt --check`, `deno lint`, `deno check`, `check-docs` (547 blocks), `check-no-waitfor`, `check-conflict-markers`, `check-skill-facts`.
- Red-first verified by reverting **only** `cell-selection.ts`: five read-count steps fail with the extra note URIs. Round-2 assertions re-checked the same way against round-1 source.

## Note on merge order

This and #5694 both edit `docs/common/verbs-over-the-cli.md` at disjoint points, so they **merge silently** — no conflict, no warning. Verified by merging the heads. Whichever lands second should rebase rather than trust the clean merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

