### PR TITLE
fix(runner): ignore values a schema cannot be when walking one

### DIFF
--- a/packages/runner/src/cfc/schema-refs.ts
+++ b/packages/runner/src/cfc/schema-refs.ts
@@ -6,6 +6,7 @@ import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import {
   forEachSubschema,
+  isSubschema,
   mapSubschemas,
   type SchemaWalkOptions,
 } from "../schema-walk.ts";
@@ -132,7 +133,7 @@ const localDefinitionNamesInScope = (
 ): Set<string> => {
   const names = new Set(Object.keys(definitions));
   const collect = (fragment: JSONSchema): void => {
-    if (typeof fragment === "boolean") return;
+    if (!isRecord(fragment)) return;
     if (typeof fragment.$ref === "string") {
       const name = localDefinitionName(fragment.$ref);
       if (name !== undefined) names.add(name);
@@ -180,7 +181,7 @@ const namespaceLocalDefinitionScope = (
   }
 
   const rewrite = (fragment: JSONSchema): JSONSchema => {
-    if (typeof fragment === "boolean") return fragment;
+    if (!isRecord(fragment)) return fragment;
     let result = fragment;
     if (typeof fragment.$ref === "string") {
       const name = localDefinitionName(fragment.$ref);
@@ -217,7 +218,7 @@ const addRefs = (target: Set<string>, source: ReadonlySet<string>): void => {
 };
 
 const summarizeCfcSchemaRefs = (schema: JSONSchema): SchemaRefSummary => {
-  if (typeof schema === "boolean") return EMPTY_REF_SUMMARY;
+  if (!isRecord(schema)) return EMPTY_REF_SUMMARY;
   const cached = schemaRefSummaryCache.get(schema);
   if (cached !== undefined) return cached;
 
@@ -310,8 +311,10 @@ export const selectReferencedCfcSchemaDefs = (
   schema: JSONSchema,
   inheritedDefinitions?: SchemaDefinitions,
 ): SchemaDefinitions | undefined => {
-  if (typeof schema === "boolean") return undefined;
-  const definitions = schema.$defs ?? inheritedDefinitions;
+  if (!isRecord(schema)) return undefined;
+  const definitions = isRecord(schema.$defs)
+    ? schema.$defs
+    : inheritedDefinitions;
   if (definitions === undefined) return undefined;
 
   const initial = summarizeCfcSchemaRefs(schema).localDefinitions;
@@ -360,7 +363,9 @@ const pruneCfcSchemaDefinitionsInternal = (
   schema: JSONSchema,
   preserveScopeBoundary: boolean,
 ): JSONSchema => {
-  if (typeof schema === "boolean") return schema;
+  // A boolean schema, and anything a schema cannot be, has no definitions to
+  // prune and is returned as it arrived.
+  if (!isRecord(schema)) return schema;
   const cacheable = isDeepFrozen(schema);
   const cache = preserveScopeBoundary
     ? prunedScopedSchemaCache
@@ -375,7 +380,9 @@ const pruneCfcSchemaDefinitionsInternal = (
     (child) => pruneCfcSchemaDefinitionsInternal(child, true),
     ALL_SUBSCHEMAS,
   );
-  if (schema.$defs !== undefined) {
+  // Only a `$defs` that is a definition map is pruned, the same test
+  // `cfcSchemaChildRoot` uses to decide whether one opens a definition scope.
+  if (isRecord(schema.$defs)) {
     const selected = selectReferencedCfcSchemaDefs(schema);
     let definitions = selected ??
       (preserveScopeBoundary ? EMPTY_DEFINITIONS : undefined);
@@ -497,6 +504,16 @@ const resolveCfcSchemaRefUncached = (
       return undefined;
     }
     schemaCursor = schemaCursor[pathToDef[i]];
+  }
+  if (!isSubschema(schemaCursor)) {
+    // A definition holding something a schema cannot be resolves no better than
+    // a name the document does not carry.
+    logger.warn("cfc", () => [
+      "Non-schema target for $ref in schema: ",
+      schemaRef,
+      fullSchema,
+    ]);
+    return undefined;
   }
   if (isRecord(schemaCursor)) {
     const schemaRefs = new Set<string>();

--- a/packages/runner/src/schema-walk.ts
+++ b/packages/runner/src/schema-walk.ts
@@ -28,10 +28,26 @@
  *
  * `$ref` resolution is opt-in per walk (see `SchemaWalkOptions.resolveRef`):
  * following a ref needs a definition scope, which is caller/runtime specific.
+ *
+ * ## Values that are not schemas
+ *
+ * A schema reaching the runtime has not necessarily come from the schema
+ * generator — it may have been written into a space by anything — so a keyword
+ * here can hold a value that is not a schema at all, and a keyword taking
+ * several subschemas can hold something that is not an array or an object. Such
+ * a value has no subschemas and cannot be rewritten into one, so the walk treats
+ * the edge as leading nowhere: the value is not visited, not descended into, and
+ * not rewritten, and it stays in place in a mapped result. Each one is reported
+ * once per walk that reaches it, at warn level, naming the keyword, the value,
+ * and the schema holding it.
  */
 
 import type { JSONSchema, JSONSchemaObj } from "@commonfabric/api";
 import { isRecord } from "@commonfabric/utils/types";
+import { getLogger } from "@commonfabric/utils/logger";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+
+const logger = getLogger("schema-walk", { level: "warn" });
 
 // The supported subschema-bearing keywords, grouped by how each keyword holds
 // its subschema(s). See the module docstring for the keywords we deliberately
@@ -88,6 +104,16 @@ export type SubschemaKeyword =
   | (typeof DEFS_KEYS)[number]
   | (typeof UNUSED_SINGLE_SUBSCHEMA_KEYS)[number]
   | (typeof UNUSED_RECORD_SUBSCHEMA_KEYS)[number];
+
+/**
+ * Everything a schema can be: `true`, `false`, or an object. `null`, a string
+ * and a number are the values a stored schema document has been seen to hold
+ * where a subschema belongs; see the module docstring for how the walk treats
+ * one. An array satisfies this, as it does every object test in this module.
+ */
+export function isSubschema(value: unknown): value is JSONSchema {
+  return typeof value === "boolean" || isRecord(value);
+}
 
 export interface SchemaWalkOptions {
   /** Also descend into `$defs` bodies. Default false. */
@@ -158,6 +184,63 @@ const recordKeywordsFor = (
   return keys;
 };
 
+/** Report a keyword holding `found` where `expected` belongs. */
+const warnNotSchema = (
+  expected: string,
+  keyword: SubschemaKeyword,
+  key: string | number | undefined,
+  found: unknown,
+  parent: JSONSchema,
+): void => {
+  logger.warn("non-schema", () => [
+    `Ignoring \`${key === undefined ? keyword : `${keyword}/${key}`}\`:`,
+    `expected ${expected}, found`,
+    toCompactDebugString(found, 120),
+    "in schema",
+    toCompactDebugString(parent, 500),
+  ]);
+};
+
+/** Whether a subschema position holds a subschema, reporting it when not. */
+const holdsSubschema = (
+  value: unknown,
+  keyword: SubschemaKeyword,
+  key: string | number | undefined,
+  parent: JSONSchema,
+): value is JSONSchema => {
+  if (isSubschema(value)) return true;
+  warnNotSchema("a schema", keyword, key, value, parent);
+  return false;
+};
+
+/** Whether an array-valued keyword holds an array, reporting it when not. */
+const holdsSubschemaArray = (
+  value: unknown,
+  keyword: SubschemaKeyword,
+  parent: JSONSchema,
+): value is readonly JSONSchema[] => {
+  if (Array.isArray(value)) return true;
+  warnNotSchema("an array of schemas", keyword, undefined, value, parent);
+  return false;
+};
+
+/** Whether a record-valued keyword holds an object, reporting it when not. */
+const holdsSubschemaRecord = (
+  value: unknown,
+  keyword: SubschemaKeyword,
+  parent: JSONSchema,
+): value is Readonly<Record<string, unknown>> => {
+  if (isRecord(value)) return true;
+  warnNotSchema(
+    "an object of named schemas",
+    keyword,
+    undefined,
+    value,
+    parent,
+  );
+  return false;
+};
+
 /**
  * Invoke `visit` on each immediate subschema of `schema` (shallow — one level).
  * A boolean schema has no subschemas. `$defs` is visited only when
@@ -178,33 +261,28 @@ export function forEachSubschema(
   const node = schema as JSONSchemaObj;
   for (const keyword of singleKeywordsFor(opts)) {
     const child = node[keyword];
-    if (child !== undefined && visit(child, keyword, undefined, undefined)) {
-      return true;
-    }
+    if (child === undefined) continue;
+    if (!holdsSubschema(child, keyword, undefined, node)) continue;
+    if (visit(child, keyword, undefined, undefined)) return true;
   }
   for (const keyword of ARRAY_SUBSCHEMA_KEYS) {
     const arr = node[keyword];
-    if (Array.isArray(arr)) {
-      for (let index = 0; index < arr.length; index++) {
-        if (visit(arr[index], keyword, undefined, index)) return true;
-      }
+    if (arr === undefined) continue;
+    if (!holdsSubschemaArray(arr, keyword, node)) continue;
+    for (let index = 0; index < arr.length; index++) {
+      const child = arr[index];
+      if (!holdsSubschema(child, keyword, index, node)) continue;
+      if (visit(child, keyword, undefined, index)) return true;
     }
   }
   for (const keyword of recordKeywordsFor(opts)) {
     const record = node[keyword];
-    if (isRecord(record)) {
-      for (const key of Object.keys(record)) {
-        if (
-          visit(
-            (record as Record<string, JSONSchema>)[key],
-            keyword,
-            key,
-            undefined,
-          )
-        ) {
-          return true;
-        }
-      }
+    if (record === undefined) continue;
+    if (!holdsSubschemaRecord(record, keyword, node)) continue;
+    for (const key of Object.keys(record)) {
+      const child = record[key];
+      if (!holdsSubschema(child, keyword, key, node)) continue;
+      if (visit(child, keyword, key, undefined)) return true;
     }
   }
   return false;
@@ -243,22 +321,27 @@ export function* subschemaEdges(
   const node = schema as JSONSchemaObj;
   for (const keyword of singleKeywordsFor(opts)) {
     const child = node[keyword];
-    if (child !== undefined) yield { schema: child, keyword };
+    if (child === undefined) continue;
+    if (!holdsSubschema(child, keyword, undefined, node)) continue;
+    yield { schema: child, keyword };
   }
   for (const keyword of ARRAY_SUBSCHEMA_KEYS) {
     const arr = node[keyword];
-    if (Array.isArray(arr)) {
-      for (let index = 0; index < arr.length; index++) {
-        yield { schema: arr[index], keyword, index };
-      }
+    if (arr === undefined) continue;
+    if (!holdsSubschemaArray(arr, keyword, node)) continue;
+    for (let index = 0; index < arr.length; index++) {
+      const child = arr[index];
+      if (!holdsSubschema(child, keyword, index, node)) continue;
+      yield { schema: child, keyword, index };
     }
   }
   for (const keyword of recordKeywordsFor(opts)) {
     const record = node[keyword];
-    if (isRecord(record)) {
-      for (const [key, child] of Object.entries(record)) {
-        yield { schema: child as JSONSchema, keyword, key };
-      }
+    if (record === undefined) continue;
+    if (!holdsSubschemaRecord(record, keyword, node)) continue;
+    for (const [key, child] of Object.entries(record)) {
+      if (!holdsSubschema(child, keyword, key, node)) continue;
+      yield { schema: child, keyword, key };
     }
   }
 }
@@ -284,15 +367,18 @@ export function mapSubschemas(
   for (const keyword of singleKeywordsFor(opts)) {
     const child = schema[keyword];
     if (child === undefined) continue;
+    if (!holdsSubschema(child, keyword, undefined, schema)) continue;
     const mapped = map(child);
     if (mapped !== child) update(keyword, mapped);
   }
   for (const keyword of ARRAY_SUBSCHEMA_KEYS) {
     const children = schema[keyword];
     if (children === undefined) continue;
+    if (!holdsSubschemaArray(children, keyword, schema)) continue;
     let mapped: JSONSchema[] | undefined;
     for (let index = 0; index < children.length; index++) {
       const child = children[index];
+      if (!holdsSubschema(child, keyword, index, schema)) continue;
       const next = map(child);
       if (next !== child) {
         mapped ??= [...children];
@@ -304,13 +390,15 @@ export function mapSubschemas(
   for (const keyword of recordKeywordsFor(opts)) {
     const children = schema[keyword];
     if (children === undefined) continue;
+    if (!holdsSubschemaRecord(children, keyword, schema)) continue;
     const entries = Object.entries(children);
-    let mapped: [string, JSONSchema][] | undefined;
+    let mapped: [string, unknown][] | undefined;
     for (let index = 0; index < entries.length; index++) {
       const [name, child] = entries[index];
-      const next = map(child as JSONSchema);
+      if (!holdsSubschema(child, keyword, name, schema)) continue;
+      const next = map(child);
       if (next !== child) {
-        mapped ??= entries as [string, JSONSchema][];
+        mapped ??= entries;
         mapped[index] = [name, next];
       }
     }
@@ -386,6 +474,9 @@ export function walkSchema(
     parent: JSONSchemaObj | undefined,
   ): void => {
     if (stopped) return;
+    // The root and a `resolveRef` result come straight from the caller; every
+    // other node arrives already filtered by `forEachSubschema`.
+    if (!isSubschema(schema)) return;
     const record = isRecord(schema);
     if (!record && !opts.visitBooleans) return;
     const control = visit({ schema, path, ...edge, parent });

--- a/packages/runner/src/schema-walk.ts
+++ b/packages/runner/src/schema-walk.ts
@@ -229,10 +229,12 @@ const holdsSubschemaArray = (
 /**
  * Whether a record-valued keyword holds an object, reporting it when not.
  *
- * An array counts, unlike in a subschema position: validation enumerates these
- * keywords with `Object.entries` and asks `Object.hasOwn`, both of which read
- * an array's indices as names, so a walk that answered "no subschemas here"
- * would answer for keys the validation does read.
+ * An array counts, unlike in a subschema position. `validateSchemaDefinition`
+ * refuses one here, but that gate gets its say over an authored schema, not
+ * over a stored one, and the validator that reads values enumerates these
+ * keywords with `Object.entries` and asks `Object.hasOwn` — both of which read
+ * an array's indices as names. A walk answering "no subschemas here" would be
+ * answering for keys a read goes on to use.
  */
 const holdsSubschemaRecord = (
   value: unknown,

--- a/packages/runner/src/schema-walk.ts
+++ b/packages/runner/src/schema-walk.ts
@@ -33,13 +33,13 @@
  *
  * A schema reaching the runtime has not necessarily come from the schema
  * generator — it may have been written into a space by anything — so a keyword
- * here can hold a value that is not a schema at all, and a keyword taking
- * several subschemas can hold something that is not an array or an object. Such
- * a value has no subschemas and cannot be rewritten into one, so the walk treats
- * the edge as leading nowhere: the value is not visited, not descended into, and
- * not rewritten, and it stays in place in a mapped result. Each one is reported
- * once per walk that reaches it, at warn level, naming the keyword, the value,
- * and the schema holding it.
+ * here can hold a value that is not a schema at all (see {@link isSubschema}),
+ * and a keyword taking several subschemas can hold something that is not the
+ * array or the object it needs. Such a value has no subschemas and cannot be
+ * rewritten into one, so the walk treats the edge as leading nowhere: the value
+ * is not visited, not descended into, and not rewritten, and it stays in place
+ * in a mapped result. Each one is reported once per walk that reaches it, at
+ * warn level, naming the keyword, the value, and the schema holding it.
  */
 
 import type { JSONSchema, JSONSchemaObj } from "@commonfabric/api";
@@ -106,13 +106,15 @@ export type SubschemaKeyword =
   | (typeof UNUSED_RECORD_SUBSCHEMA_KEYS)[number];
 
 /**
- * Everything a schema can be: `true`, `false`, or an object. `null`, a string
- * and a number are the values a stored schema document has been seen to hold
- * where a subschema belongs; see the module docstring for how the walk treats
- * one. An array satisfies this, as it does every object test in this module.
+ * Everything a schema can be: `true`, `false`, or an object that is not an
+ * array. This is the test `validateSchemaDefinition` applies to a subschema,
+ * which rejects the pre-2019 tuple spelling of `items` along with everything
+ * else an array could mean there. See the module docstring for how the walk
+ * treats a value that fails it.
  */
 export function isSubschema(value: unknown): value is JSONSchema {
-  return typeof value === "boolean" || isRecord(value);
+  return typeof value === "boolean" ||
+    (isRecord(value) && !Array.isArray(value));
 }
 
 export interface SchemaWalkOptions {
@@ -224,7 +226,14 @@ const holdsSubschemaArray = (
   return false;
 };
 
-/** Whether a record-valued keyword holds an object, reporting it when not. */
+/**
+ * Whether a record-valued keyword holds an object, reporting it when not.
+ *
+ * An array counts, unlike in a subschema position: validation enumerates these
+ * keywords with `Object.entries` and asks `Object.hasOwn`, both of which read
+ * an array's indices as names, so a walk that answered "no subschemas here"
+ * would answer for keys the validation does read.
+ */
 const holdsSubschemaRecord = (
   value: unknown,
   keyword: SubschemaKeyword,

--- a/packages/runner/test/cfc-schema-sanitization.test.ts
+++ b/packages/runner/test/cfc-schema-sanitization.test.ts
@@ -982,6 +982,23 @@ describe("cfc schema sanitization", () => {
         { items: { type: ["number", "number"] } },
         "items",
       ],
+      // A keyword holding something no schema can be. A stored schema is not
+      // always generator output, and the runner's schema walk defers to this
+      // rule for what a subschema may be.
+      [
+        { properties: { a: null } } as unknown as JSONSchema,
+        "properties.a: schema must be an object or boolean",
+      ],
+      [
+        { additionalProperties: "ab" } as unknown as JSONSchema,
+        "additionalProperties: schema must be an object or boolean",
+      ],
+      // An array is one of those, which is what makes the pre-2019 tuple
+      // spelling of `items` unreadable rather than merely unsupported.
+      [
+        { items: [{ type: "string" }] } as unknown as JSONSchema,
+        "items: schema must be an object or boolean",
+      ],
     ];
     for (const [schema, message] of malformed) {
       expect(validateSchemaDefinition(schema)).toContain(message);

--- a/packages/runner/test/cfc.test.ts
+++ b/packages/runner/test/cfc.test.ts
@@ -20,7 +20,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import { cfcAtom, ContextualFlowControl } from "../src/cfc.ts";
-import { schemaHasIfc } from "../src/schema.ts";
+import { resolveSchema, schemaHasIfc } from "../src/schema.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
 import type { JSONSchemaObj } from "@commonfabric/api";
 import {
@@ -724,6 +724,82 @@ describe("CFC schema reference discovery", () => {
     expect(ContextualFlowControl.schemaAtPath(pruned, ["child"])).toEqual(
       ContextualFlowControl.schemaAtPath(schema, ["child"]),
     );
+  });
+
+  // A schema reaching the runtime has not necessarily come from the schema
+  // generator, so a keyword can hold a value no schema can be. Pruning walks
+  // every subschema-bearing keyword, so each one is a way in.
+  describe("a keyword holding a value that is not a schema", () => {
+    const MALFORMED: [label: string, schema: JSONSchema][] = [
+      ["additionalProperties", {
+        type: "object",
+        properties: { a: { type: "number" } },
+        additionalProperties: null,
+      } as unknown as JSONSchema],
+      [
+        "properties",
+        { type: "object", properties: "ab" } as unknown as JSONSchema,
+      ],
+      [
+        "a properties entry",
+        { type: "object", properties: { a: null } } as unknown as JSONSchema,
+      ],
+      ["items", { type: "array", items: null } as unknown as JSONSchema],
+      [
+        "prefixItems",
+        { type: "array", prefixItems: "ab" } as unknown as JSONSchema,
+      ],
+      [
+        "a prefixItems entry",
+        { type: "array", prefixItems: [null] } as unknown as JSONSchema,
+      ],
+      ["allOf", { allOf: null } as unknown as JSONSchema],
+      ["an anyOf entry", { anyOf: [7] } as unknown as JSONSchema],
+      ["oneOf", { oneOf: "ab" } as unknown as JSONSchema],
+      ["not", { not: 3 } as unknown as JSONSchema],
+      ["patternProperties", { patternProperties: 4 } as unknown as JSONSchema],
+      ["$defs", { $defs: null } as unknown as JSONSchema],
+    ];
+
+    for (const [label, schema] of MALFORMED) {
+      it(`prunes a schema whose ${label} holds one`, () => {
+        expect(pruneCfcSchemaDefinitions(schema)).toEqual(schema);
+        expect(pruneCfcSchemaDefinitions(deepFreeze(schema))).toEqual(schema);
+        const refs = new Set<string>();
+        findCfcSchemaRefs(schema, refs);
+        expect(refs.size).toBe(0);
+        expect(selectReferencedCfcSchemaDefs(schema)).toBeUndefined();
+      });
+    }
+
+    it("prunes around one, keeping the definitions its siblings reach", () => {
+      const schema = {
+        type: "object",
+        properties: { bad: null, good: { $ref: "#/$defs/Kept" } },
+        additionalProperties: "ab",
+        $defs: { Kept: { type: "string" }, Dropped: { type: "number" } },
+      } as unknown as JSONSchema;
+
+      expect(pruneCfcSchemaDefinitions(schema)).toEqual({
+        type: "object",
+        properties: { bad: null, good: { $ref: "#/$defs/Kept" } },
+        additionalProperties: "ab",
+        $defs: { Kept: { type: "string" } },
+      });
+    });
+
+    it("leaves a $ref at a definition holding one unresolved", () => {
+      const schema = {
+        $ref: "#/$defs/Broken",
+        $defs: { Broken: null },
+      } as unknown as JSONSchemaObj;
+
+      expect(resolveCfcSchemaRef(schema, "#/$defs/Broken")).toBeUndefined();
+      expect(resolveCfcSchemaRefs(schema)).toBeUndefined();
+      // A schema the runtime cannot read matches nothing, rather than letting
+      // the raw value through.
+      expect(resolveSchema(schema)).toBe(false);
+    });
   });
 });
 

--- a/packages/runner/test/cfc.test.ts
+++ b/packages/runner/test/cfc.test.ts
@@ -726,6 +726,35 @@ describe("CFC schema reference discovery", () => {
     );
   });
 
+  it("carries a boolean subschema through a namespaced ref site", () => {
+    // A ref site whose target opens its own definition scope has its siblings
+    // namespaced, which walks and rewrites every subschema beside the `$ref`.
+    // `true` and `false` are schemas with nothing to rename, and the walk hands
+    // them to that rewrite like any other.
+    const schema: JSONSchemaObj = {
+      $ref: "#/$defs/Target",
+      properties: { flag: true },
+      $defs: {
+        Target: {
+          type: "object",
+          $defs: { Inner: { type: "string" } },
+          additionalProperties: { $ref: "#/$defs/Inner" },
+        },
+      },
+    };
+
+    const resolved = resolveCfcSchemaRefs(schema) as JSONSchemaObj;
+
+    expect(resolved.properties?.flag).toBe(true);
+    // The ref site's own `Target` name is renamed out of the way of the
+    // target's scope, which keeps `Inner` for itself.
+    expect(Object.keys(resolved.$defs!).toSorted()).toEqual([
+      "Inner",
+      "__cfc_ref_site_0_Target",
+    ]);
+    expect(resolved.additionalProperties).toEqual({ $ref: "#/$defs/Inner" });
+  });
+
   // A schema reaching the runtime has not necessarily come from the schema
   // generator, so a keyword can hold a value no schema can be. Pruning walks
   // every subschema-bearing keyword, so each one is a way in.

--- a/packages/runner/test/schema-walk.test.ts
+++ b/packages/runner/test/schema-walk.test.ts
@@ -449,6 +449,43 @@ describe("values that are not schemas", () => {
     expect(isSubschema({ type: "string" })).toBe(true);
     for (const [, value] of NON_SCHEMAS) expect(isSubschema(value)).toBe(false);
     expect(isSubschema(undefined)).toBe(false);
+    // An array is an object to every other test in the module, and a schema to
+    // none: `validateSchemaDefinition` rejects one where a subschema belongs,
+    // the tuple spelling of `items` included.
+    expect(isSubschema([])).toBe(false);
+    expect(isSubschema([{ type: "string" }])).toBe(false);
+  });
+
+  it("ignores an array where a subschema belongs, at every shape", () => {
+    const tuple = [{ type: "string" }];
+    const single = withWarnings(() =>
+      edgesOf({ items: tuple } as unknown as JSONSchema)
+    );
+    expect(single.result).toEqual([]);
+    expect(single.warnings[0]).toContain("items");
+    const entry = withWarnings(() =>
+      edgesOf({ properties: { a: tuple } } as unknown as JSONSchema)
+    );
+    expect(entry.result).toEqual([]);
+    expect(entry.warnings[0]).toContain("properties/a");
+    const element = withWarnings(() =>
+      edgesOf({ allOf: [tuple] } as unknown as JSONSchema)
+    );
+    expect(element.result).toEqual([]);
+    expect(element.warnings[0]).toContain("allOf/0");
+  });
+
+  it("still reads a record keyword written as an array, by index", () => {
+    // Validation enumerates `properties` with `Object.entries`, which names an
+    // array's indices, so the walk has to see the same subschemas it does.
+    const { result, warnings } = withWarnings(() =>
+      edgesOf({ properties: [{ type: "string" }] } as unknown as JSONSchema)
+    );
+    expect(result.length).toBe(1);
+    expect(result[0].keyword).toBe("properties");
+    expect(result[0].key).toBe("0");
+    expect(result[0].schema).toEqual({ type: "string" });
+    expect(warnings).toEqual([]);
   });
 
   it("visits no edge for one under any keyword, in any tier", () => {
@@ -517,19 +554,25 @@ describe("values that are not schemas", () => {
   });
 
   it("yields the same edges from the generator form", () => {
-    const { result: edges } = withWarnings(() => [
+    const { result: edges, warnings } = withWarnings(() => [
       ...subschemaEdges(
         {
+          // One of each shape the walk can refuse: a subschema position, an
+          // array container, an array entry, and a record container.
           additionalProperties: "ab",
-          properties: { bad: 7, good: { type: "string" } },
           allOf: null,
+          anyOf: [7, { type: "number" }],
+          patternProperties: "ab",
+          properties: { bad: null, good: { type: "string" } },
         } as unknown as JSONSchema,
         ALL_TIERS,
       ),
     ]);
     expect(edges).toEqual([
+      { schema: { type: "number" }, keyword: "anyOf", index: 1 },
       { schema: { type: "string" }, keyword: "properties", key: "good" },
     ]);
+    expect(warnings.length).toBe(5);
   });
 
   it("leaves one in place when mapping, and maps around it", () => {

--- a/packages/runner/test/schema-walk.test.ts
+++ b/packages/runner/test/schema-walk.test.ts
@@ -1,18 +1,23 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { getLogger } from "@commonfabric/utils/logger";
 
-import type { JSONSchema } from "@commonfabric/api";
+import type { JSONSchema, JSONSchemaObj } from "@commonfabric/api";
 import {
   anySchema,
   ARRAY_SUBSCHEMA_KEYS,
+  DEFS_KEYS,
   findSchema,
   forEachSubschema,
+  isSubschema,
   mapSubschemas,
   RECORD_SUBSCHEMA_KEYS,
   type SchemaNode,
   SINGLE_SUBSCHEMA_KEYS,
   subschemaEdges,
   type SubschemaKeyword,
+  UNUSED_RECORD_SUBSCHEMA_KEYS,
+  UNUSED_SINGLE_SUBSCHEMA_KEYS,
   walkSchema,
 } from "../src/schema-walk.ts";
 
@@ -398,6 +403,215 @@ describe("deliberately-excluded keywords", () => {
   });
 });
 
+describe("values that are not schemas", () => {
+  // A stored schema is not always schema-generator output, so a keyword can
+  // hold one of these where a subschema belongs.
+  const NON_SCHEMAS: [label: string, value: unknown][] = [
+    ["null", null],
+    ["a string", "ab"],
+    ["a number", 7],
+  ];
+  const ALL_TIERS = { includeDefs: true, includeUnused: true } as const;
+
+  /**
+   * Run `fn`, returning what it produced alongside the walk's warnings, each
+   * flattened to one line. Captured at the logger, which is where the message
+   * is decided, rather than at the console, which also answers to
+   * `LOG_TO_STDERR` and to the logger's configured level.
+   */
+  const withWarnings = <T>(
+    fn: () => T,
+  ): { result: T; warnings: string[] } => {
+    const logger = getLogger("schema-walk") as unknown as {
+      warn: (key: string, ...messages: unknown[]) => void;
+    };
+    const original = logger.warn;
+    const warnings: string[] = [];
+    logger.warn = (key, ...messages) => {
+      warnings.push([
+        key,
+        ...messages.flatMap((message) =>
+          typeof message === "function" ? message() : message
+        ),
+      ].join(" "));
+    };
+    try {
+      return { result: fn(), warnings };
+    } finally {
+      logger.warn = original;
+    }
+  };
+
+  it("isSubschema accepts booleans and objects and rejects the rest", () => {
+    expect(isSubschema(true)).toBe(true);
+    expect(isSubschema(false)).toBe(true);
+    expect(isSubschema({})).toBe(true);
+    expect(isSubschema({ type: "string" })).toBe(true);
+    for (const [, value] of NON_SCHEMAS) expect(isSubschema(value)).toBe(false);
+    expect(isSubschema(undefined)).toBe(false);
+  });
+
+  it("visits no edge for one under any keyword, in any tier", () => {
+    // Driven off the exported keyword constants, so a keyword added to the
+    // vocabulary is covered here the day it is added.
+    const positions: [label: string, schema: (value: unknown) => JSONSchema][] =
+      [];
+    for (
+      const keyword of [
+        ...SINGLE_SUBSCHEMA_KEYS,
+        ...UNUSED_SINGLE_SUBSCHEMA_KEYS,
+      ]
+    ) {
+      positions.push([keyword, (value) => ({ [keyword]: value })]);
+    }
+    for (
+      const keyword of [
+        ...RECORD_SUBSCHEMA_KEYS,
+        ...UNUSED_RECORD_SUBSCHEMA_KEYS,
+        ...DEFS_KEYS,
+      ]
+    ) {
+      positions.push([keyword, (value) => ({ [keyword]: value })]);
+      positions.push([
+        `${keyword}/x`,
+        (value) => ({ [keyword]: { x: value } }),
+      ]);
+    }
+    for (const keyword of ARRAY_SUBSCHEMA_KEYS) {
+      positions.push([keyword, (value) => ({ [keyword]: value })]);
+      positions.push([`${keyword}/0`, (value) => ({ [keyword]: [value] })]);
+    }
+
+    for (const [position, build] of positions) {
+      for (const [label, value] of NON_SCHEMAS) {
+        const where = `${position}: ${label}`;
+        const schema = build(value);
+        const walked = withWarnings(() => edgesOf(schema, ALL_TIERS));
+        expect(walked.result, where).toEqual([]);
+        expect(walked.warnings.length, where).toBe(1);
+        expect(walked.warnings[0], where).toContain(position);
+        const mapped = withWarnings(() =>
+          mapSubschemas(schema as Record<never, never>, () => ({
+            type: "string",
+          }), ALL_TIERS)
+        );
+        expect(mapped.result, where).toBe(schema);
+      }
+    }
+  });
+
+  it("visits the well-formed siblings of one, at their own key and index", () => {
+    const { result: edges } = withWarnings(() =>
+      edgesOf({
+        properties: { bad: null, good: { type: "string" } },
+        prefixItems: [null, { type: "number" }],
+      } as unknown as JSONSchema)
+    );
+    expect(edges.length).toBe(2);
+    expect(edges.find((edge) => edge.keyword === "properties")?.key).toBe(
+      "good",
+    );
+    const prefixItem = edges.find((edge) => edge.keyword === "prefixItems");
+    expect(prefixItem?.index).toBe(1);
+    expect(prefixItem?.schema).toEqual({ type: "number" });
+  });
+
+  it("yields the same edges from the generator form", () => {
+    const { result: edges } = withWarnings(() => [
+      ...subschemaEdges(
+        {
+          additionalProperties: "ab",
+          properties: { bad: 7, good: { type: "string" } },
+          allOf: null,
+        } as unknown as JSONSchema,
+        ALL_TIERS,
+      ),
+    ]);
+    expect(edges).toEqual([
+      { schema: { type: "string" }, keyword: "properties", key: "good" },
+    ]);
+  });
+
+  it("leaves one in place when mapping, and maps around it", () => {
+    const schema = {
+      additionalProperties: null,
+      properties: { bad: "ab", good: { type: "string" } },
+      prefixItems: [7, { type: "number" }],
+    } as unknown as JSONSchemaObj;
+    const { result } = withWarnings(() =>
+      mapSubschemas(
+        schema,
+        (child) =>
+          typeof child === "boolean" ? child : { ...child, title: "mapped" },
+        ALL_TIERS,
+      )
+    );
+    expect(result).toEqual({
+      additionalProperties: null,
+      properties: { bad: "ab", good: { type: "string", title: "mapped" } },
+      prefixItems: [7, { type: "number", title: "mapped" }],
+    });
+  });
+
+  it("does not descend into one, with or without visitBooleans", () => {
+    const schema = {
+      properties: { bad: null, good: { properties: { deep: true } } },
+    } as unknown as JSONSchema;
+    const plain = withWarnings(() => pathKeys(schema));
+    expect(plain.result).toEqual(["", "properties/good"]);
+    // `visitBooleans` opens the walk to `true` and `false`, not to values a
+    // schema cannot be.
+    const booleans = withWarnings(() =>
+      pathKeys(schema, { visitBooleans: true })
+    );
+    expect(booleans.result).toEqual([
+      "",
+      "properties/good",
+      "properties/good/properties/deep",
+    ]);
+  });
+
+  it("walks nothing for a root that is one", () => {
+    for (const [label, value] of NON_SCHEMAS) {
+      const root = value as JSONSchema;
+      expect(edgesOf(root), label).toEqual([]);
+      expect([...subschemaEdges(root)], label).toEqual([]);
+      expect(collect(root, { visitBooleans: true }), label).toEqual([]);
+    }
+  });
+
+  it("names the keyword, the value, and the schema holding it", () => {
+    const { warnings } = withWarnings(() =>
+      forEachSubschema(
+        {
+          type: "object",
+          properties: { a: { type: "number" } },
+          additionalProperties: null,
+        } as unknown as JSONSchema,
+        () => {},
+      )
+    );
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain("additionalProperties");
+    expect(warnings[0]).toContain("null");
+    expect(warnings[0]).toContain('"properties":{"a":{"type":"number"}}');
+  });
+
+  it("names the entry of a record keyword by key, and of an array by index", () => {
+    const byKey = withWarnings(() =>
+      forEachSubschema(
+        { properties: { a: 7 } } as unknown as JSONSchema,
+        () => {
+        },
+      )
+    );
+    expect(byKey.warnings[0]).toContain("properties/a");
+    const byIndex = withWarnings(() =>
+      forEachSubschema({ allOf: [true, 7] } as unknown as JSONSchema, () => {})
+    );
+    expect(byIndex.warnings[0]).toContain("allOf/1");
+  });
+});
 describe("resolveRef option", () => {
   const rootWithDefs: JSONSchema = {
     $defs: { Labeled: { type: "string", ifc: { integrity: ["y"] } } },

--- a/packages/runner/test/v2-watch-non-schema-selectors.test.ts
+++ b/packages/runner/test/v2-watch-non-schema-selectors.test.ts
@@ -73,10 +73,15 @@ describe("v2-watch", () => {
       // Pruning removes definitions the schema cannot reach and leaves the
       // rest as it arrived, malformed keyword and all.
       expect(normalized.schema).toEqual(schema);
-      // The watch id is a hash of the same selector, so it has to survive the
-      // schema too.
+      // Two reads asking with the same schema watch one entry, not two: the
+      // id hashes the selector's content, so it has to reach a value the
+      // hash cannot be keyed on by identity.
+      const separate = normalizeSyncSelector({
+        path: ["value"],
+        schema: structuredClone(schema),
+      });
       expect(watchIdForEntry(address, normalized, "main")).toBe(
-        watchIdForEntry(address, normalized, "main"),
+        watchIdForEntry(address, separate, "main"),
       );
     });
   }

--- a/packages/runner/test/v2-watch-non-schema-selectors.test.ts
+++ b/packages/runner/test/v2-watch-non-schema-selectors.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Sync selectors carry whatever schema a read asked with, and a schema that
+ * reached the runtime from storage is not always schema-generator output. A
+ * keyword can hold a value no schema can be, and normalization prunes each
+ * selector's definitions, so every one of those shapes passes through this
+ * walk. It runs on the storage path, away from the call site that supplied the
+ * schema, so a throw here surfaces as an uncaught error attributable to
+ * nothing.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { JSONSchema, SchemaPathSelector } from "@commonfabric/api";
+import { watchIdForEntry } from "../src/storage/v2.ts";
+import { normalizeSyncSelector } from "../src/storage/v2-watch.ts";
+import type { MIME, URI } from "@commonfabric/memory/interface";
+
+const MALFORMED: [label: string, schema: JSONSchema][] = [
+  ["additionalProperties holds null", {
+    type: "object",
+    properties: { a: { type: "number" } },
+    additionalProperties: null,
+  } as unknown as JSONSchema],
+  [
+    "properties holds a string",
+    { type: "object", properties: "ab" } as unknown as JSONSchema,
+  ],
+  [
+    "properties holds null",
+    { type: "object", properties: null } as unknown as JSONSchema,
+  ],
+  [
+    "a property holds null",
+    { type: "object", properties: { a: null } } as unknown as JSONSchema,
+  ],
+  ["items holds null", { type: "array", items: null } as unknown as JSONSchema],
+  [
+    "prefixItems holds a string",
+    { type: "array", prefixItems: "ab" } as unknown as JSONSchema,
+  ],
+  [
+    "a prefixItems entry holds null",
+    { type: "array", prefixItems: [null] } as unknown as JSONSchema,
+  ],
+  ["allOf holds null", { allOf: null } as unknown as JSONSchema],
+  ["an anyOf entry holds a number", { anyOf: [7] } as unknown as JSONSchema],
+  ["oneOf holds a string", { oneOf: "ab" } as unknown as JSONSchema],
+  ["not holds a number", { not: 3 } as unknown as JSONSchema],
+  [
+    "patternProperties holds a number",
+    { patternProperties: 4 } as unknown as JSONSchema,
+  ],
+  ["$defs holds null", { $defs: null } as unknown as JSONSchema],
+  ["a definition holds null", {
+    $ref: "#/$defs/Broken",
+    $defs: { Broken: null },
+  } as unknown as JSONSchema],
+];
+
+const address = {
+  id: "of:non-schema-selector" as URI,
+  type: "application/json" as MIME,
+};
+
+describe("v2-watch", () => {
+  for (const [label, schema] of MALFORMED) {
+    it(`normalizes a selector whose schema's ${label}`, () => {
+      const selector: SchemaPathSelector = { path: ["value"], schema };
+
+      const normalized = normalizeSyncSelector(selector);
+
+      expect(normalized.path).toEqual(["value"]);
+      // Pruning removes definitions the schema cannot reach and leaves the
+      // rest as it arrived, malformed keyword and all.
+      expect(normalized.schema).toEqual(schema);
+      // The watch id is a hash of the same selector, so it has to survive the
+      // schema too.
+      expect(watchIdForEntry(address, normalized, "main")).toBe(
+        watchIdForEntry(address, normalized, "main"),
+      );
+    });
+  }
+
+  it("keeps normalizing selectors that carry no schema at all", () => {
+    expect(normalizeSyncSelector(undefined).schema).toBe(false);
+    expect(normalizeSyncSelector({ path: [], schema: false }).schema).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
A schema reaching the runtime has not necessarily come from the schema generator. Anything can write one into a space, so a subschema-bearing keyword can hold a value that is not a schema at all, and a keyword taking several subschemas can hold something that is not an array or an object.

The central schema walk dereferenced whatever it found. Two shapes seen in practice: `additionalProperties: null` reached `mapSubschemas` and read `.not` off null, and `properties: "ab"` enumerated the string as two named subschemas `"a"` and `"b"`, which then reached a WeakMap as a key. Both raised a bare TypeError naming neither the schema nor the keyword. Every other keyword in the vocabulary had the same exposure, under the container as well as under an entry: `items`, `prefixItems`, `allOf`/`anyOf`/`oneOf`, `patternProperties`, `$defs`. Definition pruning runs on the storage path, so a read reaching one of these threw asynchronously, away from the call site that supplied the schema, which in a test run failed the whole runner with nothing to attribute it to.

The walk now decides what a schema can be in one place -- `true`, `false`, or an object -- and treats a keyword holding anything else as an edge leading nowhere. The value is not visited, not descended into, and not rewritten; it stays where it was in a mapped result, and its well-formed siblings are walked as before. Each one is reported at warn level, naming the keyword, the entry's key or index, the value, and the schema holding it, so the malformed schema is identified where it is found rather than inferred from a stack.

The ref module gets the same treatment at the entry points that take a schema from a caller rather than from the walk: pruning, ref summarizing, definition selection, and the two definition-scope rewrites. Pruning also leaves a `$defs` alone unless it is a definition map, the test `cfcSchemaChildRoot` already uses to decide whether one opens a definition scope. A `$ref` whose target holds something a schema cannot be is now unresolved rather than followed, which is what that module already does with a name a document does not carry, and `resolveSchema` answers an unresolvable ref with `false`: a schema the runtime cannot read matches nothing.

The walk's own cases run off the exported keyword constants, so a keyword added to the vocabulary is covered the day it is added. The storage path gets cases of its own, one malformed shape per keyword through `normalizeSyncSelector`, checking that the schema comes back as it arrived and that the watch id derived from it is still stable.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

