### PR TITLE
ci: report a wedged CI step as a failure, not a cancellation

### DIFF
--- a/.claude/rules/github-workflows.md
+++ b/.claude/rules/github-workflows.md
@@ -22,10 +22,30 @@ after.
 A step is placed into a phase — setup, build, test, upload — by the marker
 emoji its name begins with. The vocabulary is defined in
 `docs/development/CI_PERFORMANCE.md` under "Step phase markers" and mirrored in
-`PHASE_MARKERS` in `scripts/ci-gantt.ts`. A step whose name starts with a
+`PHASE_MARKERS` in `tasks/ci-step-phases.ts`. A step whose name starts with a
 marker that is in neither list is silently charted as "other", which is how
 setup time disappears from the timings people use to decide what to optimize.
-Adding a marker means editing the document and the script together.
+Adding a marker means editing the document and the module together.
+
+## A work step carries its own timeout
+
+In `.github/workflows/deno.yml`, every step whose marker puts it in the work
+phase carries `timeout-minutes: *work-timeout`, and its job carries
+`timeout-minutes: *job-timeout`, which is the ten minutes longer. GitHub
+cancels a job that runs past the bound on the job, so that job's conclusion is
+`cancelled` rather than `failure`, and a wedged test then looks like a run
+somebody stopped. A step that runs past the bound on the step fails, and the
+job fails with it.
+
+Both aliases point at YAML anchors declared in the `env:` block at the top of
+the file, which is where the minutes themselves are written. Add a work step
+and you add the alias, not a number; a job that needs its own bound adds a pair
+of anchors there, as the CLI integration suites have. The deploy jobs are the
+exception and carry no bound, because a deploy's duration is set by a script in
+another repository. `tasks/ci-workflow.test.ts` names those and holds every
+other job to the shape: it fails the `Check` job when a bound is missing, when
+it is written as a number rather than an alias, or when a step's anchor is
+fewer than ten minutes below its job's.
 
 ## Before splitting or rebalancing jobs
 

--- a/.github/workflows/dashboard-image.yml
+++ b/.github/workflows/dashboard-image.yml
@@ -31,24 +31,24 @@ jobs:
       # A manual run can name any ref. Publishing moves the `latest` tag that
       # the deployment follows, so a run on another ref stops here, before
       # anything from that ref is checked out or run.
-      - name: Verify the run is on main
+      - name: 🔎 Verify the run is on main
         if: ${{ github.ref != 'refs/heads/main' }}
         run: |
           echo "The dashboard image publishes only from main; this run is on ${GITHUB_REF}." >&2
           exit 1
 
-      - name: Checkout source commit
+      - name: 📥 Checkout source commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
-      - name: Setup Deno
+      - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
 
-      - name: Install dependencies
+      - name: 🔍 Install dependencies
         uses: ./.github/actions/deno-install
 
-      - name: Test dashboard
+      - name: 🧪 Test dashboard
         working-directory: packages/dashboard
         run: deno task test
 
@@ -63,12 +63,12 @@ jobs:
     env:
       IMAGE: us-central1-docker.pkg.dev/commontools-core/containers/dev-dashboard
     steps:
-      - name: Checkout source commit
+      - name: 📥 Checkout source commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
-      - name: Authenticate to Google Cloud
+      - name: 🔑 Authenticate to Google Cloud
         id: auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
@@ -78,17 +78,17 @@ jobs:
           token_format: access_token
           create_credentials_file: false
 
-      - name: Login to Artifact Registry
+      - name: 🔑 Login to Artifact Registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: us-central1-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 
-      - name: Setup Docker Buildx
+      - name: ⚙️ Setup Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
-      - name: Resolve existing immutable image
+      - name: 🔍 Resolve existing immutable image
         id: existing
         env:
           ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
@@ -117,7 +117,7 @@ jobs:
               ;;
           esac
 
-      - name: Build and push dashboard image
+      - name: 🏗️ Build and push dashboard image
         id: build
         if: ${{ steps.existing.outputs.exists != 'true' }}
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
@@ -132,13 +132,13 @@ jobs:
             ${{ env.IMAGE }}:${{ github.sha }}
             ${{ env.IMAGE }}:latest
 
-      - name: Promote existing image to latest
+      - name: 🚀 Promote existing image to latest
         if: ${{ steps.existing.outputs.exists == 'true' }}
         env:
           EXISTING_DIGEST: ${{ steps.existing.outputs.digest }}
         run: docker buildx imagetools create --tag "${IMAGE}:latest" "${IMAGE}@${EXISTING_DIGEST}"
 
-      - name: Resolve published digest
+      - name: ✅ Resolve published digest
         id: result
         env:
           BUILT_DIGEST: ${{ steps.build.outputs.digest }}
@@ -149,7 +149,7 @@ jobs:
           [[ "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
-      - name: Report immutable image reference
+      - name: 📊 Report immutable image reference
         env:
           DIGEST: ${{ steps.result.outputs.digest }}
         run: |

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -12,10 +12,36 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# The bounds the jobs below are built from. They are YAML anchors, used as
+# aliases at each job and each work step, so the numbers live here and nowhere
+# else. Most jobs take the first pair. The CLI integration suites take the
+# `cli-` ones, which are tighter because a wedged suite there is what they were
+# sized against. The environment variables holding the numbers are how a
+# workflow declares a value an anchor can name; nothing reads them.
+env:
+  WORK_TIMEOUT_MINUTES: &work-timeout 30
+  JOB_TIMEOUT_MINUTES: &job-timeout 40
+  CLI_WORK_TIMEOUT_MINUTES: &cli-work-timeout 10
+  CLI_FUSE_WORK_TIMEOUT_MINUTES: &cli-fuse-work-timeout 15
+  CLI_JOB_TIMEOUT_MINUTES: &cli-job-timeout 25
+
 # Every step name must begin with a phase-marker emoji (setup / work / shutdown).
 # scripts/ci-gantt.ts reads that emoji to split each job bar by phase. See the
 # "Step phase markers" table in docs/development/CI_PERFORMANCE.md for the
 # vocabulary and which emoji belongs to which phase.
+#
+# Every work step carries a bound of its own, and the bound on the job around it
+# is the longer of the two by ten minutes. GitHub ends a job that runs past the
+# bound on the job by cancelling it, and the job's conclusion is then
+# `cancelled`, which is the conclusion a run stopped by hand or by a newer push
+# also gets. A step that runs past the bound on the step fails, and its job
+# fails with it. So the bound that a wedged test hits first is the one on the
+# step, and a wedge is reported as a failure. tasks/ci-workflow.test.ts holds
+# every work step here to that shape, and refuses a bound written as anything
+# but an alias.
+#
+# The deploy jobs at the end carry no bound. Each hands the work to a script
+# that lives elsewhere, and how long that takes is not this workflow's to say.
 jobs:
   # ---------------------------------------------------------------------------
   # Tier 0 – These jobs all start immediately with no dependencies
@@ -23,7 +49,7 @@ jobs:
   check:
     name: "Check"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: *job-timeout
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v7
@@ -35,9 +61,11 @@ jobs:
         uses: ./.github/actions/deno-install
 
       - name: 🔎 Check codebase formatting
+        timeout-minutes: *work-timeout
         run: deno fmt --check
 
       - name: 🧹 Lint codebase
+        timeout-minutes: *work-timeout
         run: deno lint
 
       # This is the only type check for the paths listed in tasks/check.sh:
@@ -45,44 +73,55 @@ jobs:
       # --no-check and rely on it. Removing a path from check.sh removes its
       # type checking entirely.
       - name: 🔎 Type check codebase
+        timeout-minutes: *work-timeout
         run: deno task check
 
       - name: 🧭 Check agent-facing facts
+        timeout-minutes: *work-timeout
         run: deno task check-skill-facts
 
       - name: 🚧 Check tripwires
+        timeout-minutes: *work-timeout
         run: deno task check-tripwires
 
       - name: 📄 Type-check docs code blocks
+        timeout-minutes: *work-timeout
         run: deno task check-docs
 
       - name: 🚧 Guard against new polling waitFor in integration tests
+        timeout-minutes: *work-timeout
         run: deno task check-no-waitfor
 
       - name: 🩹 Check for unresolved merge-conflict markers
+        timeout-minutes: *work-timeout
         run: deno task check-conflict-markers
 
       - name: 🔎 Check for unused import map dependencies
+        timeout-minutes: *work-timeout
         run: deno task check-unused-deps
 
       - name: 🔎 Check Deno toolchain pins are aligned
+        timeout-minutes: *work-timeout
         run: deno task check-deno-pins
 
       - name: 🔎 Check single-copy packages resolve once
+        timeout-minutes: *work-timeout
         run: deno task check-single-copy-deps
 
       - name: 🔎 Check generated commonfabric/cfc types are up to date
+        timeout-minutes: *work-timeout
         working-directory: packages/static
         run: deno task check-cfc-types
 
       - name: 🔎 Check type libraries declare no withheld globals
+        timeout-minutes: *work-timeout
         working-directory: packages/static
         run: deno task check-withheld-globals
 
   cfcheck:
     name: "CFC Pattern Check (${{ matrix.shard }}/${{ matrix.total }})"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: *job-timeout
     strategy:
       fail-fast: false
       matrix:
@@ -99,6 +138,7 @@ jobs:
         uses: ./.github/actions/deno-install
 
       - name: 🔎 Check Common Fabric patterns
+        timeout-minutes: *work-timeout
         env:
           CFCHECK_SHARD: "${{ matrix.shard }}/${{ matrix.total }}"
         run: deno task cfcheck
@@ -106,7 +146,7 @@ jobs:
   pattern-compat:
     name: "Pattern Update Compatibility (${{ matrix.shard }}/${{ matrix.total }})"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: *job-timeout
     strategy:
       fail-fast: false
       matrix:
@@ -127,6 +167,7 @@ jobs:
       # structural check before swapping a pattern onto a running piece, so an
       # incompatible schema that merges here reaches every deployed piece.
       - name: 🔎 Check pattern update compatibility
+        timeout-minutes: *work-timeout
         env:
           PATTERN_COMPAT_SHARD: "${{ matrix.shard }}/${{ matrix.total }}"
         run: deno task pattern-compat
@@ -134,7 +175,7 @@ jobs:
   pattern-vintage:
     name: "Pattern Update State Continuity"
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: *job-timeout
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v7
@@ -176,12 +217,13 @@ jobs:
       # not CI steps: a gate that wrote its own evidence would be grading its
       # own homework.
       - name: 🔁 Replay every committed vintage under today's source
+        timeout-minutes: *work-timeout
         run: deno task pattern-vintage
 
   baselines-append-only:
     name: "Pattern Baselines Append-Only"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: *job-timeout
     steps:
       # Needs real history: the check diffs against the merge base, and the
       # default shallow checkout has none.
@@ -201,12 +243,13 @@ jobs:
       # of recorded JSON — so deleting a baseline without retiring its pattern
       # is refused here.
       - name: 🔎 Check pattern baselines are append-only
+        timeout-minutes: *work-timeout
         run: deno task check-baselines-append-only origin/${{ github.base_ref || 'main' }}
 
   test:
     name: "Test (${{ matrix.shard }}/${{ matrix.total }})"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: *job-timeout
     strategy:
       fail-fast: false
       matrix:
@@ -241,6 +284,7 @@ jobs:
           fi
 
       - name: 🧪 Run parallel workspace tests
+        timeout-minutes: *work-timeout
         run: deno task test
         env:
           DENO_COVERAGE_DIR: coverage/raw/workspace-${{ matrix.shard }}
@@ -263,7 +307,7 @@ jobs:
   runner-test:
     name: "Runner Tests (${{ matrix.shard }}/${{ matrix.total }})"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: *job-timeout
     strategy:
       fail-fast: false
       matrix:
@@ -280,6 +324,7 @@ jobs:
         uses: ./.github/actions/deno-install
 
       - name: 🧪 Run runner tests
+        timeout-minutes: *work-timeout
         working-directory: packages/runner
         env:
           DENO_COVERAGE_DIR: ../../coverage/raw/runner-${{ matrix.shard }}
@@ -325,7 +370,7 @@ jobs:
   build-toolshed:
     name: "Build Binary (toolshed)"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: *job-timeout
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v7
@@ -337,6 +382,7 @@ jobs:
         uses: ./.github/actions/deno-install
 
       - name: 🏗️ Build toolshed binary
+        timeout-minutes: *work-timeout
         run: deno task build-binaries toolshed
         env:
           COMMIT_SHA: ${{ github.sha }}
@@ -351,7 +397,7 @@ jobs:
   build-bg-piece-service:
     name: "Build Binary (bg-piece-service)"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: *job-timeout
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v7
@@ -363,6 +409,7 @@ jobs:
         uses: ./.github/actions/deno-install
 
       - name: 🏗️ Build bg-piece-service binary
+        timeout-minutes: *work-timeout
         run: deno task build-binaries bg-piece-service
 
       - name: 📤 Upload bg-piece-service binary
@@ -375,7 +422,7 @@ jobs:
   build-cf:
     name: "Build Binary (cf)"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: *job-timeout
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v7
@@ -387,6 +434,7 @@ jobs:
         uses: ./.github/actions/deno-install
 
       - name: 🏗️ Build cf binary
+        timeout-minutes: *work-timeout
         run: deno task build-binaries cf
 
       - name: 📤 Upload cf binary
@@ -399,7 +447,7 @@ jobs:
   generated-patterns-integration-test:
     name: "Generated Patterns Integration Tests (${{ matrix.shard }}/${{ matrix.total }})"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: *job-timeout
     strategy:
       fail-fast: false
       matrix:
@@ -433,6 +481,7 @@ jobs:
           exact-hit: ${{ steps.compile-cache.outputs.cache-hit }}
 
       - name: 🧪 Run generated patterns integration tests
+        timeout-minutes: *work-timeout
         working-directory: packages/generated-patterns
         env:
           CF_COMPILE_CACHE_FILE: ${{ github.workspace }}/.compile-cache/generated-patterns-${{ matrix.shard }}.json
@@ -479,7 +528,7 @@ jobs:
   package-integration-test:
     name: "Package Integration Tests (${{ matrix.suite_name }})"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: *job-timeout
     needs: ["build-toolshed"]
     strategy:
       fail-fast: false
@@ -543,6 +592,7 @@ jobs:
           fi
 
       - name: 🧪 Run ${{ matrix.step_name }}
+        timeout-minutes: *work-timeout
         working-directory: ${{ matrix.package_dir }}
         env:
           DENO_COVERAGE_DIR: ../../coverage/raw/package-${{ matrix.suite_name }}
@@ -583,7 +633,7 @@ jobs:
   cli-integration-test:
     name: "CLI Integration Tests (${{ matrix.suite_name }})"
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ matrix.timeout_minutes }}
+    timeout-minutes: *cli-job-timeout
     needs: ["build-toolshed", "build-cf"]
     strategy:
       fail-fast: false
@@ -594,31 +644,26 @@ jobs:
             section: piece-values
             toolshed_port: 8000
             install_fuse_deps: false
-            timeout_minutes: 10
           - suite_name: core-piece-links
             script: integration.sh
             section: piece-links
             toolshed_port: 8001
             install_fuse_deps: false
-            timeout_minutes: 10
           - suite_name: core-piece-call
             script: integration.sh
             section: piece-call
             toolshed_port: 8002
             install_fuse_deps: false
-            timeout_minutes: 10
           - suite_name: acl
             script: acl.sh
             section: ""
             toolshed_port: 8004
             install_fuse_deps: false
-            timeout_minutes: 10
           - suite_name: fuse
             script: fuse-exec.sh
             section: ""
             toolshed_port: 8003
             install_fuse_deps: true
-            timeout_minutes: 15
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v7
@@ -669,6 +714,7 @@ jobs:
 
       - name: 🧪 Run CLI integration suite
         if: ${{ startsWith(matrix.suite_name, 'core-') }}
+        timeout-minutes: *cli-work-timeout
         working-directory: packages/cli
         env:
           TOOLSHED_PORT: ${{ matrix.toolshed_port }}
@@ -684,6 +730,7 @@ jobs:
       # default MEMORY_ACL_MODE=enforce, so it deliberately sets no override.
       - name: 🧪 Run CLI ACL integration suite
         if: ${{ matrix.suite_name == 'acl' }}
+        timeout-minutes: *cli-work-timeout
         working-directory: packages/cli
         env:
           TOOLSHED_PORT: ${{ matrix.toolshed_port }}
@@ -696,6 +743,7 @@ jobs:
       # than the source-tree CLI task.
       - name: 🧪 Run CLI deno integration tests
         if: ${{ matrix.suite_name == 'core-piece-values' }}
+        timeout-minutes: *cli-work-timeout
         working-directory: packages/cli
         env:
           TOOLSHED_PORT: ${{ matrix.toolshed_port }}
@@ -706,6 +754,7 @@ jobs:
 
       - name: 🧪 Run CLI FUSE integration suite
         if: ${{ matrix.suite_name == 'fuse' }}
+        timeout-minutes: *cli-fuse-work-timeout
         working-directory: packages/cli
         env:
           TOOLSHED_PORT: ${{ matrix.toolshed_port }}
@@ -757,7 +806,7 @@ jobs:
   pattern-integration-test:
     name: "Pattern Integration Tests (${{ matrix.shard }}/${{ matrix.total }})"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: *job-timeout
     needs: ["build-toolshed"]
     strategy:
       fail-fast: false
@@ -846,6 +895,7 @@ jobs:
       # harness resolves it against a working directory that differs between the
       # two integration jobs. See docs/development/COVERAGE.md.
       - name: 🧩 Run end-to-end patterns integration tests
+        timeout-minutes: *work-timeout
         working-directory: packages/patterns
         run: |
           mapfile -t TEST_FILES < <(deno run --allow-read ../../tasks/select-pattern-integration-files.ts ${{ matrix.shard }}/${{ matrix.total }})
@@ -892,7 +942,7 @@ jobs:
   pattern-reload-integration-test:
     name: "Pattern Reload Integration Tests"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: *job-timeout
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v7
@@ -917,6 +967,7 @@ jobs:
 
       # Both kinds of coverage — see the note on pattern-integration-test above.
       - name: 🧩 Run pattern reload integration tests
+        timeout-minutes: *work-timeout
         run: |
           mkdir -p test-results
           HEADLESS=1 \
@@ -952,7 +1003,7 @@ jobs:
   pattern-unit-test:
     name: "Pattern Unit Tests (${{ matrix.chunk }}/${{ matrix.total }})"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: *job-timeout
     needs: ["build-cf"]
     strategy:
       matrix:
@@ -992,6 +1043,7 @@ jobs:
           path: common-binaries
 
       - name: 🧪 Run pattern unit tests
+        timeout-minutes: *work-timeout
         run: |
           chmod +x ./common-binaries/cf
           mkdir -p test-results .compile-cache coverage/lcov/pattern-runtime/pattern-unit-${{ matrix.chunk }}
@@ -1031,7 +1083,7 @@ jobs:
     name: "Coverage Check"
     if: (github.event_name == 'pull_request') || (github.ref_name == 'main')
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: *job-timeout
     needs:
       - check
       - test
@@ -1072,6 +1124,7 @@ jobs:
           digest-mismatch: error
 
       - name: 📊 Run coverage check
+        timeout-minutes: *work-timeout
         env:
           COVERAGE_ARTIFACTS_DIR: coverage-artifacts
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1124,8 +1177,10 @@ jobs:
       - coverage-check
     permissions: {}
     runs-on: ubuntu-latest
+    timeout-minutes: *job-timeout
     steps:
       - name: 🔎 Verify pull request jobs
+        timeout-minutes: *work-timeout
         env:
           JOB_RESULTS: ${{ toJSON(needs) }}
         run: |
@@ -1144,7 +1199,7 @@ jobs:
     name: "Attest and Upload Binaries"
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: *job-timeout
     # A release artifact must not outlive a failed pattern-migration gate.
     # Production deploys consume this artifact without rerunning those gates.
     needs:
@@ -1209,6 +1264,7 @@ jobs:
           path: coverage-artifacts
 
       - name: 🧬 Combine coverage LCOV
+        timeout-minutes: *work-timeout
         continue-on-error: true
         run: |
           deno run --allow-read --allow-write tasks/combine-coverage-lcov.ts \
@@ -1217,6 +1273,7 @@ jobs:
             --repo-name=${{ github.event.repository.name }}
 
       - name: 🔐 Process & sign binaries
+        timeout-minutes: *work-timeout
         run: |
           mkdir -p release
           mkdir -p signed
@@ -1277,6 +1334,7 @@ jobs:
 
       - name: 📝 Generate attestation for toolshed binary
         id: attest_toolshed
+        timeout-minutes: *work-timeout
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: ./dist/toolshed
@@ -1284,6 +1342,7 @@ jobs:
 
       - name: 📝 Generate attestation for bg-piece-service binary
         id: attest_bg_piece_service
+        timeout-minutes: *work-timeout
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: ./dist/bg-piece-service
@@ -1291,6 +1350,7 @@ jobs:
 
       - name: 📝 Generate attestation for cf binary
         id: attest_cf
+        timeout-minutes: *work-timeout
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: ./dist/cf
@@ -1298,6 +1358,7 @@ jobs:
 
       - name: 📝 Generate attestation for tarball
         id: attest_tarball
+        timeout-minutes: *work-timeout
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: https://storage.cloud.google.com/commontools-build-artifacts/workspace-artifacts/labs-${{ github.sha }}.tar.gz
@@ -1315,6 +1376,7 @@ jobs:
             ${{ steps.attest_tarball.outputs.bundle-path }}
 
       - name: 🔎 Verify binary attestations
+        timeout-minutes: *work-timeout
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -133,7 +133,7 @@ step we control — in `.github/workflows/*` and in the composite actions under
 each emoji belongs to exactly one phase. When you add a step, pick an emoji whose
 phase matches what the step does. When you add a genuinely new kind of step,
 choose a new emoji, then add it to both this table and the `PHASE_MARKERS` array
-in `scripts/ci-gantt.ts`, keeping the one-emoji-one-phase rule.
+in `tasks/ci-step-phases.ts`, keeping the one-emoji-one-phase rule.
 
 **setup** — fetch code, install tools and dependencies, restore caches,
 authenticate, and bring test servers and devices up before the real work:
@@ -152,6 +152,7 @@ authenticate, and bring test servers and devices up before the real work:
 | 🔌 | start a local server for tests |
 | ⏳ | wait for a service to be ready |
 | 💾 | restore or save a cache |
+| 🗃️ | restore a cached native library |
 | 🧮 | compute a cache identity |
 
 **work** — the job's actual purpose:
@@ -203,6 +204,51 @@ alongside them. The two set-up steps count as setup and the rest as shutdown.
 Any other step that reaches the chart without a recognized marker is counted as
 "other", drawn in gray, and listed on standard error when the script runs, so a
 missing marker is easy to find and fix.
+
+## Step And Job Timeouts
+
+Every work step in `.github/workflows/deno.yml` carries its own
+`timeout-minutes`, and the `timeout-minutes` on the job around it is ten minutes
+larger. The two bounds do different things when they are reached. GitHub ends a
+job that runs past the bound on the job by cancelling it, so the job's
+conclusion is `cancelled` — the conclusion that a run stopped by hand or
+superseded by a newer push also carries, and one that reads as nobody's fault. A
+step that runs past the bound on the step fails, and its job fails with it. The
+ten minutes between the two bounds are what the setup and upload steps around
+the work need, and they mean a wedged test reaches the bound on its step first
+and is reported as a failure.
+
+The minutes are written once. The top of the workflow declares them as YAML
+anchors, which GitHub Actions has accepted since September 2025:
+
+```yaml
+env:
+  WORK_TIMEOUT_MINUTES: &work-timeout 30
+  JOB_TIMEOUT_MINUTES: &job-timeout 40
+```
+
+Every job then reads `timeout-minutes: *job-timeout` and every work step
+`timeout-minutes: *work-timeout`. Changing either bound is one edit. The
+environment variables are how a workflow declares a value an anchor can name;
+nothing reads them, and merge keys (`<<:`) remain unsupported, so an anchor
+cannot carry a block that a job then overrides.
+
+The CLI integration suites take a second set of anchors, `cli-work-timeout` at
+ten minutes, `cli-fuse-work-timeout` at fifteen, and `cli-job-timeout` at
+twenty-five. Those suites were bounded against a wedge in the FUSE work when
+they were first split up, and the tighter numbers are what that sizing produced.
+A job needing its own bound adds a pair of anchors alongside these rather than a
+number next to the step.
+
+The deploy jobs carry no bound at all. A deploy hands the work to a script that
+lives outside this repository, and a bound here would cancel a deploy this
+workflow has no way to size. `tasks/ci-workflow.test.ts` names those jobs and
+asks nothing of them.
+
+For every other job, that test fails the `Check` job when a work step has no
+bound, when a job has none, when a bound is written as anything but an alias to
+an anchor, or when fewer than ten minutes separate the step's anchor from its
+job's.
 
 ## Root Test Job Shape
 

--- a/scripts/ci-gantt.ts
+++ b/scripts/ci-gantt.ts
@@ -22,7 +22,7 @@
 // phase by the marker emoji its name starts with; the segment widths are the
 // median time spent in each phase, scaled to fill the median bar. The marker
 // vocabulary lives in docs/development/CI_PERFORMANCE.md ("Step phase markers")
-// and is mirrored in PHASE_MARKERS below.
+// and is mirrored in PHASE_MARKERS in tasks/ci-step-phases.ts.
 //
 // Usage:
 //   scripts/ci-gantt.ts [options]
@@ -40,6 +40,8 @@
 //     --run-id ID           chart this workflow run ID, repeatable
 //     --theme NAME          color palette: "default" (light) or "dark"
 //     --colors JSON         override palette keys, e.g. '{"work":"#6ea8fe"}'
+
+import { type Phase, phaseOf } from "../tasks/ci-step-phases.ts";
 
 const args = Deno.args;
 function opt(name: string, def: string): string {
@@ -257,85 +259,20 @@ function latestJobsByName(jobs: Job[]): Job[] {
 //
 // Every step is placed into a phase from the marker emoji its name begins with.
 // The emoji is load-bearing: workflow and composite-action authors pick one from
-// the vocabulary below, and the chart splits each job bar into these phases
-// without having to recognise step wording. The authoritative table is
-// docs/development/CI_PERFORMANCE.md ("Step phase markers"); keep them in sync.
-// A step whose name carries no known marker lands in "other" and is reported to
-// stderr so a missing marker is easy to spot. In a normal run the only unmarked
-// steps are the ones the runner injects: "Set up job", "Post …" and "Complete
-// job" from GitHub, plus "Set up runner" and "Complete runner" from Blacksmith.
-// Those are classified below by name because their wording is not ours to set.
+// the vocabulary in tasks/ci-step-phases.ts, and the chart splits each job bar
+// into these phases without having to recognise step wording. The authoritative
+// table is docs/development/CI_PERFORMANCE.md ("Step phase markers"); keep them
+// in sync. A step whose name carries no known marker lands in "other" and is
+// reported to stderr so a missing marker is easy to spot. In a normal run the
+// only unmarked steps are the ones the runner injects: "Set up job", "Post …"
+// and "Complete job" from GitHub, plus "Set up runner" and "Complete runner"
+// from Blacksmith. Those are classified by name in that module, because their
+// wording is not ours to set.
 // ---------------------------------------------------------------------------
-
-type Phase = "setup" | "work" | "shutdown" | "other";
 
 // Chart order, left to right (matches the order steps run in). "other" trails so
 // an unmarked step stands out at the end of the bar.
 const PHASE_ORDER: Phase[] = ["setup", "work", "shutdown", "other"];
-
-// Marker emoji -> phase. Each emoji maps to exactly one phase; when a step's
-// natural emoji would land it in the wrong phase, the step name is changed to a
-// marker that fits (see docs/development/CI_PERFORMANCE.md). Matching ignores a
-// trailing variation selector, so the base emoji covers both the plain and the
-// selector-suffixed form of a glyph.
-const PHASE_MARKERS: [string, Phase][] = [
-  // setup: fetch code, install tools and dependencies, restore caches,
-  // authenticate, and bring test servers and devices up before the real work.
-  ["📥", "setup"], // checkout / download inputs
-  ["🦕", "setup"], // set up Deno
-  ["🔍", "setup"], // verify lock file & install, resolve refs
-  ["📦", "setup"], // install packages, cache dependencies
-  ["♻️", "setup"], // restore/save build caches
-  ["🛡️", "setup"], // relax sandbox for browser tests
-  ["🔧", "setup"], // enable devices
-  ["⚙️", "setup"], // set up external SDKs
-  ["🔑", "setup"], // authenticate to a cloud
-  ["🔌", "setup"], // start a local server for tests
-  ["⏳", "setup"], // wait for a service to be ready
-  ["💾", "setup"], // restore/save caches
-  ["🧮", "setup"], // compute a cache identity
-  // work: the job's actual purpose.
-  ["🔎", "work"], // checks (format, type, patterns, attestations)
-  ["🚧", "work"], // guard that fails the build on a banned pattern
-  ["🩹", "work"], // check for unresolved merge-conflict markers
-  ["✅", "work"], // validate an artifact a previous step produced
-  ["🧪", "work"], // run tests
-  ["🧩", "work"], // run integration tests
-  ["🔁", "work"], // replay captured fixtures under today's source
-  ["🧹", "work"], // lint
-  ["🧭", "work"], // check skill facts
-  ["📄", "work"], // type-check docs
-  ["🏗️", "work"], // build binaries/assets
-  ["🏋️", "work"], // run benchmarks
-  ["📊", "work"], // produce performance metrics / status reports
-  ["🧬", "work"], // combine coverage
-  ["📝", "work"], // generate attestations
-  ["🔐", "work"], // sign binaries
-  ["🚀", "work"], // deploy
-  ["💬", "work"], // post a PR comment
-  // shutdown: post-work reports, artifact uploads, log capture, teardown.
-  ["🧾", "shutdown"], // write coverage report
-  ["📤", "shutdown"], // upload artifacts
-  ["📋", "shutdown"], // capture logs on failure
-];
-
-const stripVS = (s: string) => s.replace(/\uFE0F/g, "");
-
-function phaseOf(stepName: string): Phase {
-  const name = stepName.trim();
-  // A leading marker wins, so a step named "💬 Post …" is classified by its
-  // marker rather than the "Post " rule below.
-  const norm = stripVS(name);
-  for (const [emoji, phase] of PHASE_MARKERS) {
-    if (norm.startsWith(stripVS(emoji))) return phase;
-  }
-  // Injected steps carry no marker; their wording is not ours to set. GitHub
-  // adds the "job" pair and the "Post …" steps, Blacksmith the "runner" pair.
-  if (name.startsWith("Post ")) return "shutdown";
-  if (name === "Set up job" || name === "Set up runner") return "setup";
-  if (name === "Complete job" || name === "Complete runner") return "shutdown";
-  return "other";
-}
 
 const JOBS_PER_PAGE = 100;
 async function fetchJobs(path: string): Promise<Job[]> {

--- a/tasks/ci-check-lib.test.ts
+++ b/tasks/ci-check-lib.test.ts
@@ -22,6 +22,7 @@ import {
   downloadAndExtractArtifact,
   fetchArtifactsForRun,
   fetchCurrentPRBody,
+  fetchIssueComments,
   fetchPRBody,
   fetchPRFiles,
   formatOverrideSuggestion,
@@ -673,6 +674,48 @@ Deno.test("fetchPRBody reads the live pull request body from the GitHub API", as
       requestedUrl,
       "https://api.github.com/repos/commontoolsinc/labs/pulls/3427",
     );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("fetchIssueComments reads every page of a pull request's comments", async () => {
+  const originalFetch = globalThis.fetch;
+  const requestedUrls: string[] = [];
+  try {
+    // A full page means there may be another, so the reader asks for one more.
+    // The second page comes back short and ends the walk. The comment with a
+    // null body is what the GitHub API returns for a comment whose text was
+    // deleted, and it reads back as empty rather than as null.
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({
+      id: index + 1,
+      body: `comment ${index + 1}`,
+    }));
+    const secondPage = [{ id: 101, body: null }];
+
+    globalThis.fetch = ((input, _init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      requestedUrls.push(url);
+      // Read the page from the query rather than by searching the whole URL:
+      // `per_page=100` carries `page=1` inside it.
+      const page = new URL(url).searchParams.get("page");
+      return Promise.resolve(
+        new Response(
+          JSON.stringify(page === "1" ? firstPage : secondPage),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    }) as typeof fetch;
+
+    const comments = await fetchIssueComments(5727);
+
+    assertEquals(comments.length, 101);
+    assertEquals(comments[0], { id: 1, body: "comment 1" });
+    assertEquals(comments[100], { id: 101, body: "" });
+    assertEquals(requestedUrls, [
+      "https://api.github.com/repos/commontoolsinc/labs/issues/5727/comments?per_page=100&page=1",
+      "https://api.github.com/repos/commontoolsinc/labs/issues/5727/comments?per_page=100&page=2",
+    ]);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tasks/ci-step-phases.test.ts
+++ b/tasks/ci-step-phases.test.ts
@@ -1,0 +1,54 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { PHASE_MARKERS, phaseOf } from "./ci-step-phases.ts";
+
+describe("ci-step-phases", () => {
+  describe("phaseOf", () => {
+    it("reads the phase from the marker a step name starts with", () => {
+      expect(phaseOf("📥 Checkout repository")).toBe("setup");
+      expect(phaseOf("🧪 Run parallel workspace tests")).toBe("work");
+      expect(phaseOf("📤 Upload coverage report")).toBe("shutdown");
+    });
+
+    it("reads a marker whether or not it carries a variation selector", () => {
+      expect(phaseOf("🏗️ Build toolshed binary")).toBe("work");
+      expect(phaseOf("🏗 Build toolshed binary")).toBe("work");
+    });
+
+    it("gives every marker exactly one phase", () => {
+      const phases = new Map<string, string>();
+      for (const [marker, phase] of PHASE_MARKERS) {
+        expect(phases.get(marker) ?? phase).toBe(phase);
+        phases.set(marker, phase);
+      }
+      expect(phases.size).toBe(PHASE_MARKERS.length);
+    });
+
+    it("counts the runner's own set-up steps as setup", () => {
+      expect(phaseOf("Set up job")).toBe("setup");
+      expect(phaseOf("Set up runner")).toBe("setup");
+    });
+
+    it("counts the runner's own closing steps as shutdown", () => {
+      expect(phaseOf("Complete job")).toBe("shutdown");
+      expect(phaseOf("Complete runner")).toBe("shutdown");
+      expect(phaseOf("Post 📥 Checkout repository")).toBe("shutdown");
+    });
+
+    it("prefers a leading marker to the wording after it", () => {
+      // "Post " decides a step the runner injected, and a step of ours that
+      // begins with a marker is read by that marker instead.
+      expect(phaseOf("💬 Post coverage comment")).toBe("work");
+    });
+
+    it("returns other for a name carrying no marker it knows", () => {
+      expect(phaseOf("Build and push dashboard image")).toBe("other");
+      expect(phaseOf("🦖 Feed the wrong dinosaur")).toBe("other");
+      expect(phaseOf("")).toBe("other");
+    });
+
+    it("reads a marker through the whitespace around a name", () => {
+      expect(phaseOf("  🧹 Lint codebase  ")).toBe("work");
+    });
+  });
+});

--- a/tasks/ci-step-phases.ts
+++ b/tasks/ci-step-phases.ts
@@ -1,0 +1,72 @@
+// Which phase of a job a CI step belongs to, read from the marker emoji its
+// name starts with. scripts/ci-gantt.ts splits each job bar by phase with this,
+// and tasks/ci-workflow.test.ts uses it to find the work steps a bound is
+// required on. The vocabulary lives in docs/development/CI_PERFORMANCE.md
+// ("Step phase markers") and is mirrored in PHASE_MARKERS below.
+
+export type Phase = "setup" | "work" | "shutdown" | "other";
+
+// Marker emoji -> phase. Each emoji maps to exactly one phase; when a step's
+// natural emoji would land it in the wrong phase, the step name is changed to a
+// marker that fits (see docs/development/CI_PERFORMANCE.md). Matching ignores a
+// trailing variation selector, so the base emoji covers both the plain and the
+// selector-suffixed form of a glyph.
+export const PHASE_MARKERS: [string, Phase][] = [
+  // setup: fetch code, install tools and dependencies, restore caches,
+  // authenticate, and bring test servers and devices up before the real work.
+  ["📥", "setup"], // checkout / download inputs
+  ["🦕", "setup"], // set up Deno
+  ["🔍", "setup"], // verify lock file & install, resolve refs
+  ["📦", "setup"], // install packages, cache dependencies
+  ["♻️", "setup"], // restore/save build caches
+  ["🛡️", "setup"], // relax sandbox for browser tests
+  ["🔧", "setup"], // enable devices
+  ["⚙️", "setup"], // set up external SDKs
+  ["🔑", "setup"], // authenticate to a cloud
+  ["🔌", "setup"], // start a local server for tests
+  ["⏳", "setup"], // wait for a service to be ready
+  ["💾", "setup"], // restore/save caches
+  ["🗃️", "setup"], // restore a cached native library
+  ["🧮", "setup"], // compute a cache identity
+  // work: the job's actual purpose.
+  ["🔎", "work"], // checks (format, type, patterns, attestations)
+  ["🚧", "work"], // guard that fails the build on a banned pattern
+  ["🩹", "work"], // check for unresolved merge-conflict markers
+  ["✅", "work"], // validate an artifact a previous step produced
+  ["🧪", "work"], // run tests
+  ["🧩", "work"], // run integration tests
+  ["🔁", "work"], // replay captured fixtures under today's source
+  ["🧹", "work"], // lint
+  ["🧭", "work"], // check skill facts
+  ["📄", "work"], // type-check docs
+  ["🏗️", "work"], // build binaries/assets
+  ["🏋️", "work"], // run benchmarks
+  ["📊", "work"], // produce performance metrics / status reports
+  ["🧬", "work"], // combine coverage
+  ["📝", "work"], // generate attestations
+  ["🔐", "work"], // sign binaries
+  ["🚀", "work"], // deploy
+  ["💬", "work"], // post a PR comment
+  // shutdown: post-work reports, artifact uploads, log capture, teardown.
+  ["🧾", "shutdown"], // write coverage report
+  ["📤", "shutdown"], // upload artifacts
+  ["📋", "shutdown"], // capture logs on failure
+];
+
+const stripVS = (s: string) => s.replace(/\uFE0F/g, "");
+
+export function phaseOf(stepName: string): Phase {
+  const name = stepName.trim();
+  // A leading marker wins, so a step named "💬 Post …" is classified by its
+  // marker rather than the "Post " rule below.
+  const norm = stripVS(name);
+  for (const [emoji, phase] of PHASE_MARKERS) {
+    if (norm.startsWith(stripVS(emoji))) return phase;
+  }
+  // Injected steps carry no marker; their wording is not ours to set. GitHub
+  // adds the "job" pair and the "Post …" steps, Blacksmith the "runner" pair.
+  if (name.startsWith("Post ")) return "shutdown";
+  if (name === "Set up job" || name === "Set up runner") return "setup";
+  if (name === "Complete job" || name === "Complete runner") return "shutdown";
+  return "other";
+}

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -1,4 +1,5 @@
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { phaseOf } from "./ci-step-phases.ts";
 import { EXPECTED_COVERAGE_ARTIFACT_NAMES } from "./coverage-check.ts";
 import { PATTERN_INTEGRATION_SHARD_COUNT } from "./select-pattern-integration-files.ts";
 
@@ -39,6 +40,34 @@ function stepBlock(job: string, stepName: string): string {
   return job.slice(start, end);
 }
 
+function stepBlocks(job: string): { name: string; body: string }[] {
+  return job.split(/^ {6}- name: /m).slice(1).map((step) => {
+    const nameEnd = step.indexOf("\n");
+    return { name: step.slice(0, nameEnd), body: step.slice(nameEnd + 1) };
+  });
+}
+
+// The minutes each YAML anchor in the workflow stands for, by anchor name.
+function anchoredMinutes(contents: string): Map<string, number> {
+  return new Map(
+    [...contents.matchAll(/^ +[A-Za-z_]+: &([a-z][a-z0-9-]*) (\d+)$/gm)].map((
+      match,
+    ) => [match[1], Number(match[2])]),
+  );
+}
+
+// A `timeout-minutes` value is an alias to one of those anchors, so that the
+// minutes themselves are written once. A value that is anything else — a number
+// written in place, or an expression, whose arithmetic GitHub does not document
+// anyway — has no minutes to give back and fails the check that asked.
+function boundMinutes(
+  anchors: Map<string, number>,
+  value: string,
+): number | null {
+  const alias = value.match(/^\*([a-z][a-z0-9-]*)$/);
+  return alias ? anchors.get(alias[1]) ?? null : null;
+}
+
 function neededJobIds(job: string): string[] {
   const marker = "\n    needs:\n";
   const needsStart = job.indexOf(marker);
@@ -64,6 +93,25 @@ async function workflowNames(): Promise<string[]> {
     if (entry.isFile && /\.ya?ml$/.test(entry.name)) names.push(entry.name);
   }
   return names.sort();
+}
+
+// Every YAML file under .github, so the composite actions are read alongside
+// the workflows that use them.
+async function* githubYamlPaths(
+  directory: URL = new URL("../.github/", import.meta.url),
+): AsyncGenerator<URL> {
+  for await (const entry of Deno.readDir(directory)) {
+    const path = new URL(
+      `${entry.name}${entry.isDirectory ? "/" : ""}`,
+      directory,
+    );
+    if (entry.isDirectory) yield* githubYamlPaths(path);
+    else if (/\.ya?ml$/.test(entry.name)) yield path;
+  }
+}
+
+function stepNames(contents: string): string[] {
+  return [...contents.matchAll(/^ *- name: (.+)$/gm)].map((match) => match[1]);
 }
 
 // Drops YAML comments. A `#` after whitespace ends a plain scalar, so what is
@@ -125,6 +173,84 @@ Deno.test("Status waits for every pull request validation job", async () => {
   const triggers = workflowTriggers(contents);
   assertStringIncludes(triggers, "  pull_request:\n");
   assertEquals(triggers.includes("\n    paths:"), false);
+});
+
+Deno.test("every step we name carries a phase marker", async () => {
+  // A step whose name starts with no marker in `PHASE_MARKERS` is charted as
+  // "other", which is how a job's setup time goes missing from the timings
+  // people read when deciding what to make faster. The classifier reads the
+  // marker rather than the wording, so the check is the classifier itself.
+  const unmarked: string[] = [];
+  let steps = 0;
+  for await (const path of githubYamlPaths()) {
+    for (const name of stepNames(await Deno.readTextFile(path))) {
+      steps++;
+      if (phaseOf(name) !== "other") continue;
+      unmarked.push(`${path.pathname.split("/.github/")[1]}: ${name}`);
+    }
+  }
+
+  assert(steps > 100, `only ${steps} steps found; the search read nothing`);
+  assertEquals(
+    unmarked,
+    [],
+    "these steps start with no marker from docs/development/CI_PERFORMANCE.md",
+  );
+});
+
+Deno.test("every work step is bounded before its job is", async () => {
+  // GitHub ends a job that runs past the job's own `timeout-minutes` by
+  // cancelling it, so the job's conclusion is `cancelled` — the same conclusion
+  // a run stopped by hand or superseded by a newer push carries, and one that
+  // reads as nobody's fault. A step that runs past the step's own bound fails
+  // instead, and its job fails with it. So each work step carries a bound of
+  // its own, below the bound on the job by the headroom the setup and upload
+  // steps around it need, and a wedged test is reported as a failure. Both
+  // bounds are aliases to an anchor, so each is a name here rather than a
+  // number, and the minutes behind the names are written once.
+  const headroom = 10;
+  const contents = await workflow("deno.yml");
+  const anchors = anchoredMinutes(contents);
+  // The deploy jobs hand the work to a script that lives elsewhere — one on the
+  // bastion, one in Cloud Storage — and how long that takes is not this
+  // workflow's to say. They carry no bound, so none is asked of them here.
+  const unboundedJobs = new Set(["deploy-rapids", "deploy-shell-staging"]);
+
+  for (const jobId of jobIds(contents)) {
+    if (unboundedJobs.has(jobId)) continue;
+    const job = jobBlock(contents, jobId);
+    const jobValue = job.match(/^ {4}timeout-minutes: (.+)$/m);
+    assert(jobValue, `${jobId}: job has no timeout-minutes`);
+    const jobBound = boundMinutes(anchors, jobValue[1]);
+    assert(
+      jobBound,
+      `${jobId}: timeout-minutes ${jobValue[1]} is not an anchored bound`,
+    );
+
+    const work = stepBlocks(job).filter((step) =>
+      phaseOf(step.name) === "work"
+    );
+    // Every job here does work of its own, so an empty list means the steps
+    // went unread rather than that this job had none to bound.
+    assert(work.length > 0, `${jobId}: no work step found`);
+
+    for (const step of work) {
+      const stepValue = step.body.match(/^ {8}timeout-minutes: (.+)$/m);
+      assert(stepValue, `${jobId}: "${step.name}" has no timeout-minutes`);
+      const stepBound = boundMinutes(anchors, stepValue[1]);
+      assert(
+        stepBound,
+        `${jobId}: "${step.name}" timeout-minutes ${stepValue[1]} is not an ` +
+          `anchored bound`,
+      );
+      assert(
+        jobBound - stepBound >= headroom,
+        `${jobId}: "${step.name}" is bounded at ${stepBound} minutes within a ` +
+          `job bounded at ${jobBound}, leaving under ${headroom} minutes ` +
+          `between them, so the job's bound can be the one a wedge hits first`,
+      );
+    }
+  }
 });
 
 Deno.test("Coverage Comment follows the CI workflow by name", async () => {
@@ -240,7 +366,7 @@ Deno.test("Dashboard publishes only from main, never from a pull request", async
   // branch move the `latest` tag.
   const tests = jobBlock(dashboard, "tests");
   assertEquals(tests.includes("id-token: write"), false);
-  const guard = stepBlock(tests, "Verify the run is on main");
+  const guard = stepBlock(tests, "🔎 Verify the run is on main");
   assertStringIncludes(guard, "if: ${{ github.ref != 'refs/heads/main' }}");
   assertStringIncludes(guard, "\n          exit 1\n");
 
@@ -254,7 +380,7 @@ Deno.test("Dashboard publishes only from main, never from a pull request", async
 
   // Both tags go up in the one push: the immutable commit tag the infra
   // overlay pins, and the `latest` the deployment follows.
-  const build = stepBlock(publish, "Build and push dashboard image");
+  const build = stepBlock(publish, "🏗️ Build and push dashboard image");
   assertStringIncludes(build, "\n          push: true\n");
   assertStringIncludes(
     build,


### PR DESCRIPTION
A CI job that runs past its `timeout-minutes` is not failed by GitHub; it is cancelled, and its conclusion is `cancelled`. That is the same conclusion a run somebody stopped by hand carries, and the same one the concurrency group gives a run superseded by a newer push. So a test that wedges and burns the whole bound is reported as if nobody were at fault, and the whole run shows as cancelled even when the Status gate failed on it. The killed job's log is not retained either, so the one job worth reading is the one with nothing to read.

The bound on a step behaves differently: a step that runs past its own `timeout-minutes` fails, and its job fails with it. So every work step here now carries a bound of its own, and the bound on the job around it is ten minutes larger. A wedge reaches the bound on its step first, and is reported as a failure with the log intact.

The two bounds are written once, as YAML anchors in the `env:` block at the top of the workflow, and every job and every work step reaches them by alias. GitHub Actions has accepted anchors and aliases since September 2025; merge keys are still refused, but naming a scalar is all this needs. Changing either bound is now one edit rather than sixty-five, and nobody has to keep two numbers in agreement by hand. The environment variables are only how a workflow declares a value an anchor can name; nothing reads them.

A work step may run for thirty minutes and its job for forty, which is at or above every bound any job carried before, so no step gets less time to finish in than it had. The ten minutes between the two are what the checkout, install and upload steps around the work need, and they are only ever spent once something is already wrong. The CLI integration suites gave up their own per-suite bounds of ten and fifteen minutes to this, so that matrix loses a column; the FUSE suite still bounds itself from the inside, where it can report a wedge with diagnostics.

Work steps are the ones whose name begins with a work-phase marker emoji, which is how `scripts/ci-gantt.ts` already splits a job bar into setup, work and shutdown. That table and its classifier move to `tasks/ci-step-phases.ts` so the chart and the new test read the same vocabulary. `tasks/ci-workflow.test.ts` then fails the Check job when a work step has no bound, when a job has none, when a bound is written as a number rather than as an alias, or when fewer than ten minutes separate the two anchors. So a step added later cannot quietly go back to being cancelled, and a number cannot creep back into the file.

Only `.github/workflows/deno.yml` is covered. The other workflows keep job-level bounds alone.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

