### PR TITLE
style(utils): `Logger.level` behind accessors

### DIFF
--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -547,7 +547,7 @@ export type LoggerBreakdown = {
 export class Logger {
   #moduleName: string | undefined;
   #disabled: boolean;
-  public level?: LogLevel;
+  #level: LogLevel | undefined;
   #counts: { debug: number; info: number; warn: number; error: number };
   #countsByKey: Record<
     string,
@@ -577,10 +577,10 @@ export class Logger {
     // Default to false (enabled) if not specified
     this.#disabled = options?.enabled === undefined ? false : !options.enabled;
 
-    // Set logger-specific level if provided; default to "info" when unset.
-    // This keeps behavior consistent and avoids assigning undefined with
-    // exactOptionalPropertyTypes enabled.
-    this.level = options?.level ?? getEnvLevel() ?? "info";
+    // Set logger-specific level if provided, falling back to the environment
+    // and then to "info", so that every instance reports a level rather than
+    // leaving callers to interpret its absence.
+    this.#level = options?.level ?? getEnvLevel() ?? "info";
 
     // Initialize call counts
     this.#counts = { debug: 0, info: 0, warn: 0, error: 0 };
@@ -603,6 +603,19 @@ export class Logger {
   /** @inheritDoc */
   set disabled(value: boolean) {
     this.#disabled = value;
+  }
+
+  /**
+   * Minimum level at which this logger emits. A message below it is counted
+   * but not printed.
+   */
+  get level(): LogLevel | undefined {
+    return this.#level;
+  }
+
+  /** @inheritDoc */
+  set level(value: LogLevel | undefined) {
+    this.#level = value;
   }
 
   /**
@@ -684,7 +697,7 @@ export class Logger {
       this.#lastLoggedAt = threshold;
 
       // Only log if debug level is enabled
-      if (shouldLog("debug", this.level)) {
+      if (shouldLog("debug", this.#level)) {
         const { prefix, color } = this.#getLogFormat("debug");
         const moduleName = this.#moduleName || "logger";
         const message =
@@ -722,7 +735,7 @@ export class Logger {
     this.#incrementKeyCount(key, "debug");
     if (this.#disabled) return;
     this.#maybeLogCountSummary();
-    if (shouldLog("debug", this.level)) {
+    if (shouldLog("debug", this.#level)) {
       const { prefix, color } = this.#getLogFormat("debug");
       if (shouldLogToStderr()) {
         logToStderr(
@@ -747,7 +760,7 @@ export class Logger {
     this.#incrementKeyCount(key, "info");
     if (this.#disabled) return;
     this.#maybeLogCountSummary();
-    if (shouldLog("info", this.level)) {
+    if (shouldLog("info", this.#level)) {
       const { prefix, color } = this.#getLogFormat("info");
       if (shouldLogToStderr()) {
         logToStderr(
@@ -767,7 +780,7 @@ export class Logger {
     this.#incrementKeyCount(key, "warn");
     if (this.#disabled) return;
     this.#maybeLogCountSummary();
-    if (shouldLog("warn", this.level)) {
+    if (shouldLog("warn", this.#level)) {
       const { prefix, color } = this.#getLogFormat("warn");
       if (shouldLogToStderr()) {
         logToStderr(
@@ -787,7 +800,7 @@ export class Logger {
     this.#incrementKeyCount(key, "error");
     if (this.#disabled) return;
     this.#maybeLogCountSummary();
-    if (shouldLog("error", this.level)) {
+    if (shouldLog("error", this.#level)) {
       const { prefix, color } = this.#getLogFormat("error");
       if (shouldLogToStderr()) {
         logToStderr(


### PR DESCRIPTION
Applies the no-enumerable-properties rule to `utils`. The rule itself is in
#5743, which also applies it to `data-model`; this PR is independent of that
one and touches only `packages/utils/src/logger.ts`.

`level` was the last enumerable own property on a `Logger`. It is now held in
`#level` behind a getter and a setter — a setter because callers genuinely
assign it, not only read it: `shell`'s debugger view at
`DebuggerView.ts:1598`, and `runner` tests that save, override and restore it
around a noisy section.

The practical effect is that `Object.keys()` on a `Logger` now returns `[]`
where it used to return `["level"]`, and spreading or serializing one yields
nothing. That is the point of the rule — an instance stops resembling data —
but it is a runtime change, not a rename, so it is the thing to check rather
than the type checker.

## `PathKeyMapNode` is deliberately left alone

`packages/utils/src/path-key-map.ts:131` declares a node type with three plain
fields. It qualifies for the rule's module-internal exemption: the class is
not exported, and the only thing that ever hands one back is the private
`#findNode()`, so no instance reaches a stranger who could mistake it for a
plain object. Its fields already sit at the top of the class, which is where
the ordering rule puts exposed properties, so it conforms as written.

## A stale comment, fixed because this change lands on the line it describes

The comment above the constructor's `level` assignment justified defaulting it
by "avoids assigning undefined with `exactOptionalPropertyTypes` enabled".
That flag is not enabled for `packages/utils` — the only two `deno.jsonc`
files that set it are `test-support` and `schema-generator`. Leaving a
knowingly-false rationale attached to a line being edited seemed worse than
correcting it, so it now states the reason that actually holds.

## Verification

I (an agent working on behalf of @danfuzz) checked the cross-package surface
rather than relying on this package's own suite, because `packages/utils` runs
`deno test --no-check` — a green suite there proves behavior and nothing about
types. `deno task check` is what type-checks it, and it covers `shell` and
`runner` too.

- `deno task check` — type check complete
- `deno task test` in `packages/utils` — `ok | 99 passed (660 steps) | 0 failed`
- `runner` tests that manipulate `logger.level`, run by file path rather than
  `--filter` (which matches test names, not files, and silently matches
  nothing): `cell-get-slow-warning` + `scheduler-throttle` →
  `ok | 2 passed (13 steps) | 0 failed`; `memory-v2-stacked-commit` →
  `ok | 88 passed | 0 failed`
- `deno fmt --check` and `deno lint` over the package — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9TjDnPXRSfN5DCjdbzaH1


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

