### PR TITLE
test(runner): drop the fixed sleep and deadline from the leak test

### DIFF
--- a/packages/runner/integration/derive_array_leak.test.ts
+++ b/packages/runner/integration/derive_array_leak.test.ts
@@ -19,7 +19,6 @@ import { PiecesController } from "@commonfabric/piece/ops";
 
 const { API_URL } = env;
 const SPACE_NAME_PREFIX = "runner_integration";
-const TIMEOUT_MS = 300000;
 
 // Test parameters
 const INCREMENTS_PER_CLICK = 50; // How many times each click increments (must match .tsx file)
@@ -132,13 +131,13 @@ async function runTest() {
   });
   console.log("Piece created:", piece.entityId);
 
-  // Wait for initial state
+  // Settle the piece's initialization writes before sampling the baseline.
+  // runtime.idle() drains client-side reactivity; synced() then waits for every
+  // pending commit to be confirmed durable by the memory server. The
+  // after-measurement below settles the same way, so both samples follow the
+  // same barrier.
   await runtime.idle();
   await runtime.storageManager.synced();
-
-  // Give it 5 seconds to settle after initialization
-  console.log("Waiting 5 seconds for memory to settle...");
-  await new Promise((resolve) => setTimeout(resolve, 5000));
 
   // Measure baseline server memory (where the leak occurs)
   const serverMemoryBeforeMB = await getServerMemoryMB();
@@ -208,24 +207,11 @@ async function runTest() {
   console.log(`Counter reached ${finalValue} (expected ${expectedValue})`);
 }
 
-// Run the test with timeout
+// The test runs without a per-test deadline. See
+// docs/development/waiting-in-tests.md.
 Deno.test({
   name: "derive array leak test",
-  fn: async () => {
-    let timeoutHandle: ReturnType<typeof setTimeout>;
-    const timeoutPromise = new Promise((_, reject) => {
-      timeoutHandle = setTimeout(() => {
-        reject(new Error(`Test timed out after ${TIMEOUT_MS}ms`));
-      }, TIMEOUT_MS);
-    });
-
-    try {
-      await Promise.race([runTest(), timeoutPromise]);
-      console.log("Test completed successfully");
-    } finally {
-      clearTimeout(timeoutHandle!);
-    }
-  },
+  fn: runTest,
   sanitizeResources: false,
   sanitizeOps: false,
 });


### PR DESCRIPTION
The derive-array-leak integration test carried two of the waits the repository is removing everywhere: a fixed five-second sleep before it sampled the baseline server memory, and a five-minute wall-clock deadline racing the whole test body.

The sleep sat immediately after the test already awaited runtime.idle() and storageManager.synced(). Those two are the real settle signals: idle() drains client-side reactivity, and synced() waits for every pending commit, each of which resolves only once the memory server confirms the write is durable. The five seconds waited on nothing beyond that barrier. It was introduced as a pragmatic "adjust timeouts" step rather than a wait on a named event, and it was only ever a hope that the server process would quiesce before the baseline reading. The measured quantity is the server process resident-set size, which is a coarse operating-system counter driven by V8 allocation and garbage collection, not something the durability barrier settles; the leak this test catches is hundreds of megabytes to gigabytes against a two-times threshold, so no amount of baseline sampling noise can hide it, and the sleep bought no accuracy. Removing it also makes the baseline and the after-measurement symmetric, since both now sample right after the same idle()/synced() barrier.

The deadline was a Promise.race between the test and a timer that rejected after five minutes. A fixed deadline puts a ceiling on success: a run that is merely slow, on a loaded continuous-integration host or a virtual machine that was suspended and resumed, fails even though it would have completed. The test now runs as its own function with no timer.

One trade-off is worth stating. This test drives a live memory server over a websocket, so its event loop stays open while that connection lives. Per docs/development/waiting-in-tests.md, a wait against a live-server client does not fail fast the way an in-process wait does; a genuine hang runs to the ambient continuous-integration limit rather than to a per-test error. The test already disposes the runtime and closes storage on its return paths, which is the mitigation that document prescribes, so a completed run releases the loop and the suite moves on. A true deadlock now surfaces at the job limit instead of as a five-minute per-test failure. That is the accepted cost of not capping a healthy run, and a real deadlock is a bug to fix rather than to mask behind a timer. Several sibling integration tests still carry the same deadline pattern and can be migrated the same way.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

