### PR TITLE
test(runner): drop the wall-clock deadline from nine more tests

### DIFF
--- a/packages/runner/integration/array_push.test.ts
+++ b/packages/runner/integration/array_push.test.ts
@@ -12,7 +12,6 @@ import { StorageManager } from "../src/storage/cache.deno.ts";
 (Error as any).stackTraceLimit = 100;
 
 const TOTAL_COUNT = 20;
-const TIMEOUT_MS = 180000;
 
 const OutputSchema = {
   type: "object",
@@ -168,17 +167,9 @@ Deno.test({
     const server = Deno.serve({ port: 0 }, app.fetch);
     const base = new URL(`http://${server.addr.hostname}:${server.addr.port}`);
 
-    let timeoutHandle: ReturnType<typeof setTimeout>;
-    const timeoutPromise = new Promise((_, reject) => {
-      timeoutHandle = setTimeout(() => {
-        reject(new Error(`Test timed out after ${TIMEOUT_MS}ms`));
-      }, TIMEOUT_MS);
-    });
-
     try {
-      await Promise.race([runTest(base), timeoutPromise]);
+      await runTest(base);
     } finally {
-      clearTimeout(timeoutHandle!);
       await server.shutdown();
     }
   },

--- a/packages/runner/integration/basic-persistence.test.ts
+++ b/packages/runner/integration/basic-persistence.test.ts
@@ -15,8 +15,6 @@ const identity = await Identity.fromPassphrase("test operator", keyConfig);
 
 console.log("\n=== TEST: Simple object persistence ===");
 
-const TIMEOUT_MS = 180000; // 3 minutes timeout
-
 async function test() {
   // First runtime - save data
   const runtime1 = new Runtime({
@@ -86,20 +84,7 @@ async function runTest() {
 
 Deno.test({
   name: "basic persistence test",
-  fn: async () => {
-    let timeoutHandle: ReturnType<typeof setTimeout>;
-    const timeoutPromise = new Promise((_, reject) => {
-      timeoutHandle = setTimeout(() => {
-        reject(new Error(`Test timed out after ${TIMEOUT_MS}ms`));
-      }, TIMEOUT_MS);
-    });
-
-    try {
-      await Promise.race([runTest(), timeoutPromise]);
-    } finally {
-      clearTimeout(timeoutHandle!);
-    }
-  },
+  fn: runTest,
   sanitizeResources: false,
   sanitizeOps: false,
 });

--- a/packages/runner/integration/pattern-and-data-persistence.test.ts
+++ b/packages/runner/integration/pattern-and-data-persistence.test.ts
@@ -26,8 +26,6 @@ import { env } from "@commonfabric/integration";
 
 const API_URL = new URL(env.API_URL);
 
-const TIMEOUT_MS = 180000; // 3 minutes timeout
-
 const keyConfig: IdentityCreateConfig = {
   implementation: "noble",
 };
@@ -437,20 +435,7 @@ async function testPatternAndDataPersistence() {
 
 Deno.test({
   name: "pattern and data persistence - full reactive cycle",
-  fn: async () => {
-    let timeoutHandle: ReturnType<typeof setTimeout>;
-    const timeoutPromise = new Promise((_, reject) => {
-      timeoutHandle = setTimeout(() => {
-        reject(new Error(`Test timed out after ${TIMEOUT_MS}ms`));
-      }, TIMEOUT_MS);
-    });
-
-    try {
-      await Promise.race([testPatternAndDataPersistence(), timeoutPromise]);
-    } finally {
-      clearTimeout(timeoutHandle!);
-    }
-  },
+  fn: testPatternAndDataPersistence,
   sanitizeResources: false,
   sanitizeOps: false,
 });

--- a/packages/runner/integration/sqlite-cfc-commit-eval.test.ts
+++ b/packages/runner/integration/sqlite-cfc-commit-eval.test.ts
@@ -20,8 +20,6 @@ import { Runtime } from "../src/index.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { cfcLabelViewForDereferenceTraces } from "../src/cfc/label-view.ts";
 
-const TIMEOUT_MS = 180000;
-
 async function runTest(base: URL) {
   const account = await Identity.fromPassphrase(
     "sqlite-cfc-commit-eval " + crypto.randomUUID(),
@@ -205,17 +203,9 @@ Deno.test({
   fn: async () => {
     const server = Deno.serve({ port: 0 }, app.fetch);
     const base = new URL(`http://${server.addr.hostname}:${server.addr.port}`);
-    let timeoutHandle: ReturnType<typeof setTimeout>;
-    const timeoutPromise = new Promise((_, reject) => {
-      timeoutHandle = setTimeout(
-        () => reject(new Error(`Test timed out after ${TIMEOUT_MS}ms`)),
-        TIMEOUT_MS,
-      );
-    });
     try {
-      await Promise.race([runTest(base), timeoutPromise]);
+      await runTest(base);
     } finally {
-      clearTimeout(timeoutHandle!);
       await server.shutdown();
     }
   },

--- a/packages/runner/integration/sqlite-cfc-label-link.test.ts
+++ b/packages/runner/integration/sqlite-cfc-label-link.test.ts
@@ -14,8 +14,6 @@ import { StorageManager } from "../src/storage/cache.deno.ts";
 import { cfcLabelViewForDereferenceTraces } from "../src/cfc/label-view.ts";
 import { cfcConfidentialityForObservationNode } from "../src/cfc/observation.ts";
 
-const TIMEOUT_MS = 180000;
-
 async function runTest(base: URL) {
   const account = await Identity.fromPassphrase(
     "sqlite-cfc-label-link " + crypto.randomUUID(),
@@ -130,17 +128,9 @@ Deno.test({
   fn: async () => {
     const server = Deno.serve({ port: 0 }, app.fetch);
     const base = new URL(`http://${server.addr.hostname}:${server.addr.port}`);
-    let timeoutHandle: ReturnType<typeof setTimeout>;
-    const timeoutPromise = new Promise((_, reject) => {
-      timeoutHandle = setTimeout(
-        () => reject(new Error(`Test timed out after ${TIMEOUT_MS}ms`)),
-        TIMEOUT_MS,
-      );
-    });
     try {
-      await Promise.race([runTest(base), timeoutPromise]);
+      await runTest(base);
     } finally {
-      clearTimeout(timeoutHandle!);
       await server.shutdown();
     }
   },

--- a/packages/runner/integration/sqlite-cfc-label.test.ts
+++ b/packages/runner/integration/sqlite-cfc-label.test.ts
@@ -16,8 +16,6 @@ import { StorageManager } from "../src/storage/cache.deno.ts";
 import { cfcLabelViewForDereferenceTraces } from "../src/cfc/label-view.ts";
 import { cfcConfidentialityForObservationNode } from "../src/cfc/observation.ts";
 
-const TIMEOUT_MS = 180000;
-
 async function runTest(base: URL) {
   const account = await Identity.fromPassphrase(
     "sqlite-cfc-label " + crypto.randomUUID(),
@@ -136,17 +134,9 @@ Deno.test({
   fn: async () => {
     const server = Deno.serve({ port: 0 }, app.fetch);
     const base = new URL(`http://${server.addr.hostname}:${server.addr.port}`);
-    let timeoutHandle: ReturnType<typeof setTimeout>;
-    const timeoutPromise = new Promise((_, reject) => {
-      timeoutHandle = setTimeout(
-        () => reject(new Error(`Test timed out after ${TIMEOUT_MS}ms`)),
-        TIMEOUT_MS,
-      );
-    });
     try {
-      await Promise.race([runTest(base), timeoutPromise]);
+      await runTest(base);
     } finally {
-      clearTimeout(timeoutHandle!);
       await server.shutdown();
     }
   },

--- a/packages/runner/integration/sqlite-cfc-row-label.test.ts
+++ b/packages/runner/integration/sqlite-cfc-row-label.test.ts
@@ -16,8 +16,6 @@ import { Runtime } from "../src/index.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { cfcLabelViewForDereferenceTraces } from "../src/cfc/label-view.ts";
 
-const TIMEOUT_MS = 180000;
-
 async function runTest(base: URL) {
   const account = await Identity.fromPassphrase(
     "sqlite-cfc-row-label " + crypto.randomUUID(),
@@ -265,17 +263,9 @@ Deno.test({
   fn: async () => {
     const server = Deno.serve({ port: 0 }, app.fetch);
     const base = new URL(`http://${server.addr.hostname}:${server.addr.port}`);
-    let timeoutHandle: ReturnType<typeof setTimeout>;
-    const timeoutPromise = new Promise((_, reject) => {
-      timeoutHandle = setTimeout(
-        () => reject(new Error(`Test timed out after ${TIMEOUT_MS}ms`)),
-        TIMEOUT_MS,
-      );
-    });
     try {
-      await Promise.race([runTest(base), timeoutPromise]);
+      await runTest(base);
     } finally {
-      clearTimeout(timeoutHandle!);
       await server.shutdown();
     }
   },

--- a/packages/runner/integration/sqlite-db-query-decode.test.ts
+++ b/packages/runner/integration/sqlite-db-query-decode.test.ts
@@ -13,8 +13,6 @@ import { Identity } from "@commonfabric/identity";
 import { Runtime } from "../src/index.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 
-const TIMEOUT_MS = 180000;
-
 async function runTest(base: URL) {
   const account = await Identity.fromPassphrase(
     "sqlite-db-query-decode " + crypto.randomUUID(),
@@ -122,17 +120,9 @@ Deno.test({
     const base = new URL(
       `http://${server.addr.hostname}:${server.addr.port}`,
     );
-    let timeoutHandle: ReturnType<typeof setTimeout>;
-    const timeoutPromise = new Promise((_, reject) => {
-      timeoutHandle = setTimeout(
-        () => reject(new Error(`Test timed out after ${TIMEOUT_MS}ms`)),
-        TIMEOUT_MS,
-      );
-    });
     try {
-      await Promise.race([runTest(base), timeoutPromise]);
+      await runTest(base);
     } finally {
-      clearTimeout(timeoutHandle!);
       await server.shutdown();
     }
   },

--- a/packages/runner/integration/sync-schema-path.test.ts
+++ b/packages/runner/integration/sync-schema-path.test.ts
@@ -18,8 +18,6 @@ const identity = await Identity.fromPassphrase("test operator", keyConfig);
 
 console.log("\n=== TEST: Sync Schema uses Path ===");
 
-const TIMEOUT_MS = 180000; // 3 minutes timeout
-
 function read(
   storageManager: IStorageManager,
   space: MemorySpace,
@@ -154,20 +152,7 @@ async function runTest() {
 
 Deno.test({
   name: "sync schema path test",
-  fn: async () => {
-    let timeoutHandle: ReturnType<typeof setTimeout>;
-    const timeoutPromise = new Promise((_, reject) => {
-      timeoutHandle = setTimeout(() => {
-        reject(new Error(`Test timed out after ${TIMEOUT_MS}ms`));
-      }, TIMEOUT_MS);
-    });
-
-    try {
-      await Promise.race([runTest(), timeoutPromise]);
-    } finally {
-      clearTimeout(timeoutHandle!);
-    }
-  },
+  fn: runTest,
   sanitizeResources: false,
   sanitizeOps: false,
 });


### PR DESCRIPTION
The same success-capping deadline that PR #5724 removed from the derive-array-leak test still wrapped nine sibling integration tests in packages/runner/integration. Each declared a TIMEOUT_MS constant and ran its body as Promise.race between the real work and a timer that rejected after three minutes. A fixed deadline caps success: a run that is merely slow, on a loaded continuous-integration host or a virtual machine that was suspended and resumed, fails even though it would have completed. This removes the constant and the race from all nine.

The files fall into two shapes. Three of them (basic-persistence, pattern-and-data-persistence, sync-schema-path) had no server of their own; their test function was only the timeout wrapper around a no-argument worker, so the function becomes that worker directly. The other six (array_push and the five sqlite-cfc tests) start an in-process server with Deno.serve, run the worker against it, and shut the server down in a finally. Those keep the server start and the finally that shuts it down; only the timeout machinery comes out, so the server is still torn down on every exit path.

Removing the outer deadline leaves the five sqlite tests fully bounded: each already drives a convergence poll with its own Date.now()-based bound that throws when the server round trip does not converge, so the work still terminates on its own. That inner poll is the bounded-poll case the waiting-in-tests guidance sanctions for a server round trip with no event boundary, and it is left in place. array_push and the three server-backed persistence tests settle through runtime.idle() and storageManager.synced() and, like the derive-array-leak test, now run without a per-test timer; a genuine hang surfaces at the job limit rather than as a per-test failure, which is the accepted cost of not capping a healthy run.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

