### PR TITLE
fix(runner): stop minting commits against a rejected optimistic layer

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -668,6 +668,15 @@ the per-epic implementation notes).
   on FIFO arrival) would otherwise have had to re-discover the hazard. It had
   also never shown a measured win: neutral on lunch-poll (safe but no win,
   because the staleness is only knowable on the server, not locally).
+- **What feeds it changed.** The stale floors `preempt` reads are recorded from
+  server conflict verdicts, so they only cover commits that were actually sent.
+  A commit refused before the wire for naming an already-rejected optimistic
+  layer records none. That removes a population of floors that used to exist: a
+  "pending dependency not resolved" verdict says nothing about the versions of
+  the identifiers the commit read or wrote, so the floor it recorded was
+  spurious and pre-empted commits on evidence it did not have. Anyone
+  re-measuring `preempt` is measuring against a smaller and more accurate set of
+  floors than the numbers below were taken on.
 - **Current default and planned end state.** `off` by default. `preempt` was
   measured net-negative on the lunch-poll workload (it pre-empted commits that
   would have succeeded). The code comment warns not to enable it without

--- a/docs/specs/memory-v2/03-commit-model.md
+++ b/docs/specs/memory-v2/03-commit-model.md
@@ -204,11 +204,24 @@ therefore records its FULL dependency set directly: the read's `localSeq`
 array names every pending layer of the document that the reader's
 materialized view sat on, in ascending order. Each element imposes a
 resolution requirement; the highest element — the view's top-of-stack layer
-— is the legacy staleness basis when no `basisSeq` is declared (§3.6.3). The
-client mirrors the server cascade at drop time: when a pending commit's
-optimistic writes are dropped, every queued or in-flight commit whose
-recorded dependency set names the dropped `localSeq` is locally rejected
-without waiting for the server's per-commit verdict.
+— is the legacy staleness basis when no `basisSeq` is declared (§3.6.3).
+
+The client mirrors the server cascade from the moment a rejection is KNOWN,
+not from the moment the layer leaves the overlay. A client that keeps a
+rejected layer in its overlay past the verdict — to hold the drop until the
+conflict's read repair lands, so that a retry rebuilds against repaired
+confirmed state — is still building views over that layer meanwhile, and so
+still names it. It MUST reject such a commit locally rather than send it,
+because the server can only answer it with "pending dependency not
+resolved"; the same applies to every queued or in-flight commit naming a
+`localSeq` whose optimistic writes are dropped. Deciding at the verdict
+rather than at the drop is what bounds the cost: otherwise one conflict
+spawns a doomed round trip per commit minted anywhere in that window, which
+is a run of them under sustained write load, and the window is bounded only
+by a timer the client may be in no position to fire. The local rejection's
+readiness gate waits for the dependency's drop, so the retry rebuilds
+against the repaired base rather than against the dead layer that doomed
+it.
 
 Completeness is relative to the VIEW, not to the session's commit history,
 so the array may be non-contiguous in the session's `localSeq` space. A

--- a/docs/specs/memory-v2/09-invariants.md
+++ b/docs/specs/memory-v2/09-invariants.md
@@ -189,17 +189,24 @@ tests (`packages/runner/test/memory-v2-stacked-commit.test.ts`).
 ### INV-4 — Cascade totality
 
 > If a pending commit is rejected, every commit whose recorded dependency set
-> names it is also rejected (server side), and every queued or in-flight
-> commit naming it is dropped before its verdict arrives (client mirror).
-> Combined with INV-3(a), no commit built on a rejected layer's optimistic
-> value is ever durably accepted.
+> names it is also rejected (server side), and no commit naming it is left
+> standing on the client: one already queued or in flight is dropped before
+> its verdict arrives, and one minted after the rejection is refused before
+> it is sent. Combined with INV-3(a), no commit built on a rejected layer's
+> optimistic value is ever durably accepted.
+
+The client mirror has to cover both halves because a rejected layer outlives
+its verdict: the drop waits for the conflict's read repair, and the layer is
+visible to dependency recording for that whole window. Covering only the
+drop leaves every commit minted during the repair to be sent and refused by
+the server, one round trip each.
 
 Note the division of labor: the cascade mechanism is only as good as the
 dependency sets it walks (INV-3). A complete cascade over incomplete
 dependencies still admits phantoms.
 
 Layer: server (`resolvePendingReads` rejection path); client drop cascade
-(`packages/runner/src/storage/v2.ts`).
+and pre-send refusal (`packages/runner/src/storage/v2.ts`).
 
 Soundness direction: MAY drop commits that name a rejected layer they did
 not semantically depend on (over-coupling, a wasted retry); MUST NOT leave a

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -2048,6 +2048,15 @@ class SpaceReplica implements ISpaceReplica {
   // are dropped. See the InFlightCommit doc for why zero-pending-read commits
   // are never registered.
   readonly #inFlightCommits = new Map<number, InFlightCommit>();
+  // Commits whose rejection verdict is known but whose optimistic layer is
+  // still standing in `record.pending`, because finalizeRejection holds the
+  // drop until the conflict read repair completes. buildReads names every
+  // layer it finds, so a commit minted in that window names a layer the
+  // server will never resolve. Maps the dead localSeq to a promise that
+  // settles when its drop completes: the pre-send checkpoint rejects such a
+  // commit locally and gates its retry on that promise, so the retry rebuilds
+  // against the repaired base rather than the dead one.
+  readonly #rejectedPendingLayers = new Map<number, Promise<void>>();
   // Every unsettled commit's outcome promise, keyed by localSeq (a superset
   // of #inFlightCommits: zero-read commits appear here too). The old-server
   // scalarization hold awaits these for the OMITTED lower dependencies —
@@ -3493,7 +3502,47 @@ class SpaceReplica implements ISpaceReplica {
       commit,
       source,
     );
+    const telemetry = this.#getTelemetry();
+    const pushOpId = `push:${this.#space}:${localSeq}`;
     try {
+      if (inFlight !== undefined) {
+        // A dependency rejected before this commit was even minted: its
+        // optimistic layer outlives the verdict by the length of the read
+        // repair, and buildReads names every layer still standing. Settle
+        // here so the doomed commit never reaches the wire — this is the
+        // window a single conflict otherwise turns into a run of commits the
+        // server can only reject.
+        const sealed = this.preSendRejection(inFlight);
+        if (sealed !== undefined) {
+          logger.debug("commit-dead-dependency", () => [
+            `commit rejected before send: ${sealed.message}`,
+            { localSeq, operations: operations.length },
+          ]);
+          // Traced like any other failed push, with no session id because no
+          // session was dialed. The storm this checkpoint suppresses was
+          // found by counting errored push spans, so the suppression has to
+          // be countable on the same surface.
+          telemetry?.submit({
+            type: "storage.push.start",
+            id: pushOpId,
+            operation: "transact",
+            localSeq,
+            spaceDid: this.#space,
+          });
+          telemetry?.submit({
+            type: "storage.push.error",
+            id: pushOpId,
+            error: sealed.name,
+          });
+          notifyRejectionSources(sealed);
+          return await this.finalizeRejection(
+            localSeq,
+            operations,
+            source,
+            sealed,
+          );
+        }
+      }
       // Strategy 1: a commit whose read set lands on a still-catching-up id.
       const admissionMode = conflictAdmissionMode();
       if (admissionMode !== "off") {
@@ -3517,8 +3566,6 @@ class SpaceReplica implements ISpaceReplica {
       // The push marker window covers observation flush + (re)dial + send +
       // confirm: the full client-side cost of durably landing this commit.
       // (space.did, commit.local_seq) joins to the server's memory.transact span.
-      const telemetry = this.#getTelemetry();
-      const pushOpId = `push:${this.#space}:${localSeq}`;
       telemetry?.submit({
         type: "storage.push.start",
         id: pushOpId,
@@ -3578,22 +3625,25 @@ class SpaceReplica implements ISpaceReplica {
             await Promise.all(waits);
           }
         }
-        if (inFlight?.localRejectionValue !== undefined) {
-          // A pending dependency was dropped while we awaited the scheduler
-          // batch flush or the session handshake — do not send a commit whose
-          // doom is already provable.
+        const sealed = inFlight === undefined
+          ? undefined
+          : this.preSendRejection(inFlight);
+        if (sealed !== undefined) {
+          // A pending dependency was rejected or dropped while we awaited the
+          // scheduler batch flush, the session handshake, or the old-server
+          // hold — do not send a commit whose doom is already provable.
           telemetry?.submit({
             type: "storage.push.error",
             id: pushOpId,
             sessionId: session.sessionId,
-            error: inFlight.localRejectionValue.name ?? "TransactionError",
+            error: sealed.name,
           });
-          notifyRejectionSources(inFlight.localRejectionValue);
+          notifyRejectionSources(sealed);
           return await this.finalizeRejection(
             localSeq,
             operations,
             source,
-            inFlight.localRejectionValue,
+            sealed,
           );
         }
         if (inFlight === undefined) {
@@ -3787,58 +3837,70 @@ class SpaceReplica implements ISpaceReplica {
     source: IStorageTransaction | undefined,
     rejection: StorageTransactionRejected,
   ): Promise<Result<Unit, StorageTransactionRejected>> {
-    // The fate is sealed here. The verdict-gated effect layer (verdict
-    // callbacks, outbox clearing) fires on this notification; the
-    // settlement promise and commit callbacks wait out the read-repair
-    // gate below, because a retry needs the repaired base.
-    if (source !== undefined) {
-      notifyCommitRejected(source, rejection);
-    }
-    const touched = operations.map((operation) => ({
-      id: operation.id,
-      scope: operation.scope,
-    }));
-    const hasSemanticOperations = operations.length > 0;
-    const shouldNotifySubscribers = hasSemanticOperations &&
-      this.hasNotificationSubscribers();
-    const shouldNotifySinks = hasSemanticOperations &&
-      this.hasSinkSubscribers(touched);
-    const before = shouldNotifySubscribers
-      ? Differential.checkout(
-        this,
-        touched.map(({ id, scope }) => snapshotState(this, id, scope)),
-      )
-      : undefined;
-    await this.waitForConflictReadRepair(rejection);
-    this.dropPending(localSeq);
-    // Every drop funnels through here (server conflict, preempt, cascade,
-    // reset — this is dropPending's only call site), so scanning right after
-    // the drop catches every dependant; transitivity emerges from recursion
-    // (a victim's own finalizeRejection lands back here with its localSeq).
-    this.cascadeDroppedDependency(localSeq);
-    if (before !== undefined) {
-      const changes = before.compare(this);
-      // The revert snapshots CURRENT confirmed state (which already includes
-      // any newer seq received by subscription since this commit started) and
-      // drops only this commit's pending write — so it should not stomp newer
-      // data. Counted to verify reverts stay bounded.
-      logger.debug("commit-revert", () => [
-        `revert after ${rejection.name ?? "rejection"}`,
-      ]);
-      this.#subscription.next({
-        type: "revert",
-        space: this.#space,
-        changes,
-        reason: rejection,
-        source,
-      });
-      if (shouldNotifySinks) {
-        this.notifySinks(changes);
+    // The verdict is known from here on, but this commit's optimistic layer
+    // stands in `record.pending` for as long as the read repair below runs.
+    // Mark the layer dead for that window so no new commit is minted and sent
+    // against it; the promise settles once the drop and its revert are done.
+    const dropped = Promise.withResolvers<void>();
+    this.#rejectedPendingLayers.set(localSeq, dropped.promise);
+    try {
+      // The fate is sealed here. The verdict-gated effect layer (verdict
+      // callbacks, outbox clearing) fires on this notification; the
+      // settlement promise and commit callbacks wait out the read-repair
+      // gate below, because a retry needs the repaired base.
+      if (source !== undefined) {
+        notifyCommitRejected(source, rejection);
       }
-    } else if (shouldNotifySinks) {
-      this.notifySinksForIds(touched);
+      const touched = operations.map((operation) => ({
+        id: operation.id,
+        scope: operation.scope,
+      }));
+      const hasSemanticOperations = operations.length > 0;
+      const shouldNotifySubscribers = hasSemanticOperations &&
+        this.hasNotificationSubscribers();
+      const shouldNotifySinks = hasSemanticOperations &&
+        this.hasSinkSubscribers(touched);
+      const before = shouldNotifySubscribers
+        ? Differential.checkout(
+          this,
+          touched.map(({ id, scope }) => snapshotState(this, id, scope)),
+        )
+        : undefined;
+      await this.waitForConflictReadRepair(rejection);
+      this.dropPending(localSeq);
+      // Every drop funnels through here (server conflict, preempt, cascade,
+      // reset — this is dropPending's only call site), so scanning right
+      // after the drop catches every dependant; transitivity emerges from
+      // recursion (a victim's own finalizeRejection lands back here with its
+      // localSeq).
+      this.cascadeDroppedDependency(localSeq);
+      if (before !== undefined) {
+        const changes = before.compare(this);
+        // The revert snapshots CURRENT confirmed state (which already includes
+        // any newer seq received by subscription since this commit started)
+        // and drops only this commit's pending write — so it should not stomp
+        // newer data. Counted to verify reverts stay bounded.
+        logger.debug("commit-revert", () => [
+          `revert after ${rejection.name ?? "rejection"}`,
+        ]);
+        this.#subscription.next({
+          type: "revert",
+          space: this.#space,
+          changes,
+          reason: rejection,
+          source,
+        });
+        if (shouldNotifySinks) {
+          this.notifySinks(changes);
+        }
+      } else if (shouldNotifySinks) {
+        this.notifySinksForIds(touched);
+      }
+      return { error: rejection };
+    } finally {
+      this.#rejectedPendingLayers.delete(localSeq);
+      dropped.resolve();
     }
-    return { error: rejection };
   }
 
   private buildReads(
@@ -4216,13 +4278,17 @@ class SpaceReplica implements ISpaceReplica {
   }
 
   // Locally-fabricated rejection for a commit whose doom is provable
-  // client-side (dropped pending dependency, or replica reset). Modeled on
-  // makePreemptRejection. readyToRetry resolves immediately: the PRIMARY
-  // rejection's finalizeRejection already awaited its read repair (or reset
-  // wiped the replica outright), so a cascaded victim adds no wait of its own.
+  // client-side (dropped pending dependency, dependency rejected but not yet
+  // dropped, or replica reset). Modeled on makePreemptRejection.
+  // `readyToRetry` defaults to resolving immediately, which is right once the
+  // PRIMARY rejection's finalizeRejection has awaited its read repair (or
+  // reset wiped the replica outright): the victim adds no wait of its own.
+  // A commit rejected against a layer whose repair is still running passes
+  // that repair's completion here instead.
   private makeLocalRejection(
     commit: ClientCommit,
     message: string,
+    readyToRetry: () => Promise<void> = () => Promise.resolve(),
   ): StorageTransactionRejected {
     let firstId: URI | undefined;
     for (const operation of commit.operations) {
@@ -4244,7 +4310,7 @@ class SpaceReplica implements ISpaceReplica {
         existsInHistory: false,
         history: [],
       },
-      readyToRetry: () => Promise.resolve(),
+      readyToRetry,
     };
   }
 
@@ -4256,6 +4322,58 @@ class SpaceReplica implements ISpaceReplica {
       entry.commit,
       `pending dependency dropped locally: localSeq=${droppedLocalSeq}`,
     );
+  }
+
+  /**
+   * Returns the rejection that seals `entry`'s fate before it reaches the
+   * wire, or undefined when it may still be sent. Two things seal it: a local
+   * rejection already recorded on the entry, and a dependency whose own commit
+   * has been rejected while its optimistic layer is still standing. The
+   * rejection returned for the second carries a readiness gate covering every
+   * such layer, so a retry rebuilds against a base repaired of all of them.
+   */
+  private preSendRejection(
+    entry: InFlightCommit,
+  ): StorageTransactionRejected | undefined {
+    // The first shape comes from cascadeDroppedDependency or from reset.
+    if (entry.localRejectionValue !== undefined) {
+      return entry.localRejectionValue;
+    }
+    // The second: the server never gives a rejected layer a commit row, so it
+    // can only answer a commit naming one with "pending dependency not
+    // resolved". Fabricate that verdict here instead.
+    const dead: number[] = [];
+    for (const dependency of entry.dependencies) {
+      if (this.#rejectedPendingLayers.has(dependency)) {
+        dead.push(dependency);
+      }
+    }
+    if (dead.length === 0) {
+      return undefined;
+    }
+    // A commit reading two documents can sit on two dead layers from
+    // unrelated conflicts, whose repairs land at different times. Gating on
+    // only the first would let the retry re-read through the second and be
+    // refused all over again.
+    dead.sort((left, right) => left - right);
+    const drops = dead.map((dependency) =>
+      this.#rejectedPendingLayers.get(dependency)!
+    );
+    const rejection = this.makeLocalRejection(
+      entry.commit,
+      `pending dependency rejected: localSeq=${dead.join(",")}`,
+      async () => {
+        await Promise.all(drops);
+      },
+    );
+    // Recorded on the entry, so a later drop of one of these dependencies
+    // does not cascade over it a second time. It is a ConflictError, so the
+    // refused commit's own finalizeRejection awaits the gate too: its
+    // optimistic layer, and the revert that removes it, both wait for the
+    // drops. The chain terminates because buildReads only names layers below
+    // the reader's localSeq.
+    this.rejectInFlightCommitLocally(entry, rejection);
+    return rejection;
   }
 
   /**

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -45,6 +45,7 @@ import type {
   IStorageProvider,
   StorageNotification,
 } from "../src/storage/interface.ts";
+import type { RuntimeTelemetryMarker } from "../src/telemetry.ts";
 import { setConflictAdmissionMode } from "../src/storage/v2.ts";
 import {
   NotificationRecorder,
@@ -72,6 +73,10 @@ type DocKey = keyof typeof DOCS;
 
 type TestProvider = IStorageProvider & {
   get(uri: URI): EntityDocument | undefined;
+  sink(
+    uri: URI,
+    callback: (value: EntityDocument | undefined) => void,
+  ): () => void;
 };
 
 type RootValue = FabricValue;
@@ -583,6 +588,15 @@ const createHarness = (
     memoryHost: new URL(`memory://runner-v2-stacked-${crypto.randomUUID()}`),
   }, sessionFactory);
   const notifications = new NotificationRecorder();
+  // Every push marker the replica emits, in order. A commit refused at a
+  // pre-send checkpoint still opens and closes a span, so these are what
+  // prove the refusal stays countable on the surface the storm was found on.
+  const telemetryMarkers: RuntimeTelemetryMarker[] = [];
+  storageManager.setTelemetry({
+    submit: (marker: RuntimeTelemetryMarker) => {
+      telemetryMarkers.push(marker);
+    },
+  });
   const provider = storageManager.open(space) as TestProvider;
   storageManager.subscribe(notifications);
 
@@ -674,6 +688,7 @@ const createHarness = (
     provider,
     replica,
     notifications,
+    telemetryMarkers,
     dispatch,
     pushSync: (options: PushSyncOptions) => transport.pushSync(options),
     close: async () => {
@@ -3819,6 +3834,274 @@ Deno.test("memory v2 stacked commits: conflict rejection delivered before the wi
       ),
     ]);
     assertEquals(raced, "ready");
+  } finally {
+    await harness.close();
+  }
+});
+
+Deno.test("memory v2 stacked commits: a commit minted during the read repair is not sent against the rejected layer", async () => {
+  const harness = await createHarness();
+  // Debug level so the refusal's own lazy log closure runs: the count is how
+  // the checkpoint is observed in production, alongside its push span.
+  const storageLogger = getLogger("storage.v2");
+  const previousLevel = storageLogger.level;
+  storageLogger.level = "debug";
+  const deadDependencyBaseline = getLoggerCountsBreakdown()["storage.v2"]
+    ?.["commit-dead-dependency"]?.debug ?? 0;
+  try {
+    // Both sides at seq 1: A = v1, and the runner watches A so a pushed
+    // repair frame has a subscriber.
+    await seedAccepted(harness, DOCS.A, valueFor("v1"));
+    assertEquals(
+      await harness.replica.pull([[
+        { id: DOCS.A, type: DOCUMENT_MIME },
+        undefined,
+      ]]),
+      { ok: {} },
+    );
+
+    // A foreign winner lands server-side; its fan-out is not delivered.
+    harness.model.injectRemote({
+      label: "winner",
+      operations: [{ op: "set", id: DOCS.A, value: valueFor("v2winner") }],
+    });
+    const winnerSeq = harness.model.confirmed.get(DOCS.A)!.seq;
+
+    // A document sink over A, so the rejection's revert has to reach sink
+    // subscribers as well as the notification stream.
+    const sinkValues: (RootValue | undefined)[] = [];
+    const cancelSink = harness.provider.sink(DOCS.A, (document) => {
+      sinkValues.push(document?.value as RootValue | undefined);
+    });
+
+    // The loser: reads A at the stale confirmed basis, writes A, and is
+    // rejected with a retryable conflict. Its verdict arrives at once, but
+    // finalizeRejection holds the drop until the repair frame's marker — so
+    // its optimistic layer stands on A for the whole window below.
+    const conflictBaseline = getLoggerCountsBreakdown()["storage.v2"]
+      ?.["commit-conflict"]?.debug ?? 0;
+    const loser = beginSet(
+      harness,
+      DOCS.A,
+      valueFor("v1mine"),
+      sourceFromReads([{ id: DOCS.A, seq: 1 }]),
+    );
+    harness.model.setOutcome(loser.localSeq, {
+      kind: "rejectConflict",
+      retryAfterSeq: winnerSeq,
+    });
+    // "commit-conflict" is counted synchronously in pushCommit's catch, so
+    // once the count moves the verdict has reached the runner and the repair
+    // wait is the only thing keeping the layer alive.
+    await waitForCondition(
+      () =>
+        (getLoggerCountsBreakdown()["storage.v2"]?.["commit-conflict"]
+          ?.debug ?? 0) > conflictBaseline,
+      "the conflict rejection to reach the runner",
+    );
+
+    // Inside the window a fresh commit reads A. Its read view sits on the
+    // loser's layer, so buildReads names that layer — a layer the server can
+    // only answer with "pending dependency not resolved".
+    const follower = beginSet(
+      harness,
+      DOCS.D,
+      valueFor("follower"),
+      sourceFromReads([{ id: DOCS.A }]),
+    );
+    let followerSettled = false;
+    const followerResult = follower.promise.then((result) => {
+      followerSettled = true;
+      return result;
+    });
+    assertEquals(
+      harness.replica.buildReads(
+        sourceFromReads([{ id: DOCS.A }]),
+        follower.localSeq + 1,
+      ).pending.map((read) => read.localSeq),
+      [loser.localSeq],
+    );
+
+    // Drain every queued verdict and let reactive work reach a fixpoint: if
+    // the send were going to happen it would have happened by here. Nothing
+    // beyond the seed and the loser ever reached the wire.
+    await harness.transport.drainVerdicts();
+    await clock.settle();
+    assertEquals(harness.model.transactLocalSeqs, [1, loser.localSeq]);
+    // …and the follower is held rather than spun: its rejection waits for the
+    // loser's drop, so a retry cannot start against the same dead layer.
+    assertEquals(followerSettled, false);
+
+    // Release: the catch-up carrying the winner plus the marker covering the
+    // rejected commit. The loser drops, and the follower settles behind it.
+    harness.pushSync({
+      upserts: [{ id: DOCS.A, seq: winnerSeq, value: valueFor("v2winner") }],
+      caughtUpLocalSeq: loser.localSeq,
+    });
+    await assertConflict(loser.promise, "stale confirmed read");
+    await assertConflict(
+      followerResult,
+      `pending dependency rejected: localSeq=${loser.localSeq}`,
+    );
+
+    // The follower never reached the server, and both optimistic layers are
+    // gone: A holds the winner, D is back to nothing.
+    assertEquals(
+      harness.model.transactLocalSeqs.includes(follower.localSeq),
+      false,
+    );
+    assertEquals(harness.model.applied.has(follower.localSeq), false);
+    expectVisible(harness, { A: valueFor("v2winner"), D: undefined });
+
+    // The revert reached the sink, and left it on the repaired value rather
+    // than on the optimistic one the loser wrote.
+    cancelSink();
+    assertEquals(sinkValues.at(-1), valueFor("v2winner"));
+
+    // The refusal is counted…
+    assertEquals(
+      (getLoggerCountsBreakdown()["storage.v2"]?.["commit-dead-dependency"]
+        ?.debug ?? 0) - deadDependencyBaseline,
+      1,
+    );
+    // …and traced. A commit that never dialed a session still opens and
+    // closes a push span, carrying the join keys every other push span
+    // carries, so the suppressed population stays countable where the
+    // errored `memory.transact` spans were counted.
+    const followerOpId = `push:${space}:${follower.localSeq}`;
+    assertEquals(
+      harness.telemetryMarkers.filter((marker) =>
+        "id" in marker && marker.id === followerOpId
+      ),
+      [
+        {
+          type: "storage.push.start",
+          id: followerOpId,
+          operation: "transact",
+          localSeq: follower.localSeq,
+          spaceDid: space,
+        },
+        {
+          type: "storage.push.error",
+          id: followerOpId,
+          error: "ConflictError",
+        },
+      ],
+    );
+  } finally {
+    storageLogger.level = previousLevel;
+    await harness.close();
+  }
+});
+
+Deno.test("memory v2 stacked commits: a commit sitting on two rejected layers waits for both repairs", async () => {
+  const harness = await createHarness();
+  try {
+    // A and B each seeded and watched, each then overtaken by a foreign
+    // winner the runner has not seen.
+    await seedAccepted(harness, DOCS.A, valueFor("a1"));
+    await seedAccepted(harness, DOCS.B, valueFor("b1"));
+    assertEquals(
+      await harness.replica.pull([
+        [{ id: DOCS.A, type: DOCUMENT_MIME }, undefined],
+        [{ id: DOCS.B, type: DOCUMENT_MIME }, undefined],
+      ]),
+      { ok: {} },
+    );
+    harness.model.injectRemote({
+      label: "winner-a",
+      operations: [{ op: "set", id: DOCS.A, value: valueFor("a2winner") }],
+    });
+    const winnerSeqA = harness.model.confirmed.get(DOCS.A)!.seq;
+    harness.model.injectRemote({
+      label: "winner-b",
+      operations: [{ op: "set", id: DOCS.B, value: valueFor("b2winner") }],
+    });
+    const winnerSeqB = harness.model.confirmed.get(DOCS.B)!.seq;
+
+    // Two unrelated losers, one per document. Their repairs are independent,
+    // so the markers releasing them can arrive far apart.
+    const conflictBaseline = getLoggerCountsBreakdown()["storage.v2"]
+      ?.["commit-conflict"]?.debug ?? 0;
+    const loserA = beginSet(
+      harness,
+      DOCS.A,
+      valueFor("a1mine"),
+      sourceFromReads([{ id: DOCS.A, seq: 1 }]),
+    );
+    harness.model.setOutcome(loserA.localSeq, {
+      kind: "rejectConflict",
+      retryAfterSeq: winnerSeqA,
+    });
+    const loserB = beginSet(
+      harness,
+      DOCS.B,
+      valueFor("b1mine"),
+      sourceFromReads([{ id: DOCS.B, seq: 2 }]),
+    );
+    harness.model.setOutcome(loserB.localSeq, {
+      kind: "rejectConflict",
+      retryAfterSeq: winnerSeqB,
+    });
+    await waitForCondition(
+      () =>
+        (getLoggerCountsBreakdown()["storage.v2"]?.["commit-conflict"]
+          ?.debug ?? 0) >= conflictBaseline + 2,
+      "both conflict rejections to reach the runner",
+    );
+    let loserASettled = false;
+    void loserA.promise.then(() => {
+      loserASettled = true;
+    });
+
+    // One commit reading both documents, so it sits on both dead layers.
+    const rider = beginSet(
+      harness,
+      DOCS.C,
+      valueFor("rider"),
+      sourceFromReads([{ id: DOCS.A }, { id: DOCS.B }]),
+    );
+    let riderSettled = false;
+    const riderResult = rider.promise.then((result) => {
+      riderSettled = true;
+      return result;
+    });
+    await harness.transport.drainVerdicts();
+    await clock.settle();
+    assertEquals(
+      harness.model.transactLocalSeqs,
+      [1, 2, loserA.localSeq, loserB.localSeq],
+    );
+
+    // A's repair lands. Its layer drops, but B's is still standing, so a
+    // retry now would read straight back through it. The rider must hold.
+    harness.pushSync({
+      upserts: [{ id: DOCS.A, seq: winnerSeqA, value: valueFor("a2winner") }],
+      caughtUpLocalSeq: loserA.localSeq,
+    });
+    await clock.settle();
+    assertEquals(loserASettled, true);
+    assertEquals(riderSettled, false);
+
+    // B's repair lands too, and only now does the rider settle.
+    harness.pushSync({
+      upserts: [{ id: DOCS.B, seq: winnerSeqB, value: valueFor("b2winner") }],
+      caughtUpLocalSeq: loserB.localSeq,
+    });
+    await assertConflict(loserB.promise, "stale confirmed read");
+    await assertConflict(
+      riderResult,
+      `pending dependency rejected: localSeq=${loserA.localSeq},${loserB.localSeq}`,
+    );
+    assertEquals(
+      harness.model.transactLocalSeqs.includes(rider.localSeq),
+      false,
+    );
+    expectVisible(harness, {
+      A: valueFor("a2winner"),
+      B: valueFor("b2winner"),
+      C: undefined,
+    });
   } finally {
     await harness.close();
   }


### PR DESCRIPTION
Production tracing over a 48-hour window recorded 2248 errored `memory.transact` spans whose status message was "pending dependency not resolved: N" — the server refusing a commit because an optimistic layer it named had no commit row. Reading each span's N back against the verdict the server had already returned for that local sequence number gives the same answer 2248 times out of 2248: N had already been rejected. Not one span named a dependency that went on to succeed. Not one named a dependency the server had never seen. There is no race here and no ambiguity — every single one of these round trips was spent asking the server about a layer whose fate the client had already been told.

The waste concentrates rather than spreading thin. A single genuine conflict — one commit refused with "stale confirmed read: <entity> at seq X conflicted with seq Y" — routinely produced 80 to 120 of these doomed dependants. One session turned one root conflict into 120 rejected round trips inside three seconds.

Splitting the 2248 by how long after their dependency's verdict they arrived separates two different problems. 878 of them, 39%, arrived within 5ms. Those were genuinely already in flight: the client had pipelined them before the verdict landed and could not have known. The remaining 61% arrived after the verdict, 796 of them more than 100ms after, with a p90 gap of 36.7 seconds and observed cases at 128 seconds and at 20 minutes. A commit minted two minutes after its dependency was refused is not a race. It is the client building on state it had already been told was dead.

One session shows the shape end to end, with an unbroken local sequence counter. Local sequence 2 was rejected at 18:32:45 with "stale confirmed read". Sequences 3 through 9 were each rejected with a stale confirmed read of their own. Then, at 18:34:53 — two minutes and eight seconds later — sequences 10 through 45 and beyond were sent in a 40ms burst, and every one of them came back "pending dependency not resolved: 2". Two minutes after the client learned that layer 2 was dead, it sent thirty-five commits built on it.

The cause is that a rejected commit's optimistic layer does not disappear when its verdict arrives. `finalizeRejection` deliberately holds the drop until the conflict's read repair lands, so that a retry rebuilds against repaired confirmed state rather than the stale base that lost. For the whole of that window the dead layer is still sitting in the document's pending list, and `buildReads` names every layer it finds there. The existing client-side cascade cannot close this: it scans only commits already registered as in flight, and it runs once, at drop time — which is the far end of exactly the window in which the doomed commits are being minted. That is why it catches the 39% and none of the rest.

The fix moves the client's mirror of the server's cascade from the moment the layer is dropped to the moment the rejection is known. `finalizeRejection` records the rejected local sequence number before it waits for the read repair, and clears it once the drop is done. `pushCommit` consults that set at its pre-send checkpoints: a commit naming a rejected layer is settled locally and never reaches the wire. Nothing about when the layer is dropped or when retries resume changes; the read repair the retry path depends on is untouched.

The local rejection's readiness gate is the drop of every dead layer the commit names, rather than an immediate resolve. Retrying earlier would rebuild against a layer that is still standing and be refused again, turning a network storm into a local one for the length of the repair. Gating on only the first dead layer would do the same whenever a commit reads two documents whose unrelated conflicts repair at different times, so the gate covers the whole set and the rejection message names it.

Refusing these commits before the wire would have made them invisible to tracing, which is the wrong thing to go quiet on: the problem was found by counting errored push spans, and these are precisely the commits that used to produce them. Both pre-send checkpoints now open and close a push span carrying the usual local-sequence and space join keys, with no session id at the first one because no session has been dialed.

Two regression tests drive the window directly. The first delivers a conflict verdict while withholding its repair marker, mints a fresh commit reading the same document, and asserts that nothing beyond the seed and the loser ever reached the wire and that the new commit is held rather than spun. The second runs two independent conflicts and a third commit reading both documents, releases one repair, checks the rider is still held, then releases the other. Each fails on the runner without its half of the fix, and for the right reason.

The memory-v2 specification stated the client mirror as running at drop time, and INV-4 scoped it to commits already queued or in flight — by construction excluding the ones minted inside the window, which is exactly what the invariant exists to prevent. Both now describe the whole window and say why covering only the drop is not enough.

Also recorded in the experimental-options catalogue: refusing these commits removes a population of stale floors the conflict-admission experiment used to see. A "pending dependency not resolved" verdict carries no information about the versions of the identifiers the commit touched, so those floors were spurious, but anyone re-measuring the `preempt` mode is measuring against a different input set than the recorded numbers were taken on.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

