### PR TITLE
docs(plans): what a projection key means, and what reaches the read

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -93,6 +93,13 @@ a record: archive it to `docs/history/plans/` following the procedure in
   work on verbs across both arcs that produced it: what a verb declares, what a
   caller may ask for, and what comes back. Read it for order; read the designs
   it points at for reasoning.
+- [Projection keys, and the schema a read is handed](projection-key-classification.md)
+  designs the refusal of an unrecognized `--schema` key and the rule it is half
+  of — the projection reader never hands the read boundary a schema it did not
+  construct. Four tiers rather than three, because the keys that decide an
+  untyped position's container change behavior and must be dropped once read.
+  Carries the measured blast radius and the corrections it makes to the
+  sequencing plan's account of the item.
 - [The CLI surface — implementation plan](cli-surface-implementation.md) builds
   the rest of the command surface: positional addresses, the honest top-level
   names, deprecating the spellings they replace, and merging the commands that

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -97,9 +97,10 @@ a record: archive it to `docs/history/plans/` following the procedure in
   designs the refusal of an unrecognized `--schema` key and the rule it is half
   of — the projection reader never hands the read boundary a schema it did not
   construct. Four tiers rather than three, because the keys that decide an
-  untyped position's container change behavior and must be dropped once read.
-  Carries the measured blast radius and the corrections it makes to the
-  sequencing plan's account of the item.
+  untyped position's container change behavior, so a caller's copy of one is
+  consumed rather than carried onward. Carries the measured blast radius, and
+  separates a constraint a caller supplies from the same keyword the reader
+  derives from the source schema.
 - [The CLI surface — implementation plan](cli-surface-implementation.md) builds
   the rest of the command surface: positional addresses, the honest top-level
   names, deprecating the spellings they replace, and merging the commands that

--- a/docs/plans/projection-key-classification.md
+++ b/docs/plans/projection-key-classification.md
@@ -55,7 +55,9 @@ the JSON spelling it assigns the caller's own object, unchanged, to both
 
 **That asymmetry is the whole of the problem below.** On one path the CLI hands
 the read boundary something it built. On the other it hands over what a caller
-typed.
+typed. The two inputs are not interchangeable, though, and the fix turns on
+that: a field list has only positions to state, while a JSON projection also
+states scalar types.
 
 ## The problem
 
@@ -120,18 +122,51 @@ exercise that ended at "known keys pass, unknown keys are refused" would file
 So the design has two halves, and the second is the load-bearing one:
 
 1. **A key the projection vocabulary does not contain is refused, by name.**
-2. **The schema that crosses the read boundary is built by the reader**, from
-   the mask the projection implies and the source schema, on the JSON path as
-   it already is on the concise path.
+2. **The schema that crosses the read boundary is built by the reader**, key by
+   key, out of the classification below: an honored key is carried through, a
+   consulted key is consumed during inference and dropped, a tolerated key is
+   carried only where carrying it is provably inert, and a refused key never
+   reaches construction because the projection naming it was rejected. To that
+   the reader adds a key of its own, derived from the source: `required`, below.
+
+**The mask is not the material to build from**, and it fails on the honored key
+the whole classification rests hardest on. `ProjectionMask`
+(`packages/cli/lib/cell-selection.ts:ProjectionMask`) records `true`, `false`,
+and the two containers, and nothing else. It therefore carries `type` only where
+`type` names a container: `projectionMask` reduces every scalar position to
+`true`, because a scalar is neither container and the mask has no third thing
+for it to be. **A reader that constructed the outgoing schema from the mask
+could not honor a scalar `type`, having discarded it before construction
+began.** Two losses follow, and both of them widen a read:
+
+- A scalar leaf whose declared type does not match the stored value is omitted
+  today — deliberately, documented in `packages/cli/README.md`, and tested in
+  `packages/cli/test/piece-get-transform.test.ts` ("filters and projects arrays
+  through the runtime pattern graph", which projects `{"type":"string"}` over a
+  numeric `id` and expects the property gone). That leaf masks to `true`, and
+  `selectSourceSchema` answers a `true` mask with the source's own schema, so a
+  mask-built output schema would derive the source's numeric leaf and return
+  the value the caller's `type` excluded.
+- A scalar projection standing over an object source masks to `true` the same
+  way, so a mask-built output schema is the source object's, entire.
+  `projectValue` already copies every key of an object it is handed a scalar
+  schema for; the output schema re-asserted at the read boundary is the only
+  thing standing between that value and the caller. Sourcing that schema from
+  the mask removes the only stop.
+
+The concise path can build from the mask precisely because it has no scalar type
+to lose: `conciseSelectionSchema` writes containers and `true` leaves and
+nothing else. A JSON projection states scalar types, so the two paths converge
+on the rule and not on the code.
 
 Half 2 is what makes the tiers below meaningful. Once the outgoing schema is
 constructed, a tier does not describe what gets forwarded — no key crosses the
 boundary because a caller wrote it — it describes what a caller is allowed to
-write and what the reader does with it. What the reader then puts in the schema
-it builds is a separate question, answered from the source schema.
+write and what the reader puts in the schema it builds because of it.
 
-Note that `selectSourceSchema` already carries the exact rule half 2 needs,
-with a comment giving exactly this reason:
+The reader supplies exactly one key from somewhere other than the classified
+projection, and `selectSourceSchema` already derives that key this way, with a
+comment giving exactly this reason:
 
 ```text
 A rejected position holds nothing to require. Keeping it required makes
@@ -141,11 +176,12 @@ selection rather than for the one position that declined to be read.
 
 It takes the *source* schema's `required`, filters it to the properties that
 survived selection, and re-emits it — so the schema the reader constructs does
-carry `required`, on the reader's own authority and with the source's meaning.
-That construction runs on the source-read schema and on the concise path's
-output schema, and never on the JSON path's. **This item applies an existing
-rule to a second call site rather than inventing one**, and the rule it applies
-is *derive the constraint*, not *delete the keyword*.
+carry `required`, on the reader's own authority and with the source's meaning
+rather than the caller's. That derivation runs on the source-read schema and on
+the concise path's output schema, and on no JSON-path output schema. **This item
+extends an existing derivation to a second call site rather than inventing
+one**, and what it extends is *derive the constraint*, not *delete the
+keyword*.
 
 ## Four tiers
 
@@ -167,6 +203,11 @@ further.
 `items` and `additionalProperties` to build the mask. `$link` never reaches it,
 having been lifted out one step earlier — which is why the marker is honored
 without ever being a keyword the mask has to understand.
+
+An honored key is also the only kind the reader carries into the schema it
+constructs, and `type` is why that construction reads the classified projection
+rather than the mask: a scalar leaf's declared `type` is the whole of what
+filters that leaf, and a scalar `type` is exactly what the mask does not keep.
 
 **C** is the tier that earns the fourth slot, and calling its members
 "tolerated" would be false. `impliedProjectionType` decides whether an untyped
@@ -197,11 +238,12 @@ reader happens to default to.
 (`packages/piece/src/schema-compatibility.ts`), the compatibility checker's
 record of which keywords are validation-neutral. Deriving is what keeps the two
 registries from forking when a keyword like `tier` or `deprecated` is added to
-the durable dialect. Because the outgoing schema is constructed, a tolerated key
-has no forwarding question attached to most of its members; where one arises —
-`$id` and `$schema` declare the identity and dialect of a *document*, and the
-reader is not producing the caller's document — the answer is to accept and
-drop.
+the durable dialect. Because the outgoing schema is constructed key by key, a
+tolerated key is a decision rather than a default: it is accepted from the
+caller, and it reaches the constructed schema only where carrying it is provably
+inert. `$id` and `$schema` are the plain case for dropping — they declare the
+identity and dialect of a *document*, and the reader is not producing the
+caller's document.
 
 **R** is everything else, and it keeps three keys that are *also* annotation
 keys: `default`, `$defs`, and `definitions`. All three are refused today, for
@@ -370,17 +412,33 @@ happens to a key, never what a key means.
   source schema marks a projected property required still carries `required`
   past the read boundary, filtered to the projected properties, exactly as
   `selectSourceSchema` builds it.
-- A test holds those two apart — a caller's `required` does not survive into the
-  constructed schema, and a source-derived `required` does.
-  `packages/cli/test/piece-get-transform.test.ts` asserts the second today in
-  "narrows the initial source selector to predicate and projection fields",
-  which reads the selector handed to the storage provider and expects `required`
-  filtered to the projected properties.
+- A test holds those two apart, **inspecting the output schema specifically**: a
+  caller's `required` does not survive into it, and a source-derived `required`
+  does, filtered to the projected properties. The schema it inspects is the one
+  `deriveSelectedValue` re-asserts on `result.key("value")`, read back off that
+  output cell. **A selector captured from the storage provider does not satisfy
+  this and cannot stand in for it**: that selector is `sourceReadSchema`, built
+  by a separate `selectSourceSchema` call for the source read, and an
+  implementation that kept the caller's `required` on the source read while
+  dropping it from the output schema would pass an assertion over it while
+  failing this criterion. The two schemas have to be asserted separately because
+  they are two schemas.
 - A tier T key is accepted and changes nothing about what is read.
 - A projection naming a `required` field it does not project reads the fields it
   does project, rather than nothing.
 - A misspelled `properties` beside a stated `type` is refused, rather than
   returning the whole object.
+- **A scalar leaf whose declared type does not match the stored value is still
+  omitted at a nested position**, not only at an array item: a projection
+  declaring `{"type":"string"}` for a property the source declares a number
+  returns the surrounding object without that property. This is the criterion a
+  mask-built output schema fails, and it fails it silently.
+- **A scalar projection over an object source does not widen to that object.**
+  A projection of `{"type":"string"}` against an object value behaves as it does
+  now and in particular does not return the object's fields. The mask records
+  `true` at that position, so a reader building the output schema from the mask
+  would return all of them — and `projectValue`, which copies every key of an
+  object handed a scalar schema, has that value ready to hand over.
 - A test asserts the `ANNOTATION_KEYS` relation in both directions, as the
   first of the three coupling constraints words it.
 - A test asserts a **read outcome** for a projection carrying `required`, not

--- a/docs/plans/projection-key-classification.md
+++ b/docs/plans/projection-key-classification.md
@@ -1,0 +1,371 @@
+# Projection keys, and the schema a read is handed
+
+This document designs
+[item 2 of the verbs implementation plan](verbs-implementation.md) — refusing a
+projection key the reader does not recognize — and the larger rule that refusal
+is only half of. It is written to be checkable: every claim about current
+behavior below was read out of the named code or measured against it, and the
+three places where it corrects the plan it is designing say so in those words.
+
+The command surface it governs is `--schema` on the read commands. The design
+in [shaped reads and verb results](shaped-reads-and-verb-results.md) says what a
+projection is for; this says what a projection may contain and what leaves the
+CLI because of it.
+
+In the plan's own numbering this is item 2, sequenced as step 12 behind step 9
+(item 3, a rejection propagating up through what holds it) because both change
+how a mask reduces. Its sibling refusal — step 12a, item 12, `cf` refusing an
+undeclared field on a call — is independent of it and shares its vocabulary for
+what a refusal says.
+
+## The vocabulary, briefly
+
+A **projection** is what a caller writes to `--schema` to say which parts of a
+value to read. It has two spellings, and `parseSelectionProjection`
+(`packages/cli/lib/cell-selection.ts`) chooses between them by looking at how
+the argument starts: `@` names a file holding a JSON Schema, and `{`, `true` or
+`false` is one written inline; anything else is the comma-separated field-path
+list `--select` takes. **Only the JSON Schema spelling is this document's
+subject.**
+
+Three schemas are in play on a read, and keeping them apart is most of the
+design:
+
+- The **projection** — the caller's, normalized by `normalizeProjectionSchema`.
+- The **source-read schema** — what the CLI asks the runner to load. Built by
+  `selectSourceSchema` from the piece's own declared schema, narrowed by the
+  mask the projection implies.
+- The **output schema** — re-asserted on the result in `deriveSelectedValue` as
+  `result.key("value").asSchema(outputSchema)`, and carried as the declared
+  result of the computed pattern that performs the read. This is the **read
+  boundary**: past it, a schema is the runner's to enforce, and the runner
+  enforces everything a JSON Schema can say.
+
+`resolveProjection` builds all three, and it builds them two different ways.
+For the concise spelling it derives the output schema through
+`selectSourceSchema` — constructed from the source, position by position. For
+the JSON spelling it assigns the caller's own object, unchanged, to both
+`projectionSchema` and `outputSchema`.
+
+**That asymmetry is the whole of the problem below.** On one path the CLI hands
+the read boundary something it built. On the other it hands over what a caller
+typed.
+
+## The problem
+
+`normalizeProjectionSchema` consults two denylists — `FORBIDDEN_PROJECTION_KEYS`
+(`asCell`, `default`, `ifc`, `scope`) and `UNSUPPORTED_PROJECTION_KEYS` (`$ref`,
+`$defs`, `definitions`, the composition and conditional keywords,
+`patternProperties`, `prefixItems`, `propertyNames`, `contentSchema`) — and
+every key in neither is spread into the result and carried onward. Three
+distinct failures come out of that, and they are not variations of one:
+
+| A caller writes | What comes back | Exit |
+| --- | --- | --- |
+| `{"propertes":{"title":true}}` | nothing | 0 |
+| `{"type":"object","propertes":{"title":true}}` | **the whole object**, every field | 0 |
+| `{"type":"object","required":["secret"],"properties":{"title":true}}` | nothing | 0 |
+
+**A typo can narrow a read to nothing.** With no `type` stated,
+`impliedProjectionType` has nothing to infer a container from — the misspelled
+key is in neither `OBJECT_PROJECTION_KEYS` nor `ARRAY_PROJECTION_KEYS` — so the
+normalized projection names no container at all. Its own doc comment states
+what follows: schema traversal descends `properties` only under
+`type: "object"` and `items` only under `type: "array"`, so a position with
+neither is silently empty.
+
+**A typo can also widen one.** With `type: "object"` stated, the misspelling
+means `declared.properties` is absent, so `normalizeProjectionSchema` takes its
+open branch and sets `additionalProperties: true`. The read returns every field
+the object holds, including the ones the caller deliberately did not name. This
+is disclosure-shaped: the caller's schema is the only thing standing between a
+value and its reader, and a single transposed letter removes it while reporting
+success.
+
+The widening case is the stronger motivation for this item, and it is the half
+the plan does not carry. The plan inherits "a typo selects nothing and says
+nothing" from a record written about the no-`type` case alone. Both are real,
+they are opposite, and only one of them is in the plan today.
+
+**A recognized key can empty a read entirely.** [#5734]: a projection naming a
+`required` field it does not project returns nothing at all, exit 0. `required`
+reaches the read boundary in the caller's schema, and
+`SchemaObjectTraverser.traverseObjectWithSchema`
+(`packages/runner/src/traverse.ts`) returns `undefined` for an object missing a
+required property — so the *whole selection* reads as absent, rather than the
+one position that declined to be read.
+
+No typo is involved. `required` is spelled correctly, is legal JSON Schema, and
+is a key the CLI consults on purpose. That is what makes it the case that
+decides the shape of the fix.
+
+## The rule this lands
+
+> **The projection reader must never hand the read boundary a schema it did not
+> construct itself.**
+
+Refusing unrecognized keys does not achieve this, and `required` is the proof.
+It is recognized. It is consulted — `OBJECT_PROJECTION_KEYS` lists it, so
+`impliedProjectionType` reads it to infer an object. And it is then forwarded
+verbatim into a schema the runner honors. A classification exercise that ended
+at "known keys pass, unknown keys are refused" would file `required` under
+*known*, forward it, and leave [#5734] exactly where it is.
+
+So the design has two halves, and the second is the load-bearing one:
+
+1. **A key the projection vocabulary does not contain is refused, by name.**
+2. **The schema that crosses the read boundary is built by the reader**, from
+   the mask the projection implies and the source schema, on the JSON path as
+   it already is on the concise path.
+
+Half 2 is what makes the tiers below meaningful. Once the outgoing schema is
+constructed, a tier does not describe what gets forwarded — nothing is
+forwarded — it describes what a caller is allowed to write and what the reader
+does with it.
+
+Note that `selectSourceSchema` already carries the exact rule half 2 needs,
+with a comment giving exactly this reason:
+
+```text
+A rejected position holds nothing to require. Keeping it required makes
+the object unsatisfiable, which reads as an absent value for the whole
+selection rather than for the one position that declined to be read.
+```
+
+It filters `required` down to the properties that survived selection. It runs
+on the source-read schema and on the concise path's output schema, and never on
+the JSON path's. **This item applies an existing rule to a second call site
+rather than inventing one.**
+
+## Four tiers
+
+The plan proposes three — honored, tolerated, refused. Four are needed, because
+one group of keys is neither honored nor inert: the CLI reads it, acts on it,
+and must then stop it from going any further.
+
+| Tier | Meaning | Members |
+| --- | --- | --- |
+| **H** — Honored | Drives the projection | `type`, `properties`, `items`, `additionalProperties`, `$link` |
+| **C** — Consulted | Read for container inference, then dropped | `required`, `minProperties`, `maxProperties`, `minItems`, `maxItems`, `uniqueItems` |
+| **T** — Tolerated | Accepted, changes nothing | `ANNOTATION_KEYS` less the three tier R already claims |
+| **R** — Refused | Named in an error | Everything else |
+
+**H** is what the reader acts on. `normalizeProjectionSchema` recurses through
+`properties` and `items`, lifts `$link` out into markers, and computes
+`additionalProperties`; `projectionMask` then reads `type`, `properties`,
+`items` and `additionalProperties` to build the mask. `$link` never reaches it,
+having been lifted out one step earlier — which is why the marker is honored
+without ever being a keyword the mask has to understand.
+
+**C** is the tier the plan is missing, and calling its members "tolerated"
+would be false. `impliedProjectionType` decides whether an untyped position is
+an object or an array by looking for exactly these six keys — that is the
+container inference a caller relies on for nested positions, and it is
+behavior, not decoration. Their treatment is: **consumed during inference, then
+absent from what the reader constructs.** A key that changed the read and was
+then dropped is a third thing, and a registry that records a class rather than
+a spelling — which the plan rightly asks for — has to be able to say so.
+
+**T** is derived, not restated. Its source is `ANNOTATION_KEYS`
+(`packages/piece/src/schema-compatibility.ts`), the compatibility checker's
+record of which keywords are validation-neutral. Deriving is what keeps the two
+registries from forking when a keyword like `tier` or `deprecated` is added to
+the durable dialect. Because the outgoing schema is constructed, a tolerated key
+has no forwarding question attached to most of its members; where one arises —
+`$id` and `$schema` declare the identity and dialect of a *document*, and the
+reader is not producing the caller's document — the answer is to accept and
+drop.
+
+**R** is everything else, and it keeps three keys that are *also* annotation
+keys: `default`, `$defs`, and `definitions`. All three are refused today, for
+good reasons that survive this change — `default` is controlled by the source
+schema, and the two definition keys have no meaning without the `$ref` that
+projection also refuses.
+
+## Three corrections this design makes to the plan
+
+### 1. "One edit admits a key to both" is not true
+
+The plan states that deriving the tolerated set from `ANNOTATION_KEYS` means one
+edit admits a key to both registries, and that where derivation is impossible
+the fallback is "a test asserting every annotation key the checker knows is
+non-refused by the projection reader."
+
+`ANNOTATION_KEYS` has twelve members: `$comment`, `$defs`, `$id`, `$schema`,
+`default`, `definitions`, `deprecated`, `description`, `examples`, `tags`,
+`tier`, `title`. Three of them — `default`, `$defs`, `definitions` — are already
+refused by projection and must stay refused. So the relation is not identity but
+**`ANNOTATION_KEYS` minus a stated exception set**, and admitting a key to the
+compat dialect admits it to projection only if it is not one of the three.
+
+The consequence for the fallback test is concrete: **as the plan words it, that
+test is red the day it is written**, because three of the twelve keys it asserts
+are non-refused are refused on purpose. What it should assert instead is the
+exception relation itself:
+
+> Every member of `ANNOTATION_KEYS` is either tolerated by the projection
+> reader or listed in projection's stated exception set, and every member of
+> that exception set is a member of `ANNOTATION_KEYS`.
+
+That second clause is the one that earns the test. It fails when a key is
+dropped from `ANNOTATION_KEYS` and left stranded in projection's exception list,
+which is the drift a one-directional assertion misses.
+
+`ANNOTATION_KEYS` is a module-private `const` in
+`packages/piece/src/schema-compatibility.ts`; it is not exported from that
+module, `packages/piece/src/index.ts` does not re-export it, and the package
+declares exactly two entry points (`.` and `./ops`), neither of which reaches
+schema-compatibility. So deriving requires exporting it. `packages/cli` already
+imports `@commonfabric/piece` and `@commonfabric/piece/ops` (in
+`packages/cli/lib/piece.ts` and `packages/cli/lib/callable.ts`), so the
+dependency runs from Operation down to Capabilities and introduces no inversion.
+Whether the export is the set itself or a predicate over it is an
+implementation call; the fallback test above is worth having either way, because
+it is what catches an exception list that stops matching its source.
+
+### 2. The validation half must not be derived
+
+The plan's tolerated tier is described as "the annotation and validation
+keywords". Deriving the annotation half is right. Deriving the validation half
+from the same file would be wrong, and the wrongness is not subtle.
+
+The compatibility checker's set of keys it can reason about is assembled in
+`unknownKeywordIssue` as a union of `ANNOTATION_KEYS`,
+`COMPLEX_CONSTRAINT_KEYS`, `SEMANTIC_EXTENSION_KEYS` and a list of simple
+validation keywords. That union contains `allOf`, `if`, `then`, `else`,
+`patternProperties`, `propertyNames`, `prefixItems`, `not`, `oneOf`, `contains`,
+`dependentSchemas`, `contentSchema`, `asCell`, `ifc`, and `scope` — **every one
+of which projection refuses today, deliberately, in one of its two denylists.**
+The two sets answer different questions. The checker's asks "can I prove this
+key's change safe across an update?"; projection's asks "can I honor this key
+when selecting a value?" A key can be free to change and impossible to project.
+
+So: derive the annotation tier from `ANNOTATION_KEYS`, and write the validation
+tier out by hand as a list this document's tiers H and C define. The tier table
+above is that list.
+
+### 3. The remediation advice does not work on this surface
+
+The plan says a caller met by a refusal is told to lift a source schema and
+prune it, and reasons from there that the tolerated tier must exist to receive
+what a lifted schema carries.
+
+The tier still has to exist. The advice does not work here, for a plain reason:
+**no CLI surface prints the read-side source schema.** `cf piece inspect` prints
+values. `cf piece get` has no flag that emits the schema it read against. There
+is nothing to lift.
+
+The advice is sound one surface over, which is likely where it came from. Item
+12's refusal is about a verb's event fields, and `cf piece verbs --json` carries
+`inputSchema` on every row (`PieceCallableListing`, `packages/cli/lib/piece.ts`)
+— the same schema `cf piece call <verb> --help --json` serves. A caller refused
+there can be told exactly where to look.
+
+What a read-side refusal should say instead is what the reader knows without
+any source at all: the key that was refused, the position it appeared at, and
+the vocabulary that position accepts. The denylist refusals in
+`normalizeProjectionSchema` already carry the first two —
+
+```text
+Invalid --schema at <root>.notes: "allOf" is not supported by projection schemas
+```
+
+— and the refusal this item adds should carry the third as well, because for an
+unrecognized key the accepted vocabulary is the entire remediation. A caller who
+transposed two letters needs the honored key named, not a document that cannot
+be fetched.
+
+Two smaller notes follow from this. A tolerated tier derived from the compat
+checker's annotation keys is still right, because schemas *do* get copied
+between surfaces even without a command that prints them. And this refusal and
+item 12's should share one vocabulary for what a refusal says — a caller meets
+both through `cf piece call`.
+
+## Blast radius
+
+Measured over this repository: **four** JSON Schema keywords appear in keyword
+position across every `--schema` argument written anywhere in the tree — `type`,
+`properties`, `items`, and `$link`. All four are tier H. **No tier C, T, or R
+key is used by any command in the repository, so nothing in it breaks.**
+
+How that was counted, because the count is easy to inflate. Every occurrence of
+the literal `--schema` in a tracked file was located, each one's argument
+extracted by brace-balancing from the first `{` after the flag, and each parsed
+argument walked as a schema — descending into `properties`, `items`, and
+`additionalProperties` values but **counting only keys in keyword position**.
+The distinction matters: a naive key census counts the property *names* inside a
+`properties` map, which are the caller's field names and not keywords at all,
+and inflates the answer with whatever the examples happen to read.
+
+Eighteen occurrences carry a parseable JSON Schema argument — in
+`packages/cli/integration/*.sh`, `packages/cli/README.md`,
+`packages/cli/commands/piece.ts` help examples, `skills/cf/SKILL.md`,
+`docs/common/verbs-over-the-cli.md`, and two plan documents. The rest are prose
+about the flag, error-message text naming it, or the concise field-path
+spelling. One doc example passes `@shape.json`, a file the tree does not
+contain. Two arguments did not parse and neither is a command: a display string
+in `packages/cli/integration/verb-session-demo.sh` that stands in for a schema
+rather than being one, and an elided `{"propertys":{…}}` in an archived record.
+
+The verbs plan's step table prices this item as the largest remaining step. The
+measurement does not contradict that — the work is in the classification and in
+constructing the outgoing schema, not in the refusal — but it does say the
+compatibility cost of the behavior change is zero for everything the repository
+itself runs.
+
+## Scope
+
+**In scope.** The JSON Schema spelling of `--schema`, on every command that
+takes it. [#5734] belongs here: the `required` filter and dropping tier C's keys
+from the constructed schema are the same edit as the refusal, landing in the
+same branch of `resolveProjection`, and shipping a loud refusal for typos while
+leaving an unsatisfiable `required` silently returning nothing would be a
+strange thing to have done deliberately.
+
+**Out of scope.** `--select`, entirely. Its grammar is comma-separated field
+paths — `parseSelectProjection` refuses a JSON Schema argument outright and
+points the caller at `--schema` — so it has no key vocabulary to classify, and
+its projection is built by `conciseProjectionSchema` from paths the CLI parsed
+itself. It already satisfies the rule this document lands. The same is true of
+`--schema` given the concise spelling, which takes the same path.
+
+Also out of scope: changing which keys projection *honors*. Every tier C, T, and
+R member stays exactly as (un)honored as it is now. This item changes what
+happens to a key, never what a key means.
+
+## What "done" looks like
+
+- A key in no tier is refused, and the message names the key and its position.
+- A tier C key is read for container inference and does not appear in the schema
+  the read boundary receives.
+- A tier T key is accepted and changes nothing about what is read.
+- A projection naming a `required` field it does not project reads the fields it
+  does project, rather than nothing.
+- A misspelled `properties` beside a stated `type` is refused, rather than
+  returning the whole object.
+- A test asserts the `ANNOTATION_KEYS` relation in both directions, per
+  correction 1.
+- A test asserts a **read outcome** for a projection carrying `required`, not
+  only its normalized schema — the coverage [#5734] identifies as missing from
+  `packages/cli/test/piece-get-transform.test.ts`.
+
+A command that ran only because a key was silently dropped now fails loudly.
+That is the point of the item rather than a regression against it.
+
+## What is not settled here
+
+- **Whether `ANNOTATION_KEYS` is exported as a set or behind a predicate.**
+  Either satisfies correction 1. A predicate keeps the membership question in
+  the package that owns it; a set is simpler to assert the relation over.
+- **What the refusal message offers beyond the accepted vocabulary.** A
+  near-miss suggestion against tier H is clearly worth it for a typo; whether
+  the message enumerates all of H, or only the keys legal at that position's
+  inferred container, is a wording call best made against the real output.
+- **Whether tier C's keys should be honored rather than dropped.** Dropping is
+  correct now, because nothing in the CLI enforces them and the runner enforcing
+  them produces [#5734]. If a later change wants `minItems` to mean something on
+  a projection, the registry will record that it was deliberately ignored rather
+  than overlooked — which is the whole reason the plan asks for a class rather
+  than a spelling.
+
+[#5734]: https://github.com/commontoolsinc/labs/issues/5734

--- a/docs/plans/projection-key-classification.md
+++ b/docs/plans/projection-key-classification.md
@@ -5,7 +5,7 @@ This document designs
 projection key the reader does not recognize — and the larger rule that refusal
 is only half of. It is written to be checkable: every claim about current
 behavior below was read out of the named code or measured against it, and the
-three places where it corrects the plan it is designing say so in those words.
+symbol it was read from is named beside it.
 
 The command surface it governs is `--schema` on the read commands. The design
 in [shaped reads and verb results](shaped-reads-and-verb-results.md) says what a
@@ -38,8 +38,14 @@ design:
 - The **output schema** — re-asserted on the result in `deriveSelectedValue` as
   `result.key("value").asSchema(outputSchema)`, and carried as the declared
   result of the computed pattern that performs the read. This is the **read
-  boundary**: past it, a schema is the runner's to enforce, and the runner
-  enforces everything a JSON Schema can say.
+  boundary**: past it, a schema is the runner's to act on.
+  `SchemaObjectTraverser` (`packages/runner/src/traverse.ts`) acts on the
+  traversal semantics it supports — the declared `type`, the descent through
+  `properties` and `items`, and `required`, which decides whether an object is
+  read at all. Value constraints are not among them: `minLength`, `minimum`,
+  `minItems` and their neighbours appear nowhere in that traversal. `required`
+  being one of the keywords it does act on is what makes a caller's schema
+  crossing this boundary consequential.
 
 `resolveProjection` builds all three, and it builds them two different ways.
 For the concise spelling it derives the output schema through
@@ -82,10 +88,10 @@ is disclosure-shaped: the caller's schema is the only thing standing between a
 value and its reader, and a single transposed letter removes it while reporting
 success.
 
-The widening case is the stronger motivation for this item, and it is the half
-the plan does not carry. The plan inherits "a typo selects nothing and says
-nothing" from a record written about the no-`type` case alone. Both are real,
-they are opposite, and only one of them is in the plan today.
+The widening case is the stronger motivation for this item. The two are
+opposite, both are real, and the narrowing one is the easier to reach for
+because it is what a missing `type` was fixed for twice already. A design that
+only stops narrowing leaves the disclosure-shaped half standing.
 
 **A recognized key can empty a read entirely.** [#5734]: a projection naming a
 `required` field it does not project returns nothing at all, exit 0. `required`
@@ -107,9 +113,9 @@ decides the shape of the fix.
 Refusing unrecognized keys does not achieve this, and `required` is the proof.
 It is recognized. It is consulted — `OBJECT_PROJECTION_KEYS` lists it, so
 `impliedProjectionType` reads it to infer an object. And it is then forwarded
-verbatim into a schema the runner honors. A classification exercise that ended
-at "known keys pass, unknown keys are refused" would file `required` under
-*known*, forward it, and leave [#5734] exactly where it is.
+verbatim into a schema whose `required` the runner acts on. A classification
+exercise that ended at "known keys pass, unknown keys are refused" would file
+`required` under *known*, forward it, and leave [#5734] exactly where it is.
 
 So the design has two halves, and the second is the load-bearing one:
 
@@ -119,9 +125,10 @@ So the design has two halves, and the second is the load-bearing one:
    it already is on the concise path.
 
 Half 2 is what makes the tiers below meaningful. Once the outgoing schema is
-constructed, a tier does not describe what gets forwarded — nothing is
-forwarded — it describes what a caller is allowed to write and what the reader
-does with it.
+constructed, a tier does not describe what gets forwarded — no key crosses the
+boundary because a caller wrote it — it describes what a caller is allowed to
+write and what the reader does with it. What the reader then puts in the schema
+it builds is a separate question, answered from the source schema.
 
 Note that `selectSourceSchema` already carries the exact rule half 2 needs,
 with a comment giving exactly this reason:
@@ -132,21 +139,25 @@ the object unsatisfiable, which reads as an absent value for the whole
 selection rather than for the one position that declined to be read.
 ```
 
-It filters `required` down to the properties that survived selection. It runs
-on the source-read schema and on the concise path's output schema, and never on
-the JSON path's. **This item applies an existing rule to a second call site
-rather than inventing one.**
+It takes the *source* schema's `required`, filters it to the properties that
+survived selection, and re-emits it — so the schema the reader constructs does
+carry `required`, on the reader's own authority and with the source's meaning.
+That construction runs on the source-read schema and on the concise path's
+output schema, and never on the JSON path's. **This item applies an existing
+rule to a second call site rather than inventing one**, and the rule it applies
+is *derive the constraint*, not *delete the keyword*.
 
 ## Four tiers
 
-The plan proposes three — honored, tolerated, refused. Four are needed, because
-one group of keys is neither honored nor inert: the CLI reads it, acts on it,
-and must then stop it from going any further.
+Honored, consulted, tolerated, refused. **Consulted** is the one a three-tier
+split has nowhere to put: a group of keys that is neither honored nor inert,
+because the CLI reads it, acts on it, and must then stop it from going any
+further.
 
 | Tier | Meaning | Members |
 | --- | --- | --- |
 | **H** — Honored | Drives the projection | `type`, `properties`, `items`, `additionalProperties`, `$link` |
-| **C** — Consulted | Read for container inference, then dropped | `required`, `minProperties`, `maxProperties`, `minItems`, `maxItems`, `uniqueItems` |
+| **C** — Consulted | Read for container inference; the caller's constraint goes no further | `required`, `minProperties`, `maxProperties`, `minItems`, `maxItems`, `uniqueItems` |
 | **T** — Tolerated | Accepted, changes nothing | `ANNOTATION_KEYS` less the three tier R already claims |
 | **R** — Refused | Named in an error | Everything else |
 
@@ -157,14 +168,30 @@ and must then stop it from going any further.
 having been lifted out one step earlier — which is why the marker is honored
 without ever being a keyword the mask has to understand.
 
-**C** is the tier the plan is missing, and calling its members "tolerated"
-would be false. `impliedProjectionType` decides whether an untyped position is
-an object or an array by looking for exactly these six keys — that is the
-container inference a caller relies on for nested positions, and it is
-behavior, not decoration. Their treatment is: **consumed during inference, then
-absent from what the reader constructs.** A key that changed the read and was
-then dropped is a third thing, and a registry that records a class rather than
-a spelling — which the plan rightly asks for — has to be able to say so.
+**C** is the tier that earns the fourth slot, and calling its members
+"tolerated" would be false. `impliedProjectionType` decides whether an untyped
+position is an object or an array from nine keys, and these six are the ones
+tier H does not already claim: `ARRAY_PROJECTION_KEYS` holds `items`,
+`minItems`, `maxItems` and `uniqueItems` and is tested first,
+`OBJECT_PROJECTION_KEYS` holds `properties`, `additionalProperties`,
+`required`, `minProperties` and `maxProperties`. The six tier C members
+participate on equal footing with the honored three — a position naming only
+`minItems` reads as an array — which is the container inference a caller relies
+on for nested positions, and it is behavior, not decoration.
+
+Their treatment is: **the caller's tier C constraint is consumed during
+inference and is not propagated.** That is a claim about the caller's key, not
+about the keyword. The reader may legitimately emit the same keyword from a
+different origin: `selectSourceSchema` reconstructs `required` from the *source*
+schema, filtered to the properties that survived selection, and that `required`
+carries the source's meaning across the read boundary. Discarding what the
+caller wrote must leave that derivation intact — the two are one spelling over
+two origins, and only one of them is the caller's to supply. A key that changed
+the read, was then discarded, and whose spelling the reader may re-emit on its
+own authority is a third thing. A registry that records a class rather than a
+spelling has to be able to say so — which is the reason to record a class at
+all: a key admitted without its kind has its treatment decided by whatever the
+reader happens to default to.
 
 **T** is derived, not restated. Its source is `ANNOTATION_KEYS`
 (`packages/piece/src/schema-compatibility.ts`), the compatibility checker's
@@ -182,14 +209,17 @@ good reasons that survive this change — `default` is controlled by the source
 schema, and the two definition keys have no meaning without the `$ref` that
 projection also refuses.
 
-## Three corrections this design makes to the plan
+## Three things the coupling has to respect
 
-### 1. "One edit admits a key to both" is not true
+Tier T couples the projection reader to the compatibility checker. Three
+properties of that coupling are easy to state wrongly, and each one wrong costs
+something concrete: a red test, a derivation that admits keys projection cannot
+honor, and a refusal message that sends a caller somewhere that does not exist.
 
-The plan states that deriving the tolerated set from `ANNOTATION_KEYS` means one
-edit admits a key to both registries, and that where derivation is impossible
-the fallback is "a test asserting every annotation key the checker knows is
-non-refused by the projection reader."
+### 1. The derivation is not one-to-one
+
+Deriving tier T from `ANNOTATION_KEYS` does not mean one edit admits a key to
+both registries.
 
 `ANNOTATION_KEYS` has twelve members: `$comment`, `$defs`, `$id`, `$schema`,
 `default`, `definitions`, `deprecated`, `description`, `examples`, `tags`,
@@ -198,10 +228,11 @@ refused by projection and must stay refused. So the relation is not identity but
 **`ANNOTATION_KEYS` minus a stated exception set**, and admitting a key to the
 compat dialect admits it to projection only if it is not one of the three.
 
-The consequence for the fallback test is concrete: **as the plan words it, that
-test is red the day it is written**, because three of the twelve keys it asserts
-are non-refused are refused on purpose. What it should assert instead is the
-exception relation itself:
+The consequence for the fallback test — the one that guards the coupling where
+the derivation itself cannot — is concrete. **A test asserting that every
+annotation key the checker knows is non-refused by the projection reader is red
+the day it is written**, because three of the twelve are refused on purpose.
+What it asserts instead is the exception relation itself:
 
 > Every member of `ANNOTATION_KEYS` is either tolerated by the projection
 > reader or listed in projection's stated exception set, and every member of
@@ -225,9 +256,9 @@ it is what catches an exception list that stops matching its source.
 
 ### 2. The validation half must not be derived
 
-The plan's tolerated tier is described as "the annotation and validation
-keywords". Deriving the annotation half is right. Deriving the validation half
-from the same file would be wrong, and the wrongness is not subtle.
+Tier T is the annotation keywords, derived. The validation keywords a
+projection tolerates are not derivable from the same file, and the reason is not
+subtle.
 
 The compatibility checker's set of keys it can reason about is assembled in
 `unknownKeywordIssue` as a union of `ANNOTATION_KEYS`,
@@ -244,42 +275,39 @@ So: derive the annotation tier from `ANNOTATION_KEYS`, and write the validation
 tier out by hand as a list this document's tiers H and C define. The tier table
 above is that list.
 
-### 3. The remediation advice does not work on this surface
+### 3. A refusal cannot tell a caller to lift a source schema
 
-The plan says a caller met by a refusal is told to lift a source schema and
-prune it, and reasons from there that the tolerated tier must exist to receive
-what a lifted schema carries.
+"Lift the source schema and prune it" is the natural remediation for a refusal
+over a schema-shaped argument, and it does not work on this surface, for a plain
+reason: **no CLI surface prints the read-side source schema.** `cf piece
+inspect` prints values. `cf piece get` has no flag that emits the schema it read
+against. There is nothing to lift.
 
-The tier still has to exist. The advice does not work here, for a plain reason:
-**no CLI surface prints the read-side source schema.** `cf piece inspect` prints
-values. `cf piece get` has no flag that emits the schema it read against. There
-is nothing to lift.
+It is sound one surface over. Item 12's refusal is about a verb's event fields,
+and `cf piece verbs --json` carries `inputSchema` on every row
+(`PieceCallableListing`, `packages/cli/lib/piece.ts`) — the same schema
+`cf piece call <verb> --help --json` serves. A caller refused there can be told
+exactly where to look.
 
-The advice is sound one surface over, which is likely where it came from. Item
-12's refusal is about a verb's event fields, and `cf piece verbs --json` carries
-`inputSchema` on every row (`PieceCallableListing`, `packages/cli/lib/piece.ts`)
-— the same schema `cf piece call <verb> --help --json` serves. A caller refused
-there can be told exactly where to look.
-
-What a read-side refusal should say instead is what the reader knows without
-any source at all: the key that was refused, the position it appeared at, and
-the vocabulary that position accepts. The denylist refusals in
+What a read-side refusal says instead is what the reader knows without any
+source at all: the key that was refused, the position it appeared at, and the
+vocabulary that position accepts. The denylist refusals in
 `normalizeProjectionSchema` already carry the first two —
 
 ```text
 Invalid --schema at <root>.notes: "allOf" is not supported by projection schemas
 ```
 
-— and the refusal this item adds should carry the third as well, because for an
+— and the refusal this item adds carries the third as well, because for an
 unrecognized key the accepted vocabulary is the entire remediation. A caller who
 transposed two letters needs the honored key named, not a document that cannot
 be fetched.
 
-Two smaller notes follow from this. A tolerated tier derived from the compat
-checker's annotation keys is still right, because schemas *do* get copied
-between surfaces even without a command that prints them. And this refusal and
-item 12's should share one vocabulary for what a refusal says — a caller meets
-both through `cf piece call`.
+Two smaller notes follow from this. Tier T is still worth deriving from the
+compat checker's annotation keys, because schemas *do* get copied between
+surfaces even without a command that prints them. And this refusal and item 12's
+share one vocabulary for what a refusal says — a caller meets both through
+`cf piece call`.
 
 ## Blast radius
 
@@ -316,11 +344,11 @@ itself runs.
 ## Scope
 
 **In scope.** The JSON Schema spelling of `--schema`, on every command that
-takes it. [#5734] belongs here: the `required` filter and dropping tier C's keys
-from the constructed schema are the same edit as the refusal, landing in the
-same branch of `resolveProjection`, and shipping a loud refusal for typos while
-leaving an unsatisfiable `required` silently returning nothing would be a
-strange thing to have done deliberately.
+takes it. [#5734] belongs here: deriving the constructed schema's `required`
+from the source rather than carrying the caller's is the same edit as the
+refusal, landing in the same branch of `resolveProjection`, and shipping a loud
+refusal for typos while leaving an unsatisfiable `required` silently returning
+nothing would be a strange thing to have done deliberately.
 
 **Out of scope.** `--select`, entirely. Its grammar is comma-separated field
 paths — `parseSelectProjection` refuses a JSON Schema argument outright and
@@ -336,15 +364,25 @@ happens to a key, never what a key means.
 ## What "done" looks like
 
 - A key in no tier is refused, and the message names the key and its position.
-- A tier C key is read for container inference and does not appear in the schema
-  the read boundary receives.
+- A caller-written tier C key is read for container inference and no
+  caller-written tier C constraint reaches the read boundary.
+- The reader's own derivation is untouched by the bullet above: a read whose
+  source schema marks a projected property required still carries `required`
+  past the read boundary, filtered to the projected properties, exactly as
+  `selectSourceSchema` builds it.
+- A test holds those two apart — a caller's `required` does not survive into the
+  constructed schema, and a source-derived `required` does.
+  `packages/cli/test/piece-get-transform.test.ts` asserts the second today in
+  "narrows the initial source selector to predicate and projection fields",
+  which reads the selector handed to the storage provider and expects `required`
+  filtered to the projected properties.
 - A tier T key is accepted and changes nothing about what is read.
 - A projection naming a `required` field it does not project reads the fields it
   does project, rather than nothing.
 - A misspelled `properties` beside a stated `type` is refused, rather than
   returning the whole object.
-- A test asserts the `ANNOTATION_KEYS` relation in both directions, per
-  correction 1.
+- A test asserts the `ANNOTATION_KEYS` relation in both directions, as the
+  first of the three coupling constraints words it.
 - A test asserts a **read outcome** for a projection carrying `required`, not
   only its normalized schema — the coverage [#5734] identifies as missing from
   `packages/cli/test/piece-get-transform.test.ts`.
@@ -355,17 +393,19 @@ That is the point of the item rather than a regression against it.
 ## What is not settled here
 
 - **Whether `ANNOTATION_KEYS` is exported as a set or behind a predicate.**
-  Either satisfies correction 1. A predicate keeps the membership question in
-  the package that owns it; a set is simpler to assert the relation over.
+  Either satisfies the first coupling constraint above. A predicate keeps the
+  membership question in the package that owns it; a set is simpler to assert
+  the relation over.
 - **What the refusal message offers beyond the accepted vocabulary.** A
   near-miss suggestion against tier H is clearly worth it for a typo; whether
   the message enumerates all of H, or only the keys legal at that position's
   inferred container, is a wording call best made against the real output.
-- **Whether tier C's keys should be honored rather than dropped.** Dropping is
-  correct now, because nothing in the CLI enforces them and the runner enforcing
-  them produces [#5734]. If a later change wants `minItems` to mean something on
-  a projection, the registry will record that it was deliberately ignored rather
-  than overlooked — which is the whole reason the plan asks for a class rather
-  than a spelling.
+- **Whether a caller's tier C constraint should be honored rather than
+  discarded.** Discarding it is correct now, because nothing in the CLI enforces
+  it and the runner acting on a caller's `required` produces [#5734]. If a later
+  change wants `minItems` to mean something a caller can state on a projection,
+  the registry will record that it was deliberately ignored rather than
+  overlooked — which is the whole reason to record a class rather than a
+  spelling.
 
 [#5734]: https://github.com/commontoolsinc/labs/issues/5734

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -188,10 +188,12 @@ the CLI already builds itself.
 *Exit:* an unrecognized key is refused and the message names it; a tolerated
 keyword is accepted and ignored; a consulted keyword is read for inference and
 the caller's copy goes no further, while the source-derived `required` the
-reader builds still reaches the read boundary; a projection naming a `required`
-field it does not project reads the fields it does. A command that ran only
-because a key was silently dropped now fails loudly, which is the point rather
-than a regression.
+reader builds still reaches the read boundary — asserted against the output
+schema itself, which the selector handed to the storage provider is not; a
+projection naming a `required` field it does not project reads the fields it
+does; and a caller's scalar `type` still filters the leaf it is written on, at
+depth as well as at an array item. A command that ran only because a key was
+silently dropped now fails loudly, which is the point rather than a regression.
 
 **3. A rejection propagates up through what holds it.** *(S)* The projection
 mask reduces either container whose whole selection rejects — an array whose

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -48,7 +48,7 @@ without reconstructing it.
 | 9b. closed-world event emission | **ruled against** (#5589); does not land |
 | 12. `cf` refuses an undeclared field on a call | not started — where the ruling puts this capability |
 | 4. `receipt` as a top-level envelope field | on main (#5694) |
-| 2. an unrecognized projection key is refused | not started |
+| 2. an unrecognized projection key is refused | not started; design landed (#5753) |
 | 3. a rejection propagates up through what holds it | on main (#5701) |
 | 5. `cf wish` and `cf exec` take the read options | not started |
 | 11. a caller may name a reference | not started; sequenced, gated on one measurement |
@@ -123,53 +123,75 @@ Unblocked and independent of the decision above. Not all small — items 2 and
 11 are both (M); what these share is that nothing gates them.
 
 **2. An unrecognized projection key is refused.** *(M)* Two denylists are
-consulted and every key in neither is accepted and ignored, so a typo selects
-nothing and says nothing, and any keyword given a meaning later changes
-behavior no error ever warned about. Three tiers replace them: honored,
-tolerated (the annotation and validation keywords, which a lifted source schema
-carries), and refused by name.
+consulted and every key in neither is accepted and carried onward. The design is
+[projection keys, and the schema a read is handed](projection-key-classification.md),
+which carries the tiers, the measured blast radius, and the reasoning; read it
+before picking this up. What follows is what a driver needs to sequence the
+item.
 
 This is the general form of a failure already fixed twice as instances — a
 missing `type` and an untyped `items` root each returned an empty result and
 reported nothing.
 
-*Reservation records a class, not a spelling.* An allowlist that says only
-"allowed" loses why, and a key admitted without its kind has its treatment
-decided by whatever the checker happens to default to — the original trap, one
-level up. So each reservation carries what it is: honored, tolerated because it
-is an annotation, tolerated because it is a validation keyword. A later change
-wanting to honor a tolerated key then knows it was deliberately ignored rather
-than overlooked.
+*A typo widens as readily as it narrows.* Without `type`, a misspelled
+`properties` names no container and the position reads as empty. **With `type`
+stated, the same misspelling sets `additionalProperties: true` and returns the
+whole object** — every field, including the ones the caller deliberately did not
+name. Both exit 0. The second is disclosure-shaped and is the stronger
+motivation for this item.
 
-The same discipline, on a different registry, is what classifies keys for the
-pattern compatibility checker — where the class decides whether adding and
-removing a key are both free, and where getting it wrong is what withdrew the
-July result-schema work. Sibling registries, not one: a projection is supplied
-per read and never compared across versions, so it has no add-and-remove
-semantics to get wrong. What transfers is classify-before-you-accept.
+*The general rule is bigger than the refusal.* **The projection reader must
+never hand the read boundary a schema it did not construct itself.** Refusing
+unknown keys does not reach it: `required` is recognized, legal, never reasoned
+about by the CLI beyond container inference, and acted on by the runner, so
+tolerating it forwards it. #5734 is that failure — an unsatisfiable `required`
+empties the whole read, exit 0 — and it belongs to this item. The rule its fix
+needs already exists one call site over: `selectSourceSchema` derives the
+constructed schema's `required` from the *source*, filtered to the properties
+that survived selection, with a comment giving exactly this reason.
 
-*The two registries meet at lifted schemas, and this item is what couples
-them.* Today a projection ignores every key it does not recognize, so the
-durable dialect can grow freely. Refusing unrecognized keys ends that: a caller
-is told to lift a source schema and prune it, a lifted schema carries every
-keyword the generator emits, and a keyword admitted to the compat dialect
-without also reaching projection tolerance turns a projection over a marked
-schema into a refusal — on exactly the keys made deliberately free elsewhere.
+*Four tiers, not three.* Honored (`type`, `properties`, `items`,
+`additionalProperties`, `$link`); **consulted** (`required`, `minProperties`,
+`maxProperties`, `minItems`, `maxItems`, `uniqueItems` — read for container
+inference, so they change behavior, and the caller's copy goes no further);
+tolerated; refused. Calling the consulted tier "tolerated" would be dishonest
+about what it does. What stops is the caller's constraint, not the keyword: the
+reader keeps deriving `required` from the source schema, and that derivation
+must survive the item intact.
 
-So the tolerated-as-annotation set is **derived from the compat checker's
-annotation keys rather than restating them**. One edit admits a key to both, and
-the vocabulary cannot fork. Where derivation is not possible, the fallback is a
-test asserting every annotation key the checker knows is non-refused by the
-projection reader — which converts a forgotten second list from a silent
-projection failure into a red test naming both registries.
+*Three things the coupling to the compatibility checker has to respect.*
+**Derivation is not one-to-one:** 3 of `ANNOTATION_KEYS`' 12 members —
+`default`, `$defs`, `definitions` — are refused by projection on purpose, so the
+relation is `ANNOTATION_KEYS` minus a stated exception set, and a fallback test
+asserting plain non-refusal of every annotation key would be red the day it is
+written. It asserts the exception relation in both directions instead.
+**The validation half must not derive:** the checker's `handled` set is a union
+including `allOf`, `if`/`then`/`else`, `patternProperties`, `asCell`, `ifc` and
+`scope`, every one of which projection refuses deliberately — so derive the
+annotation tier and write the validation tier by hand. **A refusal cannot point
+at a lifted schema:** no CLI surface prints the read-side source schema, so
+there is nothing to lift. That advice is sound one surface over, for item 12,
+where `cf piece verbs --json` carries `inputSchema`. A read-side refusal names
+the key, its position, and the accepted vocabulary.
 
 `tier` and `deprecated` are the newest annotation-class keys and the likeliest
 to be missing from a set drafted out of the standard JSON Schema vocabulary.
 They belong in the tolerated set on day one.
 
+*Measured: nothing in the tree breaks.* Four JSON Schema keywords appear in
+keyword position across every `--schema` argument in the repository — `type`,
+`properties`, `items`, `$link` — all honored.
+
+*Out of scope:* `--select`, whose grammar is field paths and whose projection
+the CLI already builds itself.
+
 *Exit:* an unrecognized key is refused and the message names it; a tolerated
-keyword is accepted and ignored. A command that ran only because a key was
-silently dropped now fails loudly, which is the point rather than a regression.
+keyword is accepted and ignored; a consulted keyword is read for inference and
+the caller's copy goes no further, while the source-derived `required` the
+reader builds still reaches the read boundary; a projection naming a `required`
+field it does not project reads the fields it does. A command that ran only
+because a key was silently dropped now fails loudly, which is the point rather
+than a regression.
 
 **3. A rejection propagates up through what holds it.** *(S)* The projection
 mask reduces either container whose whole selection rejects — an array whose
@@ -372,7 +394,7 @@ its own track.
 | 9 | A rejection propagates up through what holds it | **on main** (#5701) — item 3 | — | First of the projection work; the mask's asymmetry is what makes a marked field below a link load every element |
 | 10 | Two identical projections stop colliding | #5523 | 9 | Same file. Reachable the moment anything long-lived reads twice, which the command surface invites |
 | 11 | One piece, one address | #5632, #5498 | — | Trace where each id is minted; the outcome is a fix or a statement that they are aliases. Must precede step 13, which spreads the address vocabulary to two more commands |
-| 12 | An unrecognized projection key is refused | item 2 | 9 | The largest remaining step and the only one with design surface, since it couples the projection reader to the compatibility checker's annotation keys |
+| 12 | An unrecognized projection key is refused | item 2 | 9 | The largest remaining step, and the one carrying design surface, since it couples the projection reader to the compatibility checker's annotation keys. Its design is [projection keys, and the schema a read is handed](projection-key-classification.md) |
 | 12a | `cf` refuses an undeclared field on a call | item 12 | — | Same refusal shape as the step above and independent of it, so it can go either side; building them together is what keeps one vocabulary for what a refusal says |
 | 13 | `cf wish` and `cf exec` take the read options | item 5 | 11, 12 | Last by construction: it spreads the vocabulary to two more starting points, so the vocabulary should have stopped moving |
 


### PR DESCRIPTION
## Why

Verbs plan item 2 — "an unrecognized projection key is refused", step 12 in
the plan's sequencing table — is priced there as **the largest remaining
step and the only one with design surface**. Its design existed only as
prose in a chat message. Nobody could evaluate it, and the plan's own
paragraph about it carries three claims that do not survive contact with
the code:

- **The derivation is not one-to-one.** 3 of `ANNOTATION_KEYS`' 12 members
  (`default`, `$defs`, `definitions`) are refused by projection today, on
  purpose. So "one edit admits a key to both" is false, and the plan's
  named fallback test — "every annotation key the checker knows is
  non-refused by the projection reader" — **is red the day it is written**.
- **The validation half must not derive.** The compat checker's `handled`
  set is a union that includes `allOf`, `if`/`then`/`else`,
  `patternProperties`, `asCell`, `ifc` and `scope` — every one of which
  projection refuses deliberately.
- **The remediation advice is not actionable here.** "Lift a source schema
  and prune it" needs a command that prints the read-side source schema.
  None exists. It works for the sibling item (12a), where `cf piece verbs
  --json` carries `inputSchema`, and not for this one.

Two things also need saying that the plan does not say. Three tiers are not
enough — `required`, `minProperties`, `minItems` and their neighbours are
*consulted for container inference*, so they change behavior and calling
them "tolerated" would be dishonest. And a typo does not only narrow a
read: with `type` stated, misspelling `properties` sets
`additionalProperties: true` and returns the **whole object**, including
fields the caller deliberately did not name. That is disclosure-shaped and
is a stronger motivation than the one the plan currently gives; the plan
inherits only the no-`type` half, from a record written about that case.

The general rule the document lands is bigger than the item: **the
projection reader must never hand the read boundary a schema it did not
construct itself.** Refusing unknown keys alone does not achieve it —
`required` is recognized, legal, never reasoned about by the CLI, and
honored by the runner, so a merely-"tolerated" classification forwards it
and preserves #5734.

What the reader constructs *from* is the load-bearing half of that rule,
and the document is specific about it because the obvious answer is wrong.
The reader builds from the **classification**, not from the projection
mask. The mask keeps container structure and discards scalar types, so a
reader built on it could not honor `type` — a key the tiers call honored.
Concretely, it would return a scalar leaf that a declared `type` currently
filters out (behavior that is deliberate, tested and documented in
`packages/cli/README.md`), and it would widen a scalar projection over an
object source to the whole object. Building from the classification
preserves both, and needs no behavior change beyond the item.

## What Changed

**`docs/plans/projection-key-classification.md`** (new):

- **Vocabulary** — the three schemas a read builds, and the asymmetry the
  whole problem sits in: `resolveProjection` derives the concise path's
  output schema through `selectSourceSchema`, and assigns the JSON path's
  from the caller's object unchanged.
- **The problem**, as a measured table: a typo narrowing to nothing, a typo
  widening to everything, and an unsatisfiable `required` emptying the whole
  read — all three exit 0.
- **The rule**, with the argument for why key-refusal alone does not reach
  it, and the two halves that do. Half 2 names its material: the reader
  builds the outgoing schema **from the classification**, key by key, and
  explicitly **not** from the projection mask. `ProjectionMask` records
  `true`, `false` and the two containers, so a scalar `type` is gone before
  construction would begin — a mask-built output schema could not honor a
  key the mask threw away, and would both return a scalar leaf the caller's
  `type` excludes and widen a scalar-over-object projection to the entire
  source object. The concise path can build from its mask only because
  `conciseSelectionSchema` writes containers and `true` leaves, so it has no
  scalar type to lose.
- **Four tiers** — Honored, Consulted, Tolerated, Refused — with membership
  and why C has to exist. Tier C is stated as a rule about the *caller's*
  key: the caller-supplied constraint is consumed during container inference
  and not propagated, while the same keyword may still reach the read
  boundary when the reader derives it. `selectSourceSchema` reconstructs
  `required` from the source, filtered to the properties that survived
  selection, and that derivation is the one key the reader supplies from
  outside the classified projection — so the exit criterion is worded to
  exclude an implementation that strips source-derived `required` semantics.
- **Three things the tier T coupling has to respect**, each stated plainly,
  including what the fallback test asserts instead (the exception relation,
  in both directions — the second clause is what catches a key dropped from
  `ANNOTATION_KEYS` and left stranded in projection's list).
- **Blast radius**, re-measured (see Test plan).
- **Scope**: #5734 folded in; `--select` explicitly out.
- **What "done" looks like** and **what is not settled**.

**`docs/plans/README.md`**: index entry, placed away from #5682's hunk so
the two do not conflict.

**`docs/plans/verbs-implementation.md`**: item 2's body. `docs/plans/` is
live documentation, so a reader landing on the sequencing plan cannot be
left with the three-tier split, the one-to-one derivation, or the
lift-a-source-schema remediation the design replaces. Item 2 now states the
four tiers, points at `projection-key-classification.md` as the design of
record, and keeps its own text to what a driver needs to sequence the item.
The state-table row and step 12's note pick up the same pointer.

## Test plan

- `deno task check-docs` — exit 0 (550 code blocks). The new blocks are
  `text` fences, so nothing new enters the type-checked set.
- `deno task check-skill-facts` — exit 0 (45 documents).
- `deno task check-conflict-markers` — exit 0.
- `deno task docs-links --orphan` — exit 0; the new document is not orphaned.
- `deno fmt` excludes `docs/`, so prose was wrapped to 80 columns by hand;
  only table rows exceed it.
- **Blast radius re-measured rather than repeated.** Every occurrence of the
  literal `--schema` in a tracked file was located, each argument extracted
  by brace-balancing from the first `{`, and each parsed argument walked
  **counting keys in keyword position only** — property names inside a
  `properties` map are field names, not keywords, and counting them inflates
  the answer. Result: **four** keywords across the whole tree — `type`,
  `properties`, `items`, `$link` — all tier H. Zero commands break.
- Claims verified against the code, not inferred: the two denylists and the
  open-`additionalProperties` branch (`normalizeProjectionSchema`), the nine
  container-inference keys — the six tier C members alongside `properties`,
  `additionalProperties` and `items` (`impliedProjectionType`,
  `ARRAY_PROJECTION_KEYS`, `OBJECT_PROJECTION_KEYS`), the verbatim JSON-path
  assignment and the concise path's `selectSourceSchema` derivation
  (`resolveProjection`), the `required` filter and its comment
  (`selectSourceSchema`), the read-boundary re-assertion
  (`deriveSelectedValue`), the runner returning `undefined` for an object
  missing a required property
  (`SchemaObjectTraverser.traverseObjectWithSchema`) while enforcing no value
  constraints — `minLength`, `minimum`, `minItems` and their neighbours
  appear nowhere in `packages/runner/src/traverse.ts` — `ANNOTATION_KEYS`'
  membership and non-export plus the `handled` union (`unknownKeywordIssue`,
  `packages/piece/src/schema-compatibility.ts`), `packages/piece`'s two
  declared entry points, `packages/cli`'s existing import of
  `@commonfabric/piece`, and `inputSchema` on `PieceCallableListing`.
- The normalization behaviors in the problem table were also run directly
  against `parseSelectionProjection`.
- **The two schemas the `required` criterion is about are distinguished by
  the exit criteria, and no existing test covers the second.**
  `sourceReadSchema` is what the storage provider's selector shows — the
  schema in `packages/cli/test/piece-get-transform.test.ts`, "narrows the
  initial source selector to predicate and projection fields". The read
  boundary is a different schema: the output schema `deriveSelectedValue`
  re-asserts on `result.key("value")`. An implementation could keep the
  caller's `required` on the source read, drop it from the output schema,
  and pass that test, so the exit criteria require a test that inspects the
  output cell's schema and state that the provider selector cannot stand in
  for it.
- **The mask claims are read out of the code**: `ProjectionMask`'s four
  inhabitants and `projectionMask` falling through to `true` for a scalar
  position; `selectSourceSchema` returning the source unchanged for a `true`
  mask; `projectValue` copying every key of an object it is handed a schema
  whose `additionalProperties` is not `false`; `traverseObjectWithSchema`
  omitting a property whose traversal failed `invalidType`;
  `conciseSelectionSchema` emitting only containers and `true` leaves; and
  the existing assertion in "filters and projects arrays through the runtime
  pattern graph" that a `{"type":"string"}` projection over a numeric `id`
  returns the item without `id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



