### PR TITLE
docs(data-model): file headers for the `test` tree's top level

### DIFF
--- a/packages/data-model/test/SchemaAndHash.test.ts
+++ b/packages/data-model/test/SchemaAndHash.test.ts
@@ -1,3 +1,16 @@
+/**
+ * A schema paired with its hash, held so the two cannot drift apart.
+ *
+ * The pairing is trustworthy only if neither half can change after the hash
+ * was computed, so the constructor refuses a schema that is not already
+ * deep-frozen, and the instance is itself frozen with non-writable accessors.
+ *
+ * A schema may legitimately be absent, or be one of the boolean schemas, and
+ * absence is where the two readers differ on purpose: one throws and the other
+ * answers `undefined`, so a caller states up front which it is prepared for
+ * rather than discovering it.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/cell-rep.test.ts
+++ b/packages/data-model/test/cell-rep.test.ts
@@ -1,3 +1,21 @@
+/**
+ * How an entity id and a link are represented in each of the two regimes the
+ * flag selects, and the storage-tree probe that finds one.
+ *
+ * The property that matters is not that each regime produces its own form but
+ * that each refuses the other's. A reader in one regime, handed the other's
+ * representation, throws rather than accepting it -- which is what stops a
+ * value written under one setting from being quietly misread under the other.
+ *
+ * The probe differs structurally between them rather than only in shape. The
+ * legacy form is a sub-tree to descend into, while the modern one sits at the
+ * position itself, so a storage walk takes a different path in each.
+ *
+ * The wire form is a separate matter again: tagged, and validated on the way
+ * back in -- including a refusal of prototype-polluting keys, that text having
+ * arrived from outside.
+ */
+
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/cloneForMutation.test.ts
+++ b/packages/data-model/test/cloneForMutation.test.ts
@@ -1,3 +1,18 @@
+/**
+ * Preparing a value for a structured mutation by thawing only the spine along
+ * a path.
+ *
+ * The payoff is in what goes untouched. Subtrees off the spine keep their
+ * identity and with it their place in the deep-frozen cache, so re-freezing
+ * the result afterward short-circuits on them rather than walking them again
+ * -- which is why a case here inspects the cache and not only the values.
+ *
+ * The remainder is what a path can mean against a structure that does not
+ * already match it: whether a missing intermediate is created and in what
+ * shape, where a fabric instance is allowed to sit, and which of those
+ * situations is an error carrying enough detail for a caller to act on.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/cloneIfNecessary.test.ts
+++ b/packages/data-model/test/cloneIfNecessary.test.ts
@@ -1,3 +1,23 @@
+/**
+ * Cloning to a requested frozenness, and which option combinations mean
+ * anything together.
+ *
+ * Two of them are errors rather than choices, having no coherent answer to
+ * give: forcing a copy of a value that will be immutable anyway, and
+ * shallow-thawing a tree whose frozenness is mixed. Refusing those is what
+ * keeps each remaining combination meaning exactly one thing.
+ *
+ * The rest is what may be shared and what must be rebuilt. A value already in
+ * the requested state comes back as it is unless a copy was forced,
+ * inherently immutable values are never copied at all, and a null prototype is
+ * canonicalized rather than carried through, not being a shape the value type
+ * admits.
+ *
+ * Cycles are detected on the deep paths, and the subclass matrix asks the same
+ * questions of every concrete class rather than trusting one to stand in for
+ * the others.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/codecs.test.ts
+++ b/packages/data-model/test/codecs.test.ts
@@ -1,3 +1,18 @@
+/**
+ * The package's ready-made encode and decode entry points, exercised on the
+ * class set they come configured with.
+ *
+ * Much of this is that a value survives the trip, but the cases earning their
+ * space are the ones where the format's own syntax collides with ordinary
+ * data. An object keyed `/` has to escape and come back identical, and the
+ * markers other layers write into values -- a stream, an error, an alias --
+ * have to pass through untouched rather than being interpreted here.
+ *
+ * The plain-object entry point additionally refuses anything that decoded to
+ * something else, so a caller that asked for a record is not handed an array
+ * or an instance instead.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/data-uri-codec.test.ts
+++ b/packages/data-model/test/data-uri-codec.test.ts
@@ -1,3 +1,20 @@
+/**
+ * The `data:` URI form of a value: minting one, and reading one back.
+ *
+ * A minted URI stands in for the value, which pulls two demands against each
+ * other. It has to be canonical -- key insertion order cannot show through,
+ * and neither can a sort order that differs between UTF-16 and code points --
+ * while still telling apart values that ordinary equality would merge. That is
+ * where the numeric cases earn their place: `-0` and `+0` mint different URIs,
+ * the two infinities differ, and every `NaN` mints the same one whatever
+ * payload bits it happened to carry.
+ *
+ * Reading one back is deliberately strict. The media type must be this
+ * codec's, header parameters are refused, a percent-encoded payload is
+ * refused, and the payload stops at a raw query or fragment delimiter rather
+ * than swallowing it. What comes back is deep-frozen.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/deep-freeze.test.ts
+++ b/packages/data-model/test/deep-freeze.test.ts
@@ -1,3 +1,21 @@
+/**
+ * Asking whether a value is deep-frozen, and making it so, across the shapes
+ * that complicate both.
+ *
+ * Caching is the part with teeth. An answer is remembered by identity, so a
+ * wrong `true` is not one mistake but a permanent one, and several cases exist
+ * to pin when a result may be cached and when it may not. One is kept as a
+ * regression pin against a cycle that was once answered wrongly.
+ *
+ * The stricter of the two checks also asks whether the value is a
+ * `FabricValue` at all, so an accessor-backed property, a symbol key, or an
+ * array whose structure is inadmissible makes it answer `false` where a plain
+ * frozen-ness test would have said `true`.
+ *
+ * A fabric instance is reached through its own protocol member rather than by
+ * enumeration, and a primitive short-circuits ahead of all of it.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/frozen-builtins.test.ts
+++ b/packages/data-model/test/frozen-builtins.test.ts
@@ -1,3 +1,16 @@
+/**
+ * Immutable counterparts to `Map` and `Set`, and the key equality they carry
+ * over.
+ *
+ * The cases that matter are the ones where key identity is not obvious:
+ * signed zeros and the non-finite values, where a collection's notion of "the
+ * same key" is not `===` and has to be preserved rather than quietly improved
+ * upon.
+ *
+ * The set additionally carries the algebra -- union, intersection, difference
+ * -- which an immutable receiver can only express by producing a new set.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/message-quoting.test.ts
+++ b/packages/data-model/test/message-quoting.test.ts
@@ -1,3 +1,14 @@
+/**
+ * Error messages that quote the value they refused, checked at the sites where
+ * the quoted text arrives from outside.
+ *
+ * A refusal is only useful if it names what it refused, and what it refused is
+ * arbitrary text -- a class name, a hash string, a fragment of wire data --
+ * which may itself contain backticks. So each case makes the same demand:
+ * whatever went in comes back out intact, rather than being truncated or
+ * having its quoting broken by its own content.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -1,3 +1,26 @@
+/**
+ * Converting between native JS values and fabric values, in both directions
+ * and at both depths, plus the predicate saying in advance whether a value
+ * will make it across.
+ *
+ * Refusal is central here rather than incidental: conversion is a vetting
+ * boundary, and a value that cannot be represented has to be rejected rather
+ * than approximated into something that merely looks representable. A
+ * function, a class instance, an array carrying non-index properties, an
+ * `Array` subclass, a cycle -- each is refused, and refused at whatever depth
+ * it turns up.
+ *
+ * One group appears three times over, once per entry point, to pin something
+ * the conversion deliberately does not do: `toJSON()` is never consulted. A
+ * value does not get to nominate its own fabric form, because a method is code
+ * and the decision has to rest on what the value is.
+ *
+ * The remainder is the structure that has to survive the trip: an object
+ * reached twice stays shared, sparse holes and `undefined` elements are
+ * preserved rather than filled in, and an `Error` carries its cause and its
+ * own properties across.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/native-type-tags.test.ts
+++ b/packages/data-model/test/native-type-tags.test.ts
@@ -1,3 +1,20 @@
+/**
+ * Classifying a native value by what it actually is, across the cases where
+ * the obvious check fails.
+ *
+ * A prototype can be severed, an `Error` can arrive from another realm or from
+ * a subclass nobody here knows, an array can be an `Array` subclass, and an
+ * object can have no prototype at all. Each still has a right answer, so these
+ * cases are mostly the awkward shapes rather than the ordinary ones --
+ * including a run with `Error.isError` removed, to reach the fallback beneath
+ * it.
+ *
+ * A separate group pins something the classifier deliberately does not do:
+ * `toJSON()` has no bearing on what a value is. An object carrying one is
+ * still an object and a class instance carrying one is still unrecognized,
+ * whether the member is own or inherited.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/schema-hash.test.ts
+++ b/packages/data-model/test/schema-hash.test.ts
@@ -1,3 +1,17 @@
+/**
+ * Hashing a schema and interning it, so that an equal schema becomes the same
+ * object and can be named by its hash.
+ *
+ * Interning is what makes a schema comparable by identity afterward, so the
+ * cases cover the several ways one can be asked for -- with and without the
+ * hash alongside it, by lookup, by predicate, and as a tagged string -- rather
+ * than letting one entry point stand in for the rest.
+ *
+ * One group checks the interned form against the `data:` id minted for the
+ * same schema. They are two separate namings of one thing, and worth setting
+ * against each other rather than each being checked alone.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { assert } from "@std/assert";
 import { expect } from "@std/expect";

--- a/packages/data-model/test/schema-utils.test.ts
+++ b/packages/data-model/test/schema-utils.test.ts
@@ -1,3 +1,21 @@
+/**
+ * The operations that build one schema from another, where the recurring
+ * question is what may be shared.
+ *
+ * Freezing a schema deeply can reuse subtrees that are already frozen, or
+ * decline to, and which of those a caller gets is an explicit choice rather
+ * than an optimization applied behind its back -- so the same operation is run
+ * both ways.
+ *
+ * Deriving from an interned schema carries interning into the result, and two
+ * groups follow that consequence: adding properties and removing them each
+ * have to say what becomes of the interning the input arrived with.
+ *
+ * The remainder are smaller answers about a schema -- whether it constrains
+ * anything, what shape a given value type calls for, how one is turned into a
+ * key -- kept together here because they share that vocabulary.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/shallowMutableClone.test.ts
+++ b/packages/data-model/test/shallowMutableClone.test.ts
@@ -1,3 +1,17 @@
+/**
+ * The clone shaped for "write the top, then freeze the whole thing": a fresh
+ * mutable container whose every child is already deep-frozen.
+ *
+ * That combination is what makes a single `Object.freeze()` of the result
+ * sufficient, with no mutable remnant hiding underneath. Getting there costs
+ * nothing for children that were already deep-frozen, since they ride along by
+ * identity, while a mutable child is cloned rather than frozen where it lies,
+ * so the input is left as it was found.
+ *
+ * The top level is copied unconditionally, even when the input was already
+ * mutable, the caller being handed something it is expected to write to.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -1,3 +1,15 @@
+/**
+ * Membership in the `FabricValue` type, asked one level deep and asked all the
+ * way down, plus the narrowing to its plain-record arm.
+ *
+ * The two depths ask the same question at different scopes, and the cases are
+ * arranged around where that difference tells.
+ *
+ * Frozen-ness is deliberately not part of membership, and a group here says so
+ * outright -- the two are easy to conflate when nearly every fabric value in
+ * circulation happens to be frozen. Cycles are handled rather than refused.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/value-clone.test.ts
+++ b/packages/data-model/test/value-clone.test.ts
@@ -1,3 +1,21 @@
+/**
+ * Writing and removing a value at a path, each copying only the spine that
+ * changed.
+ *
+ * Off-spine subtrees keep their identity, which is the property the whole
+ * shape exists for. The rest is deciding what a path means when the structure
+ * does not already match it: a missing intermediate is created in the shape
+ * the next segment implies, while a present leaf that is not a container is
+ * refused rather than overwritten with structure.
+ *
+ * Removal turns on what counts as absent, and the answers are stricter than a
+ * property read would give. A sparse hole, an out-of-range index, and an
+ * index-like name that is not canonical all count as absent -- and absent
+ * means nothing shifts.
+ *
+ * Neither one descends into a fabric instance on its way through a path.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/value-debug-indented.test.ts
+++ b/packages/data-model/test/value-debug-indented.test.ts
@@ -1,9 +1,11 @@
-// Focused coverage guard for the public `toIndentedDebugString` wrapper.
-//
-// `toIndentedDebugString` is a one-line public function that forwards to the
-// module-private `renderDebugString(value, 2)`. This file calls it directly on
-// a spread of representative values so the wrapper is exercised on its own,
-// independent of whichever larger suite happens to reach it indirectly.
+/**
+ * Focused coverage guard for the public `toIndentedDebugString` wrapper.
+ *
+ * `toIndentedDebugString` is a one-line public function that forwards to the
+ * module-private `renderDebugString(value, 2)`. This file calls it directly on
+ * a spread of representative values so the wrapper is exercised on its own,
+ * independent of whichever larger suite happens to reach it indirectly.
+ */
 
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -1,3 +1,18 @@
+/**
+ * Rendering a value for a human to read, including the values that resist
+ * being rendered.
+ *
+ * A debug renderer is called on whatever is at hand, usually while something
+ * is already wrong, so it has to survive input that would defeat an ordinary
+ * serializer: a cycle, a value that refuses to be rendered, a structure too
+ * large to print whole. Producing something useful and bounded matters more
+ * than producing something complete, which is what the length limit is for.
+ *
+ * The compact and indented forms differ only in spacing, while the kind string
+ * names what a value is without rendering it at all. The custom inspector is
+ * how all of this reaches a `console.log()`.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/value-hash.test.ts
+++ b/packages/data-model/test/value-hash.test.ts
@@ -1,3 +1,20 @@
+/**
+ * The content hash of a fabric value: the same value hashing the same way
+ * every time, and different values hashing differently.
+ *
+ * Distinctness is the harder half, and is why each type contributes its own
+ * tag to what gets hashed. Without that, values of different types sharing
+ * underlying bytes would collide, so one group's whole job is comparing across
+ * types rather than within one.
+ *
+ * The scalar groups carry the awkward cases, being where a hash most easily
+ * merges values it ought to separate or separates ones it ought to merge.
+ *
+ * One group records types that are not handled yet. They are written as
+ * assertions about the behavior today, so the gap is visible in the suite
+ * rather than merely absent from it.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/valueEquals.test.ts
+++ b/packages/data-model/test/valueEquals.test.ts
@@ -11,8 +11,11 @@
  * for: equality is about what a value holds, not about whether it can still be
  * written to.
  *
- * Signed zeros and the non-finite numbers get their own group, being exactly
- * where a comparison written with `===` would answer differently.
+ * Signed zeros and `NaN` get their own group, being where a comparison written
+ * with `===` answers differently: `-0` and `+0` are distinct here though `===`
+ * merges them, and `NaN` equals itself though `===` denies it. The infinities
+ * sit in that group as the counterweight -- `===` already answers correctly
+ * for those, and so must this, so they pin the absence of an over-correction.
  */
 
 import { describe, it } from "@std/testing/bdd";

--- a/packages/data-model/test/valueEquals.test.ts
+++ b/packages/data-model/test/valueEquals.test.ts
@@ -1,3 +1,20 @@
+/**
+ * Content equality across the value kinds, and the subtype question that comes
+ * before it.
+ *
+ * Two values are comparable only once they are the same kind of thing, so a
+ * plain object and an array are unequal without their contents being consulted
+ * at all, as are two fabric values of different concrete classes. The cases
+ * walk that branch deliberately rather than sampling it.
+ *
+ * Frozen state must not change an answer, which is what the matrix over it is
+ * for: equality is about what a value holds, not about whether it can still be
+ * written to.
+ *
+ * Signed zeros and the non-finite numbers get their own group, being exactly
+ * where a comparison written with `===` would answer differently.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) am finishing the file-header
conformance work in `packages/data-model`, against the "File headers" section
of `docs/development/code-comment-style.md`. This covers the `test` tree's top
level. Its subdirectories are #5702 and `src` is #5700; with this one the
package is done.

Nineteen headers written from scratch, plus `value-debug-indented.test.ts`
converting its `//` block to a doc comment with its prose crossing unchanged.

### What the headers say

Each states the property its cases are arranged around:

- `data-uri-codec.test.ts` — a minted URI has to be canonical and still
  discriminating, which is where `-0` against `+0`, the two infinities, and
  every `NaN` minting a single URI earn their place.
- `cell-rep.test.ts` — each regime has to *refuse* the other's form, not merely
  produce its own. That refusal is what stops a value written under one setting
  from being quietly misread under the other.
- `deep-freeze.test.ts` — an answer is cached by identity, so a wrong `true` is
  permanent rather than momentary, which is why several cases exist only to pin
  when a result may be cached.
- `native-conversion.test.ts` — refusal is central rather than incidental:
  conversion is a vetting boundary, and a value that cannot be represented is
  rejected rather than approximated into something that merely looks
  representable.
- `cloneIfNecessary.test.ts` — two option combinations are errors rather than
  choices, having no coherent answer to give.

### One header records a gap rather than a guarantee

`value-hash.test.ts` has a group asserting the behavior of types that are not
handled yet. The header says so, so the gap sits visibly in the suite rather
than being merely absent from it.

### Two claims walked back before they shipped

Both were quantitative, and both would have been the kind of sentence that
reads fine and is false:

- The scalar groups in `value-hash.test.ts` are *not* the largest — its
  edge-case group spans more lines. The size claim is gone.
- Refusals are not "most" of `native-conversion.test.ts`; they are roughly
  eight of its forty-odd groups. Rewritten as a claim about the design rather
  than a count.

The one count that survived was checked: the `toJSON()` group in
`native-conversion.test.ts` really does appear three times, once per entry
point, verified at all three positions rather than inferred from two.

### Testing

`deno task test` in `packages/data-model`: `ok | 52 passed (2340 steps) |
0 failed`. Note that `deno task check` does not cover this package, so that
suite is the gate. `deno fmt --check` and `deno lint` are clean over the twenty
files, no added line exceeds 80 characters measured in characters rather than
bytes, and the one form conversion was checked against its committed version by
comparing the two prose word-bags.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

