### PR TITLE
style(utils): `#private` fields in `logger.ts`

### DIFF
--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -254,51 +254,51 @@ const TIMING_RESERVOIR_SIZE = 1000;
  * with O(1) memory regardless of measurement count.
  */
 class TimingDataStore {
-  private count = 0;
-  private min = Infinity;
-  private max = -Infinity;
-  private totalTime = 0;
-  private lastTime = 0;
-  private lastTimestamp = 0;
-  private samples: number[] = [];
-  private hasBaseline = false;
-  private baselineCount = 0;
-  private baselineTotalTime = 0;
-  private deltaSamples: number[] = []; // Reservoir for samples since baseline
-  private deltaCount = 0; // Count of samples since baseline
+  #count = 0;
+  #min = Infinity;
+  #max = -Infinity;
+  #totalTime = 0;
+  #lastTime = 0;
+  #lastTimestamp = 0;
+  #samples: number[] = [];
+  #hasBaseline = false;
+  #baselineCount = 0;
+  #baselineTotalTime = 0;
+  #deltaSamples: number[] = []; // Reservoir for samples since baseline
+  #deltaCount = 0; // Count of samples since baseline
 
   /**
    * Records a timing measurement.
    * @param elapsed - The elapsed time in milliseconds
    */
   record(elapsed: number): void {
-    this.count++;
-    this.totalTime += elapsed;
-    this.lastTime = elapsed;
-    this.lastTimestamp = performance.now();
+    this.#count++;
+    this.#totalTime += elapsed;
+    this.#lastTime = elapsed;
+    this.#lastTimestamp = performance.now();
 
-    if (elapsed < this.min) this.min = elapsed;
-    if (elapsed > this.max) this.max = elapsed;
+    if (elapsed < this.#min) this.#min = elapsed;
+    if (elapsed > this.#max) this.#max = elapsed;
 
     // Reservoir sampling (Algorithm R) for full history
-    if (this.samples.length < TIMING_RESERVOIR_SIZE) {
-      this.samples.push(elapsed);
+    if (this.#samples.length < TIMING_RESERVOIR_SIZE) {
+      this.#samples.push(elapsed);
     } else {
-      const j = Math.floor(Math.random() * this.count);
+      const j = Math.floor(Math.random() * this.#count);
       if (j < TIMING_RESERVOIR_SIZE) {
-        this.samples[j] = elapsed;
+        this.#samples[j] = elapsed;
       }
     }
 
     // Also record to delta reservoir if baseline is set
-    if (this.hasBaseline) {
-      this.deltaCount++;
-      if (this.deltaSamples.length < TIMING_RESERVOIR_SIZE) {
-        this.deltaSamples.push(elapsed);
+    if (this.#hasBaseline) {
+      this.#deltaCount++;
+      if (this.#deltaSamples.length < TIMING_RESERVOIR_SIZE) {
+        this.#deltaSamples.push(elapsed);
       } else {
-        const j = Math.floor(Math.random() * this.deltaCount);
+        const j = Math.floor(Math.random() * this.#deltaCount);
         if (j < TIMING_RESERVOIR_SIZE) {
-          this.deltaSamples[j] = elapsed;
+          this.#deltaSamples[j] = elapsed;
         }
       }
     }
@@ -309,16 +309,16 @@ class TimingDataStore {
    * After calling this, new samples will be tracked separately for delta CDF.
    */
   setBaseline(): void {
-    this.hasBaseline = true;
-    this.baselineCount = this.count;
-    this.baselineTotalTime = this.totalTime;
-    this.deltaSamples = [];
-    this.deltaCount = 0;
+    this.#hasBaseline = true;
+    this.#baselineCount = this.#count;
+    this.#baselineTotalTime = this.#totalTime;
+    this.#deltaSamples = [];
+    this.#deltaCount = 0;
   }
 
   /** Returns computed statistics over the recorded data. */
   getStats(): TimingStats {
-    if (this.count === 0) {
+    if (this.#count === 0) {
       return {
         count: 0,
         min: 0,
@@ -338,44 +338,44 @@ class TimingDataStore {
     }
 
     // Sort samples for percentile calculation
-    const sorted = [...this.samples].sort((a, b) => a - b);
+    const sorted = [...this.#samples].sort((a, b) => a - b);
     const p50Index = Math.floor(sorted.length * 0.5);
     const p95Index = Math.floor(sorted.length * 0.95);
     const median = sorted[p50Index] ?? 0;
 
     // Calculate CDF of all samples
-    const cdf = this.calculateCDF(sorted);
+    const cdf = this.#calculateCDF(sorted);
 
     // Calculate CDF of samples since baseline (if baseline exists and has data)
     let cdfSinceBaseline: CDFPoint[] | null = null;
-    if (this.deltaCount > 0 && this.deltaSamples.length > 0) {
-      const deltaSorted = [...this.deltaSamples].sort((a, b) => a - b);
-      cdfSinceBaseline = this.calculateCDF(deltaSorted);
+    if (this.#deltaCount > 0 && this.#deltaSamples.length > 0) {
+      const deltaSorted = [...this.#deltaSamples].sort((a, b) => a - b);
+      cdfSinceBaseline = this.#calculateCDF(deltaSorted);
     }
 
-    const countSinceBaseline = this.hasBaseline
-      ? this.count - this.baselineCount
+    const countSinceBaseline = this.#hasBaseline
+      ? this.#count - this.#baselineCount
       : 0;
-    const totalTimeSinceBaseline = this.hasBaseline
-      ? this.totalTime - this.baselineTotalTime
+    const totalTimeSinceBaseline = this.#hasBaseline
+      ? this.#totalTime - this.#baselineTotalTime
       : 0;
     const averageSinceBaseline = countSinceBaseline > 0
       ? totalTimeSinceBaseline / countSinceBaseline
       : 0;
 
     return {
-      count: this.count,
-      min: this.min,
-      max: this.max,
-      totalTime: this.totalTime,
-      average: this.totalTime / this.count,
+      count: this.#count,
+      min: this.#min,
+      max: this.#max,
+      totalTime: this.#totalTime,
+      average: this.#totalTime / this.#count,
       countSinceBaseline,
       totalTimeSinceBaseline,
       averageSinceBaseline,
       p50: median,
       p95: sorted[p95Index] ?? sorted[sorted.length - 1] ?? 0,
-      lastTime: this.lastTime,
-      lastTimestamp: this.lastTimestamp,
+      lastTime: this.#lastTime,
+      lastTimestamp: this.#lastTimestamp,
       cdf,
       cdfSinceBaseline,
     };
@@ -386,7 +386,7 @@ class TimingDataStore {
    * points where `(x, y)` means that a `y` fraction of the samples are at
    * most `x` milliseconds.
    */
-  private calculateCDF(sorted: number[]): CDFPoint[] {
+  #calculateCDF(sorted: number[]): CDFPoint[] {
     if (sorted.length === 0) return [];
 
     return sorted.map((x, i) => ({
@@ -397,13 +397,13 @@ class TimingDataStore {
 
   /** Resets all timing data. */
   reset(): void {
-    this.count = 0;
-    this.min = Infinity;
-    this.max = -Infinity;
-    this.totalTime = 0;
-    this.lastTime = 0;
-    this.lastTimestamp = 0;
-    this.samples = [];
+    this.#count = 0;
+    this.#min = Infinity;
+    this.#max = -Infinity;
+    this.#totalTime = 0;
+    this.#lastTime = 0;
+    this.#lastTimestamp = 0;
+    this.#samples = [];
   }
 }
 
@@ -545,35 +545,37 @@ export type LoggerBreakdown = {
 
 /** Logger, which handles both basic and tagged logging. */
 export class Logger {
-  private _disabled: boolean;
+  #moduleName: string | undefined;
+  #disabled: boolean;
   public level?: LogLevel;
-  private _counts: { debug: number; info: number; warn: number; error: number };
-  private _countsByKey: Record<
+  #counts: { debug: number; info: number; warn: number; error: number };
+  #countsByKey: Record<
     string,
     { debug: number; info: number; warn: number; error: number }
   >;
-  private _logCountEvery: number;
-  private _lastLoggedAt: number;
-  private _timingsByKey: Map<string, TimingDataStore> = new Map();
-  private _activeTimers: Map<string, number> = new Map();
-  private _timingBaselineActive = false;
-  private _countBaseline: {
+  #logCountEvery: number;
+  #lastLoggedAt: number;
+  #timingsByKey: Map<string, TimingDataStore> = new Map();
+  #activeTimers: Map<string, number> = new Map();
+  #timingBaselineActive = false;
+  #countBaseline: {
     debug: number;
     info: number;
     warn: number;
     error: number;
   } | null = null;
-  private _flags: Map<string, Map<string, Record<string, unknown> | true>> =
-    new Map();
+  #flags: Map<string, Map<string, Record<string, unknown> | true>> = new Map();
 
   /**
    * Constructs an instance which tags its output with `moduleName`, if given,
    * and which is configured per `options`.
    */
-  constructor(private moduleName?: string, options?: GetLoggerOptions) {
+  constructor(moduleName?: string, options?: GetLoggerOptions) {
+    this.#moduleName = moduleName;
+
     // Set initial disabled state from options
     // Default to false (enabled) if not specified
-    this._disabled = options?.enabled === undefined ? false : !options.enabled;
+    this.#disabled = options?.enabled === undefined ? false : !options.enabled;
 
     // Set logger-specific level if provided; default to "info" when unset.
     // This keeps behavior consistent and avoids assigning undefined with
@@ -581,12 +583,12 @@ export class Logger {
     this.level = options?.level ?? getEnvLevel() ?? "info";
 
     // Initialize call counts
-    this._counts = { debug: 0, info: 0, warn: 0, error: 0 };
-    this._countsByKey = {};
+    this.#counts = { debug: 0, info: 0, warn: 0, error: 0 };
+    this.#countsByKey = {};
 
     // Set logCountEvery threshold (default to 100, 0 to disable)
-    this._logCountEvery = options?.logCountEvery ?? 100;
-    this._lastLoggedAt = 0;
+    this.#logCountEvery = options?.logCountEvery ?? 100;
+    this.#lastLoggedAt = 0;
   }
 
   /**
@@ -595,12 +597,12 @@ export class Logger {
    * - false: Logger is enabled, logs are shown based on level (default)
    */
   get disabled(): boolean {
-    return this._disabled;
+    return this.#disabled;
   }
 
   /** @inheritDoc */
   set disabled(value: boolean) {
-    this._disabled = value;
+    this.#disabled = value;
   }
 
   /**
@@ -610,10 +612,10 @@ export class Logger {
    */
   get counts(): LogCounts {
     return {
-      debug: this._counts.debug,
-      info: this._counts.info,
-      warn: this._counts.warn,
-      error: this._counts.error,
+      debug: this.#counts.debug,
+      info: this.#counts.info,
+      warn: this.#counts.warn,
+      error: this.#counts.error,
       get total(): number {
         return this.debug + this.info + this.warn + this.error;
       },
@@ -626,7 +628,7 @@ export class Logger {
    */
   get countsByKey(): Record<string, LogCounts> {
     const result: Record<string, LogCounts> = {};
-    for (const [key, counts] of Object.entries(this._countsByKey)) {
+    for (const [key, counts] of Object.entries(this.#countsByKey)) {
       result[key] = {
         debug: counts.debug,
         info: counts.info,
@@ -642,16 +644,16 @@ export class Logger {
 
   /** Resets all call counts to zero, both the overall and the by-key ones. */
   resetCounts(): void {
-    this._counts.debug = 0;
-    this._counts.info = 0;
-    this._counts.warn = 0;
-    this._counts.error = 0;
-    this._countsByKey = {};
-    this._lastLoggedAt = 0;
+    this.#counts.debug = 0;
+    this.#counts.info = 0;
+    this.#counts.warn = 0;
+    this.#counts.error = 0;
+    this.#countsByKey = {};
+    this.#lastLoggedAt = 0;
   }
 
   /** Increments the count for a specific message key and log level. */
-  private incrementKeyCount(key: string, level: ActiveLogLevel): void {
+  #incrementKeyCount(key: string, level: ActiveLogLevel): void {
     // Skip reserved key name "total" to prevent corruption of breakdown totals
     if (key === "total") {
       console.warn(
@@ -660,47 +662,47 @@ export class Logger {
       );
       return;
     }
-    if (!this._countsByKey[key]) {
-      this._countsByKey[key] = { debug: 0, info: 0, warn: 0, error: 0 };
+    if (!this.#countsByKey[key]) {
+      this.#countsByKey[key] = { debug: 0, info: 0, warn: 0, error: 0 };
     }
-    this._countsByKey[key][level]++;
+    this.#countsByKey[key][level]++;
   }
 
   /**
    * Logs the count summary, if incrementing the counter has just carried the
    * total past another multiple of the configured threshold.
    */
-  private maybeLogCountSummary(): void {
+  #maybeLogCountSummary(): void {
     // Skip if disabled or logCountEvery is 0
-    if (this._logCountEvery === 0) return;
+    if (this.#logCountEvery === 0) return;
 
     const total = this.counts.total;
-    const threshold = Math.floor(total / this._logCountEvery);
+    const threshold = Math.floor(total / this.#logCountEvery);
 
     // Check if we've crossed a new threshold
-    if (threshold > this._lastLoggedAt) {
-      this._lastLoggedAt = threshold;
+    if (threshold > this.#lastLoggedAt) {
+      this.#lastLoggedAt = threshold;
 
       // Only log if debug level is enabled
       if (shouldLog("debug", this.level)) {
-        const { prefix, color } = this.getLogFormat("debug");
-        const moduleName = this.moduleName || "logger";
+        const { prefix, color } = this.#getLogFormat("debug");
+        const moduleName = this.#moduleName || "logger";
         const message =
-          `${moduleName}: ${total} log calls made (debug: ${this._counts.debug}, info: ${this._counts.info}, warn: ${this._counts.warn}, error: ${this._counts.error})`;
+          `${moduleName}: ${total} log calls made (debug: ${this.#counts.debug}, info: ${this.#counts.info}, warn: ${this.#counts.warn}, error: ${this.#counts.error})`;
         console.debug(prefix, color, message);
       }
     }
   }
 
   /** Returns the prefix and color for a log level. */
-  private getLogFormat(
+  #getLogFormat(
     level: ActiveLogLevel,
   ): { prefix: string; color: string } {
     const levelUpper = level.toUpperCase();
     const timestamp = getTimeStamp();
 
-    if (this.moduleName) {
-      const prefix = `%c[${levelUpper}][${this.moduleName}::${timestamp}]`;
+    if (this.#moduleName) {
+      const prefix = `%c[${levelUpper}][${this.#moduleName}::${timestamp}]`;
       const color = LOG_COLORS[
         `tagged${
           levelUpper.charAt(0) + level.slice(1)
@@ -716,12 +718,12 @@ export class Logger {
 
   /** Logs a debug message. */
   debug(key: string, ...messages: LogMessage[]): void {
-    this._counts.debug++;
-    this.incrementKeyCount(key, "debug");
-    if (this._disabled) return;
-    this.maybeLogCountSummary();
+    this.#counts.debug++;
+    this.#incrementKeyCount(key, "debug");
+    if (this.#disabled) return;
+    this.#maybeLogCountSummary();
     if (shouldLog("debug", this.level)) {
-      const { prefix, color } = this.getLogFormat("debug");
+      const { prefix, color } = this.#getLogFormat("debug");
       if (shouldLogToStderr()) {
         logToStderr(
           prefix.replace("%c", ""),
@@ -741,12 +743,12 @@ export class Logger {
 
   /** Logs an info message. */
   info(key: string, ...messages: LogMessage[]): void {
-    this._counts.info++;
-    this.incrementKeyCount(key, "info");
-    if (this._disabled) return;
-    this.maybeLogCountSummary();
+    this.#counts.info++;
+    this.#incrementKeyCount(key, "info");
+    if (this.#disabled) return;
+    this.#maybeLogCountSummary();
     if (shouldLog("info", this.level)) {
-      const { prefix, color } = this.getLogFormat("info");
+      const { prefix, color } = this.#getLogFormat("info");
       if (shouldLogToStderr()) {
         logToStderr(
           prefix.replace("%c", ""),
@@ -761,12 +763,12 @@ export class Logger {
 
   /** Logs a warning message. */
   warn(key: string, ...messages: LogMessage[]): void {
-    this._counts.warn++;
-    this.incrementKeyCount(key, "warn");
-    if (this._disabled) return;
-    this.maybeLogCountSummary();
+    this.#counts.warn++;
+    this.#incrementKeyCount(key, "warn");
+    if (this.#disabled) return;
+    this.#maybeLogCountSummary();
     if (shouldLog("warn", this.level)) {
-      const { prefix, color } = this.getLogFormat("warn");
+      const { prefix, color } = this.#getLogFormat("warn");
       if (shouldLogToStderr()) {
         logToStderr(
           prefix.replace("%c", ""),
@@ -781,12 +783,12 @@ export class Logger {
 
   /** Logs an error message. */
   error(key: string, ...messages: LogMessage[]): void {
-    this._counts.error++;
-    this.incrementKeyCount(key, "error");
-    if (this._disabled) return;
-    this.maybeLogCountSummary();
+    this.#counts.error++;
+    this.#incrementKeyCount(key, "error");
+    if (this.#disabled) return;
+    this.#maybeLogCountSummary();
     if (shouldLog("error", this.level)) {
-      const { prefix, color } = this.getLogFormat("error");
+      const { prefix, color } = this.#getLogFormat("error");
       if (shouldLogToStderr()) {
         logToStderr(
           prefix.replace("%c", ""),
@@ -817,7 +819,7 @@ export class Logger {
    */
   timeStart(...keys: string[]): void {
     const keyPath = keys.join("/");
-    this._activeTimers.set(keyPath, performance.now());
+    this.#activeTimers.set(keyPath, performance.now());
   }
 
   /**
@@ -827,15 +829,15 @@ export class Logger {
    */
   timeEnd(...keys: string[]): number | undefined {
     const keyPath = keys.join("/");
-    const startTime = this._activeTimers.get(keyPath);
+    const startTime = this.#activeTimers.get(keyPath);
     if (startTime === undefined) {
       return undefined;
     }
-    this._activeTimers.delete(keyPath);
+    this.#activeTimers.delete(keyPath);
 
     const endTime = performance.now();
     const elapsed = endTime - startTime;
-    this._recordTime(elapsed, keys);
+    this.#recordTime(elapsed, keys);
     return elapsed;
   }
 
@@ -871,7 +873,7 @@ export class Logger {
 
     const elapsed = endTime - startTime;
     if (keys.length > 0) {
-      this._recordTime(elapsed, keys);
+      this.#recordTime(elapsed, keys);
     }
     return elapsed;
   }
@@ -880,15 +882,15 @@ export class Logger {
    * Records timing against the full key path only, with no rollup to the
    * shorter paths.
    */
-  private _recordTime(elapsed: number, keys: string[]): void {
+  #recordTime(elapsed: number, keys: string[]): void {
     const path = keys.join("/");
-    let store = this._timingsByKey.get(path);
+    let store = this.#timingsByKey.get(path);
     if (!store) {
       store = new TimingDataStore();
-      if (this._timingBaselineActive) {
+      if (this.#timingBaselineActive) {
         store.setBaseline();
       }
-      this._timingsByKey.set(path, store);
+      this.#timingsByKey.set(path, store);
     }
     store.record(elapsed);
   }
@@ -903,7 +905,7 @@ export class Logger {
    */
   getTimeStats(...keys: string[]): TimingStats | undefined {
     const keyPath = keys.join("/");
-    const store = this._timingsByKey.get(keyPath);
+    const store = this.#timingsByKey.get(keyPath);
     return store?.getStats();
   }
 
@@ -913,7 +915,7 @@ export class Logger {
    */
   get timeStats(): Record<string, TimingStats> {
     const result: Record<string, TimingStats> = {};
-    for (const [key, store] of this._timingsByKey) {
+    for (const [key, store] of this.#timingsByKey) {
       result[key] = store.getStats();
     }
     return result;
@@ -921,9 +923,9 @@ export class Logger {
 
   /** Resets all timing statistics for this logger. */
   resetTimeStats(): void {
-    this._timingsByKey.clear();
-    this._activeTimers.clear();
-    this._timingBaselineActive = false;
+    this.#timingsByKey.clear();
+    this.#activeTimers.clear();
+    this.#timingBaselineActive = false;
   }
 
   //
@@ -935,7 +937,7 @@ export class Logger {
    * `getCountDeltas()` reports relative to them.
    */
   resetCountBaseline(): void {
-    this._countBaseline = { ...this._counts };
+    this.#countBaseline = { ...this.#counts };
   }
 
   /**
@@ -943,8 +945,8 @@ export class Logger {
    * curves show the samples taken since.
    */
   resetTimingBaseline(): void {
-    this._timingBaselineActive = true;
-    for (const store of this._timingsByKey.values()) {
+    this.#timingBaselineActive = true;
+    for (const store of this.#timingsByKey.values()) {
       store.setBaseline();
     }
   }
@@ -960,17 +962,17 @@ export class Logger {
     error: number;
     total: number;
   } {
-    if (!this._countBaseline) {
-      return { ...this._counts, total: this.getTotal() };
+    if (!this.#countBaseline) {
+      return { ...this.#counts, total: this.#getTotal() };
     }
     return {
-      debug: this._counts.debug - this._countBaseline.debug,
-      info: this._counts.info - this._countBaseline.info,
-      warn: this._counts.warn - this._countBaseline.warn,
-      error: this._counts.error - this._countBaseline.error,
-      total: this.getTotal() - (
-        this._countBaseline.debug + this._countBaseline.info +
-        this._countBaseline.warn + this._countBaseline.error
+      debug: this.#counts.debug - this.#countBaseline.debug,
+      info: this.#counts.info - this.#countBaseline.info,
+      warn: this.#counts.warn - this.#countBaseline.warn,
+      error: this.#counts.error - this.#countBaseline.error,
+      total: this.#getTotal() - (
+        this.#countBaseline.debug + this.#countBaseline.info +
+        this.#countBaseline.warn + this.#countBaseline.error
       ),
     };
   }
@@ -993,10 +995,10 @@ export class Logger {
     value: boolean,
     metadata?: Record<string, unknown>,
   ): void {
-    let group = this._flags.get(name);
+    let group = this.#flags.get(name);
     if (!group) {
       group = new Map();
-      this._flags.set(name, group);
+      this.#flags.set(name, group);
     }
     if (value) {
       group.set(id, metadata ?? true);
@@ -1015,7 +1017,7 @@ export class Logger {
       string,
       Record<string, Record<string, unknown> | null>
     > = {};
-    for (const [name, group] of this._flags) {
+    for (const [name, group] of this.#flags) {
       if (group.size > 0) {
         const entries: Record<string, Record<string, unknown> | null> = {};
         for (const [id, value] of group) {
@@ -1029,13 +1031,13 @@ export class Logger {
 
   /** Resets all flags for this logger. */
   resetFlags(): void {
-    this._flags.clear();
+    this.#flags.clear();
   }
 
   /** Returns the total count of all log calls, over all four levels. */
-  private getTotal(): number {
-    return this._counts.debug + this._counts.info + this._counts.warn +
-      this._counts.error;
+  #getTotal(): number {
+    return this.#counts.debug + this.#counts.info + this.#counts.warn +
+      this.#counts.error;
   }
 }
 


### PR DESCRIPTION
Part of bringing packages into line with the class conventions added to
`docs/development/DEVELOPMENT.md` in #5735. Companion to #5737, which covers
`content-hash`.

`logger.ts` held the last TypeScript `private` modifiers in this package —
`PathKeyMap`, `PathKeyMapNode`, `TwoLevelWeakCache`, `BoundedKeyMap`,
`LRUCache`, and `FallbackAsyncLocalStore` already use `#`. All 28 declarations
across `TimingDataStore` and `Logger`, and the 147 references to them, are
converted.

**The `_` prefix goes with the modifier.** It existed to mark privacy, which
`#` now carries, and no other `#` member anywhere in the workspace wears one.
So `private _counts` becomes `#counts`, not `#_counts`. This is the one part
of the change that is a rename rather than a modifier swap; it is confined to
this file.

**`moduleName` needed real work.** It was a constructor parameter property
(`constructor(private moduleName?: string, …)`), a form with no `#` spelling.
It is now a declared `#moduleName` field assigned in the constructor body. The
constructor's signature is unchanged, so no caller is affected.

**Member ordering in this file is deliberately not touched.** `Logger`'s
members are in no particular order — `public level?` sits among the private
fields, getters appear at four separate points, private methods are scattered
through the public ones — and conforming it means a near-total reshuffle. That
is its own change, on purpose, so this diff stays reviewable.

## Verification

The interesting risk here is not type errors. `private` fields are ordinary
runtime own properties; `#` fields are not. So `Object.keys()` on a `Logger`
returns something different after this change, and no type checker or test
would necessarily notice.

I (an agent working on behalf of @danfuzz) swept the workspace for it. The one
real-looking hit — `Object.keys(logger).length` in
`toolshed/routes/health/health.handlers.ts:193` — is browser-side JS inside a
template string, where `logger` is a plain JSON object out of
`data.timingStats` (a `Record<string, TimingStats>` over the wire), not a
`Logger`. The remaining hits enumerate the logger *registry* or public getters
that return plain objects. Nothing enumerates a real `Logger` instance, and
`TimingDataStore` never escapes this file.

For the conversion itself I inverted it: mapping every `#name` back to its
original spelling reproduces the file at `main` byte-for-byte, except for the
two hand edits (the `#moduleName` field and its assignment) and the `#flags`
declaration, which `deno fmt` rejoined onto one line now that it fits in 80
columns. Before trusting that, I corrupted one word in the converted file and
confirmed the check went red — otherwise it would be a probe that cannot fail.

- `deno task test` in `packages/utils` — `ok | 99 passed (660 steps) | 0 failed`
- `deno task check` — type check complete
- `deno fmt --check` and `deno lint` over the package — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9TjDnPXRSfN5DCjdbzaH1


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

