### PR TITLE
test(cli): strip ANSI before asserting on captured CLI output

### DIFF
--- a/packages/cli/test/alias.test.ts
+++ b/packages/cli/test/alias.test.ts
@@ -1,12 +1,12 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { cliName } from "../lib/cli-name.ts";
-import { cf, checkStderr } from "./utils.ts";
+import { cf, checkStderr, stripAnsi } from "./utils.ts";
 
 describe("CLI naming", () => {
   it("shows cf in top-level help", async () => {
     const { code, stdout, stderr } = await cf("--help");
-    const help = stdout.join("\n");
+    const help = stripAnsi(stdout.join("\n"));
 
     expect(code).toBe(0);
     checkStderr(stderr);
@@ -18,7 +18,7 @@ describe("CLI naming", () => {
 
   it("shows cf in exec help examples", async () => {
     const { code, stdout, stderr } = await cf("help exec");
-    const help = stdout.join("\n");
+    const help = stripAnsi(stdout.join("\n"));
 
     expect(code).toBe(0);
     checkStderr(stderr);

--- a/packages/cli/test/fabric-deps.test.ts
+++ b/packages/cli/test/fabric-deps.test.ts
@@ -7,7 +7,7 @@ import { slugIdForSpace } from "../../runner/src/slugs.ts";
 import { InMemoryProgram } from "@commonfabric/js-compiler";
 import { pinProgramFabricImports } from "../lib/fabric-deps.ts";
 import { collectLocalProgram } from "../lib/dev.ts";
-import { cf } from "./utils.ts";
+import { cf, stripAnsi } from "./utils.ts";
 
 const signer = await Identity.fromPassphrase("cli fabric deps test");
 const space = signer.did();
@@ -162,6 +162,6 @@ describe("cli fabric deps", () => {
     const { code, stdout } = await cf("deps update --help");
 
     expect(code).toBe(0);
-    expect(stdout.join("\n")).toContain("--check");
+    expect(stripAnsi(stdout.join("\n"))).toContain("--check");
   });
 });

--- a/packages/cli/test/inspect-churn.test.ts
+++ b/packages/cli/test/inspect-churn.test.ts
@@ -8,10 +8,16 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Database } from "@db/sqlite";
-import { cf } from "./utils.ts";
+import { cf, stripAnsi } from "./utils.ts";
 
-/** `CliResult` streams are line arrays; join before substring assertions. */
-const text = (lines: string[]): string => lines.join("\n");
+/**
+ * `CliResult` streams are line arrays; join before substring assertions.
+ *
+ * The escapes go too: the CLI colours help and error output whenever the
+ * environment asks for colour, so an assertion on raw text passes or fails by
+ * where the developer ran it.
+ */
+const text = (lines: string[]): string => stripAnsi(lines.join("\n"));
 
 const SESSION = "session:did%3Akey%3AzAlice:s1";
 

--- a/packages/cli/test/json-command.test.ts
+++ b/packages/cli/test/json-command.test.ts
@@ -189,9 +189,9 @@ describe("JSON command contracts", () => {
     const wish = await cf("wish --help");
 
     expect(pieceGet.code).toBe(0);
-    expect(pieceGet.stdout.join("\n")).toContain("--json");
+    expect(stripAnsi(pieceGet.stdout.join("\n"))).toContain("--json");
     expect(wish.code).toBe(0);
-    expect(wish.stdout.join("\n")).toContain("--json");
+    expect(stripAnsi(wish.stdout.join("\n"))).toContain("--json");
   });
 
   it("rejects --json forwarded to fuse-daemon", async () => {

--- a/packages/cli/test/main-command.test.ts
+++ b/packages/cli/test/main-command.test.ts
@@ -253,19 +253,20 @@ describe("main command", () => {
 
   it("shows exec command help before trying to resolve a mounted file", async () => {
     const { code, stdout } = await cf("exec --help");
+    const help = stripAnsi(stdout.join("\n"));
 
     expect(code).toBe(0);
-    expect(stdout.join("\n")).toContain(
+    expect(help).toContain(
       "Execute a mounted callable file from a Common Fabric FUSE mount.",
     );
-    expect(stdout.join("\n")).not.toContain("not within a mounted cf fuse");
+    expect(help).not.toContain("not within a mounted cf fuse");
   });
 
   it("shows help for the direct FUSE daemon entry point", async () => {
     const { code, stdout } = await cf("fuse-daemon --help");
 
     expect(code).toBe(0);
-    expect(stdout.join("\n")).toContain(
+    expect(stripAnsi(stdout.join("\n"))).toContain(
       "Usage:   cf fuse-daemon <mountpoint> [options]",
     );
   });

--- a/packages/cli/test/piece-label.test.ts
+++ b/packages/cli/test/piece-label.test.ts
@@ -647,7 +647,7 @@ describe("cf piece CFC labels", () => {
     expect(stripAnsi(getHelp.stdout.join("\n"))).toContain(
       "effective CFC label view",
     );
-    expect(getHelp.stdout.join("\n")).toContain("--json");
+    expect(stripAnsi(getHelp.stdout.join("\n"))).toContain("--json");
 
     const setHelp = await cf("piece set-label --help");
     expect(setHelp.code).toBe(0);

--- a/packages/cli/test/space.test.ts
+++ b/packages/cli/test/space.test.ts
@@ -10,10 +10,16 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Database } from "@db/sqlite";
 import { clonePaths } from "@commonfabric/state-inspector";
-import { cf } from "./utils.ts";
+import { cf, stripAnsi } from "./utils.ts";
 
-/** `CliResult` streams are line arrays; join before substring assertions. */
-const text = (lines: string[]): string => lines.join("\n");
+/**
+ * `CliResult` streams are line arrays; join before substring assertions.
+ *
+ * The escapes go too: the CLI colours help and error output whenever the
+ * environment asks for colour, so an assertion on raw text passes or fails by
+ * where the developer ran it.
+ */
+const text = (lines: string[]): string => stripAnsi(lines.join("\n"));
 
 /**
  * Staging directories `--from <url>` may have created, by name.


### PR DESCRIPTION
## Why

`cd packages/cli && deno task test` **exits 1 on `main`** for any developer whose environment asks for colour. One assertion compares raw stdout against a plain string that the CLI renders with escapes:

```
"\x1b[1mUsage:\x1b[22m   \x1b[95mcf fuse-daemon …"   vs   "Usage:   cf fuse-daemon <mountpoint> [options]"
```

CI never sees it — it captures non-TTY output with colour off. So the failure appears only where people actually work, on the gate this repo leans on hardest before pushing.

Two costs, and the second is the one that matters: a gate that is always red teaches people to read past it, and it quietly devalues every "the suite passes" claim made from a dev machine. Several such claims were made today and were worth less than they appeared.

Fixes #5704.

## The mechanism

`resolveColorEnabled` deliberately honours `FORCE_COLOR` / `CLICOLOR_FORCE` **even when stdout is piped**, and the test spawner clears the environment but re-inherits every name outside its `CF_*` / `EXPERIMENTAL_*` allowlist — so a shell's `FORCE_COLOR` reaches the child and Cliffy colourises.

Colour reaches captured output from exactly three places: Cliffy's help/usage/error rendering, `cf view`'s own renderer, and Deno's task echo on stderr. Nothing else in the CLI imports `@std/fmt/colors`, and neither `packages/utils` nor `packages/runner` colourises — so command reports, logs and JSON are plain.

## What Changed

**Not one site — eight, across seven files.** Every assertion on `stdout`/`stderr` in all 21 files that spawn `cf` was checked, and each candidate command probed to see whether its stream actually carries escapes.

The seven beyond the failing one were latent, passing only because their expected substring happened not to straddle a style boundary. **One was actively vacuous**: a `not.toContain("not within a mounted cf fuse")` that colour would have made unable to fail.

Two files define an identical `text()` join helper, so those were hardened at the helper rather than the call sites.

## Verified clean, deliberately untouched

`fuse-supervisor --help` (a hand-built plain string — probed, zero escapes); the `cf view` tests, which control colour with `--color never` and two of which assert on escapes on purpose; JSON payloads, where colour would fail `JSON.parse` loudly; and in-process helpers like `renderExecHelp`, which never cross a subprocess.

## The alternative, and why not

Setting `NO_COLOR=1` in the test spawner would close the class at a single site. It would also mean the suite never exercises the CLI the way developers run it, and a fault in the colour path would stop being reachable by any test. Stripping at the assertion keeps both properties.

## Test plan

- `cd packages/cli && deno task test`, exit status captured as `OUT=$(...); RC=$?` rather than through a pipe: **RC=1 before → RC=0 after.** After, on the rebased tree: parallel `1668 passed | 0 failed`, serial `174 passed | 0 failed`.
- The originally-failing test confirmed red before and green after in isolation.
- `deno fmt --check`, `deno lint`, `deno check` on all touched files.

Test files only.

## Follow-up worth someone's judgement

Nothing in `.claude/rules/` or `docs/development/` mentions ANSI or `stripAnsi`, so this convention lives only in whichever neighbour you happen to copy — and this file has now been fixed for it twice. A line in `.claude/rules/tests.md`, or a lint against un-stripped `stdout.join` under `packages/cli/test`, would stop the third.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

