### PR TITLE
docs(common): an address is for reading next, not for comparing

### DIFF
--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -343,10 +343,12 @@ dictionary of RFC 6901 pointers naming the document behind each result path, so
 the address is one `jq` hop further away but reachable.
 
 It differs from a marker in one way that matters: it **resolves**. A marker
-renders the link as stored; `--show-links` follows the chain and names the
-document at the end of it. For getting an address to compose with, the two are
-interchangeable and an in-band marker is the shorter road. For asking which
-document a path really lands in, only the resolving one answers.
+renders the link as stored; `--show-links` follows the chain as far as the
+links this replica has already materialized, and names the document it reaches.
+That is not a terminal answer — a hop whose target is not local kicks off a
+fetch nobody awaits, and a one-shot command exits before it lands, so the same
+path can resolve further on a later read. For getting an address to compose
+with, the two are interchangeable and an in-band marker is the shorter road.
 
 **An address is not an identifier to compare.** Addresses are many-to-one over
 cells, and a holder of one cannot tell a canonical id from an alias. Two
@@ -358,8 +360,10 @@ redirect. Each address reads back the same contents, which is what an address
 is for: something to read next, not a claim about canonical identity.
 
 So compose with an address; do not compare one. Two ids differing does not mean
-two pieces, and equality of contents is the question a caller actually wants
-answered.
+two pieces — and comparing contents does not rescue the question, since two
+distinct pieces can hold identical contents and one piece's contents change
+under it. **Asking whether two addresses name the same piece is not something
+the CLI supports today.**
 
 Neither route needs a verb to declare its result. A `$link` marker on a link
 position renders the address and suppresses the fetch without consulting a

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -338,24 +338,24 @@ piece it made, the address renders in place, and the next call takes it as its
 target. Identity survives the round trip instead of being flattened into a copy
 of the item's contents.
 
-`--show-links` is the **[today]** spelling of a neighbouring move, and it is
-worth knowing it is not the same one. It returns a dictionary of RFC 6901
-pointers naming the document behind each result path, so the address is one
-`jq` hop further away but reachable.
+`--show-links` is the **[today]** spelling of the same move: it returns a
+dictionary of RFC 6901 pointers naming the document behind each result path, so
+the address is one `jq` hop further away but reachable. It exists to annotate
+identity back onto a payload that had destroyed it, so a rendered in-band
+address is the direction of travel and this flag is the stopgap.
 
-The two answer different questions, and a caller who compares their `id`s finds
-them disagreeing. A `$link` marker renders the link **as stored** — the edge the
-selection already read. A piece created inside a handler and pushed into a
-collection is held through a wrapper that redirects to it, so the marker names
-the wrapper, and two positions holding one piece can render two different `id`s.
-`--show-links` follows that redirect and names the piece's canonical result
-cell, which is the identity the runtime itself compares on and is the same from
-every position the piece is reached from.
+**An address is not an identifier to compare.** Addresses are many-to-one over
+cells, and a holder of one cannot tell a canonical id from an alias. Two
+positions holding the same piece can render two different `id`s, and the two
+spellings above can disagree with each other about one piece — a piece created
+inside a handler and pushed into a collection is held through a link that
+redirects to it, and the two routes stop at different points along that
+redirect. Each address reads back the same contents, which is what an address
+is for: something to read next, not a claim about canonical identity.
 
-Both read back the same contents, so neither is wrong about the value. Only the
-resolved answer is the piece's identity. A marker address may also carry a
-non-empty `path`, and `--piece` has no path spelling, so such an address names a
-position rather than a call target.
+So compose with an address; do not compare one. Two ids differing does not mean
+two pieces, and equality of contents is the question a caller actually wants
+answered.
 
 Neither route needs a verb to declare its result. A `$link` marker on a link
 position renders the address and suppresses the fetch without consulting a

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -340,9 +340,13 @@ of the item's contents.
 
 `--show-links` is the **[today]** spelling of the same move: it returns a
 dictionary of RFC 6901 pointers naming the document behind each result path, so
-the address is one `jq` hop further away but reachable. It exists to annotate
-identity back onto a payload that had destroyed it, so a rendered in-band
-address is the direction of travel and this flag is the stopgap.
+the address is one `jq` hop further away but reachable.
+
+It differs from a marker in one way that matters: it **resolves**. A marker
+renders the link as stored; `--show-links` follows the chain and names the
+document at the end of it. For getting an address to compose with, the two are
+interchangeable and an in-band marker is the shorter road. For asking which
+document a path really lands in, only the resolving one answers.
 
 **An address is not an identifier to compare.** Addresses are many-to-one over
 cells, and a holder of one cannot tell a canonical id from an alias. Two

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -338,9 +338,24 @@ piece it made, the address renders in place, and the next call takes it as its
 target. Identity survives the round trip instead of being flattened into a copy
 of the item's contents.
 
-`--show-links` is the **[today]** spelling of the same move: it returns a
-dictionary of RFC 6901 pointers naming the document behind each result path, so
-the address is one `jq` hop further away but reachable.
+`--show-links` is the **[today]** spelling of a neighbouring move, and it is
+worth knowing it is not the same one. It returns a dictionary of RFC 6901
+pointers naming the document behind each result path, so the address is one
+`jq` hop further away but reachable.
+
+The two answer different questions, and a caller who compares their `id`s finds
+them disagreeing. A `$link` marker renders the link **as stored** — the edge the
+selection already read. A piece created inside a handler and pushed into a
+collection is held through a wrapper that redirects to it, so the marker names
+the wrapper, and two positions holding one piece can render two different `id`s.
+`--show-links` follows that redirect and names the piece's canonical result
+cell, which is the identity the runtime itself compares on and is the same from
+every position the piece is reached from.
+
+Both read back the same contents, so neither is wrong about the value. Only the
+resolved answer is the piece's identity. A marker address may also carry a
+non-empty `path`, and `--piece` has no path spelling, so such an address names a
+position rather than a call target.
 
 Neither route needs a verb to declare its result. A `$link` marker on a link
 position renders the address and suppresses the fetch without consulting a

--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -501,8 +501,16 @@ carry an entire one, and what was asked for is where the value lives.
 
 Marking a position deeper than a link names the linked document and the path
 below it — `notes[0].title`, where `notes` holds links, renders the note's own
-`id` with `path` `["title"]`. A link is a durable identity; the slot that holds
-it stops naming the same value the moment the collection is reordered.
+`id` with `path` `["title"]`. A link is a durable identity for the edge it
+records; the slot that holds it stops naming the same value the moment the
+collection is reordered.
+
+It is not, though, the piece's canonical address. A piece created inside a
+handler and pushed into a collection is held through a wrapper that redirects to
+it, so a marker names the wrapper, and two positions holding one piece render
+two different `id`s. `cf piece call --show-links` follows the redirect and names
+the canonical result cell, which is what the runtime compares on. Use a marker
+address to read a position; use the resolved one to say which piece.
 
 The marker sits beside a projection when both are wanted, and the answer
 carries both:

--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -505,12 +505,17 @@ below it — `notes[0].title`, where `notes` holds links, renders the note's own
 records; the slot that holds it stops naming the same value the moment the
 collection is reordered.
 
-It is not, though, the piece's canonical address. A piece created inside a
-handler and pushed into a collection is held through a wrapper that redirects to
-it, so a marker names the wrapper, and two positions holding one piece render
-two different `id`s. `cf piece call --show-links` follows the redirect and names
-the canonical result cell, which is what the runtime compares on. Use a marker
-address to read a position; use the resolved one to say which piece.
+**What comes back is a link to read next, not a claim about canonical
+identity.** Addresses are many-to-one over cells: a holder of one cannot tell a
+canonical id from an alias, and normal use does not require it. Two positions
+holding one piece can render two different `id`s, and a marker and
+`cf piece call --show-links` can disagree about the same piece, because a piece
+created inside a handler and pushed into a collection is held through a link
+that redirects to it and the two stop at different points along that redirect.
+
+Both read back the same contents. So feed an address into the next command
+rather than comparing it to another — two ids differing is not evidence of two
+pieces.
 
 The marker sits beside a projection when both are wanted, and the answer
 carries both:

--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -513,9 +513,11 @@ holding one piece can render two different `id`s, and a marker and
 created inside a handler and pushed into a collection is held through a link
 that redirects to it and the two stop at different points along that redirect.
 
-Both read back the same contents. So feed an address into the next command
-rather than comparing it to another — two ids differing is not evidence of two
-pieces.
+So feed an address into the next command rather than comparing it to another:
+two ids differing is not evidence of two pieces. Comparing contents answers a
+different question — distinct pieces can hold identical contents, and one
+piece's contents change under it. **Whether two addresses name the same
+piece is not a question the CLI answers today.**
 
 The marker sits beside a projection when both are wanted, and the answer
 carries both:

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -53,7 +53,7 @@ without reconstructing it.
 | 2. an unrecognized projection key is refused | not started; design landed (#5753) |
 | 3. a rejection propagates up through what holds it | on main (#5701) |
 | 5. `cf wish` and `cf exec` take the read options | not started |
-| 11. a caller may name a reference | **the CLI half is decided** — the two routes are aliases, so a statement rather than a fix; documentation in #5754, then #5632 closes. What a rendered address should *say* about indirection is #5760's |
+| 11. a caller may name a reference | **decided** — the two routes are aliases, so a statement rather than a fix; documentation in #5754, then #5632 closes. Whether a rendered address should declare itself indirect is deferred in #5760 and gates nothing |
 
 Item 9 is split because its two halves have different fates: the marks landed,
 the emission is parked.
@@ -126,8 +126,8 @@ honest one.
 
 Unblocked and independent of the decision above. Item 2 is (M). Item 11 was
 listed here as its equal and is no longer: its CLI half reduces to a
-documentation correction, and what remains of it belongs to #5760 rather than
-to this plan.
+documentation correction. What remains of it — whether a rendered address
+should declare itself indirect — is deferred in #5760 and gates nothing.
 
 **2. An unrecognized projection key is refused.** *(M)* Two denylists are
 consulted and every key in neither is accepted and carried onward. The design is
@@ -439,7 +439,7 @@ its own track.
 | 11 | One piece, one address | **decided — they are aliases**; the documentation half is #5754 | — | Measured: the two routes differ because one resolves the link chain and the other renders the link as stored. That is the read model working, not a defect, so the outcome is the statement rather than the fix. What remains is a doc correction and closing #5632 — no code changes, and step 13 is not gated on it |
 | 12 | An unrecognized projection key is refused | item 2 | 9 | The largest remaining step, and the one carrying design surface, since it couples the projection reader to the compatibility checker's annotation keys. Its design is [projection keys, and the schema a read is handed](projection-key-classification.md) |
 | 12a | `cf` refuses an undeclared field on a call | item 12 | — | Same refusal shape as the step above and independent of it, so it can go either side; building them together is what keeps one vocabulary for what a refusal says |
-| 13 | `cf wish` and `cf exec` take the read options | item 5 | 11, 12, **#5760** | Last by construction: it spreads the vocabulary to two more starting points, so the vocabulary should have stopped moving — and it has not. #5760 decides whether a caller can ask for resolution; either answer settles the grammar, but spreading it to two more commands first is the ordering this step exists to avoid |
+| 13 | `cf wish` and `cf exec` take the read options | item 5 | 11, 12 | Last by construction: it spreads the vocabulary to two more starting points, so the vocabulary should have stopped moving — and it now has. No resolving marker is planned, so the grammar step 13 spreads is the grammar that exists |
 
 **`--show-links` is not redundant, and nothing should schedule its removal
 yet.** [Verb result selection](verb-result-selection.md) prices it as a stopgap
@@ -453,18 +453,22 @@ in-band spelling can produce a resolved address at any position. That makes
 `--show-links` the only way to resolve a whole result in one pass, and an
 in-band address cannot replace what it does not do.
 
-Whether a caller should be able to ask for resolution at all is **deferred to
-[#5760]**, not decided here. Measured: resolution is a fixed point over the
-locally materialized subgraph, so the same link answers differently as
-documents load, and `resolveAsCell` fires an un-awaited sync of its own — it
-both depends on and causes loading. A marker offering resolution over that
-would ship nondeterminism under a name promising determinism, which is why it
-is not on this plan. It becomes a coherent thing to add if #5760 makes
-resolution explicit and awaited, and pointless if #5760 decides equality should
-compare addresses as stored.
+**A caller does not ask for resolution, and the projection grammar is closed.**
+Resolution is a fixed point over the locally materialized subgraph — the same
+link answers differently as documents load, and `resolveAsCell` fires an
+un-awaited sync of its own, so it both depends on and causes loading. That is
+the runtime's eventual consistency rather than a defect: a reactive holder
+re-runs as data arrives, and interim states are rarely acted on. A marker
+offering resolution over it would ship nondeterminism under a name promising
+determinism, so none is planned and the vocabulary has stopped moving.
 
-Either way, retiring the only bulk route while the question is open buys
-nothing. Keep `--show-links`; retire it when a replacement exists or the need
+Two things follow, and both are recorded in [#5760] rather than resolved here:
+whether a rendered address should declare itself indirect, deferred as not
+needed yet; and that a **non-reactive reader** is where eventual consistency
+stops paying, since `cf` exits before convergence on purpose rather than hold a
+committed write hostage to every recomputation it triggered.
+
+Keep `--show-links` meanwhile; retire it when a replacement exists or the need
 is confirmed dead. Note that `cf piece get` has never had an equivalent, so
 bulk resolution on a *read* is a gap that predates all of this.
 

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -53,7 +53,7 @@ without reconstructing it.
 | 2. an unrecognized projection key is refused | not started; design landed (#5753) |
 | 3. a rejection propagates up through what holds it | on main (#5701) |
 | 5. `cf wish` and `cf exec` take the read options | not started |
-| 11. a caller may name a reference | not started; sequenced, gated on one measurement |
+| 11. a caller may name a reference | **decided** — the two routes are aliases; documentation in #5754, then #5632 closes |
 
 Item 9 is split because its two halves have different fates: the marks landed,
 the emission is parked.
@@ -434,10 +434,30 @@ its own track.
 | 8 | `receipt` as a top-level envelope field | **on main** (#5694) — item 4 | — | Its precondition is met, it touches the call envelope alone, and it is what gives items 8 and 9 a consumer. Runs beside steps 5-7 |
 | 9 | A rejection propagates up through what holds it | **on main** (#5701) — item 3 | — | First of the projection work; the mask's asymmetry is what makes a marked field below a link load every element |
 | 10 | Two identical projections stop colliding | **on main** (#5757) — #5523 | 9 | Same file. Reachable the moment anything long-lived reads twice, which the command surface invites |
-| 11 | One piece, one address | #5632, #5498 | — | Trace where each id is minted; the outcome is a fix or a statement that they are aliases. Must precede step 13, which spreads the address vocabulary to two more commands |
+| 11 | One piece, one address | **decided — they are aliases**; the documentation half is #5754 | — | Measured: the two routes differ because one resolves the link chain and the other renders the link as stored. That is the read model working, not a defect, so the outcome is the statement rather than the fix. What remains is a doc correction and closing #5632 — no code changes, and step 13 is not gated on it |
 | 12 | An unrecognized projection key is refused | item 2 | 9 | The largest remaining step, and the one carrying design surface, since it couples the projection reader to the compatibility checker's annotation keys. Its design is [projection keys, and the schema a read is handed](projection-key-classification.md) |
 | 12a | `cf` refuses an undeclared field on a call | item 12 | — | Same refusal shape as the step above and independent of it, so it can go either side; building them together is what keeps one vocabulary for what a refusal says |
 | 13 | `cf wish` and `cf exec` take the read options | item 5 | 11, 12 | Last by construction: it spreads the vocabulary to two more starting points, so the vocabulary should have stopped moving |
+
+**`--show-links` is not redundant, and nothing should schedule its removal
+yet.** [Verb result selection](verb-result-selection.md) prices it as a stopgap
+that in-band rendering makes unnecessary. That is right about *addressing* — a
+caller wanting something to compose with reaches for a marker, which is the
+shorter road — and wrong about the job the flag has since acquired.
+
+A marker renders the link **as stored**; `--show-links` **resolves** the chain.
+`renderedLinkAddress` reshapes the link it is handed and follows nothing, so no
+in-band spelling can produce a resolved address at any position. That makes
+`--show-links` the only way to resolve a whole result in one pass, and an
+in-band address cannot replace what it does not do.
+
+Whether a caller should ever need this is settled — addresses are many-to-one
+and comparing them is not a supported question, so `cf piece inspect` covers
+the occasional single case. What is *not* settled is whether that stays true,
+and retiring the only bulk route while the question is open buys nothing and
+costs the capability. Keep it. Retire it when a replacement exists or the need
+is confirmed dead, and note that `cf piece get` has never had an equivalent —
+so bulk resolution on a *read* is a gap that predates all of this.
 
 **Running beside all of the above.** A caller naming a reference (item 11, #5560) waits on confirming
 that a sigil resolves through a *declared* event field rather than an untyped
@@ -612,7 +632,7 @@ from a plan is one nobody schedules, which is the whole reason for this table.
 | #5637 | an author's prose does not reach a caller: on a verb, on an event field, and on the event interface | step 5a — it absorbed #5559, which described one symptom and had its cause backwards |
 | #5577 | a verb returning a child piece in a doubly-linked tree crashes readback on a cycle | **fixed** by #5740 |
 | #5523 | two identical `piece get` projections in one runtime collide on the transform result cell | **fixed** by #5757 |
-| #5632 | `--show-links` and a `$link` read return different entity ids for the same piece | step 11 |
+| #5632 | `--show-links` and a `$link` read return different entity ids for the same piece | step 11 — **working as designed**; closes once #5754 lands the documentation |
 | #5498 | `getEntityId()` strips the entity URI scheme, collapsing two kinds to one identity | step 11, if it proves to be the same root |
 | #5589 | a click's `detail` and a `cf-select`'s `target.value` reach a handler as types no pattern declares | carried alongside — it belongs to whoever next touches `packages/html`. The ruling that closed item 9b also removed the only thing that ever compared the renderer's output against an author's declared type, so this has no detector left |
 | #5560 | an address a call returns cannot be passed back as a verb argument | item 11 |

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -53,7 +53,7 @@ without reconstructing it.
 | 2. an unrecognized projection key is refused | not started; design landed (#5753) |
 | 3. a rejection propagates up through what holds it | on main (#5701) |
 | 5. `cf wish` and `cf exec` take the read options | not started |
-| 11. a caller may name a reference | **decided** — the two routes are aliases, so a statement rather than a fix; documentation in #5754, then #5632 closes. Whether a rendered address should declare itself indirect is deferred in #5760 and gates nothing |
+| 11. a caller may name a reference | not started; sequenced, gated on one measurement |
 
 Item 9 is split because its two halves have different fates: the marks landed,
 the emission is parked.
@@ -462,7 +462,7 @@ re-runs as data arrives, and interim states are rarely acted on. A marker
 offering resolution over it would ship nondeterminism under a name promising
 determinism, so none is planned and the vocabulary has stopped moving.
 
-Two things follow, and both are recorded in [#5760] rather than resolved here:
+Two things follow, and both are recorded in #5760 rather than resolved here:
 whether a rendered address should declare itself indirect, deferred as not
 needed yet; and that a **non-reactive reader** is where eventual consistency
 stops paying, since `cf` exits before convergence on purpose rather than hold a
@@ -646,7 +646,7 @@ from a plan is one nobody schedules, which is the whole reason for this table.
 | #5577 | a verb returning a child piece in a doubly-linked tree crashes readback on a cycle | **fixed** by #5740 |
 | #5523 | two identical `piece get` projections in one runtime collide on the transform result cell | **fixed** by #5757 |
 | #5632 | `--show-links` and a `$link` read return different entity ids for the same piece | step 11 — **working as designed**; closes once #5754 lands the documentation |
-| #5498 | `getEntityId()` strips the entity URI scheme, collapsing two kinds to one identity | step 11, if it proves to be the same root |
+| #5498 | `getEntityId()` strips the entity URI scheme, collapsing two kinds to one identity | unscheduled. It rode ordering step 11 while that step was a question about identity; the answer there was that the two routes are aliases by design, which says nothing about a scheme the id itself drops. Independent, and still open |
 | #5589 | a click's `detail` and a `cf-select`'s `target.value` reach a handler as types no pattern declares | carried alongside — it belongs to whoever next touches `packages/html`. The ruling that closed item 9b also removed the only thing that ever compared the renderer's output against an author's declared type, so this has no detector left |
 | #5560 | an address a call returns cannot be passed back as a verb argument | item 11 |
 | #5534 | a capability probe passes while covering nothing: a dispatch rejection is not a synchronous throw | carried alongside |

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -53,7 +53,7 @@ without reconstructing it.
 | 2. an unrecognized projection key is refused | not started; design landed (#5753) |
 | 3. a rejection propagates up through what holds it | on main (#5701) |
 | 5. `cf wish` and `cf exec` take the read options | not started |
-| 11. a caller may name a reference | **decided** — the two routes are aliases; documentation in #5754, then #5632 closes |
+| 11. a caller may name a reference | **the CLI half is decided** — the two routes are aliases, so a statement rather than a fix; documentation in #5754, then #5632 closes. What a rendered address should *say* about indirection is #5760's |
 
 Item 9 is split because its two halves have different fates: the marks landed,
 the emission is parked.
@@ -124,8 +124,10 @@ honest one.
 
 ## Ready to build
 
-Unblocked and independent of the decision above. Not all small — items 2 and
-11 are both (M); what these share is that nothing gates them.
+Unblocked and independent of the decision above. Item 2 is (M). Item 11 was
+listed here as its equal and is no longer: its CLI half reduces to a
+documentation correction, and what remains of it belongs to #5760 rather than
+to this plan.
 
 **2. An unrecognized projection key is refused.** *(M)* Two denylists are
 consulted and every key in neither is accepted and carried onward. The design is
@@ -437,7 +439,7 @@ its own track.
 | 11 | One piece, one address | **decided — they are aliases**; the documentation half is #5754 | — | Measured: the two routes differ because one resolves the link chain and the other renders the link as stored. That is the read model working, not a defect, so the outcome is the statement rather than the fix. What remains is a doc correction and closing #5632 — no code changes, and step 13 is not gated on it |
 | 12 | An unrecognized projection key is refused | item 2 | 9 | The largest remaining step, and the one carrying design surface, since it couples the projection reader to the compatibility checker's annotation keys. Its design is [projection keys, and the schema a read is handed](projection-key-classification.md) |
 | 12a | `cf` refuses an undeclared field on a call | item 12 | — | Same refusal shape as the step above and independent of it, so it can go either side; building them together is what keeps one vocabulary for what a refusal says |
-| 13 | `cf wish` and `cf exec` take the read options | item 5 | 11, 12 | Last by construction: it spreads the vocabulary to two more starting points, so the vocabulary should have stopped moving |
+| 13 | `cf wish` and `cf exec` take the read options | item 5 | 11, 12, **#5760** | Last by construction: it spreads the vocabulary to two more starting points, so the vocabulary should have stopped moving — and it has not. #5760 decides whether a caller can ask for resolution; either answer settles the grammar, but spreading it to two more commands first is the ordering this step exists to avoid |
 
 **`--show-links` is not redundant, and nothing should schedule its removal
 yet.** [Verb result selection](verb-result-selection.md) prices it as a stopgap
@@ -451,13 +453,20 @@ in-band spelling can produce a resolved address at any position. That makes
 `--show-links` the only way to resolve a whole result in one pass, and an
 in-band address cannot replace what it does not do.
 
-Whether a caller should ever need this is settled — addresses are many-to-one
-and comparing them is not a supported question, so `cf piece inspect` covers
-the occasional single case. What is *not* settled is whether that stays true,
-and retiring the only bulk route while the question is open buys nothing and
-costs the capability. Keep it. Retire it when a replacement exists or the need
-is confirmed dead, and note that `cf piece get` has never had an equivalent —
-so bulk resolution on a *read* is a gap that predates all of this.
+Whether a caller should be able to ask for resolution at all is **deferred to
+[#5760]**, not decided here. Measured: resolution is a fixed point over the
+locally materialized subgraph, so the same link answers differently as
+documents load, and `resolveAsCell` fires an un-awaited sync of its own — it
+both depends on and causes loading. A marker offering resolution over that
+would ship nondeterminism under a name promising determinism, which is why it
+is not on this plan. It becomes a coherent thing to add if #5760 makes
+resolution explicit and awaited, and pointless if #5760 decides equality should
+compare addresses as stored.
+
+Either way, retiring the only bulk route while the question is open buys
+nothing. Keep `--show-links`; retire it when a replacement exists or the need
+is confirmed dead. Note that `cf piece get` has never had an equivalent, so
+bulk resolution on a *read* is a gap that predates all of this.
 
 **Running beside all of the above.** A caller naming a reference (item 11, #5560) waits on confirming
 that a sigil resolves through a *declared* event field rather than an untyped


### PR DESCRIPTION
## Why

Two live documents told callers that a `$link` marker address and `cf piece call --show-links` are the same move, so a caller who compared their `id`s for one piece found them disagreeing with nothing to explain it.

Measured against the tracker fixture, in one command and one receipt: the marker returned `SYlG…`, `--show-links` returned `SluE…`, reproduced in a second fresh space. One piece reached from three positions rendered three different marker addresses.

**What that is, though, is the design working — not a defect.** `docs/plans/shaped-reads-and-verb-results.md` states it directly: addresses are many-to-one over cells, a holder of one cannot tell a canonical id from an alias, and nothing in normal use requires them to. What comes back is a link to read next, not a claim about canonical identity.

So the harm was never the differing ids. It was two documents inviting a comparison the read model does not support.

## What Changed

- `docs/common/verb-session-walkthrough.md` — keeps `--show-links` as today's spelling of the same move, and adds the caller-facing rule: an address is not an identifier to compare.
- `docs/common/verbs-over-the-cli.md` — states the many-to-one property where a reader meets marker addresses, and says to feed an address into the next command rather than compare it.

Both note that `--show-links` exists to annotate identity back onto a payload that destroyed it, so an in-band rendered address is the direction of travel and the flag is the stopgap — per `docs/plans/verb-result-selection.md`.

No code changes. What either command returns is unchanged.

## Test plan

- `deno task check-docs` → **rc=0** (549 blocks).
- `deno task check-skill-facts` → **rc=0** (45 documents).
- `docs/` is excluded from `deno fmt`, so no fmt evidence is claimed.

The measurement ran against a live host with `packages/cli/integration/pattern/tracker.tsx` in throwaway spaces; no source file was changed and no process started or stopped.

## What this now touches, and why

`docs/plans/verbs-implementation.md` is the largest file here. An earlier
revision of this description said the plan edit was deliberately excluded; that
was true while #5730 was open against the same file and is no longer.

It carries the ordering table's step 11 outcome, step 13's dependencies, and the
`--show-links` section — the decisions this documentation correction is the
other half of.

**It does not touch plan item 11.** "A caller may name a reference" (#5560) is a
different thing from ordering step 11, "one piece, one address", and remains
unstarted with four unimplemented parts.
