### PR TITLE
docs: plan URLs as mentions

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -19,6 +19,12 @@ a record: archive it to `docs/history/plans/` following the procedure in
   remaining owner decisions and blocked stages for exchange rules.
 - [CFC TypeScript authoring](cfc_typescript_authoring.md) sequences the
   TypeScript and JSX authoring surface for CFC metadata.
+- [URLs as mentions](urls-as-mentions.md) proposes a `cellFromUrl` builtin —
+  does this URL name a cell, and which one — and the two things that follow: a
+  pasted piece URL becoming a mention, and a read-only filesystem projection
+  whose edit verb reads newly written URLs back as references. A builtin
+  because the answer cannot stay synchronous: host recognition becomes a probe
+  and space-name resolution becomes a lookup.
 - [First-class serializable factories](first-class-serializable-factories.md)
   sequences the implementation of durable pattern, module, and handler
   factories.

--- a/docs/plans/urls-as-mentions.md
+++ b/docs/plans/urls-as-mentions.md
@@ -37,8 +37,14 @@ with an explicit edit verb makes the round trip ordinary pattern code.
 
 `extractFidPayloads` (`packages/patterns/topics/topic.tsx`) is a hand-rolled
 regex over pasted text that returns bare payload strings for callers to
-re-address. Retiring it onto the builtin is part of this work, not a model for
-it.
+re-address. It is not a model for this — but retiring it is also not a
+one-for-one swap, and the difference matters. **Scanning prose for something
+that looks like a cell and deciding what a URL names are two operations**, and
+the scanner cannot do the second: it discards host, space, scheme, and path,
+so a payload it lifts out of an external URL, or out of a link into another
+space, resolves in the caller's space and names the wrong cell. A corpus
+scanner stays a corpus scanner; what it hands to `cellFromUrl` has to be a
+whole address, and `cellFromUrl` has to preserve every part of it.
 
 ## `cellFromUrl`
 

--- a/docs/plans/urls-as-mentions.md
+++ b/docs/plans/urls-as-mentions.md
@@ -1,0 +1,147 @@
+# URLs as mentions
+
+## The short version
+
+A mention made through the editor's completion becomes a reference: the text
+carries a short local key and
+[the note's reference map](../history/plans/editor-mention-references.md) says
+where it points. Text that names a cell any *other* way stays inert. Paste a
+piece's URL into a note and it is a URL — not a mention, not a backlink, and
+not something `$mentioned` or the backlinks index can see.
+
+**One builtin closes that, and two things follow from it.**
+
+`cellFromUrl` answers "does this URL name a cell, and which one". It is a
+**builtin** rather than a helper function because the answer cannot stay
+synchronous: recognizing which hosts are fabric hosts will mean probing them,
+and resolving a space name to a DID is a lookup today and a network call later.
+A builtin is how a pattern waits for an answer without a pattern having to
+block, and the shape is the one every other builtin already uses.
+
+```text
+cellFromUrl({ url })  →  { pending, cell?: ReadonlyCell<{ [NAME]: string }> }
+```
+
+A URL that names no cell resolves with no `cell` — the honest answer to "not a
+fabric URL", and not an error.
+
+**One: pasted URLs become mentions.** A paste that names a cell is rewritten to
+`[Name][key]` with the destination in the map, which is what the user meant by
+pasting it. The label comes from the destination's own name, so `modifiedTitle`
+starts false and the mention behaves like any other from then on.
+
+**Two: the filesystem projection becomes read-only, and gets a verb.** Notes
+are edited through FUSE today by writing the whole file back; that is what
+stops a projected note from carrying its reference definitions. Replacing it
+with an explicit edit verb makes the round trip ordinary pattern code.
+
+`extractFidPayloads` (`packages/patterns/topics/topic.tsx`) is a hand-rolled
+regex over pasted text that returns bare payload strings for callers to
+re-address. Retiring it onto the builtin is part of this work, not a model for
+it.
+
+## `cellFromUrl`
+
+Three questions, on three different timelines. The builtin exists so the
+surface does not have to change as each one gets slower.
+
+**Which hosts are fabric hosts.** Its own, to begin with, plus any the runtime
+is configured with. Later this has to probe an unknown host, which is the step
+that makes the whole thing properly async.
+
+**Which space.** A link can be cross-space, so a space *name* has to become a
+DID. `resolveSpaceNameSync` (`packages/runner/src/runtime.ts`) answers from
+cache; `resolveSpaceName` derives it through `createSession`, which the runtime
+already flags as name-based and provisional. Fast enough to await today, a
+network lookup later.
+
+**Which cell.** The last path segment may be a slug rather than an id, and
+turning one into the other is mechanical: `slugIdForSpace`
+(`packages/runner/src/slugs.ts`) hashes `{ space, slug }`. No connection to the
+space is needed, so this stays synchronous however the rest evolves.
+
+- [ ] Register `cellFromUrl` in `packages/runner/src/builtins/`, and declare it
+      in `packages/api/index.ts` with the `Reactive<{ pending, … }>` shape the
+      other builtins use.
+- [ ] Resolve synchronously to start with — a configured host list, a cached
+      space name, a slug hash. The point of landing it as a builtin now is that
+      making any of those a real lookup later changes no caller.
+- [ ] Retire `extractFidPayloads` and `fidPayload` in topics onto it.
+
+## The filesystem round trip
+
+`writeFsFile` (`packages/fuse/cell-bridge.ts`) parses an edited file and writes
+the **entire** body to `$FS.content`, which for a note is a write-redirecting
+link to its own content cell. Anything generated into the projection therefore
+comes back as note text on the first edit, and is generated again on the next
+read.
+
+**The projection becomes read-only, and the note exposes a verb that takes an
+edited body.** No write hook, no special case in the bridge: an edit is a call,
+like every other change to a piece.
+
+The verb is a handler, as verbs are. What it does in its body is instantiate a
+pattern — handlers and lifts can, and `note.tsx`'s own `createNewNote` already
+builds a `Note` that way — because `cellFromUrl` is a builtin, and a builtin
+resolves in the graph rather than inline. So the handler stands up this:
+
+```text
+edited markdown
+  → computed: candidate URLs and reference definitions in the body
+  → map: cellFromUrl over each candidate
+  → computed: the new content and the new reference map
+  → written to the content and references cells
+```
+
+Which makes the two halves of this plan one mechanism seen from two sides. A
+URL that names a cell becomes a reference whether it arrives by paste or by
+`vim`.
+
+### What an edited definition means
+
+The definition block is generated on the way out and **read as input on the way
+back**. A person editing it through the filesystem is editing the note's
+mentions, and that is a legitimate way to do it:
+
+| The file comes back with | Meaning |
+| --- | --- |
+| a definition unchanged | no change; writing the file back untouched is not an edit |
+| a well-formed definition added | a new reference, its URL resolved like any other |
+| a definition's URL changed | that mention repoints; the key keeps its identity |
+| a malformed definition | dropped |
+
+Only the malformed case discards anything, and it discards the line rather than
+the mention. Every other edit is taken at face value, which keeps the block
+honest: it says what the mentions are, and saying something else changes them.
+
+Repointing has one consequence worth stating. A label the user never claimed
+(`modifiedTitle` false) is rewritten to the new destination's name by the
+subscription the editor already keeps; a label they did claim stays as they
+wrote it. That is the existing rule, reached from the filesystem instead of
+from a rename.
+
+- [ ] Mark the note's `[FS]` projection read-only.
+- [ ] Read the definition block back: added and changed definitions are the
+      user's edits, malformed lines are dropped.
+- [ ] An `editProjection`-shaped verb on the note: a handler that instantiates
+      the pattern above and writes what it produces.
+- [ ] Emit the reference definitions beneath the content, now that they survive
+      a round trip.
+- [ ] Paste handling in `cf-code-editor`, once the builtin exists.
+
+## Risks
+
+**A round trip that is not exact is worse than no round trip.** A file written
+back unchanged must leave the content and the map unchanged, or every `touch`
+becomes an edit. That is the demanding half of reading definitions back as
+input: the parser has to produce exactly what the generator emitted for
+unchanged text, so "no difference" is a case the round trip recognizes rather
+than a diff it happens to compute as empty.
+
+**A read-only projection is a behavior change for anyone editing notes through
+FUSE.** The verb has to land first, and the change is worth announcing rather
+than discovering.
+
+**A pasted URL that becomes a mention is a paste that changed under the user.**
+It should be undoable in one keystroke, and it should not fire while the URL is
+still being typed out by hand.


### PR DESCRIPTION
## Why

Follow-up to the mention-references stack (#5699 and below). Plan only — no
implementation — so the design can be argued before anyone builds it.

A mention made through the editor's completion becomes a reference. Text that
names a cell **any other way** stays inert: paste a piece's URL into a note and
it is a URL, invisible to `$mentioned` and to the backlinks index.

**One builtin closes that, and two things follow from it.**

`cellFromUrl` is a **builtin** rather than a helper function because the answer
cannot stay synchronous, and the surface should not have to change when it stops
being. Three questions on three timelines, all of which the runtime already has
pieces for:

| Question | Today | Later |
| --- | --- | --- |
| Is this host a fabric host? | its own, plus a configured list | probe an unknown host |
| Which space? | `resolveSpaceNameSync` cache hit, else the name-based `createSession` derivation the runtime already flags as provisional | a network lookup |
| Which cell? | `slugIdForSpace` hashes `{space, slug}` | unchanged — mechanical, no connection needed |

The initial implementation can resolve synchronously. Landing it as a builtin
now is what makes each of those a local change later.

## The FS round trip, without a write hook

`writeFsFile` writes the entire parsed body to `$FS.content`, which for a note
is a write-redirecting link to its own content cell — so anything generated into
the projection returns as note text on the first edit.

Rather than special-casing the bridge with a write hook, **the projection
becomes read-only and the note exposes a verb that takes an edited body.** An
edit becomes a call, like every other change to a piece.

That verb is a handler, like any other verb. What it does in its body is
instantiate a pattern — which handlers and lifts can do, and which `note.tsx`'s
own `createNewNote` already does with `Note` — because `cellFromUrl` is a
builtin and a builtin resolves in the graph rather than inline:

```text
edited markdown
  → computed: candidate URLs and reference definitions in the body
  → map: cellFromUrl over each candidate
  → computed: the new content and the new reference map
  → written to the content and references cells
```

## The definition block reads both ways

Generated on the way out, **read as input on the way back**. Someone editing it
through the filesystem is editing the note's mentions, and that is a legitimate
way to do it:

| The file comes back with | Meaning |
| --- | --- |
| a definition unchanged | no change; writing the file back untouched is not an edit |
| a well-formed definition added | a new reference, its URL resolved like any other |
| a definition's URL changed | that mention repoints; the key keeps its identity |
| a malformed definition | dropped |

Only the malformed case discards anything, and it discards the line rather than
the mention. Which makes both halves of the plan one mechanism seen from two
sides: a URL that names a cell becomes a reference whether it arrives by paste
or by `vim`.

Repointing has one consequence worth stating: a label the user never claimed
(`modifiedTitle` false) is rewritten to the new destination's name by the
subscription the editor already keeps, while a label they did claim stays. The
existing rule, reached from the filesystem instead of from a rename.

## What Changed

- `docs/plans/urls-as-mentions.md` — the builtin and its three timelines, the
  read-only projection and its verb, how an edited definition is read, a work
  checklist, and three risks.
- `docs/plans/README.md` — index entry.

Retiring topics' hand-rolled `extractFidPayloads` onto the builtin is listed as
part of the work.

The remaining risk is exactness: reading definitions back as input means
unchanged text has to parse to exactly what the generator emitted, so "no
difference" is a case the round trip recognizes rather than a diff it happens to
compute as empty. Otherwise every `touch` becomes an edit.

## Test plan

Documentation only. `check-docs`, `docs-links --orphan`, and
`check-conflict-markers` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)