### PR TITLE
refactor: report test assertion operands by using assert()

### DIFF
--- a/packages/cli/test/fixtures/console-capture/console-error-allowed.test.tsx
+++ b/packages/cli/test/fixtures/console-capture/console-error-allowed.test.tsx
@@ -2,11 +2,11 @@
  * Fixture: console.error with allowConsoleErrors: true.
  * The test runner must NOT fail this despite the error.
  */
-import { action, computed, pattern, TESTS, Writable } from "commonfabric";
+import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const triggered = new Writable(false);
-  const didTrigger = computed(() => triggered.get());
+  const didTrigger = assert(() => triggered.get());
 
   const triggerError = action(() => {
     console.error("intentional-test-error: allowed by flag");

--- a/packages/cli/test/fixtures/console-capture/console-error-unallowed.test.tsx
+++ b/packages/cli/test/fixtures/console-capture/console-error-unallowed.test.tsx
@@ -2,11 +2,11 @@
  * Fixture: console.error in a computed handler with NO allowConsoleErrors flag.
  * The test runner must fail this even though the assertion passes.
  */
-import { action, computed, pattern, TESTS, Writable } from "commonfabric";
+import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const triggered = new Writable(false);
-  const didTrigger = computed(() => triggered.get());
+  const didTrigger = assert(() => triggered.get());
 
   const triggerError = action(() => {
     console.error("intentional-test-error: this should fail the test");

--- a/packages/cli/test/fixtures/console-capture/console-warn-allowed.test.tsx
+++ b/packages/cli/test/fixtures/console-capture/console-warn-allowed.test.tsx
@@ -2,11 +2,11 @@
  * Fixture: console.warn with allowConsoleWarnings: true.
  * The test runner must NOT fail this despite the warning.
  */
-import { action, computed, pattern, TESTS, Writable } from "commonfabric";
+import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const triggered = new Writable(false);
-  const didTrigger = computed(() => triggered.get());
+  const didTrigger = assert(() => triggered.get());
 
   const triggerWarn = action(() => {
     console.warn("intentional-test-warning: allowed by flag");

--- a/packages/cli/test/fixtures/console-capture/console-warn-unallowed.test.tsx
+++ b/packages/cli/test/fixtures/console-capture/console-warn-unallowed.test.tsx
@@ -2,11 +2,11 @@
  * Fixture: console.warn in a computed handler with NO allowConsoleWarnings flag.
  * The test runner must fail this even though the assertion passes.
  */
-import { action, computed, pattern, TESTS, Writable } from "commonfabric";
+import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const triggered = new Writable(false);
-  const didTrigger = computed(() => triggered.get());
+  const didTrigger = assert(() => triggered.get());
 
   const triggerWarn = action(() => {
     console.warn("intentional-test-warning: this should fail the test");

--- a/packages/cli/test/fixtures/expect-non-idempotent/expected-and-violating.test.tsx
+++ b/packages/cli/test/fixtures/expect-non-idempotent/expected-and-violating.test.tsx
@@ -3,7 +3,7 @@
  * (same shape as packages/patterns/test/non-idempotent/accumulator.test.tsx).
  * The detected violation satisfies the expectation, so this test must PASS.
  */
-import { computed, pattern, TESTS, Writable } from "commonfabric";
+import { assert, computed, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const value = new Writable("hello");
@@ -15,7 +15,7 @@ export default pattern(() => {
     log.set([...current, `${value.get()} at run #${current.length + 1}`]);
   });
 
-  const hasEntries = computed(() => log.get().length > 0);
+  const hasEntries = assert(() => log.get().length > 0);
 
   return {
     [TESTS]: [{ assertion: hasEntries }],

--- a/packages/cli/test/fixtures/expect-non-idempotent/expected-but-idempotent.test.tsx
+++ b/packages/cli/test/fixtures/expect-non-idempotent/expected-but-idempotent.test.tsx
@@ -5,12 +5,12 @@
  * FAIL with "expected non-idempotent computation(s), none detected" — a
  * silent pass here is exactly the detection regression the flag guards.
  */
-import { computed, pattern, TESTS, Writable } from "commonfabric";
+import { assert, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const value = new Writable("hello");
 
-  const ok = computed(() => value.get() === "hello");
+  const ok = assert(() => value.get() === "hello");
 
   return {
     [TESTS]: [{ assertion: ok }],

--- a/packages/cli/test/fixtures/expect-non-idempotent/multi-user-expected-but-idempotent.test.tsx
+++ b/packages/cli/test/fixtures/expect-non-idempotent/multi-user-expected-but-idempotent.test.tsx
@@ -3,17 +3,11 @@
  * trivially idempotent. No flagged participant sees a violation, so the run
  * must FAIL with the synthetic "expectNonIdempotent" result.
  */
-import {
-  computed,
-  multiUserTest,
-  pattern,
-  TESTS,
-  Writable,
-} from "commonfabric";
+import { assert, multiUserTest, pattern, TESTS, Writable } from "commonfabric";
 
 export const alice = pattern(() => {
   const value = new Writable("alice");
-  const ok = computed(() => value.get() === "alice");
+  const ok = assert(() => value.get() === "alice");
   return {
     [TESTS]: [{ assertion: ok }],
     expectNonIdempotent: true,
@@ -22,7 +16,7 @@ export const alice = pattern(() => {
 
 export const bob = pattern(() => {
   const value = new Writable("bob");
-  const ok = computed(() => value.get() === "bob");
+  const ok = assert(() => value.get() === "bob");
   return {
     [TESTS]: [{ assertion: ok }],
   };

--- a/packages/cli/test/fixtures/expect-non-idempotent/multi-user-expected-one-violation.test.tsx
+++ b/packages/cli/test/fixtures/expect-non-idempotent/multi-user-expected-one-violation.test.tsx
@@ -6,6 +6,7 @@
  * though bob (also flagged) saw none.
  */
 import {
+  assert,
   computed,
   multiUserTest,
   pattern,
@@ -23,7 +24,7 @@ export const alice = pattern(() => {
     log.set([...current, `${value.get()} at run #${current.length + 1}`]);
   });
 
-  const hasEntries = computed(() => log.get().length > 0);
+  const hasEntries = assert(() => log.get().length > 0);
   return {
     [TESTS]: [{ assertion: hasEntries }],
     expectNonIdempotent: true,
@@ -32,7 +33,7 @@ export const alice = pattern(() => {
 
 export const bob = pattern(() => {
   const value = new Writable("bob");
-  const ok = computed(() => value.get() === "bob");
+  const ok = assert(() => value.get() === "bob");
   return {
     [TESTS]: [{ assertion: ok }],
     expectNonIdempotent: true,

--- a/packages/cli/test/fixtures/expect-non-idempotent/unexpected-violation.test.tsx
+++ b/packages/cli/test/fixtures/expect-non-idempotent/unexpected-violation.test.tsx
@@ -2,7 +2,7 @@
  * A non-idempotent accumulator WITHOUT expectNonIdempotent. The detected
  * violation must FAIL the test (the long-standing default behavior).
  */
-import { computed, pattern, TESTS, Writable } from "commonfabric";
+import { assert, computed, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const value = new Writable("hello");
@@ -14,7 +14,7 @@ export default pattern(() => {
     log.set([...current, `${value.get()} at run #${current.length + 1}`]);
   });
 
-  const hasEntries = computed(() => log.get().length > 0);
+  const hasEntries = assert(() => log.get().length > 0);
 
   return {
     [TESTS]: [{ assertion: hasEntries }],

--- a/packages/cli/test/fixtures/expect-runtime-errors/expected-and-throwing.test.tsx
+++ b/packages/cli/test/fixtures/expect-runtime-errors/expected-and-throwing.test.tsx
@@ -2,11 +2,11 @@
  * Fixture: a throwing action with expectRuntimeErrors: 1.
  * The runner must treat the error as required-and-satisfied — no failure.
  */
-import { action, computed, pattern, TESTS, Writable } from "commonfabric";
+import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const untouched = new Writable(true);
-  const stillUntouched = computed(() => untouched.get());
+  const stillUntouched = assert(() => untouched.get());
 
   const throwingAction = action(() => {
     throw new Error("verb rejected: intentional fixture throw");

--- a/packages/cli/test/fixtures/expect-runtime-errors/expected-but-silent.test.tsx
+++ b/packages/cli/test/fixtures/expect-runtime-errors/expected-but-silent.test.tsx
@@ -3,11 +3,11 @@
  * The expectation asserts the loudness FIRES — zero errors must fail the run,
  * so a rejection quietly reverting to a silent return cannot pass.
  */
-import { action, computed, pattern, TESTS, Writable } from "commonfabric";
+import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const fine = new Writable(true);
-  const stillFine = computed(() => fine.get());
+  const stillFine = assert(() => fine.get());
 
   const silentAction = action(() => {
     // Deliberately does not throw.

--- a/packages/cli/test/fixtures/expect-runtime-errors/expected-count-mismatch.test.tsx
+++ b/packages/cli/test/fixtures/expect-runtime-errors/expected-count-mismatch.test.tsx
@@ -2,11 +2,11 @@
  * Fixture: expectRuntimeErrors: 2 but only one throw occurs.
  * A numeric expectation is exact — a count mismatch must fail the run.
  */
-import { action, computed, pattern, TESTS, Writable } from "commonfabric";
+import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const fine = new Writable(true);
-  const stillFine = computed(() => fine.get());
+  const stillFine = assert(() => fine.get());
 
   const throwsOnce = action(() => {
     throw new Error("verb rejected: only one of the expected two");

--- a/packages/cli/test/fixtures/pattern-coverage/subject.tsx
+++ b/packages/cli/test/fixtures/pattern-coverage/subject.tsx
@@ -1,4 +1,4 @@
-import { action, computed, pattern, TESTS, Writable } from "commonfabric";
+import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 
 function incrementCount(count: Writable<number>): void {
   count.set(count.get() + 1);
@@ -19,7 +19,7 @@ function isBobName(name: Writable<string>): boolean {
 export const singlePattern = pattern(() => {
   const count = new Writable(0);
   const increment = action(() => incrementCount(count));
-  const isOne = computed(() => countIsOne(count));
+  const isOne = assert(() => countIsOne(count));
 
   return {
     [TESTS]: [
@@ -31,7 +31,7 @@ export const singlePattern = pattern(() => {
 
 export const alice = pattern(() => {
   const name = new Writable("alice");
-  const isAlice = computed(() => isAliceName(name));
+  const isAlice = assert(() => isAliceName(name));
 
   return {
     [TESTS]: [{ assertion: isAlice }],
@@ -40,7 +40,7 @@ export const alice = pattern(() => {
 
 export const bob = pattern(() => {
   const name = new Writable("bob");
-  const isBob = computed(() => isBobName(name));
+  const isBob = assert(() => isBobName(name));
 
   return {
     [TESTS]: [{ assertion: isBob }],

--- a/packages/cli/test/fixtures/render-step/continuous-multi-user.test.tsx
+++ b/packages/cli/test/fixtures/render-step/continuous-multi-user.test.tsx
@@ -1,5 +1,6 @@
 import {
   action,
+  assert,
   computed,
   multiUserTest,
   pattern,
@@ -21,7 +22,7 @@ const alice = pattern(() => {
       )}
     </div>
   );
-  const isLate = computed(() => phase.get() === "late");
+  const isLate = assert(() => phase.get() === "late");
 
   return {
     [UI]: view,

--- a/packages/cli/test/fixtures/render-step/continuous-ui.test.tsx
+++ b/packages/cli/test/fixtures/render-step/continuous-ui.test.tsx
@@ -1,4 +1,12 @@
-import { action, computed, pattern, TESTS, UI, Writable } from "commonfabric";
+import {
+  action,
+  assert,
+  computed,
+  pattern,
+  TESTS,
+  UI,
+  Writable,
+} from "commonfabric";
 import { lateVDOMBranch } from "./subject.tsx";
 
 export default pattern(() => {
@@ -13,7 +21,7 @@ export default pattern(() => {
       )}
     </div>
   );
-  const isLate = computed(() => phase.get() === "late");
+  const isLate = assert(() => phase.get() === "late");
 
   return {
     [UI]: view,

--- a/packages/cli/test/fixtures/render-step/direct-array-render.test.tsx
+++ b/packages/cli/test/fixtures/render-step/direct-array-render.test.tsx
@@ -1,8 +1,8 @@
-import { computed, pattern, TESTS } from "commonfabric";
+import { assert, pattern, TESTS } from "commonfabric";
 
 export default pattern(() => ({
   [TESTS]: [
     { render: [null, undefined, "text", 1, true, false, []] },
-    { assertion: computed(() => true) },
+    { assertion: assert(() => true) },
   ],
 }));

--- a/packages/cli/test/fixtures/render-step/invalid-continuous-ui.test.tsx
+++ b/packages/cli/test/fixtures/render-step/invalid-continuous-ui.test.tsx
@@ -1,8 +1,8 @@
-import { computed, pattern, TESTS, UI, type VNode } from "commonfabric";
+import { assert, pattern, TESTS, UI, type VNode } from "commonfabric";
 
 export default pattern(() => ({
   // Deliberately not a real VNode at run time: this fixture feeds the runner
   // an invalid continuous-UI value to check how it reports one.
   [UI]: {} as VNode,
-  [TESTS]: [{ assertion: computed(() => true) }],
+  [TESTS]: [{ assertion: assert(() => true) }],
 }));

--- a/packages/cli/test/fixtures/render-step/multi-user.test.tsx
+++ b/packages/cli/test/fixtures/render-step/multi-user.test.tsx
@@ -1,5 +1,6 @@
 import {
   action,
+  assert,
   computed,
   multiUserTest,
   pattern,
@@ -20,7 +21,7 @@ const alice = pattern(() => {
       )}
     </div>
   );
-  const isLate = computed(() => phase.get() === "late");
+  const isLate = assert(() => phase.get() === "late");
 
   return {
     [TESTS]: [

--- a/packages/cli/test/fixtures/render-step/no-render.test.tsx
+++ b/packages/cli/test/fixtures/render-step/no-render.test.tsx
@@ -1,4 +1,11 @@
-import { action, computed, pattern, TESTS, Writable } from "commonfabric";
+import {
+  action,
+  assert,
+  computed,
+  pattern,
+  TESTS,
+  Writable,
+} from "commonfabric";
 import { lateVDOMBranch } from "./subject.tsx";
 
 export default pattern(() => {
@@ -13,7 +20,7 @@ export default pattern(() => {
       )}
     </div>
   );
-  const isLate = computed(() => phase.get() === "late");
+  const isLate = assert(() => phase.get() === "late");
   void view;
 
   return {

--- a/packages/cli/test/fixtures/render-step/primitive-render.test.tsx
+++ b/packages/cli/test/fixtures/render-step/primitive-render.test.tsx
@@ -1,4 +1,4 @@
-import { computed, pattern, TESTS } from "commonfabric";
+import { assert, pattern, TESTS } from "commonfabric";
 
 export default pattern(() => ({
   [TESTS]: [
@@ -6,6 +6,6 @@ export default pattern(() => ({
     { render: "text" },
     { render: 1 },
     { render: true },
-    { assertion: computed(() => true) },
+    { assertion: assert(() => true) },
   ],
 }));

--- a/packages/cli/test/fixtures/render-step/render-cleanup.test.tsx
+++ b/packages/cli/test/fixtures/render-step/render-cleanup.test.tsx
@@ -1,4 +1,11 @@
-import { action, computed, pattern, TESTS, Writable } from "commonfabric";
+import {
+  action,
+  assert,
+  computed,
+  pattern,
+  TESTS,
+  Writable,
+} from "commonfabric";
 import { afterRenderBranch, lateVDOMBranch } from "./subject.tsx";
 
 export default pattern(() => {
@@ -18,7 +25,7 @@ export default pattern(() => {
       })}
     </div>
   );
-  const isAfterRender = computed(() => phase.get() === "after-render");
+  const isAfterRender = assert(() => phase.get() === "after-render");
 
   return {
     [TESTS]: [

--- a/packages/cli/test/fixtures/render-step/render-step.test.tsx
+++ b/packages/cli/test/fixtures/render-step/render-step.test.tsx
@@ -1,4 +1,11 @@
-import { action, computed, pattern, TESTS, Writable } from "commonfabric";
+import {
+  action,
+  assert,
+  computed,
+  pattern,
+  TESTS,
+  Writable,
+} from "commonfabric";
 import { lateVDOMBranch } from "./subject.tsx";
 
 export default pattern(() => {
@@ -13,7 +20,7 @@ export default pattern(() => {
       )}
     </div>
   );
-  const isLate = computed(() => phase.get() === "late");
+  const isLate = assert(() => phase.get() === "late");
 
   return {
     [TESTS]: [

--- a/packages/cli/test/fixtures/render-step/skipped-render.test.tsx
+++ b/packages/cli/test/fixtures/render-step/skipped-render.test.tsx
@@ -1,4 +1,11 @@
-import { action, computed, pattern, TESTS, Writable } from "commonfabric";
+import {
+  action,
+  assert,
+  computed,
+  pattern,
+  TESTS,
+  Writable,
+} from "commonfabric";
 import { lateVDOMBranch } from "./subject.tsx";
 
 export default pattern(() => {
@@ -13,7 +20,7 @@ export default pattern(() => {
       )}
     </div>
   );
-  const isLate = computed(() => phase.get() === "late");
+  const isLate = assert(() => phase.get() === "late");
 
   return {
     [TESTS]: [

--- a/packages/cli/test/fixtures/settle/settle-step.test.tsx
+++ b/packages/cli/test/fixtures/settle/settle-step.test.tsx
@@ -4,12 +4,12 @@
  * step. The settle step is transparent: it produces no assertion result and the
  * run passes.
  */
-import { action, computed, pattern, TESTS, Writable } from "commonfabric";
+import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const flag = new Writable(false);
   const setFlag = action(() => flag.set(true));
-  const isSet = computed(() => flag.get() === true);
+  const isSet = assert(() => flag.get() === true);
 
   return {
     [TESTS]: [

--- a/packages/cli/test/fixtures/storage-host/counter.test.tsx
+++ b/packages/cli/test/fixtures/storage-host/counter.test.tsx
@@ -4,7 +4,7 @@
  * pattern actually reached to find — which is the whole point of the option
  * (the pattern-vintage capture snapshots the store afterwards).
  */
-import { action, computed, pattern, TESTS, Writable } from "commonfabric";
+import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const count = new Writable(0).for("count");
@@ -15,7 +15,7 @@ export default pattern(() => {
     [TESTS]: [
       { action: bump },
       { action: bump },
-      { assertion: computed(() => count.get() === 2) },
+      { assertion: assert(() => count.get() === 2) },
     ],
   };
 });

--- a/packages/patterns/battleship/multiplayer/multi-user.test.tsx
+++ b/packages/patterns/battleship/multiplayer/multi-user.test.tsx
@@ -11,7 +11,7 @@
  * Joins go through the programmatic `joinWithName` stream (the headless seam
  * kept by the profile migration); the profile-wish UI path needs a browser.
  */
-import { action, computed, multiUserTest, pattern, TESTS } from "commonfabric";
+import { action, assert, multiUserTest, pattern, TESTS } from "commonfabric";
 import BattleshipLobby, { type LobbyOutput } from "./lobby.tsx";
 
 interface Setup {
@@ -29,18 +29,18 @@ export const alice = pattern<{ setup: Setup }>(({ setup }) => {
     lobby.joinWithName.send("Alice");
   });
 
-  const assert_joined_slot_1 = computed(() =>
+  const assert_joined_slot_1 = assert(() =>
     lobby.myName === "Alice" &&
     lobby.myPlayerNumber === 1 &&
     lobby.player1?.name === "Alice"
   );
-  const assert_game_started = computed(() =>
+  const assert_game_started = assert(() =>
     lobby.player2?.name === "Bob" &&
     lobby.gameState.phase === "playing" &&
     lobby.gameState.currentTurn === 1
   );
   // Bob joining must not clobber Alice's PerUser slot assignment.
-  const assert_slot_unchanged = computed(() =>
+  const assert_slot_unchanged = assert(() =>
     lobby.myName === "Alice" && lobby.myPlayerNumber === 1
   );
 
@@ -64,18 +64,18 @@ export const bob = pattern<{ setup: Setup }>(({ setup }) => {
   });
 
   // Shared slot propagated from Alice's runtime.
-  const assert_sees_alice = computed(() => lobby.player1?.name === "Alice");
+  const assert_sees_alice = assert(() => lobby.player1?.name === "Alice");
   // PerUser isolation: Alice's join must not leak into Bob's identity cells
   // (unwritten PerUser cells may read as undefined in a fresh runtime).
-  const assert_not_joined_yet = computed(() =>
+  const assert_not_joined_yet = assert(() =>
     (lobby.myName ?? "") === "" && (lobby.myPlayerNumber ?? null) === null
   );
-  const assert_joined_slot_2 = computed(() =>
+  const assert_joined_slot_2 = assert(() =>
     lobby.myName === "Bob" &&
     lobby.myPlayerNumber === 2 &&
     lobby.player2?.name === "Bob"
   );
-  const assert_game_started = computed(() =>
+  const assert_game_started = assert(() =>
     lobby.gameState.phase === "playing" && lobby.gameState.currentTurn === 1
   );
 

--- a/packages/patterns/record/extraction/schema-discovery.test.tsx
+++ b/packages/patterns/record/extraction/schema-discovery.test.tsx
@@ -10,7 +10,7 @@
  *
  * Run: deno task cf test packages/patterns/record/extraction/schema-discovery.test.tsx --root packages/patterns --verbose
  */
-import { computed, pattern, TESTS } from "commonfabric";
+import { assert, computed, pattern, TESTS } from "commonfabric";
 import { getSchemaForType } from "./schema-utils.ts";
 import { getFieldToTypeMapping } from "../registry.ts";
 import Note from "../../notes/note.tsx";
@@ -24,37 +24,37 @@ export default pattern(() => {
   const unknownSchema = getSchemaForType("does-not-exist");
   const fieldMap = getFieldToTypeMapping();
 
-  const assert_real_piece_built = computed(() =>
+  const assert_real_piece_built = assert(() =>
     notesPiece !== undefined && notesPiece !== null
   );
 
   // The notes module's content field is discoverable via the registry.
-  const assert_notes_content_discoverable = computed(() =>
+  const assert_notes_content_discoverable = assert(() =>
     notesSchema?.properties?.content !== undefined
   );
 
   // A representative data module also exposes its fields.
-  const assert_address_has_fields = computed(() =>
+  const assert_address_has_fields = assert(() =>
     addressSchema?.properties !== undefined &&
     Object.keys(addressSchema.properties).length > 0
   );
 
   // The registry-driven field map is populated and carries the record-title
   // pseudo-mapping the extractor relies on.
-  const assert_map_built = computed(() =>
+  const assert_map_built = assert(() =>
     Object.keys(fieldMap).length > 0 && fieldMap.name === "record-title"
   );
 
   // The notes alias routes back to the notes module. (The `content` field is
   // shared with text-import, another content source, so it is not asserted to
   // any single owner.)
-  const assert_notes_routed = computed(() => fieldMap.notes === "notes");
+  const assert_notes_routed = assert(() => fieldMap.notes === "notes");
 
   // The content field reaches some real source module.
-  const assert_content_routed = computed(() => fieldMap.content !== undefined);
+  const assert_content_routed = assert(() => fieldMap.content !== undefined);
 
   // An unknown module type yields no schema (no accidental catch-all).
-  const assert_unknown_type_undefined = computed(() =>
+  const assert_unknown_type_undefined = assert(() =>
     unknownSchema === undefined
   );
 

--- a/packages/patterns/scrabble/multi-user.test.tsx
+++ b/packages/patterns/scrabble/multi-user.test.tsx
@@ -22,7 +22,7 @@
  *
  * Join order is deterministic (markers): Alice first, then Bob.
  */
-import { action, computed, multiUserTest, pattern, TESTS } from "commonfabric";
+import { action, assert, multiUserTest, pattern, TESTS } from "commonfabric";
 import Scrabble, { type GameOutput } from "./scrabble.tsx";
 
 interface Setup {
@@ -40,7 +40,7 @@ export const alice = pattern<{ setup: Setup }>(({ setup }) => {
     game.joinWithName.send("Alice");
   });
 
-  const assert_joined = computed(() =>
+  const assert_joined = assert(() =>
     game.myName === "Alice" &&
     (game.rack ?? []).length === 7 &&
     (game.players ?? []).length === 1 &&
@@ -48,7 +48,7 @@ export const alice = pattern<{ setup: Setup }>(({ setup }) => {
   );
   // Bob joining must not clobber Alice's PerUser identity or rack, and the
   // shared roster must resolve BOTH players in Alice's runtime.
-  const assert_sees_both = computed(() =>
+  const assert_sees_both = assert(() =>
     (game.players ?? []).length === 2 &&
     game.players?.[0]?.name === "Alice" &&
     game.players?.[1]?.name === "Bob" &&
@@ -56,7 +56,7 @@ export const alice = pattern<{ setup: Setup }>(({ setup }) => {
     (game.rack ?? []).length === 7
   );
   // Two players drew 7 tiles each from the one shared bag.
-  const assert_bag_consumed = computed(() => game.bagIndex === 14);
+  const assert_bag_consumed = assert(() => game.bagIndex === 14);
 
   return {
     [TESTS]: [
@@ -81,19 +81,19 @@ export const bob = pattern<{ setup: Setup }>(({ setup }) => {
   });
 
   // Shared roster propagated from Alice's runtime.
-  const assert_sees_alice = computed(() =>
+  const assert_sees_alice = assert(() =>
     (game.players ?? []).length === 1 &&
     game.players?.[0]?.name === "Alice"
   );
   // PerUser isolation: Alice's join must not leak into Bob's identity.
-  const assert_not_joined_yet = computed(() => game.myName === "");
+  const assert_not_joined_yet = assert(() => game.myName === "");
   // A DIFFERENT user trying to take Alice's name is rejected with a message
   // (PerSession) and stays unjoined.
-  const assert_name_taken = computed(() =>
+  const assert_name_taken = assert(() =>
     game.message === "Name Alice is already taken." &&
     game.myName === ""
   );
-  const assert_joined = computed(() =>
+  const assert_joined = assert(() =>
     game.myName === "Bob" &&
     (game.rack ?? []).length === 7 &&
     (game.players ?? []).length === 2 &&

--- a/packages/patterns/scrabble/scrabble.test.tsx
+++ b/packages/patterns/scrabble/scrabble.test.tsx
@@ -1,4 +1,4 @@
-import { action, assert, computed, pattern, TESTS } from "commonfabric";
+import { action, assert, pattern, TESTS } from "commonfabric";
 import Scrabble, { type Letter } from "./scrabble.tsx";
 
 const tile = (char: string, id: string): Letter => ({
@@ -84,7 +84,7 @@ export default pattern(() => {
     scrabble.message === "You already joined as Alice."
   );
 
-  const assert_center_word_submitted = computed(() => {
+  const assert_center_word_submitted = assert(() => {
     const board = scrabble.board;
     const player = scrabble.players[0];
     const lastEvent = scrabble.gameEvents.at(-1);
@@ -100,7 +100,7 @@ export default pattern(() => {
       scrabble.bagIndex === 9 &&
       player?.score === 4 &&
       lastEvent?.type === "word" &&
-      lastEvent.details.includes("AT (+4)") &&
+      lastEvent?.details?.includes("AT (+4)") &&
       scrabble.message.startsWith("Scored 4:");
   });
 


### PR DESCRIPTION
ACCEPT_COVERAGE_DEBT: coverage-debt: packages/cli uncovered lines = 3408 lines

Migrate the cli test fixtures and a few pattern tests from `computed(() => boolean)` assertions to `assert(() => boolean)`. A failing `assert()` names the operands it read and their values; a failing `computed()` reports only "Expected true, got false", so the migration is a diagnostics improvement on the same wide `TestStep.assertion` union — no type change, and independent of narrowing that union.

It is behavior-preserving with one exception. `assert()` records each operand as the condition runs, so it can read a subexpression that a `computed()` short-circuit would have skipped. In `scrabble.test.tsx` that subexpression — `lastEvent.details.includes(...)` — reads a property that is transiently `undefined` during a reactive settle, which threw under `assert()`. Guard the access with optional chaining so it yields `false` in that moment and the assertion settles to its real value, rather than throwing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

