### PR TITLE
fix(dashboard): measure the machine, and stop discarding red runs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,14 +1,24 @@
 name: Benchmarks
 
 # The bench-results artifacts feed the benchmark trend charts on the team ops
-# dashboard (its /bench page), which samples one successful run per four-hour
-# window, so per-push samples add no resolution beyond a four-hourly cadence.
-# Scheduled runs stay on the dedicated runner group so results remain
-# comparable across runs; use the manual trigger to measure a specific commit.
+# dashboard (its /bench page), whose trend reads one completed run per
+# four-hour window, so per-push samples add no resolution beyond a four-hourly
+# cadence. Scheduled runs stay on the dedicated runner group; use the manual
+# trigger to measure a specific commit.
 #
 # One of the benchmarks drives a browser against a running toolshed; the steps
 # that build and start that server are part of this job for its sake. See
 # docs/development/BENCHMARKS.md.
+#
+# The group is not a machine. It has served six processor models over a
+# forty-five day stretch, and two runs on one model can be a fifth apart on
+# work that touches no repository code at all, because each run gets whatever
+# share of a host the other tenants leave it. The dashboard draws a separate
+# line per processor model, which tells the models apart but not the hosts. So
+# every run also measures the machine it landed on, through
+# packages/dashboard/machine-calibration.bench.ts below, and the dashboard
+# divides that measurement out of its trend. Without it a run that landed on a
+# busy host reads on the tile as a code regression.
 on:
   schedule:
     - cron: "0 */4 * * *" # Every 4 hours
@@ -59,9 +69,14 @@ jobs:
             echo "AppArmor unprivileged-userns sysctl is unavailable; no change required."
           fi
 
-      # The two browser bench files go last so their boards are seeded and their
-      # browsers run after the micro-benchmarks have taken their measurements,
-      # rather than alongside them.
+      # The order files are listed in is not the order they run in. `deno bench`
+      # picks its own, and holds to it: listing these same files in the reverse
+      # order produces the identical report, and repeated runs of one order agree
+      # with each other. What it picks puts the two browser files first and the
+      # machine calibration near the end. That is stable enough for the
+      # calibration to measure the same point of the job every time, which is
+      # what makes it comparable across runs, but it is not something this list
+      # chooses. Adding a file here does not place it.
       - name: 🏋️ Run benchmarks
         env:
           CF_LOG_LEVEL: silent
@@ -76,16 +91,22 @@ jobs:
             packages/memory/test/v2-entity-id-list.bench.ts \
             packages/data-model/bench/hashing.bench.ts \
             packages/data-model/bench/codec-json.bench.ts \
+            packages/dashboard/machine-calibration.bench.ts \
             packages/patterns/integration/topic-board-navigation.bench.ts \
             packages/patterns/integration/topic-board-scale.bench.ts \
             > bench-results/results.json \
             2> >(tee bench-results/diagnostics.log >&2)
 
-      # Fail the run if any bench file wrote non-JSON to stdout, or if the
-      # report lists no benches. The dashboard samples successful runs only,
-      # so a corrupt artifact never reaches the charts and the failure is a
-      # visible red run. The script rides in a single-quoted shell argument —
-      # keep apostrophes out of it.
+      # Fail the run if any bench file wrote non-JSON to stdout, if the report
+      # lists no benches, or if it carries no machine calibration. Failing here
+      # makes each of those a visible red run. It does not keep the artifact
+      # out of the charts, because the dashboard reads a red run's artifact
+      # too: what it drops is an artifact it cannot parse, which is this same
+      # test applied on its side. A report without calibration is not corrupt,
+      # but the dashboard cannot tell a busy host from a code change in it, so
+      # it fails here rather than feeding an uncorrected run into the trend.
+      # The script rides in a single-quoted shell argument — keep apostrophes
+      # out of it.
       - name: ✅ Validate benchmark results
         run: |
           deno eval '
@@ -95,7 +116,20 @@ jobs:
             if (!Array.isArray(data.benches) || data.benches.length === 0) {
               throw new Error("results.json parsed but contains no benches");
             }
-            console.log(`results.json OK: ${data.benches.length} benches`);
+            const calibration = data.benches.filter((bench) =>
+              String(bench.origin ?? "").endsWith(
+                "/packages/dashboard/machine-calibration.bench.ts",
+              )
+            );
+            if (calibration.length === 0) {
+              throw new Error(
+                "results.json carries no machine-calibration benches",
+              );
+            }
+            console.log(
+              `results.json OK: ${data.benches.length} benches, ` +
+                `${calibration.length} of them machine calibration`,
+            );
           '
 
       - name: 📤 Upload benchmark results

--- a/docs/development/BENCHMARKS.md
+++ b/docs/development/BENCHMARKS.md
@@ -7,21 +7,51 @@ work.
 ## The pipeline
 
 The Benchmarks workflow (`.github/workflows/benchmarks.yml`) runs every four
-hours on a schedule, on the dedicated runner group so results stay comparable
-across runs. It runs `deno bench --json` over `packages/runner/test/*.bench.ts`
-plus explicitly listed benchmarks in `packages/utils`, `packages/fuse`,
-`packages/memory`, and `packages/patterns`. It uploads JSON stdout and a copy of
-stderr in the `bench-results` artifact with 90-day retention. A bench file
-outside those paths does not run in CI until it is added to the workflow. The
-workflow's manual trigger measures a specific commit.
+hours on a schedule, on the dedicated runner group. It runs `deno bench --json`
+over `packages/runner/test/*.bench.ts` plus explicitly listed benchmarks in
+`packages/utils`, `packages/fuse`, `packages/memory`, `packages/dashboard`, and
+`packages/patterns`. It uploads JSON stdout and a copy of stderr in the
+`bench-results` artifact with 90-day retention. A bench file outside those paths
+does not run in CI until it is added to the workflow. The workflow's manual
+trigger measures a specific commit.
 
-The team ops dashboard charts benchmark trends on its `/bench` page, sampling
-one successful run per four-hour window from those artifacts. Each
+The team ops dashboard charts benchmark trends on its `/bench` page, and its
+trend reads one completed run per four-hour window from those artifacts. Each
 benchmark is identified by its origin file, group, and name. The report's CPU
 field divides that benchmark into one line per processor. The dashboard never
 connects measurements from different processors. A report without a CPU
 identity is unusable for trends because its measurements cannot be assigned to
 a processor.
+
+The runner group does not make two runs comparable, and the processor field
+only goes part of the way. Over a forty-five day stretch the group served six
+processor models, and within one model two runs have measured a fifth apart on
+work that touches no repository code, because a run gets whatever share of a
+shared host the other tenants leave it. So every run also measures the machine,
+through the benchmarks in `packages/dashboard/machine-calibration.bench.ts`,
+which call no repository code. The dashboard divides their geometric mean out of
+each step of its index, and leaves them out of the index, the benchmark count
+and the drill-down. See
+[the investigation](../history/development/performance/2026-08-benchmark-headline-machine-noise.md)
+for what an uncorrected run did to the tile.
+
+That correction reaches as far as the machine and no further. A host that is
+busy for the whole job is measured and divided out. Anything that slows one
+phase of the job and not another is not, because the calibration is one
+measurement taken at one point. The browser benchmarks below are the case to
+hold in mind: they run against a toolshed this same job started, and contention
+between the browser and that server sits inside their numbers with nothing to
+subtract it against.
+
+Which point of the job the calibration is taken at is `deno bench`'s to choose,
+not the workflow's. It does not run files in the order they are listed: listing
+the same files in reverse produces the identical report, and the two browser
+files run first rather than last where the list puts them. The order it picks
+is stable — repeated runs of one file set agree — and stability is what the
+calibration actually needs, because a ruler read at the same point of every job
+compares across jobs. Adding a bench file to the list does not place it, so
+neither the calibration's position nor any other file's can be arranged from
+here.
 
 Benchmark numbers are not gated, and neither is CI wall time. The only per-PR
 gate is the coverage-debt ratchet (`tasks/coverage-check.ts`), which never
@@ -37,9 +67,11 @@ single file.
 **Stdout must stay pure JSON.** The workflow redirects all of stdout to
 `results.json`. One stray line printed by any bench file corrupts the
 artifact for every benchmark in the run, not just the offending file. A
-validation step fails the run when the artifact is not valid JSON or lists
-no benches; since the dashboard samples successful runs only, corruption
-never reaches the charts and shows up as a red run in the Actions tab. This
+validation step fails the run when the artifact is not valid JSON, lists no
+benches, or carries no machine calibration, so each of those shows up as a red
+run in the Actions tab. What keeps corruption off the charts is the dashboard
+applying the same test to the artifact it downloads, rather than the run's
+colour: a red run's measurements are charted like any other run's. This
 applies to module-scope code as well as bench bodies. Write diagnostics to
 stderr. Module-scope diagnostics may use `console.error`. The JSON reporter
 captures console output from benchmark bodies, so body diagnostics that need
@@ -96,6 +128,20 @@ over. So:
 `packages/runner/test/esm-verifier.bench.ts` shows the pattern: short stable
 names, per-module labels derived from source paths, sizes logged to stderr.
 
+**The calibration bodies stay as they are.** The bodies in
+`packages/dashboard/machine-calibration.bench.ts` are the ruler every other
+benchmark is measured against, so editing one moves its timings and the
+dashboard reads that move as the machine changing under a processor that did
+not change. Adding a benchmark to that file is safe, and so is removing one:
+each pair of runs is compared over the calibration benchmarks they share, so
+one present on only one side takes no part. Rewriting one is not. Two things
+keep those bodies honest, and both are easy to undo by accident. Each runs long
+enough — a few hundred microseconds — that the just-in-time compiler has
+settled before the measurement, because a body of a few tens of microseconds is
+measured partly interpreted and partly compiled, and which it is varies between
+runs by more than the machine does. And each takes an explicit warmup, so that
+settling happens before the timings start.
+
 ## The end-to-end navigation benchmark
 
 `packages/patterns/integration/topic-board-navigation.bench.ts` measures what a
@@ -116,13 +162,14 @@ Three things follow from it being an end-to-end measurement:
   it, and relaxes the AppArmor restriction Astral needs, all before the
   benchmark step. Locally, start the dev servers and pass `API_URL` and
   `FRONTEND_URL`.
-- **A failure is a red run.** `deno bench` exits non-zero when a benchmark
-  throws, and this one throws when the shell raises an uncaught exception or a
-  navigation never completes. The report still lists every other benchmark, and
-  the dashboard drops only the series it could not measure — but the run is red
-  and that window contributes nothing to any chart. Each segment waits on the
-  event it is waiting for, with no deadline of its own, so it fails when
-  something is genuinely broken rather than when the runner is busy.
+- **A failure is a red run, but not a lost window.** `deno bench` exits
+  non-zero when a benchmark throws, and this one throws when the shell raises an
+  uncaught exception or a navigation never completes. The report still lists
+  every other benchmark, the workflow still uploads it, and the dashboard reads
+  it: the run is red in the Actions tab and drops only the series it could not
+  measure. Each segment waits on the event it is waiting for, with no deadline
+  of its own, so it fails when something is genuinely broken rather than when
+  the runner is busy.
 - **The `sign in` segment reads coarser than the others.** It calls the shared
   `login` helper from `@commonfabric/integration/shell-utils`, which polls the
   page on a 50ms interval, and a wall-clock measurement taken around a poll is

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -335,6 +335,10 @@ One line per archived document; each document's header carries the fuller
   replay registry hashed a key on every `sync()` call. Also why the
   write-vs-commit benchmark alongside it was not a regression at all, and how
   normalizing by a run median can manufacture a step, August 2026.
+- [2026-08-benchmark-headline-machine-noise.md](development/performance/2026-08-benchmark-headline-machine-noise.md)
+  — why the dashboard's 21% benchmark headline was mostly the host two runs
+  landed on: the runner group serves several machines under one processor name,
+  and neither the artifact nor the tile could tell them apart. August 2026.
 - [coverage-ratchet-noise-2026-07-28.md](development/coverage-ratchet-noise-2026-07-28.md)
   — why a rename-only pull request owed coverage debt: a wall-clock-guarded
   diagnostic and a shard re-partition each moved the `packages/runner`

--- a/docs/history/development/performance/2026-08-benchmark-headline-machine-noise.md
+++ b/docs/history/development/performance/2026-08-benchmark-headline-machine-noise.md
@@ -1,0 +1,243 @@
+---
+status: historical
+created: 2026-08-07
+archived: 2026-08-07
+reason: "Why the benchmark tile's 21% headline was mostly the host a run landed on, and what changed in the workflow and the tile to stop it."
+---
+
+# The part of the 21% benchmark headline that was not code, 7 August 2026
+
+## Question
+
+The team dashboard's benchmark tile read `▲21%` over 392 benchmarks and the
+last 13 days. A companion investigation, recorded in
+`2026-08-benchmark-headline-decomposition.md`, decomposed that figure and found
+that the named step regressions do not account for it: undoing all of them,
+including the one already fixed, takes 21.0% only to 13.2%. This document is
+about the remainder, and the remainder turned out to be the larger part.
+
+Two questions were put. Did the environment under the processor the headline
+belongs to change? And does the tile overstate on a line that has few runs
+behind it?
+
+The answers are that the processor's environment did not change, that the
+runner group nonetheless does not hand two runs the same machine, and that the
+tile had no way to see the difference. Correcting for it takes the headline
+from 21.0% to 4.4%, and it makes the three processors agree with each other
+rather than disagree by a factor of six.
+
+## How the figures below were produced
+
+Every `bench-results` artifact the `Benchmarks` workflow produced on `main`
+between 18 June and 7 August 2026 was downloaded: 485 successful runs, of which
+481 still had a readable artifact. The four that did not are all from 19 and 20
+June, before the tile's 45-day window opens.
+
+Each artifact was parsed the way `packages/dashboard/tiles/benchmark.ts` parses
+it, and the per-processor index was rebuilt from the same rule: an index starts
+at one and is multiplied, run by run, by the geometric mean of the
+per-benchmark ratios over the benchmarks two neighboring runs share. The window
+and the headline percentage come from the same `trendPct` the dashboard calls.
+The rebuild reproduces the tile exactly: the headline belongs to the
+`INTEL(R) XEON(R) PLATINUM 8573C` line, whose window holds 20 runs spanning
+12.7 days, and the newest run carries 392 benchmarks.
+
+Where the text below needs to know how fast a machine was, rather than how fast
+the repository was, it reads the benchmarks in `packages/utils`. Those run no
+runner code: they are cache and deep-equal loops over data already in memory.
+The measure used is the geometric mean of the absolute timings of the 18 such
+benchmarks that every run of a given processor shares, divided by that
+processor's own median. Call it the machine factor. A factor of 1.20 means the
+run measured everything, including work that calls nothing, a fifth slower than
+that processor usually measures it.
+
+## What the runner group actually serves
+
+The workflow pins the runner group, and the comment above the pin said results
+stay comparable across runs because of it. They do not.
+
+Over the 45 days the tile charts, the group served six processor models:
+`AMD EPYC 7763 64-Core Processor`, `AMD EPYC 9V74 80-Core Processor`,
+`INTEL(R) XEON(R) PLATINUM 8573C`, `INTEL(R) XEON(R) PLATINUM 8573B`,
+`Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz` and `Intel(R) Xeon(R) 6973P-C`.
+The tile draws one line per model, which handles that.
+
+What it does not handle is that a model is not a machine. Here is the machine
+factor's spread within each model, over the same 45 days:
+
+| Processor | Runs | 5th percentile | 95th percentile | Spread | Runs off by more than a tenth |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| AMD EPYC 7763 | 241 | 0.991 | 1.014 | 1.023 | 0 |
+| AMD EPYC 9V74 | 135 | 0.777 | 1.015 | 1.306 | 13 |
+| Intel Xeon Platinum 8573C | 39 | 0.990 | 1.195 | 1.207 | 3 |
+
+The EPYC 7763 is steady to within a couple of percent across 241 runs. The
+other two are not, and they are not noisy in a way that averages out. The EPYC
+9V74's runs fall into two clusters, one at about 114 microseconds and one at
+about 88, twenty-three percent apart, with 13 of its 135 runs in the faster
+one and no drift between them over time. Under one processor name, the group
+is serving at least two machines.
+
+The 8573C is the mirror image: a tight baseline at about 98 microseconds with
+three runs sitting a fifth above it. A run gets whatever share of a shared
+host the other tenants leave it, and about one run in ten does not get all of
+it.
+
+## The 8573C's environment did not change
+
+Its machine factor is flat across all 39 of its runs, from 1 July to 6 August.
+There is no step, no drift, and no relationship to the Deno version. Whatever
+made the headline move, it was not the 8573C becoming a different machine.
+
+For completeness, one environment change does sit inside the window and is
+real: `mise.toml`'s Deno pin rolled from 2.8.1 to 2.9.4 on 29 July, in commit
+`fbdd14d3f`. That is a repository change rather than a runner change, it
+reaches every processor, and it moved the runner benchmarks by about three
+percent on the EPYC 7763 and about two and a half on the EPYC 9V74. On the
+8573C it moved them by nothing measurable. It is a legitimate part of the
+measured history and is not the subject of this document.
+
+## The headline rests on two runs that landed on a slow host
+
+The 8573C's 20-run window ends with two runs, at 20:59 and 21:47 UTC on 6
+August, 48 minutes apart. One is the only manual dispatch in the whole 50-day
+run list; the other is the scheduled run that followed it. They are on
+different commits, so they are two honest measurements — of two different
+commits, on a machine that was not itself.
+
+Both have a machine factor of 1.196 and 1.195. Every benchmark in both runs is
+up by about the same amount, including the pure arithmetic loops that touch no
+repository code at all. Reading the whole distribution of per-benchmark ratios
+rather than its centre says the same thing: on a typical 8573C run the ratios
+against its neighbours sit with a median of 0.985 and a 75th percentile of
+1.000, so the bulk of the benchmarks agree; on these two the 25th percentile is
+already at 1.085 and 1.037. A commit does not make 392 unrelated benchmarks
+uniformly slower. A busy host does.
+
+Those two runs are window points 18 and 19, and the fit reads its final level
+off points 17, 18 and 19.
+
+## What the fit does with them, and why the reported figure exceeds the move
+
+The window's index ends 13.3% above where it starts. The tile reports 21.0%.
+The gap is worth stating precisely, because it is not where one might guess.
+
+`trendPct` fits flat levels separated by change points and reports the last
+level against the first. On this window it places change points after sample 3
+and after sample 17, giving three levels which, expressed against the first,
+are 1.0000, 1.0506 and 1.2098. The last level is the median of samples 17, 18
+and 19, which is 1.1329 — the same value as the window's last sample. So the
+fit does not overstate at that end at all.
+
+The whole of the gap is at the other end. The first level is the median of
+samples 0, 1 and 2, which is 0.9364, while sample 0 is 1.0000. The series drops
+about seven percent between the first and second samples and stays down, and
+that drop is real: the machine factor is normal at both runs, so the runner
+benchmarks genuinely got faster while the pure loops did not. `MIN_SEGMENT` is
+3, so the change-point search is not allowed to put a boundary one sample in,
+and the first level therefore averages across a change it could not see. The
+fit's inference — that a single low-lying sample is more likely to be one odd
+run than a level of its own — is a reasonable policy when about one run in ten
+lands off-norm. On this particular window it is wrong, and it inflates the
+answer by about seven points.
+
+So the fit is doing what it was built to do, including the deliberate and
+tested behaviour of reporting a step in the newest three samples at full size.
+What it was fed was contaminated. The correction belongs upstream of the fit,
+in what the index is made of.
+
+## The tile also counted one moment twice
+
+There is a second, smaller defect, and it is the reason a single slow episode
+could supply two of the three samples the final level rests on.
+
+The workflow's comment says the dashboard samples one successful run per
+four-hour window. The dashboard does not. `sampleBenchmarkRuns` buckets at
+`ciHistoryBucketMs(CI_HISTORY_MIN_DAYS)`, which is one day divided by 200
+points, or 7.2 minutes. That is the right resolution for the drill-down's
+one-day view, which is what the bucket was chosen for, and it is far finer
+resolution than a 13-day trend over twenty points wants. Two runs 48 minutes
+apart entered the fit as two independent samples of the level.
+
+## What changed
+
+Two changes, one for each question.
+
+**The workflow now measures the machine.** A new file,
+`packages/dashboard/machine-calibration.bench.ts`, holds twelve benchmarks that
+import nothing and call no repository code: integer and floating-point
+arithmetic, short-lived and retained allocation, array and typed-array traffic,
+string building, hash-table churn, prototype dispatch, closure allocation and a
+JSON round trip. The `Benchmarks` workflow runs them alongside the product
+benchmarks, in the same report and the same artifact, and its validation step
+now fails a run whose report carries none of them. Their bodies are the ruler,
+so they do not change; adding or removing one is safe, because each pair of
+runs is compared over the calibration benchmarks they share.
+
+The first draft of that file was written with bodies of a few tens of
+microseconds each, and measuring it showed it was a worse ruler than the thing
+it was measuring. Over six runs on one machine its geometric mean varied by a
+factor of 1.85 while the `packages/utils` benchmarks in the same runs varied by
+1.37, and the two did not move together: their ratio varied by a factor of
+2.01, which is the signature of noise the calibration was making rather than
+noise it was finding. The cause was measurement length. A body of a few tens of
+microseconds is partly interpreted and partly compiled while it is being timed,
+and which it is varies between runs by more than the machine does. Growing each
+body to a few hundred microseconds and giving every one an explicit warmup
+brought the calibration's own variation to 1.28 against the utils benchmarks'
+1.31, and their ratio to 1.21. Every calibration benchmark now varies against
+the utils geometric mean by less than the widest of the utils benchmarks does.
+The whole file adds about seven seconds to a job that runs for nine minutes.
+
+**The tile divides that measurement out, and reads one run per four hours.**
+Each index step is now the geometric mean of the product benchmarks' ratios
+divided by the geometric mean of the calibration benchmarks' ratios. The
+calibration benchmarks take no other part: they are absent from the index, from
+the benchmark count on the tile, and from the drill-down. A run from before the
+calibration landed carries none, and the step into or out of it is left
+uncorrected rather than guessed at. Separately, the index reads one run per
+`BENCH_TREND_BUCKET_MS`, four hours, matching the workflow's cron; the
+drill-down still keeps every run.
+
+The trend fit in `packages/dashboard/trend.ts` was left alone, on the reasoning
+above: its behaviour on this window is defensible, and the changes that would
+have blunted it — a longer minimum segment, or a stricter change-point
+threshold — would trade a spurious red for a spurious green on a tile whose job
+is catching regressions.
+
+## What the changes do to the numbers
+
+Replaying the whole 45-day history through the tile's own helpers, with the
+`packages/utils` benchmarks standing in for the calibration file that the
+historical artifacts predate:
+
+| | Intel Xeon Platinum 8573C | AMD EPYC 7763 | AMD EPYC 9V74 | Headline |
+| --- | ---: | ---: | ---: | ---: |
+| As the tile reported it | 21.0% | 3.2% | 5.0% | 21.0% |
+| Reading one run per four hours | 8.7% | 3.2% | 5.0% | 8.7% |
+| Dividing out the machine | 0.0% | 3.9% | 4.4% | 4.4% |
+| Both | 0.0% | 3.9% | 4.4% | 4.4% |
+
+The headline goes from 21.0% to 4.4%, which is below the 5% threshold that
+turns the tile orange. The check that matters more than the number is the last
+row's agreement: three machines measuring the same commits over the same days
+now say 0.0%, 3.9% and 4.4% instead of 21.0%, 3.2% and 5.0%. A repository does
+not get six times slower on one machine and not on another.
+
+For the original question, that means the remainder the decomposition left —
+13.2% on the headline processor after every named step regression was undone —
+was very largely not code. It was the host two runs landed on, read by a fit
+that had no way to know.
+
+## What this does not cover
+
+The calibration removes anything that changes the machine's raw throughput
+between two runs. A toolchain roll that made pure arithmetic slower would be
+divided out along with the busy hosts, and the tile would then report only what
+the repository's code did relative to it. That is the right reading for a tile
+that asks whether our code got slower, and the per-benchmark drill-down still
+carries the absolute timings for anyone asking the other question.
+
+The calibration also cannot help a run from before it landed. The historical
+artifacts have none, so the tile's older steps stay uncorrected until 14 days
+of calibrated runs have accumulated.

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -300,7 +300,7 @@ surveillance tool.
 | prod errors | SigNoz trace error rate for one service (errored spans / all spans): last-12h headline, with a per-hour sparkline over the retained trace history (~2 weeks) and the last-12h slice that feeds the headline highlighted. Scoped to `PROD_SERVICE` — the same SigNoz holds staging and one-off perf runs, whose rates are not production's. Gray (not red) when SigNoz is unreachable. Pops out to the SigNoz logs explorer | `SIGNOZ_URL`, `SIGNOZ_API_KEY`; optional `PROD_SERVICE`, `SIGNOZ_UI_URL` for the pop-out |
 | cloud spend | BigQuery billing export, after credits, projected to month-end from the available part of a 14-day daily-cost window early in the month. The header shows actual MTD spend. The highlighted part of the 45-day chart shows the days used for the estimate | `GCP_BILLING_TABLE` (+ Workload Identity, or `GCP_SA_KEY` locally), optional `GCP_DAILY_BUDGET` |
 | ci spend | GitHub Actions and Blacksmith billing, projected to month-end in USD. Each configured source gets a line in the shared 45-day chart and an MTD label. The header shows combined MTD spend. A source that cannot be read shows `$???`, while the headline remains a lower bound from the sources that did respond. A month whose usage report cannot be read breaks that source's line across those days rather than charting them as $0 | either or both of `GH_TOKEN` (with org billing read) and `BLACKSMITH_API_TOKEN`; optional `GH_BILLING_ORG`, `BLACKSMITH_ORG`, `CI_MONTHLY_BUDGET` |
-| benchmarks | a scale-invariant index of benchmark performance on `benchmarks.yml` main runs, trended over ~45 days (each run vs the last, geometric mean of per-benchmark changes, so every benchmark weighs the same): red when the most recent run failed or produced no valid data (the main signal), orange only on a broad across-the-board rise. Adding or removing a benchmark is a non-event. Drills through to the per-benchmark history | `GH_TOKEN` |
+| benchmarks | a scale-invariant index of benchmark performance on `benchmarks.yml` main runs, trended over ~45 days (each run vs the last, geometric mean of per-benchmark changes, so every benchmark weighs the same, divided by the same run's machine calibration so a busy host does not read as a code change): red when the most recent run failed or produced no valid data (the main signal), orange only on a broad across-the-board rise. Adding or removing a benchmark is a non-event. Drills through to the per-benchmark history | `GH_TOKEN` |
 | performance history → `/bench?view=runtime` | runtime benchmark trends, labs or loom CI duration history, and a detailed CI run Gantt. Historical views support windows from 1 through 45 days, date axes, and duration sorting. CI includes end-to-end workflow time, every job, and slowest-shard group lines | `GH_TOKEN` |
 | model spend | OpenAI + Anthropic + OpenRouter usage APIs. Headline is the projected full-month spend (extrapolated from the recent daily rate, spilling into last month when this month is under two weeks old), summed across providers. OpenAI and Anthropic (which expose per-day cost) are charted as one line each over ~45 days, with a recent daily-rate slice highlighted and each line's MTD in the right gutter; OpenRouter (monthly total only, abbreviated "OR") is folded into the totals. The subtitle is the bullet-separated key (`OpenAI • Anthropic • OR $0`); the combined MTD sits in the header (the `aside` slot); the span the chart covers is in its bottom-left corner (the `duration` slot). A provider we can't read shows `$???` and drops the tile to gray, but the rest still chart and total | any of `OPENAI_ADMIN_KEY`, `ANTHROPIC_ADMIN_KEY`, `OPENROUTER_KEY`; optional `MODEL_MONTHLY_BUDGET` |
 | discord online | Discord gateway presence, team vs visitors over time | `DISCORD_BOT_TOKEN`, `DISCORD_GUILD_ID` (Server Members + Presence intents) |
@@ -630,7 +630,8 @@ Notes:
   `bench-results` artifact with 90-day retention. There is no committed
   history. Each CPU's index compares a run with the previous run on the same
   CPU. It multiplies the previous index by the **geometric mean of the
-  per-benchmark changes**. Every benchmark weighs the same regardless of size.
+  per-benchmark changes**, then **divides out the machine**. Every benchmark
+  weighs the same regardless of size.
   **Only a broad, across-the-board move shifts an index.** A regression in one
   benchmark barely registers, however slow that benchmark is. The drill-down
   covers individual benchmarks. A summed total would instead be dominated by
@@ -676,7 +677,23 @@ Notes:
   absent from one side of that adjacent comparison, so it drops out of the
   geometric mean.
   A CPU change starts another line instead of connecting measurements from
-  unlike machines. A gap longer than one fifth of the chart width breaks a
+  unlike machines. A CPU model is not a machine, though. The runner group has
+  served six processor models over a forty-five day stretch, and two runs on
+  one model have measured a fifth apart on work that touches no repository code
+  at all, because a run gets whatever share of a shared host the other tenants
+  leave it. So the workflow also runs
+  `packages/dashboard/machine-calibration.bench.ts`, whose benchmarks call no
+  repository code, and each step divides their geometric mean out of the
+  product benchmarks' one. What is left is what the repository did. Those
+  calibration benchmarks are the tile's ruler rather than one of the things it
+  measures: they are absent from the index, from the benchmark count, and from
+  the drill-down. A run from before the calibration landed carries none, and
+  the step into or out of it is left uncorrected rather than guessed at. The
+  index also reads **one run per `BENCH_TREND_BUCKET_MS`**, matching the
+  workflow's four-hourly cron, so a rerun or a manual dispatch minutes from a
+  scheduled run does not put two samples of one moment into the fit. The
+  drill-down keeps every run. A gap longer than one fifth of the chart width
+  breaks a
   CPU's line. Any sample isolated by those breaks appears as a point. A CPU
   with one sample also appears as a point until another sample can form a line.
   A large rise reads as a fold multiplier (`▲44×`) once it passes 4x. This
@@ -711,10 +728,17 @@ Notes:
     to download.
   - The tile drills through to the per-benchmark history behind `/bench`, which the
     tile's collection keeps warm in the background. The collection lists
-    benchmark runs on main. It samples one run per shortest-view bucket,
-    downloads that artifact, and unzips it in the process. It then reads each
-    benchmark's timings and CPU. A report without a CPU identity is cached as
-    unusable instead of being pooled with measurements from unknown machines.
+    benchmark runs on main. It samples one completed run per shortest-view
+    bucket, whatever colour it finished, downloads that artifact, and unzips it
+    in the process. It then reads each benchmark's timings and CPU. A run's
+    colour does not say whether it measured anything: `deno bench` exits
+    non-zero when one benchmark throws, having already written a complete report
+    of the rest, and dropping those runs cost about a seventh of the history in
+    blocks a dozen runs long. The artifact decides instead. A report without a
+    CPU identity, or one that will not parse, is cached as unusable instead of
+    being pooled with measurements from unknown machines; because a run
+    attempt's artifact never changes, that verdict is kept rather than retried,
+    while a read that failed outright is retried.
     Cache entries written before CPU identity was stored are fetched again.
     Each completed artifact check is persisted before it is counted as
     finished. Only new runs and attempts are fetched after the first fill or a

--- a/packages/dashboard/config.ts
+++ b/packages/dashboard/config.ts
@@ -38,5 +38,11 @@ export const DUR_MAX_AGE_HOURS = 6;
 // several distinct days, so the recent slice is measured in days, not hours.
 export const BENCH_TREND_MIN_RUNS = 20;
 export const BENCH_TREND_MAX_AGE_DAYS = 14;
+// The trend reads one run per bucket of this length, matching the
+// benchmarks.yml cron. The collection keeps every run, for the drill-down's
+// shortest view; the trend does not want that resolution, because runs closer
+// together than the cadence are one moment in wall clock, and counting them
+// separately lets one moment supply a whole level of the fit.
+export const BENCH_TREND_BUCKET_MS = 4 * 60 * 60_000;
 export const RECENT_WINDOW = 10; // recent completed runs scanned for the recent-runs status
 export const RECENT_DISPLAY = 50; // rows the recent-runs tile shows

--- a/packages/dashboard/machine-calibration.bench.ts
+++ b/packages/dashboard/machine-calibration.bench.ts
@@ -1,0 +1,176 @@
+/**
+ * Measures the machine the Benchmarks workflow landed on, so the dashboard can
+ * divide it out of what the repository did.
+ *
+ * The workflow runs this file alongside the product benchmarks and uploads its
+ * timings in the same bench-results artifact. Nothing here imports or calls
+ * repository code, so a change to these numbers between two runs on the same
+ * processor is a change in the machine: its clock, its memory, its allocator,
+ * or how much of it another tenant was using. The benchmark tile divides that
+ * out of its per-processor index, so a run that landed on a busy host reads as
+ * the busy host it was rather than as a code regression.
+ *
+ * The bodies below are the ruler, so they do not change. Editing one moves its
+ * timings, and the tile reads that move as the machine changing under a
+ * processor that did not. Adding a benchmark is safe: the tile compares each
+ * pair of runs over the calibration benchmarks they share, so one that exists
+ * on only the newer side takes no part until both sides carry it. Removing one
+ * is safe for the same reason. Rewriting one is not.
+ *
+ * The set spans what a shared host actually slows down: arithmetic throughput,
+ * allocation and collection, memory bandwidth, and the hash-table work every
+ * interpreter leans on. It says nothing about anything else, and is not a
+ * benchmark of the repository: the tile keeps these out of its index, its
+ * benchmark count and its drill-down.
+ */
+
+// Every body accumulates into this. It is exported so the work behind it is
+// observable outside the module and cannot be dropped as dead.
+export let sink = 0;
+
+// The warmup each body takes, in calls. Two things keep a ruler from wobbling
+// on its own. Each body runs long enough — a few hundred microseconds — that
+// the just-in-time compiler has settled by the time it is measured, because a
+// body of a few tens of microseconds is measured partly interpreted and partly
+// compiled, and which it is varies between runs by more than the machine does.
+// And the warmup below puts that settling before the timings rather than
+// inside them. Anything declared once belongs at module scope for the same
+// reason: a class declared inside a body is a new class on every call, with
+// new shapes for the compiler to learn each time.
+const WARMUP = 200;
+
+class Doubler {
+  constructor(readonly value: number) {}
+  get doubled(): number {
+    return this.value * 2;
+  }
+}
+
+interface Link {
+  value: number;
+  next: Link | null;
+}
+
+Deno.bench("machine calibration - integer arithmetic", {
+  warmup: WARMUP,
+}, () => {
+  let total = 0;
+  for (let i = 1; i <= 200_000; i++) {
+    total = (total + i * 2654435761) | 0;
+    total ^= total >>> 13;
+  }
+  sink += total;
+});
+
+Deno.bench("machine calibration - floating point arithmetic", {
+  warmup: WARMUP,
+}, () => {
+  let total = 0;
+  for (let i = 1; i <= 200_000; i++) {
+    total += Math.sqrt(i) / (i + 0.5);
+  }
+  sink += total;
+});
+
+Deno.bench("machine calibration - short-lived object allocation", {
+  warmup: WARMUP,
+}, () => {
+  let total = 0;
+  for (let i = 0; i < 200_000; i++) {
+    const point = { x: i, y: i + 1, z: i + 2 };
+    total += point.x + point.y + point.z;
+  }
+  sink += total;
+});
+
+Deno.bench("machine calibration - retained object graph", {
+  warmup: WARMUP,
+}, () => {
+  const held: Link[] = [];
+  let previous: Link | null = null;
+  for (let i = 0; i < 100_000; i++) {
+    previous = { value: i, next: previous };
+    if ((i & 1023) === 0) held.push(previous);
+  }
+  sink += held.length;
+});
+
+Deno.bench("machine calibration - array fill and sum", {
+  warmup: WARMUP,
+}, () => {
+  const values = new Array<number>(200_000);
+  for (let i = 0; i < values.length; i++) values[i] = i & 255;
+  let total = 0;
+  for (let i = 0; i < values.length; i++) total += values[i];
+  sink += total;
+});
+
+Deno.bench("machine calibration - typed array write and read", {
+  warmup: WARMUP,
+}, () => {
+  const values = new Float64Array(200_000);
+  for (let i = 0; i < values.length; i++) values[i] = i * 0.5;
+  let total = 0;
+  for (let i = 0; i < values.length; i++) total += values[i];
+  sink += total;
+});
+
+Deno.bench("machine calibration - string building", {
+  warmup: WARMUP,
+}, () => {
+  let text = "";
+  for (let i = 0; i < 40_000; i++) text += (i & 15).toString(16);
+  sink += text.length;
+});
+
+Deno.bench("machine calibration - map insert and read", {
+  warmup: WARMUP,
+}, () => {
+  const map = new Map<number, number>();
+  for (let i = 0; i < 50_000; i++) map.set(i, i * 3);
+  let total = 0;
+  for (let i = 0; i < 50_000; i++) total += map.get(i)!;
+  sink += total;
+});
+
+Deno.bench("machine calibration - set insert and lookup", {
+  warmup: WARMUP,
+}, () => {
+  const set = new Set<string>();
+  for (let i = 0; i < 20_000; i++) set.add(`k${i & 4095}`);
+  let total = 0;
+  for (let i = 0; i < 20_000; i++) if (set.has(`k${i}`)) total++;
+  sink += total;
+});
+
+Deno.bench("machine calibration - property access through a prototype", {
+  warmup: WARMUP,
+}, () => {
+  let total = 0;
+  for (let i = 0; i < 200_000; i++) total += new Doubler(i).doubled;
+  sink += total;
+});
+
+Deno.bench("machine calibration - closure allocation and call", {
+  warmup: WARMUP,
+}, () => {
+  let total = 0;
+  for (let i = 0; i < 200_000; i++) {
+    const add = (value: number) => value + i;
+    total = add(total) & 0xffffff;
+  }
+  sink += total;
+});
+
+Deno.bench("machine calibration - json round trip", {
+  warmup: WARMUP,
+}, () => {
+  let total = 0;
+  for (let i = 0; i < 4_000; i++) {
+    const parsed = JSON.parse(
+      JSON.stringify({ id: i, tags: ["a", "b", "c"], nested: { depth: i } }),
+    ) as { id: number };
+    total += parsed.id;
+  }
+  sink += total;
+});

--- a/packages/dashboard/tiles/benchmark.test.ts
+++ b/packages/dashboard/tiles/benchmark.test.ts
@@ -16,7 +16,7 @@ import {
 } from "@std/assert";
 import { expect } from "@std/expect";
 import type { Ctx, TileView } from "../types.ts";
-import { REPO } from "../config.ts";
+import { BENCH_TREND_BUCKET_MS, REPO } from "../config.ts";
 import { BenchmarkHistoryStore } from "../benchmark-history-cache.ts";
 import {
   availableGeneratedCpuColor,
@@ -27,7 +27,9 @@ import {
   benchmarkHistoryProgressResponse,
   benchmarkRerunHandoff,
   benchmarkTrend,
+  benchmarkTrendRuns,
   benchPage,
+  CALIBRATION_FILE,
   formatNs,
   jsonFromZip,
   pointsForWindow,
@@ -272,6 +274,8 @@ const artifactCalls = (calls: string[]) =>
   calls.filter((c) => c.includes("/artifacts"));
 const apiCalls = (calls: string[]) =>
   calls.filter((call) => !call.startsWith("/rate_limit"));
+const runListCalls = (calls: string[]) =>
+  calls.filter((call) => call.startsWith(runsPath));
 
 // ------------------------------------------------------------ bench json
 
@@ -921,9 +925,9 @@ Deno.test("/bench?view=ci serves CI job history through the same drill-down", as
   }
 });
 
-Deno.test("benchmark: paging stops at the 45-day cutoff; failures and out-of-window runs are not sampled", async () => {
+Deno.test("benchmark: paging stops at the 45-day cutoff, and an out-of-window run is not sampled", async () => {
   // One full page whose oldest run is past the window: the loop stops there rather
-  // than asking for page 2. Nothing on it is both successful and in-window.
+  // than asking for page 2. The run that succeeded is out of the window.
   const page1 = [
     ...Array.from(
       { length: 99 },
@@ -933,8 +937,8 @@ Deno.test("benchmark: paging stops at the 45-day cutoff; failures and out-of-win
   ];
   await withApi({ pages: { 1: page1 } }, async (calls) => {
     const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
-    // The most recent run is a failure, so the tile reads red; the only success
-    // is out of the window, so there is no duration to headline.
+    // The most recent run is a failure, so the tile reads red; none of the runs
+    // sampled had an artifact, so there is nothing to headline.
     assertEquals(v.status, "bad");
     assertEquals(v.value, "—");
     // Every failure on the page, in a row. The one success is older than the
@@ -943,8 +947,15 @@ Deno.test("benchmark: paging stops at the 45-day cutoff; failures and out-of-win
     assertMatch(v.sub ?? "", /^last good \d+ days ago · 99 runs failed$/);
     assertEquals(v.href, "/bench?view=runtime&repo=labs");
     assertEquals(v.hint, "metrics ↗");
-    assertEquals(apiCalls(calls).length, 1); // page 2 was never asked for
-    assertEquals(artifactCalls(calls), []); // and no artifact was downloaded
+    assertEquals(runListCalls(calls).length, 1); // page 2 was never asked for
+    // A red run is read for its artifact like any other, because whether it
+    // measured anything is the artifact's answer and not the conclusion's. The
+    // run past the cutoff is not read at all.
+    assertEquals(artifactCalls(calls).length, 99);
+    assertEquals(
+      artifactCalls(calls).filter((call) => call.includes("/1099/")),
+      [],
+    );
   });
 });
 
@@ -958,7 +969,7 @@ Deno.test("benchmark: an empty page ends the paging", async () => {
     assertEquals(v.sub, "last 100 runs failed"); // every run in the window failed
     // A full page still inside the window is followed; the empty page 2 stops it.
     assertEquals(
-      apiCalls(calls).map((c) => c.match(/[?&]page=(\d+)/)![1]),
+      runListCalls(calls).map((c) => c.match(/[?&]page=(\d+)/)![1]),
       ["1", "2"],
     );
   });
@@ -1053,6 +1064,250 @@ Deno.test("benchmark: the trend reads the recent window only, not the whole hist
       ">1 benchmark · last 19 days</div>",
     );
   });
+});
+
+// Ten daily runs of one product benchmark and one calibration benchmark. The
+// last five carry `productFactor` on the product benchmark and `machineFactor`
+// on the calibration one, which is how a change in the repository and a change
+// in the host each look in an artifact.
+async function withCalibratedRuns(
+  idBase: number,
+  productFactor: number,
+  machineFactor: number,
+  run: () => Promise<void>,
+): Promise<void> {
+  const artifacts: Api["artifacts"] = {};
+  const zips: Api["zips"] = {};
+  const runs: GhRun[] = [];
+  for (let day = 0; day < 10; day++) {
+    const id = idBase + day;
+    const shifted = day >= 5;
+    runs.push(ghRun(id, SAMPLED_BASE - (9 - day) * DAY));
+    artifacts[id] = [{ id: id * 10, name: "bench-results", expired: false }];
+    zips[id * 10] = await benchZip(report([
+      bench("packages/a/x.bench.ts", null, "work", {
+        avg: 5e6 * (shifted ? productFactor : 1),
+      } as Timings),
+      bench(CALIBRATION_FILE, null, "integer arithmetic", {
+        avg: 1e6 * (shifted ? machineFactor : 1),
+      } as Timings),
+    ]));
+  }
+  await withApi(
+    { pages: { 1: [...runs].reverse() }, artifacts, zips },
+    run,
+  );
+}
+
+Deno.test("benchmark: a run on a slower host reads as the host, not as a rise", async () => {
+  // Everything the run measured is a quarter slower, the calibration included.
+  // No commit slows arithmetic that calls nothing; the host does. Dividing the
+  // calibration out of each step leaves the index where it was.
+  await withCalibratedRuns(11_100, 1.25, 1.25, async () => {
+    const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    assertEquals(v.status, "good");
+    assertStringIncludes(v.value ?? "", "flat");
+  });
+});
+
+Deno.test("benchmark: a rise the machine did not cause reads at its full size", async () => {
+  // The same quarter, this time on the product benchmarks alone while the
+  // calibration holds. That is the repository getting slower, and the index
+  // says so.
+  await withCalibratedRuns(11_200, 1.25, 1, async () => {
+    const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    assertEquals(v.status, "warn");
+    assertStringIncludes(v.value ?? "", "▲25%");
+  });
+});
+
+Deno.test("benchmark: a machine that sped up leaves the repository where it was", async () => {
+  // The host got a fifth faster and took the product benchmarks with it. The
+  // calibration moved by the same fifth, so the index does not read a win the
+  // repository did not earn.
+  await withCalibratedRuns(11_300, 0.8, 0.8, async () => {
+    const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    assertEquals(v.status, "good");
+    assertStringIncludes(v.value ?? "", "flat");
+  });
+});
+
+Deno.test("benchmark: the calibration is the ruler, not one of the benchmarks", async () => {
+  // Three product benchmarks and two calibration ones. The count line and the
+  // drill-down's rows both read the three.
+  const artifacts: Api["artifacts"] = {};
+  const zips: Api["zips"] = {};
+  const runs: GhRun[] = [];
+  for (let day = 0; day < 8; day++) {
+    const id = 11_400 + day;
+    runs.push(ghRun(id, SAMPLED_BASE - (7 - day) * DAY));
+    artifacts[id] = [{ id: id * 10, name: "bench-results", expired: false }];
+    zips[id * 10] = await benchZip(report([
+      ...Array.from({ length: 3 }, (_, i) =>
+        bench("packages/a/x.bench.ts", null, `work ${i}`, {
+          avg: 5e6,
+        } as Timings)),
+      ...Array.from({ length: 2 }, (_, i) =>
+        bench(CALIBRATION_FILE, null, `calibration ${i}`, {
+          avg: 1e6,
+        } as Timings)),
+    ]));
+  }
+  await withApi(
+    { pages: { 1: [...runs].reverse() }, artifacts, zips },
+    async () => {
+      const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+      assertStringIncludes(v.extra ?? "", ">3 benchmarks");
+      const html = benchPage("p99", "file", 45, SAMPLED_BASE);
+      assertEquals(
+        rows(html).map((row) => row.name),
+        ["work 0", "work 1", "work 2"],
+      );
+      assert(!html.includes("calibration 0"));
+    },
+  );
+});
+
+Deno.test("benchmark: runs from before the calibration read uncorrected", async () => {
+  // The calibration lands at the sixth run, and the host slows by a fifth at
+  // the eighth. Two things move the product benchmark: a real quarter at the
+  // sixth run, which no calibration is there to judge, and the host's fifth at
+  // the eighth, which one is. So the boundary step passes through at its face
+  // value and the later step is corrected away, leaving the quarter. Reading
+  // both uncorrected would say a half instead.
+  const artifacts: Api["artifacts"] = {};
+  const zips: Api["zips"] = {};
+  const runs: GhRun[] = [];
+  for (let day = 0; day < 10; day++) {
+    const id = 11_500 + day;
+    runs.push(ghRun(id, SAMPLED_BASE - (9 - day) * DAY));
+    artifacts[id] = [{ id: id * 10, name: "bench-results", expired: false }];
+    const host = day >= 7 ? 1.2 : 1;
+    const benches = [
+      bench("packages/a/x.bench.ts", null, "work", {
+        avg: 5e6 * (day >= 5 ? 1.25 : 1) * host,
+      } as Timings),
+    ];
+    if (day >= 5) {
+      benches.push(
+        bench(CALIBRATION_FILE, null, "integer arithmetic", {
+          avg: 1e6 * host,
+        } as Timings),
+      );
+    }
+    zips[id * 10] = await benchZip(report(benches));
+  }
+  await withApi(
+    { pages: { 1: [...runs].reverse() }, artifacts, zips },
+    async () => {
+      const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+      assertEquals(v.status, "warn");
+      assertStringIncludes(v.value ?? "", "▲25%");
+      assertStringIncludes(v.extra ?? "", ">1 benchmark");
+    },
+  );
+});
+
+Deno.test("benchmark: runs inside one trend bucket are one sample, newest kept", () => {
+  const run = (at: number) => ({ at });
+  const base = Math.floor(SAMPLED_BASE / BENCH_TREND_BUCKET_MS) *
+    BENCH_TREND_BUCKET_MS;
+  assertEquals(
+    benchmarkTrendRuns([
+      run(base + BENCH_TREND_BUCKET_MS + 60_000),
+      run(base + 30 * 60_000),
+      run(base + 60_000),
+      run(base + BENCH_TREND_BUCKET_MS),
+    ]),
+    [run(base + 30 * 60_000), run(base + BENCH_TREND_BUCKET_MS + 60_000)],
+  );
+  // A run alone in its bucket is kept whole, and the order out is ascending.
+  assertEquals(
+    benchmarkTrendRuns([run(base + 2 * BENCH_TREND_BUCKET_MS), run(base)]),
+    [run(base), run(base + 2 * BENCH_TREND_BUCKET_MS)],
+  );
+});
+
+Deno.test("benchmark: a red run's measurements still reach the trend", async () => {
+  // Eight daily runs whose one benchmark climbs. Three of them are red, because
+  // `deno bench` exits non-zero when any single benchmark throws — having
+  // already written a complete report of every other one. Dropping those three
+  // would leave five distinct days, under the week a trend needs, and the tile
+  // would read "new" while the climb went unreported.
+  const artifacts: Api["artifacts"] = {};
+  const zips: Api["zips"] = {};
+  const runs: GhRun[] = [];
+  for (let day = 0; day < 8; day++) {
+    const id = 11_600 + day;
+    // The newest run is green, so the tile is judging a trend and not an outage.
+    const red = day === 2 || day === 4 || day === 6;
+    runs.push(ghRun(id, SAMPLED_BASE - (7 - day) * DAY, red ? "failure" : "success"));
+    artifacts[id] = [{ id: id * 10, name: "bench-results", expired: false }];
+    zips[id * 10] = await benchZip(
+      report([
+        bench("packages/a/x.bench.ts", null, "work", {
+          avg: (5 + day) * 1e6,
+        } as Timings),
+      ]),
+    );
+  }
+  await withApi(
+    { pages: { 1: [...runs].reverse() }, artifacts, zips },
+    async (calls) => {
+      const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+      assertEquals(v.status, "warn"); // a trend, not "new" and not an outage
+      assertStringIncludes(v.value ?? "", "▲");
+      // Every run was read for its artifact, the three red ones included.
+      assertEquals(
+        artifactCalls(calls).filter((call) => call.endsWith("/artifacts"))
+          .length,
+        8,
+      );
+    },
+  );
+});
+
+Deno.test("benchmark: a run still in flight is not sampled", async () => {
+  // A conclusion of null is not a colour, it is an absence: the run has not
+  // finished and has no artifact to read. Only completed runs are sampled.
+  const id = 11_700;
+  const inFlight = {
+    ...ghRun(11_701, SAMPLED_BASE + HOUR),
+    status: "in_progress",
+    conclusion: null,
+  };
+  await withApi({
+    pages: { 1: [inFlight, ghRun(id, SAMPLED_BASE)] },
+    artifacts: {
+      [id]: [{ id: id * 10, name: "bench-results", expired: false }],
+    },
+    zips: {
+      [id * 10]: await benchZip(
+        report([
+          bench("packages/a/x.bench.ts", null, "work", { avg: 5e6 } as Timings),
+        ]),
+      ),
+    },
+  }, async (calls) => {
+    await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    assertEquals(
+      artifactCalls(calls).filter((call) => call.includes("/11701/")),
+      [],
+    );
+  });
+});
+
+Deno.test("benchmark: the calibration the tile divides out is the one CI runs", async () => {
+  // The correction is only as good as the artifact carrying it. The tile names
+  // one file, the workflow runs one file, and its validation step fails a run
+  // that produced no calibration. Nothing else keeps those three together.
+  const root = new URL("../../../", import.meta.url);
+  await Deno.stat(new URL(CALIBRATION_FILE, root));
+  const workflow = await Deno.readTextFile(
+    new URL(".github/workflows/benchmarks.yml", root),
+  );
+  assertStringIncludes(workflow, `\n            ${CALIBRATION_FILE} \\\n`);
+  assertStringIncludes(workflow, `"/${CALIBRATION_FILE}",`);
 });
 
 Deno.test("benchmark: returns a failed rising view after the run list settles", async () => {
@@ -1457,12 +1712,14 @@ Deno.test("benchmark: a run that finished green but produced no valid data reads
 });
 
 Deno.test("benchmark: unusable artifacts gray out cold, then a blipped read is retried and recovers", async () => {
-  // Four successful runs in four different windows, each with an artifact unusable
+  // Five successful runs in five different windows, each with an artifact unusable
   // a different way. On a cold cache the sum has nothing to read, so the tile grays
-  // out rather than inventing a number. 401 (only an expired artifact and the wrong
-  // one) and 403 (a zip holding no report) reach a definite answer and are settled;
-  // 402 (the zip download failed) and 404 (the listing itself failed) reach no
-  // answer and must be retried when the source recovers. An isolated cache keeps
+  // out rather than inventing a number. The split is whether the answer can change
+  // on a later try. 401 (only an expired artifact and the wrong one), 403 (a zip
+  // holding no report) and 405 (a report that will not parse) are settled: the
+  // bytes were read and a run attempt keeps the artifact it uploaded. 402 (the zip
+  // download failed) and 404 (the listing itself failed) reached no answer at all
+  // and must be retried when the source recovers. An isolated cache keeps
   // the cold-start assertion honest — a shared cache would leak another test's runs.
   const directory = await Deno.makeTempDir({ prefix: "benchmark-unusable-" });
   const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
@@ -1472,6 +1729,7 @@ Deno.test("benchmark: unusable artifacts gray out cold, then a blipped read is r
     ghRun(401, BASE - 3 * DAY),
     ghRun(402, BASE - 2 * DAY),
     ghRun(403, BASE - 1 * DAY),
+    ghRun(405, BASE - HOUR),
     ghRun(404, BASE),
   ];
   const art = (id: number, name = "bench-results", expired = false) => ({
@@ -1486,6 +1744,7 @@ Deno.test("benchmark: unusable artifacts gray out cold, then a blipped read is r
       401: [art(4_010, "bench-results", true), art(4_011, "coverage")], // expired, and the wrong artifact
       402: [art(4_020)], // the zip download fails
       403: [art(4_030)], // the zip holds no json
+      405: [art(4_050)], // the zip holds a report that will not parse
       404: 500, // the listing itself fails
     },
     zips: {
@@ -1495,6 +1754,7 @@ Deno.test("benchmark: unusable artifacts gray out cold, then a blipped read is r
         method: 0,
         data: bytes("nothing useful"),
       }]),
+      4_050: await benchZip("this is not the report"),
     },
   });
   globalThis.fetch = ((input: RequestInfo | URL) => {
@@ -1543,6 +1803,10 @@ Deno.test("benchmark: unusable artifacts gray out cold, then a blipped read is r
     assert(
       !calls.some((c) => c.includes("/runs/403/artifacts")),
       "a zip with no report is settled",
+    );
+    assert(
+      !calls.some((c) => c.includes("/runs/405/artifacts")),
+      "a report that will not parse is settled",
     );
   } finally {
     globalThis.fetch = originalFetch;
@@ -1995,9 +2259,13 @@ Deno.test("benchmark: CPU lines split across large gaps and use distinct colors"
         pointCount: match[1].split(" ").length,
         stroke: match[2],
       }));
+      // Eight points on each of the two long lines. The first CPU has nine
+      // runs, but two of them sit in one collection bucket, minutes apart, and
+      // the trend reads one run per BENCH_TREND_BUCKET_MS. The drill-down below
+      // still counts all nine.
       assertEquals(
         tileLines.map((line) => line.pointCount).sort((a, b) => a - b),
-        [2, 2, 2, 2, 2, 2, 8, 9],
+        [2, 2, 2, 2, 2, 2, 8, 8],
       );
       assertEquals(new Set(tileLines.map((line) => line.stroke)).size, 8);
       const tileMarkerColors = [

--- a/packages/dashboard/tiles/benchmark.ts
+++ b/packages/dashboard/tiles/benchmark.ts
@@ -18,14 +18,28 @@
  *
  * A benchmark added or removed is absent from one side of an adjacent
  * comparison, so it does not move the index. A processor change starts another
- * line instead of connecting unlike machines. Each line's recent window
- * contains the runs in the last BENCH_TREND_MAX_AGE_DAYS or the newest
- * BENCH_TREND_MIN_RUNS, whichever is larger, and the full line spans about 45
- * days. The failed state reads the workflow-run list and the latest run's
- * cached result, so it works when artifacts cannot be read. Without usable
- * data, the dashboard keeps the last completed color and values while a fetch
- * runs, and reads "benchmark data unavailable" after an empty fetch. A failed
- * fetch keeps the last-known processor lines gray and names the reason.
+ * line instead of connecting unlike machines. A processor model is not a
+ * machine, though: the runner group hands a run whatever share of a shared host
+ * the other tenants leave it, and hosts under one model have measured a fifth
+ * apart on work that touches no repository code. So each step also divides out
+ * the machine, read from the calibration benchmarks the same run carries, and a
+ * run that landed on a busy host reads as the busy host it was. The index takes
+ * one run per BENCH_TREND_BUCKET_MS, matching the benchmarks.yml cadence, so a
+ * re-run or a manual dispatch does not put two samples of one moment into the
+ * fit. Each line's recent window contains the runs in the last
+ * BENCH_TREND_MAX_AGE_DAYS or the newest BENCH_TREND_MIN_RUNS, whichever is
+ * larger, and the full line spans about 45 days.
+ *
+ * A red run is read like any other: `deno bench` exits non-zero when one
+ * benchmark throws, having written a complete report of the rest, so a run's
+ * colour says nothing about whether it measured anything. What decides that is
+ * the artifact, which has to parse, name a processor, and carry benchmarks the
+ * tile trends. The failed state reads the workflow-run list and the latest
+ * run's cached result, so it is unaffected by which runs the trend samples, and
+ * it works when artifacts cannot be read. Without usable data, the dashboard
+ * keeps the last completed color and values while a fetch runs, and reads
+ * "benchmark data unavailable" after an empty fetch. A failed fetch keeps the
+ * last-known processor lines gray and names the reason.
  *
  * Every collection pages the run list, once a minute, which is the cadence the
  * run state needs. The artifact history behind the tile moves with the runs
@@ -78,6 +92,7 @@ import {
   SPARK_FADE,
 } from "../lib.ts";
 import {
+  BENCH_TREND_BUCKET_MS,
   BENCH_TREND_MAX_AGE_DAYS,
   BENCH_TREND_MIN_RUNS,
   REPO,
@@ -345,6 +360,27 @@ const benchKey = (b: Bench): string =>
     b.group ? b.group + "/" : ""
   }${b.name}`;
 
+// The benchmarks that measure the machine rather than the repository. The
+// Benchmarks workflow runs this file alongside the product benchmarks and its
+// bodies call no repository code, so what moves them between two runs on one
+// processor is the host. They are the tile's ruler, not one of the things it
+// measures: they set each run's machine factor and take no other part, so they
+// are absent from the index, from the benchmark count, and from the
+// drill-down. Runs from before the calibration landed carry none, and read
+// uncorrected.
+export const CALIBRATION_FILE =
+  "packages/dashboard/machine-calibration.bench.ts";
+const isCalibrationKey = (key: string): boolean =>
+  key.startsWith(`${CALIBRATION_FILE} > `);
+
+// How many of a run's benchmarks are the repository's. Zero means the run
+// measured nothing the tile trends, whatever else its artifact holds.
+const productMetricCount = (run: { metrics: Map<string, Stats> }): number => {
+  let count = 0;
+  for (const key of run.metrics.keys()) if (!isCalibrationKey(key)) count++;
+  return count;
+};
+
 const UNKNOWN_CPU = "Unknown CPU";
 
 // Wall-clock span of a series (first to last point), in milliseconds.
@@ -497,6 +533,7 @@ async function loadRun(
 ): Promise<{ cached: boolean; error?: unknown }> {
   let cpu = UNKNOWN_CPU;
   let metrics = new Map<string, Stats>();
+  let zip: Uint8Array<ArrayBuffer> | undefined;
   try {
     const arts = await github.json<{ artifacts?: Artifact[] }>(
       `repos/${REPO}/actions/runs/${run.id}/artifacts`,
@@ -505,16 +542,7 @@ async function loadRun(
     const art = (arts.artifacts ?? []).find((a) =>
       a.name === ARTIFACT && !a.expired
     );
-    if (art) {
-      const json = await jsonFromZip(await fetchZip(art.id, token, github));
-      if (json) {
-        const report = parseBenchmarkReport(json);
-        if (report.cpu !== undefined) {
-          cpu = report.cpu;
-          metrics = report.metrics;
-        }
-      }
-    }
+    if (art) zip = await fetchZip(art.id, token, github);
   } catch (error) {
     // The read failed, so whether this run has usable results is still unknown.
     // Caching the empty map here would answer that question with "no" and never ask
@@ -522,6 +550,24 @@ async function loadRun(
     // from the trend for the life of the process. Record nothing and retry on the
     // next refresh.
     return { cached: false, error };
+  }
+  if (zip !== undefined) {
+    try {
+      const json = await jsonFromZip(zip);
+      const report = json === null ? undefined : parseBenchmarkReport(json);
+      if (report?.cpu !== undefined) {
+        cpu = report.cpu;
+        metrics = report.metrics;
+      }
+    } catch {
+      // Reading bytes already in hand is deterministic, and a run attempt's
+      // artifact never changes, so an artifact that will not parse now will not
+      // parse later either. That is the same answer as a run with no artifact
+      // at all, and it is recorded the same way: an empty map, which reads as
+      // no benchmark data. Reporting it instead would gray the whole tile on
+      // one bad artifact and hold back the refresh marker for as long as that
+      // artifact stayed in the window.
+    }
   }
   benchmarkStore.set({
     runId: run.id,
@@ -564,6 +610,7 @@ function assembleBenchmarkSeries(
   for (const run of [...runs].sort((a, b) => a.at - b.at)) {
     if (run.cpu === undefined) continue;
     for (const [key, stats] of run.metrics) {
+      if (isCalibrationKey(key)) continue;
       let byCpu = byKey.get(key);
       if (!byCpu) {
         byCpu = new Map();
@@ -598,7 +645,7 @@ function assembleBenchmarkSnapshot(runs: Run[]): BenchmarkSeries[] {
   return assembleBenchmarkSeries(
     runs.flatMap((run) => {
       const cached = currentBenchmarkRun(run);
-      return cached?.cpu !== undefined && cached.metrics.size > 0
+      return cached?.cpu !== undefined && productMetricCount(cached) > 0
         ? [cached]
         : [];
     }),
@@ -660,13 +707,24 @@ async function markBenchmarkRefreshed(
   benchmarkRefreshedAt = benchmarkStore.refreshedAt;
 }
 
+// Every completed run in the window, thinned to one per collection bucket. A
+// run's colour does not decide whether it measured anything: `deno bench` exits
+// non-zero when any one benchmark throws, having already written a complete
+// report of the rest, and the workflow uploads that report either way. Over one
+// recent 45-day stretch, 26 of the 30 red runs carried an artifact
+// indistinguishable from a green run's, and they arrived in blocks of a dozen
+// or more consecutive runs — so the runs the tile lost were concentrated
+// exactly where a thinned line does the most damage. What makes a run usable is
+// the artifact, and every reader below already checks that: a report has to
+// parse, name a processor, and carry benchmarks the tile trends. The tile's red
+// state is unaffected, because it reads the run list rather than this sample.
 export function sampleBenchmarkRuns<
   T extends { created_at: string; conclusion: string | null },
 >(runs: T[], cutoff: number): T[] {
   const perBucket = new Map<number, T>();
   for (const run of runs) {
     const at = Date.parse(run.created_at);
-    if (run.conclusion !== "success" || at < cutoff) continue;
+    if (run.conclusion === null || at < cutoff) continue;
     const bucket = Math.floor(at / COLLECTION_BUCKET_MS);
     const current = perBucket.get(bucket);
     if (!current || at > Date.parse(current.created_at)) {
@@ -698,17 +756,19 @@ const errorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
 
 // The geometric mean of the per-benchmark ratios between two runs on the same
-// processor, over the benchmarks they share (each with a positive average).
-// Geometric, not arithmetic, so a benchmark that doubles and one that halves
-// cancel to no change. A benchmark in only one of the two runs is not in the
-// ratio, so adding or removing one is not a change. 1 when the runs share
-// nothing.
-function benchmarkStepRatio(
+// processor, over the benchmarks they share that match `select` (each with a
+// positive average). Geometric, not arithmetic, so a benchmark that doubles and
+// one that halves cancel to no change. A benchmark in only one of the two runs
+// is not in the ratio, so adding or removing one is not a change. 1 when the
+// runs share nothing selected.
+function sharedBenchmarkRatio(
   previous: CachedBenchmarkRun,
   current: CachedBenchmarkRun,
+  select: (key: string) => boolean,
 ): number {
   let logSum = 0, count = 0;
   for (const [key, stats] of current.metrics) {
+    if (!select(key)) continue;
     const before = previous.metrics.get(key);
     if (before && before.avg > 0 && stats.avg > 0) {
       logSum += Math.log(stats.avg / before.avg);
@@ -716,6 +776,32 @@ function benchmarkStepRatio(
     }
   }
   return count ? Math.exp(logSum / count) : 1;
+}
+
+// How the repository's benchmarks moved between two runs on the same processor.
+function benchmarkStepRatio(
+  previous: CachedBenchmarkRun,
+  current: CachedBenchmarkRun,
+): number {
+  return sharedBenchmarkRatio(
+    previous,
+    current,
+    (key) => !isCalibrationKey(key),
+  );
+}
+
+// How the machine moved between two runs on the same processor, read from the
+// calibration benchmarks. Two runs on one processor model are not two runs on
+// one machine: a run gets whatever share of a shared host is left to it, and
+// hosts under a single model have measured a fifth apart on work that touches
+// no repository code. Dividing this out of the step leaves what the repository
+// did. 1 when either run predates the calibration, which leaves that step
+// uncorrected rather than guessing at it.
+function machineStepRatio(
+  previous: CachedBenchmarkRun,
+  current: CachedBenchmarkRun,
+): number {
+  return sharedBenchmarkRatio(previous, current, isCalibrationKey);
 }
 
 const CPU_COLORS = [
@@ -812,6 +898,23 @@ interface BenchmarkCpuIndex {
 
 type CpuBenchmarkRun = CachedBenchmarkRun & { cpu: string };
 
+// One run per trend bucket on one processor, newest kept, oldest first. The
+// collection keeps far finer resolution than this, because the drill-down's
+// shortest view needs it, and the trend does not: the benchmarks run four-
+// hourly, so runs closer together than that are a re-run, a manual dispatch or
+// a schedule catching up. Counted as separate samples they let one stretch of
+// wall clock supply the whole of a level, and a level the headline is read off
+// rests on as few as three samples.
+export function benchmarkTrendRuns<T extends { at: number }>(runs: T[]): T[] {
+  const perBucket = new Map<number, T>();
+  for (const run of runs) {
+    const bucket = Math.floor(run.at / BENCH_TREND_BUCKET_MS);
+    const current = perBucket.get(bucket);
+    if (!current || run.at > current.at) perBucket.set(bucket, run);
+  }
+  return [...perBucket.values()].sort((a, b) => a.at - b.at);
+}
+
 function benchmarkCpuIndices(
   cached: CpuBenchmarkRun[],
   now: number,
@@ -826,12 +929,15 @@ function benchmarkCpuIndices(
   const colors = cpuColors(byCpu.keys());
   return [...byCpu]
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([cpu, runs]) => {
-      runs.sort((a, b) => a.at - b.at);
+    .map(([cpu, sampled]) => {
+      const runs = benchmarkTrendRuns(sampled);
       const points: { at: number; index: number }[] = [];
       let index = 1;
       for (let run = 0; run < runs.length; run++) {
-        if (run > 0) index *= benchmarkStepRatio(runs[run - 1], runs[run]);
+        if (run > 0) {
+          index *= benchmarkStepRatio(runs[run - 1], runs[run]) /
+            machineStepRatio(runs[run - 1], runs[run]);
+        }
         points.push({ at: runs[run].at, index });
       }
       const inWindow = points.filter((point) =>
@@ -971,16 +1077,17 @@ function benchmarkIndexView(
   const latestResult = latestCompleted?.conclusion === "success"
     ? benchmarkStore.get(latestCompleted.id)
     : undefined;
-  const noData = latestResult !== undefined && latestResult.metrics.size === 0;
+  const noData = latestResult !== undefined &&
+    productMetricCount(latestResult) === 0;
   const failed = failedCi || noData;
   const failSub = failedCi
     ? benchmarkFailureLabel(runs, now)
     : "no benchmark data";
-  // The successful runs with processor identities and readable artifacts in the
-  // window, oldest -> newest.
+  // The runs with processor identities and readable artifacts in the window,
+  // oldest -> newest. The artifact decides, not the run's colour.
   const cached = (benchmarkStore.refreshedRuns() ?? benchmarkStore.list(cutoff))
     .filter((run): run is CpuBenchmarkRun =>
-      run.at >= cutoff && run.cpu !== undefined && run.metrics.size > 0
+      run.at >= cutoff && run.cpu !== undefined && productMetricCount(run) > 0
     )
     .sort((a, b) => a.at - b.at);
   const indices = benchmarkCpuIndices(cached, now);
@@ -1024,7 +1131,7 @@ function benchmarkIndexView(
   // Headline: the window's trend.
   const value = escapeHtml(headline.trend.label);
   const latest = cached[cached.length - 1];
-  const count = latest.metrics.size;
+  const count = productMetricCount(latest);
   // Name the highlighted window's span beside the count, like CI duration names its
   // median window — in days (via humanSpan), not "runs", so it does not read as the
   // main-CI run count. Only when a window is actually highlighted; otherwise the


### PR DESCRIPTION
The benchmark tile's headline read a 21% rise over 392 benchmarks and 13 days. The named step regressions do not account for it: undoing all of them takes the figure only to 13.2%. The remainder is not code.

WHAT THE TILE WAS MEASURING

The tile draws one line per processor model so it never compares unlike machines. A processor model is not a machine. Over the 45 days it charts, the pinned runner group served six processor models, and within one model a run gets whatever share of a shared host the other tenants leave it. Reading the `packages/utils` benchmarks, which run no runner code, as a hardware control: the EPYC 7763 is steady to 2% across 241 runs, but 13 of the EPYC 9V74's 135 runs land on a host 23% faster than the rest, and 3 of the 8573C's 39 land on one about 20% slower.

The 8573C's own baseline is flat across all 45 days, so its environment did not drift. What happened is that its last two runs, 48 minutes apart, both landed on a slow host: every benchmark in both is up by about a fifth, including the pure arithmetic loops that call nothing. A commit does not make 392 unrelated benchmarks uniformly slower; a busy host does. Those two runs are two of the three samples the trend fit reads its final level from, so the headline is the host.

Nothing in the artifact let the tile know that, because the only machine identity it carried was the processor model string. So the Benchmarks workflow now also measures the machine.
`packages/dashboard/machine-calibration.bench.ts` holds twelve benchmarks that import nothing and call no repository code, spanning arithmetic throughput, allocation and collection, memory bandwidth and hash-table work. The workflow runs them in the same report and the same artifact, and its validation step fails a run whose report carries none of them. Each index step now divides the geometric mean of the calibration benchmarks' ratios out of the product benchmarks' one, leaving what the repository did. The calibration is the tile's ruler rather than one of the things it measures, so it is absent from the index, the benchmark count and the drill-down. A run from before the calibration carries none, and that step is left uncorrected rather than guessed at.

Sizing the calibration mattered more than its shape. Written first with bodies of a few tens of microseconds, it was a worse ruler than the thing it measured: over six runs on one machine its geometric mean varied by a factor of 1.85 against the utils benchmarks' 1.37, and their ratio varied by 2.01, which is noise the calibration was making rather than finding. A body that short is measured partly interpreted and partly compiled, and which it is varies between runs by more than the machine does. Bodies of a few hundred microseconds with an explicit warmup bring its own variation to 1.28 against the utils benchmarks' 1.31 and their ratio to 1.21, and cost about seven seconds in a job that runs for nine minutes.

The correction reaches as far as the machine and no further, which BENCHMARKS.md now says: a host busy for the whole job is divided out, but the browser benchmarks run against a toolshed this same job started, and contention between them sits inside their numbers with nothing to subtract it against.

Which point of the job the calibration is read at is deno bench's to choose, and not the workflow list's. It does not run files in the order they are listed: listing the same files in reverse produces the identical report, and the two browser files run first rather than last where the list puts them. The order it picks is stable across runs, which is what a ruler needs, but it is not arranged from the workflow, and the comment there that claimed otherwise is corrected.

WHICH RUNS IT WAS MEASURING

Two smaller defects fed the same failure, and both are about how few samples a level rests on.

The workflow's comment said the dashboard samples one run per four-hour window. It did not: the collection buckets at 7.2 minutes, which is the resolution the drill-down's one-day view needs and far more than a 13-day trend over twenty points wants. That is how one slow episode supplied two of the three samples behind the final level. The trend now reads one run per BENCH_TREND_BUCKET_MS, matching the cron, while the drill-down keeps every run.

The trend also sampled successful runs only. That reads as caution and behaves as data loss: `deno bench` exits non-zero when any single benchmark throws, having already written a complete report of every other one, and the workflow uploads it either way. Over the last 200 runs, 30 were red and 26 carried an artifact indistinguishable from a green run's. They arrive in blocks — eleven consecutive runs on 23 and 24 July, fifteen across 8 to 10 August — so the runs the tile lost were concentrated exactly where a thinned line does the most damage. Sampling now takes every completed run and lets the artifact decide, which every reader already checked: it has to parse, name a processor, and carry benchmarks the tile trends. The tile's red state is untouched, because it reads the workflow-run list rather than this sample.

That widening newly exposes a corrupt artifact to the sampler, and the read path would have refetched one on every refresh forever. It retried anything that threw, on the reasoning that a blip must not settle a run's fate for the life of the process. That covers a failed fetch and not a failed parse: once the bytes are in hand the answer is deterministic, and a run attempt's artifact never changes. The two are now separated.

WHAT THE CHANGES DO TO THE NUMBERS

Replaying the history through the tile's own helpers, the headline goes from 21.0% to 4.4%, and the three processors move from 21.0%, 3.2% and 5.0% to 0.0%, 3.9% and 4.4%. Three machines measuring the same commits over the same days now agree. Recovering the red runs puts 14% more runs into the last 45 days and takes the trend windows from 33, 21 and 20 samples to 39, 28 and 20.

The trend fit in packages/dashboard/trend.ts is unchanged. Its 21.0% against the window's own 13.3% end-to-end move is entirely the first level, which averages across a real improvement that landed one sample into the window because the change-point search may not place a boundary that close to an edge. Distrusting a lone sample is the right policy when about one run in ten lands off-norm, and the changes that would have blunted it would trade a spurious red for a spurious green on a tile whose job is catching regressions.

The investigation is recorded in
docs/history/development/performance/2026-08-benchmark-headline-machine-noise.md.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

