### PR TITLE
test(data-model): unit tests for `BaseCodecEngine` itself

### DIFF
--- a/packages/data-model/src/codec-common/BaseFabricPrimitive.ts
+++ b/packages/data-model/src/codec-common/BaseFabricPrimitive.ts
@@ -12,7 +12,8 @@
 
 import type { CodecForFormat } from "@/codec-interface/interface.ts";
 import type { JsonCodecValue } from "@/codec-json/interface.ts";
-import { FabricPrimitive, JSON_CODEC } from "@/interface.ts";
+import { FabricPrimitive } from "@/interface.ts";
+import { JSON_CODEC } from "@/codec-interface/interface.ts";
 import { toCompactDebugString } from "@/value-debug.ts";
 
 /**

--- a/packages/data-model/src/codec-interface/index.ts
+++ b/packages/data-model/src/codec-interface/index.ts
@@ -3,6 +3,7 @@ export {
   type CodecForFormat,
   type FabricClassWithNonterminalCodec,
   type FabricCodec,
+  JSON_CODEC,
   type NonterminalCodec,
   type ReconstructionContext,
   type SerializationContext,

--- a/packages/data-model/src/codec-interface/interface.ts
+++ b/packages/data-model/src/codec-interface/interface.ts
@@ -22,6 +22,28 @@ import type { FabricInstance, FabricValue } from "@/interface.ts";
 export const CODEC: unique symbol = Symbol("data-model.codec");
 
 /**
+ * Well-known symbol for binding the static getter
+ * `FabricClassWithJsonCodec[JSON_CODEC]` on a `FabricPrimitive` class.
+ *
+ * A `FabricPrimitive`'s codec is bound per wire format, not once for all of
+ * them, because these classes are where the formats disagree. `FabricBytes`
+ * encodes to a base64url string, which is JSON's answer and nobody else's: a
+ * format that carries bytes natively wants a different codec, or none, and
+ * says so by looking up a different symbol.
+ *
+ * What differs can be the _kind_ of codec and not merely the state it
+ * produces, which is why the binding is per format rather than a property of
+ * the class. `FabricRegExp` expands into a record of strings under JSON,
+ * which has no pattern type of its own to terminate into.
+ *
+ * That is what separates these from a `FabricInstance`'s codec, bound to the
+ * generic `[CODEC]`: an instance's codec only expands an instance into other
+ * `FabricValue`s and leaves every terminal decision to whatever walks the
+ * result, so one binding serves every format.
+ */
+export const JSON_CODEC: unique symbol = Symbol("data-model.jsonCodecEngine");
+
+/**
  * Interface for codecs (encoder-decoder objects). These are objects which can
  * extract "essential state" out of values (objects per se or otherwise) and
  * also take such "essential state" and produce values that are equivalent (in

--- a/packages/data-model/src/codec-json/interface.ts
+++ b/packages/data-model/src/codec-json/interface.ts
@@ -10,7 +10,7 @@
  */
 
 import type { WireFormat } from "@/codec-interface/interface.ts";
-import { JSON_CODEC } from "@/interface.ts";
+import { JSON_CODEC } from "@/codec-interface/interface.ts";
 
 /**
  * Tag prefix on the encoded form of a fabric value. The prefix is explicit so

--- a/packages/data-model/src/fabric-primitives/FabricBytes.ts
+++ b/packages/data-model/src/fabric-primitives/FabricBytes.ts
@@ -13,7 +13,7 @@ import {
   ReconstructionContext,
   TerminalCodec,
 } from "@/codec-interface/interface.ts";
-import { JSON_CODEC } from "@/interface.ts";
+import { JSON_CODEC } from "@/codec-interface/interface.ts";
 
 /**
  * Immutable byte sequence in the fabric type system.

--- a/packages/data-model/src/fabric-primitives/FabricEpochDays.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochDays.ts
@@ -15,7 +15,7 @@ import {
   type ReconstructionContext,
   type TerminalCodec,
 } from "@/codec-interface/interface.ts";
-import { JSON_CODEC } from "@/interface.ts";
+import { JSON_CODEC } from "@/codec-interface/interface.ts";
 import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 

--- a/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
@@ -15,7 +15,7 @@ import {
   type ReconstructionContext,
   type TerminalCodec,
 } from "@/codec-interface/interface.ts";
-import { JSON_CODEC } from "@/interface.ts";
+import { JSON_CODEC } from "@/codec-interface/interface.ts";
 import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 

--- a/packages/data-model/src/fabric-primitives/FabricHash.ts
+++ b/packages/data-model/src/fabric-primitives/FabricHash.ts
@@ -17,7 +17,7 @@ import {
   type NonterminalCodec,
   type ReconstructionContext,
 } from "@/codec-interface/interface.ts";
-import { JSON_CODEC } from "@/interface.ts";
+import { JSON_CODEC } from "@/codec-interface/interface.ts";
 import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 

--- a/packages/data-model/src/fabric-primitives/FabricRegExp.ts
+++ b/packages/data-model/src/fabric-primitives/FabricRegExp.ts
@@ -11,7 +11,7 @@ import {
   type NonterminalCodec,
   type ReconstructionContext,
 } from "@/codec-interface/interface.ts";
-import { JSON_CODEC } from "@/interface.ts";
+import { JSON_CODEC } from "@/codec-interface/interface.ts";
 import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 import { isPlainObject } from "@commonfabric/utils/types";

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -16,33 +16,6 @@
 //
 
 /**
- * Well-known symbol for binding the static getter
- * `FabricClassWithJsonCodec[JSON_CODEC]` on a `FabricPrimitive` class.
- *
- * A `FabricPrimitive`'s codec is bound per wire format, not once for all of
- * them, because these classes are where the formats disagree. `FabricBytes`
- * encodes to a base64url string, which is JSON's answer and nobody else's: a
- * format that carries bytes natively wants a different codec, or none, and
- * says so by looking up a different symbol.
- *
- * What differs can be the _kind_ of codec and not merely the state it
- * produces, which is why the binding is per format rather than a property of
- * the class. `FabricRegExp` expands into a record of strings under JSON,
- * which has no pattern type of its own to terminate into.
- *
- * That is what separates these from a `FabricInstance`'s codec, bound to the
- * generic `[CODEC]`: an instance's codec only expands an instance into other
- * `FabricValue`s and leaves every terminal decision to whatever walks the
- * result, so one binding serves every format.
- *
- * It lives here, with the type universe, rather than beside either the classes
- * that bind it or the format that reads it. Both of those have importers in
- * the other direction, and this module imports nothing, so a symbol here is
- * reachable from anywhere without closing a cycle.
- */
-export const JSON_CODEC: unique symbol = Symbol("data-model.jsonCodecEngine");
-
-/**
  * Abstract base class for all fabric-system value types. This is the common
  * superclass of `FabricInstance` (object-like protocol types) and
  * `FabricPrimitive` (immutable special primitives). It enables a single

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -15,7 +15,7 @@ import {
 // that cycle fails with "Cannot access 'BaseFabricInstance' before
 // initialization". `codecOf.ts` itself is a leaf.
 import { codecOf } from "@/codec-common/codecOf.ts";
-import { JSON_CODEC } from "@/interface.ts";
+import { JSON_CODEC } from "@/codec-interface/interface.ts";
 
 /**
  * Sentinel marker used to wrap content that should appear unquoted in the

--- a/packages/data-model/test/codec-common/BaseCodecEngine.test.ts
+++ b/packages/data-model/test/codec-common/BaseCodecEngine.test.ts
@@ -1,0 +1,214 @@
+// Tests for the whole-value codec engine base class, exercised through a
+// minimal format of its own (see `probe-engine.ts`) rather than through
+// `JsonCodecEngine`. What is under test is the part no wire format decides for
+// itself, and a format whose containers do the least a container can do is
+// what makes those decisions observable.
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import type { FabricValue } from "@/interface.ts";
+import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/codec-interface/index.ts";
+import { isDeepFrozen } from "@/deep-freeze.ts";
+import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
+import { UnknownValue } from "@/codec-common/UnknownValue.ts";
+import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
+import {
+  Marker,
+  NESTED,
+  newProbeEngine,
+  NONTERMINAL_HOST,
+  type ProbeValue,
+  Tagged,
+  TERMINAL_HOST,
+} from "./probe-engine.ts";
+
+const CONTEXT = EMPTY_RECONSTRUCTION_CONTEXT;
+
+describe("BaseCodecEngine", () => {
+  describe("terminal vs. nonterminal codecs", () => {
+    // The two host codecs return the identical state, `{ inner: "X" }`, and
+    // differ only in which base class they extend. Everything below is
+    // therefore the engine's doing rather than theirs.
+
+    it("leaves a terminal codec's state alone", () => {
+      const { engine } = newProbeEngine();
+      const encoded = engine.encode(TERMINAL_HOST) as Tagged;
+
+      expect(encoded.tag).toBe("T@1");
+      // `"X"` has a codec of its own, and it was not consulted: a terminal
+      // state is already in the format's domain, so the walk stops here.
+      expect(encoded.state).toEqual({ inner: NESTED });
+    });
+
+    it("walks a nonterminal codec's state", () => {
+      const { engine } = newProbeEngine();
+      const encoded = engine.encode(NONTERMINAL_HOST) as Tagged;
+
+      expect(encoded.tag).toBe("N@1");
+      // The same state, expanded: `"X"` is a fabric value, so the walk went on
+      // and `XCodec` encoded it under its own tag.
+      const inner = (encoded.state as { inner: ProbeValue }).inner as Tagged;
+      expect(inner).toBeInstanceOf(Tagged);
+      expect(inner.tag).toBe("X@1");
+      expect(inner.state).toBe("encoded-X");
+    });
+
+    it("hands a terminal codec the state exactly as it arrived", () => {
+      const { engine, record } = newProbeEngine();
+      // Hand-built so that both hosts are given the identical wire state.
+      const wire = new Tagged("T@1", { inner: new Tagged("X@1", "encoded-X") });
+
+      engine.decode(wire, CONTEXT);
+
+      const seen = record.decoded[0] as { inner: unknown };
+      // Undecoded: the inner tag is still a tag, not the value it stands for.
+      expect(seen.inner).toBeInstanceOf(Tagged);
+    });
+
+    it("hands a nonterminal codec state that has been decoded", () => {
+      const { engine, record } = newProbeEngine();
+      const wire = new Tagged("N@1", { inner: new Tagged("X@1", "encoded-X") });
+
+      engine.decode(wire, CONTEXT);
+
+      const seen = record.decoded[0] as { inner: unknown };
+      // Decoded: the walk reached the inner tag before this codec was called.
+      expect(seen.inner).toBe("decoded-X");
+    });
+
+    it("reads the kind from the codec's base class, not from its state", () => {
+      // The clinching case: identical states in, different wire forms out.
+      const { engine } = newProbeEngine();
+
+      expect((engine.encode(TERMINAL_HOST) as Tagged).state)
+        .toEqual({ inner: NESTED });
+      expect(
+        ((engine.encode(NONTERMINAL_HOST) as Tagged).state as {
+          inner: ProbeValue;
+        }).inner,
+      ).toBeInstanceOf(Tagged);
+    });
+  });
+
+  describe("encodeValue()", () => {
+    it("emits a self-representing value as it stands", () => {
+      const { engine } = newProbeEngine();
+
+      expect(engine.encode(42)).toBe(42);
+      expect(engine.encode("plain")).toBe("plain");
+    });
+
+    it("takes the tag from `tagForValue()` rather than from the value", () => {
+      const { engine } = newProbeEngine();
+
+      expect((engine.encode(TERMINAL_HOST) as Tagged).tag).toBe("T@1");
+    });
+
+    it("throws given a `FabricSpecialObject` no codec claims", () => {
+      const { engine } = newProbeEngine();
+
+      expect(() => engine.encode(new FabricBytes(new Uint8Array([1]))))
+        .toThrow(/No codec registered for `FabricSpecialObject` subclass/);
+    });
+
+    it("throws given a value that is no `FabricValue` at all", () => {
+      const { engine } = newProbeEngine();
+
+      expect(() => engine.encode(new Date() as unknown as FabricValue))
+        .toThrow(/no applicable codec/);
+    });
+
+    it("throws given a circular reference", () => {
+      const { engine } = newProbeEngine();
+      const value: Record<string, FabricValue> = { a: 1 };
+      value.self = value;
+
+      expect(() => engine.encode(value)).toThrow(/Circular reference/);
+    });
+
+    it("does not mistake a repeated value for a circular one", () => {
+      // The same object twice over is not a cycle, so `seen` has to be unwound
+      // as the walk leaves each value rather than only grown. A `Marker`
+      // rather than a plain object, because that bookkeeping lives on the
+      // codec-matched path and a container never reaches it.
+      const { engine } = newProbeEngine();
+      const shared = new Marker() as unknown as FabricValue;
+
+      expect(() => engine.encode({ x: shared, y: shared })).not.toThrow();
+    });
+  });
+
+  describe("decodeTagged()", () => {
+    it("wraps an unrecognized tag in an `UnknownValue`, decoded state kept", () => {
+      const { engine } = newProbeEngine();
+      const result = engine.decode(
+        new Tagged("Nope@1", new Tagged("X@1", "encoded-X")),
+        CONTEXT,
+      );
+
+      expect(result).toBeInstanceOf(UnknownValue);
+      // Not a rejection: the state is walked so that what is inside a tag
+      // nobody claims still round-trips.
+      expect((result as UnknownValue).state).toBe("decoded-X");
+    });
+
+    it("rejects an empty tag rather than naming an `UnknownValue` with one", () => {
+      const { engine } = newProbeEngine();
+
+      expect(() => engine.decode(new Tagged("", "x"), CONTEXT))
+        .toThrow(/empty tag/);
+    });
+
+    it("deep-freezes what a codec returns", () => {
+      // `MarkerCodec.decode()` returns a mutable nested object. Every other
+      // codec here returns a primitive, which is deep-frozen however the
+      // engine behaves, and so could not witness this.
+      const { engine } = newProbeEngine();
+      const result = engine.decode(new Tagged("M@1", "m"), CONTEXT);
+
+      expect(result).toEqual({ deep: { n: 1 } });
+      expect(isDeepFrozen(result)).toBe(true);
+    });
+  });
+
+  describe("`lenient`", () => {
+    it("raises a codec's rejection when not lenient", () => {
+      const { engine } = newProbeEngine();
+
+      expect(engine.lenient).toBe(false);
+      expect(() => engine.decode(new Tagged("", "x"), CONTEXT)).toThrow();
+    });
+
+    it("keeps a malformation the engine found, when lenient", () => {
+      const { engine } = newProbeEngine({ lenient: true });
+      const result = engine.decode(new Tagged("", "x"), CONTEXT);
+
+      expect(result).toBeInstanceOf(ProblematicValue);
+      expect((result as ProblematicValue).error).toMatch(/empty tag/);
+    });
+
+    it("deep-freezes the `ProblematicValue` it keeps", () => {
+      // A `ProblematicValue` is not frozen at construction, so this is what
+      // witnesses the contract on that arm.
+      const { engine } = newProbeEngine({ lenient: true });
+
+      expect(isDeepFrozen(engine.decode(new Tagged("", "x"), CONTEXT)))
+        .toBe(true);
+    });
+
+    it("is `false` by default", () => {
+      expect(newProbeEngine().engine.lenient).toBe(false);
+    });
+
+    it("does not reach an unrecognized tag either way", () => {
+      // An unclaimed tag is not a rejection, so `lenient` has no say in it.
+      const wire = new Tagged("Nope@1", "x");
+
+      expect(newProbeEngine().engine.decode(wire, CONTEXT))
+        .toBeInstanceOf(UnknownValue);
+      expect(newProbeEngine({ lenient: true }).engine.decode(wire, CONTEXT))
+        .toBeInstanceOf(UnknownValue);
+    });
+  });
+});

--- a/packages/data-model/test/codec-common/BaseCodecEngine.test.ts
+++ b/packages/data-model/test/codec-common/BaseCodecEngine.test.ts
@@ -173,42 +173,111 @@ describe("BaseCodecEngine", () => {
   });
 
   describe("`lenient`", () => {
-    it("raises a codec's rejection when not lenient", () => {
-      const { engine } = newProbeEngine();
+    // A codec rejects a state in one of two ways, and which it picks is the
+    // codec author's business rather than a caller's. `lenient` is what
+    // decides what a caller sees, so it has to settle BOTH ways -- which is
+    // why each group below covers both. `ThrowingCodec` and `RejectingCodec`
+    // differ in nothing but that choice.
 
-      expect(engine.lenient).toBe(false);
-      expect(() => engine.decode(new Tagged("", "x"), CONTEXT)).toThrow();
-    });
+    /** A wire form whose codec rejects by throwing. */
+    const THROWN = new Tagged("Throws@1", "x");
 
-    it("keeps a malformation the engine found, when lenient", () => {
-      const { engine } = newProbeEngine({ lenient: true });
-      const result = engine.decode(new Tagged("", "x"), CONTEXT);
+    /** A wire form whose codec rejects by returning a report. */
+    const RETURNED = new Tagged("Rejects@1", "x");
 
-      expect(result).toBeInstanceOf(ProblematicValue);
-      expect((result as ProblematicValue).error).toMatch(/empty tag/);
-    });
+    /** A wire form the walk itself finds malformed, no codec involved. */
+    const MALFORMED = new Tagged("", "x");
 
-    it("deep-freezes the `ProblematicValue` it keeps", () => {
-      // A `ProblematicValue` is not frozen at construction, so this is what
-      // witnesses the contract on that arm.
-      const { engine } = newProbeEngine({ lenient: true });
-
-      expect(isDeepFrozen(engine.decode(new Tagged("", "x"), CONTEXT)))
-        .toBe(true);
-    });
+    /** A wire form under a tag no codec claims, which is not a rejection. */
+    const UNCLAIMED = new Tagged("Nope@1", "x");
 
     it("is `false` by default", () => {
       expect(newProbeEngine().engine.lenient).toBe(false);
     });
 
-    it("does not reach an unrecognized tag either way", () => {
-      // An unclaimed tag is not a rejection, so `lenient` has no say in it.
-      const wire = new Tagged("Nope@1", "x");
+    describe("when `lenient === false`", () => {
+      it("raises a codec's throw", () => {
+        const { engine } = newProbeEngine();
 
-      expect(newProbeEngine().engine.decode(wire, CONTEXT))
-        .toBeInstanceOf(UnknownValue);
-      expect(newProbeEngine({ lenient: true }).engine.decode(wire, CONTEXT))
-        .toBeInstanceOf(UnknownValue);
+        expect(() => engine.decode(THROWN, CONTEXT))
+          .toThrow(/rejected by throwing/);
+      });
+
+      it("turns a `ProblematicValue` a codec returned into a throw", () => {
+        // The half that used to do nothing: this rejection stood either way
+        // before, so the setting governed only the codecs that threw.
+        const { engine } = newProbeEngine();
+
+        expect(() => engine.decode(RETURNED, CONTEXT))
+          .toThrow(/rejected by returning/);
+      });
+
+      it("raises a malformation the walk itself found", () => {
+        const { engine } = newProbeEngine();
+
+        expect(() => engine.decode(MALFORMED, CONTEXT)).toThrow(/empty tag/);
+      });
+
+      it("wraps an unclaimed tag in an `UnknownValue` regardless", () => {
+        // Not a rejection, so the setting has no say in it.
+        const { engine } = newProbeEngine();
+
+        expect(engine.decode(UNCLAIMED, CONTEXT)).toBeInstanceOf(UnknownValue);
+      });
+    });
+
+    describe("when `lenient === true`", () => {
+      it("turns a codec's throw into a `ProblematicValue`", () => {
+        const { engine } = newProbeEngine({ lenient: true });
+        const result = engine.decode(THROWN, CONTEXT);
+
+        expect(result).toBeInstanceOf(ProblematicValue);
+        // Carrying the codec's own message, so what went wrong survives the
+        // conversion.
+        expect((result as ProblematicValue).error)
+          .toMatch(/rejected by throwing/);
+        expect((result as ProblematicValue).wireTypeTag).toBe("Throws@1");
+      });
+
+      it("lets a `ProblematicValue` a codec returned stand", () => {
+        const { engine } = newProbeEngine({ lenient: true });
+        const result = engine.decode(RETURNED, CONTEXT);
+
+        expect(result).toBeInstanceOf(ProblematicValue);
+        expect((result as ProblematicValue).error)
+          .toMatch(/rejected by returning/);
+      });
+
+      it("keeps a malformation the walk itself found", () => {
+        const { engine } = newProbeEngine({ lenient: true });
+        const result = engine.decode(MALFORMED, CONTEXT);
+
+        expect(result).toBeInstanceOf(ProblematicValue);
+        expect((result as ProblematicValue).error).toMatch(/empty tag/);
+      });
+
+      it("deep-freezes a `ProblematicValue` a codec returned", () => {
+        // The codec arm's freeze: this report is the codec's own product.
+        const { engine } = newProbeEngine({ lenient: true });
+
+        expect(isDeepFrozen(engine.decode(RETURNED, CONTEXT))).toBe(true);
+      });
+
+      it("deep-freezes a `ProblematicValue` it built itself", () => {
+        // The other arm, and a separate line of code: one is the engine
+        // wrapping a throw, the other the walk reporting a malformation.
+        // Neither stands in for the other.
+        const { engine } = newProbeEngine({ lenient: true });
+
+        expect(isDeepFrozen(engine.decode(THROWN, CONTEXT))).toBe(true);
+        expect(isDeepFrozen(engine.decode(MALFORMED, CONTEXT))).toBe(true);
+      });
+
+      it("wraps an unclaimed tag in an `UnknownValue` regardless", () => {
+        const { engine } = newProbeEngine({ lenient: true });
+
+        expect(engine.decode(UNCLAIMED, CONTEXT)).toBeInstanceOf(UnknownValue);
+      });
     });
   });
 });

--- a/packages/data-model/test/codec-common/codecOf.test.ts
+++ b/packages/data-model/test/codec-common/codecOf.test.ts
@@ -16,7 +16,8 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import { FabricSpecialObject, JSON_CODEC } from "@/interface.ts";
+import { FabricSpecialObject } from "@/interface.ts";
+import { JSON_CODEC } from "@/codec-interface/interface.ts";
 import {
   CODEC,
   codecOf,

--- a/packages/data-model/test/codec-common/probe-engine.ts
+++ b/packages/data-model/test/codec-common/probe-engine.ts
@@ -1,0 +1,288 @@
+// A minimal wire format, existing only so that `BaseCodecEngine` can be tested
+// as itself.
+//
+// Going through `JsonCodecEngine` would test the base and JSON's container
+// handling together, and for the question these fixtures exist to answer --
+// what a terminal codec's state does that a nonterminal one's does not -- JSON
+// is nearly blind: where a state is a record of strings, a walk that descends
+// into it and one that passes it through emit the same bytes. This format's
+// tagged form is a class instead, so "walked" and "not walked" are visibly
+// different things.
+
+import type { FabricValue } from "@/interface.ts";
+import { BaseCodecEngine } from "@/codec-common/BaseCodecEngine.ts";
+import { BaseNonterminalCodec } from "@/codec-interface/BaseNonterminalCodec.ts";
+import { BaseTerminalCodec } from "@/codec-interface/BaseTerminalCodec.ts";
+import type {
+  ReconstructionContext,
+  WireFormat,
+} from "@/codec-interface/interface.ts";
+import { CodecRegistry } from "@/codec-common/CodecRegistry.ts";
+
+/**
+ * This format's tagged form. A class, so that it cannot be mistaken for a
+ * `FabricValue` -- which is what lets a test see whether a state was walked.
+ */
+export class Tagged {
+  constructor(readonly tag: string, readonly state: ProbeValue) {
+    Object.freeze(this);
+  }
+}
+
+/** This format's transport tree. */
+export type ProbeValue =
+  | null
+  | undefined
+  | boolean
+  | number
+  | string
+  | bigint
+  | Marker
+  | Tagged
+  | readonly ProbeValue[]
+  | { readonly [key: string]: ProbeValue };
+
+/** The value the two host codecs nest inside their state. */
+export const NESTED = 7n;
+
+/**
+ * Codec for {@link NESTED}, whose whole purpose is to sit inside another
+ * codec's state. Its input, encoded and decoded forms are three different
+ * values, so a test can tell which of them it is looking at.
+ */
+export class XCodec extends BaseTerminalCodec<ProbeValue> {
+  constructor() {
+    super("X@1", undefined);
+  }
+
+  override canEncode(value: FabricValue): boolean {
+    return value === NESTED;
+  }
+
+  encode(_value: FabricValue): ProbeValue {
+    return "encoded-X";
+  }
+
+  decode(
+    _typeTag: string,
+    _state: ProbeValue,
+    _context: ReconstructionContext,
+  ): FabricValue {
+    return "decoded-X";
+  }
+}
+
+/** The value the terminal host codec claims. */
+export const TERMINAL_HOST = 1;
+
+/** The value the nonterminal host codec claims, whose state is identical. */
+export const NONTERMINAL_HOST = "N";
+
+/** What a host codec was handed, recorded so a test can assert on it. */
+export type HostRecord = {
+  /** States passed to `encode()`. */
+  encoded: FabricValue[];
+
+  /** States passed to `decode()`. */
+  decoded: unknown[];
+};
+
+/** Builds a fresh, empty record. */
+export function newRecord(): HostRecord {
+  return { encoded: [], decoded: [] };
+}
+
+/**
+ * Terminal codec whose state holds a value another codec could encode. Being
+ * terminal, that nested value is the engine's business to leave alone.
+ */
+export class TerminalHostCodec extends BaseTerminalCodec<ProbeValue> {
+  constructor(readonly record: HostRecord) {
+    super("T@1", undefined);
+  }
+
+  override canEncode(value: FabricValue): boolean {
+    return value === TERMINAL_HOST;
+  }
+
+  encode(value: FabricValue): ProbeValue {
+    this.record.encoded.push(value);
+    return { inner: NESTED };
+  }
+
+  decode(
+    _typeTag: string,
+    state: ProbeValue,
+    _context: ReconstructionContext,
+  ): FabricValue {
+    this.record.decoded.push(state);
+    return TERMINAL_HOST;
+  }
+}
+
+/**
+ * Nonterminal counterpart to {@link TerminalHostCodec}, returning the very
+ * same state. Everything the two do differently is the engine's doing.
+ */
+export class NonterminalHostCodec extends BaseNonterminalCodec {
+  constructor(readonly record: HostRecord) {
+    super("N@1", undefined);
+  }
+
+  override canEncode(value: FabricValue): boolean {
+    return value === NONTERMINAL_HOST;
+  }
+
+  encode(value: FabricValue): FabricValue {
+    this.record.encoded.push(value);
+    return { inner: NESTED };
+  }
+
+  decode(
+    _typeTag: string,
+    state: FabricValue,
+    _context: ReconstructionContext,
+  ): FabricValue {
+    this.record.decoded.push(state);
+    return NONTERMINAL_HOST;
+  }
+}
+
+/**
+ * A value that is an OBJECT and is claimed by a codec. The primitive-keyed
+ * codecs above cannot stand in for it: the engine's cycle bookkeeping only
+ * engages for an object, so nothing else reaches it.
+ */
+export class Marker {
+  constructor(readonly note: string = "m") {
+    Object.freeze(this);
+  }
+}
+
+/**
+ * Codec for {@link Marker}, reached by class rather than by primitive type.
+ * Its `decode()` returns a MUTABLE nested object on purpose: every other codec
+ * here returns a primitive, which is deep-frozen whatever the engine does, and
+ * so cannot witness the freeze the engine promises.
+ */
+export class MarkerCodec extends BaseTerminalCodec<ProbeValue> {
+  constructor() {
+    super("M@1", Marker as unknown as new (...args: never[]) => object);
+  }
+
+  encode(_value: FabricValue): ProbeValue {
+    return "m";
+  }
+
+  decode(
+    _typeTag: string,
+    _state: ProbeValue,
+    _context: ReconstructionContext,
+  ): FabricValue {
+    return { deep: { n: 1 } };
+  }
+}
+
+/**
+ * The engine. Its containers do the least a container can do, so that what a
+ * test observes is the base class and not this.
+ */
+export class ProbeEngine extends BaseCodecEngine<ProbeValue> {
+  //
+  // Instance members
+  //
+
+  override encode(value: FabricValue): ProbeValue {
+    return this.encodeValue(value);
+  }
+
+  override decode(
+    data: ProbeValue,
+    context: ReconstructionContext,
+  ): FabricValue {
+    return this.decodeValue(data, context);
+  }
+
+  protected override wrapTag(tag: string, state: ProbeValue): ProbeValue {
+    return new Tagged(tag, state);
+  }
+
+  protected override encodeArray(
+    value: readonly FabricValue[],
+    seen: Set<object>,
+  ): ProbeValue {
+    ProbeEngine.enterOrThrow(seen, value);
+    const result = value.map((v) => this.encodeValue(v, seen));
+    seen.delete(value);
+    return result;
+  }
+
+  protected override encodePlainObject(
+    value: Record<string, FabricValue>,
+    seen: Set<object>,
+  ): ProbeValue {
+    ProbeEngine.enterOrThrow(seen, value);
+    const result: Record<string, ProbeValue> = {};
+    for (const [k, v] of Object.entries(value)) {
+      result[k] = this.encodeValue(v, seen);
+    }
+    seen.delete(value);
+    return result;
+  }
+
+  protected override decodeValue(
+    data: ProbeValue,
+    context: ReconstructionContext,
+  ): FabricValue {
+    if (data instanceof Tagged) {
+      return this.decodeTagged(data.tag, data.state, context);
+    } else if (Array.isArray(data)) {
+      return data.map((d) => this.decodeValue(d, context));
+    } else if ((data !== null) && (typeof data === "object")) {
+      const result: Record<string, FabricValue> = {};
+      for (const [k, v] of Object.entries(data)) {
+        result[k] = this.decodeValue(v as ProbeValue, context);
+      }
+      return result;
+    }
+
+    return data as FabricValue;
+  }
+}
+
+/**
+ * This format, as a `CodecRegistry` needs one. Its symbol is its own: nothing
+ * binds a codec under it, since every codec here is registered directly.
+ */
+const PROBE_FORMAT: WireFormat<ProbeValue> = Object.freeze({
+  codecSymbol: Symbol("test.probeFormatCodec"),
+});
+
+/**
+ * Builds an engine over a registry carrying the three codecs above, plus the
+ * self-representing primitives a walk needs to get anywhere.
+ */
+export function newProbeEngine(
+  options?: { lenient?: boolean; record?: HostRecord },
+): { engine: ProbeEngine; record: HostRecord } {
+  const record = options?.record ?? newRecord();
+  const registry = new CodecRegistry<ProbeValue>(PROBE_FORMAT);
+
+  // Registered by primitive type, which is how `codecFromValue()` reaches a
+  // codec for a value that is not an instance of a class it names. Each claims
+  // exactly one value of its type, so every other value of that type falls
+  // through to self-representation below -- which the registry tries second.
+  registry.registerPrimitive("bigint", new XCodec());
+  registry.registerPrimitive("number", new TerminalHostCodec(record));
+  registry.registerPrimitive("string", new NonterminalHostCodec(record));
+  registry.register(new MarkerCodec());
+  for (const t of ["null", "boolean", "number", "string", "bigint"] as const) {
+    registry.registerSelfRep(t);
+  }
+  Object.freeze(registry);
+
+  return {
+    engine: new ProbeEngine({ registry, lenient: options?.lenient ?? false }),
+    record,
+  };
+}

--- a/packages/data-model/test/codec-common/probe-engine.ts
+++ b/packages/data-model/test/codec-common/probe-engine.ts
@@ -24,8 +24,23 @@ import { CodecRegistry } from "@/codec-common/CodecRegistry.ts";
  * `FabricValue` -- which is what lets a test see whether a state was walked.
  */
 export class Tagged {
-  constructor(readonly tag: string, readonly state: ProbeValue) {
+  readonly #tag: string;
+  readonly #state: ProbeValue;
+
+  constructor(tag: string, state: ProbeValue) {
+    this.#tag = tag;
+    this.#state = state;
     Object.freeze(this);
+  }
+
+  /** The wire type tag. */
+  get tag(): string {
+    return this.#tag;
+  }
+
+  /** The state carried under it. */
+  get state(): ProbeValue {
+    return this.#state;
   }
 }
 
@@ -97,8 +112,16 @@ export function newRecord(): HostRecord {
  * terminal, that nested value is the engine's business to leave alone.
  */
 export class TerminalHostCodec extends BaseTerminalCodec<ProbeValue> {
-  constructor(readonly record: HostRecord) {
+  readonly #record: HostRecord;
+
+  constructor(record: HostRecord) {
     super("T@1", undefined);
+    this.#record = record;
+  }
+
+  /** What this codec has been handed. */
+  get record(): HostRecord {
+    return this.#record;
   }
 
   override canEncode(value: FabricValue): boolean {
@@ -106,7 +129,7 @@ export class TerminalHostCodec extends BaseTerminalCodec<ProbeValue> {
   }
 
   encode(value: FabricValue): ProbeValue {
-    this.record.encoded.push(value);
+    this.#record.encoded.push(value);
     return { inner: NESTED };
   }
 
@@ -115,7 +138,7 @@ export class TerminalHostCodec extends BaseTerminalCodec<ProbeValue> {
     state: ProbeValue,
     _context: ReconstructionContext,
   ): FabricValue {
-    this.record.decoded.push(state);
+    this.#record.decoded.push(state);
     return TERMINAL_HOST;
   }
 }
@@ -125,8 +148,16 @@ export class TerminalHostCodec extends BaseTerminalCodec<ProbeValue> {
  * same state. Everything the two do differently is the engine's doing.
  */
 export class NonterminalHostCodec extends BaseNonterminalCodec {
-  constructor(readonly record: HostRecord) {
+  readonly #record: HostRecord;
+
+  constructor(record: HostRecord) {
     super("N@1", undefined);
+    this.#record = record;
+  }
+
+  /** What this codec has been handed. */
+  get record(): HostRecord {
+    return this.#record;
   }
 
   override canEncode(value: FabricValue): boolean {
@@ -134,7 +165,7 @@ export class NonterminalHostCodec extends BaseNonterminalCodec {
   }
 
   encode(value: FabricValue): FabricValue {
-    this.record.encoded.push(value);
+    this.#record.encoded.push(value);
     return { inner: NESTED };
   }
 
@@ -143,7 +174,7 @@ export class NonterminalHostCodec extends BaseNonterminalCodec {
     state: FabricValue,
     _context: ReconstructionContext,
   ): FabricValue {
-    this.record.decoded.push(state);
+    this.#record.decoded.push(state);
     return NONTERMINAL_HOST;
   }
 }
@@ -154,8 +185,16 @@ export class NonterminalHostCodec extends BaseNonterminalCodec {
  * engages for an object, so nothing else reaches it.
  */
 export class Marker {
-  constructor(readonly note: string = "m") {
+  readonly #note: string;
+
+  constructor(note: string = "m") {
+    this.#note = note;
     Object.freeze(this);
+  }
+
+  /** A label, so that two markers can be told apart. */
+  get note(): string {
+    return this.#note;
   }
 }
 

--- a/packages/data-model/test/codec-common/probe-engine.ts
+++ b/packages/data-model/test/codec-common/probe-engine.ts
@@ -18,6 +18,7 @@ import type {
   WireFormat,
 } from "@/codec-interface/interface.ts";
 import { CodecRegistry } from "@/codec-common/CodecRegistry.ts";
+import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
 
 /**
  * This format's tagged form. A class, so that it cannot be mistaken for a
@@ -180,6 +181,63 @@ export class NonterminalHostCodec extends BaseNonterminalCodec {
 }
 
 /**
+ * Codec that rejects a state by THROWING. Reachable by tag only: nothing
+ * encodes to it, since what it exists to exercise is the decode side.
+ */
+export class ThrowingCodec extends BaseTerminalCodec<ProbeValue> {
+  constructor() {
+    super("Throws@1", undefined);
+  }
+
+  override canEncode(_value: FabricValue): boolean {
+    return false;
+  }
+
+  encode(_value: FabricValue): ProbeValue {
+    throw new Error("Shouldn't happen: this codec never encodes.");
+  }
+
+  decode(
+    typeTag: string,
+    _state: ProbeValue,
+    _context: ReconstructionContext,
+  ): FabricValue {
+    throw new Error(`${typeTag}: rejected by throwing`);
+  }
+}
+
+/**
+ * Codec that rejects a state by RETURNING a `ProblematicValue`, which is the
+ * other way the spec sanctions. Its counterpart above returns nothing and
+ * throws; the engine is what makes the two indistinguishable to a caller.
+ */
+export class RejectingCodec extends BaseTerminalCodec<ProbeValue> {
+  constructor() {
+    super("Rejects@1", undefined);
+  }
+
+  override canEncode(_value: FabricValue): boolean {
+    return false;
+  }
+
+  encode(_value: FabricValue): ProbeValue {
+    throw new Error("Shouldn't happen: this codec never encodes.");
+  }
+
+  decode(
+    typeTag: string,
+    state: ProbeValue,
+    _context: ReconstructionContext,
+  ): FabricValue {
+    return new ProblematicValue(
+      typeTag,
+      state as FabricValue,
+      "rejected by returning",
+    );
+  }
+}
+
+/**
  * A value that is an OBJECT and is claimed by a codec. The primitive-keyed
  * codecs above cannot stand in for it: the engine's cycle bookkeeping only
  * engages for an object, so nothing else reaches it.
@@ -315,6 +373,8 @@ export function newProbeEngine(
   registry.registerPrimitive("number", new TerminalHostCodec(record));
   registry.registerPrimitive("string", new NonterminalHostCodec(record));
   registry.register(new MarkerCodec());
+  registry.register(new ThrowingCodec());
+  registry.register(new RejectingCodec());
   for (const t of ["null", "boolean", "number", "string", "bigint"] as const) {
     registry.registerSelfRep(t);
   }

--- a/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
@@ -11,7 +11,7 @@
  * offset is at or past the end copies nothing rather than failing.
  */
 
-import { JSON_CODEC } from "@/interface.ts";
+import { JSON_CODEC } from "@/codec-interface/interface.ts";
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
@@ -11,7 +11,7 @@
  * Malformed state decodes to a `ProblematicValue` rather than throwing.
  */
 
-import { JSON_CODEC } from "@/interface.ts";
+import { JSON_CODEC } from "@/codec-interface/interface.ts";
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
@@ -11,7 +11,7 @@
  * conversion leaves an instance alone even when asked for something mutable.
  */
 
-import { JSON_CODEC } from "@/interface.ts";
+import { JSON_CODEC } from "@/codec-interface/interface.ts";
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/fabric-primitives/FabricHash.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricHash.test.ts
@@ -11,7 +11,7 @@
  * when a caller explicitly transfers it.
  */
 
-import { JSON_CODEC } from "@/interface.ts";
+import { JSON_CODEC } from "@/codec-interface/interface.ts";
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -15,7 +15,7 @@
  * as well -- two values differing only in it hash differently.
  */
 
-import { JSON_CODEC } from "@/interface.ts";
+import { JSON_CODEC } from "@/codec-interface/interface.ts";
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 


### PR DESCRIPTION
`BaseCodecEngine` had no unit tests of its own. Its behavior was reached only
through `JsonCodecEngine`, and I (an agent working on behalf of @danfuzz) am
closing that gap before more formats are built on it.

Going through JSON tests the base and JSON's container handling together, and
for the property these tests exist to pin, JSON is nearly blind: where a
codec's state is a record of strings, a walk that descends into it and one that
passes it through emit the same bytes. So these go through a minimal format of
their own, whose tagged form is a **class** — which makes "walked" and "not
walked" visibly different values — and whose containers do the least a
container can do, so that what an assertion sees is the base class rather than
the fixture.

## The terminal/nonterminal difference, pinned four ways

Two host codecs return the **identical** state, `{ inner: 7n }`, and differ only
in which base class they extend. Every difference in outcome is therefore the
engine's doing:

| | terminal | nonterminal |
|---|---|---|
| **encode** | state left alone; nested value stays raw | state walked; nested value gets its own tag |
| **decode** | handed the state exactly as it arrived, tag undecoded | handed the decoded form |

Each of four ablations — forcing either side to treat every codec as one kind —
turns exactly the test that names it red, and no others.

## What `lenient` settles, in all four combinations

A codec rejects a state in one of two ways, and which it picks is the codec
author's business rather than a caller's. So the engine has to settle both,
and the tests are grouped as `when \`lenient === false\`` and
`when \`lenient === true\`` to make that symmetry show in the run. Two codecs
stand in for the two ways, differing in nothing else.

Two of these had no coverage at all before, and they are the diagonals:
strictly, a `ProblematicValue` a codec *returned* becomes a throw — the half of
`lenient: false` that used to do nothing; leniently, a codec's *throw* becomes a
returned `ProblematicValue` carrying the codec's own message.

A malformation the walk finds for itself (an empty tag) answers to the same
setting, and an unclaimed tag answers to neither, being an `UnknownValue`
rather than a rejection.

## The rest of the base

The `SELF_REP` arm, the tag coming from `tagForValue()` rather than the value,
both encode-side throws, cycle detection, and the deep-frozen contract — split
across the two separate places the engine builds a `ProblematicValue`, since
neither stands in for the other.

## Tests that did not test anything, found by ablating

Three stayed green under an ablation that should have killed them, each because
the test never reached the code:

- **Cycle bookkeeping.** The engine's `seen` enter/exit engages only for an
  object matched by a *codec*; a plain object goes through a container arm and
  never reaches it.
- **The deep-frozen contract.** Every other codec here returns a primitive from
  `decode()`, which is deep-frozen however the engine behaves.
- **A codec's rejection.** Every `lenient` test decoded an empty tag, which is
  the walk's own detection — and one was named "raises a codec's rejection"
  while exercising exactly the opposite path.

A `Marker` class — claimed by a codec, returning a mutable nested object —
witnesses the first two; the two rejecting codecs witness the third.

## Two non-test changes

- The probe fixture holds its state in `#private` fields behind accessors. The
  refinement in #5743 says a class exposes no enumerable properties and that a
  constructor parameter property is a field declaration in disguise; the
  module-internal exemption does not reach these, since the fixture exports
  them all. It suits `Tagged` in particular, whose whole job is to be
  unmistakable for a plain object.
- **`JSON_CODEC` moves to `codec-interface/`**, beside `CODEC`. It sat in the
  top-level `interface.ts` because at the time everything under `codec-*` had
  importers running the other way; `codec-interface/` imports no runtime value
  from anywhere in the package, so nothing taken from it can close a cycle
  either. The paragraph of its doc comment that justified the old home goes
  with the move. 14 files repointed.

## Verification

`data-model` reports `53 passed (2382 steps)`; `deno task check`,
`fmt --check` (4429 files), `lint`, `check-docs`, `check-no-waitfor` and
`check-conflict-markers` are green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


