### PR TITLE
docs(ts-transformer): date the eager-read resolution when the call was made

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_design_deltas.md
+++ b/docs/specs/ts-transformer/ts_transformers_design_deltas.md
@@ -108,7 +108,7 @@ Language deltas found by adversarial verification of the target-language
 matrix (implementation vs normative spec). Resolution status is recorded on
 each finding:
 
-- **Top-level eager-read carve-out (#3725, 2026-05-28) — resolved 2026-08-07 by
+- **Top-level eager-read carve-out (#3725, 2026-05-28) — resolved 2026-08-12 by
   ratifying the has-a-lowerable-site rule.** A `.get()` read on a
   `Cell`/`Writable`/`Stream` in pattern-owned context is part of the language
   wherever a lowerable expression site can carry it; that site lowers into a


### PR DESCRIPTION
## What

One-word correction in the design-deltas record: the eager-read ratification entry said "resolved 2026-08-07"; the call was made and landed on 2026-08-12 (2026-08-07 was when the question was raised on #5454). The file's convention dates a resolved entry by its resolving event, as the optional-call entry does.

## Note on the linksView unwrap

This PR originally also carried the `topic.tsx` `linksView` computed()-ectomy (#5454's motivating case). It is withdrawn for now — deliberately, not lost: pattern coverage showed the unwrap silently stops the links-card JSX (`topic.tsx` lines 891–920) from evaluating under the real reconciler, which is precisely the "silent non-render" case the topics suite's coverage tripwire exists to catch. The cause is a producer/consumer idiom mismatch: the unwrap turns `linksView` into a lift + `filterWithPattern` reactive collection, while both consumers — `hasLinks = computed(() => linksView.length > 0)` and the JSX `{computed(() => linksView.map(...))}` — are still written against the computed-array shape. The honest unwrap modernizes the consumers in the same change (direct JSX `{linksView.map(...)}`, now legal under the ratified rule, plus a links render-coverage assertion) and rides with the `commentsView` follow-up instead. Parked on `fable/linksview-unwrap-parked`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)