### PR TITLE
feat(cli): a verb's help says what the verb returns

### DIFF
--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -155,18 +155,12 @@ cf piece verbs --piece board
 ```text
 PATTERN cf:module/ZPxyGdkkv-YmizdHdNx5DIlqlpc9JRSm5iXTl4Tb2T0#default
 NAME    KIND    ON     MARKS
-$NAME   handler result
 addItem handler result
-items   handler result
 ```
 
-**Two of those three rows are not verbs.** `items` is the board's array of root
-items and `$NAME` is its display name — data, not callables, and
-`cf piece call --piece board items` will not do anything useful. The listing
-over-reports: its forced-stream fallback answers the cast for values that are
-not streams
-([#5576](https://github.com/commontoolsinc/labs/issues/5576)). Only `addItem`
-is real here.
+**One row, because the board declares one verb.** `items` is the board's array
+of root items and `$NAME` is its display name; both are data, and data is not
+callable, so neither is offered to a caller as something to call.
 
 Slug resolution sits on the shared path (`resolvePieceConfigWithPieces`,
 `packages/cli/lib/piece.ts`), so every command below takes `board` too.
@@ -314,12 +308,14 @@ hands back, and not what either is for.
 
 ```bash
 cf piece call --piece board <TAB>
-addItem  items  $NAME
+addItem
 ```
 
 Verb names and piece addresses complete against the space
 (`shapeVerbCandidates` / `liveCandidates`,
-`packages/cli/lib/completion/providers.ts`), in bash and zsh.
+`packages/cli/lib/completion/providers.ts`), in bash and zsh. The candidates
+map one-for-one over the listing in step 1, so completion offers what that
+command names and nothing besides.
 
 What does not complete is a result field — `--select 'it<TAB>'` has nothing to
 offer. The knowledge exists now: the help page above enumerates `item`, off the

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -106,9 +106,9 @@ interface ItemOutput {
 **A verb says what it does; its parameters describe themselves.** The comment
 on `addItem` does not restate what it takes or returns, because
 `AddItemEvent.title` and `AddItemResult.item` already say so where they are
-declared — which is also where `--help` would source a flag's prose and an
-`Output:` line. Restating it in the verb comment would be the same content
-twice, and the copy that goes stale when a parameter changes.
+declared — which is where `--help` sources its `Output:` line today, and where
+it would source a flag's prose. Restating it in the verb comment would be the
+same content twice, and the copy that goes stale when a parameter changes.
 
 **One interface, holding both.** An item's fields and its verbs sit together
 because that is what an item *is*: a child in `children` is a full item, and
@@ -192,17 +192,27 @@ JSON input:
 
 Flags after `--`:
   --title <string>    Required.
+
+Output:
+  The invocation's `result`:
+    item <json>
 ```
 
-**Structure is published; prose is not.** The flags are the whole of what `cf`
-can currently say about a verb — there is no `Output:` section, because this
-page cannot see a declared result and a fixed claim about output would be false
-for every verb that declares one. The split is worth holding onto:
+**Structure is published; prose is not.** The flags and the result fields are
+the whole of what `cf` can currently say about a verb. The split is worth
+holding onto:
 
 | | Where it comes from | Survives? |
 | --- | --- | --- |
 | flag name, placeholder, required-ness | the event's **type** — `{ title: string }` | **yes** |
+| result field name and placeholder | the result's **type** — `AddItemResult` | **yes** |
 | what `title` means, what the verb is for | the author's **doc comments** | **no** |
+
+The `Output:` section names the position a caller collects the value from —
+the settled Invocation JSON's `result` — because that is where a handler's
+result arrives, rather than on stdout the way a tool's does. A verb that
+declares nothing carries no such section at all, which is how the page tells
+the two shapes apart without asserting anything false about either.
 
 The structural half needs nothing authored per pattern:
 `parseObjectInput` builds a `FlagDescriptor` per input-schema property, so
@@ -229,15 +239,17 @@ The renderer is ready for two of the three: `specificFlagLines` reads a
 were given one, and a listing row would carry one as soon as it were supplied.
 The verb's *purpose* needs a second change on top, because
 `renderPieceCallHelp` has nowhere to put it — the page runs Usage, JSON input,
-Flags, with no summary line.
+Flags, Output, with no summary line.
 
-So the help page shows `--title <string>  Required.` and stops.
+So the help page names `--title <string>  Required.` and `item <json>`, and
+says nothing about what either means.
 
 ### What the page becomes **[blocked]**
 
 Every line below already exists as a doc comment in `tracker.tsx`. Nothing here
 is invented for the illustration — this is that file's own prose, reaching a
-caller:
+caller. The structure around it is what the page renders today; the prose is
+what it does not:
 
 ```text
 Usage:
@@ -252,7 +264,8 @@ Flags after `--`:
   --title <string>    Required. One line naming the work.
 
 Output:
-  item     The root item this call created.
+  The invocation's `result`:
+    item <json>       The root item this call created.
 ```
 
 **Three levels of documentation, three different fates.** An author writes each
@@ -263,23 +276,23 @@ each parameter describes itself:
 | --- | --- | --- | --- |
 | the verb — *what it does* | the `Stream` property | **yes**, beside the `$ref` | no |
 | an **input** parameter | a field of the event interface | **yes**, in `$defs.<Event>.properties` | no |
-| an **output** parameter | a field of the result interface | **no** | no |
+| an **output** parameter | a field of the result interface | **yes**, on the declared result | **yes**, under `--help --json` |
 
 The first two are the same loss: emitted, then absent from the resolved schema
 the CLI is served, so they come back together
 ([#5637](https://github.com/commontoolsinc/labs/issues/5637)).
 
-The third is different in kind, and it is the one worth understanding. There is
-no structured description of an output parameter *anywhere*, no matter what the
-author writes — because the result type is not compiled at all. `Stream<E, R>`
-compiles `E` and drops `R`, so `$defs` on this pattern holds
-`AddItemEvent`, `AddChildEvent`, `BlockOnEvent`, `FinishEvent`,
-`RecordNoteEvent` and no `Result` interface of any kind. A comment on
-`AddItemResult.item` has nothing to be attached to.
+The third travels furthest, and it is the one worth understanding. A verb's
+declared result reaches `cf` **unresolved** — `--help --json` on `addItem`
+serves `properties.item` as a `$ref` into `$defs.ItemOutput` carrying
+`"description": "The root item this call created."`, the author's own comment,
+verbatim. Nothing strips it, because nothing resolves it. Where the input side
+loses its prose to `$ref` resolution, the output side keeps it.
 
-That is verbs plan item 1 — a verb's declared result reaching the runtime —
-and until it lands, output documentation has no home rather than a broken
-pipe.
+What drops it is the last step: the text page renders each result property as
+`name <placeholder>` and never reads the `description` beside it. So the prose
+is on the wire and one line of rendering away, which is a different problem
+from the two above and a much smaller one.
 
 The summary is worth one more note. An event *interface's* comment would be the
 other candidate for that line, and it is the one thing here that genuinely
@@ -287,19 +300,15 @@ never compiles — so sourcing the summary from the verb's own comment, which is
 already emitted, is both the smaller change and the better place for an author
 to write it.
 
-Three things are wrong with that page rather than missing from it.
-
-**`Output:` is false.** `addItem` declares a result and returns one; the value
-arrives on `invocation.result`. The handler branch of `renderPieceCallHelp`
-prints the fixed string regardless.
+Two things are missing from that page, and they are the same thing twice.
 
 **A flag's prose never arrives**, per the measurement above — the renderer is
 ready for it and the resolution does not carry it.
 
 **The verb's purpose is absent** for the same reason, not a different one: its
 comment is emitted and lost in the same step, and the page has no summary line
-to print it on even once it survives. `cf` can say what `addItem` takes and not
-what it is for.
+to print it on even once it survives. `cf` can say what `addItem` takes and
+hands back, and not what either is for.
 
 ## 3. Complete against the live piece **[today]**
 
@@ -313,7 +322,10 @@ Verb names and piece addresses complete against the space
 `packages/cli/lib/completion/providers.ts`), in bash and zsh.
 
 What does not complete is a result field — `--select 'it<TAB>'` has nothing to
-offer, because nothing in the system knows the result has a field called `item`.
+offer. The knowledge exists now: the help page above enumerates `item`, off the
+same declared result a completion provider would read. What is missing is the
+provider consulting it, which is the same wiring a derived default selection
+needs.
 
 ## 4. Create, and carry the address forward **[today]**
 
@@ -408,16 +420,15 @@ Declared results make an **output** self-describing; this is about what an
 
 | Gap | Needs |
 | --- | --- |
-| `Output:` claims a handler returns nothing | Nothing — it is wrong, not missing |
 | A flag's prose absent from its help page | Same loss as the row below — emitted into the `$def`, absent from the resolved schema the CLI is served |
 | A verb's purpose absent from its help page | A genuine emission gap, then a renderer one — an event interface's comment never compiles, and the page has no summary line |
 | A verb's own doc comment absent everywhere | Not emission — it is emitted and lost when the event `$ref` is resolved for the CLI |
-| A result field's prose | Item 1 first — there is no declared result on the wire to hang it on |
-| Result fields listed in help | A declared result |
-| `--select` completion, and refusal before the call | A declared result |
+| A result field's prose absent from the text page | Only the renderer — the description is already served under `--help --json`, beside the field it documents |
+| `--select` completion, and refusal before the call | A provider reading the declared result the help page already resolves |
 | An address accepted as an argument | The round-trip property above |
 
-Eight rows, six distinct gaps: the three prose rows are one problem seen from
-three sides — an author writes about a verb on its event interface, on an event
-field, or on the verb itself, and none of it reaches a caller. Of the six,
-three need no decision from anyone.
+Six rows, five distinct gaps: the three prose rows above the fourth are one
+problem seen from three sides — an author writes about a verb on its event
+interface, on an event field, or on the verb itself, and none of it reaches a
+caller. The fourth is not that problem: an output field's prose does reach the
+CLI, and only the text renderer drops it.

--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -100,6 +100,26 @@ do I get" are answerable before the first call rather than by making one:
 A value-less verb carries no `outputSchema` at all, which is how a caller tells
 the two apart without calling.
 
+One verb at a time, `--help` answers the same question from the callable
+itself:
+
+```bash
+cf piece call --piece <piece> <verb> --help
+```
+
+```text
+Output:
+  The invocation's `result`:
+    note <json>
+```
+
+The section names where the value arrives rather than describing stdout,
+because a handler's result rides the Invocation JSON below. A value-less verb's
+page carries no `Output:` section at all — the same distinction the listing
+draws, drawn on the page a caller is already reading before the first call.
+`--help --json` serves the declared result as `outputSchema`, descriptions and
+all, for a client that wants the schema rather than the summary.
+
 ### Call a verb and read its result
 
 `cf piece call` prints one settled **Invocation JSON** object on stdout:

--- a/packages/cli/integration/verbs-over-the-cli.sh
+++ b/packages/cli/integration/verbs-over-the-cli.sh
@@ -94,6 +94,21 @@ check "false" "$(echo "$VERBS" | jq -r '.verbs[] |
   select(.name == "touch") | has("outputSchema")' 2>/dev/null)" \
   "a value-less verb advertises no result"
 
+# The same declaration reaches the page a caller reads before calling ONE verb,
+# where the listing answers for the whole piece. It names where the value
+# arrives — the Invocation JSON's result — because that is what a handler's
+# caller collects rather than stdout.
+HELP=$($CF piece call --piece "$BOARD" $ARGS createNote --help 2>/dev/null)
+check "1" "$(printf '%s\n' "$HELP" | grep -c '^Output:')" \
+  "createNote's help page carries an Output section"
+check "1" "$(printf '%s\n' "$HELP" | grep -c '^    note ')" \
+  "createNote's help page enumerates the result field it declared"
+# And a value-less verb's page carries no Output section at all, the same
+# distinction the listing draws.
+VOID_HELP=$($CF piece call --piece "$BOARD" $ARGS touch --help 2>/dev/null)
+check "0" "$(printf '%s\n' "$VOID_HELP" | grep -c '^Output:')" \
+  "a value-less verb's help page carries no Output section"
+
 step "3. A create hands back the piece it created"
 R=$($CF piece call --quiet --piece "$BOARD" $ARGS --invocation create-1 \
   createNote '{"title":"First note","body":"written at create"}' 2>/dev/null)

--- a/packages/cli/lib/callable-command.ts
+++ b/packages/cli/lib/callable-command.ts
@@ -33,7 +33,16 @@ export interface CallableCommandExecutionOptions<
   commandSpec: ExecCommandSpec;
   rawArgs: string[];
   deps?: TDeps;
-  renderHelp: (commandSpec: ExecCommandSpec, parsed: ParsedExecArgs) => string;
+  /** Render the help page, once the parse has established one was asked for.
+   *
+   * Allowed to be async so a renderer can resolve something it needs ONLY
+   * here: `cf piece call` reads a handler's declared result off the compiled
+   * pattern, and every other invocation of the command has no use for it. A
+   * synchronous renderer satisfies this signature unchanged. */
+  renderHelp: (
+    commandSpec: ExecCommandSpec,
+    parsed: ParsedExecArgs,
+  ) => string | Promise<string>;
   validateRawArgs?: (
     rawArgs: string[],
     commandSpec: ExecCommandSpec,
@@ -96,7 +105,7 @@ export async function executeCallableCommand<
 
   if (parsed.showHelp) {
     return {
-      helpText: renderHelp(commandSpec, parsed),
+      helpText: await renderHelp(commandSpec, parsed),
       parsed,
       resolved,
     };

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -781,6 +781,55 @@ function outputPropertyLines(schema: JSONSchema): string[] {
   ];
 }
 
+/** A handler's declared result, named at the position a caller reads it from:
+ * the settled Invocation JSON's `result` key, not the command's stdout. An
+ * object result enumerates its fields the way a tool's does; anything else
+ * names its type, because a scalar result still has a shape worth publishing.
+ */
+function invocationResultLines(schema: JSONSchema): string[] {
+  const properties = objectProperties(schema);
+  if (!properties || Object.keys(properties).length === 0) {
+    return [
+      "  The invocation's `result`:",
+      ...schemaShapeString(schema).split("\n").map((line) => `    ${line}`),
+    ];
+  }
+
+  return [
+    "  The invocation's `result`:",
+    ...Object.entries(properties).map(([key, propertySchema]) =>
+      `    ${key} ${valuePlaceholder(propertySchema)}`
+    ),
+  ];
+}
+
+/** The `Output:` section of a help page, or nothing at all.
+ *
+ * A DECLARED result decides it, not the callable kind. A verb declared
+ * `Stream<E, R>` enumerates `R` exactly as a tool enumerates its pattern's
+ * result; a handler that declares nothing keeps no section at all, because an
+ * absent section reports that the page has nothing to say, where a fixed claim
+ * about output would be false for every verb that returns one.
+ *
+ * The two kinds name different positions because a caller collects them from
+ * different places: a tool's result IS the command's stdout, and a handler's
+ * rides the settled Invocation JSON.
+ */
+function outputSectionLines(spec: ExecCommandSpec): string[] {
+  if (spec.outputSchemaSummary === undefined) {
+    return spec.callableKind === "tool"
+      ? ["", "Output:", "  JSON on success."]
+      : [];
+  }
+  return [
+    "",
+    "Output:",
+    ...(spec.callableKind === "handler"
+      ? invocationResultLines(spec.outputSchemaSummary)
+      : outputPropertyLines(spec.outputSchemaSummary)),
+  ];
+}
+
 function usageCommandPrefix(
   mountedFilePath: string,
   invocationStyle: "cf" | "direct",
@@ -1011,25 +1060,13 @@ export function renderExecHelp(
   ];
 
   if (spec.callableKind === "handler") {
-    // No `Output:` section. A verb declared `Stream<E, R>` returns a result and
-    // the caller reads it off the invocation, so claiming there is none is
-    // false for exactly the verbs a caller most wants described. Saying nothing
-    // is the honest position until a handler's declared result reaches this
-    // path; the listing already carries it (`cf piece verbs --json`).
     lines.push("");
     lines.push("Alternatively, write JSON to this file to invoke the handler.");
     if (handlerAllowsInvokeWithoutInputs(spec.inputSchema)) {
       lines.push("Invoke alone will call the handler without any inputs.");
     }
-  } else if (spec.outputSchemaSummary !== undefined) {
-    lines.push("");
-    lines.push("Output:");
-    lines.push(...outputPropertyLines(spec.outputSchemaSummary));
-  } else if (spec.callableKind === "tool") {
-    lines.push("");
-    lines.push("Output:");
-    lines.push("  JSON on success.");
   }
+  lines.push(...outputSectionLines(spec));
 
   return lines.join("\n");
 }
@@ -1112,25 +1149,13 @@ export function renderPieceCallHelp(
   }
 
   if (spec.callableKind === "handler") {
-    // No `Output:` section. A verb declared `Stream<E, R>` returns a result and
-    // the caller reads it off the invocation, so claiming there is none is
-    // false for exactly the verbs a caller most wants described. Saying nothing
-    // is the honest position until a handler's declared result reaches this
-    // path; the listing already carries it (`cf piece verbs --json`).
     lines.push("");
     lines.push("Alternatively, write JSON to this file to invoke the handler.");
     if (handlerAllowsInvokeWithoutInputs(spec.inputSchema)) {
       lines.push("Invoke alone will call the handler without any inputs.");
     }
-  } else if (spec.outputSchemaSummary !== undefined) {
-    lines.push("");
-    lines.push("Output:");
-    lines.push(...outputPropertyLines(spec.outputSchemaSummary));
-  } else if (spec.callableKind === "tool") {
-    lines.push("");
-    lines.push("Output:");
-    lines.push("  JSON on success.");
   }
+  lines.push(...outputSectionLines(spec));
 
   return lines.join("\n");
 }

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -1148,12 +1148,15 @@ export function renderPieceCallHelp(
     lines.push(...specificFlags);
   }
 
-  if (spec.callableKind === "handler") {
+  // No write-through note here, unlike the mounted-file page above: this
+  // command takes its payload as an argument, and there is no file for a
+  // caller to write JSON to.
+  if (
+    spec.callableKind === "handler" &&
+    handlerAllowsInvokeWithoutInputs(spec.inputSchema)
+  ) {
     lines.push("");
-    lines.push("Alternatively, write JSON to this file to invoke the handler.");
-    if (handlerAllowsInvokeWithoutInputs(spec.inputSchema)) {
-      lines.push("Invoke alone will call the handler without any inputs.");
-    }
+    lines.push("Invoke alone will call the handler without any inputs.");
   }
   lines.push(...outputSectionLines(spec));
 

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1730,10 +1730,15 @@ async function resolvePieceCallable(
     );
   }
 
-  if (resolved.callableKind === "handler" && resolved !== onInputCell) {
+  if (
+    resolved.callableKind === "handler" && resolved !== onInputCell &&
+    typeof piece?.getPattern === "function"
+  ) {
     // The forced-stream fallback dispatches on the result cell too, so it
     // claims a declared result on the same terms the ordinary result-cell path
-    // does.
+    // does. A piece surface with no pattern to consult carries no thunk at all,
+    // which is the honest statement — the absence says this resolution cannot
+    // describe a result, rather than promising an answer that is always none.
     return {
       ...resolved,
       declaredResult: () => declaredVerbResult(piece, callableName),
@@ -1893,13 +1898,13 @@ function declaredVerbResults(
  *
  * The pattern is advisory exactly as it is in the listing: a piece whose
  * pattern will not resolve still calls its verbs, it just cannot say what one
- * hands back.
+ * hands back. `getPattern` throwing is the whole of that condition here —
+ * whether a piece HAS one is settled before the thunk is attached.
  */
 async function declaredVerbResult(
   piece: any,
   callableName: string,
 ): Promise<JSONSchema | undefined> {
-  if (typeof piece?.getPattern !== "function") return undefined;
   try {
     return declaredVerbResults(await piece.getPattern()).get(callableName);
   } catch {
@@ -2049,14 +2054,14 @@ export async function listPieceCallables(
 /** The command spec a help page is rendered from: the resolved one, plus the
  * verb's declared result where the resolution can supply one.
  *
- * A spec that already carries an `outputSchemaSummary` is a tool's, whose
- * result schema rides its callable cell — it is returned untouched rather than
- * re-derived, so `callableCommandSpec` keeps deciding what a tool publishes. */
+ * Only a handler's resolution carries the thunk, so a tool's spec passes
+ * through untouched and `callableCommandSpec` keeps deciding what a tool
+ * publishes — its result schema rides its callable cell and is already on the
+ * spec. */
 async function withDeclaredResult(
   spec: ExecCommandSpec,
   resolved: ResolvedPieceCallable,
 ): Promise<ExecCommandSpec> {
-  if (spec.outputSchemaSummary !== undefined) return spec;
   const declared = await resolved.declaredResult?.();
   return declared === undefined ? spec : {
     ...spec,

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -280,6 +280,16 @@ async function resultProjectionFailedAtPath(
 
 export interface ResolvedPieceCallable extends CallableResolution {
   commandSpec: ExecCommandSpec;
+  /** This verb's declared result, resolved on demand.
+   *
+   * A THUNK rather than a value, because the two callers want it at different
+   * prices. Every `cf piece call` passes through resolution, and only `--help`
+   * has anything to do with a result schema — so the compiled pattern this
+   * needs is loaded when a page asks for it and never for a dispatch. Present
+   * for a handler exposed on the piece's result cell, which is the only place
+   * a declared result can be matched from; a tool's result schema already
+   * rides its callable cell and reaches `commandSpec` directly. */
+  declaredResult?: () => Promise<JSONSchema | undefined>;
 }
 
 export interface PieceCallableDependencies extends CallableExecutionDeps {
@@ -1694,25 +1704,40 @@ async function resolvePieceCallable(
     deps,
   );
 
-  const resolved = (await tryResolvePieceCallableAt(
+  const onResultCell = await tryResolvePieceCallableAt(
     piece,
     pieces,
     space,
     callableName,
     "result",
-  )) ??
-    (await tryResolvePieceCallableAt(
-      piece,
-      pieces,
-      space,
-      callableName,
-      "input",
-    )) ??
+  );
+  // Held apart from the walk only to record WHERE the callable was found: a
+  // declared result is keyed by the PATTERN's result properties, so a
+  // same-named verb reached on the input cell is a different stream that
+  // merely shares its name. The listing draws the same line.
+  const onInputCell = onResultCell ? null : await tryResolvePieceCallableAt(
+    piece,
+    pieces,
+    space,
+    callableName,
+    "input",
+  );
+  const resolved = onResultCell ?? onInputCell ??
     (await tryResolvePieceHandler(piece, pieces, space, callableName));
   if (!resolved) {
     throw new Error(
       `Callable "${callableName}" not found on piece ${config.piece}`,
     );
+  }
+
+  if (resolved.callableKind === "handler" && resolved !== onInputCell) {
+    // The forced-stream fallback dispatches on the result cell too, so it
+    // claims a declared result on the same terms the ordinary result-cell path
+    // does.
+    return {
+      ...resolved,
+      declaredResult: () => declaredVerbResult(piece, callableName),
+    };
   }
 
   if (resolved.callableKind === "tool") {
@@ -1858,6 +1883,30 @@ function declaredVerbResults(
   return declared;
 }
 
+/** One verb's declared result, matched through the piece's compiled pattern.
+ *
+ * The same lookup a listing makes for every row, made for a single name — one
+ * matcher, so the help page and `cf piece verbs` can never describe the same
+ * verb differently. It runs on the help path alone, reached through the thunk
+ * on `ResolvedPieceCallable`, which is why loading the pattern is affordable
+ * here.
+ *
+ * The pattern is advisory exactly as it is in the listing: a piece whose
+ * pattern will not resolve still calls its verbs, it just cannot say what one
+ * hands back.
+ */
+async function declaredVerbResult(
+  piece: any,
+  callableName: string,
+): Promise<JSONSchema | undefined> {
+  if (typeof piece?.getPattern !== "function") return undefined;
+  try {
+    return declaredVerbResults(await piece.getPattern()).get(callableName);
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Enumerate every callable a piece exposes (verb contract: Verb discovery,
  * docs/plans/pattern-verb-contract.md). Everything in the durable schema is
@@ -1997,6 +2046,24 @@ export async function listPieceCallables(
   };
 }
 
+/** The command spec a help page is rendered from: the resolved one, plus the
+ * verb's declared result where the resolution can supply one.
+ *
+ * A spec that already carries an `outputSchemaSummary` is a tool's, whose
+ * result schema rides its callable cell — it is returned untouched rather than
+ * re-derived, so `callableCommandSpec` keeps deciding what a tool publishes. */
+async function withDeclaredResult(
+  spec: ExecCommandSpec,
+  resolved: ResolvedPieceCallable,
+): Promise<ExecCommandSpec> {
+  if (spec.outputSchemaSummary !== undefined) return spec;
+  const declared = await resolved.declaredResult?.();
+  return declared === undefined ? spec : {
+    ...spec,
+    outputSchemaSummary: declared,
+  };
+}
+
 export async function executePieceCallable(
   config: PieceConfig,
   callableName: string,
@@ -2014,14 +2081,21 @@ export async function executePieceCallable(
     commandSpec: resolved.commandSpec,
     rawArgs,
     deps,
-    renderHelp: (commandSpec, parsed) =>
-      parsed.showHelpJson
-        ? renderExecHelpJson(commandSpec)
+    renderHelp: async (commandSpec, parsed) => {
+      // The declared result is fetched HERE and nowhere earlier: the parse has
+      // established that a page is being rendered, so the pattern load it
+      // costs is spent on a caller who asked what the verb hands back. Both
+      // spellings of the page take it — `--help --json` serves the schema
+      // itself as `outputSchema`, the text page enumerates its fields.
+      const spec = await withDeclaredResult(commandSpec, resolved);
+      return parsed.showHelpJson
+        ? renderExecHelpJson(spec)
         : renderPieceCallHelp(
           deps.helpCommandPrefix ??
             cliCommand(["piece", "call", "...", callableName]),
-          commandSpec,
-        ),
+          spec,
+        );
+    },
   });
 }
 

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -1074,6 +1074,73 @@ describe("renderPieceCallHelp", () => {
       "Invoke alone will call the handler without any inputs.",
     );
   });
+
+  it("enumerates a handler's declared result under Output", () => {
+    const help = renderPieceCallHelp(
+      "cf piece call ... addItem",
+      makeSpec(
+        "handler",
+        {
+          type: "object",
+          properties: { title: { type: "string" } },
+          required: ["title"],
+        },
+        {
+          type: "object",
+          properties: {
+            item: { type: "object" },
+            openBelow: { type: "number" },
+          },
+        },
+      ),
+    );
+
+    // The section closes the page, so comparing the tail compares the whole
+    // section: `title <string>` also occurs in the flags above it as
+    // `--title <string>`, which a containment check could not tell apart.
+    expect(help.slice(help.indexOf("\n\nOutput:\n"))).toBe(
+      [
+        "",
+        "",
+        "Output:",
+        "  The invocation's `result`:",
+        "    item <json-object>",
+        "    openBelow <number>",
+      ].join("\n"),
+    );
+  });
+
+  it("names the type of a handler result that is not an object", () => {
+    const help = renderPieceCallHelp(
+      "cf piece call ... rename",
+      makeSpec(
+        "handler",
+        { type: "object", properties: { title: { type: "string" } } },
+        { type: "array", items: { type: "string" } },
+      ),
+    );
+
+    expect(help.slice(help.indexOf("\n\nOutput:\n"))).toBe(
+      [
+        "",
+        "",
+        "Output:",
+        "  The invocation's `result`:",
+        "    string[]",
+      ].join("\n"),
+    );
+  });
+
+  it("carries no Output section for a handler that declares no result", () => {
+    const help = renderPieceCallHelp(
+      "cf piece call ... archive",
+      makeSpec("handler", { type: "object", properties: {} }),
+    );
+
+    // The value-less shape, which is the common one: the page says nothing
+    // about output rather than asserting there is none.
+    expect(help).not.toContain("Output:");
+  });
 });
 
 describe("exec command user-facing errors", () => {

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -1131,6 +1131,24 @@ describe("renderPieceCallHelp", () => {
     );
   });
 
+  it("mentions no file to write JSON to, there being none in this context", () => {
+    const help = renderPieceCallHelp(
+      "cf piece call ... onAddContact",
+      makeSpec("handler", { asCell: ["stream"] } as JSONSchema),
+    );
+
+    // The write-through note belongs to the mounted-file page, which this
+    // renderer shares its body with. `cf piece call` takes its payload as an
+    // argument and mounts nothing, so the sentence would name a file the
+    // caller has no way to reach — and it is the last line of the page.
+    expect(help).not.toContain("write JSON to this file");
+    expect(help).not.toContain("Alternatively");
+    // The neighbouring note is about this command's own spelling, and stays.
+    expect(help).toContain(
+      "Invoke alone will call the handler without any inputs.",
+    );
+  });
+
   it("carries no Output section for a handler that declares no result", () => {
     const help = renderPieceCallHelp(
       "cf piece call ... archive",

--- a/packages/cli/test/piece-call-help-live.test.ts
+++ b/packages/cli/test/piece-call-help-live.test.ts
@@ -1,0 +1,182 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { executePieceCallable } from "../lib/piece.ts";
+
+/**
+ * One pattern with three verbs: a declared object result, a declared scalar
+ * result, and the value-less shape.
+ *
+ * The help page is driven against a COMPILED, RUN pattern rather than a
+ * hand-built graph, because the thing under test is a structural match against
+ * what the compiler emits: a handler node's `$event` input and the result
+ * property exposing that handler's stream are the same cell written twice, and
+ * a double asserts that agreement instead of demonstrating it. The declared
+ * result itself is lowered by the transformer from `Stream<E, R>`'s `R`, which
+ * only a real compile produces.
+ */
+const PROGRAM = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      'import { action, cell, pattern, Stream } from "commonfabric";',
+      "",
+      "interface AddEvent { title: string; }",
+      "interface AddResult { title: string; total: number; }",
+      "interface RenameEvent { title: string; }",
+      "",
+      "interface Out {",
+      "  items: string[];",
+      "  add: Stream<AddEvent, AddResult>;",
+      "  rename: Stream<RenameEvent, string>;",
+      "  clear: Stream<void>;",
+      "}",
+      "",
+      "export default pattern<Record<string, never>, Out>(() => {",
+      "  const items = cell<string[]>([]);",
+      "  const add = action<AddEvent, AddResult>((event) => {",
+      "    items.push(event.title);",
+      "    return { title: event.title, total: items.get().length };",
+      "  });",
+      "  const rename = action<RenameEvent, string>((event) => {",
+      "    items.set([event.title]);",
+      "    return event.title;",
+      "  });",
+      "  const clear = action(() => { items.set([]); });",
+      "  return { items, add, rename, clear };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+const CONFIG = {
+  apiUrl: "http://localhost:8000",
+  identity: "/tmp/test-identity.pem",
+  piece: "fid1:live",
+  space: "" as string,
+};
+
+/** Drive `cf piece call <verb> <args>` against a freshly run instance of the
+ * program above, and hand back what the command produced. */
+async function callVerb(
+  verb: string,
+  rawArgs: string[],
+): Promise<{ helpText?: string; patternLoads: number }> {
+  const signer = await Identity.fromPassphrase("piece-call-help-live");
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL("https://example.com"),
+    storageManager,
+  });
+  const space = signer.did();
+
+  try {
+    const compiled = await runtime.patternManager.compilePattern(
+      PROGRAM as never,
+      { space },
+    );
+    const tx = runtime.edit();
+    const rootCell = runtime.getCell(space, "call-help-live", undefined, tx);
+    const root = runtime.run(tx, compiled, {}, rootCell);
+    runtime.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    await root.pull();
+
+    // The piece surface the callable resolver walks, plus the pattern handle
+    // it reads a declared result through. Counting the loads is how the test
+    // sees whether the help path paid for one — a call that dispatches must
+    // not.
+    let patternLoads = 0;
+    const piece = {
+      result: { getCell: () => Promise.resolve(root) },
+      input: {
+        getCell: () => Promise.resolve(runtime.getCell(space, "empty-input")),
+      },
+      getCell: () => root,
+      getPattern: () => {
+        patternLoads++;
+        return Promise.resolve(compiled);
+      },
+    };
+
+    const executed = await executePieceCallable(
+      { ...CONFIG, space },
+      verb,
+      rawArgs,
+      {
+        loadPieces: () => Promise.resolve({ getSpace: () => space } as never),
+        loadPiece: () => Promise.resolve(piece as never),
+      },
+    );
+    return { helpText: executed.helpText, patternLoads };
+  } finally {
+    await runtime.dispose?.();
+    await storageManager.close?.();
+  }
+}
+
+/** The page's `Output:` section, which closes it, or `undefined` when the page
+ * carries none. Sliced out and compared whole rather than searched for its
+ * lines: `title <string>` occurs in the flags above it as `--title <string>`,
+ * so a containment check would pass against a page with no output section at
+ * all. */
+function outputSection(helpText: string | undefined): string | undefined {
+  const marker = "\n\nOutput:\n";
+  const at = (helpText ?? "").indexOf(marker);
+  return at === -1 ? undefined : helpText!.slice(at + marker.length);
+}
+
+describe("cf piece call --help against a live piece", () => {
+  it("enumerates the fields of a verb's declared result", async () => {
+    const { helpText } = await callVerb("add", ["--help"]);
+
+    // Both fields of `AddResult`, each with the placeholder its type renders
+    // as, named at the position a caller collects them from.
+    expect(outputSection(helpText)).toBe(
+      [
+        "  The invocation's `result`:",
+        "    title <string>",
+        "    total <number>",
+      ].join("\n"),
+    );
+  });
+
+  it("names the type of a declared result that is not an object", async () => {
+    const { helpText } = await callVerb("rename", ["--help"]);
+
+    expect(outputSection(helpText)).toBe(
+      ["  The invocation's `result`:", "    string"].join("\n"),
+    );
+  });
+
+  it("carries no output section for a verb that declares no result", async () => {
+    const { helpText } = await callVerb("clear", ["--help"]);
+
+    // The value-less shape says nothing about output rather than claiming
+    // there is none: absence is the honest report, and it is what tells a
+    // caller this verb differs from `add`.
+    expect(outputSection(helpText)).toBeUndefined();
+    expect(helpText).toContain("Usage:");
+  });
+
+  it("serves the declared result as outputSchema under --help --json", async () => {
+    const { helpText } = await callVerb("add", ["--help", "--json"]);
+
+    const served = JSON.parse(helpText ?? "{}");
+    expect(served.callableKind).toBe("handler");
+    expect(served.outputSchema).toMatchObject({
+      properties: { title: { type: "string" }, total: { type: "number" } },
+    });
+  });
+
+  it("loads the pattern for a help page and not for a dispatch", async () => {
+    expect((await callVerb("add", ["--help"])).patternLoads).toBe(1);
+    // The same verb, called for real. Resolution is the same path; the
+    // declared result is a thunk nobody pulls, so no pattern is loaded to
+    // serve a page this caller never asked for.
+    expect((await callVerb("add", ["--title", "milk"])).patternLoads).toBe(0);
+  });
+});

--- a/packages/cli/test/piece-call-help-live.test.ts
+++ b/packages/cli/test/piece-call-help-live.test.ts
@@ -64,6 +64,7 @@ const CONFIG = {
 async function callVerb(
   verb: string,
   rawArgs: string[],
+  options: { patternError?: Error } = {},
 ): Promise<{ helpText?: string; patternLoads: number }> {
   const signer = await Identity.fromPassphrase("piece-call-help-live");
   const storageManager = StorageManager.emulate({ as: signer });
@@ -98,7 +99,9 @@ async function callVerb(
       getCell: () => root,
       getPattern: () => {
         patternLoads++;
-        return Promise.resolve(compiled);
+        return options.patternError
+          ? Promise.reject(options.patternError)
+          : Promise.resolve(compiled);
       },
     };
 
@@ -170,6 +173,21 @@ describe("cf piece call --help against a live piece", () => {
     expect(served.outputSchema).toMatchObject({
       properties: { title: { type: "string" }, total: { type: "number" } },
     });
+  });
+
+  it("serves the page without an output section when the pattern will not load", async () => {
+    // The message a piece with no reachable pattern identity fails with. The
+    // pattern is advisory on this path: losing it costs the page its `Output:`
+    // section and nothing else, where letting the failure out would cost a
+    // caller the whole help page for a verb they can still call.
+    const { helpText, patternLoads } = await callVerb("add", ["--help"], {
+      patternError: new Error("piece missing pattern identity"),
+    });
+
+    expect(patternLoads).toBe(1);
+    expect(outputSection(helpText)).toBeUndefined();
+    expect(helpText).toContain("cf piece call ... add --help");
+    expect(helpText).toContain("--title <string>");
   });
 
   it("loads the pattern for a help page and not for a dispatch", async () => {


### PR DESCRIPTION
## Why

`cf piece verbs --json` reports a handler's declared result. `cf piece call <verb> --help` did not — it showed nothing about output at all, having only just stopped asserting the false "No output on success." (#5680). So a caller could learn what a verb *returns* only from the machine-readable listing, never from the page they read before calling.

This is the second half of #5558, and the plumbing #5577 rides on: the same lookup that fills in the help page is what lets a readback be bounded by the result the verb declares.

## What Changed

`ResolvedPieceCallable` gains a `declaredResult` **thunk**. `resolvePieceCallable` attaches it for a handler reached on the piece's **result** cell — including the forced-stream fallback, which dispatches there too — and not for one reached on the input cell, since a same-named input stream is a different stream.

It reuses the existing `declaredVerbResults` matcher for a single name, so **the help page and `cf piece verbs` cannot disagree** about what a verb returns. `callableCommandSpec`'s signature is untouched, per #5619's reasoning.

Both renderers' tails collapse into one `outputSectionLines(spec)`, keyed on whether a result is *declared* rather than on callable kind. A handler's section reads ``The invocation's `result`:`` because that is where the value arrives; a tool's lines are byte-identical to before.

## The cost decision, and why it shaped the design

`resolvePieceCallable` runs on **every** `cf piece call`, while only `--help` has any use for a result schema. Resolving the pattern there would make every dispatch pay for a page nobody asked for — a real regression on the hot path to serve a cold one.

Hence the thunk: it is pulled inside `renderHelp`, which runs only after the parse establishes that help was requested. That is the entire reason `callable-command.ts` is in this diff — `renderHelp` widened to `string | Promise<string>` and is awaited.

**Asserted, not claimed.** The live test counts `getPattern()` calls: **1 for `--help`, 0 for a real invocation.**

## Test plan

- Red-first in **two stages**, each reverting only source and keeping the tests: revert `exec-schema.ts` alone and the renderer tests fail while the plumbing tests pass; revert `piece.ts` alone and the plumbing tests fail while the renderer tests stay green. Each half is pinned independently.
- The live test drives a **compiled, run pattern** through `patternManager.compilePattern`, so the structural `$event`-to-result-property match is exercised against what the compiler emits rather than a hand-built graph.
- `deno fmt --check` and `deno lint` repo-wide, `deno check`, `check-docs`, `check-skill-facts`, `check-conflict-markers`, `check-no-waitfor`.
- `packages/cli` suite: RC=1 before and after **identically** — the one failure is the unrelated un-stripped-ANSI assertion (#5704, fixed in #5714).

**One honest gap:** the three new assertions in `verbs-over-the-cli.sh` have not been executed. They need a live toolshed I did not start. `bash -n` passes and the asserted strings are exact measurements, but they are unrun — and that script is not in CI either (#5685).

## A finding that changes #5637 and #5558

**A declared result's field descriptions already reach the CLI.** Measured against `tracker.tsx`: `--help --json` on `addItem` serves `properties.item` as `{"$ref": "#/$defs/ItemOutput", "description": "The root item this call created."}` — the author's comment, verbatim.

The reason is that the **result** schema arrives *unresolved*, so nothing strips it, while the **input** schema arrives resolved — which is why its prose is lost. That is the mechanism behind #5637, and it means the remaining half is a rendering line rather than an emission gap: the text renderer prints `name <placeholder>` and never reads the `description` sitting beside it.

Left out deliberately: #5558 frames that fix as covering tools too, and doing it handler-only would create an asymmetry. The walkthrough claimed flatly that output prose exists nowhere; that claim is corrected here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

