### PR TITLE
test(patterns): wait on events, not sleeps, in the chatbot test

### DIFF
--- a/packages/patterns/integration/chatbot.test.ts
+++ b/packages/patterns/integration/chatbot.test.ts
@@ -1,6 +1,10 @@
-import { env, waitForCondition } from "@commonfabric/integration";
-import { sleep } from "@commonfabric/utils/sleep";
+import {
+  awaitViewSettled,
+  env,
+  waitForCondition,
+} from "@commonfabric/integration";
 import { ShellIntegration } from "@commonfabric/integration/shell-utils";
+import { waitForDisabled } from "./cfc-browser-helpers.ts";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
 import { assert, assertEquals } from "@std/assert";
@@ -109,8 +113,9 @@ describe("Chat pattern test", () => {
       const testMessage = "Hello, how are you?";
       await inputElement.type(testMessage);
 
-      // Wait a bit for UI to process the input
-      await sleep(100);
+      // The send button stays disabled until the typed value reaches the
+      // prompt's state; wait for it to enable before clicking.
+      await waitForDisabled(page, "#cf-prompt-input-send-button", false);
 
       // Click the send button by ID
       const sendButton = await page.waitForSelector(
@@ -189,8 +194,8 @@ describe("Chat pattern test", () => {
     fn: async () => {
       const page = shell.page();
 
-      // Wait for system to settle
-      await sleep(200);
+      // Wait for the view to settle after the previous turn.
+      await awaitViewSettled(page);
 
       // Ask a second question - need to refocus the input first
       const inputElement = await page.waitForSelector("input", {
@@ -207,8 +212,9 @@ describe("Chat pattern test", () => {
       const secondMessage = "What is the capital of France?";
       await inputElement.type(secondMessage);
 
-      // Wait a bit for UI to process the input
-      await sleep(100);
+      // The send button stays disabled until the typed value reaches the
+      // prompt's state; wait for it to enable before clicking.
+      await waitForDisabled(page, "#cf-prompt-input-send-button", false);
 
       // Click the send button by ID
       const sendButton = await page.waitForSelector(
@@ -219,9 +225,6 @@ describe("Chat pattern test", () => {
       );
       assert(sendButton, "Should find send button");
       await sendButton.click();
-
-      // Wait for UI to update
-      await sleep(200);
 
       // Wait for new assistant response - at least 4 messages total
       await waitForCondition(


### PR DESCRIPTION
The chatbot integration test paced four steps with fixed `sleep()` calls. Each fixed wait is both a floor on how long the step takes and a ceiling on how long the work is allowed to take: a machine slower than the delay proceeds before the UI is ready, and a fast machine still pays the full delay. Replace all four with waits that resolve on the event each one was standing in for.

Two `sleep(100)` calls sat between typing a message and clicking the send button, to "let the UI process the input". The send button is a cf-button whose disabled state is derived from the prompt component's own `value`, which the textarea's input handler sets locally; while it is disabled the button suppresses clicks in the capture phase, so a click dispatched before the typed text lands is dropped and no message is sent. Wait on that exact transition with `waitForDisabled(page, "#cf-prompt-input-send-button", false)`, which resolves once the button is enabled and clickable.

One `sleep(200)` labelled "wait for system to settle" is the reactive settle it describes; replace it with `awaitViewSettled(page)`, which resolves once the worker has settled, the vdom batch has been applied, and Lit has finished its update cycle.

The last `sleep(200)` sat immediately before a `waitForCondition` that already waits for the chat-message count to reach four. The condition is the real wait, so the delay in front of it was redundant; drop it.

No new sleep, timeout, or retry loop is introduced. Removing the last `sleep` import leaves the file importing only what it uses.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

