### PR TITLE
ci(coverage): name the lines a regression is charged for

### DIFF
--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -269,6 +269,51 @@ the one-line and the braced form of the same guard, and it changed between deno
 condition's own count. See
 [deno coverage: one-line guard reported uncovered when its branch is not taken](deno-coverage-guard-line-artifact.md).
 
+### Paths reached only when something happens twice
+
+The other common shape is a line that runs only on the second occurrence of
+something within one process: a cache that is populated the second time it is
+asked, a guard that turns away a duplicate, a retry that only a second failure
+reaches. Whether a suite produces that second occurrence is often decided by
+scheduling rather than by anything a test asserts, so the line is covered on
+some runs and not on others.
+
+Write a test that produces the second occurrence itself rather than one that
+performs an operation and hopes the suite repeats it. The
+`records one violation for an action caught twice` case in
+`packages/runner/test/scheduler-pull-idempotency.test.ts` is the worked
+example. It reaches the deduplication guard in `runIdempotencyRecheck()` by
+running one action twice over an input it moves, and it distinguishes a
+deduplicated second detection from a single detection by having the action
+write an incrementing count, so the recorded violation says which detection it
+came from.
+
+An assertion that only counts the outcome would pass either way and would leave
+the line's coverage exactly as environment-dependent as it was.
+[The August 2026 record](../history/development/coverage-flake-idempotency-dedup-2026-08-12.md)
+follows one such line from a group-level `+2` down to the guard and the test.
+
+### What the check says when the regression is not the pull request's
+
+The gate compares whole-group counts, so a flapping line fails whichever pull
+request is measured against a run that happened to cover it, however unrelated
+the diff. The check recognizes that case and says so: when a gated group is over
+its baseline and none of the lines the pull request added are uncovered, it
+reads the coverage reports of the `main` run its baseline came from and names
+every line this run leaves uncovered that the baseline run covered.
+
+The comment lists those lines file by file, gives the `ACCEPT_COVERAGE_DEBT`
+line that lets the pull request through, and carries a prompt for a fresh agent
+session to make the lines cover the same way every time. The author's pull
+request is not the place to fix them, and it is not held up waiting for someone
+to.
+
+Only files the pull request left alone are compared. A file it changed has
+different content in the two checkouts, so the same line number means a
+different line in each report and no comparison is possible. When the baseline
+run's coverage artifacts cannot be read — expired, or the download failed — the
+check falls back to the ordinary regression comment.
+
 ## Ratchet baselines and accepting debt
 
 The ratchet applies per source group and only to the groups a PR changes: for

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -343,6 +343,10 @@ One line per archived document; each document's header carries the fuller
   — why a rename-only pull request owed coverage debt: a wall-clock-guarded
   diagnostic and a shard re-partition each moved the `packages/runner`
   uncovered-line count with no change to that package, July 2026.
+- [coverage-flake-idempotency-dedup-2026-08-12.md](development/coverage-flake-idempotency-dedup-2026-08-12.md)
+  — which two lines a benchmark-only pull request was charged for, and why the
+  suggestion comment could not name a file: a guard reached only when one
+  action is caught non-idempotent twice in a process, August 2026.
 - [scoped-cells-field-notes.md](development/scoped-cells-field-notes.md) —
   field journal from the first scoped-cell patterns.
 - [2026-07-02-convergence-evidence-appendix.md](plans/2026-07-02-convergence-evidence-appendix.md)

--- a/docs/history/development/coverage-flake-idempotency-dedup-2026-08-12.md
+++ b/docs/history/development/coverage-flake-idempotency-dedup-2026-08-12.md
@@ -1,0 +1,109 @@
+---
+status: historical
+created: 2026-08-12
+archived: 2026-08-12
+reason: "Investigation record: the two uncovered lines that failed the coverage gate on PR #5711, which the suggestion comment could not tie to a file."
+---
+
+# The two lines a benchmark-only pull request was charged for, August 2026
+
+## Conclusion
+
+[PR #5711](https://github.com/commontoolsinc/labs/pull/5711) changed a
+benchmark file, two dashboard files and some documentation. Its Coverage Check
+job reported `packages/runner` at 4614 uncovered lines against a `main`
+baseline of 4612, and the suggestion comment said it could not tie the increase
+to any file in the diff.
+
+The two lines are 333 and 334 of
+`packages/runner/src/scheduler/diagnosis.ts`: the early `return` and its
+closing brace inside the guard that stops `runIdempotencyRecheck()` recording a
+second violation for an action it has already recorded one for.
+
+```ts
+const actionId = state.getActionId(action);
+// Deduplicate: only record first violation per action.
+if (state.idempotencyViolations.some((v) => v.actionId === actionId)) {
+  return;
+}
+```
+
+Nothing in the pull request could have added a tracked line to that group. Its
+only change under `packages/runner` is to `test/cell.bench.ts`, which the
+metric excludes twice over: `test` is an excluded path segment and `.bench.ts`
+an excluded file suffix. The suggestion comment could not name a file because
+it looks for newly added lines among the changed files, and the changed files
+contributed none.
+
+Those two lines run only when one action is caught being non-idempotent twice
+in a single process. Whether that happens is a scheduling race, so the lines
+are covered on some runs and not on others, and `packages/runner` was sitting
+exactly at its baseline with no headroom for the difference.
+
+## What the runs measured
+
+Every count below is from the `Test (7/8)` job's LCOV artifact, reading the
+lines of `runIdempotencyRecheck()`: line 326 counts arrivals at the
+external-move check, which is one per detected violation; line 336 counts
+violations actually recorded; line 333 counts the duplicates turned away.
+
+| Run | What it was | Detections (326) | Recorded (336) | Duplicates (333) |
+| --- | --- | ---: | ---: | ---: |
+| 31634280324 | `main` at `96b4086a`, the baseline | 4 | 3 | 1 |
+| 31635473455 | PR #5711, the failing run | 3 | 3 | 0 |
+| 31636354109 | PR #5711, the next run | 4 | 3 | 1 |
+| local | the one test file, run by hand | 3 | 3 | 0 |
+
+The source under `packages/runner` is identical across all four. Three
+violations are recorded every time; what moves is whether a fourth detection
+arrives for an action already recorded.
+
+Rescoring both CI artifact sets against the checkout with the gate's own
+`tasks/coverage-metrics.ts` reproduces the job's numbers exactly — 4612 for the
+baseline and 4614 for the failing run, along with 276763 and 276767 for the
+whole workspace, 641 and 643 for `packages/memory`, and 76 for both readings of
+`packages/dashboard`. So the whole of the gated increase is those two lines,
+and no other file in the group moved.
+
+The run immediately after the failing one, against the same baseline run and
+with the same source, measured 4612 and passed.
+
+## Where the detections come from
+
+Shard 7 of 8 runs the CLI package's test slices 1, 8 and 9, plus `shell` and
+`identity`. The idempotency rechecks all come from one file in slice 1,
+`packages/cli/test/test-runner-expect-non-idempotent.test.ts`: running that
+file alone reproduces the whole shard's counts, three detections and three
+recorded violations. It drives three fixtures that are genuinely
+non-idempotent, each an accumulator that appends to the log it reads.
+
+Reading the log it appends to is what makes such a computation re-trigger
+itself: the write schedules another run, and every run gets its own idempotency
+recheck. The first recheck records the violation. A second recheck for the same
+action reaches the dedup guard and returns. Whether a second run happens before
+the test's assertions settle and the runtime is disposed is a race between the
+scheduler draining its queue and the test finishing, and CI runs that file
+alongside thirteen others under `deno test --parallel`.
+
+## What was done
+
+`packages/runner/test/scheduler-pull-idempotency.test.ts` gained a case that
+reaches the guard deterministically: an action that writes an incrementing
+count, so that every run differs from the recheck that verifies it, run twice
+by moving an input it reads. That is four invocations, two detections and one
+recorded violation, and the recorded one carries the writes of the first
+detection rather than the second. Removing the guard fails the test with two
+violations recorded.
+
+## Also moving, but not gated
+
+Two other files differed between the same two runs, and neither was gated for
+this pull request:
+
+- `packages/memory/v2/client.ts` lines 1101 and 1102, the `#closed` guard in
+  `scheduleAck()`, covered exactly once by the `package-runner` job in the
+  baseline run and not at all in the failing one. This is the same kind of
+  race, and it will charge two lines to the next pull request that touches
+  `packages/memory` while the group has no headroom.
+- `packages/integration/page.ts`, seven lines, which the metric does not track
+  at all: `integration` is an excluded path segment.

--- a/packages/runner/test/scheduler-pull-idempotency.test.ts
+++ b/packages/runner/test/scheduler-pull-idempotency.test.ts
@@ -82,6 +82,66 @@ describe("inline idempotency check mode", () => {
     );
   });
 
+  it("records one violation for an action caught twice", async () => {
+    runtime.scheduler.enableIdempotencyCheck();
+
+    const input = runtime.getCell<number>(
+      space,
+      "inline-dedup-input",
+      undefined,
+      tx,
+    );
+    input.set(0);
+    const output = runtime.getCell<number>(
+      space,
+      "inline-dedup-output",
+      undefined,
+      tx,
+    );
+    output.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+
+    // Writes a different value on every invocation, so the recheck's second
+    // run always differs from the run it verifies. Counting the invocations
+    // rather than drawing a random number tells the two detections apart: the
+    // first records writes of 1 and 2, the second of 3 and 4.
+    let invocations = 0;
+    const counter: Action = (actionTx) => {
+      input.withTx(actionTx).get();
+      output.withTx(actionTx).send(++invocations);
+    };
+    (
+      counter as Action & {
+        writes: ReturnType<typeof output.getAsNormalizedFullLink>[];
+      }
+    ).writes = [output.getAsNormalizedFullLink()];
+    runtime.scheduler.subscribe(
+      counter,
+      logFor(
+        [toMemorySpaceAddress(input.getAsNormalizedFullLink())],
+        [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
+      ),
+      {},
+    );
+    await output.pull();
+
+    // Moving the input runs the action a second time, which the recheck flags
+    // a second time.
+    const external = runtime.edit();
+    input.withTx(external).set(1);
+    await external.commit();
+    await output.pull();
+
+    // Two runs and two rechecks.
+    expect(invocations).toBe(4);
+
+    const violations = runtime.scheduler.getIdempotencyViolations();
+    expect(violations.length).toBe(1);
+    expect(Object.values(violations[0].runs[0].writes)).toEqual([1]);
+    expect(Object.values(violations[0].runs[1].writes)).toEqual([2]);
+  });
+
   it("does not flag idempotent computations in inline mode", async () => {
     runtime.scheduler.enableIdempotencyCheck();
 

--- a/tasks/ci-check-lib.test.ts
+++ b/tasks/ci-check-lib.test.ts
@@ -12,6 +12,7 @@ import {
   type Artifact,
   type BaselineSample,
   buildCoverageDebtSuggestionComment,
+  buildCoverageDebtUnattributedComment,
   buildCoverageResolvedComment,
   type CompileCacheStates,
   COVERAGE_BASELINE_RESET_MARKER,
@@ -1018,4 +1019,69 @@ Deno.test("newestArtifactsByName keeps the latest re-run upload per name", () =>
       ["test-timing-pattern-unit-4", 200],
     ],
   );
+});
+
+Deno.test("buildCoverageDebtUnattributedComment names the lines and how to skip the check", () => {
+  const comment = buildCoverageDebtUnattributedComment({
+    groups: [{ group: "packages/runner", target: 4612, current: 4614 }],
+    files: [
+      {
+        relativePath: "packages/runner/src/scheduler/diagnosis.ts",
+        lines: [333, 334],
+      },
+    ],
+  });
+
+  // Same marker as the other coverage comments, so the poster keeps updating
+  // the one comment rather than adding a second.
+  assertStringIncludes(comment, COVERAGE_SUGGESTION_MARKER);
+  assertStringIncludes(
+    comment,
+    "<summary><h3>🕵🏻‍♀️ Test coverage regressed by 2 lines</h3></summary>",
+  );
+  assertStringIncludes(comment, "not introduced by this PR");
+  assertStringIncludes(comment, "inconsistently covered");
+  assertStringIncludes(comment, "The following lines are affected:");
+  assertStringIncludes(
+    comment,
+    "`packages/runner/src/scheduler/diagnosis.ts`: 333, 334",
+  );
+  // The line to paste into the description, with the count this PR measured.
+  assertStringIncludes(
+    comment,
+    "ACCEPT_COVERAGE_DEBT: coverage-debt: packages/runner uncovered lines = 4614 lines",
+  );
+  // The agent prompt is about the flapping lines, not about this PR.
+  assertStringIncludes(comment, "### Prompt for an AI coding agent");
+  assertStringIncludes(comment, "covered on some runs");
+  assertStringIncludes(
+    comment,
+    "  packages/runner/src/scheduler/diagnosis.ts: 333, 334",
+  );
+  assertStringIncludes(comment, "docs/development/COVERAGE.md");
+  // Repetition is not offered as evidence: the prompt asks for the new test to
+  // be measured on its own instead.
+  assertStringIncludes(comment, "Do not try to establish that a line is fixed");
+  assertStringIncludes(comment, "deno coverage --lcov coverage/raw/line-check");
+  assertStringIncludes(comment, "DA:<line>,<hits>");
+  assertFalse(comment.includes("twice from a clean profile directory"));
+  // None of the "this PR adds uncovered lines" copy survives.
+  assertFalse(comment.includes("This PR adds source lines"));
+  assertFalse(comment.includes("Could not tie the regression"));
+});
+
+Deno.test("buildCoverageDebtUnattributedComment counts files and lines past the cap", () => {
+  const comment = buildCoverageDebtUnattributedComment({
+    groups: [{ group: "tasks", target: 0, current: 40 }],
+    files: Array.from({ length: 25 }, (_, index) => ({
+      relativePath: `tasks/file-${String(index).padStart(2, "0")}.ts`,
+      lines: Array.from({ length: 30 }, (_, line) => line + 1),
+    })),
+  });
+
+  // 20 files listed, 5 counted; 20 lines listed per file, 10 counted.
+  assertStringIncludes(comment, "`tasks/file-19.ts`");
+  assertFalse(comment.includes("`tasks/file-20.ts`"));
+  assertStringIncludes(comment, "…and 5 more file(s)._");
+  assertStringIncludes(comment, "…and 10 more");
 });

--- a/tasks/ci-check-lib.ts
+++ b/tasks/ci-check-lib.ts
@@ -1042,6 +1042,169 @@ export function buildCoverageDebtSuggestionComment(
   return out.join("\n");
 }
 
+/** One file's lines that this PR leaves uncovered and the baseline covered. */
+export interface CoverageUnattributedFile {
+  relativePath: string;
+  lines: number[];
+}
+
+export interface CoverageDebtUnattributedInput {
+  groups: CoverageSuggestionGroup[];
+  files: CoverageUnattributedFile[];
+}
+
+/** How many affected files the comment names before it starts counting. */
+const MAX_UNATTRIBUTED_FILES = 20;
+/** How many line numbers one file contributes before the rest are counted. */
+const MAX_UNATTRIBUTED_LINES_PER_FILE = 20;
+
+/** `a.ts:3, 4, 5` — one file's affected lines, capped and counted. */
+function formatUnattributedFile(file: CoverageUnattributedFile): string {
+  const shown = file.lines.slice(0, MAX_UNATTRIBUTED_LINES_PER_FILE);
+  const rest = file.lines.length - shown.length;
+  const lines = shown.join(", ") + (rest > 0 ? `, …and ${rest} more` : "");
+  return `\`${file.relativePath}\`: ${lines}`;
+}
+
+/** The `ACCEPT_COVERAGE_DEBT:` line that takes one group off the ratchet. */
+export function coverageOverrideLine(group: CoverageSuggestionGroup): string {
+  return `ACCEPT_COVERAGE_DEBT: ${COVERAGE_METRIC_PREFIX} ${group.group} ` +
+    `uncovered lines = ${uncoveredLineCount(group.current)}`;
+}
+
+/**
+ * Build the prompt for an agent asked to make the affected lines cover the same
+ * way on every run. The work is on the lines themselves, not on this pull
+ * request, so the prompt is written to be pasted into a fresh session.
+ */
+function buildUnattributedPrompt(
+  files: CoverageUnattributedFile[],
+  omitted: number,
+): string[] {
+  const lines: string[] = [
+    "The lines below are covered on some runs of the CI test suite and not on",
+    "others, with no change to their source. That makes the coverage-debt gate",
+    "fail on pull requests that did not touch them, because the gate compares",
+    "one measurement of a source group against another.",
+    "",
+    "Find out what each line's coverage depends on, and add or extend a test so",
+    "the line is executed on every run and under every configuration. Common",
+    "causes: a branch taken only when an operation happens twice in one process,",
+    "a guard on elapsed wall-clock time, a path reached only when work lands in",
+    "a particular order, and a file that only some shards load. Write real",
+    "tests: do not delete assertions, mark lines ignored, or weaken the gate.",
+    "",
+    "Affected lines:",
+    "",
+  ];
+
+  for (const file of files) {
+    const shown = file.lines.slice(0, MAX_UNATTRIBUTED_LINES_PER_FILE);
+    const rest = file.lines.length - shown.length;
+    lines.push(
+      `  ${file.relativePath}: ${shown.join(", ")}${
+        rest > 0 ? `, and ${rest} more` : ""
+      }`,
+    );
+  }
+  if (omitted > 0) lines.push(`  ...and ${omitted} more file(s).`);
+
+  lines.push(
+    "",
+    'docs/development/COVERAGE.md, under "Coverage must not depend on the',
+    'execution environment", states the policy and works through examples of',
+    "each cause. Read it first.",
+    "",
+    "Do not try to establish that a line is fixed by running the suite several",
+    "times and finding it covered each time. A line covered on most runs looks",
+    "settled in any number of runs you have the patience for, and a run that",
+    "covers it by luck reads exactly like one that covers it by design. What",
+    "makes a line deterministic is a test that drives the condition the line",
+    "needs, so that reaching the line is what the test is for.",
+    "",
+    "Confirm that by measuring the test you added on its own. Run it the way",
+    "its package runs tests — the package's deno.jsonc gives the flags — with a",
+    "clean profile directory:",
+    "",
+    "  rm -rf coverage/raw/line-check",
+    '  DENO_COVERAGE_DIR="$(pwd)/coverage/raw/line-check" \\',
+    "    deno test <flags> <the test file you added>",
+    "  deno coverage --lcov coverage/raw/line-check > line-check.lcov",
+    "",
+    "Find the file's SF: record in line-check.lcov and read the DA:<line>,<hits>",
+    "entry for each affected line. Every one of them must show a nonzero hit",
+    "count from that test alone. A line still covered only when the rest of the",
+    "suite runs is a line still covered by accident.",
+  );
+
+  return lines;
+}
+
+/**
+ * Build the Markdown body for a regression none of the pull request's own added
+ * lines account for: every affected line is in a file the pull request left
+ * alone, and the baseline run covered it. Carries the same hidden marker as the
+ * other coverage comments, so the poster keeps updating the one comment.
+ */
+export function buildCoverageDebtUnattributedComment(
+  input: CoverageDebtUnattributedInput,
+): string {
+  const files = input.files.slice(0, MAX_UNATTRIBUTED_FILES);
+  const omitted = input.files.length - files.length;
+  const overBy = input.groups.reduce(
+    (sum, group) => sum + (group.current - group.target),
+    0,
+  );
+
+  const out: string[] = [COVERAGE_SUGGESTION_MARKER];
+  out.push("<details open>");
+  out.push(
+    coverageSummary(`Test coverage regressed by ${uncoveredLineCount(overBy)}`),
+  );
+  out.push("");
+  out.push(
+    "For some reason there are lines marked as uncovered in this PR that are " +
+      "not introduced by this PR and that were previously covered on `main`. " +
+      "This is likely because there are lines that are inconsistently covered " +
+      "on `main`.",
+  );
+  out.push("");
+  out.push("The following lines are affected:");
+  out.push("");
+  for (const file of files) {
+    out.push(`- ${formatUnattributedFile(file)}`);
+  }
+  if (omitted > 0) {
+    out.push(`- _…and ${omitted} more file(s)._`);
+  }
+  out.push("");
+  out.push(
+    "To skip coverage checking for this PR, add the following to the PR's " +
+      "description:",
+  );
+  out.push("");
+  out.push("```text");
+  for (const group of input.groups) {
+    out.push(coverageOverrideLine(group));
+  }
+  out.push("```");
+  out.push("");
+  out.push("### Prompt for an AI coding agent");
+  out.push("");
+  out.push(
+    "Copy the block below into a new AI coding agent session to improve our " +
+      "coverage and reduce this kind of flakiness in the future:",
+  );
+  out.push("");
+  out.push("````text");
+  out.push(...buildUnattributedPrompt(files, omitted));
+  out.push("````");
+  out.push("");
+  out.push("</details>");
+
+  return out.join("\n");
+}
+
 /**
  * Describe how a group's uncovered-line count moved between its `main` baseline
  * and this PR, for the "Change" column of the resolved comment's table.

--- a/tasks/coverage-check.test.ts
+++ b/tasks/coverage-check.test.ts
@@ -15,10 +15,12 @@ import {
   type WorkflowRun,
 } from "./ci-check-lib.ts";
 import {
+  baselineLcovForRun,
   type BaselineRunContext,
   type BaselineRunReading,
   buildBaselineRunContext,
   buildCoverageRows,
+  buildUnattributedRegressionBody,
   collectCurrentCacheStates,
   copyCoverageArtifactFiles,
   currentWorkflowRunFromEvent,
@@ -2134,4 +2136,147 @@ Deno.test("buildCoverageRows reports a rise from a zero baseline as complete", (
   );
   assertEquals(held.rows[0].status, "OK");
   assertEquals(held.rows[0].pctIncrease, 0);
+});
+
+/** A regressed group whose baseline came from `main` run 900. */
+function unattributedFailure(): Row {
+  return {
+    metric: "coverage-debt: packages/example uncovered lines",
+    status: "OVER",
+    current: 3,
+    baseline: 1,
+    baselineRunId: 900,
+  };
+}
+
+/** A checkout holding one source file, with reports for two runs of it. */
+async function withFlakyLineCheckout(
+  run: (context: {
+    rootDir: string;
+    lcov: string;
+    baselineLcov: string;
+  }) => Promise<void>,
+): Promise<void> {
+  const rootDir = await Deno.makeTempDir({ prefix: "coverage-unattributed-" });
+  try {
+    const sourcePath = path.join(rootDir, "packages/example/src/racy.ts");
+    await Deno.mkdir(path.dirname(sourcePath), { recursive: true });
+    await Deno.writeTextFile(
+      sourcePath,
+      ["export const a = 1;", "export const b = 2;"].join("\n"),
+    );
+    const report = (secondLineHits: number) =>
+      [
+        `SF:${sourcePath}`,
+        "DA:1,1",
+        `DA:2,${secondLineHits}`,
+        "end_of_record",
+      ].join("\n");
+    await run({
+      rootDir,
+      lcov: report(0),
+      baselineLcov: report(2),
+    });
+  } finally {
+    await Deno.remove(rootDir, { recursive: true });
+  }
+}
+
+Deno.test("buildUnattributedRegressionBody names lines the baseline run covered", async () => {
+  await withFlakyLineCheckout(async ({ rootDir, lcov, baselineLcov }) => {
+    const body = await buildUnattributedRegressionBody({
+      rootDir,
+      groups: [{ group: "packages/example", target: 1, current: 3 }],
+      coverageFailures: [unattributedFailure()],
+      // The PR changed a file in another group entirely.
+      prFiles: [{ filename: "packages/other/src/mod.ts" }],
+      lcov,
+      readBaselineLcov: (runId) => {
+        assertEquals(runId, 900);
+        return Promise.resolve(baselineLcov);
+      },
+    });
+
+    assertStringIncludes(body ?? "", "`packages/example/src/racy.ts`: 2");
+    assertStringIncludes(body ?? "", "not introduced by this PR");
+  });
+});
+
+Deno.test("buildUnattributedRegressionBody skips a line in a file the PR changed", async () => {
+  await withFlakyLineCheckout(async ({ rootDir, lcov, baselineLcov }) => {
+    const body = await buildUnattributedRegressionBody({
+      rootDir,
+      groups: [{ group: "packages/example", target: 1, current: 3 }],
+      coverageFailures: [unattributedFailure()],
+      prFiles: [{ filename: "packages/example/src/racy.ts" }],
+      lcov,
+      readBaselineLcov: () => Promise.resolve(baselineLcov),
+    });
+
+    assertEquals(body, null);
+  });
+});
+
+Deno.test("buildUnattributedRegressionBody gives up without a readable baseline run", async () => {
+  await withFlakyLineCheckout(async ({ rootDir, lcov }) => {
+    const noRunId = await buildUnattributedRegressionBody({
+      rootDir,
+      groups: [{ group: "packages/example", target: 1, current: 3 }],
+      coverageFailures: [{
+        ...unattributedFailure(),
+        baselineRunId: undefined,
+      }],
+      prFiles: [],
+      lcov,
+      readBaselineLcov: () => {
+        throw new Error("must not be read without a baseline run");
+      },
+    });
+    assertEquals(noRunId, null);
+
+    // The run exists but its coverage artifacts have expired or failed to
+    // download; the caller falls back to the ordinary comment.
+    const unreadable = await buildUnattributedRegressionBody({
+      rootDir,
+      groups: [{ group: "packages/example", target: 1, current: 3 }],
+      coverageFailures: [unattributedFailure()],
+      prFiles: [],
+      lcov,
+      readBaselineLcov: () => Promise.resolve(null),
+    });
+    assertEquals(unreadable, null);
+  });
+});
+
+Deno.test("writeCoverageDebtSuggestion falls back to the ordinary comment when the baseline is unreadable", async () => {
+  const failures = [unattributedFailure()];
+  const payload = await payloadFrom(() =>
+    writeCoverageDebtSuggestion(
+      4211,
+      failures,
+      [],
+      "",
+      () => Promise.resolve(null),
+    )
+  );
+
+  assertEquals(payload?.state, "regressed");
+  assertStringIncludes(payload?.body ?? "", "Could not tie the regression");
+});
+
+Deno.test("baselineLcovForRun gives up on a run with no coverage artifacts", async () => {
+  const lcov = await baselineLcovForRun(900, () =>
+    Promise.resolve([
+      { id: 1, name: "perf-metrics", size_in_bytes: 10, expired: false },
+    ]));
+
+  assertEquals(lcov, null);
+});
+
+Deno.test("baselineLcovForRun gives up when the artifact listing fails", async () => {
+  const lcov = await baselineLcovForRun(900, () => {
+    throw new Error("artifact listing unavailable");
+  });
+
+  assertEquals(lcov, null);
 });

--- a/tasks/coverage-check.test.ts
+++ b/tasks/coverage-check.test.ts
@@ -22,6 +22,7 @@ import {
   buildCoverageRows,
   buildUnattributedRegressionBody,
   collectCurrentCacheStates,
+  combinedLcovFromArtifacts,
   copyCoverageArtifactFiles,
   currentWorkflowRunFromEvent,
   fetchAncestorRanks,
@@ -2279,4 +2280,48 @@ Deno.test("baselineLcovForRun gives up when the artifact listing fails", async (
   });
 
   assertEquals(lcov, null);
+});
+
+Deno.test("combinedLcovFromArtifacts joins every artifact's uploaded report", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "coverage-artifacts-" });
+  try {
+    const artifacts = [
+      { id: 11, name: "coverage-profile-runner-1" },
+      { id: 12, name: "coverage-profile-workspace-7" },
+    ].map((artifact) => ({ ...artifact, size_in_bytes: 64, expired: false }));
+
+    for (const [index, artifact] of artifacts.entries()) {
+      const artifactDir = path.join(dir, artifact.name);
+      await Deno.mkdir(artifactDir, { recursive: true });
+      await Deno.writeTextFile(
+        path.join(artifactDir, `${artifact.name}.lcov`),
+        [
+          `SF:/home/runner/work/labs/labs/packages/example/src/mod-${index}.ts`,
+          "DA:1,1",
+          "end_of_record",
+        ].join("\n"),
+      );
+    }
+
+    const { lcov, sourceDescription } = await combinedLcovFromArtifacts(
+      artifacts,
+      dir,
+    );
+
+    assertStringIncludes(lcov, "packages/example/src/mod-0.ts");
+    assertStringIncludes(lcov, "packages/example/src/mod-1.ts");
+    assertEquals(sourceDescription, "2 LCOV report files");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("combinedLcovFromArtifacts refuses to report on no artifacts at all", async () => {
+  // An empty set is not an empty report: it means the run uploaded nothing,
+  // which must be an error rather than a workspace scored as uncovered.
+  await assertRejects(
+    () => combinedLcovFromArtifacts([]),
+    Error,
+    "contained no profile or LCOV files",
+  );
 });

--- a/tasks/coverage-check.test.ts
+++ b/tasks/coverage-check.test.ts
@@ -1,6 +1,7 @@
 import {
   assert,
   assertEquals,
+  assertFalse,
   assertRejects,
   assertStringIncludes,
 } from "@std/assert";
@@ -2324,4 +2325,63 @@ Deno.test("combinedLcovFromArtifacts refuses to report on no artifacts at all", 
     Error,
     "contained no profile or LCOV files",
   );
+});
+
+Deno.test("buildUnattributedRegressionBody holds each group against its own baseline run", async () => {
+  const rootDir = await Deno.makeTempDir({ prefix: "coverage-unattributed-" });
+  try {
+    const alphaPath = path.join(rootDir, "packages/alpha/src/mod.ts");
+    const betaPath = path.join(rootDir, "packages/beta/src/mod.ts");
+    await Deno.mkdir(path.dirname(alphaPath), { recursive: true });
+    await Deno.mkdir(path.dirname(betaPath), { recursive: true });
+    await Deno.writeTextFile(alphaPath, "export const alpha = 1;\n");
+    await Deno.writeTextFile(betaPath, "export const beta = 1;\n");
+
+    const report = (alphaHits: number, betaHits: number) =>
+      [
+        `SF:${alphaPath}`,
+        `DA:1,${alphaHits}`,
+        "end_of_record",
+        `SF:${betaPath}`,
+        `DA:1,${betaHits}`,
+        "end_of_record",
+      ].join("\n");
+
+    // Two groups regress, and their baselines resolve to different main runs.
+    // Run 901 covered both lines; run 902 covered neither. Only alpha is held
+    // against 901, so only alpha regressed — beta's own baseline never covered
+    // its line, which makes it existing debt.
+    const read = new Map([[901, report(1, 1)], [902, report(0, 0)]]);
+    const body = await buildUnattributedRegressionBody({
+      rootDir,
+      groups: [
+        { group: "packages/alpha", target: 1, current: 2 },
+        { group: "packages/beta", target: 1, current: 2 },
+      ],
+      coverageFailures: [
+        {
+          metric: "coverage-debt: packages/alpha uncovered lines",
+          status: "OVER",
+          current: 2,
+          baseline: 1,
+          baselineRunId: 901,
+        },
+        {
+          metric: "coverage-debt: packages/beta uncovered lines",
+          status: "OVER",
+          current: 2,
+          baseline: 1,
+          baselineRunId: 902,
+        },
+      ],
+      prFiles: [],
+      lcov: report(0, 0),
+      readBaselineLcov: (runId) => Promise.resolve(read.get(runId) ?? null),
+    });
+
+    assertStringIncludes(body ?? "", "`packages/alpha/src/mod.ts`: 1");
+    assertFalse((body ?? "").includes("packages/beta/src/mod.ts"));
+  } finally {
+    await Deno.remove(rootDir, { recursive: true });
+  }
 });

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -26,6 +26,7 @@ import {
   type BaselineOverrides,
   type BaselineSample,
   buildCoverageDebtSuggestionComment,
+  buildCoverageDebtUnattributedComment,
   CACHE_STATE_ARTIFACT_PREFIX,
   COMPILE_CACHE_FAMILIES,
   type CompileCacheStates,
@@ -39,6 +40,7 @@ import {
   type CoverageResolvedGroup,
   type CoverageSuggestionFileLines,
   type CoverageSuggestionGroup,
+  type CoverageUnattributedFile,
   downloadAndExtractArtifact,
   downloadAndParseCoverageBaseline,
   fetchArtifactsForRun,
@@ -69,6 +71,7 @@ import { walk } from "@std/fs/walk";
 import * as path from "@std/path";
 import {
   collectCoverageDebtMetricsFromLcov,
+  collectRegressedLines,
   collectUncoveredLinesForFiles,
   COVERAGE_PROFILE_ARTIFACT_PREFIX,
   lcovFromCoverageProfile,
@@ -1129,6 +1132,8 @@ export interface Row {
   baseline?: number;
   /** Head SHA of the run that baseline came from. */
   baselineSha?: string;
+  /** Id of the run that baseline came from. */
+  baselineRunId?: number;
   pctIncrease?: number;
 }
 
@@ -1222,6 +1227,7 @@ export function buildCoverageRows(
     const stats = {
       baseline: latestBaseline,
       baselineSha: baselineSample?.sha,
+      baselineRunId: baselineSample?.runId,
       pctIncrease,
     };
 
@@ -1262,33 +1268,26 @@ export function printMetricTable(rows: Row[], includeStatus = false): void {
   printTextTable(headers, metricTableRows(rows, includeStatus), align);
 }
 
-async function extractCoverageDebtSamples(
-  run: WorkflowRun,
-  artifacts: Artifact[],
-  coverageArtifactsDir?: string,
-): Promise<{ samples: Map<string, BaselineSample>; lcov: string }> {
-  const metrics = new Map<string, BaselineSample>();
-  const coverageArtifacts = newestArtifactsByName(artifacts.filter(
+/** The coverage-profile artifacts of one run, one per artifact name. */
+function coverageProfileArtifacts(artifacts: Artifact[]): Artifact[] {
+  return newestArtifactsByName(artifacts.filter(
     (artifact) =>
       artifact.name.startsWith(COVERAGE_PROFILE_ARTIFACT_PREFIX) &&
       !artifact.expired,
   ));
-  const coverageArtifactNames = new Set(
-    coverageArtifacts.map((artifact) => artifact.name),
-  );
-  const missingArtifacts = EXPECTED_COVERAGE_ARTIFACT_NAMES.filter((name) =>
-    !coverageArtifactNames.has(name)
-  );
+}
 
-  if (missingArtifacts.length > 0) {
-    throw new Error(
-      `Missing coverage profile artifact(s): ${missingArtifacts.join(", ")}`,
-    );
-  }
-
+/**
+ * Join one run's coverage-profile artifacts into a single LCOV report. A job
+ * uploads its own LCOV; the profile-file branch reads the raw V8 profiles a
+ * run predating that upload carries.
+ */
+async function combinedLcovFromArtifacts(
+  coverageArtifacts: Artifact[],
+  coverageArtifactsDir?: string,
+): Promise<{ lcov: string; sourceDescription: string }> {
   const profileDir = await Deno.makeTempDir({ prefix: "coverage-profiles-" });
   const lcovDir = await Deno.makeTempDir({ prefix: "coverage-lcov-" });
-  let lcov = "";
   try {
     let profileFileCount = 0;
     let lcovFileCount = 0;
@@ -1309,30 +1308,14 @@ async function extractCoverageDebtSamples(
       );
     }
 
-    lcov = lcovFileCount > 0
-      ? await readCombinedLcov(lcovDir)
-      : await lcovFromCoverageProfile(profileDir);
-
-    // Every coverage stream feeds the gate: V8 runtime coverage, unit pattern
-    // coverage (TN:pattern-runtime), and integration pattern coverage
-    // (TN:pattern-runtime-integration) all join here, and a line covered by any
-    // of them counts covered. So a pattern line an end-to-end flow exercises
-    // that the unit suite does not lowers the gated debt.
-    const coverageMetrics = await collectCoverageDebtMetricsFromLcov({
-      rootDir: Deno.cwd(),
-      lcov,
-    });
-    for (const metric of coverageMetrics) {
-      metrics.set(metric.name, sampleForRun(run, metric.uncoveredLines));
-    }
-
-    console.log(
-      `Extracted ${coverageMetrics.length} coverage debt metrics from ${
-        lcovFileCount > 0
-          ? `${lcovFileCount} LCOV report files`
-          : `${profileFileCount} coverage profile files`
-      }.`,
-    );
+    return {
+      lcov: lcovFileCount > 0
+        ? await readCombinedLcov(lcovDir)
+        : await lcovFromCoverageProfile(profileDir),
+      sourceDescription: lcovFileCount > 0
+        ? `${lcovFileCount} LCOV report files`
+        : `${profileFileCount} coverage profile files`,
+    };
   } finally {
     try {
       await Deno.remove(profileDir, { recursive: true });
@@ -1341,8 +1324,78 @@ async function extractCoverageDebtSamples(
       await Deno.remove(lcovDir, { recursive: true });
     } catch { /* ignore cleanup errors */ }
   }
+}
+
+async function extractCoverageDebtSamples(
+  run: WorkflowRun,
+  artifacts: Artifact[],
+  coverageArtifactsDir?: string,
+): Promise<{ samples: Map<string, BaselineSample>; lcov: string }> {
+  const metrics = new Map<string, BaselineSample>();
+  const coverageArtifacts = coverageProfileArtifacts(artifacts);
+  const coverageArtifactNames = new Set(
+    coverageArtifacts.map((artifact) => artifact.name),
+  );
+  const missingArtifacts = EXPECTED_COVERAGE_ARTIFACT_NAMES.filter((name) =>
+    !coverageArtifactNames.has(name)
+  );
+
+  if (missingArtifacts.length > 0) {
+    throw new Error(
+      `Missing coverage profile artifact(s): ${missingArtifacts.join(", ")}`,
+    );
+  }
+
+  const { lcov, sourceDescription } = await combinedLcovFromArtifacts(
+    coverageArtifacts,
+    coverageArtifactsDir,
+  );
+
+  // Every coverage stream feeds the gate: V8 runtime coverage, unit pattern
+  // coverage (TN:pattern-runtime), and integration pattern coverage
+  // (TN:pattern-runtime-integration) all join here, and a line covered by any
+  // of them counts covered. So a pattern line an end-to-end flow exercises
+  // that the unit suite does not lowers the gated debt.
+  const coverageMetrics = await collectCoverageDebtMetricsFromLcov({
+    rootDir: Deno.cwd(),
+    lcov,
+  });
+  for (const metric of coverageMetrics) {
+    metrics.set(metric.name, sampleForRun(run, metric.uncoveredLines));
+  }
+
+  console.log(
+    `Extracted ${coverageMetrics.length} coverage debt metrics from ${sourceDescription}.`,
+  );
 
   return { samples: metrics, lcov };
+}
+
+/**
+ * Join the coverage-profile artifacts of a `main` run into one LCOV report.
+ * Returns null when the run has none, or when the download fails: the comment
+ * this feeds is best-effort, and a regression is reported either way.
+ */
+export async function baselineLcovForRun(
+  runId: number,
+  fetchArtifacts: (runId: number) => Promise<Artifact[]> = fetchArtifactsForRun,
+): Promise<string | null> {
+  try {
+    const artifacts = coverageProfileArtifacts(await fetchArtifacts(runId));
+    if (artifacts.length === 0) {
+      console.warn(
+        `  Warning: baseline run ${runId} has no coverage profile artifacts.`,
+      );
+      return null;
+    }
+    const { lcov } = await combinedLcovFromArtifacts(artifacts);
+    return lcov;
+  } catch (error) {
+    console.warn(
+      `  Warning: could not read coverage from baseline run ${runId}: ${error}`,
+    );
+    return null;
+  }
 }
 
 /** File the coverage-comment payload is written to; tests override via env. */
@@ -1377,6 +1430,72 @@ export async function writeCoverageComment(
 }
 
 /**
+ * Build the body naming the lines a regression the pull request did not cause
+ * is charged for: lines this run leaves uncovered in files the pull request
+ * never touched, which the baseline run covered.
+ *
+ * Returns null when there is nothing to say — no baseline run to compare
+ * against, its coverage cannot be read, or every affected line is in a file the
+ * pull request changed — and the caller falls back to the ordinary comment.
+ */
+export interface UnattributedRegressionOptions {
+  rootDir: string;
+  groups: CoverageSuggestionGroup[];
+  coverageFailures: Row[];
+  prFiles: PRFile[];
+  /** LCOV from this run. */
+  lcov: string;
+  readBaselineLcov: (runId: number) => Promise<string | null>;
+}
+
+export async function buildUnattributedRegressionBody(
+  options: UnattributedRegressionOptions,
+): Promise<string | null> {
+  const baselineRunIds = new Set(
+    options.coverageFailures
+      .map((failure) => failure.baselineRunId)
+      .filter((runId): runId is number => runId !== undefined),
+  );
+  if (baselineRunIds.size === 0) return null;
+
+  const changedFiles = new Set(
+    options.prFiles.map((prFile) => prFile.filename.replaceAll("\\", "/")),
+  );
+  const failingGroups = new Set(options.groups.map((group) => group.group));
+
+  // One regressed group is the common case, and every group then shares a
+  // baseline run. Several groups can resolve to different runs, so each run's
+  // report is compared and the results joined.
+  const files: CoverageUnattributedFile[] = [];
+  for (const runId of baselineRunIds) {
+    const baselineLcov = await options.readBaselineLcov(runId);
+    if (baselineLcov === null) continue;
+    const regressed = await collectRegressedLines({
+      rootDir: options.rootDir,
+      lcov: options.lcov,
+      baselineLcov,
+      groups: failingGroups,
+      changedFiles,
+    });
+    for (const file of regressed) {
+      files.push({ relativePath: file.relativePath, lines: file.lines });
+    }
+  }
+
+  if (files.length === 0) return null;
+
+  const total = files.reduce((sum, file) => sum + file.lines.length, 0);
+  console.log(
+    `Regression not attributable to this PR's added lines: ${total} line(s) ` +
+      `across ${files.length} unchanged file(s) that the baseline run covered.`,
+  );
+  return buildCoverageDebtUnattributedComment({
+    groups: options.groups,
+    files,
+  });
+}
+
+/**
  * Write the coverage-debt regression comment to a file for a later workflow to
  * post. The gate runs on `pull_request`, where fork PRs get a read-only token
  * and cannot comment, so the `coverage-comment` workflow_run job posts this from
@@ -1388,6 +1507,8 @@ export async function writeCoverageDebtSuggestion(
   coverageFailures: Row[],
   prFiles: PRFile[],
   lcov: string,
+  readBaselineLcov: (runId: number) => Promise<string | null> =
+    baselineLcovForRun,
 ): Promise<void> {
   const groups = coverageFailures
     .map((failure) => ({
@@ -1434,7 +1555,21 @@ export async function writeCoverageDebtSuggestion(
   }
 
   try {
-    const body = buildCoverageDebtSuggestionComment({ groups, files });
+    // Nothing the pull request added accounts for the regression, so the lines
+    // it is charged for are somewhere it did not touch. Say which ones by
+    // comparing this run against the baseline run line by line.
+    const unattributed = files.length === 0
+      ? await buildUnattributedRegressionBody({
+        rootDir: Deno.cwd(),
+        groups,
+        coverageFailures,
+        prFiles,
+        lcov,
+        readBaselineLcov,
+      })
+      : null;
+    const body = unattributed ??
+      buildCoverageDebtSuggestionComment({ groups, files });
     const payload: CoverageCommentPayload = {
       prNumber,
       state: "regressed",

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -1451,30 +1451,35 @@ export interface UnattributedRegressionOptions {
 export async function buildUnattributedRegressionBody(
   options: UnattributedRegressionOptions,
 ): Promise<string | null> {
-  const baselineRunIds = new Set(
-    options.coverageFailures
-      .map((failure) => failure.baselineRunId)
-      .filter((runId): runId is number => runId !== undefined),
-  );
-  if (baselineRunIds.size === 0) return null;
+  // Each metric resolves its own ratchet baseline, so two regressed groups can
+  // be held against two different `main` runs. A group is compared against the
+  // run its own baseline came from and no other: another run measured a
+  // different commit, where the same line may legitimately have been covered.
+  const groupsByBaselineRun = new Map<number, Set<string>>();
+  for (const failure of options.coverageFailures) {
+    const runId = failure.baselineRunId;
+    if (runId === undefined) continue;
+    const group = coverageMetricGroupName(failure.metric);
+    if (group === null) continue;
+    const groups = groupsByBaselineRun.get(runId) ?? new Set<string>();
+    groups.add(group);
+    groupsByBaselineRun.set(runId, groups);
+  }
+  if (groupsByBaselineRun.size === 0) return null;
 
   const changedFiles = new Set(
     options.prFiles.map((prFile) => prFile.filename.replaceAll("\\", "/")),
   );
-  const failingGroups = new Set(options.groups.map((group) => group.group));
 
-  // One regressed group is the common case, and every group then shares a
-  // baseline run. Several groups can resolve to different runs, so each run's
-  // report is compared and the results joined.
   const files: CoverageUnattributedFile[] = [];
-  for (const runId of baselineRunIds) {
+  for (const [runId, groups] of groupsByBaselineRun) {
     const baselineLcov = await options.readBaselineLcov(runId);
     if (baselineLcov === null) continue;
     const regressed = await collectRegressedLines({
       rootDir: options.rootDir,
       lcov: options.lcov,
       baselineLcov,
-      groups: failingGroups,
+      groups,
       changedFiles,
     });
     for (const file of regressed) {

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -1282,7 +1282,7 @@ function coverageProfileArtifacts(artifacts: Artifact[]): Artifact[] {
  * uploads its own LCOV; the profile-file branch reads the raw V8 profiles a
  * run predating that upload carries.
  */
-async function combinedLcovFromArtifacts(
+export async function combinedLcovFromArtifacts(
   coverageArtifacts: Artifact[],
   coverageArtifactsDir?: string,
 ): Promise<{ lcov: string; sourceDescription: string }> {

--- a/tasks/coverage-metrics.test.ts
+++ b/tasks/coverage-metrics.test.ts
@@ -373,6 +373,7 @@ Deno.test("collectRegressedLines names lines the baseline covered and this run d
   try {
     const flakyPath = path.join(rootDir, "packages/example/src/flaky.ts");
     const steadyPath = path.join(rootDir, "packages/example/src/steady.ts");
+    const debtPath = path.join(rootDir, "packages/example/src/debt.ts");
     await Deno.mkdir(path.dirname(flakyPath), { recursive: true });
     await Deno.writeTextFile(
       flakyPath,
@@ -383,6 +384,8 @@ Deno.test("collectRegressedLines names lines the baseline covered and this run d
       ].join("\n"),
     );
     await Deno.writeTextFile(steadyPath, "export const steady = 1;\n");
+    // Uncovered in both runs: existing debt, not something this run lost.
+    await Deno.writeTextFile(debtPath, "export const owed = 1;\n");
 
     const report = (flakyHits: string[]) =>
       [
@@ -391,6 +394,9 @@ Deno.test("collectRegressedLines names lines the baseline covered and this run d
         "end_of_record",
         `SF:${steadyPath}`,
         "DA:1,1",
+        "end_of_record",
+        `SF:${debtPath}`,
+        "DA:1,0",
         "end_of_record",
       ].join("\n");
 
@@ -403,6 +409,8 @@ Deno.test("collectRegressedLines names lines the baseline covered and this run d
       changedFiles: new Set(),
     });
 
+    // Only the line that moved: the file uncovered in both runs is not one
+    // this run regressed, and the file covered in both has nothing to report.
     assertEquals(regressed, [{
       relativePath: "packages/example/src/flaky.ts",
       metricGroup: "packages/example",

--- a/tasks/coverage-metrics.test.ts
+++ b/tasks/coverage-metrics.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import * as path from "@std/path";
 import {
   collectCoverageDebtMetricsFromLcov,
+  collectRegressedLines,
   collectSourceFiles,
   collectUncoveredLinesForFiles,
   countTrackedSourceLines,
@@ -360,6 +361,132 @@ Deno.test("collectUncoveredLinesForFiles surfaces non-NotFound read failures", a
         files: ["packages/example/src/mod.ts"],
       })
     );
+  } finally {
+    await Deno.remove(rootDir, { recursive: true });
+  }
+});
+
+Deno.test("collectRegressedLines names lines the baseline covered and this run did not", async () => {
+  const rootDir = await Deno.makeTempDir({
+    prefix: "coverage-regressed-test-",
+  });
+  try {
+    const flakyPath = path.join(rootDir, "packages/example/src/flaky.ts");
+    const steadyPath = path.join(rootDir, "packages/example/src/steady.ts");
+    await Deno.mkdir(path.dirname(flakyPath), { recursive: true });
+    await Deno.writeTextFile(
+      flakyPath,
+      [
+        "export const one = 1;",
+        "export const two = 2;",
+        "export const three = 3;",
+      ].join("\n"),
+    );
+    await Deno.writeTextFile(steadyPath, "export const steady = 1;\n");
+
+    const report = (flakyHits: string[]) =>
+      [
+        `SF:${flakyPath}`,
+        ...flakyHits,
+        "end_of_record",
+        `SF:${steadyPath}`,
+        "DA:1,1",
+        "end_of_record",
+      ].join("\n");
+
+    const regressed = await collectRegressedLines({
+      rootDir,
+      // Line 2 covered before and not now; line 3 uncovered in both.
+      lcov: report(["DA:1,1", "DA:2,0", "DA:3,0"]),
+      baselineLcov: report(["DA:1,1", "DA:2,4", "DA:3,0"]),
+      groups: new Set(["packages/example"]),
+      changedFiles: new Set(),
+    });
+
+    assertEquals(regressed, [{
+      relativePath: "packages/example/src/flaky.ts",
+      metricGroup: "packages/example",
+      lines: [2],
+    }]);
+  } finally {
+    await Deno.remove(rootDir, { recursive: true });
+  }
+});
+
+Deno.test("collectRegressedLines skips changed files and other groups", async () => {
+  const rootDir = await Deno.makeTempDir({
+    prefix: "coverage-regressed-test-",
+  });
+  try {
+    const changedPath = path.join(rootDir, "packages/example/src/changed.ts");
+    const otherPath = path.join(rootDir, "packages/other/src/mod.ts");
+    await Deno.mkdir(path.dirname(changedPath), { recursive: true });
+    await Deno.mkdir(path.dirname(otherPath), { recursive: true });
+    await Deno.writeTextFile(changedPath, "export const changed = 1;\n");
+    await Deno.writeTextFile(otherPath, "export const other = 1;\n");
+
+    const regressed = await collectRegressedLines({
+      rootDir,
+      lcov: [
+        `SF:${changedPath}`,
+        "DA:1,0",
+        "end_of_record",
+        `SF:${otherPath}`,
+        "DA:1,0",
+        "end_of_record",
+      ].join("\n"),
+      baselineLcov: [
+        `SF:${changedPath}`,
+        "DA:1,2",
+        "end_of_record",
+        `SF:${otherPath}`,
+        "DA:1,2",
+        "end_of_record",
+      ].join("\n"),
+      // A file the PR changed has line numbers that moved between the two
+      // checkouts, and a group the PR did not regress is not being explained.
+      groups: new Set(["packages/example"]),
+      changedFiles: new Set(["packages/example/src/changed.ts"]),
+    });
+
+    assertEquals(regressed, []);
+  } finally {
+    await Deno.remove(rootDir, { recursive: true });
+  }
+});
+
+Deno.test("collectRegressedLines counts a file the baseline reported and this run did not", async () => {
+  const rootDir = await Deno.makeTempDir({
+    prefix: "coverage-regressed-test-",
+  });
+  try {
+    const droppedPath = path.join(rootDir, "packages/example/src/dropped.ts");
+    await Deno.mkdir(path.dirname(droppedPath), { recursive: true });
+    await Deno.writeTextFile(
+      droppedPath,
+      ["export const first = 1;", "export const second = 2;"].join("\n"),
+    );
+
+    const regressed = await collectRegressedLines({
+      rootDir,
+      // No record at all: a file no job loaded this time owes every tracked
+      // line, the same rule the debt metric charges it by.
+      lcov: "",
+      baselineLcov: [
+        `SF:${droppedPath}`,
+        "DA:1,1",
+        "DA:2,1",
+        "end_of_record",
+      ].join("\n"),
+      groups: new Set(["packages/example"]),
+      changedFiles: new Set(),
+    });
+
+    assertEquals(regressed, [{
+      relativePath: "packages/example/src/dropped.ts",
+      metricGroup: "packages/example",
+      lines: [1, 2],
+    }]);
   } finally {
     await Deno.remove(rootDir, { recursive: true });
   }

--- a/tasks/coverage-metrics.ts
+++ b/tasks/coverage-metrics.ts
@@ -184,6 +184,82 @@ export async function collectUncoveredLinesForFiles(
   return result;
 }
 
+/** One file's lines that this run leaves uncovered and an earlier run covered. */
+export interface RegressedSourceLines {
+  relativePath: string;
+  metricGroup: string;
+  lines: number[];
+}
+
+export interface RegressedLinesOptions {
+  rootDir: string;
+  /** LCOV from the run being gated. */
+  lcov: string;
+  /** LCOV from the `main` run its ratchet baseline came from. */
+  baselineLcov: string;
+  /** Metric groups to inspect; every other group is left alone. */
+  groups: Set<string>;
+  /** Repository-relative POSIX paths the pull request changed. */
+  changedFiles: Set<string>;
+}
+
+/**
+ * Find the lines a run leaves uncovered that its baseline run covered, for
+ * source files the pull request did not touch.
+ *
+ * A group can end up over its baseline without the diff adding a single
+ * uncovered line, because the two counts come from two separate measurements of
+ * the same code. A line reached only on some runs — one whose branch depends on
+ * scheduling, on load, or on how test files were distributed — moves the count
+ * on its own. This says which lines moved, so the flapping line can be given a
+ * test that covers it every time.
+ *
+ * Files the pull request changed are skipped: their line numbers moved between
+ * the two checkouts, so a line number means something different in each report.
+ * An untouched file has identical content in both, since the baseline measures
+ * the base-branch commit this run merged.
+ */
+export async function collectRegressedLines(
+  options: RegressedLinesOptions,
+): Promise<RegressedSourceLines[]> {
+  const sourceFiles = await collectSourceFiles(options.rootDir);
+  const candidates = sourceFiles.filter((source) =>
+    options.groups.has(source.metricGroup) &&
+    !options.changedFiles.has(source.relativePath)
+  );
+  const groupByPath = new Map(
+    candidates.map((source) => [source.relativePath, source.metricGroup]),
+  );
+  const paths = candidates.map((source) => source.relativePath);
+
+  const [now, before] = await Promise.all([
+    collectUncoveredLinesForFiles({
+      rootDir: options.rootDir,
+      lcov: options.lcov,
+      files: paths,
+    }),
+    collectUncoveredLinesForFiles({
+      rootDir: options.rootDir,
+      lcov: options.baselineLcov,
+      files: paths,
+    }),
+  ]);
+
+  const regressed: RegressedSourceLines[] = [];
+  for (const [relativePath, uncoveredNow] of now) {
+    const uncoveredBefore = new Set(before.get(relativePath) ?? []);
+    const lines = uncoveredNow.filter((line) => !uncoveredBefore.has(line));
+    if (lines.length === 0) continue;
+    regressed.push({
+      relativePath,
+      metricGroup: groupByPath.get(relativePath) ??
+        metricGroupFor(relativePath),
+      lines,
+    });
+  }
+  return regressed.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+}
+
 export async function collectSourceFiles(
   rootDir: string,
 ): Promise<SourceFile[]> {


### PR DESCRIPTION
The coverage gate compares whole-group uncovered-line counts, so a line covered on some runs and not on others fails whichever pull request is measured against a run that happened to cover it, however unrelated the diff. The comment the gate posted in that case said only that it could not tie the regression to a file, and offered a command to measure the group again, which reproduces neither the run that failed nor the run it was compared against. The author had no way to learn which lines they were being charged for.

The check now recognizes the case and says which lines. When a gated group is over its baseline and none of the lines the pull request added are uncovered, it reads the coverage reports of the main run the baseline came from and names every line this run leaves uncovered that the baseline run covered. The comment lists them file by file, gives the ACCEPT_COVERAGE_DEBT line that lets the pull request through, and carries a prompt for a fresh agent session to give those lines tests that cover them every time. Fixing them is not the author's pull request's job, and it is no longer held up waiting for that.

Only files the pull request left alone are compared. A file it changed has different content in the two checkouts, so the same line number means a different line in each report. The comparison is best-effort: when the baseline run's coverage artifacts cannot be read, the ordinary regression comment is written instead.

The prompt does not offer repetition as proof that a line is fixed. A line covered on nine runs in ten survives any number of runs an author has the patience for, and a run that covers a line by luck reads exactly like one that covers it by design. What settles the question is where the coverage comes from: a test written to drive the condition the line needs covers it whenever that test runs, so the prompt asks for the new test to be measured on its own and for each affected line's hit count to be nonzero from that test alone.

Also fixes the line that prompted all this. The guard in runIdempotencyRecheck() that stops a second violation being recorded for an already-flagged action had no test. It ran only when the CLI package's expectNonIdempotent fixtures, whose computations append to the log they read, happened to re-trigger themselves once more before their test run finished — a race between the scheduler draining its queue and the runtime being disposed. The new case produces the second detection itself: an action writes an incrementing count, so each run differs from the recheck that verifies it, and moving an input it reads runs it a second time. The recorded violation carries the writes of the first detection, which is what tells a deduplicated second detection apart from a single detection; a test that only counted violations would pass either way and leave the lines as environment-dependent as before.

The investigation that found those two lines is recorded under docs/history, and the coverage document gains the general shape — a line reached only when something happens twice in one process — alongside a description of what the check now reports.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

