### PR TITLE
test(cli): pin the wait that only sometimes goes round

### DIFF
--- a/packages/cli/test/multi-user-test-runner.test.ts
+++ b/packages/cli/test/multi-user-test-runner.test.ts
@@ -7,7 +7,8 @@
  *
  * What these tests hold in place is that contract as an author meets it: a
  * marker carries state across, a marker announced from a replica that predates
- * another participant's announcement still arrives, a false assertion is
+ * another participant's announcement still arrives, a wait outlives a change to
+ * the announcer's document that is not the awaited marker, a false assertion is
  * reported for what it read rather than for running out of time, and a marker
  * nobody announces is still a deadlock. The propagation gap itself is too
  * small to observe in a fixture this size — the barrier's discriminating
@@ -17,12 +18,78 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { resolve } from "@std/path";
+import { Identity } from "@commonfabric/identity";
+import { StandaloneMemoryServer } from "@commonfabric/memory/v2/standalone";
 import { runTests } from "../lib/test-runner.ts";
+import type {
+  WorkerRequest,
+  WorkerResponse,
+} from "../lib/multi-user-test-worker.ts";
 
 const FIXTURES = resolve(import.meta.dirname!, "fixtures/multi-user-markers");
 
 function fixture(name: string): string {
   return resolve(FIXTURES, name);
+}
+
+/**
+ * One participant worker, driven by hand over the same request/response
+ * protocol the orchestrator uses.
+ *
+ * The orchestrator issues `awaitMarker` only for a marker it has already seen
+ * announced, so through it a wait always begins on a marker the announcer has
+ * committed and settled — which of the wait's two paths runs is then left to
+ * how fast the announcement reaches the awaiting replica. This client leaves a
+ * call in flight while it drives another worker, which is what lets a test
+ * choose the order instead.
+ */
+class ParticipantWorkerClient {
+  readonly name: string;
+  #worker: Worker;
+  #nextId = 1;
+  #pending = new Map<
+    number,
+    { resolve: (value: unknown) => void; reject: (error: Error) => void }
+  >();
+
+  constructor(name: string) {
+    this.name = name;
+    this.#worker = new Worker(
+      new URL("../lib/multi-user-test-worker.ts", import.meta.url),
+      { type: "module", name: `marker-wait:${name}` },
+    );
+    this.#worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
+      const pending = this.#pending.get(event.data.id);
+      if (!pending) return;
+      this.#pending.delete(event.data.id);
+      if ("error" in event.data) {
+        pending.reject(new Error(`[${this.name}] ${event.data.error}`));
+      } else {
+        pending.resolve(event.data.ok);
+      }
+    };
+    // Without this a worker-level failure would leave every call pending, and
+    // a test that reports nothing is worse than one that reports the error.
+    this.#worker.onerror = (event) => {
+      const error = new Error(`[${this.name}] worker error: ${event.message}`);
+      for (const pending of this.#pending.values()) pending.reject(error);
+      this.#pending.clear();
+    };
+  }
+
+  call(cmd: string, args: Record<string, unknown> = {}): Promise<unknown> {
+    const id = this.#nextId++;
+    const request: WorkerRequest = { id, cmd, args };
+    return new Promise((resolve, reject) => {
+      this.#pending.set(id, { resolve, reject });
+      this.#worker.postMessage(request);
+    });
+  }
+
+  async close(): Promise<void> {
+    await this.call("dispose").catch(() => {});
+    this.#worker.terminate();
+  }
 }
 
 describe(
@@ -71,6 +138,78 @@ describe(
       expect(passed).toBe(0);
       expect(failed).toBe(1);
       expect(results[0].results[0].error).toContain("Expected true, got false");
+    });
+
+    it("holds a wait open across a change that is not the marker", async () => {
+      // The wait re-reads on every change to the announcer's document, so the
+      // marker it was given releases it and nothing else does.
+      //
+      // Driving the workers directly is what orders it that way. The
+      // orchestrator announces a marker before it asks anyone to wait for it,
+      // so through it the wait's first read decides the outcome. Here bob's
+      // wait starts on a marker alice has not been asked for — that request
+      // goes out a round trip later — and alice's other marker wakes the wait
+      // onto a document that still lacks the one it wants.
+      const server = StandaloneMemoryServer.start();
+      const spaceName = crypto.randomUUID();
+      const names = ["alice", "bob"];
+      const workers = new Map<string, ParticipantWorkerClient>();
+      try {
+        for (const [index, name] of names.entries()) {
+          const client = new ParticipantWorkerClient(name);
+          workers.set(name, client);
+          const identity = await Identity.fromPassphrase(
+            `test-runner ${name}`,
+            { implementation: "noble" },
+          );
+          await client.call("init", {
+            rawIdentity: identity.serialize(),
+            spaceName,
+            apiUrl: server.url.href,
+            // Any two-participant descriptor will do: the markers this test
+            // announces and awaits are its own, not the fixture's steps.
+            testPath: fixture("marker-barrier.test.tsx"),
+            root: FIXTURES,
+            participant: name,
+            participants: names,
+            seedDefaults: index === 0,
+          });
+        }
+        const alice = workers.get("alice")!;
+        const bob = workers.get("bob")!;
+
+        // The outcome is an order rather than a moment: "not released yet" is
+        // only worth asserting against something bob has demonstrably seen.
+        const order: string[] = [];
+        let failure: unknown;
+        const waiting = bob.call("awaitMarker", {
+          announcedBy: "alice",
+          marker: "wanted",
+        }).then(() => {
+          order.push("released");
+        }, (error: unknown) => {
+          failure = error;
+        });
+
+        await alice.call("label", { marker: "unwanted" });
+        // A second wait, for the marker alice did announce, returns once bob's
+        // replica holds it — so the first wait has now seen the change that
+        // must not release it.
+        await bob.call("awaitMarker", {
+          announcedBy: "alice",
+          marker: "unwanted",
+        });
+        order.push("saw the other marker");
+        expect(failure).toBeUndefined();
+
+        await alice.call("label", { marker: "wanted" });
+        await waiting;
+        if (failure !== undefined) throw failure;
+        expect(order).toEqual(["saw the other marker", "released"]);
+      } finally {
+        for (const client of workers.values()) await client.close();
+        await server.close().catch(() => {});
+      }
     });
 
     it("reports a marker nobody announces as a deadlock", async () => {


### PR DESCRIPTION
## Why

`packages/cli`'s uncovered-line count **oscillates between 3409 and 3411 on a single line**, so CI's coverage ratchet fails whichever PR happens to draw the unlucky run. #5701 was charged for it today with a diff that never touched the file.

The line is `await next;` in `waitForMarker` (`packages/cli/lib/multi-user-test-worker.ts`). It executes only when the marker is **absent on the first check** and the loop goes round — a race between participants. Across 8 recent main runs its hit count was `0,0,1,2,0,0,0,1`.

`docs/development/COVERAGE.md` § *"Coverage must not depend on the execution environment"* names this exactly: a line whose coverage moves with the environment is a **test defect**, not gate noise, and must not be waved through with `ACCEPT_COVERAGE_DEBT` — an override would pin main's floor at the unlucky value and hide the flake permanently.

## What Changed

One test, and **`waitForMarker` itself is untouched** — nothing was exported to reach it. The function is correct; capturing `changed.promise` before the read is what stops a racing change from being missed.

**Why not through the orchestrator.** `runMultiUserTestPattern` only issues `awaitMarker` for a marker already in its `announced` map, so every wait it drives starts on a marker that is already committed and settled — which is precisely why the first read usually succeeds. A fixture built on it cannot express "absent, then arrives".

So the test spawns the two participant workers itself and speaks the same `WorkerRequest`/`WorkerResponse` protocol, leaving one participant's `awaitMarker` in flight while driving the other. The awaited marker is not requested until a round trip later, so it cannot exist at the first read; the *other* participant's marker then wakes the wait onto a document that still lacks the one it wants. `await next;` runs twice, structurally rather than by luck.

The assertion is an **order, not a moment**: a second `awaitMarker` for the marker that *was* announced returns only once the replica holds it, so the first wait has demonstrably seen a change that must not release it.

## Measured

| | |
| --- | --- |
| before | `DA:184,0` `DA:185,0` — two uncovered lines |
| after | `DA:184,2` `DA:185,2` on 11 of 12 runs, `4` on the twelfth. **Never 0.** |

12 repeat runs of the committed version, all green, plus 20 of an earlier version. That removes exactly the ±2 swing behind the 3409↔3411 oscillation.

## The check that nearly wasn't load-bearing

Mutating the wait to release on *any* change to the document — the defect the test exists to catch — and re-running: **the first version of this test passed the mutant.** Its `expect(released).toBe(false)` lost the race, so the negative assertion proved nothing. That is what the ordering anchor replaced it with; the mutant now fails on the recorded order.

Worth stating because a test that cannot fail is this repo's most expensive recurring defect, and this one was one revision away from being another.

## Test plan

`multi-user-test-runner.test.ts` passes all six cases in the full suite. `deno fmt --check`, `deno lint`, `deno check`, `check-no-waitfor`: clean. Test file only.

`deno task test` for `packages/cli` is RC=1 **before and after, identically** — the single failure is the unrelated un-stripped-ANSI assertion tracked as #5704 and fixed in #5714.

## Follow-up: this shape has now been fixed at least four times

`traverse.ts` (COVERAGE.md's own case study), #5351 (two lines, two packages), #5668 (an interval clock's error branch), and this one. Every instance is "a branch reached only when an async race lands one way", and every one was discovered weeks later when the ratchet charged an unrelated PR.

**Nothing detects it at introduction** — there is no coverage-stability check in `tasks/`. The general form is cheap and the parts exist: run a package's suite twice in one job and diff the per-line hit sets; any line that moves is a flake, reported the day it lands rather than on someone else's PR. `tasks/lcov.ts` and `tasks/coverage-metrics.ts` already have the parser and the walker.

Four instances is a mechanism, not a run of bad luck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

