### PR TITLE
perf(benchmarks): trend by p75; time only the operation

### DIFF
--- a/docs/development/BENCHMARKS.md
+++ b/docs/development/BENCHMARKS.md
@@ -23,6 +23,41 @@ connects measurements from different processors. A report without a CPU
 identity is unusable for trends because its measurements cannot be assigned to
 a processor.
 
+The trend compares the 75th percentile of each benchmark between runs, not its
+average. `deno bench` measures a benchmark for a roughly fixed wall-clock
+budget, so a single stalled sample raises the reported average by the length of
+the stall divided by that budget, no matter how many samples the run collected.
+The runners stall for a fifth of a second often enough to matter, and against a
+budget of half a second that is a quarter added to the average — the size of
+the moves the trend exists to find.
+
+The 75th percentile is far enough up the distribution to move when a change
+makes some but not all of an operation's runs slower, and far enough down that
+a stalled sample or two cannot reach it. The fastest sample survives a stall
+equally well, but it is the floor of the distribution and so is blind to a
+change that leaves the floor alone and widens everything above it — a slow path
+taken only sometimes moves nothing it can see. That is why the trend does not
+read `min`.
+
+How much protection that is depends on how many samples the run collected,
+because the 75th percentile ignores the slowest quarter of them and no more. A
+benchmark that fits 31 samples into the budget absorbs seven stalls before one
+reaches the figure the trend reads; one that fits 11 absorbs two. The slowest
+benchmarks in the repository are down at that end, so a benchmark written to
+take tens of milliseconds per iteration is buying less of this protection than
+one written to take tens of microseconds.
+
+What the trend still cannot see is a change confined above the 75th percentile,
+and on a user-facing timing that tail is what a person actually notices. Reading
+it from these runs would first need the runner's stalls told apart from the tail
+the code itself produces, which the current sample counts do not allow: on the
+busiest processor `p99` puts 11% of neighbouring run pairs more than a quarter
+apart with no change behind them, against 2% for the 75th percentile. Until
+that is separable, the drill-down's ladder from `min` to `max` is where the tail
+is visible. A benchmark that measures a whole user-facing journey rather than
+one operation has a different balance here, because its tail is the thing being
+measured.
+
 The runner group does not make two runs comparable, and the processor field
 only goes part of the way. Over a forty-five day stretch the group served six
 processor models, and within one model two runs have measured a fifth apart on
@@ -127,6 +162,26 @@ over. So:
 
 `packages/runner/test/esm-verifier.bench.ts` shows the pattern: short stable
 names, per-module labels derived from source paths, sizes logged to stderr.
+
+**Time only the operation the name promises.** `Deno.bench` times the whole
+body unless the body takes the context argument and calls `b.start()` and
+`b.end()` around the part under test. A body that builds a runtime, a storage
+manager, or a fixture of documents, and then measures without that bracket,
+reports the fixture as though it were the operation. Two costs follow. The
+first is that the benchmark cannot see what it is named for: before its
+measurement was bracketed, `Cell equals - comparison operations (100x)` in
+`packages/runner/test/cell.bench.ts` spent 93% of its reported time building
+and tearing down a runtime, so doubling the cost of `Cell.equals()` would have
+moved it by 7%. The second is the reverse — a change to runtime construction or
+to commit moves every benchmark shaped like that one, which reads on the chart
+as a regression in whatever each is named for. The two `Cell getAsLink`
+benchmarks in the same file show the bracket in place.
+
+Many bench bodies in the repository still measure their fixture along with
+their operation, so this is a rule for new benches rather than a description of
+the tree. Bracketing an existing one changes the number it reports, which the
+dashboard reads as a one-off step in that benchmark's line; the name stays the
+same, so the series continues rather than restarting.
 
 **The calibration bodies stay as they are.** The bodies in
 `packages/dashboard/machine-calibration.bench.ts` are the ruler every other

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -339,6 +339,10 @@ One line per archived document; each document's header carries the fuller
   — why the dashboard's 21% benchmark headline was mostly the host two runs
   landed on: the runner group serves several machines under one processor name,
   and neither the artifact nor the tile could tell them apart. August 2026.
+- [2026-08-cell-bench-micro-steps.md](development/performance/2026-08-cell-bench-micro-steps.md)
+  — why the two `cell.bench.ts` steps inside the 21% benchmark headline are not
+  regressions: one stalled runner sample per run, folded into the average the
+  trend read, August 2026.
 - [coverage-ratchet-noise-2026-07-28.md](development/coverage-ratchet-noise-2026-07-28.md)
   — why a rename-only pull request owed coverage debt: a wall-clock-guarded
   diagnostic and a shard re-partition each moved the `packages/runner`

--- a/docs/history/development/performance/2026-08-cell-bench-micro-steps.md
+++ b/docs/history/development/performance/2026-08-cell-bench-micro-steps.md
@@ -1,0 +1,310 @@
+---
+status: historical
+created: 2026-08-07
+archived: 2026-08-07
+reason: "Why the two cell.bench.ts micro-benchmark steps in the 21% benchmark headline are not regressions, and what was changed so the trend stops reporting them."
+---
+
+# The two `cell.bench.ts` micro-benchmark steps are stalled runners
+
+## Question
+
+A decomposition of the dashboard's 21% benchmark headline, run over every
+`bench-results` artifact the Benchmarks workflow produced on `main` between 24
+June and 7 August 2026, listed nineteen corroborated step regressions. Two of
+them are in `packages/runner/test/cell.bench.ts`:
+
+| Benchmark | Step | Processors | Confined to |
+| --- | ---: | ---: | --- |
+| Cell concurrent — multiple cells | 1.33× | 2 of 3 | after `dd63b3d25`, by `c97de0181` |
+| Cell equals — comparison operations | 1.32× | 2 of 3 | intervals disagree |
+
+These are the two smallest of the corroborated moves, and both are
+per-operation micro-benchmarks where a hundred operations are timed together.
+Are they real?
+
+## Result
+
+Neither is real. Both are a single stalled sample inside one run, folded into
+the arithmetic mean that the dashboard reads.
+
+Every elevated reading in the artifact history arrives with two companions: a
+maximum sample of 150 to 270 milliseconds against a typical sample of 6 to 25
+milliseconds, and a reduced sample count, because a stalled sample eats the
+measurement budget that would otherwise have bought more samples. Removing the
+single largest sample from each run collapses the run-to-run spread to the
+level of the ordinary noise, on every processor. Checking out both ends of the
+named commit range and measuring locally reproduces no step at all.
+
+The bench file is unchanged across the range, and so, as far as these two
+benchmarks can see, is everything they measure.
+
+## The artifact history
+
+Each run below is one `bench-results` artifact from the Benchmarks workflow.
+`avg` is the number the dashboard reads. `trimmed` is the mean recomputed with
+the single largest sample removed, which is the whole of the correction.
+
+`Cell concurrent - multiple cells (100x)`, on the two processors the step was
+reported from. Times are microseconds.
+
+| Processor | Run | Commit | avg | max | samples | trimmed |
+| --- | --- | --- | ---: | ---: | ---: | ---: |
+| EPYC 9V74 | 1 Aug 12:24 | `ee84effe3` | 21,304 | 25,145 | 34 | 21,187 |
+| EPYC 9V74 | 3 Aug 09:10 | `c97de0181` | 31,393 | 208,873 | 30 | 25,273 |
+| Xeon 8573C | 2 Aug 20:22 | `dd63b3d25` | 17,180 | 20,139 | 40 | 17,105 |
+| Xeon 8573C | 3 Aug 13:06 | `c97de0181` | 26,347 | 195,693 | 26 | 19,573 |
+
+The step is the pair of rows whose maximum sample is around 200,000
+microseconds. Both runs that read low have a maximum of about 20,000, which is
+the ordinary top of the distribution. The run that reads high on each processor
+collected fewer samples than the run that reads low, which is what a stall does
+to a fixed measurement budget.
+
+On the processor with by far the most runs, the EPYC 7763, the step is absent
+altogether. Its four runs of `dd63b3d25` read 24,599, 24,645, 24,628 and
+26,321. Its next two runs are inside the candidate range — `a4112009b` and
+`6efb92fb9` — and read 24,180 and 25,052. Nothing moved.
+
+`Cell equals - comparison operations (100x)` is the same mechanism, and its
+per-processor boundaries disagree because the stalls fall on different runs.
+On the EPYC 9V74 and the Xeon 8573C the run at `c97de0181` is one of the clean
+ones, with a maximum of 9,744 and 11,637 microseconds, and it is the *earlier*
+run that carries the stall. So on those two processors the benchmark reads
+faster after the boundary than before it. On the EPYC 7763 the readings
+alternate run by run between about 6,400 when the maximum is 10,000 and about
+8,400 when the maximum is 150,000.
+
+Removing one sample per run accounts for all of it. Over the same window:
+
+| Benchmark | Processor | Spread of `avg` | Spread of trimmed mean | Spread of `p75` | Spread of `min` |
+| --- | --- | ---: | ---: | ---: | ---: |
+| Cell concurrent | EPYC 7763 | 1.79× | 1.23× | 1.26× | 1.13× |
+| Cell concurrent | EPYC 9V74 | 1.60× | 1.21× | 1.20× | 1.22× |
+| Cell concurrent | Xeon 8573C | 1.62× | 1.25× | 1.24× | 1.36× |
+| Cell equals | EPYC 7763 | 1.93× | 1.23× | 1.32× | 1.14× |
+| Cell equals | EPYC 9V74 | 1.49× | 1.17× | 1.30× | 1.32× |
+| Cell equals | Xeon 8573C | 1.43× | 1.34× | 1.45× | 1.43× |
+
+A claimed step of 1.25 to 1.41 times sits inside a spread of 1.43 to 1.93
+times. It is not distinguishable from the sampling, and once one sample per run
+is removed there is nothing left of it.
+
+## Measuring both ends of the range locally
+
+Both ends of the range named for `Cell concurrent` were checked out into
+separate worktrees, `dd63b3d25` and `c97de0181`, and the two benchmarks were
+extracted into a file of their own so one measurement takes seconds. Each end
+was measured eight times, alternating between them so that any drift in the
+machine falls on both sides equally. Apple M5 Max, Deno 2.9.4, the same
+`--v8-flags=--expose-gc` the workflow passes.
+
+| Benchmark | Before the range | After the range | Ratio | Claimed |
+| --- | ---: | ---: | ---: | ---: |
+| Cell concurrent — multiple cells | 9,815 | 9,731 | 0.99× | 1.25× and 1.41× |
+| Cell equals — comparison operations | 3,853 | 4,022 | 1.04× | 1.25× and 1.38× |
+
+The eight readings on each side overlap: `Cell equals` ranged from 3,737 to
+4,324 before and from 3,737 to 4,115 after. There was nothing to bisect, so no
+bisect was run.
+
+## Why a stall lands on the average this hard
+
+`deno bench` measures each benchmark for a roughly fixed amount of wall-clock
+time and reports the mean over however many samples fit. From the artifacts
+that budget is about half a second for `Cell equals`, which collects around 90
+samples of about 5.9 milliseconds, and about three quarters of a second for
+`Cell concurrent`, which collects around 31 samples of about 24.6 milliseconds.
+
+A single stall of a fifth of a second added to a measurement window of half a
+second raises the mean by about 40%, and the sample count has nothing to do
+with it. The stall is a fixed quantity of time added to a fixed budget. That
+arithmetic is the whole of the reported steps: the stalls in the artifacts run
+from 150 to 270 milliseconds, and the steps run from 1.25 to 1.45 times.
+
+The same reasoning says the shape of the benchmark body cannot fix this. If a
+body times only part of itself, a stall reaches the reported number only when
+it lands inside the timed part, but when it does land there it is divided by a
+proportionally smaller measured total. The expected inflation is the stall
+divided by the whole budget either way. Bracketing a body makes the event
+rarer and correspondingly larger, which raises the variance rather than
+lowering it. Measurements of the bracketed benchmarks confirmed that: their
+averages moved about over a wider range than the unbracketed ones did.
+
+What escapes the stall is any statistic a handful of samples cannot reach. A
+stall can only push a sample up, so with 30 or more samples in a run it lands
+above the 75th percentile and leaves it alone.
+
+The first attempt at this read the fastest sample instead, on the reasoning that
+a stall never reaches the minimum while a change in the code moves the minimum
+along with everything else. The second half of that is wrong. The minimum is the
+floor of the distribution, and a change that leaves the best case alone while
+making some fraction of runs slower moves nothing the floor can see: a path that
+starts missing a cache, a branch that fires only on certain shapes. Such a
+change widens the distribution upward, and only a statistic above the floor
+registers it. Reading `min` would have traded one blind spot for another.
+
+Two candidates survive that. Below is every statistic `deno bench` reports,
+against the regressions in this window that have since been root-caused and
+fixed, and against the three moves that have been shown to be artifacts. Each
+figure is the median across processors of the ratio between the median of the
+six days before the boundary and the six days after.
+
+| Benchmark | `min` | `p75` | `avg` | `p99` | `p999` |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| READ-MODIFY-WRITE, 1000 items | 7.55× | 6.88× | 7.04× | 6.17× | 6.17× |
+| READ-MODIFY-WRITE, 3000 items | 7.57× | 6.86× | 7.01× | 6.74× | 6.74× |
+| READ-MODIFY-WRITE, 100 items | 6.75× | 6.73× | 6.45× | 5.68× | 5.68× |
+| Immutable cell — storage manager setup and cleanup | 9.55× | 9.07× | 8.60× | 5.91× | 2.72× |
+| flat list read — schemaless, 1000 items | 2.41× | 2.26× | 2.43× | 3.42× | 3.42× |
+| flat list read — schemaless, 3000 items | 2.44× | 4.42× | 3.03× | 4.63× | 4.63× |
+| schema read depth — schemaless, 1000 items | 2.09× | 1.89× | 2.32× | 4.41× | 4.41× |
+| Cell.set() — multiple transactions | 1.45× | 1.50× | 1.50× | 1.53× | 1.53× |
+| *v2-entity-id-list — current live-1k-small* | *1.08×* | *1.09×* | *1.98×* | *11.65×* | *62.13×* |
+| *Cell concurrent — multiple cells* | *1.01×* | *1.02×* | *1.08×* | *1.04×* | *1.04×* |
+| *Cell equals — comparison operations* | *1.01×* | *0.99×* | *0.99×* | *1.02×* | *1.02×* |
+
+The last three rows are the artifacts, in italics. `current live-1k-small` is
+one:
+[`2026-08-schemaless-read-membership-walk.md`](2026-08-schemaless-read-membership-walk.md)
+measured it twice at each commit across the range and found no step, and its
+series carries the stall signature — the same commit reads 326,036 and 569,757
+microseconds on different runs, with the sample count halving on the slower one.
+Its tail statistics move by 12 and 62 times on nothing at all.
+
+Every statistic detects every confirmed regression, the weakest detection being
+1.45 times. They differ entirely on the false ones. `avg`, `p99` and `p999` all
+fire on `current live-1k-small`; `min` and `p75` do not. The same separation
+shows in the rate at which two neighbouring runs disagree by more than a quarter
+with no change behind them, over every benchmark in the artifacts:
+
+| Processor | Runs | `min` | `p75` | `avg` | `p99` | `p999` |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| AMD EPYC 7763 | 221 | 1.2% | 2.1% | 2.5% | 11.2% | 13.8% |
+| AMD EPYC 9V74 | 125 | 11.2% | 10.8% | 10.9% | 18.0% | 19.7% |
+| Intel Xeon 8573C | 39 | 5.0% | 6.7% | 6.8% | 17.1% | 20.6% |
+
+So `p75` matches `min` on both detection and rejection while not being blind to
+a widening distribution, and it is what the trend now reads.
+
+This is a limit of the sampling rather than a claim that the tail does not
+matter. On a user-facing timing the tail is exactly what a person notices, and
+`p99` would be the right lens. It is unusable here because at these sample
+counts, on shared runners, `p99` is mostly a measure of how badly the runner
+stalled — 11 to 21% of neighbouring run pairs disagree by more than a quarter
+with nothing behind it. Separating the runner's stalls from the tail the code
+produces is what would make the tail readable, and nothing here does that.
+
+## Reproducing the signature deliberately
+
+To confirm the reading, the stall was injected rather than waited for: one
+iteration in sixty burns a fifth of a second in a busy loop, in the phase of
+the body that builds the fixture. `Cell equals` went from 5,188 to 8,830
+microseconds, a factor of 1.70; its sample count fell from 106 to 69; and its
+maximum sample became 203,805 microseconds. That is the artifact signature
+exactly — the elevated average, the reduced sample count and the maximum near
+200,000 all appear together, as they do in every elevated run in the history.
+
+This experiment places the stall outside the timed region on purpose, so it
+demonstrates that the signature is reproducible. It does not demonstrate that
+bracketing removes the noise, and the measurements above say it does not.
+
+## Not the same thing as a slow host
+
+[`2026-08-benchmark-headline-machine-noise.md`](2026-08-benchmark-headline-machine-noise.md)
+found the larger part of the same 21% headline in the machine: the runner group
+serves several hosts under one processor name, and a run that lands on a busy
+one reads slow in everything it measures. Every run now also measures the
+machine, through benchmarks that call no repository code, and the tile divides
+their movement out of each step of its index.
+
+That correction does not cover what is described here, and the two are worth
+keeping apart. A busy host is slow for the whole job, so it shows up in the
+calibration benchmarks and divides out. A stall of a fifth of a second lands in
+one sample of one benchmark. The calibration benchmarks run at some other point
+in the job and are not touched by it, so there is nothing in their movement to
+divide it out with. What removes it is not measuring the machine but reading a
+statistic that a single sample cannot reach, which is why both changes are
+needed.
+
+## A second defect these two benchmarks have
+
+Both benchmarks time their fixture along with the operation they name. The body
+of `Cell equals - comparison operations (100x)` builds a storage manager, a
+runtime and a transaction, creates three cells, writes two of them, commits,
+performs 200 comparisons, commits again and disposes of the runtime — and
+`Deno.bench` times all of it.
+
+Measured on the Apple M5 Max with the comparisons timed separately, the 200
+comparisons are 282 microseconds of a 3,837-microsecond body. The benchmark
+named for `Cell.equals()` is 93% runtime construction and teardown. Doubling
+the cost of `Cell.equals()` would move it by 7%, which is far inside its own
+noise. `Cell concurrent` is less extreme: its thousand `get()` calls are 3,647
+microseconds of a 9,672-microsecond body, so 38% of what it reports.
+
+This is a second way to manufacture the signal the investigation was chasing.
+A change to runtime construction or to commit moves every benchmark shaped like
+this, and each one reads on the chart as a regression in whatever it is named
+for.
+
+## What was changed
+
+Three changes. Two address the defects above; the third is a mislabelled column
+found while checking what the drill-down actually plots.
+
+`packages/runner/test/cell.bench.ts` now brackets both measurements with
+`b.start()` and `b.end()`, which is the form the two `Cell getAsLink`
+benchmarks a few hundred lines above already use, and which the two bodies were
+already written for — each had a `// Measure ...` comment marking the point the
+bracket belongs at. This does not reduce the noise, and is not meant to; it
+makes each benchmark report the operation it is named for. Both will read
+substantially lower from the next run onward, which the dashboard shows as a
+one-off step in those two lines.
+
+`packages/dashboard/tiles/benchmark.ts` compares 75th percentiles rather than
+averages when it builds the per-processor index. The parser already carried
+`p75` through into the cached statistics, so no cache format changed and no
+history needed refetching.
+
+`packages/dashboard/tiles/benchmark.test.ts` gained two tests, one for each way
+the statistic can be wrong. The first feeds the tile twenty-four runs whose 75th
+percentile never moves and whose average steps up 40% halfway through, and
+asserts the trend reads flat; reading the average reports a warning instead. The
+second feeds it twenty-four runs whose fastest sample never moves and whose 75th
+percentile steps up 45%, and asserts the trend reports the whole of that rise;
+reading the fastest sample reports it as flat.
+
+The drill-down's measurement ladder offered `p0`, `p50`, `p75`, `p99`, `p99.5`,
+`p99.9` and `p100`. The `p50` column was plotting `avg`, which is the arithmetic
+mean. The label inverts what it describes. A percentile is a rank, so a reader
+takes `p50` for the typical case and expects a few slow samples not to move it,
+when the mean is the one figure in that ladder a single slow sample can carry.
+Measured directly, with a benchmark whose samples are nine at 100 microseconds
+and one at 10 milliseconds, `deno bench` reports an `avg` of 1,090 microseconds
+against a `p75` of 100. The column is now called `mean`, and a link saved under
+the old name still opens it instead of falling back to the default column.
+
+## Left alone
+
+Many bench bodies in the repository time their fixture along with their
+operation. Of the 366 `Deno.bench` bodies written at the top level of a bench
+file, 138 build a runtime or a storage manager without bracketing, once the two
+changed here are taken out. `packages/runner/test/cell.bench.ts` still has 37,
+`cell-set.bench.ts` 28, `storage.bench.ts` 21, and `scheduler.bench.ts` 19.
+Each one reports its fixture as though it were the operation it names.
+Converting them is a larger piece of work than this investigation, and each
+conversion moves the number that benchmark reports.
+
+The sweep in the decomposition flagged three `flat list read` benchmarks and
+two `cell-schema-read-depth` benchmarks as steps whose per-processor intervals
+disagree. Those turned out to be a real regression on the storage read path,
+recorded in
+[`2026-08-schemaless-read-membership-walk.md`](2026-08-schemaless-read-membership-walk.md).
+A stalled sample is one way for a step to be reported that nothing caused; it
+is not the only explanation for a disagreeing interval, and it was not the
+explanation there.
+
+Those same benchmarks collect 11 to 21 samples per run, which is few enough
+that a single stalled sample moves their reported mean by a median of 8 to 23%,
+so their measurements carry the noise described here on top of the real step.
+Nothing here re-examines their size.

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -756,10 +756,13 @@ Notes:
     A late-starting CPU line sits at the right. A single sample appears as a
     point. A stale line visibly ends short of the current date. The dashboard
     tile leaves out the CPU legend to keep the compact chart readable.
-    Selectors choose which measurement to plot (a percentile ladder — **p0** =
-    min, **p50** = the mean, **p75**, **p99**, **p99.5**, **p99.9**, **p100** =
-    max) and whether to group by source **file** or sort by latest **duration**
-    or **trend**. A "hide green" checkbox drops the steady ones. A slider from 1
+    Selectors choose which measurement to plot (**p0** = the fastest sample,
+    **mean** = the arithmetic mean, **p75**, **p99**, **p99.5**, **p99.9**,
+    **p100** = the slowest) and whether to group by source **file** or sort by
+    latest **duration** or **trend**. The mean selector was once labelled
+    `p50`, and `?stat=p50` still opens it so that a saved link does not quietly
+    fall back to the default column.
+    A "hide green" checkbox drops the steady ones. A slider from 1
     through 45 days changes the visible calendar range. The displayed samples
     are spread across at most 200 time buckets, so a shorter window uses more of
     the collected samples per day. Each graph chooses its vertical scale after

--- a/packages/dashboard/tiles/benchmark.test.ts
+++ b/packages/dashboard/tiles/benchmark.test.ts
@@ -1267,6 +1267,87 @@ Deno.test("benchmark: a red run's measurements still reach the trend", async () 
   );
 });
 
+Deno.test("benchmark: a regression above the floor moves the trend", async () => {
+  // Twenty-four daily runs of one benchmark whose fastest sample never moves
+  // while its 75th percentile steps up by 45% halfway through: the shape of a
+  // change that leaves the best case alone and makes some fraction of the runs
+  // slower, such as a path that starts missing a cache. The trend reads the
+  // rise. Comparing fastest samples would read it as flat, because the floor is
+  // exactly where it was.
+  const at = (d: number) => SAMPLED_BASE - (23 - d) * DAY;
+  const artifacts: Api["artifacts"] = {};
+  const zips: Api["zips"] = {};
+  const runs: GhRun[] = [];
+  for (let d = 0; d <= 23; d++) {
+    const id = 9_040 + d;
+    runs.push(ghRun(id, at(d)));
+    artifacts[id] = [{ id: id * 10, name: "bench-results", expired: false }];
+    const slow = d >= 12;
+    zips[id * 10] = await benchZip(
+      report([
+        bench("packages/a/x.bench.ts", null, "b", {
+          min: 1e6,
+          avg: slow ? 1.3e6 : 1.05e6,
+          max: slow ? 2.2e6 : 1.3e6,
+          p75: slow ? 1.6e6 : 1.1e6,
+          p99: slow ? 2e6 : 1.2e6,
+          p995: slow ? 2.1e6 : 1.25e6,
+          p999: slow ? 2.15e6 : 1.28e6,
+        } as Timings),
+      ]),
+    );
+  }
+  await withApi(
+    { pages: { 1: [...runs].reverse() }, artifacts, zips },
+    async () => {
+      const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+      assertEquals(v.status, "warn");
+      assertStringIncludes(v.value ?? "", "▲45%"); // the whole of the p75 step
+    },
+  );
+});
+
+Deno.test("benchmark: a stalled sample does not move the trend", async () => {
+  // Twenty-four daily runs of one benchmark whose 75th percentile never moves,
+  // so nothing about the code being measured changed over the window. From the
+  // halfway point each run also carries one stalled sample, which shows up as a
+  // far larger maximum and drags the reported average up by 40% — the shape a
+  // stalled runner leaves in an artifact. A handful of stalled samples cannot
+  // reach the 75th percentile, so the trend reads flat. Comparing averages
+  // would read a 40% step that no commit caused.
+  const at = (d: number) => SAMPLED_BASE - (23 - d) * DAY;
+  const artifacts: Api["artifacts"] = {};
+  const zips: Api["zips"] = {};
+  const runs: GhRun[] = [];
+  for (let d = 0; d <= 23; d++) {
+    const id = 9_000 + d;
+    runs.push(ghRun(id, at(d)));
+    artifacts[id] = [{ id: id * 10, name: "bench-results", expired: false }];
+    const stalled = d >= 12;
+    zips[id * 10] = await benchZip(
+      report([
+        bench("packages/a/x.bench.ts", null, "b", {
+          min: 1e6,
+          avg: stalled ? 1.4e6 : 1e6,
+          max: stalled ? 40e6 : 1.2e6,
+          p75: 1.1e6,
+          p99: 1.15e6,
+          p995: 1.18e6,
+          p999: 1.19e6,
+        } as Timings),
+      ]),
+    );
+  }
+  await withApi(
+    { pages: { 1: [...runs].reverse() }, artifacts, zips },
+    async () => {
+      const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+      assertEquals(v.status, "good");
+      assertStringIncludes(v.value ?? "", "flat");
+    },
+  );
+});
+
 Deno.test("benchmark: a run still in flight is not sampled", async () => {
   // A conclusion of null is not a colour, it is an absence: the run has not
   // finished and has no artifact to read. Only completed runs are sampled.
@@ -2822,17 +2903,23 @@ Deno.test("benchmark collection retains enough runs for the shortest history win
 });
 
 Deno.test("/bench: the measurement selector changes what is plotted", async () => {
-  const p50 = rows(await page("?stat=p50"));
-  assertEquals(p50.find((r) => r.name === "hot/steep")?.value, "10ms"); // the mean, half the p99
-  // A benchmark that reported only an average reads the same at every percentile.
-  assertEquals(p50.find((r) => r.name === "flat")?.value, "2.5ms");
+  const mean = rows(await page("?stat=mean"));
+  assertEquals(mean.find((r) => r.name === "hot/steep")?.value, "10ms"); // the mean, half the p99
+  // A benchmark that reported only an average reads the same at every measurement.
+  assertEquals(mean.find((r) => r.name === "flat")?.value, "2.5ms");
   assertEquals(
     rows(await page("?stat=p0")).find((r) => r.name === "flat")?.value,
     "2.5ms",
   );
   assertStringIncludes(
-    await page("?stat=p50"),
-    "<title>Benchmarks — p50</title>",
+    await page("?stat=mean"),
+    "<title>Benchmarks — mean</title>",
+  );
+  // The mean column was once labelled p50, so a link saved under that name still
+  // opens it rather than falling back to the default.
+  assertEquals(
+    rows(await page("?stat=p50")).find((r) => r.name === "hot/steep")?.value,
+    "10ms",
   );
   // An unknown measurement falls back to the default rather than blanking the page.
   assertStringIncludes(

--- a/packages/dashboard/tiles/benchmark.ts
+++ b/packages/dashboard/tiles/benchmark.ts
@@ -155,11 +155,11 @@ const performanceBenchmarkGitHub: BenchmarkGitHub = {
 
 // deno bench reports these seven timings per benchmark (all nanoseconds).
 type Stats = BenchmarkStats;
-// Shown as one percentile ladder: min is p0, the average stands in for p50, max is
-// p100. (avg is the mean, not a true median, but reads consistently here.)
+// Shown as a ladder from the fastest sample to the slowest. Each label names
+// the timing it plots: six percentiles and the mean.
 const STATS: { label: string; field: keyof Stats }[] = [
   { label: "p0", field: "min" },
-  { label: "p50", field: "avg" },
+  { label: "mean", field: "avg" },
   { label: "p75", field: "p75" },
   { label: "p99", field: "p99" },
   { label: "p99.5", field: "p995" },
@@ -757,10 +757,37 @@ const errorMessage = (error: unknown): string =>
 
 // The geometric mean of the per-benchmark ratios between two runs on the same
 // processor, over the benchmarks they share that match `select` (each with a
-// positive average). Geometric, not arithmetic, so a benchmark that doubles and
-// one that halves cancel to no change. A benchmark in only one of the two runs
-// is not in the ratio, so adding or removing one is not a change. 1 when the
-// runs share nothing selected.
+// positive 75th percentile). Geometric, not arithmetic, so a benchmark that
+// doubles and one that halves cancel to no change. A benchmark in only one of
+// the two runs is not in the ratio, so adding or removing one is not a change.
+// 1 when the runs share nothing selected.
+//
+// The ratio compares the 75th percentile of each benchmark rather than its
+// average. `deno bench` measures each benchmark for a fixed wall-clock budget,
+// so one stalled sample raises the reported average by the stall divided by
+// that budget, whatever the sample count. A stall of a fifth of a second
+// against a budget of half a second is a quarter added to the average, which is
+// the size of the moves the trend is meant to detect. The runners stall that
+// long often enough that reading the average reports steps no commit caused.
+//
+// The 75th percentile is far enough up the distribution to move when a change
+// makes some but not all of an operation's runs slower, and far enough down
+// that a handful of stalled samples cannot reach it. The fastest sample
+// survives a stall equally well but is the floor of the distribution, so it is
+// blind to a change that leaves the floor alone and widens everything above it
+// — a slow path taken only sometimes moves nothing it can see.
+//
+// Both the product ratio and the calibration ratio read this one statistic, and
+// have to: an index step divides the second out of the first, and two different
+// statistics would not cancel.
+//
+// A change confined above the 75th percentile is still invisible here, and on
+// user-facing timings that tail is what a person actually notices. Reading it
+// from these runs would need the stalls told apart from the tail the code
+// produces, which the current sample counts do not allow: on the busiest
+// processor, `p99` puts 11% of neighbouring run pairs more than a quarter
+// apart with no change behind them, against 2% for the 75th percentile. The
+// drill-down plots the whole ladder from `min` to `max` in the meantime.
 function sharedBenchmarkRatio(
   previous: CachedBenchmarkRun,
   current: CachedBenchmarkRun,
@@ -770,8 +797,8 @@ function sharedBenchmarkRatio(
   for (const [key, stats] of current.metrics) {
     if (!select(key)) continue;
     const before = previous.metrics.get(key);
-    if (before && before.avg > 0 && stats.avg > 0) {
-      logSum += Math.log(stats.avg / before.avg);
+    if (before && before.p75 > 0 && stats.p75 > 0) {
+      logSum += Math.log(stats.p75 / before.p75);
       count++;
     }
   }
@@ -1717,7 +1744,10 @@ export function benchPage(
   repo: CiHistorySourceKey = "labs",
   options: BenchmarkPageOptions = {},
 ): string {
-  const stat = STATS.find((s) => s.label === statLabel) ??
+  // "p50" is what the mean column used to be called, so a link saved under the
+  // old name still opens the column it named.
+  const requested = statLabel === "p50" ? "mean" : statLabel;
+  const stat = STATS.find((s) => s.label === requested) ??
     STATS.find((s) => s.label === DEFAULT_LABEL)!;
   const sort = sortMode === "trend" || sortMode === "duration"
     ? sortMode
@@ -2004,7 +2034,7 @@ export function benchPage(
 
   const rangeContent = `<div id="range-content">
     ${progressHtml}${refreshNotice}
-    <p class="legend">Percentile of per-op time across a run's samples — p0 = min, p50 = mean, p100 = max. Lower is faster. Each CPU has its own coloured line. The value, trend, and row colour use the CPU with the most benchmark samples in the selected ${days}-day window; a tie uses the CPU with the newest sample. Fewer than seven distinct days are marked new. Duration and trend sorting use the displayed value and trend.</p>
+    <p class="legend">Per-op time across a run's samples — p0 = the fastest, p100 = the slowest, mean = the arithmetic mean. Lower is faster. Each CPU has its own coloured line. The value, trend, and row colour use the CPU with the most benchmark samples in the selected ${days}-day window; a tie uses the CPU with the newest sample. Fewer than seven distinct days are marked new. Duration and trend sorting use the displayed value and trend.</p>
     ${body}
     ${cpuLegend}
     <p class="note">Successful main runs come from the <a href="https://github.com/${REPO}/actions/workflows/${WORKFLOW}" target="_blank" rel="noopener">${WORKFLOW} runs ↗</a> (deno bench artifacts). Collection keeps enough samples for the shortest window, and charts reduce longer windows to about ${CI_HISTORY_POINT_TARGET} evenly spaced points.</p>

--- a/packages/runner/test/cell.bench.ts
+++ b/packages/runner/test/cell.bench.ts
@@ -1145,7 +1145,7 @@ Deno.bench("Cell large - deeply nested object (100x navigation)", async () => {
 });
 
 // Benchmark: Concurrent operations
-Deno.bench("Cell concurrent - multiple cells (100x)", async () => {
+Deno.bench("Cell concurrent - multiple cells (100x)", async (b) => {
   const { runtime, storageManager, tx } = setup();
 
   // Create multiple cells
@@ -1160,15 +1160,17 @@ Deno.bench("Cell concurrent - multiple cells (100x)", async () => {
   await tx.commit();
 
   // Measure concurrent access
+  b.start();
   for (let i = 0; i < 100; i++) {
     cells.forEach((cell) => cell.get());
   }
+  b.end();
 
   await cleanup(runtime, storageManager, tx);
 });
 
 // Benchmark: Cell equals comparison
-Deno.bench("Cell equals - comparison operations (100x)", async () => {
+Deno.bench("Cell equals - comparison operations (100x)", async (b) => {
   const { runtime, storageManager, tx } = setup();
 
   const cell1 = runtime.getCell<number>(space, "bench-equals-1", undefined, tx);
@@ -1185,10 +1187,12 @@ Deno.bench("Cell equals - comparison operations (100x)", async () => {
   await tx.commit();
 
   // Measure equals operations
+  b.start();
   for (let i = 0; i < 100; i++) {
     cell1.equals(cell1Same); // Should be true
     cell1.equals(cell2); // Should be false
   }
+  b.end();
 
   await cleanup(runtime, storageManager, tx);
 });


### PR DESCRIPTION
Two benchmarks in packages/runner/test/cell.bench.ts were reported as
regressing by between 1.25 and 1.41 times over the first week of August
2026. Neither move is real. Each is a single stalled runner sample
inside one run, folded into the arithmetic mean the dashboard read.

WHAT THE ARTIFACTS SHOW

Every elevated reading arrives with a maximum sample near 200
milliseconds against a typical sample of 6 to 25 milliseconds, and with
a reduced sample count, because a stall eats the measurement budget that
would otherwise have bought more samples. Removing the single largest
sample from each run leaves the series flat on all three processors.
Checking out both ends of the commit range the steps were attributed to,
and measuring each end eight times alternately, reproduces no step. On
the processor with the most runs behind it there is no step to begin
with.

WHY A STALL REACHES THE AVERAGE

The benchmark tile builds a per-processor index by multiplying, run by
run, the geometric mean of the per-benchmark ratios between neighbouring
runs, and it took each ratio from the average `deno bench` reports.
`deno bench` measures a benchmark for a roughly fixed amount of
wall-clock time and reports the mean over however many samples fit into
it, so one stalled sample raises that mean by the length of the stall
divided by the budget. The sample count makes no difference: the stall
is a fixed quantity of time added to a fixed budget. Against the
half-second budget a small benchmark gets, a fifth of a second is a
quarter added to the average, which is the size of the moves the trend
exists to find.

WHAT THE TREND READS NOW

The 75th percentile. That is far enough up the distribution to move when
a change makes some but not all of an operation's runs slower, and far
enough down that a handful of stalled samples cannot reach it. The
fastest sample survives a stall equally well and was the first choice
here, but it is the floor of the distribution and so is blind to a
change that leaves the floor alone and widens everything above it — a
path that starts missing a cache moves nothing it can see.

Checked against the regressions in the charted window that have since
been root-caused and fixed, and against the three moves shown to be
artifacts, every statistic `deno bench` reports detects every confirmed
regression, the weakest detection being 1.45 times. They differ on the
false ones. `avg`, `p99` and `p999` all fire on `current live-1k-small`,
which the schemaless-read investigation measured twice at each commit
across its range and found no step in: they read it as 1.98, 11.65 and
62.13 times, against 1.08 and 1.09 for `min` and `p75`. The same
separation appears in the rate at which two neighbouring runs disagree
by more than a quarter with nothing behind it: on the busiest processor,
2.1% for `p75` and 2.5% for `avg` against 11.2% for `p99`.

A change confined above the 75th percentile stays invisible, and on a
user-facing timing that tail is what a person actually notices. Reading
it from these runs would first need the runner's stalls told apart from
the tail the code itself produces, which the current sample counts do
not allow. The drill-down's ladder is where the tail stays visible
meanwhile. The parser already carried every percentile into the cached
statistics, so no cache format changes and no history needs refetching.

WHAT THE LADDER CALLS THE MEAN

The ladder offered `p0`, `p50`, `p75`, `p99`, `p99.5`, `p99.9` and
`p100`, and the `p50` column was plotting `avg`, the arithmetic mean.
The label inverts what it describes: a percentile is a rank, so a reader
takes `p50` for the typical case and expects a few slow samples not to
move it, when the mean is the one figure in the ladder a single slow
sample can carry. A benchmark whose samples are nine at 100 microseconds
and one at 10 milliseconds reports a `p75` of 100 and an `avg` of 1090,
and the column labelled `p50` showed 1090. It is now called `mean` in
the ladder, in the legend and in the dashboard README, and a link saved
under the old name still opens it rather than quietly falling back to
the default column.

WHAT THE TWO BENCHMARKS WERE TIMING

`Deno.bench` times the whole body unless the body takes the context
argument and brackets the part under test. Both of these build a storage
manager, a runtime and a transaction, create and write cells, commit,
perform the operation they are named for, commit again and dispose of
the runtime, and report all of it as though it were the operation. Timed
separately, the 200 comparisons in "Cell equals - comparison operations
(100x)" are 282 microseconds of a 3,837-microsecond body, so the
benchmark named for `Cell.equals()` is 93% runtime construction and
teardown; doubling the cost of `Cell.equals()` would move it by 7%. The
thousand reads in "Cell concurrent - multiple cells (100x)" are 3,647
microseconds of a 9,672-microsecond body. The consequence runs both
ways: neither benchmark can see a regression in what it names, and both
move whenever runtime construction or commit changes, which reads on the
chart as a regression in the named operation.

Bracketing does not reduce the run-to-run noise and is not meant to.
Both benchmarks will report substantially lower numbers from the next
run onward, which the dashboard shows as a one-off step in those two
lines; their names are unchanged, so the series continue rather than
restart.

WHAT IS LEFT

Many bench bodies still time their fixture along with their operation:
of the 366 `Deno.bench` bodies written at the top level of a bench file,
138 build a runtime or a storage manager without bracketing. Converting
them is larger work than this, and each conversion moves the number that
benchmark reports.