### PR TITLE
feat(cli): accept LLM-friendly piece references at intake seams

### DIFF
--- a/packages/cf-harness/src/handle-table.ts
+++ b/packages/cf-harness/src/handle-table.ts
@@ -14,6 +14,7 @@ import {
 } from "@commonfabric/runner/entity-kind";
 import {
   addressKey,
+  CELL_SCOPE_VALUES,
   createLLMFriendlyLink,
   type NormalizedFullLink,
   parseLLMFriendlyLink,
@@ -210,6 +211,11 @@ const ENTITY_ID_SOURCE = `(?:${
 // A path segment ends at whitespace, quotes, backticks, or closing
 // punctuation, so an address at the end of a sentence does not swallow it.
 const PATH_SEGMENT_SOURCE = `[^/\\s"'\`\\)\\]\\}>,;]+`;
+const SCOPE_SUFFIX_SOURCE = `(?:@(?:${[...CELL_SCOPE_VALUES].join("|")}))?`;
+// This scans free prose for occurrences — unanchored, global, with the
+// leading slash optional — which is a different job from the runner's
+// `matchLLMFriendlyLink`, an anchored gate over a whole string that is
+// already known to be a reference. Neither can stand in for the other.
 const LINK_OCCURRENCE_SOURCE =
   // An optional cross-space prefix ending in `/`, or a bare leading `/`.
   `((?:/@did:[^/\\s]+)?/)?` +
@@ -220,7 +226,7 @@ const LINK_OCCURRENCE_SOURCE =
   `${ENTITY_ID_SOURCE}` +
   // `@space` is consumed too: it is the default scope, so the canonical
   // serialization of the minted ref simply drops it.
-  `(?:@(?:user|session|space))?` +
+  SCOPE_SUFFIX_SOURCE +
   `((?:/${PATH_SEGMENT_SOURCE})*)`;
 
 /**

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -70,6 +70,21 @@ generate-markdown | cf view --language markdown --rendered
 generate-bytes | cf view --language binary
 ```
 
+## Piece references
+
+Commands that take a piece accept two textual reference forms:
+
+- The canonical fabric reference: the LLM-friendly link form,
+  `/[@did:.../]of:fid1:<id>[@scope][/path]`. This is the one reference syntax of
+  the fabric — the same string names the same cell in patterns, in the shell,
+  and here. A path embedded in a canonical `--piece` reference prefixes the
+  command's positional path argument.
+- The CLI's bare form: `pieceId[@scope]`, `pieceId[@scope]/path` at link
+  endpoints, and slugs. This is a convenience alias for interactive use.
+
+New reference-syntax capabilities land in the canonical form first; the alias
+does not grow a capability the canonical form lacks.
+
 ## Piece discovery
 
 `cf piece ls` lists the pieces in the selected space's piece registry. It reads

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -912,6 +912,11 @@ const EX_ID = `--identity ./my.key`;
 const EX_URL = `--url ${RAW_EX_URL}`;
 const EX_COMP = `--api-url ${RAW_EX_COMP.apiUrl} --space ${RAW_EX_COMP.space}`;
 const EX_COMP_PIECE = `${EX_COMP} --piece ${RAW_EX_COMP.piece!}`;
+const PIECE_OPTION_HELP =
+  "The target piece: an id, slug, or LLM-friendly reference " +
+  "(/of:fid1:.../).";
+const PIECE_OPTION_PATH_HELP = `${PIECE_OPTION_HELP} A path embedded in ` +
+  `the reference prefixes the positional path.`;
 const PIECE_REGISTRY_LINK_EXAMPLE = [
   cliText(
     `cf piece link ${EX_ID} ${EX_COMP} fid1:abc123 fid1:piece1/pieceRegistry`,
@@ -1088,6 +1093,7 @@ export const piece = new Command()
     setQuietMode(!!options.quiet);
     const spaceConfig = parseSpaceOptions(options);
     const source = parseLink(sourceRef, { space: spaceConfig.space });
+    collectEmbeddedSpace(spaceConfig, source);
     await setPieceSlug(
       spaceConfig,
       slug,
@@ -1109,7 +1115,7 @@ export const piece = new Command()
     cliText(`cf piece step ${EX_ID} ${EX_COMP_PIECE}`),
     `Start, wait for idle+synced, then stop piece "${RAW_EX_COMP.piece!}".`,
   )
-  .option("-c,--piece <piece:string>", "The target piece ID.")
+  .option("-c,--piece <piece:string>", PIECE_OPTION_HELP)
   .action(async (options) => {
     const pieceConfig = parsePieceOptions(options);
     await stepPiece(pieceConfig);
@@ -1126,7 +1132,7 @@ export const piece = new Command()
     cliText(`echo '{"foo":5}' | cf piece apply ${EX_ID} ${EX_URL}`),
     `Applies the input '{"foo":5}' to piece "${RAW_EX_COMP.piece!}".`,
   )
-  .option("-c,--piece <piece:string>", "The target piece ID.")
+  .option("-c,--piece <piece:string>", PIECE_OPTION_HELP)
   .action(async (options) =>
     applyPieceInput(parsePieceOptions(options), await drainStdin())
   )
@@ -1141,7 +1147,7 @@ export const piece = new Command()
     cliText(`cf piece getsrc ${EX_ID} ${EX_URL} ./out`),
     `Retrieve the source for "${RAW_EX_COMP.piece!}" and place in ./out`,
   )
-  .option("-c,--piece <piece:string>", "The target piece ID.")
+  .option("-c,--piece <piece:string>", PIECE_OPTION_HELP)
   .arguments("<outpath:string>")
   .action((options, outPath) =>
     savePiecePattern(parsePieceOptions(options), absPath(outPath))
@@ -1157,7 +1163,7 @@ export const piece = new Command()
     cliText(`cf piece setsrc ${EX_ID} ${EX_URL} ./main.tsx`),
     `Update the source for "${RAW_EX_COMP.piece!}" with ./main.tsx`,
   )
-  .option("-c,--piece <piece:string>", "The target piece ID.")
+  .option("-c,--piece <piece:string>", PIECE_OPTION_HELP)
   .option(
     "--main-export <export:string>",
     'Named export from entry for pattern definition. Defaults to "default".',
@@ -1217,7 +1223,7 @@ export const piece = new Command()
     cliText(`cf piece inspect ${EX_ID} ${EX_URL}`),
     `Inspect detailed information about piece "${RAW_EX_COMP.piece!}".`,
   )
-  .option("-c,--piece <piece:string>", "The target piece ID.")
+  .option("-c,--piece <piece:string>", PIECE_OPTION_HELP)
   .option("--json", "Output raw JSON data")
   .option(
     "--summary",
@@ -1312,7 +1318,7 @@ Source Origin: ${pieceData.patternRef?.source.origin ?? "<unknown>"}
     cliText(`cf piece view ${EX_ID} ${EX_URL}`),
     `Display the view for piece "${RAW_EX_COMP.piece!}".`,
   )
-  .option("-c,--piece <piece:string>", "The target piece ID.")
+  .option("-c,--piece <piece:string>", PIECE_OPTION_HELP)
   .option("--json", "Output raw JSON data")
   .action(async (options) => {
     const pieceConfig = parsePieceOptions(options);
@@ -1343,7 +1349,7 @@ Source Origin: ${pieceData.patternRef?.source.origin ?? "<unknown>"}
     cliText(`cf piece render ${EX_ID} ${EX_COMP_PIECE} --watch`),
     `Watch and re-render piece "${RAW_EX_COMP.piece!}" when UI changes.`,
   )
-  .option("-c,--piece <piece:string>", "The target piece ID.")
+  .option("-c,--piece <piece:string>", PIECE_OPTION_HELP)
   .option("--json", "Output HTML as JSON")
   .option("-w,--watch", "Watch for changes and re-render")
   .option(
@@ -1462,6 +1468,7 @@ well-known IDs. See docs/common/concepts/well-known-ids.md for IDs and usage.`,
     const sqliteSource = parseSqliteSource(sourceRef);
     if (sqliteSource) {
       const target = parseLink(targetRef, { space: spaceConfig.space });
+      collectEmbeddedSpace(spaceConfig, target);
       if (!target.path) {
         throw new ValidationError(
           `Target reference must include a path. Expected: pieceId/path/to/field`,
@@ -1487,6 +1494,8 @@ well-known IDs. See docs/common/concepts/well-known-ids.md for IDs and usage.`,
       space: spaceConfig.space,
     });
     const target = parseLink(targetRef, { space: spaceConfig.space });
+    collectEmbeddedSpace(spaceConfig, source);
+    collectEmbeddedSpace(spaceConfig, target);
 
     // For linking, sources can be either:
     // 1. pieceId (links entire result cell)
@@ -1591,7 +1600,7 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
     ),
     "Return each item's address instead of its contents.",
   )
-  .option("-c,--piece <piece:string>", "The target piece ID.")
+  .option("-c,--piece <piece:string>", PIECE_OPTION_PATH_HELP)
   .option("--input", "Read from the piece's input cell instead of result cell")
   .option(
     "--step",
@@ -1664,7 +1673,7 @@ declared, derived, and link-carried labels. Omit path to inspect the root.`,
     cliText(`cf piece get-label ${EX_ID} ${EX_COMP_PIECE} secret --input`),
     "Get the effective label on an input value.",
   )
-  .option("-c,--piece <piece:string>", "The target piece ID.")
+  .option("-c,--piece <piece:string>", PIECE_OPTION_PATH_HELP)
   .option("--input", "Read from the piece's input cell instead of result cell")
   .option(
     "--json",
@@ -1700,7 +1709,7 @@ updated effective label view.`),
     ),
     "Remove declared integrity claims from an input value.",
   )
-  .option("-c,--piece <piece:string>", "The target piece ID.")
+  .option("-c,--piece <piece:string>", PIECE_OPTION_PATH_HELP)
   .option("--input", "Write to the piece's input cell instead of result cell")
   .option(
     "--json",
@@ -1729,7 +1738,7 @@ JSON VALUES: Strings need quotes: echo '"hello"' | cf piece set ...`),
     ),
     `Set a nested object value in piece input "${RAW_EX_COMP.piece!}".`,
   )
-  .option("-c,--piece <piece:string>", "The target piece ID.")
+  .option("-c,--piece <piece:string>", PIECE_OPTION_PATH_HELP)
   .option("--input", "Write to the piece's input cell instead of result cell")
   .arguments("<path:string>")
   .action(async (options, pathString) => {
@@ -1740,7 +1749,7 @@ JSON VALUES: Strings need quotes: echo '"hello"' | cf piece set ...`),
     await setCellValue(pieceConfig, pathSegments, value, {
       input: options.input,
     });
-    render(`Set value at path: ${pathString}`);
+    render(`Set value at path: ${pathSegments.join("/")}`);
     hint(
       cliText(
         `TIP: Computed values may be stale. Run 'cf piece step --piece ${pieceConfig.piece} ...' to trigger recomputation.`,
@@ -1825,7 +1834,7 @@ after --. Handlers interpret piped input when no input argument is present.`,
     ),
     "Return the address of what the verb returned instead of its contents.",
   )
-  .option("-c,--piece <piece:string>", "The target piece ID.")
+  .option("-c,--piece <piece:string>", PIECE_OPTION_HELP)
   .option(
     "--invocation <id:string>",
     "Idempotency key for a handler call (before the callable name), and " +
@@ -2033,7 +2042,7 @@ after --. Handlers interpret piped input when no input argument is present.`,
     cliText(`cf piece verbs ${EX_ID} ${EX_URL} --json`),
     "Machine-readable listing: name, kind, and input schema per verb.",
   )
-  .option("-c,--piece <piece:string>", "The target piece ID.")
+  .option("-c,--piece <piece:string>", PIECE_OPTION_HELP)
   .option("--json", "Output machine-readable JSON.")
   .option(
     "--all",
@@ -2113,7 +2122,7 @@ after --. Handlers interpret piped input when no input argument is present.`,
     cliText(`cf piece rm ${EX_ID} ${EX_URL}`),
     `Remove piece "${RAW_EX_COMP.piece!}".`,
   )
-  .option("-c,--piece <piece:string>", "The target piece ID.")
+  .option("-c,--piece <piece:string>", PIECE_OPTION_HELP)
   .action(async (options) => {
     const pieceConfig = parsePieceOptions(options);
     await removePiece(pieceConfig);
@@ -2518,6 +2527,7 @@ export function parseSpaceOptions(
       output.piece = llmRef.pieceId;
       if (llmRef.scope) output.pieceScope = llmRef.scope;
       if (llmRef.path.length > 0) output.piecePath = llmRef.path;
+      if (llmRef.embeddedSpace) output.embeddedSpaces = [llmRef.embeddedSpace];
     } else {
       const parsedPiece = parseScopedIdSegment(input.piece);
       output.piece = parsedPiece.id;
@@ -2538,6 +2548,22 @@ export function parseSpaceOptions(
 }
 
 /**
+ * Fold the space DID embedded in a parsed link reference into the command's
+ * config, for the deferred check `loadPieces` runs once the session has
+ * resolved the target space to a DID.
+ */
+function collectEmbeddedSpace(
+  config: SpaceConfig,
+  ref: { embeddedSpace?: string },
+): void {
+  if (ref.embeddedSpace === undefined) return;
+  config.embeddedSpaces = [
+    ...(config.embeddedSpaces ?? []),
+    ref.embeddedSpace,
+  ];
+}
+
+/**
  * The full path a piece data command addresses: any path embedded in an
  * LLM-friendly `--piece` reference, followed by the positional path argument.
  */
@@ -2554,12 +2580,18 @@ export function mergePiecePath(
 export function parseLink(
   ref: string,
   options?: { allowWellKnown?: boolean; space?: string },
-): { pieceId: string; scope?: CellScope; path?: (string | number)[] } {
+): {
+  pieceId: string;
+  scope?: CellScope;
+  path?: (string | number)[];
+  embeddedSpace?: string;
+} {
   const llmRef = normalizeLLMFriendlyRef(ref, { space: options?.space });
   if (llmRef) {
     return {
       pieceId: llmRef.pieceId,
       ...(llmRef.scope && { scope: llmRef.scope }),
+      ...(llmRef.embeddedSpace && { embeddedSpace: llmRef.embeddedSpace }),
       ...(llmRef.path.length > 0 && { path: llmRef.path }),
     };
   }

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -53,6 +53,7 @@ import { cliText } from "../lib/cli-name.ts";
 import { absPath } from "../lib/utils.ts";
 import type { CellScope } from "@commonfabric/api";
 import { parseCellPath } from "@commonfabric/runner";
+import { parseScopedIdSegment } from "@commonfabric/runner/shared";
 import { UI } from "@commonfabric/runner";
 import ports from "@commonfabric/ports" with { type: "json" };
 import type { PiecePatternRef } from "@commonfabric/piece/ops";
@@ -2406,25 +2407,19 @@ export async function setPieceSourceFromCommand(
   return pieceConfig;
 }
 
-const CELL_SCOPE_VALUES = new Set(["space", "user", "session"]);
-
-function parseScopedIdSegment(id: string): {
-  id: string;
-  scope?: CellScope;
-} {
-  const scopeSeparator = id.lastIndexOf("@");
-  if (scopeSeparator === -1) return { id };
-
-  const scope = id.slice(scopeSeparator + 1);
-  const scopedId = id.slice(0, scopeSeparator);
-  if (!scopedId || !CELL_SCOPE_VALUES.has(scope)) {
+/**
+ * Like `parseScopedIdSegment`, except a rejected `@scope` suffix is raised
+ * as a usage error, the suffix being something the user typed.
+ */
+function parseScopedId(id: string): { id: string; scope?: CellScope } {
+  try {
+    return parseScopedIdSegment(id);
+  } catch (error) {
     throw new ValidationError(
-      `Invalid scope suffix "@${scope}". Expected @space, @user, or @session.`,
+      error instanceof Error ? error.message : String(error),
       { exitCode: 1 },
     );
   }
-
-  return { id: scopedId, scope: scope as CellScope };
 }
 
 function parseSetHomeOptions(
@@ -2529,7 +2524,7 @@ export function parseSpaceOptions(
       if (llmRef.path.length > 0) output.piecePath = llmRef.path;
       if (llmRef.embeddedSpace) output.embeddedSpaces = [llmRef.embeddedSpace];
     } else {
-      const parsedPiece = parseScopedIdSegment(input.piece);
+      const parsedPiece = parseScopedId(input.piece);
       output.piece = parsedPiece.id;
       if (parsedPiece.scope) output.pieceScope = parsedPiece.scope;
     }
@@ -2604,7 +2599,7 @@ export function parseLink(
     );
   }
 
-  const parsedPiece = parseScopedIdSegment(parts[0]);
+  const parsedPiece = parseScopedId(parts[0]);
   const pieceId = parsedPiece.id;
 
   if (parts.length === 1) {
@@ -2642,7 +2637,7 @@ function parseUrl(
     );
   }
   if (!piece) return { apiUrl, space };
-  const parsedPiece = parseScopedIdSegment(piece);
+  const parsedPiece = parseScopedId(piece);
   return {
     apiUrl,
     space,

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -913,7 +913,7 @@ const EX_URL = `--url ${RAW_EX_URL}`;
 const EX_COMP = `--api-url ${RAW_EX_COMP.apiUrl} --space ${RAW_EX_COMP.space}`;
 const EX_COMP_PIECE = `${EX_COMP} --piece ${RAW_EX_COMP.piece!}`;
 const PIECE_OPTION_HELP =
-  "The target piece: an id, slug, or LLM-friendly reference " +
+  "The target piece: an id, slug, or canonical LLM-friendly reference " +
   "(/of:fid1:.../).";
 const PIECE_OPTION_PATH_HELP = `${PIECE_OPTION_HELP} A path embedded in ` +
   `the reference prefixes the positional path.`;

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -44,6 +44,7 @@ import type {
   InvocationPhase,
 } from "../lib/callable.ts";
 import { newSessionId } from "../lib/session.ts";
+import { normalizeLLMFriendlyRef } from "../lib/llm-friendly-ref.ts";
 import { renderPiece } from "../lib/piece-render.ts";
 import { parseSqliteSource } from "../lib/sqlite-source.ts";
 import { render, safeStringify } from "../lib/render.ts";
@@ -1086,7 +1087,7 @@ export const piece = new Command()
   .action(async (options, slug, sourceRef) => {
     setQuietMode(!!options.quiet);
     const spaceConfig = parseSpaceOptions(options);
-    const source = parseLink(sourceRef);
+    const source = parseLink(sourceRef, { space: spaceConfig.space });
     await setPieceSlug(
       spaceConfig,
       slug,
@@ -1460,7 +1461,7 @@ well-known IDs. See docs/common/concepts/well-known-ids.md for IDs and usage.`,
     // BEFORE parseLink (the sqlite: scheme is not a piece ref).
     const sqliteSource = parseSqliteSource(sourceRef);
     if (sqliteSource) {
-      const target = parseLink(targetRef);
+      const target = parseLink(targetRef, { space: spaceConfig.space });
       if (!target.path) {
         throw new ValidationError(
           `Target reference must include a path. Expected: pieceId/path/to/field`,
@@ -1481,8 +1482,11 @@ well-known IDs. See docs/common/concepts/well-known-ids.md for IDs and usage.`,
     }
 
     // Parse source and target references - handle both pieceId/path and well-known IDs
-    const source = parseLink(sourceRef, { allowWellKnown: true });
-    const target = parseLink(targetRef);
+    const source = parseLink(sourceRef, {
+      allowWellKnown: true,
+      space: spaceConfig.space,
+    });
+    const target = parseLink(targetRef, { space: spaceConfig.space });
 
     // For linking, sources can be either:
     // 1. pieceId (links entire result cell)
@@ -1618,10 +1622,10 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
   .action(async (options, pathString) => {
     setQuietMode(!!options.quiet);
     const pieceConfig = {
-      ...parsePieceOptions(options),
+      ...parsePieceOptions(options, { acceptsPath: true }),
       jsonOutput: true,
     };
-    const pathSegments = pathString ? parseCellPath(pathString) : [];
+    const pathSegments = mergePiecePath(pieceConfig, pathString);
     try {
       const selection = await parseCellSelectionOptions(options);
       const value = await getCellValue(pieceConfig, pathSegments, {
@@ -1730,8 +1734,8 @@ JSON VALUES: Strings need quotes: echo '"hello"' | cf piece set ...`),
   .arguments("<path:string>")
   .action(async (options, pathString) => {
     setQuietMode(!!options.quiet);
-    const pieceConfig = parsePieceOptions(options);
-    const pathSegments = parseCellPath(pathString);
+    const pieceConfig = parsePieceOptions(options, { acceptsPath: true });
+    const pathSegments = mergePiecePath(pieceConfig, pathString);
     const value = await drainStdin();
     await setCellValue(pieceConfig, pathSegments, value, {
       input: options.input,
@@ -2255,10 +2259,10 @@ export async function getCellCfcLabelFromCommand(
 ): Promise<void> {
   setQuietMode(!!options.quiet);
   const pieceConfig = {
-    ...parsePieceOptions(options),
+    ...parsePieceOptions(options, { acceptsPath: true }),
     jsonOutput: true,
   };
-  const pathSegments = pathString ? parseCellPath(pathString) : [];
+  const pathSegments = mergePiecePath(pieceConfig, pathString);
   const label = await (deps.getCellCfcLabel ?? getCellCfcLabel)(
     pieceConfig,
     pathSegments,
@@ -2274,10 +2278,10 @@ export async function setCellCfcLabelFromCommand(
 ): Promise<void> {
   setQuietMode(!!options.quiet);
   const pieceConfig = {
-    ...parsePieceOptions(options),
+    ...parsePieceOptions(options, { acceptsPath: true }),
     jsonOutput: true,
   };
-  const pathSegments = pathString ? parseCellPath(pathString) : [];
+  const pathSegments = mergePiecePath(pieceConfig, pathString);
   const update = await (deps.drainStdin ?? drainStdin)();
   const label = await (deps.setCellCfcLabel ?? setCellCfcLabel)(
     pieceConfig,
@@ -2433,7 +2437,10 @@ function parseSetHomeOptions(
   return { identity: absPath(input.identity), apiUrl };
 }
 
-export function parsePieceOptions(input: PieceCLIOptions): PieceConfig {
+export function parsePieceOptions(
+  input: PieceCLIOptions,
+  parseOptions?: { acceptsPath?: boolean },
+): PieceConfig {
   const options = parseSpaceOptions(input);
   if (!("piece" in options) || !options.piece) {
     throw new ValidationError(
@@ -2441,7 +2448,16 @@ export function parsePieceOptions(input: PieceCLIOptions): PieceConfig {
       { exitCode: 1 },
     );
   }
-  return options as PieceConfig;
+  const config = options as PieceConfig;
+  if (config.piecePath?.length && !parseOptions?.acceptsPath) {
+    throw new ValidationError(
+      `The piece reference embeds a path ("${
+        config.piecePath.join("/")
+      }") but this command takes a piece id only.`,
+      { exitCode: 1 },
+    );
+  }
+  return config;
 }
 
 // With args and env vars shadowing each other, and multiple
@@ -2495,9 +2511,18 @@ export function parseSpaceOptions(
   if (input.piece) {
     // Do not validate here -- piece is only
     // required via `parsePieceOptions`
-    const parsedPiece = parseScopedIdSegment(input.piece);
-    output.piece = parsedPiece.id;
-    if (parsedPiece.scope) output.pieceScope = parsedPiece.scope;
+    const llmRef = normalizeLLMFriendlyRef(input.piece, {
+      space: input.space,
+    });
+    if (llmRef) {
+      output.piece = llmRef.pieceId;
+      if (llmRef.scope) output.pieceScope = llmRef.scope;
+      if (llmRef.path.length > 0) output.piecePath = llmRef.path;
+    } else {
+      const parsedPiece = parseScopedIdSegment(input.piece);
+      output.piece = parsedPiece.id;
+      if (parsedPiece.scope) output.pieceScope = parsedPiece.scope;
+    }
   }
 
   output.apiUrl = normalizeApiUrl(input.apiUrl);
@@ -2512,10 +2537,33 @@ export function parseSpaceOptions(
   return output as PieceConfig;
 }
 
+/**
+ * The full path a piece data command addresses: any path embedded in an
+ * LLM-friendly `--piece` reference, followed by the positional path argument.
+ */
+export function mergePiecePath(
+  pieceConfig: PieceConfig,
+  pathString?: string,
+): (string | number)[] {
+  return [
+    ...(pieceConfig.piecePath ?? []),
+    ...(pathString ? parseCellPath(pathString) : []),
+  ];
+}
+
 export function parseLink(
   ref: string,
-  _options?: { allowWellKnown?: boolean },
+  options?: { allowWellKnown?: boolean; space?: string },
 ): { pieceId: string; scope?: CellScope; path?: (string | number)[] } {
+  const llmRef = normalizeLLMFriendlyRef(ref, { space: options?.space });
+  if (llmRef) {
+    return {
+      pieceId: llmRef.pieceId,
+      ...(llmRef.scope && { scope: llmRef.scope }),
+      ...(llmRef.path.length > 0 && { path: llmRef.path }),
+    };
+  }
+
   const parts = ref.split("/");
   if (parts.length < 1) {
     throw new ValidationError(

--- a/packages/cli/lib/llm-friendly-ref.ts
+++ b/packages/cli/lib/llm-friendly-ref.ts
@@ -10,22 +10,30 @@ export interface NormalizedLLMFriendlyRef {
   pieceId: string;
   scope?: CellScope;
   /**
-   * Path segments embedded in the reference, in the segment form
-   * `parseCellPath` produces: a segment of digits is a number.
+   * Path segments embedded in the reference: a canonical array-index
+   * segment is a number, everything else stays a string.
    */
   path: (string | number)[];
 }
 
 /**
- * Convert a decoded link path segment to the form `parseCellPath` produces
- * for a positional path argument, so an embedded path and a positional path
- * address the same cells. Not `parseCellPath` itself, because that splits on
- * `/` and a JSON-pointer segment may contain one.
+ * A canonical array-index token: `0`, or digits without a leading zero.
+ * Only these convert to numbers; a non-canonical numeric-looking token
+ * such as `01`, `007`, `1.5`, or `-2` names a string property, and
+ * converting it would address a different cell than the pointer names.
+ */
+const canonicalArrayIndex = /^(0|[1-9][0-9]*)$/;
+
+/**
+ * Convert a decoded link path segment to the number-or-string form the
+ * CLI's cell traversal uses, so an embedded path and a positional path
+ * address the same cells. Not the runner's `parseCellPath`, because that
+ * splits on `/` (a JSON-pointer segment may contain one) and coerces any
+ * numeric-looking token — including non-canonical ones like `01` — to a
+ * number; here only canonical array indices convert, deliberately.
  */
 function toCellPathSegment(segment: string): string | number {
-  if (segment === "") return segment;
-  const num = Number(segment);
-  return Number.isInteger(num) && num >= 0 ? num : segment;
+  return canonicalArrayIndex.test(segment) ? Number(segment) : segment;
 }
 
 /**

--- a/packages/cli/lib/llm-friendly-ref.ts
+++ b/packages/cli/lib/llm-friendly-ref.ts
@@ -13,9 +13,10 @@ import { ValidationError } from "@cliffy/command";
 import type { CellScope } from "@commonfabric/api";
 import { isDID } from "@commonfabric/identity";
 import {
+  linkPathSegmentToCellPathSegment,
   matchLLMFriendlyLink,
   parseLLMFriendlyLink,
-} from "@commonfabric/runner";
+} from "@commonfabric/runner/shared";
 
 /** A piece reference normalized from its LLM-friendly link form. */
 export interface NormalizedLLMFriendlyRef {
@@ -66,37 +67,6 @@ export function validateEmbeddedSpaces(
 }
 
 /**
- * A canonical array-index token: `0`, or digits without a leading zero.
- * Only these convert to numbers; a non-canonical numeric-looking token
- * such as `01`, `007`, `1.5`, or `-2` names a string property, and
- * converting it would address a different cell than the pointer names.
- */
-const canonicalArrayIndex = /^(0|[1-9][0-9]*)$/;
-
-/**
- * The largest valid JS array index, 2^32 - 2. A canonical token above it
- * cannot name an array element, and past `Number.MAX_SAFE_INTEGER` the
- * conversion itself is lossy — `Number("9007199254740993")` rounds to a
- * neighboring integer and would address a different cell — so larger
- * tokens stay strings.
- */
-const MAX_ARRAY_INDEX = 4294967294;
-
-/**
- * Convert a decoded link path segment to the number-or-string form the
- * CLI's cell traversal uses, so an embedded path and a positional path
- * address the same cells. Not the runner's `parseCellPath`, because that
- * splits on `/` (a JSON-pointer segment may contain one) and coerces any
- * numeric-looking token — including non-canonical ones like `01` — to a
- * number; here only canonical array-index tokens convert, deliberately.
- */
-function toCellPathSegment(segment: string): string | number {
-  if (!canonicalArrayIndex.test(segment)) return segment;
-  const num = Number(segment);
-  return num <= MAX_ARRAY_INDEX ? num : segment;
-}
-
-/**
  * Normalize an LLM-friendly piece reference — `/of:fid1:abc.../path`,
  * optionally with a `/@did:.../` space prefix or an `@scope` suffix on the
  * id — into the piece id, scope, and path the CLI's own intake uses.
@@ -126,14 +96,9 @@ export function normalizeLLMFriendlyRef(
     );
   }
 
-  // The parser throws rather than return a link without an id; the guard
-  // narrows the optional field on its return type.
-  if (parsed.id === undefined) {
-    throw new ValidationError(
-      'Target must include a piece handle, e.g. "/of:fid1:abc123/path".',
-      { exitCode: 1 },
-    );
-  }
+  // The parser throws rather than return a link without an id, so the
+  // optional field on its return type is populated here.
+  const pieceId = parsed.id!;
 
   let embeddedSpace: string | undefined;
   if (parsed.space) {
@@ -147,9 +112,9 @@ export function normalizeLLMFriendlyRef(
   }
 
   return {
-    pieceId: parsed.id,
+    pieceId,
     ...(parsed.scope && { scope: parsed.scope as CellScope }),
     ...(embeddedSpace !== undefined && { embeddedSpace }),
-    path: parsed.path.map(toCellPathSegment),
+    path: parsed.path.map(linkPathSegmentToCellPathSegment),
   };
 }

--- a/packages/cli/lib/llm-friendly-ref.ts
+++ b/packages/cli/lib/llm-friendly-ref.ts
@@ -1,5 +1,6 @@
 import { ValidationError } from "@cliffy/command";
 import type { CellScope } from "@commonfabric/api";
+import { isDID } from "@commonfabric/identity";
 import {
   matchLLMFriendlyLink,
   parseLLMFriendlyLink,
@@ -10,10 +11,47 @@ export interface NormalizedLLMFriendlyRef {
   pieceId: string;
   scope?: CellScope;
   /**
+   * The space DID embedded in the reference, when the command's target
+   * space is a name (or absent) rather than a DID. A name only resolves to
+   * a DID once a session opens, so the comparison is deferred: carry this
+   * to `validateEmbeddedSpaces` with the session's resolved space DID. A
+   * DID-configured target space is compared at parse time instead and
+   * never sets this field.
+   */
+  embeddedSpace?: string;
+  /**
    * Path segments embedded in the reference: a canonical array-index
    * segment is a number, everything else stays a string.
    */
   path: (string | number)[];
+}
+
+function spaceMismatchError(
+  embedded: string,
+  target: string,
+): ValidationError {
+  return new ValidationError(
+    `Reference names space "${embedded}" but the command targets ` +
+      `space "${target}".`,
+    { exitCode: 1 },
+  );
+}
+
+/**
+ * The deferred counterpart of `normalizeLLMFriendlyRef`'s parse-time
+ * embedded-space check: compare the space DIDs embedded in a command's
+ * references against the space DID its session actually resolved to.
+ * Call it once the session exists; `resolvedSpace` is that DID.
+ */
+export function validateEmbeddedSpaces(
+  embeddedSpaces: readonly string[] | undefined,
+  resolvedSpace: string,
+): void {
+  for (const embedded of embeddedSpaces ?? []) {
+    if (embedded !== resolvedSpace) {
+      throw spaceMismatchError(embedded, resolvedSpace);
+    }
+  }
 }
 
 /**
@@ -25,15 +63,26 @@ export interface NormalizedLLMFriendlyRef {
 const canonicalArrayIndex = /^(0|[1-9][0-9]*)$/;
 
 /**
+ * The largest valid JS array index, 2^32 - 2. A canonical token above it
+ * cannot name an array element, and past `Number.MAX_SAFE_INTEGER` the
+ * conversion itself is lossy — `Number("9007199254740993")` rounds to a
+ * neighboring integer and would address a different cell — so larger
+ * tokens stay strings.
+ */
+const MAX_ARRAY_INDEX = 4294967294;
+
+/**
  * Convert a decoded link path segment to the number-or-string form the
  * CLI's cell traversal uses, so an embedded path and a positional path
  * address the same cells. Not the runner's `parseCellPath`, because that
  * splits on `/` (a JSON-pointer segment may contain one) and coerces any
  * numeric-looking token — including non-canonical ones like `01` — to a
- * number; here only canonical array indices convert, deliberately.
+ * number; here only canonical array-index tokens convert, deliberately.
  */
 function toCellPathSegment(segment: string): string | number {
-  return canonicalArrayIndex.test(segment) ? Number(segment) : segment;
+  if (!canonicalArrayIndex.test(segment)) return segment;
+  const num = Number(segment);
+  return num <= MAX_ARRAY_INDEX ? num : segment;
 }
 
 /**
@@ -45,7 +94,10 @@ function toCellPathSegment(segment: string): string | number {
  * a caller can fall through to its existing handling. The grammar itself is
  * the runner's (`parseLLMFriendlyLink`); a reference that matches the form
  * but fails to parse is a usage error, as is an embedded space DID that
- * differs from the space the command targets.
+ * differs from a DID-configured target space. When `options.space` is a
+ * name (or absent), the embedded DID comes back as `embeddedSpace` for the
+ * caller to validate through `validateEmbeddedSpaces` once the session has
+ * resolved the name.
  */
 export function normalizeLLMFriendlyRef(
   ref: string,
@@ -72,17 +124,21 @@ export function normalizeLLMFriendlyRef(
     );
   }
 
-  if (parsed.space && options.space && parsed.space !== options.space) {
-    throw new ValidationError(
-      `Reference names space "${parsed.space}" but the command targets ` +
-        `space "${options.space}".`,
-      { exitCode: 1 },
-    );
+  let embeddedSpace: string | undefined;
+  if (parsed.space) {
+    if (options.space !== undefined && isDID(options.space)) {
+      if (parsed.space !== options.space) {
+        throw spaceMismatchError(parsed.space, options.space);
+      }
+    } else {
+      embeddedSpace = parsed.space;
+    }
   }
 
   return {
     pieceId: parsed.id,
     ...(parsed.scope && { scope: parsed.scope as CellScope }),
+    ...(embeddedSpace !== undefined && { embeddedSpace }),
     path: parsed.path.map(toCellPathSegment),
   };
 }

--- a/packages/cli/lib/llm-friendly-ref.ts
+++ b/packages/cli/lib/llm-friendly-ref.ts
@@ -1,0 +1,80 @@
+import { ValidationError } from "@cliffy/command";
+import type { CellScope } from "@commonfabric/api";
+import {
+  matchLLMFriendlyLink,
+  parseLLMFriendlyLink,
+} from "@commonfabric/runner";
+
+/** A piece reference normalized from its LLM-friendly link form. */
+export interface NormalizedLLMFriendlyRef {
+  pieceId: string;
+  scope?: CellScope;
+  /**
+   * Path segments embedded in the reference, in the segment form
+   * `parseCellPath` produces: a segment of digits is a number.
+   */
+  path: (string | number)[];
+}
+
+/**
+ * Convert a decoded link path segment to the form `parseCellPath` produces
+ * for a positional path argument, so an embedded path and a positional path
+ * address the same cells. Not `parseCellPath` itself, because that splits on
+ * `/` and a JSON-pointer segment may contain one.
+ */
+function toCellPathSegment(segment: string): string | number {
+  if (segment === "") return segment;
+  const num = Number(segment);
+  return Number.isInteger(num) && num >= 0 ? num : segment;
+}
+
+/**
+ * Normalize an LLM-friendly piece reference — `/of:fid1:abc.../path`,
+ * optionally with a `/@did:.../` space prefix or an `@scope` suffix on the
+ * id — into the piece id, scope, and path the CLI's own intake uses.
+ *
+ * Returns `undefined` when `ref` is not in the LLM-friendly form at all, so
+ * a caller can fall through to its existing handling. The grammar itself is
+ * the runner's (`parseLLMFriendlyLink`); a reference that matches the form
+ * but fails to parse is a usage error, as is an embedded space DID that
+ * differs from the space the command targets.
+ */
+export function normalizeLLMFriendlyRef(
+  ref: string,
+  options: { space?: string } = {},
+): NormalizedLLMFriendlyRef | undefined {
+  if (!matchLLMFriendlyLink.test(ref.trim())) return undefined;
+
+  let parsed;
+  try {
+    parsed = parseLLMFriendlyLink(ref);
+  } catch (error) {
+    throw new ValidationError(
+      error instanceof Error ? error.message : String(error),
+      { exitCode: 1 },
+    );
+  }
+
+  // The parser throws rather than return a link without an id; the guard
+  // narrows the optional field on its return type.
+  if (parsed.id === undefined) {
+    throw new ValidationError(
+      'Target must include a piece handle, e.g. "/of:fid1:abc123/path".',
+      { exitCode: 1 },
+    );
+  }
+
+  if (parsed.space && options.space && parsed.space !== options.space) {
+    throw new ValidationError(
+      `Reference names space "${parsed.space}" but the command targets ` +
+        `space "${options.space}".`,
+      { exitCode: 1 },
+    );
+  }
+
+  return {
+    pieceId: parsed.id,
+    ...(parsed.scope && { scope: parsed.scope as CellScope }),
+    path: parsed.path.map(toCellPathSegment),
+  };
+}

--- a/packages/cli/lib/llm-friendly-ref.ts
+++ b/packages/cli/lib/llm-friendly-ref.ts
@@ -1,3 +1,14 @@
+/**
+ * The LLM-friendly link form — `/[@did:.../]of:fid1:<id>[@scope][/path]`,
+ * the runner's `parseLLMFriendlyLink` grammar — is the canonical reference
+ * syntax of the fabric: the same string names the same cell in patterns, in
+ * the shell, and at this CLI's intake seams. The CLI's bare grammar
+ * (`pieceId[@scope]`, `pieceId[@scope]/path` at link endpoints, and slugs)
+ * is a convenience alias for interactive use. New reference-syntax
+ * capabilities land in the canonical form first, and the alias must not
+ * grow a capability the canonical form lacks.
+ */
+
 import { ValidationError } from "@cliffy/command";
 import type { CellScope } from "@commonfabric/api";
 import { isDID } from "@commonfabric/identity";

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -117,6 +117,13 @@ export interface PieceSearchResult {
 export interface PieceConfig extends SpaceConfig {
   piece: string;
   pieceScope?: CellScope;
+  /**
+   * Path segments embedded in an LLM-friendly `--piece` reference. A command
+   * that reads or writes at a path prepends these to its positional path
+   * argument; a command whose intake is id-only rejects a reference that
+   * carries them.
+   */
+  piecePath?: (string | number)[];
 }
 
 export interface SetPiecePatternOptions {

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -89,6 +89,7 @@ import {
   CellSelectionError,
   deriveSelectedValue,
 } from "./cell-selection.ts";
+import { validateEmbeddedSpaces } from "./llm-friendly-ref.ts";
 
 export interface EntryConfig {
   mainPath: string;
@@ -105,6 +106,13 @@ export interface SpaceConfig {
   identity: string;
   jsonOutput?: boolean;
   deferSpaceCellSync?: boolean;
+  /**
+   * Space DIDs embedded in LLM-friendly references given to this command,
+   * carried here when `space` is a name rather than a DID. A name only
+   * resolves to a DID once the session opens, so `loadPieces` checks each
+   * of these against the session's resolved space DID.
+   */
+  embeddedSpaces?: string[];
 }
 
 /** Metadata returned for a piece whose stored data matches a search query. */
@@ -432,6 +440,10 @@ export async function loadPieces(
     "loadPieces.makeSession",
     () => makeSession(config),
   );
+  // A `--space` given as a name has only now resolved to a DID; this is the
+  // deferred half of the embedded-space check `normalizeLLMFriendlyRef`
+  // performs at parse time for a DID-configured space.
+  validateEmbeddedSpaces(config.embeddedSpaces, session.space);
   // Use a const ref object so we can assign later while keeping const binding
   const piecesRef: { current?: PiecesController } = {};
   const runtimeErrors: CliRuntimeErrorRecord[] = [];

--- a/packages/cli/test/llm-friendly-ref.test.ts
+++ b/packages/cli/test/llm-friendly-ref.test.ts
@@ -1,12 +1,16 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { normalizeLLMFriendlyRef } from "../lib/llm-friendly-ref.ts";
+import {
+  normalizeLLMFriendlyRef,
+  validateEmbeddedSpaces,
+} from "../lib/llm-friendly-ref.ts";
 
 // The 43-character id length matches the entity ids the runtime mints, and
 // clears the runner parser's handle-length threshold.
 const ID = "baedreiabcdefghijklmnopqrstuvwxyz0123456789";
 const HANDLE = `of:fid1:${ID}`;
 const DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+const OTHER_DID = "did:key:z6MkrZ1r5XBFZjBU34qyD8fueMbMRkKw17BZaq2ivKFjnz2z";
 
 describe("llm-friendly-ref", () => {
   it("returns undefined for references outside the LLM-friendly form", () => {
@@ -37,6 +41,17 @@ describe("llm-friendly-ref", () => {
     });
   });
 
+  it("keeps canonical segments beyond the array-index range as strings", () => {
+    expect(
+      normalizeLLMFriendlyRef(
+        `/${HANDLE}/items/4294967294/4294967295/9007199254740993`,
+      ),
+    ).toEqual({
+      pieceId: HANDLE,
+      path: ["items", 4294967294, "4294967295", "9007199254740993"],
+    });
+  });
+
   it("parses a scope suffix on the id segment", () => {
     expect(normalizeLLMFriendlyRef(`/${HANDLE}@session/draft`)).toEqual({
       pieceId: HANDLE,
@@ -60,12 +75,36 @@ describe("llm-friendly-ref", () => {
     });
   });
 
-  it("rejects an embedded space DID that names another space", () => {
+  it("rejects an embedded DID that differs from a DID target space", () => {
     expect(() =>
-      normalizeLLMFriendlyRef(`/@${DID}/${HANDLE}`, { space: "other-space" })
+      normalizeLLMFriendlyRef(`/@${DID}/${HANDLE}`, { space: OTHER_DID })
     ).toThrow(
       `Reference names space "${DID}" but the command targets ` +
-        `space "other-space".`,
+        `space "${OTHER_DID}".`,
+    );
+  });
+
+  it("defers an embedded DID when the target space is a name", () => {
+    expect(
+      normalizeLLMFriendlyRef(`/@${DID}/${HANDLE}/value`, {
+        space: "my-space",
+      }),
+    ).toEqual({
+      pieceId: HANDLE,
+      embeddedSpace: DID,
+      path: ["value"],
+    });
+  });
+
+  it("passes a deferred embedded DID that matches the resolved space", () => {
+    expect(() => validateEmbeddedSpaces([DID], DID)).not.toThrow();
+    expect(() => validateEmbeddedSpaces(undefined, DID)).not.toThrow();
+  });
+
+  it("rejects a deferred embedded DID against another resolved space", () => {
+    expect(() => validateEmbeddedSpaces([DID], OTHER_DID)).toThrow(
+      `Reference names space "${DID}" but the command targets ` +
+        `space "${OTHER_DID}".`,
     );
   });
 

--- a/packages/cli/test/llm-friendly-ref.test.ts
+++ b/packages/cli/test/llm-friendly-ref.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { normalizeLLMFriendlyRef } from "../lib/llm-friendly-ref.ts";
+
+// The 43-character id length matches the entity ids the runtime mints, and
+// clears the runner parser's handle-length threshold.
+const ID = "baedreiabcdefghijklmnopqrstuvwxyz0123456789";
+const HANDLE = `of:fid1:${ID}`;
+const DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+
+describe("llm-friendly-ref", () => {
+  it("returns undefined for references outside the LLM-friendly form", () => {
+    expect(normalizeLLMFriendlyRef("piece1")).toBeUndefined();
+    expect(normalizeLLMFriendlyRef("piece1@user")).toBeUndefined();
+    expect(normalizeLLMFriendlyRef(HANDLE)).toBeUndefined();
+    expect(normalizeLLMFriendlyRef("piece1/path/to/field")).toBeUndefined();
+  });
+
+  it("normalizes an id-only reference to the bare handle", () => {
+    expect(normalizeLLMFriendlyRef(`/${HANDLE}`)).toEqual({
+      pieceId: HANDLE,
+      path: [],
+    });
+  });
+
+  it("converts embedded path segments the way a positional path is", () => {
+    expect(normalizeLLMFriendlyRef(`/${HANDLE}/items/0/title`)).toEqual({
+      pieceId: HANDLE,
+      path: ["items", 0, "title"],
+    });
+  });
+
+  it("parses a scope suffix on the id segment", () => {
+    expect(normalizeLLMFriendlyRef(`/${HANDLE}@session/draft`)).toEqual({
+      pieceId: HANDLE,
+      scope: "session",
+      path: ["draft"],
+    });
+  });
+
+  it("rejects an invalid scope suffix", () => {
+    expect(() => normalizeLLMFriendlyRef(`/${HANDLE}@bogus`)).toThrow(
+      /Invalid scope suffix/,
+    );
+  });
+
+  it("accepts an embedded space DID that matches the target space", () => {
+    expect(
+      normalizeLLMFriendlyRef(`/@${DID}/${HANDLE}/value`, { space: DID }),
+    ).toEqual({
+      pieceId: HANDLE,
+      path: ["value"],
+    });
+  });
+
+  it("rejects an embedded space DID that names another space", () => {
+    expect(() =>
+      normalizeLLMFriendlyRef(`/@${DID}/${HANDLE}`, { space: "other-space" })
+    ).toThrow(
+      `Reference names space "${DID}" but the command targets ` +
+        `space "other-space".`,
+    );
+  });
+
+  it("surfaces the runner parser's rejection of short ids", () => {
+    expect(() => normalizeLLMFriendlyRef("/of:short")).toThrow(
+      /must use handles/,
+    );
+  });
+});

--- a/packages/cli/test/llm-friendly-ref.test.ts
+++ b/packages/cli/test/llm-friendly-ref.test.ts
@@ -30,6 +30,13 @@ describe("llm-friendly-ref", () => {
     });
   });
 
+  it("converts only canonical array-index segments to numbers", () => {
+    expect(normalizeLLMFriendlyRef(`/${HANDLE}/items/0/10/01/007`)).toEqual({
+      pieceId: HANDLE,
+      path: ["items", 0, 10, "01", "007"],
+    });
+  });
+
   it("parses a scope suffix on the id segment", () => {
     expect(normalizeLLMFriendlyRef(`/${HANDLE}@session/draft`)).toEqual({
       pieceId: HANDLE,

--- a/packages/cli/test/piece-cell-operations.test.ts
+++ b/packages/cli/test/piece-cell-operations.test.ts
@@ -41,11 +41,22 @@ describe("parseCellPath", () => {
 
   it("should not convert non-integer numbers", () => {
     expect(parseCellPath("value/3.14/pi")).toEqual(["value", "3.14", "pi"]);
-    // Note: 1e5 is considered an integer (100000) by JavaScript
     expect(parseCellPath("data/1e5/scientific")).toEqual([
       "data",
-      100000,
+      "1e5",
       "scientific",
+    ]);
+  });
+
+  it("keeps a leading-zero segment as a string", () => {
+    expect(parseCellPath("items/01/name")).toEqual(["items", "01", "name"]);
+  });
+
+  it("keeps a segment past the largest array index as a string", () => {
+    expect(parseCellPath("items/4294967294/4294967295")).toEqual([
+      "items",
+      4294967294,
+      "4294967295",
     ]);
   });
 

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -67,6 +67,8 @@ const ID = "~/.my.key";
 // clears the runner parser's handle-length threshold.
 const LLM_HANDLE = `of:fid1:${"baedreiabcdefghijklmnopqrstuvwxyz0123456789"}`;
 const SPACE_DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+const OTHER_SPACE_DID =
+  "did:key:z6MkrZ1r5XBFZjBU34qyD8fueMbMRkKw17BZaq2ivKFjnz2z";
 const FULL_URL = `${API_URL}/${SPACE}/${PIECE}`;
 const NO_PIECE_FULL_URL = `${API_URL}/${SPACE}`;
 
@@ -360,13 +362,25 @@ describe("cli piece parsing", () => {
     expect(() =>
       parsePieceOptions({
         ...base,
-        space: SPACE,
+        space: OTHER_SPACE_DID,
         piece: `/@${SPACE_DID}/${LLM_HANDLE}`,
       })
     ).toThrow(
       `Reference names space "${SPACE_DID}" but the command targets ` +
-        `space "${SPACE}".`,
+        `space "${OTHER_SPACE_DID}".`,
     );
+    // A named space resolves to a DID only once the session opens, so the
+    // embedded DID is carried for loadPieces' deferred check rather than
+    // compared against the raw name here.
+    expect(parsePieceOptions({
+      ...base,
+      space: SPACE,
+      piece: `/@${SPACE_DID}/${LLM_HANDLE}`,
+    })).toMatchObject({
+      space: SPACE,
+      piece: LLM_HANDLE,
+      embeddedSpaces: [SPACE_DID],
+    });
   });
 
   it("parsePieceOptions() throws on incomplete input", () => {
@@ -604,8 +618,19 @@ describe("cli piece parsing", () => {
         path: ["field"],
       });
       expect(() =>
-        parseLink(`/@${SPACE_DID}/${LLM_HANDLE}/field`, { space: SPACE })
+        parseLink(`/@${SPACE_DID}/${LLM_HANDLE}/field`, {
+          space: OTHER_SPACE_DID,
+        })
       ).toThrow(/names space/);
+      // With a named target space the DID rides along for the deferred
+      // check loadPieces runs against the session's resolved space.
+      expect(
+        parseLink(`/@${SPACE_DID}/${LLM_HANDLE}/field`, { space: SPACE }),
+      ).toEqual({
+        pieceId: LLM_HANDLE,
+        embeddedSpace: SPACE_DID,
+        path: ["field"],
+      });
     });
   });
 

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -43,6 +43,7 @@ import {
   formatPatternIdentity,
   formatPatternRef,
   localPatternEntry,
+  mergePiecePath,
   normalizeApiUrl,
   parseLink,
   parsePieceOptions,
@@ -62,6 +63,10 @@ const API_URL = "https://cf.dev";
 const SPACE = "common-knowledge";
 const PIECE = "abcdefghijklmnopqrstuvwxyz";
 const ID = "~/.my.key";
+// The 43-character id length matches the entity ids the runtime mints, and
+// clears the runner parser's handle-length threshold.
+const LLM_HANDLE = `of:fid1:${"baedreiabcdefghijklmnopqrstuvwxyz0123456789"}`;
+const SPACE_DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
 const FULL_URL = `${API_URL}/${SPACE}/${PIECE}`;
 const NO_PIECE_FULL_URL = `${API_URL}/${SPACE}`;
 
@@ -313,6 +318,57 @@ describe("cli piece parsing", () => {
       pieceScope: "session",
     });
   });
+  it("parsePieceOptions() resolves an LLM-friendly --piece like the bare handle", () => {
+    const base = { apiUrl: API_URL, space: SPACE, identity: ID };
+    expect(parsePieceOptions({ ...base, piece: `/${LLM_HANDLE}` })).toEqual(
+      parsePieceOptions({ ...base, piece: LLM_HANDLE }),
+    );
+    expect(
+      parsePieceOptions({ ...base, piece: `/${LLM_HANDLE}@session` }),
+    ).toMatchObject({
+      piece: LLM_HANDLE,
+      pieceScope: "session",
+    });
+  });
+
+  it("parsePieceOptions() carries an embedded path only where the command accepts one", () => {
+    const base = { apiUrl: API_URL, space: SPACE, identity: ID };
+    const config = parsePieceOptions(
+      { ...base, piece: `/${LLM_HANDLE}/items/0` },
+      { acceptsPath: true },
+    );
+    expect(config).toMatchObject({
+      piece: LLM_HANDLE,
+      piecePath: ["items", 0],
+    });
+    expect(mergePiecePath(config, "title")).toEqual(["items", 0, "title"]);
+    expect(mergePiecePath(config)).toEqual(["items", 0]);
+    expect(() => parsePieceOptions({ ...base, piece: `/${LLM_HANDLE}/items` }))
+      .toThrow(/takes a piece id only/);
+  });
+
+  it("parsePieceOptions() checks an embedded space DID against the target space", () => {
+    const base = { apiUrl: API_URL, identity: ID };
+    expect(parsePieceOptions({
+      ...base,
+      space: SPACE_DID,
+      piece: `/@${SPACE_DID}/${LLM_HANDLE}`,
+    })).toMatchObject({
+      space: SPACE_DID,
+      piece: LLM_HANDLE,
+    });
+    expect(() =>
+      parsePieceOptions({
+        ...base,
+        space: SPACE,
+        piece: `/@${SPACE_DID}/${LLM_HANDLE}`,
+      })
+    ).toThrow(
+      `Reference names space "${SPACE_DID}" but the command targets ` +
+        `space "${SPACE}".`,
+    );
+  });
+
   it("parsePieceOptions() throws on incomplete input", () => {
     expect(() =>
       parsePieceOptions({
@@ -526,6 +582,30 @@ describe("cli piece parsing", () => {
       const result = parseLink("piece/field/");
       expect(result.pieceId).toBe("piece");
       expect(result.path).toEqual(["field", ""]);
+    });
+
+    it("parses an LLM-friendly reference like the bare form", () => {
+      expect(parseLink(`/${LLM_HANDLE}`)).toEqual({ pieceId: LLM_HANDLE });
+      expect(parseLink(`/${LLM_HANDLE}/data/items/0/title`)).toEqual(
+        parseLink(`${LLM_HANDLE}/data/items/0/title`),
+      );
+      expect(parseLink(`/${LLM_HANDLE}@user/field`)).toEqual({
+        pieceId: LLM_HANDLE,
+        scope: "user",
+        path: ["field"],
+      });
+    });
+
+    it("checks an embedded space DID against the target space", () => {
+      expect(
+        parseLink(`/@${SPACE_DID}/${LLM_HANDLE}/field`, { space: SPACE_DID }),
+      ).toEqual({
+        pieceId: LLM_HANDLE,
+        path: ["field"],
+      });
+      expect(() =>
+        parseLink(`/@${SPACE_DID}/${LLM_HANDLE}/field`, { space: SPACE })
+      ).toThrow(/names space/);
     });
   });
 

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@std/testing/bdd";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import {
@@ -71,6 +71,11 @@ const OTHER_SPACE_DID =
   "did:key:z6MkrZ1r5XBFZjBU34qyD8fueMbMRkKw17BZaq2ivKFjnz2z";
 const FULL_URL = `${API_URL}/${SPACE}/${PIECE}`;
 const NO_PIECE_FULL_URL = `${API_URL}/${SPACE}`;
+// A key the commands below can open a session with; they never reach a
+// server, so which identity it names does not matter.
+const TEST_PKCS8_KEY = `-----BEGIN PRIVATE KEY-----
+MMC4CAQAwBQYDK2VwBCIEICWSvx4QOW+mogjWSsjInQaPpmjErsDBqf2ZOoK+Y4IO
+-----END PRIVATE KEY-----`;
 
 describe("cli piece parsing", () => {
   it("formats structured pattern references for human output", () => {
@@ -631,6 +636,79 @@ describe("cli piece parsing", () => {
         embeddedSpace: SPACE_DID,
         path: ["field"],
       });
+    });
+  });
+
+  describe("embedded space DIDs given to a link command", () => {
+    // A `--space` given as a name resolves to a DID only when the session
+    // opens, so a DID embedded in a reference rides along to that point and
+    // is compared there. Each command below reaches the comparison without a
+    // server: the session derives the space key from the name locally, and
+    // the check runs before any storage is opened.
+    let identityPath = "";
+
+    beforeEach(async () => {
+      identityPath = await Deno.makeTempFile({ suffix: ".key" });
+      await Deno.writeTextFile(identityPath, TEST_PKCS8_KEY);
+    });
+
+    afterEach(async () => {
+      await Deno.remove(identityPath);
+    });
+
+    const options = () =>
+      `--identity ${identityPath} --api-url ${API_URL} --space ${SPACE}`;
+
+    const spaceRefusal = async (command: string) => {
+      const { code, stderr } = await cf(command);
+      expect(code).toBe(1);
+      return stripAnsi(stderr.join("\n"));
+    };
+
+    it("refuses a link whose source names another space", async () => {
+      expect(
+        await spaceRefusal(
+          `piece link ${options()} ` +
+            `/@${SPACE_DID}/${LLM_HANDLE}/notes ${LLM_HANDLE}/inbox`,
+        ),
+      ).toContain(`Reference names space "${SPACE_DID}"`);
+    });
+
+    it("refuses a link whose target names another space", async () => {
+      expect(
+        await spaceRefusal(
+          `piece link ${options()} ` +
+            `${LLM_HANDLE}/notes /@${SPACE_DID}/${LLM_HANDLE}/inbox`,
+        ),
+      ).toContain(`Reference names space "${SPACE_DID}"`);
+    });
+
+    it("refuses a sqlite link whose target names another space", async () => {
+      expect(
+        await spaceRefusal(
+          `piece link ${options()} ` +
+            `sqlite:/tmp/reference-data.db /@${SPACE_DID}/${LLM_HANDLE}/refDb`,
+        ),
+      ).toContain(`Reference names space "${SPACE_DID}"`);
+    });
+
+    it("refuses a slug whose source names another space", async () => {
+      expect(
+        await spaceRefusal(
+          `piece set-slug ${options()} ` +
+            `project-notes /@${SPACE_DID}/${LLM_HANDLE}/notes`,
+        ),
+      ).toContain(`Reference names space "${SPACE_DID}"`);
+    });
+
+    it("still requires a path on a link target given in the canonical form", async () => {
+      // The path rule is the bare form's, and reaching it proves the
+      // canonical endpoint was parsed rather than refused as unrecognized.
+      expect(
+        await spaceRefusal(
+          `piece link ${options()} ${LLM_HANDLE}/notes /${LLM_HANDLE}`,
+        ),
+      ).toContain("Target reference must include a path.");
     });
   });
 

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -123,6 +123,7 @@ export {
   isCellLink as isLink,
   isWriteRedirectLink,
   KeepAsCell,
+  matchLLMFriendlyLink,
   parseLink,
   parseLinkOrThrow,
   parseLLMFriendlyLink,

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -19,9 +19,20 @@ import type {
   MemoryAddressPathComponent,
 } from "./storage/interface.ts";
 
-const CELL_SCOPE_VALUES = new Set(["space", "user", "session"]);
+/** The scopes an `@scope` suffix on a link handle may name. */
+export const CELL_SCOPE_VALUES: ReadonlySet<string> = new Set([
+  "space",
+  "user",
+  "session",
+]);
 
-function parseScopedIdSegment(idSegment: string): {
+/**
+ * Splits a link's id segment into the id and the scope its `@scope` suffix
+ * names, leaving the scope absent when the segment carries no suffix. Throws
+ * when a suffix is present but names something other than a scope, or leaves
+ * no id in front of it.
+ */
+export function parseScopedIdSegment(idSegment: string): {
   id: string;
   scope?: CellScope;
 } {
@@ -336,6 +347,32 @@ export function decodeJsonPointer(pointer: string): string[] {
   return pointer
     .split("/")
     .map((token) => token.replace(/~1/g, "/").replace(/~0/g, "~"));
+}
+
+/** A canonical array-index token: `0`, or digits without a leading zero. */
+const canonicalArrayIndex = /^(0|[1-9][0-9]*)$/;
+
+/** The largest valid JS array index, 2^32 - 2. */
+const MAX_ARRAY_INDEX = 4294967294;
+
+/**
+ * Converts one path segment of a reference to the number-or-string form cell
+ * traversal addresses with. Only a canonical index token — `0`, or digits
+ * with no leading zero — whose value is a valid JS array index (at most
+ * `4294967294`) becomes a number; every other token stays a string.
+ *
+ * Both halves of that rule keep a segment addressing the cell it names. A
+ * non-canonical token such as `01` names a property of that spelling rather
+ * than element `1`, and above `Number.MAX_SAFE_INTEGER` the conversion is
+ * itself lossy — `Number("9007199254740993")` is `9007199254740992` — so
+ * either conversion would silently address a different cell.
+ */
+export function linkPathSegmentToCellPathSegment(
+  segment: string,
+): string | number {
+  if (!canonicalArrayIndex.test(segment)) return segment;
+  const index = Number(segment);
+  return index <= MAX_ARRAY_INDEX ? index : segment;
 }
 
 // Matches both standard links (/of:...) and cross-space links (/@did:...)

--- a/packages/runner/src/piece-helpers.ts
+++ b/packages/runner/src/piece-helpers.ts
@@ -7,7 +7,7 @@ import {
 import { isObjectOrArray } from "../../utils/src/types.ts";
 import { getLogger } from "../../utils/src/logger.ts";
 import { type Cell, isCell, isStream } from "./cell.ts";
-import { isSigilLink } from "./link-types.ts";
+import { isSigilLink, linkPathSegmentToCellPathSegment } from "./link-types.ts";
 import { parseLink } from "./link-utils.ts";
 import {
   normalizePatternSource,
@@ -26,17 +26,17 @@ const logger = getLogger("piece-helpers");
 
 export type CellPath = (string | number)[];
 
+/**
+ * Splits a slash-separated cell path into its segments, converting each one
+ * through {@link linkPathSegmentToCellPathSegment} so that a path written on
+ * the command line addresses the same cells as the same path embedded in a
+ * reference. An empty path is no segments at all.
+ */
 export function parseCellPath(path: string): CellPath {
   if (!path || path.trim() === "") {
     return [];
   }
-  return path.split("/").map((segment) => {
-    if (segment === "") {
-      return segment;
-    }
-    const num = Number(segment);
-    return Number.isInteger(num) && num >= 0 ? num : segment;
-  });
+  return path.split("/").map(linkPathSegmentToCellPathSegment);
 }
 
 export function resolveCellPath<T>(

--- a/packages/runner/src/shared.ts
+++ b/packages/runner/src/shared.ts
@@ -6,11 +6,15 @@
 
 export {
   addressKey,
+  CELL_SCOPE_VALUES,
   createLLMFriendlyLink,
   isAliasBinding,
   isSigilLink,
+  linkPathSegmentToCellPathSegment,
+  matchLLMFriendlyLink,
   type NormalizedFullLink,
   parseLLMFriendlyLink,
+  parseScopedIdSegment,
 } from "./link-types.ts";
 export {
   isLinkRef,

--- a/packages/runner/test/link-types.test.ts
+++ b/packages/runner/test/link-types.test.ts
@@ -1,0 +1,68 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  linkPathSegmentToCellPathSegment,
+  parseScopedIdSegment,
+} from "../src/link-types.ts";
+
+describe("link-types", () => {
+  describe("linkPathSegmentToCellPathSegment()", () => {
+    it("returns a number for a canonical index token", () => {
+      expect(linkPathSegmentToCellPathSegment("0")).toBe(0);
+      expect(linkPathSegmentToCellPathSegment("7")).toBe(7);
+      expect(linkPathSegmentToCellPathSegment("4294967294")).toBe(4294967294);
+    });
+
+    it("returns the token itself for a leading-zero index", () => {
+      expect(linkPathSegmentToCellPathSegment("01")).toBe("01");
+      expect(linkPathSegmentToCellPathSegment("007")).toBe("007");
+    });
+
+    it("returns the token itself for a numeric form that is not an index", () => {
+      expect(linkPathSegmentToCellPathSegment("-1")).toBe("-1");
+      expect(linkPathSegmentToCellPathSegment("3.14")).toBe("3.14");
+      expect(linkPathSegmentToCellPathSegment("1e3")).toBe("1e3");
+      expect(linkPathSegmentToCellPathSegment("0x10")).toBe("0x10");
+      expect(linkPathSegmentToCellPathSegment(" 1 ")).toBe(" 1 ");
+    });
+
+    it("returns the token itself past the largest array index", () => {
+      expect(linkPathSegmentToCellPathSegment("4294967295")).toBe("4294967295");
+      expect(linkPathSegmentToCellPathSegment("9007199254740993")).toBe(
+        "9007199254740993",
+      );
+    });
+
+    it("returns the token itself for an ordinary property name", () => {
+      expect(linkPathSegmentToCellPathSegment("title")).toBe("title");
+      expect(linkPathSegmentToCellPathSegment("")).toBe("");
+    });
+  });
+
+  describe("parseScopedIdSegment()", () => {
+    it("returns the segment unchanged when it carries no suffix", () => {
+      expect(parseScopedIdSegment("of:fid1:abc")).toEqual({
+        id: "of:fid1:abc",
+      });
+    });
+
+    it("returns the id and the scope named by the suffix", () => {
+      expect(parseScopedIdSegment("of:fid1:abc@session")).toEqual({
+        id: "of:fid1:abc",
+        scope: "session",
+      });
+    });
+
+    it("throws when the suffix names something other than a scope", () => {
+      expect(() => parseScopedIdSegment("of:fid1:abc@any")).toThrow(
+        /Invalid scope suffix/,
+      );
+    });
+
+    it("throws when no id precedes the suffix", () => {
+      expect(() => parseScopedIdSegment("@user")).toThrow(
+        /Invalid scope suffix/,
+      );
+    });
+  });
+});

--- a/packages/runner/test/piece-helpers.test.ts
+++ b/packages/runner/test/piece-helpers.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, assertThrows } from "@std/assert";
+import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
@@ -50,6 +51,16 @@ describe("parseCellPath", () => {
       "negative",
     ]);
     assertEquals(parseCellPath(""), []);
+  });
+
+  it("converts only the segments that are canonical array indexes", () => {
+    expect(parseCellPath("items/01/1e3/ 1 /4294967295")).toEqual([
+      "items",
+      "01",
+      "1e3",
+      " 1 ",
+      "4294967295",
+    ]);
   });
 });
 


### PR DESCRIPTION
Stacked on #5736. Part of [CT-2003](https://linear.app/common-tools/issue/CT-2003/run-pattern-code-based-tool-calls-against-the-fabric-composing-with-ct).

## Why

The session handle substitution in #5736 emits the canonical LLM-friendly reference form (`/of:fid1:<id>[@scope][/path]`, optional `/@did/` prefix) into `cf` commands, but the CLI's reference intake rejected it (`SyntaxError` in `FabricHash.fromString` — reproduced live in the P0a smoke test). This closes that gap so a handle forwarded by an agent flows through a real `cf` command.

## What

One shared helper, `normalizeLLMFriendlyRef` (`packages/cli/lib/llm-friendly-ref.ts`), built on the runner's `matchLLMFriendlyLink`/`parseLLMFriendlyLink` (grammar not re-implemented; runner core stays strict — only an export added). Routed through every piece-reference intake seam in `commands/piece.ts`:

- `--piece` resolution for all piece commands; an embedded path is carried as `piecePath` and **prepended** to the positional path where the command accepts one (`get`, `set`, `get-label`, `set-label`)
- id-only commands error clearly on an embedded path — no silent truncation
- `parseLink` (both `link` endpoints, `set-slug` source) accepts the form with the same semantics
- an embedded space DID must match the command's target space, else: `Reference names space "X" but the command targets space "Y".`

## Test plan

- New `test/llm-friendly-ref.test.ts` (8 cases) + `piece.test.ts` coverage including the exact smoke-failure form (`/of:fid1:` + 43-char id ≡ bare handle)
- `packages/cli`: 1671 passed; the single failing file is an untracked leftover on the test machine, verified failing identically without this change
- fmt/lint/check clean on touched files

Linear-issue: CT-2003

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

