### PR TITLE
refactor(data-model): a codec engine base class, and what `lenient` means

### DIFF
--- a/docs/plans/first-class-serializable-factories.md
+++ b/docs/plans/first-class-serializable-factories.md
@@ -209,12 +209,12 @@ Expected implementation and test files:
 
 - `packages/data-model/src/codec-common/` for the codec/state validator
 - `packages/data-model/src/codec-common/CodecRegistry.ts`
-- `packages/data-model/src/codec-json/JsonCodec.ts`
+- `packages/data-model/src/codec-json/JsonCodecEngine.ts`
 - `packages/data-model/src/codecs.ts`
 - `packages/data-model/src/codec-json/impl.ts`
 - `packages/data-model/test/codec-common/FactoryCodec.test.ts`
 - `packages/data-model/test/codec-common/CodecRegistry.test.ts`
-- `packages/data-model/test/codec-json/JsonCodec.test.ts`
+- `packages/data-model/test/codec-json/JsonCodecEngine.test.ts`
 - `packages/data-model/test/codec-json/impl.test.ts`
 - a focused `packages/data-model/test/fabric-factory.test.ts`
 

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -2563,9 +2563,10 @@ Circular references are detected via a `Set<object>` tracked during the walk.
 7. **Arrays** — recursively deserialized; `hole` entries reconstructed as
    true holes (absent indices).
 8. **Plain objects** — recursively deserialized; output frozen. Any
-   `/`-prefixed key in a plain (non-single-key-tagged) object is reserved:
-   the walker produces a `ProblematicValue` rather than silently
-   round-tripping it (Section 9 of `3-json-encoding.md`).
+   `/`-prefixed key in a plain (non-single-key-tagged) object is reserved, as
+   is any name this runtime reserves: rather than silently round-trip it, the
+   walker rejects it, settled against `lenient` as in step 3 (Section 9 of
+   `3-json-encoding.md`).
 
 > **Previous design: type handlers + class registry.** The earlier design
 > dispatched per-type logic to `TypeHandler` objects (which did their own

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -2266,11 +2266,11 @@ under the preserved tag, so the wire form is identical to that of the
 value the `ProblematicValue` stands in for (and a later decode under a
 then-recognized tag can recover the real value). The `error` field aids
 in-process debugging by recording what went wrong; the failure-construction
-paths (e.g., lenient mode) populate it. Whether to wrap failures in
-`ProblematicValue` or to throw is an implementation decision that may vary
-by context — strict contexts (e.g., tests) may prefer to throw, while
-lenient contexts (e.g., production reconstruction) may prefer graceful
-degradation.
+paths populate it. Whether a decode failure surfaces as a
+`ProblematicValue` or as a throw is the encoding context's `lenient`
+setting alone, not the codec's: a strict context (e.g., tests) raises
+either form of rejection, while a lenient one (e.g., production
+reconstruction) degrades either into a value.
 
 ---
 
@@ -2543,8 +2543,10 @@ Circular references are detected via a `Set<object>` tracked during the walk.
    bare `"/"` key) as an encoding error, producing a `ProblematicValue`
    (Section 3.5; see also Section 9 of `3-json-encoding.md`).
 4. **Codec dispatch** — `codecFromTag()` routes the tag to its registered
-   codec's `decode()`. When `JsonCodecEngine` is in lenient mode, codec
-   exceptions produce `ProblematicValue`. Values returned from this arm
+   codec's `decode()`, and settles the codec's verdict against `lenient`:
+   leniently, a throw becomes a `ProblematicValue`; strictly, a
+   `ProblematicValue` the codec returned becomes a throw. Values returned
+   from this arm
    are guaranteed deep-frozen at the walker boundary (the contract holds
    for both the codec-produced value and the lenient-mode
    `ProblematicValue`), so callers need not each freeze. This contract is
@@ -3188,10 +3190,10 @@ This applies at every point where deserialized data is consumed:
   concrete example.
 
 - **JSON-side codec decoding** (Section 3 of `3-json-encoding.md`) must
-  validate the format of its state before processing. Malformed input
-  should produce a `ProblematicValue` rather than throwing or silently
-  producing garbage (a codec may also throw and rely on a lenient context
-  to do the wrapping; Section 4.5).
+  validate the format of its state before processing. Malformed input must
+  be rejected rather than silently producing garbage; a codec rejects by
+  throwing or by returning a `ProblematicValue`, and the encoding context
+  settles the two against its `lenient` setting (Section 4.5).
 
 - **Hashing** (Section 6.3) may operate on values that have been
   through a deserialization round-trip. Code that extracts properties from

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -2285,7 +2285,7 @@ encoding/decoding.
 
 ### 4.2 Codec Value Types
 
-`JsonCodec` uses an intermediate tree representation during serialization
+`JsonCodecEngine` uses an intermediate tree representation during serialization
 and deserialization. This type is internal to the JSON implementation — it
 is not part of the public boundary interface.
 
@@ -2353,7 +2353,7 @@ export interface SerializationContext<SerializedForm = unknown> {
 }
 ```
 
-`JsonCodec` implements `SerializationContext<string>`:
+`JsonCodecEngine` implements `SerializationContext<string>`:
 
 - `encode(value)` serializes a `FabricValue` into the `/<Type>@<Version>`
   tagged wire format, then stringifies the result.
@@ -2376,20 +2376,20 @@ Encode:  value -> codec.encode(value) -> serialized form (e.g., JSON string)
 Decode:  serialized form -> codec.decode(data, context) -> FabricValue
 ```
 
-Internally, `JsonCodec`'s `encode()` method calls a private encode walker
+Internally, `JsonCodecEngine`'s `encode()` method calls a private encode walker
 (`#encodeValue()`) to walk the `FabricValue` tree and produce a
 `JsonCodecValue` tree, then stringifies it. The `decode()` method parses
 the JSON string, then calls a private decode walker (`#decodeValue()`) to
 walk the `JsonCodecValue` tree and reconstruct modern runtime types. The
-recursive descent and codec dispatch are entirely internal to `JsonCodec`.
+recursive descent and codec dispatch are entirely internal to `JsonCodecEngine`.
 
 ### 4.5 Codecs, the Registry, and Internal Tree Walking
 
 The serialization and deserialization logic is implemented as private
-methods on `JsonCodec`. It dispatches per-type logic to the **codecs**
+methods on `JsonCodecEngine`. It dispatches per-type logic to the **codecs**
 (Section 2.4) held in a **`CodecRegistry`** — an index of which codec
 handles which class (for encoding) and which tag (for decoding). Codecs
-are shallow: `JsonCodec` owns recursion and tag-wrapping, and each codec
+are shallow: `JsonCodecEngine` owns recursion and tag-wrapping, and each codec
 translates exactly one layer.
 
 ```typescript
@@ -2506,7 +2506,7 @@ types) are handled by the walker itself after no codec matches.
 
 #### Private encode walker (`#encodeValue()`)
 
-`JsonCodec`'s private encode walker processes the `FabricValue` tree:
+`JsonCodecEngine`'s private encode walker processes the `FabricValue` tree:
 
 1. **Codec dispatch** — `codecFromValue()` finds how to encode the value.
    A `SELF_REP` result means the value is its own wire form (emitted
@@ -2531,7 +2531,7 @@ Circular references are detected via a `Set<object>` tracked during the walk.
 
 #### Private decode walker (`#decodeValue()`)
 
-`JsonCodec`'s private decode walker processes the `JsonCodecValue` tree:
+`JsonCodecEngine`'s private decode walker processes the `JsonCodecValue` tree:
 
 1. **Tag unwrapping** — checks for single-key objects with `/`-prefixed
    keys.
@@ -2543,7 +2543,7 @@ Circular references are detected via a `Set<object>` tracked during the walk.
    bare `"/"` key) as an encoding error, producing a `ProblematicValue`
    (Section 3.5; see also Section 9 of `3-json-encoding.md`).
 4. **Codec dispatch** — `codecFromTag()` routes the tag to its registered
-   codec's `decode()`. When `JsonCodec` is in lenient mode, codec
+   codec's `decode()`. When `JsonCodecEngine` is in lenient mode, codec
    exceptions produce `ProblematicValue`. Values returned from this arm
    are guaranteed deep-frozen at the walker boundary (the contract holds
    for both the codec-produced value and the lenient-mode
@@ -2569,7 +2569,7 @@ Circular references are detected via a `Set<object>` tracked during the walk.
 > everything else; tag resolution checked a `wireTypeTag` property on each
 > instance. That made the wire-serializable surface implicit and smeared
 > the format mechanics across every handler. The codec model replaces all
-> of it: codecs are shallow (`JsonCodec` owns recursion and tag-wrapping),
+> of it: codecs are shallow (`JsonCodecEngine` owns recursion and tag-wrapping),
 > the surface is explicit and curated, the class registry is retired
 > (concrete types decode through their own codecs; unknown tags fall
 > straight to `UnknownValue`), and per-instance `wireTypeTag` survives
@@ -2578,7 +2578,7 @@ Circular references are detected via a `Set<object>` tracked during the walk.
 > **Previous design.** The earlier spec presented `serialize()` and
 > `deserialize()` as standalone top-level functions that received the
 > `SerializationContext` as a parameter. The current design moves these into
-> private methods on `JsonCodec`, keeping the public API clean
+> private methods on `JsonCodecEngine`, keeping the public API clean
 > (`encode()`/`decode()` only) and allowing the codec to encapsulate its
 > internal state (registry, codec view, lenient mode) without threading it
 > through every recursive call.
@@ -2666,7 +2666,7 @@ export function plainObjectFromJson<T extends object = object>(
 export function seemsLikeJsonEncodedFabricValue(value: string): boolean;
 ```
 
-`codecs.ts` creates a single stateless `JsonCodec` instance at module load
+`codecs.ts` creates a single stateless `JsonCodecEngine` instance at module load
 time and reuses it for all encode/decode operations.
 
 The `memory` package wraps these at its serialization boundary

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -2540,8 +2540,11 @@ Circular references are detected via a `Set<object>` tracked during the walk.
    `3-json-encoding.md`.
 3. **State decode + bare-`/` check** — for any other tag, the walker first
    recursively decodes the wrapped state, then rejects an empty tag (a
-   bare `"/"` key) as an encoding error, producing a `ProblematicValue`
-   (Section 3.5; see also Section 9 of `3-json-encoding.md`).
+   bare `"/"` key) as an encoding error. That rejection, and every other
+   malformed-wire fault the walker finds for itself, is settled against
+   `lenient` exactly as a codec's is: a `ProblematicValue` leniently
+   (Section 3.5), a raise strictly (see also Section 9 of
+   `3-json-encoding.md`).
 4. **Codec dispatch** — `codecFromTag()` routes the tag to its registered
    codec's `decode()`, and settles the codec's verdict against `lenient`:
    leniently, a throw becomes a `ProblematicValue`; strictly, a

--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -409,8 +409,8 @@ escape, or encoding error — never a literal user-data key.
 Specifically:
 
 - **Objects with a bare `"/"` key** (i.e., the tag name is empty after
-  stripping the leading `/`) are always encoding errors — produce
-  `ProblematicValue`. No valid tag has an empty name.
+  stripping the leading `/`) are always encoding errors, and are rejected. No
+  valid tag has an empty name.
 - **Single-key objects** whose sole key starts with `/` are either a tagged
   value of a known type (e.g. `{ "/Error@1": ... }`), a built-in escape
   (`/object`, `/quote`), or an unrecognized tag. A syntactically well-formed

--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -416,11 +416,17 @@ Specifically:
   (`/object`, `/quote`), or an unrecognized tag. A syntactically well-formed
   but unrecognized tag (e.g. `{ "/Future@2": ... }`) must be treated as
   `UnknownValue` (see Section 8) to preserve it for round-tripping. Structural
-  violations — e.g. a tag name that cannot be a valid type identifier — should
-  produce `ProblematicValue`.
+  violations — e.g. a tag name that cannot be a valid type identifier — are
+  rejected.
 - **Multi-key objects** containing one or more `/`-prefixed keys are structural
-  encoding errors — produce `ProblematicValue`. They are not valid plain
-  objects.
+  encoding errors, and are rejected. They are not valid plain objects.
+
+A structural violation is malformed wire data the encoding context detects
+itself, rather than a state a codec refuses, and the two are settled the same
+way: against `lenient` (see `1-fabric-values.md` Section 4.5). A lenient
+context yields a `ProblematicValue`, and a strict one raises. Which of the two
+noticed the fault is an implementation detail of where a check lives, and does
+not reach a caller.
 
 The `/object` escape (Section 6) ensures that legitimate plain objects with
 `/`-prefixed keys are always wrapped before reaching the wire, so a conforming

--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -221,11 +221,13 @@ round-trip correctly.
 > `BigInt@1`, `EpochNsec@1`, `EpochDays@1`, or `Bytes@1`) must validate that
 > its state is a `string` containing valid base64url (padded or unpadded) before decoding. On
 > malformed input — wrong type, invalid format, or missing fields — the codec
-> should produce a `ProblematicValue` (see `1-fabric-values.md` Section 3.5)
-> rather than silently producing garbage; a codec may either construct the
-> `ProblematicValue` directly or throw and rely on a lenient encoding
-> context to do the wrapping (see `1-fabric-values.md` Section 4.5). This
-> principle applies to
+> must reject it rather than silently produce garbage. A codec may reject by
+> throwing, or by returning a `ProblematicValue` (see `1-fabric-values.md`
+> Section 3.5); the two are equivalent, because the encoding context settles
+> them into one answer according to its own `lenient` setting (see
+> `1-fabric-values.md` Section 4.5). Which one a codec uses is therefore a
+> matter of what reads well where it is written, and carries no meaning for a
+> caller. This principle applies to
 > all codecs. Wire data is untrusted input. See `1-fabric-values.md`
 > Section 7.4 for the broader principle that applies to all code consuming
 > deserialized values.
@@ -379,8 +381,9 @@ for:
   in `UnknownValue` / `ProblematicValue` (read back through their codecs'
   `tagForValue()`), and constructing `UnknownValue` for tags with no
   registered codec.
-- In lenient mode, converting codec `decode()` throws into
-  `ProblematicValue`.
+- Settling a codec's rejection according to `lenient`: in lenient mode a
+  codec's throw becomes a `ProblematicValue`, and in strict mode a
+  `ProblematicValue` a codec returns becomes a throw.
 
 Note: `/object` escaping (Section 6) is applied directly by the context's
 private encode walker in its plain-objects path, since it is structural

--- a/docs/specs/space-model/1-data-model.md
+++ b/docs/specs/space-model/1-data-model.md
@@ -828,8 +828,9 @@ Concretely:
   a known type, a built-in escape (`/object`, `/quote`), or an unrecognized
   tag (preserved as `UnknownValue` for round-tripping).
 - A multi-key object containing one or more `/`-prefixed keys among its
-  keys is a structural encoding error — also `ProblematicValue`. It is not
-  a valid plain object.
+  keys is a structural encoding error, and is rejected the same way: a
+  `ProblematicValue` from a lenient context, a raise from a strict one. It is
+  not a valid plain object.
 
 See Section 9 of the formal spec for the full rule and the
 `ProblematicValue` interpretation across the cases above.

--- a/docs/specs/sparse-array-preservation.md
+++ b/docs/specs/sparse-array-preservation.md
@@ -109,7 +109,7 @@ because their sparse support was part of the original design:
   `shallowFabricFromNativeValue` and `fabricFromNativeValue` use `i in arr`
   checks. Every accepted array goes through `cloneHelper()`, which rebuilds it
   with `new Array(length)` and copies only the indices that are present.
-- **`packages/data-model/src/codec-json/JsonCodec.ts`** — Encodes a run of
+- **`packages/data-model/src/codec-json/JsonCodecEngine.ts`** — Encodes a run of
   holes as a single hole-tagged count; decoding rebuilds them as true holes.
 - **`packages/data-model/src/value-hash.ts`** — Feeds holes to the hash
   directly, coalescing each run into one hole entry.

--- a/packages/data-model/src/codec-common/BaseCodecEngine.ts
+++ b/packages/data-model/src/codec-common/BaseCodecEngine.ts
@@ -139,36 +139,41 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
       // A self-representing primitive is its own wire form.
       return value as Encoded;
     } else if (matched) {
+      // `value` matched from the registry as either a non-self-representing
+      // primitive or a `FabricSpecialObject`.
       return this.#encodeTagged(value, matched, seen ?? new Set());
-    }
-
-    // Self-representing primitives returned above, so `value` is an object
-    // from here on, and the two container arms are what an ordinary one takes.
-    // Neither can claim a `FabricSpecialObject`: `isPlainObject()` tests the
-    // prototype, and one of those has a class.
-
-    if (Array.isArray(value)) {
+    } else if (Array.isArray(value)) {
       return this.encodeArray(value, seen ?? new Set());
     } else if (isPlainObject(value)) {
+      // Note: `isPlainObject()` means what it says; notably, it returns `false`
+      // for `FabricSpecialObject`s.
       return this.encodePlainObject(value, seen ?? new Set());
-    } else if (value instanceof FabricSpecialObject) {
-      // Every `FabricSpecialObject` has to be recognized by a registered
-      // codec. Nothing matched above, so this one is not carried.
+    }
+
+    // At this point, we know `value` can't be encoded. We just need to figure
+    // out the right error message.
+
+    if (value instanceof FabricSpecialObject) {
       throw new Error(
         `No codec registered for \`FabricSpecialObject\` subclass ${
           backtickQuote(value.constructor.name)
         }.`,
       );
+    } else {
+      // `value` is a primitive, a function, or a non-`FabricSpecialObject`
+      // instance (non-plain object). Distinguish them in the error message. The
+      // notable primitive case here is uninterned symbols (which are forbidden
+      // by the data model but cannot be forbidden in the type system). The
+      // instance and function cases are all almost certainly due to something
+      // upstream lying about the type of `value`.
+      const typeName = typeof value;
+      const label = (typeName === "object") ? "instance" : typeName;
+      throw new Error(
+        `Cannot encode ${label} ${
+          backtickQuote(toCompactDebugString(value, 50))
+        }: no applicable codec.`,
+      );
     }
-
-    // Every `FabricValue` object case is handled above, so what is left is
-    // always an error -- generally traceable to a type-system lie somewhere
-    // upstream.
-    throw new Error(
-      `Cannot encode ${
-        backtickQuote(toCompactDebugString(value, 50))
-      }: no applicable codec.`,
-    );
   }
 
   /** Encodes one value through the codec the registry matched to it. */

--- a/packages/data-model/src/codec-common/BaseCodecEngine.ts
+++ b/packages/data-model/src/codec-common/BaseCodecEngine.ts
@@ -1,0 +1,304 @@
+import { backtickQuote } from "@commonfabric/utils/markdown";
+import { isPlainObject } from "@commonfabric/utils/types";
+
+import { FabricSpecialObject, type FabricValue } from "@/interface.ts";
+import { toCompactDebugString } from "@/value-debug.ts";
+import { deepFreeze } from "@/deep-freeze.ts";
+import { BaseTerminalCodec } from "@/codec-interface/BaseTerminalCodec.ts";
+import type {
+  CodecForFormat,
+  NonterminalCodec,
+  ReconstructionContext,
+  SerializationContext,
+  TerminalCodec,
+} from "@/codec-interface/interface.ts";
+import { type CodecRegistry, SELF_REP } from "./CodecRegistry.ts";
+import { ProblematicValue } from "./ProblematicValue.ts";
+import { UnknownValue } from "./UnknownValue.ts";
+
+/**
+ * Base class for a whole-value codec: the object that walks a fabric value
+ * into one wire format's transport tree and back. What lives here is the part
+ * that consults the codec registry and acts on what it says; what a subclass
+ * supplies is everything specific to how its format writes a container down.
+ *
+ * Two type parameters, because a format's transport tree is not necessarily
+ * what crosses its public boundary. `Encoded` is the tree the walk and the
+ * codecs work in; `SerializedForm` is what `encode()` returns and `decode()`
+ * accepts. JSON's differ -- a `JsonCodecValue` tree, reduced to a `string` by
+ * a stringify step -- and a format whose tree is what crosses leaves the
+ * second parameter to default to the first.
+ *
+ * The division is between what a format decides and what it must not:
+ *
+ * * A self-representing value is emitted as it stands, and a value matching no
+ *   codec is either a container or an error.
+ * * A terminal codec's state is final and a nonterminal codec's is walked
+ *   again -- read off the codec's base class, on both sides of the trip.
+ * * A tag comes from `tagForValue()` rather than from the value.
+ * * An unrecognized tag becomes an `UnknownValue`, and an empty one an error,
+ *   per Section 9 of the formal spec.
+ * * A codec's `decode()` result is deep-frozen, and a throw from one is
+ *   re-raised or wrapped according to `lenient`.
+ *
+ * None of those is a property of a wire format, and every one of them is a
+ * decision a walker could quietly get wrong: a state expanded when it should
+ * have been passed through, or the reverse, surfaces far from the dispatch
+ * that decided it, and where a state is a record of strings the two choices
+ * emit byte-identical output. Holding them in one place is worth more than the
+ * lines it saves.
+ *
+ * What a subclass owns is everything about containers, and that is where a
+ * format is entitled to differ: whether keys are ordered, whether a key can
+ * collide with the tag form and so needs escaping, and how an absent array
+ * index is written down. A format that answers those differently is not
+ * varying an implementation detail; it is being a different format.
+ */
+export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
+  implements SerializationContext<SerializedForm> {
+  /**
+   * Whether a failed reconstruction produces a `ProblematicValue` instead of
+   * throwing.
+   */
+  readonly lenient: boolean;
+
+  /** Registry consulted for per-type encoding and decoding. */
+  protected readonly registry: CodecRegistry<Encoded>;
+
+  /**
+   * Constructs an instance. `options.registry` supplies the codecs this
+   * instance encodes and decodes with, and so decides which classes it can
+   * carry; there is no default, because which classes participate is a
+   * question this class has no standing to answer. `options.lenient` makes a
+   * failed reconstruction produce a `ProblematicValue` instead of throwing.
+   */
+  constructor(
+    options: { registry: CodecRegistry<Encoded>; lenient?: boolean },
+  ) {
+    this.lenient = options.lenient ?? false;
+    this.registry = options.registry;
+  }
+
+  //
+  // Instance members
+  //
+
+  /**
+   * Encodes a fabric value into this format's serialized form, ready to cross
+   * whatever boundary the format exists for.
+   *
+   * The result carries a marker identifying the format, so that a receiver can
+   * tell one of these from an arbitrary value arriving on the same channel.
+   * What that marker is belongs to the format.
+   *
+   * @throws If `value` holds something the format cannot carry: a
+   *   `FabricSpecialObject` whose class no codec in the registry claims, a
+   *   cycle, or an object that is no kind of `FabricValue` at all.
+   */
+  abstract encode(value: FabricValue): SerializedForm;
+
+  /**
+   * Decodes this format's serialized form back into a fabric value.
+   *
+   * `context` supplies what reconstruction needs beyond the data itself,
+   * chiefly the ability to resolve a cell reference.
+   *
+   * A codec that rejects the state it is handed either throws or is wrapped in
+   * a `ProblematicValue`, according to {@link #lenient}. A tag no codec in the
+   * registry claims becomes an `UnknownValue`, which is not a failure: it is
+   * how a value survives a round trip through a reader that does not know the
+   * type.
+   *
+   * @throws If `data` does not carry this format's marker, or if a codec
+   *   rejects a state and this instance is not lenient.
+   */
+  abstract decode(
+    data: SerializedForm,
+    context: ReconstructionContext,
+  ): FabricValue;
+
+  /**
+   * Encodes a fabric value into the transport tree, dispatching on what the
+   * registry says about it and handing a container to this format's own arms.
+   *
+   * `seen` carries the values whose encoding is in progress, so that a cycle
+   * is caught rather than followed. It is created on the first arm that needs
+   * one rather than up front, so that encoding a lone self-representing value
+   * -- much the commonest case, and the one where a fixed cost shows up most
+   * -- allocates nothing.
+   */
+  protected encodeValue(value: FabricValue, seen?: Set<object>): Encoded {
+    const matched = this.registry.codecFromValue(value);
+
+    if (matched === SELF_REP) {
+      // A self-representing primitive is its own wire form.
+      return value as Encoded;
+    } else if (matched) {
+      return this.#encodeTagged(value, matched, seen ?? new Set());
+    }
+
+    // Self-representing primitives returned above, so `value` is an object
+    // from here on, and the two container arms are what an ordinary one takes.
+    // Neither can claim a `FabricSpecialObject`: `isPlainObject()` tests the
+    // prototype, and one of those has a class.
+
+    if (Array.isArray(value)) {
+      return this.encodeArray(value, seen ?? new Set());
+    } else if (isPlainObject(value)) {
+      return this.encodePlainObject(value, seen ?? new Set());
+    } else if (value instanceof FabricSpecialObject) {
+      // Every `FabricSpecialObject` has to be recognized by a registered
+      // codec. Nothing matched above, so this one is not carried.
+      throw new Error(
+        `No codec registered for \`FabricSpecialObject\` subclass ${
+          backtickQuote(value.constructor.name)
+        }.`,
+      );
+    }
+
+    // Every `FabricValue` object case is handled above, so what is left is
+    // always an error -- generally traceable to a type-system lie somewhere
+    // upstream.
+    throw new Error(
+      `Cannot encode ${
+        backtickQuote(toCompactDebugString(value, 50))
+      }: no applicable codec.`,
+    );
+  }
+
+  /** Encodes one value through the codec the registry matched to it. */
+  #encodeTagged(
+    value: FabricValue,
+    matched: CodecForFormat<Encoded>,
+    seen: Set<object>,
+  ): Encoded {
+    const isObject = (value !== null) && (typeof value === "object");
+
+    if (isObject) {
+      BaseCodecEngine.enterOrThrow(seen, value as object);
+    }
+
+    // `tagForValue()` rather than any direct property of `value`, because the
+    // value need not know which codec is being used for it: the tag is the
+    // codec's determination, not the value's.
+    //
+    // A terminal codec's state is already in this format's domain, so it is
+    // final; a nonterminal codec's is made of fabric values, which this walk
+    // has yet to expand.
+    const tag = matched.tagForValue(value);
+    const state = (matched instanceof BaseTerminalCodec)
+      ? (matched as TerminalCodec<Encoded>).encode(value)
+      : this.encodeValue((matched as NonterminalCodec).encode(value), seen);
+
+    if (isObject) {
+      seen.delete(value as object);
+    }
+
+    return this.wrapTag(tag, state);
+  }
+
+  /**
+   * Decodes one tagged value, dispatching on the tag through the registry. A
+   * subclass calls this once it has recognized a tagged form and taken off
+   * whatever meta-tags this format defines for itself.
+   *
+   * Frozen-ness contract: a value returned through the codec arm here is
+   * deep-frozen, so callers do not each have to freeze. The unknown-tag
+   * fallback is a separate arm and is intentionally NOT covered by it.
+   */
+  protected decodeTagged(
+    tag: string,
+    rawState: Encoded,
+    context: ReconstructionContext,
+  ): FabricValue {
+    const matched = this.registry.codecFromTag(tag);
+
+    if (matched === undefined) {
+      const state = this.decodeValue(rawState, context);
+
+      // An empty tag is an encoding error whatever follows it, per Section 9
+      // of the formal spec, so it is reported rather than preserved as an
+      // `UnknownValue` with no name. Otherwise the tag is simply one this
+      // registry does not carry, and the unknown form is kept so that it
+      // round-trips. Neither of these is covered by the deep-frozen contract
+      // the codec arm below states.
+      return (tag === "")
+        ? new ProblematicValue(tag, state, "tagged value has an empty tag")
+        : new UnknownValue(tag, state);
+    }
+
+    // A terminal codec takes the state exactly as it arrived; a nonterminal
+    // one takes it expanded. The casts restate what `instanceof` just
+    // established, which TypeScript drops on a generic class.
+    const terminal = matched instanceof BaseTerminalCodec;
+    const state = terminal ? rawState : this.decodeValue(rawState, context);
+
+    try {
+      // A codec's `decode()` promises deep-frozen results rather than relying
+      // on every caller to freeze, so both returns here pass through
+      // `deepFreeze()`. That covers the codec's own product -- a
+      // `FabricPrimitive` is already frozen, making it an O(1) cache hit --
+      // and the lenient fallback alike.
+      return deepFreeze(
+        terminal
+          ? (matched as TerminalCodec<Encoded>).decode(tag, rawState, context)
+          : (matched as NonterminalCodec).decode(
+            tag,
+            state as FabricValue,
+            context,
+          ),
+      );
+    } catch (e: unknown) {
+      if (!this.lenient) {
+        throw e;
+      }
+
+      // Report over the state the codec was actually handed, so that it says
+      // what the codec choked on.
+      return deepFreeze(
+        new ProblematicValue(
+          tag,
+          state as FabricValue,
+          e instanceof Error ? e.message : String(e),
+        ),
+      );
+    }
+  }
+
+  /** Encodes an array, which is this format's business entirely. */
+  protected abstract encodeArray(
+    value: readonly FabricValue[],
+    seen: Set<object>,
+  ): Encoded;
+
+  /** Encodes a plain object, which is this format's business entirely. */
+  protected abstract encodePlainObject(
+    value: Record<string, FabricValue>,
+    seen: Set<object>,
+  ): Encoded;
+
+  /** Wraps a tag and state into this format's tagged wire form. */
+  protected abstract wrapTag(tag: string, state: Encoded): Encoded;
+
+  /** Decodes a transport tree back into fabric values. */
+  protected abstract decodeValue(
+    data: Encoded,
+    context: ReconstructionContext,
+  ): FabricValue;
+
+  //
+  // Static members
+  //
+
+  /**
+   * Adds a value to the in-progress set, refusing a repeat visit.
+   *
+   * @throws If `value` is already in `seen`.
+   */
+  protected static enterOrThrow(seen: Set<object>, value: object): void {
+    if (seen.has(value)) {
+      throw new Error("Circular reference detected during serialization");
+    }
+    seen.add(value);
+  }
+}

--- a/packages/data-model/src/codec-common/BaseCodecEngine.ts
+++ b/packages/data-model/src/codec-common/BaseCodecEngine.ts
@@ -103,10 +103,15 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
    * `context` supplies what reconstruction needs beyond the data itself,
    * chiefly the ability to resolve a cell reference.
    *
-   * A codec that rejects the state it is handed either throws or is wrapped in
-   * a `ProblematicValue`, according to {@link #lenient}. A tag no codec in the
-   * registry claims becomes an `UnknownValue`, which is not a failure: it is
-   * how a value survives a round trip through a reader that does not know the
+   * A codec rejects a state it will not accept in one of two ways, by
+   * throwing or by returning a `ProblematicValue`, and which one it picks is
+   * the codec author's business. {@link #lenient} decides what a caller sees,
+   * settling both into the same answer: strictly, either form of rejection
+   * raises; leniently, either becomes a `ProblematicValue` in the result.
+   *
+   * A tag no codec in the registry claims is a different matter, and becomes
+   * an `UnknownValue` under both settings. That is not a rejection: it is how
+   * a value survives a round trip through a reader that does not know the
    * type.
    *
    * @throws If `data` does not carry this format's marker, or if a codec
@@ -233,21 +238,16 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
     const terminal = matched instanceof BaseTerminalCodec;
     const state = terminal ? rawState : this.decodeValue(rawState, context);
 
+    let decoded: FabricValue;
+
     try {
-      // A codec's `decode()` promises deep-frozen results rather than relying
-      // on every caller to freeze, so both returns here pass through
-      // `deepFreeze()`. That covers the codec's own product -- a
-      // `FabricPrimitive` is already frozen, making it an O(1) cache hit --
-      // and the lenient fallback alike.
-      return deepFreeze(
-        terminal
-          ? (matched as TerminalCodec<Encoded>).decode(tag, rawState, context)
-          : (matched as NonterminalCodec).decode(
-            tag,
-            state as FabricValue,
-            context,
-          ),
-      );
+      decoded = terminal
+        ? (matched as TerminalCodec<Encoded>).decode(tag, rawState, context)
+        : (matched as NonterminalCodec).decode(
+          tag,
+          state as FabricValue,
+          context,
+        );
     } catch (e: unknown) {
       if (!this.lenient) {
         throw e;
@@ -263,6 +263,21 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
         ),
       );
     }
+
+    if (!this.lenient && (decoded instanceof ProblematicValue)) {
+      // The two ways a codec reports a state it will not accept -- throwing,
+      // and returning one of these -- are the codec author's choice and say
+      // nothing about what a caller wants. `lenient` is what says that, so
+      // this instance settles both into the same answer: a strict decode
+      // fails, whichever way the codec spelled it.
+      throw new Error(`\`${tag}\`: ${decoded.error}`);
+    }
+
+    // A codec's `decode()` promises deep-frozen results rather than relying on
+    // every caller to freeze. That covers the codec's own product -- a
+    // `FabricPrimitive` is already frozen, making it an O(1) cache hit -- and
+    // the lenient fallback above alike.
+    return deepFreeze(decoded);
   }
 
   /** Encodes an array, which is this format's business entirely. */

--- a/packages/data-model/src/codec-common/BaseCodecEngine.ts
+++ b/packages/data-model/src/codec-common/BaseCodecEngine.ts
@@ -176,6 +176,36 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
     }
   }
 
+  /**
+   * Reports wire data this engine itself found malformed, settled against
+   * {@link #lenient}: strictly it raises, and leniently it becomes a
+   * `ProblematicValue` in the result.
+   *
+   * A codec rejecting a state it was handed goes through the same setting, in
+   * {@link #decodeTagged}. Which of the two noticed is an implementation
+   * detail of where a check happens to live, so it does not decide what a
+   * caller sees; `lenient` does.
+   *
+   * @param wireTypeTag The tag the malformed data arrived under, or the
+   *   meta-tag naming the structure at fault.
+   * @param state The data at fault, preserved so that a lenient result
+   *   round-trips.
+   * @param error What is wrong with it, phrased to stand on its own -- it is
+   *   the whole of the message when this raises.
+   * @throws If this engine is not lenient.
+   */
+  protected reportMalformed(
+    wireTypeTag: string,
+    state: FabricValue,
+    error: string,
+  ): FabricValue {
+    if (!this.lenient) {
+      throw new Error(error);
+    }
+
+    return deepFreeze(new ProblematicValue(wireTypeTag, state, error));
+  }
+
   /** Encodes one value through the codec the registry matched to it. */
   #encodeTagged(
     value: FabricValue,
@@ -233,7 +263,7 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
       // round-trips. Neither of these is covered by the deep-frozen contract
       // the codec arm below states.
       return (tag === "")
-        ? new ProblematicValue(tag, state, "tagged value has an empty tag")
+        ? this.reportMalformed(tag, state, "tagged value has an empty tag")
         : new UnknownValue(tag, state);
     }
 

--- a/packages/data-model/src/codec-common/index.ts
+++ b/packages/data-model/src/codec-common/index.ts
@@ -27,6 +27,7 @@ export * from "@/codec-interface/index.ts";
 
 export { codecOf } from "./codecOf.ts";
 export { CodecRegistry } from "./CodecRegistry.ts";
+export { BaseCodecEngine } from "./BaseCodecEngine.ts";
 
 export { BaseFabricInstance } from "./BaseFabricInstance.ts";
 export { BaseFabricPrimitive } from "./BaseFabricPrimitive.ts";

--- a/packages/data-model/src/codec-common/index.ts
+++ b/packages/data-model/src/codec-common/index.ts
@@ -1,7 +1,8 @@
 /**
  * This directory holds the codec system's active machinery: the registry that
- * indexes codecs, the lookup that finds a class's codec, the abstract bases
- * every participating class extends, and the `ExplicitTagValue` family. It is
+ * indexes codecs, the lookup that finds a class's codec, the base class a
+ * whole-value codec engine extends, the abstract bases every participating
+ * class extends, and the `ExplicitTagValue` family. It is
  * also the package's public face for the codec system as a whole, re-exporting
  * the declarations in `codec-interface/` so that an outside caller has one
  * entry point rather than two.
@@ -17,9 +18,9 @@
  * `codec-json/` holds the four that JSON needs.
  *
  * The classes here are the codec system's own. That covers the two abstract
- * bases every participating class extends, and the `ExplicitTagValue` family,
- * whose members exist only because a decode went wrong or found a tag that no
- * codec claimed. A class a caller models data with belongs in
+ * bases every participating class extends, the base that each format's engine
+ * extends, and the `ExplicitTagValue` family, whose members exist only because
+ * a decode went wrong or found a tag that no codec claimed. A class a caller models data with belongs in
  * `fabric-instances/` or `fabric-primitives/` instead.
  */
 

--- a/packages/data-model/src/codec-common/index.ts
+++ b/packages/data-model/src/codec-common/index.ts
@@ -1,11 +1,10 @@
 /**
  * This directory holds the codec system's active machinery: the registry that
- * indexes codecs, the lookup that finds a class's codec, the base class a
- * whole-value codec engine extends, the abstract bases every participating
- * class extends, and the `ExplicitTagValue` family. It is
- * also the package's public face for the codec system as a whole, re-exporting
- * the declarations in `codec-interface/` so that an outside caller has one
- * entry point rather than two.
+ * indexes codecs, the lookup that finds a class's codec, the abstract bases
+ * described below, and the `ExplicitTagValue` family. It is also the package's
+ * public face for the codec system as a whole, re-exporting the declarations
+ * in `codec-interface/` so that an outside caller has one entry point rather
+ * than two.
  *
  * That convenience is for this barrel alone. A module inside the package
  * imports the file it wants directly -- nothing here imports this barrel --
@@ -17,11 +16,17 @@
  * format cannot carry some type belongs with that format instead:
  * `codec-json/` holds the four that JSON needs.
  *
- * The classes here are the codec system's own. That covers the two abstract
- * bases every participating class extends, the base that each format's engine
- * extends, and the `ExplicitTagValue` family, whose members exist only because
- * a decode went wrong or found a tag that no codec claimed. A class a caller models data with belongs in
- * `fabric-instances/` or `fabric-primitives/` instead.
+ * Two kinds of abstract base live here, and counting them together is a
+ * mistake: nothing extends one kind and the other. `BaseFabricInstance` and
+ * `BaseFabricPrimitive` are what a VALUE extends in order to participate in a
+ * wire format at all, one per branch of the fabric type hierarchy.
+ * `BaseCodecEngine` is what an ENGINE extends, one per wire format -- the
+ * thing that walks such values and drives their codecs.
+ *
+ * Besides those, the classes here are the `ExplicitTagValue` family, whose
+ * members exist only because a decode went wrong or found a tag that no codec
+ * claimed. A class a caller models data with belongs in `fabric-instances/`
+ * or `fabric-primitives/` instead.
  */
 
 export * from "@/codec-interface/index.ts";

--- a/packages/data-model/src/codec-json/JsonCodecEngine.ts
+++ b/packages/data-model/src/codec-json/JsonCodecEngine.ts
@@ -67,7 +67,7 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
 
   /** Serializes a fabric value to UTF-8 JSON bytes. */
   encodeToBytes(value: FabricValue): Uint8Array {
-    return this.toBytes(this.encodeValue(value));
+    return JsonCodecEngine.#toBytes(this.encodeValue(value));
   }
 
   /** Deserializes UTF-8 JSON bytes back into a fabric value. */
@@ -75,7 +75,7 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
     bytes: Uint8Array,
     context: ReconstructionContext,
   ): FabricValue {
-    const tree = this.fromBytes(bytes);
+    const tree = JsonCodecEngine.#fromBytes(bytes);
     return this.decodeValue(tree, context);
   }
 
@@ -97,42 +97,6 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
     state: JsonCodecValue,
   ): JsonCodecValue {
     return { [`/${tag}`]: state } as JsonCodecValue;
-  }
-
-  /**
-   * Unwraps a wire representation. Detects single-key objects with `/`-prefixed
-   * keys. Returns `{ tag, state }` or `null` if not a tagged value. The
-   * returned `state` is extracted directly from `data`, so if `data` is
-   * deep-frozen (as it should be) then `state` will be too.
-   *
-   * See Section 5.4 of the formal spec.
-   */
-  private unwrapTag(
-    data: JsonCodecValue,
-  ): { tag: string; state: JsonCodecValue } | null {
-    if (!isPlainObject(data)) {
-      return null;
-    }
-
-    if (!JsonCodecEngine.#isEncodedInstance(data)) {
-      return null;
-    }
-
-    // `#isEncodedInstance()` guaranteed a single-property object, so this
-    // destructures that one entry.
-    const [key, value] = Object.entries(data)[0]!;
-    return { tag: key.slice(1), state: value };
-  }
-
-  /** Converts a codec-value tree to UTF-8-encoded JSON bytes. */
-  private toBytes(data: JsonCodecValue): Uint8Array {
-    return JsonCodecEngine.#textEncoder.encode(JSON.stringify(data));
-  }
-
-  /** Parses UTF-8-encoded JSON bytes back into a codec-value tree. */
-  private fromBytes(bytes: Uint8Array): JsonCodecValue {
-    const json = JsonCodecEngine.#textDecoder.decode(bytes);
-    return JsonCodecEngine.#parseWireText(json);
   }
 
   /**
@@ -227,7 +191,7 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
     data: JsonCodecValue,
     context: ReconstructionContext,
   ): FabricValue {
-    const decoded = this.unwrapTag(data);
+    const decoded = JsonCodecEngine.#unwrapTag(data);
     if (decoded !== null) {
       const { tag, state: rawState } = decoded;
 
@@ -244,7 +208,7 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
           // Same reservation as the plain-object arm below: the assignment
           // cannot rebuild these names.
           if (isUnsafeObjectKey(key)) {
-            return new ProblematicValue(
+            return this.reportMalformed(
               key,
               inner,
               `object contains a key this runtime reserves: "${key}"`,
@@ -307,13 +271,13 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
     const result: FabricValue[] = new Array(data.length);
     let targetIndex = 0;
     for (const entry of data) {
-      const entryDecoded = this.unwrapTag(entry);
+      const entryDecoded = JsonCodecEngine.#unwrapTag(entry);
       if (
         entryDecoded !== null && entryDecoded.tag === CODEC_META_TAGS.hole
       ) {
         const count = entryDecoded.state;
         if (!JsonCodecEngine.#isHoleCount(count)) {
-          return new ProblematicValue(
+          return this.reportMalformed(
             CODEC_META_TAGS.hole,
             count,
             `hole: expected a positive integer count, got ${
@@ -335,7 +299,7 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
     // machinery, which says nothing about the wire that caused it.
     const MAX_ARRAY_LENGTH = 0xffff_ffff;
     if (targetIndex > MAX_ARRAY_LENGTH) {
-      return new ProblematicValue(
+      return this.reportMalformed(
         CODEC_META_TAGS.hole,
         data,
         `hole: runs total ${targetIndex} elements, past the ` +
@@ -359,7 +323,7 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
     const result: Record<string, FabricValue> = {};
     for (const [key, val] of Object.entries(data)) {
       if (key.startsWith("/")) {
-        return new ProblematicValue(
+        return this.reportMalformed(
           key.slice(1),
           data,
           `object contains reserved /-prefixed key: "${key}"`,
@@ -371,7 +335,7 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
       // implementation, whose write path refuses it, so report it rather than
       // decoding something the bytes do not say.
       if (isUnsafeObjectKey(key)) {
-        return new ProblematicValue(
+        return this.reportMalformed(
           key,
           data,
           `object contains a key this runtime reserves: "${key}"`,
@@ -391,6 +355,42 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
 
   /** Shared text decoder, created once. */
   static readonly #textDecoder = new TextDecoder();
+
+  /**
+   * Unwraps a wire representation. Detects single-key objects with `/`-prefixed
+   * keys. Returns `{ tag, state }` or `null` if not a tagged value. The
+   * returned `state` is extracted directly from `data`, so if `data` is
+   * deep-frozen (as it should be) then `state` will be too.
+   *
+   * See Section 5.4 of the formal spec.
+   */
+  static #unwrapTag(
+    data: JsonCodecValue,
+  ): { tag: string; state: JsonCodecValue } | null {
+    if (!isPlainObject(data)) {
+      return null;
+    }
+
+    if (!JsonCodecEngine.#isEncodedInstance(data)) {
+      return null;
+    }
+
+    // `#isEncodedInstance()` guaranteed a single-property object, so this
+    // destructures that one entry.
+    const [key, value] = Object.entries(data)[0]!;
+    return { tag: key.slice(1), state: value };
+  }
+
+  /** Converts a codec-value tree to UTF-8-encoded JSON bytes. */
+  static #toBytes(data: JsonCodecValue): Uint8Array {
+    return JsonCodecEngine.#textEncoder.encode(JSON.stringify(data));
+  }
+
+  /** Parses UTF-8-encoded JSON bytes back into a codec-value tree. */
+  static #fromBytes(bytes: Uint8Array): JsonCodecValue {
+    const json = JsonCodecEngine.#textDecoder.decode(bytes);
+    return JsonCodecEngine.#parseWireText(json);
+  }
 
   /**
    * Registry for the throwaway checks in the testing helpers below: this

--- a/packages/data-model/src/codec-json/JsonCodecEngine.ts
+++ b/packages/data-model/src/codec-json/JsonCodecEngine.ts
@@ -2,23 +2,20 @@ import { backtickQuote } from "@commonfabric/utils/markdown";
 import { isPlainObject, isUnsafeObjectKey } from "@commonfabric/utils/types";
 import { utf8SortedKeysOf } from "@commonfabric/utils/utf8";
 
-import { FabricSpecialObject, type FabricValue } from "@/interface.ts";
+import type { FabricValue } from "@/interface.ts";
+import { BaseCodecEngine } from "@/codec-common/BaseCodecEngine.ts";
 import { toCompactDebugString } from "@/value-debug.ts";
 import {
   CODEC,
-  type NonterminalCodec,
   type ReconstructionContext,
-  type SerializationContext,
-  type TerminalCodec,
 } from "@/codec-interface/interface.ts";
-import { BaseTerminalCodec } from "@/codec-interface/BaseTerminalCodec.ts";
 import { deepFreeze } from "@/deep-freeze.ts";
 import { EmptyReconstructionContext } from "@/codec-interface/EmptyReconstructionContext.ts";
 import { UnknownValue } from "@/codec-common/UnknownValue.ts";
 import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
 import { ENCODING_PREFIX_TAG, type JsonCodecValue } from "./interface.ts";
 import { createBaseJsonRegistry } from "./createBaseJsonRegistry.ts";
-import { type CodecRegistry, SELF_REP } from "@/codec-common/CodecRegistry.ts";
+import type { CodecRegistry } from "@/codec-common/CodecRegistry.ts";
 import { CODEC_META_TAGS } from "@/codec-interface/codec-meta-tags.ts";
 
 /**
@@ -33,48 +30,30 @@ import { CODEC_META_TAGS } from "@/codec-interface/codec-meta-tags.ts";
  * private. Per-type encoding/decoding is delegated to the `FabricCodec`s in
  * the `CodecRegistry`.
  */
-export class JsonCodec implements SerializationContext<string> {
-  /**
-   * Whether a failed reconstruction produces a `ProblematicValue` instead of
-   * throwing.
-   */
-  readonly lenient: boolean;
-
-  /** Registry consulted for per-type encoding and decoding. */
-  readonly #registry: CodecRegistry<JsonCodecValue>;
-
-  /**
-   * Constructs an instance. `options.registry` supplies the codecs this
-   * instance encodes and decodes with, and so decides which classes it can
-   * carry; there is no default, because which classes participate is a
-   * question this class has no standing to answer. `options.lenient` makes a
-   * failed reconstruction produce a `ProblematicValue` instead of throwing.
-   */
-  constructor(
-    options: { registry: CodecRegistry<JsonCodecValue>; lenient?: boolean },
-  ) {
-    this.lenient = options.lenient ?? false;
-    this.#registry = options.registry;
-  }
-
+export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
   //
   // Instance members
   //
 
   /**
-   * Encodes a fabric value to a JSON string. Serializes fabric types into
-   * the `/<Type>@<Version>` tagged wire format, then stringifies.
+   * @inheritDoc
+   *
+   * Walks the value into the `/<Type>@<Version>` tagged tree, stringifies it,
+   * and prefixes the format tag.
    */
-  encode(value: FabricValue): string {
-    return ENCODING_PREFIX_TAG + JSON.stringify(this.#encodeValue(value));
+  override encode(value: FabricValue): string {
+    return ENCODING_PREFIX_TAG +
+      JSON.stringify(this.encodeValue(value));
   }
 
   /**
-   * Decodes a JSON string back into a fabric value. Parses the string,
-   * then deserializes tagged forms back into runtime types.
+   * @inheritDoc
+   *
+   * Checks the format tag, parses what follows it, and walks the resulting
+   * tree back into fabric values.
    */
-  decode(data: string, context: ReconstructionContext): FabricValue {
-    if (!JsonCodec.seemsLikeEncoded(data)) {
+  override decode(data: string, context: ReconstructionContext): FabricValue {
+    if (!JsonCodecEngine.seemsLikeEncoded(data)) {
       const excerpt = (data.length <= 50) ? data : `${data.slice(0, 50)}...`;
       throw new Error(
         `Not a JSON-encoded \`FabricValue\` string: ${backtickQuote(excerpt)}`,
@@ -82,13 +61,13 @@ export class JsonCodec implements SerializationContext<string> {
     }
 
     const json = data.slice(ENCODING_PREFIX_TAG.length);
-    const parsed = JsonCodec.#parseWireText(json);
-    return this.#decodeValue(parsed, context);
+    const parsed = JsonCodecEngine.#parseWireText(json);
+    return this.decodeValue(parsed, context);
   }
 
   /** Serializes a fabric value to UTF-8 JSON bytes. */
   encodeToBytes(value: FabricValue): Uint8Array {
-    return this.toBytes(this.#encodeValue(value));
+    return this.toBytes(this.encodeValue(value));
   }
 
   /** Deserializes UTF-8 JSON bytes back into a fabric value. */
@@ -97,15 +76,27 @@ export class JsonCodec implements SerializationContext<string> {
     context: ReconstructionContext,
   ): FabricValue {
     const tree = this.fromBytes(bytes);
-    return this.#decodeValue(tree, context);
+    return this.decodeValue(tree, context);
   }
 
   /**
-   * Wraps a tag and state into the `/<tag>` wire format. Prepends `/` to the
-   * tag to produce the JSON key. See Section 5.2 of the formal spec.
+   * @inheritDoc
+   *
+   * Prepends `/` to the tag to produce the JSON key. See Section 5.2 of the
+   * formal spec.
+   *
+   * The result is not frozen. A serialize-side tree is stringified and
+   * discarded without ever reaching a caller, so the deep-frozen invariant
+   * `JsonCodecValue` states does not cover it, and freezing every tagged node
+   * on the way out is measurable on small values. The meta-tag call sites
+   * below freeze what they build, where the cost is already paid by the
+   * rebuild around it.
    */
-  private wrapTag(tag: string, state: JsonCodecValue): JsonCodecValue {
-    return Object.freeze({ [`/${tag}`]: state } as JsonCodecValue);
+  protected override wrapTag(
+    tag: string,
+    state: JsonCodecValue,
+  ): JsonCodecValue {
+    return { [`/${tag}`]: state } as JsonCodecValue;
   }
 
   /**
@@ -123,7 +114,7 @@ export class JsonCodec implements SerializationContext<string> {
       return null;
     }
 
-    if (!JsonCodec.#isEncodedInstance(data)) {
+    if (!JsonCodecEngine.#isEncodedInstance(data)) {
       return null;
     }
 
@@ -135,153 +126,89 @@ export class JsonCodec implements SerializationContext<string> {
 
   /** Converts a codec-value tree to UTF-8-encoded JSON bytes. */
   private toBytes(data: JsonCodecValue): Uint8Array {
-    return JsonCodec.#textEncoder.encode(JSON.stringify(data));
+    return JsonCodecEngine.#textEncoder.encode(JSON.stringify(data));
   }
 
   /** Parses UTF-8-encoded JSON bytes back into a codec-value tree. */
   private fromBytes(bytes: Uint8Array): JsonCodecValue {
-    const json = JsonCodec.#textDecoder.decode(bytes);
-    return JsonCodec.#parseWireText(json);
+    const json = JsonCodecEngine.#textDecoder.decode(bytes);
+    return JsonCodecEngine.#parseWireText(json);
   }
 
   /**
-   * Encodes a fabric value into the codec-value tree. Recursively processes
-   * nested values. See Section 4.5 of the formal spec.
+   * @inheritDoc
+   *
+   * A run of holes is spelled as a `/hole` count, JSON having no way to write
+   * an absent index.
    */
-  #encodeValue(
-    value: FabricValue,
-    _seen?: Set<object>,
+  protected override encodeArray(
+    value: readonly FabricValue[],
+    seen: Set<object>,
   ): JsonCodecValue {
-    const matched = this.#registry.codecFromValue(value);
+    JsonCodecEngine.enterOrThrow(seen, value);
 
-    if (matched === SELF_REP) {
-      // A self-representing primitive is its own wire form.
-      return value as JsonCodecValue;
-    } else if (matched) {
-      const seen = _seen ?? new Set<object>();
-      let addedToSeen = false;
-
-      if (value !== null && typeof value === "object") {
-        if (seen.has(value as object)) {
-          throw new Error("Circular reference detected during serialization");
-        }
-        seen.add(value as object);
-        addedToSeen = true;
-      }
-
-      // We use `tagForValue()` here rather than relying on any direct property
-      // of `value`, because `value` might not actually know what codec is being
-      // used for it, and it is up to the _codec_ not the value per se to
-      // determine the correct tag.
-      //
-      // A terminal codec's state is already in this format's domain, so it is
-      // final; a nonterminal codec's is made of fabric values, which this
-      // walker has yet to expand.
-      const tag = matched.tagForValue(value);
-      const finalState = (matched instanceof BaseTerminalCodec)
-        ? matched.encode(value) as JsonCodecValue
-        : this.#encodeValue(matched.encode(value) as FabricValue, seen);
-      const result: JsonCodecValue = { [`/${tag}`]: finalState };
-
-      if (addedToSeen) {
-        seen.delete(value as object);
-      }
-
-      return result;
-    } else if (value instanceof FabricSpecialObject) {
-      // Every `FabricSpecialObject` (that is, all objects that are
-      // `FabricValue`s other than plain objects and plain arrays must be
-      // recognized by a registered codec. Complain here since we didn't find a
-      // `codec` above.
-      throw new Error(
-        `No codec registered for fabric object class: ${
-          backtickQuote(value.constructor.name)
-        }`,
-      );
-    }
-
-    // Self-representing primitives returned `SELF_REP` above. Past this point,
-    // `value` is an `object`.
-
-    // Arrays
-    if (Array.isArray(value)) {
-      const seen = _seen ?? new Set<object>();
-      if (seen.has(value)) {
-        throw new Error("Circular reference detected during serialization");
-      }
-      seen.add(value);
-
-      const result: JsonCodecValue[] = [];
-      let i = 0;
-      while (i < value.length) {
-        if (!(i in value)) {
-          let count = 0;
-          while (i < value.length && !(i in value)) {
-            count++;
-            i++;
-          }
-          result.push(this.wrapTag(CODEC_META_TAGS.hole, count));
-        } else {
-          result.push(
-            this.#encodeValue(value[i], seen),
-          );
+    const result: JsonCodecValue[] = [];
+    let i = 0;
+    while (i < value.length) {
+      if (!(i in value)) {
+        let count = 0;
+        while (i < value.length && !(i in value)) {
+          count++;
           i++;
         }
+        result.push(Object.freeze(this.wrapTag(CODEC_META_TAGS.hole, count)));
+      } else {
+        result.push(this.encodeValue(value[i]!, seen));
+        i++;
       }
-
-      seen.delete(value);
-      return result as JsonCodecValue;
     }
 
-    // The only legit object we can have at this point is a plain object. (The
-    // other `FabricValue` object cases were handled above. So, if we find
-    // ourselves looking at a non-plain object at this point, it's always an
-    // error (and probably a case that can be tracked down to a typesystem lie
-    // of some sort).
-    if (!isPlainObject(value)) {
-      throw new Error(
-        `Cannot encode ${
-          backtickQuote(toCompactDebugString(value, 50))
-        }: no applicable codec.`,
-      );
-    }
+    seen.delete(value);
+    return result as JsonCodecValue;
+  }
 
-    // Plain objects
-    const seen = _seen ?? new Set<object>();
-    if (seen.has(value as object)) {
-      throw new Error("Circular reference detected during serialization");
-    }
-    seen.add(value as object);
+  /**
+   * @inheritDoc
+   *
+   * Keys are visited in UTF-8 byte order, matching the canonical order
+   * `value-hash.ts` uses, so that this encoding is deterministic across
+   * implementations and across objects whose keys differ only in insertion
+   * order. See `3-json-encoding.md` Section 10.
+   *
+   * A `/`-prefixed key collides with the tag form, so an object bearing one is
+   * escaped per Section 5.6: all values are encoded first, and if every one is
+   * quote-safe the whole object is wrapped in `/quote` with any `/quote`
+   * children collapsed into it, and otherwise in `/object` so that the decoder
+   * walks the entries.
+   */
+  protected override encodePlainObject(
+    value: Record<string, FabricValue>,
+    seen: Set<object>,
+  ): JsonCodecValue {
+    JsonCodecEngine.enterOrThrow(seen, value);
 
-    // Iterate keys in UTF-8 byte order. This matches the canonical key order
-    // used by `value-hash.ts`, and makes JSON encoding deterministic across
-    // implementations and across objects whose keys differ only in insertion
-    // order. See `3-json-encoding.md` Section 10 for the spec.
     const result: Record<string, JsonCodecValue> = {};
-    const valueRec = value as Record<string, FabricValue>;
     let anySlashKey = false;
-    for (const key of utf8SortedKeysOf(valueRec)) {
+    for (const key of utf8SortedKeysOf(value)) {
       if (key.startsWith("/")) {
         anySlashKey = true;
       }
-      result[key] = this.#encodeValue(valueRec[key], seen);
+      result[key] = this.encodeValue(value[key]!, seen);
     }
-    seen.delete(value as object);
+    seen.delete(value);
 
-    // Apply escaping per Section 5.6 for plain objects with /-prefixed keys.
-    // Serialize all values first (post-pass), then check if all are quote-safe.
-    // If so, unwrap any /quote children and wrap the whole object with /quote.
-    // Otherwise wrap with /object so the decoder deserializes entries.
     if (anySlashKey) {
-      if (Object.values(result).every((v) => JsonCodec.#isQuoteSafe(v))) {
+      if (Object.values(result).every((v) => JsonCodecEngine.#isQuoteSafe(v))) {
         const unquoted = Object.freeze(
           Object.fromEntries(
-            Object.entries(result).map(([k, v]) => [k, JsonCodec.#unquote(v)]),
+            Object.entries(result).map((
+              [k, v],
+            ) => [k, JsonCodecEngine.#unquote(v)]),
           ),
         );
-        return this.wrapTag(CODEC_META_TAGS.quote, unquoted) as JsonCodecValue;
+        return Object.freeze(this.wrapTag(CODEC_META_TAGS.quote, unquoted));
       }
-      return this.wrapTag(CODEC_META_TAGS.object, result) as JsonCodecValue;
+      return Object.freeze(this.wrapTag(CODEC_META_TAGS.object, result));
     }
 
     return result as JsonCodecValue;
@@ -296,7 +223,7 @@ export class JsonCodec implements SerializationContext<string> {
    * freeze. The unknown-tag fallback (`UnknownValue`) is a separate arm and is
    * intentionally NOT covered by this contract.
    */
-  #decodeValue(
+  protected override decodeValue(
     data: JsonCodecValue,
     context: ReconstructionContext,
   ): FabricValue {
@@ -323,76 +250,14 @@ export class JsonCodec implements SerializationContext<string> {
               `object contains a key this runtime reserves: "${key}"`,
             );
           }
-          result[key] = this.#decodeValue(val, context);
+          result[key] = this.decodeValue(val, context);
         }
         return Object.freeze(result);
       }
 
-      // Registry-based (tag lookup) dispatch. The lookup comes first because
-      // it decides what form the state is wanted in: a terminal codec takes
-      // the state exactly as it arrived, and everything else takes state this
-      // walker has decoded. (`/quote` and `/object` returned above; no codec
-      // ever sees their state, and `/quote` contents alone go undecoded.)
-      const matched = this.#registry.codecFromTag(tag);
-
-      if (matched === undefined) {
-        const state = this.#decodeValue(rawState, context);
-
-        // A bare `"/"` key (empty tag after stripping the leading slash) is
-        // always an encoding error per spec §9 — no valid tag has an empty
-        // name. Produce a `ProblematicValue` rather than an `UnknownValue`
-        // with an empty tag.
-        //
-        // Otherwise the tag is simply one this registry does not carry, and
-        // the unknown form is preserved so that it round-trips. Neither of
-        // these is covered by the deep-frozen contract that the codec arm
-        // below states.
-        return (tag === "")
-          ? new ProblematicValue(tag, state, `object has bare "/" key`)
-          : new UnknownValue(tag, state);
-      }
-
-      // A terminal codec takes the state exactly as it arrived; a nonterminal
-      // one takes it expanded. The two casts restate what `instanceof` just
-      // established, which TypeScript drops on a generic class.
-      const terminal = matched instanceof BaseTerminalCodec;
-      const state = terminal ? rawState : this.#decodeValue(rawState, context);
-
-      try {
-        // A codec's `decode()` promises deep-frozen results rather than
-        // relying on every caller to freeze, so both returns here pass through
-        // `deepFreeze()`. That covers the codec's own product -- a
-        // `FabricPrimitive` is already frozen, making it an O(1) cache hit --
-        // and the lenient fallback alike. The two arms above are separate and
-        // deliberately not covered.
-        return deepFreeze(
-          terminal
-            ? (matched as TerminalCodec<JsonCodecValue>).decode(
-              tag,
-              rawState,
-              context,
-            )
-            : (matched as NonterminalCodec).decode(
-              tag,
-              state as FabricValue,
-              context,
-            ),
-        );
-      } catch (e: unknown) {
-        if (!this.lenient) {
-          throw e;
-        }
-
-        // Report over the state the codec was actually handed, so that it says
-        // what the codec choked on.
-        return deepFreeze(
-          new ProblematicValue(
-            tag,
-            state,
-            e instanceof Error ? e.message : String(e),
-          ),
-        );
-      }
+      // `/quote` and `/object` returned above, so no codec ever sees their
+      // state, and `/quote` contents alone go undecoded.
+      return this.decodeTagged(tag, rawState, context);
     }
 
     // Primitives pass through.
@@ -403,71 +268,94 @@ export class JsonCodec implements SerializationContext<string> {
       return data;
     }
 
-    // Arrays: recursively deserialize elements.
-    //
-    // One pass. A `/hole` run advances the write index past the indices it
-    // stands for, leaving them absent, and the final length is set from that
-    // index so that a run in the last position is preserved. Counting the
-    // logical length first would mean walking and unwrapping every entry a
-    // second time, for a number this pass arrives at anyway.
-    //
-    // The result is still sized up front, at the entry count. That is exact
-    // whenever the array has no holes, which is the ordinary case, and an
-    // underestimate otherwise -- growing from there beats growing from empty,
-    // and a short array of holes is common enough to be worth not pessimizing.
-    //
-    // A run's count is validated, wire data being untrusted. Left unchecked it
-    // is added to the write index directly, so a string concatenates onto it
-    // and a negative or fractional one makes the length assignment throw --
-    // failures with no bearing on what went wrong. A run stands for at least
-    // one absent index, and anything else is reported instead.
     if (Array.isArray(data)) {
-      const result: FabricValue[] = new Array(data.length);
-      let targetIndex = 0;
-      for (const entry of data) {
-        const entryDecoded = this.unwrapTag(entry);
-        if (
-          entryDecoded !== null && entryDecoded.tag === CODEC_META_TAGS.hole
-        ) {
-          const count = entryDecoded.state;
-          if (!JsonCodec.#isHoleCount(count)) {
-            return new ProblematicValue(
-              CODEC_META_TAGS.hole,
-              count,
-              `hole: expected a positive integer count, got ${
-                backtickQuote(toCompactDebugString(count, 30))
-              }`,
-            );
-          }
-          targetIndex += count;
-        } else {
-          result[targetIndex] = this.#decodeValue(entry, context);
-          targetIndex++;
-        }
-      }
-
-      // The total is bounded here rather than each advance being bounded as
-      // it happens, because both a single run and the running total can pass
-      // what an array may hold, and one check at the end covers both. Beyond
-      // that, the assignment below throws `RangeError` from the array
-      // machinery, which says nothing about the wire that caused it.
-      const MAX_ARRAY_LENGTH = 0xffff_ffff;
-      if (targetIndex > MAX_ARRAY_LENGTH) {
-        return new ProblematicValue(
-          CODEC_META_TAGS.hole,
-          data,
-          `hole: runs total ${targetIndex} elements, past the ` +
-            `${MAX_ARRAY_LENGTH} an array can hold`,
-        );
-      }
-
-      result.length = targetIndex;
-      return Object.freeze(result);
+      return this.#decodeArray(data, context);
     }
 
-    // Plain objects: recursively deserialize values and freeze. Any
-    // `/`-prefixed key is reserved per spec — return `ProblematicValue` on
-    // first occurrence rather than silently round-tripping the object.
+    // `Array.isArray()` above removed the array arm, but TypeScript keeps it
+    // in the union; the remaining member is the record.
+    return this.#decodePlainObject(
+      data as Record<string, JsonCodecValue>,
+      context,
+    );
+  }
+
+  /**
+   * Arrays: recursively deserialize elements.
+   *
+   * One pass. A `/hole` run advances the write index past the indices it
+   * stands for, leaving them absent, and the final length is set from that
+   * index so that a run in the last position is preserved. Counting the
+   * logical length first would mean walking and unwrapping every entry a
+   * second time, for a number this pass arrives at anyway.
+   *
+   * The result is still sized up front, at the entry count. That is exact
+   * whenever the array has no holes, which is the ordinary case, and an
+   * underestimate otherwise -- growing from there beats growing from empty,
+   * and a short array of holes is common enough to be worth not pessimizing.
+   *
+   * A run's count is validated, wire data being untrusted. Left unchecked it
+   * is added to the write index directly, so a string concatenates onto it
+   * and a negative or fractional one makes the length assignment throw --
+   * failures with no bearing on what went wrong. A run stands for at least
+   * one absent index, and anything else is reported instead.
+   */
+  #decodeArray(
+    data: readonly JsonCodecValue[],
+    context: ReconstructionContext,
+  ): FabricValue {
+    const result: FabricValue[] = new Array(data.length);
+    let targetIndex = 0;
+    for (const entry of data) {
+      const entryDecoded = this.unwrapTag(entry);
+      if (
+        entryDecoded !== null && entryDecoded.tag === CODEC_META_TAGS.hole
+      ) {
+        const count = entryDecoded.state;
+        if (!JsonCodecEngine.#isHoleCount(count)) {
+          return new ProblematicValue(
+            CODEC_META_TAGS.hole,
+            count,
+            `hole: expected a positive integer count, got ${
+              backtickQuote(toCompactDebugString(count, 30))
+            }`,
+          );
+        }
+        targetIndex += count;
+      } else {
+        result[targetIndex] = this.decodeValue(entry, context);
+        targetIndex++;
+      }
+    }
+
+    // The total is bounded here rather than each advance being bounded as
+    // it happens, because both a single run and the running total can pass
+    // what an array may hold, and one check at the end covers both. Beyond
+    // that, the assignment below throws `RangeError` from the array
+    // machinery, which says nothing about the wire that caused it.
+    const MAX_ARRAY_LENGTH = 0xffff_ffff;
+    if (targetIndex > MAX_ARRAY_LENGTH) {
+      return new ProblematicValue(
+        CODEC_META_TAGS.hole,
+        data,
+        `hole: runs total ${targetIndex} elements, past the ` +
+          `${MAX_ARRAY_LENGTH} an array can hold`,
+      );
+    }
+
+    result.length = targetIndex;
+    return Object.freeze(result);
+  }
+
+  /**
+   * Plain objects: recursively deserialize values and freeze. Any
+   * `/`-prefixed key is reserved per spec — return `ProblematicValue` on
+   * first occurrence rather than silently round-tripping the object.
+   */
+  #decodePlainObject(
+    data: Record<string, JsonCodecValue>,
+    context: ReconstructionContext,
+  ): FabricValue {
     const result: Record<string, FabricValue> = {};
     for (const [key, val] of Object.entries(data)) {
       if (key.startsWith("/")) {
@@ -489,7 +377,7 @@ export class JsonCodec implements SerializationContext<string> {
           `object contains a key this runtime reserves: "${key}"`,
         );
       }
-      result[key] = this.#decodeValue(val, context);
+      result[key] = this.decodeValue(val, context);
     }
     return Object.freeze(result);
   }
@@ -573,11 +461,11 @@ export class JsonCodec implements SerializationContext<string> {
   static #isQuoteSafe(v: JsonCodecValue): boolean {
     if (v === null || typeof v !== "object") return true;
     if (Array.isArray(v)) {
-      return v.every((item) => JsonCodec.#isQuoteSafe(item));
+      return v.every((item) => JsonCodecEngine.#isQuoteSafe(item));
     }
-    if (!JsonCodec.#isEncodedInstance(v)) {
+    if (!JsonCodecEngine.#isEncodedInstance(v)) {
       return Object.values(v).every((item) =>
-        JsonCodec.#isQuoteSafe(item as JsonCodecValue)
+        JsonCodecEngine.#isQuoteSafe(item as JsonCodecValue)
       );
     }
     return Object.keys(v)[0] === "/quote";
@@ -592,16 +480,16 @@ export class JsonCodec implements SerializationContext<string> {
     if (v === null || typeof v !== "object") {
       return v;
     } else if (Array.isArray(v)) {
-      const result = v.map(JsonCodec.#unquote) as JsonCodecValue;
+      const result = v.map(JsonCodecEngine.#unquote) as JsonCodecValue;
       return Object.freeze(result);
     } else if (
-      JsonCodec.#isEncodedInstance(v) && Object.keys(v)[0] === "/quote"
+      JsonCodecEngine.#isEncodedInstance(v) && Object.keys(v)[0] === "/quote"
     ) {
       return (v as Record<string, JsonCodecValue>)["/quote"]!;
     } else {
       const result = Object.fromEntries(
         Object.entries(v).map(
-          ([k, val]) => [k, JsonCodec.#unquote(val as JsonCodecValue)],
+          ([k, val]) => [k, JsonCodecEngine.#unquote(val as JsonCodecValue)],
         ),
       ) as JsonCodecValue;
       return Object.freeze(result);
@@ -653,10 +541,10 @@ export class JsonCodec implements SerializationContext<string> {
   static unwrapEncodedValueForTesting(
     encoded: string,
     isMalformed = false,
-    registry: CodecRegistry<JsonCodecValue> = JsonCodec.#testingRegistry,
+    registry: CodecRegistry<JsonCodecValue> = JsonCodecEngine.#testingRegistry,
   ): string {
     if (isMalformed) {
-      if (!JsonCodec.seemsLikeEncoded(encoded)) {
+      if (!JsonCodecEngine.seemsLikeEncoded(encoded)) {
         throw new Error(
           `Not a JSON-encoded \`FabricValue\` string: ${
             backtickQuote(encoded)
@@ -668,9 +556,9 @@ export class JsonCodec implements SerializationContext<string> {
       // establish that `encoded` really is one of ours, rather than a string
       // that happens to begin with the right few characters. (`decode()` checks
       // the tag first, so the malformed branch above loses nothing.)
-      new JsonCodec({ registry }).decode(
+      new JsonCodecEngine({ registry }).decode(
         encoded,
-        JsonCodec.#testingReconstructionContext,
+        JsonCodecEngine.#testingReconstructionContext,
       );
     }
 
@@ -709,17 +597,17 @@ export class JsonCodec implements SerializationContext<string> {
   static wrapEncodedValueForTesting(
     json: string,
     isMalformed = false,
-    registry: CodecRegistry<JsonCodecValue> = JsonCodec.#testingRegistry,
+    registry: CodecRegistry<JsonCodecValue> = JsonCodecEngine.#testingRegistry,
   ): string {
     const encoded = ENCODING_PREFIX_TAG + json;
 
     if (!isMalformed) {
       // Throwaway decode and re-encode; both results are discarded. See above.
-      const jsonCodec = new JsonCodec({ registry });
-      jsonCodec.encode(
-        jsonCodec.decode(
+      const jsonCodecEngine = new JsonCodecEngine({ registry });
+      jsonCodecEngine.encode(
+        jsonCodecEngine.decode(
           encoded,
-          JsonCodec.#testingReconstructionContext,
+          JsonCodecEngine.#testingReconstructionContext,
         ),
       );
     }

--- a/packages/data-model/src/codec-json/impl.ts
+++ b/packages/data-model/src/codec-json/impl.ts
@@ -1,10 +1,10 @@
-import { JsonCodec } from "./JsonCodec.ts";
+import { JsonCodecEngine } from "./JsonCodecEngine.ts";
 
 /**
  * Indicates if the given text has a "first-blush" appearance as text in the
- * JSON-embedded encoding that `JsonCodec` defines, by looking for its
+ * JSON-embedded encoding that `JsonCodecEngine` defines, by looking for its
  * format-identifying prefix tag.
  */
 export function seemsLikeJsonEncodedFabricValue(value: string): boolean {
-  return JsonCodec.seemsLikeEncoded(value);
+  return JsonCodecEngine.seemsLikeEncoded(value);
 }

--- a/packages/data-model/src/codec-json/index.ts
+++ b/packages/data-model/src/codec-json/index.ts
@@ -11,4 +11,4 @@ export { SymbolCodec } from "./SymbolCodec.ts";
 export { UndefinedCodec } from "./UndefinedCodec.ts";
 
 // Whole-value codec for the wire format.
-export { JsonCodec } from "./JsonCodec.ts";
+export { JsonCodecEngine } from "./JsonCodecEngine.ts";

--- a/packages/data-model/src/codec-json/interface.ts
+++ b/packages/data-model/src/codec-json/interface.ts
@@ -15,7 +15,7 @@ import { JSON_CODEC } from "@/interface.ts";
 /**
  * Tag prefix on the encoded form of a fabric value. The prefix is explicit so
  * as to make it unambiguous whether a given JSON-ish text string is the result
- * of encoding by `JsonCodec` vs. being JSON from some other source. The tag
+ * of encoding by `JsonCodecEngine` vs. being JSON from some other source. The tag
  * stands for "Fabric Value Json, version 1."
  */
 export const ENCODING_PREFIX_TAG = "fvj1:" as const;

--- a/packages/data-model/src/codecs.ts
+++ b/packages/data-model/src/codecs.ts
@@ -21,7 +21,7 @@ import type { ReconstructionContext } from "./codec-interface/interface.ts";
 import { EmptyReconstructionContext } from "./codec-interface/EmptyReconstructionContext.ts";
 import type { CodecRegistry } from "./codec-common/CodecRegistry.ts";
 import type { JsonCodecValue } from "./codec-json/interface.ts";
-import { JsonCodec } from "./codec-json/JsonCodec.ts";
+import { JsonCodecEngine } from "./codec-json/JsonCodecEngine.ts";
 import { createBaseJsonRegistry } from "./codec-json/createBaseJsonRegistry.ts";
 import { codecClasses as primitiveClasses } from "./fabric-primitives/index.ts";
 import { codecClasses as instanceClasses } from "./fabric-instances/index.ts";
@@ -51,21 +51,21 @@ export function createDefaultJsonRegistry(): CodecRegistry<JsonCodecValue> {
 }
 
 /**
- * Constructs a `JsonCodec` over {@link createDefaultJsonRegistry}, for a
+ * Constructs a `JsonCodecEngine` over {@link createDefaultJsonRegistry}, for a
  * caller that wants this package's classes rather than a set of its own.
  * `options.lenient` is passed through.
  */
-export function newDefaultJsonCodec(
+export function newDefaultJsonCodecEngine(
   options?: { lenient?: boolean },
-): JsonCodec {
-  return new JsonCodec({
+): JsonCodecEngine {
+  return new JsonCodecEngine({
     registry: createDefaultJsonRegistry(),
     lenient: options?.lenient ?? false,
   });
 }
 
 /** Shared JSON codec. */
-const jsonCodec = newDefaultJsonCodec();
+const jsonCodecEngine = newDefaultJsonCodecEngine();
 
 /**
  * Shared empty `ReconstructionContext` used when a JSON decode is requested
@@ -88,7 +88,7 @@ const JSON_DECODE_EMPTY_CONTEXT = Object.freeze(
  * JSON-embedded encoding, prefixed with the format-identifying tag `fvj1:`.
  */
 export function jsonFromValue(value: FabricValue): string {
-  return jsonCodec.encode(value);
+  return jsonCodecEngine.encode(value);
 }
 
 /**
@@ -131,7 +131,7 @@ export function valueFromJson(
   json: string,
   context?: ReconstructionContext | undefined,
 ): FabricValue {
-  return jsonCodec.decode(
+  return jsonCodecEngine.decode(
     json,
     context ?? JSON_DECODE_EMPTY_CONTEXT,
   );

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -40,7 +40,7 @@
  * the other direction, and this module imports nothing, so a symbol here is
  * reachable from anywhere without closing a cycle.
  */
-export const JSON_CODEC: unique symbol = Symbol("data-model.jsonCodec");
+export const JSON_CODEC: unique symbol = Symbol("data-model.jsonCodecEngine");
 
 /**
  * Abstract base class for all fabric-system value types. This is the common

--- a/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
@@ -135,10 +135,22 @@ function toWireFormat(value: FabricValue): JsonCodecValue {
  * Helper: decode from a codec-value tree. Stringifies to JSON first (tagged as
  * an encoded value), then feeds through the public decode API.
  */
-function fromWireFormat(data: JsonCodecValue): FabricValue {
-  const { jsonCodecEngine, runtime } = makeTestCodec();
+function fromWireFormat(
+  data: JsonCodecValue,
+  malformed = false,
+): FabricValue {
+  // Lenient, because much of what this decodes is malformed on purpose and
+  // the point is to inspect what the engine made of it; a strict engine
+  // raises instead, which the tests below pin separately. `malformed` goes on
+  // to the wrap helper, whose own validity check is a strict decode, and so
+  // rejects exactly the payloads these cases are made of.
+  const jsonCodecEngine = newDefaultJsonCodecEngine({ lenient: true });
+  const runtime = new TestReconstructionContext();
   return jsonCodecEngine.decode(
-    JsonCodecEngine.wrapEncodedValueForTesting(JSON.stringify(data)),
+    JsonCodecEngine.wrapEncodedValueForTesting(
+      JSON.stringify(data),
+      malformed,
+    ),
     runtime,
   );
 }
@@ -713,7 +725,9 @@ describe("JsonCodecEngine", () => {
 
     /** Decodes a hand-built array, which is deliberately not encodable. */
     function decodeArray(entries: JsonCodecValue[]): FabricValue {
-      const { jsonCodecEngine, runtime } = makeTestCodec();
+      // Lenient; see `fromWireFormat()` above.
+      const jsonCodecEngine = newDefaultJsonCodecEngine({ lenient: true });
+      const runtime = new TestReconstructionContext();
       return jsonCodecEngine.decode(
         JsonCodecEngine.wrapEncodedValueForTesting(
           JSON.stringify(entries),
@@ -1144,7 +1158,7 @@ describe("JsonCodecEngine", () => {
         // Wire data without a `/quote` or `/object` wrapper: the decoder must
         // not silently round-trip it as a plain object.
         const data = { a: 1, "/b": 2 } as JsonCodecValue;
-        const result = fromWireFormat(data);
+        const result = fromWireFormat(data, true);
         expect(result).toBeInstanceOf(ProblematicValue);
       });
 
@@ -1154,7 +1168,7 @@ describe("JsonCodecEngine", () => {
         // must produce a `ProblematicValue`, not an `UnknownValue` with an
         // empty tag.
         const data = { "/": "x" } as JsonCodecValue;
-        const result = fromWireFormat(data);
+        const result = fromWireFormat(data, true);
         expect(result).toBeInstanceOf(ProblematicValue);
       });
 
@@ -1229,22 +1243,22 @@ describe("JsonCodecEngine", () => {
         // property, so a literal cannot express this wire shape at all.
         // `JSON.parse()`, which is how such bytes actually arrive, does create
         // the own property.
-        expect(fromWireFormat({ ["__proto__"]: { hostile: true }, a: 1 }))
+        expect(fromWireFormat({ ["__proto__"]: { hostile: true }, a: 1 }, true))
           .toBeInstanceOf(ProblematicValue);
-        expect(fromWireFormat({ ["constructor"]: "c" }))
+        expect(fromWireFormat({ ["constructor"]: "c" }, true))
           .toBeInstanceOf(ProblematicValue);
       });
 
       it("produces a `ProblematicValue` for a reserved key nested in the graph", () => {
         const result = fromWireFormat({
           nested: { ["__proto__"]: 1 },
-        }) as Record<string, unknown>;
+        }, true) as Record<string, unknown>;
         expect(result.nested).toBeInstanceOf(ProblematicValue);
         expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
       });
 
       it("produces a `ProblematicValue` for a reserved key inside `/object`", () => {
-        expect(fromWireFormat({ "/object": { ["__proto__"]: 1 } }))
+        expect(fromWireFormat({ "/object": { ["__proto__"]: 1 } }, true))
           .toBeInstanceOf(ProblematicValue);
       });
 
@@ -1275,12 +1289,12 @@ describe("JsonCodecEngine", () => {
           });
 
           const hostile = { hostile: true };
-          expect(fromWireFormat({ ["__proto__"]: hostile, a: 1 }))
+          expect(fromWireFormat({ ["__proto__"]: hostile, a: 1 }, true))
             .toBeInstanceOf(ProblematicValue);
 
           const nested = fromWireFormat({
             deep: { ["__proto__"]: hostile },
-          }) as Record<string, unknown>;
+          }, true) as Record<string, unknown>;
           expect(nested.deep).toBeInstanceOf(ProblematicValue);
           expect(Object.getPrototypeOf(nested)).toBe(Object.prototype);
 
@@ -1794,6 +1808,44 @@ describe("JsonCodecEngine", () => {
       const jsonCodecEngine = newDefaultJsonCodecEngine({ lenient: true });
       expect(jsonCodecEngine.lenient).toBe(true);
     });
+  });
+
+  describe("malformed wire the engine itself detects", () => {
+    /** The wire shapes the engine rejects without any codec being consulted. */
+    const CASES: readonly (readonly [string, JsonCodecValue, RegExp])[] = [
+      ["a bare `/` key", { "/": "x" }, /empty tag/],
+      ["a `/`-prefixed key in a bare object", { a: 1, "/b": 2 }, /reserved/],
+      ["a key this runtime reserves", { ["__proto__"]: 1 }, /reserves/],
+      [
+        "a `/hole` count that is not one",
+        [{ "/hole": "2" }],
+        /positive integer/,
+      ],
+    ];
+
+    for (const [what, wire, message] of CASES) {
+      it(`throws given ${what}, when not lenient`, () => {
+        const jsonCodecEngine = newDefaultJsonCodecEngine();
+
+        expect(jsonCodecEngine.lenient).toBe(false);
+        expect(() =>
+          jsonCodecEngine.decode(
+            JsonCodecEngine.wrapEncodedValueForTesting(
+              JSON.stringify(wire),
+              true, // Malformed on purpose; that is what these are about.
+            ),
+            new TestReconstructionContext(),
+          )
+        ).toThrow(message);
+      });
+
+      it(`returns a \`ProblematicValue\` given ${what}, when lenient`, () => {
+        // The same detection, kept as a value. Which side of this a caller
+        // gets is `lenient` and nothing else -- notably not whether a codec
+        // or the walk noticed, which these cases are the walk noticing.
+        expect(fromWireFormat(wire, true)).toBeInstanceOf(ProblematicValue);
+      });
+    }
   });
 
   describe("complex round-trips", () => {

--- a/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
@@ -25,8 +25,11 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import { JsonCodec } from "@/codec-json/JsonCodec.ts";
-import { createDefaultJsonRegistry, newDefaultJsonCodec } from "@/codecs.ts";
+import { JsonCodecEngine } from "@/codec-json/JsonCodecEngine.ts";
+import {
+  createDefaultJsonRegistry,
+  newDefaultJsonCodecEngine,
+} from "@/codecs.ts";
 import { FabricInstance, type FabricValue } from "@/interface.ts";
 import { JSON_FORMAT, type JsonCodecValue } from "@/codec-json/interface.ts";
 import { UnknownValue } from "@/codec-common/UnknownValue.ts";
@@ -98,22 +101,22 @@ class UnregisteredInstance extends BaseFabricInstance {
  * The encoding prefix tag, named once for the assertions below that pin the
  * wire form or that feed the decoder deliberately broken input. Bridging
  * between encoded strings and codec-value trees does NOT go through this --
- * that is what `JsonCodec`'s wrap/unwrap helpers are for.
+ * that is what `JsonCodecEngine`'s wrap/unwrap helpers are for.
  */
 const ENCODING_PREFIX = "fvj1:";
 
 /** Creates a standard test codec (non-lenient) and a mock runtime. */
 function makeTestCodec() {
-  const jsonCodec = newDefaultJsonCodec();
+  const jsonCodecEngine = newDefaultJsonCodecEngine();
   const runtime = new TestReconstructionContext();
-  return { jsonCodec, runtime };
+  return { jsonCodecEngine, runtime };
 }
 
 /** Helper: encode then decode (round-trip) through the public API. */
 function roundTrip(value: FabricValue): FabricValue {
-  const { jsonCodec, runtime } = makeTestCodec();
-  const encoded = jsonCodec.encode(value);
-  return jsonCodec.decode(encoded, runtime);
+  const { jsonCodecEngine, runtime } = makeTestCodec();
+  const encoded = jsonCodecEngine.encode(value);
+  return jsonCodecEngine.decode(encoded, runtime);
 }
 
 /**
@@ -121,10 +124,10 @@ function roundTrip(value: FabricValue): FabricValue {
  * Used for assertions about the intermediate codec value.
  */
 function toWireFormat(value: FabricValue): JsonCodecValue {
-  const { jsonCodec } = makeTestCodec();
-  const encoded = jsonCodec.encode(value);
+  const { jsonCodecEngine } = makeTestCodec();
+  const encoded = jsonCodecEngine.encode(value);
   return JSON.parse(
-    JsonCodec.unwrapEncodedValueForTesting(encoded),
+    JsonCodecEngine.unwrapEncodedValueForTesting(encoded),
   ) as JsonCodecValue;
 }
 
@@ -133,14 +136,14 @@ function toWireFormat(value: FabricValue): JsonCodecValue {
  * an encoded value), then feeds through the public decode API.
  */
 function fromWireFormat(data: JsonCodecValue): FabricValue {
-  const { jsonCodec, runtime } = makeTestCodec();
-  return jsonCodec.decode(
-    JsonCodec.wrapEncodedValueForTesting(JSON.stringify(data)),
+  const { jsonCodecEngine, runtime } = makeTestCodec();
+  return jsonCodecEngine.decode(
+    JsonCodecEngine.wrapEncodedValueForTesting(JSON.stringify(data)),
     runtime,
   );
 }
 
-describe("JsonCodec", () => {
+describe("JsonCodecEngine", () => {
   describe("`registry` constructor option", () => {
     // An empty registry recognizes no class and no tag, so it differs from the
     // built-in one on any fabric class. `FabricError` is the probe: the
@@ -148,25 +151,28 @@ describe("JsonCodec", () => {
     // the empty registry's behavior instead, in both directions.
 
     it("throws on encode for a class the supplied registry lacks", () => {
-      const jsonCodec = new JsonCodec({
+      const jsonCodecEngine = new JsonCodecEngine({
         registry: new CodecRegistry(JSON_FORMAT),
       });
       const value = FabricError.fromNativeError(new Error("boom"));
 
-      expect(() => jsonCodec.encode(value)).toThrow(
-        "No codec registered for fabric object class: `FabricError`",
+      expect(() => jsonCodecEngine.encode(value)).toThrow(
+        "No codec registered for `FabricSpecialObject` subclass `FabricError`.",
       );
     });
 
     it("returns an `UnknownValue` on decode for a tag the supplied registry lacks", () => {
-      const wire = newDefaultJsonCodec().encode(
+      const wire = newDefaultJsonCodecEngine().encode(
         FabricError.fromNativeError(new Error("boom")),
       );
-      const jsonCodec = new JsonCodec({
+      const jsonCodecEngine = new JsonCodecEngine({
         registry: new CodecRegistry(JSON_FORMAT),
       });
 
-      const result = jsonCodec.decode(wire, new TestReconstructionContext());
+      const result = jsonCodecEngine.decode(
+        wire,
+        new TestReconstructionContext(),
+      );
 
       expect(result).toBeInstanceOf(UnknownValue);
       expect((result as UnknownValue).wireTypeTag).toBe("Error@1");
@@ -258,8 +264,8 @@ describe("JsonCodec", () => {
     /** Builds a codec over the default registry plus the given probe. */
     function codecWith(
       probe: ProbeTerminalCodec | ProbeNonterminalCodec,
-    ): JsonCodec {
-      return new JsonCodec({
+    ): JsonCodecEngine {
+      return new JsonCodecEngine({
         registry: createDefaultJsonRegistry().extend(probe),
       });
     }
@@ -292,7 +298,7 @@ describe("JsonCodec", () => {
       const probe = new ProbeTerminalCodec();
 
       codecWith(probe).decode(
-        JsonCodec.wrapEncodedValueForTesting(
+        JsonCodecEngine.wrapEncodedValueForTesting(
           JSON.stringify({ [`/${PROBE_TAG}`]: { "/Bytes@1": "AQID" } }),
           true,
         ),
@@ -308,17 +314,17 @@ describe("JsonCodec", () => {
       // returning a `ProblematicValue` -- which the spec sanctions alongside
       // throwing, `3-json-encoding.md` Section 7 letting a codec do either.
       // Non-lenient, so nothing here is wrapping a throw.
-      const jsonCodec = newDefaultJsonCodec();
+      const jsonCodecEngine = newDefaultJsonCodecEngine();
 
-      const result = jsonCodec.decode(
-        JsonCodec.wrapEncodedValueForTesting(
+      const result = jsonCodecEngine.decode(
+        JsonCodecEngine.wrapEncodedValueForTesting(
           JSON.stringify({ "/BigInt@1": { "/Undefined@1": "bad" } }),
           true, // Undecodable on purpose; that is what this test is about.
         ),
         new TestReconstructionContext(),
       );
 
-      expect(jsonCodec.lenient).toBe(false);
+      expect(jsonCodecEngine.lenient).toBe(false);
       expect(result).toBeInstanceOf(ProblematicValue);
       expect((result as unknown as ProblematicValue).wireTypeTag).toBe(
         "BigInt@1",
@@ -329,7 +335,7 @@ describe("JsonCodec", () => {
       const probe = new ProbeNonterminalCodec();
 
       codecWith(probe).decode(
-        JsonCodec.wrapEncodedValueForTesting(
+        JsonCodecEngine.wrapEncodedValueForTesting(
           JSON.stringify({ [`/${PROBE_TAG}`]: { "/Bytes@1": "AQID" } }),
           true,
         ),
@@ -342,14 +348,14 @@ describe("JsonCodec", () => {
 
   describe("`encodeToBytes()` / `decodeFromBytes()` (bytes entry points)", () => {
     it("returns `Uint8Array` from `encodeToBytes()`", () => {
-      const { jsonCodec } = makeTestCodec();
-      const result = jsonCodec.encodeToBytes(42);
+      const { jsonCodecEngine } = makeTestCodec();
+      const result = jsonCodecEngine.encodeToBytes(42);
       expect(result).toBeInstanceOf(Uint8Array);
     });
 
     it("produces valid JSON bytes from `encodeToBytes()`", () => {
-      const { jsonCodec } = makeTestCodec();
-      const bytes = jsonCodec.encodeToBytes(
+      const { jsonCodecEngine } = makeTestCodec();
+      const bytes = jsonCodecEngine.encodeToBytes(
         { a: 1 },
       );
       const json = new TextDecoder().decode(bytes);
@@ -357,9 +363,9 @@ describe("JsonCodec", () => {
     });
 
     it("decodes a `Uint8Array` through `decodeFromBytes()`", () => {
-      const { jsonCodec, runtime } = makeTestCodec();
+      const { jsonCodecEngine, runtime } = makeTestCodec();
       const bytes = new TextEncoder().encode(JSON.stringify({ a: 1 }));
-      const result = jsonCodec.decodeFromBytes(
+      const result = jsonCodecEngine.decodeFromBytes(
         bytes,
         runtime,
       ) as Record<string, FabricValue>;
@@ -367,13 +373,13 @@ describe("JsonCodec", () => {
     });
 
     it("round-trips through `Uint8Array`", () => {
-      const { jsonCodec, runtime } = makeTestCodec();
+      const { jsonCodecEngine, runtime } = makeTestCodec();
       const value = {
         name: "test",
         count: 42,
       };
-      const bytes = jsonCodec.encodeToBytes(value);
-      const result = jsonCodec.decodeFromBytes(
+      const bytes = jsonCodecEngine.encodeToBytes(value);
+      const result = jsonCodecEngine.decodeFromBytes(
         bytes,
         runtime,
       ) as Record<string, FabricValue>;
@@ -382,10 +388,10 @@ describe("JsonCodec", () => {
     });
 
     it("round-trips `FabricError` through `Uint8Array`", () => {
-      const { jsonCodec, runtime } = makeTestCodec();
+      const { jsonCodecEngine, runtime } = makeTestCodec();
       const err = FabricError.fromNativeError(new TypeError("oops"));
-      const bytes = jsonCodec.encodeToBytes(err);
-      const result = jsonCodec.decodeFromBytes(
+      const bytes = jsonCodecEngine.encodeToBytes(err);
+      const result = jsonCodecEngine.decodeFromBytes(
         bytes,
         runtime,
       );
@@ -396,21 +402,21 @@ describe("JsonCodec", () => {
     });
 
     it("round-trips `undefined` through `Uint8Array`", () => {
-      const { jsonCodec, runtime } = makeTestCodec();
-      const bytes = jsonCodec.encodeToBytes(undefined);
-      const result = jsonCodec.decodeFromBytes(bytes, runtime);
+      const { jsonCodecEngine, runtime } = makeTestCodec();
+      const bytes = jsonCodecEngine.encodeToBytes(undefined);
+      const result = jsonCodecEngine.decodeFromBytes(bytes, runtime);
       expect(result).toBe(undefined);
     });
 
     it("round-trips complex structure through `Uint8Array`", () => {
-      const { jsonCodec, runtime } = makeTestCodec();
+      const { jsonCodecEngine, runtime } = makeTestCodec();
       const value = {
         users: [{ name: "Alice" }, { name: "Bob" }],
         error: FabricError.fromNativeError(new Error("fail")),
         nothing: undefined,
       };
-      const bytes = jsonCodec.encodeToBytes(value);
-      const result = jsonCodec.decodeFromBytes(
+      const bytes = jsonCodecEngine.encodeToBytes(value);
+      const result = jsonCodecEngine.decodeFromBytes(
         bytes,
         runtime,
       ) as Record<string, FabricValue>;
@@ -568,10 +574,10 @@ describe("JsonCodec", () => {
     it("loudly fails to encode an unencodable value (unique / uninterned `Symbol`)", () => {
       // `SymbolCodec.canEncode()` returns false for unique symbols (no
       // registry key), so no codec claims them. A default-configured
-      // `JsonCodec` must then fail loudly rather than silently flatten the
+      // `JsonCodecEngine` must then fail loudly rather than silently flatten the
       // symbol to `{}`.
-      const { jsonCodec } = makeTestCodec();
-      expect(() => jsonCodec.encode(Symbol("nope"))).toThrow(
+      const { jsonCodecEngine } = makeTestCodec();
+      expect(() => jsonCodecEngine.encode(Symbol("nope"))).toThrow(
         "no applicable codec",
       );
     });
@@ -636,16 +642,16 @@ describe("JsonCodec", () => {
 
   describe("un-registered instance types", () => {
     it("throws when encoding a `FabricInstance` with no registered codec", () => {
-      const { jsonCodec } = makeTestCodec();
-      expect(() => jsonCodec.encode(new UnregisteredInstance()))
+      const { jsonCodecEngine } = makeTestCodec();
+      expect(() => jsonCodecEngine.encode(new UnregisteredInstance()))
         .toThrow("No codec registered");
     });
 
     it("throws on a non-plain object with no codec (e.g. a raw `Map`)", () => {
       // A non-plain object that is neither a FabricInstance nor codec-handled
       // must fail loudly, not be mis-encoded as a plain object.
-      const { jsonCodec } = makeTestCodec();
-      expect(() => jsonCodec.encode(new Map() as unknown as FabricValue))
+      const { jsonCodecEngine } = makeTestCodec();
+      expect(() => jsonCodecEngine.encode(new Map() as unknown as FabricValue))
         .toThrow("no applicable codec");
     });
   });
@@ -690,9 +696,12 @@ describe("JsonCodec", () => {
 
     /** Decodes a hand-built array, which is deliberately not encodable. */
     function decodeArray(entries: JsonCodecValue[]): FabricValue {
-      const { jsonCodec, runtime } = makeTestCodec();
-      return jsonCodec.decode(
-        JsonCodec.wrapEncodedValueForTesting(JSON.stringify(entries), true),
+      const { jsonCodecEngine, runtime } = makeTestCodec();
+      return jsonCodecEngine.decode(
+        JsonCodecEngine.wrapEncodedValueForTesting(
+          JSON.stringify(entries),
+          true,
+        ),
         runtime,
       );
     }
@@ -908,9 +917,9 @@ describe("JsonCodec", () => {
         const obj1 = { x: 1, y: 2, z: 3 };
         const obj2 = { z: 3, x: 1, y: 2 };
         const obj3 = { y: 2, z: 3, x: 1 };
-        const jsonCodec = newDefaultJsonCodec();
-        expect(jsonCodec.encode(obj1)).toBe(jsonCodec.encode(obj2));
-        expect(jsonCodec.encode(obj1)).toBe(jsonCodec.encode(obj3));
+        const jsonCodecEngine = newDefaultJsonCodecEngine();
+        expect(jsonCodecEngine.encode(obj1)).toBe(jsonCodecEngine.encode(obj2));
+        expect(jsonCodecEngine.encode(obj1)).toBe(jsonCodecEngine.encode(obj3));
       });
 
       it("sorts keys in nested plain objects", () => {
@@ -1358,42 +1367,42 @@ describe("JsonCodec", () => {
 
   describe("circular reference detection", () => {
     it("throws on object referencing itself", () => {
-      const { jsonCodec } = makeTestCodec();
+      const { jsonCodecEngine } = makeTestCodec();
       const obj: Record<string, unknown> = {};
       obj.self = obj;
-      expect(() => jsonCodec.encode(obj as FabricValue)).toThrow(
+      expect(() => jsonCodecEngine.encode(obj as FabricValue)).toThrow(
         "Circular reference",
       );
     });
 
     it("throws on array referencing itself", () => {
-      const { jsonCodec } = makeTestCodec();
+      const { jsonCodecEngine } = makeTestCodec();
       const arr: unknown[] = [];
       arr.push(arr);
-      expect(() => jsonCodec.encode(arr as FabricValue)).toThrow(
+      expect(() => jsonCodecEngine.encode(arr as FabricValue)).toThrow(
         "Circular reference",
       );
     });
 
     it("throws on indirect circular reference (A -> B -> A)", () => {
-      const { jsonCodec } = makeTestCodec();
+      const { jsonCodecEngine } = makeTestCodec();
       const a: Record<string, unknown> = {};
       const b: Record<string, unknown> = {};
       a.ref = b;
       b.ref = a;
-      expect(() => jsonCodec.encode(a as FabricValue)).toThrow(
+      expect(() => jsonCodecEngine.encode(a as FabricValue)).toThrow(
         "Circular reference",
       );
     });
 
     it("throws on `FabricInstance` whose state references itself", () => {
-      const { jsonCodec } = makeTestCodec();
+      const { jsonCodecEngine } = makeTestCodec();
       // Create an instance with a circular reference in its state.
       const state = { eek: [] as FabricValue[] };
       state.eek.push(state);
 
       const us = new UnknownValue("Test@1", state);
-      expect(() => jsonCodec.encode(us))
+      expect(() => jsonCodecEngine.encode(us))
         .toThrow(
           "Circular reference",
         );
@@ -1421,14 +1430,14 @@ describe("JsonCodec", () => {
     });
 
     it("lenient mode wraps failed handler reconstruction", () => {
-      const jsonCodec = newDefaultJsonCodec({ lenient: true });
+      const jsonCodecEngine = newDefaultJsonCodecEngine({ lenient: true });
       const runtime = new TestReconstructionContext();
 
       // BigInt@1 with a non-string state produces ProblematicValue
       // in lenient mode because the handler validates the state type.
       const data = { "/BigInt@1": 42 } as JsonCodecValue;
-      const result = jsonCodec.decode(
-        JsonCodec.wrapEncodedValueForTesting(JSON.stringify(data)),
+      const result = jsonCodecEngine.decode(
+        JsonCodecEngine.wrapEncodedValueForTesting(JSON.stringify(data)),
         runtime,
       );
       expect(result).toBeInstanceOf(ProblematicValue);
@@ -1444,11 +1453,11 @@ describe("JsonCodec", () => {
       // What the state assertion pins is what the *report* carries, which is
       // the wire form. That the *codec* is handed the wire form is a separate
       // fact, pinned separately above.
-      const jsonCodec = newDefaultJsonCodec({ lenient: true });
+      const jsonCodecEngine = newDefaultJsonCodecEngine({ lenient: true });
       const data = { "/Undefined@1": { "/Bytes@1": "AQID" } } as JsonCodecValue;
 
-      const result = jsonCodec.decode(
-        JsonCodec.wrapEncodedValueForTesting(
+      const result = jsonCodecEngine.decode(
+        JsonCodecEngine.wrapEncodedValueForTesting(
           JSON.stringify(data),
           true, // Undecodable on purpose; that is what this test is about.
         ),
@@ -1461,8 +1470,24 @@ describe("JsonCodec", () => {
       expect(prob.state).toEqual({ "/Bytes@1": "AQID" });
     });
 
+    it("deep-freezes the `ProblematicValue` it wraps a throw in", () => {
+      // A `ProblematicValue` is not frozen at construction, so this is what
+      // witnesses the deep-frozen contract on the lenient path. The codecs
+      // that report by RETURNING one are frozen by the arm above instead, so
+      // neither arm stands in for the other.
+      const jsonCodecEngine = newDefaultJsonCodecEngine({ lenient: true });
+      const data = { "/Undefined@1": { "/Bytes@1": "AQID" } } as JsonCodecValue;
+
+      const result = jsonCodecEngine.decode(
+        JsonCodecEngine.wrapEncodedValueForTesting(JSON.stringify(data), true),
+        new TestReconstructionContext(),
+      );
+
+      expect(isDeepFrozen(result)).toBe(true);
+    });
+
     it("lenient mode wraps failed class-registry reconstruction", () => {
-      const jsonCodec = newDefaultJsonCodec({ lenient: true });
+      const jsonCodecEngine = newDefaultJsonCodecEngine({ lenient: true });
       const runtime = new TestReconstructionContext();
 
       // Map@1's codec always throws on decode ("not yet implemented"),
@@ -1470,8 +1495,8 @@ describe("JsonCodec", () => {
       const data = {
         "/Map@1": [["key", "value"]],
       } as JsonCodecValue;
-      const result = jsonCodec.decode(
-        JsonCodec.wrapEncodedValueForTesting(
+      const result = jsonCodecEngine.decode(
+        JsonCodecEngine.wrapEncodedValueForTesting(
           JSON.stringify(data),
           true, // Undecodable on purpose; that is what this test is about.
         ),
@@ -1556,10 +1581,10 @@ describe("JsonCodec", () => {
       // lenient catch produces a ProblematicValue -- still a codec-arm return,
       // so the contract deep-freezes it (not a crash: it is the value
       // lenient mode produces precisely to avoid crashing).
-      const jsonCodec = newDefaultJsonCodec({ lenient: true });
+      const jsonCodecEngine = newDefaultJsonCodecEngine({ lenient: true });
       const runtime = new TestReconstructionContext();
-      const result = jsonCodec.decode(
-        JsonCodec.wrapEncodedValueForTesting(
+      const result = jsonCodecEngine.decode(
+        JsonCodecEngine.wrapEncodedValueForTesting(
           JSON.stringify({ "/BigInt@1": 42 }),
         ),
         runtime,
@@ -1597,13 +1622,13 @@ describe("JsonCodec", () => {
     function decodeBothPaths(
       data: JsonCodecValue,
     ): { viaString: FabricValue; viaBytes: FabricValue } {
-      const { jsonCodec, runtime } = makeTestCodec();
+      const { jsonCodecEngine, runtime } = makeTestCodec();
       const json = JSON.stringify(data);
-      const viaString = jsonCodec.decode(
-        JsonCodec.wrapEncodedValueForTesting(json),
+      const viaString = jsonCodecEngine.decode(
+        JsonCodecEngine.wrapEncodedValueForTesting(json),
         runtime,
       );
-      const viaBytes = jsonCodec.decodeFromBytes(
+      const viaBytes = jsonCodecEngine.decodeFromBytes(
         new TextEncoder().encode(json),
         runtime,
       );
@@ -1643,9 +1668,9 @@ describe("JsonCodec", () => {
       const wire = {
         "/quote": { outer: { inner: [1, 2] } },
       } as JsonCodecValue;
-      const { jsonCodec, runtime } = makeTestCodec();
-      const result = jsonCodec.decode(
-        JsonCodec.wrapEncodedValueForTesting(JSON.stringify(wire)),
+      const { jsonCodecEngine, runtime } = makeTestCodec();
+      const result = jsonCodecEngine.decode(
+        JsonCodecEngine.wrapEncodedValueForTesting(JSON.stringify(wire)),
         runtime,
       ) as Record<string, Record<string, FabricValue[]>>;
 
@@ -1664,8 +1689,8 @@ describe("JsonCodec", () => {
       const wire = {
         "/quote": { outer: { inner: [{ deep: 1 }] } },
       } as JsonCodecValue;
-      const { jsonCodec, runtime } = makeTestCodec();
-      const result = jsonCodec.decodeFromBytes(
+      const { jsonCodecEngine, runtime } = makeTestCodec();
+      const result = jsonCodecEngine.decodeFromBytes(
         new TextEncoder().encode(JSON.stringify(wire)),
         runtime,
       ) as Record<string, Record<string, Array<Record<string, FabricValue>>>>;
@@ -1691,47 +1716,47 @@ describe("JsonCodec", () => {
     });
   });
 
-  describe("JsonCodec", () => {
+  describe("JsonCodecEngine", () => {
     it("`encode()` returns a prefixed JSON string", () => {
-      const jsonCodec = newDefaultJsonCodec();
-      const result = jsonCodec.encode(42);
+      const jsonCodecEngine = newDefaultJsonCodecEngine();
+      const result = jsonCodecEngine.encode(42);
       expect(typeof result).toBe("string");
-      expect(JsonCodec.seemsLikeEncoded(result)).toBe(true);
+      expect(JsonCodecEngine.seemsLikeEncoded(result)).toBe(true);
       expect(
-        JSON.parse(JsonCodec.unwrapEncodedValueForTesting(result)),
+        JSON.parse(JsonCodecEngine.unwrapEncodedValueForTesting(result)),
       ).toBe(42);
     });
 
     it("`decode()` parses a prefixed JSON string back to a value", () => {
-      const jsonCodec = newDefaultJsonCodec();
+      const jsonCodecEngine = newDefaultJsonCodecEngine();
       const runtime = new TestReconstructionContext();
-      const result = jsonCodec.decode(
-        JsonCodec.wrapEncodedValueForTesting("42"),
+      const result = jsonCodecEngine.decode(
+        JsonCodecEngine.wrapEncodedValueForTesting("42"),
         runtime,
       );
       expect(result).toBe(42);
     });
 
     it("`encode()`/`decode()` round-trip for tagged types", () => {
-      const jsonCodec = newDefaultJsonCodec();
+      const jsonCodecEngine = newDefaultJsonCodecEngine();
       const runtime = new TestReconstructionContext();
       const se = FabricError.fromNativeError(new Error("test"));
-      const encoded = jsonCodec.encode(se);
-      const decoded = jsonCodec.decode(encoded, runtime);
+      const encoded = jsonCodecEngine.encode(se);
+      const decoded = jsonCodecEngine.decode(encoded, runtime);
       expect(decoded).toBeInstanceOf(FabricError);
       expect((decoded as unknown as FabricError).message).toBe("test");
     });
 
     it("`encodeToBytes()`/`decodeFromBytes()` round-trip", () => {
-      const jsonCodec = newDefaultJsonCodec();
+      const jsonCodecEngine = newDefaultJsonCodecEngine();
       const runtime = new TestReconstructionContext();
       const data = {
         name: "test",
         error: FabricError.fromNativeError(new Error("fail")),
       };
-      const bytes = jsonCodec.encodeToBytes(data);
+      const bytes = jsonCodecEngine.encodeToBytes(data);
       expect(bytes).toBeInstanceOf(Uint8Array);
-      const decoded = jsonCodec.decodeFromBytes(bytes, runtime) as Record<
+      const decoded = jsonCodecEngine.decodeFromBytes(bytes, runtime) as Record<
         string,
         FabricValue
       >;
@@ -1740,13 +1765,13 @@ describe("JsonCodec", () => {
     });
 
     it("`.lenient` defaults to `false`", () => {
-      const jsonCodec = newDefaultJsonCodec();
-      expect(jsonCodec.lenient).toBe(false);
+      const jsonCodecEngine = newDefaultJsonCodecEngine();
+      expect(jsonCodecEngine.lenient).toBe(false);
     });
 
     it("`.lenient` can be set to `true`", () => {
-      const jsonCodec = newDefaultJsonCodec({ lenient: true });
-      expect(jsonCodec.lenient).toBe(true);
+      const jsonCodecEngine = newDefaultJsonCodecEngine({ lenient: true });
+      expect(jsonCodecEngine.lenient).toBe(true);
     });
   });
 
@@ -1820,29 +1845,29 @@ describe("JsonCodec", () => {
   describe("test-only prefix helpers", () => {
     describe("`unwrapEncodedValueForTesting()`", () => {
       it("yields the JSON text under the tag", () => {
-        const encoded = newDefaultJsonCodec().encode(42);
-        expect(JsonCodec.unwrapEncodedValueForTesting(encoded))
+        const encoded = newDefaultJsonCodecEngine().encode(42);
+        expect(JsonCodecEngine.unwrapEncodedValueForTesting(encoded))
           .toBe("42");
       });
 
       it("round-trips with `wrapEncodedValueForTesting()`", () => {
-        const encoded = newDefaultJsonCodec().encode(
+        const encoded = newDefaultJsonCodecEngine().encode(
           { b: 1, a: [true, null] },
         );
-        const json = JsonCodec.unwrapEncodedValueForTesting(encoded);
-        expect(JsonCodec.wrapEncodedValueForTesting(json))
+        const json = JsonCodecEngine.unwrapEncodedValueForTesting(encoded);
+        expect(JsonCodecEngine.wrapEncodedValueForTesting(json))
           .toBe(encoded);
       });
 
       it("preserves a value plain JSON could not carry", () => {
         // The case that motivates having a golden format at all: these survive
         // the trip only as tagged forms.
-        const encoded = newDefaultJsonCodec().encode(
+        const encoded = newDefaultJsonCodecEngine().encode(
           { z: -0, n: NaN, i: -Infinity },
         );
-        const rebuilt = newDefaultJsonCodec().decode(
-          JsonCodec.wrapEncodedValueForTesting(
-            JsonCodec.unwrapEncodedValueForTesting(encoded),
+        const rebuilt = newDefaultJsonCodecEngine().decode(
+          JsonCodecEngine.wrapEncodedValueForTesting(
+            JsonCodecEngine.unwrapEncodedValueForTesting(encoded),
           ),
           new TestReconstructionContext(),
         ) as Record<string, number>;
@@ -1854,25 +1879,27 @@ describe("JsonCodec", () => {
       it("throws given a string carrying no tag", () => {
         // The whole point of the tag: untagged JSON is not one of ours, however
         // well-formed it happens to be.
-        expect(() => JsonCodec.unwrapEncodedValueForTesting("42"))
+        expect(() => JsonCodecEngine.unwrapEncodedValueForTesting("42"))
           .toThrow();
       });
 
       it("throws given an empty string", () => {
-        expect(() => JsonCodec.unwrapEncodedValueForTesting(""))
+        expect(() => JsonCodecEngine.unwrapEncodedValueForTesting(""))
           .toThrow();
       });
 
       it("throws given a tag with nothing after it", () => {
         // `seemsLikeEncoded()` accepts this, so only the throwaway decode
         // catches it.
-        expect(() => JsonCodec.unwrapEncodedValueForTesting(ENCODING_PREFIX))
+        expect(() =>
+          JsonCodecEngine.unwrapEncodedValueForTesting(ENCODING_PREFIX)
+        )
           .toThrow();
       });
 
       it("throws given a tag followed by text that will not parse", () => {
         expect(() =>
-          JsonCodec.unwrapEncodedValueForTesting(
+          JsonCodecEngine.unwrapEncodedValueForTesting(
             `${ENCODING_PREFIX}{nope`,
           )
         ).toThrow();
@@ -1882,17 +1909,17 @@ describe("JsonCodec", () => {
     describe("`wrapEncodedValueForTesting()`", () => {
       it("produces something the codec accepts", () => {
         const { runtime } = makeTestCodec();
-        const encoded = JsonCodec.wrapEncodedValueForTesting(
+        const encoded = JsonCodecEngine.wrapEncodedValueForTesting(
           JSON.stringify({ a: 1 }),
         );
-        expect(JsonCodec.seemsLikeEncoded(encoded)).toBe(true);
-        expect(newDefaultJsonCodec().decode(encoded, runtime))
+        expect(JsonCodecEngine.seemsLikeEncoded(encoded)).toBe(true);
+        expect(newDefaultJsonCodecEngine().decode(encoded, runtime))
           .toEqual({ a: 1 });
       });
 
       it("returns the body unaltered beneath the tag", () => {
         const body = JSON.stringify({ b: 2, a: 1 });
-        expect(JsonCodec.wrapEncodedValueForTesting(body))
+        expect(JsonCodecEngine.wrapEncodedValueForTesting(body))
           .toBe(`${ENCODING_PREFIX}${body}`);
       });
 
@@ -1900,27 +1927,27 @@ describe("JsonCodec", () => {
         // The re-encoded form is not compared against the input, so whitespace
         // is immaterial -- which is what lets a golden file be readable.
         const pretty = JSON.stringify({ a: 1, b: [2, 3] }, null, 2);
-        const encoded = JsonCodec.wrapEncodedValueForTesting(pretty);
+        const encoded = JsonCodecEngine.wrapEncodedValueForTesting(pretty);
         const { runtime } = makeTestCodec();
-        expect(newDefaultJsonCodec().decode(encoded, runtime))
+        expect(newDefaultJsonCodecEngine().decode(encoded, runtime))
           .toEqual({ a: 1, b: [2, 3] });
       });
 
       it("throws given text that will not parse", () => {
-        expect(() => JsonCodec.wrapEncodedValueForTesting("{nope"))
+        expect(() => JsonCodecEngine.wrapEncodedValueForTesting("{nope"))
           .toThrow();
       });
 
       it("throws given an empty body", () => {
-        expect(() => JsonCodec.wrapEncodedValueForTesting(""))
+        expect(() => JsonCodecEngine.wrapEncodedValueForTesting(""))
           .toThrow();
       });
 
       it("throws given an already-tagged string", () => {
         // Double-tagging is a mistake worth catching: the tag is not part of
         // the JSON, so the result would not parse.
-        const encoded = newDefaultJsonCodec().encode(42);
-        expect(() => JsonCodec.wrapEncodedValueForTesting(encoded))
+        const encoded = newDefaultJsonCodecEngine().encode(42);
+        expect(() => JsonCodecEngine.wrapEncodedValueForTesting(encoded))
           .toThrow();
       });
     });
@@ -1934,7 +1961,7 @@ describe("JsonCodec", () => {
 
       it("refuses a payload undecodable by the given registry's codecs", () => {
         expect(() =>
-          JsonCodec.wrapEncodedValueForTesting(
+          JsonCodecEngine.wrapEncodedValueForTesting(
             undecodable,
             false,
             createDefaultJsonRegistry(),
@@ -1943,19 +1970,19 @@ describe("JsonCodec", () => {
       });
 
       it("wraps a tag no registered codec claims", () => {
-        expect(JsonCodec.wrapEncodedValueForTesting(undecodable))
+        expect(JsonCodecEngine.wrapEncodedValueForTesting(undecodable))
           .toBe(`${ENCODING_PREFIX}${undecodable}`);
       });
 
       it("wraps an undecodable payload when told it is deliberate", () => {
         expect(
-          JsonCodec.wrapEncodedValueForTesting(undecodable, true),
+          JsonCodecEngine.wrapEncodedValueForTesting(undecodable, true),
         ).toBe(`${ENCODING_PREFIX}${undecodable}`);
       });
 
       it("unwraps an undecodable payload when told it is deliberate", () => {
         expect(
-          JsonCodec.unwrapEncodedValueForTesting(
+          JsonCodecEngine.unwrapEncodedValueForTesting(
             `${ENCODING_PREFIX}${undecodable}`,
             true,
           ),
@@ -1966,13 +1993,13 @@ describe("JsonCodec", () => {
         // Malformed means malformed: the flag is a caller saying the payload is
         // broken on purpose, so nothing is checked and the tag simply goes on
         // the front.
-        expect(JsonCodec.wrapEncodedValueForTesting("{nope", true))
+        expect(JsonCodecEngine.wrapEncodedValueForTesting("{nope", true))
           .toBe(`${ENCODING_PREFIX}{nope`);
       });
 
       it("unwraps text that will not parse at all", () => {
         expect(
-          JsonCodec.unwrapEncodedValueForTesting(
+          JsonCodecEngine.unwrapEncodedValueForTesting(
             `${ENCODING_PREFIX}{nope`,
             true,
           ),
@@ -1982,7 +2009,7 @@ describe("JsonCodec", () => {
       it("still requires the tag on unwrap, however deliberate", () => {
         // Not a judgment about the payload: stripping a prefix that is not
         // there yields nonsense, not the body.
-        expect(() => JsonCodec.unwrapEncodedValueForTesting("42", true))
+        expect(() => JsonCodecEngine.unwrapEncodedValueForTesting("42", true))
           .toThrow();
       });
     });

--- a/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
@@ -310,11 +310,11 @@ describe("JsonCodecEngine", () => {
 
     it("lets a terminal codec judge a state that names a tag", () => {
       // A terminal codec's state is its own business, so a tag appearing
-      // inside one is just data. `BigInt@1` sees a non-string and reports by
-      // returning a `ProblematicValue` -- which the spec sanctions alongside
-      // throwing, `3-json-encoding.md` Section 7 letting a codec do either.
-      // Non-lenient, so nothing here is wrapping a throw.
-      const jsonCodecEngine = newDefaultJsonCodecEngine();
+      // inside one is just data rather than something the walker expands.
+      // `BigInt@1` sees a non-string and rejects it, which is the judgment
+      // this pins; a lenient engine keeps that verdict as a value, naming the
+      // tag whose codec made it.
+      const jsonCodecEngine = newDefaultJsonCodecEngine({ lenient: true });
 
       const result = jsonCodecEngine.decode(
         JsonCodecEngine.wrapEncodedValueForTesting(
@@ -324,11 +324,28 @@ describe("JsonCodecEngine", () => {
         new TestReconstructionContext(),
       );
 
-      expect(jsonCodecEngine.lenient).toBe(false);
       expect(result).toBeInstanceOf(ProblematicValue);
       expect((result as unknown as ProblematicValue).wireTypeTag).toBe(
         "BigInt@1",
       );
+    });
+
+    it("throws a codec's rejection when not lenient, tag named", () => {
+      // The same rejection, through a strict engine. `BigInt@1` reports by
+      // RETURNING a `ProblematicValue` rather than throwing, and the engine
+      // settles the two reporting styles into one answer.
+      const jsonCodecEngine = newDefaultJsonCodecEngine();
+
+      expect(jsonCodecEngine.lenient).toBe(false);
+      expect(() =>
+        jsonCodecEngine.decode(
+          JsonCodecEngine.wrapEncodedValueForTesting(
+            JSON.stringify({ "/BigInt@1": { "/Undefined@1": "bad" } }),
+            true, // Undecodable on purpose; that is what this test is about.
+          ),
+          new TestReconstructionContext(),
+        )
+      ).toThrow(/`BigInt@1`: bigint: expected string state/);
     });
 
     it("hands a nonterminal codec state that has been expanded", () => {
@@ -1437,7 +1454,10 @@ describe("JsonCodecEngine", () => {
       // in lenient mode because the handler validates the state type.
       const data = { "/BigInt@1": 42 } as JsonCodecValue;
       const result = jsonCodecEngine.decode(
-        JsonCodecEngine.wrapEncodedValueForTesting(JSON.stringify(data)),
+        JsonCodecEngine.wrapEncodedValueForTesting(
+          JSON.stringify(data),
+          true, // Malformed on purpose; the helper's own check is strict.
+        ),
         runtime,
       );
       expect(result).toBeInstanceOf(ProblematicValue);
@@ -1586,6 +1606,7 @@ describe("JsonCodecEngine", () => {
       const result = jsonCodecEngine.decode(
         JsonCodecEngine.wrapEncodedValueForTesting(
           JSON.stringify({ "/BigInt@1": 42 }),
+          true, // Malformed on purpose; the helper's own check is strict.
         ),
         runtime,
       );

--- a/packages/data-model/test/codecs.test.ts
+++ b/packages/data-model/test/codecs.test.ts
@@ -23,7 +23,7 @@ import {
   valueFromJson,
 } from "@/codecs.ts";
 import { seemsLikeJsonEncodedFabricValue } from "@/codec-json/impl.ts";
-import { JsonCodec } from "@/codec-json/JsonCodec.ts";
+import { JsonCodecEngine } from "@/codec-json/JsonCodecEngine.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
 import type { FabricValue } from "@/fabric-value.ts";
 import { BaseReconstructionContext } from "@/codec-interface/BaseReconstructionContext.ts";
@@ -53,7 +53,7 @@ function expectWireFormat(value: FabricValue, expected: unknown): void {
   const json = jsonFromValue(value);
   expect(seemsLikeJsonEncodedFabricValue(json)).toBe(true);
   expect(
-    JSON.parse(JsonCodec.unwrapEncodedValueForTesting(json)),
+    JSON.parse(JsonCodecEngine.unwrapEncodedValueForTesting(json)),
   ).toEqual(expected);
 }
 

--- a/packages/data-model/test/data-uri-codec.test.ts
+++ b/packages/data-model/test/data-uri-codec.test.ts
@@ -23,7 +23,7 @@ import {
   toUnpaddedBase64url,
 } from "@commonfabric/utils/base64url";
 import {
-  JsonCodec,
+  JsonCodecEngine,
   seemsLikeJsonEncodedFabricValue,
 } from "@/codec-json/index.ts";
 import { jsonFromValue } from "@/codecs.ts";
@@ -213,7 +213,7 @@ describe("data-uri-codec", () => {
     it("throws given invalid payload text past the codec tag", () => {
       expect(() =>
         valueFromDataUriPayloadText(
-          JsonCodec.wrapEncodedValueForTesting("{nope", true),
+          JsonCodecEngine.wrapEncodedValueForTesting("{nope", true),
         )
       ).toThrow();
     });
@@ -351,7 +351,7 @@ describe("data-uri-codec", () => {
         expect(() =>
           valueFromDataUri(
             uriOf(
-              JsonCodec.wrapEncodedValueForTesting("{nope", true),
+              JsonCodecEngine.wrapEncodedValueForTesting("{nope", true),
             ),
           )
         ).toThrow();

--- a/packages/data-model/test/message-quoting.test.ts
+++ b/packages/data-model/test/message-quoting.test.ts
@@ -15,7 +15,7 @@ import { expect } from "@std/expect";
 import { cloneIfNecessary } from "@/value-clone.ts";
 import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
 import { hashOf } from "@/value-hash.ts";
-import { newDefaultJsonCodec } from "@/codecs.ts";
+import { newDefaultJsonCodecEngine } from "@/codecs.ts";
 import { EmptyReconstructionContext } from "@/codec-common/index.ts";
 import { backtickQuote } from "@commonfabric/utils/markdown";
 
@@ -82,13 +82,13 @@ describe("message quoting", () => {
     });
   });
 
-  describe("`JsonCodec.decode()`", () => {
+  describe("`JsonCodecEngine.decode()`", () => {
     it("hands back the excerpt it refused", () => {
       const context = new EmptyReconstructionContext(false);
       for (const data of HOSTILE) {
         let message = "";
         try {
-          newDefaultJsonCodec().decode(data, context);
+          newDefaultJsonCodecEngine().decode(data, context);
         } catch (e) {
           message = (e as Error).message;
         }

--- a/packages/runner/test/attestation-data-uri.test.ts
+++ b/packages/runner/test/attestation-data-uri.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { JsonCodec } from "@commonfabric/data-model/codec-json";
+import { JsonCodecEngine } from "@commonfabric/data-model/codec-json";
 import { jsonFromValue } from "@commonfabric/data-model/codecs";
 import { toUnpaddedBase64url } from "@commonfabric/utils/base64url";
 import { DATA_URI_MEDIA_TYPE } from "@commonfabric/data-model/data-uri-codec";
@@ -62,7 +62,7 @@ describe("attestation `load()` of `data:` URIs", () => {
   it("errors on an undecodable payload past the codec tag", () => {
     const { ok, error } = load({
       id: uriOf(
-        JsonCodec.wrapEncodedValueForTesting("{nope", true),
+        JsonCodecEngine.wrapEncodedValueForTesting("{nope", true),
       ),
     });
     expect(ok).toBeUndefined();

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -2,7 +2,7 @@ import { DID, Identity, type Session } from "@commonfabric/identity";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { FabricSpecialObject } from "@commonfabric/data-model/fabric-value";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
-import { newDefaultJsonCodec } from "@commonfabric/data-model/codecs";
+import { newDefaultJsonCodecEngine } from "@commonfabric/data-model/codecs";
 import { type ACL, isACLUser, isCapability } from "@commonfabric/memory/acl";
 import {
   PieceController,
@@ -183,7 +183,7 @@ import {
 } from "./runtime-error.ts";
 
 const MAX_SERIALIZATION_DEPTH = 5;
-const blobUploadCodec = newDefaultJsonCodec();
+const blobUploadCodec = newDefaultJsonCodecEngine();
 
 function spaceAclResponse(
   runtime: Runtime,

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -553,7 +553,7 @@ export class CellHandle<T = unknown> {
     //
     // TODO(danfuzz): carry the whole `FabricValue` domain across this
     // connection, at which point this becomes a conversion rather than a
-    // refusal. `JsonCodec` is the mechanism, and the gap it closes is the one
+    // refusal. `JsonCodecEngine` is the mechanism, and the gap it closes is the one
     // marked on `WireCellValue` in `protocol/types.ts`.
     if (value instanceof FabricSpecialObject) {
       throw new Error(

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -275,7 +275,7 @@ export interface CellGetRequest extends BaseRequest {
  * `bigint` or a `symbol`, both of which are `FabricValue` arms. The transport
  * is `postMessage` rather than JSON, so that is a gap rather than a limit --
  * though structured clone alone does not close it, a class instance arriving
- * with its prototype and private fields gone. `JsonCodec`
+ * with its prototype and private fields gone. `JsonCodecEngine`
  * (`@commonfabric/data-model/codec-json`) is the mechanism, already used for
  * blob-upload bodies in `backends/runtime-processor.ts`. Until then
  * `CellHandle.serialize()` refuses all three, so what the gap costs is a throw

--- a/packages/schema-generator/test/fixtures-runner.test.ts
+++ b/packages/schema-generator/test/fixtures-runner.test.ts
@@ -8,7 +8,7 @@ import {
   createUnifiedDiff,
   defineFixtureSuite,
 } from "@commonfabric/test-support/fixture-runner";
-import { JsonCodec } from "@commonfabric/data-model/codec-json";
+import { JsonCodecEngine } from "@commonfabric/data-model/codec-json";
 import { jsonFromValue, valueFromJson } from "@commonfabric/data-model/codecs";
 import {
   FabricPrimitive,
@@ -188,13 +188,13 @@ async function runSchemaTransform(inputPath: string): Promise<SchemaResult> {
  *
  * The encoding's prefix tag identifies it on the wire but is not part of the
  * JSON, so it cannot survive pretty-printing. Taking it off and putting it back
- * goes through `JsonCodec`'s test-only helpers, which is what keeps the tag
+ * goes through `JsonCodecEngine`'s test-only helpers, which is what keeps the tag
  * defined in exactly one place. Key order needs no help: a conforming encoder
  * emits plain-object keys in canonical order.
  */
 function encodeGolden(value: unknown): string {
   const body = JSON.parse(
-    JsonCodec.unwrapEncodedValueForTesting(
+    JsonCodecEngine.unwrapEncodedValueForTesting(
       jsonFromValue(value as FabricValue),
     ),
   );
@@ -204,7 +204,7 @@ function encodeGolden(value: unknown): string {
 /** Inverse of {@link encodeGolden}. */
 function decodeGolden(text: string): unknown {
   return valueFromJson(
-    JsonCodec.wrapEncodedValueForTesting(text.trim()),
+    JsonCodecEngine.wrapEncodedValueForTesting(text.trim()),
   );
 }
 

--- a/packages/toolshed/routes/blobs/blobs.index.ts
+++ b/packages/toolshed/routes/blobs/blobs.index.ts
@@ -7,13 +7,13 @@ import { memoryServer } from "@/routes/storage/memory.ts";
 import { isDID } from "@commonfabric/identity";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { hashOf } from "@commonfabric/data-model/value-hash";
-import { newDefaultJsonCodec } from "@commonfabric/data-model/codecs";
+import { newDefaultJsonCodecEngine } from "@commonfabric/data-model/codecs";
 import { EmptyReconstructionContext } from "@commonfabric/data-model/codec-common";
 import { decodeMemoryBoundary } from "@commonfabric/memory/v2";
 import type { Context } from "@hono/hono";
 
 const router = createRouter();
-const blobUploadCodec = newDefaultJsonCodec();
+const blobUploadCodec = newDefaultJsonCodecEngine();
 const blobReconstructionContext = new EmptyReconstructionContext(
   true,
   "blob upload payloads cannot contain cell references",

--- a/packages/toolshed/routes/blobs/blobs.test.ts
+++ b/packages/toolshed/routes/blobs/blobs.test.ts
@@ -8,7 +8,7 @@ import env from "@/env.ts";
 import { Identity } from "@commonfabric/identity";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { hashOf } from "@commonfabric/data-model/value-hash";
-import { newDefaultJsonCodec } from "@commonfabric/data-model/codecs";
+import { newDefaultJsonCodecEngine } from "@commonfabric/data-model/codecs";
 import { encodeMemoryBoundary } from "@commonfabric/memory/v2";
 import type { URI } from "@commonfabric/memory/interface";
 import { Runtime } from "@commonfabric/runner";
@@ -25,7 +25,7 @@ const app = createApp()
 const encodeBlobPayload = (payload: { type: string; body: FabricBytes }) =>
   encodeMemoryBoundary(payload);
 
-const blobUploadCodec = newDefaultJsonCodec();
+const blobUploadCodec = newDefaultJsonCodecEngine();
 
 describe("Blob Routes", () => {
   let server: Deno.HttpServer;

--- a/tasks/pattern-compat-lib.ts
+++ b/tasks/pattern-compat-lib.ts
@@ -22,7 +22,7 @@
 import { type JSONSchema, type Pattern } from "@commonfabric/runner";
 import { validateSchemaDefinition } from "@commonfabric/runner/cfc";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
-import { JsonCodec } from "@commonfabric/data-model/codec-json";
+import { JsonCodecEngine } from "@commonfabric/data-model/codec-json";
 import { jsonFromValue, valueFromJson } from "@commonfabric/data-model/codecs";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { assertPatternSchemasBackwardCompatible } from "../packages/piece/src/schema-compatibility.ts";
@@ -155,7 +155,7 @@ export interface StoredBaseline extends PatternContract {
  */
 export function encodeBaseline(stored: StoredBaseline): string {
   const body = JSON.parse(
-    JsonCodec.unwrapEncodedValueForTesting(
+    JsonCodecEngine.unwrapEncodedValueForTesting(
       jsonFromValue(stored as unknown as FabricValue),
     ),
   );
@@ -165,7 +165,7 @@ export function encodeBaseline(stored: StoredBaseline): string {
 /** Inverse of {@link encodeBaseline}. */
 export function decodeBaseline(text: string): StoredBaseline {
   return valueFromJson(
-    JsonCodec.wrapEncodedValueForTesting(text.trim()),
+    JsonCodecEngine.wrapEncodedValueForTesting(text.trim()),
   ) as unknown as StoredBaseline;
 }
 


### PR DESCRIPTION
Two things that turned out to be one: the whole-value codec had a name that
put it among the per-type codecs it drives, and it carried machinery that
belongs to no particular wire format. I (an agent working on behalf of
@danfuzz) am separating both.

## The name

`JsonCodec` sat among `BigIntCodec`, `SymbolCodec`, `UndefinedCodec` and the
rest — same suffix, different kind of thing. Those are per-type codecs the
registry holds; this is what drives them. It is `JsonCodecEngine` now, over a
new `BaseCodecEngine`, with `newDefaultJsonCodec()` following as
`newDefaultJsonCodecEngine()`.

## The base class

`BaseCodecEngine` holds what a format must not decide for itself:

- A self-representing value is emitted as it stands.
- A terminal codec's state is final; a nonterminal codec's is walked again.
- A tag comes from `tagForValue()`, not from the value.
- An unrecognized tag becomes an `UnknownValue`; an empty one is an error.
- A codec's result is deep-frozen.

None of those is a property of a wire format, and each is a decision a walker
could get wrong far from where it shows — a state expanded when it should have
been passed through surfaces nowhere near the dispatch that decided it, and
where a state is a record of strings the two choices emit byte-identical
output.

What stays with the format is everything about containers: key order, escaping
a key that collides with the tag form, and how an absent array index is written
down. Four protected hooks carry it — `encodeArray`, `encodePlainObject`,
`wrapTag`, `decodeValue`.

Two type parameters, because a format's transport tree is not necessarily what
crosses its boundary: `Encoded` is the tree the walk works in,
`SerializedForm` is what `encode()` returns. JSON's differ, and a format whose
tree is what crosses takes the default. That lets the base declare
`SerializationContext` and the abstract `encode()` / `decode()` pair, so the
public contract is documented once at the level that guarantees it.

## What `lenient` means

Reacquainting ourselves with `lenient` produced a surprise, so it is tightened
here. A codec rejects a state in one of two ways — throwing, or returning a
`ProblematicValue` — and which it picks is the codec author's business. It used
to decide what a caller got: a throw answered to `lenient`, while a returned
`ProblematicValue` stood either way, so half of `lenient: false` did nothing.
The engine finds wire data malformed on its own too (an empty tag, a `/hole`
count that is not a count, a reserved key), and those did the same.

All of it now answers to `lenient` alone. Strictly, every rejection raises;
leniently, every rejection becomes a `ProblematicValue`. Which of codec or walk
noticed a fault is an implementation detail of where a check lives, and no
longer reaches a caller.

The spec moves with this rather than waiting, since it is a contract stated
outright rather than a shape transcribed: seven passages across
`3-json-encoding.md`, `1-fabric-values.md` and `space-model/1-data-model.md`.

## Also

`unwrapTag()`, `toBytes()` and `fromBytes()` were TypeScript-`private`
instance methods reading no instance state. They are real-private statics now,
in the static-members section, leaving no TypeScript-`private` member anywhere
in the package.

## Verification

Behavior is unchanged apart from `lenient`, which is the point of the change
and is pinned by new tests on both sides of it.

| suite | |
|---|---|
| `data-model` | `52 passed (2351 steps)` |
| `runner` | `1195 passed (6397 steps)` |
| `schema-generator` | `55 passed (295 steps)` |
| `toolshed` | `136 passed (409 steps)` |

Plus `deno task check`, `fmt --check` (4423 files), `lint`, `check-docs` (548
blocks), `check-skill-facts`, `check-conflict-markers`, `check-no-waitfor`.

Nine ablations of the base turn the suite red, each verified to have actually
applied: encode-treats-all-nonterminal, decode-treats-all-terminal, both
`deepFreeze` paths, the cycle guard, the `SELF_REP` arm, lenient-catch
re-raises, and the malformation helper forced to never raise and to always
raise.

Benchmarks are being measured separately and will be added here. The earlier
rounds found three regressions, all artifacts of the extraction rather than
costs of it, and all removed: a `Set` allocated eagerly where the original
allocated lazily, an `Object.freeze` on the per-value tagged path that the
original did not do, and a `decodeValue` split only half way.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

