### PR TITLE
fix(cli): a repeated piece get projection is one read, not a collision

### DIFF
--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -15,6 +15,7 @@ import {
   type MemorySpace,
   type NormalizedFullLink,
   parseLink,
+  type Pattern,
   type Runtime,
   sanitizeSchemaForLinks,
 } from "@commonfabric/runner";
@@ -2115,6 +2116,52 @@ function arrayItemProjectionError(flag: ProjectionFlag): CellSelectionError {
   );
 }
 
+/**
+ * What one runtime keeps for the transform reads it has already served.
+ *
+ * Both fields answer the same question — which pattern object a repeat of a
+ * read hands to `runtime.run`.
+ *
+ * `run` decides "the same pattern as last time" by comparing pattern pointers,
+ * and a hand-built pattern's pointer is minted per pattern OBJECT rather than
+ * per structure (#5756). A repeat that rebuilds a structurally identical
+ * pattern therefore reads as a pattern change, and a change re-stages the
+ * stored argument and validates it against the incoming argument schema. A
+ * projection has narrowed that schema, so the source's other fields come back
+ * as additional properties and the read fails with a schema error nothing in
+ * the request explains. Running the pattern the cell was set up with is the
+ * same setup instead, and answers.
+ *
+ * A pattern object does not cross runtimes: its pointer is indexed in the
+ * runtime that minted it, and the nested patterns behind it do not resolve
+ * elsewhere. A second runtime over one storage session therefore needs its own
+ * result cell rather than the setup stored on the first runtime's, which is
+ * what `discriminator` gives it.
+ */
+interface TransformReads {
+  /** Separates this runtime's transform cells from another runtime's. */
+  readonly discriminator: number;
+  /** The pattern each transform result cell runs, by space-qualified id. */
+  readonly patterns: Map<string, Pattern>;
+}
+
+const transformReads = new WeakMap<Runtime, TransformReads>();
+
+let nextTransformDiscriminator = 0;
+
+/** The reads `runtime` has served, minting the record on its first one. */
+function transformReadsFor(runtime: Runtime): TransformReads {
+  let reads = transformReads.get(runtime);
+  if (reads === undefined) {
+    reads = {
+      discriminator: ++nextTransformDiscriminator,
+      patterns: new Map(),
+    };
+    transformReads.set(runtime, reads);
+  }
+  return reads;
+}
+
 /** Optional hooks into {@link deriveSelectedValue}'s internals. */
 export interface DeriveSelectedValueDependencies {
   /** Called with the cell the returned value was read from. */
@@ -2403,24 +2450,38 @@ export async function deriveSelectedValue(
   );
 
   const tx = runtime.edit();
+  const reads = transformReadsFor(runtime);
   const resultCell = runtime.getCell(
     space,
     {
       pieceGetTransform: {
+        // A pattern graph belongs to the runtime that runs it, so two runtimes
+        // sharing one storage session read from separate cells.
+        runtime: reads.discriminator,
         source: sourceValueCell.getAsNormalizedFullLink(),
         filter: selection.filter?.source,
         schema: selection.projection?.source,
+        // The pattern's shape branches on this, and a source whose schema names
+        // no root kind reads it off the value — so a source that changes kind
+        // is a different read rather than the same one answered differently.
+        sourceIsArray,
       },
     },
     mainResultSchema,
     tx,
     "session",
   );
+  const resultLink = resultCell.getAsNormalizedFullLink();
+  const readKey = `${resultLink.space}/${resultLink.id}`;
+  // The repeat runs the pattern this cell was set up with; the first read of a
+  // selection is the one that installs it.
+  const installedPattern = reads.patterns.get(readKey);
+  if (installedPattern === undefined) reads.patterns.set(readKey, mainPattern);
   const errors = runtimeErrorLog(runtime);
   const errorCountBefore = errors.length;
   const result = runtime.run(
     tx,
-    mainPattern,
+    installedPattern ?? mainPattern,
     {
       value: sourceValueCell.asSchema(sourceReadSchema).getAsLink({
         includeSchema: true,

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -3184,6 +3184,181 @@ describe("cf piece get transforms", () => {
     });
   });
 
+  describe("a read repeated over one host", () => {
+    const itemsSchema = {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          id: { type: "number" },
+          title: { type: "string" },
+        },
+      },
+    } as const satisfies JSONSchema;
+
+    /** A committed array source, so a read has something to project. */
+    async function seededSource(
+      host: Runtime,
+      cause: string,
+      value: Array<{ id: number; title: string }>,
+    ): Promise<Cell<unknown>> {
+      const tx = host.edit();
+      const source = host.getCell(space, cause, itemsSchema, tx);
+      source.set(value);
+      expect((await tx.commit()).ok).toBeDefined();
+      return source as Cell<unknown>;
+    }
+
+    /** The value `selection` reads, beside the cell it was answered from. */
+    async function readWithCell(
+      host: Runtime,
+      source: Cell<unknown>,
+      selection: Parameters<typeof deriveSelectedValue>[3],
+    ): Promise<{ value: unknown; cell: string }> {
+      let outputCell: Cell<unknown> | undefined;
+      const value = await deriveSelectedValue(host, space, source, selection, {
+        onOutputCell: (cell) => outputCell = cell,
+      });
+      return { value, cell: outputCell!.getAsNormalizedFullLink().id };
+    }
+
+    it("answers the repeat from the cell the first read set up", async () => {
+      const source = await seededSource(runtime, "repeat-identical-source", [
+        { id: 1, title: "First" },
+        { id: 2, title: "Second" },
+      ]);
+      const selection = { projection: await parseSelectionProjection("id") };
+
+      const first = await readWithCell(runtime, source, selection);
+      const second = await readWithCell(runtime, source, selection);
+
+      expect(first.value).toEqual([{ id: 1 }, { id: 2 }]);
+      expect(second.value).toEqual([{ id: 1 }, { id: 2 }]);
+      // The same cell, not a fresh one per read: the repeat reuses the
+      // transform the first read installed rather than minting its own.
+      expect(second.cell).toBe(first.cell);
+    });
+
+    it("answers the repeat with a source change made between the reads", async () => {
+      const source = await seededSource(runtime, "repeat-restated-source", [
+        { id: 1, title: "First" },
+      ]);
+      const selection = { projection: await parseSelectionProjection("id") };
+
+      const first = await readWithCell(runtime, source, selection);
+      expect(first.value).toEqual([{ id: 1 }]);
+
+      const tx = runtime.edit();
+      source.withTx(tx).set([
+        { id: 1, title: "First" },
+        { id: 2, title: "Second" },
+      ]);
+      expect((await tx.commit()).ok).toBeDefined();
+
+      // The reused cell answers what the source says now. A repeat that
+      // replayed the first read's stored answer would still report one row.
+      const second = await readWithCell(runtime, source, selection);
+      expect(second.value).toEqual([{ id: 1 }, { id: 2 }]);
+      expect(second.cell).toBe(first.cell);
+    });
+
+    it("answers each differing selection from its own cell", async () => {
+      const source = await seededSource(runtime, "repeat-distinct-source", [
+        { id: 1, title: "First" },
+        { id: 2, title: "Second" },
+      ]);
+
+      const ids = await readWithCell(runtime, source, {
+        projection: await parseSelectionProjection("id"),
+      });
+      const titles = await readWithCell(runtime, source, {
+        projection: await parseSelectionProjection("title"),
+      });
+      const filtered = await readWithCell(runtime, source, {
+        filter: parseSelectionFilter(".id == 2"),
+        projection: await parseSelectionProjection("id"),
+      });
+      const other = await seededSource(runtime, "repeat-other-source", [
+        { id: 7, title: "Other" },
+      ]);
+      const elsewhere = await readWithCell(runtime, other, {
+        projection: await parseSelectionProjection("id"),
+      });
+      const repeat = await readWithCell(runtime, source, {
+        projection: await parseSelectionProjection("id"),
+      });
+
+      expect(ids.value).toEqual([{ id: 1 }, { id: 2 }]);
+      expect(titles.value).toEqual([{ title: "First" }, { title: "Second" }]);
+      expect(filtered.value).toEqual([{ id: 2 }]);
+      expect(elsewhere.value).toEqual([{ id: 7 }]);
+      // A differing projection, filter or source is a different read and gets
+      // its own cell; only the repeat lands back on the first read's.
+      expect(
+        new Set([ids.cell, titles.cell, filtered.cell, elsewhere.cell]).size,
+      ).toBe(4);
+      expect(repeat.cell).toBe(ids.cell);
+    });
+
+    it("answers a repeat whose source changed root kind between the reads", async () => {
+      // A source whose schema names no root kind has its array-ness read off
+      // the value, and the projection's shape follows it. So the two reads
+      // below ask the same thing of two different shapes, and answering the
+      // second from the first read's transform would map over a non-array.
+      const tx = runtime.edit();
+      const source = runtime.getCell(
+        space,
+        "repeat-kind-flip-source",
+        true,
+        tx,
+      );
+      source.set([{ id: 1, title: "First" }] as never);
+      expect((await tx.commit()).ok).toBeDefined();
+      const selection = { projection: await parseSelectionProjection("id") };
+
+      expect(await deriveSelectedValue(runtime, space, source, selection))
+        .toEqual([{ id: 1 }]);
+
+      const flip = runtime.edit();
+      source.withTx(flip).set({ id: 9, title: "Ninth" } as never);
+      expect((await flip.commit()).ok).toBeDefined();
+
+      expect(await deriveSelectedValue(runtime, space, source, selection))
+        .toEqual({ id: 9 });
+    });
+
+    it("answers a second runtime's identical read over the same session", async () => {
+      const source = await seededSource(runtime, "repeat-two-hosts-source", [
+        { id: 1, title: "First" },
+      ]);
+      const selection = { projection: await parseSelectionProjection("id") };
+      const first = await readWithCell(runtime, source, selection);
+      expect(first.value).toEqual([{ id: 1 }]);
+
+      const second = new Runtime({
+        apiUrl: new URL("https://example.com"),
+        storageManager,
+        cfcEnforcementMode: "observe",
+        cfcFlowLabels: "persist",
+      });
+      try {
+        const sourceThere = second.getCell(
+          space,
+          "repeat-two-hosts-source",
+          itemsSchema,
+        );
+        const read = await readWithCell(second, sourceThere, selection);
+        expect(read.value).toEqual([{ id: 1 }]);
+        // A pattern graph belongs to the runtime that runs it, so the second
+        // runtime answers from its own cell rather than inheriting the setup
+        // stored on the first runtime's.
+        expect(read.cell).not.toBe(first.cell);
+      } finally {
+        await second.dispose();
+      }
+    });
+  });
+
   function derivedConfidentiality(id: string): string[] {
     type StoredEntry = {
       origin?: string;


### PR DESCRIPTION
## Why

Two identical `cf piece get` projections served by one long-lived host collide.
The second read fails with `updated arguments do not match the candidate
schema` — a schema error about a read that worked moments earlier, with nothing
in the request to explain it. A caller cannot tell it from a genuine problem in
their own projection.

Nothing hits this today because `cf piece get` runs once per process, so each
invocation builds its own storage manager and its own session. It is reachable
from any host that retains a storage manager across requests, which is exactly
the shape of the `cf` session daemon in #5423 — so this is a fix ahead of that
work rather than a hypothetical.

Closes #5523. Step 10 of `docs/plans/verbs-implementation.md`. Stacked on #5740;
review that first.

**The issue's mechanism needed one correction, and it decided the fix.** The
issue reads the failure as "the second `runtime.run` against an existing cause
fails". The narrower truth: `Runner.setupInternal` decides "the same pattern as
last time" by comparing pattern pointers, and a hand-built pattern's pointer is
minted per pattern *object* rather than per structure (#5756, filed against
`packages/runner` — the upstream cause, not fixed here). A repeat that rebuilds
a structurally identical pattern therefore reads as a pattern change, which
re-stages the stored argument and validates it against the incoming argument
schema. A projection has narrowed that schema, so the source's other fields come
back as additional properties.

Two consequences worth having written down:

- The collision only *throws* when the projection narrows away a property the
  source actually carries. A repeat of `--select id,title` over a source holding
  exactly `id` and `title` succeeds today.
- Two runtimes over one retained storage manager fail the same way. The issue
  names that case; it had not been measured. It is fixed here too, and it cannot
  be fixed by sharing a pattern object across runtimes — a keyless pattern
  pointer is indexed in the runtime that minted it, and the second runtime dies
  with `map: op pattern keyless:… did not evaluate in this session and carries
  no graph`.

**Direction.** The issue offers two: vary the cause per read, or make an
existing transform cell reusable when the arguments are identical. This takes
the second. The first mints a session cell per read, so a client polling one
read through the #5423 daemon grows one cell per poll, unbounded — a worse
defect than the collision, in the very host the fix exists for. Reuse is
bounded: one cell and one pattern per distinct selection per runtime, all
dropped with the runtime through a `WeakMap`.

**What reuse costs.** It does not change when a read recomputes. The graph is
stopped after each read and re-running it over the same cell recomputes from the
current source; there is no cached-answer path, and a test commits a row between
two reads and asserts the repeat sees it. The residual cost is that the freshly
built pattern is discarded on a repeat — the same graph construction every read
does today, so no regression.

## What Changed

`packages/cli/lib/cell-selection.ts`, in `deriveSelectedValue`:

- A per-runtime `TransformReads` record, held in a `WeakMap`, remembers the
  pattern each transform result cell was set up with. A repeat runs that pattern
  instead of a freshly built one, so setup sees the same pattern rather than a
  change.
- That record also carries a discriminator, now part of the cell's cause: a
  pattern graph belongs to the runtime that runs it, so two runtimes sharing one
  storage session read from separate cells instead of one inheriting the other's
  stored setup.
- The cause also carries the source's observed array-ness. The pattern's shape
  branches on it, and a source whose schema names no root kind has it read off
  the value — so a source that changes kind is a different read rather than the
  same one answered differently.

No documentation describes this behaviour, so none changed. The plan's step 10
row is not touched here; it is being sequenced separately.

## Test plan

Five tests in `packages/cli/test/piece-get-transform.test.ts`, under a new
`a read repeated over one host` describe.

**Red first.** Four of the five fail against this PR's base, each with the
documented `updated arguments do not match the candidate schema: value: 0:
additional property title`:

```
deno test -A test/piece-get-transform.test.ts   → exit 1
  answers the repeat from the cell the first read set up ......... FAILED
  answers the repeat with a source change made between the reads .. FAILED
  answers each differing selection from its own cell .............. FAILED
  answers a second runtime's identical read over the same session . FAILED
```

With the fix, all five pass and the file's 105 pre-existing steps are unmoved
(110 steps, 0 failed).

**One of these tests was green before the fix, and that is why it is spelled the
way it is.** The recompute test was first written with `--select id,title` over
a source holding exactly `id` and `title` — and it passed against the unfixed
code, because a projection that narrows nothing never trips the re-stage
validation. A test that passes before the fix is not a test of the fix. It was
rewritten to project `id` from a source that also carries `title`, which is the
spelling that fails. Please do not "simplify" it back: the narrowing is the
whole mechanism.

**The fifth test is a different kind of test, and is labelled as one here rather
than left to be discovered.** `answers a repeat whose source changed root kind
between the reads` passes against the base — it is not a reproduction of #5523.
It guards the *cause's completeness* against this PR's own design: with
`sourceIsArray` removed from the cause, it fails with `Could not apply piece get
transform: map currently only supports arrays` (measured). It exists so that
field cannot be deleted as dead weight.

Gates, each exit code captured on its own line rather than after a pipe:

| Command | Exit |
| --- | --- |
| `cd packages/cli && deno task test` | 0 — 174 passed (206 steps), 0 failed |
| `deno fmt --check` | 0 |
| `deno lint` | 0 |
| `deno task check-no-waitfor` | 0 |

No `waitFor`, `setTimeout`, sleep or retry loop in the new tests. `deno task
check-docs` not run — no document changed. Note that `deno task check` does not
cover `packages/cli/lib`, so it is not evidence for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

