### PR TITLE
refactor(tasks): stamp the skipped artifact, drop retro-classification

### DIFF
--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -358,16 +358,22 @@ current. The ratchet skips a cold sample when choosing among the
 base-branch commit and its ancestors, so a cold `main` run cannot lower the
 baseline that warm PRs are held to.
 
-A run without a recorded cache state — an artifact carrying no stamp, or a run
-whose cache-state artifact failed to upload — is retro-classified from the
-compile fingerprint (`tasks/compile-cache-state.ts` mirrors the `cc-*` key globs,
-drift-guarded by a test that parses the workflow): if the fingerprint paths
-changed against the run's predecessor, every family is treated as cold; if
-unchanged, warm. The same fingerprint inference backstops the current run when
-its cache-state artifact is missing. Fingerprint inference cannot see
-non-fingerprint cold causes (cache eviction, cache-service outages): a run cold
-for those reasons and lacking a recorded state stays unknown, so it is treated
-as not-cold and may still be used as a baseline.
+Every run stamps its own `perf-metrics.json`, so a baseline run's coldness is
+read straight off the artifact that run published. Before writing the stamp, a
+run fills in any family whose cache-state artifact did not arrive, using the
+compile fingerprint: `tasks/compile-cache-state.ts` mirrors the `cc-*` key globs
+(drift-guarded by a test that parses the workflow) and compares the run's commit
+against the commit whose cache it would have restored — the pull request's own
+changed files, or the previous `main` run for a push. A family with no recorded
+state is filled cold when those paths changed. Recorded states are ground truth
+and always win. The rate-limit skip path writes the same stamped artifact, so a
+run cut short still tells later runs whether it was cold.
+
+Neither source is complete. Fingerprint inference cannot see non-fingerprint
+cold causes (cache eviction, cache-service outages), and a run whose cache-state
+artifacts and fingerprint comparison both failed publishes no stamp at all. A
+run with no recorded state is treated as not-cold and may still be used as a
+baseline.
 
 ## Which `main` run the ratchet compares against
 

--- a/tasks/compile-cache-state.test.ts
+++ b/tasks/compile-cache-state.test.ts
@@ -8,10 +8,11 @@ import {
   inferCurrentRunFallbackState,
   matcherForGlob,
   pathTouchesCompileCacheKey,
-  recordUnstampedBaselineRunState,
-  uniformCacheStates,
 } from "./compile-cache-state.ts";
-import type { CompileCacheStates } from "./ci-check-lib.ts";
+import {
+  COMPILE_CACHE_FAMILIES,
+  type CompileCacheStates,
+} from "./ci-check-lib.ts";
 
 async function captureLogs(fn: () => void | Promise<void>): Promise<string[]> {
   const logs: string[] = [];
@@ -65,14 +66,6 @@ Deno.test("classifyCacheKeyState is cold iff a changed file touches the key set"
     "cold",
   );
   assertEquals(classifyCacheKeyState([]), "warm");
-});
-
-Deno.test("uniformCacheStates covers every compile-cache family", () => {
-  const cold = uniformCacheStates("cold");
-  assertEquals(Object.values(cold), Object.keys(cold).map(() => "cold"));
-  assert(Object.keys(cold).includes("pattern-unit"));
-  assert(Object.keys(cold).includes("pattern-integration"));
-  assert(Object.keys(cold).includes("generated-patterns"));
 });
 
 Deno.test("classifyRunAgainstPredecessor classifies via changed files", async () => {
@@ -315,7 +308,7 @@ Deno.test("fillMissingFamiliesFromFingerprint fills only unknown families, only 
   assertEquals(recorded["pattern-integration"], "cold");
   assertEquals(recorded["generated-patterns"], "cold");
 
-  const allFamilies = Object.keys(uniformCacheStates("cold")).sort();
+  const allFamilies = [...COMPILE_CACHE_FAMILIES].sort();
   assertEquals(Object.keys(recorded).sort(), allFamilies);
   assertEquals(filled, allFamilies.length - 1);
   // A non-zero fill is announced in the transcript, with the count.
@@ -335,54 +328,4 @@ Deno.test("fillMissingFamiliesFromFingerprint is a no-op (and silent) for warm a
     assertEquals(recorded, { "pattern-unit": "warm" });
     assertEquals(logs.length, 0);
   }
-});
-
-Deno.test("recordUnstampedBaselineRunState retro-classifies against the predecessor and logs only cold", async () => {
-  // Cold: the compare against the predecessor touches the key set → every
-  // family recorded cold, with a transcript line naming the run.
-  const cold = new Map<number, CompileCacheStates>();
-  const coldLogs = await captureLogs(() =>
-    recordUnstampedBaselineRunState(
-      cold,
-      { id: 42, head_sha: "head" },
-      "prev",
-      "PR #4586",
-      (base, head) => {
-        assertEquals([base, head], ["prev", "head"]);
-        return Promise.resolve(["deno.lock"]);
-      },
-    )
-  );
-  assertEquals(cold.get(42), uniformCacheStates("cold"));
-  assertEquals(coldLogs.length, 1);
-  assert(coldLogs[0]!.includes("42"));
-  assert(coldLogs[0]!.includes("PR #4586"));
-  assert(coldLogs[0]!.includes("retro-classified cold"));
-
-  // Warm: the compare touches nothing in the key set → uniform-warm, no log.
-  const warm = new Map<number, CompileCacheStates>();
-  const warmLogs = await captureLogs(() =>
-    recordUnstampedBaselineRunState(
-      warm,
-      { id: 7, head_sha: "head" },
-      "prev",
-      "abc1234",
-      () => Promise.resolve(["docs/readme.md"]),
-    )
-  );
-  assertEquals(warm.get(7), uniformCacheStates("warm"));
-  assertEquals(warmLogs.length, 0);
-
-  // Unknown: no predecessor → records nothing, and never runs the compare.
-  const unknown = new Map<number, CompileCacheStates>();
-  await recordUnstampedBaselineRunState(
-    unknown,
-    { id: 9, head_sha: "head" },
-    undefined,
-    "def5678",
-    () => {
-      throw new Error("must not compare without a predecessor");
-    },
-  );
-  assertEquals(unknown.size, 0);
 });

--- a/tasks/compile-cache-state.ts
+++ b/tasks/compile-cache-state.ts
@@ -24,7 +24,6 @@
 
 import {
   COMPILE_CACHE_FAMILIES,
-  type CompileCacheState,
   type CompileCacheStates,
   githubGet,
   REPO,
@@ -150,22 +149,6 @@ export async function classifyRunAgainstPredecessor(
 }
 
 /**
- * Expand a run-level fingerprint verdict to per-family states: a fingerprint
- * rotation colds every family at once (the shared key prefix), and a
- * fingerprint-stable run restored (at least) via restore-keys everywhere.
- * Used to retro-classify runs whose artifacts predate the recorded stamp.
- */
-export function uniformCacheStates(
-  state: CompileCacheState,
-): CompileCacheStates {
-  const states: CompileCacheStates = {};
-  for (const family of COMPILE_CACHE_FAMILIES) {
-    states[family] = state;
-  }
-  return states;
-}
-
-/**
  * The current run's fallback fingerprint verdict, used only to fill families
  * that have no recorded cache state. A PR run reads its own changed-file list;
  * a main-push run compares its head against the latest prior baseline run.
@@ -229,35 +212,4 @@ export function fillMissingFamiliesFromFingerprint(
     );
   }
   return filled;
-}
-
-/**
- * Retro-classify an unstamped baseline run — one whose artifacts carry no
- * recorded stamp — from the compile fingerprint against its predecessor, and
- * record the result in `cacheStatesByRunId` keyed by run id. A "cold"/"warm"
- * verdict applies to every family at once (the shared key prefix); "unknown"
- * (no predecessor, or an unreadable compare) records nothing, leaving the run
- * to gate on its kept samples like any run whose cache state cannot be
- * determined. A cold retro-classification is logged for the CI transcript.
- * `fetchChanged` is injected so the classification is testable offline.
- */
-export async function recordUnstampedBaselineRunState(
-  cacheStatesByRunId: Map<number, CompileCacheStates>,
-  run: { id: number; head_sha: string },
-  predecessorSha: string | undefined,
-  label: string,
-  fetchChanged?: (baseSha: string, headSha: string) => Promise<string[]>,
-): Promise<void> {
-  const inferred = await classifyRunAgainstPredecessor(
-    run.head_sha,
-    predecessorSha,
-    fetchChanged,
-  );
-  if (inferred === "unknown") return;
-  cacheStatesByRunId.set(run.id, uniformCacheStates(inferred));
-  if (inferred === "cold") {
-    console.log(
-      `  Baseline run ${run.id} (${label}) retro-classified cold: compile fingerprint changed vs predecessor.`,
-    );
-  }
 }

--- a/tasks/coverage-check.test.ts
+++ b/tasks/coverage-check.test.ts
@@ -639,7 +639,11 @@ Deno.test("fetchBaselineRunsForCheck fetches main head and baseline runs", async
       return new Response("unexpected request", { status: 404 });
     },
     () =>
-      fetchBaselineRunsForCheck(new Map(), 1, (message) => logs.push(message)),
+      fetchBaselineRunsForCheck(
+        { metrics: new Map() },
+        1,
+        (message) => logs.push(message),
+      ),
   );
 
   assertEquals(result, { mainHeadSha: SHA_A, baselineRuns: [run] });
@@ -695,7 +699,7 @@ Deno.test("formatErrorForLog keeps the first line only", () => {
   assertEquals(formatErrorForLog("plain\nsecond"), "plain");
 });
 
-Deno.test("githubApiOrSkip writes metrics and exits on rate limits", async () => {
+Deno.test("githubApiOrSkip writes the stamped artifact and exits on rate limits", async () => {
   const metrics = new Map<string, BaselineSample>([
     ["job: Check", makeSample()],
   ]);
@@ -706,7 +710,7 @@ Deno.test("githubApiOrSkip writes metrics and exits on rate limits", async () =>
         githubApiOrSkip(
           "collecting test data",
           () => Promise.reject(new Error("rate limit exceeded")),
-          metrics,
+          { metrics, compileCacheStates: { "pattern-unit": "cold" } },
         ).then(() => {})
       )
     );
@@ -719,6 +723,9 @@ Deno.test("githubApiOrSkip writes metrics and exits on rate limits", async () =>
     );
     const file = JSON.parse(await Deno.readTextFile("perf-metrics.json"));
     assertEquals(file.metrics[0].name, "job: Check");
+    // The skip path carries the compile cache stamp, so a later run reading
+    // this artifact still sees that this run was cold.
+    assertEquals(file.compileCacheStates, { "pattern-unit": "cold" });
   } finally {
     await Deno.remove("perf-metrics.json").catch(() => {});
   }
@@ -730,7 +737,7 @@ Deno.test("githubApiOrSkip rethrows non-rate-limit errors", async () => {
       githubApiOrSkip(
         "collecting test data",
         () => Promise.reject(new Error("plain failure")),
-        new Map(),
+        { metrics: new Map() },
       ),
     Error,
     "plain failure",

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -64,7 +64,6 @@ import {
 import {
   fillMissingFamiliesFromFingerprint,
   inferCurrentRunFallbackState,
-  recordUnstampedBaselineRunState,
 } from "./compile-cache-state.ts";
 import { walk } from "@std/fs/walk";
 import * as path from "@std/path";
@@ -110,10 +109,35 @@ function isGitHubRateLimitError(error: unknown): boolean {
   return /\b(rate limit|rate-limited|ratelimit)\b/i.test(message);
 }
 
+/**
+ * The perf-metrics artifact this run publishes: its coverage metrics, and the
+ * compile cache states that stamp them. A later run reads the stamp to decide
+ * whether this run was cold, so every path that writes the artifact writes
+ * both halves.
+ */
+export interface PerfMetricsArtifact {
+  metrics: Map<string, BaselineSample>;
+  compileCacheStates?: CompileCacheStates;
+}
+
+/** Writes the artifact to {@link PERF_METRICS_FILE}, and says so. */
+async function writePerfMetricsArtifact(
+  artifact: PerfMetricsArtifact,
+): Promise<void> {
+  await writeCoverageBaselineFile(
+    PERF_METRICS_FILE,
+    artifact.metrics,
+    artifact.compileCacheStates,
+  );
+  console.log(
+    `Wrote ${PERF_METRICS_FILE} with ${artifact.metrics.size} metrics.`,
+  );
+}
+
 export async function githubApiOrSkip<T>(
   description: string,
   operation: () => Promise<T>,
-  metricsForArtifact: Map<string, BaselineSample>,
+  artifact: PerfMetricsArtifact,
 ): Promise<T> {
   try {
     return await operation();
@@ -123,10 +147,7 @@ export async function githubApiOrSkip<T>(
     console.warn(
       `  Warning: GitHub API rate limit while ${description}: ${error}`,
     );
-    await writeCoverageBaselineFile(PERF_METRICS_FILE, metricsForArtifact);
-    console.log(
-      `Wrote ${PERF_METRICS_FILE} with ${metricsForArtifact.size} metrics.`,
-    );
+    await writePerfMetricsArtifact(artifact);
     console.log(
       "Skipping coverage check because GitHub API rate limits prevent collecting the baseline data.",
     );
@@ -716,7 +737,7 @@ export async function fetchArtifactsForRunBestEffort(
 }
 
 export async function fetchBaselineRunsForCheck(
-  metricsForArtifact: Map<string, BaselineSample>,
+  artifact: PerfMetricsArtifact,
   baselineRunCount = BASELINE_RUNS,
   log: (message: string) => void = console.log,
 ): Promise<{ mainHeadSha: string; baselineRuns: WorkflowRun[] }> {
@@ -724,7 +745,7 @@ export async function fetchBaselineRunsForCheck(
   const mainHeadSha = await githubApiOrSkip(
     "fetching current main branch head",
     () => fetchMainHeadSha(),
-    metricsForArtifact,
+    artifact,
   );
   log(`Current main head is ${mainHeadSha}.`);
   log("Fetching recent main-branch runs for baseline...");
@@ -734,7 +755,7 @@ export async function fetchBaselineRunsForCheck(
       githubGet<{ workflow_runs: WorkflowRun[] }>(
         workflowRunsPathForBaseline(baselineRunCount),
       ),
-    metricsForArtifact,
+    artifact,
   );
   return { mainHeadSha, baselineRuns: baselineData.workflow_runs };
 }
@@ -1638,6 +1659,15 @@ export async function main() {
   });
   fillMissingFamiliesFromFingerprint(currentCacheStates, inferredRunState);
 
+  // Both halves of the artifact travel together from here on: every GitHub
+  // call is wrapped so a rate limit writes this same stamped payload before
+  // skipping the check. `metrics` and `compileCacheStates` are the live
+  // objects, so later additions to either are picked up.
+  const perfArtifact: PerfMetricsArtifact = {
+    metrics: currentMetrics,
+    compileCacheStates: currentCacheStates,
+  };
+
   // Extract coverage debt metrics from coverage profile artifacts.
   let coverageDataError: unknown;
   let coverageLcov = "";
@@ -1663,14 +1693,7 @@ export async function main() {
     );
   }
 
-  await writeCoverageBaselineFile(
-    PERF_METRICS_FILE,
-    currentMetrics,
-    currentCacheStates,
-  );
-  console.log(
-    `Wrote ${PERF_METRICS_FILE} with ${currentMetrics.size} metrics.`,
-  );
+  await writePerfMetricsArtifact(perfArtifact);
 
   if (coverageDataError && !informationalOnly) {
     console.error(
@@ -1692,7 +1715,7 @@ export async function main() {
 
   // 3. Fetch recent main-branch push runs for baseline
   const { mainHeadSha, baselineRuns } = await fetchBaselineRunsForCheck(
-    currentMetrics,
+    perfArtifact,
   );
   reportBaselineRunAvailability(baselineRuns, mainHeadSha);
 
@@ -1708,20 +1731,9 @@ export async function main() {
     b.created_at.localeCompare(a.created_at) || b.id - a.id
   );
 
-  // For each baseline run, its predecessor in the newest-first list — the run
-  // whose saved compile cache it would have restored. Fuels retro-
-  // classification of a run whose perf-metrics artifact carries no recorded
-  // cache state.
-  const predecessorShaByRunId = new Map<number, string>();
-  for (let i = 0; i < runsNewestFirst.length - 1; i++) {
-    predecessorShaByRunId.set(
-      runsNewestFirst[i].id,
-      runsNewestFirst[i + 1].head_sha,
-    );
-  }
-
   // Compile cache states per baseline run, from tagged perf-metrics
-  // artifacts. Runs with no artifact stay absent (unknown).
+  // artifacts. A run whose artifact is missing or carries no stamp stays
+  // absent, which the ratchet reads as not-cold.
   const cacheStatesByRunId = new Map<number, CompileCacheStates>();
   const isRunCold = (runId: number): boolean => {
     const states = cacheStatesByRunId.get(runId);
@@ -1742,17 +1754,6 @@ export async function main() {
       );
       if (baseline?.compileCacheStates) {
         cacheStatesByRunId.set(run.id, baseline.compileCacheStates);
-      } else {
-        // A run whose perf-metrics artifact is missing or carries no recorded
-        // cache state: retro-classify it from the compile fingerprint against
-        // its predecessor, so a cold main run is not picked as the coverage
-        // ratchet baseline (see recordUnstampedBaselineRunState).
-        await recordUnstampedBaselineRunState(
-          cacheStatesByRunId,
-          run,
-          predecessorShaByRunId.get(run.id),
-          context.pr ? `PR #${context.pr.number}` : run.head_sha.slice(0, 8),
-        );
       }
 
       const overrides = context.pr
@@ -1770,7 +1771,7 @@ export async function main() {
         overrides,
         cold: isRunCold(run.id),
       };
-    }, currentMetrics);
+    }, perfArtifact);
 
   // 5. Compare the current run's coverage debt against the ratchet baseline.
 
@@ -1782,7 +1783,7 @@ export async function main() {
     readRun: readBaselineRun,
     isPullRequest: prNumber !== null,
     guard: (description, operation) =>
-      githubApiOrSkip(description, operation, currentMetrics),
+      githubApiOrSkip(description, operation, perfArtifact),
   }).finally(() => reportBaselineContextResults(visitedContexts));
 
   if (acceptingRuns > 0) {


### PR DESCRIPTION
The coverage ratchet must not take a cold-compile main run as its baseline: a cold run covers compile branches that only execute on a cold cache, so its lower coverage debt would hold later warm pull requests to an unreachable bar. Three separate mechanisms were answering that one question. A run records per-shard cache states into its own perf-metrics.json artifact, which is ground truth. A run with families missing from that record fills them from the compile fingerprint before writing. And a third layer re-derived the answer for historical baseline runs whose artifact carried no stamp at all, spending one GitHub compare API call per unstamped run to do it.

The third layer no longer earns its place, but only once the first one stops being sabotaged. When a GitHub rate limit cuts the check short, githubApiOrSkip writes perf-metrics.json so the run still publishes its coverage numbers — and it wrote that file with the metrics alone, overwriting the stamped file the check had already written moments earlier. The gate was manufacturing exactly the unstamped artifacts the retro-classification layer existed to repair. So the two changes land together: deleting the layer without the write fix would drop a repair for a fault the same file keeps causing.

The fix threads the compile cache states through to the skip path. The metrics map and the cache states are always the same pair — they are the two halves of one artifact — so they now travel as a single PerfMetricsArtifact value through githubApiOrSkip and fetchBaselineRunsForCheck, and one helper writes the artifact for both the normal path and the skip path.

With that in place, retro-classification cannot change an outcome. It fired in two situations. Either the baseline run had no readable perf-metrics artifact, in which case that run contributed no samples to any timeline, and the ratchet only ever asks whether a run was cold for runs that appear in a timeline — so the verdict was recorded and never read. Or the artifact parsed but carried no stamp, which after the write fix means the producing run lost its cache-state artifacts and its own fingerprint comparison as well; retro-classification then reruns the same compare against the same predecessor and reaches the same verdict, and a warm verdict is indistinguishable from no verdict to every consumer. The layer was built when unstamped runs from before the stamp rollout filled the twenty-run baseline window, and when a since-removed performance gate consumed these verdicts across a median where a single misjudged run skewed the whole window. Neither condition holds.

Deleted: recordUnstampedBaselineRunState and uniformCacheStates from compile-cache-state.ts, the per-run predecessor map and the else-branch that called them in coverage-check.ts, and their tests. One surviving test read the family list back out of uniformCacheStates and now reads COMPILE_CACHE_FAMILIES directly.

The residual gap is unchanged in kind and is now stated plainly in the coverage documentation: fingerprint inference cannot see a cold cache caused by eviction or a cache-service outage, and a run that loses both its cache-state artifacts and its fingerprint comparison publishes no stamp. A run with no recorded state is treated as not-cold and may still be chosen as a baseline.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

