### PR TITLE
docs(data-model): file headers for the `test` subdirectories

### DIFF
--- a/packages/data-model/test/codec-common/BaseFabricCodec.test.ts
+++ b/packages/data-model/test/codec-common/BaseFabricCodec.test.ts
@@ -1,3 +1,15 @@
+/**
+ * What the codec base class does on its own, before a concrete codec overrides
+ * anything.
+ *
+ * Two of its answers come straight from what it was constructed with, and both
+ * are optional: a codec naming no handled class cannot recognize a value by
+ * class, and one naming no tag cannot produce a tag. Each is covered in both
+ * the supplied and the omitted form, because the omitted form is where the
+ * base either answers `undefined` or insists on being overridden, and those
+ * are different promises.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/codec-common/CodecRegistry.test.ts
+++ b/packages/data-model/test/codec-common/CodecRegistry.test.ts
@@ -1,3 +1,24 @@
+/**
+ * The registry's two jobs -- accepting codecs and answering lookups -- and the
+ * line that freezing draws between them.
+ *
+ * Acceptance is where the refusals live. A codec has to be classifiable, the
+ * base class it extends being the only record of what its state means, and it
+ * has to carry a tag. Both conditions are checked on every route in rather
+ * than on one of them, since a registration that arrived by a side door is
+ * still one the walker will trust.
+ *
+ * Lookup answers from a value, from a tag, or with the sentinel meaning that
+ * no codec is needed. Which symbol a class's codec is read from is settled
+ * here too: the format-agnostic binding wins over the format's own when a
+ * class has both, and a binding belonging to some other format is not
+ * consulted at all.
+ *
+ * Freezing then separates the two jobs. Every mutator refuses afterward while
+ * every lookup still answers, and extending yields a new registry carrying the
+ * base's registrations without the base itself gaining anything.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/codec-common/EmptyReconstructionContext.test.ts
+++ b/packages/data-model/test/codec-common/EmptyReconstructionContext.test.ts
@@ -1,3 +1,15 @@
+/**
+ * The stand-in used when a decode has no runtime behind it: a shared singleton
+ * that refuses every cell resolution, and the class it is an instance of.
+ *
+ * Refusing is the entire behavior, so what is left to get right is that it
+ * refuses informatively and cannot be talked out of it -- the failure names
+ * the ref it was asked for, and the singleton is frozen so `getCell()` cannot
+ * be swapped. The class is exported so a caller can frame that failure for its
+ * own situation, and only the clause after the colon is the caller's to
+ * supply.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/codec-common/codecOf.test.ts
+++ b/packages/data-model/test/codec-common/codecOf.test.ts
@@ -1,3 +1,18 @@
+/**
+ * Which symbol a value's codec is found under, and what happens when the
+ * answer is absent or ambiguous.
+ *
+ * An instance binds one format-agnostic `[CODEC]`, while a primitive's codec
+ * terminates an encoding and so is bound per wire format under that format's
+ * own symbol. Asking without naming a format therefore succeeds for the one
+ * and fails for the other, which is most of what these cases pin.
+ *
+ * The precedence case is built on a double rather than a real class, because
+ * nothing in the tree binds both symbols. With a real class the two could not
+ * disagree, and the case would pass whichever way the lookup happened to be
+ * written.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/codec-json/BigIntCodec.test.ts
+++ b/packages/data-model/test/codec-json/BigIntCodec.test.ts
@@ -1,3 +1,17 @@
+/**
+ * `bigint` over a wire that has no such type, encoded as two's-complement
+ * bytes in unpadded base64url.
+ *
+ * Two's complement is what gives the boundary values their weight: a magnitude
+ * that would otherwise set the top bit needs a sign-extension byte in front of
+ * it, so the round trips step across that point in both signs as well as
+ * covering zero and the large cases.
+ *
+ * Malformed state decodes to a `ProblematicValue` rather than throwing. The
+ * wire is not trusted, and a decode that cannot make sense of what it was
+ * handed still has to produce a value.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/codec-json/JsonCodec.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodec.test.ts
@@ -1,3 +1,27 @@
+/**
+ * The JSON codec end to end: what a value becomes as text and as bytes, and
+ * what comes back.
+ *
+ * The hard part is that JSON is also the escape mechanism. A tagged form is
+ * itself a `/`-keyed object, so a plain object that happens to carry such a
+ * key is ambiguous with one, and the quoting rules exist to tell the two apart
+ * in every direction. Several groups of cases here do nothing but police that
+ * boundary.
+ *
+ * Arrays are the other place the format has to express something JSON cannot.
+ * A hole is not `null`, so runs of them are written explicitly, and a run
+ * arriving malformed has to be handled rather than trusted.
+ *
+ * Two invariants run underneath all of it. Encoding is deterministic, key
+ * order included, so the same value yields the same text. And decoding
+ * produces a deep-frozen result, identically whether it began as text or as
+ * bytes -- the places where the decoder hands back an extracted sub-tree
+ * directly are sound only if nothing can mutate it afterward.
+ *
+ * Lenient mode is what happens when a value will not decode at all: it becomes
+ * a `ProblematicValue` rather than an exception.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/codec-json/SpecialNumberCodec.test.ts
+++ b/packages/data-model/test/codec-json/SpecialNumberCodec.test.ts
@@ -1,3 +1,17 @@
+/**
+ * The numeric values JSON cannot carry -- negative zero, `NaN`, and the two
+ * infinities -- written as literal strings.
+ *
+ * Round-tripping them is the point, and the sign of zero is what makes that
+ * more than a formality: `-0` has to come back as `-0` rather than as `0`,
+ * which ordinary equality would not notice either way. Every `NaN` bit pattern
+ * encodes to the same literal, the distinctions among them not being ones this
+ * format carries.
+ *
+ * A state that is not a recognized literal decodes to a `ProblematicValue`
+ * rather than throwing.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/codec-json/SymbolCodec.test.ts
+++ b/packages/data-model/test/codec-json/SymbolCodec.test.ts
@@ -1,3 +1,14 @@
+/**
+ * Symbols on the wire, which is possible only because the registry makes some
+ * of them nameable.
+ *
+ * An interned symbol is fully described by its key, so encoding is writing
+ * that key down and decoding is asking the registry for the same symbol back
+ * -- the round trip returns the identical instance rather than an equal one.
+ * A unique symbol has no key, and is refused because nothing about it could be
+ * written down and recovered.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/codec-json/UndefinedCodec.test.ts
+++ b/packages/data-model/test/codec-json/UndefinedCodec.test.ts
@@ -1,3 +1,13 @@
+/**
+ * `undefined` on a wire whose nearest neighbor is `null`, and the care that
+ * distinction takes.
+ *
+ * The encoded state is itself `null`, so the codec's whole job is keeping the
+ * two apart: it claims `undefined` and refuses `null`, and on the way back a
+ * state that is not `null` is treated as a malformed encoding rather than as
+ * something to salvage.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/codec-json/createBaseJsonRegistry.test.ts
+++ b/packages/data-model/test/codec-json/createBaseJsonRegistry.test.ts
@@ -1,3 +1,14 @@
+/**
+ * The JSON registry before any fabric class is added to it: what it already
+ * knows, and what it deliberately does not.
+ *
+ * It carries only the types JSON itself cannot express, and marks JSON's own
+ * scalars as needing no codec at all. No fabric class is in it, which is what
+ * leaves the choice of participating classes to whoever extends it. Each call
+ * builds a fresh registry and hands it back frozen, so extending means
+ * deriving a new one rather than adding to something shared.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/codec-json/impl.test.ts
+++ b/packages/data-model/test/codec-json/impl.test.ts
@@ -1,3 +1,14 @@
+/**
+ * The cheap test for whether a string is this package's encoded form rather
+ * than JSON from somewhere else.
+ *
+ * It decides on the prefix alone and never parses, so the cases are about
+ * where that suffices and where it would be too eager: the bare prefix counts,
+ * a prefix that is partial or not at the front does not, and plain JSON that
+ * happens to look similar does not. One case feeds it real encoder output, so
+ * the shape recognized here cannot drift from the shape produced.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/fabric-instances/BaseFabricInstance.test.ts
+++ b/packages/data-model/test/fabric-instances/BaseFabricInstance.test.ts
@@ -1,3 +1,19 @@
+/**
+ * The clone template methods, and exactly when one may answer with the
+ * instance it was given rather than a new one.
+ *
+ * Identity comes back only where it is indistinguishable from a fresh copy,
+ * which is a narrower condition than it first looks. A shallow clone may
+ * return `this` for an already-frozen instance; a deep clone may not, unless
+ * the instance is deep-frozen -- a merely-shallowly-frozen one still has a
+ * mutable interior, and is the case separating the two rules. Asking for a
+ * mutable result allocates regardless of what the original was.
+ *
+ * The cases count core invocations rather than only comparing results, since
+ * producing a correct value and producing it without allocating are different
+ * claims and only one of them shows up in the output.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/fabric-instances/ExplicitTagValue.test.ts
+++ b/packages/data-model/test/fabric-instances/ExplicitTagValue.test.ts
@@ -1,3 +1,12 @@
+/**
+ * The base shared by values that carry their own wire tag rather than taking
+ * one from their class.
+ *
+ * There is little to pin at this level. The base only exposes what a concrete
+ * subclass supplies, and what carrying a tag per instance actually means is
+ * settled by the subclasses that do it.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -1,3 +1,24 @@
+/**
+ * `Error` as a fabric value, where most of the difficulty is that a native
+ * error carries two names and arbitrary extra properties.
+ *
+ * `type` and `name` are stored separately, and the encoding leans on their
+ * usual agreement: `name` is written as `null` when it matches `type`, and
+ * spelled out only when it does not. Decoding has to invert that, rebuild the
+ * right `Error` subclass from `type`, and still accept older state in which
+ * only `name` was present.
+ *
+ * Everything beyond the fixed slots goes to the extras bag, which is where the
+ * refusals concentrate. A slot's own name cannot be used as an extras key, and
+ * a prototype-reaching key is refused on the way in and dropped again when it
+ * arrives from the wire -- state parsed from outside cannot be assumed to have
+ * been built by this code.
+ *
+ * One case records a gap rather than a guarantee: a mutable deep clone still
+ * shares its nested `cause`, and the assertion states that as the behavior
+ * today.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/fabric-instances/FabricLink.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricLink.test.ts
@@ -1,3 +1,19 @@
+/**
+ * A link as a fabric instance: a payload object wrapped so that it can carry
+ * arbitrary nested values, a stored schema among them.
+ *
+ * Being an instance rather than a primitive is the first consequence -- a link
+ * is mutable until frozen rather than born immutable. The payload is validated
+ * on the way in, and the keys it refuses are the prototype-bearing ones: a
+ * payload is a plain record, and a key that would reach the prototype chain is
+ * not data.
+ *
+ * Cloning carries the interesting promises. A frozen deep clone shares an
+ * already-deep-frozen subtree rather than copying it, a mutable deep clone
+ * shares nothing, and a mutable shallow clone shares the payload reference
+ * outright.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/fabric-instances/FabricMap.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricMap.test.ts
@@ -1,3 +1,15 @@
+/**
+ * A `Map` as a fabric instance, which is at present only half a value.
+ *
+ * Native conversion is the part that works: a frozen form is produced on
+ * request, an already-frozen one is handed back rather than rebuilt, and a
+ * mutable form is copied only when what it holds is frozen.
+ *
+ * The freeze protocols and the codec are stubs that throw, and these cases
+ * assert the throwing deliberately. An unimplemented member asserted to throw
+ * is a recorded gap; one that is merely never called is a gap nobody can see.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/fabric-instances/FabricSet.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricSet.test.ts
@@ -1,3 +1,15 @@
+/**
+ * A `Set` as a fabric instance, which is at present only half a value.
+ *
+ * Native conversion is the part that works: a frozen form is produced on
+ * request, an already-frozen one is passed through rather than rebuilt, and a
+ * mutable form is copied only when what it holds is frozen.
+ *
+ * The freeze protocols and the codec throw as unimplemented stubs, and these
+ * cases assert that throwing on purpose. A gap that is asserted is recorded; a
+ * gap that is merely untested is invisible.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/fabric-instances/ProblematicValue.test.ts
+++ b/packages/data-model/test/fabric-instances/ProblematicValue.test.ts
@@ -1,3 +1,15 @@
+/**
+ * What a decode produces when it recognized the tag but could not make sense
+ * of the state: the tag, the state as it arrived, and the error explaining the
+ * refusal.
+ *
+ * Keeping all three is what lets a bad encoding survive a round trip without
+ * being either lost or believed. Encoding one writes back the bare state, the
+ * tag it carries being per-instance and travelling separately, so a value that
+ * could not be understood is re-emitted as what it was rather than as what
+ * this runtime would have written in its place.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/fabric-instances/UnknownValue.test.ts
+++ b/packages/data-model/test/fabric-instances/UnknownValue.test.ts
@@ -1,3 +1,13 @@
+/**
+ * What a decode produces for a tag it does not recognize: that tag, and the
+ * state untouched.
+ *
+ * Nothing here can interpret the state, so nothing tries. Encoding one writes
+ * the bare state back under the tag it came with, which is what lets a value
+ * this runtime has no codec for pass through unharmed rather than being
+ * dropped or rewritten into something it was not.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/fabric-instances/fixtures.ts
+++ b/packages/data-model/test/fabric-instances/fixtures.ts
@@ -1,3 +1,13 @@
+/**
+ * Shared doubles for the fabric-instance tests: a reconstruction context that
+ * refuses to resolve a cell, and the two recursion callbacks for driving the
+ * freeze protocols by hand.
+ *
+ * The callbacks let a test invoke a protocol member on an instance directly,
+ * rather than reaching it through the generic entry point that would otherwise
+ * do the walking.
+ */
+
 import { BaseReconstructionContext } from "@/codec-common/BaseReconstructionContext.ts";
 import type { FabricValue } from "@/interface.ts";
 import { deepFreeze, isDeepFrozen } from "@/deep-freeze.ts";

--- a/packages/data-model/test/fabric-primitives/BaseFabricPrimitive.test.ts
+++ b/packages/data-model/test/fabric-primitives/BaseFabricPrimitive.test.ts
@@ -1,3 +1,17 @@
+/**
+ * The primitive base class's own behavior, which comes down to one invariant.
+ *
+ * Every concrete primitive is required to extend this class rather than the
+ * contract above it, and the type guard enforces that rather than merely
+ * reporting on it: a value that is a `FabricPrimitive` but not a
+ * `BaseFabricPrimitive` is a broken subclass, so the guard throws instead of
+ * quietly answering `false` and letting the mistake travel.
+ *
+ * The placeholder member is here in order to be a member at all -- an instance
+ * type with nothing in it would make an ordinary `value is` guard collapse --
+ * and its only observable behavior is refusing to be called.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
@@ -1,3 +1,16 @@
+/**
+ * An immutable byte sequence, and the copying that immutability costs.
+ *
+ * The constructor cannot simply hold the array it was handed, since the caller
+ * still has a reference and could write through it, so the bytes are copied in
+ * -- with an opt-in transfer for a caller willing to give up its own access.
+ * Reads pay the same way round: a slice hands back a copy rather than a view.
+ *
+ * The cases that need stating are where a byte count meets an empty or
+ * exhausted range. Empty bytes encode to the empty string, and a copy whose
+ * offset is at or past the end copies nothing rather than failing.
+ */
+
 import { JSON_CODEC } from "@/interface.ts";
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";

--- a/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
@@ -1,3 +1,16 @@
+/**
+ * A day count as a fabric primitive: always frozen, wrapping a `bigint`, and
+ * encoded to a flat base64 string.
+ *
+ * Days before the epoch are the case worth keeping, a negative count being
+ * where an encoding stops round-tripping if it was only ever tried on
+ * positive ones. Conversion leaves an instance alone even when asked for
+ * something mutable, the value being immutable by construction rather than by
+ * request.
+ *
+ * Malformed state decodes to a `ProblematicValue` rather than throwing.
+ */
+
 import { JSON_CODEC } from "@/interface.ts";
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";

--- a/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
@@ -1,3 +1,16 @@
+/**
+ * A nanosecond timestamp as a fabric primitive: always frozen, wrapping a
+ * `bigint`, and encoded to a flat base64 string.
+ *
+ * Holding a `bigint` rather than a number is the reason the class exists, so
+ * the cases reach for magnitudes past where a double stops being exact -- a
+ * far-future timestamp as well as pre-epoch ones -- rather than staying near
+ * zero, where any representation would look correct.
+ *
+ * Malformed state decodes to a `ProblematicValue` rather than throwing, and
+ * conversion leaves an instance alone even when asked for something mutable.
+ */
+
 import { JSON_CODEC } from "@/interface.ts";
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";

--- a/packages/data-model/test/fabric-primitives/FabricHash.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricHash.test.ts
@@ -1,3 +1,16 @@
+/**
+ * A hash as a fabric primitive: bytes, plus the tag naming the algorithm that
+ * produced them.
+ *
+ * The tag is part of the value rather than decoration on it, which is why the
+ * string form carries it, why parsing rejects a string with no tag or with
+ * more than one separator, and why a tag other than the usual one has to
+ * survive a round trip rather than being normalized away.
+ *
+ * It hands out copies rather than views, and takes ownership of its input only
+ * when a caller explicitly transfers it.
+ */
+
 import { JSON_CODEC } from "@/interface.ts";
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -1,3 +1,20 @@
+/**
+ * A regular expression stored as data -- source, flags, and the flavor saying
+ * whose dialect they are written in -- rather than as a live `RegExp`.
+ *
+ * The flavor is what makes this more than a wrapper. A pattern in the dialect
+ * this runtime understands is validated and can be handed back as a native
+ * `RegExp`; one in any other flavor is stored faithfully and not parsed at
+ * all, so a pattern JS would reject survives a round trip instead of becoming
+ * a `ProblematicValue`. What fails is asking such a value for a native form,
+ * and it fails at that point rather than when the value was stored.
+ *
+ * Nothing is aliased in either direction: the constructor does not keep the
+ * `RegExp` it was given, and each read builds a fresh one, so mutating what
+ * comes back cannot reach the stored value. The flavor counts toward identity
+ * as well -- two values differing only in it hash differently.
+ */
+
 import { JSON_CODEC } from "@/interface.ts";
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";

--- a/packages/data-model/test/fabric-primitives/schema-type.test.ts
+++ b/packages/data-model/test/fabric-primitives/schema-type.test.ts
@@ -1,3 +1,15 @@
+/**
+ * The schema type name for each primitive class, and the agreement among the
+ * hand-maintained lists that name them.
+ *
+ * The mapping under test, the roster of classes that travel over the wire, and
+ * the vocabulary the api package publishes all have to hold the same set, and
+ * nothing derives any of them from another. So the check is exact membership
+ * in both directions against a table this file writes out for itself, which is
+ * what turns "a class was added and only one list was updated" into a failure
+ * rather than a silent gap.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) am continuing the file-header
conformance work in `packages/data-model`, against the "File headers" section
of `docs/development/code-comment-style.md`. This covers the `test` tree's
subdirectories — `codec-common`, `codec-json`, `fabric-instances`, and
`fabric-primitives` — plus the shared fixture module the instance tests draw
on. The `test` tree's top level follows separately, and `src` is #5700.

All twenty-seven are headers written from scratch. Nothing in this package had
one sitting in the wrong place.

### What the headers say

Each states the property its cases are arranged around, rather than
summarizing them:

- `FabricRegExp.test.ts` — a regexp is stored as data (source, flags, flavor)
  rather than as a live `RegExp`. A pattern in a flavor this runtime does not
  speak is kept faithfully and never parsed, so one JS would reject survives a
  round trip instead of becoming a `ProblematicValue`; what fails is asking
  such a value for a native form, and it fails then rather than at store time.
- `JsonCodec.test.ts` — JSON is also the escape mechanism. A tagged form is
  itself a `/`-keyed object, so a plain object carrying such a key is ambiguous
  with one, and several groups of cases do nothing but police that boundary.
- `CodecRegistry.test.ts` — the line freezing draws between accepting codecs
  and answering lookups: every mutator refuses afterward while every lookup
  still answers.
- `FabricHash.test.ts` — the algorithm tag is part of the value rather than
  decoration on it, which is why parsing rejects a string with no tag or with
  more than one separator, and why an unusual tag has to survive a round trip
  rather than being normalized away.
- `BigIntCodec.test.ts` — two's complement is what gives the boundary values
  their weight, a magnitude that would set the top bit needing a
  sign-extension byte in front of it.

### Three headers record a gap rather than a guarantee

That seemed the honest thing for those files to open with:

- `FabricMap` and `FabricSet` convert to and from native values, but their
  freeze protocols and codecs are stubs that throw, and the cases assert the
  throwing deliberately. An asserted gap is recorded; an untested one is
  invisible.
- `FabricError.test.ts` has one case stating that a mutable deep clone still
  shares its nested `cause`. The header reports that as current behavior
  without ascribing intent to it, there being no `TODO` on the case to support
  a stronger reading.

### One note worth flagging to a reviewer

`BaseFabricInstance.test.ts` counts clone-core invocations rather than only
comparing results, because producing a correct value and producing it without
allocating are different claims and only one of them shows up in the output.
Its header says so, since a reader who misses that will misread every identity
case in the file.

### Testing

`deno task test` in `packages/data-model`: `ok | 52 passed (2340 steps) |
0 failed`. Note that `deno task check` does not cover this package, so that
suite is the gate. `deno fmt --check` and `deno lint` are clean over the
twenty-seven files, and no added line exceeds 80 characters measured in
characters rather than bytes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

