### PR TITLE
docs(development): class member ordering, and `#` over TS `private`

### DIFF
--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -33,6 +33,27 @@ about one aspect of the runtime, are indexed in
 - Import either from `@commonfabric/api` (internal API) or
   `@commonfabric/api/interface` (external API), but not both.
 
+### Classes
+
+- Use JavaScript `#privateName` fields and methods rather than TypeScript's
+  `private` modifier. `protected` has no such counterpart, and stays a
+  TypeScript modifier.
+- The default order of items within a class is:
+  1. Private instance variables.
+  2. The constructor.
+  3. The abstract members, public and protected alike.
+  4. The remaining instance members, ordered from most to least access: public,
+     then protected, then private. Getters and setters come before methods.
+  5. Private static variables.
+  6. The remaining static members, ordered as the instance members are.
+- Three of those groups take a
+  [section marker](code-comment-style.md#section-markers), when the class has
+  meaningful sections to delineate or is large enough for one to earn its
+  keep: `Subclass contract` ahead of the abstract members, `Instance members`
+  ahead of the remaining instance members, and `Static members` ahead of the
+  private static variables.
+- Depart from that order when there is a compelling reason to, not by default.
+
 ### Comments
 
 - Comments explain **why**, not what, and describe the system as it stands.
@@ -156,12 +177,12 @@ validated types.
 
 ```ts
 class Data {
-  private inner: any;
+  #inner: any;
   constructor(inner: any) {
-    this.inner = inner;
+    this.#inner = inner;
   }
   process() {
-    // if (typeof this.inner === "object")
+    // if (typeof this.#inner === "object")
   }
 }
 
@@ -349,12 +370,12 @@ In both cases, we can maintain multiple caches, or instances of cache consumers.
 
 ```ts
 export class Cache {
-  private map: Map<string, string> = new Map();
+  #map: Map<string, string> = new Map();
   get(key: string): string | undefined {
-    return this.map.get(key);
+    return this.#map.get(key);
   }
   set(key: string, value: string) {
-    this.map.set(key, value);
+    this.#map.set(key, value);
   }
 }
 ```


### PR DESCRIPTION
Two class-level conventions this repository follows were not written down
anywhere under `docs/`. This adds a `Classes` subsection to
`## Style & Conventions` in `docs/development/DEVELOPMENT.md`, alongside the
existing `Formatting`, `Imports`, and `Comments` subsections — the same
altitude, and the same shape of short bullets that hand off to a dedicated
document when a topic outgrows them.

## What it says

**Private members.** Use JavaScript `#privateName` fields and methods rather
than TypeScript's `private` modifier. `protected` has no such counterpart and
stays a TypeScript modifier.

**Class member order.** Private instance variables, the constructor, the
abstract members, the remaining instance members ordered from most to least
access, private static variables, then the remaining static members. Three of
those groups take a section marker — `Subclass contract` ahead of the abstract
members, `Instance members`, and `Static members` — all three governed by one
condition: the class has meaningful sections to delineate, or is large enough
for a marker to earn its keep. The marker format itself is not restated here;
the bullet links to `code-comment-style.md#section-markers`, which already
defines it.

Abstract members, public and protected alike, sit together right after the
constructor as the subclass-facing surface of the class.

## Also in this change

Two `✅ Prefer` examples elsewhere in the same file declared `private inner` and
`private map`. The new rule a hundred lines above them says otherwise, so both
now use `#`. I (an agent working on behalf of @danfuzz) made that call as part
of the same change rather than leaving the file arguing with itself; it is the
only edit here that was not directly requested.

## Verification

Documentation-only, and `docs/` is in the `fmt.exclude` list in `deno.jsonc`,
so the 80-column wrap is hand-maintained and was checked by hand.

- `deno fmt --check` — 4423 files, clean
- `deno lint` — 4421 files, clean
- `deno task check-docs` — 548 blocks pass, including the two edited `ts`
  blocks, which compile with `#` fields
- `deno task check-conflict-markers`, `deno task check-skill-facts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9TjDnPXRSfN5DCjdbzaH1


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

