### PR TITLE
fix(fuse): stop deep piece data from crashing the projection

### DIFF
--- a/docs/specs/fuse-filesystem/3-json-mapping.md
+++ b/docs/specs/fuse-filesystem/3-json-mapping.md
@@ -109,6 +109,34 @@ the full JSON representation of that subtree. This is essential for:
    - `result/items/` — directory with `0/`, `1/`, etc.
 4. Writing to a `.json` file replaces the entire subtree with the parsed
    JSON value.
+5. A `.json` file spells out 128 levels of nested objects and arrays beneath
+   itself. Anything below that is written as the string
+   `"[Max depth exceeded]"`.
+6. A value that appears twice along the same chain of parents — a circular
+   reference — is written as the string `"[Circular]"`.
+
+### Nesting Depth
+
+The 128-level bound is measured from the value each `.json` file holds, not
+from the root of the piece. A directory at every level of the data carries its
+own `.json` sibling, so data below the bound stays readable through the `.json`
+sibling of a directory closer to it:
+
+```bash
+# Spells out 128 levels from the result root, and marks what is below them.
+cat result.json
+
+# Spells out 128 levels from `deeply/nested/value` instead.
+cat result/deeply/nested/value.json
+```
+
+The directory tree itself is not bounded. Every level of the data has its
+directory entry and its leaf files, however deep the nesting goes, so no value
+is unreachable — only the aggregate views of it are abbreviated.
+
+Because a truncated `.json` file does not carry the whole subtree, writing one
+back replaces the elided part with the marker string. Write to a `.json` file
+closer to the data, or to the leaf files, to change something below the bound.
 
 ### Callable Sigils In Aggregate JSON
 

--- a/docs/specs/fuse-filesystem/4-read-write.md
+++ b/docs/specs/fuse-filesystem/4-read-write.md
@@ -135,6 +135,12 @@ target path parsing rules and examples.
 5. Apply `cell.set()` at the appropriate path using the same commit-confirmed
    acknowledgement contract as scalar writes.
 
+The buffer is written through as it was parsed. A `.json` file whose read form
+abbreviated part of the value — see
+[nesting depth](./3-json-mapping.md#nesting-depth) — carries that abbreviation
+into the cell on write-back, so a change below the depth bound goes to a
+`.json` file closer to the data.
+
 ### `write` to `.handler` File
 
 1. Buffer writes until `flush` or `release`.

--- a/packages/fuse/annotations.test.ts
+++ b/packages/fuse/annotations.test.ts
@@ -638,3 +638,45 @@ Deno.test("CFC generation changes on value or label metadata changes without ino
   assertNotEquals(original.generation, valueChanged.generation);
   assertNotEquals(original.generation, labelChanged.generation);
 });
+
+Deno.test("subtree labels cover nesting deeper than the call stack", () => {
+  // A label walk that recurses per level overflows well before this depth.
+  const depth = 20_000;
+  let chain: Record<string, unknown> = { title: "bottom" };
+  const titlePath: string[] = ["chain"];
+  for (let level = 0; level < depth; level++) chain = { next: chain };
+  for (let level = 0; level < depth; level++) titlePath.push("next");
+  titlePath.push("title");
+
+  const tree = new FsTree();
+  const annotator = makeAnnotator(tree, [
+    { path: titlePath, label: TITLE_LABEL },
+    { path: ["tag"], label: BODY_LABEL },
+  ]);
+
+  // The label of a leaf buried below the stack's depth reaches the root, and
+  // joins with the labels of the leaves the walk reaches on its way.
+  assertEquals(
+    annotator.subtreeLabel({ chain, tag: "shallow" }, []).confidentiality,
+    [...TITLE_LABEL.confidentiality, ...BODY_LABEL.confidentiality],
+  );
+});
+
+Deno.test("an unlabeled leaf fails a deep subtree label closed", () => {
+  const depth = 20_000;
+  let chain: Record<string, unknown> = { title: "bottom" };
+  for (let level = 0; level < depth; level++) chain = { next: chain };
+
+  const tree = new FsTree();
+  const annotator = makeAnnotator(tree, [{ path: ["tag"], label: BODY_LABEL }]);
+  const label = annotator.subtreeLabel({ chain, tag: "shallow" }, []);
+
+  assert(
+    JSON.stringify(label).includes(CFC_FAIL_CLOSED_ATOM_CLASS),
+    "an unlabeled leaf below the stack's depth must fail the join closed",
+  );
+  assertEquals(
+    label.confidentiality?.slice(-1),
+    BODY_LABEL.confidentiality,
+  );
+});

--- a/packages/fuse/annotations.test.ts
+++ b/packages/fuse/annotations.test.ts
@@ -680,3 +680,51 @@ Deno.test("an unlabeled leaf fails a deep subtree label closed", () => {
     BODY_LABEL.confidentiality,
   );
 });
+
+Deno.test("a value met twice fails its second subtree label closed", () => {
+  const tree = new FsTree();
+  const annotator = makeAnnotator(tree, [
+    { path: ["first", "text"], label: TITLE_LABEL },
+    { path: ["second", "text"], label: BODY_LABEL },
+  ]);
+  const shared = { text: "same" };
+
+  const label = annotator.subtreeLabel({ first: shared, second: shared }, []);
+
+  // The first visit walks into the object and picks up its leaf's label. The
+  // second meets an object already seen, so it labels the whole of `second`
+  // at once and fails closed rather than walking it again.
+  assertEquals(label.confidentiality?.[0], TITLE_LABEL.confidentiality[0]);
+  assert(
+    JSON.stringify(label).includes(CFC_FAIL_CLOSED_ATOM_CLASS),
+    "the repeated value must fail closed",
+  );
+  assertEquals(
+    JSON.stringify(label).includes(JSON.stringify(BODY_LABEL.confidentiality)),
+    false,
+    "the repeated value must not pick up the label of the path it repeats at",
+  );
+});
+
+Deno.test("an empty container takes the label of its own path", () => {
+  const tree = new FsTree();
+  const annotator = makeAnnotator(tree, [
+    { path: ["items"], label: TITLE_LABEL },
+    { path: ["meta"], label: BODY_LABEL },
+  ]);
+
+  // An empty array and an empty object have no leaves to contribute a label,
+  // so each stands for itself.
+  assertEquals(
+    annotator.subtreeLabel([], ["items"]).confidentiality,
+    TITLE_LABEL.confidentiality,
+  );
+  assertEquals(
+    annotator.subtreeLabel({}, ["meta"]).confidentiality,
+    BODY_LABEL.confidentiality,
+  );
+  assertEquals(
+    annotator.subtreeLabel({ items: [], meta: {} }, []).confidentiality,
+    [...TITLE_LABEL.confidentiality, ...BODY_LABEL.confidentiality],
+  );
+});

--- a/packages/fuse/annotations.ts
+++ b/packages/fuse/annotations.ts
@@ -377,7 +377,13 @@ function canonicalLabelForGeneration(label: CfcLabel): CfcLabel {
   return canonical;
 }
 
-export function joinLabels(...labels: Array<CfcLabel | undefined>): CfcLabel {
+/**
+ * `joinLabels` over a list. Takes the labels as an array so that a join over
+ * as many labels as a value has nodes stays within the argument limit.
+ */
+export function joinLabelList(
+  labels: ReadonlyArray<CfcLabel | undefined>,
+): CfcLabel {
   const joined: CfcLabel = {};
   for (const key of labelKeys()) {
     const seen = new Set<string>();
@@ -397,6 +403,10 @@ export function joinLabels(...labels: Array<CfcLabel | undefined>): CfcLabel {
     }
   }
   return joined;
+}
+
+export function joinLabels(...labels: Array<CfcLabel | undefined>): CfcLabel {
+  return joinLabelList(labels);
 }
 
 function failClosedLabel(): CfcLabel {
@@ -533,42 +543,79 @@ export class CfcProjectionAnnotator {
     return joinLabels(...labels);
   }
 
+  /**
+   * The label covering `value` and everything under it: the labels of its
+   * leaves, joined. A value already met along the way contributes the
+   * fail-closed label instead of being walked again.
+   *
+   * The walk holds its own stack of nodes still to visit rather than
+   * recursing, so a value nests as deeply as it likes without reaching the
+   * call stack's limit. Nodes come off that stack in the order a depth-first
+   * walk reaches them, which is the order `joinLabelList` keeps.
+   */
   subtreeLabel(
     value: unknown,
     path: readonly CfcPathSegment[],
     seen = new WeakSet<object>(),
   ): CfcLabel {
-    if (isLeafValue(value)) {
-      return this.labelAt(path);
+    interface PendingNode {
+      value: unknown;
+      path: readonly CfcPathSegment[];
     }
+    const contributions: CfcLabel[] = [];
+    const pending: PendingNode[] = [{ value, path }];
 
-    if (typeof value === "object" && value !== null) {
-      if (seen.has(value)) {
-        return labelWithFailClosed(this.labelAt(path));
+    while (pending.length > 0) {
+      const node = pending.pop()!;
+
+      if (isLeafValue(node.value)) {
+        contributions.push(this.labelAt(node.path));
+        continue;
       }
-      seen.add(value);
+
+      if (typeof node.value === "object" && node.value !== null) {
+        if (seen.has(node.value)) {
+          contributions.push(labelWithFailClosed(this.labelAt(node.path)));
+          continue;
+        }
+        seen.add(node.value);
+      }
+
+      // Children go on in reverse so the last one pushed — the first child —
+      // is the next one taken.
+      if (Array.isArray(node.value)) {
+        if (node.value.length === 0) {
+          contributions.push(this.labelAt(node.path));
+          continue;
+        }
+        for (let index = node.value.length - 1; index >= 0; index--) {
+          pending.push({
+            value: node.value[index],
+            path: [...node.path, index],
+          });
+        }
+        continue;
+      }
+
+      if (isRecord(node.value)) {
+        const entries = Object.entries(node.value);
+        if (entries.length === 0) {
+          contributions.push(this.labelAt(node.path));
+          continue;
+        }
+        for (let index = entries.length - 1; index >= 0; index--) {
+          const [key, entry] = entries[index];
+          pending.push({ value: entry, path: [...node.path, key] });
+        }
+        continue;
+      }
+
+      contributions.push(this.labelAt(node.path));
     }
 
-    if (Array.isArray(value)) {
-      if (value.length === 0) return this.labelAt(path);
-      return joinLabels(
-        ...value.map((entry, index) =>
-          this.subtreeLabel(entry, [...path, index], seen)
-        ),
-      );
-    }
-
-    if (isRecord(value)) {
-      const entries = Object.entries(value);
-      if (entries.length === 0) return this.labelAt(path);
-      return joinLabels(
-        ...entries.map(([key, entry]) =>
-          this.subtreeLabel(entry, [...path, key], seen)
-        ),
-      );
-    }
-
-    return this.labelAt(path);
+    return contributions.length === 1
+      ? contributions[0]
+      : joinLabelList(contributions);
   }
 
   namespaceLabel(value: unknown, path: readonly CfcPathSegment[]): CfcLabel {

--- a/packages/fuse/annotations.ts
+++ b/packages/fuse/annotations.ts
@@ -597,20 +597,17 @@ export class CfcProjectionAnnotator {
         continue;
       }
 
-      if (isRecord(node.value)) {
-        const entries = Object.entries(node.value);
-        if (entries.length === 0) {
-          contributions.push(this.labelAt(node.path));
-          continue;
-        }
-        for (let index = entries.length - 1; index >= 0; index--) {
-          const [key, entry] = entries[index];
-          pending.push({ value: entry, path: [...node.path, key] });
-        }
+      // Everything left is a record: a leaf, a link ref and an array each
+      // took an arm above.
+      const entries = Object.entries(node.value as Record<string, unknown>);
+      if (entries.length === 0) {
+        contributions.push(this.labelAt(node.path));
         continue;
       }
-
-      contributions.push(this.labelAt(node.path));
+      for (let index = entries.length - 1; index >= 0; index--) {
+        const [key, entry] = entries[index];
+        pending.push({ value: entry, path: [...node.path, key] });
+      }
     }
 
     return contributions.length === 1

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -33,7 +33,7 @@ import {
   type FsValue,
   isSigilLink,
   isVNode,
-  safeStringify,
+  stringifyEntryValue,
 } from "./tree-builder.ts";
 import {
   decodeFuseComponent,
@@ -3637,7 +3637,7 @@ export class CellBridge {
           const vnodeIno = this.tree.addFile(
             parentIno,
             fileName,
-            safeStringify(val),
+            stringifyEntryValue(this.tree, parentIno, fileName, val),
             "object",
           );
           const contentLabel = annotator?.subtreeLabel(val, [key]);

--- a/packages/fuse/tree-builder.test.ts
+++ b/packages/fuse/tree-builder.test.ts
@@ -1,5 +1,5 @@
 // tree-builder.test.ts — Unit tests for JSON-to-tree conversion and symlink parsing
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
 import { FsTree } from "./tree.ts";
 import {
   buildCallableScript,
@@ -421,6 +421,24 @@ function chainDepth(value: unknown): { depth: number; tail: unknown } {
   }
   return { depth, tail: cursor };
 }
+
+Deno.test("safeStringify - a circular edge at the depth bound reads as circular", () => {
+  // Objects at nesting levels 0 to the bound, the deepest pointing at the
+  // root, so the back edge falls exactly where the depth bound would bite.
+  const nodes: Record<string, unknown>[] = [];
+  for (let level = 0; level < MAX_JSON_DEPTH; level++) nodes.push({});
+  for (let level = 0; level < MAX_JSON_DEPTH - 1; level++) {
+    nodes[level].next = nodes[level + 1];
+  }
+  nodes[MAX_JSON_DEPTH - 1].next = nodes[0];
+
+  // Circular, not out of depth: nothing lies below the back edge that a
+  // deeper bound would have shown.
+  assertEquals(chainDepth(JSON.parse(safeStringify(nodes[0]))), {
+    depth: MAX_JSON_DEPTH,
+    tail: "[Circular]",
+  });
+});
 
 Deno.test("safeStringify - spells out nesting up to the depth bound", () => {
   const shallow = JSON.parse(safeStringify(nestedChain(MAX_JSON_DEPTH - 2)));
@@ -1677,5 +1695,46 @@ Deno.test("makeLinkResolver leaves malformed link paths inert", () => {
       },
     }, 0),
     null,
+  );
+});
+
+Deno.test("a failure during a rebuild names where the entry mounts", async () => {
+  // A rebuild of a prop that already exists assembles under a staging root and
+  // reconciles onto the live tree afterwards. The staging name is internal and
+  // never appears in the mount, so the failure names the live path instead.
+  const tree = new FsTree();
+  const piece = tree.addDir(tree.addDir(tree.rootIno, "pieces"), "todo-app");
+  const unserializable = { items: [{ count: 1n }] };
+
+  const rebuild = await assertRejects(
+    () => buildPendingJsonTreeAsync(tree, piece, "result", unserializable),
+    Error,
+    "/pieces/todo-app/result.json",
+  );
+  assertEquals(rebuild.message.includes(".result.pending"), false);
+
+  const firstHydration = await assertRejects(
+    () => buildJsonTreeAsync(tree, piece, "result", unserializable),
+    Error,
+  );
+  // Both routes reach the same mounted file, so both name the same path.
+  assertEquals(firstHydration.message, rebuild.message);
+});
+
+Deno.test("a failure under the [FS] staging container names the piece entry", () => {
+  const tree = new FsTree();
+  const piece = tree.addDir(tree.addDir(tree.rootIno, "pieces"), "todo-app");
+  const stage = tree.addDir(piece, ".fs.pending");
+  const fsValue = {
+    type: "application/json",
+    content: { count: 1n },
+  } as unknown as FsValue;
+
+  // The staging container's children land on the piece directory itself, so
+  // the container drops out of the path rather than being renamed.
+  assertThrows(
+    () => buildFsProjection(tree, stage, fsValue, "of:entity-1"),
+    Error,
+    "/pieces/todo-app/index.json",
   );
 });

--- a/packages/fuse/tree-builder.test.ts
+++ b/packages/fuse/tree-builder.test.ts
@@ -7,9 +7,11 @@ import {
   isPatternToolValue,
 } from "./callables.ts";
 import {
+  buildFsProjection,
   buildJsonTree,
   buildJsonTreeAsync,
   buildPendingJsonTreeAsync,
+  type FsValue,
   isHandlerCell,
   isSigilLink,
   isStreamValue,
@@ -475,6 +477,70 @@ Deno.test("buildJsonTree - projects nesting deeper than the call stack", () => {
   assertEquals(
     JSON.parse(getFileContent(tree, parentIno, "next.json")),
     { leaf: "bottom" },
+  );
+});
+
+Deno.test("buildFsProjection - application/json writes index.json", () => {
+  const tree = new FsTree();
+  const fsValue: FsValue = {
+    type: "application/json",
+    content: { title: "My Todos", count: 3 },
+  };
+
+  const ino = buildFsProjection(tree, tree.rootIno, fsValue, "of:entity-1");
+
+  assertEquals(tree.lookup(tree.rootIno, "index.json"), ino);
+  const node = tree.getNode(ino);
+  assertEquals(node?.kind === "file" ? node.jsonType : undefined, "object");
+  // `entityId` leads, so a reader sees which entity the projection came from.
+  assertEquals(
+    JSON.parse(getFileContent(tree, tree.rootIno, "index.json")),
+    { entityId: "of:entity-1", title: "My Todos", count: 3 },
+  );
+});
+
+Deno.test("buildFsProjection - a pattern cannot overwrite entityId", () => {
+  const tree = new FsTree();
+  const fsValue = {
+    type: "application/json",
+    content: { entityId: "of:forged", title: "My Todos" },
+  } as FsValue;
+
+  buildFsProjection(tree, tree.rootIno, fsValue, "of:entity-1");
+
+  assertEquals(
+    JSON.parse(getFileContent(tree, tree.rootIno, "index.json")),
+    { entityId: "of:entity-1", title: "My Todos" },
+  );
+});
+
+Deno.test("buildFsProjection - an unknown type falls back to index.txt", () => {
+  const tree = new FsTree();
+  const fsValue = { type: "text/csv", content: "a,b" } as unknown as FsValue;
+
+  const ino = buildFsProjection(tree, tree.rootIno, fsValue, "of:entity-1");
+
+  assertEquals(tree.lookup(tree.rootIno, "index.txt"), ino);
+  assertEquals(tree.lookup(tree.rootIno, "index.json"), undefined);
+  assertEquals(tree.lookup(tree.rootIno, "index.md"), undefined);
+  assertEquals(
+    JSON.parse(getFileContent(tree, tree.rootIno, "index.txt")),
+    { type: "text/csv", content: "a,b" },
+  );
+});
+
+Deno.test("buildFsProjection - names the failing entry when a value cannot serialize", () => {
+  const tree = new FsTree();
+  const piece = tree.addDir(tree.rootIno, "todo-app");
+  const fsValue = {
+    type: "application/json",
+    content: { count: 1n },
+  } as unknown as FsValue;
+
+  assertThrows(
+    () => buildFsProjection(tree, piece, fsValue, "of:entity-1"),
+    Error,
+    "/todo-app/index.json",
   );
 });
 

--- a/packages/fuse/tree-builder.test.ts
+++ b/packages/fuse/tree-builder.test.ts
@@ -1,5 +1,5 @@
 // tree-builder.test.ts — Unit tests for JSON-to-tree conversion and symlink parsing
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import { FsTree } from "./tree.ts";
 import {
   buildCallableScript,
@@ -13,7 +13,10 @@ import {
   isHandlerCell,
   isSigilLink,
   isStreamValue,
+  MAX_DEPTH_MARKER,
+  MAX_JSON_DEPTH,
   safeStringify,
+  stringifyEntryValue,
   transformStreamValues,
 } from "./tree-builder.ts";
 import { CellBridge } from "./cell-bridge.ts";
@@ -395,6 +398,98 @@ Deno.test("safeStringify - preserves shared DAG objects", () => {
     a: { leaf: "same" },
     b: { leaf: "same" },
   });
+});
+
+/** A chain of `depth` nested objects, each under the key `next`. */
+function nestedChain(depth: number): Record<string, unknown> {
+  let value: Record<string, unknown> = { leaf: "bottom" };
+  for (let i = 0; i < depth; i++) value = { next: value };
+  return value;
+}
+
+/** How many levels of `next` the parsed chain spells out, and what ends it. */
+function chainDepth(value: unknown): { depth: number; tail: unknown } {
+  let depth = 0;
+  let cursor = value;
+  while (cursor !== null && typeof cursor === "object") {
+    const next = (cursor as Record<string, unknown>).next;
+    if (next === undefined) break;
+    depth++;
+    cursor = next;
+  }
+  return { depth, tail: cursor };
+}
+
+Deno.test("safeStringify - spells out nesting up to the depth bound", () => {
+  const shallow = JSON.parse(safeStringify(nestedChain(MAX_JSON_DEPTH - 2)));
+  assertEquals(chainDepth(shallow), {
+    depth: MAX_JSON_DEPTH - 2,
+    tail: { leaf: "bottom" },
+  });
+});
+
+Deno.test("safeStringify - marks values nested below the depth bound", () => {
+  const deep = JSON.parse(safeStringify(nestedChain(MAX_JSON_DEPTH * 4)));
+  assertEquals(chainDepth(deep), {
+    depth: MAX_JSON_DEPTH,
+    tail: MAX_DEPTH_MARKER,
+  });
+});
+
+Deno.test("safeStringify - survives nesting deeper than the call stack", () => {
+  // A serializer that recurses per level overflows well before this depth.
+  const result = JSON.parse(safeStringify(nestedChain(100_000)));
+  assertEquals(chainDepth(result).tail, MAX_DEPTH_MARKER);
+});
+
+Deno.test("safeStringify - bounds depth per value, not across siblings", () => {
+  const wide = { a: nestedChain(4), b: nestedChain(4) };
+  const result = JSON.parse(safeStringify(wide)) as Record<string, unknown>;
+  assertEquals(chainDepth(result.a).tail, { leaf: "bottom" });
+  assertEquals(chainDepth(result.b).tail, { leaf: "bottom" });
+});
+
+Deno.test("buildJsonTree - projects nesting deeper than the call stack", () => {
+  const depth = MAX_JSON_DEPTH * 8;
+  const tree = new FsTree();
+  buildJsonTree(tree, tree.rootIno, "deep", nestedChain(depth));
+
+  // Every level keeps its directory entry, so the leaf the root's `.json`
+  // sibling elides is still reachable through the directory tree.
+  let ino = tree.lookup(tree.rootIno, "deep")!;
+  for (let level = 0; level < depth; level++) {
+    const next = tree.lookup(ino, "next");
+    assertEquals(next !== undefined, true, `level ${level} is missing`);
+    ino = next!;
+  }
+  assertEquals(getFileContent(tree, ino, "leaf"), "bottom");
+
+  // A `.json` sibling far enough down the chain spells out what the root's
+  // elided, so the bound hides no data.
+  assertEquals(
+    chainDepth(JSON.parse(getFileContent(tree, tree.rootIno, "deep.json")))
+      .tail,
+    MAX_DEPTH_MARKER,
+  );
+  const parentIno = tree.parents.get(ino)!;
+  assertEquals(
+    JSON.parse(getFileContent(tree, parentIno, "next.json")),
+    { leaf: "bottom" },
+  );
+});
+
+Deno.test("stringifyEntryValue - names the failing entry's mounted path", () => {
+  const tree = new FsTree();
+  const space = tree.addDir(tree.rootIno, "did:key:zSpace");
+  const pieces = tree.addDir(space, "pieces");
+  const piece = tree.addDir(pieces, "todo-app");
+
+  const error = assertThrows(
+    () => stringifyEntryValue(tree, piece, "result.json", { count: 1n }),
+    Error,
+    "/did:key:zSpace/pieces/todo-app/result.json",
+  );
+  assertEquals((error as Error).cause instanceof TypeError, true);
 });
 
 Deno.test("FsTree - addSymlink", () => {

--- a/packages/fuse/tree-builder.ts
+++ b/packages/fuse/tree-builder.ts
@@ -28,7 +28,26 @@ function encodeJsonEntryName(
 }
 
 /**
- * JSON.stringify that replaces circular references with "[Circular]".
+ * How many levels of nested objects and arrays a `.json` file spells out. A
+ * value below the last of them is written as `MAX_DEPTH_MARKER`.
+ *
+ * `JSON.stringify` descends one call frame per level of nesting, so an
+ * unbounded value would exhaust the call stack. The bound also holds the size
+ * of a single `.json` file down, since a directory at every level of a deep
+ * value carries a `.json` sibling spelling out everything beneath it.
+ *
+ * The bound is measured from the value being serialized, not from the root of
+ * the piece, so data below it stays readable through the `.json` sibling of a
+ * directory closer to it.
+ */
+export const MAX_JSON_DEPTH = 128;
+
+/** Written in place of a value nested deeper than `MAX_JSON_DEPTH`. */
+export const MAX_DEPTH_MARKER = "[Max depth exceeded]";
+
+/**
+ * JSON.stringify that replaces circular references with "[Circular]" and
+ * values nested deeper than `MAX_JSON_DEPTH` with `MAX_DEPTH_MARKER`.
  *
  * TODO(danfuzz): this is an unsafe use of `stringify()` for fabric values:
  * the piece prop values this file renders are live in-process cell reads,
@@ -49,6 +68,7 @@ export function safeStringify(value: unknown, indent = 2): string {
         ) {
           ancestors.pop();
         }
+        if (ancestors.length >= MAX_JSON_DEPTH) return MAX_DEPTH_MARKER;
         if (ancestors.includes(val)) return "[Circular]";
         ancestors.push(val);
       }
@@ -56,6 +76,29 @@ export function safeStringify(value: unknown, indent = 2): string {
     },
     indent,
   );
+}
+
+/**
+ * `safeStringify` for a value bound for the filesystem entry `fsName` under
+ * `parentIno`. A value that cannot be serialized fails with the mounted path
+ * of that entry, which names the piece holding the value and the path to it
+ * within the piece.
+ */
+export function stringifyEntryValue(
+  tree: FsTree,
+  parentIno: bigint,
+  fsName: string,
+  value: unknown,
+): string {
+  try {
+    return safeStringify(value);
+  } catch (cause) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    throw new Error(
+      `Cannot serialize ${tree.childPath(parentIno, fsName)}: ${detail}`,
+      { cause },
+    );
+  }
 }
 
 /**
@@ -158,14 +201,19 @@ export function buildFsProjection(
   if (fsValue.type === "application/json") {
     const { entityId: _skipEntityId, ...safeContent } = fsValue.content ?? {};
     const obj = { entityId, ...safeContent };
-    return tree.addFile(parentIno, "index.json", safeStringify(obj), "object");
+    return tree.addFile(
+      parentIno,
+      "index.json",
+      stringifyEntryValue(tree, parentIno, "index.json", obj),
+      "object",
+    );
   }
 
   // Fallback: unknown type
   return tree.addFile(
     parentIno,
     "index.txt",
-    safeStringify(fsValue),
+    stringifyEntryValue(tree, parentIno, "index.txt", fsValue),
     "object",
   );
 }
@@ -304,7 +352,7 @@ function addJsonAggregateSibling(
   const ino = tree.addFile(
     parentIno,
     jsonName,
-    safeStringify(value),
+    stringifyEntryValue(tree, parentIno, jsonName, value),
     jsonType,
   );
   annotation?.annotator.annotateJsonAggregate(ino, annotation.path, value);
@@ -511,7 +559,10 @@ async function drainJsonTreeBuildAsync(
  * - array → directory with an entry per index (jsonType "array")
  *
  * Circular references are replaced with "[Circular]".
- * Also synthesizes `.json` sibling files for directory nodes.
+ * Also synthesizes `.json` sibling files for directory nodes. A `.json`
+ * sibling spells out `MAX_JSON_DEPTH` levels of nesting beneath itself and
+ * writes `MAX_DEPTH_MARKER` below that; the directory tree carries the whole
+ * value regardless of how deep it goes.
  *
  * Entries are created level by level, and the whole value is projected before
  * this returns. Callers that must not block the event loop for a large value

--- a/packages/fuse/tree-builder.ts
+++ b/packages/fuse/tree-builder.ts
@@ -28,6 +28,49 @@ function encodeJsonEntryName(
 }
 
 /**
+ * The staging entries a rebuild builds under, and the name each one's contents
+ * take once the rebuild reconciles them onto the live tree. A prop's staging
+ * root becomes the prop; the `[FS]` staging container maps to nothing, since
+ * its children move onto the piece directory itself.
+ *
+ * A user key that looks like one of these is encoded by `encodeJsonEntryName`,
+ * so a path component spelled this way is always the internal entry.
+ */
+const STAGING_ENTRY_MOUNTED_NAMES: ReadonlyArray<[string, string | null]> = [
+  [".input.pending", "input"],
+  [".result.pending", "result"],
+  [".fs.pending", null],
+];
+
+/** Where a path component lands once a rebuild reconciles, or null if it goes. */
+function mountedPathComponent(component: string): string | null {
+  for (const [staging, mounted] of STAGING_ENTRY_MOUNTED_NAMES) {
+    if (component === staging) return mounted;
+    if (component === `${staging}.json`) {
+      return mounted === null ? null : `${mounted}.json`;
+    }
+  }
+  return component;
+}
+
+/**
+ * The path an entry mounts at, for a build that may still be running under a
+ * staging root. Reports where a reader will find the entry rather than where
+ * the rebuild happens to be assembling it.
+ */
+function mountedEntryPath(
+  tree: FsTree,
+  parentIno: bigint,
+  fsName: string,
+): string {
+  return tree.childPath(parentIno, fsName)
+    .split("/")
+    .map(mountedPathComponent)
+    .filter((component) => component !== null)
+    .join("/");
+}
+
+/**
  * How many levels of nested objects and arrays a `.json` file spells out. A
  * value below the last of them is written as `MAX_DEPTH_MARKER`.
  *
@@ -68,8 +111,11 @@ export function safeStringify(value: unknown, indent = 2): string {
         ) {
           ancestors.pop();
         }
-        if (ancestors.length >= MAX_JSON_DEPTH) return MAX_DEPTH_MARKER;
+        // Circularity is a property of the value and the depth bound is a
+        // property of this rendering, so a value that is both reads as
+        // circular: there is nothing below it that a deeper bound would show.
         if (ancestors.includes(val)) return "[Circular]";
+        if (ancestors.length >= MAX_JSON_DEPTH) return MAX_DEPTH_MARKER;
         ancestors.push(val);
       }
       return val;
@@ -95,7 +141,9 @@ export function stringifyEntryValue(
   } catch (cause) {
     const detail = cause instanceof Error ? cause.message : String(cause);
     throw new Error(
-      `Cannot serialize ${tree.childPath(parentIno, fsName)}: ${detail}`,
+      `Cannot serialize ${
+        mountedEntryPath(tree, parentIno, fsName)
+      }: ${detail}`,
       { cause },
     );
   }

--- a/packages/fuse/tree.ts
+++ b/packages/fuse/tree.ts
@@ -97,9 +97,14 @@ export class FsTree {
     return this.nextIno++;
   }
 
-  private trackPath(ino: bigint, parentIno: bigint, name: string): void {
+  /** The path an entry named `name` under `parentIno` has, or would have. */
+  childPath(parentIno: bigint, name: string): string {
     const parentPath = this.getPath(parentIno);
-    const path = parentPath === "/" ? `/${name}` : `${parentPath}/${name}`;
+    return parentPath === "/" ? `/${name}` : `${parentPath}/${name}`;
+  }
+
+  private trackPath(ino: bigint, parentIno: bigint, name: string): void {
+    const path = this.childPath(parentIno, name);
     this.paths.set(path, ino);
     this.inoPaths.set(ino, path);
     this.inoNames.set(ino, name);


### PR DESCRIPTION
Projecting a piece onto the filesystem walks its value iteratively, so the directory tree it builds does not recurse per level of nesting. Two things it does at each node still did.

The `.json` sibling every directory carries goes through `safeStringify`, which wraps `JSON.stringify`. That descends one call frame per level, so a piece whose data nested a few thousand levels deep — a chain of `{next: {next: ...}}`, which nothing stops a pattern from producing — threw `RangeError: Maximum call stack size exceeded` out of the rebuild. Nothing in the error said which piece or which path held the value.

The CFC label walk had the same shape. `subtreeLabel` recursed over every descendant to join their labels, and overflowed the stack around three thousand levels whenever CFC annotations were on.

Bound the serializer and make the label walk iterative.

`safeStringify` now spells out 128 levels of nesting and writes `"[Max depth exceeded]"` below them, alongside the `"[Circular]"` marker it already wrote for a value that referred back to itself. The bound is measured from the value being serialized rather than from the root of the piece, so every level of a deep value is still spelled out by the `.json` sibling of a directory close enough to it, and the directory tree itself carries the whole value however deep it goes. The bound also holds down the total size of a projection: a directory at every level carries a `.json` file spelling out everything beneath it, so an unbounded serializer made a deep value cost memory in proportion to the cube of its depth.

A depth bound would be the wrong answer for labels, which exist to say what a subtree may contain — cutting the walk short would under-label what it skipped. `subtreeLabel` instead keeps its own stack of nodes still to visit and collects the labels its leaves contribute in the order a depth-first walk reaches them. `joinLabels` gains a companion taking its labels as a list, since joining one label per node of a large value would otherwise exceed the argument limit. The labels this produces are the ones it produced before; a differential test against the recursive definition over five thousand generated values, including shared objects, link references and empty containers, found no divergence.

Serialization that fails for some other reason — a value carrying a `BigInt`, say — now reports the mounted path of the file it was bound for, which names both the piece and the path within it, and keeps the original error as its cause.

Documents the depth bound and the circular-reference marker in the `.json` sibling contract, and notes in the read/write semantics that writing back a `.json` file carries whatever its read form abbreviated.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

