### PR TITLE
fix(cli): a result that points back at its container renders the circle as an address

### DIFF
--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -190,6 +190,49 @@ projection leaves every surviving path where it was; it does not compose with
 
 `packages/cli/README.md` has the grammar and the supported schema subset.
 
+### A result that points back at its container
+
+A verb that hands back the piece it created returns a value you can reach from
+inside itself, whenever that piece carries a back-reference — `parent` beside
+`children`, the shape [self-reference](concepts/self-reference.md) documents.
+A circle has no JSON rendering, so there is nothing to write for a readback
+that follows one.
+
+Ask for no shape and `cf` derives one from the verb's declared result. The
+position where the declared type re-enters itself is the position that closes
+the circle, so that position renders its address and the rest reads as it
+always did:
+
+```bash
+cf piece call --piece "$EPIC" addChild -- --title "Session cookie handling"
+```
+
+```json
+{
+  "invocation": "c5df…",
+  "status": "settled",
+  "result": {
+    "item": {
+      "title": "Session cookie handling",
+      "status": "open",
+      "children": [],
+      "parent": { "$link": { "id": "of:fid1:…", "…": "…" } }
+    }
+  }
+}
+```
+
+That address is the one a `$link` marker would have produced by hand, so the
+derived answer and a written one agree. A shape you asked for wins outright:
+`--filter`, `--select` and `--schema` are applied to the receipt first and
+leave no circle behind for anything to bound.
+
+Where nothing bounds it — the verb declares no result, or the declaration
+leaves the closing position wide — the call names the position the circle
+closes at and the receipt to collect the outcome from, and exits nonzero. Read
+that as the result being unrenderable, never as the mutation having failed:
+**the write landed**, and the message says so.
+
 ### Retries are safe, and cheap to reason about
 
 `--invocation <id>` makes a call idempotent. The id is your own word for the

--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -223,15 +223,22 @@ cf piece call --piece "$EPIC" addChild -- --title "Session cookie handling"
 ```
 
 That address is the one a `$link` marker would have produced by hand, so the
-derived answer and a written one agree. A shape you asked for wins outright:
-`--filter`, `--select` and `--schema` are applied to the receipt first and
-leave no circle behind for anything to bound.
+derived answer and a written one agree. A shape you asked for wins wherever it
+renders: `--filter`, `--select` and `--schema` are applied to the receipt first,
+and one that narrows past the circle — `--select item.title` — comes back
+exactly as written, with nothing derived added to it. One that keeps the circle
+— `--select item`, which names the re-entering subtree whole — is bounded on the
+way out like an unshaped readback, and answers in the declaration's shape: the
+shape asked for had no rendering at all.
 
-Where nothing bounds it — the verb declares no result, or the declaration
-leaves the closing position wide — the call names the position the circle
-closes at and the receipt to collect the outcome from, and exits nonzero. Read
-that as the result being unrenderable, never as the mutation having failed:
-**the write landed**, and the message says so.
+Where nothing bounds it — the verb declares no result, the declaration leaves
+the closing position wide, or a `--filter` is in play, whose surviving elements
+no longer say which positions they came from and so cannot carry an address —
+the call names the position the circle closes at and the receipt to collect the
+outcome from, and exits nonzero. Read that as the result being unrenderable,
+never as the mutation having failed: **the write landed**, and the message says
+so. A `--filter` reaches a renderable answer by naming a projection beside it
+that narrows past the circle.
 
 ### Retries are safe, and cheap to reason about
 

--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -228,8 +228,10 @@ renders: `--filter`, `--select` and `--schema` are applied to the receipt first,
 and one that narrows past the circle — `--select item.title` — comes back
 exactly as written, with nothing derived added to it. One that keeps the circle
 — `--select item`, which names the re-entering subtree whole — is bounded on the
-way out like an unshaped readback, and answers in the declaration's shape: the
-shape asked for had no rendering at all.
+way out, and the bound is a cut into what you selected rather than a shape that
+replaces it: the closing position renders its address, and no position you did
+not name comes back beside it. `--select item.parent` names the closing position
+itself, and answers with that one address alone.
 
 Where nothing bounds it — the verb declares no result, the declaration leaves
 the closing position wide, or a `--filter` is in play, whose surviving elements

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -397,6 +397,50 @@ Three cases follow from that:
   are no longer the ones they came from — so `--filter --show-links` is refused,
   the same refusal a `$link` marker meets for the same reason.
 
+#### A result that points back at itself
+
+A verb returning the piece it created hands back a value that can be reached
+from inside itself, whenever that piece carries a back-reference — `parent`
+beside `children`, the shape
+[self-reference](../../docs/common/concepts/self-reference.md) documents. A
+circle has no JSON rendering at all, so a readback that follows one has nothing
+to write.
+
+Where the caller named no shape, `cf` derives one from the verb's declared
+result. The declaration is the boundary the author drew: the position where the
+declared type re-enters itself is the position that closes the circle, so that
+position renders its address and everything else reads as it always did.
+
+```json
+{
+  "item": {
+    "title": "Rotate signing key",
+    "status": "open",
+    "children": [],
+    "parent": { "$link": { "id": "of:fid1:…", "…": "…" } }
+  }
+}
+```
+
+Three things follow:
+
+- **It is the same `$link` a caller writes by hand.** The derived bound is
+  answered by the selection step above, so `--schema` over the same position
+  produces the same address.
+- **A caller's own shape is never overruled.** `--filter`, `--select` and
+  `--schema` are applied to the receipt first, which leaves no circle for
+  anything to derive a bound for. Nothing derived can reach a call that asked
+  for a shape.
+- **Nothing else pays for it.** A result that renders is written out exactly as
+  it was read, and the compiled pattern a declared result is matched through is
+  loaded only where a readback cannot render.
+
+Where nothing bounds the circle — the verb declares no result, or the
+declaration it made leaves the closing position wide — the call reports the
+position the circle closes at, states that the handling committed, and names the
+receipt to collect the outcome from. It exits nonzero: the outcome could not be
+rendered. The write still landed, which is the property the message leads with.
+
 ## Built Binary
 
 `deno task build-binaries cf` compiles the CLI to `dist/cf` — fully

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -427,19 +427,30 @@ Three things follow:
 - **It is the same `$link` a caller writes by hand.** The derived bound is
   answered by the selection step above, so `--schema` over the same position
   produces the same address.
-- **A caller's own shape is never overruled.** `--filter`, `--select` and
-  `--schema` are applied to the receipt first, which leaves no circle for
-  anything to derive a bound for. Nothing derived can reach a call that asked
-  for a shape.
+- **A caller's own shape wins wherever it renders.** `--filter`, `--select` and
+  `--schema` are applied to the receipt first, and a projection that narrows
+  past the circle — `--select item.title` — is answered exactly as written, with
+  nothing derived added to it. A projection that names the re-entering subtree
+  whole — `--select item` — keeps the circle it selected, and is bounded on the
+  way out like an unshaped readback: the answer is then the declaration's shape,
+  because the one asked for had no rendering at all.
 - **Nothing else pays for it.** A result that renders is written out exactly as
   it was read, and the compiled pattern a declared result is matched through is
   loaded only where a readback cannot render.
 
-Where nothing bounds the circle — the verb declares no result, or the
-declaration it made leaves the closing position wide — the call reports the
-position the circle closes at, states that the handling committed, and names the
-receipt to collect the outcome from. It exits nonzero: the outcome could not be
-rendered. The write still landed, which is the property the message leads with.
+Where nothing bounds the circle — the verb declares no result, the declaration
+it made leaves the closing position wide, or a `--filter` is in play — the call
+reports the position the circle closes at, states that the handling committed,
+and names the receipt to collect the outcome from. It exits nonzero: the outcome
+could not be rendered. The write still landed, which is the property the message
+leads with.
+
+A `--filter` is the case with no bound to reach for rather than one that failed:
+the predicate hands back the elements themselves, which no longer say which
+positions they came from, and a bound is written in addresses, which name
+positions — the refusal `--filter --show-links` earns above, for the same
+reason. Narrowing past the circle with a projection beside the predicate —
+`--filter '.status == "open"' --select title` — renders.
 
 ## Built Binary
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -424,19 +424,23 @@ position renders its address and everything else reads as it always did.
 
 Three things follow:
 
-- **It is the same `$link` a caller writes by hand.** The derived bound is
-  answered by the selection step above, so `--schema` over the same position
-  produces the same address.
+- **It is the same `$link` a caller writes by hand.** The derived bound composes
+  its addresses through the same walk the selection step above composes a
+  written `$link` with, so `--schema` over the same position produces the same
+  address.
 - **A caller's own shape wins wherever it renders.** `--filter`, `--select` and
   `--schema` are applied to the receipt first, and a projection that narrows
   past the circle — `--select item.title` — is answered exactly as written, with
   nothing derived added to it. A projection that names the re-entering subtree
-  whole — `--select item` — keeps the circle it selected, and is bounded on the
-  way out like an unshaped readback: the answer is then the declaration's shape,
-  because the one asked for had no rendering at all.
+  whole — `--select item` — keeps the circle it selected and is bounded on the
+  way out, but the bound is a cut into what was selected rather than a shape
+  that replaces it: the closing position renders its address, and no position
+  the caller did not name comes back beside it. `--select item.parent` names the
+  closing position itself, and is answered with that one address alone.
 - **Nothing else pays for it.** A result that renders is written out exactly as
   it was read, and the compiled pattern a declared result is matched through is
-  loaded only where a readback cannot render.
+  loaded only where a readback cannot render. The bound itself is a walk over
+  the value already in hand: no second read, no pattern graph, no transaction.
 
 Where nothing bounds the circle — the verb declares no result, the declaration
 it made leaves the closing position wide, or a `--filter` is in play — the call

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -439,8 +439,9 @@ Three things follow:
   closing position itself, and is answered with that one address alone.
 - **Nothing else pays for it.** A result that renders is written out exactly as
   it was read, and the compiled pattern a declared result is matched through is
-  loaded only where a readback cannot render. The bound itself is a walk over
-  the value already in hand: no second read, no pattern graph, no transaction.
+  loaded only where a readback cannot render. The bound itself is a cut into the
+  value already in hand — no pattern graph and no transaction — leaving the
+  address walk a written `$link` is composed through as the only work beside it.
 
 Where nothing bounds the circle — the verb declares no result, the declaration
 it made leaves the closing position wide, or a `--filter` is in play — the call

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -3,7 +3,7 @@
 # not work yet. Its companion `verb-session-demo.sh` shows the session as it is
 # meant to read; this one is the thing that keeps that honest.
 #
-# Four steps assert a GAP rather than a capability. Each fails loudly the day
+# Three steps assert a GAP rather than a capability. Each fails loudly the day
 # the gap closes, so this script is how we find out that a capability arrived
 # rather than discovering it months later in a stale document.
 #
@@ -12,9 +12,6 @@
 # It deploys pattern/tracker.tsx and nothing else. That fixture belongs to this
 # session alone, so a change to a pattern the product ships can never break a
 # demonstration of what driving one through `cf` looks like.
-#
-# Two steps assert a gap rather than a capability, and say so. When the gap
-# closes they fail, which is the point: this script is how we find out.
 #
 # Run standalone against any host:
 #   API_URL=http://localhost:8000 packages/cli/integration/verb-session-gaps.sh
@@ -187,19 +184,23 @@ $CF piece call --quiet --piece "$KID" $ARGS \
   blockOn "{\"on\":\"$OTHER\"}" >/dev/null 2>&1
 gap "$?" "blockOn with a bare address"
 
-step "11. GAP: a verb returning a child piece crashes readback"
-# The returned item carries `parent`, which points back at its container, so
-# the result is cyclic and rendering it fails — issue #5577. The write lands
-# regardless, which is the property worth not losing.
+step "11. a verb returning a child piece renders the circle as an address"
+# The returned item carries `parent`, which points back at its container. The
+# readback bounds the result with the verb's own declared result and renders
+# the position where the declared type re-enters itself as an address, so the
+# whole outcome is JSON and the write it reports stays legible.
 BEFORE=$($CF piece get --quiet --piece "$EPIC" children $ARGS --step 2>/dev/null |
   jq -r 'length')
-$CF piece call --quiet --piece "$EPIC" $ARGS \
-  addChild '{"title":"Cycle probe"}' >/dev/null 2>&1
-gap "$?" "addChild readback on a doubly-linked tree"
+CALLED=$($CF piece call --quiet --piece "$EPIC" $ARGS \
+  addChild '{"title":"Cycle probe"}' 2>/dev/null)
+RC=$?
+check "0" "$RC" "addChild readback on a doubly-linked tree"
+BACKREF=$(printf '%s' "$CALLED" | jq -r '.result.item.parent["$link"].id // ""')
+check "of:" "${BACKREF:0:3}" \
+  "the position that closes the circle answers an address"
 AFTER=$($CF piece get --quiet --piece "$EPIC" children $ARGS --step 2>/dev/null |
   jq -r 'length')
-check "$((BEFORE + 1))" "$AFTER" \
-  "the write landed anyway — an absent result is not a failed mutation"
+check "$((BEFORE + 1))" "$AFTER" "the write the result describes landed"
 
 ELAPSED=$(($(date +%s) - START))
 printf '\n== %d passed, %d failed — %ds wall clock\n' "$PASS" "$FAIL" "$ELAPSED"

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -756,14 +756,20 @@ function circularResultPath(value: unknown): string | undefined {
  * the same selection step `--select`/`--schema` are answered by, so a derived
  * bound and a hand-written one produce the same vocabulary.
  *
- * A caller who named a selection never reaches here: their shape is applied to
- * the receipt first and there is no circle left to bound. Nothing derived can
- * therefore overrule what a caller asked for.
+ * A caller's own shape is applied to the receipt first and, where the value it
+ * produces renders, this is never reached: nothing derived narrows a result a
+ * caller already asked a renderable question of. A selection that keeps the
+ * circle does reach here — a projection can name the re-entering subtree whole,
+ * which selects the circle rather than cutting past it — and the bound answers
+ * in the caller's place. Their shape had no rendering at all, and the
+ * declaration's is the one in reach that does.
  *
- * Refuses where the declaration cannot bound it — no declaration at all, or one
- * whose recursion does not reach the closing position. A refusal names where
- * the circle closes and how to collect the outcome, which beats a stack trace
- * for a handling that already committed.
+ * Refuses where nothing in reach bounds it: no declaration at all, a
+ * declaration whose recursion does not reach the closing position, or a
+ * `--filter` beside it — a filtered array's elements no longer say which
+ * positions they came from, and the bound is written in addresses, which name
+ * positions. A refusal names where the circle closes and how to collect the
+ * outcome, which beats a stack trace for a handling that already committed.
  */
 async function boundCyclicResult(
   resolved: CallableResolution,
@@ -772,34 +778,45 @@ async function boundCyclicResult(
   receiptId: string | undefined,
   deps: CallableExecutionDeps,
 ): Promise<unknown> {
-  const declared = await resolved.declaredResult?.();
-  const projection = declaredResultProjection(declared);
-  if (projection !== undefined) {
-    const bounded = await (deps.deriveSelectedValue ?? deriveSelectedValue)(
-      resolved.pieces.runtime,
-      resolved.space,
-      receiptCell,
-      { projection },
-    );
-    // The bound is only as good as the declaration: a position the declaration
-    // left wide can still expand into the circle, and answering with a value
-    // that cannot be written would move the same failure one step later.
-    if (bounded !== undefined && circularResultPath(bounded) === undefined) {
-      return bounded;
-    }
-  }
   // Each wording is its own statement, so a reader of the coverage report can
   // tell which of them a test has ever produced. Inside one expression they
   // could not: a ternary is a single statement, and its untaken arm is
   // credited with the count of the statement holding it, so a wording nothing
   // has ever emitted reads exactly like one every call emits.
   let whyUnbounded: string;
-  if (declared === undefined) {
-    whyUnbounded = "This verb declares no result for `cf` to bound the " +
-      "readback with.";
+  if (deps.selection?.filter !== undefined) {
+    // Decided before the declaration is reached for, because reaching for it
+    // costs a pattern load and no derivation from it can be applied here: the
+    // selection step refuses a `$link` beside a `--filter` on the same grounds
+    // this refusal names, and every derived bound is `$link`s.
+    whyUnbounded = "This call's --filter is answered with the elements " +
+      "themselves, which no longer say which positions they came from, so " +
+      "the addresses a bound is written in cannot be composed beside it.";
   } else {
-    whyUnbounded = "This verb's declared result leaves the closing position " +
-      "unbounded.";
+    const declared = await resolved.declaredResult?.();
+    const projection = declaredResultProjection(declared);
+    if (projection !== undefined) {
+      const bounded = await (deps.deriveSelectedValue ?? deriveSelectedValue)(
+        resolved.pieces.runtime,
+        resolved.space,
+        receiptCell,
+        { projection },
+      );
+      // The bound is only as good as the declaration: a position the
+      // declaration left wide can still expand into the circle, and answering
+      // with a value that cannot be written would move the same failure one
+      // step later.
+      if (bounded !== undefined && circularResultPath(bounded) === undefined) {
+        return bounded;
+      }
+    }
+    if (declared === undefined) {
+      whyUnbounded = "This verb declares no result for `cf` to bound the " +
+        "readback with.";
+    } else {
+      whyUnbounded = "This verb's declared result leaves the closing " +
+        "position unbounded.";
+    }
   }
   throw new CyclicResultError(
     `Cannot render the result of "${resolved.cellKey}": it closes a circle at ` +
@@ -928,21 +945,26 @@ export async function executeResolvedCallable(
       ) {
         result = value;
       }
-      if (deps.selection !== undefined && result !== undefined) {
-        // Only where a result exists. Shaping the empty witness would report
-        // `{}` for a verb whose whole answer is that it returned nothing, and
-        // that omission is the distinction the empty receipt exists to draw.
-        result = await selectCallResult(
-          resolved,
-          receipt,
-          deps.selection,
-          deps,
-        );
-      } else if (result !== undefined) {
-        // Nobody asked for a shape, so the whole result is what goes out —
-        // unless it closes a circle, which has no JSON rendering at all. The
-        // check reads a value already in hand and touches no storage, so a
-        // result that renders reaches stdout exactly as it always has.
+      if (result !== undefined) {
+        // Both steps run only where a result exists. Shaping the empty witness
+        // would report `{}` for a verb whose whole answer is that it returned
+        // nothing, and that omission is the distinction the empty receipt
+        // exists to draw.
+        if (deps.selection !== undefined) {
+          result = await selectCallResult(
+            resolved,
+            receipt,
+            deps.selection,
+            deps,
+          );
+        }
+        // Whatever the value in hand came from — the whole receipt, or the
+        // caller's own shape over it — what goes out is written as JSON, and a
+        // circle has no JSON writing at all. A selection is no exemption: a
+        // projection that names the re-entering subtree whole keeps the circle
+        // it selected. The check reads a value already in hand and touches no
+        // storage, so a result that renders reaches stdout exactly as it always
+        // has, and the bound below engages only where one does not.
         const cycle = circularResultPath(result);
         if (cycle !== undefined) {
           result = await boundCyclicResult(

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -788,14 +788,24 @@ async function boundCyclicResult(
       return bounded;
     }
   }
+  // Each wording is its own statement, so a reader of the coverage report can
+  // tell which of them a test has ever produced. Inside one expression they
+  // could not: a ternary is a single statement, and its untaken arm is
+  // credited with the count of the statement holding it, so a wording nothing
+  // has ever emitted reads exactly like one every call emits.
+  let whyUnbounded: string;
+  if (declared === undefined) {
+    whyUnbounded = "This verb declares no result for `cf` to bound the " +
+      "readback with.";
+  } else {
+    whyUnbounded = "This verb's declared result leaves the closing position " +
+      "unbounded.";
+  }
   throw new CyclicResultError(
     `Cannot render the result of "${resolved.cellKey}": it closes a circle at ` +
       `"${cycle}", and JSON has no way to write one. The handling ` +
       "COMMITTED — the write landed, and only this rendering failed. " +
-      (declared === undefined
-        ? "This verb declares no result for `cf` to bound the readback with."
-        : "This verb's declared result leaves the closing position " +
-          "unbounded.") +
+      whyUnbounded +
       " Collect the outcome with a shape that bounds it: " +
       (receiptId === undefined
         ? "read the receipt with --select or --schema."

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -20,6 +20,7 @@ import {
 import {
   type CellSelection,
   CellSelectionError,
+  declaredResultProjection,
   deriveSelectedValue,
 } from "./cell-selection.ts";
 import type { ExecCommandSpec } from "./exec-schema.ts";
@@ -41,6 +42,19 @@ export interface CallableResolution {
   cellKey: string;
   pieces: PiecesController;
   space: MemorySpace;
+  /** This verb's declared result, resolved on demand.
+   *
+   * A THUNK rather than a value, because reaching it costs a pattern load and
+   * almost no call needs it. Two callers do: `--help`, which enumerates what a
+   * verb hands back, and a readback whose value closes a circle, which bounds
+   * itself with the declaration rather than failing. A readback that renders
+   * asks nothing of it, so an ordinary dispatch still loads no pattern.
+   *
+   * Absent where the resolution cannot match a declaration to the verb — a
+   * handler reached on the piece's input cell, a piece surface with no pattern
+   * to consult — which says this resolution cannot describe a result rather
+   * than promising there is none. */
+  declaredResult?: () => Promise<JSONSchema | undefined>;
 }
 
 /** The phases a handler invocation passes through, reported on early exit so
@@ -652,6 +666,146 @@ async function selectCallResult(
   return selected;
 }
 
+/**
+ * A result that cannot be written as JSON because it closes a circle, and that
+ * nothing in reach bounds: the verb declared no result, or the declaration it
+ * did make leaves the closing position unbounded.
+ *
+ * A distinct type because the condition is a rendering failure over a handling
+ * that COMMITTED, which is the one thing the message has to carry — the caller
+ * is holding a nonzero exit for a mutation that landed.
+ */
+export class CyclicResultError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CyclicResultError";
+  }
+}
+
+/**
+ * Helper for {@link circularResultPath}: the position, as a JSON pointer, that
+ * is reachable from inside itself.
+ *
+ * Ancestors, not visits: a value reachable by two paths is written twice and
+ * renders fine, while a value reachable from inside itself has no rendering at
+ * all. Own enumerable keys and nothing else, which is what a serializer reads.
+ *
+ * A node carrying `toJSON` is a leaf here, because it is a leaf to the
+ * serializer too: what gets written is whatever that method returns, and the
+ * properties underneath are never visited. The runtime objects a readback
+ * surfaces — a stream on a returned piece — are exactly that case, and their
+ * internals do refer back to themselves.
+ */
+function locateResultCycle(value: unknown): string | undefined {
+  const ancestors = new Set<object>();
+  const walk = (node: unknown, path: string[]): string | undefined => {
+    if (typeof node !== "object" || node === null) return undefined;
+    if (ancestors.has(node)) return encodeJsonPointer(["", ...path]);
+    if (typeof (node as { toJSON?: unknown }).toJSON === "function") {
+      return undefined;
+    }
+    ancestors.add(node);
+    try {
+      const keys = Array.isArray(node)
+        ? node.map((_, index) => String(index))
+        : Object.keys(node);
+      for (const key of keys) {
+        const found = walk(
+          (node as Record<string, unknown>)[key],
+          [...path, key],
+        );
+        if (found !== undefined) return found;
+      }
+      return undefined;
+    } finally {
+      ancestors.delete(node);
+    }
+  };
+  return walk(value, []);
+}
+
+/**
+ * The JSON pointer of the position where `value` closes a circle, or
+ * `undefined` where `value` can be written as JSON.
+ *
+ * Two witnesses have to agree before this reports one. The serializer decides
+ * whether the value renders at all — it is the thing whose failure is being
+ * prevented, so nothing else gets to overrule it — and the walk beside it
+ * decides where. A value the serializer writes is left alone whatever the walk
+ * thinks, and a serializer failure the walk cannot place is left alone too:
+ * `JSON.stringify` refuses more than circles, and a refusal that is not one is
+ * not this path's to answer.
+ */
+function circularResultPath(value: unknown): string | undefined {
+  try {
+    JSON.stringify(value);
+    return undefined;
+  } catch {
+    return locateResultCycle(value);
+  }
+}
+
+/**
+ * Bound a readback that closes a circle with the verb's own declared result,
+ * and hand back the value that bounds to.
+ *
+ * The declaration is the boundary the AUTHOR drew: the position where the
+ * declared type re-enters itself is the position that closes the circle, so
+ * rendering an address there cuts exactly where the shape says it should, and
+ * leaves every other position reading as it already did. It is applied through
+ * the same selection step `--select`/`--schema` are answered by, so a derived
+ * bound and a hand-written one produce the same vocabulary.
+ *
+ * A caller who named a selection never reaches here: their shape is applied to
+ * the receipt first and there is no circle left to bound. Nothing derived can
+ * therefore overrule what a caller asked for.
+ *
+ * Refuses where the declaration cannot bound it — no declaration at all, or one
+ * whose recursion does not reach the closing position. A refusal names where
+ * the circle closes and how to collect the outcome, which beats a stack trace
+ * for a handling that already committed.
+ */
+async function boundCyclicResult(
+  resolved: CallableResolution,
+  receiptCell: Cell<any>,
+  cycle: string,
+  receiptId: string | undefined,
+  deps: CallableExecutionDeps,
+): Promise<unknown> {
+  const declared = await resolved.declaredResult?.();
+  const projection = declaredResultProjection(declared);
+  if (projection !== undefined) {
+    const bounded = await (deps.deriveSelectedValue ?? deriveSelectedValue)(
+      resolved.pieces.runtime,
+      resolved.space,
+      receiptCell,
+      { projection },
+    );
+    // The bound is only as good as the declaration: a position the declaration
+    // left wide can still expand into the circle, and answering with a value
+    // that cannot be written would move the same failure one step later.
+    if (bounded !== undefined && circularResultPath(bounded) === undefined) {
+      return bounded;
+    }
+  }
+  throw new CyclicResultError(
+    `Cannot render the result of "${resolved.cellKey}": it closes a circle at ` +
+      `"${cycle}", and JSON has no way to write one. The handling ` +
+      "COMMITTED — the write landed, and only this rendering failed. " +
+      (declared === undefined
+        ? "This verb declares no result for `cf` to bound the readback with."
+        : "This verb's declared result leaves the closing position " +
+          "unbounded.") +
+      " Collect the outcome with a shape that bounds it: " +
+      (receiptId === undefined
+        ? "read the receipt with --select or --schema."
+        : `cf piece get --piece ${receiptId} ` +
+          `--schema '{"properties":{"<field>":{"$link":true}}}'.`) +
+      " Calling the verb again under --select or --schema shapes it at the " +
+      "call, but runs the handler body a second time.",
+  );
+}
+
 export async function executeResolvedCallable(
   resolved: CallableResolution,
   input: unknown,
@@ -774,6 +928,21 @@ export async function executeResolvedCallable(
           deps.selection,
           deps,
         );
+      } else if (result !== undefined) {
+        // Nobody asked for a shape, so the whole result is what goes out —
+        // unless it closes a circle, which has no JSON rendering at all. The
+        // check reads a value already in hand and touches no storage, so a
+        // result that renders reaches stdout exactly as it always has.
+        const cycle = circularResultPath(result);
+        if (cycle !== undefined) {
+          result = await boundCyclicResult(
+            resolved,
+            receipt,
+            cycle,
+            receiptAddress?.id,
+            deps,
+          );
+        }
       }
       if (deps.showLinks) {
         // After readback and after the selection, off the same receipt the

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -18,9 +18,9 @@ import {
   classifyCallableEntry,
 } from "../../fuse/callables.ts";
 import {
+  boundReadValue,
   type CellSelection,
   CellSelectionError,
-  declaredResultProjection,
   deriveSelectedValue,
 } from "./cell-selection.ts";
 import type { ExecCommandSpec } from "./exec-schema.ts";
@@ -752,17 +752,17 @@ function circularResultPath(value: unknown): string | undefined {
  * The declaration is the boundary the AUTHOR drew: the position where the
  * declared type re-enters itself is the position that closes the circle, so
  * rendering an address there cuts exactly where the shape says it should, and
- * leaves every other position reading as it already did. It is applied through
- * the same selection step `--select`/`--schema` are answered by, so a derived
- * bound and a hand-written one produce the same vocabulary.
+ * leaves every other position reading as it already did. The addresses are
+ * written by the same walk `--select`/`--schema` compose theirs with, so a
+ * derived bound and a hand-written one name the same position the same way.
  *
- * A caller's own shape is applied to the receipt first and, where the value it
- * produces renders, this is never reached: nothing derived narrows a result a
- * caller already asked a renderable question of. A selection that keeps the
- * circle does reach here — a projection can name the re-entering subtree whole,
- * which selects the circle rather than cutting past it — and the bound answers
- * in the caller's place. Their shape had no rendering at all, and the
- * declaration's is the one in reach that does.
+ * The cut is applied to `value` — the result already in hand — and never reads
+ * a second one. That is what lets it bound a result a caller ALREADY shaped
+ * without widening it: a projection can name the re-entering subtree whole,
+ * which selects the circle rather than cutting past it, and the cut then
+ * removes the closing position from what they selected rather than answering
+ * with the declaration's whole shape in its place. Where a caller's own shape
+ * renders, this is never reached at all.
  *
  * Refuses where nothing in reach bounds it: no declaration at all, a
  * declaration whose recursion does not reach the closing position, or a
@@ -774,6 +774,7 @@ function circularResultPath(value: unknown): string | undefined {
 async function boundCyclicResult(
   resolved: CallableResolution,
   receiptCell: Cell<any>,
+  value: unknown,
   cycle: string,
   receiptId: string | undefined,
   deps: CallableExecutionDeps,
@@ -794,21 +795,12 @@ async function boundCyclicResult(
       "the addresses a bound is written in cannot be composed beside it.";
   } else {
     const declared = await resolved.declaredResult?.();
-    const projection = declaredResultProjection(declared);
-    if (projection !== undefined) {
-      const bounded = await (deps.deriveSelectedValue ?? deriveSelectedValue)(
-        resolved.pieces.runtime,
-        resolved.space,
-        receiptCell,
-        { projection },
-      );
-      // The bound is only as good as the declaration: a position the
-      // declaration left wide can still expand into the circle, and answering
-      // with a value that cannot be written would move the same failure one
-      // step later.
-      if (bounded !== undefined && circularResultPath(bounded) === undefined) {
-        return bounded;
-      }
+    const bounded = await boundReadValue(receiptCell, declared, value);
+    // The bound is only as good as the declaration: a position the declaration
+    // left wide can still expand into the circle, and answering with a value
+    // that cannot be written would move the same failure one step later.
+    if (bounded !== undefined && circularResultPath(bounded) === undefined) {
+      return bounded;
     }
     if (declared === undefined) {
       whyUnbounded = "This verb declares no result for `cf` to bound the " +
@@ -970,6 +962,7 @@ export async function executeResolvedCallable(
           result = await boundCyclicResult(
             resolved,
             receipt,
+            result,
             cycle,
             receiptAddress?.id,
             deps,

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -1011,6 +1011,181 @@ export async function parseCellSelectionOptions(options: {
     : { filter, projection };
 }
 
+/**
+ * The `source` a derived projection records, in place of the text a caller
+ * would have typed. It reaches the derived read's cause, so it is a fixed
+ * string rather than a rendering of the schema: two calls that derive the same
+ * bound from the same receipt should land on the same cell.
+ */
+const DERIVED_PROJECTION_SOURCE = "<the verb's declared result>";
+
+/**
+ * One position of a derivation, and whether the walk cut anything at or below
+ * it. An absent `schema` drops the position: nothing is read there and no
+ * address stands in for it.
+ */
+interface DerivedPosition {
+  schema?: unknown;
+  /** A `$link` marker was emitted at or below this position. */
+  cut: boolean;
+}
+
+/** The position reads whatever is stored, which is what an unbounded read
+ * already does — so a derivation that only ever answers this bounds nothing. */
+const DERIVED_WHOLE: DerivedPosition = { schema: true, cut: false };
+
+/** The position renders its address instead of being followed. */
+const DERIVED_ADDRESS: DerivedPosition = {
+  schema: { [LINK_MARKER_KEY]: true },
+  cut: true,
+};
+
+/** The position contributes nothing: a stream is a dispatch surface, and there
+ * is no value at it to read or address. */
+const DERIVED_DROPPED: DerivedPosition = { cut: false };
+
+/**
+ * The schema a local JSON pointer names inside `root`. Only the local form is
+ * resolved, which is the only form a lowered declared result carries; anything
+ * else reads as an unresolvable reference and leaves the position unbounded.
+ */
+function schemaAtLocalRef(
+  root: JSONSchema,
+  ref: string,
+): JSONSchema | undefined {
+  if (!ref.startsWith("#")) return undefined;
+  const pointer = ref.slice(1);
+  if (pointer !== "" && !pointer.startsWith("/")) return undefined;
+  let current: unknown = root;
+  for (const segment of pointer.split("/").slice(1)) {
+    if (!isRecord(current)) return undefined;
+    const key = segment.replaceAll("~1", "/").replaceAll("~0", "~");
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current === undefined || typeof current === "boolean" ||
+      isRecord(current)
+    ? current as JSONSchema | undefined
+    : undefined;
+}
+
+/**
+ * Helper for {@link declaredResultProjection}: one position of the declared
+ * result, written as the projection position it derives.
+ *
+ * `following` holds the references the walk is already inside. A reference it
+ * already holds is the cut: the declared type re-enters itself there, so
+ * following it once more is what closes the circle. Every other position is
+ * left as wide as it was declared — the derivation bounds a recursion and
+ * narrows nothing else.
+ */
+function derivePosition(
+  schema: JSONSchema | undefined,
+  root: JSONSchema,
+  following: ReadonlySet<string>,
+): DerivedPosition {
+  if (schema === undefined || typeof schema === "boolean") return DERIVED_WHOLE;
+  // A stream carries no value: it renders as the empty object and reading it
+  // says nothing. `asCell` otherwise says how a position is held rather than
+  // what shape it has, and the shape beside it is what decides the cut.
+  if (Array.isArray(schema.asCell) && schema.asCell.includes("stream")) {
+    return DERIVED_DROPPED;
+  }
+
+  if (typeof schema.$ref === "string") {
+    if (following.has(schema.$ref)) return DERIVED_ADDRESS;
+    const target = schemaAtLocalRef(root, schema.$ref);
+    if (target === undefined) return DERIVED_WHOLE;
+    return derivePosition(
+      target,
+      root,
+      new Set([...following, schema.$ref]),
+    );
+  }
+
+  const branches = [
+    ...schema.anyOf ?? [],
+    ...schema.oneOf ?? [],
+    ...schema.allOf ?? [],
+  ];
+  if (branches.length > 0) {
+    // A projection states one shape per position, and a union does not. Where
+    // any branch re-enters, the position renders its address: that answers
+    // every branch, since an address names the position rather than describing
+    // what sits at it. `parent: Item | null` is the case — a root's null still
+    // has a position, and it is the position the caller would follow.
+    return branches.some((branch) =>
+        derivePosition(branch, root, following).cut
+      )
+      ? DERIVED_ADDRESS
+      : DERIVED_WHOLE;
+  }
+
+  if (schema.type === "array" || schema.items !== undefined) {
+    const items = derivePosition(schema.items, root, following);
+    if (!items.cut) return DERIVED_WHOLE;
+    // The elements are what re-enter, so each renders its own address rather
+    // than the array position's — a caller wants the children, not the slot
+    // holding them.
+    return items.schema === undefined
+      ? DERIVED_DROPPED
+      : { schema: { type: "array", items: items.schema }, cut: true };
+  }
+
+  if (schema.type === "object" || schema.properties !== undefined) {
+    const declared = schema.properties;
+    if (!isRecord(declared)) return DERIVED_WHOLE;
+    const properties: Record<string, unknown> = {};
+    let cut = false;
+    for (const [key, child] of Object.entries(declared)) {
+      const derived = derivePosition(child as JSONSchema, root, following);
+      cut ||= derived.cut;
+      if (derived.schema !== undefined) properties[key] = derived.schema;
+    }
+    // Only where something below re-enters. An object that holds no recursion
+    // is left whole, so the positions this derivation does not need to bound
+    // read exactly as an unbounded readback reads them.
+    return cut
+      ? { schema: { type: "object", properties }, cut }
+      : DERIVED_WHOLE;
+  }
+
+  return DERIVED_WHOLE;
+}
+
+/**
+ * The projection a verb's declared result bounds its own readback with, or
+ * `undefined` where the declaration bounds nothing.
+ *
+ * A declared result that re-enters itself — the `parent`/`children` shape
+ * `docs/common/concepts/self-reference.md` documents — describes a value that
+ * closes a circle, and a circle has no JSON rendering. The bound is written in
+ * the author's own terms: every position the declaration names is read as
+ * declared, and the position where the declaration re-enters renders its
+ * address instead of being followed. That is a cut at the boundary the author
+ * drew, and it is the same `$link` vocabulary a caller writes by hand.
+ *
+ * `undefined` where nothing re-enters: a declaration that describes a finite
+ * value is not a bound, and answering with one would narrow a result that
+ * renders perfectly well. The caller's own `--select`/`--schema` is the wider
+ * instrument and stays the only thing that narrows a result on request.
+ *
+ * The derived projection is written in the `--schema` language and reports
+ * itself as that flag, which is the flag that replaces it.
+ */
+export function declaredResultProjection(
+  declared: JSONSchema | undefined,
+): SelectionProjection | undefined {
+  if (declared === undefined || typeof declared === "boolean") return undefined;
+  const derived = derivePosition(declared, declared, new Set());
+  if (!derived.cut || derived.schema === undefined) return undefined;
+  return {
+    source: DERIVED_PROJECTION_SOURCE,
+    ...normalizeProjectionSchema(derived.schema),
+    kind: "json",
+    flag: "--schema",
+  };
+}
+
 function schemaTypes(schema: JSONSchema | undefined): string[] {
   if (!isRecord(schema)) return [];
   return Array.isArray(schema.type)

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -1102,11 +1102,16 @@ function derivePosition(
     );
   }
 
-  const branches = [
-    ...schema.anyOf ?? [],
-    ...schema.oneOf ?? [],
-    ...schema.allOf ?? [],
-  ];
+  // `allOf` is a conjunction: every member describes the same value at once,
+  // so a member that re-enters says nothing about whether the members beside it
+  // can be read, and cutting on its account would drop what they contribute. A
+  // projection states one shape per position, so the cut and the rest cannot be
+  // stated together either. The position is left as wide as it was declared,
+  // and a readback that still closes a circle after that refuses and names the
+  // position — which beats answering a different question quietly.
+  if (schema.allOf !== undefined) return DERIVED_WHOLE;
+
+  const branches = [...schema.anyOf ?? [], ...schema.oneOf ?? []];
   if (branches.length > 0) {
     // A projection states one shape per position, and a union does not. Where
     // any branch re-enters, the position renders its address: that answers
@@ -2484,4 +2489,93 @@ export async function deriveSelectedValue(
   } finally {
     runtime.runner.stop(resultCell);
   }
+}
+
+/**
+ * Helper for {@link boundReadValue}: `markers` restricted to the positions the
+ * value in hand actually holds.
+ *
+ * `values` is every value occupying one position: the single value below a
+ * property, and every element below `items`, which one marker answers for at
+ * once.
+ *
+ * The restriction is what keeps a bound from widening. A marker composition
+ * writes its key whether or not the value has one, because it is normally
+ * composed onto a value projected by the very schema the markers came from. A
+ * bound applied to a value someone else already shaped has no such agreement:
+ * every position that caller narrowed away has to lose its marker too, or it
+ * comes back as an address and the answer holds more than was asked for.
+ */
+function markersHeldBy(
+  markers: LinkMarkers,
+  values: readonly unknown[],
+): LinkMarkers | undefined {
+  const held = values.filter((value) => value !== undefined);
+  if (held.length === 0) return undefined;
+  const kept: LinkMarkers = {};
+  if (markers.marked === true) kept.marked = true;
+  if (markers.items !== undefined) {
+    const elements = held.flatMap((value) => Array.isArray(value) ? value : []);
+    const items = markersHeldBy(markers.items, elements);
+    if (items !== undefined) kept.items = items;
+  }
+  if (markers.properties !== undefined) {
+    const properties: Record<string, LinkMarkers> = {};
+    for (const [key, child] of Object.entries(markers.properties)) {
+      const below = held.flatMap((value) =>
+        isRecord(value) && !Array.isArray(value) && key in value
+          ? [(value as Record<string, unknown>)[key]]
+          : []
+      );
+      const childMarkers = markersHeldBy(child, below);
+      if (childMarkers !== undefined) properties[key] = childMarkers;
+    }
+    if (Object.keys(properties).length > 0) kept.properties = properties;
+  }
+  return Object.keys(kept).length === 0 ? undefined : kept;
+}
+
+/**
+ * `value`, read from `sourceCell`, with the positions `declared` re-enters
+ * rendered as their addresses — or `undefined` where the declaration bounds
+ * nothing.
+ *
+ * A value that closes a circle has no JSON rendering, and the declaration is
+ * the boundary its author drew: the position where the declared type re-enters
+ * itself is the position that closes the circle, so an address there cuts
+ * exactly where the shape says it should. The addresses are composed by the
+ * same walk {@link deriveSelectedValue} composes its own with, off the same
+ * cell, so a derived bound and a hand-written `$link` name the same position
+ * the same way.
+ *
+ * Applied to the value already in hand rather than read afresh, which is what
+ * lets it bound a result a caller has ALREADY shaped without widening it: the
+ * cut removes positions and never adds one, so whatever `--select`/`--schema`
+ * narrowed to stays narrowed. Reading a second time through the derived
+ * projection cannot do that — it answers with the declaration's whole shape,
+ * which for a caller who named one field is a projection handing back the
+ * fields they did not name. Working off the value in hand also runs no pattern
+ * graph and commits no transaction: bounding a readback costs the pattern load
+ * the declaration sits behind, and nothing else.
+ */
+export async function boundReadValue(
+  sourceCell: Cell<unknown>,
+  declared: JSONSchema | undefined,
+  value: unknown,
+): Promise<unknown> {
+  const projection = declaredResultProjection(declared);
+  if (projection === undefined) return undefined;
+  // The derived projection is written at fixed depth, so it is applied at
+  // fixed depth: `kind` is `"json"` for everything `declaredResultProjection`
+  // returns, and a concise field list's implicit array traversal has no part
+  // in a shape derived from a declaration.
+  const projected = projectValue(value, projection.schema);
+  const markers = projection.markers === undefined
+    ? undefined
+    : markersHeldBy(projection.markers, [value]);
+  return markers === undefined ? projected : await composeLinkAddresses(
+    sourcePosition(sourceCell),
+    markers,
+    projected,
+  );
 }

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -2555,8 +2555,8 @@ function markersHeldBy(
  * projection cannot do that — it answers with the declaration's whole shape,
  * which for a caller who named one field is a projection handing back the
  * fields they did not name. Working off the value in hand also runs no pattern
- * graph and commits no transaction: bounding a readback costs the pattern load
- * the declaration sits behind, and nothing else.
+ * graph and commits no transaction; what remains is the address walk itself,
+ * which is the same one a hand-written `$link` is composed through.
  */
 export async function boundReadValue(
   sourceCell: Cell<unknown>,

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -278,18 +278,17 @@ async function resultProjectionFailedAtPath(
   ) !== undefined;
 }
 
+/**
+ * A resolved piece callable: the shared resolution plus the command spec its
+ * flags and help page are built from.
+ *
+ * `declaredResult` (on {@link CallableResolution}) is attached here for a
+ * handler exposed on the piece's result cell, which is the only place a
+ * declared result can be matched from; a tool's result schema already rides
+ * its callable cell and reaches `commandSpec` directly.
+ */
 export interface ResolvedPieceCallable extends CallableResolution {
   commandSpec: ExecCommandSpec;
-  /** This verb's declared result, resolved on demand.
-   *
-   * A THUNK rather than a value, because the two callers want it at different
-   * prices. Every `cf piece call` passes through resolution, and only `--help`
-   * has anything to do with a result schema — so the compiled pattern this
-   * needs is loaded when a page asks for it and never for a dispatch. Present
-   * for a handler exposed on the piece's result cell, which is the only place
-   * a declared result can be matched from; a tool's result schema already
-   * rides its callable cell and reaches `commandSpec` directly. */
-  declaredResult?: () => Promise<JSONSchema | undefined>;
 }
 
 export interface PieceCallableDependencies extends CallableExecutionDeps {

--- a/packages/cli/test/declaredResultProjection.test.ts
+++ b/packages/cli/test/declaredResultProjection.test.ts
@@ -1,0 +1,150 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { JSONSchema } from "@commonfabric/runner";
+import { declaredResultProjection } from "../lib/cell-selection.ts";
+
+/**
+ * The declared result of a verb that hands an item back, with `Item` naming
+ * itself through `parent`. That recursion is the only thing a derived bound
+ * cuts, so every case here hangs its own position beside `item` and reads how
+ * the derivation treats that position while the walk is already cutting
+ * somewhere else. A declaration that re-enters nowhere derives no projection
+ * at all, which would leave nothing to read.
+ *
+ * The declaration shapes below are the ones a compiled pattern cannot be made
+ * to produce — a reference out of the document, a reference to a name that is
+ * not there, a position with no shape under it — which is why they are driven
+ * through the derivation directly rather than through a live verb. The
+ * recursion they hang off is the same one the transformer lowers, spelled the
+ * same way: a local `$ref` into `$defs`.
+ */
+function declarationBeside(
+  beside: Readonly<Record<string, JSONSchema>>,
+): JSONSchema {
+  return {
+    type: "object",
+    properties: { item: { $ref: "#/$defs/Item" }, ...beside },
+    $defs: {
+      Item: {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          parent: { $ref: "#/$defs/Item" },
+        },
+      },
+    },
+  };
+}
+
+/** The projection schema {@link declarationBeside}'s declaration derives. */
+function derivedSchemaBeside(
+  beside: Readonly<Record<string, JSONSchema>>,
+): JSONSchema | undefined {
+  return declaredResultProjection(declarationBeside(beside))?.schema;
+}
+
+/**
+ * `item` as the derivation writes it: `title` read as declared, and `parent`
+ * rendering its address instead of being followed back into the item. The
+ * `false` is what the position holds once its `$link` marker has been lifted
+ * out into the projection's `markers`.
+ */
+const CUT_ITEM = {
+  type: "object",
+  properties: { title: true, parent: false },
+  additionalProperties: false,
+};
+
+describe("declaredResultProjection", () => {
+  it("returns a `$link` marker at the position where the declaration re-enters", () => {
+    expect(declaredResultProjection(declarationBeside({}))).toEqual({
+      source: "<the verb's declared result>",
+      schema: {
+        type: "object",
+        properties: { item: CUT_ITEM },
+        additionalProperties: false,
+      },
+      markers: {
+        properties: { item: { properties: { parent: { marked: true } } } },
+      },
+      kind: "json",
+      flag: "--schema",
+    });
+  });
+
+  it("returns `undefined` where the verb declares no result to bound with", () => {
+    expect(declaredResultProjection(undefined)).toBeUndefined();
+    expect(declaredResultProjection(true)).toBeUndefined();
+  });
+
+  it("returns `undefined` for a declaration that re-enters nowhere", () => {
+    expect(declaredResultProjection({
+      type: "object",
+      properties: {
+        title: { type: "string" },
+        tags: { type: "array", items: { type: "string" } },
+      },
+    })).toBeUndefined();
+  });
+
+  it("returns `true` at an array position that declares no `items`", () => {
+    expect(derivedSchemaBeside({ history: { type: "array" } })).toEqual({
+      type: "object",
+      properties: { item: CUT_ITEM, history: true },
+      additionalProperties: false,
+    });
+  });
+
+  it("returns `true` at a position declared as `true`", () => {
+    expect(derivedSchemaBeside({ anything: true })).toEqual({
+      type: "object",
+      properties: { item: CUT_ITEM, anything: true },
+      additionalProperties: false,
+    });
+  });
+
+  it("returns `true` at an object position that declares no properties", () => {
+    expect(derivedSchemaBeside({ metadata: { type: "object" } })).toEqual({
+      type: "object",
+      properties: { item: CUT_ITEM, metadata: true },
+      additionalProperties: false,
+    });
+  });
+
+  describe("a `$ref` the declaration does not resolve", () => {
+    /** What every case in this group derives: the reference contributes no
+     * bound, so its position is read exactly as an unbounded readback reads
+     * it, and the recursion beside it is still cut. */
+    const unbounded = {
+      type: "object",
+      properties: { item: CUT_ITEM, origin: true },
+      additionalProperties: false,
+    };
+
+    it("returns `true` at a position whose `$ref` names nothing in the declaration", () => {
+      expect(derivedSchemaBeside({ origin: { $ref: "#/$defs/Missing" } }))
+        .toEqual(unbounded);
+    });
+
+    it("returns `true` at a position whose `$ref` points outside the declaration", () => {
+      expect(
+        derivedSchemaBeside({
+          origin: { $ref: "https://example.com/item.json#/$defs/Item" },
+        }),
+      ).toEqual(unbounded);
+    });
+
+    it("returns `true` at a position whose `$ref` names an anchor rather than a pointer", () => {
+      expect(derivedSchemaBeside({ origin: { $ref: "#Item" } }))
+        .toEqual(unbounded);
+    });
+
+    it("returns `true` at a position whose `$ref` walks past a name the declaration does not have", () => {
+      // `$defs/Item` has no `title` of its own — the title sits under
+      // `properties` — so the walk runs out of document with a segment left.
+      expect(
+        derivedSchemaBeside({ origin: { $ref: "#/$defs/Item/title/type" } }),
+      ).toEqual(unbounded);
+    });
+  });
+});

--- a/packages/cli/test/declaredResultProjection.test.ts
+++ b/packages/cli/test/declaredResultProjection.test.ts
@@ -111,6 +111,41 @@ describe("declaredResultProjection", () => {
     });
   });
 
+  it("returns a `$link` marker at a position one branch of a union re-enters", () => {
+    // `anyOf`/`oneOf` are a choice of shape, and a projection states one shape
+    // per position. An address answers every branch at once, since it names the
+    // position rather than describing what sits at it.
+    expect(derivedSchemaBeside({
+      origin: { anyOf: [{ $ref: "#/$defs/Item" }, { type: "null" }] },
+    })).toEqual({
+      type: "object",
+      properties: { item: CUT_ITEM, origin: false },
+      additionalProperties: false,
+    });
+  });
+
+  it("returns `true` at a conjunction, rather than one member's shape without the others", () => {
+    // `allOf` is a conjunction: the value satisfies every member at once, so a
+    // member that re-enters does not make the position a choice between shapes.
+    // Answering with the re-entering member alone would drop `at`, which is a
+    // projection handing back a different value than the declaration describes.
+    // The derivation cannot state two shapes at one position, so it leaves the
+    // position as wide as it was declared; a readback that then still closes a
+    // circle refuses legibly, naming the position it closes at.
+    expect(derivedSchemaBeside({
+      origin: {
+        allOf: [
+          { type: "object", properties: { of: { $ref: "#/$defs/Item" } } },
+          { type: "object", properties: { at: { type: "string" } } },
+        ],
+      },
+    })).toEqual({
+      type: "object",
+      properties: { item: CUT_ITEM, origin: true },
+      additionalProperties: false,
+    });
+  });
+
   describe("a `$ref` the declaration does not resolve", () => {
     /** What every case in this group derives: the reference contributes no
      * bound, so its position is read exactly as an unbounded readback reads

--- a/packages/cli/test/piece-call-cyclic-result-live.test.ts
+++ b/packages/cli/test/piece-call-cyclic-result-live.test.ts
@@ -1,0 +1,293 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { type Cell, Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { CyclicResultError } from "../lib/callable.ts";
+import { parseSelectProjection } from "../lib/cell-selection.ts";
+import { executePieceCallable } from "../lib/piece.ts";
+
+/**
+ * A work item that carries a back-reference: the doubly-linked shape
+ * `docs/common/concepts/self-reference.md` documents, reduced to the two
+ * fields that close the circle. `addChild` files a child under this item and
+ * hands it back, so the returned piece's `parent` is the container and the
+ * container's `children` holds the returned piece.
+ *
+ * Driven against a COMPILED, RUN pattern rather than a hand-built value,
+ * because both halves of what is under test are things the runtime constructs
+ * and a double would only assert back. The circle has to be a real one — the
+ * same object reached from inside itself, through links the runner resolved —
+ * and the bound is derived from a declared result the TRANSFORMER lowered,
+ * whose recursion is spelled with `$ref`/`$defs` that no hand-written schema
+ * would predict.
+ *
+ * Three verbs, for the three answers a readback can give:
+ *
+ * - `addChild` returns the new item, and its declared result re-enters itself.
+ * - `addChildSelf` returns the CONTAINER, so the circle closes through a
+ *   collection rather than through a single field.
+ * - `addChildLoose` returns the same container behind `unknown`, which
+ *   declares a shape that bounds nothing.
+ */
+const PROGRAM = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      'import { action, type Default, NAME, pattern, type PatternFactory, SELF, type Stream, Writable } from "commonfabric";',
+      "",
+      "interface AddChildEvent { title: string; }",
+      "interface AddChildResult { item: ItemOutput; }",
+      "interface ContainerResult { container: ItemOutput; }",
+      "interface LooseResult { container: unknown; }",
+      "interface FinishEvent { note: string; }",
+      "interface FinishResult { status: string; note: string; }",
+      "",
+      "export interface ItemOutput {",
+      "  addChild: Stream<AddChildEvent, AddChildResult>;",
+      "  addChildSelf: Stream<AddChildEvent, ContainerResult>;",
+      "  addChildLoose: Stream<AddChildEvent, LooseResult>;",
+      "  finish: Stream<FinishEvent, FinishResult>;",
+      "  [NAME]: string;",
+      "  title: string;",
+      "  status: string;",
+      "  parent: ItemOutput | null;",
+      "  children: ItemOutput[];",
+      "}",
+      "",
+      "interface ItemInput {",
+      "  title: string | Default<'Untitled'>;",
+      "  parent?: ItemOutput | null | Default<null>;",
+      "}",
+      "",
+      "export const Item: PatternFactory<ItemInput, ItemOutput> = pattern<ItemInput, ItemOutput>(",
+      "  ({ title, parent, [SELF]: self }) => {",
+      "    const status = new Writable('open');",
+      "    const children = new Writable<ItemOutput[]>([]);",
+      "    const addChild = action<AddChildEvent, AddChildResult>((event) => {",
+      "      const item = Item({ title: event.title, parent: self });",
+      "      children.push(item);",
+      "      return { item };",
+      "    });",
+      "    const addChildSelf = action<AddChildEvent, ContainerResult>((event) => {",
+      "      children.push(Item({ title: event.title, parent: self }));",
+      "      return { container: self };",
+      "    });",
+      "    const addChildLoose = action<AddChildEvent, LooseResult>((event) => {",
+      "      children.push(Item({ title: event.title, parent: self }));",
+      "      return { container: self as unknown };",
+      "    });",
+      "    const finish = action<FinishEvent, FinishResult>((event) => {",
+      "      status.set('done');",
+      "      return { status: 'done', note: event.note };",
+      "    });",
+      "    return {",
+      "      [NAME]: title,",
+      "      title,",
+      "      status,",
+      "      parent,",
+      "      children,",
+      "      addChild,",
+      "      addChildSelf,",
+      "      addChildLoose,",
+      "      finish,",
+      "    };",
+      "  },",
+      ");",
+      "",
+      "export default Item;",
+    ].join("\n"),
+  }],
+};
+
+const CONFIG = {
+  apiUrl: "http://localhost:8000",
+  identity: "/tmp/test-identity.pem",
+  piece: "fid1:live",
+  space: "" as string,
+};
+
+interface Tracker {
+  /** Dispatch `verb` the way `cf piece call` does, under an invocation id so
+   * the outcome is read back off the handling's receipt. */
+  call: (
+    verb: string,
+    rawArgs: string[],
+    extra?: Record<string, unknown>,
+  ) => Promise<unknown>;
+  /** How many times a caller reached for the compiled pattern. The declared
+   * result is behind it, so this is what a readback pays to bound itself. */
+  patternLoads: () => number;
+  root: Cell<any>;
+}
+
+/** Run the program above as a root item and hand a driver to `body`. */
+async function withTracker<T>(
+  passphrase: string,
+  body: (tracker: Tracker) => Promise<T>,
+): Promise<T> {
+  const signer = await Identity.fromPassphrase(passphrase);
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL("https://example.com"),
+    storageManager,
+  });
+  const space = signer.did();
+
+  try {
+    const compiled = await runtime.patternManager.compilePattern(
+      PROGRAM as never,
+      { space },
+    );
+    const tx = runtime.edit();
+    const rootCell = runtime.getCell(space, "cyclic-live", undefined, tx);
+    const root = runtime.run(tx, compiled, { title: "Root" }, rootCell);
+    runtime.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    await root.pull();
+
+    let patternLoads = 0;
+    const piece = {
+      result: { getCell: () => Promise.resolve(root) },
+      input: {
+        getCell: () =>
+          Promise.resolve(runtime.getCell(space, "cyclic-live-input")),
+      },
+      getCell: () => root,
+      getPattern: () => {
+        patternLoads++;
+        return Promise.resolve(compiled);
+      },
+    };
+    const deps = {
+      loadPieces: () =>
+        Promise.resolve({ getSpace: () => space, runtime } as never),
+      loadPiece: () => Promise.resolve(piece as never),
+    };
+
+    let dispatched = 0;
+    return await body({
+      root,
+      patternLoads: () => patternLoads,
+      call: async (verb, rawArgs, extra = {}) => {
+        dispatched++;
+        const executed = await executePieceCallable(
+          { ...CONFIG, space },
+          verb,
+          rawArgs,
+          {
+            ...deps,
+            invocation: { id: `inv-${dispatched}`, session: "sess" },
+            ...extra,
+          } as never,
+        );
+        return executed.invocation?.result;
+      },
+    });
+  } finally {
+    await runtime.dispose?.();
+    await storageManager.close?.();
+  }
+}
+
+/** The item titles the root currently files beneath it, read straight off the
+ * cell rather than through any rendering, so it says what committed. */
+function childTitles(root: Cell<any>): string[] {
+  return (root.key("children").get() ?? []).map((child: any) => child.title);
+}
+
+describe("cf piece call on a piece that points back at its container", () => {
+  it("renders the returned piece, with the back-reference as an address", async () => {
+    await withTracker("cyclic-returns-child", async ({ call }) => {
+      const result = await call("addChild", [
+        "--title",
+        "Rotate signing key",
+      ]) as any;
+
+      // The whole point: this is what the command writes to stdout, and it
+      // used to be the throw.
+      expect(() => JSON.stringify(result)).not.toThrow();
+      expect(result.item.title).toBe("Rotate signing key");
+      expect(result.item.status).toBe("open");
+      // `parent` is where the declared type re-enters itself, so it renders an
+      // address rather than being followed back into the container. The
+      // address names the deepest link the walk crossed plus the segments
+      // below it, which is the child's own document and the field on it.
+      expect(result.item.parent.$link.id.startsWith("of:")).toBe(true);
+      expect(result.item.parent.$link.space.startsWith("did:")).toBe(true);
+      expect(result.item.parent.$link.scope).toBe("space");
+      expect(result.item.parent.$link.path).toEqual(["parent"]);
+      // A stream is a dispatch surface, not a value, and carries nothing to
+      // read at the position it occupies.
+      expect(Object.hasOwn(result.item, "addChild")).toBe(false);
+    });
+  });
+
+  it("answers a collection that re-enters with one address per element", async () => {
+    await withTracker("cyclic-returns-container", async ({ call }) => {
+      await call("addChildSelf", ["--title", "First"]);
+      const result = await call("addChildSelf", ["--title", "Second"]) as any;
+
+      expect(() => JSON.stringify(result)).not.toThrow();
+      expect(result.container.title).toBe("Root");
+      // Each child is addressed by its own document rather than by the slot it
+      // sits in, so the answers survive a reordering of the collection.
+      const ids = result.container.children.map((child: any) => child.$link.id);
+      expect(ids.length).toBe(2);
+      expect(new Set(ids).size).toBe(2);
+      expect(ids.every((id: string) => id.startsWith("of:"))).toBe(true);
+    });
+  });
+
+  it("leaves a caller's own selection in charge of the shape", async () => {
+    await withTracker("cyclic-explicit-selection", async ({ call }) => {
+      const result = await call("addChild", ["--title", "Selected"], {
+        selection: { projection: parseSelectProjection("item.title") },
+      }) as any;
+
+      // Exactly what was asked for: no derived address anywhere, because the
+      // caller's shape is applied to the receipt and leaves no circle behind
+      // for anything to bound.
+      expect(result).toEqual({ item: { title: "Selected" } });
+    });
+  });
+
+  it("refuses legibly, naming the committed write, where the declaration bounds nothing", async () => {
+    await withTracker("cyclic-undeclared", async ({ call, root }) => {
+      const error = await call("addChildLoose", ["--title", "Unbounded"])
+        .then(() => undefined, (thrown: unknown) => thrown);
+
+      expect(error).toBeInstanceOf(CyclicResultError);
+      const message = (error as Error).message;
+      // Where the circle closes, so a caller can see which field to bound.
+      expect(message).toContain(
+        'closes a circle at "/container/children/0/parent"',
+      );
+      // The property worth not losing: an unrenderable result is not a failed
+      // mutation, and the message says so rather than leaving a stack trace to
+      // read as "the call failed".
+      expect(message).toContain("COMMITTED");
+      expect(message).toContain("cf piece get --piece of:");
+      expect(message).toContain("declared result leaves the closing position");
+
+      // And the write did land.
+      expect(childTitles(root)).toEqual(["Unbounded"]);
+    });
+  });
+
+  it("pays for the declared result only where the result will not render", async () => {
+    await withTracker(
+      "cyclic-pattern-load-cost",
+      async ({ call, patternLoads }) => {
+        await call("finish", ["--note", "Shipped"]);
+        // A result that renders is written out exactly as it was read: nothing
+        // is derived, so no compiled pattern is loaded to derive it from.
+        expect(patternLoads()).toBe(0);
+
+        await call("addChild", ["--title", "Bounded"]);
+        expect(patternLoads()).toBe(1);
+      },
+    );
+  });
+});

--- a/packages/cli/test/piece-call-cyclic-result-live.test.ts
+++ b/packages/cli/test/piece-call-cyclic-result-live.test.ts
@@ -5,6 +5,7 @@ import { type Cell, type JSONSchema, Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { CyclicResultError } from "../lib/callable.ts";
 import {
+  deriveSelectedValue,
   parseSelectionFilter,
   parseSelectionProjection,
   parseSelectProjection,
@@ -327,6 +328,56 @@ describe("cf piece call on a piece that points back at its container", () => {
       // present in what `--select item` selects on its own, so this is what
       // separates the bound engaging from the raw selection going out.
       expect(Object.hasOwn(result.item, "addChild")).toBe(false);
+    });
+  });
+
+  it("answers a `--select` that names the closing position with that position alone", async () => {
+    await withTracker("cyclic-selection-names-cut", async ({ call }) => {
+      const result = await call("addChild", ["--title", "Pointed"], {
+        selection: { projection: parseSelectProjection("item.parent") },
+      }) as any;
+
+      expect(() => JSON.stringify(result)).not.toThrow();
+      // `item.parent` IS the position where the declared type re-enters, so
+      // this caller asked for exactly the thing that has no rendering. The
+      // address stands in for it, which is the whole of what a bound does.
+      expect(result.item.parent.$link.id.startsWith("of:")).toBe(true);
+      expect(result.item.parent.$link.path).toEqual(["parent"]);
+      // And nothing else comes back. Naming the absent fields is the point: an
+      // assertion that only checked `parent` would pass just as well against a
+      // bound that answered with the declaration's whole shape, which is a
+      // projection handing back MORE than the caller named.
+      expect(Object.hasOwn(result.item, "$NAME")).toBe(false);
+      expect(Object.hasOwn(result.item, "title")).toBe(false);
+      expect(Object.hasOwn(result.item, "status")).toBe(false);
+      expect(Object.hasOwn(result.item, "children")).toBe(false);
+      expect(Object.keys(result.item)).toEqual(["parent"]);
+      expect(Object.keys(result)).toEqual(["item"]);
+    });
+  });
+
+  it("bounds a readback off the value in hand rather than reading a second one", async () => {
+    await withTracker("cyclic-bound-read-cost", async ({ call }) => {
+      let reads = 0;
+      const counted: typeof deriveSelectedValue = (...args) => {
+        reads++;
+        return deriveSelectedValue(...args);
+      };
+
+      await call("addChild", ["--title", "Unshaped"], {
+        deriveSelectedValue: counted,
+      });
+      // Nothing was asked of the selection step, and the bound is a walk over
+      // the value the readback already holds: it runs no pattern graph and
+      // commits no transaction, so this call reads the receipt once.
+      expect(reads).toBe(0);
+
+      await call("addChild", ["--title", "Shaped"], {
+        selection: { projection: parseSelectProjection("item") },
+        deriveSelectedValue: counted,
+      });
+      // Exactly the caller's own read. The bound adds none.
+      expect(reads).toBe(1);
     });
   });
 

--- a/packages/cli/test/piece-call-cyclic-result-live.test.ts
+++ b/packages/cli/test/piece-call-cyclic-result-live.test.ts
@@ -367,9 +367,9 @@ describe("cf piece call on a piece that points back at its container", () => {
       await call("addChild", ["--title", "Unshaped"], {
         deriveSelectedValue: counted,
       });
-      // Nothing was asked of the selection step, and the bound is a walk over
+      // Nothing was asked of the selection step, and the bound is a cut into
       // the value the readback already holds: it runs no pattern graph and
-      // commits no transaction, so this call reads the receipt once.
+      // commits no transaction, so this call derives nothing at all.
       expect(reads).toBe(0);
 
       await call("addChild", ["--title", "Shaped"], {

--- a/packages/cli/test/piece-call-cyclic-result-live.test.ts
+++ b/packages/cli/test/piece-call-cyclic-result-live.test.ts
@@ -4,7 +4,11 @@ import { Identity } from "@commonfabric/identity";
 import { type Cell, type JSONSchema, Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { CyclicResultError } from "../lib/callable.ts";
-import { parseSelectProjection } from "../lib/cell-selection.ts";
+import {
+  parseSelectionFilter,
+  parseSelectionProjection,
+  parseSelectProjection,
+} from "../lib/cell-selection.ts";
 import { executePieceCallable } from "../lib/piece.ts";
 
 /**
@@ -22,15 +26,18 @@ import { executePieceCallable } from "../lib/piece.ts";
  * whose recursion is spelled with `$ref`/`$defs` that no hand-written schema
  * would predict.
  *
- * Three verbs, for the three answers a readback can give:
+ * Four verbs, for the answers a readback can give:
  *
  * - `addChild` returns the new item, and its declared result re-enters itself.
  * - `addChildSelf` returns the CONTAINER, so the circle closes through a
  *   collection rather than through a single field.
  * - `addChildLoose` returns the same container behind `unknown`, which
  *   declares a shape that bounds nothing.
+ * - `addChildren` returns an ARRAY of items, which is the one root a
+ *   `--filter` can be applied to and so the only way to reach a filtered
+ *   readback of a value that closes a circle.
  *
- * A fourth answer needs no fourth verb: `addChild` reached on the piece's
+ * One more answer needs no further verb: `addChild` reached on the piece's
  * INPUT cell, under the name `fileUnder`, is a resolution a declared result
  * cannot be keyed to at all. The harness wires that surface up for it.
  */
@@ -49,6 +56,7 @@ const PROGRAM = {
       "interface FinishResult { status: string; note: string; }",
       "",
       "export interface ItemOutput {",
+      "  addChildren: Stream<AddChildEvent, ItemOutput[]>;",
       "  addChild: Stream<AddChildEvent, AddChildResult>;",
       "  addChildSelf: Stream<AddChildEvent, ContainerResult>;",
       "  addChildLoose: Stream<AddChildEvent, LooseResult>;",
@@ -74,6 +82,11 @@ const PROGRAM = {
       "      children.push(item);",
       "      return { item };",
       "    });",
+      "    const addChildren = action<AddChildEvent, ItemOutput[]>((event) => {",
+      "      const item = Item({ title: event.title, parent: self });",
+      "      children.push(item);",
+      "      return [item];",
+      "    });",
       "    const addChildSelf = action<AddChildEvent, ContainerResult>((event) => {",
       "      children.push(Item({ title: event.title, parent: self }));",
       "      return { container: self };",
@@ -92,6 +105,7 @@ const PROGRAM = {
       "      status,",
       "      parent,",
       "      children,",
+      "      addChildren,",
       "      addChild,",
       "      addChildSelf,",
       "      addChildLoose,",
@@ -269,17 +283,130 @@ describe("cf piece call on a piece that points back at its container", () => {
     });
   });
 
+  // The pair below is one contrast, and it is the whole point of both halves:
+  // `item.title` narrows PAST the position where the declared type re-enters,
+  // so the value it produces holds no circle and nothing derived touches it;
+  // `item` names the re-entering subtree WHOLE, so the circle the caller
+  // selected is still in the value and the bound has to engage. Both spellings
+  // are a selection, and only one of them leaves a readback with nothing to do
+  // — a suite holding either alone tests half of that and reads like it tests
+  // all of it.
   it("leaves a caller's own selection in charge of the shape", async () => {
     await withTracker("cyclic-explicit-selection", async ({ call }) => {
       const result = await call("addChild", ["--title", "Selected"], {
         selection: { projection: parseSelectProjection("item.title") },
       }) as any;
 
-      // Exactly what was asked for: no derived address anywhere, because the
-      // caller's shape is applied to the receipt and leaves no circle behind
-      // for anything to bound.
+      // Exactly what was asked for, and only that: the caller's shape narrowed
+      // past the circle, so there is nothing for a bound to do and no derived
+      // address anywhere. An implementation that bounded every selected result
+      // would answer with the declaration's shape here — `status`, `parent`
+      // and `children` beside the one field asked for — and fail.
       expect(result).toEqual({ item: { title: "Selected" } });
     });
+  });
+
+  it("returns an address at the closing position for a `--select` that keeps the circle", async () => {
+    await withTracker("cyclic-selection-retains", async ({ call }) => {
+      const result = await call("addChild", ["--title", "Retained"], {
+        selection: { projection: parseSelectProjection("item") },
+      }) as any;
+
+      // `--select item` selects the whole re-entering subtree, so the value the
+      // caller's own shape produces closes the same circle the unshaped
+      // readback does. It reaches stdout as JSON either way.
+      expect(() => JSON.stringify(result)).not.toThrow();
+      expect(result.item.title).toBe("Retained");
+      // The closing position renders its address, exactly as it does with no
+      // selection at all: this is the declared bound answering.
+      expect(result.item.parent.$link.id.startsWith("of:")).toBe(true);
+      expect(result.item.parent.$link.path).toEqual(["parent"]);
+      // And the answer is the DECLARATION's shape, not the caller's: their
+      // shape had no rendering at all, so the one in reach that does answers in
+      // its place. A verb's streams are dropped by that derivation and are
+      // present in what `--select item` selects on its own, so this is what
+      // separates the bound engaging from the raw selection going out.
+      expect(Object.hasOwn(result.item, "addChild")).toBe(false);
+    });
+  });
+
+  it("returns the same address for a `--schema` projection that keeps the circle", async () => {
+    await withTracker("cyclic-schema-retains", async ({ call }) => {
+      // The same hole through the other projection spelling. It is a separate
+      // grammar rather than an alias — a JSON Schema states its own depth where
+      // a concise field list traverses arrays implicitly — so it is driven
+      // rather than assumed to follow.
+      const result = await call("addChild", ["--title", "Schema"], {
+        selection: {
+          projection: await parseSelectionProjection(
+            '{"properties":{"item":true}}',
+          ),
+        },
+      }) as any;
+
+      expect(() => JSON.stringify(result)).not.toThrow();
+      expect(result.item.title).toBe("Schema");
+      expect(result.item.parent.$link.path).toEqual(["parent"]);
+    });
+  });
+
+  // The `--filter` pair, and the same contrast: a predicate hands back the
+  // elements themselves, so it can only keep a circle, never narrow past one.
+  // What decides between the two is the projection written beside it.
+  it("returns the elements a `--filter` keeps where the projection beside it renders", async () => {
+    await withTracker("cyclic-filter-renders", async ({ call }) => {
+      const result = await call("addChildren", ["--title", "Kept"], {
+        selection: {
+          filter: parseSelectionFilter('.title == "Kept"'),
+          projection: parseSelectProjection("title"),
+        },
+      }) as any;
+
+      // The projection beside the predicate narrows past the circle, so the
+      // surviving element renders and nothing is derived. An implementation
+      // that refused every cyclic-verb `--filter` outright would fail here.
+      expect(result).toEqual([{ title: "Kept" }]);
+    });
+  });
+
+  it("refuses a `--filter` that keeps the circle, naming the committed write", async () => {
+    await withTracker(
+      "cyclic-filter-retains",
+      async ({ call, patternLoads, root }) => {
+        const error = await call("addChildren", ["--title", "Filtered"], {
+          selection: { filter: parseSelectionFilter('.title == "Filtered"') },
+        }).then(() => undefined, (thrown: unknown) => thrown);
+
+        // Without the projection above, the predicate's survivor is the item
+        // itself, circle and all. Nothing can bound it: the bound is written in
+        // addresses, and the selection step refuses an address beside a
+        // `--filter` because a filtered array's elements no longer say which
+        // positions they came from. So the answer here is a refusal rather than
+        // a bound — and a legible one, rather than the `JSON.stringify` throw
+        // an unrenderable result reaches the terminal as, which says nothing
+        // about the write.
+        expect(error).toBeInstanceOf(CyclicResultError);
+        const message = (error as Error).message;
+        expect(message).toContain('closes a circle at "/0/parent/children/0"');
+        expect(message).toContain(
+          "This call's --filter is answered with the elements themselves",
+        );
+        expect(message).toContain("COMMITTED");
+        // Neither of the other two wordings: the declaration is never consulted
+        // here, so a refusal claiming it bounds nothing would be a false
+        // statement about the verb.
+        expect(message).not.toContain("declares no result");
+        expect(message).not.toContain("leaves the closing position");
+        // And no compiled pattern was loaded to reach that declaration with. A
+        // derivation that cannot be applied is not worth a pattern load, which
+        // is why the `--filter` is decided before the declaration is reached
+        // for.
+        expect(patternLoads()).toBe(0);
+        // The handling landed, which is what the refusal says and what makes it
+        // a rendering failure rather than a failed call.
+        expect(childTitles(root)).toEqual(["Filtered"]);
+      },
+    );
   });
 
   it("refuses legibly, naming the committed write, where the declaration bounds nothing", async () => {

--- a/packages/cli/test/piece-call-cyclic-result-live.test.ts
+++ b/packages/cli/test/piece-call-cyclic-result-live.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
-import { type Cell, Runtime } from "@commonfabric/runner";
+import { type Cell, type JSONSchema, Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { CyclicResultError } from "../lib/callable.ts";
 import { parseSelectProjection } from "../lib/cell-selection.ts";
@@ -29,6 +29,10 @@ import { executePieceCallable } from "../lib/piece.ts";
  *   collection rather than through a single field.
  * - `addChildLoose` returns the same container behind `unknown`, which
  *   declares a shape that bounds nothing.
+ *
+ * A fourth answer needs no fourth verb: `addChild` reached on the piece's
+ * INPUT cell, under the name `fileUnder`, is a resolution a declared result
+ * cannot be keyed to at all. The harness wires that surface up for it.
  */
 const PROGRAM = {
   main: "/main.tsx",
@@ -108,6 +112,13 @@ const CONFIG = {
   space: "" as string,
 };
 
+/** The piece's input cell, carrying one stream. A piece receives streams as
+ * arguments, and this is the surface a verb reached there is resolved on. */
+const INPUT_CELL_SCHEMA = {
+  type: "object",
+  properties: { fileUnder: { asCell: ["stream"] } },
+} as const satisfies JSONSchema;
+
 interface Tracker {
   /** Dispatch `verb` the way `cf piece call` does, under an invocation id so
    * the outcome is read back off the handling's receipt. */
@@ -147,12 +158,30 @@ async function withTracker<T>(
     expect((await tx.commit()).error).toBeUndefined();
     await root.pull();
 
+    // The same stream the pattern put on `addChild`, reached on the piece's
+    // INPUT cell under a name the result cell does not carry. `cf piece call`
+    // resolves a name on the result cell first, so `fileUnder` is the
+    // input-cell resolution — and a declared result is keyed by the PATTERN's
+    // result properties, which is why that resolution can match none.
+    const inputTx = runtime.edit();
+    const inputCell = runtime.getCell(
+      space,
+      "cyclic-live-input",
+      INPUT_CELL_SCHEMA,
+      inputTx,
+    );
+    inputCell.setRaw({ fileUnder: root.key("addChild").getAsLink() } as never);
+    runtime.prepareTxForCommit(inputTx);
+    expect((await inputTx.commit()).error).toBeUndefined();
+
     let patternLoads = 0;
     const piece = {
       result: { getCell: () => Promise.resolve(root) },
       input: {
         getCell: () =>
-          Promise.resolve(runtime.getCell(space, "cyclic-live-input")),
+          Promise.resolve(
+            runtime.getCell(space, "cyclic-live-input", INPUT_CELL_SCHEMA),
+          ),
       },
       getCell: () => root,
       getPattern: () => {
@@ -274,6 +303,43 @@ describe("cf piece call on a piece that points back at its container", () => {
       // And the write did land.
       expect(childTitles(root)).toEqual(["Unbounded"]);
     });
+  });
+
+  it("refuses a verb it can match no declaration to without consulting a pattern", async () => {
+    await withTracker(
+      "cyclic-no-declaration",
+      async ({ call, patternLoads, root }) => {
+        // `fileUnder` is the piece's own `addChild`, reached on the input cell.
+        // The dispatch and the circle are identical; what differs is that this
+        // resolution carries no declared result to bound the readback with.
+        const error = await call("fileUnder", ["--title", "Undeclared"])
+          .then(() => undefined, (thrown: unknown) => thrown);
+
+        expect(error).toBeInstanceOf(CyclicResultError);
+        const message = (error as Error).message;
+        expect(message).toContain(
+          "This verb declares no result for `cf` to bound the readback with.",
+        );
+        // Nothing bounds the readback, so the position named is where the walk
+        // itself closes: the returned item, reached again from inside its own
+        // container. With a declaration in hand the cut lands at `parent` and
+        // the walk never gets this far.
+        expect(message).toContain(
+          'closes a circle at "/item/parent/children/0"',
+        );
+        expect(message).toContain("COMMITTED");
+        expect(message).toContain("cf piece get --piece of:");
+        expect(message).not.toContain("leaves the closing position");
+        // No pattern was loaded to look for a declaration, because this
+        // resolution attaches no thunk to reach one through.
+        expect(patternLoads()).toBe(0);
+        // And the handling landed. The refusal is a rendering failure over a
+        // write that committed, which is why it is a throw and not an
+        // invocation whose `result` is quietly omitted — an omitted `result`
+        // reports a verb that returned nothing.
+        expect(childTitles(root)).toEqual(["Undeclared"]);
+      },
+    );
   });
 
   it("pays for the declared result only where the result will not render", async () => {


### PR DESCRIPTION
Closes #5577.

## Why

A verb that hands back the piece it just created returns a value reachable from inside itself whenever that piece carries a back-reference — `parent` beside `children`. A circle has no JSON rendering, so `cf piece call addChild` on the doubly-linked tracker **committed the write and then failed to say what it had done**.

That is the worst shape a failure can take here: the mutation landed, and the caller was told only that something went wrong. Anyone driving a tree from the command line hits it on the first `addChild`, and it is one of the five things the tracker fixture exists to demonstrate.

## What changed

The receipt readback asks whether the result it holds can be written as JSON. Where it cannot, it bounds the result with the verb's **own declared result** and renders it through the same selection step `--select`/`--schema` already go through — no second projection path.

```json
{ "item": { "title": "Rotate signing key", "status": "open", "children": [],
            "parent": { "$link": { "id": "of:fid1:…", "…": "…" } } } }
```

Four design calls worth review:

- **Where the cut goes** — at the position where the declared type re-enters itself, not at every reference position. Recursion is a property the schema states (`$ref` into `$defs`, verified against a real compile), and it is the boundary the pattern author drew. Marking every object position would put an address on plain records that never closed a circle.
- **Engagement is on the circle, not on every call.** Two costs forced this rather than taste: the declared result sits behind a pattern load, and `piece-call-help-live.test.ts` pins that a dispatch loads none. A result that renders asks nothing of it. Named cost: a verb that is cyclic only sometimes renders in two shapes.
- **A verb declaring nothing gets a legible refusal, not a crash** — naming the closing position, stating the handling **COMMITTED**, and handing over `cf piece get --piece <receipt>`. Exit stays nonzero, but `result` is never omitted, since omission means "the verb returned nothing".
- **The caller's own selection wins by construction** — applied first, so no circle survives for anything to bound. No precedence rule to get wrong.

Detection and rendering agree by construction: `JSON.stringify` decides *whether*, an ancestor walk decides *where*, and the bound engages only when both agree.

`declaredResult` moves from `piece.ts` to `callable.ts` and gains a second caller; its doc comment is rewritten to say so rather than keeping the `--help`-only claim.

Deliberately **not** done: the returned piece's own address at non-recursive positions. That changes what every verb result renders by default, for reasons unrelated to the circle — a result-contract call (#5632 / plan item 11), not this defect's.

## Test plan

- **`packages/cli/test/piece-call-cyclic-result-live.test.ts`** (new, 5 cases) drives a compiled, run pattern with real cells. Red-first: with the readback wiring reverted and the tests kept, **4 of 5 fail**, the first on `expect(() => JSON.stringify(result)).not.toThrow()` — the defect itself. The 5th guards the caller-override path and passes either way, by design.
- `cd packages/cli && deno task test` → **rc=0**, and also rc=0 on the same tree with the change removed, so the baseline claim has a real exit code behind it.
- `deno fmt --check` (root, 4423 files), `deno lint`, `deno task check-docs`, `deno task check-skill-facts`, `deno task check-no-waitfor` — all rc=0.
- `deno task check` does **not** list `packages/cli/lib`, so it is not evidence here; `deno check` was run directly on the changed lib files.

**One thing is unexecuted and should not be read as passing.** `packages/cli/integration/verb-session-gaps.sh` step 11 is flipped from asserting the gap to asserting the capability, but the harness needs a live host and was not run. `bash -n` passes and the jq path matches the envelope the file's other steps already use (`.result.…`, not `.item.…`). To exercise it:

```bash
API_URL=http://localhost:8000 packages/cli/integration/verb-session-gaps.sh
```

Docs updated in the same change: `packages/cli/README.md`, `docs/common/verbs-over-the-cli.md`, and the harness header's gap count.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

