### PR TITLE
refactor(integration): waitForTextWhileSettling owns its timeout

### DIFF
--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -8,7 +8,6 @@ import {
 } from "@commonfabric/integration";
 import { toIndentedDebugString } from "@commonfabric/data-model/value-debug";
 
-const DEFAULT_CFC_BROWSER_TIMEOUT = 30_000;
 /**
  * Attribute a mark predicate stamps on the element it resolved, so the test can
  * then address exactly that element. Each mark is a unique whitespace-separated
@@ -524,6 +523,14 @@ export async function settleView(page: Page): Promise<void> {
   await awaitViewSettled(page);
 }
 
+// Built-in safety net for a genuinely stuck settle, matching
+// `waitForCondition`'s precedent. The loop resolves the instant the text
+// appears and drives a real view settle between checks, so this bound is never
+// the common-case latency; it is generous enough to cover the slowest
+// legitimate effect (cross-browser propagation of an optimistic write) without
+// capping a check that is still making progress.
+const WAIT_FOR_TEXT_WHILE_SETTLING_TIMEOUT = 300_000; // 5 minutes
+
 /**
  * Wait for `selector` to contain `text` after a stimulus has been dispatched,
  * driving the shell to settle between checks and resolving the instant the text
@@ -548,16 +555,16 @@ async function waitForTextWhileSettling(
   page: Page,
   selector: string,
   text: string,
-  { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ): Promise<void> {
-  const deadline = Date.now() + timeout;
+  const deadline = Date.now() + WAIT_FOR_TEXT_WHILE_SETTLING_TIMEOUT;
   if (await textIsPresent(page, selector, text)) return;
   do {
     await awaitViewSettled(page);
     if (await textIsPresent(page, selector, text)) return;
   } while (Date.now() < deadline);
   throw new Error(
-    `"${selector}" did not contain "${text}" within ${timeout}ms`,
+    `"${selector}" did not contain "${text}" within ` +
+      `${WAIT_FOR_TEXT_WHILE_SETTLING_TIMEOUT}ms`,
   );
 }
 
@@ -642,7 +649,6 @@ export async function clickTrustedActionAndWaitForText(
   action: string,
   selector: string,
   text: string,
-  { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ) {
   let actionProbe: TrustedActionProbe | undefined;
   let textProbe: TextProbe | undefined;
@@ -677,7 +683,7 @@ export async function clickTrustedActionAndWaitForText(
   // optimistic perUser/perSpace write whose chip trails the commit is caught by
   // the same wait.
   try {
-    await waitForTextWhileSettling(page, selector, text, { timeout });
+    await waitForTextWhileSettling(page, selector, text);
   } catch (cause) {
     actionProbe ??= await readTrustedActionProbe(page, action).catch(() =>
       undefined
@@ -1654,7 +1660,6 @@ export async function clickCfButtonAndWaitForText(
   buttonSelector: string,
   textSelector: string,
   text: string,
-  { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ) {
   let textProbe: TextProbe | undefined;
 
@@ -1682,7 +1687,7 @@ export async function clickCfButtonAndWaitForText(
   // few cycles after the click — including an optimistic perUser/perSpace write
   // whose chip trails the commit — is captured without ever re-clicking.
   try {
-    await waitForTextWhileSettling(page, textSelector, text, { timeout });
+    await waitForTextWhileSettling(page, textSelector, text);
   } catch (cause) {
     textProbe = await readTextProbe(page, textSelector).catch(() => undefined);
     throw new Error(

--- a/packages/patterns/integration/cfc-group-chat-demo-two-browsers.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo-two-browsers.test.ts
@@ -52,7 +52,6 @@ import {
 } from "./cfc-browser-helpers.ts";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME, CFC_BROWSER_PROFILE_COUNT } = env;
-const PROPAGATION_TIMEOUT = 60_000;
 const SAVE_PROFILE_ACTION = "TrustedGroupChatSaveProfile";
 const PROFILE_COUNT = Math.max(2, CFC_BROWSER_PROFILE_COUNT);
 
@@ -205,7 +204,6 @@ describe(
               SAVE_PROFILE_ACTION,
               "#trusted-profile-status",
               userNames[0],
-              { timeout: PROPAGATION_TIMEOUT },
             ),
         );
         await Promise.all(
@@ -251,7 +249,6 @@ describe(
                 SAVE_PROFILE_ACTION,
                 "#trusted-profile-status",
                 userNames[index],
-                { timeout: PROPAGATION_TIMEOUT },
               ),
           );
         }

--- a/packages/patterns/integration/cfc-render-policy-demo.test.ts
+++ b/packages/patterns/integration/cfc-render-policy-demo.test.ts
@@ -106,7 +106,6 @@ describe("cfc render policy demo integration test", () => {
           "TrustedRevealHealthData",
           "#trusted-health-visible",
           "Sensitive health data: migraine treatment plan",
-          { timeout: 45_000 },
         ),
     );
     await timeline.run(


### PR DESCRIPTION
The CFC browser integration test helpers threaded a caller-supplied 30-second timeout through `waitForTextWhileSettling` and its two wrappers, `clickTrustedActionAndWaitForText` and
`clickCfButtonAndWaitForText`. Every layer carried a `{ timeout = DEFAULT_CFC_BROWSER_TIMEOUT }` parameter whose only job was to feed that one wait. After the trusted-click rework removed the timeouts from the selector-wait helpers, this was the last caller-managed timeout left in the file.

A 30-second cap on a settle-driven wait puts a ceiling on success: a wait that would have completed a moment later — a slow cross-browser propagation of an optimistic write — cannot complete once it hits the cap. The two callers that most needed the extra time had to widen the cap test by test, threading a 60-second `PROPAGATION_TIMEOUT` and a one-off 45-second literal down through the wrappers. That per-call widening is exactly the plumbing removed elsewhere by the change that gave `settleView` and `waitForCondition` a built-in safety net.

Move the bound to where the wait lives. `waitForTextWhileSettling` now carries a built-in `WAIT_FOR_TEXT_WHILE_SETTLING_TIMEOUT` of five minutes, matching the `WAIT_FOR_CONDITION_TIMEOUT` precedent in `packages/integration/utils.ts`. The loop still bounds itself and still drives a real view settle between checks — an integration test holds no UI subscription, so a passive wait would sit on a DOM that nothing pumps — but the bound is now a generous net that fires only on a genuinely stuck settle rather than a ceiling every caller had to reason about.

- Remove the `{ timeout }` parameter from `waitForTextWhileSettling`, `clickTrustedActionAndWaitForText`, and `clickCfButtonAndWaitForText`, and their forwarding into the wait.
- Delete the now-unused `DEFAULT_CFC_BROWSER_TIMEOUT` constant.
- The three test call sites that passed a timeout drop it, and the now-unused `PROPAGATION_TIMEOUT` constant in the group-chat two-browser test is deleted.

This completes the second and third steps of simplifying the helpers' timeouts; the first, the astral selector-wait timeouts, landed earlier. It follows the same pattern as the `settleView` and `waitForCondition` change.

Verified with deno check, deno lint, and deno fmt --check across the patterns integration helper and the affected test files.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

