### PR TITLE
feat(cf-harness): run_pattern — code-based tool calls against a fabric space

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -570,9 +570,11 @@ With all three present (`CF_HARNESS_FABRIC_API_URL`,
 `CF_HARNESS_FABRIC_IDENTITY`, and `CF_HARNESS_FABRIC_SPACE` are the environment
 fallbacks), the `run_pattern` tool joins the parent tool surface; with none, the
 tool is absent and runs behave exactly as before; a partial set is a
-configuration error naming the missing flags. `--fabric-space` accepts a space
-name or a `did:key`, and `--describe-capabilities` reports `runPattern` among
-its features.
+configuration error naming the missing flags. The same holds under an explicit
+allowlist: `--allow-tool run_pattern` without the three session flags is a
+configuration error, and the tool is never offered to the model without a
+session. `--fabric-space` accepts a space name or a `did:key`, and
+`--describe-capabilities` reports `runPattern` among its features.
 
 `run_pattern` executes on the trusted host side — it never enters the docker
 sandbox. The session (a `PiecesController` against the deployed API) is built
@@ -588,16 +590,17 @@ to the pattern as a live cell reference; everything else passes through as plain
 JSON. The deployed piece is deliberately unregistered — it never appears in the
 space's piece list.
 
-A successful run returns `{ status: "ok", resultRef, pieceId }`, where
+A successful run returns `{ status: "ok", resultRef }` to the model, where
 `resultRef` is the canonical LLM-friendly link to the piece's result cell, plus
 the schema-sanitized `value` (with `linkedStringCount`) when `resultSchema` was
 given. In `session` handle mode the ordinary outbound swap turns `resultRef`
 (and any link strings inside `value`) into `cfh:a:` tokens at the model
 boundary, and the ordinary inbound swap resolves such a token passed back
 through `inputs`; the tool itself carries no handle code. The persisted
-tool-output artifact keeps the raw reference and the raw result value. Compiler
-diagnostics come back raw as `{ status: "compile-error", message }` so the model
-can iterate on the source.
+tool-output artifact keeps the raw reference, the raw result value, and the
+`pieceId` — a bare fabric identifier the handle boundary never swaps, so it
+stays out of the model-facing rendering. Compiler diagnostics come back raw as
+`{ status: "compile-error", message }` so the model can iterate on the source.
 
 Interactive chat stdio transport:
 

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -593,10 +593,20 @@ structured error before anything is created, and a live-cell input whose current
 value does not match the compiled pattern's argument schema for its key is
 refused the same way — named after the offending key, with no piece persisted.
 The deployed piece is deliberately unregistered — it never appears in the
-space's piece list. When the run's abort signal fires while the tool is waiting
-for the pattern to settle, the tool stops the created piece and returns a
-structured `cancelled` error; the signal is the only cancellation source — there
-is no timeout.
+space's piece list — and deliberately detached: no origin is recorded, because
+model-authored source starts detached under the piece source-lifecycle spec.
+Run→piece provenance is carried by the run's persisted artifacts instead —
+run-state and the tool-output artifact record the `pieceId`. When the run's
+abort signal fires while the tool is waiting for the pattern to settle, the tool
+stops the created piece and returns a structured `cancelled` error; the signal
+is the only cancellation source — there is no timeout.
+
+Every `run_pattern` invocation persists such a piece in the configured space. A
+cancelled run stops its piece, but no piece is ever deleted, and each piece's
+source-history revision is a storage-retention root the piece list does not
+reveal. Tooling that enumerates a space's contents from the piece list must not
+assume the list is exhaustive, and there is no garbage collection for these
+pieces yet.
 
 A successful run returns `{ status: "ok", resultRef }` to the model, where
 `resultRef` is the canonical LLM-friendly link to the piece's result cell, plus

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -54,6 +54,8 @@ What works today:
   - `edit_file`
   - `write_file`
   - `delegate_task`
+  - `run_pattern` (present only when the run configures a fabric session; see
+    [Running patterns against a Fabric space](#running-patterns-against-a-fabric-space))
 - targeted exact-string edits plus whole-file replace/create and append writes
 - initial and in-run image attachments for model vision-capable flows
 - bounded public HTTP(S) fetches through `web_fetch`, with redirect validation,
@@ -119,6 +121,11 @@ network confinement model.
   cell addresses, minted per run, recorded in run state, and carried across
   `--resume-run`; see
   [Session-local address handles](#session-local-address-handles)
+- an opt-in `run_pattern` tool (`--fabric-api-url`, `--fabric-identity`, and
+  `--fabric-space` together) that compiles and runs a pattern against a deployed
+  Fabric space from the trusted host side and returns a live result cell
+  reference; see
+  [Running patterns against a Fabric space](#running-patterns-against-a-fabric-space)
 
 What is not done yet:
 
@@ -144,6 +151,8 @@ What is not done yet:
   - core execution engine, run state, tool execution
 - [src/handle-table.ts](src/handle-table.ts)
   - session-local address handle table: token minting and both swap directions
+- [src/fabric-session.ts](src/fabric-session.ts)
+  - lazy, cached trusted Fabric session behind the `run_pattern` tool
 - [src/prompt-loop.ts](src/prompt-loop.ts)
   - bounded prompt/tool loop
 - [src/model/](src/model)
@@ -542,6 +551,53 @@ object; the return's `linkedStringCount` counts only the positions still sealed.
 Denial-path tool messages are not swapped; that coverage, cross-agent handle
 semantics, value handles, and an explicit release/readback mechanism are listed
 in [docs/ROADMAP.md](docs/ROADMAP.md).
+
+### Running patterns against a Fabric space
+
+Three flags configure one trusted Fabric session, and all of them go together:
+
+```bash
+cd packages/cf-harness
+deno task run -- \
+  --workspace /path/to/workspace \
+  --fabric-api-url https://toolshed.example/ \
+  --fabric-identity ~/.cf/agent.pkcs8 \
+  --fabric-space my-space \
+  --prompt "Deploy a pattern that doubles its input and report the result."
+```
+
+With all three present (`CF_HARNESS_FABRIC_API_URL`,
+`CF_HARNESS_FABRIC_IDENTITY`, and `CF_HARNESS_FABRIC_SPACE` are the environment
+fallbacks), the `run_pattern` tool joins the parent tool surface; with none, the
+tool is absent and runs behave exactly as before; a partial set is a
+configuration error naming the missing flags. `--fabric-space` accepts a space
+name or a `did:key`, and `--describe-capabilities` reports `runPattern` among
+its features.
+
+`run_pattern` executes on the trusted host side — it never enters the docker
+sandbox. The session (a `PiecesController` against the deployed API) is built
+lazily on the tool's first invocation and cached for the run; a session that
+fails to build surfaces as an ordinary tool-output error rather than a run
+failure.
+
+The tool takes exactly one of `sourceText` (inline pattern source) or
+`sourcePath` (a workspace-relative file, confined to the workspace root), an
+optional `inputs` object, and an optional `resultSchema`. An `inputs` string
+value that is a whole-string LLM-friendly link (`/of:fid1:.../path`) is passed
+to the pattern as a live cell reference; everything else passes through as plain
+JSON. The deployed piece is deliberately unregistered — it never appears in the
+space's piece list.
+
+A successful run returns `{ status: "ok", resultRef, pieceId }`, where
+`resultRef` is the canonical LLM-friendly link to the piece's result cell, plus
+the schema-sanitized `value` (with `linkedStringCount`) when `resultSchema` was
+given. In `session` handle mode the ordinary outbound swap turns `resultRef`
+(and any link strings inside `value`) into `cfh:a:` tokens at the model
+boundary, and the ordinary inbound swap resolves such a token passed back
+through `inputs`; the tool itself carries no handle code. The persisted
+tool-output artifact keeps the raw reference and the raw result value. Compiler
+diagnostics come back raw as `{ status: "compile-error", message }` so the model
+can iterate on the source.
 
 Interactive chat stdio transport:
 

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -611,17 +611,17 @@ pieces yet.
 A successful run returns `{ status: "ok", resultRef }` to the model, where
 `resultRef` is the canonical LLM-friendly link to the piece's result cell, plus
 the schema-sanitized `value` (with `linkedStringCount`) when `resultSchema` was
-given. In `session` handle mode the ordinary outbound swap turns `resultRef`
-(and any link strings inside `value`) into `cfh:a:` tokens at the model
-boundary, and the ordinary inbound swap resolves such a token passed back
-through `inputs`; the tool itself carries no handle code. The persisted
-tool-output artifact keeps the raw reference, the raw result value, and the
-`pieceId` — a bare fabric identifier the handle boundary never swaps, so it
-stays out of the model-facing rendering. Compiler diagnostics come back as
-`{ status: "compile-error", message }` so the model can iterate on the source;
-bare fabric identifiers a diagnostic can embed (compiler-generated `fid1:`
-module roots, DIDs, `data:` URIs) are replaced with a `[fabric-id]` placeholder
-in the model-facing message, while the persisted artifact keeps the raw text.
+given. The ordinary outbound swap turns `resultRef` (and any link strings inside
+`value`) into `cfh:a:` tokens at the model boundary, and the ordinary inbound
+swap resolves such a token passed back through `inputs`; the tool itself carries
+no handle code. The persisted tool-output artifact keeps the raw reference, the
+raw result value, and the `pieceId` — a bare fabric identifier the handle
+boundary never swaps, so it stays out of the model-facing rendering. Compiler
+diagnostics come back as `{ status: "compile-error", message }` so the model can
+iterate on the source; bare fabric identifiers a diagnostic can embed
+(compiler-generated `fid1:` module roots, DIDs, `data:` URIs) are replaced with
+a `[fabric-id]` placeholder in the model-facing message, while the persisted
+artifact keeps the raw text.
 
 Interactive chat stdio transport:
 

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -578,17 +578,25 @@ session. `--fabric-space` accepts a space name or a `did:key`, and
 
 `run_pattern` executes on the trusted host side — it never enters the docker
 sandbox. The session (a `PiecesController` against the deployed API) is built
-lazily on the tool's first invocation and cached for the run; a session that
-fails to build surfaces as an ordinary tool-output error rather than a run
-failure.
+lazily on the tool's first invocation; construction verifies the configured
+space's authorization, and only a healthy session is cached for the run. A
+session that fails to build surfaces as an ordinary tool-output error rather
+than a run failure, and the next tool call retries the construction.
 
-The tool takes exactly one of `sourceText` (inline pattern source) or
-`sourcePath` (a workspace-relative file, confined to the workspace root), an
-optional `inputs` object, and an optional `resultSchema`. An `inputs` string
-value that is a whole-string LLM-friendly link (`/of:fid1:.../path`) is passed
-to the pattern as a live cell reference; everything else passes through as plain
-JSON. The deployed piece is deliberately unregistered — it never appears in the
-space's piece list.
+The tool takes `sourceText` (inline pattern source, at most 256 KiB — an
+over-cap source is a structured tool error), an optional `inputs` object, and an
+optional `resultSchema`. An `inputs` string value that is a whole-string
+LLM-friendly link (`/of:fid1:.../path`) is passed to the pattern as a live cell
+reference; everything else passes through as plain JSON. A link that resolves
+into a space other than the configured session space is refused with a
+structured error before anything is created, and a live-cell input whose current
+value does not match the compiled pattern's argument schema for its key is
+refused the same way — named after the offending key, with no piece persisted.
+The deployed piece is deliberately unregistered — it never appears in the
+space's piece list. When the run's abort signal fires while the tool is waiting
+for the pattern to settle, the tool stops the created piece and returns a
+structured `cancelled` error; the signal is the only cancellation source — there
+is no timeout.
 
 A successful run returns `{ status: "ok", resultRef }` to the model, where
 `resultRef` is the canonical LLM-friendly link to the piece's result cell, plus
@@ -599,8 +607,11 @@ boundary, and the ordinary inbound swap resolves such a token passed back
 through `inputs`; the tool itself carries no handle code. The persisted
 tool-output artifact keeps the raw reference, the raw result value, and the
 `pieceId` — a bare fabric identifier the handle boundary never swaps, so it
-stays out of the model-facing rendering. Compiler diagnostics come back raw as
-`{ status: "compile-error", message }` so the model can iterate on the source.
+stays out of the model-facing rendering. Compiler diagnostics come back as
+`{ status: "compile-error", message }` so the model can iterate on the source;
+bare fabric identifiers a diagnostic can embed (compiler-generated `fid1:`
+module roots, DIDs, `data:` URIs) are replaced with a `[fabric-id]` placeholder
+in the model-facing message, while the persisted artifact keeps the raw text.
 
 Interactive chat stdio transport:
 

--- a/packages/cf-harness/docs/CURRENT_STATE.md
+++ b/packages/cf-harness/docs/CURRENT_STATE.md
@@ -64,12 +64,17 @@ The current package provides:
   and dispatch, `delegate_task` arguments excepted;
 - an opt-in `run_pattern` tool (`--fabric-api-url`, `--fabric-identity`, and
   `--fabric-space` configured together, or their `CF_HARNESS_FABRIC_*`
-  environment fallbacks): compiles and runs a pattern against a deployed Fabric
-  space from the trusted host side over a lazy per-run session, passes
-  whole-string LLM-friendly link inputs as live cells, returns the result cell's
-  canonical reference plus an optionally schema-sanitized value, and leaves the
-  piece out of the space's registered piece list; without the session
-  configuration the tool is absent from the tool surface.
+  environment fallbacks): compiles and runs an inline `sourceText` pattern
+  (capped at 256 KiB) against a deployed Fabric space from the trusted host side
+  over a lazy per-run session that caches only a healthy, authorized
+  construction; passes whole-string LLM-friendly link inputs as live cells,
+  refusing links into another space and live-cell values that mismatch the
+  compiled argument schema before any piece exists; honors the run's abort
+  signal by stopping the created piece and returning a structured `cancelled`
+  error; scrubs bare fabric identifiers from model-facing diagnostics; returns
+  the result cell's canonical reference plus an optionally schema-sanitized
+  value, and leaves the piece out of the space's registered piece list; without
+  the session configuration the tool is absent from the tool surface.
 
 Run the capability probe instead of copying this list into adapters:
 

--- a/packages/cf-harness/docs/CURRENT_STATE.md
+++ b/packages/cf-harness/docs/CURRENT_STATE.md
@@ -61,7 +61,15 @@ The current package provides:
   run for cell addresses, recorded in `run-state.json`, and carried across
   resume; the prompt loop swaps addresses to tokens in model-bound tool output
   and resolves tokens in model-authored tool arguments before policy evaluation
-  and dispatch, `delegate_task` arguments excepted.
+  and dispatch, `delegate_task` arguments excepted;
+- an opt-in `run_pattern` tool (`--fabric-api-url`, `--fabric-identity`, and
+  `--fabric-space` configured together, or their `CF_HARNESS_FABRIC_*`
+  environment fallbacks): compiles and runs a pattern against a deployed Fabric
+  space from the trusted host side over a lazy per-run session, passes
+  whole-string LLM-friendly link inputs as live cells, returns the result cell's
+  canonical reference plus an optionally schema-sanitized value, and leaves the
+  piece out of the space's registered piece list; without the session
+  configuration the tool is absent from the tool surface.
 
 Run the capability probe instead of copying this list into adapters:
 

--- a/packages/cf-harness/docs/CURRENT_STATE.md
+++ b/packages/cf-harness/docs/CURRENT_STATE.md
@@ -73,8 +73,10 @@ The current package provides:
   signal by stopping the created piece and returning a structured `cancelled`
   error; scrubs bare fabric identifiers from model-facing diagnostics; returns
   the result cell's canonical reference plus an optionally schema-sanitized
-  value, and leaves the piece out of the space's registered piece list; without
-  the session configuration the tool is absent from the tool surface.
+  value, and leaves the piece detached (no recorded origin) and out of the
+  space's registered piece list, with run→piece provenance carried by the run's
+  persisted artifacts; without the session configuration the tool is absent from
+  the tool surface.
 
 Run the capability probe instead of copying this list into adapters:
 
@@ -119,6 +121,12 @@ mode.
 - Package-default sandbox networking is a provisional bridge-oriented posture,
   not the final destination policy model. Product adapters may narrow it.
 - Delegation is serial: only one child runs at a time.
+- Every `run_pattern` invocation persists an unlisted piece in the configured
+  space. An aborted run stops its piece, but no piece is ever deleted, and each
+  piece's source-history revision is a storage-retention root the piece list
+  does not reveal. Tooling that enumerates a space's contents from the piece
+  list must not assume the list is exhaustive; there is no garbage collection
+  for these pieces yet.
 - Model-driven dynamic skill activation is not implemented. Skills are
   explicitly preloaded by the caller; child skills are profile-controlled.
 - Resume is transcript-oriented and does not recover an arbitrary partially

--- a/packages/cf-harness/docs/ROADMAP.md
+++ b/packages/cf-harness/docs/ROADMAP.md
@@ -59,7 +59,22 @@ permanently growing implementation plan.
   reads routed through the same policy surface as `read_file`, with CFC
   observation metadata on the source bytes.
 
-## 6. Evolve skills only from concrete needs
+## 6. Bound, retain, and check `run_pattern` side effects
+
+- Give each `run_pattern` invocation a resource ceiling and deadline, aligned
+  with the hosted-pattern-authoring prerequisite that an agent session runs
+  under configured limits on model tokens, tool invocations, CPU, memory, and
+  disk; today only the abort signal bounds an invocation.
+- Define a retention and deletion story for the unlisted pieces `run_pattern`
+  persists and for the run-state handle table. Each invocation leaves a
+  stopped-but-never-deleted piece whose source-history revision is a
+  storage-retention root invisible to the piece list, and handle-table entries
+  accumulate per run with no expiry.
+- Add an outbound CFC flow check on compiled pattern source. The current
+  space-equality gate covers inbound input links only; nothing checks what a
+  compiled pattern's own code sends out of the session space.
+
+## 7. Evolve skills only from concrete needs
 
 - Keep explicit caller preload and profile-scoped child skills as the stable
   path.

--- a/packages/cf-harness/docs/ROADMAP.md
+++ b/packages/cf-harness/docs/ROADMAP.md
@@ -1,7 +1,7 @@
 # cf-harness Roadmap
 
 Status: live, non-normative\
-Last reviewed: 2026-07-22
+Last reviewed: 2026-08-13
 
 This document lists remaining work. Shipped milestones belong in
 [CURRENT_STATE.md](CURRENT_STATE.md), tests, and history rather than in a
@@ -51,7 +51,15 @@ permanently growing implementation plan.
 - Extend resume only where external side-effect replay semantics can be made
   explicit and testable.
 
-## 5. Evolve skills only from concrete needs
+## 5. Mediate file-based pattern sources for `run_pattern`
+
+- `run_pattern` accepts only inline `sourceText`; a workspace-file source (the
+  former `sourcePath`) is a trusted-host read channel whose compile diagnostics
+  can exfiltrate file content, so reintroduce it only as a mediated capability:
+  reads routed through the same policy surface as `read_file`, with CFC
+  observation metadata on the source bytes.
+
+## 6. Evolve skills only from concrete needs
 
 - Keep explicit caller preload and profile-scoped child skills as the stable
   path.

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -431,7 +431,8 @@ Options:
   --workspace <path>            Workspace host path (defaults to current directory)
   --cwd <path>                  Initial working directory inside the workspace
   --focus-root <path>           Narrow exploration to a workspace subpath when possible
-  --allow-tool <tool>           Restrict available tools (repeatable: bash | read_file | view_image | web_fetch | read_skill_resource | run_skill_script | edit_file | write_file | delegate_task)
+  --allow-tool <tool>           Restrict available tools (repeatable: bash | read_file | view_image | web_fetch | read_skill_resource | run_skill_script | edit_file | write_file | delegate_task | run_pattern);
+                                run_pattern additionally requires the three --fabric-* session flags
   --allow-skill-script <spec>   Allow exact skill script execution (repeatable: skill:scripts/path)
   --allow-subagent-profile <p>  Authorize delegate_task to spawn a profile (repeatable: default | browser | web_fetch | web_search)
   --output-mode <mode>          operator | batch (default: operator)
@@ -551,6 +552,7 @@ const CLI_PARENT_TOOL_IDS = [
   "edit_file",
   "write_file",
   "delegate_task",
+  "run_pattern",
 ] as const satisfies readonly BuiltinToolId[];
 
 const uniqueStrings = <T extends string>(
@@ -1579,6 +1581,17 @@ export const parseCfHarnessCliArgs = async (
       identityKeyPath: resolve(cwd, fabricIdentity!),
       space: fabricSpace!,
     };
+  }
+  // An allowlisted `run_pattern` with no session to run it against is a
+  // configuration contradiction, surfaced here rather than as a tool that is
+  // silently absent from the run.
+  if (
+    allowedToolIds?.includes("run_pattern") === true &&
+    fabricSession === undefined
+  ) {
+    throw new Error(
+      "--allow-tool run_pattern requires a fabric session; missing --fabric-api-url, --fabric-identity, and --fabric-space",
+    );
   }
   const apiKey = env.CF_HARNESS_API_KEY ?? env.OPENAI_API_KEY;
   const apiKeySource = env.CF_HARNESS_API_KEY !== undefined

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -15,6 +15,7 @@ import type { JSONSchema } from "@commonfabric/api";
 import { type CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import {
   DEFAULT_GATEWAY_BASE_URL,
+  type HarnessFabricSessionConfig,
   type HarnessGatewayAuthMode,
   type HarnessModelProviderId,
   isHarnessModelProviderId,
@@ -169,6 +170,9 @@ const CLI_STRING_FLAGS = [
   "sandbox-docker-runtime",
   "max-model-turns",
   "fabric-mount",
+  "fabric-api-url",
+  "fabric-identity",
+  "fabric-space",
   "host-mount",
   "browser-access-lease-id",
   "browser-access-cdp-url",
@@ -238,6 +242,7 @@ export interface CfHarnessCliConfig {
   sandboxImage?: string;
   sandboxDockerRuntime?: string;
   fabricMount?: string;
+  fabricSession?: HarnessFabricSessionConfig;
   hostMounts: readonly CfHarnessHostMountConfig[];
 }
 
@@ -286,6 +291,7 @@ export interface CfHarnessCliCapabilities {
     structuredAuthControl: true;
     credentialHealth: true;
     loomLocalOwnerBinding: false;
+    runPattern: true;
   };
 }
 
@@ -467,6 +473,10 @@ Options:
   --sandbox-image <image>       Docker image for the runsc-cfc sandbox (default: ${DEFAULT_DOCKER_RUNSC_IMAGE})
   --sandbox-docker-runtime <n>  Docker runtime for the sandbox (default: runsc-cfc)
   --fabric-mount <path>         Host path for a Fabric FUSE mount (mounted at /fabric in the sandbox)
+  --fabric-api-url <url>        Deployed Fabric API URL for the run_pattern tool
+  --fabric-identity <path>      PKCS#8 identity keyfile for the run_pattern fabric session
+  --fabric-space <space>        Target space (name or did:key) for the run_pattern tool;
+                                all three --fabric-* session flags go together
   --host-mount <spec>           Extra host bind mount (repeatable: name=<id>,source=<host>,target=<sandbox>,mode=readonly|writable)
   --max-model-turns <n>         Maximum model turns before aborting
   --print-transcript            Print the final transcript JSON after the response
@@ -485,6 +495,9 @@ Environment:
   CF_HARNESS_PROMPT_CACHE_MODE  Default value for --prompt-cache-mode
   CF_HARNESS_HOME               Local cf-harness credential/config directory
   CF_HARNESS_DOCKER_NETWORK_MODE none | bridge | host (default: bridge)
+  CF_HARNESS_FABRIC_API_URL     Default value for --fabric-api-url
+  CF_HARNESS_FABRIC_IDENTITY    Default value for --fabric-identity
+  CF_HARNESS_FABRIC_SPACE       Default value for --fabric-space
   CF_HARNESS_SANDBOX_IMAGE      Default value for --sandbox-image
   CF_HARNESS_SANDBOX_DOCKER_RUNTIME Default value for --sandbox-docker-runtime
   ${CFC_RESULT_DIR_ENV} Fallback for --cfc-result-dir
@@ -581,6 +594,7 @@ export const createCfHarnessCliCapabilities = (): CfHarnessCliCapabilities => ({
     structuredAuthControl: true,
     credentialHealth: true,
     loomLocalOwnerBinding: false,
+    runPattern: true,
   },
 });
 
@@ -1335,6 +1349,9 @@ export const parseCfHarnessCliArgs = async (
         "CF_HARNESS_CFC_ENFORCEMENT_MODE",
       ),
       CF_CFC_MODE: Deno.env.get("CF_CFC_MODE"),
+      CF_HARNESS_FABRIC_API_URL: Deno.env.get("CF_HARNESS_FABRIC_API_URL"),
+      CF_HARNESS_FABRIC_IDENTITY: Deno.env.get("CF_HARNESS_FABRIC_IDENTITY"),
+      CF_HARNESS_FABRIC_SPACE: Deno.env.get("CF_HARNESS_FABRIC_SPACE"),
       CF_HARNESS_SANDBOX_IMAGE: Deno.env.get("CF_HARNESS_SANDBOX_IMAGE"),
       CF_HARNESS_SANDBOX_DOCKER_RUNTIME: Deno.env.get(
         "CF_HARNESS_SANDBOX_DOCKER_RUNTIME",
@@ -1511,6 +1528,58 @@ export const parseCfHarnessCliArgs = async (
   const fabricMount = rawFabricMount !== undefined
     ? resolve(cwd, rawFabricMount)
     : undefined;
+  const fabricSessionFlagValue = (
+    flag: "fabric-api-url" | "fabric-identity" | "fabric-space",
+    envValue: string | undefined,
+  ): string | undefined => {
+    const raw = typeof args[flag] === "string"
+      ? args[flag].trim()
+      : nonEmptyEnvValue(envValue);
+    if (raw === "") {
+      throw new Error(`--${flag} requires a non-empty value`);
+    }
+    return raw;
+  };
+  const fabricApiUrl = fabricSessionFlagValue(
+    "fabric-api-url",
+    env.CF_HARNESS_FABRIC_API_URL,
+  );
+  const fabricIdentity = fabricSessionFlagValue(
+    "fabric-identity",
+    env.CF_HARNESS_FABRIC_IDENTITY,
+  );
+  const fabricSpace = fabricSessionFlagValue(
+    "fabric-space",
+    env.CF_HARNESS_FABRIC_SPACE,
+  );
+  let fabricSession: HarnessFabricSessionConfig | undefined;
+  if (
+    fabricApiUrl !== undefined || fabricIdentity !== undefined ||
+    fabricSpace !== undefined
+  ) {
+    const missing = [
+      ...(fabricApiUrl === undefined ? ["--fabric-api-url"] : []),
+      ...(fabricIdentity === undefined ? ["--fabric-identity"] : []),
+      ...(fabricSpace === undefined ? ["--fabric-space"] : []),
+    ];
+    if (missing.length > 0) {
+      throw new Error(
+        `--fabric-api-url, --fabric-identity, and --fabric-space configure one fabric session and go together; missing ${
+          missing.join(", ")
+        }`,
+      );
+    }
+    try {
+      new URL(fabricApiUrl!);
+    } catch {
+      throw new Error(`--fabric-api-url must be a valid URL: ${fabricApiUrl}`);
+    }
+    fabricSession = {
+      apiUrl: fabricApiUrl!,
+      identityKeyPath: resolve(cwd, fabricIdentity!),
+      space: fabricSpace!,
+    };
+  }
   const apiKey = env.CF_HARNESS_API_KEY ?? env.OPENAI_API_KEY;
   const apiKeySource = env.CF_HARNESS_API_KEY !== undefined
     ? "CF_HARNESS_API_KEY"
@@ -1575,6 +1644,7 @@ export const parseCfHarnessCliArgs = async (
     ...(sandboxImage !== undefined ? { sandboxImage } : {}),
     ...(sandboxDockerRuntime !== undefined ? { sandboxDockerRuntime } : {}),
     ...(fabricMount !== undefined ? { fabricMount } : {}),
+    ...(fabricSession !== undefined ? { fabricSession } : {}),
     hostMounts,
   };
 };
@@ -2835,6 +2905,9 @@ export const runCfHarnessCli = async (
           ? { browserAccess: parsed.browserAccess }
           : {}),
         cfcEnforcementModeOverride: parsed.cfcEnforcementModeOverride,
+        ...(parsed.fabricSession !== undefined
+          ? { fabricSession: parsed.fabricSession }
+          : {}),
         ...(effectiveRunManifest !== undefined
           ? { runManifest: effectiveRunManifest }
           : {}),
@@ -2994,6 +3067,9 @@ export const runCfHarnessCli = async (
           ? { browserAccess: parsed.browserAccess }
           : {}),
         cfcEnforcementModeOverride: parsed.cfcEnforcementModeOverride,
+        ...(parsed.fabricSession !== undefined
+          ? { fabricSession: parsed.fabricSession }
+          : {}),
         ...(runManifest !== undefined ? { runManifest } : {}),
         ...(parsed.runManifestPath !== undefined
           ? { runManifestPath: parsed.runManifestPath }

--- a/packages/cf-harness/src/config.ts
+++ b/packages/cf-harness/src/config.ts
@@ -15,6 +15,19 @@ export const DEFAULT_GATEWAY_BASE_URL = "https://llm.stage.commontools.dev/";
 export const DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE =
   "enforce-explicit" as const satisfies CfcEnforcementMode;
 export type HarnessGatewayAuthMode = "bearer" | "none";
+
+/**
+ * Connection settings for the trusted Fabric session behind the
+ * `run_pattern` tool: the deployed API URL, a PKCS#8 identity keyfile path
+ * on the host, and the target space (a name or a `did:key`). When present,
+ * the run offers `run_pattern` in the parent tool surface; when absent, the
+ * tool is unavailable.
+ */
+export interface HarnessFabricSessionConfig {
+  apiUrl: string;
+  identityKeyPath: string;
+  space: string;
+}
 export type HarnessModelProviderId =
   | "openai-compatible-gateway"
   | "openai-codex";
@@ -30,6 +43,7 @@ interface HarnessCommonConfig {
   artifactRoot?: string;
   cfcEnforcementMode: CfcEnforcementMode;
   cfcEnforcementModeSource: HarnessCfcEnforcementModeSource;
+  fabricSession?: HarnessFabricSessionConfig;
   sandbox?: DockerRunscSandboxConfig;
   runManifest?: HarnessRunManifest;
   runManifestPath?: string;
@@ -78,6 +92,7 @@ export interface ResolveHarnessConfigOptions {
   cfcEnforcementMode?: CfcEnforcementMode;
   inheritedCfcEnforcementMode?: CfcEnforcementMode;
   cfcEnforcementModeOverride?: string | CfcEnforcementMode;
+  fabricSession?: HarnessFabricSessionConfig;
   sandbox?: DockerRunscSandboxConfig;
   runManifest?: HarnessRunManifest;
   runManifestPath?: string;
@@ -214,6 +229,9 @@ export const resolveHarnessConfig = (
       : {}),
     cfcEnforcementMode: resolveCfcEnforcementMode(options),
     cfcEnforcementModeSource: resolveCfcEnforcementModeSource(options),
+    ...(options.fabricSession !== undefined
+      ? { fabricSession: options.fabricSession }
+      : {}),
   };
   if (modelProvider === "openai-codex") {
     return {

--- a/packages/cf-harness/src/contracts/policy.ts
+++ b/packages/cf-harness/src/contracts/policy.ts
@@ -87,7 +87,6 @@ export interface HarnessDelegateTaskToolInputSummary {
 export interface HarnessRunPatternToolInputSummary {
   type: "cf-harness.tool-input-summary";
   toolId: "run_pattern";
-  sourcePath?: string;
   sourceTextBytes?: number;
   sourceTextDigest?: string;
   inputCount?: number;

--- a/packages/cf-harness/src/contracts/policy.ts
+++ b/packages/cf-harness/src/contracts/policy.ts
@@ -84,6 +84,17 @@ export interface HarnessDelegateTaskToolInputSummary {
   maxModelTurns?: number;
 }
 
+export interface HarnessRunPatternToolInputSummary {
+  type: "cf-harness.tool-input-summary";
+  toolId: "run_pattern";
+  sourcePath?: string;
+  sourceTextBytes?: number;
+  sourceTextDigest?: string;
+  inputCount?: number;
+  resultSchemaBytes?: number;
+  resultSchemaDigest?: string;
+}
+
 export type HarnessToolInputSummary =
   | HarnessBashToolInputSummary
   | HarnessReadFileToolInputSummary
@@ -93,6 +104,7 @@ export type HarnessToolInputSummary =
   | HarnessEditFileToolInputSummary
   | HarnessWriteFileToolInputSummary
   | HarnessDelegateTaskToolInputSummary
+  | HarnessRunPatternToolInputSummary
   | {
     type: "cf-harness.tool-input-summary";
     toolId: BuiltinToolId;

--- a/packages/cf-harness/src/contracts/tool-descriptor.ts
+++ b/packages/cf-harness/src/contracts/tool-descriptor.ts
@@ -10,7 +10,8 @@ export type BuiltinToolId =
   | "run_skill_script"
   | "edit_file"
   | "write_file"
-  | "delegate_task";
+  | "delegate_task"
+  | "run_pattern";
 
 export const DEFAULT_PARENT_TOOL_IDS = [
   "bash",

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -120,9 +120,18 @@ import {
   type RunSkillScriptToolOutput,
 } from "./tools/run-skill-script.ts";
 import {
+  type RunPatternToolInput,
+  type RunPatternToolOutput,
+} from "./tools/run-pattern.ts";
+import {
   type WriteFileToolInput,
   type WriteFileToolOutput,
 } from "./tools/write-file.ts";
+import {
+  cacheHarnessFabricSessionFactory,
+  createHarnessFabricSessionFactory,
+  type HarnessFabricSessionFactory,
+} from "./fabric-session.ts";
 import { getBuiltinTool } from "./tools/registry.ts";
 
 export interface BuiltinToolInputMap {
@@ -136,6 +145,7 @@ export interface BuiltinToolInputMap {
   edit_file: EditFileToolInput;
   write_file: WriteFileToolInput;
   delegate_task: DelegateTaskToolInput;
+  run_pattern: RunPatternToolInput;
 }
 
 export interface BuiltinToolOutputMap {
@@ -149,6 +159,7 @@ export interface BuiltinToolOutputMap {
   edit_file: EditFileToolOutput;
   write_file: WriteFileToolOutput;
   delegate_task: DelegateTaskToolOutput;
+  run_pattern: RunPatternToolOutput;
 }
 
 interface ToolOutputWithId {
@@ -170,6 +181,14 @@ export interface CreateHarnessEngineOptions
   sandboxRuntime?: SandboxRuntime;
   artifactStore?: HarnessArtifactStore;
   processRunner?: ProcessRunner;
+  /**
+   * Injection seam for the `run_pattern` fabric session, mirroring how
+   * `sandboxRuntime` replaces the engine-built sandbox. When absent, a
+   * factory is built from `fabricSession` in the resolved config; when both
+   * are absent, `run_pattern` has no session and stays out of the parent
+   * tool surface.
+   */
+  fabricSessionFactory?: HarnessFabricSessionFactory;
   now?: () => string;
 }
 
@@ -290,6 +309,7 @@ export class CfHarnessEngine {
   #runState: HarnessRunState;
   #outputSequence: number;
   readonly #now: () => string;
+  readonly #fabricSessionFactory?: HarnessFabricSessionFactory;
   readonly #hostMounts: readonly HostSandboxMount[];
   readonly #ownedRunscConfig?: DockerRunscSandboxConfig;
   readonly #resumedRun: boolean;
@@ -370,6 +390,15 @@ export class CfHarnessEngine {
     });
     const runId = options.runState?.runId ?? options.runId ??
       crypto.randomUUID();
+    // The session behind `run_pattern` is expensive and remote, so it is
+    // built lazily on the tool's first invocation and cached for the run.
+    const fabricSessionFactory = options.fabricSessionFactory ??
+      (this.config.fabricSession !== undefined
+        ? createHarnessFabricSessionFactory(this.config.fabricSession)
+        : undefined);
+    this.#fabricSessionFactory = fabricSessionFactory === undefined
+      ? undefined
+      : cacheHarnessFabricSessionFactory(fabricSessionFactory);
     const sandboxConfig = options.sandboxRuntime === undefined
       ? resolveSandboxConfig(this.config, {
         workspaceHostPath: options.workspaceHostPath,
@@ -462,6 +491,16 @@ export class CfHarnessEngine {
 
   getRunState(): HarnessRunState {
     return structuredClone(this.#runState);
+  }
+
+  /**
+   * Whether the run can build a fabric session for `run_pattern` — either
+   * an injected factory or `fabricSession` connection config. The prompt
+   * loop offers `run_pattern` in the default parent tool surface exactly
+   * when this holds.
+   */
+  get fabricSessionAvailable(): boolean {
+    return this.#fabricSessionFactory !== undefined;
   }
 
   bindRunModel(model: string): HarnessRunState {
@@ -1289,6 +1328,9 @@ export class CfHarnessEngine {
       allowedSkillScripts: this.config.allowedSkillScripts,
       skillScriptExecutionTarget: this.config.skillScriptExecutionTarget,
       browserAccess: this.config.browserAccess,
+      ...(this.#fabricSessionFactory !== undefined
+        ? { getFabricSession: this.#fabricSessionFactory }
+        : {}),
       sandbox: this.sandbox,
       hostProcessRunner: this.hostProcessRunner,
       resolvePath: (path: string) =>

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -391,7 +391,8 @@ export class CfHarnessEngine {
     const runId = options.runState?.runId ?? options.runId ??
       crypto.randomUUID();
     // The session behind `run_pattern` is expensive and remote, so it is
-    // built lazily on the tool's first invocation and cached for the run.
+    // built lazily on the tool's first invocation and cached for the run
+    // while healthy; a failed construction is retried on the next call.
     const fabricSessionFactory = options.fabricSessionFactory ??
       (this.config.fabricSession !== undefined
         ? createHarnessFabricSessionFactory(this.config.fabricSession)
@@ -960,6 +961,7 @@ export class CfHarnessEngine {
   async invokeBuiltinTool<TToolId extends BuiltinToolId>(
     toolId: TToolId,
     input: BuiltinToolInputMap[TToolId],
+    options: { signal?: AbortSignal } = {},
   ): Promise<BuiltinToolInvocationResult<TToolId>> {
     const tool = getBuiltinTool(toolId);
     if (tool === undefined) {
@@ -974,7 +976,7 @@ export class CfHarnessEngine {
     );
     try {
       const output = await tool.invoke(
-        this.#createToolContext(),
+        this.#createToolContext(options.signal),
         input,
       ) as BuiltinToolOutputMap[TToolId];
       return await this.recordBuiltinToolOutput(toolId, input, output);
@@ -1317,12 +1319,13 @@ export class CfHarnessEngine {
     return invocation;
   }
 
-  #createToolContext() {
+  #createToolContext(signal?: AbortSignal) {
     return {
       runId: this.#runState.runId,
       cfcEnforcementMode: this.#runState.cfcEnforcementMode,
       currentDir: this.#runState.currentDir,
       workspaceHostPath: this.workspaceHostPath,
+      ...(signal !== undefined ? { signal } : {}),
       skillRegistry: this.#runState.skillRegistry,
       skillActivations: this.#runState.skillActivations,
       allowedSkillScripts: this.config.allowedSkillScripts,

--- a/packages/cf-harness/src/fabric-session.ts
+++ b/packages/cf-harness/src/fabric-session.ts
@@ -1,0 +1,86 @@
+/**
+ * The trusted Fabric session behind the `run_pattern` tool: a
+ * `PiecesController` connected to a deployed API, built lazily on the tool's
+ * first invocation and cached for the rest of the run. Everything here runs
+ * on the trusted host side — nothing in this module ever enters the docker
+ * sandbox.
+ */
+
+import { createSession, Identity, isDID } from "@commonfabric/identity";
+import { PiecesController } from "@commonfabric/piece/ops";
+import {
+  experimentalOptionsFromEnv,
+  Runtime,
+  runtimePresets,
+} from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache";
+import type { HarnessFabricSessionConfig } from "./config.ts";
+
+export interface HarnessFabricSession {
+  pieces: PiecesController;
+}
+
+/**
+ * Builds the run's Fabric session. The engine caches the result, so a
+ * factory is called at most once per run; a construction failure surfaces as
+ * an ordinary `run_pattern` tool-output error and is not retried.
+ */
+export type HarnessFabricSessionFactory = () => Promise<HarnessFabricSession>;
+
+/**
+ * Default factory over `config`: loads the PKCS#8 identity from disk and
+ * connects a `PiecesController` to the deployed API. A space name goes
+ * through `PiecesController.initialize`; a `did:key` space needs the manual
+ * `createSession` path, since `initialize` accepts only a name.
+ */
+export const createHarnessFabricSessionFactory = (
+  config: HarnessFabricSessionConfig,
+): HarnessFabricSessionFactory =>
+async () => {
+  const identity = await Identity.fromPkcs8(
+    await Deno.readFile(config.identityKeyPath),
+  );
+  const apiUrl = new URL(config.apiUrl);
+  if (!isDID(config.space)) {
+    return {
+      pieces: await PiecesController.initialize({
+        apiUrl,
+        identity,
+        spaceName: config.space,
+      }),
+    };
+  }
+  const session = await createSession({ identity, spaceDid: config.space });
+  // Shared first-party posture for client runtimes against a deployed API,
+  // matching `PiecesController.initialize`; trust provenance stays a visible
+  // delta of this session.
+  const runtime = new Runtime(runtimePresets.remoteClient({
+    apiUrl,
+    storageManager: StorageManager.open({
+      as: session.as,
+      memoryHost: apiUrl,
+      spaceIdentity: session.spaceIdentity,
+    }),
+    experimental: experimentalOptionsFromEnv((key) => Deno.env.get(key)),
+    trustSnapshotProvider: () => ({
+      id: `principal:${session.as.did()}`,
+      actingPrincipal: session.as.did(),
+    }),
+  }));
+  const pieces = new PiecesController(session, runtime);
+  await pieces.synced();
+  return { pieces };
+};
+
+/**
+ * Wraps `factory` so the session is built once and shared by every
+ * invocation in the run. A rejected construction is cached too: the run
+ * carries no reconnect logic, so a session that failed to build stays
+ * failed.
+ */
+export const cacheHarnessFabricSessionFactory = (
+  factory: HarnessFabricSessionFactory,
+): HarnessFabricSessionFactory => {
+  let session: Promise<HarnessFabricSession> | undefined;
+  return () => session ??= factory();
+};

--- a/packages/cf-harness/src/fabric-session.ts
+++ b/packages/cf-harness/src/fabric-session.ts
@@ -76,11 +76,12 @@ async () => {
  * Wraps `factory` so the session is built once and shared by every
  * invocation in the run. A rejected construction is cached too: the run
  * carries no reconnect logic, so a session that failed to build stays
- * failed.
+ * failed. A synchronous throw from the factory folds into that cached
+ * rejection, so the factory is never invoked twice.
  */
 export const cacheHarnessFabricSessionFactory = (
   factory: HarnessFabricSessionFactory,
 ): HarnessFabricSessionFactory => {
   let session: Promise<HarnessFabricSession> | undefined;
-  return () => session ??= factory();
+  return () => session ??= Promise.resolve().then(factory);
 };

--- a/packages/cf-harness/src/fabric-session.ts
+++ b/packages/cf-harness/src/fabric-session.ts
@@ -1,9 +1,9 @@
 /**
  * The trusted Fabric session behind the `run_pattern` tool: a
  * `PiecesController` connected to a deployed API, built lazily on the tool's
- * first invocation and cached for the rest of the run. Everything here runs
- * on the trusted host side — nothing in this module ever enters the docker
- * sandbox.
+ * first invocation and cached for the rest of the run while healthy.
+ * Everything here runs on the trusted host side — nothing in this module ever
+ * enters the docker sandbox.
  */
 
 import { createSession, Identity, isDID } from "@commonfabric/identity";
@@ -21,17 +21,37 @@ export interface HarnessFabricSession {
 }
 
 /**
- * Builds the run's Fabric session. The engine caches the result, so a
- * factory is called at most once per run; a construction failure surfaces as
- * an ordinary `run_pattern` tool-output error and is not retried.
+ * Builds the run's Fabric session. The engine caches a healthy result so a
+ * factory is called at most once per run while its session holds; a
+ * construction failure surfaces as an ordinary `run_pattern` tool-output
+ * error, and the next tool call invokes the factory again.
  */
 export type HarnessFabricSessionFactory = () => Promise<HarnessFabricSession>;
+
+/**
+ * Surfaces a permanent authorization denial for the controller's configured
+ * space. The storage layer's per-space contract (see
+ * `authorizationError()` in `packages/runner/src/storage/v2.ts`) keeps
+ * `synced()` quiet on a denial — a denied cross-space link must stay a silent
+ * absent read — so a caller that must reach a specific space reads the
+ * per-space status after `synced()` and throws it deliberately. Minimal
+ * replica of the CLI's post-`synced()` check in `packages/cli/lib/piece.ts`.
+ */
+const assertSpaceAuthorized = (pieces: PiecesController): void => {
+  const authorizationError = pieces.runtime.storageManager
+    .authorizationError?.(pieces.getSpace());
+  if (authorizationError) {
+    throw authorizationError;
+  }
+};
 
 /**
  * Default factory over `config`: loads the PKCS#8 identity from disk and
  * connects a `PiecesController` to the deployed API. A space name goes
  * through `PiecesController.initialize`; a `did:key` space needs the manual
- * `createSession` path, since `initialize` accepts only a name.
+ * `createSession` path, since `initialize` accepts only a name. Either way,
+ * an unauthorized space fails construction rather than yielding a session
+ * whose every read is a silent absence.
  */
 export const createHarnessFabricSessionFactory = (
   config: HarnessFabricSessionConfig,
@@ -42,13 +62,13 @@ async () => {
   );
   const apiUrl = new URL(config.apiUrl);
   if (!isDID(config.space)) {
-    return {
-      pieces: await PiecesController.initialize({
-        apiUrl,
-        identity,
-        spaceName: config.space,
-      }),
-    };
+    const pieces = await PiecesController.initialize({
+      apiUrl,
+      identity,
+      spaceName: config.space,
+    });
+    assertSpaceAuthorized(pieces);
+    return { pieces };
   }
   const session = await createSession({ identity, spaceDid: config.space });
   // Shared first-party posture for client runtimes against a deployed API,
@@ -69,19 +89,34 @@ async () => {
   }));
   const pieces = new PiecesController(session, runtime);
   await pieces.synced();
+  assertSpaceAuthorized(pieces);
   return { pieces };
 };
 
 /**
- * Wraps `factory` so the session is built once and shared by every
- * invocation in the run. A rejected construction is cached too: the run
- * carries no reconnect logic, so a session that failed to build stays
- * failed. A synchronous throw from the factory folds into that cached
- * rejection, so the factory is never invoked twice.
+ * Wraps `factory` so a healthy session is built once and shared by every
+ * invocation in the run. An in-flight construction is shared too, but a
+ * REJECTED construction clears the cache: the failure still reaches every
+ * caller awaiting it, and the next tool call invokes the factory again
+ * rather than replaying a terminal failure for the rest of the run. A
+ * synchronous throw from the factory folds into the same rejected promise.
  */
 export const cacheHarnessFabricSessionFactory = (
   factory: HarnessFabricSessionFactory,
 ): HarnessFabricSessionFactory => {
   let session: Promise<HarnessFabricSession> | undefined;
-  return () => session ??= Promise.resolve().then(factory);
+  return () => {
+    if (session === undefined) {
+      const attempt: Promise<HarnessFabricSession> = Promise.resolve()
+        .then(factory)
+        .catch((error) => {
+          if (session === attempt) {
+            session = undefined;
+          }
+          throw error;
+        });
+      session = attempt;
+    }
+    return session;
+  };
 };

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -564,6 +564,36 @@ const summarizeToolInput = async (
           : {}),
       };
     }
+    case "run_pattern": {
+      const sourceTextSummary = typeof input.sourceText === "string"
+        ? await summarizeSensitiveText(input.sourceText)
+        : undefined;
+      const resultSchemaSummary = input.resultSchema !== undefined
+        ? await summarizeSensitiveText(JSON.stringify(input.resultSchema))
+        : undefined;
+      return {
+        type: "cf-harness.tool-input-summary",
+        toolId,
+        ...(typeof input.sourcePath === "string"
+          ? { sourcePath: input.sourcePath }
+          : {}),
+        ...(sourceTextSummary !== undefined
+          ? {
+            sourceTextBytes: sourceTextSummary.bytes,
+            sourceTextDigest: sourceTextSummary.digest,
+          }
+          : {}),
+        ...(isObjectRecord(input.inputs)
+          ? { inputCount: Object.keys(input.inputs).length }
+          : {}),
+        ...(resultSchemaSummary !== undefined
+          ? {
+            resultSchemaBytes: resultSchemaSummary.bytes,
+            resultSchemaDigest: resultSchemaSummary.digest,
+          }
+          : {}),
+      };
+    }
   }
   return {
     type: "cf-harness.tool-input-summary",
@@ -1838,8 +1868,14 @@ export class CfHarnessPromptLoop {
     this.#parentToolAllowanceMode = options.allowedToolIds === undefined
       ? "all-builtins"
       : "restricted";
+    // `run_pattern` joins the default parent tool surface exactly when the
+    // run can build a fabric session; without one the tool is absent rather
+    // than present-but-failing.
     this.#allowedToolIds = new Set(
-      options.allowedToolIds ?? DEFAULT_PROMPT_LOOP_TOOL_IDS,
+      options.allowedToolIds ??
+        (this.engine.fabricSessionAvailable
+          ? [...DEFAULT_PROMPT_LOOP_TOOL_IDS, "run_pattern" as const]
+          : DEFAULT_PROMPT_LOOP_TOOL_IDS),
     );
     this.#nativeModelToolIds = options.nativeModelToolIds ?? [];
     this.#allowedSubagentProfiles = new Set(
@@ -2754,6 +2790,12 @@ export class CfHarnessPromptLoop {
       return {
         output: toModelFacingWebFetchOutput(output as WebFetchToolOutput),
       };
+    }
+    if (toolId === "run_pattern" && isObjectRecord(output)) {
+      // The persisted artifact keeps the raw result value; the model sees
+      // only `resultRef` and the schema-sanitized `value`.
+      const { rawValue: _rawValue, ...publicOutput } = output;
+      return { output: stripInternalCfcFields(publicOutput) };
     }
     if (!toolOutputNeedsSandboxMediation(toolId, output)) {
       return { output: stripInternalCfcFields(output) };

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -94,6 +94,7 @@ import { isEditFileToolSuccessOutput } from "./tools/edit-file.ts";
 import { isReadFileToolSuccessOutput } from "./tools/read-file.ts";
 import { isStructuredFileToolErrorOutput } from "./tools/file-errors.ts";
 import { isViewImageToolSuccessOutput } from "./tools/view-image.ts";
+import { scrubBareFabricIdentifiers } from "./tools/run-pattern.ts";
 import {
   toModelFacingWebFetchOutput,
   type WebFetchToolOutput,
@@ -574,9 +575,6 @@ const summarizeToolInput = async (
       return {
         type: "cf-harness.tool-input-summary",
         toolId,
-        ...(typeof input.sourcePath === "string"
-          ? { sourcePath: input.sourcePath }
-          : {}),
         ...(sourceTextSummary !== undefined
           ? {
             sourceTextBytes: sourceTextSummary.bytes,
@@ -2617,6 +2615,7 @@ export class CfHarnessPromptLoop {
         : await this.#invokeBuiltinTool(
           toolCall.function.name,
           input,
+          signal,
         );
     } catch (error) {
       recordActivity({
@@ -2799,9 +2798,19 @@ export class CfHarnessPromptLoop {
       // — a bare fabric identifier the handle boundary never swaps, and
       // redundant with `resultRef` since the piece cell is the result cell.
       // The model sees only `resultRef` and the schema-sanitized `value`.
+      // Free-text diagnostic fields can embed compiler-generated bare
+      // fabric identifiers the handle boundary never swaps, so those fields
+      // are scrubbed here; the artifact keeps the raw text.
       const { rawValue: _rawValue, pieceId: _pieceId, ...publicOutput } =
         output;
-      return { output: stripInternalCfcFields(publicOutput) };
+      const scrubbed: Record<string, unknown> = { ...publicOutput };
+      for (const field of ["message", "valueError"]) {
+        const text = scrubbed[field];
+        if (typeof text === "string") {
+          scrubbed[field] = scrubBareFabricIdentifiers(text);
+        }
+      }
+      return { output: stripInternalCfcFields(scrubbed) };
     }
     if (!toolOutputNeedsSandboxMediation(toolId, output)) {
       return { output: stripInternalCfcFields(output) };
@@ -2896,6 +2905,7 @@ export class CfHarnessPromptLoop {
   async #invokeBuiltinTool<TToolId extends BuiltinToolId>(
     toolId: TToolId,
     input: Record<string, unknown>,
+    signal?: AbortSignal,
   ): Promise<{
     output: Awaited<ReturnType<CfHarnessEngine["invokeBuiltinTool"]>>["output"];
     resultRef: ToolResultRef;
@@ -2903,6 +2913,7 @@ export class CfHarnessPromptLoop {
     const result = await this.engine.invokeBuiltinTool(
       toolId,
       input as unknown as BuiltinToolInputMap[TToolId],
+      signal !== undefined ? { signal } : {},
     );
     return {
       output: result.output,

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -1868,14 +1868,17 @@ export class CfHarnessPromptLoop {
     this.#parentToolAllowanceMode = options.allowedToolIds === undefined
       ? "all-builtins"
       : "restricted";
-    // `run_pattern` joins the default parent tool surface exactly when the
-    // run can build a fabric session; without one the tool is absent rather
-    // than present-but-failing.
+    // `run_pattern` joins the tool surface exactly when the run can build a
+    // fabric session; without one the tool is absent rather than
+    // present-but-failing, even when an explicit allowlist names it.
+    const requestedToolIds = options.allowedToolIds ??
+      (this.engine.fabricSessionAvailable
+        ? [...DEFAULT_PROMPT_LOOP_TOOL_IDS, "run_pattern" as const]
+        : DEFAULT_PROMPT_LOOP_TOOL_IDS);
     this.#allowedToolIds = new Set(
-      options.allowedToolIds ??
-        (this.engine.fabricSessionAvailable
-          ? [...DEFAULT_PROMPT_LOOP_TOOL_IDS, "run_pattern" as const]
-          : DEFAULT_PROMPT_LOOP_TOOL_IDS),
+      this.engine.fabricSessionAvailable
+        ? requestedToolIds
+        : requestedToolIds.filter((toolId) => toolId !== "run_pattern"),
     );
     this.#nativeModelToolIds = options.nativeModelToolIds ?? [];
     this.#allowedSubagentProfiles = new Set(
@@ -2792,9 +2795,12 @@ export class CfHarnessPromptLoop {
       };
     }
     if (toolId === "run_pattern" && isObjectRecord(output)) {
-      // The persisted artifact keeps the raw result value; the model sees
-      // only `resultRef` and the schema-sanitized `value`.
-      const { rawValue: _rawValue, ...publicOutput } = output;
+      // The persisted artifact keeps the raw result value and the piece id
+      // — a bare fabric identifier the handle boundary never swaps, and
+      // redundant with `resultRef` since the piece cell is the result cell.
+      // The model sees only `resultRef` and the schema-sanitized `value`.
+      const { rawValue: _rawValue, pieceId: _pieceId, ...publicOutput } =
+        output;
       return { output: stripInternalCfcFields(publicOutput) };
     }
     if (!toolOutputNeedsSandboxMediation(toolId, output)) {

--- a/packages/cf-harness/src/tools/registry.ts
+++ b/packages/cf-harness/src/tools/registry.ts
@@ -5,6 +5,7 @@ import { delegateTaskTool } from "./delegate-task.ts";
 import { editFileTool } from "./edit-file.ts";
 import { readFileTool } from "./read-file.ts";
 import { readSkillResourceTool } from "./read-skill-resource.ts";
+import { runPatternTool } from "./run-pattern.ts";
 import { runSkillScriptTool } from "./run-skill-script.ts";
 import { webFetchTool } from "./web-fetch.ts";
 import { viewImageTool } from "./view-image.ts";
@@ -22,6 +23,7 @@ export const BUILTIN_TOOLS = [
   editFileTool,
   writeFileTool,
   delegateTaskTool,
+  runPatternTool,
 ] as const;
 
 export const BUILTIN_TOOL_REGISTRY = new Map<

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -28,6 +28,12 @@ export interface RunPatternToolSuccessOutput {
   status: "ok";
   /** Canonical LLM-friendly link to the piece's result cell. */
   resultRef: string;
+  /**
+   * Piece id for the persisted tool-output artifact. A bare fabric
+   * identifier the handle boundary never swaps, and the piece cell is the
+   * result cell, so the prompt loop strips it from the model-facing
+   * rendering; only `resultRef` reaches model context.
+   */
   pieceId: string;
   /** Sanitized result value; present only when `resultSchema` was given. */
   value?: unknown;

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -1,0 +1,295 @@
+import type { JSONSchema } from "@commonfabric/api";
+import { matchLLMFriendlyLink } from "@commonfabric/runner";
+import {
+  createLLMFriendlyLink,
+  parseLLMFriendlyLink,
+} from "@commonfabric/runner/shared";
+import {
+  join as joinHostPath,
+  normalize as normalizeHostPath,
+} from "@std/path";
+import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
+import { defineOwnEntry } from "../handle-table.ts";
+import {
+  parseStructuredResultSchema,
+  validateAndSanitizeStructuredResult,
+} from "../structured-result.ts";
+import type { HarnessToolDefinition } from "./types.ts";
+
+export interface RunPatternToolInput {
+  sourceText?: string;
+  sourcePath?: string;
+  inputs?: Record<string, unknown>;
+  resultSchema?: JSONSchema;
+}
+
+export interface RunPatternToolSuccessOutput {
+  outputId: string;
+  status: "ok";
+  /** Canonical LLM-friendly link to the piece's result cell. */
+  resultRef: string;
+  pieceId: string;
+  /** Sanitized result value; present only when `resultSchema` was given. */
+  value?: unknown;
+  linkedStringCount?: number;
+  /** Why `value` is absent despite a `resultSchema`: the raw result did not
+   * match the schema. */
+  valueError?: string;
+  /**
+   * Raw result value for the persisted tool-output artifact. Stripped from
+   * the model-facing rendering by the prompt loop, so only the sanitized
+   * `value` reaches model context.
+   */
+  rawValue?: unknown;
+}
+
+export interface RunPatternToolErrorOutput {
+  outputId: string;
+  status: "compile-error" | "error";
+  message: string;
+}
+
+export type RunPatternToolOutput =
+  | RunPatternToolSuccessOutput
+  | RunPatternToolErrorOutput;
+
+export const isRunPatternToolSuccessOutput = (
+  output: unknown,
+): output is RunPatternToolSuccessOutput =>
+  typeof output === "object" && output !== null &&
+  "status" in output && output.status === "ok" &&
+  "resultRef" in output && typeof output.resultRef === "string";
+
+export const runPatternToolDescriptor: HarnessToolDescriptor = {
+  toolId: "run_pattern",
+  title: "Run Pattern",
+  description:
+    "Compile and run a Common Fabric pattern in the configured space, returning a reference to its live result cell. The piece is not registered in the space's piece list.",
+  effectClass: "side-effect",
+  inputSchema: {
+    type: "object",
+    properties: {
+      sourceText: {
+        type: "string",
+        description:
+          "Pattern source (TypeScript/TSX). Exactly one of sourceText and sourcePath must be given.",
+      },
+      sourcePath: {
+        type: "string",
+        description:
+          "Workspace-relative path to a pattern source file. Exactly one of sourceText and sourcePath must be given.",
+      },
+      inputs: {
+        type: "object",
+        additionalProperties: true,
+        description:
+          'Input values for the pattern. A string value that is a whole-string LLM-friendly link (e.g. "/of:fid1:abc.../path") is passed as a live cell reference; everything else passes through as plain JSON.',
+      },
+      resultSchema: {
+        anyOf: [
+          { type: "boolean" },
+          { type: "object", additionalProperties: true },
+        ],
+        description:
+          "Optional JSON Schema for the result value. When provided, the sanitized result value is returned alongside resultRef.",
+      },
+    },
+    additionalProperties: false,
+  } satisfies JSONSchema,
+  outputSchema: {
+    oneOf: [{
+      type: "object",
+      properties: {
+        outputId: { type: "string" },
+        status: { type: "string", enum: ["ok"] },
+        resultRef: { type: "string" },
+        pieceId: { type: "string" },
+        value: {},
+        linkedStringCount: { type: "integer", minimum: 0 },
+        valueError: { type: "string" },
+      },
+      required: ["outputId", "status", "resultRef", "pieceId"],
+      additionalProperties: false,
+    }, {
+      type: "object",
+      properties: {
+        outputId: { type: "string" },
+        status: { type: "string", enum: ["compile-error", "error"] },
+        message: { type: "string" },
+      },
+      required: ["outputId", "status", "message"],
+      additionalProperties: false,
+    }],
+  } satisfies JSONSchema,
+  tags: ["fabric", "pattern", "piece"],
+};
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+/**
+ * A raw result may hold values `JSON.stringify` cannot carry into the
+ * tool-output artifact (a cycle through the reactive graph, say), so the
+ * round trip both proves serializability and normalizes cells to their
+ * serialized link form. Returns `undefined` when the value does not
+ * serialize.
+ */
+const asSerializableValue = (value: unknown): unknown => {
+  try {
+    const encoded = JSON.stringify(value);
+    return encoded === undefined ? undefined : JSON.parse(encoded);
+  } catch {
+    return undefined;
+  }
+};
+
+export const runPatternTool: HarnessToolDefinition<
+  RunPatternToolInput,
+  RunPatternToolOutput
+> = {
+  descriptor: runPatternToolDescriptor,
+  async invoke(context, input) {
+    const outputId = context.nextOutputId("run_pattern");
+    const errorOutput = (
+      status: RunPatternToolErrorOutput["status"],
+      message: string,
+    ): RunPatternToolErrorOutput => ({ outputId, status, message });
+    if (context.getFabricSession === undefined) {
+      return errorOutput(
+        "error",
+        "run_pattern requires a fabric session; configure --fabric-api-url, --fabric-identity, and --fabric-space",
+      );
+    }
+    if (
+      (input.sourceText === undefined) === (input.sourcePath === undefined)
+    ) {
+      return errorOutput(
+        "error",
+        "run_pattern requires exactly one of sourceText and sourcePath",
+      );
+    }
+    let parsedResultSchema;
+    try {
+      parsedResultSchema = parseStructuredResultSchema(input.resultSchema, {
+        label: "run_pattern resultSchema",
+      });
+    } catch (error) {
+      return errorOutput("error", errorMessage(error));
+    }
+    let sourceText: string;
+    if (input.sourcePath !== undefined) {
+      const workspaceRoot = context.workspaceHostPath;
+      if (workspaceRoot === undefined) {
+        return errorOutput(
+          "error",
+          "run_pattern sourcePath requires a workspace",
+        );
+      }
+      const resolved = normalizeHostPath(
+        joinHostPath(workspaceRoot, input.sourcePath),
+      );
+      if (!await context.isHostPathWithinWorkspace(resolved)) {
+        return errorOutput(
+          "error",
+          `run_pattern sourcePath resolves outside the workspace: ${input.sourcePath}`,
+        );
+      }
+      try {
+        sourceText = await Deno.readTextFile(resolved);
+      } catch (error) {
+        return errorOutput(
+          "error",
+          `run_pattern could not read sourcePath ${input.sourcePath}: ${
+            errorMessage(error)
+          }`,
+        );
+      }
+    } else {
+      sourceText = input.sourceText!;
+    }
+    let session;
+    try {
+      session = await context.getFabricSession();
+    } catch (error) {
+      return errorOutput(
+        "error",
+        `fabric session unavailable: ${errorMessage(error)}`,
+      );
+    }
+    const { pieces } = session;
+    const space = pieces.getSpace();
+    // Whole-string LLM-friendly links become live cell references; the
+    // prompt loop has already resolved any handle tokens, so the strings
+    // seen here carry canonical addresses. Non-link strings and non-strings
+    // pass through as plain JSON.
+    let pieceInput: Record<string, unknown> | undefined;
+    if (input.inputs !== undefined) {
+      const converted: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(input.inputs)) {
+        let entry = value;
+        if (
+          typeof value === "string" && matchLLMFriendlyLink.test(value.trim())
+        ) {
+          try {
+            entry = pieces.runtime.getCellFromLink(
+              parseLLMFriendlyLink(value, space),
+            );
+          } catch {
+            // Not a parseable link after all — keep the plain string.
+          }
+        }
+        defineOwnEntry(converted, key, entry);
+      }
+      pieceInput = converted;
+    }
+    let piece;
+    try {
+      // Deliberately unregistered: no `pieces.add()` and no default-pattern
+      // touch, so the piece never appears in the space's piece list. The
+      // origin must be URL-shaped or the piece renders as detached.
+      piece = await pieces.create(sourceText, {
+        ...(pieceInput !== undefined ? { input: pieceInput } : {}),
+        start: true,
+        origin: `https://cf-harness.invalid/run/${context.runId}`,
+      });
+    } catch (error) {
+      // Compiler diagnostics are the model's feedback loop, so the raw
+      // message goes back unredacted.
+      return errorOutput("compile-error", errorMessage(error));
+    }
+    await pieces.runtime.settled();
+    await pieces.synced();
+    const resultCell = await piece.result.getCell();
+    const resultRef = createLLMFriendlyLink(
+      resultCell.getAsNormalizedFullLink(),
+      space,
+    );
+    const rawValue = asSerializableValue(await piece.result.get());
+    let value: unknown;
+    let linkedStringCount: number | undefined;
+    let valueError: string | undefined;
+    if (parsedResultSchema !== undefined) {
+      try {
+        const sanitized = validateAndSanitizeStructuredResult({
+          schema: parsedResultSchema.schema,
+          value: rawValue,
+          opaqueHandleId: outputId,
+        });
+        value = sanitized.value;
+        linkedStringCount = sanitized.linkedStringCount;
+      } catch (error) {
+        valueError = errorMessage(error);
+      }
+    }
+    return {
+      outputId,
+      status: "ok",
+      resultRef,
+      pieceId: piece.id,
+      ...(value !== undefined ? { value } : {}),
+      ...(linkedStringCount !== undefined ? { linkedStringCount } : {}),
+      ...(valueError !== undefined ? { valueError } : {}),
+      ...(rawValue !== undefined ? { rawValue } : {}),
+    };
+  },
+};

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -340,16 +340,16 @@ export const runPatternTool: HarnessToolDefinition<
     let piece: PieceController<unknown>;
     try {
       // Deliberately unregistered: no `pieces.add()` and no default-pattern
-      // touch, so the piece never appears in the space's piece list. The
-      // origin must be URL-shaped or the piece renders as detached.
+      // touch, so the piece never appears in the space's piece list. No
+      // origin either: model-authored source starts detached under the piece
+      // source-lifecycle spec, and run→piece provenance lives in the run's
+      // persisted artifacts — run-state and the tool-output artifact record
+      // the `pieceId`.
       const pieceCell = await pieces.runPersistent(
         pattern,
         pieceInput ?? {},
         undefined,
-        {
-          start: true,
-          origin: `https://cf-harness.invalid/run/${context.runId}`,
-        },
+        { start: true },
       );
       piece = new PieceController(pieces, pieceCell);
     } catch (error) {

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -1,12 +1,9 @@
 import type { JSONSchema } from "@commonfabric/api";
-import {
-  type Cell,
-  compileAndSavePattern,
-  matchLLMFriendlyLink,
-} from "@commonfabric/runner";
+import { type Cell, compileAndSavePattern } from "@commonfabric/runner";
 import { validateAgainstSchema } from "@commonfabric/runner/cfc";
 import {
   createLLMFriendlyLink,
+  matchLLMFriendlyLink,
   parseLLMFriendlyLink,
 } from "@commonfabric/runner/shared";
 import { PieceController } from "@commonfabric/piece/ops";

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -1,13 +1,15 @@
 import type { JSONSchema } from "@commonfabric/api";
-import { matchLLMFriendlyLink } from "@commonfabric/runner";
+import {
+  type Cell,
+  compileAndSavePattern,
+  matchLLMFriendlyLink,
+} from "@commonfabric/runner";
+import { validateAgainstSchema } from "@commonfabric/runner/cfc";
 import {
   createLLMFriendlyLink,
   parseLLMFriendlyLink,
 } from "@commonfabric/runner/shared";
-import {
-  join as joinHostPath,
-  normalize as normalizeHostPath,
-} from "@std/path";
+import { PieceController } from "@commonfabric/piece/ops";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import { defineOwnEntry } from "../handle-table.ts";
 import {
@@ -18,10 +20,12 @@ import type { HarnessToolDefinition } from "./types.ts";
 
 export interface RunPatternToolInput {
   sourceText?: string;
-  sourcePath?: string;
   inputs?: Record<string, unknown>;
   resultSchema?: JSONSchema;
 }
+
+/** Upper bound on `sourceText`, enforced with a structured tool error. */
+export const RUN_PATTERN_MAX_SOURCE_TEXT_BYTES = 256 * 1024;
 
 export interface RunPatternToolSuccessOutput {
   outputId: string;
@@ -51,7 +55,7 @@ export interface RunPatternToolSuccessOutput {
 
 export interface RunPatternToolErrorOutput {
   outputId: string;
-  status: "compile-error" | "error";
+  status: "compile-error" | "error" | "cancelled";
   message: string;
 }
 
@@ -77,13 +81,7 @@ export const runPatternToolDescriptor: HarnessToolDescriptor = {
     properties: {
       sourceText: {
         type: "string",
-        description:
-          "Pattern source (TypeScript/TSX). Exactly one of sourceText and sourcePath must be given.",
-      },
-      sourcePath: {
-        type: "string",
-        description:
-          "Workspace-relative path to a pattern source file. Exactly one of sourceText and sourcePath must be given.",
+        description: "Pattern source (TypeScript/TSX). At most 256 KiB.",
       },
       inputs: {
         type: "object",
@@ -100,6 +98,7 @@ export const runPatternToolDescriptor: HarnessToolDescriptor = {
           "Optional JSON Schema for the result value. When provided, the sanitized result value is returned alongside resultRef.",
       },
     },
+    required: ["sourceText"],
     additionalProperties: false,
   } satisfies JSONSchema,
   outputSchema: {
@@ -120,7 +119,10 @@ export const runPatternToolDescriptor: HarnessToolDescriptor = {
       type: "object",
       properties: {
         outputId: { type: "string" },
-        status: { type: "string", enum: ["compile-error", "error"] },
+        status: {
+          type: "string",
+          enum: ["compile-error", "error", "cancelled"],
+        },
         message: { type: "string" },
       },
       required: ["outputId", "status", "message"],
@@ -132,6 +134,25 @@ export const runPatternToolDescriptor: HarnessToolDescriptor = {
 
 const errorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
+
+/**
+ * Replaces bare fabric identifiers in model-facing diagnostic text with a
+ * fixed placeholder. Compiler diagnostics can embed compiler-generated bare
+ * tagged hashes (e.g. the `/fid1:.../` virtual module roots), DIDs, and
+ * `data:` URIs — none of which the handle boundary swaps, since it only
+ * handles the `of:`/`computed:` schemed link forms. A negative lookbehind
+ * leaves those schemed forms (and `cfh:` handle tokens) alone: their embedded
+ * hash is always preceded by a colon. Raw text stays in the persisted
+ * artifact; only the model-facing rendering is scrubbed.
+ */
+export const scrubBareFabricIdentifiers = (text: string): string =>
+  text
+    .replaceAll(/\bdata:[^\s"'`)\]}]+/g, "[fabric-id]")
+    .replaceAll(/\bdid:[a-z0-9]+:[A-Za-z0-9._%-]+/g, "[fabric-id]")
+    .replaceAll(
+      /(?<![A-Za-z0-9:])[A-Za-z0-9]+:[A-Za-z0-9_-]{43}(?![A-Za-z0-9_-])/g,
+      "[fabric-id]",
+    );
 
 /**
  * A raw result may hold values `JSON.stringify` cannot carry into the
@@ -149,6 +170,43 @@ const asSerializableValue = (value: unknown): unknown => {
   }
 };
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * Awaits `work` unless `signal` aborts first. Resolution (not rejection)
+ * signals the abort so the losing promise never surfaces as an unhandled
+ * rejection; the signal is the only cancellation source — no timeout puts an
+ * upper bound on `work` completing.
+ */
+const raceWithAbort = async (
+  work: Promise<void>,
+  signal: AbortSignal | undefined,
+): Promise<"completed" | "aborted"> => {
+  if (signal === undefined) {
+    await work;
+    return "completed";
+  }
+  if (signal.aborted) {
+    work.catch(() => {});
+    return "aborted";
+  }
+  let onAbort!: () => void;
+  const aborted = new Promise<"aborted">((resolve) => {
+    onAbort = () => resolve("aborted");
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+  try {
+    return await Promise.race([
+      work.then(() => "completed" as const),
+      aborted,
+    ]);
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+    work.catch(() => {});
+  }
+};
+
 export const runPatternTool: HarnessToolDefinition<
   RunPatternToolInput,
   RunPatternToolOutput
@@ -160,18 +218,25 @@ export const runPatternTool: HarnessToolDefinition<
       status: RunPatternToolErrorOutput["status"],
       message: string,
     ): RunPatternToolErrorOutput => ({ outputId, status, message });
+    const cancelledOutput = (): RunPatternToolErrorOutput =>
+      errorOutput("cancelled", "run_pattern was cancelled");
     if (context.getFabricSession === undefined) {
       return errorOutput(
         "error",
         "run_pattern requires a fabric session; configure --fabric-api-url, --fabric-identity, and --fabric-space",
       );
     }
-    if (
-      (input.sourceText === undefined) === (input.sourcePath === undefined)
-    ) {
+    if (input.sourceText === undefined) {
+      return errorOutput("error", "run_pattern requires sourceText");
+    }
+    const sourceText = input.sourceText;
+    const sourceTextBytes = new TextEncoder().encode(sourceText).length;
+    if (sourceTextBytes > RUN_PATTERN_MAX_SOURCE_TEXT_BYTES) {
       return errorOutput(
         "error",
-        "run_pattern requires exactly one of sourceText and sourcePath",
+        `run_pattern sourceText exceeds the ${
+          RUN_PATTERN_MAX_SOURCE_TEXT_BYTES / 1024
+        } KiB limit (${sourceTextBytes} bytes)`,
       );
     }
     let parsedResultSchema;
@@ -181,37 +246,6 @@ export const runPatternTool: HarnessToolDefinition<
       });
     } catch (error) {
       return errorOutput("error", errorMessage(error));
-    }
-    let sourceText: string;
-    if (input.sourcePath !== undefined) {
-      const workspaceRoot = context.workspaceHostPath;
-      if (workspaceRoot === undefined) {
-        return errorOutput(
-          "error",
-          "run_pattern sourcePath requires a workspace",
-        );
-      }
-      const resolved = normalizeHostPath(
-        joinHostPath(workspaceRoot, input.sourcePath),
-      );
-      if (!await context.isHostPathWithinWorkspace(resolved)) {
-        return errorOutput(
-          "error",
-          `run_pattern sourcePath resolves outside the workspace: ${input.sourcePath}`,
-        );
-      }
-      try {
-        sourceText = await Deno.readTextFile(resolved);
-      } catch (error) {
-        return errorOutput(
-          "error",
-          `run_pattern could not read sourcePath ${input.sourcePath}: ${
-            errorMessage(error)
-          }`,
-        );
-      }
-    } else {
-      sourceText = input.sourceText!;
     }
     let session;
     try {
@@ -224,11 +258,18 @@ export const runPatternTool: HarnessToolDefinition<
     }
     const { pieces } = session;
     const space = pieces.getSpace();
+    const signal = context.signal;
+    if (signal?.aborted) {
+      return cancelledOutput();
+    }
     // Whole-string LLM-friendly links become live cell references; the
     // prompt loop has already resolved any handle tokens, so the strings
     // seen here carry canonical addresses. Non-link strings and non-strings
-    // pass through as plain JSON.
+    // pass through as plain JSON. A link that resolves outside the session's
+    // configured space is refused before anything is created: the session's
+    // authority ends at its own space.
     let pieceInput: Record<string, unknown> | undefined;
+    const liveCellInputs: Array<{ key: string; cell: Cell<unknown> }> = [];
     if (input.inputs !== undefined) {
       const converted: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(input.inputs)) {
@@ -236,35 +277,98 @@ export const runPatternTool: HarnessToolDefinition<
         if (
           typeof value === "string" && matchLLMFriendlyLink.test(value.trim())
         ) {
+          let link;
           try {
-            entry = pieces.runtime.getCellFromLink(
-              parseLLMFriendlyLink(value, space),
-            );
+            link = parseLLMFriendlyLink(value, space);
           } catch {
             // Not a parseable link after all — keep the plain string.
+          }
+          if (link !== undefined) {
+            if (link.space !== space) {
+              return errorOutput(
+                "error",
+                `run_pattern input "${key}" reference targets another space; only references into the configured session space are allowed`,
+              );
+            }
+            const cell = pieces.runtime.getCellFromLink(link);
+            liveCellInputs.push({ key, cell });
+            entry = cell;
           }
         }
         defineOwnEntry(converted, key, entry);
       }
       pieceInput = converted;
     }
-    let piece;
+    let pattern;
+    try {
+      pattern = await compileAndSavePattern(pieces.runtime, sourceText, {
+        space,
+      });
+    } catch (error) {
+      // Compiler diagnostics are the model's feedback loop, so the full
+      // message goes into the artifact; the prompt loop scrubs bare fabric
+      // identifiers from the model-facing rendering.
+      return errorOutput("compile-error", errorMessage(error));
+    }
+    // A live-cell input's current value must match the compiled pattern's
+    // argument schema for its key before any piece exists, so a mismatch is
+    // a model-correctable error rather than a persisted broken piece.
+    const argumentProperties = isRecord(pattern.argumentSchema) &&
+        isRecord(pattern.argumentSchema.properties)
+      ? pattern.argumentSchema.properties
+      : undefined;
+    if (argumentProperties !== undefined) {
+      for (const { key, cell } of liveCellInputs) {
+        const propertySchema = argumentProperties[key];
+        if (propertySchema === undefined) {
+          continue;
+        }
+        await cell.sync();
+        const failure = validateAgainstSchema(
+          propertySchema as JSONSchema,
+          cell.get(),
+          pattern.argumentSchema,
+        );
+        if (failure !== undefined) {
+          return errorOutput(
+            "error",
+            `run_pattern input "${key}" does not match the pattern's argument schema: ${failure}`,
+          );
+        }
+      }
+    }
+    let piece: PieceController<unknown>;
     try {
       // Deliberately unregistered: no `pieces.add()` and no default-pattern
       // touch, so the piece never appears in the space's piece list. The
       // origin must be URL-shaped or the piece renders as detached.
-      piece = await pieces.create(sourceText, {
-        ...(pieceInput !== undefined ? { input: pieceInput } : {}),
-        start: true,
-        origin: `https://cf-harness.invalid/run/${context.runId}`,
-      });
+      const pieceCell = await pieces.runPersistent(
+        pattern,
+        pieceInput ?? {},
+        undefined,
+        {
+          start: true,
+          origin: `https://cf-harness.invalid/run/${context.runId}`,
+        },
+      );
+      piece = new PieceController(pieces, pieceCell);
     } catch (error) {
-      // Compiler diagnostics are the model's feedback loop, so the raw
-      // message goes back unredacted.
-      return errorOutput("compile-error", errorMessage(error));
+      return errorOutput("error", errorMessage(error));
     }
-    await pieces.runtime.settled();
-    await pieces.synced();
+    const barrier = (async () => {
+      await pieces.runtime.settled();
+      await pieces.synced();
+    })();
+    if (await raceWithAbort(barrier, signal) === "aborted") {
+      // Stop without the usual `stopPiece` idle wait: the abort path must
+      // not wait on the very scheduler the signal is escaping.
+      try {
+        pieces.runtime.runner.stop(piece.getCell());
+      } catch {
+        // Best-effort: the cancelled output stands either way.
+      }
+      return cancelledOutput();
+    }
     const resultCell = await piece.result.getCell();
     const resultRef = createLLMFriendlyLink(
       resultCell.getAsNormalizedFullLink(),

--- a/packages/cf-harness/src/tools/types.ts
+++ b/packages/cf-harness/src/tools/types.ts
@@ -16,6 +16,7 @@ import type {
   HarnessSkillScriptExecutionTarget,
 } from "../contracts/skill.ts";
 import type { HarnessBrowserAccessLease } from "../contracts/browser-access.ts";
+import type { HarnessFabricSession } from "../fabric-session.ts";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import type { ToolOutputId } from "../contracts/tool-result.ts";
 import type { ProcessRunner } from "../sandbox/process-runner.ts";
@@ -29,6 +30,12 @@ export interface HarnessToolContext {
   allowedSkillScripts?: readonly HarnessAllowedSkillScript[];
   skillScriptExecutionTarget: HarnessSkillScriptExecutionTarget;
   browserAccess?: HarnessBrowserAccessLease;
+  /**
+   * The run's trusted Fabric session, lazy and cached by the engine.
+   * Undefined when the run has no fabric session configured, which also
+   * keeps `run_pattern` out of the tool surface.
+   */
+  getFabricSession?: () => Promise<HarnessFabricSession>;
   sandbox: SandboxRuntime;
   hostProcessRunner: ProcessRunner;
   currentDir: string;

--- a/packages/cf-harness/src/tools/types.ts
+++ b/packages/cf-harness/src/tools/types.ts
@@ -36,6 +36,12 @@ export interface HarnessToolContext {
    * keeps `run_pattern` out of the tool surface.
    */
   getFabricSession?: () => Promise<HarnessFabricSession>;
+  /**
+   * The prompt loop's run-level abort signal, when the invocation came
+   * through the loop. The only cancellation source a tool may honor — no
+   * tool-side timeout supplements it. Tools are free to ignore it.
+   */
+  signal?: AbortSignal;
   sandbox: SandboxRuntime;
   hostProcessRunner: ProcessRunner;
   currentDir: string;

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -383,6 +383,46 @@ Deno.test("parseCfHarnessCliArgs rejects a partial fabric session naming the mis
   );
 });
 
+Deno.test("parseCfHarnessCliArgs rejects --allow-tool run_pattern without the fabric session flags", async () => {
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        ["--prompt", "hi", "--allow-tool", "run_pattern"],
+        { cwd: "/tmp/project", env: {} },
+      ),
+    Error,
+    "missing --fabric-api-url, --fabric-identity, and --fabric-space",
+  );
+});
+
+Deno.test("parseCfHarnessCliArgs accepts --allow-tool run_pattern alongside the fabric session flags", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    [
+      "--prompt",
+      "hi",
+      "--allow-tool",
+      "run_pattern",
+      "--fabric-api-url",
+      "https://toolshed.example/",
+      "--fabric-identity",
+      "keys/agent.pkcs8",
+      "--fabric-space",
+      "my-space",
+    ],
+    { cwd: "/tmp/project", env: {} },
+  );
+
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.allowedToolIds, ["run_pattern"]);
+  assertEquals(parsed.fabricSession, {
+    apiUrl: "https://toolshed.example/",
+    identityKeyPath: "/tmp/project/keys/agent.pkcs8",
+    space: "my-space",
+  });
+});
+
 Deno.test("parseCfHarnessCliArgs rejects a fabric API URL that does not parse", async () => {
   await assertRejects(
     () =>
@@ -1672,7 +1712,10 @@ Deno.test("runCfHarnessCli prints machine-readable capabilities", async () => {
   assertEquals(capabilities.type, "cf-harness.capabilities");
   assertEquals(capabilities.version, 1);
   assertEquals(capabilities.parentToolIds.includes("web_fetch"), true);
+  assertEquals(capabilities.parentToolIds.includes("run_pattern"), true);
   assertEquals(capabilities.parentToolIds.includes("bash-no-sandbox"), false);
+  assertEquals(capabilities.builtinToolIds.includes("run_pattern"), true);
+  assertEquals(capabilities.features.runPattern, true);
   assertEquals(capabilities.builtinToolIds.includes("bash-no-sandbox"), true);
   assertEquals(capabilities.subagentProfiles.includes("web_search"), true);
   assertEquals(capabilities.nativeModelToolIds.includes("google_search"), true);

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -314,6 +314,96 @@ Deno.test("parseCfHarnessCliArgs accepts CFC mode from environment", async () =>
   assertEquals(parsed.cfcEnforcementModeOverride, "enforce-strict");
 });
 
+Deno.test("parseCfHarnessCliArgs parses the three --fabric-* session flags together", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    [
+      "--prompt",
+      "hi",
+      "--fabric-api-url",
+      "https://toolshed.example/",
+      "--fabric-identity",
+      "keys/agent.pkcs8",
+      "--fabric-space",
+      "my-space",
+    ],
+    { cwd: "/tmp/project", env: {} },
+  );
+
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.fabricSession, {
+    apiUrl: "https://toolshed.example/",
+    identityKeyPath: "/tmp/project/keys/agent.pkcs8",
+    space: "my-space",
+  });
+
+  const unset = await parseCfHarnessCliArgs(
+    ["--prompt", "hi"],
+    { cwd: "/tmp/project", env: {} },
+  );
+  if ("help" in unset) {
+    throw new Error("expected config result");
+  }
+  assertEquals(unset.fabricSession, undefined);
+});
+
+Deno.test("parseCfHarnessCliArgs accepts fabric session settings from the environment", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    ["--prompt", "hi"],
+    {
+      cwd: "/tmp/project",
+      env: {
+        CF_HARNESS_FABRIC_API_URL: "https://toolshed.example/",
+        CF_HARNESS_FABRIC_IDENTITY: "/keys/agent.pkcs8",
+        CF_HARNESS_FABRIC_SPACE: "did:key:z6MkfExample",
+      },
+    },
+  );
+
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.fabricSession, {
+    apiUrl: "https://toolshed.example/",
+    identityKeyPath: "/keys/agent.pkcs8",
+    space: "did:key:z6MkfExample",
+  });
+});
+
+Deno.test("parseCfHarnessCliArgs rejects a partial fabric session naming the missing flags", async () => {
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        ["--prompt", "hi", "--fabric-space", "my-space"],
+        { cwd: "/tmp/project", env: {} },
+      ),
+    Error,
+    "missing --fabric-api-url, --fabric-identity",
+  );
+});
+
+Deno.test("parseCfHarnessCliArgs rejects a fabric API URL that does not parse", async () => {
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        [
+          "--prompt",
+          "hi",
+          "--fabric-api-url",
+          "not a url",
+          "--fabric-identity",
+          "keys/agent.pkcs8",
+          "--fabric-space",
+          "my-space",
+        ],
+        { cwd: "/tmp/project", env: {} },
+      ),
+    Error,
+    "--fabric-api-url must be a valid URL",
+  );
+});
+
 Deno.test("parseCfHarnessCliArgs resolves run manifest paths", async () => {
   const parsed = await parseCfHarnessCliArgs(
     ["--prompt", "hi", "--run-manifest", "loom-run.json"],

--- a/packages/cf-harness/test/fabric-session.test.ts
+++ b/packages/cf-harness/test/fabric-session.test.ts
@@ -21,15 +21,36 @@ describe("fabric-session", () => {
       expect(calls).toBe(1);
     });
 
-    it("invokes a factory that throws synchronously exactly once across two calls, rejecting both", async () => {
+    it("shares one in-flight construction between concurrent calls even when it rejects", async () => {
       let calls = 0;
       const cached = cacheHarnessFabricSessionFactory(() => {
         calls += 1;
-        throw new Error("construction failed");
+        return Promise.reject(new Error("construction failed"));
+      });
+      const first = cached();
+      const second = cached();
+      expect(second).toBe(first);
+      await expect(first).rejects.toThrow("construction failed");
+      expect(calls).toBe(1);
+    });
+
+    // Only a HEALTHY session is cached: a rejected construction clears the
+    // cache so a later tool call retries the factory instead of replaying a
+    // terminal failure for the rest of the run. This deliberately supersedes
+    // the earlier behavior of caching the rejection forever.
+    it("invokes a synchronously-throwing factory again after its rejection settles, and a later attempt can succeed", async () => {
+      let calls = 0;
+      const session = {} as HarnessFabricSession;
+      const cached = cacheHarnessFabricSessionFactory(() => {
+        calls += 1;
+        if (calls === 1) {
+          throw new Error("construction failed");
+        }
+        return Promise.resolve(session);
       });
       await expect(cached()).rejects.toThrow("construction failed");
-      await expect(cached()).rejects.toThrow("construction failed");
-      expect(calls).toBe(1);
+      expect(await cached()).toBe(session);
+      expect(calls).toBe(2);
     });
   });
 });

--- a/packages/cf-harness/test/fabric-session.test.ts
+++ b/packages/cf-harness/test/fabric-session.test.ts
@@ -1,0 +1,35 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  cacheHarnessFabricSessionFactory,
+  type HarnessFabricSession,
+} from "../src/fabric-session.ts";
+
+describe("fabric-session", () => {
+  describe("cacheHarnessFabricSessionFactory()", () => {
+    it("returns the same session promise for every call", async () => {
+      let calls = 0;
+      const session = {} as HarnessFabricSession;
+      const cached = cacheHarnessFabricSessionFactory(() => {
+        calls += 1;
+        return Promise.resolve(session);
+      });
+      const first = cached();
+      const second = cached();
+      expect(second).toBe(first);
+      expect(await first).toBe(session);
+      expect(calls).toBe(1);
+    });
+
+    it("invokes a factory that throws synchronously exactly once across two calls, rejecting both", async () => {
+      let calls = 0;
+      const cached = cacheHarnessFabricSessionFactory(() => {
+        calls += 1;
+        throw new Error("construction failed");
+      });
+      await expect(cached()).rejects.toThrow("construction failed");
+      await expect(cached()).rejects.toThrow("construction failed");
+      expect(calls).toBe(1);
+    });
+  });
+});

--- a/packages/cf-harness/test/prompt-loop-handles.test.ts
+++ b/packages/cf-harness/test/prompt-loop-handles.test.ts
@@ -8,7 +8,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createSession, Identity } from "@commonfabric/identity";
-import { PiecesController } from "@commonfabric/piece/ops";
+import { PieceController, PiecesController } from "@commonfabric/piece/ops";
 import { type Cell, isCell, Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { CfHarnessEngine } from "../src/engine.ts";
@@ -776,23 +776,23 @@ describe("prompt-loop address handles", () => {
     try {
       // Record each deployment so the second call's converted input — the
       // cell the tool resolved from the substituted ref — is observable.
+      // The tool persists through `runPersistent`, the single path that
+      // creates a piece.
       const created: Array<{
         input: Record<string, unknown> | undefined;
-        piece: Awaited<ReturnType<PiecesController["create"]>>;
+        piece: Cell<unknown>;
       }> = [];
-      const originalCreate = pieces.create.bind(pieces);
-      pieces.create = (async (
-        program: Parameters<PiecesController["create"]>[0],
-        options?: Parameters<PiecesController["create"]>[1],
-        cause?: Parameters<PiecesController["create"]>[2],
+      const originalRunPersistent = pieces.runPersistent.bind(pieces);
+      pieces.runPersistent = (async (
+        ...args: Parameters<PiecesController["runPersistent"]>
       ) => {
-        const piece = await originalCreate(program, options, cause);
+        const piece = await originalRunPersistent(...args);
         created.push({
-          input: options?.input as Record<string, unknown> | undefined,
+          input: args[1] as Record<string, unknown> | undefined,
           piece,
         });
         return piece;
-      }) as PiecesController["create"];
+      }) as PiecesController["runPersistent"];
       const doublingSource = [
         "import { computed, pattern } from 'commonfabric';",
         "export default pattern<{ n: number }, { doubled: number }>(",
@@ -899,7 +899,8 @@ describe("prompt-loop address handles", () => {
       expect(created.length).toBe(2);
       const src = created[1]?.input?.src;
       expect(isCell(src)).toBe(true);
-      const firstResult = await created[0]!.piece.result.getCell();
+      const firstResult = await new PieceController(pieces, created[0]!.piece)
+        .result.getCell();
       expect((src as Cell<unknown>).getAsNormalizedFullLink().id).toBe(
         firstResult.getAsNormalizedFullLink().id,
       );

--- a/packages/cf-harness/test/prompt-loop-handles.test.ts
+++ b/packages/cf-harness/test/prompt-loop-handles.test.ts
@@ -7,6 +7,10 @@
 
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import { PiecesController } from "@commonfabric/piece/ops";
+import { type Cell, isCell, Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { CfHarnessEngine } from "../src/engine.ts";
 import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
 import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
@@ -751,5 +755,155 @@ describe("prompt-loop address handles", () => {
       request.command.includes("note ")
     );
     expect(dispatched?.command).toContain(command);
+  });
+
+  it("carries a `run_pattern` result ref to the model as a token and resolves that token in the next call's input back to the ref", async () => {
+    const runId = "run-handles-run-pattern";
+    const signer = await Identity.fromPassphrase("run-pattern handles");
+    const storageManager = StorageManager.emulate({ as: signer });
+    const fabricRuntime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+    });
+    const pieces = new PiecesController(
+      await createSession({
+        identity: signer,
+        spaceName: `run-pattern-handles-${crypto.randomUUID()}`,
+      }),
+      fabricRuntime,
+    );
+    await pieces.synced();
+    try {
+      // Record each deployment so the second call's converted input — the
+      // cell the tool resolved from the substituted ref — is observable.
+      const created: Array<{
+        input: Record<string, unknown> | undefined;
+        piece: Awaited<ReturnType<PiecesController["create"]>>;
+      }> = [];
+      const originalCreate = pieces.create.bind(pieces);
+      pieces.create = (async (
+        program: Parameters<PiecesController["create"]>[0],
+        options?: Parameters<PiecesController["create"]>[1],
+        cause?: Parameters<PiecesController["create"]>[2],
+      ) => {
+        const piece = await originalCreate(program, options, cause);
+        created.push({
+          input: options?.input as Record<string, unknown> | undefined,
+          piece,
+        });
+        return piece;
+      }) as PiecesController["create"];
+      const doublingSource = [
+        "import { computed, pattern } from 'commonfabric';",
+        "export default pattern<{ n: number }, { doubled: number }>(",
+        "  ({ n }) => ({ doubled: computed(() => n * 2) }),",
+        ");",
+      ].join("\n");
+      const echoSource = [
+        "import { computed, pattern } from 'commonfabric';",
+        "interface Source { doubled: number; }",
+        "export default pattern<{ src: Source }, { copied: number }>(",
+        "  ({ src }) => ({ copied: computed(() => src.doubled) }),",
+        ");",
+      ].join("\n");
+      const runPatternTurn = (
+        id: string,
+        args: Record<string, unknown>,
+      ) => ({
+        choices: [{
+          index: 0,
+          message: {
+            role: "assistant",
+            content: "",
+            tool_calls: [{
+              id,
+              type: "function",
+              function: {
+                name: "run_pattern",
+                arguments: JSON.stringify(args),
+              },
+            }],
+          },
+        }],
+      });
+      // The second call's argument depends on the token minted during the
+      // run, so the model side is scripted dynamically off the request
+      // transcript rather than as fixed payloads.
+      const requestBodies: unknown[] = [];
+      let firstToolContent: string | undefined;
+      const fetchFn: typeof fetch = (_input, init) => {
+        requestBodies.push(JSON.parse(String(init?.body)));
+        const turn = requestBodies.length;
+        let payload: unknown;
+        if (turn === 1) {
+          payload = runPatternTurn("call-1", {
+            sourceText: doublingSource,
+            inputs: { n: 3 },
+            resultSchema: {
+              type: "object",
+              properties: { doubled: { type: "number" } },
+            },
+          });
+        } else if (turn === 2) {
+          const chat = chatViewOfRequest(requestBodies[1]);
+          const toolMessage = [...chat.messages].reverse().find(
+            (message) => message.role === "tool",
+          );
+          firstToolContent = toolMessage?.content ?? "";
+          const token =
+            (JSON.parse(firstToolContent) as { resultRef: string }).resultRef;
+          payload = runPatternTurn("call-2", {
+            sourceText: echoSource,
+            inputs: { src: token },
+          });
+        } else {
+          payload = finalTurn("Done.");
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify(responsesBodyFromChatFixture(payload)), {
+            status: 200,
+          }),
+        );
+      };
+      const loop = new CfHarnessPromptLoop({
+        apiKey: "test-key",
+        engine: new CfHarnessEngine({
+          sandboxRuntime: new FakeSandboxRuntime(),
+          runId,
+          model: "gpt-5.4",
+          cfcEnforcementMode: "disabled",
+          handleMode: "session",
+          fabricSessionFactory: () => Promise.resolve({ pieces }),
+        }),
+        fetchFn,
+      });
+
+      await loop.runPrompt({ prompt: "Run the pattern twice." });
+
+      // Outbound: the model-facing tool message carries a token where the
+      // ref would be, and no raw address or raw result value.
+      const firstOutput = JSON.parse(firstToolContent!) as {
+        resultRef: string;
+        value: { doubled: number };
+        rawValue?: unknown;
+      };
+      expect(firstOutput.resultRef).toMatch(/^cfh:a:/);
+      expect(firstToolContent).not.toContain("of:");
+      expect(firstOutput.value.doubled).toBe(6);
+      expect(firstOutput.rawValue).toBeUndefined();
+      // Inbound: the token the model wrote came back to the tool as the
+      // canonical ref, which the tool converted to a live cell aimed at the
+      // first piece's result — with zero handle code in the tool itself.
+      expect(created.length).toBe(2);
+      const src = created[1]?.input?.src;
+      expect(isCell(src)).toBe(true);
+      const firstResult = await created[0]!.piece.result.getCell();
+      expect((src as Cell<unknown>).getAsNormalizedFullLink().id).toBe(
+        firstResult.getAsNormalizedFullLink().id,
+      );
+    } finally {
+      await fabricRuntime.dispose();
+      await storageManager.close();
+    }
   });
 });

--- a/packages/cf-harness/test/prompt-loop-handles.test.ts
+++ b/packages/cf-harness/test/prompt-loop-handles.test.ts
@@ -881,16 +881,18 @@ describe("prompt-loop address handles", () => {
       await loop.runPrompt({ prompt: "Run the pattern twice." });
 
       // Outbound: the model-facing tool message carries a token where the
-      // ref would be, and no raw address or raw result value.
+      // ref would be, and no raw address, raw result value, or bare piece
+      // id.
       const firstOutput = JSON.parse(firstToolContent!) as {
         resultRef: string;
         value: { doubled: number };
-        rawValue?: unknown;
       };
       expect(firstOutput.resultRef).toMatch(/^cfh:a:/);
       expect(firstToolContent).not.toContain("of:");
+      expect(firstToolContent).not.toContain("fid1:");
       expect(firstOutput.value.doubled).toBe(6);
-      expect(firstOutput.rawValue).toBeUndefined();
+      expect(firstOutput).not.toHaveProperty("rawValue");
+      expect(firstOutput).not.toHaveProperty("pieceId");
       // Inbound: the token the model wrote came back to the tool as the
       // canonical ref, which the tool converted to a live cell aimed at the
       // first piece's result — with zero handle code in the tool itself.

--- a/packages/cf-harness/test/prompt-loop-handles.test.ts
+++ b/packages/cf-harness/test/prompt-loop-handles.test.ts
@@ -872,7 +872,6 @@ describe("prompt-loop address handles", () => {
           runId,
           model: "gpt-5.4",
           cfcEnforcementMode: "disabled",
-          handleMode: "session",
           fabricSessionFactory: () => Promise.resolve({ pieces }),
         }),
         fetchFn,

--- a/packages/cf-harness/test/prompt-loop-run-pattern.test.ts
+++ b/packages/cf-harness/test/prompt-loop-run-pattern.test.ts
@@ -1,0 +1,240 @@
+/**
+ * The model-facing boundary of `run_pattern` diagnostics: compiler messages
+ * can embed compiler-generated bare fabric identifiers (the `/fid1:.../`
+ * virtual module roots) which the handle boundary deliberately never swaps,
+ * so the prompt loop scrubs them from the model-bound rendering while the
+ * persisted artifact keeps the raw text.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import { PiecesController } from "@commonfabric/piece/ops";
+import { Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { normalize } from "@std/path/posix";
+import { CfHarnessEngine } from "../src/engine.ts";
+import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
+import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
+import { scrubBareFabricIdentifiers } from "../src/tools/run-pattern.ts";
+import { responsesBodyFromChatFixture } from "./support/responses-fixture.ts";
+import type { HarnessArtifactStore } from "../src/artifacts.ts";
+import type {
+  SandboxCommandRequest,
+  SandboxCommandResult,
+  SandboxRuntime,
+  SandboxRuntimeDescription,
+  SandboxShellRequest,
+} from "../src/sandbox/types.ts";
+
+class FakeSandboxRuntime implements SandboxRuntime {
+  describe(): SandboxRuntimeDescription {
+    return {
+      kind: "docker-runsc-cfc",
+      defaultWorkingDirectory: this.defaultWorkingDirectory(),
+      cfc: { runtimeRequested: true, workspaceMountPath: "/workspace" },
+    };
+  }
+
+  resolvePath(path: string, cwd = this.defaultWorkingDirectory()): string {
+    return normalize(path.startsWith("/") ? path : `${cwd}/${path}`);
+  }
+
+  isPathWithinWorkspace(path: string): boolean {
+    return path === "/workspace" || path.startsWith("/workspace/");
+  }
+
+  isPathWithinAllowedRoots(path: string): boolean {
+    return this.isPathWithinWorkspace(path);
+  }
+
+  defaultWorkingDirectory(): string {
+    return "/workspace";
+  }
+
+  run(_request: SandboxCommandRequest): Promise<SandboxCommandResult> {
+    return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+  }
+
+  runShell(request: SandboxShellRequest): Promise<SandboxCommandResult> {
+    if (request.command.includes(CAPABILITY_PROBE_SENTINEL)) {
+      return Promise.resolve({
+        stdout: "bash\tpresent\t/bin/bash\tGNU bash, version 5.2.26(1)-release",
+        stderr: "",
+        exitCode: 0,
+      });
+    }
+    return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+  }
+}
+
+/** Artifact store that records tool outputs in memory, touching no disk. */
+class RecordingArtifactStore implements HarnessArtifactStore {
+  readonly artifactRoot = "/artifacts";
+  readonly runRoot: string;
+  readonly toolOutputs: Array<{
+    toolId: string;
+    outputId: string;
+    output: unknown;
+  }> = [];
+
+  constructor(runId: string) {
+    this.runRoot = `${this.artifactRoot}/${runId}`;
+  }
+
+  persistRunState(): Promise<string> {
+    return Promise.resolve(`${this.runRoot}/run-state.json`);
+  }
+
+  persistTranscript(): Promise<string> {
+    return Promise.resolve(`${this.runRoot}/transcript.json`);
+  }
+
+  persistCapabilitySnapshot(): Promise<string> {
+    return Promise.resolve(`${this.runRoot}/capabilities.json`);
+  }
+
+  persistCfcPolicySnapshot(): Promise<string> {
+    return Promise.resolve(`${this.runRoot}/policy-snapshot.json`);
+  }
+
+  persistRunReport(): Promise<string> {
+    return Promise.resolve(`${this.runRoot}/run-report.json`);
+  }
+
+  persistToolOutput(
+    toolId: string,
+    outputId: string,
+    output: unknown,
+  ): Promise<string> {
+    this.toolOutputs.push({ toolId, outputId, output });
+    return Promise.resolve(
+      `${this.runRoot}/tool-outputs/${outputId}-${toolId}.json`,
+    );
+  }
+}
+
+describe("prompt-loop run_pattern model boundary", () => {
+  describe("scrubBareFabricIdentifiers()", () => {
+    it("replaces bare tagged hashes, DIDs, and data URIs with the placeholder", () => {
+      const hash = "A".repeat(43);
+      expect(scrubBareFabricIdentifiers(
+        `Could not resolve "/fid1:${hash}/missing.ts".`,
+      )).toBe('Could not resolve "/[fabric-id]/missing.ts".');
+      expect(scrubBareFabricIdentifiers("space did:key:z6MkfffTest denied"))
+        .toBe("space [fabric-id] denied");
+      expect(scrubBareFabricIdentifiers("at data:application/json;base64,AAAA"))
+        .toBe("at [fabric-id]");
+    });
+
+    it("leaves schemed link forms and handle tokens untouched", () => {
+      const hash = "B".repeat(43);
+      const schemed = `/of:fid1:${hash}/items/0`;
+      const computed = `computed:fid1:${hash}`;
+      const token = "cfh:a:abcde";
+      const text = `see ${schemed} then ${computed} and ${token}`;
+      expect(scrubBareFabricIdentifiers(text)).toBe(text);
+    });
+  });
+
+  it("keeps bare fabric identifiers in compile diagnostics out of the model-facing tool message while the artifact keeps the raw text", async () => {
+    const signer = await Identity.fromPassphrase("run-pattern scrub");
+    const storageManager = StorageManager.emulate({ as: signer });
+    const fabricRuntime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+    });
+    const pieces = new PiecesController(
+      await createSession({
+        identity: signer,
+        spaceName: `run-pattern-scrub-${crypto.randomUUID()}`,
+      }),
+      fabricRuntime,
+    );
+    await pieces.synced();
+    try {
+      const runId = "run-pattern-scrub";
+      const artifactStore = new RecordingArtifactStore(runId);
+      const brokenSource = [
+        "import { computed, pattern } from 'commonfabric';",
+        "import { helper } from './missing.ts';",
+        "export default pattern<{ n: number }, { doubled: number }>(",
+        "  ({ n }) => ({ doubled: computed(() => helper(n)) }),",
+        ");",
+      ].join("\n");
+      const requestBodies: unknown[] = [];
+      const fetchFn: typeof fetch = (_input, init) => {
+        requestBodies.push(JSON.parse(String(init?.body)));
+        const payload = requestBodies.length === 1
+          ? {
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "",
+                tool_calls: [{
+                  id: "call-1",
+                  type: "function",
+                  function: {
+                    name: "run_pattern",
+                    arguments: JSON.stringify({ sourceText: brokenSource }),
+                  },
+                }],
+              },
+            }],
+          }
+          : {
+            choices: [{
+              index: 0,
+              message: { role: "assistant", content: "Done." },
+            }],
+          };
+        return Promise.resolve(
+          new Response(JSON.stringify(responsesBodyFromChatFixture(payload)), {
+            status: 200,
+          }),
+        );
+      };
+      const loop = new CfHarnessPromptLoop({
+        apiKey: "test-key",
+        engine: new CfHarnessEngine({
+          sandboxRuntime: new FakeSandboxRuntime(),
+          artifactStore,
+          runId,
+          model: "gpt-5.4",
+          cfcEnforcementMode: "disabled",
+          fabricSessionFactory: () => Promise.resolve({ pieces }),
+        }),
+        fetchFn,
+      });
+
+      const result = await loop.runPrompt({ prompt: "Run the pattern." });
+
+      const toolMessage = result.transcript.find(
+        (message) => message.role === "tool",
+      );
+      expect(toolMessage?.content).toBeDefined();
+      const toolContent = toolMessage!.content!;
+      const parsed = JSON.parse(toolContent) as {
+        status: string;
+        message: string;
+      };
+      expect(parsed.status).toBe("compile-error");
+      expect(parsed.message).toContain("[fabric-id]");
+      expect(toolContent).not.toMatch(/fid1:[A-Za-z0-9_-]{43}/);
+      expect(toolContent).not.toContain("did:key:");
+      expect(toolContent).not.toContain("data:");
+      // The persisted artifact keeps the raw diagnostic — the scrub is a
+      // model-boundary rendering, not a rewrite of the record.
+      const persisted = artifactStore.toolOutputs.find(
+        (entry) => entry.toolId === "run_pattern",
+      );
+      const persistedMessage =
+        (persisted?.output as { message: string }).message;
+      expect(persistedMessage).toMatch(/fid1:[A-Za-z0-9_-]{43}/);
+    } finally {
+      await fabricRuntime.dispose();
+      await storageManager.close();
+    }
+  });
+});

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -1874,6 +1874,109 @@ Deno.test("CfHarnessPromptLoop only advertises allowed tools when a tool allowli
   );
 });
 
+const noToolCallFetch =
+  (fetchCalls: RequestInit[]): typeof fetch => (_input, init) => {
+    fetchCalls.push(init ?? {});
+    return Promise.resolve(
+      new Response(
+        JSON.stringify(responsesBodyFromChatFixture({
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "No tool call needed.",
+            },
+          }],
+        })),
+        { status: 200 },
+      ),
+    );
+  };
+
+Deno.test("CfHarnessPromptLoop advertises run_pattern in the default tool surface when a fabric session is configured", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: "run-pattern-default-surface",
+      model: "gpt-5.4",
+      fabricSessionFactory: () =>
+        Promise.reject(new Error("session is never built in this test")),
+    }),
+    fetchFn: noToolCallFetch(fetchCalls),
+  });
+
+  await loop.runPrompt({ prompt: "Say hi." });
+
+  const request = JSON.parse(String(fetchCalls[0]?.body)) as {
+    tools: Array<{ function: { name: string } }>;
+  };
+  assertEquals(
+    chatViewOfRequest(request).tools.map((name) => name),
+    [
+      "bash",
+      "read_file",
+      "view_image",
+      "read_skill_resource",
+      "edit_file",
+      "write_file",
+      "delegate_task",
+      "run_pattern",
+    ],
+  );
+});
+
+Deno.test("CfHarnessPromptLoop advertises run_pattern from an explicit allowlist when a fabric session is configured", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    allowedToolIds: ["read_file", "run_pattern"],
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: "run-pattern-allowlisted",
+      model: "gpt-5.4",
+      fabricSessionFactory: () =>
+        Promise.reject(new Error("session is never built in this test")),
+    }),
+    fetchFn: noToolCallFetch(fetchCalls),
+  });
+
+  await loop.runPrompt({ prompt: "Say hi." });
+
+  const request = JSON.parse(String(fetchCalls[0]?.body)) as {
+    tools: Array<{ function: { name: string } }>;
+  };
+  assertEquals(
+    chatViewOfRequest(request).tools.map((name) => name),
+    ["read_file", "run_pattern"],
+  );
+});
+
+Deno.test("CfHarnessPromptLoop drops run_pattern from an explicit allowlist when no fabric session is configured", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    allowedToolIds: ["read_file", "run_pattern"],
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: "run-pattern-no-session",
+      model: "gpt-5.4",
+    }),
+    fetchFn: noToolCallFetch(fetchCalls),
+  });
+
+  await loop.runPrompt({ prompt: "Say hi." });
+
+  const request = JSON.parse(String(fetchCalls[0]?.body)) as {
+    tools: Array<{ function: { name: string } }>;
+  };
+  assertEquals(
+    chatViewOfRequest(request).tools.map((name) => name),
+    ["read_file"],
+  );
+});
+
 Deno.test("CfHarnessPromptLoop delegates one fresh child run and returns a summary-only result", async () => {
   const requestBodies: Array<{
     messages: Array<{ role: string; content: string }>;

--- a/packages/cf-harness/test/run-pattern.test.ts
+++ b/packages/cf-harness/test/run-pattern.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { join } from "@std/path";
+import { normalize } from "@std/path/posix";
+import { createSession, Identity } from "@commonfabric/identity";
+import { PiecesController } from "@commonfabric/piece/ops";
+import { Runtime } from "@commonfabric/runner";
+import { createLLMFriendlyLink } from "@commonfabric/runner/shared";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { CfHarnessEngine } from "../src/engine.ts";
+import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
+import type {
+  RunPatternToolErrorOutput,
+  RunPatternToolSuccessOutput,
+} from "../src/tools/run-pattern.ts";
+import type {
+  SandboxCommandRequest,
+  SandboxCommandResult,
+  SandboxRuntime,
+  SandboxRuntimeDescription,
+  SandboxShellRequest,
+} from "../src/sandbox/types.ts";
+
+const signer = await Identity.fromPassphrase("cf-harness run-pattern tool");
+
+const DOUBLING_PATTERN_SOURCE = [
+  "import { computed, pattern } from 'commonfabric';",
+  "interface Input { n: number; }",
+  "interface Output { doubled: number; }",
+  "export default pattern<Input, Output>(({ n }) => ({",
+  "  doubled: computed(() => n * 2),",
+  "}));",
+  "",
+].join("\n");
+
+const DOUBLED_RESULT_SCHEMA = {
+  type: "object",
+  properties: { doubled: { type: "number" } },
+  required: ["doubled"],
+} as const;
+
+class FakeSandboxRuntime implements SandboxRuntime {
+  describe(): SandboxRuntimeDescription {
+    return {
+      kind: "docker-runsc-cfc",
+      defaultWorkingDirectory: this.defaultWorkingDirectory(),
+      cfc: { runtimeRequested: true, workspaceMountPath: "/workspace" },
+    };
+  }
+
+  resolvePath(path: string, cwd = this.defaultWorkingDirectory()): string {
+    return normalize(path.startsWith("/") ? path : `${cwd}/${path}`);
+  }
+
+  isPathWithinWorkspace(path: string): boolean {
+    return path === "/workspace" || path.startsWith("/workspace/");
+  }
+
+  isPathWithinAllowedRoots(path: string): boolean {
+    return this.isPathWithinWorkspace(path);
+  }
+
+  defaultWorkingDirectory(): string {
+    return "/workspace";
+  }
+
+  run(_request: SandboxCommandRequest): Promise<SandboxCommandResult> {
+    return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+  }
+
+  runShell(request: SandboxShellRequest): Promise<SandboxCommandResult> {
+    if (request.command.includes(CAPABILITY_PROBE_SENTINEL)) {
+      return Promise.resolve({
+        stdout: "bash\tpresent\t/bin/bash\tGNU bash, version 5.2.26(1)-release",
+        stderr: "",
+        exitCode: 0,
+      });
+    }
+    return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+  }
+}
+
+describe("run-pattern", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let pieces: PiecesController;
+
+  beforeEach(async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+    });
+    pieces = new PiecesController(
+      await createSession({
+        identity: signer,
+        spaceName: `run-pattern-${crypto.randomUUID()}`,
+      }),
+      runtime,
+    );
+    await pieces.synced();
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  function createEngine(options: { workspaceHostPath?: string } = {}) {
+    return new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: `run-pattern-test-${crypto.randomUUID()}`,
+      cfcEnforcementMode: "disabled",
+      fabricSessionFactory: () => Promise.resolve({ pieces }),
+      ...(options.workspaceHostPath !== undefined
+        ? { workspaceHostPath: options.workspaceHostPath }
+        : {}),
+    });
+  }
+
+  describe("runPatternTool", () => {
+    it("runs inline `sourceText` and returns a `resultRef` with the sanitized `value`", async () => {
+      const engine = createEngine();
+      const result = await engine.invokeBuiltinTool("run_pattern", {
+        sourceText: DOUBLING_PATTERN_SOURCE,
+        inputs: { n: 21 },
+        resultSchema: DOUBLED_RESULT_SCHEMA,
+      });
+      const output = result.output as RunPatternToolSuccessOutput;
+      expect(output.status).toBe("ok");
+      expect(output.resultRef).toMatch(/^\/of:/);
+      expect(output.pieceId.length).toBeGreaterThan(0);
+      expect((output.value as { doubled: number }).doubled).toBe(42);
+      expect(output.linkedStringCount).toBe(0);
+    });
+
+    it("passes a whole-string LLM-friendly link input as a live cell reference", async () => {
+      const space = pieces.getSpace();
+      const seed = runtime.getCell<number>(space, "run-pattern-seed", {
+        type: "number",
+      });
+      const { error } = await runtime.editWithRetry((tx) => {
+        seed.withTx(tx).set(7);
+      });
+      expect(error).toBeUndefined();
+      await runtime.idle();
+      const seedRef = createLLMFriendlyLink(
+        seed.getAsNormalizedFullLink(),
+        space,
+      );
+      const engine = createEngine();
+      const result = await engine.invokeBuiltinTool("run_pattern", {
+        sourceText: DOUBLING_PATTERN_SOURCE,
+        inputs: { n: seedRef },
+        resultSchema: DOUBLED_RESULT_SCHEMA,
+      });
+      const output = result.output as RunPatternToolSuccessOutput;
+      expect(output.status).toBe("ok");
+      expect((output.value as { doubled: number }).doubled).toBe(14);
+    });
+
+    it("returns a `compile-error` output carrying the raw diagnostics without failing the run", async () => {
+      const engine = createEngine();
+      const result = await engine.invokeBuiltinTool("run_pattern", {
+        sourceText: "this is not a pattern ((",
+      });
+      const output = result.output as RunPatternToolErrorOutput;
+      expect(output.status).toBe("compile-error");
+      expect(output.message.length).toBeGreaterThan(0);
+      expect(result.runState.status).toBe("completed");
+    });
+
+    it("returns an error when both `sourceText` and `sourcePath` are given", async () => {
+      const engine = createEngine();
+      const result = await engine.invokeBuiltinTool("run_pattern", {
+        sourceText: DOUBLING_PATTERN_SOURCE,
+        sourcePath: "pattern.tsx",
+      });
+      const output = result.output as RunPatternToolErrorOutput;
+      expect(output.status).toBe("error");
+      expect(output.message).toContain("exactly one");
+    });
+
+    it("returns an error when neither `sourceText` nor `sourcePath` is given", async () => {
+      const engine = createEngine();
+      const result = await engine.invokeBuiltinTool("run_pattern", {});
+      const output = result.output as RunPatternToolErrorOutput;
+      expect(output.status).toBe("error");
+      expect(output.message).toContain("exactly one");
+    });
+
+    it("reads `sourcePath` from inside the workspace", async () => {
+      const workspace = await Deno.makeTempDir({
+        prefix: "cf-harness-run-pattern-",
+      });
+      try {
+        await Deno.writeTextFile(
+          join(workspace, "pattern.tsx"),
+          DOUBLING_PATTERN_SOURCE,
+        );
+        const engine = createEngine({ workspaceHostPath: workspace });
+        const result = await engine.invokeBuiltinTool("run_pattern", {
+          sourcePath: "pattern.tsx",
+          inputs: { n: 4 },
+          resultSchema: DOUBLED_RESULT_SCHEMA,
+        });
+        const output = result.output as RunPatternToolSuccessOutput;
+        expect(output.status).toBe("ok");
+        expect((output.value as { doubled: number }).doubled).toBe(8);
+      } finally {
+        await Deno.remove(workspace, { recursive: true });
+      }
+    });
+
+    it("returns an error for a `sourcePath` that resolves outside the workspace", async () => {
+      const workspace = await Deno.makeTempDir({
+        prefix: "cf-harness-run-pattern-",
+      });
+      try {
+        const engine = createEngine({ workspaceHostPath: workspace });
+        const result = await engine.invokeBuiltinTool("run_pattern", {
+          sourcePath: "../escape.tsx",
+        });
+        const output = result.output as RunPatternToolErrorOutput;
+        expect(output.status).toBe("error");
+        expect(output.message).toContain("outside the workspace");
+      } finally {
+        await Deno.remove(workspace, { recursive: true });
+      }
+    });
+
+    it("leaves the created piece out of the space's registered piece list", async () => {
+      const engine = createEngine();
+      const result = await engine.invokeBuiltinTool("run_pattern", {
+        sourceText: DOUBLING_PATTERN_SOURCE,
+        inputs: { n: 1 },
+      });
+      expect((result.output as RunPatternToolSuccessOutput).status).toBe("ok");
+      const registered = await pieces.getRegisteredPieces();
+      expect(registered.length).toBe(0);
+    });
+  });
+});

--- a/packages/cf-harness/test/run-pattern.test.ts
+++ b/packages/cf-harness/test/run-pattern.test.ts
@@ -212,11 +212,17 @@ describe("run-pattern", () => {
       }
     });
 
-    it("returns an error for a `sourcePath` that resolves outside the workspace", async () => {
-      const workspace = await Deno.makeTempDir({
+    it("returns an error for a `sourcePath` that resolves to an existing file outside the workspace", async () => {
+      const outer = await Deno.makeTempDir({
         prefix: "cf-harness-run-pattern-",
       });
       try {
+        const workspace = join(outer, "workspace");
+        await Deno.mkdir(workspace);
+        await Deno.writeTextFile(
+          join(outer, "escape.tsx"),
+          DOUBLING_PATTERN_SOURCE,
+        );
         const engine = createEngine({ workspaceHostPath: workspace });
         const result = await engine.invokeBuiltinTool("run_pattern", {
           sourcePath: "../escape.tsx",
@@ -225,7 +231,7 @@ describe("run-pattern", () => {
         expect(output.status).toBe("error");
         expect(output.message).toContain("outside the workspace");
       } finally {
-        await Deno.remove(workspace, { recursive: true });
+        await Deno.remove(outer, { recursive: true });
       }
     });
 

--- a/packages/cf-harness/test/run-pattern.test.ts
+++ b/packages/cf-harness/test/run-pattern.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { join } from "@std/path";
 import { normalize } from "@std/path/posix";
 import { createSession, Identity } from "@commonfabric/identity";
 import { PiecesController } from "@commonfabric/piece/ops";
@@ -9,9 +8,10 @@ import { createLLMFriendlyLink } from "@commonfabric/runner/shared";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { CfHarnessEngine } from "../src/engine.ts";
 import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
-import type {
-  RunPatternToolErrorOutput,
-  RunPatternToolSuccessOutput,
+import {
+  RUN_PATTERN_MAX_SOURCE_TEXT_BYTES,
+  type RunPatternToolErrorOutput,
+  type RunPatternToolSuccessOutput,
 } from "../src/tools/run-pattern.ts";
 import type {
   SandboxCommandRequest,
@@ -38,6 +38,25 @@ const DOUBLED_RESULT_SCHEMA = {
   properties: { doubled: { type: "number" } },
   required: ["doubled"],
 } as const;
+
+/**
+ * A minimal default-pattern program exposing the piece registry, so the
+ * space has a REAL registry rather than the detached always-empty fallback.
+ */
+const DEFAULT_PATTERN_SOURCE = [
+  "/// <cf-disable-transform />",
+  "import { handler, pattern } from 'commonfabric';",
+  "const addPiece = handler<{ piece: unknown }, { pieceRegistry: unknown[] }>(",
+  "  ({ piece }, { pieceRegistry }) => {",
+  "    pieceRegistry.push(piece);",
+  "  },",
+  "  { proxy: true },",
+  ");",
+  "export default pattern<{ pieceRegistry: unknown[] }>(({ pieceRegistry }) => ({",
+  "  pieceRegistry,",
+  "  addPiece: addPiece({ pieceRegistry }),",
+  "}));",
+].join("\n");
 
 class FakeSandboxRuntime implements SandboxRuntime {
   describe(): SandboxRuntimeDescription {
@@ -106,16 +125,28 @@ describe("run-pattern", () => {
     await storageManager?.close();
   });
 
-  function createEngine(options: { workspaceHostPath?: string } = {}) {
+  function createEngine() {
     return new CfHarnessEngine({
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: `run-pattern-test-${crypto.randomUUID()}`,
       cfcEnforcementMode: "disabled",
       fabricSessionFactory: () => Promise.resolve({ pieces }),
-      ...(options.workspaceHostPath !== undefined
-        ? { workspaceHostPath: options.workspaceHostPath }
-        : {}),
     });
+  }
+
+  /** Counts `runPersistent` calls, the single path that persists a piece. */
+  function spyOnRunPersistent(): { calls: number } {
+    const spy = { calls: 0 };
+    const original = pieces.runPersistent.bind(pieces);
+    pieces.runPersistent = ((
+      ...args: Parameters<
+        PiecesController["runPersistent"]
+      >
+    ) => {
+      spy.calls += 1;
+      return original(...args);
+    }) as PiecesController["runPersistent"];
+    return spy;
   }
 
   describe("runPatternTool", () => {
@@ -170,72 +201,145 @@ describe("run-pattern", () => {
       expect(result.runState.status).toBe("completed");
     });
 
-    it("returns an error when both `sourceText` and `sourcePath` are given", async () => {
-      const engine = createEngine();
-      const result = await engine.invokeBuiltinTool("run_pattern", {
-        sourceText: DOUBLING_PATTERN_SOURCE,
-        sourcePath: "pattern.tsx",
-      });
-      const output = result.output as RunPatternToolErrorOutput;
-      expect(output.status).toBe("error");
-      expect(output.message).toContain("exactly one");
-    });
-
-    it("returns an error when neither `sourceText` nor `sourcePath` is given", async () => {
+    it("returns an error when `sourceText` is missing", async () => {
       const engine = createEngine();
       const result = await engine.invokeBuiltinTool("run_pattern", {});
       const output = result.output as RunPatternToolErrorOutput;
       expect(output.status).toBe("error");
-      expect(output.message).toContain("exactly one");
+      expect(output.message).toContain("requires sourceText");
     });
 
-    it("reads `sourcePath` from inside the workspace", async () => {
-      const workspace = await Deno.makeTempDir({
-        prefix: "cf-harness-run-pattern-",
+    it("returns an error for a `sourceText` over the size cap without creating a piece", async () => {
+      const spy = spyOnRunPersistent();
+      const engine = createEngine();
+      const result = await engine.invokeBuiltinTool("run_pattern", {
+        sourceText: "x".repeat(RUN_PATTERN_MAX_SOURCE_TEXT_BYTES + 1),
       });
-      try {
-        await Deno.writeTextFile(
-          join(workspace, "pattern.tsx"),
-          DOUBLING_PATTERN_SOURCE,
-        );
-        const engine = createEngine({ workspaceHostPath: workspace });
-        const result = await engine.invokeBuiltinTool("run_pattern", {
-          sourcePath: "pattern.tsx",
-          inputs: { n: 4 },
-          resultSchema: DOUBLED_RESULT_SCHEMA,
-        });
-        const output = result.output as RunPatternToolSuccessOutput;
-        expect(output.status).toBe("ok");
-        expect((output.value as { doubled: number }).doubled).toBe(8);
-      } finally {
-        await Deno.remove(workspace, { recursive: true });
-      }
+      const output = result.output as RunPatternToolErrorOutput;
+      expect(output.status).toBe("error");
+      expect(output.message).toContain("256 KiB limit");
+      expect(spy.calls).toBe(0);
     });
 
-    it("returns an error for a `sourcePath` that resolves to an existing file outside the workspace", async () => {
-      const outer = await Deno.makeTempDir({
-        prefix: "cf-harness-run-pattern-",
+    it("returns an error for a link input targeting another space without creating a piece", async () => {
+      const spy = spyOnRunPersistent();
+      const engine = createEngine();
+      const foreignRef = `/@did:key:z6MkforeignSpaceForRunPatternTest/of:fid1:${
+        "A".repeat(43)
+      }/`;
+      const result = await engine.invokeBuiltinTool("run_pattern", {
+        sourceText: DOUBLING_PATTERN_SOURCE,
+        inputs: { n: foreignRef },
       });
-      try {
-        const workspace = join(outer, "workspace");
-        await Deno.mkdir(workspace);
-        await Deno.writeTextFile(
-          join(outer, "escape.tsx"),
-          DOUBLING_PATTERN_SOURCE,
-        );
-        const engine = createEngine({ workspaceHostPath: workspace });
-        const result = await engine.invokeBuiltinTool("run_pattern", {
-          sourcePath: "../escape.tsx",
-        });
-        const output = result.output as RunPatternToolErrorOutput;
-        expect(output.status).toBe("error");
-        expect(output.message).toContain("outside the workspace");
-      } finally {
-        await Deno.remove(outer, { recursive: true });
-      }
+      const output = result.output as RunPatternToolErrorOutput;
+      expect(output.status).toBe("error");
+      expect(output.message).toContain("targets another space");
+      expect(spy.calls).toBe(0);
     });
 
-    it("leaves the created piece out of the space's registered piece list", async () => {
+    it("returns an error for a live-cell input whose value does not match the argument schema, creating no piece", async () => {
+      const space = pieces.getSpace();
+      const seed = runtime.getCell(
+        space,
+        "run-pattern-shape-mismatch",
+        {
+          type: "object",
+          properties: { foo: { type: "number" } },
+        } as const,
+      );
+      const { error } = await runtime.editWithRetry((tx) => {
+        seed.withTx(tx).set({ foo: 1 });
+      });
+      expect(error).toBeUndefined();
+      await runtime.idle();
+      const seedRef = createLLMFriendlyLink(
+        seed.getAsNormalizedFullLink(),
+        space,
+      );
+      const spy = spyOnRunPersistent();
+      const engine = createEngine();
+      const result = await engine.invokeBuiltinTool("run_pattern", {
+        sourceText: DOUBLING_PATTERN_SOURCE,
+        inputs: { n: seedRef },
+      });
+      const output = result.output as RunPatternToolErrorOutput;
+      expect(output.status).toBe("error");
+      expect(output.message).toContain('input "n"');
+      expect(output.message).toContain("argument schema");
+      expect(spy.calls).toBe(0);
+    });
+
+    it("returns a `cancelled` output and stops the piece when the signal aborts during the settle barrier", async () => {
+      const controller = new AbortController();
+      // Abort exactly when the tool reaches its post-create barrier, and
+      // hold the barrier open so only the signal can win the race.
+      const runtimeWithSettled = runtime as unknown as {
+        settled: () => Promise<void>;
+      };
+      runtimeWithSettled.settled = () => {
+        controller.abort();
+        return new Promise<void>(() => {});
+      };
+      const stopped: unknown[] = [];
+      const runner = runtime.runner as unknown as {
+        stop: (cell: unknown) => unknown;
+      };
+      const originalStop = runner.stop.bind(runtime.runner);
+      runner.stop = (cell) => {
+        stopped.push(cell);
+        return originalStop(cell);
+      };
+      const engine = createEngine();
+      const result = await engine.invokeBuiltinTool("run_pattern", {
+        sourceText: DOUBLING_PATTERN_SOURCE,
+        inputs: { n: 1 },
+      }, { signal: controller.signal });
+      const output = result.output as RunPatternToolErrorOutput;
+      expect(output.status).toBe("cancelled");
+      expect(output.message).toContain("cancelled");
+      expect(stopped.length).toBe(1);
+      expect(result.runState.status).toBe("completed");
+    });
+
+    it("surfaces a rejected session construction as a structured error and invokes the factory again on the next call", async () => {
+      let factoryCalls = 0;
+      const engine = new CfHarnessEngine({
+        sandboxRuntime: new FakeSandboxRuntime(),
+        runId: `run-pattern-test-${crypto.randomUUID()}`,
+        cfcEnforcementMode: "disabled",
+        fabricSessionFactory: () => {
+          factoryCalls += 1;
+          return Promise.reject(
+            new Error("authorization denied for the configured space"),
+          );
+        },
+      });
+      const first = await engine.invokeBuiltinTool("run_pattern", {
+        sourceText: DOUBLING_PATTERN_SOURCE,
+      });
+      const firstOutput = first.output as RunPatternToolErrorOutput;
+      expect(firstOutput.status).toBe("error");
+      expect(firstOutput.message).toContain("fabric session unavailable");
+      expect(firstOutput.message).toContain("authorization denied");
+      const second = await engine.invokeBuiltinTool("run_pattern", {
+        sourceText: DOUBLING_PATTERN_SOURCE,
+      });
+      expect((second.output as RunPatternToolErrorOutput).status).toBe(
+        "error",
+      );
+      expect(factoryCalls).toBe(2);
+    });
+
+    it("leaves the created piece out of the space's real registered piece list", async () => {
+      // A real default pattern first: without one, `getRegisteredPieces()`
+      // reads a detached always-empty fallback and the assertion below
+      // holds vacuously.
+      const defaultRoot = await pieces.create(DEFAULT_PATTERN_SOURCE, {
+        input: { pieceRegistry: [] },
+      });
+      await pieces.linkDefaultPattern(defaultRoot.getCell());
+      await runtime.idle();
+      await pieces.synced();
       const engine = createEngine();
       const result = await engine.invokeBuiltinTool("run_pattern", {
         sourceText: DOUBLING_PATTERN_SOURCE,
@@ -244,6 +348,14 @@ describe("run-pattern", () => {
       expect((result.output as RunPatternToolSuccessOutput).status).toBe("ok");
       const registered = await pieces.getRegisteredPieces();
       expect(registered.length).toBe(0);
+      // The registry observes registration, proving the zero above is a
+      // decision by the tool and not an inert list.
+      const control = await pieces.create(DOUBLING_PATTERN_SOURCE, {
+        input: { n: 2 },
+      });
+      await pieces.add([control.getCell()]);
+      const afterAdd = await pieces.getRegisteredPieces();
+      expect(afterAdd.length).toBe(1);
     });
   });
 });

--- a/packages/cf-harness/test/tools-registry.test.ts
+++ b/packages/cf-harness/test/tools-registry.test.ts
@@ -22,8 +22,9 @@ Deno.test("builtin tool registry includes the agreed first-pass tool floor", () 
     "edit_file",
     "write_file",
     "delegate_task",
+    "run_pattern",
   ]);
-  assertEquals(BUILTIN_TOOL_REGISTRY.size, 10);
+  assertEquals(BUILTIN_TOOL_REGISTRY.size, 11);
   assertEquals(
     [...DEFAULT_PARENT_TOOL_IDS],
     [


### PR DESCRIPTION
Stacked on #5747 (which stacks on #5736). P1 of [CT-2003](https://linear.app/common-tools/issue/CT-2003/run-pattern-code-based-tool-calls-against-the-fabric-composing-with-ct) — the prototype milestone.

## What

A `run_pattern` builtin tool: the model supplies Common Fabric pattern source (`sourceText` inline, or `sourcePath` workspace-confined), optional `inputs`, optional `resultSchema`. The harness compiles and deploys it **unlisted** (durable in the space, absent from the root piece list, `origin` = URL-shaped harness run marker), waits on `runtime.settled()`, and returns the result cell's canonical reference plus a sanitized value.

Design properties:

- **Trusted-side execution**: the fabric session (`PiecesController.initialize`, or manual `createSession` for DID-addressed spaces) lives in the harness process; the tool never enters the Docker sandbox. Enabled only when `--fabric-api-url` + `--fabric-identity` + `--fabric-space` are all present (all-or-none validated); without them the tool is absent and behavior is unchanged.
- **The tool contains zero handle-table code.** It accepts whole-string LLM-friendly refs as inputs (converted to live cell references — by-reference wiring, not copies) and emits canonical ref strings in its output; the generic session-handle boundary from #5736 tokenizes both directions. `rawValue` goes to artifacts only and is stripped at the model boundary.
- Compile errors return raw as structured tool output — the model's feedback loop, not a run failure.
- Result values sanitize through the same runner machinery as subagent structured returns (inert primitives pass; free-form strings seal).

## End-to-end demo (real model, live fabric — artifacts verified)

One run, gpt-5.5, `--handle-mode session`: the model discovered a deployed counter's address via `cf` (saw only `cfh:a:qfj6p`), **wrote a pattern itself** (`plusTen: computed(() => src.value + 10)`), called `run_pattern` with the token as the `src` input, and reported `plusTen: 10` plus a fresh result token `cfh:a:fpxpb`. Transcript contains **zero** raw ids and 5 tokens; the raw artifact carries the real refs. Independently confirmed from the host: the result cell reads `10` via `cf piece get`, and the piece is absent from the space's piece registry. An agent programmed the fabric through code it wrote, over data it never saw.

## Test plan

- New `test/run-pattern.test.ts` over an emulated in-memory `PiecesController`: inline source, live-cell input wiring (seed 7 → doubled 14), compile-error recovery, arg validation, path traversal guard, unlisted assertion
- Prompt-loop round trip: tool message carries the token (never the raw ref, never `rawValue`); a second call passes the token back and the tool receives the substituted ref — proving the boundary does both directions with no tool-side handle code
- `packages/cf-harness`: 621 passed (3 known tmpdir-sandbox failures pass unsandboxed); fmt/lint/check clean

Linear-issue: CT-2003

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

