### PR TITLE
docs: record the hosted-pattern-authoring ↔ cf-harness fabric-tooling interaction

### DIFF
--- a/docs/plans/hosted-pattern-authoring-tooling-feedback.md
+++ b/docs/plans/hosted-pattern-authoring-tooling-feedback.md
@@ -49,5 +49,10 @@ report in its failure result.
   every disallowed field, and permitted diagnostic metadata reaches the triage
   sink only after the CFC check passes.
 
+`cfh:` session tokens remain excluded from automatic export like any other
+identifier. They are run-salted and meaningless outside a run, but the export
+projection is an allowlist of enumerated categories, not a per-identifier
+judgment; the handle table, not the token, is the sensitive artifact.
+
 Success means an agent can report a missing or defective tool without gaining
 authority or creating a new path for source, request, or session data to leave.

--- a/docs/plans/hosted-pattern-authoring.md
+++ b/docs/plans/hosted-pattern-authoring.md
@@ -115,6 +115,11 @@ and recovered after a service restart. No stage can publish source yet.
 - [ ] Add provider-independent fixtures for compile failure, test failure,
   repair followed by success, cancellation, and process recovery.
 
+The harness fabric session
+(`packages/cf-harness/src/fabric-session.ts`) provides a host-side,
+authorization-verified runtime target with no fabric credential inside the
+sandbox; the adapter builds on it rather than constructing its own.
+
 Success means a server-hosted session can produce a candidate and objective
 verification evidence. The target remains unchanged.
 
@@ -147,6 +152,10 @@ verification evidence. The target remains unchanged.
 - [ ] Linearize cancellation against the transition to `publishing`. Test both
   race outcomes and report `too_late` when publication wins.
 
+`cf-harness` cancels at the tool level through request abort; reuse that
+mechanism when linearizing cancellation instead of adding a second
+interruption path.
+
 Success means an authorized compatible candidate changes the intended piece
 once and every failure leaves it unchanged.
 
@@ -177,6 +186,12 @@ once and every failure leaves it unchanged.
 - [ ] Route both clients through the shared start and session APIs.
 - [ ] Add one browser test and one CLI test that assert the same service request
   and final source revision.
+
+The harness handle table and diagnostic scrubber
+(`packages/cf-harness/src/handle-table.ts`) redact fabric identifiers at the
+model boundary; the identifier-free progress events here are a separate
+person-facing projection, but they reuse that scrubber rather than
+reimplementing identifier detection.
 
 Success means the menu and CLI complete the same existing-piece steel thread
 without either client running an agent or performing publication.

--- a/docs/specs/hosted-pattern-authoring.md
+++ b/docs/specs/hosted-pattern-authoring.md
@@ -24,7 +24,7 @@ authored-program manifest still required by the piece source lifecycle.
 
 ## Last updated
 
-2026-08-11
+2026-08-13
 
 ## Goal
 
@@ -381,8 +381,9 @@ workspace. Resume continues the same harness session when its access labels and
 credentials still permit it. It does not create a second session that lacks
 the first session's observed-information record.
 
-Workspace files, request text, transcripts, tool payloads, and model responses
-are retained while a session can resume. After a terminal result they are
+Workspace files, request text, transcripts, tool payloads, model responses,
+and the harness run-state handle table are retained while a session can
+resume. After a terminal result they are
 deleted at the end of a configured finite retention window. The creating
 principal can request earlier deletion, subject to the ordinary audit policy.
 A minimal result record may remain, but it contains no request text, source,
@@ -390,6 +391,53 @@ transcript, or tool payload. Production start is disabled until a default
 window and storage collection mechanism are configured. The shared
 [retention and execution provenance plan](../plans/retention-and-provenance.md)
 owns the unresolved default duration and CFC review.
+
+## Relationship to the cf-harness fabric tooling
+
+`cf-harness` carries fabric-facing tooling of its own: a host-side fabric
+session, a `run_pattern` tool, session-scoped handles for fabric addresses,
+and LLM-friendly address intake in the CLI. These components overlap with
+parts of this specification. This section records where a component satisfies
+a requirement here, where it must not be mistaken for one, and what it adds to
+the retention and identifier obligations above.
+
+- **The fabric session is an available isolated runtime target.** The harness
+  fabric session (`packages/cf-harness/src/fabric-session.ts`) constructs an
+  authorization-verified `PiecesController` on the host side, so no fabric
+  credential exists inside the sandbox. The isolated-runtime-target
+  requirement in the authoring session stands as written; this component
+  satisfies its credential-absence prerequisite by construction.
+
+- **`run_pattern` is not this specification's verification gate.** The harness
+  `run_pattern` tool is an exploration and smoke capability. It takes
+  single-string, test-less pattern source and produces an unlisted piece.
+  Publication here requires `cf check`, retained test files in the
+  authored-program manifest, and trusted publication. A pattern that ran under
+  `run_pattern` has passed none of those gates.
+
+- **Spaces may contain unlisted pieces.** Harness-created pieces are durable,
+  absent from the piece list, and their source-history revisions are
+  storage-retention roots. Root validation, retention, and space-clone
+  reasoning over "the pieces in a space" must not assume the piece list is
+  exhaustive.
+
+- **Handles redact at the model boundary; the progress surface is separate.**
+  Session handles (`cfh:` tokens,
+  `packages/cf-harness/src/handle-table.ts`) replace fabric identifiers at the
+  model boundary. This specification's exclusion of identifiers from progress
+  events is a separate, person-facing projection and remains required. The
+  identifier scrubber for compile diagnostics — bare tagged hashes, DIDs,
+  `data:` URIs — covers the identifier class that handles cannot reach.
+
+- **The handle table is retained session state.** The retention window
+  enumerated under failure and cancellation includes the harness run-state
+  handle table alongside transcripts and tool payloads, because it is a
+  durable address-to-token map of every fabric address a run touched.
+
+- **Address intake.** The CLI's LLM-friendly reference normalization
+  (`packages/cli/lib/llm-friendly-ref.ts`) provides the client-side shape for
+  this specification's piece-address syntax. The authenticated server remains
+  the resolution authority.
 
 ## Relationship to nearby systems
 


### PR DESCRIPTION
For @Hixie — you asked whether the CT-2003 cf-harness work overlaps with the hosted-pattern-authoring spec (#5646). Answer: complementary, no conflicts, several reuse candidates, and a few of your spec's assumptions need one amendment. This PR records the interaction **in the authoring documents themselves** so it survives as spec text rather than a PR thread.

## What this adds

**`docs/specs/hosted-pattern-authoring.md`** — new section *"Relationship to the cf-harness fabric tooling"*:
- The cf-harness fabric session (`packages/cf-harness/src/fabric-session.ts`) is an available implementation of the spec's "isolated runtime target" — host-side, authorization-verified, satisfying the credential-absence prerequisite by construction (no fabric credential inside the sandbox).
- **`run_pattern` is a smoke/exploration capability, not this spec's verification gate** — it is single-string, test-less, and unlisted; publication still requires `cf check` + retained test manifests + trusted publication. Stated explicitly so nobody drifts into reusing it there.
- **Spaces may contain unlisted pieces**: harness-created pieces are durable, absent from the piece list, and their source-history revisions are storage-retention roots — root validation, retention, and space-clone reasoning must not assume the piece list is exhaustive.
- Session handles (`cfh:` tokens) redact identifiers at the *model* boundary; the spec's person-facing progress projection is separate and still required. The diagnostic scrubber covers the identifier class handles cannot.
- The retention enumeration now includes the harness run-state handle table (a durable address→token map of every address a run touched).
- LLM-friendly address intake (`packages/cli/lib/llm-friendly-ref.ts`) is the client-side shape for the spec's piece-address syntax; the authenticated server remains the resolution authority.

**`docs/plans/hosted-pattern-authoring.md`** — Stage 2/3/4 pointers to the reusable components (fabric session, tool-level abort cancellation, handle table + scrubber) so stages build on rather than duplicate them.

**`docs/plans/hosted-pattern-authoring-tooling-feedback.md`** — `cfh:` tokens stay excluded from automatic export like any identifier; the handle table, not the token, is the sensitive artifact.

## Ordering note

The cited cf-harness/cli paths arrive with the open CT-2003 stack (#5736 → #5747 → #5748); this PR should land with or after it. On the stack side, the one contradiction found in the analysis is being fixed there, not here: `run_pattern` currently stamps a synthetic URL origin, but per `docs/specs/piece-source-lifecycle.md` LLM-generated code starts *detached* — the stack is switching to a truthful detached origin.

Gates: `check-docs` (548 blocks pass), `check-conflict-markers` clean.

Linear-issue: CT-2003

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

