### PR TITLE
docs: make the historical-documentation index mergeable

### DIFF
--- a/.claude/rules/documentation.md
+++ b/.claude/rules/documentation.md
@@ -20,6 +20,15 @@ in `docs/history/` from the start, with the metadata header defined in
 `docs/history/README.md`. It is not written as a live document and archived
 afterwards.
 
+Every document there is listed in `docs/history/INDEX.md`, and two rules about
+that file are not guessable from looking at it. An entry is a single line
+however long it runs, and the file holds nothing besides its preamble, its
+section headings, and the entries. Git merges it with the `union` driver so
+that branches archiving documents at the same time do not conflict, and both
+rules are what make that driver safe; `docs/history/README.md` gives the
+reasoning. `deno task check-docs-history-index` enforces them, and also names
+any document in the tree that no entry covers.
+
 ## Where a new live document goes
 
 The map in `docs/README.md` says which directory holds what; read it rather

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,9 @@
-
 # Use bd merge for beads JSONL files
 .beads/beads.jsonl merge=beads
+
+# The historical-documentation index is appended to by many branches at once.
+# The union driver keeps both sides' additions instead of raising a conflict.
+# It works a line at a time, so the file is restricted to one-line entries and
+# carries no editable prose; docs/history/README.md explains the rules and
+# `deno task check-docs-history-index` enforces them.
+docs/history/INDEX.md merge=union

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -88,6 +88,9 @@ jobs:
         timeout-minutes: *work-timeout
         run: deno task check-docs
 
+      - name: 🔎 Check the historical-documentation index
+        run: deno task check-docs-history-index
+
       - name: 🚧 Guard against new polling waitFor in integration tests
         timeout-minutes: *work-timeout
         run: deno task check-no-waitfor

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -89,6 +89,7 @@ jobs:
         run: deno task check-docs
 
       - name: 🔎 Check the historical-documentation index
+        timeout-minutes: *work-timeout
         run: deno task check-docs-history-index
 
       - name: 🚧 Guard against new polling waitFor in integration tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,11 @@ the rules therein. These include:
   new one — historical.
 - When you produce a point-in-time artifact (a report on completed work, an
   audit, a post-mortem), create it in `docs/history/` with the metadata header
-  defined in `docs/history/README.md`.
+  defined in `docs/history/README.md`, and add an entry for it to
+  `docs/history/INDEX.md`. That entry is a single line, however long it runs,
+  and that file holds nothing but its preamble, its section headings, and the
+  entries — both rules are what let git merge concurrent additions to the index
+  without a conflict.
 - When a live plan or design reaches "done" or is abandoned — for example, your
   change lands its last phase — archive it to `docs/history/` following the
   procedure in `docs/README.md`.
@@ -200,6 +204,9 @@ Each of these gates fails CI on its own, and none of them run as part of
   event
 - `deno task check-docs` — a TypeScript block under `docs/` that stopped
   compiling
+- `deno task check-docs-history-index` — an entry in `docs/history/INDEX.md`
+  that is wrapped, duplicated, or points at nothing, or a document in that tree
+  that no entry covers
 - `deno task check-conflict-markers` — an unresolved merge-conflict marker left
   in a file, which `docs/` has no other mechanical gate against
 - `deno task check-skill-facts` — a path or import cited by a skill, an

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -45,6 +45,7 @@
     "check-docs": "deno run --allow-read --allow-write --allow-run --allow-env ./docs/check.ts",
     "check-no-waitfor": "deno run --allow-read ./tasks/check-no-waitfor.ts",
     "check-conflict-markers": "deno run --allow-read --allow-run=git ./tasks/check-conflict-markers.ts",
+    "check-docs-history-index": "deno run --allow-read ./tasks/check-docs-history-index.ts",
     "check-unused-deps": "deno run --allow-read --allow-run=git ./tasks/check-unused-deps.ts",
     "check-deno-pins": "deno run --allow-read ./tasks/check-deno-pins.ts",
     "check-single-copy-deps": "deno run --allow-read ./tasks/check-single-copy-deps.ts",

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,9 @@ or abandoned plans, and superseded designs. Their value is as a record of
 what happened or what was known at a moment, so their content is **never
 updated**. Each one carries a metadata header giving at least its creation
 date. The rules and the header format are in
-[`history/README.md`](history/README.md).
+[`history/README.md`](history/README.md), and
+[`history/INDEX.md`](history/INDEX.md) lists every document in the tree with a
+line saying what it records.
 
 ## Moving a document from live to historical
 
@@ -64,13 +66,19 @@ because your own change is what completed the plan — archive the document:
    that, an archived document receives only the edits
    [`history/README.md`](history/README.md) permits: mechanical link fixes
    and metadata-header corrections.
-4. Add a one-line entry for it to the index in
-   [`history/README.md`](history/README.md).
+4. Add an entry for it to [`history/INDEX.md`](history/INDEX.md). An entry is
+   a single line, however long it runs, and that file holds nothing but its
+   preamble, its section headings, and the entries. Both rules are what let
+   git merge concurrent additions to the index without a conflict;
+   [`history/README.md`](history/README.md) explains the mechanism.
 
-Steps 3 and 4 are the ones that go wrong quietly, and `deno task docs-links`
-checks both: `--orphan` names every document nothing links to, which is what a
-missed index entry looks like from the outside. It is worth running whenever
-you move or rename more than one document at a time — see
+Step 4 is checked by `deno task check-docs-history-index`, which runs in
+continuous integration: it enforces the shape of the index, and it names any
+document in the tree that no entry covers.
+
+Step 3 goes wrong quietly, and `deno task docs-links --orphan` names every
+document nothing links to. It is worth running whenever you move or rename
+more than one document at a time — see
 [`development/README.md`](development/README.md#tools) for its other modes.
 
 ## Creating a new historical document
@@ -138,7 +146,7 @@ it as the code change it is.
 - [`plans/`](plans/README.md) — pending implementation plans
 - [`tutorial/`](tutorial/README.md) — the two-part system tutorial
 - [`history/`](history/README.md) — archived point-in-time records (see
-  above)
+  above), listed in [`history/INDEX.md`](history/INDEX.md)
 - [`check.md`](check.md) — how the TypeScript code blocks embedded in these
   documents are type-checked in CI (`deno task check-docs`); `history/` is
   exempt

--- a/docs/history/INDEX.md
+++ b/docs/history/INDEX.md
@@ -1,0 +1,131 @@
+# Index of historical documents
+
+One line per archived document; [`README.md`](README.md) has the rules for this tree and for this file.
+
+## Audits and reports
+
+- [cf-view-parser-adapter-spike-2026-08.md](packages/cli/cf-view-parser-adapter-spike-2026-08.md) — Python, Go, shell, and HTML parser-adapter measurements, August 2026.
+- [cf-view-parser-adapter-spike-2026-08-methodology.md](packages/cli/cf-view-parser-adapter-spike-2026-08-methodology.md) — retained fixtures and procedure for the parser-adapter measurements, August 2026.
+- [estuary-source-migration-2026-08-04.md](packages/patterns/lunch-poll/estuary-source-migration-2026-08-04.md) — rehearsal and live `setsrc` moving the Estuary lunch poll onto the mainline pattern, August 2026.
+- [two-toolchain-vintage-rehearsal.md](two-toolchain-vintage-rehearsal.md) — first old-toolchain vintage capture (2026-06-18 `home.tsx`): procedure, capture script, and measurements, August 2026.
+- [cf-view-language-coverage-2026-07.md](packages/cli/cf-view-language-coverage-2026-07.md) — active-repository syntax inventory and `cf view` support snapshot, July 2026.
+- [cf-view-rendered-markdown-impact-2026-07.md](packages/cli/cf-view-rendered-markdown-impact-2026-07.md) — source/rendered pager and Markdown feature impact report, July 2026.
+- [cf-json-argument-audit-2026-07.md](packages/cli/cf-json-argument-audit-2026-07.md) — command-by-command audit of `cf --json` behavior, July 2026.
+- [cts-docs-audit-2026-07.md](cts-docs-audit-2026-07.md) — ts-transformers/schema-generator documentation audit, July 2026.
+- [library-comparison.md](scripts/benchmark-object-hashing/library-comparison.md) — the stable-object-hashing library comparison that chose a per-environment SHA-256 implementation and pointed away from a full Merkle tree, March 2026.
+- [cfc-spec-audit.md](cfc-spec-audit.md) — the CFC spec versus the packages/runner implementation, June 2026.
+- [invalid-state-representations-report.md](future-tasks/code-quality-tasks/invalid-state-representations-report.md) and [module-graph-import-issues-report.md](future-tasks/code-quality-tasks/module-graph-import-issues-report.md) — code-quality audits, June 2025.
+- [scheduler-v2/current-system-inventory.md](specs/scheduler-v2/current-system-inventory.md) — the v1 scheduler's mechanisms and their v2 dispositions, June 2026.
+- [PREEXISTING_BUGS.md](packages/patterns/PREEXISTING_BUGS.md) — pattern runtime bug survey, December 2025.
+- [piece-timeout-hangs-investigation.md](packages/cli/piece-timeout-hangs-investigation.md) — why the CLI tool-result poll was replaced event-driven and why the piece-start and sync bounds could not be removed at the CLI layer, July 2026.
+- [2026-07-27-session-paging-out-of-memory.md](packages/patterns/agent-sessions-debug/2026-07-27-session-paging-out-of-memory.md) — paging the agent-sessions debug table exhausts the browser runtime's heap, July 2026.
+- [2026-07-28-list-window-child-retention.md](packages/runner/2026-07-28-list-window-child-retention.md) — why a moving list window retained every child run it started, and what the fix covered, July 2026.
+- [2026-07-28-completed-transaction-retention.md](packages/runner/2026-07-28-completed-transaction-retention.md) — a completed transaction kept the activity of everything it read, and the unbounded document cache that still exhausts a browser tab, July 2026.
+- [2026-08-04-coverage-gate-base-branch-drift.md](development/2026-08-04-coverage-gate-base-branch-drift.md) — why Coverage Check failed `packages/runner` at random: the ratchet graded a pull request merged with a newer `main` against an older `main` baseline, August 2026.
+- [pattern-update-open-argument-investigation.md](plans/pattern-update-open-argument-investigation.md) — why the open-argument update class went unvalidated on the repair path, and the correction of an earlier measurement that named the wrong mechanism, July 2026.
+
+## Executed plans and work orders
+
+- [cf-harness implementation plan](packages/cf-harness/docs/IMPLEMENTATION_PLAN.md) — April 2026 package bootstrap plan and implementation checkpoint.
+- [2026-03-17-ct-exec-fuse-callables.md](plans/2026-03-17-ct-exec-fuse-callables.md) and [its test plan](plans/2026-03-17-ct-exec-fuse-callables-test-plan.md) — `cf exec` and mounted callable files.
+- [pattern-update-state-continuity.md](plans/pattern-update-state-continuity.md) — the Tier 2 state-continuity gate: capture and replay machinery, test-populated vintages, and value comparison, executed 2026-07/08. Records the measurements that decided the design, including the ones that reversed it (raw beats gzipped storage; a cross-DID restore reads fine).
+- [assertion-diagnostics.md](plans/assertion-diagnostics.md) — power-assert operand reporting for pattern-test assertions, with the compile-time constraints that shaped it, executed 2026-07.
+- [cfc-future-work-implementation.md](plans/cfc-future-work-implementation.md) — the CFC future-work epics (clause core, exchange rules/policy, observation classes, integrity floors, sqlite row-set, deployment flips), executed 2026-07.
+- [pattern-verb-contract-implementation.md](plans/pattern-verb-contract-implementation.md) — the verb-contract workstreams as built: the `topics` Part 1 rework, the `Stream<E, R>` authoring surface, the invocation protocol with caller-supplied ids and receipt readback, and the client affordances. Records the C3 result-schema withdrawal, the closed-world event-emission migration the update gate forced, and the measurements behind each, July–August 2026.
+- [shaped-reads-implementation.md](plans/shaped-reads-implementation.md) — the read-layer stages, the reasoning for ordering session-scoped invocation ids ahead of anything that publishes a receipt address, and the descriptive-receipt decision, August 2026.
+- [retiring-llm-tool-call-deadlines.md](development/proposals/retiring-llm-tool-call-deadlines.md) — replacing the LLM tool-call deadline with a run-scoped quiescence barrier, and narrowing the dialog message-drop heuristic the deadline's argument did not reach, executed 2026-07.
+- [STANDARD_DECORATORS_MIGRATION_PLAN.md](development/STANDARD_DECORATORS_MIGRATION_PLAN.md) — the cutover to standard decorators.
+- [content-addressed-action-identity-implementation-plan.md](specs/content-addressed-action-identity-implementation-plan.md) — the action-identity migration.
+- [module-loading-implementation-plan.md](specs/module-loading-implementation-plan.md) — the ESM module-record loader rollout.
+- [pattern-id-retirement.md](specs/pattern-id-retirement.md) — retiring pattern ids (work orders W0–W4).
+- [scheduler-v2/migration-plan.md](specs/scheduler-v2/migration-plan.md) — the v1→v2 scheduler migration phases, as executed (#4288).
+- [scheduler-v2/implementation/00-README.md](specs/scheduler-v2/implementation/00-README.md) — the scheduler-v2 work-order index and reading order.
+- [01-phase0-remove-push-mode.md](specs/scheduler-v2/implementation/01-phase0-remove-push-mode.md) — scheduler-v2 work order: remove push mode.
+- [02-phaseE0-event-identity.md](specs/scheduler-v2/implementation/02-phaseE0-event-identity.md) — scheduler-v2 work order: event identity and rejection taxonomy.
+- [03-phaseE1-speculation-lineage.md](specs/scheduler-v2/implementation/03-phaseE1-speculation-lineage.md) — scheduler-v2 work order: speculation lineage.
+- [04-phaseE2-receipts.md](specs/scheduler-v2/implementation/04-phaseE2-receipts.md) — scheduler-v2 work order: receipts as result cells.
+- [05-phase1-static-write-surface.md](specs/scheduler-v2/implementation/05-phase1-static-write-surface.md) — scheduler-v2 work order: static write surface.
+- [06-phase2-tx-identity.md](specs/scheduler-v2/implementation/06-phase2-tx-identity.md) — scheduler-v2 work order: transaction-carried identity.
+- [07-phase3-cutover.md](specs/scheduler-v2/implementation/07-phase3-cutover.md) — scheduler-v2 work order: node records, liveness, the new settle pass (the cutover).
+- [08-later-phases.md](specs/scheduler-v2/implementation/08-later-phases.md) — scheduler-v2 work order: post-cutover phases 4, 5, 7.
+- [PROGRESS.md](specs/scheduler-v2/implementation/PROGRESS.md) — the scheduler-v2 implementation progress log.
+- [persistent-scheduler-state/implementation_notes.md](specs/persistent-scheduler-state/implementation_notes.md) — implementation journal for the persistent scheduler-state rollout.
+- [system-pattern-updates-implementation-plan.md](specs/pattern-imports/system-pattern-updates-implementation-plan.md) — system-pattern auto-update (M0 toolshed `?identity`, M1 version gate, M2 `patternSource`, M3 in-place swap, M4 flag rollout), shipped 2026-07.
+- [sqlite-builtin/implementation-plan.md](specs/sqlite-builtin/implementation-plan.md) — the SQLite builtin workstreams, as built.
+- [PLANNED_FIXES.md](packages/cli/PLANNED_FIXES.md) — cli fix batches.
+- [AUTOSAVE-PLAN.md](packages/ui/src/v2/components/cf-file-download/AUTOSAVE-PLAN.md) — cf-file-download auto-save.
+- [2026-07-23-pathless-piece-read.md](plans/2026-07-23-pathless-piece-read.md) — why a path-less `cf piece get` returned `undefined` while every child path read fine, and the partial-object projection at the piece read boundary that fixed it, July 2026.
+
+## Shipped or superseded designs and decision records
+
+- [action-id-per-instance-decision.md](specs/action-id-per-instance-decision.md) — per-instance action identity.
+- [declared-verb-results-case.md](plans/declared-verb-results-case.md) — the case for carrying a verb's declared result on `module.resultSchema` in the interim rather than waiting for the Fabric-types stream; decided yes, conditionally, August 2026.
+- [cfc-render-membership-lookup.md](specs/cfc-render-membership-lookup.md) — render-time space-membership lookup.
+- [cfc-s16-default-transition-design.md](specs/cfc-s16-default-transition-design.md) — S16 default-label transition.
+- [cfc-trusted-agent-tool-integrity.md](specs/cfc-trusted-agent-tool-integrity.md) — trusted-agent tool-input integrity scoping.
+- [compilation-cache.md](specs/compilation-cache.md) — the removed AMD compilation cache.
+- [module-loading-amd-bundle-identity.md](specs/module-loading-amd-bundle-identity.md) — the removed AMD bundle pipeline and the bundle-grained identity defect that motivated content-addressed module loading.
+- [module-loading-verifier-and-engine-design.md](specs/module-loading-verifier-and-engine-design.md) — verifier port and engine integration.
+- [capability-wrappers.md](specs/pattern-construction/capability-wrappers.md) — superseded pattern-construction exploration.
+- [pattern-integration-tests.md](specs/pattern-construction/pattern-integration-tests.md) — early harness design the shipped harness diverged from.
+- [pull-based-scheduler/README.md](specs/pull-based-scheduler/README.md) — redirect stub for the retired v1 scheduler behavior reference, superseded by scheduler-v2.
+- [federation-pr5-design.md](development/federation-pr5-design.md) — earlier federation auth design, replaced by memory-v2 auth.
+- [DESIGN_ifelse_schema_injection.md](packages/ts-transformers/DESIGN_ifelse_schema_injection.md), [LITERAL_WIDENING_DESIGN.md](packages/ts-transformers/docs/LITERAL_WIDENING_DESIGN.md), and [SAFE_CONTEXT_TRANSFORMS_DESIGN.md](packages/ts-transformers/docs/SAFE_CONTEXT_TRANSFORMS_DESIGN.md) — transformer design records.
+- [MIGRATION_SUMMARY.md](packages/ui/src/v2/MIGRATION_SUMMARY.md) — the ui v2 migration.
+- [CELL_CONTROLLER_DESIGN.md](packages/ui/src/v2/core/CELL_CONTROLLER_DESIGN.md) — the pitch for the ui v2 CellController, July 2025. The controller shipped; the transaction strategies, change grouping, batching, validation and undo/redo it proposes did not.
+- [unified-storage-stack.md](future-tasks/unified-storage-stack.md) — DocImpl-era storage-unification plan, superseded by the v2 stack.
+- [hierarchical-params-spec.md](packages/ts-transformers/docs/hierarchical-params-spec.md) — hierarchical-capture implementation rationale, superseded by the behavior spec.
+- [pr3154-review-guide.md](specs/ts-transformer/pr3154-review-guide.md) — reviewer entrypoint for the shipped PR-3154 transformer architecture.
+
+## Investigations, journals, and working notes
+
+- [2026-08-lunch-poll-join-name-fill-timeout.md](development/debugging/2026-08-lunch-poll-join-name-fill-timeout.md) — why the lunch poll's intermittent `#lp-join-name` fill timeout is not a fill-helper problem: the field never renders because the "Continue as guest" handler's write does not reach the rendered view, and settling the view before the fill does not change it. Includes a local reproduction, August 2026.
+- [cf-harness Loom migration notes](packages/cf-harness/docs/LOOM_MIGRATION_NOTES.md) — April 2026 pre-integration assessment of Loom's Codex batch and interactive paths.
+- [bug3-suggestion-alias-verification-2026-07.md](packages/patterns/bug3-suggestion-alias-verification-2026-07.md) — verification that the December 2025 survey's Bug 3 (Counter values rendering as raw `$alias` objects when instantiated via `fetchAndRunPattern`) does not reproduce; the dynamically-compiled render path resolves reactive and computed values correctly, July 2026.
+- [reverse-invalidation-deadlock.md](packages/fuse/reverse-invalidation-deadlock.md) — root cause of the FUSE daemon hang that flaked the CLI FUSE integration suite: synchronous reverse invalidation deadlocking the request thread, July 2026.
+- [2026-07-fuse-t-integration-flake-accumulated-nfs-state.md](packages/fuse/2026-07-fuse-t-integration-flake-accumulated-nfs-state.md) — a FUSE-T integration-suite failure that looked like a #4811 daemon regression but was accumulated stale kernel NFS mounts from SIGKILL churn; directory visibility works via mtime plus the NFS attribute-cache bound, not `notify_inval_entry`, July 2026.
+- [settle-wave-2026-03-findings.md](development/debugging/settle-wave-2026-03-findings.md) — March 2026 settle-wave measurements.
+- [2026-07-cf-profile-capture-exit-130.md](development/debugging/2026-07-cf-profile-capture-exit-130.md) — root cause of the cf-profile capture exit-130 CI flake, July 2026.
+- [2026-07-group-chat-idempotency-false-positive.md](development/debugging/2026-07-group-chat-idempotency-false-positive.md) — root cause of the group-chat idempotency false-positive CI flake, July 2026.
+- [default-app-note-create.md](development/performance/default-app-note-create.md), [two-browsers-cold-start.md](development/performance/two-browsers-cold-start.md), and [pattern-integration-compile-bound.md](development/performance/pattern-integration-compile-bound.md) — June 2026 profiling snapshots.
+- [2026-07-pattern-capability-ci-duration-increase.md](development/performance/2026-07-pattern-capability-ci-duration-increase.md) — root cause of the July 2026 labs CI duration increase: two unsharded pattern time-capability sweeps, especially the 56-pattern sweep on shard 3.
+- [2026-07-ci-duration-profile.md](development/performance/2026-07-ci-duration-profile.md) — July 2026 Deno Workflow profile, including compile-cache validation, duplicate work, workspace shard balance, and follow-up experiments.
+- [2026-07-binary-artifact-transfer.md](development/performance/2026-07-binary-artifact-transfer.md) — binary artifact file and byte transfer snapshot before the per-binary workflow split, July 2026.
+- [2026-08-scheduler-liveness-maintenance.md](development/performance/2026-08-scheduler-liveness-maintenance.md) — why deriving demand refcounts from the roots on every change cost a growing list cubic work, and what incremental maintenance measured instead, August 2026.
+- [2026-08-read-modify-write-artifact-walk.md](development/performance/2026-08-read-modify-write-artifact-walk.md) — why reading a list, changing one element, and writing it back grew seven times more expensive: the builder-artifact walk on the raw write path read into the query results a read hands out, August 2026.
+- [2026-08-storage-manager-construction-cost.md](development/performance/2026-08-storage-manager-construction-cost.md) — the tenfold step in the immutable-cell storage-manager benchmark traced to an eager default-route resolution in the constructor, why the benchmark times only construction, and why the guard for it counts URL parses rather than comparing values, August 2026.
+- [2026-08-schemaless-read-membership-walk.md](development/performance/2026-08-schemaless-read-membership-walk.md) — why the schemaless whole-array read benchmarks stepped by two to three times: the storage read path re-derived, per read, that what the replica holds is a `FabricValue`, August 2026.
+- [2026-08-immutable-cell-data-uri-mint.md](development/performance/2026-08-immutable-cell-data-uri-mint.md) — the two July 2026 steps in the create-data-URI benchmark: a byte array allocated per mint on the way to the base64url payload, which is fixed, and the canonical `FabricValue` encoding, whose cost is the price of content addressing and stays.
+- [2026-08-subscription-sync-replay-registry.md](development/performance/2026-08-subscription-sync-replay-registry.md) — why registering many selectors on one document got a quarter slower: the replay registry hashed a key on every `sync()` call. Also why the write-vs-commit benchmark alongside it was not a regression at all, and how normalizing by a run median can manufacture a step, August 2026.
+- [2026-08-benchmark-headline-machine-noise.md](development/performance/2026-08-benchmark-headline-machine-noise.md) — why the dashboard's 21% benchmark headline was mostly the host two runs landed on: the runner group serves several machines under one processor name, and neither the artifact nor the tile could tell them apart. August 2026.
+- [2026-08-cell-bench-micro-steps.md](development/performance/2026-08-cell-bench-micro-steps.md) — why the two `cell.bench.ts` steps inside the 21% benchmark headline are not regressions: one stalled runner sample per run, folded into the average the trend read, August 2026.
+- [coverage-flake-idempotency-dedup-2026-08-12.md](development/coverage-flake-idempotency-dedup-2026-08-12.md) — which two lines a benchmark-only pull request was charged for, and why the suggestion comment could not name a file: a guard reached only when one action is caught non-idempotent twice in a process, August 2026.
+- [coverage-ratchet-noise-2026-07-28.md](development/coverage-ratchet-noise-2026-07-28.md) — why a rename-only pull request owed coverage debt: a wall-clock-guarded diagnostic and a shard re-partition each moved the `packages/runner` uncovered-line count with no change to that package, July 2026.
+- [scoped-cells-field-notes.md](development/scoped-cells-field-notes.md) — field journal from the first scoped-cell patterns.
+- [2026-07-02-convergence-evidence-appendix.md](plans/2026-07-02-convergence-evidence-appendix.md) — convergence-investigation evidence.
+- [cellset-lww-context.md](specs/memory-v2/cellset-lww-context.md) — working context for the cellset LWW fix.
+- [scheduler-v2/addenda/00-README.md](specs/scheduler-v2/addenda/00-README.md) — index of the scheduler-v2 performance-investigation addenda, June–July 2026.
+- [01-headline-and-node-multiplication.md](specs/scheduler-v2/addenda/01-headline-and-node-multiplication.md) — scheduler-v2 addendum: the headline A/B regression root-caused to node multiplication.
+- [02-multi-runtime-amplification-and-commit-cost.md](specs/scheduler-v2/addenda/02-multi-runtime-amplification-and-commit-cost.md) — scheduler-v2 addendum: multi-runtime commit/push amplification and per-commit cost.
+- [03-transaction-census.md](specs/scheduler-v2/addenda/03-transaction-census.md) — scheduler-v2 addendum: census of what the extra commits are.
+- [04-refuted-free-fixes.md](specs/scheduler-v2/addenda/04-refuted-free-fixes.md) — scheduler-v2 addendum: refuted free fixes (declared reads, asCell read-depth).
+- [05-serialized-scheduler-state-is-reload-only.md](specs/scheduler-v2/addenda/05-serialized-scheduler-state-is-reload-only.md) — scheduler-v2 addendum: serialized scheduler state is reload-only, not a version skip.
+- [06-cross-runtime-adoption-what-would-be-needed.md](specs/scheduler-v2/addenda/06-cross-runtime-adoption-what-would-be-needed.md) — scheduler-v2 addendum: what cross-runtime derivation adoption would need.
+- [07-pull-side-gate-no-go.md](specs/scheduler-v2/addenda/07-pull-side-gate-no-go.md) — scheduler-v2 addendum: the pull-side gate measured as a structural no-go.
+- [08-effect-defer-neutral.md](specs/scheduler-v2/addenda/08-effect-defer-neutral.md) — scheduler-v2 addendum: per-wave effect coalescing measured neutral.
+- [09-remediation-direction.md](specs/scheduler-v2/addenda/09-remediation-direction.md) — scheduler-v2 addendum: remediation direction — coalesce/dedup, not version-skip.
+- [specs/server-side-execution/](specs/server-side-execution/) — the v1 server-primary execution learning run (2026-07-07 to 2026-08-02): original design, implementation plan, context-lattice claims, client-passivity design, claim-deletion scoping, and the orchestration log carrying the full lesson record; start at its [README](specs/server-side-execution/README.md). Superseded by the live [server-primary execution v2 spec](../specs/server-side-execution/README.md).
+- [OPTIMIZATION-JOURNAL.md](packages/runner/test/traverse-replay/OPTIMIZATION-JOURNAL.md) — traverse optimization log.
+- [SCHEMA_INJECTION_NOTES.md](packages/ts-transformers/SCHEMA_INJECTION_NOTES.md), [TEST_PLAN_schema_injection.md](packages/ts-transformers/TEST_PLAN_schema_injection.md), [FALLBACK_POLICY_EXAMPLES.md](packages/ts-transformers/docs/FALLBACK_POLICY_EXAMPLES.md), and [outstanding-questions-for-manager.md](packages/ts-transformers/docs/outstanding-questions-for-manager.md) — schema-injection working notes.
+- [parking-coordinator/summary.md](packages/patterns/factory-outputs/parking-coordinator/summary.md) — factory-run summary.
+- [DRAG-DROP-MULTI-TAB-FIX.md](packages/patterns/record/design/DRAG-DROP-MULTI-TAB-FIX.md) and [EXTRACTION-IMPROVEMENTS.md](packages/patterns/record/design/EXTRACTION-IMPROVEMENTS.md) — record-pattern investigation and improvement notes.
+- [2026-07-unbounded-runtime-caches.md](development/performance/2026-07-unbounded-runtime-caches.md) — the four runtime caches that grew with everything a session had ever touched, and what bounding them measured, July 2026.
+- [2026-08-settled-transaction-retention.md](development/performance/2026-08-settled-transaction-retention.md) — what a settled storage transaction keeps reachable, and which of those retention paths show up without per-element list child release, August 2026.
+- [2026-08-fabric-value-validation-cost.md](development/performance/2026-08-fabric-value-validation-cost.md) — where the write path's validation time went in the benchmarks from 2026-07-29, August 2026.
+- [noattrcache-mount-option-evaluation.md](packages/fuse/noattrcache-mount-option-evaluation.md) — the two-stage evaluation and live-stack measurements behind defaulting FUSE-T mounts to a one-second attribute-cache timeout, July 2026.
+- [stable-inode-mtime-verification.md](packages/fuse/stable-inode-mtime-verification.md) — the on-hardware FUSE-T check of stable inodes and a moving mtime, including the measurement showing same-size staleness is bounded rather than unbounded, July 2026.
+- [dropping-json-serialization.md](spikes/dropping-json-serialization.md) — what a research branch found when `toJSON()` and load-bearing `JSON.stringify` were removed from the runtime; the breakage is the deliverable, not a design, August 2026.
+
+## The retired tutorial site
+
+- [tutorials/](tutorials/) — the complete MyST source of the retired docs.commontools.dev site: nine chapters, example code and images, and the build scaffolding, entered at [index.md](tutorials/index.md). Its state chapters and LLM tour teach the retired `cell()` API.

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -12,8 +12,9 @@ The test for which is which: if the system changed, would someone edit this
 document, or write a new one and leave this one alone? Edit it — it is live.
 Write a new one — it is historical.
 
-This README is the one live document in the tree: it states the rules, must
-be kept accurate as they evolve, and carries no metadata header.
+This README and [`INDEX.md`](INDEX.md) are the two live documents in the tree.
+This one states the rules and must be kept accurate as they evolve; the index
+lists every archived document. Neither carries a metadata header.
 
 ## Rules
 
@@ -82,331 +83,32 @@ add these keys at the top of that block instead of adding a second block.
 
 ## Index
 
-One line per archived document; each document's header carries the fuller
-`reason`. When you archive a document, add its line here.
+[`INDEX.md`](INDEX.md) lists every archived document, one line each, grouped by
+what kind of record it is. When you archive a document, or create one here,
+add its line there.
 
-### Audits and reports
+Two constraints on that file are worth knowing before you edit it, because a
+check enforces both and neither is guessable from looking at it:
 
-- [cf-view-parser-adapter-spike-2026-08.md](packages/cli/cf-view-parser-adapter-spike-2026-08.md)
-  — Python, Go, shell, and HTML parser-adapter measurements, August 2026.
-- [cf-view-parser-adapter-spike-2026-08-methodology.md](packages/cli/cf-view-parser-adapter-spike-2026-08-methodology.md)
-  — retained fixtures and procedure for the parser-adapter measurements,
-  August 2026.
-- [estuary-source-migration-2026-08-04.md](packages/patterns/lunch-poll/estuary-source-migration-2026-08-04.md)
-  — rehearsal and live `setsrc` moving the Estuary lunch poll onto the mainline
-  pattern, August 2026.
-- [two-toolchain-vintage-rehearsal.md](two-toolchain-vintage-rehearsal.md)
-  — first old-toolchain vintage capture (2026-06-18 `home.tsx`): procedure,
-  capture script, and measurements, August 2026.
-- [cf-view-language-coverage-2026-07.md](packages/cli/cf-view-language-coverage-2026-07.md)
-  — active-repository syntax inventory and `cf view` support snapshot, July
-  2026.
-- [cf-view-rendered-markdown-impact-2026-07.md](packages/cli/cf-view-rendered-markdown-impact-2026-07.md)
-  — source/rendered pager and Markdown feature impact report, July 2026.
-- [cf-json-argument-audit-2026-07.md](packages/cli/cf-json-argument-audit-2026-07.md)
-  — command-by-command audit of `cf --json` behavior, July 2026.
-- [cts-docs-audit-2026-07.md](cts-docs-audit-2026-07.md) —
-  ts-transformers/schema-generator documentation audit, July 2026.
-- [library-comparison.md](scripts/benchmark-object-hashing/library-comparison.md)
-  — the stable-object-hashing library comparison that chose a per-environment
-  SHA-256 implementation and pointed away from a full Merkle tree, March 2026.
-- [cfc-spec-audit.md](cfc-spec-audit.md) — the CFC spec versus the
-  packages/runner implementation, June 2026.
-- [invalid-state-representations-report.md](future-tasks/code-quality-tasks/invalid-state-representations-report.md)
-  and
-  [module-graph-import-issues-report.md](future-tasks/code-quality-tasks/module-graph-import-issues-report.md)
-  — code-quality audits, June 2025.
-- [scheduler-v2/current-system-inventory.md](specs/scheduler-v2/current-system-inventory.md)
-  — the v1 scheduler's mechanisms and their v2 dispositions, June 2026.
-- [PREEXISTING_BUGS.md](packages/patterns/PREEXISTING_BUGS.md) — pattern
-  runtime bug survey, December 2025.
-- [piece-timeout-hangs-investigation.md](packages/cli/piece-timeout-hangs-investigation.md)
-  — why the CLI tool-result poll was replaced event-driven and why the
-  piece-start and sync bounds could not be removed at the CLI layer, July 2026.
-- [2026-07-27-session-paging-out-of-memory.md](packages/patterns/agent-sessions-debug/2026-07-27-session-paging-out-of-memory.md)
-  — paging the agent-sessions debug table exhausts the browser runtime's heap,
-  July 2026.
-- [2026-07-28-list-window-child-retention.md](packages/runner/2026-07-28-list-window-child-retention.md)
-  — why a moving list window retained every child run it started, and what the
-  fix covered, July 2026.
-- [2026-07-28-completed-transaction-retention.md](packages/runner/2026-07-28-completed-transaction-retention.md)
-  — a completed transaction kept the activity of everything it read, and the
-  unbounded document cache that still exhausts a browser tab, July 2026.
-- [2026-08-04-coverage-gate-base-branch-drift.md](development/2026-08-04-coverage-gate-base-branch-drift.md)
-  — why Coverage Check failed `packages/runner` at random: the ratchet graded a
-  pull request merged with a newer `main` against an older `main` baseline,
-  August 2026.
-- [pattern-update-open-argument-investigation.md](plans/pattern-update-open-argument-investigation.md)
-  — why the open-argument update class went unvalidated on the repair path, and
-  the correction of an earlier measurement that named the wrong mechanism,
-  July 2026.
+- An entry is a single line, however long it runs. It is never wrapped, even
+  though every other document in this repository wraps at 80 columns.
+- The file holds nothing but its preamble, its section headings, and the
+  entries. Notes, caveats, and explanations go in this README instead.
 
-### Executed plans and work orders
+Both exist so that git can merge the index without a conflict. `.gitattributes`
+gives it the built-in `union` merge driver, which combines what two branches
+each added rather than stopping to ask. The driver works a line at a time, so a
+wrapped entry can lose one of its lines to an identically worded line in
+another entry, and a paragraph two branches both edit is kept twice. Restricting
+the file to one-line entries takes both failures off the table: a line either
+belongs to exactly one entry or is one of the fixed headings.
 
-- [cf-harness implementation plan](packages/cf-harness/docs/IMPLEMENTATION_PLAN.md)
-  — April 2026 package bootstrap plan and implementation checkpoint.
-- [2026-03-17-ct-exec-fuse-callables.md](plans/2026-03-17-ct-exec-fuse-callables.md)
-  and [its test plan](plans/2026-03-17-ct-exec-fuse-callables-test-plan.md) —
-  `cf exec` and mounted callable files.
-- [pattern-update-state-continuity.md](plans/pattern-update-state-continuity.md)
-  — the Tier 2 state-continuity gate: capture and replay machinery,
-  test-populated vintages, and value comparison, executed 2026-07/08. Records
-  the measurements that decided the design, including the ones that reversed
-  it (raw beats gzipped storage; a cross-DID restore reads fine).
-- [assertion-diagnostics.md](plans/assertion-diagnostics.md) — power-assert
-  operand reporting for pattern-test assertions, with the compile-time
-  constraints that shaped it, executed 2026-07.
-- [cfc-future-work-implementation.md](plans/cfc-future-work-implementation.md)
-  — the CFC future-work epics (clause core, exchange rules/policy,
-  observation classes, integrity floors, sqlite row-set, deployment flips),
-  executed 2026-07.
-- [pattern-verb-contract-implementation.md](plans/pattern-verb-contract-implementation.md)
-  — the verb-contract workstreams as built: the `topics` Part 1 rework, the
-  `Stream<E, R>` authoring surface, the invocation protocol with caller-supplied
-  ids and receipt readback, and the client affordances. Records the C3
-  result-schema withdrawal, the closed-world event-emission migration the update
-  gate forced, and the measurements behind each, July–August 2026.
-- [shaped-reads-implementation.md](plans/shaped-reads-implementation.md) — the
-  read-layer stages, the reasoning for ordering session-scoped invocation ids
-  ahead of anything that publishes a receipt address, and the descriptive-receipt
-  decision, August 2026.
-- [retiring-llm-tool-call-deadlines.md](development/proposals/retiring-llm-tool-call-deadlines.md)
-  — replacing the LLM tool-call deadline with a run-scoped quiescence barrier,
-  and narrowing the dialog message-drop heuristic the deadline's argument did
-  not reach, executed 2026-07.
-- [STANDARD_DECORATORS_MIGRATION_PLAN.md](development/STANDARD_DECORATORS_MIGRATION_PLAN.md)
-  — the cutover to standard decorators.
-- [content-addressed-action-identity-implementation-plan.md](specs/content-addressed-action-identity-implementation-plan.md)
-  — the action-identity migration.
-- [module-loading-implementation-plan.md](specs/module-loading-implementation-plan.md)
-  — the ESM module-record loader rollout.
-- [pattern-id-retirement.md](specs/pattern-id-retirement.md) — retiring
-  pattern ids (work orders W0–W4).
-- [scheduler-v2/migration-plan.md](specs/scheduler-v2/migration-plan.md) — the
-  v1→v2 scheduler migration phases, as executed (#4288).
-- [scheduler-v2/implementation/00-README.md](specs/scheduler-v2/implementation/00-README.md)
-  — the scheduler-v2 work-order index and reading order.
-- [01-phase0-remove-push-mode.md](specs/scheduler-v2/implementation/01-phase0-remove-push-mode.md)
-  — scheduler-v2 work order: remove push mode.
-- [02-phaseE0-event-identity.md](specs/scheduler-v2/implementation/02-phaseE0-event-identity.md)
-  — scheduler-v2 work order: event identity and rejection taxonomy.
-- [03-phaseE1-speculation-lineage.md](specs/scheduler-v2/implementation/03-phaseE1-speculation-lineage.md)
-  — scheduler-v2 work order: speculation lineage.
-- [04-phaseE2-receipts.md](specs/scheduler-v2/implementation/04-phaseE2-receipts.md)
-  — scheduler-v2 work order: receipts as result cells.
-- [05-phase1-static-write-surface.md](specs/scheduler-v2/implementation/05-phase1-static-write-surface.md)
-  — scheduler-v2 work order: static write surface.
-- [06-phase2-tx-identity.md](specs/scheduler-v2/implementation/06-phase2-tx-identity.md)
-  — scheduler-v2 work order: transaction-carried identity.
-- [07-phase3-cutover.md](specs/scheduler-v2/implementation/07-phase3-cutover.md)
-  — scheduler-v2 work order: node records, liveness, the new settle pass (the
-  cutover).
-- [08-later-phases.md](specs/scheduler-v2/implementation/08-later-phases.md) —
-  scheduler-v2 work order: post-cutover phases 4, 5, 7.
-- [PROGRESS.md](specs/scheduler-v2/implementation/PROGRESS.md) — the
-  scheduler-v2 implementation progress log.
-- [persistent-scheduler-state/implementation_notes.md](specs/persistent-scheduler-state/implementation_notes.md)
-  — implementation journal for the persistent scheduler-state rollout.
-- [system-pattern-updates-implementation-plan.md](specs/pattern-imports/system-pattern-updates-implementation-plan.md)
-  — system-pattern auto-update (M0 toolshed `?identity`, M1 version gate, M2
-  `patternSource`, M3 in-place swap, M4 flag rollout), shipped 2026-07.
-- [sqlite-builtin/implementation-plan.md](specs/sqlite-builtin/implementation-plan.md)
-  — the SQLite builtin workstreams, as built.
-- [PLANNED_FIXES.md](packages/cli/PLANNED_FIXES.md) — cli fix batches.
-- [AUTOSAVE-PLAN.md](packages/ui/src/v2/components/cf-file-download/AUTOSAVE-PLAN.md)
-  — cf-file-download auto-save.
+`deno task check-docs-history-index` checks the format, that every entry points
+at something that exists, that no document is indexed twice, and that no
+document in the tree is missing from the index. It runs in continuous
+integration. An entry may point at a directory, which covers everything
+beneath it — that is how the retired tutorial site and the server-side-execution
+learning run are each carried by one line.
 
-### Shipped or superseded designs and decision records
-
-- [action-id-per-instance-decision.md](specs/action-id-per-instance-decision.md)
-  — per-instance action identity.
-- [declared-verb-results-case.md](plans/declared-verb-results-case.md) — the
-  case for carrying a verb's declared result on `module.resultSchema` in the
-  interim rather than waiting for the Fabric-types stream; decided yes,
-  conditionally, August 2026.
-- [cfc-render-membership-lookup.md](specs/cfc-render-membership-lookup.md) —
-  render-time space-membership lookup.
-- [cfc-s16-default-transition-design.md](specs/cfc-s16-default-transition-design.md)
-  — S16 default-label transition.
-- [cfc-trusted-agent-tool-integrity.md](specs/cfc-trusted-agent-tool-integrity.md)
-  — trusted-agent tool-input integrity scoping.
-- [compilation-cache.md](specs/compilation-cache.md) — the removed AMD
-  compilation cache.
-- [module-loading-amd-bundle-identity.md](specs/module-loading-amd-bundle-identity.md)
-  — the removed AMD bundle pipeline and the bundle-grained identity defect that
-  motivated content-addressed module loading.
-- [module-loading-verifier-and-engine-design.md](specs/module-loading-verifier-and-engine-design.md)
-  — verifier port and engine integration.
-- [capability-wrappers.md](specs/pattern-construction/capability-wrappers.md)
-  — superseded pattern-construction exploration.
-- [pattern-integration-tests.md](specs/pattern-construction/pattern-integration-tests.md)
-  — early harness design the shipped harness diverged from.
-- [pull-based-scheduler/README.md](specs/pull-based-scheduler/README.md) —
-  redirect stub for the retired v1 scheduler behavior reference, superseded by
-  scheduler-v2.
-- [federation-pr5-design.md](development/federation-pr5-design.md) — earlier
-  federation auth design, replaced by memory-v2 auth.
-- [DESIGN_ifelse_schema_injection.md](packages/ts-transformers/DESIGN_ifelse_schema_injection.md),
-  [LITERAL_WIDENING_DESIGN.md](packages/ts-transformers/docs/LITERAL_WIDENING_DESIGN.md),
-  and
-  [SAFE_CONTEXT_TRANSFORMS_DESIGN.md](packages/ts-transformers/docs/SAFE_CONTEXT_TRANSFORMS_DESIGN.md)
-  — transformer design records.
-- [MIGRATION_SUMMARY.md](packages/ui/src/v2/MIGRATION_SUMMARY.md) — the ui v2
-  migration.
-- [CELL_CONTROLLER_DESIGN.md](packages/ui/src/v2/core/CELL_CONTROLLER_DESIGN.md)
-  — the pitch for the ui v2 CellController, July 2025. The controller shipped;
-  the transaction strategies, change grouping, batching, validation and
-  undo/redo it proposes did not.
-- [unified-storage-stack.md](future-tasks/unified-storage-stack.md) —
-  DocImpl-era storage-unification plan, superseded by the v2 stack.
-- [hierarchical-params-spec.md](packages/ts-transformers/docs/hierarchical-params-spec.md)
-  — hierarchical-capture implementation rationale, superseded by the behavior
-  spec.
-- [pr3154-review-guide.md](specs/ts-transformer/pr3154-review-guide.md) —
-  reviewer entrypoint for the shipped PR-3154 transformer architecture.
-
-### Investigations, journals, and working notes
-
-- [2026-08-lunch-poll-join-name-fill-timeout.md](development/debugging/2026-08-lunch-poll-join-name-fill-timeout.md)
-  — why the lunch poll's intermittent `#lp-join-name` fill timeout is not a
-  fill-helper problem: the field never renders because the "Continue as guest"
-  handler's write does not reach the rendered view, and settling the view before
-  the fill does not change it. Includes a local reproduction, August 2026.
-- [cf-harness Loom migration notes](packages/cf-harness/docs/LOOM_MIGRATION_NOTES.md)
-  — April 2026 pre-integration assessment of Loom's Codex batch and interactive paths.
-- [bug3-suggestion-alias-verification-2026-07.md](packages/patterns/bug3-suggestion-alias-verification-2026-07.md)
-  — verification that the December 2025 survey's Bug 3 (Counter values
-  rendering as raw `$alias` objects when instantiated via `fetchAndRunPattern`)
-  does not reproduce; the dynamically-compiled render path resolves reactive and
-  computed values correctly, July 2026.
-- [reverse-invalidation-deadlock.md](packages/fuse/reverse-invalidation-deadlock.md)
-  — root cause of the FUSE daemon hang that flaked the CLI FUSE integration
-  suite: synchronous reverse invalidation deadlocking the request thread,
-  July 2026.
-- [2026-07-fuse-t-integration-flake-accumulated-nfs-state.md](packages/fuse/2026-07-fuse-t-integration-flake-accumulated-nfs-state.md)
-  — a FUSE-T integration-suite failure that looked like a #4811 daemon
-  regression but was accumulated stale kernel NFS mounts from SIGKILL churn;
-  directory visibility works via mtime plus the NFS attribute-cache bound, not
-  `notify_inval_entry`, July 2026.
-- [settle-wave-2026-03-findings.md](development/debugging/settle-wave-2026-03-findings.md)
-  — March 2026 settle-wave measurements.
-- [2026-07-cf-profile-capture-exit-130.md](development/debugging/2026-07-cf-profile-capture-exit-130.md)
-  — root cause of the cf-profile capture exit-130 CI flake, July 2026.
-- [2026-07-group-chat-idempotency-false-positive.md](development/debugging/2026-07-group-chat-idempotency-false-positive.md)
-  — root cause of the group-chat idempotency false-positive CI flake, July 2026.
-- [default-app-note-create.md](development/performance/default-app-note-create.md),
-  [two-browsers-cold-start.md](development/performance/two-browsers-cold-start.md),
-  and
-  [pattern-integration-compile-bound.md](development/performance/pattern-integration-compile-bound.md)
-  — June 2026 profiling snapshots.
-- [2026-07-pattern-capability-ci-duration-increase.md](development/performance/2026-07-pattern-capability-ci-duration-increase.md)
-  — root cause of the July 2026 labs CI duration increase: two unsharded
-  pattern time-capability sweeps, especially the 56-pattern sweep on shard 3.
-- [2026-07-ci-duration-profile.md](development/performance/2026-07-ci-duration-profile.md)
-  — July 2026 Deno Workflow profile, including compile-cache validation,
-  duplicate work, workspace shard balance, and follow-up experiments.
-- [2026-07-binary-artifact-transfer.md](development/performance/2026-07-binary-artifact-transfer.md)
-  — binary artifact file and byte transfer snapshot before the per-binary
-  workflow split, July 2026.
-- [2026-08-scheduler-liveness-maintenance.md](development/performance/2026-08-scheduler-liveness-maintenance.md)
-  — why deriving demand refcounts from the roots on every change cost a growing
-  list cubic work, and what incremental maintenance measured instead, August
-  2026.
-- [2026-08-read-modify-write-artifact-walk.md](development/performance/2026-08-read-modify-write-artifact-walk.md)
-  — why reading a list, changing one element, and writing it back grew seven
-  times more expensive: the builder-artifact walk on the raw write path read
-  into the query results a read hands out, August 2026.
-- [2026-08-storage-manager-construction-cost.md](development/performance/2026-08-storage-manager-construction-cost.md)
-  — the tenfold step in the immutable-cell storage-manager benchmark traced to
-  an eager default-route resolution in the constructor, why the benchmark
-  times only construction, and why the guard for it counts URL parses rather
-  than comparing values, August 2026.
-- [2026-08-schemaless-read-membership-walk.md](development/performance/2026-08-schemaless-read-membership-walk.md)
-  — why the schemaless whole-array read benchmarks stepped by two to three
-  times: the storage read path re-derived, per read, that what the replica
-  holds is a `FabricValue`, August 2026.
-- [2026-08-immutable-cell-data-uri-mint.md](development/performance/2026-08-immutable-cell-data-uri-mint.md)
-  — the two July 2026 steps in the create-data-URI benchmark: a byte array
-  allocated per mint on the way to the base64url payload, which is fixed, and
-  the canonical `FabricValue` encoding, whose cost is the price of content
-  addressing and stays.
-- [2026-08-subscription-sync-replay-registry.md](development/performance/2026-08-subscription-sync-replay-registry.md)
-  — why registering many selectors on one document got a quarter slower: the
-  replay registry hashed a key on every `sync()` call. Also why the
-  write-vs-commit benchmark alongside it was not a regression at all, and how
-  normalizing by a run median can manufacture a step, August 2026.
-- [2026-08-benchmark-headline-machine-noise.md](development/performance/2026-08-benchmark-headline-machine-noise.md)
-  — why the dashboard's 21% benchmark headline was mostly the host two runs
-  landed on: the runner group serves several machines under one processor name,
-  and neither the artifact nor the tile could tell them apart. August 2026.
-- [2026-08-cell-bench-micro-steps.md](development/performance/2026-08-cell-bench-micro-steps.md)
-  — why the two `cell.bench.ts` steps inside the 21% benchmark headline are not
-  regressions: one stalled runner sample per run, folded into the average the
-  trend read, August 2026.
-- [coverage-ratchet-noise-2026-07-28.md](development/coverage-ratchet-noise-2026-07-28.md)
-  — why a rename-only pull request owed coverage debt: a wall-clock-guarded
-  diagnostic and a shard re-partition each moved the `packages/runner`
-  uncovered-line count with no change to that package, July 2026.
-- [coverage-flake-idempotency-dedup-2026-08-12.md](development/coverage-flake-idempotency-dedup-2026-08-12.md)
-  — which two lines a benchmark-only pull request was charged for, and why the
-  suggestion comment could not name a file: a guard reached only when one
-  action is caught non-idempotent twice in a process, August 2026.
-- [scoped-cells-field-notes.md](development/scoped-cells-field-notes.md) —
-  field journal from the first scoped-cell patterns.
-- [2026-07-02-convergence-evidence-appendix.md](plans/2026-07-02-convergence-evidence-appendix.md)
-  — convergence-investigation evidence.
-- [cellset-lww-context.md](specs/memory-v2/cellset-lww-context.md) — working
-  context for the cellset LWW fix.
-- [scheduler-v2/addenda/00-README.md](specs/scheduler-v2/addenda/00-README.md)
-  — index of the scheduler-v2 performance-investigation addenda, June–July
-  2026.
-- [01-headline-and-node-multiplication.md](specs/scheduler-v2/addenda/01-headline-and-node-multiplication.md)
-  — scheduler-v2 addendum: the headline A/B regression root-caused to node
-  multiplication.
-- [02-multi-runtime-amplification-and-commit-cost.md](specs/scheduler-v2/addenda/02-multi-runtime-amplification-and-commit-cost.md)
-  — scheduler-v2 addendum: multi-runtime commit/push amplification and
-  per-commit cost.
-- [03-transaction-census.md](specs/scheduler-v2/addenda/03-transaction-census.md)
-  — scheduler-v2 addendum: census of what the extra commits are.
-- [04-refuted-free-fixes.md](specs/scheduler-v2/addenda/04-refuted-free-fixes.md)
-  — scheduler-v2 addendum: refuted free fixes (declared reads, asCell
-  read-depth).
-- [05-serialized-scheduler-state-is-reload-only.md](specs/scheduler-v2/addenda/05-serialized-scheduler-state-is-reload-only.md)
-  — scheduler-v2 addendum: serialized scheduler state is reload-only, not a
-  version skip.
-- [06-cross-runtime-adoption-what-would-be-needed.md](specs/scheduler-v2/addenda/06-cross-runtime-adoption-what-would-be-needed.md)
-  — scheduler-v2 addendum: what cross-runtime derivation adoption would need.
-- [07-pull-side-gate-no-go.md](specs/scheduler-v2/addenda/07-pull-side-gate-no-go.md)
-  — scheduler-v2 addendum: the pull-side gate measured as a structural no-go.
-- [08-effect-defer-neutral.md](specs/scheduler-v2/addenda/08-effect-defer-neutral.md)
-  — scheduler-v2 addendum: per-wave effect coalescing measured neutral.
-- [09-remediation-direction.md](specs/scheduler-v2/addenda/09-remediation-direction.md)
-  — scheduler-v2 addendum: remediation direction — coalesce/dedup, not
-  version-skip.
-- [server-side-execution/](specs/server-side-execution/README.md) — the v1
-  server-primary execution learning run (2026-07-07 → 2026-08-02): original
-  design, implementation plan, context-lattice claims, client-passivity
-  design, claim-deletion scoping, and the orchestration log carrying the
-  full lesson record. Superseded by the live
-  [server-primary execution v2 spec](../specs/server-side-execution/README.md).
-- [OPTIMIZATION-JOURNAL.md](packages/runner/test/traverse-replay/OPTIMIZATION-JOURNAL.md)
-  — traverse optimization log.
-- [SCHEMA_INJECTION_NOTES.md](packages/ts-transformers/SCHEMA_INJECTION_NOTES.md),
-  [TEST_PLAN_schema_injection.md](packages/ts-transformers/TEST_PLAN_schema_injection.md),
-  [FALLBACK_POLICY_EXAMPLES.md](packages/ts-transformers/docs/FALLBACK_POLICY_EXAMPLES.md),
-  and
-  [outstanding-questions-for-manager.md](packages/ts-transformers/docs/outstanding-questions-for-manager.md)
-  — schema-injection working notes.
-- [parking-coordinator/summary.md](packages/patterns/factory-outputs/parking-coordinator/summary.md)
-  — factory-run summary.
-- [DRAG-DROP-MULTI-TAB-FIX.md](packages/patterns/record/design/DRAG-DROP-MULTI-TAB-FIX.md)
-  and
-  [EXTRACTION-IMPROVEMENTS.md](packages/patterns/record/design/EXTRACTION-IMPROVEMENTS.md)
-  — record-pattern investigation and improvement notes.
-
-### The retired tutorial site
-
-- [tutorials/](tutorials/index.md) — the complete MyST source of the retired
-  docs.commontools.dev site: nine chapters, example code and images, and the
-  build scaffolding. Its state chapters and LLM tour teach the retired
-  `cell()` API.
+A directory covered that way still needs a way in for a reader, so its entry
+links the document to start from as well.

--- a/docs/history/spikes/dropping-json-serialization.md
+++ b/docs/history/spikes/dropping-json-serialization.md
@@ -1,7 +1,7 @@
 ---
 status: historical
 created: 2026-08-01
-archived: 2026-08-04
+archived: 2026-08-01
 reason: "Research spike: findings from removing `toJSON()` and load-bearing `JSON.stringify` from the runtime."
 ---
 

--- a/docs/history/spikes/dropping-json-serialization.md
+++ b/docs/history/spikes/dropping-json-serialization.md
@@ -1,6 +1,7 @@
 ---
 status: historical
 created: 2026-08-01
+archived: 2026-08-04
 reason: "Research spike: findings from removing `toJSON()` and load-bearing `JSON.stringify` from the runtime."
 ---
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -5,7 +5,7 @@ live documentation: when the behavior a spec describes changes, the spec must
 change in the same commit (see [`../README.md`](../README.md)).
 
 Two kinds of documents graduate out of this tree into
-[`../history/specs/`](../history/README.md):
+[`../history/specs/`](../history/specs/):
 
 - an implementation plan or work order whose work is complete or abandoned;
 - a design document for a change that shipped, where the document describes

--- a/docs/specs/ts-transformer/README.md
+++ b/docs/specs/ts-transformer/README.md
@@ -18,7 +18,7 @@ update when behavior changes.
 | [`cfc_authoring_contract.md`](cfc_authoring_contract.md) | Contract (core implemented) | CFC-aware authoring surface: alias set + lowering rules to `ifc.*`; see its status header for letter-vs-shipped deltas |
 | [`cfc_ui_helper_contract.md`](cfc_ui_helper_contract.md) | Contract (implemented) | UiAction / UiPromptSlot / UiDisclosure JSX rewrite + `ifc.uiContract` hints |
 | [`../schema-generator/ts_to_json_schema_mapping.md`](../schema-generator/ts_to_json_schema_mapping.md) | **Descriptive** | The TypeScript→JSON Schema mapping rules (the other half of the language contract) |
-| [Historical records](../../history/README.md) | Historical | Superseded designs and PR-scoped artifacts; nothing there describes the current system |
+| [Historical records](../../history/INDEX.md) | Historical | Superseded designs and PR-scoped artifacts; nothing there describes the current system |
 
 Related, outside this directory: [JSON Schema](../json_schema.md), the runtime
 schema dialect these schemas target; the `JSONSchema` type in

--- a/tasks/check-docs-history-index.test.ts
+++ b/tasks/check-docs-history-index.test.ts
@@ -1,5 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { dirname, fromFileUrl, join } from "@std/path";
+import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
 import {
   checkIndex,
   checkShape,
@@ -7,7 +9,11 @@ import {
   type HistoryTree,
   readTree,
   report,
+  run,
 } from "./check-docs-history-index.ts";
+
+const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
+const SCRIPT = join(REPO_ROOT, "tasks/check-docs-history-index.ts");
 
 const TITLE = "# Index of historical documents";
 const PROSE = "One line per archived document; the rules are in `README.md`.";
@@ -246,13 +252,14 @@ describe("checkIndex", () => {
 
 describe("report", () => {
   it("states the counts when nothing is wrong", () => {
-    expect(report([], 111, 138)).toEqual([
+    expect(report("docs/history/INDEX.md", [], 111, 138)).toEqual([
       "docs/history/INDEX.md: 111 entries covering 138 documents.",
     ]);
   });
 
   it("gives a line number for a problem that has one, and none otherwise", () => {
     const lines = report(
+      "docs/history/INDEX.md",
       [
         { lineNumber: 7, message: "specs/gone.md does not exist" },
         { message: "docs/history/specs/a.md is missing from the index" },
@@ -266,6 +273,120 @@ describe("report", () => {
       "  docs/history/specs/a.md is missing from the index",
     );
     expect(lines[lines.length - 1]).toContain("README.md");
+  });
+});
+
+describe("run", () => {
+  it("reports a clean tree by its counts", async () => {
+    const root = await Deno.makeTempDir();
+    try {
+      await Deno.mkdir(`${root}/specs`);
+      await Deno.writeTextFile(`${root}/README.md`, "rules");
+      await Deno.writeTextFile(`${root}/specs/a.md`, "an audit");
+      await Deno.writeTextFile(
+        `${root}/INDEX.md`,
+        index(
+          "## Audits and reports",
+          "",
+          "- [a.md](specs/a.md) — an audit, July 2026.",
+        ),
+      );
+
+      const { lines, ok } = await run(root);
+
+      expect(ok).toBe(true);
+      // The report names the index it read, not the repository's own.
+      expect(lines).toEqual([
+        `${root}/INDEX.md: 1 entries covering 1 documents.`,
+      ]);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("reports a document the index leaves out", async () => {
+    const root = await Deno.makeTempDir();
+    try {
+      await Deno.mkdir(`${root}/specs`);
+      await Deno.writeTextFile(`${root}/specs/a.md`, "an audit");
+      await Deno.writeTextFile(`${root}/specs/forgotten.md`, "another");
+      await Deno.writeTextFile(
+        `${root}/INDEX.md`,
+        index(
+          "## Audits and reports",
+          "",
+          "- [a.md](specs/a.md) — an audit, July 2026.",
+        ),
+      );
+
+      const { lines, ok } = await run(root);
+
+      expect(ok).toBe(false);
+      expect(lines[0]).toContain("needs fixing");
+      expect(lines.join("\n")).toContain(
+        "docs/history/specs/forgotten.md is missing from the index",
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+});
+
+describe("the check as CI runs it", () => {
+  it("passes over this repository's own history tree", async () => {
+    // Runs the script the way `deno task` does, so the entry point that CI
+    // depends on — reading the repository's index, printing, choosing an exit
+    // code — is exercised rather than assumed.
+    const output = await runDenoCommandWithTemporaryLock({
+      root: REPO_ROOT,
+      args: (lockPath) => [
+        "run",
+        "--config",
+        join(REPO_ROOT, "deno.jsonc"),
+        "--lock",
+        lockPath,
+        "--allow-read",
+        SCRIPT,
+      ],
+    });
+    const stdout = new TextDecoder().decode(output.stdout);
+    expect(output.code).toBe(0);
+    expect(stdout).toContain("docs/history/INDEX.md:");
+    expect(stdout).toContain("entries covering");
+  });
+
+  it("exits non-zero over a tree whose index is wrong", async () => {
+    // The behavior the gate is: failing. A check that reported a problem and
+    // exited 0 would let every one of these through CI.
+    const root = await Deno.makeTempDir();
+    try {
+      await Deno.writeTextFile(`${root}/forgotten.md`, "an unindexed record");
+      await Deno.writeTextFile(
+        `${root}/INDEX.md`,
+        index("## Audits and reports", "", "- [gone.md](gone.md) — a record."),
+      );
+
+      const output = await runDenoCommandWithTemporaryLock({
+        root: REPO_ROOT,
+        args: (lockPath) => [
+          "run",
+          "--config",
+          join(REPO_ROOT, "deno.jsonc"),
+          "--lock",
+          lockPath,
+          "--allow-read",
+          SCRIPT,
+          root,
+        ],
+      });
+
+      expect(output.code).toBe(1);
+      const stderr = new TextDecoder().decode(output.stderr);
+      expect(stderr).toContain("gone.md does not exist");
+      expect(stderr).toContain("forgotten.md is missing from the index");
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
   });
 });
 

--- a/tasks/check-docs-history-index.test.ts
+++ b/tasks/check-docs-history-index.test.ts
@@ -1,6 +1,13 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { checkShape, coversPath } from "./check-docs-history-index.ts";
+import {
+  checkIndex,
+  checkShape,
+  coversPath,
+  type HistoryTree,
+  readTree,
+  report,
+} from "./check-docs-history-index.ts";
 
 const TITLE = "# Index of historical documents";
 const PROSE = "One line per archived document; the rules are in `README.md`.";
@@ -122,6 +129,150 @@ describe("checkShape", () => {
     ].join("\n"));
     expect(problems.length).toBe(1);
     expect(problems[0].lineNumber).toBe(1);
+  });
+});
+
+const tree = (...documents: string[]): HistoryTree => {
+  const paths = new Set<string>();
+  for (const document of documents) {
+    paths.add(document);
+    const segments = document.split("/");
+    for (let depth = 1; depth < segments.length; depth += 1) {
+      const directory = segments.slice(0, depth).join("/");
+      paths.add(directory);
+      paths.add(`${directory}/`);
+    }
+  }
+  return { documents, paths };
+};
+
+describe("checkIndex", () => {
+  it("passes an index that names every document once", () => {
+    const { problems, entryCount } = checkIndex(
+      index(
+        "## Audits and reports",
+        "",
+        "- [a.md](specs/a.md) — an audit, July 2026.",
+        "- [b.md](plans/b.md) — another audit, August 2026.",
+      ),
+      tree("specs/a.md", "plans/b.md"),
+    );
+    expect(problems).toEqual([]);
+    expect(entryCount).toBe(2);
+  });
+
+  it("reports an entry pointing at a document that is not there", () => {
+    const { problems } = checkIndex(
+      index(
+        "## Audits and reports",
+        "",
+        "- [gone.md](specs/gone.md) — an audit whose document moved.",
+      ),
+      tree("specs/a.md"),
+    );
+    expect(problems.map((problem) => problem.message)).toEqual([
+      "specs/gone.md does not exist",
+      "docs/history/specs/a.md is missing from the index",
+    ]);
+  });
+
+  it("reports a document no entry covers", () => {
+    const { problems } = checkIndex(
+      index(
+        "## Audits and reports",
+        "",
+        "- [a.md](specs/a.md) — an audit, July 2026.",
+      ),
+      tree("specs/a.md", "development/performance/unindexed.md"),
+    );
+    expect(problems.length).toBe(1);
+    expect(problems[0].message).toContain(
+      "docs/history/development/performance/unindexed.md is missing",
+    );
+    expect(problems[0].lineNumber).toBeUndefined();
+  });
+
+  it("lets one entry naming a directory cover the whole subtree", () => {
+    const { problems } = checkIndex(
+      index(
+        "## The retired tutorial site",
+        "",
+        "- [tutorials/](tutorials/) — the retired site, entered at " +
+          "[index.md](tutorials/index.md).",
+      ),
+      tree("tutorials/index.md", "tutorials/state.md", "tutorials/notes.md"),
+    );
+    expect(problems).toEqual([]);
+  });
+
+  it("carries the shape problems through alongside the coverage ones", () => {
+    const { problems } = checkIndex(
+      index(
+        "## Audits and reports",
+        "",
+        "- [a.md](specs/a.md) — an audit that runs long,",
+        "  July 2026.",
+      ),
+      tree("specs/a.md"),
+    );
+    expect(problems.length).toBe(1);
+    expect(problems[0].message).toContain("never wrapped");
+  });
+});
+
+describe("report", () => {
+  it("states the counts when nothing is wrong", () => {
+    expect(report([], 111, 138)).toEqual([
+      "docs/history/INDEX.md: 111 entries covering 138 documents.",
+    ]);
+  });
+
+  it("gives a line number for a problem that has one, and none otherwise", () => {
+    const lines = report(
+      [
+        { lineNumber: 7, message: "specs/gone.md does not exist" },
+        { message: "docs/history/specs/a.md is missing from the index" },
+      ],
+      1,
+      2,
+    );
+    expect(lines[0]).toContain("needs fixing");
+    expect(lines[2]).toBe("  line 7: specs/gone.md does not exist");
+    expect(lines[3]).toBe(
+      "  docs/history/specs/a.md is missing from the index",
+    );
+    expect(lines[lines.length - 1]).toContain("README.md");
+  });
+});
+
+describe("readTree", () => {
+  it("finds every document, and registers each directory both ways", async () => {
+    const root = await Deno.makeTempDir();
+    try {
+      await Deno.mkdir(`${root}/specs/scheduler-v2`, { recursive: true });
+      await Deno.writeTextFile(`${root}/README.md`, "rules");
+      await Deno.writeTextFile(`${root}/INDEX.md`, "index");
+      await Deno.writeTextFile(`${root}/audit.md`, "a");
+      await Deno.writeTextFile(`${root}/specs/a.md`, "b");
+      await Deno.writeTextFile(`${root}/specs/scheduler-v2/PROGRESS.md`, "c");
+      await Deno.writeTextFile(`${root}/specs/diagram.png`, "not markdown");
+
+      const tree = await readTree(root);
+
+      expect(tree.documents).toEqual([
+        "audit.md",
+        "specs/a.md",
+        "specs/scheduler-v2/PROGRESS.md",
+      ]);
+      // A directory entry may be written with or without the trailing slash.
+      expect(tree.paths.has("specs")).toBe(true);
+      expect(tree.paths.has("specs/")).toBe(true);
+      expect(tree.paths.has("specs/scheduler-v2/")).toBe(true);
+      // A non-Markdown file is a valid target but is not itself a document.
+      expect(tree.paths.has("specs/diagram.png")).toBe(true);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
   });
 });
 

--- a/tasks/check-docs-history-index.test.ts
+++ b/tasks/check-docs-history-index.test.ts
@@ -117,6 +117,30 @@ describe("checkShape", () => {
     expect(entries[0].targets).toEqual(["specs/a.md"]);
   });
 
+  it("ignores a link to somewhere off the filesystem", () => {
+    const { problems, entries } = checkShape(index(
+      "## Audits and reports",
+      "",
+      "- [a.md](specs/a.md) — an audit, measured against " +
+        "[the site](https://example.com/thing).",
+    ));
+    expect(problems).toEqual([]);
+    expect(entries[0].targets).toEqual(["specs/a.md"]);
+  });
+
+  it("reports an index with no sections rather than reading it as entries", () => {
+    const { problems, entries } = checkShape([
+      TITLE,
+      "",
+      PROSE,
+      "",
+      "- [a.md](specs/a.md) — an audit filed under no section.",
+    ].join("\n"));
+    expect(problems.length).toBe(1);
+    expect(problems[0].message).toContain("no `## ` section heading");
+    expect(entries).toEqual([]);
+  });
+
   it("requires the title", () => {
     const { problems } = checkShape([
       "# Historical documents",

--- a/tasks/check-docs-history-index.test.ts
+++ b/tasks/check-docs-history-index.test.ts
@@ -1,0 +1,143 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { checkShape, coversPath } from "./check-docs-history-index.ts";
+
+const TITLE = "# Index of historical documents";
+const PROSE = "One line per archived document; the rules are in `README.md`.";
+
+const index = (...body: string[]): string =>
+  [TITLE, "", PROSE, "", ...body].join("\n");
+
+describe("checkShape", () => {
+  it("accepts a title, one line of prose, headings, and one-line entries", () => {
+    const { problems, entries } = checkShape(index(
+      "## Audits and reports",
+      "",
+      "- [a.md](specs/a.md) — an audit, July 2026.",
+      "",
+      "## Executed plans and work orders",
+      "",
+      "- [b.md](plans/b.md) — a plan, August 2026.",
+    ));
+    expect(problems).toEqual([]);
+    expect(entries.map((entry) => entry.targets)).toEqual([
+      ["specs/a.md"],
+      ["plans/b.md"],
+    ]);
+  });
+
+  it("reads every target from an entry that groups several documents", () => {
+    const { problems, entries } = checkShape(index(
+      "## Investigations, journals, and working notes",
+      "",
+      "- [a.md](packages/a.md) and [b.md](packages/b.md) — working notes.",
+    ));
+    expect(problems).toEqual([]);
+    expect(entries[0].targets).toEqual(["packages/a.md", "packages/b.md"]);
+  });
+
+  it("rejects a wrapped entry, which a union merge can splice", () => {
+    // The failure this exists for: two branches each add an entry whose last
+    // line is "  August 2026.", and the union merge keeps that line once.
+    const { problems } = checkShape(index(
+      "## Audits and reports",
+      "",
+      "- [a.md](specs/a.md) — an audit of the thing that was audited,",
+      "  August 2026.",
+    ));
+    expect(problems.length).toBe(1);
+    expect(problems[0].lineNumber).toBe(8);
+    expect(problems[0].message).toContain("never wrapped");
+  });
+
+  it("rejects prose after the first section heading", () => {
+    const { problems } = checkShape(index(
+      "## Audits and reports",
+      "",
+      "Some note about this section.",
+      "",
+      "- [a.md](specs/a.md) — an audit, July 2026.",
+    ));
+    expect(problems.length).toBe(1);
+    expect(problems[0].message).toContain("section heading or an entry");
+  });
+
+  it("rejects a second paragraph in the preamble", () => {
+    const { problems } = checkShape([
+      TITLE,
+      "",
+      PROSE,
+      "",
+      "A second paragraph, which two branches could edit at once.",
+      "",
+      "## Audits and reports",
+      "",
+      "- [a.md](specs/a.md) — an audit, July 2026.",
+    ].join("\n"));
+    expect(problems.length).toBe(1);
+    expect(problems[0].message).toContain("exactly one line of prose");
+  });
+
+  it("reports the same document indexed twice", () => {
+    const { problems } = checkShape(index(
+      "## Audits and reports",
+      "",
+      "- [a.md](specs/a.md) — an audit, July 2026.",
+      "- [a.md](specs/a.md) — an audit, rewritten, July 2026.",
+    ));
+    expect(problems.length).toBe(1);
+    expect(problems[0].lineNumber).toBe(8);
+    expect(problems[0].message).toContain("already indexed on line 7");
+  });
+
+  it("reports an entry that links nothing", () => {
+    const { problems } = checkShape(index(
+      "## Audits and reports",
+      "",
+      "- an audit, July 2026.",
+    ));
+    expect(problems.length).toBe(1);
+    expect(problems[0].message).toContain("links nothing");
+  });
+
+  it("ignores links that leave the tree", () => {
+    const { problems, entries } = checkShape(index(
+      "## Shipped or superseded designs and decision records",
+      "",
+      "- [a.md](specs/a.md) — superseded by the [live spec](../specs/a.md).",
+    ));
+    expect(problems).toEqual([]);
+    expect(entries[0].targets).toEqual(["specs/a.md"]);
+  });
+
+  it("requires the title", () => {
+    const { problems } = checkShape([
+      "# Historical documents",
+      "",
+      PROSE,
+      "",
+      "## Audits and reports",
+      "",
+      "- [a.md](specs/a.md) — an audit, July 2026.",
+    ].join("\n"));
+    expect(problems.length).toBe(1);
+    expect(problems[0].lineNumber).toBe(1);
+  });
+});
+
+describe("coversPath", () => {
+  it("covers the document it names", () => {
+    expect(coversPath("specs/a.md", "specs/a.md")).toBe(true);
+    expect(coversPath("specs/a.md", "specs/b.md")).toBe(false);
+  });
+
+  it("covers a whole subtree when it names a directory", () => {
+    expect(coversPath("tutorials/", "tutorials/index.md")).toBe(true);
+    expect(coversPath("tutorials/", "tutorials/images/notes.md")).toBe(true);
+    expect(coversPath("tutorials/", "plans/a.md")).toBe(false);
+  });
+
+  it("does not let a document name cover its siblings", () => {
+    expect(coversPath("tutorials/index.md", "tutorials/state.md")).toBe(false);
+  });
+});

--- a/tasks/check-docs-history-index.ts
+++ b/tasks/check-docs-history-index.ts
@@ -17,13 +17,13 @@
 // finds. An entry may point at a directory, which covers every document
 // beneath it.
 //
-// Usage: deno run --allow-read ./tasks/check-docs-history-index.ts
+// Usage: deno run --allow-read ./tasks/check-docs-history-index.ts [root]
+// The root defaults to this repository's docs/history.
 
-import { dirname, fromFileUrl, join } from "@std/path";
+import { dirname, fromFileUrl, join, relative, SEPARATOR } from "@std/path";
 
 const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
 const HISTORY_DIR = "docs/history";
-const INDEX_PATH = `${HISTORY_DIR}/INDEX.md`;
 
 /** A link target as written in an entry, and the entry it came from. */
 export interface IndexEntry {
@@ -171,17 +171,18 @@ export function checkIndex(
 
 /** The lines a run prints, so that reporting is decided without printing. */
 export function report(
+  indexPath: string,
   problems: readonly IndexProblem[],
   entryCount: number,
   documentCount: number,
 ): string[] {
   if (problems.length === 0) {
     return [
-      `${INDEX_PATH}: ${entryCount} entries covering ${documentCount} documents.`,
+      `${indexPath}: ${entryCount} entries covering ${documentCount} documents.`,
     ];
   }
   return [
-    `${INDEX_PATH} needs fixing:`,
+    `${indexPath} needs fixing:`,
     "",
     ...problems.map((problem) => {
       const where = problem.lineNumber === undefined
@@ -223,17 +224,25 @@ export async function readTree(root: string): Promise<HistoryTree> {
   return { documents, paths };
 }
 
-async function main() {
-  const text = await Deno.readTextFile(join(REPO_ROOT, INDEX_PATH));
-  const tree = await readTree(join(REPO_ROOT, HISTORY_DIR));
+/** Checks the tree under `root`, whose index is `root/INDEX.md`. */
+export async function run(
+  root: string,
+): Promise<{ lines: string[]; ok: boolean }> {
+  const indexPath = join(root, "INDEX.md");
+  const text = await Deno.readTextFile(indexPath);
+  const tree = await readTree(root);
   const { problems, entryCount } = checkIndex(text, tree);
-  const lines = report(problems, entryCount, tree.documents.length);
-  if (problems.length === 0) {
-    console.log(lines.join("\n"));
-    return;
-  }
-  console.error(lines.join("\n"));
-  Deno.exit(1);
+  const name = indexPath.startsWith(`${REPO_ROOT}${SEPARATOR}`)
+    ? relative(REPO_ROOT, indexPath)
+    : indexPath;
+  return {
+    lines: report(name, problems, entryCount, tree.documents.length),
+    ok: problems.length === 0,
+  };
 }
 
-if (import.meta.main) await main();
+if (import.meta.main) {
+  const { lines, ok } = await run(Deno.args[0] ?? join(REPO_ROOT, HISTORY_DIR));
+  console[ok ? "log" : "error"](lines.join("\n"));
+  if (!ok) Deno.exit(1);
+}

--- a/tasks/check-docs-history-index.ts
+++ b/tasks/check-docs-history-index.ts
@@ -19,7 +19,7 @@
 //
 // Usage: deno run --allow-read ./tasks/check-docs-history-index.ts
 
-import { dirname, fromFileUrl, join, relative } from "@std/path";
+import { dirname, fromFileUrl, join } from "@std/path";
 
 const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
 const HISTORY_DIR = "docs/history";
@@ -136,75 +136,103 @@ export function coversPath(target: string, documentPath: string): boolean {
   return target === documentPath;
 }
 
-async function markdownFilesUnder(directory: string): Promise<string[]> {
-  const found: string[] = [];
-  for await (const entry of Deno.readDir(join(REPO_ROOT, directory))) {
-    const path = `${directory}/${entry.name}`;
-    if (entry.isDirectory) {
-      found.push(...await markdownFilesUnder(path));
-    } else if (entry.name.endsWith(".md")) {
-      found.push(path);
-    }
-  }
-  return found;
+/** The tree the index describes, as paths relative to docs/history/. */
+export interface HistoryTree {
+  /** Every archived document, excluding README.md and INDEX.md. */
+  readonly documents: readonly string[];
+  /** Every path an entry may point at: those documents and every directory. */
+  readonly paths: ReadonlySet<string>;
 }
 
-async function exists(path: string): Promise<boolean> {
-  try {
-    await Deno.stat(join(REPO_ROOT, path));
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function main() {
-  const text = await Deno.readTextFile(join(REPO_ROOT, INDEX_PATH));
+/** Everything wrong with an index, given the tree it is supposed to describe. */
+export function checkIndex(
+  text: string,
+  tree: HistoryTree,
+): { problems: IndexProblem[]; entryCount: number } {
   const { problems, entries } = checkShape(text);
-
   const targets = entries.flatMap((entry) =>
     entry.targets.map((target) => ({ target, lineNumber: entry.lineNumber }))
   );
+
   for (const { target, lineNumber } of targets) {
-    if (await exists(`${HISTORY_DIR}/${target}`)) continue;
-    problems.push({
-      lineNumber,
-      message: `${target} does not exist`,
-    });
+    if (tree.paths.has(target)) continue;
+    problems.push({ lineNumber, message: `${target} does not exist` });
   }
 
-  const documents = (await markdownFilesUnder(HISTORY_DIR))
-    .map((path) => relative(HISTORY_DIR, path))
-    .filter((path) => path !== "README.md" && path !== "INDEX.md")
-    .sort();
-  const unindexed = documents.filter((document) =>
-    !targets.some(({ target }) => coversPath(target, document))
-  );
-  for (const document of unindexed) {
+  for (const document of tree.documents) {
+    if (targets.some(({ target }) => coversPath(target, document))) continue;
     problems.push({
       message: `${HISTORY_DIR}/${document} is missing from the index`,
     });
   }
 
+  return { problems, entryCount: entries.length };
+}
+
+/** The lines a run prints, so that reporting is decided without printing. */
+export function report(
+  problems: readonly IndexProblem[],
+  entryCount: number,
+  documentCount: number,
+): string[] {
   if (problems.length === 0) {
-    console.log(
-      `${INDEX_PATH}: ${entries.length} entries covering ` +
-        `${documents.length} documents.`,
-    );
+    return [
+      `${INDEX_PATH}: ${entryCount} entries covering ${documentCount} documents.`,
+    ];
+  }
+  return [
+    `${INDEX_PATH} needs fixing:`,
+    "",
+    ...problems.map((problem) => {
+      const where = problem.lineNumber === undefined
+        ? ""
+        : `line ${problem.lineNumber}: `;
+      return `  ${where}${problem.message}`;
+    }),
+    "",
+    `The rules, and why they are what they are, are in ` +
+    `${HISTORY_DIR}/README.md under "Index".`,
+  ];
+}
+
+/** Reads the tree under an absolute root into the shape `checkIndex` takes. */
+export async function readTree(root: string): Promise<HistoryTree> {
+  const documents: string[] = [];
+  const paths = new Set<string>();
+  const walk = async (relativeDirectory: string): Promise<void> => {
+    const absolute = join(root, relativeDirectory);
+    for await (const entry of Deno.readDir(absolute)) {
+      const path = relativeDirectory === ""
+        ? entry.name
+        : `${relativeDirectory}/${entry.name}`;
+      if (entry.isDirectory) {
+        // Trailing slash included and omitted: an entry may write either.
+        paths.add(path);
+        paths.add(`${path}/`);
+        await walk(path);
+        continue;
+      }
+      paths.add(path);
+      if (!entry.name.endsWith(".md")) continue;
+      if (path === "README.md" || path === "INDEX.md") continue;
+      documents.push(path);
+    }
+  };
+  await walk("");
+  documents.sort();
+  return { documents, paths };
+}
+
+async function main() {
+  const text = await Deno.readTextFile(join(REPO_ROOT, INDEX_PATH));
+  const tree = await readTree(join(REPO_ROOT, HISTORY_DIR));
+  const { problems, entryCount } = checkIndex(text, tree);
+  const lines = report(problems, entryCount, tree.documents.length);
+  if (problems.length === 0) {
+    console.log(lines.join("\n"));
     return;
   }
-
-  console.error(`${INDEX_PATH} needs fixing:\n`);
-  for (const problem of problems) {
-    const where = problem.lineNumber === undefined
-      ? ""
-      : `line ${problem.lineNumber}: `;
-    console.error(`  ${where}${problem.message}`);
-  }
-  console.error(
-    `\nThe rules, and why they are what they are, are in ` +
-      `${HISTORY_DIR}/README.md under "Index".`,
-  );
+  console.error(lines.join("\n"));
   Deno.exit(1);
 }
 

--- a/tasks/check-docs-history-index.ts
+++ b/tasks/check-docs-history-index.ts
@@ -1,0 +1,211 @@
+#!/usr/bin/env -S deno run --allow-read
+//
+// Checks the shape and the coverage of docs/history/INDEX.md.
+//
+// That file is merged with git's `union` driver (see .gitattributes), so two
+// branches that each archive a document combine without a conflict. The driver
+// works a line at a time, which is what the shape rules protect: every entry
+// occupies exactly one line, and the only prose is a single line above the
+// first section heading. A line therefore belongs to exactly one entry, to one
+// of the headings, or to that one prose line, and a union merge can neither
+// splice two entries together nor keep two versions of a paragraph.
+//
+// Nothing else enforces this. `deno fmt` skips docs/, and a wrapped entry
+// looks right until the day two branches archive documents at once.
+//
+// Coverage is the other half: a document nobody indexed is a document nobody
+// finds. An entry may point at a directory, which covers every document
+// beneath it.
+//
+// Usage: deno run --allow-read ./tasks/check-docs-history-index.ts
+
+import { dirname, fromFileUrl, join, relative } from "@std/path";
+
+const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
+const HISTORY_DIR = "docs/history";
+const INDEX_PATH = `${HISTORY_DIR}/INDEX.md`;
+
+/** A link target as written in an entry, and the entry it came from. */
+export interface IndexEntry {
+  /** 1-based line number in the index. */
+  readonly lineNumber: number;
+  /** Link targets on that line, relative to docs/history/. */
+  readonly targets: readonly string[];
+}
+
+export interface IndexProblem {
+  readonly lineNumber?: number;
+  readonly message: string;
+}
+
+const LINK = /\[[^\]]*\]\(([^)\s]+)\)/g;
+
+/** Link targets inside docs/history/, with any fragment dropped. */
+const targetsOf = (line: string): string[] => {
+  const targets: string[] = [];
+  for (const match of line.matchAll(LINK)) {
+    const target = match[1].split("#")[0];
+    if (target === "" || /^[a-z]+:/.test(target)) continue;
+    if (target.startsWith("../")) continue;
+    targets.push(target);
+  }
+  return targets;
+};
+
+/**
+ * The shape rules. Line 1 is the title, line 3 is the one prose line, and
+ * everything past the first section heading is a heading, an entry, or blank.
+ */
+export function checkShape(
+  text: string,
+): { problems: IndexProblem[]; entries: IndexEntry[] } {
+  const problems: IndexProblem[] = [];
+  const entries: IndexEntry[] = [];
+  const lines = text.split("\n");
+
+  if (lines[0] !== "# Index of historical documents") {
+    problems.push({
+      lineNumber: 1,
+      message: "the first line must be `# Index of historical documents`",
+    });
+  }
+
+  const firstSection = lines.findIndex((line) => line.startsWith("## "));
+  if (firstSection === -1) {
+    problems.push({ message: "the index has no `## ` section heading" });
+    return { problems, entries };
+  }
+
+  const preamble = lines.slice(1, firstSection).filter((line) =>
+    line.trim() !== ""
+  );
+  if (preamble.length !== 1) {
+    problems.push({
+      lineNumber: 2,
+      message:
+        `expected exactly one line of prose between the title and the first ` +
+        `section heading, found ${preamble.length}. Prose here cannot be ` +
+        `merged safely; put it in ${HISTORY_DIR}/README.md instead`,
+    });
+  }
+
+  for (let index = firstSection; index < lines.length; index += 1) {
+    const line = lines[index];
+    const lineNumber = index + 1;
+    if (line.trim() === "" || line.startsWith("## ")) continue;
+    if (!line.startsWith("- ")) {
+      problems.push({
+        lineNumber,
+        message: line.startsWith(" ")
+          ? "an entry is one line, never wrapped; join this onto the entry above"
+          : "expected a section heading or an entry starting with `- `",
+      });
+      continue;
+    }
+    const targets = targetsOf(line);
+    if (targets.length === 0) {
+      problems.push({ lineNumber, message: "this entry links nothing" });
+      continue;
+    }
+    entries.push({ lineNumber, targets });
+  }
+
+  const seen = new Map<string, number>();
+  for (const entry of entries) {
+    for (const target of entry.targets) {
+      const first = seen.get(target);
+      if (first === undefined) {
+        seen.set(target, entry.lineNumber);
+        continue;
+      }
+      problems.push({
+        lineNumber: entry.lineNumber,
+        message: `${target} is already indexed on line ${first}. A union ` +
+          `merge keeps both sides of an entry two branches each rewrote; ` +
+          `delete whichever line is stale`,
+      });
+    }
+  }
+
+  return { problems, entries };
+}
+
+/** Documents an entry covers: itself, or everything under it if a directory. */
+export function coversPath(target: string, documentPath: string): boolean {
+  if (target.endsWith("/")) return documentPath.startsWith(target);
+  return target === documentPath;
+}
+
+async function markdownFilesUnder(directory: string): Promise<string[]> {
+  const found: string[] = [];
+  for await (const entry of Deno.readDir(join(REPO_ROOT, directory))) {
+    const path = `${directory}/${entry.name}`;
+    if (entry.isDirectory) {
+      found.push(...await markdownFilesUnder(path));
+    } else if (entry.name.endsWith(".md")) {
+      found.push(path);
+    }
+  }
+  return found;
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(join(REPO_ROOT, path));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  const text = await Deno.readTextFile(join(REPO_ROOT, INDEX_PATH));
+  const { problems, entries } = checkShape(text);
+
+  const targets = entries.flatMap((entry) =>
+    entry.targets.map((target) => ({ target, lineNumber: entry.lineNumber }))
+  );
+  for (const { target, lineNumber } of targets) {
+    if (await exists(`${HISTORY_DIR}/${target}`)) continue;
+    problems.push({
+      lineNumber,
+      message: `${target} does not exist`,
+    });
+  }
+
+  const documents = (await markdownFilesUnder(HISTORY_DIR))
+    .map((path) => relative(HISTORY_DIR, path))
+    .filter((path) => path !== "README.md" && path !== "INDEX.md")
+    .sort();
+  const unindexed = documents.filter((document) =>
+    !targets.some(({ target }) => coversPath(target, document))
+  );
+  for (const document of unindexed) {
+    problems.push({
+      message: `${HISTORY_DIR}/${document} is missing from the index`,
+    });
+  }
+
+  if (problems.length === 0) {
+    console.log(
+      `${INDEX_PATH}: ${entries.length} entries covering ` +
+        `${documents.length} documents.`,
+    );
+    return;
+  }
+
+  console.error(`${INDEX_PATH} needs fixing:\n`);
+  for (const problem of problems) {
+    const where = problem.lineNumber === undefined
+      ? ""
+      : `line ${problem.lineNumber}: `;
+    console.error(`  ${where}${problem.message}`);
+  }
+  console.error(
+    `\nThe rules, and why they are what they are, are in ` +
+      `${HISTORY_DIR}/README.md under "Index".`,
+  );
+  Deno.exit(1);
+}
+
+if (import.meta.main) await main();


### PR DESCRIPTION
Every branch that archives a document, or writes a report or a post-mortem into docs/history/, adds a line to the index that used to live in docs/history/README.md. Branches doing that at the same time land their lines at the same place in the same file, so one of them hits a merge conflict on the way in. Over the last month that file was touched by 44 commits, almost all of them adding two to five lines, and the conflicts are routine rather than exceptional.

Git can combine concurrent additions to a file by itself. Its built-in `union` merge driver takes both sides of a conflicting region instead of stopping, which is exactly right for a list that only ever grows. It needs no per-clone configuration, unlike a named custom driver, which matters here because a named driver that nobody configured is silently inert.

The driver works one line at a time, and that is the constraint the rest of this change is built around. Two failures follow from it. A wrapped entry can lose one of its lines to an identically worded line in another entry: two entries that both end "  August 2026." merge into one entry carrying the other's date. And a paragraph that two branches both edit is kept twice, once in each version. Both were reproduced against the file as it stood before deciding on this shape.

So the index moves to docs/history/INDEX.md, which carries the union merge attribute, and takes a shape that puts both failures out of reach. An entry is one line however long it runs, so a line belongs to exactly one entry. The file holds nothing but a title, one line of prose, the section headings, and the entries, so there is no paragraph to keep two versions of. The 104 existing entries are unwrapped, not rewritten. README.md keeps the rules and gains the reasoning for these two, since neither is guessable from looking at the file.

Nothing else enforces a shape like that: `deno fmt` skips docs/, and a wrapped entry looks right until the day two branches archive at once. The new `deno task check-docs-history-index` gate enforces it, and reports the residue the driver can leave behind — the same document indexed twice, which is what a union merge produces when two branches each rewrite one entry. It also names any document in the tree that no entry covers.

That last check found seven documents nobody had indexed: three performance investigations, two FUSE-T verification records, an executed plan, and a research spike. They get entries here. An entry may point at a directory, covering everything beneath it, which is how the retired tutorial site and the server-primary execution learning run are each carried by one line. While adding the spike's entry, its metadata header turned out to be missing the required `archived` key, which is filled in from the commit that added it.

The workflow step that runs the gate takes the marker emoji the other checks in that job take. A step is sorted into a phase by that marker, and one that appears neither in the documented vocabulary nor in PHASE_MARKERS in scripts/ci-gantt.ts is charted as "other", which is how a step's time disappears from the timings people use to decide what to optimize.

Moving the index also leaves four links aimed at the rules when what the reader wants is the list of records. The docs map and the historical- documentation section both describe the tree, so each now names the index alongside the rules. The ts-transformer spec corpus has a table row labeled "Historical records", which is a promise to show the records. The specs README says documents graduate into `../history/specs/` and linked the rules instead of that directory; it links the directory the sentence names. The remaining references stay pointed at the rules, being about what may be edited in that tree, the metadata header, or the archiving procedure.

Two branches archiving a document at once now rebase cleanly and keep both entries. The same pair of commits against the previous format conflicts.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

ACCEPT_COVERAGE_DEBT: coverage-debt: tasks uncovered lines = 1302 lines