### PR TITLE
feat(cf-harness): add persistent provider and auth controls

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -140,7 +140,8 @@ What is not done yet:
 - [src/model/](src/model)
   - provider-neutral model client, gateway adapter, and Codex Responses adapter
 - [src/auth/](src/auth)
-  - owner-keyed credential store and OpenAI Codex OAuth flows
+  - persistent provider settings, owner-keyed credential storage, bounded
+    credential health, and OpenAI Codex OAuth flows
 - [src/cli.ts](src/cli.ts)
   - package-local operator CLI
 - [src/provenance.ts](src/provenance.ts)
@@ -238,6 +239,11 @@ cd packages/cf-harness
 deno task run -- auth login openai-codex
 deno task run -- auth login openai-codex --device
 
+# Inspect or persist the provider preference used by new direct runs.
+deno task run -- config inspect --json
+deno task run -- config init openai-compatible-gateway --json
+deno task run -- config set openai-codex --json
+
 # Inspect local credential status and the live, subscription-scoped model catalog.
 deno task run -- auth status openai-codex
 deno task run -- models openai-codex
@@ -252,11 +258,25 @@ deno task run -- \
 deno task run -- auth logout openai-codex
 ```
 
-Local credentials live under `CF_HARNESS_HOME` (by default
-`~/.cf-harness/auth.json`). The directory and file are created with modes `0700`
-and `0600`, and updates replace the file atomically. `cf-harness` never imports
-or shares `~/.codex/auth.json`. A failed refresh does not fall back to
-`OPENAI_API_KEY`, the Common Tools gateway, or unauthenticated mode.
+The provider preference lives in `CF_HARNESS_HOME/config.json`; local
+credentials and bounded refresh health live in `CF_HARNESS_HOME/auth.json` (by
+default under `~/.cf-harness`). The home and files use private permissions, and
+mutations serialize through advisory locks before atomic replacement. The
+canonical home path and its ancestor chain are a trusted host configuration; the
+stores reject a symlink at the home, target, or lock path but do not claim
+descriptor-relative protection against an attacker who can replace trusted
+ancestors concurrently. `cf-harness` never imports or shares
+`~/.codex/auth.json`. A failed refresh does not fall back to `OPENAI_API_KEY`,
+the Common Tools gateway, or unauthenticated mode.
+
+Direct runs resolve a provider from explicit CLI, environment, persistent
+preference, then the historical gateway default. Provider resolution does not
+resolve or rewrite model aliases. Resume retains the recorded provider and
+ignores the persistent preference; an explicit conflicting provider is a
+`provider-mismatch` failure. Structured config and auth commands use versioned
+JSON result envelopes. Login emits a versioned NDJSON authorization event before
+its terminal result. These responses expose connection health but no tokens,
+full account identifiers, expiries, or raw provider errors.
 
 Resume a root run with `--resume-run <run-root-or-run-state.json>`. Codex resume
 keeps the recorded provider, model, exact credential owner, and encrypted

--- a/packages/cf-harness/deno.jsonc
+++ b/packages/cf-harness/deno.jsonc
@@ -27,6 +27,8 @@
     "./auth/types": "./src/auth/types.ts",
     "./auth/credential-store": "./src/auth/credential-store.ts",
     "./auth/openai-codex": "./src/auth/openai-codex.ts",
+    "./auth/provider-settings": "./src/auth/provider-settings.ts",
+    "./control-errors": "./src/control-errors.ts",
     "./contracts/prompt-slot": "./src/contracts/prompt-slot.ts",
     "./contracts/cfc-invocation-context": "./src/contracts/cfc-invocation-context.ts",
     "./contracts/image": "./src/contracts/image.ts",

--- a/packages/cf-harness/docs/CURRENT_STATE.md
+++ b/packages/cf-harness/docs/CURRENT_STATE.md
@@ -34,6 +34,8 @@ The current package provides:
 
 - batch CLI execution with bounded model turns and optional streamed events;
 - machine-readable capability discovery with `--describe-capabilities`;
+- persistent provider configuration and structured config/auth control, with
+  durable bounded Codex refresh health;
 - workspace, Fabric, and explicit host mounts with path containment;
 - sandboxed shell, file, image, web-fetch, skills, edit/write, and delegation
   tools;

--- a/packages/cf-harness/docs/OPENAI_CODEX_PROTOCOL.md
+++ b/packages/cf-harness/docs/OPENAI_CODEX_PROTOCOL.md
@@ -45,6 +45,14 @@ may rotate the refresh token and must be persisted atomically. Every OAuth and
 Codex API fetch rejects HTTP redirects so credential-bearing bodies, account
 headers, and prompts cannot leave the pinned origins.
 
+The credential document stores credentials and bounded terminal refresh health
+in one versioned transaction. Version-1 documents remain readable without a
+status-side mutation and migrate on the next successful mutation. Successful
+login or refresh clears terminal health; `invalid_grant`, refresh-token reuse,
+and revoked responses persist `reconnect-required` before returning a typed auth
+failure. Transient failures do not change health, and structured status does not
+expose token material, account identifiers, expiry, or raw responses.
+
 ## Pinned Responses contract
 
 - Endpoint: `https://chatgpt.com/backend-api/codex/responses`

--- a/packages/cf-harness/src/auth/credential-store.ts
+++ b/packages/cf-harness/src/auth/credential-store.ts
@@ -50,6 +50,15 @@ export interface HarnessCredentialRecord {
   health?: HarnessCredentialHealth;
 }
 
+const assertValidCredentialRecord = (
+  record: HarnessCredentialRecord,
+): HarnessCredentialRecord => {
+  if (record.health !== undefined && record.credential === undefined) {
+    throw new Error("credential health requires a credential");
+  }
+  return record;
+};
+
 /**
  * Host-side Loom adapter contract. Implementations keep token material in
  * Loom's encrypted secret backend and resolve only opaque authenticated owner
@@ -145,10 +154,13 @@ export class InMemoryHarnessCredentialStore implements HarnessCredentialStore {
     ) => Promise<HarnessCredential | undefined> | HarnessCredential | undefined,
     signal?: AbortSignal,
   ): Promise<HarnessCredential | undefined> {
-    return this.updateRecord(ownerKey, providerId, async (current) => ({
-      credential: await updater(current.credential),
-      ...(current.health !== undefined ? { health: current.health } : {}),
-    }), signal).then((record) => record.credential);
+    return this.updateRecord(ownerKey, providerId, async (current) => {
+      const credential = await updater(current.credential);
+      return credential === undefined ? {} : {
+        credential,
+        ...(current.health !== undefined ? { health: current.health } : {}),
+      };
+    }, signal).then((record) => record.credential);
   }
 
   async delete(
@@ -172,14 +184,16 @@ export class InMemoryHarnessCredentialStore implements HarnessCredentialStore {
   ): Promise<HarnessCredentialRecord> {
     const key = credentialKey(ownerKey, providerId);
     return this.#queue.run(key, async () => {
-      const next = await updater({
-        ...(this.#credentials.get(key) !== undefined
-          ? { credential: structuredClone(this.#credentials.get(key)!) }
-          : {}),
-        ...(this.#health.get(key) !== undefined
-          ? { health: structuredClone(this.#health.get(key)!) }
-          : {}),
-      });
+      const next = assertValidCredentialRecord(
+        await updater({
+          ...(this.#credentials.get(key) !== undefined
+            ? { credential: structuredClone(this.#credentials.get(key)!) }
+            : {}),
+          ...(this.#health.get(key) !== undefined
+            ? { health: structuredClone(this.#health.get(key)!) }
+            : {}),
+        }),
+      );
       if (next.credential === undefined) this.#credentials.delete(key);
       else this.#credentials.set(key, structuredClone(next.credential));
       if (next.health === undefined) this.#health.delete(key);
@@ -543,10 +557,13 @@ export class FileHarnessCredentialStore implements HarnessCredentialStore {
     ) => Promise<HarnessCredential | undefined> | HarnessCredential | undefined,
     signal?: AbortSignal,
   ): Promise<HarnessCredential | undefined> {
-    return this.updateRecord(ownerKey, providerId, async (current) => ({
-      credential: await updater(current.credential),
-      ...(current.health !== undefined ? { health: current.health } : {}),
-    }), signal).then((record) => record.credential);
+    return this.updateRecord(ownerKey, providerId, async (current) => {
+      const credential = await updater(current.credential);
+      return credential === undefined ? {} : {
+        credential,
+        ...(current.health !== undefined ? { health: current.health } : {}),
+      };
+    }, signal).then((record) => record.credential);
   }
 
   async delete(
@@ -584,14 +601,16 @@ export class FileHarnessCredentialStore implements HarnessCredentialStore {
           const currentHealth = Object.hasOwn(document.health, ownerKey)
             ? document.health[ownerKey]
             : undefined;
-          const next = await updater({
-            ...(currentProviders?.[providerId] !== undefined
-              ? { credential: currentProviders[providerId] }
-              : {}),
-            ...(currentHealth?.[providerId] !== undefined
-              ? { health: currentHealth[providerId] }
-              : {}),
-          });
+          const next = assertValidCredentialRecord(
+            await updater({
+              ...(currentProviders?.[providerId] !== undefined
+                ? { credential: currentProviders[providerId] }
+                : {}),
+              ...(currentHealth?.[providerId] !== undefined
+                ? { health: currentHealth[providerId] }
+                : {}),
+            }),
+          );
           const providers = { ...(currentProviders ?? {}) };
           if (next.credential === undefined) delete providers[providerId];
           else providers[providerId] = next.credential;

--- a/packages/cf-harness/src/auth/credential-store.ts
+++ b/packages/cf-harness/src/auth/credential-store.ts
@@ -1,10 +1,15 @@
 import { dirname, join, resolve } from "@std/path";
 import type {
   HarnessCredential,
+  HarnessCredentialHealth,
   HarnessCredentialProviderId,
 } from "./types.ts";
 
 export interface HarnessCredentialStore {
+  getRecord(
+    ownerKey: string,
+    providerId: HarnessCredentialProviderId,
+  ): Promise<HarnessCredentialRecord>;
   get(
     ownerKey: string,
     providerId: HarnessCredentialProviderId,
@@ -26,6 +31,23 @@ export interface HarnessCredentialStore {
     ownerKey: string,
     providerId: HarnessCredentialProviderId,
   ): Promise<void>;
+  getHealth(
+    ownerKey: string,
+    providerId: HarnessCredentialProviderId,
+  ): Promise<HarnessCredentialHealth | undefined>;
+  updateRecord(
+    ownerKey: string,
+    providerId: HarnessCredentialProviderId,
+    updater: (
+      current: HarnessCredentialRecord,
+    ) => Promise<HarnessCredentialRecord> | HarnessCredentialRecord,
+    signal?: AbortSignal,
+  ): Promise<HarnessCredentialRecord>;
+}
+
+export interface HarnessCredentialRecord {
+  credential?: HarnessCredential;
+  health?: HarnessCredentialHealth;
 }
 
 /**
@@ -88,15 +110,23 @@ const fileMutationQueue = new KeyedMutationQueue();
 
 export class InMemoryHarnessCredentialStore implements HarnessCredentialStore {
   readonly #credentials = new Map<string, HarnessCredential>();
+  readonly #health = new Map<string, HarnessCredentialHealth>();
   readonly #queue = new KeyedMutationQueue();
 
-  get(ownerKey: string, providerId: HarnessCredentialProviderId) {
-    const credential = this.#credentials.get(
-      credentialKey(ownerKey, providerId),
-    );
-    return Promise.resolve(
-      credential === undefined ? undefined : structuredClone(credential),
-    );
+  getRecord(ownerKey: string, providerId: HarnessCredentialProviderId) {
+    const key = credentialKey(ownerKey, providerId);
+    const credential = this.#credentials.get(key);
+    const health = this.#health.get(key);
+    return Promise.resolve({
+      ...(credential === undefined
+        ? {}
+        : { credential: structuredClone(credential) }),
+      ...(health === undefined ? {} : { health: structuredClone(health) }),
+    });
+  }
+
+  async get(ownerKey: string, providerId: HarnessCredentialProviderId) {
+    return (await this.getRecord(ownerKey, providerId)).credential;
   }
 
   async set(
@@ -104,7 +134,7 @@ export class InMemoryHarnessCredentialStore implements HarnessCredentialStore {
     providerId: HarnessCredentialProviderId,
     credential: HarnessCredential,
   ): Promise<void> {
-    await this.update(ownerKey, providerId, () => credential);
+    await this.updateRecord(ownerKey, providerId, () => ({ credential }));
   }
 
   update(
@@ -115,27 +145,51 @@ export class InMemoryHarnessCredentialStore implements HarnessCredentialStore {
     ) => Promise<HarnessCredential | undefined> | HarnessCredential | undefined,
     signal?: AbortSignal,
   ): Promise<HarnessCredential | undefined> {
-    const key = credentialKey(ownerKey, providerId);
-    return this.#queue.run(key, async () => {
-      const current = this.#credentials.get(key);
-      const next = await updater(
-        current === undefined ? undefined : structuredClone(current),
-      );
-      if (next === undefined) this.#credentials.delete(key);
-      else this.#credentials.set(key, structuredClone(next));
-      return next === undefined ? undefined : structuredClone(next);
-    }, signal);
+    return this.updateRecord(ownerKey, providerId, async (current) => ({
+      credential: await updater(current.credential),
+      ...(current.health !== undefined ? { health: current.health } : {}),
+    }), signal).then((record) => record.credential);
   }
 
   async delete(
     ownerKey: string,
     providerId: HarnessCredentialProviderId,
   ): Promise<void> {
-    await this.update(ownerKey, providerId, () => undefined);
+    await this.updateRecord(ownerKey, providerId, () => ({}));
+  }
+
+  async getHealth(ownerKey: string, providerId: HarnessCredentialProviderId) {
+    return (await this.getRecord(ownerKey, providerId)).health;
+  }
+
+  updateRecord(
+    ownerKey: string,
+    providerId: HarnessCredentialProviderId,
+    updater: (
+      current: HarnessCredentialRecord,
+    ) => Promise<HarnessCredentialRecord> | HarnessCredentialRecord,
+    signal?: AbortSignal,
+  ): Promise<HarnessCredentialRecord> {
+    const key = credentialKey(ownerKey, providerId);
+    return this.#queue.run(key, async () => {
+      const next = await updater({
+        ...(this.#credentials.get(key) !== undefined
+          ? { credential: structuredClone(this.#credentials.get(key)!) }
+          : {}),
+        ...(this.#health.get(key) !== undefined
+          ? { health: structuredClone(this.#health.get(key)!) }
+          : {}),
+      });
+      if (next.credential === undefined) this.#credentials.delete(key);
+      else this.#credentials.set(key, structuredClone(next.credential));
+      if (next.health === undefined) this.#health.delete(key);
+      else this.#health.set(key, structuredClone(next.health));
+      return structuredClone(next);
+    }, signal);
   }
 }
 
-interface CredentialDocument {
+interface CredentialDocumentV1 {
   version: 1;
   owners: Record<
     string,
@@ -143,9 +197,19 @@ interface CredentialDocument {
   >;
 }
 
+interface CredentialDocument {
+  version: 2;
+  owners: CredentialDocumentV1["owners"];
+  health: Record<
+    string,
+    Partial<Record<HarnessCredentialProviderId, HarnessCredentialHealth>>
+  >;
+}
+
 const emptyDocument = (): CredentialDocument => ({
-  version: 1,
+  version: 2,
   owners: Object.create(null),
+  health: Object.create(null),
 });
 
 const setOwn = <T extends object>(
@@ -173,6 +237,16 @@ const isCredential = (value: unknown): value is HarnessCredential => {
     typeof input.accountId === "string";
 };
 
+const isHealth = (value: unknown): value is HarnessCredentialHealth => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const input = value as Record<string, unknown>;
+  return input.status === "reconnect-required" &&
+    (input.reason === "invalid-grant" || input.reason === "revoked" ||
+      input.reason === "refresh-token-reused");
+};
+
 const parseDocument = (text: string): CredentialDocument => {
   const parsed = JSON.parse(text) as unknown;
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
@@ -180,7 +254,8 @@ const parseDocument = (text: string): CredentialDocument => {
   }
   const input = parsed as Record<string, unknown>;
   if (
-    input.version !== 1 || typeof input.owners !== "object" ||
+    (input.version !== 1 && input.version !== 2) ||
+    typeof input.owners !== "object" ||
     input.owners === null || Array.isArray(input.owners)
   ) {
     throw new Error("unsupported credential store format");
@@ -204,7 +279,42 @@ const parseDocument = (text: string): CredentialDocument => {
       credential === undefined ? {} : { "openai-codex": credential },
     );
   }
-  return { version: 1, owners };
+  const health: CredentialDocument["health"] = Object.create(null);
+  if (input.version === 2) {
+    if (
+      typeof input.health !== "object" || input.health === null ||
+      Array.isArray(input.health)
+    ) {
+      throw new Error("invalid credential health entries");
+    }
+    for (const [owner, rawProviders] of Object.entries(input.health)) {
+      if (
+        typeof rawProviders !== "object" || rawProviders === null ||
+        Array.isArray(rawProviders)
+      ) {
+        throw new Error("invalid credential health owner entry");
+      }
+      const raw = rawProviders as Record<string, unknown>;
+      const providerHealth = raw["openai-codex"];
+      if (providerHealth !== undefined && !isHealth(providerHealth)) {
+        throw new Error("invalid openai-codex credential health entry");
+      }
+      setOwn(
+        health,
+        owner,
+        providerHealth === undefined ? {} : { "openai-codex": providerHealth },
+      );
+      if (
+        providerHealth !== undefined &&
+        owners[owner]?.["openai-codex"] === undefined
+      ) {
+        throw new Error(
+          "openai-codex credential health requires a credential",
+        );
+      }
+    }
+  }
+  return { version: 2, owners, health };
 };
 
 export interface FileHarnessCredentialStoreOptions {
@@ -392,12 +502,29 @@ export class FileHarnessCredentialStore implements HarnessCredentialStore {
     }
   }
 
-  async get(ownerKey: string, providerId: HarnessCredentialProviderId) {
+  async getRecord(
+    ownerKey: string,
+    providerId: HarnessCredentialProviderId,
+  ): Promise<HarnessCredentialRecord> {
     const document = await this.#read();
     const providers = Object.hasOwn(document.owners, ownerKey)
       ? document.owners[ownerKey]
       : undefined;
-    return providers?.[providerId];
+    const health = Object.hasOwn(document.health, ownerKey)
+      ? document.health[ownerKey]
+      : undefined;
+    return {
+      ...(providers?.[providerId] === undefined
+        ? {}
+        : { credential: providers[providerId] }),
+      ...(health?.[providerId] === undefined
+        ? {}
+        : { health: health[providerId] }),
+    };
+  }
+
+  async get(ownerKey: string, providerId: HarnessCredentialProviderId) {
+    return (await this.getRecord(ownerKey, providerId)).credential;
   }
 
   async set(
@@ -405,7 +532,7 @@ export class FileHarnessCredentialStore implements HarnessCredentialStore {
     providerId: HarnessCredentialProviderId,
     credential: HarnessCredential,
   ): Promise<void> {
-    await this.update(ownerKey, providerId, () => credential);
+    await this.updateRecord(ownerKey, providerId, () => ({ credential }));
   }
 
   update(
@@ -416,9 +543,36 @@ export class FileHarnessCredentialStore implements HarnessCredentialStore {
     ) => Promise<HarnessCredential | undefined> | HarnessCredential | undefined,
     signal?: AbortSignal,
   ): Promise<HarnessCredential | undefined> {
-    // Every mutation rewrites the whole document. The stable advisory lock
-    // serializes read/modify/write transactions across processes as well as
-    // across distinct store instances in this process.
+    return this.updateRecord(ownerKey, providerId, async (current) => ({
+      credential: await updater(current.credential),
+      ...(current.health !== undefined ? { health: current.health } : {}),
+    }), signal).then((record) => record.credential);
+  }
+
+  async delete(
+    ownerKey: string,
+    providerId: HarnessCredentialProviderId,
+  ): Promise<void> {
+    await this.updateRecord(ownerKey, providerId, () => ({}));
+  }
+
+  async getHealth(
+    ownerKey: string,
+    providerId: HarnessCredentialProviderId,
+  ): Promise<HarnessCredentialHealth | undefined> {
+    return (await this.getRecord(ownerKey, providerId)).health;
+  }
+
+  updateRecord(
+    ownerKey: string,
+    providerId: HarnessCredentialProviderId,
+    updater: (
+      current: HarnessCredentialRecord,
+    ) => Promise<HarnessCredentialRecord> | HarnessCredentialRecord,
+    signal?: AbortSignal,
+  ): Promise<HarnessCredentialRecord> {
+    // Credentials and their health share this transaction so a refresh cannot
+    // expose a terminal result without durably recording the same conclusion.
     return fileMutationQueue.run(
       this.path,
       () =>
@@ -427,28 +581,38 @@ export class FileHarnessCredentialStore implements HarnessCredentialStore {
           const currentProviders = Object.hasOwn(document.owners, ownerKey)
             ? document.owners[ownerKey]
             : undefined;
-          const current = currentProviders?.[providerId];
-          const next = await updater(current);
+          const currentHealth = Object.hasOwn(document.health, ownerKey)
+            ? document.health[ownerKey]
+            : undefined;
+          const next = await updater({
+            ...(currentProviders?.[providerId] !== undefined
+              ? { credential: currentProviders[providerId] }
+              : {}),
+            ...(currentHealth?.[providerId] !== undefined
+              ? { health: currentHealth[providerId] }
+              : {}),
+          });
           const providers = { ...(currentProviders ?? {}) };
-          if (next === undefined) delete providers[providerId];
-          else providers[providerId] = next;
+          if (next.credential === undefined) delete providers[providerId];
+          else providers[providerId] = next.credential;
           if (Object.keys(providers).length === 0) {
             delete document.owners[ownerKey];
           } else {
             setOwn(document.owners, ownerKey, providers);
           }
+          const health = { ...(currentHealth ?? {}) };
+          if (next.health === undefined) delete health[providerId];
+          else health[providerId] = next.health;
+          if (Object.keys(health).length === 0) {
+            delete document.health[ownerKey];
+          } else {
+            setOwn(document.health, ownerKey, health);
+          }
           await this.#write(document);
-          return next;
+          return structuredClone(next);
         }, signal),
       signal,
     );
-  }
-
-  async delete(
-    ownerKey: string,
-    providerId: HarnessCredentialProviderId,
-  ): Promise<void> {
-    await this.update(ownerKey, providerId, () => undefined);
   }
 
   lastValidSnapshot(): unknown {

--- a/packages/cf-harness/src/auth/openai-codex.ts
+++ b/packages/cf-harness/src/auth/openai-codex.ts
@@ -8,10 +8,12 @@ import {
   type HarnessCredentialOwnerRef,
 } from "../contracts/run-manifest.ts";
 import {
+  type HarnessCredentialHealth,
   type HarnessCredentialStatus,
   OPENAI_CODEX_PROVIDER_ID,
   type OpenAICodexOAuthCredential,
 } from "./types.ts";
+import { HarnessControlError } from "../control-errors.ts";
 
 export const OPENAI_CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 export const OPENAI_CODEX_AUTH_ORIGIN = "https://auth.openai.com";
@@ -36,6 +38,7 @@ const activeBrowserLoginOwners = new Set<string>();
 export type OpenAICodexAuthErrorKind =
   | "invalid_grant"
   | "revoked"
+  | "refresh_token_reused"
   | "malformed_response"
   | "network"
   | "storage"
@@ -164,14 +167,14 @@ const readTokenResponse = async (
     }
     const kind: OpenAICodexAuthErrorKind = code === "invalid_grant"
       ? "invalid_grant"
-      : code === "refresh_token_reused" || response.status === 401
+      : code === "refresh_token_reused"
+      ? "refresh_token_reused"
+      : response.status === 401
       ? "revoked"
       : "provider";
     throw new OpenAICodexAuthError(
       kind,
-      `OpenAI Codex token ${operation} failed (${response.status})${
-        code ? `: ${code}` : ""
-      }`,
+      `OpenAI Codex token ${operation} failed (${response.status})`,
     );
   }
   let json: TokenResponse;
@@ -296,11 +299,14 @@ export class OpenAICodexCredentialResolver {
   async resolve(signal?: AbortSignal): Promise<OpenAICodexOAuthCredential> {
     if (signal?.aborted) throw abortReason(signal);
     let current: OpenAICodexOAuthCredential | undefined;
+    let health: HarnessCredentialHealth | undefined;
     try {
-      current = await this.#store.get(
+      const record = await this.#store.getRecord(
         this.#ownerKey,
         OPENAI_CODEX_PROVIDER_ID,
       );
+      current = record.credential;
+      health = record.health;
     } catch {
       if (signal?.aborted) throw abortReason(signal);
       throw new OpenAICodexAuthError(
@@ -310,26 +316,40 @@ export class OpenAICodexCredentialResolver {
     }
     if (signal?.aborted) throw abortReason(signal);
     if (!current) {
-      throw new Error(
+      throw new HarnessControlError(
+        "provider-auth-required",
         "OpenAI Codex is not connected for this credential owner",
+      );
+    }
+    if (health !== undefined) {
+      throw new HarnessControlError(
+        "provider-auth-required",
+        `OpenAI Codex must be reconnected (${health.reason})`,
       );
     }
     if (current.expiresAt - this.#refreshSkewMs > this.#now()) return current;
     let refreshed: OpenAICodexOAuthCredential | undefined;
     try {
-      refreshed = await this.#store.update(
+      const record = await this.#store.updateRecord(
         this.#ownerKey,
         OPENAI_CODEX_PROVIDER_ID,
-        async (latest) => {
+        async (currentRecord) => {
           if (signal?.aborted) throw abortReason(signal);
+          const latest = currentRecord.credential;
           if (!latest) {
-            throw new OpenAICodexAuthError(
-              "revoked",
+            throw new HarnessControlError(
+              "provider-auth-required",
               "OpenAI Codex credential was disconnected",
             );
           }
+          if (currentRecord.health !== undefined) {
+            throw new HarnessControlError(
+              "provider-auth-required",
+              `OpenAI Codex must be reconnected (${currentRecord.health.reason})`,
+            );
+          }
           if (latest.expiresAt - this.#refreshSkewMs > this.#now()) {
-            return latest;
+            return currentRecord;
           }
           let response: Response;
           try {
@@ -351,19 +371,33 @@ export class OpenAICodexCredentialResolver {
               "OpenAI Codex token refresh failed before receiving a response",
             );
           }
-          const credential = await readTokenResponse(
-            response,
-            "refresh",
-            this.#now(),
-            latest.refreshToken,
-          );
-          return credential;
+          try {
+            const credential = await readTokenResponse(
+              response,
+              "refresh",
+              this.#now(),
+              latest.refreshToken,
+            );
+            return { credential };
+          } catch (error) {
+            const terminal = terminalHealthOf(error);
+            if (terminal === undefined) throw error;
+            return { credential: latest, health: terminal };
+          }
         },
         signal,
       );
+      if (record.health !== undefined) {
+        throw new HarnessControlError(
+          "provider-auth-required",
+          `OpenAI Codex must be reconnected (${record.health.reason})`,
+        );
+      }
+      refreshed = record.credential;
       if (signal?.aborted) throw abortReason(signal);
     } catch (error) {
       if (signal?.aborted) throw abortReason(signal);
+      if (error instanceof HarnessControlError) throw error;
       if (error instanceof OpenAICodexAuthError) throw error;
       throw new OpenAICodexAuthError(
         "storage",
@@ -607,7 +641,7 @@ export const loginOpenAICodexWithBrowser = async (options: {
       signal: options.signal,
       now: options.now,
     });
-    await options.authService.save(credential);
+    await options.authService.save(credential, options.signal);
     return credential;
   } finally {
     activeBrowserLoginOwners.delete(options.authService.ownerKey);
@@ -627,26 +661,61 @@ export class OpenAICodexAuthService {
     readonly ownerKey: string,
   ) {}
 
-  async save(credential: OpenAICodexOAuthCredential): Promise<void> {
-    await this.store.set(this.ownerKey, OPENAI_CODEX_PROVIDER_ID, credential);
+  async save(
+    credential: OpenAICodexOAuthCredential,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    await this.store.updateRecord(
+      this.ownerKey,
+      OPENAI_CODEX_PROVIDER_ID,
+      () => {
+        signal?.throwIfAborted();
+        return { credential };
+      },
+      signal,
+    );
   }
 
   async status(now = Date.now()): Promise<HarnessCredentialStatus> {
-    const credential = await this.store.get(
+    const record = await this.store.getRecord(
       this.ownerKey,
       OPENAI_CODEX_PROVIDER_ID,
     );
-    return credential
-      ? {
+    const { credential, health } = record;
+    if (health !== undefined) {
+      return {
         providerId: OPENAI_CODEX_PROVIDER_ID,
-        signedIn: true,
-        expiresAt: credential.expiresAt,
-        expired: credential.expiresAt <= now,
-      }
-      : { providerId: OPENAI_CODEX_PROVIDER_ID, signedIn: false };
+        status: "reconnect-required",
+        refreshHealth: "reconnect-required",
+        reason: health.reason,
+      };
+    }
+    return credential === undefined
+      ? { providerId: OPENAI_CODEX_PROVIDER_ID, status: "disconnected" }
+      : {
+        providerId: OPENAI_CODEX_PROVIDER_ID,
+        status: "connected",
+        refreshHealth: credential.expiresAt <= now ? "refresh-on-use" : "ready",
+      };
   }
 
   async logout(): Promise<void> {
     await this.store.delete(this.ownerKey, OPENAI_CODEX_PROVIDER_ID);
   }
 }
+
+const terminalHealthOf = (
+  error: unknown,
+): HarnessCredentialHealth | undefined => {
+  if (!(error instanceof OpenAICodexAuthError)) return undefined;
+  if (error.kind === "invalid_grant") {
+    return { status: "reconnect-required", reason: "invalid-grant" };
+  }
+  if (error.kind === "revoked") {
+    return { status: "reconnect-required", reason: "revoked" };
+  }
+  if (error.kind === "refresh_token_reused") {
+    return { status: "reconnect-required", reason: "refresh-token-reused" };
+  }
+  return undefined;
+};

--- a/packages/cf-harness/src/auth/openai-codex.ts
+++ b/packages/cf-harness/src/auth/openai-codex.ts
@@ -674,6 +674,7 @@ export class OpenAICodexAuthService {
       },
       signal,
     );
+    signal?.throwIfAborted();
   }
 
   async status(now = Date.now()): Promise<HarnessCredentialStatus> {

--- a/packages/cf-harness/src/auth/openai-codex.ts
+++ b/packages/cf-harness/src/auth/openai-codex.ts
@@ -309,8 +309,8 @@ export class OpenAICodexCredentialResolver {
       health = record.health;
     } catch {
       if (signal?.aborted) throw abortReason(signal);
-      throw new OpenAICodexAuthError(
-        "storage",
+      throw new HarnessControlError(
+        "provider-unavailable",
         "OpenAI Codex credential storage could not be read",
       );
     }
@@ -398,13 +398,23 @@ export class OpenAICodexCredentialResolver {
     } catch (error) {
       if (signal?.aborted) throw abortReason(signal);
       if (error instanceof HarnessControlError) throw error;
-      if (error instanceof OpenAICodexAuthError) throw error;
-      throw new OpenAICodexAuthError(
-        "storage",
+      if (error instanceof OpenAICodexAuthError) {
+        throw new HarnessControlError(
+          "provider-unavailable",
+          error.message,
+        );
+      }
+      throw new HarnessControlError(
+        "provider-unavailable",
         "OpenAI Codex credential storage could not be updated",
       );
     }
-    if (!refreshed) throw new Error("OpenAI Codex credential was disconnected");
+    if (!refreshed) {
+      throw new HarnessControlError(
+        "provider-auth-required",
+        "OpenAI Codex credential was disconnected",
+      );
+    }
     return refreshed;
   }
 }

--- a/packages/cf-harness/src/auth/provider-settings.ts
+++ b/packages/cf-harness/src/auth/provider-settings.ts
@@ -16,7 +16,7 @@ export type HarnessProviderSettingsState =
   | { state: "missing" }
   | { state: "configured"; settings: HarnessProviderSettings }
   | { state: "invalid"; detail: string }
-  | { state: "unsupported-version"; version: number | string | null }
+  | { state: "unsupported-version"; version: number | null }
   | { state: "unreadable"; detail: string };
 
 export interface HarnessProviderResolution {
@@ -39,8 +39,8 @@ const parseDocument = (text: string): HarnessProviderSettingsState => {
   }
   const input = parsed as Record<string, unknown>;
   if (input.version !== HARNESS_PROVIDER_SETTINGS_VERSION) {
-    const version = typeof input.version === "number" ||
-        typeof input.version === "string" || input.version === null
+    const version = typeof input.version === "number" &&
+        Number.isSafeInteger(input.version)
       ? input.version
       : null;
     return { state: "unsupported-version", version };
@@ -266,7 +266,10 @@ export class FileHarnessProviderSettingsStore {
     }
   }
 
-  async #write(settings: HarnessProviderSettings): Promise<void> {
+  async #write(
+    settings: HarnessProviderSettings,
+    signal?: AbortSignal,
+  ): Promise<void> {
     const temporaryPath = join(
       dirname(this.path),
       `.config-${crypto.randomUUID()}.tmp`,
@@ -279,6 +282,7 @@ export class FileHarnessProviderSettingsStore {
         { createNew: true, mode: 0o600 },
       );
       await Deno.chmod(temporaryPath, 0o600);
+      signal?.throwIfAborted();
       await Deno.rename(temporaryPath, this.path);
     } catch (error) {
       failure = error;
@@ -310,7 +314,7 @@ export class FileHarnessProviderSettingsStore {
             version: HARNESS_PROVIDER_SETTINGS_VERSION,
             modelProvider,
           } as const;
-          await this.#write(settings);
+          await this.#write(settings, signal);
           return { settings, changed: true };
         }, signal),
       signal,
@@ -337,7 +341,7 @@ export class FileHarnessProviderSettingsStore {
           } as const;
           const changed = state.state === "missing" ||
             state.settings.modelProvider !== modelProvider;
-          if (changed) await this.#write(settings);
+          if (changed) await this.#write(settings, signal);
           return { settings, changed };
         }, signal),
       signal,
@@ -353,11 +357,11 @@ const stateError = (
 ): HarnessControlError =>
   new HarnessControlError(
     "provider-configuration-required",
-    `Provider settings are ${state.state}: ${
-      state.state === "unsupported-version"
-        ? `version ${String(state.version)}`
-        : state.detail
-    }`,
+    state.state === "unsupported-version"
+      ? "Provider settings use an unsupported version"
+      : state.state === "unreadable"
+      ? "Provider settings are unreadable"
+      : "Provider settings are invalid",
   );
 
 /** Resolves the provider with manual CLI precedence. */

--- a/packages/cf-harness/src/auth/provider-settings.ts
+++ b/packages/cf-harness/src/auth/provider-settings.ts
@@ -1,0 +1,395 @@
+import { dirname, join, resolve } from "@std/path";
+import {
+  type HarnessModelProviderId,
+  isHarnessModelProviderId,
+} from "../config.ts";
+import { HarnessControlError } from "../control-errors.ts";
+
+export const HARNESS_PROVIDER_SETTINGS_VERSION = 1 as const;
+
+export interface HarnessProviderSettings {
+  version: typeof HARNESS_PROVIDER_SETTINGS_VERSION;
+  modelProvider: HarnessModelProviderId;
+}
+
+export type HarnessProviderSettingsState =
+  | { state: "missing" }
+  | { state: "configured"; settings: HarnessProviderSettings }
+  | { state: "invalid"; detail: string }
+  | { state: "unsupported-version"; version: number | string | null }
+  | { state: "unreadable"; detail: string };
+
+export interface HarnessProviderResolution {
+  provider: HarnessModelProviderId;
+  source: "explicit" | "environment" | "persistent" | "default";
+}
+
+const detailOf = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+const parseDocument = (text: string): HarnessProviderSettingsState => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text) as unknown;
+  } catch {
+    return { state: "invalid", detail: "settings file is not valid JSON" };
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return { state: "invalid", detail: "settings file must contain an object" };
+  }
+  const input = parsed as Record<string, unknown>;
+  if (input.version !== HARNESS_PROVIDER_SETTINGS_VERSION) {
+    const version = typeof input.version === "number" ||
+        typeof input.version === "string" || input.version === null
+      ? input.version
+      : null;
+    return { state: "unsupported-version", version };
+  }
+  if (!isHarnessModelProviderId(input.modelProvider)) {
+    return {
+      state: "invalid",
+      detail: "settings file contains an invalid model provider",
+    };
+  }
+  return {
+    state: "configured",
+    settings: {
+      version: HARNESS_PROVIDER_SETTINGS_VERSION,
+      modelProvider: input.modelProvider,
+    },
+  };
+};
+
+class KeyedMutationQueue {
+  readonly #tails = new Map<string, Promise<void>>();
+
+  async run<T>(
+    key: string,
+    operation: () => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    const previous = this.#tails.get(key) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.catch(() => {}).then(() => current);
+    this.#tails.set(key, tail);
+    const clearTail = () => {
+      if (this.#tails.get(key) === tail) this.#tails.delete(key);
+    };
+    void tail.then(clearTail, clearTail);
+    try {
+      const turn = previous.catch(() => {});
+      if (signal === undefined) {
+        await turn;
+      } else {
+        signal.throwIfAborted();
+        await new Promise<void>((resolve, reject) => {
+          const onAbort = () => reject(signal.reason);
+          signal.addEventListener("abort", onAbort, { once: true });
+          void turn.then(() => {
+            signal.removeEventListener("abort", onAbort);
+            resolve();
+          });
+        });
+        signal.throwIfAborted();
+      }
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+}
+
+const mutationQueue = new KeyedMutationQueue();
+
+export interface FileHarnessProviderSettingsStoreOptions {
+  path: string;
+  /** @internal Observability hook used by lock-contention tests. */
+  onLockAcquisitionStarted?: () => void;
+}
+
+/** Secure persistent storage for the machine's default model provider. */
+export class FileHarnessProviderSettingsStore {
+  readonly path: string;
+  readonly #onLockAcquisitionStarted?: () => void;
+
+  constructor(options: FileHarnessProviderSettingsStoreOptions) {
+    this.path = resolve(options.path);
+    this.#onLockAcquisitionStarted = options.onLockAcquisitionStarted;
+  }
+
+  async #ensurePrivateDirectory(): Promise<void> {
+    const directory = dirname(this.path);
+    await Deno.mkdir(directory, { recursive: true, mode: 0o700 });
+    const info = await Deno.lstat(directory);
+    if (info.isSymlink || !info.isDirectory) {
+      throw new Error("provider settings directory must not be a symlink");
+    }
+    if (
+      Deno.build.os !== "windows" && info.mode !== null &&
+      (info.mode & 0o077) !== 0
+    ) {
+      throw new Error(
+        "provider settings directory must have private permissions",
+      );
+    }
+  }
+
+  async #assertPrivateRegularFile(
+    path: string,
+    label: "provider settings" | "provider settings lock",
+    allowMissing = true,
+  ): Promise<void> {
+    try {
+      const info = await Deno.lstat(path);
+      if (info.isSymlink || !info.isFile) {
+        throw new Error(`${label} file must be a regular file`);
+      }
+      if (
+        Deno.build.os !== "windows" && info.mode !== null &&
+        (info.mode & 0o077) !== 0
+      ) {
+        throw new Error(`${label} file must have private permissions`);
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound && allowMissing) return;
+      throw error;
+    }
+  }
+
+  async #withFileLock<T>(
+    operation: () => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    await this.#ensurePrivateDirectory();
+    const lockPath = `${this.path}.lock`;
+    let lockFile: Deno.FsFile;
+    try {
+      lockFile = await Deno.open(lockPath, {
+        createNew: true,
+        read: true,
+        write: true,
+        mode: 0o600,
+      });
+    } catch (error) {
+      if (!(error instanceof Deno.errors.AlreadyExists)) throw error;
+      await this.#assertPrivateRegularFile(
+        lockPath,
+        "provider settings lock",
+        false,
+      );
+      lockFile = await Deno.open(lockPath, { read: true, write: true });
+    }
+    let locked = false;
+    let cleanupDetached = false;
+    try {
+      await this.#assertPrivateRegularFile(
+        lockPath,
+        "provider settings lock",
+        false,
+      );
+      signal?.throwIfAborted();
+      const lockPromise = lockFile.lock(true).then(() => {
+        locked = true;
+      });
+      this.#onLockAcquisitionStarted?.();
+      if (signal === undefined) {
+        await lockPromise;
+      } else {
+        let removeAbortListener = () => {};
+        const aborted = new Promise<"aborted">((resolve) => {
+          const onAbort = () => resolve("aborted");
+          signal.addEventListener("abort", onAbort, { once: true });
+          removeAbortListener = () =>
+            signal.removeEventListener("abort", onAbort);
+        });
+        let outcome: "locked" | "aborted";
+        try {
+          outcome = await Promise.race([
+            lockPromise.then(() => "locked" as const),
+            aborted,
+          ]);
+        } finally {
+          removeAbortListener();
+        }
+        if (outcome === "aborted") {
+          cleanupDetached = true;
+          void (async () => {
+            try {
+              await lockPromise;
+              await lockFile.unlock().catch(() => {});
+            } catch {
+              // The caller has already observed cancellation.
+            } finally {
+              lockFile.close();
+            }
+          })();
+          signal.throwIfAborted();
+        }
+      }
+      signal?.throwIfAborted();
+      return await operation();
+    } finally {
+      if (!cleanupDetached) {
+        if (locked) await lockFile.unlock().catch(() => {});
+        lockFile.close();
+      }
+    }
+  }
+
+  async inspect(): Promise<HarnessProviderSettingsState> {
+    try {
+      const directory = dirname(this.path);
+      const directoryInfo = await Deno.lstat(directory);
+      if (directoryInfo.isSymlink || !directoryInfo.isDirectory) {
+        return {
+          state: "unreadable",
+          detail: "provider settings directory must not be a symlink",
+        };
+      }
+      if (
+        Deno.build.os !== "windows" && directoryInfo.mode !== null &&
+        (directoryInfo.mode & 0o077) !== 0
+      ) {
+        return {
+          state: "unreadable",
+          detail: "provider settings directory must have private permissions",
+        };
+      }
+      await this.#assertPrivateRegularFile(this.path, "provider settings");
+      return parseDocument(await Deno.readTextFile(this.path));
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) return { state: "missing" };
+      return { state: "unreadable", detail: detailOf(error) };
+    }
+  }
+
+  async #write(settings: HarnessProviderSettings): Promise<void> {
+    const temporaryPath = join(
+      dirname(this.path),
+      `.config-${crypto.randomUUID()}.tmp`,
+    );
+    let failure: unknown;
+    try {
+      await Deno.writeTextFile(
+        temporaryPath,
+        `${JSON.stringify(settings, null, 2)}\n`,
+        { createNew: true, mode: 0o600 },
+      );
+      await Deno.chmod(temporaryPath, 0o600);
+      await Deno.rename(temporaryPath, this.path);
+    } catch (error) {
+      failure = error;
+    }
+    try {
+      await Deno.remove(temporaryPath);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound) && failure === undefined) {
+        throw error;
+      }
+    }
+    if (failure !== undefined) throw failure;
+  }
+
+  initialize(
+    modelProvider: HarnessModelProviderId,
+    signal?: AbortSignal,
+  ): Promise<{ settings: HarnessProviderSettings; changed: boolean }> {
+    return mutationQueue.run(
+      this.path,
+      () =>
+        this.#withFileLock(async () => {
+          const state = await this.inspect();
+          if (state.state === "configured") {
+            return { settings: state.settings, changed: false };
+          }
+          if (state.state !== "missing") throw stateError(state);
+          const settings = {
+            version: HARNESS_PROVIDER_SETTINGS_VERSION,
+            modelProvider,
+          } as const;
+          await this.#write(settings);
+          return { settings, changed: true };
+        }, signal),
+      signal,
+    );
+  }
+
+  set(
+    modelProvider: HarnessModelProviderId,
+    signal?: AbortSignal,
+  ): Promise<{ settings: HarnessProviderSettings; changed: boolean }> {
+    return mutationQueue.run(
+      this.path,
+      () =>
+        this.#withFileLock(async () => {
+          const state = await this.inspect();
+          if (
+            state.state !== "missing" && state.state !== "configured"
+          ) {
+            throw stateError(state);
+          }
+          const settings = {
+            version: HARNESS_PROVIDER_SETTINGS_VERSION,
+            modelProvider,
+          } as const;
+          const changed = state.state === "missing" ||
+            state.settings.modelProvider !== modelProvider;
+          if (changed) await this.#write(settings);
+          return { settings, changed };
+        }, signal),
+      signal,
+    );
+  }
+}
+
+const stateError = (
+  state: Exclude<
+    HarnessProviderSettingsState,
+    { state: "missing" | "configured" }
+  >,
+): HarnessControlError =>
+  new HarnessControlError(
+    "provider-configuration-required",
+    `Provider settings are ${state.state}: ${
+      state.state === "unsupported-version"
+        ? `version ${String(state.version)}`
+        : state.detail
+    }`,
+  );
+
+/** Resolves the provider with manual CLI precedence. */
+export const resolveHarnessModelProviderPreference = async (options: {
+  store: Pick<FileHarnessProviderSettingsStore, "inspect">;
+  explicit?: HarnessModelProviderId;
+  environment?: HarnessModelProviderId;
+  strict?: boolean;
+}): Promise<HarnessProviderResolution> => {
+  if (options.explicit !== undefined) {
+    return { provider: options.explicit, source: "explicit" };
+  }
+  if (options.environment !== undefined) {
+    return { provider: options.environment, source: "environment" };
+  }
+  const state = await options.store.inspect();
+  if (state.state === "configured") {
+    return { provider: state.settings.modelProvider, source: "persistent" };
+  }
+  if (state.state === "missing" && options.strict !== true) {
+    return { provider: "openai-compatible-gateway", source: "default" };
+  }
+  if (state.state === "missing") {
+    throw new HarnessControlError(
+      "provider-configuration-required",
+      "A persistent model provider must be configured",
+    );
+  }
+  throw stateError(state);
+};
+
+/** Returns the provider settings path for one canonical harness home. */
+export const defaultHarnessProviderSettingsPath = (
+  harnessHome: string,
+): string => join(resolve(harnessHome), "config.json");

--- a/packages/cf-harness/src/auth/types.ts
+++ b/packages/cf-harness/src/auth/types.ts
@@ -12,9 +12,29 @@ export interface OpenAICodexOAuthCredential {
 
 export type HarnessCredential = OpenAICodexOAuthCredential;
 
-export interface HarnessCredentialStatus {
-  providerId: HarnessCredentialProviderId;
-  signedIn: boolean;
-  expiresAt?: number;
-  expired?: boolean;
+export type HarnessCredentialTerminalReason =
+  | "invalid-grant"
+  | "revoked"
+  | "refresh-token-reused";
+
+export interface HarnessCredentialHealth {
+  status: "reconnect-required";
+  reason: HarnessCredentialTerminalReason;
 }
+
+export type HarnessCredentialStatus =
+  | {
+    providerId: HarnessCredentialProviderId;
+    status: "disconnected";
+  }
+  | {
+    providerId: HarnessCredentialProviderId;
+    status: "connected";
+    refreshHealth: "ready" | "refresh-on-use";
+  }
+  | {
+    providerId: HarnessCredentialProviderId;
+    status: "reconnect-required";
+    refreshHealth: "reconnect-required";
+    reason: HarnessCredentialTerminalReason;
+  };

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -1375,7 +1375,8 @@ export const parseCfHarnessCliArgs = async (
   if (
     (rawExplicitModelProvider !== undefined &&
       explicitModelProvider === undefined) ||
-    (rawEnvironmentModelProvider !== undefined &&
+    (rawExplicitModelProvider === undefined &&
+      rawEnvironmentModelProvider !== undefined &&
       environmentModelProvider === undefined)
   ) {
     throw new Error(

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -2431,13 +2431,13 @@ const runCfHarnessConfigCommand = async (
           "CF_HARNESS_MODEL_PROVIDER must be openai-compatible-gateway or openai-codex",
         );
       }
-      if (
+      if (environment !== undefined) {
+        effectiveProvider = environment;
+        effectiveSource = "environment";
+      } else if (
         state.state === "configured" || state.state === "missing"
       ) {
-        if (environment !== undefined) {
-          effectiveProvider = environment;
-          effectiveSource = "environment";
-        } else if (state.state === "configured") {
+        if (state.state === "configured") {
           effectiveProvider = state.settings.modelProvider;
           effectiveSource = "persistent";
         } else {

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_GATEWAY_BASE_URL,
   type HarnessGatewayAuthMode,
   type HarnessModelProviderId,
+  isHarnessModelProviderId,
   parseCfcEnforcementMode,
   parseHarnessGatewayAuthMode,
 } from "./config.ts";
@@ -97,6 +98,11 @@ import {
   type HarnessCredentialStore,
 } from "./auth/credential-store.ts";
 import {
+  defaultHarnessProviderSettingsPath,
+  FileHarnessProviderSettingsStore,
+  resolveHarnessModelProviderPreference,
+} from "./auth/provider-settings.ts";
+import {
   completeOpenAICodexDeviceAuthorization,
   loginOpenAICodexWithBrowser,
   OpenAICodexAuthService,
@@ -117,6 +123,10 @@ import {
   setCurrentProvenance,
   setProvenanceCommand,
 } from "./provenance.ts";
+import {
+  HarnessControlError,
+  type HarnessControlErrorCode,
+} from "./control-errors.ts";
 
 const DEFAULT_MODEL = "gpt-5.6-terra";
 const DEFAULT_MAX_MODEL_TURNS = 8;
@@ -272,6 +282,10 @@ export interface CfHarnessCliCapabilities {
     promptCacheControls: true;
     reasoningEffort: true;
     compactThreshold: true;
+    persistentProviderConfig: true;
+    structuredAuthControl: true;
+    credentialHealth: true;
+    loomLocalOwnerBinding: false;
   };
 }
 
@@ -302,6 +316,12 @@ export interface RunCfHarnessCliDependencies {
     options: CreateHarnessPromptLoopOptions,
   ) => Pick<CfHarnessPromptLoop, "runPrompt" | "runTranscript">;
   credentialStore?: HarnessCredentialStore;
+  providerSettingsStore?: Pick<
+    FileHarnessProviderSettingsStore,
+    "inspect" | "initialize" | "set"
+  >;
+  controlSignal?: AbortSignal;
+  loginOpenAICodex?: typeof loginOpenAICodexWithBrowser;
   openAICodexCredentialResolver?: OpenAICodexCredentialResolverLike & {
     ownerKey?: string;
     credentialOwner?: HarnessCredentialOwnerRef;
@@ -388,10 +408,17 @@ export const installCfHarnessSignalHandlers = (
 const usage = `Usage: deno run -A src/main.ts [options] [prompt text]
 
 Options:
-  auth login openai-codex [--device]
+  config inspect [--json]       Inspect configured and effective provider
+  config init <provider> [--json]
+                                Initialize provider only when absent
+  config set <provider> [--json]
+                                Persist the default model provider
+  auth login openai-codex [--device] [--json]
                                 Connect a ChatGPT/Codex subscription
-  auth status openai-codex      Show local connection status without secrets
-  auth logout openai-codex      Remove only cf-harness local credentials
+  auth status openai-codex [--json]
+                                Show local connection status without secrets
+  auth logout openai-codex [--json]
+                                Remove only cf-harness local credentials
   models openai-codex           List models advertised for this subscription
   whoami [--json]               Show the provenance this host reports to the gateway,
                                 including the principal that identifies its requests
@@ -550,6 +577,10 @@ export const createCfHarnessCliCapabilities = (): CfHarnessCliCapabilities => ({
     promptCacheControls: true,
     reasoningEffort: true,
     compactThreshold: true,
+    persistentProviderConfig: true,
+    structuredAuthControl: true,
+    credentialHealth: true,
+    loomLocalOwnerBinding: false,
   },
 });
 
@@ -1138,7 +1169,10 @@ const parseStructuredResultConfig = async (
 
 export const parseCfHarnessCliArgs = async (
   argv: readonly string[],
-  deps: Pick<RunCfHarnessCliDependencies, "cwd" | "env" | "readTextFile"> = {},
+  deps: Pick<
+    RunCfHarnessCliDependencies,
+    "cwd" | "env" | "readTextFile" | "providerSettingsStore"
+  > = {},
 ): Promise<CfHarnessCliConfig | { help: true }> => {
   const normalizedArgv = argv[0] === "--" ? argv.slice(1) : argv;
   const args = parseArgs([...normalizedArgv], {
@@ -1324,15 +1358,31 @@ export const parseCfHarnessCliArgs = async (
     throw new Error("gateway auth mode must be one of bearer, none");
   }
   const gatewayAuthMode = parsedGatewayAuthMode ?? "bearer";
-  const rawModelProvider = typeof args["model-provider"] === "string"
+  const harnessHome = resolve(
+    nonEmptyEnvValue(env.CF_HARNESS_HOME) ??
+      join(nonEmptyEnvValue(env.HOME) ?? cwd, ".cf-harness"),
+  );
+  const rawExplicitModelProvider = typeof args["model-provider"] === "string"
     ? args["model-provider"]
-    : nonEmptyEnvValue(env.CF_HARNESS_MODEL_PROVIDER);
-  const modelProvider = parseModelProvider(rawModelProvider);
-  if (rawModelProvider !== undefined && modelProvider === undefined) {
+    : undefined;
+  const rawEnvironmentModelProvider = nonEmptyEnvValue(
+    env.CF_HARNESS_MODEL_PROVIDER,
+  );
+  const explicitModelProvider = parseModelProvider(rawExplicitModelProvider);
+  const environmentModelProvider = parseModelProvider(
+    rawEnvironmentModelProvider,
+  );
+  if (
+    (rawExplicitModelProvider !== undefined &&
+      explicitModelProvider === undefined) ||
+    (rawEnvironmentModelProvider !== undefined &&
+      environmentModelProvider === undefined)
+  ) {
     throw new Error(
       "model provider must be one of openai-compatible-gateway, openai-codex",
     );
   }
+  const modelProvider = explicitModelProvider ?? environmentModelProvider;
   const reasoningEffort = typeof args["reasoning-effort"] === "string"
     ? nonEmptyEnvValue(args["reasoning-effort"])
     : nonEmptyEnvValue(env.CF_HARNESS_REASONING_EFFORT);
@@ -1381,10 +1431,6 @@ export const parseCfHarnessCliArgs = async (
       "gateway URL/auth options cannot be used with --model-provider openai-codex",
     );
   }
-  const harnessHome = resolve(
-    nonEmptyEnvValue(env.CF_HARNESS_HOME) ??
-      join(nonEmptyEnvValue(env.HOME) ?? cwd, ".cf-harness"),
-  );
   const readTextFile = deps.readTextFile ?? Deno.readTextFile;
   const structuredResult = await parseStructuredResultConfig(args, {
     cwd,
@@ -1586,7 +1632,8 @@ const createSelectedModelClient = async (options: {
   let resolver = options.deps.openAICodexCredentialResolver;
   if (options.loom) {
     if (resolver === undefined) {
-      throw new Error(
+      throw new HarnessControlError(
+        "provider-auth-required",
         "Loom openai-codex runs require an injected owner-bound credential resolver",
       );
     }
@@ -2241,6 +2288,178 @@ const defaultOpenUrl = async (url: string): Promise<void> => {
   }
 };
 
+interface HarnessControlResult<T> {
+  type: "cf-harness.control-result";
+  version: 1;
+  ok: true;
+  command: string;
+  result: T;
+}
+
+interface HarnessControlFailure {
+  type: "cf-harness.control-result";
+  version: 1;
+  ok: false;
+  command: string;
+  error: {
+    code: HarnessControlErrorCode;
+    message: string;
+  };
+}
+
+const writeJsonControlResult = <T>(
+  io: CfHarnessCliIO,
+  command: string,
+  result: T,
+): void => {
+  const envelope: HarnessControlResult<T> = {
+    type: "cf-harness.control-result",
+    version: 1,
+    ok: true,
+    command,
+    result,
+  };
+  io.stdout(`${JSON.stringify(envelope)}\n`);
+};
+
+const writeJsonControlFailure = (
+  io: CfHarnessCliIO,
+  command: string,
+  error: unknown,
+): void => {
+  const controlError = error instanceof HarnessControlError
+    ? error
+    : error instanceof DOMException && error.name === "AbortError"
+    ? new HarnessControlError(
+      "operation-canceled",
+      "The cf-harness control operation was canceled",
+    )
+    : new HarnessControlError(
+      "provider-unavailable",
+      "The cf-harness control operation failed",
+    );
+  const envelope: HarnessControlFailure = {
+    type: "cf-harness.control-result",
+    version: 1,
+    ok: false,
+    command,
+    error: { code: controlError.code, message: controlError.message },
+  };
+  io.stdout(`${JSON.stringify(envelope)}\n`);
+};
+
+const writeJsonControlEvent = <T>(
+  io: CfHarnessCliIO,
+  command: string,
+  event: string,
+  data: T,
+): void => {
+  io.stdout(`${
+    JSON.stringify({
+      type: "cf-harness.control-event",
+      version: 1,
+      command,
+      event,
+      data,
+    })
+  }\n`);
+};
+
+const harnessHomeForControl = (
+  deps: RunCfHarnessCliDependencies,
+): string => {
+  const env = deps.env ?? {
+    CF_HARNESS_HOME: Deno.env.get("CF_HARNESS_HOME"),
+    HOME: Deno.env.get("HOME"),
+  };
+  const cwd = resolve(deps.cwd ?? Deno.cwd());
+  return resolve(
+    nonEmptyEnvValue(env.CF_HARNESS_HOME) ??
+      join(nonEmptyEnvValue(env.HOME) ?? cwd, ".cf-harness"),
+  );
+};
+
+const runCfHarnessConfigCommand = async (
+  argv: readonly string[],
+  deps: RunCfHarnessCliDependencies,
+  io: CfHarnessCliIO,
+): Promise<number | undefined> => {
+  const normalized = argv[0] === "--" ? argv.slice(1) : [...argv];
+  if (normalized[0] !== "config") return undefined;
+  const action = normalized[1];
+  const json = normalized.includes("--json");
+  const positional = normalized.slice(2).filter((value) => value !== "--json");
+  if (
+    (action !== "inspect" && action !== "init" && action !== "set") ||
+    (action === "inspect" ? positional.length !== 0 : positional.length !== 1)
+  ) {
+    throw new Error("usage: config inspect|init|set [provider] [--json]");
+  }
+  const command = `config.${action}`;
+  const store = deps.providerSettingsStore ??
+    new FileHarnessProviderSettingsStore({
+      path: defaultHarnessProviderSettingsPath(harnessHomeForControl(deps)),
+    });
+  try {
+    if (action === "inspect") {
+      const state = await store.inspect();
+      let effectiveProvider: HarnessModelProviderId | undefined;
+      let effectiveSource: "persistent" | "default" | undefined;
+      if (state.state === "configured") {
+        effectiveProvider = state.settings.modelProvider;
+        effectiveSource = "persistent";
+      } else if (state.state === "missing") {
+        effectiveProvider = "openai-compatible-gateway";
+        effectiveSource = "default";
+      }
+      const result = {
+        state: state.state,
+        ...(state.state === "configured"
+          ? { configuredProvider: state.settings.modelProvider }
+          : {}),
+        ...(effectiveProvider !== undefined
+          ? { effectiveProvider, effectiveSource }
+          : {}),
+        ...(state.state === "invalid" || state.state === "unreadable"
+          ? { detail: state.detail }
+          : {}),
+        ...(state.state === "unsupported-version"
+          ? { version: state.version }
+          : {}),
+      };
+      if (json) writeJsonControlResult(io, command, result);
+      else io.stdout(`${JSON.stringify(result, null, 2)}\n`);
+      return state.state === "invalid" || state.state === "unreadable" ||
+          state.state === "unsupported-version"
+        ? 1
+        : 0;
+    }
+    const provider = positional[0];
+    if (!isHarnessModelProviderId(provider)) {
+      throw new HarnessControlError(
+        "provider-configuration-required",
+        "Model provider must be openai-compatible-gateway or openai-codex",
+      );
+    }
+    const result = action === "init"
+      ? await store.initialize(provider)
+      : await store.set(provider);
+    if (json) writeJsonControlResult(io, command, result);
+    else {
+      io.stdout(
+        `model provider: ${result.settings.modelProvider} (${
+          result.changed ? "saved" : "unchanged"
+        })\n`,
+      );
+    }
+    return 0;
+  } catch (error) {
+    if (!json) throw error;
+    writeJsonControlFailure(io, command, error);
+    return 1;
+  }
+};
+
 const runCfHarnessAuthCommand = async (
   argv: readonly string[],
   deps: RunCfHarnessCliDependencies,
@@ -2258,56 +2477,117 @@ const runCfHarnessAuthCommand = async (
       "usage: auth login|status|logout openai-codex [--device]",
     );
   }
-  const env = deps.env ?? {
-    CF_HARNESS_HOME: Deno.env.get("CF_HARNESS_HOME"),
-    HOME: Deno.env.get("HOME"),
-  };
-  const cwd = resolve(deps.cwd ?? Deno.cwd());
-  const harnessHome = resolve(
-    nonEmptyEnvValue(env.CF_HARNESS_HOME) ??
-      join(nonEmptyEnvValue(env.HOME) ?? cwd, ".cf-harness"),
-  );
+  const json = normalized.includes("--json");
+  const command = `auth.${action}`;
+  const harnessHome = harnessHomeForControl(deps);
   const store = deps.credentialStore ?? new FileHarnessCredentialStore({
     path: defaultHarnessCredentialStorePath(harnessHome),
   });
   const auth = new OpenAICodexAuthService(store, "local");
   if (action === "status") {
-    const status = await auth.status();
-    io.stdout(
-      status.signedIn
-        ? `openai-codex: connected (${
-          status.expired ? "refresh required" : "ready"
-        })\n`
-        : "openai-codex: not connected\n",
-    );
-    return status.signedIn ? 0 : 1;
+    try {
+      const status = await auth.status();
+      if (json) writeJsonControlResult(io, command, status);
+      else {
+        io.stdout(
+          status.status === "connected"
+            ? `openai-codex: connected (${
+              status.refreshHealth === "refresh-on-use"
+                ? "refresh required"
+                : "ready"
+            })\n`
+            : status.status === "reconnect-required"
+            ? `openai-codex: reconnect required (${status.reason})\n`
+            : "openai-codex: not connected\n",
+        );
+      }
+      return status.status === "connected" ? 0 : 1;
+    } catch (error) {
+      if (!json) throw error;
+      writeJsonControlFailure(io, command, error);
+      return 1;
+    }
   }
   if (action === "logout") {
-    await auth.logout();
-    io.stdout("openai-codex: disconnected\n");
-    return 0;
+    try {
+      await auth.logout();
+      const result = { providerId: "openai-codex", status: "disconnected" };
+      if (json) writeJsonControlResult(io, command, result);
+      else io.stdout("openai-codex: disconnected\n");
+      return 0;
+    } catch (error) {
+      if (!json) throw error;
+      writeJsonControlFailure(io, command, error);
+      return 1;
+    }
   }
-  if (normalized.slice(3).some((argument) => argument !== "--device")) {
-    throw new Error("auth login openai-codex accepts only --device");
+  if (
+    normalized.slice(3).some((argument) =>
+      argument !== "--device" && argument !== "--json"
+    )
+  ) {
+    throw new Error("auth login openai-codex accepts only --device and --json");
   }
-  if (normalized.includes("--device")) {
-    const device = await startOpenAICodexDeviceAuthorization();
-    io.stdout(
-      `Open ${device.verificationUrl} and enter code ${device.userCode}\n`,
+  const loginController = new AbortController();
+  const signal = deps.controlSignal ?? loginController.signal;
+  const cleanupSignal = deps.controlSignal !== undefined
+    ? () => {}
+    : (deps.registerSignalHandler ?? defaultRegisterSignalHandler)(
+      ["SIGINT", "SIGTERM"],
+      () =>
+        loginController.abort(new DOMException("login canceled", "AbortError")),
     );
-    const credential = await completeOpenAICodexDeviceAuthorization({ device });
-    await auth.save(credential);
-  } else {
-    await loginOpenAICodexWithBrowser({
-      authService: auth,
-      onAuthorizationUrl: async (url) => {
-        io.stdout(`Open this URL to connect openai-codex:\n${url}\n`);
-        await (deps.openUrl ?? defaultOpenUrl)(url);
-      },
-    });
+  try {
+    if (normalized.includes("--device")) {
+      const device = await startOpenAICodexDeviceAuthorization({ signal });
+      if (json) {
+        writeJsonControlEvent(io, command, "authorization-required", {
+          method: "device",
+          verificationUrl: device.verificationUrl,
+          userCode: device.userCode,
+        });
+      } else {
+        io.stdout(
+          `Open ${device.verificationUrl} and enter code ${device.userCode}\n`,
+        );
+      }
+      const credential = await completeOpenAICodexDeviceAuthorization({
+        device,
+        signal,
+      });
+      await auth.save(credential, signal);
+    } else {
+      await (deps.loginOpenAICodex ?? loginOpenAICodexWithBrowser)({
+        authService: auth,
+        signal,
+        onAuthorizationUrl: async (url) => {
+          if (json) {
+            writeJsonControlEvent(io, command, "authorization-required", {
+              method: "browser",
+              url,
+            });
+          } else {
+            io.stdout(`Open this URL to connect openai-codex:\n${url}\n`);
+          }
+          await (deps.openUrl ?? defaultOpenUrl)(url);
+        },
+      });
+    }
+    const result = {
+      providerId: "openai-codex",
+      status: "connected",
+      refreshHealth: "ready",
+    };
+    if (json) writeJsonControlResult(io, command, result);
+    else io.stdout("openai-codex: connected\n");
+    return 0;
+  } catch (error) {
+    if (!json) throw error;
+    writeJsonControlFailure(io, command, error);
+    return 1;
+  } finally {
+    cleanupSignal();
   }
-  io.stdout("openai-codex: connected\n");
-  return 0;
 };
 
 /**
@@ -2316,7 +2596,8 @@ const runCfHarnessAuthCommand = async (
  */
 export const cfHarnessCliCommandName = (argv: readonly string[]): string => {
   const first = argv[0] === "--" ? argv[1] : argv[0];
-  return first === "auth" || first === "models" || first === "whoami"
+  return first === "auth" || first === "config" || first === "models" ||
+      first === "whoami"
     ? first
     : "prompt";
 };
@@ -2338,6 +2619,8 @@ export const runCfHarnessCli = async (
     );
   };
   try {
+    const configResult = await runCfHarnessConfigCommand(argv, deps, io);
+    if (configResult !== undefined) return configResult;
     const authResult = await runCfHarnessAuthCommand(argv, deps, io);
     if (authResult !== undefined) return authResult;
     const modelsResult = await runCfHarnessModelsCommand(argv, deps, io);
@@ -2434,7 +2717,8 @@ export const runCfHarnessCli = async (
         requestedProvider !== undefined &&
         requestedProvider !== recordedProvider
       ) {
-        throw new Error(
+        throw new HarnessControlError(
+          "provider-mismatch",
           `resume provider mismatch: run uses ${recordedProvider}, requested ${requestedProvider}`,
         );
       }
@@ -2464,7 +2748,8 @@ export const runCfHarnessCli = async (
           credentialOwner,
         )
       ) {
-        throw new Error(
+        throw new HarnessControlError(
+          "provider-mismatch",
           "resume credential owner mismatch: requested owner does not match the recorded run",
         );
       }
@@ -2476,7 +2761,8 @@ export const runCfHarnessCli = async (
         modelProvider === "openai-codex" && loom &&
         recordedRunManifest?.credentialOwner === undefined
       ) {
-        throw new Error(
+        throw new HarnessControlError(
+          "provider-auth-required",
           "Loom openai-codex runs require an authenticated credential owner reference",
         );
       }
@@ -2599,7 +2885,12 @@ export const runCfHarnessCli = async (
     } else {
       const modelProvider = parsed.modelProvider ??
         runManifest?.modelProvider ??
-        "openai-compatible-gateway";
+        (await resolveHarnessModelProviderPreference({
+          store: deps.providerSettingsStore ??
+            new FileHarnessProviderSettingsStore({
+              path: defaultHarnessProviderSettingsPath(parsed.harnessHome),
+            }),
+        })).provider;
       if (
         modelProvider === "openai-codex" && parsed.gatewayConfigurationExplicit
       ) {
@@ -2623,7 +2914,8 @@ export const runCfHarnessCli = async (
         modelProvider === "openai-codex" && runManifest?.source === "loom" &&
         runManifest.credentialOwner === undefined
       ) {
-        throw new Error(
+        throw new HarnessControlError(
+          "provider-auth-required",
           "Loom openai-codex runs require an authenticated credential owner reference",
         );
       }

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -2326,8 +2326,14 @@ const writeJsonControlFailure = (
   io: CfHarnessCliIO,
   command: string,
   error: unknown,
+  signal?: AbortSignal,
 ): void => {
-  const controlError = error instanceof HarnessControlError
+  const controlError = signal?.aborted
+    ? new HarnessControlError(
+      "operation-canceled",
+      "The cf-harness control operation was canceled",
+    )
+    : error instanceof HarnessControlError
     ? error
     : error instanceof DOMException && error.name === "AbortError"
     ? new HarnessControlError(
@@ -2389,28 +2395,55 @@ const runCfHarnessConfigCommand = async (
   const action = normalized[1];
   const json = normalized.includes("--json");
   const positional = normalized.slice(2).filter((value) => value !== "--json");
-  if (
-    (action !== "inspect" && action !== "init" && action !== "set") ||
-    (action === "inspect" ? positional.length !== 0 : positional.length !== 1)
-  ) {
-    throw new Error("usage: config inspect|init|set [provider] [--json]");
-  }
-  const command = `config.${action}`;
+  const command = action === undefined ? "config" : `config.${action}`;
   const store = deps.providerSettingsStore ??
     new FileHarnessProviderSettingsStore({
       path: defaultHarnessProviderSettingsPath(harnessHomeForControl(deps)),
     });
   try {
+    if (
+      (action !== "inspect" && action !== "init" && action !== "set") ||
+      (action === "inspect" ? positional.length !== 0 : positional.length !== 1)
+    ) {
+      throw new HarnessControlError(
+        "invalid-request",
+        "usage: config inspect|init|set [provider] [--json]",
+      );
+    }
     if (action === "inspect") {
       const state = await store.inspect();
       let effectiveProvider: HarnessModelProviderId | undefined;
-      let effectiveSource: "persistent" | "default" | undefined;
-      if (state.state === "configured") {
-        effectiveProvider = state.settings.modelProvider;
-        effectiveSource = "persistent";
-      } else if (state.state === "missing") {
-        effectiveProvider = "openai-compatible-gateway";
-        effectiveSource = "default";
+      let effectiveSource:
+        | "environment"
+        | "persistent"
+        | "default"
+        | undefined;
+      const rawEnvironment = nonEmptyEnvValue(
+        deps.env?.CF_HARNESS_MODEL_PROVIDER ??
+          (deps.env === undefined
+            ? Deno.env.get("CF_HARNESS_MODEL_PROVIDER")
+            : undefined),
+      );
+      const environment = parseModelProvider(rawEnvironment);
+      if (rawEnvironment !== undefined && environment === undefined) {
+        throw new HarnessControlError(
+          "invalid-request",
+          "CF_HARNESS_MODEL_PROVIDER must be openai-compatible-gateway or openai-codex",
+        );
+      }
+      if (
+        state.state === "configured" || state.state === "missing"
+      ) {
+        if (environment !== undefined) {
+          effectiveProvider = environment;
+          effectiveSource = "environment";
+        } else if (state.state === "configured") {
+          effectiveProvider = state.settings.modelProvider;
+          effectiveSource = "persistent";
+        } else {
+          effectiveProvider = "openai-compatible-gateway";
+          effectiveSource = "default";
+        }
       }
       const result = {
         state: state.state,
@@ -2419,9 +2452,6 @@ const runCfHarnessConfigCommand = async (
           : {}),
         ...(effectiveProvider !== undefined
           ? { effectiveProvider, effectiveSource }
-          : {}),
-        ...(state.state === "invalid" || state.state === "unreadable"
-          ? { detail: state.detail }
           : {}),
         ...(state.state === "unsupported-version"
           ? { version: state.version }
@@ -2442,8 +2472,8 @@ const runCfHarnessConfigCommand = async (
       );
     }
     const result = action === "init"
-      ? await store.initialize(provider)
-      : await store.set(provider);
+      ? await store.initialize(provider, deps.controlSignal)
+      : await store.set(provider, deps.controlSignal);
     if (json) writeJsonControlResult(io, command, result);
     else {
       io.stdout(
@@ -2455,7 +2485,7 @@ const runCfHarnessConfigCommand = async (
     return 0;
   } catch (error) {
     if (!json) throw error;
-    writeJsonControlFailure(io, command, error);
+    writeJsonControlFailure(io, command, error, deps.controlSignal);
     return 1;
   }
 };
@@ -2469,21 +2499,29 @@ const runCfHarnessAuthCommand = async (
   if (normalized[0] !== "auth") return undefined;
   const action = normalized[1];
   const provider = normalized[2];
-  if (
-    (action !== "login" && action !== "status" && action !== "logout") ||
-    provider !== "openai-codex"
-  ) {
-    throw new Error(
-      "usage: auth login|status|logout openai-codex [--device]",
-    );
-  }
   const json = normalized.includes("--json");
-  const command = `auth.${action}`;
+  const command = action === undefined ? "auth" : `auth.${action}`;
   const harnessHome = harnessHomeForControl(deps);
   const store = deps.credentialStore ?? new FileHarnessCredentialStore({
     path: defaultHarnessCredentialStorePath(harnessHome),
   });
   const auth = new OpenAICodexAuthService(store, "local");
+  const allowedArguments = action === "login"
+    ? new Set(["--device", "--json"])
+    : new Set(["--json"]);
+  if (
+    (action !== "login" && action !== "status" && action !== "logout") ||
+    provider !== "openai-codex" ||
+    normalized.slice(3).some((argument) => !allowedArguments.has(argument))
+  ) {
+    const error = new HarnessControlError(
+      "invalid-request",
+      "usage: auth login|status|logout openai-codex [--device] [--json]",
+    );
+    if (!json) throw error;
+    writeJsonControlFailure(io, command, error, deps.controlSignal);
+    return 1;
+  }
   if (action === "status") {
     try {
       const status = await auth.status();
@@ -2504,7 +2542,7 @@ const runCfHarnessAuthCommand = async (
       return status.status === "connected" ? 0 : 1;
     } catch (error) {
       if (!json) throw error;
-      writeJsonControlFailure(io, command, error);
+      writeJsonControlFailure(io, command, error, deps.controlSignal);
       return 1;
     }
   }
@@ -2517,16 +2555,9 @@ const runCfHarnessAuthCommand = async (
       return 0;
     } catch (error) {
       if (!json) throw error;
-      writeJsonControlFailure(io, command, error);
+      writeJsonControlFailure(io, command, error, deps.controlSignal);
       return 1;
     }
-  }
-  if (
-    normalized.slice(3).some((argument) =>
-      argument !== "--device" && argument !== "--json"
-    )
-  ) {
-    throw new Error("auth login openai-codex accepts only --device and --json");
   }
   const loginController = new AbortController();
   const signal = deps.controlSignal ?? loginController.signal;
@@ -2583,7 +2614,7 @@ const runCfHarnessAuthCommand = async (
     return 0;
   } catch (error) {
     if (!json) throw error;
-    writeJsonControlFailure(io, command, error);
+    writeJsonControlFailure(io, command, error, signal);
     return 1;
   } finally {
     cleanupSignal();

--- a/packages/cf-harness/src/control-errors.ts
+++ b/packages/cf-harness/src/control-errors.ts
@@ -1,0 +1,21 @@
+/** Stable failure codes exposed at cf-harness control boundaries. */
+export type HarnessControlErrorCode =
+  | "provider-configuration-required"
+  | "provider-auth-required"
+  | "provider-mismatch"
+  | "provider-unavailable"
+  | "operation-canceled";
+
+/**
+ * A machine-classifiable provider failure whose message and cause graph are
+ * safe to persist in run metadata or return from a control command.
+ */
+export class HarnessControlError extends Error {
+  constructor(
+    readonly code: HarnessControlErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "HarnessControlError";
+  }
+}

--- a/packages/cf-harness/src/control-errors.ts
+++ b/packages/cf-harness/src/control-errors.ts
@@ -1,5 +1,6 @@
 /** Stable failure codes exposed at cf-harness control boundaries. */
 export type HarnessControlErrorCode =
+  | "invalid-request"
   | "provider-configuration-required"
   | "provider-auth-required"
   | "provider-mismatch"

--- a/packages/cf-harness/src/index.ts
+++ b/packages/cf-harness/src/index.ts
@@ -17,6 +17,8 @@ export * from "./model/openai-codex-responses.ts";
 export * from "./auth/types.ts";
 export * from "./auth/credential-store.ts";
 export * from "./auth/openai-codex.ts";
+export * from "./auth/provider-settings.ts";
+export * from "./control-errors.ts";
 export * from "./contracts/http-fetch.ts";
 export * from "./contracts/image.ts";
 export * from "./contracts/prompt-slot.ts";

--- a/packages/cf-harness/src/model/openai-codex-responses.ts
+++ b/packages/cf-harness/src/model/openai-codex-responses.ts
@@ -456,6 +456,7 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
         ...baseAttempt,
         ...(responseBodyBytes !== undefined ? { responseBodyBytes } : {}),
       });
+      if (request.signal?.aborted) throw abortReason(request.signal);
       if (response.status === 429) {
         throw providerUnavailable("OpenAI Codex usage limit reached");
       }

--- a/packages/cf-harness/src/model/openai-codex-responses.ts
+++ b/packages/cf-harness/src/model/openai-codex-responses.ts
@@ -156,7 +156,6 @@ const selectedHeaders = (
     const name of [
       "x-request-id",
       "x-openai-request-id",
-      "retry-after",
       "content-type",
     ]
   ) {
@@ -447,18 +446,18 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
         : {}),
     };
     if (!response.ok) {
-      const errorBody = await response.text();
+      let responseBodyBytes: number | undefined;
+      try {
+        responseBodyBytes = textBytes(await response.text());
+      } catch {
+        if (request.signal?.aborted) throw abortReason(request.signal);
+      }
       await emitAttempt(request.onAttempt, {
         ...baseAttempt,
-        responseBodyBytes: textBytes(errorBody),
+        ...(responseBodyBytes !== undefined ? { responseBodyBytes } : {}),
       });
       if (response.status === 429) {
-        const retryAfter = response.headers.get("retry-after");
-        throw providerUnavailable(
-          `OpenAI Codex usage limit reached${
-            retryAfter ? `; retry after ${retryAfter}` : ""
-          }`,
-        );
+        throw providerUnavailable("OpenAI Codex usage limit reached");
       }
       if (response.status === 401 || response.status === 403) {
         throw providerAuthRequired(

--- a/packages/cf-harness/src/model/openai-codex-responses.ts
+++ b/packages/cf-harness/src/model/openai-codex-responses.ts
@@ -11,6 +11,7 @@ import {
   toResponsesTools,
 } from "./responses-protocol.ts";
 import type { OpenAICodexOAuthCredential } from "../auth/types.ts";
+import { HarnessControlError } from "../control-errors.ts";
 import type {
   HarnessModelAttemptDiagnostic,
   HarnessModelCatalogEntry,
@@ -43,6 +44,12 @@ export interface OpenAICodexResponsesClientOptions {
 const OPENAI_CODEX_PROVIDER_ID = "openai-codex";
 const OPENAI_CODEX_RESPONSES_LABEL = "Codex Responses";
 
+const providerUnavailable = (message: string): HarnessControlError =>
+  new HarnessControlError("provider-unavailable", message);
+
+const providerAuthRequired = (message: string): HarnessControlError =>
+  new HarnessControlError("provider-auth-required", message);
+
 const textBytes = (text: string): number =>
   new TextEncoder().encode(text).byteLength;
 
@@ -71,7 +78,7 @@ async function* parseSse(
   signal?: AbortSignal,
 ): AsyncGenerator<Record<string, unknown>> {
   if (!response.body) {
-    throw new Error("Codex Responses stream did not include a body");
+    throw providerUnavailable("Codex Responses stream did not include a body");
   }
   const reader = response.body.getReader();
   if (signal?.aborted) {
@@ -90,9 +97,9 @@ async function* parseSse(
       let read: ReadableStreamReadResult<Uint8Array>;
       try {
         read = await reader.read();
-      } catch (error) {
+      } catch {
         if (signal?.aborted) throw abortReason(signal);
-        throw error;
+        throw providerUnavailable("Codex Responses stream read failed");
       }
       const { value, done } = read;
       if (signal?.aborted) throw abortReason(signal);
@@ -111,12 +118,14 @@ async function* parseSse(
         try {
           parsed = JSON.parse(data);
         } catch {
-          throw new Error("Codex Responses stream contained malformed JSON");
+          throw providerUnavailable(
+            "Codex Responses stream contained malformed JSON",
+          );
         }
         if (
           typeof parsed !== "object" || parsed === null || Array.isArray(parsed)
         ) {
-          throw new Error(
+          throw providerUnavailable(
             "Codex Responses stream contained a non-object event",
           );
         }
@@ -125,7 +134,7 @@ async function* parseSse(
       if (done) break;
     }
     if (buffered.trim().length > 0) {
-      throw new Error(
+      throw providerUnavailable(
         "Codex Responses stream ended with an incomplete SSE event",
       );
     }
@@ -217,23 +226,34 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
     if (signal?.aborted) throw abortReason(signal);
     const url = new URL(OPENAI_CODEX_MODELS_URL);
     url.searchParams.set("client_version", OPENAI_CODEX_CLIENT_VERSION);
-    const response = await this.#fetchFn(url, {
-      method: "GET",
-      redirect: "error",
-      headers: {
-        Authorization: `Bearer ${credential.accessToken}`,
-        "chatgpt-account-id": credential.accountId,
-        originator: "cf-harness",
-        "User-Agent": "cf-harness",
-      },
-      signal,
-    });
+    let response: Response;
+    try {
+      response = await this.#fetchFn(url, {
+        method: "GET",
+        redirect: "error",
+        headers: {
+          Authorization: `Bearer ${credential.accessToken}`,
+          "chatgpt-account-id": credential.accountId,
+          originator: "cf-harness",
+          "User-Agent": "cf-harness",
+        },
+        signal,
+      });
+    } catch {
+      if (signal?.aborted) throw abortReason(signal);
+      throw providerUnavailable("OpenAI Codex model discovery failed");
+    }
     if (signal?.aborted) {
       await response.body?.cancel(signal.reason).catch(() => {});
       throw abortReason(signal);
     }
     if (!response.ok) {
-      throw new Error(
+      if (response.status === 401 || response.status === 403) {
+        throw providerAuthRequired(
+          "OpenAI Codex authentication is no longer accepted",
+        );
+      }
+      throw providerUnavailable(
         `OpenAI Codex model discovery failed (${response.status})`,
       );
     }
@@ -242,15 +262,19 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
       body = await response.json() as Record<string, unknown>;
     } catch {
       if (signal?.aborted) throw abortReason(signal);
-      throw new Error("OpenAI Codex model discovery returned invalid JSON");
+      throw providerUnavailable(
+        "OpenAI Codex model discovery returned invalid JSON",
+      );
     }
     if (signal?.aborted) throw abortReason(signal);
     if (!Array.isArray(body.models)) {
-      throw new Error("OpenAI Codex model discovery omitted the models array");
+      throw providerUnavailable(
+        "OpenAI Codex model discovery omitted the models array",
+      );
     }
     return body.models.map((raw): HarnessModelCatalogEntry => {
       if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
-        throw new Error(
+        throw providerUnavailable(
           "OpenAI Codex model discovery returned an invalid model",
         );
       }
@@ -259,7 +283,7 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
         typeof model.slug !== "string" ||
         typeof model.display_name !== "string"
       ) {
-        throw new Error(
+        throw providerUnavailable(
           "OpenAI Codex model discovery returned an invalid model",
         );
       }
@@ -395,7 +419,7 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
         errorDetail,
       });
       if (request.signal?.aborted) throw abortReason(request.signal);
-      throw new Error(errorDetail);
+      throw providerUnavailable("OpenAI Codex transport request failed");
     }
     const endedAt = this.#now();
     const baseAttempt: HarnessModelAttemptDiagnostic = {
@@ -430,13 +454,18 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
       });
       if (response.status === 429) {
         const retryAfter = response.headers.get("retry-after");
-        throw new Error(
+        throw providerUnavailable(
           `OpenAI Codex usage limit reached${
             retryAfter ? `; retry after ${retryAfter}` : ""
           }`,
         );
       }
-      throw new Error(
+      if (response.status === 401 || response.status === 403) {
+        throw providerAuthRequired(
+          "OpenAI Codex authentication is no longer accepted",
+        );
+      }
+      throw providerUnavailable(
         `OpenAI Codex Responses request failed (${response.status})`,
       );
     }
@@ -454,7 +483,7 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
         streamedItems.push(event.item);
       }
       if (type === "error") {
-        throw new Error(
+        throw providerUnavailable(
           "OpenAI Codex Responses stream returned an error event",
         );
       }
@@ -466,7 +495,7 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
           typeof event.response !== "object" || event.response === null ||
           Array.isArray(event.response)
         ) {
-          throw new Error(
+          throw providerUnavailable(
             "Codex Responses terminal event did not include a response object",
           );
         }
@@ -475,7 +504,7 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
       }
     }
     if (!terminal) {
-      throw new Error(
+      throw providerUnavailable(
         "Codex Responses stream ended without a terminal response event",
       );
     }
@@ -500,13 +529,21 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
       ...normalizedUsage,
       estimateWithheldReason: "provider-pricing-unavailable" as const,
     };
-    return {
-      assistant: normalizeTerminalResponse(
+    let assistant: ReturnType<typeof normalizeTerminalResponse>;
+    try {
+      assistant = normalizeTerminalResponse(
         terminal,
         request.model,
         OPENAI_CODEX_PROVIDER_ID,
         OPENAI_CODEX_RESPONSES_LABEL,
-      ),
+      );
+    } catch {
+      throw providerUnavailable(
+        "OpenAI Codex returned an invalid terminal response",
+      );
+    }
+    return {
+      assistant,
       ...(usage !== undefined ? { usage } : {}),
     };
   }

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -32,6 +32,7 @@ import {
 } from "../src/prompt-loop.ts";
 import { InMemoryHarnessCredentialStore } from "../src/auth/credential-store.ts";
 import type { HarnessModelClient } from "../src/model/client.ts";
+import { HarnessControlError } from "../src/control-errors.ts";
 
 const ONE_PIXEL_PNG = decodeBase64(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p94AAAAASUVORK5CYII=",
@@ -1598,6 +1599,10 @@ Deno.test("runCfHarnessCli prints machine-readable capabilities", async () => {
   );
   assertEquals(capabilities.cliFlags.includes("--describe-capabilities"), true);
   assertEquals(capabilities.repeatableCliFlags.includes("--allow-tool"), true);
+  assertEquals(capabilities.features.persistentProviderConfig, true);
+  assertEquals(capabilities.features.structuredAuthControl, true);
+  assertEquals(capabilities.features.credentialHealth, true);
+  assertEquals(capabilities.features.loomLocalOwnerBinding, false);
 });
 
 Deno.test("installCfHarnessSignalHandlers terminalizes the active run before exiting", async () => {
@@ -4132,6 +4137,34 @@ Deno.test("Loom Codex invocation requires an authenticated owner reference", asy
   ]);
 });
 
+Deno.test("Loom Codex invocation requires an injected owner-bound resolver", async () => {
+  const { io, stderr } = createIoBuffers();
+  const exitCode = await runCfHarnessCli(
+    ["--run-manifest", "/tmp/loom-owner.json", "--prompt", "hello"],
+    {
+      io,
+      cwd: "/tmp/project",
+      env: {},
+      readTextFile: () =>
+        Promise.resolve(JSON.stringify({
+          type: "cf-harness.loom-run-manifest",
+          version: 1,
+          source: "loom",
+          modelProvider: "openai-codex",
+          credentialOwner: {
+            type: "cf-harness.credential-owner-ref",
+            version: 1,
+            ownerKey: "local",
+          },
+        })),
+    },
+  );
+  assertEquals(exitCode, 1);
+  assertEquals(stderr, [
+    "Loom openai-codex runs require an injected owner-bound credential resolver\n",
+  ]);
+});
+
 Deno.test("Loom Codex invocation preserves two users' owner bindings", async () => {
   const owners: string[] = [];
   for (const ownerKey of ["loom:user-a", "loom:user-b"]) {
@@ -4294,12 +4327,12 @@ Deno.test("structured config commands expose stable success and failure envelope
     },
     changed: true,
   });
-  assertEquals(
-    (await Deno.stat(join(home, "config.json"))).mode! & 0o777,
-    Deno.build.os === "windows"
-      ? (await Deno.stat(join(home, "config.json"))).mode! & 0o777
-      : 0o600,
-  );
+  if (Deno.build.os !== "windows") {
+    assertEquals(
+      (await Deno.stat(join(home, "config.json"))).mode! & 0o777,
+      0o600,
+    );
+  }
 
   await Deno.writeTextFile(join(home, "config.json"), "{secret-corruption", {
     mode: 0o600,
@@ -4319,10 +4352,319 @@ Deno.test("structured config commands expose stable success and failure envelope
     command: "config.set",
     error: {
       code: "provider-configuration-required",
-      message: "Provider settings are invalid: settings file is not valid JSON",
+      message: "Provider settings are invalid",
     },
   });
   assertEquals(failed.stdout[0].includes("secret-corruption"), false);
+});
+
+Deno.test("config inspect reports environment precedence and rejects invalid environment", async () => {
+  const home = await Deno.makeTempDir();
+  const overridden = createIoBuffers();
+  assertEquals(
+    await runCfHarnessCli(["config", "inspect", "--json"], {
+      io: overridden.io,
+      env: {
+        CF_HARNESS_HOME: home,
+        CF_HARNESS_MODEL_PROVIDER: "openai-codex",
+      },
+    }),
+    0,
+  );
+  assertEquals(JSON.parse(overridden.stdout[0]).result, {
+    state: "missing",
+    effectiveProvider: "openai-codex",
+    effectiveSource: "environment",
+  });
+
+  const invalid = createIoBuffers();
+  assertEquals(
+    await runCfHarnessCli(["config", "inspect", "--json"], {
+      io: invalid.io,
+      env: {
+        CF_HARNESS_HOME: home,
+        CF_HARNESS_MODEL_PROVIDER: "not-a-provider",
+      },
+    }),
+    1,
+  );
+  assertEquals(JSON.parse(invalid.stdout[0]).error.code, "invalid-request");
+});
+
+Deno.test("structured control usage failures always return one bounded envelope", async () => {
+  const cases = [
+    ["config", "bogus", "--json"],
+    ["config", "inspect", "extra", "--json"],
+    ["auth", "status", "bad-provider", "--json"],
+    ["auth", "status", "openai-codex", "--unexpected", "--json"],
+    ["auth", "logout", "openai-codex", "--device", "--json"],
+    ["auth", "login", "openai-codex", "--unexpected", "--json"],
+  ];
+  for (const argv of cases) {
+    const buffers = createIoBuffers();
+    assertEquals(
+      await runCfHarnessCli(argv, {
+        io: buffers.io,
+        env: {},
+        credentialStore: new InMemoryHarnessCredentialStore(),
+      }),
+      1,
+    );
+    assertEquals(buffers.stdout.length, 1);
+    const envelope = JSON.parse(buffers.stdout[0]);
+    assertEquals(envelope.ok, false);
+    assertEquals(envelope.error.code, "invalid-request");
+    assertEquals(buffers.stderr, []);
+  }
+});
+
+Deno.test("config provider validation is structured only when requested", async () => {
+  const structured = createIoBuffers();
+  assertEquals(
+    await runCfHarnessCli(["config", "set", "invalid", "--json"], {
+      io: structured.io,
+      env: {},
+    }),
+    1,
+  );
+  assertEquals(
+    JSON.parse(structured.stdout[0]).error.code,
+    "provider-configuration-required",
+  );
+
+  const human = createIoBuffers();
+  assertEquals(
+    await runCfHarnessCli(["config", "set", "invalid"], {
+      io: human.io,
+      env: {},
+    }),
+    1,
+  );
+  assertEquals(human.stdout, []);
+  assertStringIncludes(human.stderr[0], "Model provider must be");
+});
+
+Deno.test("structured logout success and control failures stay bounded", async () => {
+  const successStore = new InMemoryHarnessCredentialStore();
+  const success = createIoBuffers();
+  assertEquals(
+    await runCfHarnessCli(
+      ["auth", "logout", "openai-codex", "--json"],
+      { io: success.io, env: {}, credentialStore: successStore },
+    ),
+    0,
+  );
+  assertEquals(JSON.parse(success.stdout[0]).result.status, "disconnected");
+
+  const failingStore = new InMemoryHarnessCredentialStore();
+  failingStore.delete = () => Promise.reject(new Error("secret-delete"));
+  const failedLogout = createIoBuffers();
+  assertEquals(
+    await runCfHarnessCli(
+      ["auth", "logout", "openai-codex", "--json"],
+      { io: failedLogout.io, env: {}, credentialStore: failingStore },
+    ),
+    1,
+  );
+  assertEquals(
+    JSON.parse(failedLogout.stdout[0]).error.code,
+    "provider-unavailable",
+  );
+  assertEquals(failedLogout.stdout[0].includes("secret-delete"), false);
+
+  const failedHuman = createIoBuffers();
+  assertEquals(
+    await runCfHarnessCli(["auth", "logout", "openai-codex"], {
+      io: failedHuman.io,
+      env: {},
+      credentialStore: failingStore,
+    }),
+    1,
+  );
+  assertStringIncludes(failedHuman.stderr[0], "secret-delete");
+});
+
+Deno.test("structured config output redacts corrupt values and unreadable details", async () => {
+  const sentinel = "refresh-secret-sentinel";
+  for (
+    const state of [
+      { state: "unsupported-version" as const, version: null },
+      { state: "unreadable" as const, detail: sentinel },
+    ]
+  ) {
+    const store = {
+      inspect: () => Promise.resolve(state),
+      initialize: () => Promise.reject(new Error("unused")),
+      set: () => Promise.reject(new Error("unused")),
+    };
+    const inspect = createIoBuffers();
+    assertEquals(
+      await runCfHarnessCli(["config", "inspect", "--json"], {
+        io: inspect.io,
+        env: {},
+        providerSettingsStore: store,
+      }),
+      1,
+    );
+    assertEquals(inspect.stdout[0].includes(sentinel), false);
+
+    const mutate = createIoBuffers();
+    const rejectingStore = {
+      ...store,
+      set: () =>
+        Promise.reject(
+          new HarnessControlError(
+            "provider-configuration-required",
+            state.state === "unreadable"
+              ? "Provider settings are unreadable"
+              : "Provider settings use an unsupported version",
+          ),
+        ),
+    };
+    assertEquals(
+      await runCfHarnessCli(
+        ["config", "set", "openai-codex", "--json"],
+        { io: mutate.io, env: {}, providerSettingsStore: rejectingStore },
+      ),
+      1,
+    );
+    assertEquals(mutate.stdout[0].includes(sentinel), false);
+  }
+});
+
+Deno.test("structured config cancellation is typed and preserves missing state", async () => {
+  const home = await Deno.makeTempDir();
+  const controller = new AbortController();
+  controller.abort(new Error("cancel-secret-sentinel"));
+  const buffers = createIoBuffers();
+  assertEquals(
+    await runCfHarnessCli(
+      ["config", "set", "openai-codex", "--json"],
+      {
+        io: buffers.io,
+        env: { CF_HARNESS_HOME: home },
+        controlSignal: controller.signal,
+      },
+    ),
+    1,
+  );
+  assertEquals(JSON.parse(buffers.stdout[0]).error.code, "operation-canceled");
+  assertEquals(buffers.stdout[0].includes("cancel-secret-sentinel"), false);
+  await assertRejects(
+    () => Deno.stat(join(home, "config.json")),
+    Deno.errors.NotFound,
+  );
+});
+
+Deno.test("persisted provider preference selects the direct-run model client", async () => {
+  const providerSettingsStore = {
+    inspect: () =>
+      Promise.resolve({
+        state: "configured" as const,
+        settings: {
+          version: 1 as const,
+          modelProvider: "openai-codex" as const,
+        },
+      }),
+    initialize: () => Promise.reject(new Error("unused")),
+    set: () => Promise.reject(new Error("unused")),
+  };
+  let selectedProvider: string | undefined;
+  const buffers = createIoBuffers();
+  assertEquals(
+    await runCfHarnessCli(["--prompt", "hello"], {
+      io: buffers.io,
+      cwd: "/tmp/project",
+      env: {},
+      providerSettingsStore,
+      createModelClient: (options) => {
+        selectedProvider = options.provider;
+        return {
+          providerId: "openai-codex",
+          complete: () => Promise.reject(new Error("unused")),
+        };
+      },
+      createPromptLoop: () => ({
+        runPrompt: () =>
+          Promise.resolve(completedCliResult("persisted-provider")),
+        runTranscript: () => Promise.reject(new Error("unexpected resume")),
+      }),
+    }),
+    0,
+  );
+  assertEquals(selectedProvider, "openai-codex");
+});
+
+Deno.test("human config and auth controls preserve operator output", async () => {
+  const providerSettingsStore = {
+    inspect: () => Promise.resolve({ state: "missing" as const }),
+    initialize: () =>
+      Promise.resolve({
+        settings: {
+          version: 1 as const,
+          modelProvider: "openai-compatible-gateway" as const,
+        },
+        changed: true,
+      }),
+    set: () =>
+      Promise.resolve({
+        settings: {
+          version: 1 as const,
+          modelProvider: "openai-codex" as const,
+        },
+        changed: false,
+      }),
+  };
+  for (
+    const [argv, expected] of [
+      [["config", "inspect"], '"state": "missing"'],
+      [["config", "init", "openai-compatible-gateway"], "(saved)"],
+      [["config", "set", "openai-codex"], "(unchanged)"],
+    ] as const
+  ) {
+    const buffers = createIoBuffers();
+    assertEquals(
+      await runCfHarnessCli(argv, {
+        io: buffers.io,
+        env: {},
+        providerSettingsStore,
+      }),
+      0,
+    );
+    assertStringIncludes(buffers.stdout[0], expected);
+  }
+
+  const store = new InMemoryHarnessCredentialStore();
+  await store.set("local", "openai-codex", {
+    type: "oauth",
+    providerId: "openai-codex",
+    accessToken: "access",
+    refreshToken: "refresh",
+    expiresAt: 0,
+    accountId: "account",
+  });
+  const expired = createIoBuffers();
+  assertEquals(
+    await runCfHarnessCli(["auth", "status", "openai-codex"], {
+      io: expired.io,
+      env: {},
+      credentialStore: store,
+    }),
+    0,
+  );
+  assertEquals(expired.stdout, [
+    "openai-codex: connected (refresh required)\n",
+  ]);
+  const logout = createIoBuffers();
+  assertEquals(
+    await runCfHarnessCli(["auth", "logout", "openai-codex"], {
+      io: logout.io,
+      env: {},
+      credentialStore: store,
+    }),
+    0,
+  );
+  assertEquals(logout.stdout, ["openai-codex: disconnected\n"]);
 });
 
 Deno.test("structured auth status exposes bounded health without credential fields", async () => {

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -4255,6 +4255,222 @@ Deno.test("local auth status and logout are provider-scoped and secret-free", as
   assertEquals(await store.get("local", "openai-codex"), undefined);
 });
 
+Deno.test("structured config commands expose stable success and failure envelopes", async () => {
+  const home = await Deno.makeTempDir();
+  const env = { CF_HARNESS_HOME: home };
+
+  const missing = createIoBuffers();
+  assertEquals(
+    await runCfHarnessCli(["config", "inspect", "--json"], {
+      io: missing.io,
+      env,
+    }),
+    0,
+  );
+  assertEquals(JSON.parse(missing.stdout[0]), {
+    type: "cf-harness.control-result",
+    version: 1,
+    ok: true,
+    command: "config.inspect",
+    result: {
+      state: "missing",
+      effectiveProvider: "openai-compatible-gateway",
+      effectiveSource: "default",
+    },
+  });
+
+  const initialized = createIoBuffers();
+  assertEquals(
+    await runCfHarnessCli(
+      ["config", "init", "openai-compatible-gateway", "--json"],
+      { io: initialized.io, env },
+    ),
+    0,
+  );
+  assertEquals(JSON.parse(initialized.stdout[0]).result, {
+    settings: {
+      version: 1,
+      modelProvider: "openai-compatible-gateway",
+    },
+    changed: true,
+  });
+  assertEquals(
+    (await Deno.stat(join(home, "config.json"))).mode! & 0o777,
+    Deno.build.os === "windows"
+      ? (await Deno.stat(join(home, "config.json"))).mode! & 0o777
+      : 0o600,
+  );
+
+  await Deno.writeTextFile(join(home, "config.json"), "{secret-corruption", {
+    mode: 0o600,
+  });
+  const failed = createIoBuffers();
+  assertEquals(
+    await runCfHarnessCli(
+      ["config", "set", "openai-codex", "--json"],
+      { io: failed.io, env },
+    ),
+    1,
+  );
+  assertEquals(JSON.parse(failed.stdout[0]), {
+    type: "cf-harness.control-result",
+    version: 1,
+    ok: false,
+    command: "config.set",
+    error: {
+      code: "provider-configuration-required",
+      message: "Provider settings are invalid: settings file is not valid JSON",
+    },
+  });
+  assertEquals(failed.stdout[0].includes("secret-corruption"), false);
+});
+
+Deno.test("structured auth status exposes bounded health without credential fields", async () => {
+  const store = new InMemoryHarnessCredentialStore();
+  await store.updateRecord("local", "openai-codex", () => ({
+    credential: {
+      type: "oauth",
+      providerId: "openai-codex",
+      accessToken: "access-secret",
+      refreshToken: "refresh-secret",
+      expiresAt: 0,
+      accountId: "account-secret",
+    },
+    health: { status: "reconnect-required", reason: "invalid-grant" },
+  }));
+  const { io, stdout } = createIoBuffers();
+
+  assertEquals(
+    await runCfHarnessCli(["auth", "status", "openai-codex", "--json"], {
+      io,
+      env: {},
+      credentialStore: store,
+    }),
+    1,
+  );
+  assertEquals(JSON.parse(stdout[0]), {
+    type: "cf-harness.control-result",
+    version: 1,
+    ok: true,
+    command: "auth.status",
+    result: {
+      providerId: "openai-codex",
+      status: "reconnect-required",
+      refreshHealth: "reconnect-required",
+      reason: "invalid-grant",
+    },
+  });
+  assertEquals(stdout[0].includes("secret"), false);
+  assertEquals(stdout[0].includes("expiresAt"), false);
+});
+
+Deno.test("structured browser login emits JSON events and a bounded result", async () => {
+  const store = new InMemoryHarnessCredentialStore();
+  const { io, stdout } = createIoBuffers();
+
+  assertEquals(
+    await runCfHarnessCli(["auth", "login", "openai-codex", "--json"], {
+      io,
+      env: {},
+      credentialStore: store,
+      openUrl: () => {},
+      loginOpenAICodex: async (options) => {
+        await options.onAuthorizationUrl("https://auth.example/authorize");
+        const credential = {
+          type: "oauth" as const,
+          providerId: "openai-codex" as const,
+          accessToken: "access-secret",
+          refreshToken: "refresh-secret",
+          expiresAt: 4_000_000_000_000,
+          accountId: "account-secret",
+        };
+        await options.authService.save(credential);
+        return credential;
+      },
+    }),
+    0,
+  );
+  assertEquals(JSON.parse(stdout[0]), {
+    type: "cf-harness.control-event",
+    version: 1,
+    command: "auth.login",
+    event: "authorization-required",
+    data: {
+      method: "browser",
+      url: "https://auth.example/authorize",
+    },
+  });
+  assertEquals(JSON.parse(stdout[1]), {
+    type: "cf-harness.control-result",
+    version: 1,
+    ok: true,
+    command: "auth.login",
+    result: {
+      providerId: "openai-codex",
+      status: "connected",
+      refreshHealth: "ready",
+    },
+  });
+  assertEquals(JSON.stringify(stdout).includes("secret"), false);
+});
+
+Deno.test("structured login cancellation preserves prior auth and provider state", async () => {
+  const store = new InMemoryHarnessCredentialStore();
+  const previous = {
+    type: "oauth" as const,
+    providerId: "openai-codex" as const,
+    accessToken: "previous-access",
+    refreshToken: "previous-refresh",
+    expiresAt: 4_000_000_000_000,
+    accountId: "previous-account",
+  };
+  await store.set("local", "openai-codex", previous);
+  const controller = new AbortController();
+  controller.abort(new DOMException("cancel-secret", "AbortError"));
+  const { io, stdout } = createIoBuffers();
+
+  assertEquals(
+    await runCfHarnessCli(["auth", "login", "openai-codex", "--json"], {
+      io,
+      env: {},
+      credentialStore: store,
+      controlSignal: controller.signal,
+    }),
+    1,
+  );
+  assertEquals(JSON.parse(stdout[0]), {
+    type: "cf-harness.control-result",
+    version: 1,
+    ok: false,
+    command: "auth.login",
+    error: {
+      code: "operation-canceled",
+      message: "The cf-harness control operation was canceled",
+    },
+  });
+  assertEquals(await store.get("local", "openai-codex"), previous);
+  assertEquals(stdout[0].includes("cancel-secret"), false);
+});
+
+Deno.test("structured auth failures discard secret-bearing cause graphs", async () => {
+  const store = new InMemoryHarnessCredentialStore();
+  store.getRecord = () => Promise.reject(new Error("storage-secret-sentinel"));
+  const { io, stdout } = createIoBuffers();
+
+  assertEquals(
+    await runCfHarnessCli(["auth", "status", "openai-codex", "--json"], {
+      io,
+      env: {},
+      credentialStore: store,
+    }),
+    1,
+  );
+  const result = JSON.parse(stdout[0]);
+  assertEquals(result.ok, false);
+  assertEquals(result.error.code, "provider-unavailable");
+  assertEquals(stdout[0].includes("storage-secret-sentinel"), false);
+});
+
 Deno.test("models openai-codex reports live provider order", async () => {
   const { io, stdout, stderr } = createIoBuffers();
   const exitCode = await runCfHarnessCli(["models", "openai-codex"], {

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -4501,12 +4501,15 @@ Deno.test("structured config output redacts corrupt values and unreadable detail
     assertEquals(
       await runCfHarnessCli(["config", "inspect", "--json"], {
         io: inspect.io,
-        env: {},
+        env: { CF_HARNESS_MODEL_PROVIDER: "openai-codex" },
         providerSettingsStore: store,
       }),
       1,
     );
     assertEquals(inspect.stdout[0].includes(sentinel), false);
+    const inspectResult = JSON.parse(inspect.stdout[0]).result;
+    assertEquals(inspectResult.effectiveProvider, "openai-codex");
+    assertEquals(inspectResult.effectiveSource, "environment");
 
     const mutate = createIoBuffers();
     const rejectingStore = {

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -4030,6 +4030,18 @@ Deno.test("parseCfHarnessCliArgs selects openai-codex without an API key", async
   assertEquals(parsed.apiKey, undefined);
 });
 
+Deno.test("parseCfHarnessCliArgs applies explicit provider before environment validation", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    ["--model-provider", "openai-codex", "--prompt", "hello"],
+    {
+      cwd: "/tmp/project",
+      env: { CF_HARNESS_MODEL_PROVIDER: "not-a-provider" },
+    },
+  );
+  if ("help" in parsed) throw new Error("expected config result");
+  assertEquals(parsed.modelProvider, "openai-codex");
+});
+
 Deno.test("parseCfHarnessCliArgs rejects gateway configuration for openai-codex", async () => {
   await assertRejects(
     () =>

--- a/packages/cf-harness/test/credential-store.test.ts
+++ b/packages/cf-harness/test/credential-store.test.ts
@@ -280,6 +280,9 @@ Deno.test("file credential store rejects malformed owners and expiries fail-clos
   const path = join(root, "auth.json");
   const malformedDocuments = [
     '{"version":1,"owners":[]}',
+    '{"version":2,"owners":{},"health":[]}',
+    '{"version":2,"owners":{},"health":{"local":[]}}',
+    '{"version":2,"owners":{"local":{"openai-codex":{"type":"oauth","providerId":"openai-codex","accessToken":"access","refreshToken":"refresh","expiresAt":1,"accountId":"account"}}},"health":{"local":{"openai-codex":[]}}}',
     '{"version":1,"owners":{"local":{"openai-codex":{"type":"oauth","providerId":"openai-codex","accessToken":"access","refreshToken":"refresh","expiresAt":1e999,"accountId":"account"}}}}',
     '{"version":2,"owners":{},"health":{"local":{"openai-codex":{"status":"reconnect-required","reason":"revoked"}}}}',
   ];
@@ -372,4 +375,95 @@ Deno.test("credential health is atomic with credentials and logout removes both"
   await store.delete("local", "openai-codex");
   assertEquals(await store.get("local", "openai-codex"), undefined);
   assertEquals(await store.getHealth("local", "openai-codex"), undefined);
+});
+
+Deno.test("file credential health lookup and logout survive reopen", async () => {
+  const root = await Deno.makeTempDir();
+  const path = join(root, "auth.json");
+  const store = new FileHarnessCredentialStore({ path });
+  await store.updateRecord("local", "openai-codex", () => ({
+    credential: credential("local"),
+    health: { status: "reconnect-required", reason: "revoked" },
+  }));
+  const reopened = new FileHarnessCredentialStore({ path });
+  assertEquals(await reopened.getHealth("local", "openai-codex"), {
+    status: "reconnect-required",
+    reason: "revoked",
+  });
+  await reopened.delete("local", "openai-codex");
+  assertEquals(await reopened.getRecord("local", "openai-codex"), {});
+});
+
+for (
+  const [name, createStore] of [
+    [
+      "in-memory",
+      () => ({
+        store: new InMemoryHarnessCredentialStore() as HarnessCredentialStore,
+        readBytes: undefined,
+      }),
+    ],
+    [
+      "file",
+      async () => {
+        const root = await Deno.makeTempDir();
+        const path = join(root, "auth.json");
+        return {
+          store: new FileHarnessCredentialStore({
+            path,
+          }) as HarnessCredentialStore,
+          readBytes: () => Deno.readTextFile(path),
+        };
+      },
+    ],
+  ] as const
+) {
+  Deno.test(`${name} credential store rejects orphan health atomically`, async () => {
+    const { store, readBytes } = await createStore();
+    await store.set("local", "openai-codex", credential("original"));
+    const originalBytes = await readBytes?.();
+
+    await assertRejects(
+      () =>
+        store.updateRecord("local", "openai-codex", () => ({
+          health: { status: "reconnect-required", reason: "revoked" },
+        })),
+      Error,
+      "credential health requires a credential",
+    );
+    assertEquals(
+      (await store.get("local", "openai-codex"))?.accountId,
+      "account-original",
+    );
+    if (readBytes !== undefined) {
+      assertEquals(await readBytes(), originalBytes);
+    }
+
+    await store.updateRecord("local", "openai-codex", () => ({
+      credential: credential("unhealthy"),
+      health: { status: "reconnect-required", reason: "revoked" },
+    }));
+    await store.update("local", "openai-codex", () => undefined);
+    assertEquals(await store.getRecord("local", "openai-codex"), {});
+  });
+}
+
+Deno.test("file credential store finishes an atomic commit after its updater starts", async () => {
+  const root = await Deno.makeTempDir();
+  const path = join(root, "auth.json");
+  const store = new FileHarnessCredentialStore({ path });
+  await store.set("local", "openai-codex", credential("original"));
+  const controller = new AbortController();
+
+  await store.updateRecord("local", "openai-codex", () => {
+    controller.abort(new Error("late cancellation"));
+    return { credential: credential("replacement") };
+  }, controller.signal);
+  assertEquals(
+    (await new FileHarnessCredentialStore({ path }).get(
+      "local",
+      "openai-codex",
+    ))?.accountId,
+    "account-replacement",
+  );
 });

--- a/packages/cf-harness/test/credential-store.test.ts
+++ b/packages/cf-harness/test/credential-store.test.ts
@@ -281,6 +281,7 @@ Deno.test("file credential store rejects malformed owners and expiries fail-clos
   const malformedDocuments = [
     '{"version":1,"owners":[]}',
     '{"version":1,"owners":{"local":{"openai-codex":{"type":"oauth","providerId":"openai-codex","accessToken":"access","refreshToken":"refresh","expiresAt":1e999,"accountId":"account"}}}}',
+    '{"version":2,"owners":{},"health":{"local":{"openai-codex":{"status":"reconnect-required","reason":"revoked"}}}}',
   ];
   for (const malformed of malformedDocuments) {
     await Deno.writeTextFile(path, malformed, { mode: 0o600 });
@@ -306,4 +307,69 @@ Deno.test("logout deletes only the selected owner/provider entry", async () => {
     (await store.get("loom:user-b", "openai-codex"))?.accountId,
     "account-b",
   );
+});
+
+Deno.test("version-1 credential documents migrate on mutation without losing owners", async () => {
+  const root = await Deno.makeTempDir();
+  const path = join(root, "auth.json");
+  const original = {
+    version: 1,
+    owners: {
+      local: { "openai-codex": credential("local") },
+      other: { "openai-codex": credential("other") },
+    },
+  };
+  const originalText = `${JSON.stringify(original, null, 2)}\n`;
+  await Deno.writeTextFile(path, originalText, { mode: 0o600 });
+  const store = new FileHarnessCredentialStore({ path });
+
+  assertEquals(
+    (await store.get("local", "openai-codex"))?.accountId,
+    "account-local",
+  );
+  assertEquals(await Deno.readTextFile(path), originalText);
+  await store.set("local", "openai-codex", credential("updated"));
+
+  const migrated = JSON.parse(await Deno.readTextFile(path));
+  assertEquals(migrated.version, 2);
+  assertEquals(migrated.health, {});
+  assertEquals(
+    migrated.owners.other["openai-codex"].accountId,
+    "account-other",
+  );
+  assertEquals(
+    migrated.owners.local["openai-codex"].accountId,
+    "account-updated",
+  );
+});
+
+Deno.test("credential store never overwrites unknown future documents", async () => {
+  const root = await Deno.makeTempDir();
+  const path = join(root, "auth.json");
+  const future = '{"version":3,"owners":{},"health":{},"future":true}';
+  await Deno.writeTextFile(path, future, { mode: 0o600 });
+  const store = new FileHarnessCredentialStore({ path });
+
+  await assertRejects(
+    () => store.set("local", "openai-codex", credential("replacement")),
+    Error,
+    "unsupported credential store format",
+  );
+  assertEquals(await Deno.readTextFile(path), future);
+});
+
+Deno.test("credential health is atomic with credentials and logout removes both", async () => {
+  const store = new InMemoryHarnessCredentialStore();
+  await store.updateRecord("local", "openai-codex", () => ({
+    credential: credential("local"),
+    health: { status: "reconnect-required", reason: "revoked" },
+  }));
+
+  assertEquals(await store.getHealth("local", "openai-codex"), {
+    status: "reconnect-required",
+    reason: "revoked",
+  });
+  await store.delete("local", "openai-codex");
+  assertEquals(await store.get("local", "openai-codex"), undefined);
+  assertEquals(await store.getHealth("local", "openai-codex"), undefined);
 });

--- a/packages/cf-harness/test/openai-codex-auth.test.ts
+++ b/packages/cf-harness/test/openai-codex-auth.test.ts
@@ -21,6 +21,7 @@ import {
   InMemoryHarnessCredentialStore,
 } from "../src/auth/credential-store.ts";
 import type { OpenAICodexOAuthCredential } from "../src/auth/types.ts";
+import { HarnessControlError } from "../src/control-errors.ts";
 
 const errorGraphText = (input: unknown): string => {
   const parts: string[] = [];
@@ -350,11 +351,11 @@ Deno.test("Codex credential resolution preserves abort during credential reads",
   });
   const store = new InMemoryHarnessCredentialStore();
   await store.set("local", "openai-codex", credential);
-  const originalGet = store.get.bind(store);
-  store.get = async (ownerKey, providerId) => {
+  const originalGetRecord = store.getRecord.bind(store);
+  store.getRecord = async (ownerKey, providerId) => {
     markReadStarted();
     await readHeld;
-    return await originalGet(ownerKey, providerId);
+    return await originalGetRecord(ownerKey, providerId);
   };
   const resolver = new OpenAICodexCredentialResolver({
     store,
@@ -712,12 +713,162 @@ Deno.test("Codex refresh classifies invalid grants without exposing tokens", asy
   });
 
   const error = await assertRejects(() => resolver.resolve());
-  assertEquals(error instanceof OpenAICodexAuthError, true);
-  assertEquals((error as OpenAICodexAuthError).kind, "invalid_grant");
+  assertEquals(error instanceof HarnessControlError, true);
+  assertEquals((error as HarnessControlError).code, "provider-auth-required");
   assertEquals(
     (error as Error).message.includes("do-not-print-refresh"),
     false,
   );
+});
+
+Deno.test("Codex terminal refresh health persists and prevents another request", async () => {
+  const store = new InMemoryHarnessCredentialStore();
+  await store.set("local", "openai-codex", {
+    type: "oauth",
+    providerId: "openai-codex",
+    accessToken: "expired-access",
+    refreshToken: "terminal-refresh-secret",
+    expiresAt: 0,
+    accountId: "account-secret",
+  });
+  let requests = 0;
+  const resolver = new OpenAICodexCredentialResolver({
+    store,
+    ownerKey: "local",
+    now: () => 100_000,
+    fetchFn: () => {
+      requests += 1;
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: "refresh_token_reused",
+              detail: "secret-provider-detail",
+            },
+          }),
+          { status: 400 },
+        ),
+      );
+    },
+  });
+
+  const first = await assertRejects(() => resolver.resolve());
+  assertEquals((first as HarnessControlError).code, "provider-auth-required");
+  assertEquals(errorGraphText(first).includes("secret"), false);
+  assertEquals(await store.getHealth("local", "openai-codex"), {
+    status: "reconnect-required",
+    reason: "refresh-token-reused",
+  });
+  const second = await assertRejects(() => resolver.resolve());
+  assertEquals((second as HarnessControlError).code, "provider-auth-required");
+  assertEquals(requests, 1);
+});
+
+Deno.test("Codex transient refresh failures leave credential health unchanged", async () => {
+  const store = new InMemoryHarnessCredentialStore();
+  await store.set("local", "openai-codex", {
+    type: "oauth",
+    providerId: "openai-codex",
+    accessToken: "expired-access",
+    refreshToken: "transient-refresh-secret",
+    expiresAt: 0,
+    accountId: "account-secret",
+  });
+  const resolver = new OpenAICodexCredentialResolver({
+    store,
+    ownerKey: "local",
+    now: () => 100_000,
+    fetchFn: () => Promise.reject(new Error("transient-refresh-secret")),
+  });
+
+  const error = await assertRejects(() => resolver.resolve());
+  assertEquals((error as OpenAICodexAuthError).kind, "network");
+  assertEquals(
+    errorGraphText(error).includes("transient-refresh-secret"),
+    false,
+  );
+  assertEquals(await store.getHealth("local", "openai-codex"), undefined);
+  assertEquals(
+    (await store.get("local", "openai-codex"))?.refreshToken,
+    "transient-refresh-secret",
+  );
+});
+
+Deno.test("Codex login clears terminal credential health", async () => {
+  const store = new InMemoryHarnessCredentialStore();
+  await store.updateRecord("local", "openai-codex", () => ({
+    credential: {
+      type: "oauth",
+      providerId: "openai-codex",
+      accessToken: "old-access",
+      refreshToken: "old-refresh",
+      expiresAt: 0,
+      accountId: "old-account",
+    },
+    health: { status: "reconnect-required", reason: "revoked" },
+  }));
+  const auth = new OpenAICodexAuthService(store, "local");
+
+  await auth.save({
+    type: "oauth",
+    providerId: "openai-codex",
+    accessToken: "new-access",
+    refreshToken: "new-refresh",
+    expiresAt: 4_000_000_000_000,
+    accountId: "new-account",
+  });
+
+  assertEquals(await store.getHealth("local", "openai-codex"), undefined);
+  assertEquals(await auth.status(), {
+    providerId: "openai-codex",
+    status: "connected",
+    refreshHealth: "ready",
+  });
+});
+
+Deno.test("Codex login cancellation while queued preserves prior auth", async () => {
+  const store = new InMemoryHarnessCredentialStore();
+  const previous: OpenAICodexOAuthCredential = {
+    type: "oauth",
+    providerId: "openai-codex",
+    accessToken: "old-access",
+    refreshToken: "old-refresh",
+    expiresAt: 4_000_000_000_000,
+    accountId: "old-account",
+  };
+  await store.set("local", "openai-codex", previous);
+  let releaseMutation!: () => void;
+  const mutationHeld = new Promise<void>((resolve) => {
+    releaseMutation = resolve;
+  });
+  let markMutationStarted!: () => void;
+  const mutationStarted = new Promise<void>((resolve) => {
+    markMutationStarted = resolve;
+  });
+  const holding = store.updateRecord(
+    "local",
+    "openai-codex",
+    async (record) => {
+      markMutationStarted();
+      await mutationHeld;
+      return record;
+    },
+  );
+  await mutationStarted;
+  const auth = new OpenAICodexAuthService(store, "local");
+  const controller = new AbortController();
+  const saving = auth.save({
+    ...previous,
+    accessToken: "new-access",
+    refreshToken: "new-refresh",
+  }, controller.signal);
+  const reason = new DOMException("login canceled", "AbortError");
+  controller.abort(reason);
+
+  await assertRejects(() => saving, DOMException, "login canceled");
+  releaseMutation();
+  await holding;
+  assertEquals(await store.get("local", "openai-codex"), previous);
 });
 
 Deno.test("Codex token exchange rejects malformed token responses before persistence", async () => {

--- a/packages/cf-harness/test/openai-codex-auth.test.ts
+++ b/packages/cf-harness/test/openai-codex-auth.test.ts
@@ -230,6 +230,8 @@ Deno.test("Codex credential resolution never falls back after revocation", async
   });
 
   const error = await assertRejects(() => resolver.resolve()) as Error;
+  assertEquals(error instanceof HarnessControlError, true);
+  assertEquals((error as HarnessControlError).code, "provider-unavailable");
   assertEquals(error.message.includes("secret-refresh-token"), false);
   assertEquals(error.message, "OpenAI Codex token refresh failed (400)");
 });
@@ -892,7 +894,8 @@ Deno.test("Codex transient refresh failures leave credential health unchanged", 
   });
 
   const error = await assertRejects(() => resolver.resolve());
-  assertEquals((error as OpenAICodexAuthError).kind, "network");
+  assertEquals(error instanceof HarnessControlError, true);
+  assertEquals((error as HarnessControlError).code, "provider-unavailable");
   assertEquals(
     errorGraphText(error).includes("transient-refresh-secret"),
     false,

--- a/packages/cf-harness/test/openai-codex-auth.test.ts
+++ b/packages/cf-harness/test/openai-codex-auth.test.ts
@@ -5,6 +5,7 @@ import {
   assertStringIncludes,
   assertThrows,
 } from "@std/assert";
+import { join } from "@std/path";
 import {
   completeOpenAICodexDeviceAuthorization,
   createOpenAICodexBrowserAuthorization,
@@ -18,6 +19,7 @@ import {
   startOpenAICodexDeviceAuthorization,
 } from "../src/auth/openai-codex.ts";
 import {
+  FileHarnessCredentialStore,
   InMemoryHarnessCredentialStore,
 } from "../src/auth/credential-store.ts";
 import type { OpenAICodexOAuthCredential } from "../src/auth/types.ts";
@@ -230,6 +232,51 @@ Deno.test("Codex credential resolution never falls back after revocation", async
   const error = await assertRejects(() => resolver.resolve()) as Error;
   assertEquals(error.message.includes("secret-refresh-token"), false);
   assertEquals(error.message, "OpenAI Codex token refresh failed (400)");
+});
+
+Deno.test("Codex credential resolution fails before traffic when disconnected or unhealthy", async () => {
+  const disconnected = new InMemoryHarnessCredentialStore();
+  let requests = 0;
+  const disconnectedResolver = new OpenAICodexCredentialResolver({
+    store: disconnected,
+    ownerKey: "local",
+    fetchFn: () => {
+      requests++;
+      return Promise.reject(new Error("unexpected request"));
+    },
+  });
+  await assertRejects(
+    () => disconnectedResolver.resolve(),
+    HarnessControlError,
+    "not connected",
+  );
+
+  const unhealthy = new InMemoryHarnessCredentialStore();
+  await unhealthy.updateRecord("local", "openai-codex", () => ({
+    credential: {
+      type: "oauth",
+      providerId: "openai-codex",
+      accessToken: "access",
+      refreshToken: "refresh",
+      expiresAt: 1,
+      accountId: "account",
+    },
+    health: { status: "reconnect-required", reason: "revoked" },
+  }));
+  const unhealthyResolver = new OpenAICodexCredentialResolver({
+    store: unhealthy,
+    ownerKey: "local",
+    fetchFn: () => {
+      requests++;
+      return Promise.reject(new Error("unexpected request"));
+    },
+  });
+  await assertRejects(
+    () => unhealthyResolver.resolve(),
+    HarnessControlError,
+    "must be reconnected",
+  );
+  assertEquals(requests, 0);
 });
 
 Deno.test("Codex browser login validates state and persists only after exchange", async () => {
@@ -764,6 +811,69 @@ Deno.test("Codex terminal refresh health persists and prevents another request",
   assertEquals(requests, 1);
 });
 
+Deno.test("Codex refresh rotation and terminal health survive file-store reopen", async () => {
+  const root = await Deno.makeTempDir();
+  const path = join(root, "auth.json");
+  const store = new FileHarnessCredentialStore({ path });
+  await store.set("local", "openai-codex", {
+    type: "oauth",
+    providerId: "openai-codex",
+    accessToken: "expired-access",
+    refreshToken: "refresh-old",
+    expiresAt: 1,
+    accountId: "acct-1",
+  });
+  const rotating = new OpenAICodexCredentialResolver({
+    store,
+    ownerKey: "local",
+    now: () => 10_000,
+    fetchFn: () =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            access_token: jwt({
+              "https://api.openai.com/auth": { chatgpt_account_id: "acct-1" },
+            }),
+            refresh_token: "refresh-new",
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        ),
+      ),
+  });
+  await rotating.resolve();
+  assertEquals(
+    (await new FileHarnessCredentialStore({ path }).get(
+      "local",
+      "openai-codex",
+    ))?.refreshToken,
+    "refresh-new",
+  );
+
+  await store.updateRecord("local", "openai-codex", (record) => ({
+    credential: { ...record.credential!, expiresAt: 1 },
+  }));
+  const terminal = new OpenAICodexCredentialResolver({
+    store,
+    ownerKey: "local",
+    now: () => 10_000,
+    fetchFn: () =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: "invalid_grant" }), {
+          status: 400,
+        }),
+      ),
+  });
+  await assertRejects(() => terminal.resolve(), HarnessControlError);
+  assertEquals(
+    (await new FileHarnessCredentialStore({ path }).getRecord(
+      "local",
+      "openai-codex",
+    )).health,
+    { status: "reconnect-required", reason: "invalid-grant" },
+  );
+});
+
 Deno.test("Codex transient refresh failures leave credential health unchanged", async () => {
   const store = new InMemoryHarnessCredentialStore();
   await store.set("local", "openai-codex", {
@@ -869,6 +979,33 @@ Deno.test("Codex login cancellation while queued preserves prior auth", async ()
   releaseMutation();
   await holding;
   assertEquals(await store.get("local", "openai-codex"), previous);
+});
+
+Deno.test("Codex login reports late cancellation after its atomic save", async () => {
+  const store = new InMemoryHarnessCredentialStore();
+  const controller = new AbortController();
+  const reason = new Error("login canceled after commit");
+  const originalUpdateRecord = store.updateRecord.bind(store);
+  store.updateRecord = async (...args) => {
+    const result = await originalUpdateRecord(...args);
+    controller.abort(reason);
+    return result;
+  };
+  const auth = new OpenAICodexAuthService(store, "local");
+  const credential: OpenAICodexOAuthCredential = {
+    type: "oauth",
+    providerId: "openai-codex",
+    accessToken: "new-access",
+    refreshToken: "new-refresh",
+    expiresAt: 4_000_000_000_000,
+    accountId: "new-account",
+  };
+
+  const error = await assertRejects(() =>
+    auth.save(credential, controller.signal)
+  );
+  assertStrictEquals(error, reason);
+  assertEquals(await store.get("local", "openai-codex"), credential);
 });
 
 Deno.test("Codex token exchange rejects malformed token responses before persistence", async () => {

--- a/packages/cf-harness/test/openai-codex-responses.test.ts
+++ b/packages/cf-harness/test/openai-codex-responses.test.ts
@@ -866,7 +866,10 @@ Deno.test("Codex Responses quota errors are concise and do not retain response b
           JSON.stringify({
             error: { message: "access-secret account acct-123" },
           }),
-          { status: 429 },
+          {
+            status: 429,
+            headers: { "retry-after": "retry-secret-sentinel" },
+          },
         ),
       ),
   });
@@ -890,6 +893,7 @@ Deno.test("Codex Responses quota errors are concise and do not retain response b
   const serialized = JSON.stringify(attempts);
   assertEquals(serialized.includes("access-secret"), false);
   assertEquals(serialized.includes("acct-123"), false);
+  assertEquals(serialized.includes("retry-secret-sentinel"), false);
   assertStringIncludes(serialized, '"httpStatus":429');
 });
 
@@ -951,6 +955,31 @@ Deno.test("Codex transport errors redact credential and account values", async (
   assertEquals(serialized.includes("refresh-secret"), false);
   assertEquals(serialized.includes("acct-123"), false);
   assertStringIncludes(serialized, "[redacted]");
+});
+
+Deno.test("Codex Responses bounds failures while reading provider error bodies", async () => {
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      controller.error(new Error("provider-body-secret-sentinel"));
+    },
+  });
+  const client = new OpenAICodexResponsesClient({
+    credentialResolver: { resolve: () => Promise.resolve(credential) },
+    fetchFn: () => Promise.resolve(new Response(body, { status: 503 })),
+  });
+
+  const error = await assertRejects(() =>
+    client.complete({
+      model: "gpt-5.4",
+      transcript: [{ role: "user", content: "hi" }],
+      tools: [],
+      nativeModelToolIds: [],
+      runId: "run-error-body",
+    })
+  );
+  assertEquals(error instanceof HarnessControlError, true);
+  assertEquals((error as HarnessControlError).code, "provider-unavailable");
+  assertEquals(errorGraphText(error).includes("secret-sentinel"), false);
 });
 
 Deno.test("Codex Responses abort cancels an active stream without retry", async () => {

--- a/packages/cf-harness/test/openai-codex-responses.test.ts
+++ b/packages/cf-harness/test/openai-codex-responses.test.ts
@@ -10,6 +10,7 @@ import {
   OpenAICodexResponsesClient,
 } from "../src/model/openai-codex-responses.ts";
 import type { OpenAICodexOAuthCredential } from "../src/auth/types.ts";
+import { HarnessControlError } from "../src/control-errors.ts";
 import { createHarnessImageAttachment } from "../src/image-attachments.ts";
 
 const credential: OpenAICodexOAuthCredential = {
@@ -690,8 +691,8 @@ Deno.test("Codex Responses client rejects incomplete tool calls", async () => {
         nativeModelToolIds: [],
         runId: "run-incomplete-call",
       }),
-    Error,
-    "incomplete tool call",
+    HarnessControlError,
+    "invalid terminal response",
   );
 });
 
@@ -770,8 +771,8 @@ Deno.test("Codex Responses client rejects conflicting duplicate tool-call ids", 
         nativeModelToolIds: [],
         runId: "run-duplicate",
       }),
-    Error,
-    "conflicting duplicate tool-call ids",
+    HarnessControlError,
+    "invalid terminal response",
   );
 });
 
@@ -827,6 +828,34 @@ Deno.test("Codex model discovery is live, owner-authenticated, and ordered", asy
   assertEquals(models[0].supportedReasoningEfforts, ["high"]);
 });
 
+Deno.test("Codex model discovery classifies provider failures", async () => {
+  for (
+    const [fetchFn, expectedCode] of [
+      [
+        () => Promise.resolve(new Response("unauthorized", { status: 401 })),
+        "provider-auth-required",
+      ],
+      [
+        () => Promise.resolve(new Response("unavailable", { status: 503 })),
+        "provider-unavailable",
+      ],
+      [
+        () => Promise.reject(new Error("network detail")),
+        "provider-unavailable",
+      ],
+    ] as const
+  ) {
+    const client = new OpenAICodexResponsesClient({
+      credentialResolver: { resolve: () => Promise.resolve(credential) },
+      fetchFn,
+    });
+
+    const error = await assertRejects(() => client.listModels());
+    assertEquals(error instanceof HarnessControlError, true);
+    assertEquals((error as HarnessControlError).code, expectedCode);
+  }
+});
+
 Deno.test("Codex Responses quota errors are concise and do not retain response bodies", async () => {
   const attempts: unknown[] = [];
   const client = new OpenAICodexResponsesClient({
@@ -856,10 +885,38 @@ Deno.test("Codex Responses quota errors are concise and do not retain response b
   );
 
   assertEquals((error as Error).message, "OpenAI Codex usage limit reached");
+  assertEquals(error instanceof HarnessControlError, true);
+  assertEquals((error as HarnessControlError).code, "provider-unavailable");
   const serialized = JSON.stringify(attempts);
   assertEquals(serialized.includes("access-secret"), false);
   assertEquals(serialized.includes("acct-123"), false);
   assertStringIncludes(serialized, '"httpStatus":429');
+});
+
+Deno.test("Codex Responses classifies provider HTTP failures", async () => {
+  for (
+    const [status, expectedCode] of [
+      [401, "provider-auth-required"],
+      [503, "provider-unavailable"],
+    ] as const
+  ) {
+    const client = new OpenAICodexResponsesClient({
+      credentialResolver: { resolve: () => Promise.resolve(credential) },
+      fetchFn: () => Promise.resolve(new Response("unavailable", { status })),
+    });
+
+    const error = await assertRejects(() =>
+      client.complete({
+        model: "gpt-5.4",
+        transcript: [{ role: "user", content: "hi" }],
+        tools: [],
+        nativeModelToolIds: [],
+        runId: "run-provider-unavailable",
+      })
+    );
+    assertEquals(error instanceof HarnessControlError, true);
+    assertEquals((error as HarnessControlError).code, expectedCode);
+  }
 });
 
 Deno.test("Codex transport errors redact credential and account values", async () => {
@@ -888,6 +945,8 @@ Deno.test("Codex transport errors redact credential and account values", async (
   );
 
   const serialized = `${errorGraphText(error)}${JSON.stringify(attempts)}`;
+  assertEquals(error instanceof HarnessControlError, true);
+  assertEquals((error as HarnessControlError).code, "provider-unavailable");
   assertEquals(serialized.includes("access-secret"), false);
   assertEquals(serialized.includes("refresh-secret"), false);
   assertEquals(serialized.includes("acct-123"), false);
@@ -1068,8 +1127,8 @@ Deno.test("Codex Responses recognizes response.failed as terminal", async () => 
         nativeModelToolIds: [],
         runId: "run-response-failed",
       }),
-    Error,
-    "ended with status failed",
+    HarnessControlError,
+    "invalid terminal response",
   );
 });
 

--- a/packages/cf-harness/test/openai-codex-responses.test.ts
+++ b/packages/cf-harness/test/openai-codex-responses.test.ts
@@ -982,6 +982,31 @@ Deno.test("Codex Responses bounds failures while reading provider error bodies",
   assertEquals(errorGraphText(error).includes("secret-sentinel"), false);
 });
 
+Deno.test("Codex Responses preserves abort during provider error diagnostics", async () => {
+  const controller = new AbortController();
+  const reason = new Error("abort during provider diagnostics");
+  const client = new OpenAICodexResponsesClient({
+    credentialResolver: { resolve: () => Promise.resolve(credential) },
+    fetchFn: () =>
+      Promise.resolve(new Response("unavailable", { status: 503 })),
+  });
+
+  const error = await assertRejects(() =>
+    client.complete({
+      model: "gpt-5.4",
+      transcript: [{ role: "user", content: "hi" }],
+      tools: [],
+      nativeModelToolIds: [],
+      runId: "run-abort-error-diagnostics",
+      signal: controller.signal,
+      onAttempt: () => {
+        controller.abort(reason);
+      },
+    })
+  );
+  assertStrictEquals(error, reason);
+});
+
 Deno.test("Codex Responses abort cancels an active stream without retry", async () => {
   let canceled = false;
   let requests = 0;

--- a/packages/cf-harness/test/provider-settings.test.ts
+++ b/packages/cf-harness/test/provider-settings.test.ts
@@ -1,0 +1,203 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import {
+  FileHarnessProviderSettingsStore,
+  resolveHarnessModelProviderPreference,
+} from "../src/auth/provider-settings.ts";
+import { HarnessControlError } from "../src/control-errors.ts";
+
+describe("provider-settings", () => {
+  describe("FileHarnessProviderSettingsStore", () => {
+    it("initializes once and preserves the existing file byte for byte", async () => {
+      const root = await Deno.makeTempDir();
+      const path = join(root, "home", "config.json");
+      const store = new FileHarnessProviderSettingsStore({ path });
+
+      expect(await store.initialize("openai-compatible-gateway")).toEqual({
+        settings: {
+          version: 1,
+          modelProvider: "openai-compatible-gateway",
+        },
+        changed: true,
+      });
+      const original = await Deno.readTextFile(path);
+      expect(await store.initialize("openai-codex")).toEqual({
+        settings: {
+          version: 1,
+          modelProvider: "openai-compatible-gateway",
+        },
+        changed: false,
+      });
+      expect(await Deno.readTextFile(path)).toBe(original);
+      if (Deno.build.os !== "windows") {
+        expect((await Deno.stat(path)).mode! & 0o777).toBe(0o600);
+        expect((await Deno.stat(join(root, "home"))).mode! & 0o777).toBe(
+          0o700,
+        );
+      }
+    });
+
+    it("serializes concurrent updates across store instances", async () => {
+      const root = await Deno.makeTempDir();
+      const path = join(root, "config.json");
+      const first = new FileHarnessProviderSettingsStore({ path });
+      const second = new FileHarnessProviderSettingsStore({ path });
+
+      await Promise.all([
+        first.set("openai-codex"),
+        second.set("openai-compatible-gateway"),
+      ]);
+
+      const state = await first.inspect();
+      expect(state.state).toBe("configured");
+      if (state.state === "configured") {
+        expect([
+          "openai-codex",
+          "openai-compatible-gateway",
+        ]).toContain(state.settings.modelProvider);
+      }
+      expect(JSON.parse(await Deno.readTextFile(path)).version).toBe(1);
+    });
+
+    it("reports corrupt and unsupported documents without overwriting them", async () => {
+      const root = await Deno.makeTempDir();
+      const path = join(root, "config.json");
+      const store = new FileHarnessProviderSettingsStore({ path });
+      for (
+        const document of [
+          "{broken",
+          '{"version":99,"modelProvider":"openai-codex"}',
+        ]
+      ) {
+        await Deno.writeTextFile(path, document, { mode: 0o600 });
+        const state = await store.inspect();
+        expect(["invalid", "unsupported-version"]).toContain(state.state);
+        await expect(store.set("openai-codex")).rejects.toBeInstanceOf(
+          HarnessControlError,
+        );
+        expect(await Deno.readTextFile(path)).toBe(document);
+      }
+    });
+
+    it("rejects public homes, target symlinks, and lock symlinks", async () => {
+      if (Deno.build.os === "windows") return;
+      const root = await Deno.makeTempDir();
+      const publicHome = join(root, "public");
+      await Deno.mkdir(publicHome, { mode: 0o755 });
+      const publicStore = new FileHarnessProviderSettingsStore({
+        path: join(publicHome, "config.json"),
+      });
+      expect((await publicStore.inspect()).state).toBe("unreadable");
+
+      const privateHome = join(root, "private");
+      await Deno.mkdir(privateHome, { mode: 0o700 });
+      const target = join(root, "target");
+      await Deno.writeTextFile(target, "{}");
+      const path = join(privateHome, "config.json");
+      await Deno.symlink(target, path);
+      expect(
+        (await new FileHarnessProviderSettingsStore({ path }).inspect()).state,
+      )
+        .toBe("unreadable");
+
+      await Deno.remove(path);
+      await Deno.symlink(target, `${path}.lock`);
+      await expect(
+        new FileHarnessProviderSettingsStore({ path }).set("openai-codex"),
+      ).rejects.toThrow("lock file must be a regular file");
+    });
+
+    it("cancels a queued mutation before it writes", async () => {
+      const root = await Deno.makeTempDir();
+      const store = new FileHarnessProviderSettingsStore({
+        path: join(root, "config.json"),
+      });
+      let releaseFirst!: () => void;
+      const firstHeld = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      let markLockStarted!: () => void;
+      const lockStarted = new Promise<void>((resolve) => {
+        markLockStarted = resolve;
+      });
+      const lockPath = `${store.path}.lock`;
+      const lock = await Deno.open(lockPath, {
+        create: true,
+        read: true,
+        write: true,
+        mode: 0o600,
+      });
+      await lock.lock(true);
+      const observed = new FileHarnessProviderSettingsStore({
+        path: store.path,
+        onLockAcquisitionStarted: markLockStarted,
+      });
+      const controller = new AbortController();
+      const pending = observed.set("openai-codex", controller.signal);
+      await lockStarted;
+      const reason = new DOMException("settings update canceled", "AbortError");
+      controller.abort(reason);
+      await expect(pending).rejects.toBe(reason);
+      await lock.unlock();
+      lock.close();
+      releaseFirst();
+      await firstHeld;
+      expect((await store.inspect()).state).toBe("missing");
+    });
+  });
+
+  describe("resolveHarnessModelProviderPreference()", () => {
+    it("applies explicit, environment, persistent, and default precedence", async () => {
+      const configured = {
+        inspect: () =>
+          Promise.resolve({
+            state: "configured" as const,
+            settings: {
+              version: 1 as const,
+              modelProvider: "openai-codex" as const,
+            },
+          }),
+      };
+      expect(
+        await resolveHarnessModelProviderPreference({
+          store: configured,
+          explicit: "openai-compatible-gateway",
+          environment: "openai-codex",
+        }),
+      ).toEqual({
+        provider: "openai-compatible-gateway",
+        source: "explicit",
+      });
+      expect(
+        await resolveHarnessModelProviderPreference({
+          store: configured,
+          environment: "openai-compatible-gateway",
+        }),
+      ).toEqual({
+        provider: "openai-compatible-gateway",
+        source: "environment",
+      });
+      expect(await resolveHarnessModelProviderPreference({ store: configured }))
+        .toEqual({ provider: "openai-codex", source: "persistent" });
+      expect(
+        await resolveHarnessModelProviderPreference({
+          store: { inspect: () => Promise.resolve({ state: "missing" }) },
+        }),
+      ).toEqual({
+        provider: "openai-compatible-gateway",
+        source: "default",
+      });
+    });
+
+    it("requires persistent configuration in strict mode", async () => {
+      const resolution = resolveHarnessModelProviderPreference({
+        store: { inspect: () => Promise.resolve({ state: "missing" }) },
+        strict: true,
+      });
+      await expect(resolution).rejects.toMatchObject({
+        code: "provider-configuration-required",
+      });
+    });
+  });
+});

--- a/packages/cf-harness/test/provider-settings.test.ts
+++ b/packages/cf-harness/test/provider-settings.test.ts
@@ -67,6 +67,8 @@ describe("provider-settings", () => {
       for (
         const document of [
           "{broken",
+          "[]",
+          '{"version":1,"modelProvider":"invalid"}',
           '{"version":99,"modelProvider":"openai-codex"}',
         ]
       ) {
@@ -145,6 +147,75 @@ describe("provider-settings", () => {
       await firstHeld;
       expect((await store.inspect()).state).toBe("missing");
     });
+
+    it("reports a symlinked settings home as unreadable", async () => {
+      if (Deno.build.os === "windows") return;
+      const root = await Deno.makeTempDir();
+      const realHome = join(root, "real");
+      const linkedHome = join(root, "linked");
+      await Deno.mkdir(realHome, { mode: 0o700 });
+      await Deno.symlink(realHome, linkedHome);
+      const store = new FileHarnessProviderSettingsStore({
+        path: join(linkedHome, "config.json"),
+      });
+      expect((await store.inspect()).state).toBe("unreadable");
+      await expect(store.set("openai-codex")).rejects.toThrow(
+        "must not be a symlink",
+      );
+    });
+
+    it("honors an advisory lock held by another process", async () => {
+      if (Deno.build.os === "windows") return;
+      const root = await Deno.makeTempDir();
+      const path = join(root, "config.json");
+      const lockPath = `${path}.lock`;
+      const holder = new Deno.Command(Deno.execPath(), {
+        args: [
+          "eval",
+          "--quiet",
+          `const file = await Deno.open(Deno.args[0], { create: true, read: true, write: true, mode: 0o600 });
+await file.lock(true);
+console.log("locked");
+await Deno.stdin.read(new Uint8Array(1));
+await file.unlock();
+file.close();`,
+          lockPath,
+        ],
+        cwd: root,
+        stdin: "piped",
+        stdout: "piped",
+        stderr: "null",
+      }).spawn();
+      const stdout = holder.stdout.getReader();
+      let output = "";
+      while (!output.includes("locked")) {
+        const { value, done } = await stdout.read();
+        if (done) throw new Error("lock holder exited before acquiring lock");
+        output += new TextDecoder().decode(value);
+      }
+      stdout.releaseLock();
+
+      let markStarted!: () => void;
+      const started = new Promise<void>((resolve) => {
+        markStarted = resolve;
+      });
+      const controller = new AbortController();
+      const store = new FileHarnessProviderSettingsStore({
+        path,
+        onLockAcquisitionStarted: markStarted,
+      });
+      const pending = store.set("openai-codex", controller.signal);
+      await started;
+      const reason = new Error("cross-process settings cancellation");
+      controller.abort(reason);
+      await expect(pending).rejects.toBe(reason);
+
+      const stdin = holder.stdin.getWriter();
+      await stdin.write(new Uint8Array([1]));
+      await stdin.close();
+      expect((await holder.status).success).toBe(true);
+      expect((await store.inspect()).state).toBe("missing");
+    });
   });
 
   describe("resolveHarnessModelProviderPreference()", () => {
@@ -197,6 +268,20 @@ describe("provider-settings", () => {
       });
       await expect(resolution).rejects.toMatchObject({
         code: "provider-configuration-required",
+      });
+      await expect(
+        resolveHarnessModelProviderPreference({
+          store: {
+            inspect: () =>
+              Promise.resolve({
+                state: "invalid" as const,
+                detail: "secret detail",
+              }),
+          },
+        }),
+      ).rejects.toMatchObject({
+        code: "provider-configuration-required",
+        message: "Provider settings are invalid",
       });
     });
   });


### PR DESCRIPTION
## Why

Loom needs a durable, machine-readable cf-harness provider and authentication contract before it can safely let a local single-user installation select a personal ChatGPT/Codex subscription. Without that contract, a missing or unhealthy Codex credential can be confused with the historical gateway default, risking silent use of the shared API budget.

This is Slice 1 of the implementation plan approved in commontoolsinc/loom#4819. It is intentionally dark to Loom: it establishes upstream state and control contracts while advertising that Loom-local owner binding is not yet available.

## What Changed

- add versioned, private, atomic `CF_HARNESS_HOME/config.json` provider settings with inspect/init/set operations
- add structured JSON config/auth results and NDJSON login authorization events with bounded error envelopes
- migrate `auth.json` from v1 to v2 on mutation and persist credential health atomically without allowing orphan health records
- add stable, secret-free provider/auth control error codes
- preserve recorded provider/owner semantics on resume and expose granular capability flags
- honor environment-over-persistent provider precedence in config inspection
- document direct-run precedence, storage boundaries, and structured control behavior

The implementation also incorporates the useful safety lessons from Loom PR #4792: keep durable state out of Loom, expose non-secret capability/manifest metadata, and prevent gateway configuration from accompanying Codex runs.

## Test plan

- `cd packages/cf-harness && deno test --no-lock --allow-read --allow-write --allow-run --allow-ffi --allow-net --allow-env test` — 642 passed
- `deno task check`
- `deno lint`
- `deno fmt --check`
- `deno task check-docs`
- `deno task check-no-waitfor`
- `deno task check-conflict-markers`
- `git diff --check`
- coverage debt: 2,430 uncovered cf-harness lines, below the 2,433-line baseline
