### PR TITLE
style(content-hash): order `BaseIncrementalHasher`'s members

### DIFF
--- a/packages/content-hash/src/BaseIncrementalHasher.ts
+++ b/packages/content-hash/src/BaseIncrementalHasher.ts
@@ -13,6 +13,34 @@ import type { IncrementalHasher } from "@/interface.ts";
 export abstract class BaseIncrementalHasher implements IncrementalHasher {
   #done: boolean = false;
 
+  //
+  // Subclass contract
+  //
+
+  /**
+   * Passes data to the underlying hash implementation. Called by the base
+   * class when there is data to be hashed. `data` must not be retained past
+   * the call: it can be a buffer the base class reuses, as well as one owned
+   * by the original caller. An implementation that needs to keep the bytes
+   * must copy them.
+   */
+  protected abstract _rawUpdate(data: Uint8Array): void;
+
+  /**
+   * Performs a digest operation using the underlying hash implementation.
+   * Called by the base class. May ignore the `encoding` and always return a
+   * `Uint8Array`. An array result becomes `digest()`'s return value directly,
+   * so it must be freshly allocated and unshared -- never a window onto WASM
+   * memory, a pooled allocation, or anything else that outlives the call.
+   */
+  protected abstract _rawDigest(
+    encoding: string | undefined,
+  ): Uint8Array | string;
+
+  //
+  // Instance members
+  //
+
   /** @inheritDoc */
   digest(): Uint8Array;
   digest(encoding: "base64url"): string;
@@ -56,24 +84,4 @@ export abstract class BaseIncrementalHasher implements IncrementalHasher {
       throw new Error("Cannot use instance: `digest()` already done.");
     }
   }
-
-  /**
-   * Passes data to the underlying hash implementation. Called by the base
-   * class when there is data to be hashed. `data` must not be retained past
-   * the call: it can be a buffer the base class reuses, as well as one owned
-   * by the original caller. An implementation that needs to keep the bytes
-   * must copy them.
-   */
-  protected abstract _rawUpdate(data: Uint8Array): void;
-
-  /**
-   * Performs a digest operation using the underlying hash implementation.
-   * Called by the base class. May ignore the `encoding` and always return a
-   * `Uint8Array`. An array result becomes `digest()`'s return value directly,
-   * so it must be freshly allocated and unshared -- never a window onto WASM
-   * memory, a pooled allocation, or anything else that outlives the call.
-   */
-  protected abstract _rawDigest(
-    encoding: string | undefined,
-  ): Uint8Array | string;
 }


### PR DESCRIPTION
First of the packages being brought into line with the class conventions
added to `docs/development/DEVELOPMENT.md` in #5735: `#privateName` over
TypeScript's `private`, and a defined order for class members with abstract
members clustered right after the constructor under a `Subclass contract`
section marker.

`content-hash` needs nothing on the `private` axis — it has no `private`
modifiers at all. Its eleven `protected` ones stay as they are; the rule
explicitly leaves `protected` alone, since it has no `#` counterpart.

On the ordering axis, exactly one of the package's six classes violated the
convention. `BaseIncrementalHasher` kept `_rawUpdate()` and `_rawDigest()` —
its entire subclass-facing surface, and the reason the class exists — at the
bottom, below the concrete members that call them. They now sit together
directly after the private instance variables, under a `Subclass contract`
marker, with an `Instance members` marker heading the rest.

`BaseSmallChunkUpdatingHasher`, `WasmCollectingHasher`, `WasmUpdatingHasher`,
`NobleHasher`, and `DenoHasher` already conform and are untouched.

Worth naming as a judgment call rather than a mechanical consequence: the
markers here rest on the "meaningful sections to delineate" limb of the
condition, not on size. The class body is 74 lines with five members, which is
not obviously large enough for a marker to earn its keep — but the split
between the subclass contract and the concrete members that call it is a real
section distinction, and that is what carries it.

## Verification

The diff is a pure move. I (an agent working on behalf of @danfuzz) checked
that mechanically rather than inferring it from a green suite: stripping blank
lines and sorting both versions of the file, the two line sets differ only by
the six added marker lines. Every other line is byte-identical, so no doc
comment or body was silently reworded on the way past.

- `deno task test` in `packages/content-hash` — `ok | 2 passed (725 steps) | 0 failed`
- `deno fmt --check` and `deno lint` over the package — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9TjDnPXRSfN5DCjdbzaH1


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


