### PR TITLE
refactor(utils): name each object-shape predicate for the array case

### DIFF
--- a/packages/background-piece-service/src/worker-ipc.ts
+++ b/packages/background-piece-service/src/worker-ipc.ts
@@ -1,5 +1,5 @@
 import { isKeyPairRaw, KeyPairRaw } from "@commonfabric/identity";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 
 export enum WorkerIPCMessageType {
   Initialize = "initialize",
@@ -20,7 +20,7 @@ export type InitializationData = {
 export function isInitializationData(
   value: unknown,
 ): value is InitializationData {
-  return !!(isRecord(value) &&
+  return !!(isObjectOrArray(value) &&
     typeof value.did === "string" &&
     typeof value.toolshedUrl === "string" &&
     isKeyPairRaw(value.rawIdentity));
@@ -31,7 +31,7 @@ export type RunData = {
 };
 
 export function isRunData(value: unknown): value is RunData {
-  return !!(isRecord(value) &&
+  return !!(isObjectOrArray(value) &&
     typeof value.pieceId === "string");
 }
 
@@ -49,7 +49,7 @@ export type WorkerIPCRequest = {
 };
 
 export function isWorkerIPCRequest(value: unknown): value is WorkerIPCRequest {
-  if (!isRecord(value) || typeof value.msgId !== "number") {
+  if (!isObjectOrArray(value) || typeof value.msgId !== "number") {
     return false;
   }
   if (value.type === WorkerIPCMessageType.Cleanup) {
@@ -73,7 +73,7 @@ export type WorkerIPCResponse = {
 export function isWorkerIPCResponse(
   value: unknown,
 ): value is WorkerIPCResponse {
-  return !!(isRecord(value) &&
+  return !!(isObjectOrArray(value) &&
     typeof value.msgId === "number" &&
     ("error" in value ? typeof value.error === "string" : true) &&
     ("type" in value ? typeof value.type === "string" : true));

--- a/packages/cf-harness/src/contracts/prompt-slot.ts
+++ b/packages/cf-harness/src/contracts/prompt-slot.ts
@@ -1,5 +1,5 @@
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 
 export type PromptSlotRole = "direct-command" | "context" | "quote";
 
@@ -48,7 +48,7 @@ const PROMPT_SLOT_ROLES: readonly PromptSlotRole[] = [
 ];
 
 const isJsonObject = (input: unknown): input is Record<string, unknown> =>
-  isRecord(input) && !Array.isArray(input);
+  isObjectNotArray(input);
 
 const isPromptSlotRole = (input: unknown): input is PromptSlotRole =>
   typeof input === "string" &&

--- a/packages/cf-harness/src/contracts/run-manifest.ts
+++ b/packages/cf-harness/src/contracts/run-manifest.ts
@@ -2,7 +2,7 @@ import {
   type CfcEnforcementMode,
   isCfcEnforcementMode,
 } from "@commonfabric/runner/cfc";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 import {
   normalizePromptSlotBinding,
   type PromptSlotBinding,
@@ -59,7 +59,7 @@ export interface LoomRunManifest {
 export type HarnessRunManifest = LoomRunManifest;
 
 const isJsonObject = (input: unknown): input is Record<string, unknown> =>
-  isRecord(input) && !Array.isArray(input);
+  isObjectNotArray(input);
 
 const isLoomRunManifestType = (input: unknown): boolean =>
   input === undefined || input === LOOM_RUN_MANIFEST_TYPE;

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -18,7 +18,7 @@ import {
   type Runtime,
   sanitizeSchemaForLinks,
 } from "@commonfabric/runner";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import { runtimeErrorLog } from "./callable.ts";
 
 type PredicateComparisonOperator = "==" | "!=" | "<" | "<=" | ">" | ">=";
@@ -630,7 +630,7 @@ function normalizeProjectionSchema(
       `Invalid --schema at ${path}: false cannot project a value`,
     );
   }
-  if (!isRecord(schema) || Array.isArray(schema)) {
+  if (!isObjectNotArray(schema)) {
     throw new CellSelectionError(
       `Invalid --schema at ${path}: expected a JSON Schema object`,
     );
@@ -667,7 +667,7 @@ function normalizeProjectionSchema(
     ? { ...declared }
     : { type: implied, ...declared };
   if (declared.properties !== undefined) {
-    if (!isRecord(declared.properties) || Array.isArray(declared.properties)) {
+    if (!isObjectNotArray(declared.properties)) {
       throw new CellSelectionError(
         `Invalid --schema at ${path}: "properties" must be an object`,
       );
@@ -1012,7 +1012,7 @@ export async function parseCellSelectionOptions(options: {
 }
 
 function schemaTypes(schema: JSONSchema | undefined): string[] {
-  if (!isRecord(schema)) return [];
+  if (!isObjectOrArray(schema)) return [];
   return Array.isArray(schema.type)
     ? schema.type.filter((value): value is string => typeof value === "string")
     : typeof schema.type === "string"
@@ -1040,7 +1040,9 @@ function walkSchemaRoot<T>(
   root: JSONSchema = schema ?? true,
   ancestors = new Set<object>(),
 ): T {
-  if (!isRecord(schema) || ancestors.has(schema)) return behavior.unknown;
+  if (!isObjectOrArray(schema) || ancestors.has(schema)) {
+    return behavior.unknown;
+  }
   ancestors.add(schema);
   const documentRoot = schema.$defs !== undefined ? schema : root;
   try {
@@ -1146,7 +1148,7 @@ function schemaAtArrayItem(
 function dereferencedElementSchema(
   schema: JSONSchema | undefined,
 ): JSONSchema {
-  if (!isRecord(schema) || schema.asCell === undefined) {
+  if (!isObjectOrArray(schema) || schema.asCell === undefined) {
     return schema ?? true;
   }
   const { asCell: _asCell, ...dereferenced } = schema;
@@ -1157,7 +1159,7 @@ function filteredOutputSchema(
   sourceSchema: JSONSchema | undefined,
   outputItemSchema: JSONSchema | undefined,
 ): JSONSchema {
-  if (!isRecord(sourceSchema)) {
+  if (!isObjectOrArray(sourceSchema)) {
     return { type: "array", items: true };
   }
   const { items: _items, prefixItems: _prefixItems, ...metadata } =
@@ -1260,7 +1262,7 @@ function projectionMask(schema: JSONSchema): ProjectionMask {
   // source over a keyword that says nothing about that position.
   if (
     objectSchema.additionalProperties === true ||
-    isRecord(objectSchema.additionalProperties)
+    isObjectOrArray(objectSchema.additionalProperties)
   ) {
     return true;
   }
@@ -1416,7 +1418,7 @@ function projectValue(
       projectValue(item, itemSchema, implicitArrayTraversal)
     );
   }
-  if (!isRecord(value)) return value;
+  if (!isObjectOrArray(value)) return value;
   if (implicitArrayTraversal && schema.items !== undefined) {
     return projectValue(value, schema.items, implicitArrayTraversal);
   }
@@ -1518,7 +1520,7 @@ export function selectSourceSchema(
   // the same container shape as the current value. Keep that read permissive;
   // the materializing projector still applies the mask and drops siblings.
   if (source === undefined || source === true) return true;
-  if (source === false || mask === true || !isRecord(mask)) {
+  if (source === false || mask === true || !isObjectOrArray(mask)) {
     return source;
   }
   if (source.$ref !== undefined) {
@@ -1783,7 +1785,7 @@ function positionBelow(
   return walkedPosition(
     position.cell.key(key),
     { ...position.address, path: [...position.address.path, key] },
-    isRecord(container) ? { value: container[key] } : undefined,
+    isObjectOrArray(container) ? { value: container[key] } : undefined,
   );
 }
 
@@ -1899,9 +1901,7 @@ async function composeLinkAddresses(
       );
     }
   } else if (markers.properties !== undefined) {
-    const projectedRecord = isRecord(projected) && !Array.isArray(projected)
-      ? projected
-      : {};
+    const projectedRecord = isObjectNotArray(projected) ? projected : {};
     const record: Record<string, unknown> = { ...projectedRecord };
     for (const [key, child] of Object.entries(markers.properties)) {
       record[key] = await composeLinkAddresses(
@@ -1920,9 +1920,7 @@ async function composeLinkAddresses(
       path: [...position.address.path],
     },
   };
-  return isRecord(composed) && !Array.isArray(composed)
-    ? { ...address, ...composed }
-    : address;
+  return isObjectNotArray(composed) ? { ...address, ...composed } : address;
 }
 
 /**
@@ -1991,7 +1989,7 @@ export async function deriveSelectedValue(
     );
   }
   const declaredSourceSchema = sourceCell.schema;
-  const sourceSchema = isRecord(declaredSourceSchema) &&
+  const sourceSchema = isObjectOrArray(declaredSourceSchema) &&
       declaredSourceSchema.asCell !== undefined
     ? dereferencedElementSchema(declaredSourceSchema)
     : declaredSourceSchema;

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -57,7 +57,7 @@ import {
 import { codecOf } from "@commonfabric/data-model/codec-common";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
-import { isPlainObject, isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray, isPlainObject } from "@commonfabric/utils/types";
 import { pinProgramFabricImports, renderPinRewrite } from "./fabric-deps.ts";
 import { isHandlerCell, isStreamValue } from "../../fuse/callables.ts";
 import { throwOnSpaceAuthorizationError } from "./utils.ts";
@@ -1822,9 +1822,11 @@ function listingMarks(
   rootSchema: unknown,
   name: string,
 ): { tier?: "wrapper"; deprecated?: boolean } {
-  if (!isRecord(rootSchema) || !isRecord(rootSchema.properties)) return {};
+  if (!isObjectOrArray(rootSchema) || !isObjectOrArray(rootSchema.properties)) {
+    return {};
+  }
   const property = (rootSchema.properties as Record<string, unknown>)[name];
-  if (!isRecord(property)) return {};
+  if (!isObjectOrArray(property)) return {};
   return {
     ...(property.tier === "wrapper" ? { tier: "wrapper" as const } : {}),
     ...(property.deprecated === true ? { deprecated: true } : {}),
@@ -1838,10 +1840,10 @@ function listingMarks(
  * of aliases falls back to whole-link equality, which can only miss — and a
  * miss costs a row its `outputSchema`, never gives it the wrong one. */
 function samePatternLink(left: unknown, right: unknown): boolean {
-  if (!isRecord(left) || !isRecord(right)) return false;
+  if (!isObjectOrArray(left) || !isObjectOrArray(right)) return false;
   const leftAlias = left.$alias;
   const rightAlias = right.$alias;
-  if (!isRecord(leftAlias) || !isRecord(rightAlias)) {
+  if (!isObjectOrArray(leftAlias) || !isObjectOrArray(rightAlias)) {
     return deepEqual(left, right);
   }
   return deepEqual(leftAlias.partialCause, rightAlias.partialCause) &&
@@ -1867,17 +1869,17 @@ function declaredVerbResults(
 ): Map<string, JSONSchema> {
   const declared = new Map<string, JSONSchema>();
   const result = pattern?.result;
-  if (!isRecord(result)) return declared;
+  if (!isObjectOrArray(result)) return declared;
   const nodes = Array.isArray(pattern?.nodes) ? pattern.nodes : [];
   for (const [name, link] of Object.entries(result)) {
     let resultSchema: JSONSchema | undefined;
     let matched = 0;
     for (const node of nodes) {
-      if (!isRecord(node) || !isRecord(node.inputs)) continue;
+      if (!isObjectOrArray(node) || !isObjectOrArray(node.inputs)) continue;
       if (!samePatternLink(link, node.inputs.$event)) continue;
       matched++;
       const module = node.module;
-      if (isRecord(module) && module.resultSchema !== undefined) {
+      if (isObjectOrArray(module) && module.resultSchema !== undefined) {
         resultSchema = module.resultSchema as JSONSchema;
       }
     }
@@ -1960,10 +1962,11 @@ export async function listPieceCallables(
     if (cellProp === "result") resultRoot = rootCell;
     const value = rootCell.get?.();
     const schema = rootCell.schema;
-    const schemaKeys = isRecord(schema) && isRecord(schema.properties)
-      ? Object.keys(schema.properties)
-      : [];
-    const valueKeys = isRecord(value) ? Object.keys(value) : [];
+    const schemaKeys =
+      isObjectOrArray(schema) && isObjectOrArray(schema.properties)
+        ? Object.keys(schema.properties)
+        : [];
+    const valueKeys = isObjectOrArray(value) ? Object.keys(value) : [];
     for (const name of new Set([...valueKeys, ...schemaKeys])) {
       if (listings.has(name)) continue; // result shadows input, like call
       const callableCell = rootCell.key(name).asSchemaFromLinks();
@@ -2014,7 +2017,7 @@ export async function listPieceCallables(
     : undefined;
   if (pieceCell) {
     const pieceValue = pieceCell.get?.();
-    if (isRecord(pieceValue)) {
+    if (isObjectOrArray(pieceValue)) {
       for (const name of Object.keys(pieceValue)) {
         if (!listings.has(name)) rejected.add(name);
       }
@@ -2542,7 +2545,7 @@ async function inspectSlugTargetCell(
   const target = await resolveSlugTargetCell(pieces, slug);
   await target.pull();
   const result = target.get() as Readonly<unknown>;
-  const name = isRecord(result) && typeof result[NAME] === "string"
+  const name = isObjectOrArray(result) && typeof result[NAME] === "string"
     ? result[NAME]
     : undefined;
   const identityRef = getPatternIdentityRef(target);
@@ -2745,8 +2748,8 @@ export async function setCellCfcLabel(
   }
 
   const { observes: requestedObserves, ...label } = update;
-  const schemaIfc = isRecord(targetCell.schema) &&
-      isRecord(targetCell.schema.ifc)
+  const schemaIfc = isObjectOrArray(targetCell.schema) &&
+      isObjectOrArray(targetCell.schema.ifc)
     ? targetCell.schema.ifc
     : undefined;
   const existingObservationClasses = new Set<
@@ -3060,7 +3063,7 @@ export async function recreateSpaceRootPattern(
 
 function isVNodeLike(value: unknown): value is VNode {
   const visited = new Set<object>();
-  while (isRecord(value) && UI in value) {
+  while (isObjectOrArray(value) && UI in value) {
     if (visited.has(value)) return false; // Cycle detected
     visited.add(value);
     value = value[UI];

--- a/packages/data-model/src/cell-rep.ts
+++ b/packages/data-model/src/cell-rep.ts
@@ -6,8 +6,8 @@
 
 import { backtickQuote } from "@commonfabric/utils/markdown";
 import {
+  isObjectOrArray,
   isPlainObject,
-  isRecord,
   isUnsafeObjectKey,
 } from "@commonfabric/utils/types";
 import { FabricHash } from "@/fabric-primitives/index.ts";
@@ -82,7 +82,7 @@ export function entityRefFrom(hash: FabricHash): EntityRef {
 export function isEntityRef(value: unknown): value is EntityRef {
   return modernCellRepEnabled
     ? value instanceof FabricHash
-    : isRecord(value) && typeof value["/"] === "string";
+    : isObjectOrArray(value) && typeof value["/"] === "string";
 }
 
 /**
@@ -92,7 +92,7 @@ export function isEntityRef(value: unknown): value is EntityRef {
 export function entityRefToString(value: EntityRef): string {
   if (modernCellRepEnabled) {
     if (value instanceof FabricHash) return value.taggedHashString;
-  } else if (isRecord(value) && typeof value["/"] === "string") {
+  } else if (isObjectOrArray(value) && typeof value["/"] === "string") {
     return value["/"];
   }
   throw new Error(
@@ -152,9 +152,9 @@ export function linkRefFrom<Payload extends FabricPlainObject>(
 function isLegacyLinkEnvelope(
   value: unknown,
 ): value is { "/": { [LINK_V1_TAG]: FabricPlainObject } } {
-  return isRecord(value) &&
+  return isObjectOrArray(value) &&
     Object.keys(value).length === 1 &&
-    isRecord(value["/"]) &&
+    isObjectOrArray(value["/"]) &&
     LINK_V1_TAG in value["/"];
 }
 
@@ -219,7 +219,9 @@ export function linkPayloadAtProbe(
   if (modernCellRepEnabled) {
     return isLinkRef(probeValue) ? linkRefPayload(probeValue) : undefined;
   }
-  return isRecord(probeValue) ? probeValue as FabricPlainObject : undefined;
+  return isObjectOrArray(probeValue)
+    ? probeValue as FabricPlainObject
+    : undefined;
 }
 
 //

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -19,7 +19,7 @@
 import { backtickQuote } from "@commonfabric/utils/markdown";
 import {
   isInstance,
-  isRecord,
+  isObjectOrArray,
   isUnsafeObjectKey,
   unsafeObjectKeyIn,
 } from "@commonfabric/utils/types";
@@ -432,7 +432,7 @@ function fabricFromNativeValueInternal(
   converted: Map<object, FabricValue>,
   freeze: boolean,
 ): FabricValue {
-  const isOriginalRecord = isRecord(original);
+  const isOriginalRecord = isObjectOrArray(original);
 
   if (isOriginalRecord && converted.has(original)) {
     const cached = converted.get(original);
@@ -462,7 +462,7 @@ function fabricFromNativeValueInternal(
   }
 
   // Primitives, `null`, and `undefined` don't need recursion or freezing.
-  // Spelled as a `typeof` test rather than `!isRecord()` so the non-object
+  // Spelled as a `typeof` test rather than `!isObjectOrArray()` so the non-object
   // arms of `FabricValueLayer` narrow: every non-object layer value is
   // already a `FabricValue`.
   //

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -197,10 +197,11 @@ export function isFabricValue(value: unknown): value is FabricValue {
  * accepts, minus `null`. The name spells out the array case because "object"
  * alone reads as excluding it.
  *
- * The runtime behavior matches a bare `isRecord()` exactly. The difference is
- * static: `isRecord()` narrows to `Record<string | number | symbol, unknown>`,
- * which discards the fact that the value is a `FabricValue` -- so a guarded
- * value can no longer be handed to a `FabricValue` API. This keeps that half.
+ * The runtime behavior matches a bare `isObjectOrArray()` exactly. The
+ * difference is static: `isObjectOrArray()` narrows to
+ * `Record<string, unknown>`, which discards the fact that the value is a
+ * `FabricValue` -- so a guarded value can no longer be handed to a
+ * `FabricValue` API. This keeps that half.
  *
  * Contrast `isFabricPlainObject()`, which is strictly narrower at RUNTIME: it
  * accepts only plain objects, rejecting arrays and `FabricSpecialObject`s. The
@@ -216,7 +217,8 @@ export function isFabricObjectOrArray(
  * Narrows to the plain-record arm of `FabricValue` (`FabricPlainObject`): an
  * object whose prototype is `Object.prototype` or `null`. This rejects arrays,
  * `FabricSpecialObject`s, and other class instances (`Date`, `Map`, …), none of
- * which are representable as a `FabricPlainObject`. Unlike a bare `isRecord()`
+ * which are representable as a `FabricPlainObject`. Unlike a bare
+ * `isObjectOrArray()`
  * check, it preserves the value type — `FabricPlainObject`'s string index of
  * `FabricValue` keeps an indexed value typed as a `FabricValue`.
  *

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -40,7 +40,7 @@ import type { CfcAtom } from "@commonfabric/api/cfc";
 import type { CellRef } from "@commonfabric/runtime-client";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { getLogger } from "@commonfabric/utils/logger";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import type {
   ChildNodeState,
   NodeState,
@@ -1340,7 +1340,7 @@ export class WorkerReconciler {
     const kinds = policy.caveatKindAllow;
     if (
       kinds !== undefined && kinds.length > 0 &&
-      isRecord(atom) && atom.type === CFC_CAVEAT_ATOM_TYPE &&
+      isObjectOrArray(atom) && atom.type === CFC_CAVEAT_ATOM_TYPE &&
       typeof atom.kind === "string" && kinds.includes(atom.kind)
     ) {
       return true;

--- a/packages/html/test/assert.ts
+++ b/packages/html/test/assert.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 
 export class AssertionError<A, E> extends Error {
   actual: A | undefined;
@@ -45,7 +45,7 @@ export const matchObject = (
   expected: unknown,
   message = "",
 ) => {
-  if (!isRecord(actual) || !isRecord(expected)) {
+  if (!isObjectOrArray(actual) || !isObjectOrArray(expected)) {
     throw new AssertionError({
       message: message || "Both arguments must be objects",
       actual,
@@ -63,7 +63,7 @@ export const matchObject = (
         });
       }
 
-      if (isRecord(expected[key]) && isRecord(actual[key])) {
+      if (isObjectOrArray(expected[key]) && isObjectOrArray(actual[key])) {
         // Recursively check nested objects
         matchObject(actual[key], expected[key], message);
       } else if (actual[key] !== expected[key]) {

--- a/packages/identity/src/interface.ts
+++ b/packages/identity/src/interface.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 
 export type DID = `did:${string}:${string}`;
 export type DIDKey = `did:key:${string}`;
@@ -128,7 +128,7 @@ export type KeyPairRaw = CryptoKeyPair | InsecureCryptoKeyPair;
 export function isCryptoKeyPair(input: unknown): input is CryptoKeyPair {
   return !!(
     globalThis.CryptoKey &&
-    isRecord(input) &&
+    isObjectOrArray(input) &&
     input.privateKey instanceof globalThis.CryptoKey &&
     input.publicKey instanceof globalThis.CryptoKey
   );
@@ -138,7 +138,7 @@ export function isInsecureCryptoKeyPair(
   input: unknown,
 ): input is InsecureCryptoKeyPair {
   return !!(
-    isRecord(input) &&
+    isObjectOrArray(input) &&
     input.privateKey instanceof Uint8Array &&
     input.publicKey instanceof Uint8Array
   );

--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import type { JSONValue } from "@commonfabric/api";
 import { isPureJson } from "@commonfabric/pure-json";
 import type {
@@ -56,7 +56,7 @@ export function isLLMNativeModelToolId(
 export function isLLMNativeModelToolResult(
   input: unknown,
 ): input is LLMNativeModelToolResult {
-  return isRecord(input) && !Array.isArray(input) &&
+  return isObjectNotArray(input) &&
     input.type === "cf-harness.native-model-tool-result" &&
     isLLMNativeModelToolId(input.toolId) &&
     (!("provider" in input) || typeof input.provider === "string");
@@ -130,7 +130,7 @@ function isArrayOf<T>(
 export function isLLMRequestMetadata(
   input: unknown,
 ): input is LLMRequestMetadata {
-  if (!isRecord(input) || Array.isArray(input)) return false;
+  if (!isObjectNotArray(input)) return false;
   // An `undefined` value means "absent": JSON drops the key, so it is not part
   // of what crosses the boundary and does not have to be pure JSON.
   const present = Object.fromEntries(
@@ -144,34 +144,34 @@ export function isLLMRequestMetadata(
 export function isLLMContent(input: unknown): input is LLMContent {
   return typeof input === "string" || (Array.isArray(input) && input.every(
     (item) =>
-      isRecord(item) &&
+      isObjectOrArray(item) &&
       (item.type === "text" || item.type === "image" ||
         item.type === "tool-call" || item.type === "tool-result"),
   ));
 }
 
 export function isLLMToolCall(input: unknown): input is LLMToolCall {
-  return isRecord(input) && !Array.isArray(input) &&
+  return isObjectNotArray(input) &&
     typeof input.id === "string" &&
     typeof input.name === "string" &&
-    isRecord(input.arguments);
+    isObjectOrArray(input.arguments);
 }
 
 export function isLLMToolResult(input: unknown): input is LLMToolResult {
-  return isRecord(input) && !Array.isArray(input) &&
+  return isObjectNotArray(input) &&
     typeof input.toolCallId === "string" &&
     (!("error" in input) || typeof input.error === "string");
 }
 
 export function isLLMTool(input: unknown): input is LLMTool {
-  return isRecord(input) && !Array.isArray(input) &&
+  return isObjectNotArray(input) &&
     typeof input.description === "string" &&
-    isRecord(input.inputSchema) &&
+    isObjectOrArray(input.inputSchema) &&
     (!("handler" in input) || typeof input.handler === "function");
 }
 
 export function isLLMMessage(input: unknown): input is BuiltInLLMMessage {
-  return isRecord(input) && !Array.isArray(input) &&
+  return isObjectNotArray(input) &&
     (input.role === "user" || input.role === "assistant" ||
       input.role === "tool") &&
     isLLMContent(input.content) &&
@@ -205,7 +205,7 @@ export function extractTextFromLLMResponse(response: LLMResponse): string {
 }
 
 export function isLLMRequest(input: unknown): input is LLMRequest {
-  return isRecord(input) && !Array.isArray(input) &&
+  return isObjectNotArray(input) &&
     typeof input.model === "string" && isLLMMessages(input.messages) &&
     ("cache" in input) &&
     (!("system" in input) || typeof input.system === "string") &&
@@ -214,7 +214,7 @@ export function isLLMRequest(input: unknown): input is LLMRequest {
     (!("stop" in input) || typeof input.stop === "string") &&
     (!("mode" in input) || input.mode === "json") &&
     (!("metadata" in input) || isLLMRequestMetadata(input.metadata)) &&
-    (!("tools" in input) || (isRecord(input.tools) &&
+    (!("tools" in input) || (isObjectOrArray(input.tools) &&
       Object.values(input.tools).every((tool: unknown) => isLLMTool(tool)))) &&
     (!("nativeModelToolIds" in input) ||
       (Array.isArray(input.nativeModelToolIds) &&

--- a/packages/memory/acl.ts
+++ b/packages/memory/acl.ts
@@ -1,4 +1,4 @@
-import { isObjectOrArray } from "@commonfabric/utils/types";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 import { ACL, ACLUser, ANYONE, Capability, DID, DIDKey } from "./interface.ts";
 import { isDID } from "../identity/src/interface.ts";
 
@@ -30,7 +30,7 @@ export function isCapability(value: unknown): value is Capability {
 }
 
 export function isACL(value: unknown): value is ACL {
-  if (!isObjectOrArray(value)) return false;
+  if (!isObjectNotArray(value)) return false;
   for (const [did, cap] of Object.entries(value)) {
     if (!isACLUser(did)) return false;
     if (!isCapability(cap)) return false;

--- a/packages/memory/acl.ts
+++ b/packages/memory/acl.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { ACL, ACLUser, ANYONE, Capability, DID, DIDKey } from "./interface.ts";
 import { isDID } from "../identity/src/interface.ts";
 
@@ -30,7 +30,7 @@ export function isCapability(value: unknown): value is Capability {
 }
 
 export function isACL(value: unknown): value is ACL {
-  if (!isRecord(value)) return false;
+  if (!isObjectOrArray(value)) return false;
   for (const [did, cap] of Object.entries(value)) {
     if (!isACLUser(did)) return false;
     if (!isCapability(cap)) return false;

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -10,7 +10,7 @@ import type {
   SchemaPathSelector,
 } from "@commonfabric/api";
 import { EmptyReconstructionContext } from "@commonfabric/data-model/codec-common";
-import { isObject, isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 
 export const MEMORY_PROTOCOL = "memory" as const;
@@ -979,7 +979,7 @@ export const compatibleMemoryProtocolFlags = (
 export const parseMemoryProtocolFlags = (
   value: unknown,
 ): MemoryProtocolFlags | null => {
-  if (!isRecord(value) || Array.isArray(value)) {
+  if (!isObjectNotArray(value)) {
     return null;
   }
 
@@ -1152,7 +1152,7 @@ export const toDocumentSelector = (
 
 export const isEntityDocument = (
   value: unknown,
-): value is EntityDocument => isObject(value);
+): value is EntityDocument => isObjectNotArray(value);
 
 export const getEntityDocumentMetadata = (
   document: EntityDocument,

--- a/packages/memory/v2/patch.ts
+++ b/packages/memory/v2/patch.ts
@@ -6,7 +6,7 @@ import {
   cloneIfNecessary,
   valueEqual,
 } from "@commonfabric/data-model/fabric-value";
-import { isInstance, isObject } from "@commonfabric/utils/types";
+import { isInstance, isObjectNotArray } from "@commonfabric/utils/types";
 import { type EntityDocument, isEntityDocument, type PatchOp } from "../v2.ts";
 import { encodePointer, parsePointer } from "./path.ts";
 
@@ -495,7 +495,7 @@ const isArraySegment = (segment: string): boolean =>
   /^(0|[1-9]\d*)$/.test(segment);
 
 const isPatchObject = (value: FabricValue): value is PatchObject =>
-  isObject(value) && !isInstance(value);
+  isObjectNotArray(value) && !isInstance(value);
 
 const isContainer = (value: FabricValue): value is PatchContainer =>
   Array.isArray(value) || isPatchObject(value);

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -16,7 +16,7 @@ import {
 } from "@commonfabric/runner/traverse";
 import type { JSONSchema } from "../../runner/src/builder/types.ts";
 import { ExtendedStorageTransaction } from "../../runner/src/storage/extended-storage-transaction.ts";
-import { isObject } from "@commonfabric/utils/types";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 import type { FabricValue } from "@commonfabric/api";
 import type { MemorySpace, MIME, URI } from "../interface.ts";
 import { internPathSelector } from "@commonfabric/data-model/schema-utils";
@@ -608,7 +608,7 @@ const loadFactsForDoc = (
   }
   traversalContext.schemaTracker.add(docKey, internedSelector);
 
-  if (!isObject(fact.value)) {
+  if (!isObjectNotArray(fact.value)) {
     return;
   }
 

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -53,7 +53,7 @@ import {
 } from "@commonfabric/data-model/cell-rep";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { createSession, Identity, type Session } from "@commonfabric/identity";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { getLogger } from "@commonfabric/utils/logger";
 import { ensureNotRenderThread } from "@commonfabric/utils/env";
 import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
@@ -742,7 +742,7 @@ export class PiecesController<T = unknown> {
         // fire is worse than a marker that says so, because it reads as a guard
         // while being incapable of acting as one. Refusing here needs that
         // error handling changed first.
-        if (!isRecord(value) || depth > maxDepth) return;
+        if (!isObjectOrArray(value) || depth > maxDepth) return;
 
         // Prevent cycles in our traversal by tracking object references directly
         if (visited.has(value)) return;
@@ -882,7 +882,7 @@ export class PiecesController<T = unknown> {
       //
       // TODO(danfuzz): refusing one here waits on the same thing -- this walk's
       // `catch` swallows, so a throw would not surface.
-      if (!isRecord(value) || depth > maxDepth) return false;
+      if (!isObjectOrArray(value) || depth > maxDepth) return false;
 
       // Prevent cycles in our traversal by tracking object references directly
       if (visited.has(value)) return false;
@@ -934,7 +934,7 @@ export class PiecesController<T = unknown> {
               );
             }
           }
-        } else if (isRecord(value)) {
+        } else if (isObjectOrArray(value)) {
           // Process regular object properties
           const keys = Object.keys(value);
           for (let i = 0; i < keys.length; i++) {

--- a/packages/piece/test/piece-references.test.ts
+++ b/packages/piece/test/piece-references.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import {
   entityRefFromString,
   entityRefToString,
@@ -53,7 +53,8 @@ describe("Piece reference detection", () => {
 
       // Check if the value is a cell-link reference (EntityRef cell + path)
       if (
-        isRecord(value) && isEntityRef(value.cell) && value.path !== undefined
+        isObjectOrArray(value) && isEntityRef(value.cell) &&
+        value.path !== undefined
       ) {
         const addr = entityRefToString(value.cell);
         if (!foundRefs.includes(addr)) {
@@ -62,7 +63,7 @@ describe("Piece reference detection", () => {
       }
 
       // Recursively search objects and arrays
-      if (isRecord(value)) {
+      if (isObjectOrArray(value)) {
         // Check all properties of objects
         if (!Array.isArray(value)) {
           for (const key in value) {
@@ -148,7 +149,7 @@ describe("Piece reference detection", () => {
       const seenIds = new Set<string>();
 
       const traverse = (value: unknown): void => {
-        if (!isRecord(value)) return;
+        if (!isObjectOrArray(value)) return;
 
         // Check for direct cell reference
         if (isEntityRef(value.cell) && value.path !== undefined) {
@@ -160,7 +161,7 @@ describe("Piece reference detection", () => {
         }
 
         // Check for $alias reference
-        if (isRecord(value.$alias) && isEntityRef(value.$alias.cell)) {
+        if (isObjectOrArray(value.$alias) && isEntityRef(value.$alias.cell)) {
           const addr = entityRefToString(value.$alias.cell);
           if (!seenIds.has(addr)) {
             refs.push(addr);
@@ -281,12 +282,12 @@ describe("Piece reference detection", () => {
       const value = (doc as MockDoc).get?.();
 
       // If document has a metadata-linked result cell, follow it
-      if (isRecord(value) && value.resultCell) {
+      if (isObjectOrArray(value) && value.resultCell) {
         return followMetadataToResult(value.resultCell, visited, depth + 1);
       }
 
       // If we've reached the end and have result metadata, return it
-      if (isRecord(value) && isRecord(value.result)) {
+      if (isObjectOrArray(value) && isObjectOrArray(value.result)) {
         return value.result.cell;
       }
 

--- a/packages/piece/test/reference-detection.test.ts
+++ b/packages/piece/test/reference-detection.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
-import { isObject, isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 
 /**
  * These tests focus on the core functionality used by our piece reference detection
@@ -92,14 +92,15 @@ describe("Reference detection core functionality", () => {
 
       // Check for alias
       if (
-        isRecord(value) && isRecord(value.$alias) && isRecord(value.$alias.cell)
+        isObjectOrArray(value) && isObjectOrArray(value.$alias) &&
+        isObjectOrArray(value.$alias.cell)
       ) {
         // FIXME: types
         foundReferences.push(value.$alias.cell.id as string);
       }
 
       // Recursively search through object properties
-      if (isObject(value)) {
+      if (isObjectNotArray(value)) {
         for (const key in value) {
           recursiveSearch((value as Record<string, unknown>)[key]);
         }
@@ -166,8 +167,8 @@ describe("Reference detection core functionality", () => {
       if (!value) return;
 
       // Check if value might be a cell link
-      const isCellLink = isRecord(value) &&
-        isRecord(value.cell) &&
+      const isCellLink = isObjectOrArray(value) &&
+        isObjectOrArray(value.cell) &&
         "path" in value;
       if (isCellLink) {
         foundReferences.push({
@@ -179,7 +180,8 @@ describe("Reference detection core functionality", () => {
 
       // Check for alias
       if (
-        isRecord(value) && isRecord(value.$alias) && isRecord(value.$alias.cell)
+        isObjectOrArray(value) && isObjectOrArray(value.$alias) &&
+        isObjectOrArray(value.$alias.cell)
       ) {
         foundReferences.push({
           type: "alias",
@@ -189,7 +191,7 @@ describe("Reference detection core functionality", () => {
       }
 
       // Recursively search
-      if (isObject(value)) {
+      if (isObjectNotArray(value)) {
         for (const key in value) {
           detectReferences((value as Record<string, unknown>)[key]);
         }

--- a/packages/runner/src/builder/built-in.ts
+++ b/packages/runner/src/builder/built-in.ts
@@ -33,7 +33,7 @@ import type {
   WishState,
 } from "commonfabric";
 import { h } from "@commonfabric/html";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { isCell } from "../cell.ts";
 import { sqliteQueryNodeFactory } from "../builtins/sqlite/query-node.ts";
 import { LLMDialogResultSchema } from "../builtins/llm-schemas.ts";
@@ -450,7 +450,7 @@ export function wish<T = unknown>(
   let param;
   let resultSchema;
 
-  if (schema !== undefined && isRecord(target) && !isCell(target)) {
+  if (schema !== undefined && isObjectOrArray(target) && !isCell(target)) {
     param = {
       schema,
       ...target, // Pass in after, so schema here overrides any schema in target

--- a/packages/runner/src/builder/node-utils.ts
+++ b/packages/runner/src/builder/node-utils.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import type { CfcConfClause } from "../cfc/clause.ts";
 import { type FactoryInput, type JSONSchema, type NodeRef } from "./types.ts";
 import { ContextualFlowControl } from "../cfc.ts";
@@ -19,7 +19,7 @@ export function connectInputAndOutputs(node: NodeRef) {
     if (isCell(value)) {
       const exported = value.export();
       if (exported.frame !== node.frame) {
-        const implementation = isRecord(node.module)
+        const implementation = isObjectOrArray(node.module)
           ? node.module.implementation
           : undefined;
         const sourceLocation = typeof implementation === "function"
@@ -49,7 +49,9 @@ export function connectInputAndOutputs(node: NodeRef) {
 
   // We will also apply ifc tags from inputs to outputs, unless the module has
   // precise built-in flow handling for its result.
-  if (!isRecord(node.module) || node.module.propagateInputIfc !== false) {
+  if (
+    !isObjectOrArray(node.module) || node.module.propagateInputIfc !== false
+  ) {
     applyInputIfcToOutput(node.inputs, node.outputs);
   }
 }
@@ -106,9 +108,10 @@ function attachCfcToOutputs(
     // we may have fields in the output schema, so incorporate those
     const joined = new Set<unknown>(lubConfidentiality);
     ContextualFlowControl.joinSchema(joined, outputSchema);
-    const ifc = (isRecord(outputSchema) && outputSchema.ifc !== undefined)
-      ? { ...outputSchema.ifc }
-      : {};
+    const ifc =
+      (isObjectOrArray(outputSchema) && outputSchema.ifc !== undefined)
+        ? { ...outputSchema.ifc }
+        : {};
     ifc.confidentiality = ContextualFlowControl.lub(joined);
     const outpuSchemaObj = (outputSchema === true || outputSchema === undefined)
       ? {}
@@ -126,7 +129,7 @@ function attachCfcToOutputs(
       // set during construction, so we cannot override it here.
     }
     return;
-  } else if (isRecord(outputs)) {
+  } else if (isObjectOrArray(outputs)) {
     // Descend into objects and arrays.
     //
     // A `FabricPrimitive` among them is inert here and correctly so: it has

--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import {
   ARRAY_SUBSCHEMA_KEYS,
@@ -240,7 +240,7 @@ export function patternFromFrame<T, R>(
  * on it.
  */
 export function assertNoReservedCauseKeys(cause: unknown): void {
-  if (isRecord(cause) && "$generated" in cause) {
+  if (isObjectOrArray(cause) && "$generated" in cause) {
     throw new Error(
       `Cannot use cause ${
         toCompactDebugString(cause)
@@ -306,7 +306,7 @@ function factoryFromPattern<T, R>(
   });
 
   // First from results
-  if (isRecord(outputs) && !isCell(outputs)) {
+  if (isObjectOrArray(outputs) && !isCell(outputs)) {
     Object.entries(outputs).forEach(([key, value]: [string, unknown]) => {
       if (isCell(value)) {
         const exported = value.export();
@@ -326,7 +326,7 @@ function factoryFromPattern<T, R>(
   allCells.forEach((cell) => {
     if (cell.export().path.length) return;
     cell.export().nodes.forEach((node: NodeRef) => {
-      if (isRecord(node.inputs)) {
+      if (isObjectOrArray(node.inputs)) {
         Object.entries(node.inputs).forEach(([key, input]) => {
           if (
             isReactive(input) && input.export().cell === cell &&
@@ -387,7 +387,7 @@ function factoryFromPattern<T, R>(
       return;
     }
 
-    const isStream = isRecord(value) && value.$stream === true;
+    const isStream = isObjectOrArray(value) && value.$stream === true;
     let partialCause: JSONValue;
     if (name === undefined) {
       partialCause = nextAnonymousPartialCause(isStream);
@@ -682,7 +682,7 @@ function asCellGrantsWritableHere(
   for (const entry of schema.asCell) {
     const kind = typeof entry === "string"
       ? entry
-      : isRecord(entry)
+      : isObjectOrArray(entry)
       ? entry.kind
       : undefined;
     if (typeof kind !== "string" || !READ_ONLY_CELL_KINDS.has(kind)) {
@@ -706,7 +706,7 @@ function asCellGrantsWritableHere(
  */
 function schemaMayGrantWritableHandles(schema: unknown): boolean {
   if (Array.isArray(schema)) return schema.some(schemaMayGrantWritableHandles);
-  if (!isRecord(schema)) return false;
+  if (!isObjectOrArray(schema)) return false;
   if (asCellGrantsWritableHere(schema)) return true;
   if ("$ref" in schema || "$dynamicRef" in schema) return true;
   return Object.values(schema).some(schemaMayGrantWritableHandles);
@@ -855,7 +855,7 @@ function assignComputedCellKinds(
     if (!schemaMayGrantWritableHandles(schema)) return;
     const collectAll = () =>
       collectCellRoots(value).forEach((root) => out.add(root));
-    if (!isRecord(schema) || Array.isArray(schema)) {
+    if (!isObjectNotArray(schema)) {
       // A grant may exist but the schema is not a plain object (unreachable
       // for booleans, which never grant): fail safe.
       collectAll();
@@ -918,18 +918,17 @@ function assignComputedCellKinds(
       }
       return;
     }
-    // TODO(danfuzz): `isRecord` admits a `FabricInstance`, whose
+    // TODO(danfuzz): `isObjectOrArray` admits a `FabricInstance`, whose
     // `Object.entries` are empty, so it takes this branch and collects
     // nothing instead of falling to the fail-safe `collectAll()` below. A
     // cell root reachable only through the instance's codec contents is
     // then never disqualified from the `computed` tag — the ack-and-drop
     // this function exists to prevent. (A `FabricPrimitive` passes the same
     // gate, harmlessly: it holds no cell roots.)
-    if (isRecord(target) && !isReactive(target)) {
-      const properties =
-        isRecord(schema.properties) && !Array.isArray(schema.properties)
-          ? schema.properties
-          : undefined;
+    if (isObjectOrArray(target) && !isReactive(target)) {
+      const properties = isObjectNotArray(schema.properties)
+        ? schema.properties
+        : undefined;
       for (const [key, child] of Object.entries(target)) {
         const childSchema = properties !== undefined && key in properties
           ? properties[key]
@@ -966,11 +965,13 @@ function assignComputedCellKinds(
       // is writable.
       if (module.writableProxy === true) return all();
       const schema = module.argumentSchema;
-      const properties = isRecord(schema) && !Array.isArray(schema) &&
-          isRecord(schema.properties) && !Array.isArray(schema.properties)
+      const properties = isObjectNotArray(schema) &&
+          isObjectNotArray(schema.properties)
         ? schema.properties
         : undefined;
-      if (properties === undefined || !isRecord(node.inputs)) return all();
+      if (properties === undefined || !isObjectOrArray(node.inputs)) {
+        return all();
+      }
       const roots = new Set<OpaqueCell<any>>();
       for (const [key, bound] of Object.entries(node.inputs)) {
         if (key === "$ctx" && properties[key] !== undefined) {
@@ -1032,7 +1033,7 @@ function assignComputedCellKinds(
     if (writers.some(writerDisqualifies)) return;
     if (disqualified.has(root)) return;
     const { value } = root.export();
-    if (isRecord(value) && value.$stream === true) return;
+    if (isObjectOrArray(value) && value.$stream === true) return;
     const descriptor = derivedInternalCells.find((candidate) =>
       deepEqual(candidate.partialCause, partialCause)
     );
@@ -1248,7 +1249,7 @@ function schemaWithDefault(
   if (schema === false) {
     return { not: true, default: value as JSONValue };
   }
-  if (isRecord(schema)) {
+  if (isObjectOrArray(schema)) {
     return schema.default === undefined
       ? { ...schema, default: value as JSONValue }
       : schema;

--- a/packages/runner/src/builder/to-encodable-form.ts
+++ b/packages/runner/src/builder/to-encodable-form.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { isInertArray } from "@commonfabric/utils/arrays";
 import { isInertPlainObject } from "@commonfabric/utils/objects";
 import {
@@ -149,7 +149,7 @@ export function withAliasBindings(
   // A `FabricPrimitive` is an atomic value whose state lives in private fields
   // (zero enumerable own-props), so the `for...in` copy below would flatten it
   // to `{}`. It leaves whole, and it leaves FIRST: it is also a record, so an
-  // `isRecord()` test would otherwise claim it.
+  // `isObjectOrArray()` test would otherwise claim it.
   if (value instanceof FabricPrimitive) return value;
 
   // A `FabricInstance` is NOT a leaf. It is a container reached by its codec
@@ -178,7 +178,9 @@ export function withAliasBindings(
   // null-prototype object -- each producing a plain object that satisfies
   // `isFabricValue()` while meaning something else. Nothing downstream can
   // catch it, because what it produces is genuinely valid.
-  if (isRecord(value) && !isPattern(value) && !isInertPlainObject(value)) {
+  if (
+    isObjectOrArray(value) && !isPattern(value) && !isInertPlainObject(value)
+  ) {
     value = shallowFabricFromNativeValue(value);
     // The conversion mints either arm: a `Uint8Array` becomes a `FabricBytes`,
     // an `Error` a `FabricError`.
@@ -187,7 +189,7 @@ export function withAliasBindings(
   }
 
   // If this is an object or a pattern, process each key recursively.
-  if (isRecord(value) || isPattern(value)) {
+  if (isObjectOrArray(value) || isPattern(value)) {
     // Guard against circular object references (e.g. schema objects with
     // shared identity between $defs and sibling properties).
     if (!seen) seen = new WeakMap();

--- a/packages/runner/src/builder/traverse-utils.ts
+++ b/packages/runner/src/builder/traverse-utils.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import {
   FabricInstance,
   FabricPrimitive,
@@ -27,8 +27,8 @@ export function traverseValue(
 
   // Prevent infinite recursion
   if (seen.has(value) || seen.has(result)) return value;
-  if (isRecord(result)) seen.add(result);
-  else if (isRecord(unprocessedValue)) seen.add(unprocessedValue);
+  if (isObjectOrArray(result)) seen.add(result);
+  else if (isObjectOrArray(unprocessedValue)) seen.add(unprocessedValue);
 
   // A `FabricInstance` is NOT a leaf. It is a container reached by its codec
   // contents rather than by property name, which this walk cannot do, so the
@@ -62,7 +62,7 @@ export function traverseValue(
     !isCell(value) &&
     !isCellResultForDereferencing(value) &&
     !((value as object) instanceof FabricPrimitive) &&
-    (isRecord(value) || isPattern(value))
+    (isObjectOrArray(value) || isPattern(value))
   ) {
     if (Array.isArray(value)) {
       return (value as Array<any>).map((v) => traverseValue(v, fn, seen));

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import type { EntityKind } from "../entity-kind.ts";
 import type { PatternBuilder } from "./pattern.ts";
 import type { NormalizedFullLink } from "../link-types.ts";
@@ -196,7 +196,7 @@ export type StreamValue = {
 };
 
 export function isStreamValue(value: unknown): value is StreamValue {
-  return isRecord(value) && "$stream" in value && value.$stream === true;
+  return isObjectOrArray(value) && "$stream" in value && value.$stream === true;
 }
 
 declare module "@commonfabric/api" {

--- a/packages/runner/src/builtins/fetch.ts
+++ b/packages/runner/src/builtins/fetch.ts
@@ -3,7 +3,7 @@ import type {
   JSONSchema,
   JSONSchemaObj,
 } from "@commonfabric/api";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { type Cell } from "../cell.ts";
 import { type Action } from "../scheduler.ts";
@@ -180,7 +180,7 @@ const asTypeArray = (type: unknown): string[] =>
  * Exported for unit testing only — not part of the fetch builtin surface.
  */
 export function schemaWithOpenObjects(schema: JSONSchema): JSONSchema {
-  if (!isRecord(schema)) return schema;
+  if (!isObjectOrArray(schema)) return schema;
   // Default-tier walk plus `$defs`. The never-emitted keywords (`contains`,
   // `if`/`then`/`else`, ...) are deliberately NOT rewritten — opening objects
   // under them would make those paths look supported; if one becomes emitted,

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -34,7 +34,11 @@ import {
   LLMToolSchema,
 } from "./llm-schemas.ts";
 import { getLogger } from "@commonfabric/utils/logger";
-import { isBoolean, isObject, isRecord } from "@commonfabric/utils/types";
+import {
+  isBoolean,
+  isObjectNotArray,
+  isObjectOrArray,
+} from "@commonfabric/utils/types";
 import type { JSONSchemaObj } from "../builder/types.ts";
 import {
   ARRAY_SUBSCHEMA_KEYS,
@@ -184,7 +188,7 @@ function normalizeInputSchema(schemaLike: unknown): JSONSchema {
       additionalProperties: inputSchema,
     };
   }
-  if (!isObject(inputSchema)) inputSchema = { type: "object" };
+  if (!isObjectNotArray(inputSchema)) inputSchema = { type: "object" };
   const stripped = stripInjectedResult(inputSchema);
   return prepareSchemaForLLM(stripped);
 }
@@ -406,7 +410,7 @@ function simplifySchemaForContext(
   depth: number = 0,
   maxDepth: number = 3,
 ): JSONSchema {
-  if (!isRecord(schema)) {
+  if (!isObjectOrArray(schema)) {
     return schema;
   }
 
@@ -445,7 +449,7 @@ function simplifySchemaForContext(
 
     // Keep properties, dropping $-prefixed ones ($UI, $TYPE, etc. are
     // internal/VDOM); their values are simplified by the walk below
-    if (key === "properties" && isRecord(value)) {
+    if (key === "properties" && isObjectOrArray(value)) {
       simplified[key] = Object.fromEntries(
         Object.entries(value).filter(([name]) => !name.startsWith("$")),
       );
@@ -607,7 +611,7 @@ function serializeForLLMObservation(
     }
   }
 
-  if (!isRecord(value)) {
+  if (!isObjectOrArray(value)) {
     return {
       value,
       observedConfidentiality: nodeConfidentiality,
@@ -717,7 +721,7 @@ function serializeForLLMObservation(
       });
       observedParts.push(child.observedConfidentiality);
 
-      if (isRecord(child.value) && isCellResultForDereferencing(v)) {
+      if (isObjectOrArray(child.value) && isCellResultForDereferencing(v)) {
         const link = getCellOrThrow(v).resolveAsCell()
           .getAsNormalizedFullLink();
         if (!hasDataUriScheme(link.id)) {
@@ -816,7 +820,7 @@ function traverseAndCellify(
       try {
         const parsed = JSON.parse(trimmed);
         if (
-          isRecord(parsed) && typeof parsed["@link"] === "string" &&
+          isObjectOrArray(parsed) && typeof parsed["@link"] === "string" &&
           Object.keys(parsed).length === 1 &&
           matchLLMFriendlyLink.test(parsed["@link"])
         ) {
@@ -833,7 +837,7 @@ function traverseAndCellify(
   // - it's a record with a single key "/"
   // - the value of the "/" key is a string that matches the URI pattern
   if (
-    isRecord(value) && typeof value["@link"] === "string" &&
+    isObjectOrArray(value) && typeof value["@link"] === "string" &&
     Object.keys(value).length === 1 && matchLLMFriendlyLink.test(value["@link"])
   ) {
     const link = parseLLMFriendlyLink(value["@link"], space);
@@ -868,7 +872,7 @@ function traverseAndCellify(
     );
   }
 
-  if (isRecord(value)) {
+  if (isObjectOrArray(value)) {
     return Object.fromEntries(
       Object.entries(value).map((
         [key, value],
@@ -938,7 +942,7 @@ function resolveDirectContextCellRef(cell: unknown): Cell<any> | undefined {
     ? getCellOrThrow(cell).resolveAsCell()
     : isCell(cell)
     ? cell.resolveAsCell()
-    : isRecord(cell) && typeof cell.resolveAsCell === "function"
+    : isObjectOrArray(cell) && typeof cell.resolveAsCell === "function"
     ? cell.resolveAsCell()
     : undefined;
 }
@@ -1168,7 +1172,7 @@ function ensureString(
   field: string,
   example: string,
 ): string {
-  if (isRecord(value) && typeof value["@link"] === "string") {
+  if (isObjectOrArray(value) && typeof value["@link"] === "string") {
     return ensureString(value["@link"], field, example);
   }
   if (typeof value === "string") {
@@ -1613,7 +1617,7 @@ function buildAvailableCellsDocumentationWithObservation(
         : concreteCell.get() ?? concreteCell.getRaw();
       if (
         value === undefined &&
-        isRecord(schemaInfo) &&
+        isObjectOrArray(schemaInfo) &&
         Object.hasOwn(schemaInfo, "default")
       ) {
         value = (schemaInfo as Record<string, unknown>).default;
@@ -2091,9 +2095,10 @@ function toolAllowsObservedConfidentiality(
   }
 
   const toolSchema = toolCatalog.llmTools[toolName]?.inputSchema;
-  const maxConfidentiality = isRecord(toolSchema) && isRecord(toolSchema.ifc)
-    ? toolSchema.ifc.maxConfidentiality
-    : undefined;
+  const maxConfidentiality =
+    isObjectOrArray(toolSchema) && isObjectOrArray(toolSchema.ifc)
+      ? toolSchema.ifc.maxConfidentiality
+      : undefined;
   // A non-array ceiling means none was declared. A declared (even empty) ceiling
   // is enforced: an empty array is "public only". Delegate to
   // cfcObservationFitsCeiling rather than special-casing empty as allow-all,
@@ -2139,11 +2144,11 @@ function toolInputRequiredIntegrityFailure(
   path: string,
   trust: CfcFloorTrustContext,
 ): string | undefined {
-  if (!isRecord(schema)) {
+  if (!isObjectOrArray(schema)) {
     return undefined;
   }
   const ifc = schema.ifc;
-  if (isRecord(ifc) && Array.isArray(ifc.requiredIntegrity)) {
+  if (isObjectOrArray(ifc) && Array.isArray(ifc.requiredIntegrity)) {
     const required = ifc.requiredIntegrity;
     if (required.length > 0) {
       const integrity = toolInputValueIntegrity(runtime, space, value);
@@ -2163,14 +2168,14 @@ function toolInputRequiredIntegrityFailure(
       }
     }
   }
-  if (isRecord(schema.properties)) {
+  if (isObjectOrArray(schema.properties)) {
     for (const [key, childSchema] of Object.entries(schema.properties)) {
       // Only gate fields the model actually supplied. An absent (e.g. optional)
       // field carries no value to gate; treating it as `undefined` would fail
       // an optional field's floor and over-block the call. A required field the
       // model omitted is a structural error handled by ordinary input
       // validation, not a floor bypass — there is no injected value to gate.
-      if (!isRecord(value) || !Object.hasOwn(value, key)) {
+      if (!isObjectOrArray(value) || !Object.hasOwn(value, key)) {
         continue;
       }
       const failure = toolInputRequiredIntegrityFailure(
@@ -2200,7 +2205,7 @@ function toolInputRequiredIntegrityFailure(
       const slotSchema = prefixItems !== undefined && index < prefixItems.length
         ? prefixItems[index]
         : schema.items;
-      if (!isRecord(slotSchema)) continue;
+      if (!isObjectOrArray(slotSchema)) continue;
       const failure = toolInputRequiredIntegrityFailure(
         runtime,
         space,
@@ -2640,7 +2645,7 @@ function handleUpdateArgument(
   // Apply updates to argument fields
   runtime.editWithRetry((tx) => {
     if (
-      isRecord(cellifiedValue) && !Array.isArray(cellifiedValue) &&
+      isObjectNotArray(cellifiedValue) &&
       !isCell(cellifiedValue)
     ) {
       argumentCell.withTx(tx).update(cellifiedValue);
@@ -2813,7 +2818,8 @@ async function handleInvoke(
       // the caller's ordinary field. The advertised schema hides `result`
       // (stripInjectedResult), so a well-behaved caller never sends one and
       // always gets the injected cell.
-      const injectResult = !(isRecord(input) && Object.hasOwn(input, "result"));
+      const injectResult =
+        !(isObjectOrArray(input) && Object.hasOwn(input, "result"));
       handler.withTx(tx).send(
         injectResult
           ? {
@@ -4059,7 +4065,7 @@ Some operations (especially \`invoke()\` with patterns) create "Pages" - running
 
 function getSchemaTypeString(schema: JSONSchema): string {
   let defs;
-  if (isRecord(schema)) {
+  if (isObjectOrArray(schema)) {
     // Convert schema to TypeScript-like string for readability
     defs = (schema as Record<string, unknown>).$defs as
       | Record<string, JSONSchema>

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -49,7 +49,7 @@ import {
   LLMResultSchema,
   LLMToolSchema,
 } from "./llm-schemas.ts";
-import { isObject, isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import {
   getCellOrThrow,
   isCellResultForDereferencing,
@@ -127,11 +127,11 @@ function setStampedModelOutput(
 function mergeLlmDerivedIntoNode(
   node: Record<string, unknown>,
 ): Record<string, unknown> {
-  const ifc = isRecord(node.ifc) ? node.ifc : {};
+  const ifc = isObjectOrArray(node.ifc) ? node.ifc : {};
   const addIntegrity = Array.isArray(ifc.addIntegrity) ? ifc.addIntegrity : [];
   const stamp = cfcAtom.llmDerived();
   const already = addIntegrity.some((atom) =>
-    isRecord(atom) && isRecord(stamp) && atom.type === stamp.type
+    isObjectOrArray(atom) && isObjectOrArray(stamp) && atom.type === stamp.type
   );
   return {
     ...node,
@@ -175,11 +175,11 @@ function withLlmDerivedStamp(schema: JSONSchema | undefined): JSONSchema {
   const stampNode = (node: Record<string, unknown>): JSONSchema =>
     mapSubschemas(
       mergeLlmDerivedIntoNode(node) as JSONSchemaObj,
-      (child) => (isRecord(child) ? stampNode(child) : child),
+      (child) => (isObjectOrArray(child) ? stampNode(child) : child),
       { includeDefs: true, includeUnused: true },
     );
 
-  const base: Record<string, unknown> = isRecord(schema)
+  const base: Record<string, unknown> = isObjectOrArray(schema)
     ? schema
     : { type: "object" };
   return internSchema(stampNode(base));
@@ -588,7 +588,7 @@ async function pullContextCells(
         ? getCellOrThrow(value).resolveAsCell()
         : isCell(value)
         ? value.resolveAsCell()
-        : isRecord(value) && typeof value.resolveAsCell === "function"
+        : isObjectOrArray(value) && typeof value.resolveAsCell === "function"
         ? value.resolveAsCell()
         : undefined;
       await resolved?.pull?.();
@@ -1359,7 +1359,7 @@ export function generateObject<T extends Record<string, unknown>>(
         observedConfidentiality: [],
       };
     // Determine whether to use the tool-calling path or the direct generateObject path
-    const hasTools = isObject(tools) && Object.keys(tools).length > 0;
+    const hasTools = isObjectNotArray(tools) && Object.keys(tools).length > 0;
     const validationSchema = schemaSanitizePromptInjection
       ? toDeepFrozenSchema(schema)
       : undefined;

--- a/packages/runner/src/builtins/op-pattern-ref.ts
+++ b/packages/runner/src/builtins/op-pattern-ref.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import type { Pattern } from "../builder/types.ts";
 import type { MemorySpace } from "../cell.ts";
 import type { Runtime } from "../runtime.ts";
@@ -29,9 +29,9 @@ export interface PatternRefSentinel {
 export function isPatternRefSentinel(
   value: unknown,
 ): value is PatternRefSentinel {
-  if (!isRecord(value)) return false;
+  if (!isObjectOrArray(value)) return false;
   const ref = (value as { $patternRef?: unknown }).$patternRef;
-  return isRecord(ref) && typeof ref.identity === "string" &&
+  return isObjectOrArray(ref) && typeof ref.identity === "string" &&
     typeof ref.symbol === "string";
 }
 

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1,8 +1,9 @@
 import {
   type Immutable,
   isFunction,
+  isObjectNotArray,
+  isObjectOrArray,
   isPlainContainer,
-  isRecord,
 } from "@commonfabric/utils/types";
 import {
   cloneIfNecessary,
@@ -250,7 +251,7 @@ const storedSchemaForWritePolicyInput = (
   }, {
     meta: { ...ignoreReadForScheduling, ...internalVerifierRead },
   });
-  if (!isRecord(stored) || stored.value === undefined) {
+  if (!isObjectOrArray(stored) || stored.value === undefined) {
     return undefined;
   }
   return ContextualFlowControl.getSchemaAtPath(
@@ -634,7 +635,7 @@ export function elementSchemaFor(
   arraySchema: JSONSchema | undefined,
   index?: number,
 ): JSONSchema | undefined {
-  if (!isRecord(arraySchema)) return undefined;
+  if (!isObjectOrArray(arraySchema)) return undefined;
   const prefixItems = Array.isArray(arraySchema.prefixItems)
     ? arraySchema.prefixItems as JSONSchema[]
     : undefined;
@@ -642,7 +643,7 @@ export function elementSchemaFor(
       index < prefixItems.length
     ? prefixItems[index]
     : arraySchema.items;
-  if (!isRecord(covering) || Array.isArray(covering)) {
+  if (!isObjectNotArray(covering)) {
     return covering as JSONSchema | undefined;
   }
   const defs = arraySchema.$defs;
@@ -1646,7 +1647,7 @@ export class CellImpl<T extends FabricValue>
           "help: use in handlers for partial updates, or .set() for non-object values",
       );
     }
-    if (!isRecord(values)) {
+    if (!isObjectOrArray(values)) {
       throw new Error(
         "Cell.update() requires transaction and object value\n" +
           "help: use in handlers for partial updates, or .set() for non-object values",
@@ -1675,7 +1676,7 @@ export class CellImpl<T extends FabricValue>
       // just wants to know whether the value could be an object.
       const allowsObject = resolvedSchema === undefined ||
         ContextualFlowControl.isTrueSchema(resolvedSchema) ||
-        (isRecord(resolvedSchema) &&
+        (isObjectOrArray(resolvedSchema) &&
           (resolvedSchema.type === "object" ||
             (Array.isArray(resolvedSchema.type) &&
               resolvedSchema.type.includes("object")) ||
@@ -1755,7 +1756,7 @@ export class CellImpl<T extends FabricValue>
       // and assigning that back to `currentValue` would discard the narrowing
       // this block exists to establish.
       const created: FabricValue[] =
-        isRecord(resolvedSchema) && Array.isArray(resolvedSchema.default)
+        isObjectOrArray(resolvedSchema) && Array.isArray(resolvedSchema.default)
           ? processDefaultValue(
             this.runtime,
             this.tx,
@@ -1836,7 +1837,7 @@ export class CellImpl<T extends FabricValue>
       // Annotated for the same reason as in `push()`: `processDefaultValue()`
       // answers `any`, which would discard the narrowing on assignment.
       const created: FabricValue[] =
-        isRecord(resolvedSchema) && Array.isArray(resolvedSchema.default)
+        isObjectOrArray(resolvedSchema) && Array.isArray(resolvedSchema.default)
           ? processDefaultValue(
             this.runtime,
             this.tx,
@@ -2224,7 +2225,7 @@ export class CellImpl<T extends FabricValue>
 
     // Determine the kind based on schema flags
     let kind: CellKind = this._kind;
-    if (isRecord(childSchema)) {
+    if (isObjectOrArray(childSchema)) {
       const asCellValues = ContextualFlowControl.getAsCellValues(childSchema);
       // we can override the kind of cell we use for a key
       if (asCellValues.length > 0) {
@@ -3247,7 +3248,7 @@ function maybeConvertArrayPathToDataURILink(
     | undefined;
 
   for (let i = 0; i < link.path.length; i++) {
-    if (!isRecord(current)) {
+    if (!isObjectOrArray(current)) {
       break;
     }
 
@@ -3259,7 +3260,7 @@ function maybeConvertArrayPathToDataURILink(
         break;
       }
       next = (current as unknown as Record<string, FabricValue>)[segment];
-      if (isRecord(next) && !isCellLink(next)) {
+      if (isObjectOrArray(next) && !isCellLink(next)) {
         candidate = {
           value: next,
           path: [...prefix, segment],
@@ -3490,7 +3491,7 @@ export function convertCellsToLinks(
   path: readonly string[] = [],
   ancestors: Map<object, readonly string[]> = new Map(),
 ): FabricValue {
-  if (isRecord(value) && ancestors.has(value)) {
+  if (isObjectOrArray(value) && ancestors.has(value)) {
     return linkRefFrom({ path: ancestors.get(value) });
   }
 
@@ -3499,7 +3500,7 @@ export function convertCellsToLinks(
     return linkToCell(getCellOrThrow(value), options);
   } else if (isCell(value)) {
     return linkToCell(value, options);
-  } else if (!(isRecord(value) || isFunction(value))) {
+  } else if (!(isObjectOrArray(value) || isFunction(value))) {
     return value as FabricValue;
   }
 
@@ -3541,13 +3542,13 @@ export function convertCellsToLinks(
     //
     // TODO(danfuzz): Both container branches below build a fresh container,
     // throwing away the copy just made above. One copy could serve both.
-    if (!isRecord(converted)) {
+    if (!isObjectOrArray(converted)) {
       // `shallowFabricFromNativeValue()` converted this into a primitive value
       // of some sort.
       //
       // `FabricValueLayer` is looser than `FabricValue` -- its containers hold
       // `unknown`, being unconverted until the recursion reaches them -- and
-      // `isRecord()` does not narrow an array out of the union. The cast is
+      // `isObjectOrArray()` does not narrow an array out of the union. The cast is
       // that gap, not a claim about the value.
       return converted as FabricValue;
     } else if (converted instanceof FabricPrimitive) {
@@ -3697,7 +3698,7 @@ function schemaWithDefaultAndScope<T>(
 export function schemaCellScope(
   schema: JSONSchema | undefined,
 ): CellScope | undefined {
-  return isRecord(schema) && isCellScope(schema.scope)
+  return isObjectOrArray(schema) && isCellScope(schema.scope)
     ? schema.scope
     : undefined;
 }

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -1,6 +1,6 @@
 import { JSONSchemaObj, type JSONValue } from "@commonfabric/api";
 import type { CfcConfClause } from "./cfc/clause.ts";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import type {
@@ -79,7 +79,7 @@ const buildSymbolicSchemaAtPathClassifier = (
 ): SymbolicSchemaAtPathClassifier | undefined => {
   if (typeof schema === "boolean") return () => "boolean";
   const schemaRoot = cfcSchemaChildRoot(schema, fullSchema);
-  const rootKey = isRecord(schemaRoot) ? schemaRoot : schema;
+  const rootKey = isObjectOrArray(schemaRoot) ? schemaRoot : schema;
   if (rootedSchemaVisitIsActive(active, rootKey, schema)) return undefined;
   const nextActive = { root: rootKey, schema, parent: active };
   {
@@ -282,7 +282,7 @@ export class ContextualFlowControl {
     // schema `default` fields; plain `JSON.stringify` would silently
     // mis-encode them.
     const schemaRoot = cfcSchemaChildRoot(schema, fullSchema);
-    const rootKey = isRecord(schemaRoot) ? schemaRoot : schema;
+    const rootKey = isObjectOrArray(schemaRoot) ? schemaRoot : schema;
     const canonical = internSchema(schema) as JSONSchemaObj;
     if (rootedSchemaVisitIsActive(active, rootKey, canonical)) {
       // we've already joined this
@@ -356,7 +356,7 @@ export class ContextualFlowControl {
     confidentiality: readonly CfcConfClause[],
   ): JSONSchema {
     const joined = new Set<unknown>(confidentiality);
-    if (isRecord(schema) && schema.ifc !== undefined) {
+    if (isObjectOrArray(schema) && schema.ifc !== undefined) {
       ContextualFlowControl.addIfcAtoms(joined, schema.ifc.confidentiality);
     }
     // If we have no confidentiality, we can leave the schema
@@ -512,11 +512,13 @@ export class ContextualFlowControl {
     if (schema === false) return false;
     if (schema === true && extraConfidentiality === undefined) return true;
     // Take defs from schema if available
-    const defs = isRecord(schema) && schema.$defs ? schema.$defs : undefined;
+    const defs = isObjectOrArray(schema) && schema.$defs
+      ? schema.$defs
+      : undefined;
     const cacheable = extraConfidentiality === undefined &&
       typeof defaultEmptyProperties === "boolean" &&
       typeof defaultMissingProperty === "boolean" &&
-      isRecord(schema) && isDeepFrozen(schema);
+      isObjectOrArray(schema) && isDeepFrozen(schema);
     if (!cacheable) {
       return ContextualFlowControl.schemaAtPathInternal(
         schema,
@@ -575,7 +577,7 @@ export class ContextualFlowControl {
       )
     ) {
       // If the cursor is a $ref, get the target location
-      if (isRecord(cursor) && "$ref" in cursor) {
+      if (isObjectOrArray(cursor) && "$ref" in cursor) {
         // Follow the reference
         cursor = ContextualFlowControl.resolveSchemaRefsOrThrow(
           cursor,
@@ -583,12 +585,12 @@ export class ContextualFlowControl {
         );
         // Resolve schema refs can resolve to a fullSchema, in which case we
         // need to replace our defs.
-        if (isRecord(cursor) && cursor.$defs) {
+        if (isObjectOrArray(cursor) && cursor.$defs) {
           defs = cursor.$defs;
         }
       }
       if (
-        isRecord(cursor) &&
+        isObjectOrArray(cursor) &&
         (Array.isArray(cursor.type) || "anyOf" in cursor || "oneOf" in cursor)
       ) {
         const subSchemas = new Set<JSONSchema>();
@@ -599,7 +601,7 @@ export class ContextualFlowControl {
           ? [...cursorObject.anyOf, ...cursorObject.oneOf]
           : cursorObject.anyOf ?? cursorObject.oneOf ?? [];
         for (const entry of options) {
-          const entryDefs = isRecord(entry) && entry.$defs !== undefined
+          const entryDefs = isObjectOrArray(entry) && entry.$defs !== undefined
             ? entry.$defs as Record<string, JSONSchema>
             : defs;
           const optSchema = ContextualFlowControl.schemaAtPathInternal(
@@ -702,11 +704,11 @@ export class ContextualFlowControl {
         // we can only descend into objects and arrays or unknown
         return false;
       }
-      if (isRecord(cursor) && cursor.$defs) {
+      if (isObjectOrArray(cursor) && cursor.$defs) {
         defs = cursor.$defs;
       }
     }
-    if (isRecord(cursor) && cursor.ifc !== undefined) {
+    if (isObjectOrArray(cursor) && cursor.ifc !== undefined) {
       ContextualFlowControl.addIfcAtoms(joined, cursor.ifc.confidentiality);
     }
     if (typeof cursor === "boolean") {
@@ -752,7 +754,7 @@ export class ContextualFlowControl {
   static getAsCellValues(
     schema: JSONSchema | undefined,
   ): readonly AsCellEntry[] {
-    if (isRecord(schema) && Array.isArray(schema.asCell)) {
+    if (isObjectOrArray(schema) && Array.isArray(schema.asCell)) {
       return schema.asCell;
     }
     return [];
@@ -784,7 +786,7 @@ export class ContextualFlowControl {
   static getSchemaScopeCap(
     schema: JSONSchema | undefined,
   ): SchemaScope | undefined {
-    if (!isRecord(schema)) return undefined;
+    if (!isObjectOrArray(schema)) return undefined;
     const entryScope = ContextualFlowControl.getAsCellScope(
       ContextualFlowControl.getAsCellValues(schema).at(0),
     );
@@ -812,7 +814,7 @@ export class ContextualFlowControl {
   static getAsCellFollowScopeCap(
     schema: JSONSchema | undefined,
   ): SchemaScope | undefined {
-    if (!isRecord(schema)) return undefined;
+    if (!isObjectOrArray(schema)) return undefined;
     const entryScope = ContextualFlowControl.getAsCellScope(
       ContextualFlowControl.getAsCellValues(schema).at(0),
     );

--- a/packages/runner/src/cfc/atom-classes.ts
+++ b/packages/runner/src/cfc/atom-classes.ts
@@ -1,5 +1,5 @@
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 
 /**
  * Integrity-atom propagation classes (spec §15 registry, §3.1.6.1):
@@ -58,7 +58,7 @@ const CLASS_BY_TYPE = new Map<string, PropagationClass>([
 ]);
 
 export const atomPropagationClass = (atom: unknown): PropagationClass => {
-  if (isRecord(atom) && typeof atom.type === "string") {
+  if (isObjectOrArray(atom) && typeof atom.type === "string") {
     return CLASS_BY_TYPE.get(atom.type) ?? "value-bound";
   }
   // String atoms and kind-shaped records (authored-by /

--- a/packages/runner/src/cfc/atom-pattern.ts
+++ b/packages/runner/src/cfc/atom-pattern.ts
@@ -64,7 +64,7 @@ type VarPlaceholder = { readonly var: string };
 export const isAtomVarPlaceholder = (
   value: unknown,
 ): value is VarPlaceholder =>
-  isObjectOrArray(value) &&
+  isObjectNotArray(value) &&
   Object.keys(value).length === 1 &&
   typeof (value as { var?: unknown }).var === "string" &&
   (value as { var: string }).var.length > 0;
@@ -401,7 +401,7 @@ type ExpiresAtom = { type: string; timestamp: number };
 // it — silently bypassing the fail-closed intent. Non-canonical Expires
 // records therefore fall through to structural equality only (below).
 const isOrderedExpiresAtom = (value: unknown): value is ExpiresAtom =>
-  isObjectOrArray(value) &&
+  isObjectNotArray(value) &&
   Object.keys(value).length === 2 &&
   (value as { type?: unknown }).type === CFC_ATOM_TYPE.Expires &&
   typeof (value as { timestamp?: unknown }).timestamp === "number" &&

--- a/packages/runner/src/cfc/atom-pattern.ts
+++ b/packages/runner/src/cfc/atom-pattern.ts
@@ -1,7 +1,7 @@
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import type { CfcAtom } from "@commonfabric/api/cfc";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import {
   commitmentAwareEquals,
   containsCfcFieldCommitment,
@@ -64,13 +64,13 @@ type VarPlaceholder = { readonly var: string };
 export const isAtomVarPlaceholder = (
   value: unknown,
 ): value is VarPlaceholder =>
-  isRecord(value) &&
+  isObjectOrArray(value) &&
   Object.keys(value).length === 1 &&
   typeof (value as { var?: unknown }).var === "string" &&
   (value as { var: string }).var.length > 0;
 
 const isMalformedVarBearingRecord = (value: unknown): boolean =>
-  isRecord(value) && Object.hasOwn(value, "var") &&
+  isObjectOrArray(value) && Object.hasOwn(value, "var") &&
   !isAtomVarPlaceholder(value);
 
 /**
@@ -82,7 +82,7 @@ const isMalformedVarBearingRecord = (value: unknown): boolean =>
  */
 const patternIsConcrete = (pattern: unknown): boolean => {
   if (Array.isArray(pattern)) return pattern.every(patternIsConcrete);
-  if (isRecord(pattern)) {
+  if (isObjectOrArray(pattern)) {
     if (Object.hasOwn(pattern, "var")) return false;
     // An explicit-`undefined` field is the absence-requirement form — a
     // shape constraint, not a value — so the pattern is not concrete.
@@ -171,11 +171,11 @@ const matchPatternValue = (
     }
     return current;
   }
-  if (isRecord(pattern)) {
+  if (isObjectOrArray(pattern)) {
     // A record pattern constrains records only. Arrays are records to
-    // `isRecord`, so exclude them explicitly — an array atom never matches a
+    // `isObjectOrArray`, so exclude them explicitly — an array atom never matches a
     // record pattern.
-    if (!isRecord(value) || Array.isArray(value)) {
+    if (!isObjectNotArray(value)) {
       return null;
     }
     let current: AtomPatternBindings | null = bindings;
@@ -316,7 +316,7 @@ const instantiateValue = (
     }
     return { value: items };
   }
-  if (isRecord(pattern)) {
+  if (isObjectOrArray(pattern)) {
     const record: Record<string, unknown> = {};
     for (const [key, fieldPattern] of Object.entries(pattern)) {
       if (fieldPattern === undefined) continue;
@@ -368,13 +368,13 @@ export const instantiateAtomPattern = (
 export const conceptGuard = (
   pattern: unknown,
 ): { uri: string | undefined } | undefined => {
-  // `isRecord` admits arrays (`typeof [] === "object"`), and an array can carry
+  // `isObjectOrArray` admits arrays (`typeof [] === "object"`), and an array can carry
   // own `type`/`uri` properties — exclude it explicitly so only the canonical
   // OBJECT shape `{ type, uri }` can route to trust-closure satisfaction. A
   // Concept-shaped array is not the canonical shape and fails closed to
   // ordinary matching, in keeping with the discipline below.
   if (
-    !isRecord(pattern) || Array.isArray(pattern) ||
+    !isObjectNotArray(pattern) ||
     isAtomVarPlaceholder(pattern) ||
     (pattern as { type?: unknown }).type !== CFC_ATOM_TYPE.Concept
   ) {
@@ -401,7 +401,7 @@ type ExpiresAtom = { type: string; timestamp: number };
 // it — silently bypassing the fail-closed intent. Non-canonical Expires
 // records therefore fall through to structural equality only (below).
 const isOrderedExpiresAtom = (value: unknown): value is ExpiresAtom =>
-  isRecord(value) &&
+  isObjectOrArray(value) &&
   Object.keys(value).length === 2 &&
   (value as { type?: unknown }).type === CFC_ATOM_TYPE.Expires &&
   typeof (value as { timestamp?: unknown }).timestamp === "number" &&

--- a/packages/runner/src/cfc/clause.ts
+++ b/packages/runner/src/cfc/clause.ts
@@ -1,6 +1,6 @@
 import { CFC_ATOM_TYPE, type CfcAtom } from "@commonfabric/api/cfc";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { atomEntails } from "./atom-pattern.ts";
 import { uniqueCfcAtoms } from "./observation.ts";
@@ -28,7 +28,7 @@ export type CfcOrClause = { readonly anyOf: readonly CfcAtom[] };
 export type CfcConfClause = CfcAtom | CfcOrClause;
 
 export const isOrClause = (value: unknown): value is CfcOrClause =>
-  isRecord(value) &&
+  isObjectOrArray(value) &&
   Array.isArray((value as { anyOf?: unknown }).anyOf) &&
   Object.keys(value).length === 1;
 

--- a/packages/runner/src/cfc/exchange-eval.ts
+++ b/packages/runner/src/cfc/exchange-eval.ts
@@ -8,7 +8,7 @@ import {
   matchAtomPattern,
   matchAtomPatternAgainstAtoms,
 } from "./atom-pattern.ts";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import {
   CFC_ATOM_TYPE,
   type CfcAtom,
@@ -264,7 +264,7 @@ const policyRefHomeClauses = (
   if (record.digest.length === 0) return homes;
   for (let index = 0; index < confidentiality.length; index++) {
     for (const alternative of clauseAlternatives(confidentiality[index])) {
-      if (!isRecord(alternative) || Array.isArray(alternative)) continue;
+      if (!isObjectNotArray(alternative)) continue;
       const atom = alternative as {
         type?: unknown;
         name?: unknown;
@@ -309,7 +309,7 @@ const isModulePolicyCandidate = (value: Record<string, unknown>): boolean =>
 const isExactModulePolicyRef = (
   value: unknown,
 ): value is CfcModulePolicyRefAtom => {
-  if (!isRecord(value) || Array.isArray(value)) return false;
+  if (!isObjectNotArray(value)) return false;
   if (
     value.type !== CFC_ATOM_TYPE.Policy || value.policyRefKind !== "module" ||
     typeof value.moduleIdentity !== "string" ||
@@ -336,7 +336,7 @@ const collectSelectedModulePolicyRefs = (
   const failures: ModulePolicyResolutionFailure[] = [];
   for (const clause of confidentiality) {
     for (const alternative of clauseAlternatives(clause)) {
-      if (!isRecord(alternative) || Array.isArray(alternative)) continue;
+      if (!isObjectNotArray(alternative)) continue;
       if (
         alternative.type !== CFC_ATOM_TYPE.Policy &&
         alternative.type !== CFC_ATOM_TYPE.Context
@@ -387,11 +387,11 @@ const modulePolicyRefHomeClauses = (
 };
 
 const isThisPolicyPattern = (value: unknown): boolean =>
-  isRecord(value) && Object.keys(value).length === 1 &&
+  isObjectOrArray(value) && Object.keys(value).length === 1 &&
   value.thisPolicy === true;
 
 const isThisPolicySubjectPattern = (value: unknown): boolean =>
-  isRecord(value) && Object.keys(value).length === 1 &&
+  isObjectOrArray(value) && Object.keys(value).length === 1 &&
   value.thisPolicyField === "subject";
 
 const bindThisPolicy = (
@@ -403,7 +403,7 @@ const bindThisPolicy = (
   if (Array.isArray(value)) {
     return value.map((entry) => bindThisPolicy(entry, reference));
   }
-  if (!isRecord(value)) return value;
+  if (!isObjectOrArray(value)) return value;
   return Object.fromEntries(
     Object.entries(value).map(([key, field]) => [
       key,
@@ -492,7 +492,7 @@ const grantGuardQuery = (
   consumption: CfcGrantConsumptionContext,
 ): CfcGrantResolverQuery | undefined => {
   if (
-    !isRecord(pattern) || Array.isArray(pattern) ||
+    !isObjectNotArray(pattern) ||
     isAtomVarPlaceholder(pattern)
   ) {
     return undefined;

--- a/packages/runner/src/cfc/grants.ts
+++ b/packages/runner/src/cfc/grants.ts
@@ -1,6 +1,6 @@
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import type { CfcAtom } from "@commonfabric/api/cfc";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import type { URI } from "@commonfabric/memory/interface";
 import { getCommitPreconditionsConfig } from "@commonfabric/memory/v2";
 import type {
@@ -338,7 +338,7 @@ const isDid = (value: unknown): value is string =>
 // pattern matching when the entry later lands in a clause — refuse at write.
 const containsVarKey = (value: unknown): boolean => {
   if (Array.isArray(value)) return value.some(containsVarKey);
-  if (!isRecord(value)) return false;
+  if (!isObjectOrArray(value)) return false;
   if (Object.hasOwn(value, "var")) return true;
   return Object.values(value).some(containsVarKey);
 };
@@ -353,7 +353,7 @@ const containsVarKey = (value: unknown): boolean => {
 export const disallowedGrantAudienceEntryReason = (
   entry: unknown,
 ): string | undefined => {
-  if (!isRecord(entry) || Array.isArray(entry)) {
+  if (!isObjectNotArray(entry)) {
     return "audience entries must be principal-like atom records";
   }
   if (isOrClause(entry)) {
@@ -391,7 +391,7 @@ export const prepareCfcGrantWrite = (
   actingPrincipal: string | undefined,
   now: number = Date.now(),
 ): { space: MemorySpace; id: URI; value: CfcGrant } => {
-  if (!isRecord(input) || Array.isArray(input)) {
+  if (!isObjectNotArray(input)) {
     throw new Error("cfc-grant: write input must be an object");
   }
   const { kind, owner, resource, audience } = input;
@@ -453,7 +453,7 @@ export const prepareCfcGrantWrite = (
   if (input.revoked !== undefined) {
     const revoked = input.revoked;
     if (
-      !isRecord(revoked) || typeof revoked.at !== "number" ||
+      !isObjectOrArray(revoked) || typeof revoked.at !== "number" ||
       !Number.isFinite(revoked.at) || !isDid(revoked.by)
     ) {
       throw new Error("cfc-grant: revoked must be { at: number, by: DID }");
@@ -508,7 +508,7 @@ export const verifyCfcGrantDocument = (
   id: string,
   value: unknown,
 ): CfcGrant | undefined => {
-  if (!isRecord(value) || Array.isArray(value)) return undefined;
+  if (!isObjectNotArray(value)) return undefined;
   const candidate = value as Partial<CfcGrant> & Record<string, unknown>;
   if (candidate.version !== CFC_GRANT_VERSION) return undefined;
   if (
@@ -542,7 +542,7 @@ export const verifyCfcGrantDocument = (
   if (candidate.revoked !== undefined) {
     const revoked = candidate.revoked;
     if (
-      !isRecord(revoked) || typeof revoked.at !== "number" ||
+      !isObjectOrArray(revoked) || typeof revoked.at !== "number" ||
       !isDid((revoked as { by?: unknown }).by)
     ) {
       return undefined;

--- a/packages/runner/src/cfc/label-field-classification.ts
+++ b/packages/runner/src/cfc/label-field-classification.ts
@@ -1,5 +1,5 @@
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 
 /**
  * Cross-space label-metadata representation classes (inv-12 / SC-14 / SC-25;
@@ -198,7 +198,7 @@ export const classifyAtomField = (
   atom: unknown,
   field: readonly string[],
 ): LabelFieldRepresentationClass | undefined => {
-  if (!isRecord(atom)) {
+  if (!isObjectOrArray(atom)) {
     return undefined;
   }
   if (typeof atom.type === "string") {

--- a/packages/runner/src/cfc/label-introspection.ts
+++ b/packages/runner/src/cfc/label-introspection.ts
@@ -1,6 +1,6 @@
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import type { CfcConfClause } from "./clause.ts";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { encodePointer, parsePointer } from "../../../memory/v2/path.ts";
 import type { NormalizedFullLink } from "../link-utils.ts";
 import { normalizeCellScope } from "../scope.ts";
@@ -291,7 +291,7 @@ const atomProjectionLabel = (
         walk(element, contextAtom, [...valuePath, String(index)])
       );
     }
-    if (!isRecord(value)) {
+    if (!isObjectOrArray(value)) {
       return true;
     }
     if (isCfcFieldCommitment(value)) {
@@ -487,7 +487,7 @@ export const evaluateConfLabelQuery = (
         ];
         let matched = true;
         for (const { field, familyTypes, expected } of predicates) {
-          if (!isRecord(atom)) {
+          if (!isObjectOrArray(atom)) {
             // A bare string atom is a type-only atom: its entire content is
             // its (public) type tag, so `atomType` equality applies to the
             // atom itself; every other field is absent (no match, shape-only

--- a/packages/runner/src/cfc/label-metadata-population.ts
+++ b/packages/runner/src/cfc/label-metadata-population.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import type { CfcConfClause } from "./clause.ts";
 import { canonicalizeLogicalPath } from "./canonical.ts";
 import { clauseAlternatives } from "./clause.ts";
@@ -139,7 +139,7 @@ const scanAlternative = (
     if (Array.isArray(value)) {
       return value.some((element) => scanNested(element, contextAtom));
     }
-    if (!isRecord(value)) {
+    if (!isObjectOrArray(value)) {
       return false;
     }
     if (isCfcFieldCommitment(value)) {
@@ -169,7 +169,7 @@ const scanAlternative = (
   if (Array.isArray(alternative)) {
     return alternative.some((element) => scanNested(element, undefined));
   }
-  if (!isRecord(alternative)) {
+  if (!isObjectOrArray(alternative)) {
     // Bare string atoms are type-only tags: their entire content is the
     // public type observation.
     return false;

--- a/packages/runner/src/cfc/label-representation.ts
+++ b/packages/runner/src/cfc/label-representation.ts
@@ -1,7 +1,7 @@
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import type { CfcConfClause } from "./clause.ts";
 import type { CfcAtom } from "@commonfabric/api/cfc";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import {
   CLASSIFIED_KIND_FAMILIES,
@@ -41,7 +41,7 @@ export type CfcFieldCommitment = { readonly digestOf: string };
 export const isCfcFieldCommitment = (
   value: unknown,
 ): value is CfcFieldCommitment =>
-  isRecord(value) && !Array.isArray(value) &&
+  isObjectNotArray(value) &&
   Object.keys(value).length === 1 &&
   typeof (value as { digestOf?: unknown }).digestOf === "string";
 
@@ -76,7 +76,10 @@ export const commitmentAwareEquals = (a: unknown, b: unknown): boolean => {
     return a.length === b.length &&
       a.every((element, index) => commitmentAwareEquals(element, b[index]));
   }
-  if (isRecord(a) && isRecord(b) && !Array.isArray(a) && !Array.isArray(b)) {
+  if (
+    isObjectOrArray(a) && isObjectOrArray(b) && !Array.isArray(a) &&
+    !Array.isArray(b)
+  ) {
     const aKeys = Object.keys(a);
     if (aKeys.length !== Object.keys(b).length) return false;
     return aKeys.every((key) =>
@@ -98,7 +101,7 @@ export const commitmentAwareEquals = (a: unknown, b: unknown): boolean => {
 export const containsCfcFieldCommitment = (value: unknown): boolean => {
   if (isCfcFieldCommitment(value)) return true;
   if (Array.isArray(value)) return value.some(containsCfcFieldCommitment);
-  if (isRecord(value)) {
+  if (isObjectOrArray(value)) {
     return Object.values(value).some(containsCfcFieldCommitment);
   }
   return false;
@@ -137,7 +140,7 @@ const transformValue = (
     });
     return changed ? out : value;
   }
-  if (!isRecord(value)) {
+  if (!isObjectOrArray(value)) {
     return value;
   }
   // A record is an ATOM (classification-context reset) when it carries a

--- a/packages/runner/src/cfc/label-view.ts
+++ b/packages/runner/src/cfc/label-view.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import {
   isPrimitiveCellLink,
@@ -124,7 +124,7 @@ export const cfcLabelViewForCellWithStatus = (
   cell: unknown,
 ): CfcLabelViewStatus => {
   if (
-    !isRecord(cell) ||
+    !isObjectOrArray(cell) ||
     typeof cell.getAsNormalizedFullLink !== "function"
   ) {
     return { view: getCarriedCfcLabelView(cell), readFailed: false };

--- a/packages/runner/src/cfc/link-label-view.ts
+++ b/packages/runner/src/cfc/link-label-view.ts
@@ -20,7 +20,7 @@ import {
   FabricInstance,
   FabricPrimitive,
 } from "@commonfabric/data-model/fabric-value";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { refuseFabricInstance } from "../fabric-special-object.ts";
 import type { CellLinkRefPayload, SigilLink } from "../sigil-types.ts";
 import type { CfcLabelView } from "./label-view-core.ts";
@@ -133,7 +133,7 @@ function transformSigilCfcLabelViews(
     });
     return changed ? out : value;
   }
-  // A `FabricPrimitive` is `isRecord` and leaves ahead of the record branch. It
+  // A `FabricPrimitive` is `isObjectOrArray` and leaves ahead of the record branch. It
   // holds no sigil link, so returning it whole is the answer.
   if (value instanceof FabricPrimitive) return value;
 
@@ -154,7 +154,7 @@ function transformSigilCfcLabelViews(
     refuseFabricInstance(value, "when transforming sigil CFC label views");
   }
 
-  if (isRecord(value)) {
+  if (isObjectOrArray(value)) {
     let changed = false;
     const out: Record<string, unknown> = {};
     for (const [key, item] of Object.entries(value)) {

--- a/packages/runner/src/cfc/metadata.ts
+++ b/packages/runner/src/cfc/metadata.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import type { URI } from "@commonfabric/memory/interface";
 import type { NormalizedFullLink } from "../link-utils.ts";
 import type {
@@ -22,7 +22,8 @@ const isPrefix = (
   left.every((segment, index) => segment === right[index]);
 
 const isCfcMetadata = (value: unknown): value is CfcMetadata =>
-  isRecord(value) && value.version === 1 && isRecord(value.labelMap) &&
+  isObjectOrArray(value) && value.version === 1 &&
+  isObjectOrArray(value.labelMap) &&
   Array.isArray(value.labelMap.entries);
 
 export const readStoredCfcMetadata = (
@@ -45,7 +46,7 @@ export const readStoredCfcMetadata = (
   if (isCfcMetadata(document)) {
     return document;
   }
-  return isRecord(document) && isCfcMetadata(document.cfc)
+  return isObjectOrArray(document) && isCfcMetadata(document.cfc)
     ? document.cfc
     : undefined;
 };

--- a/packages/runner/src/cfc/observation.ts
+++ b/packages/runner/src/cfc/observation.ts
@@ -2,7 +2,7 @@ import type { JSONSchema, JSONValue } from "@commonfabric/api";
 import type { CfcAtom } from "@commonfabric/api/cfc";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import {
   cfcLabelPathPrefixMatches,
@@ -116,8 +116,8 @@ export const cfcConfidentialityForObservationNode = (
   const observes = options.observes ?? "value";
 
   if (
-    observes === "value" && isRecord(options.schema) &&
-    isRecord(options.schema.ifc)
+    observes === "value" && isObjectOrArray(options.schema) &&
+    isObjectOrArray(options.schema.ifc)
   ) {
     joined.push(...(options.schema.ifc.confidentiality ?? []));
   }
@@ -218,10 +218,10 @@ const integrityAtomSatisfies = (
     // Concept-typed `actual` locally, BEFORE the resolver, so a misconfigured
     // trust statement whose `concrete` is itself Concept-shaped cannot let a
     // smuggled `Concept` atom pool-match its way through — fail closed here
-    // rather than lean on the upstream mint gate. `isRecord` admits arrays, so
+    // rather than lean on the upstream mint gate. `isObjectOrArray` admits arrays, so
     // this catches a Concept-typed array shape too.
     return concept.uri !== undefined &&
-      !(isRecord(actual) &&
+      !(isObjectOrArray(actual) &&
         (actual as { type?: unknown }).type === CFC_ATOM_TYPE.Concept) &&
       trust?.trustResolver !== undefined &&
       trust.trustResolver.conceptSatisfied(
@@ -279,7 +279,8 @@ export const cfcIntegrityWitnessKey = (
 ): string | null => {
   if (!integrityAtomSatisfies(required, actual, trust)) return null;
   if (
-    isRecord(actual) && isRecord((actual as { scope?: unknown }).scope) &&
+    isObjectOrArray(actual) &&
+    isObjectOrArray((actual as { scope?: unknown }).scope) &&
     (actual as { scope: { valueRef?: unknown } }).scope.valueRef !== undefined
   ) {
     const scope = { ...(actual as { scope: Record<string, unknown> }).scope };

--- a/packages/runner/src/cfc/policy.ts
+++ b/packages/runner/src/cfc/policy.ts
@@ -1,6 +1,6 @@
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import { type AtomPattern, isAtomVarPlaceholder } from "./atom-pattern.ts";
 
 export const CFC_POLICY_MANIFEST_ID_PREFIX = "of:cfc-policy-manifest:";
@@ -245,13 +245,13 @@ const rejectUnknownKeys = (
 };
 
 // A PLAIN object (prototype `Object.prototype` or null) — the shape authored
-// TS literals and parsed JSON produce. `isRecord` alone admits `Map`, `Set`,
+// TS literals and parsed JSON produce. `isObjectOrArray` alone admits `Map`, `Set`,
 // and class instances, whose own-enumerable string keys are usually empty, so
 // the field-by-field validation below would read NO guards and wave through
 // an unguarded rule (cubic P1 on #4562). Config that is not a plain object
 // fails closed here.
 const isPlainRecord = (value: unknown): value is Record<string, unknown> => {
-  if (!isRecord(value) || Array.isArray(value)) return false;
+  if (!isObjectNotArray(value)) return false;
   const proto = Object.getPrototypeOf(value);
   return proto === Object.prototype || proto === null;
 };
@@ -295,7 +295,7 @@ const validateTemplatePattern = (
     );
     return;
   }
-  if (!isRecord(value)) return;
+  if (!isObjectOrArray(value)) return;
   if (Object.hasOwn(value, "var")) {
     if (!isAtomVarPlaceholder(value)) {
       throw new Error(`cfcPolicyManifest: malformed variable in ${where}`);
@@ -333,7 +333,7 @@ const collectPatternVariables = (
     value.forEach((entry) => collectPatternVariables(entry, variables));
     return;
   }
-  if (isRecord(value)) {
+  if (isObjectOrArray(value)) {
     Object.values(value).forEach((field) =>
       collectPatternVariables(field, variables)
     );

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -25,7 +25,7 @@ import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { normalizeIdentitySource } from "./writer-claim-correspondence.ts";
 import type { FabricValue } from "@commonfabric/api";
 import type { MemorySpace, URI } from "@commonfabric/memory/interface";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import type { JSONSchema } from "../builder/types.ts";
 import { forEachSubschema } from "../schema-walk.ts";
 import { arrayMatchesPositionally } from "../schema-match.ts";
@@ -351,7 +351,7 @@ const CURRENT_PRINCIPAL_CLAIM_KINDS = new Set([
 ]);
 
 const isCurrentPrincipalPlaceholder = (value: unknown): boolean =>
-  isRecord(value) && value[CURRENT_PRINCIPAL_PLACEHOLDER_KEY] === true;
+  isObjectOrArray(value) && value[CURRENT_PRINCIPAL_PLACEHOLDER_KEY] === true;
 
 const hasCurrentPrincipalPlaceholder = (value: unknown): boolean => {
   if (isCurrentPrincipalPlaceholder(value)) {
@@ -360,7 +360,7 @@ const hasCurrentPrincipalPlaceholder = (value: unknown): boolean => {
   if (Array.isArray(value)) {
     return value.some(hasCurrentPrincipalPlaceholder);
   }
-  if (isRecord(value)) {
+  if (isObjectOrArray(value)) {
     return Object.values(value).some(hasCurrentPrincipalPlaceholder);
   }
   return false;
@@ -378,7 +378,7 @@ const resolveCurrentPrincipalPlaceholders = (
       resolveCurrentPrincipalPlaceholders(entry, actingPrincipal)
     );
   }
-  if (!isRecord(value)) {
+  if (!isObjectOrArray(value)) {
     return value;
   }
 
@@ -417,7 +417,7 @@ const isCurrentPrincipalClaimAtom = (value: unknown): value is {
   readonly kind: string;
   readonly subject?: unknown;
 } =>
-  isRecord(value) &&
+  isObjectOrArray(value) &&
   typeof value.kind === "string" &&
   CURRENT_PRINCIPAL_CLAIM_KINDS.has(value.kind);
 
@@ -429,7 +429,7 @@ const hasLiteralDidCurrentPrincipalClaim = (value: unknown): boolean => {
     return typeof value.subject === "string" &&
       value.subject.startsWith("did:");
   }
-  if (isRecord(value)) {
+  if (isObjectOrArray(value)) {
     return Object.values(value).some(hasLiteralDidCurrentPrincipalClaim);
   }
   return false;
@@ -452,7 +452,7 @@ const literalDidSubjectsForPrincipalClaim = (
     }
     return subjects;
   }
-  if (isRecord(value)) {
+  if (isObjectOrArray(value)) {
     for (const entry of Object.values(value)) {
       literalDidSubjectsForPrincipalClaim(entry, kind, subjects);
     }
@@ -489,7 +489,7 @@ const metadataAppliesToAnyPath = (
 ): boolean => paths.some((path) => metadataAppliesToPath(metadata, path));
 
 const hasPersistedPolicyClaim = (schema: JSONSchema): boolean => {
-  if (!isRecord(schema) || !isRecord(schema.ifc)) {
+  if (!isObjectOrArray(schema) || !isObjectOrArray(schema.ifc)) {
     return false;
   }
   return schema.ifc.writeAuthorizedBy !== undefined ||
@@ -525,7 +525,7 @@ const writeAuthorizedByReason = (
   targetSpace: MemorySpace,
   targetIdentity?: ImplementationIdentity,
 ): string | undefined => {
-  if (!isRecord(schema) || !isRecord(schema.ifc)) {
+  if (!isObjectOrArray(schema) || !isObjectOrArray(schema.ifc)) {
     return undefined;
   }
   const claim = schema.ifc.writeAuthorizedBy;
@@ -603,7 +603,7 @@ const parseWriteAuthorizedByBindingIdentity = (
   file: string;
   path: string[];
 } | undefined => {
-  if (!isRecord(claim) || !isRecord(claim.__ctWriterIdentityOf)) {
+  if (!isObjectOrArray(claim) || !isObjectOrArray(claim.__ctWriterIdentityOf)) {
     return undefined;
   }
   const identity = claim.__ctWriterIdentityOf;
@@ -811,7 +811,7 @@ const storedMetadataFor = (
   }, {
     meta: INTERNAL_VERIFIER_META,
   });
-  return isRecord(document) && isRecord(document.cfc)
+  return isObjectOrArray(document) && isObjectOrArray(document.cfc)
     ? document.cfc as CfcMetadata
     : undefined;
 };
@@ -1042,7 +1042,7 @@ const stripWriterIdentityStamp = (value: unknown): unknown => {
   if (Array.isArray(value)) {
     return value.map(stripWriterIdentityStamp);
   }
-  if (!isRecord(value)) {
+  if (!isObjectOrArray(value)) {
     return value;
   }
 
@@ -1087,15 +1087,15 @@ export const storedSchemaCoversCandidateEnvelope = (
   if (schemasEqualIgnoringWriterStamp(stored, candidate)) {
     return true;
   }
-  if (!isRecord(stored) || !isRecord(candidate)) {
+  if (!isObjectOrArray(stored) || !isObjectOrArray(candidate)) {
     return false;
   }
   if (candidate.ifc !== undefined) {
     return false;
   }
 
-  if (isRecord(candidate.properties)) {
-    if (!isRecord(stored.properties)) {
+  if (isObjectOrArray(candidate.properties)) {
+    if (!isObjectOrArray(stored.properties)) {
       return false;
     }
     const storedProperties = stored.properties;
@@ -1233,7 +1233,7 @@ const rebindWriteAuthorizedByClaimsInner = (
     });
     return changed ? next : value;
   }
-  if (!isRecord(value)) {
+  if (!isObjectOrArray(value)) {
     return value;
   }
 
@@ -1245,7 +1245,9 @@ const rebindWriteAuthorizedByClaimsInner = (
     next[key] = rebound;
   }
 
-  if (isRecord(value.ifc) && isRecord(value.ifc.writeAuthorizedBy)) {
+  if (
+    isObjectOrArray(value.ifc) && isObjectOrArray(value.ifc.writeAuthorizedBy)
+  ) {
     const claim = value.ifc.writeAuthorizedBy;
     // Stamp an unstamped claim with the content-addressed moduleIdentity —
     // the only verification arm (the legacy bundleId arm retired with the
@@ -1253,11 +1255,11 @@ const rebindWriteAuthorizedByClaimsInner = (
     // stamp is NOT unstamped: it is recognized as stamped — and unservable —
     // so it fails closed at verification instead of being silently re-bound
     // to whichever verified writer touches it next.
-    const bindingFile = isRecord(claim.__ctWriterIdentityOf) &&
+    const bindingFile = isObjectOrArray(claim.__ctWriterIdentityOf) &&
         typeof claim.__ctWriterIdentityOf.file === "string"
       ? normalizeIdentitySource(claim.__ctWriterIdentityOf.file)
       : undefined;
-    const bindingPath = isRecord(claim.__ctWriterIdentityOf) &&
+    const bindingPath = isObjectOrArray(claim.__ctWriterIdentityOf) &&
         Array.isArray(claim.__ctWriterIdentityOf.path)
       ? claim.__ctWriterIdentityOf.path as readonly string[]
       : undefined;
@@ -1281,7 +1283,7 @@ const rebindWriteAuthorizedByClaimsInner = (
       ids.writerFile === bindingFile &&
       arraysEqual(ids.writerPath, bindingPath);
     if (
-      isRecord(claim.__ctWriterIdentityOf) &&
+      isObjectOrArray(claim.__ctWriterIdentityOf) &&
       claim.__ctWriterIdentityOf.bundleId === undefined &&
       claim.__ctWriterIdentityOf.moduleIdentity === undefined &&
       writerOwnsBinding
@@ -1408,7 +1410,7 @@ const valueWriteTargets = (
       // envelope's other members (`source`, `cfc`) are the runtime surfaces
       // the raw-path exclusions above keep out of flow labeling.
       const writtenValue = rawPath.length === 0
-        ? (isRecord(write.value)
+        ? (isObjectOrArray(write.value)
           ? (write.value as { value?: unknown }).value
           : undefined)
         : write.value;
@@ -1418,7 +1420,7 @@ const valueWriteTargets = (
       // `value` member (the detail's presence flag describes the envelope,
       // not the member — definedness stands in at that one level).
       const previousWrittenValue = rawPath.length === 0
-        ? (isRecord(write.previousValue)
+        ? (isObjectOrArray(write.previousValue)
           ? (write.previousValue as { value?: unknown }).value
           : undefined)
         : write.previousValue;
@@ -1495,7 +1497,7 @@ export const flowReadExcluded = (
 // non-link leaf (string, number, boolean, null) makes the value content.
 // Such writes get `structure` (shape-only) stamps instead of covering
 // `derived` ones — see `pureLinkContainerPaths`.
-// TODO(danfuzz): `isRecord` admits a `FabricSpecialObject`, whose
+// TODO(danfuzz): `isObjectOrArray` admits a `FabricSpecialObject`, whose
 // `Object.values` are empty and vacuously "all links" — so a `FabricBytes`
 // leaf, or a `FabricInstance` with real contents, classifies as pure link
 // structure and the write receives shape-only stamps in place of its content
@@ -1507,7 +1509,7 @@ const isPureLinkStructure = (value: unknown): boolean => {
   if (Array.isArray(value)) {
     return value.every((member) => isPureLinkStructure(member));
   }
-  if (isRecord(value)) {
+  if (isObjectOrArray(value)) {
     return Object.values(value).every((member) => isPureLinkStructure(member));
   }
   return false;
@@ -1539,11 +1541,11 @@ const pureLinkContainerPaths = (
     );
     return;
   }
-  // TODO(danfuzz): same `isRecord` gap as `isPureLinkStructure` above: a
+  // TODO(danfuzz): same `isObjectOrArray` gap as `isPureLinkStructure` above: a
   // `FabricPrimitive` is pushed as if it were a container (a stamp path for
   // an opaque leaf), and a `FabricInstance`'s codec contents are never
   // enumerated, so nothing nested in one gets a per-slot stamp.
-  if (isRecord(value)) {
+  if (isObjectOrArray(value)) {
     out.push(path);
     for (const [key, member] of Object.entries(value)) {
       pureLinkContainerPaths(member, [...path, key], out);
@@ -2002,8 +2004,8 @@ export const flowLabelWorkExists = (
       // value embeds a `cfc` record (the raw-seed idiom).
       if (
         write.address.path[0] === "cfc" ||
-        (write.address.path.length === 0 && isRecord(write.value) &&
-          isRecord((write.value as { cfc?: unknown }).cfc))
+        (write.address.path.length === 0 && isObjectOrArray(write.value) &&
+          isObjectOrArray((write.value as { cfc?: unknown }).cfc))
       ) {
         selfMintedDocs.add(targetKey({
           space: write.address.space,
@@ -2121,7 +2123,7 @@ const walkIfcSchema = (
     return entries;
   }
   const schemaRoot = cfcSchemaChildRoot(schema, root);
-  const rootKey = isRecord(schemaRoot) ? schemaRoot : schema;
+  const rootKey = isObjectOrArray(schemaRoot) ? schemaRoot : schema;
   for (let cursor = active; cursor !== undefined; cursor = cursor.parent) {
     if (cursor.root === rootKey && cursor.schema === schema) return entries;
   }
@@ -2246,7 +2248,7 @@ const walkIfcSchema = (
 };
 
 const policyOnlySchema = (schema: JSONSchema): JSONSchema => {
-  if (!isRecord(schema) || !isRecord(schema.ifc)) {
+  if (!isObjectOrArray(schema) || !isObjectOrArray(schema.ifc)) {
     return {};
   }
   return { ifc: { ...schema.ifc } } as JSONSchema;
@@ -2257,7 +2259,10 @@ const linkWritePolicyOnlySchema = (
   path: readonly string[],
 ): JSONSchema => {
   const policy = policyOnlySchema(schema);
-  if (!isRecord(policy) || !isRecord(policy.ifc) || !path.includes("*")) {
+  if (
+    !isObjectOrArray(policy) || !isObjectOrArray(policy.ifc) ||
+    !path.includes("*")
+  ) {
     return policy;
   }
   const { integrity: _integrity, ...ifc } = policy.ifc;
@@ -2279,7 +2284,9 @@ const storedSchemaClaimsForLinkWrites = (
       continue;
     }
     const policySchema = linkWritePolicyOnlySchema(entry.schema, entry.path);
-    if (isRecord(policySchema) && Object.keys(policySchema).length === 0) {
+    if (
+      isObjectOrArray(policySchema) && Object.keys(policySchema).length === 0
+    ) {
       continue;
     }
     const envelope = schemaEnvelopeForTargetPath(
@@ -2300,7 +2307,7 @@ const storedSchemaClaimsForLinkWrites = (
 const declaredObservesClass = (
   schema: JSONSchema,
 ): LabelObservationClass | undefined => {
-  const observes = isRecord(schema) && isRecord(schema.ifc)
+  const observes = isObjectOrArray(schema) && isObjectOrArray(schema.ifc)
     ? (schema.ifc as { observes?: unknown }).observes
     : undefined;
   return observes === "value" || observes === "shape" ||
@@ -2313,7 +2320,7 @@ const unsupportedTrustSensitiveReason = (
   schema: JSONSchema,
   path: readonly string[],
 ): string | undefined => {
-  if (!isRecord(schema) || !isRecord(schema.ifc)) {
+  if (!isObjectOrArray(schema) || !isObjectOrArray(schema.ifc)) {
     return undefined;
   }
   // Claims the runner does not implement. A write to a path declaring one must
@@ -2346,7 +2353,7 @@ const disallowedAuthoredClauseReason = (
   schema: JSONSchema,
   path: readonly string[],
 ): string | undefined => {
-  if (!isRecord(schema) || !isRecord(schema.ifc)) {
+  if (!isObjectOrArray(schema) || !isObjectOrArray(schema.ifc)) {
     return undefined;
   }
   const confidentiality = (schema.ifc as Record<string, unknown>)
@@ -2360,7 +2367,7 @@ const disallowedAuthoredClauseReason = (
     }
     for (const alternative of clauseAlternatives(clause)) {
       if (
-        isRecord(alternative) && typeof alternative.type === "string" &&
+        isObjectOrArray(alternative) && typeof alternative.type === "string" &&
         FORBIDDEN_OR_CLAUSE_ALTERNATIVE_TYPES.has(alternative.type)
       ) {
         return `authored OR-clause alternative of type ${alternative.type} ` +
@@ -2375,7 +2382,7 @@ const disallowedAuthoredClauseReason = (
 const exactCopySourcePath = (
   schema: JSONSchema,
 ): readonly string[] | undefined => {
-  if (!isRecord(schema) || !isRecord(schema.ifc)) {
+  if (!isObjectOrArray(schema) || !isObjectOrArray(schema.ifc)) {
     return undefined;
   }
   return claimPathToLogicalPath(schema.ifc.exactCopyOf);
@@ -2418,14 +2425,14 @@ const parseCanonicalPointer = (
 const projectionClaimSpec = (
   schema: JSONSchema,
 ): ProjectionClaim | "malformed" | undefined => {
-  const ifc = isRecord(schema) && isRecord(schema.ifc)
+  const ifc = isObjectOrArray(schema) && isObjectOrArray(schema.ifc)
     ? schema.ifc as { projection?: unknown }
     : undefined;
   const claim = ifc?.projection;
   if (claim === undefined) {
     return undefined;
   }
-  if (!isRecord(claim)) {
+  if (!isObjectOrArray(claim)) {
     return "malformed";
   }
   const source = parseCanonicalPointer(claim.from);
@@ -2493,11 +2500,13 @@ const projectedSourceLabel = (
         integrity.push(atom);
         continue;
       }
-      if (!isRecord(atom) || atomPropagationClass(atom) === "provenance") {
+      if (
+        !isObjectOrArray(atom) || atomPropagationClass(atom) === "provenance"
+      ) {
         continue;
       }
       const scope = (atom as { scope?: unknown }).scope;
-      if (scope !== undefined && !isRecord(scope)) {
+      if (scope !== undefined && !isObjectOrArray(scope)) {
         continue;
       }
       integrity.push({
@@ -2517,7 +2526,7 @@ const currentPrincipalIntegrityReason = (
   schema: JSONSchema,
   path: readonly string[],
 ): string | undefined => {
-  if (!isRecord(schema) || !isRecord(schema.ifc)) {
+  if (!isObjectOrArray(schema) || !isObjectOrArray(schema.ifc)) {
     return undefined;
   }
 
@@ -2757,7 +2766,7 @@ const writeInstallsInitialSchemaDefault = (
   path: readonly string[],
   schema: JSONSchema | undefined,
 ): boolean => {
-  if (!isRecord(schema) || !("default" in schema)) {
+  if (!isObjectOrArray(schema) || !("default" in schema)) {
     return false;
   }
   const pathTarget = { ...target, path };
@@ -2906,7 +2915,7 @@ const schemaTypeMatchesValue = (
       case "number":
         return typeof value === "number";
       case "object":
-        return isRecord(value) && !Array.isArray(value);
+        return isObjectNotArray(value);
       case "string":
         return typeof value === "string";
       default:
@@ -2965,7 +2974,7 @@ const policySchemaMatchesValue = (
   // TODO(danfuzz): these `deepEqual` checks call two same-class fabric
   // values equal regardless of contents, so a fabric-valued `const`/`enum`
   // condition matches the wrong value; and the `properties` arm below admits
-  // a `FabricSpecialObject` through `isRecord` and reads `undefined` for
+  // a `FabricSpecialObject` through `isObjectOrArray` and reads `undefined` for
   // every key, matching vacuously. Each fails open — the ifc entry applies
   // (or the policy passes) with nothing actually checked. `valueEqual` and a
   // `FabricSpecialObject` gate are the fabric-aware shapes;
@@ -2999,7 +3008,7 @@ const policySchemaMatchesValue = (
       policySchemaMatchesValue(branch, value, schemaRoot)
     );
   }
-  if (isRecord(value) && isRecord(schema.properties)) {
+  if (isObjectOrArray(value) && isObjectOrArray(schema.properties)) {
     return Object.entries(schema.properties).every(([key, childSchema]) =>
       value[key] === undefined ||
       policySchemaMatchesValue(childSchema, value[key], schemaRoot)
@@ -3443,7 +3452,7 @@ const STRUCTURAL_LINK_PROVENANCE_ATOM_TYPES = new Set<string>([
 ]);
 
 const isNonEndorsementProvenanceAtom = (atom: unknown): boolean =>
-  (isRecord(atom) && typeof atom.type === "string" &&
+  (isObjectOrArray(atom) && typeof atom.type === "string" &&
     STRUCTURAL_LINK_PROVENANCE_ATOM_TYPES.has(atom.type)) ||
   // The current-principal claim family (authored-by / represents-principal) is
   // an identity provenance claim gated separately by
@@ -3628,7 +3637,7 @@ const verifyInputRequirements = (
     ) {
       continue;
     }
-    const ifc = isRecord(entry.schema) ? entry.schema.ifc : undefined;
+    const ifc = isObjectOrArray(entry.schema) ? entry.schema.ifc : undefined;
     const unsupportedTrustSensitive = unsupportedTrustSensitiveReason(
       entry.schema,
       entry.path,
@@ -4025,7 +4034,7 @@ const derivePersistedLabel = (
   sourceEntryLabels?: Map<string, IFCLabel>,
   owningSpace?: MemorySpace,
 ): IFCLabel => {
-  const ifc = isRecord(schema) ? schema.ifc : undefined;
+  const ifc = isObjectOrArray(schema) ? schema.ifc : undefined;
   const actingPrincipal = tx.getCfcState().trustSnapshot?.actingPrincipal;
   const copiedInputLabel = sourceEntryLabels && exactCopySourcePath(schema)
     ? sourceEntryLabels.get(pathKey(exactCopySourcePath(schema)!))
@@ -4095,13 +4104,13 @@ const resolvePolicyOfValue = (
   if (Array.isArray(value)) {
     return value.map((entry) => resolvePolicyOfValue(tx, entry, owningSpace));
   }
-  if (!isRecord(value)) return value;
+  if (!isObjectOrArray(value)) return value;
   if (
     value.type === CFC_ATOM_TYPE.Policy &&
     value.policyRefKind === "module"
   ) {
     if (
-      !isRecord(value.subject) ||
+      !isObjectOrArray(value.subject) ||
       value.subject[OWNING_SPACE_PLACEHOLDER] !== true
     ) {
       throw new Error(
@@ -4112,7 +4121,7 @@ const resolvePolicyOfValue = (
   if (
     value.type === CFC_ATOM_TYPE.Policy &&
     value.policyRefKind === "module" &&
-    isRecord(value.subject) &&
+    isObjectOrArray(value.subject) &&
     value.subject[OWNING_SPACE_PLACEHOLDER] === true
   ) {
     if (
@@ -4156,7 +4165,7 @@ const modulePolicyReferencesIn = (value: unknown): unknown[] => {
       candidate.forEach(visit);
       return;
     }
-    if (!isRecord(candidate)) return;
+    if (!isObjectOrArray(candidate)) return;
     if (
       candidate.type === CFC_ATOM_TYPE.Policy &&
       candidate.policyRefKind === "module" &&
@@ -4266,7 +4275,7 @@ const RUNTIME_MINTED_INTEGRITY_ATOM_TYPES = new Set<string>([
 ]);
 
 const isRuntimeMintedIntegrityAtom = (atom: unknown): boolean =>
-  (isRecord(atom) && typeof atom.type === "string" &&
+  (isObjectOrArray(atom) && typeof atom.type === "string" &&
     RUNTIME_MINTED_INTEGRITY_ATOM_TYPES.has(atom.type)) ||
   // Compile-cache attestation (string-shaped, see CFC_COMPILED_BY_ATOM):
   // marks a stored doc as system-compiler output, which the cache loader
@@ -4399,7 +4408,7 @@ const setupResultSchemaFor = (
   }, {
     meta: INTERNAL_VERIFIER_META,
   });
-  if (!isRecord(document)) {
+  if (!isObjectOrArray(document)) {
     return undefined;
   }
   const schema = (document as Record<string, unknown>).schema;
@@ -4621,7 +4630,7 @@ export const loadSchemaDocument = (
   }, {
     meta: INTERNAL_VERIFIER_META,
   });
-  if (!isRecord(existing) || existing.value === undefined) {
+  if (!isObjectOrArray(existing) || existing.value === undefined) {
     throw new Error(`stored schemaHash ${schemaHash} is missing or unreadable`);
   }
   const schema = existing.value as JSONSchema;
@@ -4897,7 +4906,7 @@ const noteModulePolicyResolutionFailures = (
   }[],
 ): void => {
   for (const failure of failures) {
-    const reference = isRecord(failure.reference)
+    const reference = isObjectOrArray(failure.reference)
       ? failure.reference
       : undefined;
     const digest = typeof reference?.policyDigest === "string"
@@ -5123,7 +5132,7 @@ const verifyWriteFloor = (
     entries.map((entry) => [pathKey(entry.path), entry.label]),
   );
   for (const entry of entries) {
-    const ifc = isRecord(entry.schema) ? entry.schema.ifc : undefined;
+    const ifc = isObjectOrArray(entry.schema) ? entry.schema.ifc : undefined;
     const floor = Array.isArray(ifc?.requiredIntegrity)
       ? ifc.requiredIntegrity
       : [];
@@ -5713,9 +5722,10 @@ export const prepareBoundaryCommit = (
           ) {
             return [];
           }
-          const ifc = isRecord(entry.schema) && isRecord(entry.schema.ifc)
-            ? entry.schema.ifc
-            : undefined;
+          const ifc =
+            isObjectOrArray(entry.schema) && isObjectOrArray(entry.schema.ifc)
+              ? entry.schema.ifc
+              : undefined;
           if (
             ifc !== undefined &&
             (Object.hasOwn(ifc, "confidentiality") ||
@@ -5897,7 +5907,7 @@ export const prepareBoundaryCommit = (
       let current: unknown = base;
       for (const key of path) {
         if (
-          (Array.isArray(current) || isRecord(current)) &&
+          (Array.isArray(current) || isObjectOrArray(current)) &&
           Object.hasOwn(current as object, key)
         ) {
           current = (current as Record<string, unknown>)[key];

--- a/packages/runner/src/cfc/render-ceiling.ts
+++ b/packages/runner/src/cfc/render-ceiling.ts
@@ -1,6 +1,6 @@
 import { CFC_ATOM_TYPE, type CfcAtom, cfcAtom } from "@commonfabric/api/cfc";
 import type { CfcConfClause } from "./clause.ts";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import {
   buildCfcPolicySnapshot,
   type ExchangeRule,
@@ -151,7 +151,7 @@ export const spaceAtomIdsInConfidentiality = (
   for (const clause of confidentiality) {
     for (const alternative of clauseAlternatives(clause as CfcConfClause)) {
       if (
-        isRecord(alternative) &&
+        isObjectOrArray(alternative) &&
         (alternative as { type?: unknown }).type === CFC_ATOM_TYPE.Space &&
         typeof (alternative as { id?: unknown }).id === "string"
       ) {

--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -2,7 +2,10 @@ import { internSchema } from "@commonfabric/data-model/schema-hash";
 import type { CfcAtom } from "@commonfabric/api/cfc";
 import type { CfcConfClause } from "./clause.ts";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
-import { isReadonlyRecord, isRecord } from "@commonfabric/utils/types";
+import {
+  isObjectOrArray,
+  isReadonlyObjectOrArray,
+} from "@commonfabric/utils/types";
 import type { JSONSchema, JSONSchemaObj } from "../builder/types.ts";
 import { forEachSubschema } from "../schema-walk.ts";
 import { normalizeClause } from "./clause.ts";
@@ -35,7 +38,7 @@ const asSchemaObject = (
   if (schema === true) {
     return {};
   }
-  if (!isRecord(schema)) {
+  if (!isObjectOrArray(schema)) {
     throw new Error(`unsupported schema form at ${path || "/"}`);
   }
   return schema as JSONSchemaObj;
@@ -68,7 +71,7 @@ type WriterIdentityClaim = {
 };
 
 const isWriterIdentityClaim = (value: unknown): value is WriterIdentityClaim =>
-  isRecord(value) && isRecord(value.__ctWriterIdentityOf);
+  isObjectOrArray(value) && isObjectOrArray(value.__ctWriterIdentityOf);
 
 // The per-input provenance fields a verified write may have stamped onto a
 // writer-identity claim. New claims carry only the content-addressed
@@ -305,7 +308,7 @@ const mergeIfc = (
 // descending them (`includeDefs`). This walk does not resolve `$ref`, so a
 // definition referenced but not inlined is only seen through `$defs`.
 const branchContainsIfc = (schema: JSONSchema): boolean => {
-  if (!isRecord(schema)) return false;
+  if (!isObjectOrArray(schema)) return false;
   if ((schema as JSONSchemaObj).ifc !== undefined) return true;
   return forEachSubschema(schema, (child) => branchContainsIfc(child), {
     includeDefs: true,
@@ -316,7 +319,7 @@ const assertNoDivergentIfcBranches = (
   schema: JSONSchema,
   path = "",
 ): void => {
-  if (!isRecord(schema)) {
+  if (!isObjectOrArray(schema)) {
     return;
   }
   const object = schema as JSONSchemaObj;
@@ -396,7 +399,7 @@ const mergeRequired = (
     if (generatedOutputCovers(options, [...path, name])) {
       continue;
     }
-    if (!isRecord(property) || property.default === undefined) {
+    if (!isObjectOrArray(property) || property.default === undefined) {
       // Typed so the CFC prepare catch can tag this as the recoverable
       // schema-migration class (see migration-reason.ts) without sniffing the
       // message. The message text stays human-readable and unchanged.
@@ -408,7 +411,7 @@ const mergeRequired = (
   return merged;
 };
 
-// TODO(danfuzz): `isReadonlyRecord` admits a `FabricSpecialObject` on either
+// TODO(danfuzz): `isReadonlyObjectOrArray` admits a `FabricSpecialObject` on either
 // side, and the spread copies zero properties from one — so two fabric
 // defaults merge to `{}`, and a plain-record `existing` plus a fabric
 // `candidate` silently drops the candidate's value. Wants a
@@ -423,7 +426,7 @@ const mergeDefaults = (
   if (candidate === undefined) {
     return existing;
   }
-  if (isReadonlyRecord(existing) && isReadonlyRecord(candidate)) {
+  if (isReadonlyObjectOrArray(existing) && isReadonlyObjectOrArray(candidate)) {
     return { ...existing, ...candidate };
   }
   return candidate;

--- a/packages/runner/src/cfc/schema-refs.ts
+++ b/packages/runner/src/cfc/schema-refs.ts
@@ -1,5 +1,5 @@
 import type { JSONSchema, JSONSchemaObj } from "@commonfabric/api";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { getLogger } from "@commonfabric/utils/logger";
 import { utf8Compare } from "@commonfabric/utils/utf8";
 import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
@@ -94,8 +94,8 @@ export const cfcSchemaChildRoot = (
   schema: JSONSchema,
   inheritedRoot: JSONSchema,
 ): JSONSchema =>
-  isRecord(schema) && isRecord(schema.$defs) &&
-    !(isRecord(inheritedRoot) && schema.$defs === inheritedRoot.$defs)
+  isObjectOrArray(schema) && isObjectOrArray(schema.$defs) &&
+    !(isObjectOrArray(inheritedRoot) && schema.$defs === inheritedRoot.$defs)
     ? schema
     : inheritedRoot;
 
@@ -107,7 +107,7 @@ export const cfcSchemaIsTrue = (schema: JSONSchema): boolean => {
   if (schema === true) {
     return true;
   }
-  return isRecord(schema) &&
+  return isObjectOrArray(schema) &&
     Object.keys(schema).every((key) =>
       cfcSchemaIsInternalKey(key) || key === "default" || key === "$defs"
     );
@@ -115,7 +115,7 @@ export const cfcSchemaIsTrue = (schema: JSONSchema): boolean => {
 
 export const cfcSchemaIsFalse = (schema: JSONSchema): boolean =>
   schema === false ||
-  (isRecord(schema) && Object.hasOwn(schema, "not") &&
+  (isObjectOrArray(schema) && Object.hasOwn(schema, "not") &&
     cfcSchemaIsTrue(schema["not"]!));
 
 const localDefinitionName = (schemaRef: string): string | undefined => {
@@ -133,14 +133,14 @@ const localDefinitionNamesInScope = (
 ): Set<string> => {
   const names = new Set(Object.keys(definitions));
   const collect = (fragment: JSONSchema): void => {
-    if (!isRecord(fragment)) return;
+    if (!isObjectOrArray(fragment)) return;
     if (typeof fragment.$ref === "string") {
       const name = localDefinitionName(fragment.$ref);
       if (name !== undefined) names.add(name);
     }
     forEachSubschema(fragment, (child) => {
       if (
-        isRecord(child) && isRecord(child.$defs) &&
+        isObjectOrArray(child) && isObjectOrArray(child.$defs) &&
         child.$defs !== definitions
       ) return;
       collect(child);
@@ -149,7 +149,7 @@ const localDefinitionNamesInScope = (
   collect(schema);
   for (const definition of Object.values(definitions)) {
     if (
-      isRecord(definition) && isRecord(definition.$defs) &&
+      isObjectOrArray(definition) && isObjectOrArray(definition.$defs) &&
       definition.$defs !== definitions
     ) continue;
     collect(definition);
@@ -181,7 +181,7 @@ const namespaceLocalDefinitionScope = (
   }
 
   const rewrite = (fragment: JSONSchema): JSONSchema => {
-    if (!isRecord(fragment)) return fragment;
+    if (!isObjectOrArray(fragment)) return fragment;
     let result = fragment;
     if (typeof fragment.$ref === "string") {
       const name = localDefinitionName(fragment.$ref);
@@ -193,7 +193,8 @@ const namespaceLocalDefinitionScope = (
     return mapSubschemas(
       result,
       (child) =>
-        isRecord(child) && isRecord(child.$defs) && child.$defs !== definitions
+        isObjectOrArray(child) && isObjectOrArray(child.$defs) &&
+          child.$defs !== definitions
           ? child
           : rewrite(child),
       ALL_SUBSCHEMAS,
@@ -204,7 +205,7 @@ const namespaceLocalDefinitionScope = (
   const rewrittenDefinitions = Object.fromEntries(
     Object.entries(definitions).map(([name, definition]) => [
       renamed.get(name)!,
-      isRecord(definition) && isRecord(definition.$defs) &&
+      isObjectOrArray(definition) && isObjectOrArray(definition.$defs) &&
         definition.$defs !== definitions
         ? definition
         : rewrite(definition),
@@ -218,7 +219,7 @@ const addRefs = (target: Set<string>, source: ReadonlySet<string>): void => {
 };
 
 const summarizeCfcSchemaRefs = (schema: JSONSchema): SchemaRefSummary => {
-  if (!isRecord(schema)) return EMPTY_REF_SUMMARY;
+  if (!isObjectOrArray(schema)) return EMPTY_REF_SUMMARY;
   const cached = schemaRefSummaryCache.get(schema);
   if (cached !== undefined) return cached;
 
@@ -235,7 +236,7 @@ const summarizeCfcSchemaRefs = (schema: JSONSchema): SchemaRefSummary => {
     // A child carrying its own `$defs` starts a new local-ref scope. Its refs
     // still count for the public findRefs() walk, but must not retain names in
     // the parent's definition map.
-    if (!(isRecord(child) && child.$defs !== undefined)) {
+    if (!(isObjectOrArray(child) && child.$defs !== undefined)) {
       addRefs(localDefinitions, childSummary.localDefinitions);
     }
   }, ALL_SUBSCHEMAS);
@@ -311,8 +312,8 @@ export const selectReferencedCfcSchemaDefs = (
   schema: JSONSchema,
   inheritedDefinitions?: SchemaDefinitions,
 ): SchemaDefinitions | undefined => {
-  if (!isRecord(schema)) return undefined;
-  const definitions = isRecord(schema.$defs)
+  if (!isObjectOrArray(schema)) return undefined;
+  const definitions = isObjectOrArray(schema.$defs)
     ? schema.$defs
     : inheritedDefinitions;
   if (definitions === undefined) return undefined;
@@ -365,7 +366,7 @@ const pruneCfcSchemaDefinitionsInternal = (
 ): JSONSchema => {
   // A boolean schema, and anything a schema cannot be, has no definitions to
   // prune and is returned as it arrived.
-  if (!isRecord(schema)) return schema;
+  if (!isObjectOrArray(schema)) return schema;
   const cacheable = isDeepFrozen(schema);
   const cache = preserveScopeBoundary
     ? prunedScopedSchemaCache
@@ -382,7 +383,7 @@ const pruneCfcSchemaDefinitionsInternal = (
   );
   // Only a `$defs` that is a definition map is pruned, the same test
   // `cfcSchemaChildRoot` uses to decide whether one opens a definition scope.
-  if (isRecord(schema.$defs)) {
+  if (isObjectOrArray(schema.$defs)) {
     const selected = selectReferencedCfcSchemaDefs(schema);
     let definitions = selected ??
       (preserveScopeBoundary ? EMPTY_DEFINITIONS : undefined);
@@ -422,7 +423,7 @@ export const resolveCfcSchemaRef = (
   if (Object.hasOwn(embeddedSchemas, schemaRef)) {
     return embeddedSchemas[schemaRef];
   }
-  const cacheable = isRecord(fullSchema) && isDeepFrozen(fullSchema);
+  const cacheable = isObjectOrArray(fullSchema) && isDeepFrozen(fullSchema);
   if (cacheable) {
     const byRef = resolvedRefCache.get(fullSchema);
     if (byRef !== undefined && byRef.has(schemaRef)) {
@@ -449,7 +450,7 @@ export const resolveCfcSchemaRefRoot = (
   let current = schema;
   let root = fullSchema;
   const seenRefs = new Map<JSONSchema, Set<string>>();
-  while (isRecord(current) && typeof current.$ref === "string") {
+  while (isObjectOrArray(current) && typeof current.$ref === "string") {
     const ref = current.$ref;
     let refsForRoot = seenRefs.get(root);
     if (refsForRoot?.has(ref)) break;
@@ -493,7 +494,7 @@ const resolveCfcSchemaRefUncached = (
   let schemaCursor: unknown = fullSchema;
   for (let i = 1; i < pathToDef.length; i++) {
     if (
-      !isRecord(schemaCursor) ||
+      !isObjectOrArray(schemaCursor) ||
       !Object.hasOwn(schemaCursor, pathToDef[i])
     ) {
       logger.warn("cfc", () => [
@@ -515,13 +516,13 @@ const resolveCfcSchemaRefUncached = (
     ]);
     return undefined;
   }
-  if (isRecord(schemaCursor)) {
+  if (isObjectOrArray(schemaCursor)) {
     const schemaRefs = new Set<string>();
     findCfcSchemaRefs(schemaCursor, schemaRefs);
     if (schemaRefs.size > 0 && schemaCursor.$defs === undefined) {
       schemaCursor = {
         ...schemaCursor,
-        ...(isRecord(fullSchema) && fullSchema.$defs &&
+        ...(isObjectOrArray(fullSchema) && fullSchema.$defs &&
           { $defs: fullSchema.$defs }),
       };
     }
@@ -547,7 +548,7 @@ export const resolveCfcSchemaRefs = (
 ): JSONSchema | undefined => {
   const cacheable = isDeepFrozen(schemaObj) &&
     (fullSchema === schemaObj ||
-      (isRecord(fullSchema) && isDeepFrozen(fullSchema)));
+      (isObjectOrArray(fullSchema) && isDeepFrozen(fullSchema)));
   let byFull: WeakMap<object, JSONSchema | typeof RESOLVED_UNDEFINED>;
   if (cacheable) {
     const fullKey = fullSchema as object;
@@ -589,11 +590,11 @@ const resolveCfcSchemaRefsUncached = (
     let resolvedRoot = initialRoot;
     while (pendingSiblings.length > 0) {
       const { schema: siblings, root: siblingRoot } = pendingSiblings.pop()!;
-      if (isRecord(resolved)) {
+      if (isObjectOrArray(resolved)) {
         const resolvedDefinitions = resolved.$defs ??
-          (isRecord(resolvedRoot) ? resolvedRoot.$defs : undefined);
+          (isObjectOrArray(resolvedRoot) ? resolvedRoot.$defs : undefined);
         let scopedSiblings = siblings;
-        let siblingDefinitions = isRecord(siblingRoot)
+        let siblingDefinitions = isObjectOrArray(siblingRoot)
           ? siblingRoot.$defs
           : undefined;
         if (siblingRoot !== resolvedRoot) {
@@ -601,10 +602,10 @@ const resolveCfcSchemaRefsUncached = (
           // scopes. Namespace even an empty ref-site definition map: its
           // unresolved local refs must not begin resolving against target defs
           // merely because the two scopes are flattened into one object.
-          const targetDefinitions = isRecord(resolvedDefinitions)
+          const targetDefinitions = isObjectOrArray(resolvedDefinitions)
             ? resolvedDefinitions
             : {};
-          const refSiteDefinitions = isRecord(siblingDefinitions)
+          const refSiteDefinitions = isObjectOrArray(siblingDefinitions)
             ? siblingDefinitions
             : {};
           scopedSiblings = namespaceLocalDefinitionScope(
@@ -618,8 +619,8 @@ const resolveCfcSchemaRefsUncached = (
         // the target and in its ref-site siblings originate in different
         // document scopes. Ref-site names are namespaced above, leaving the
         // target's existing names authoritative.
-        const definitions = isRecord(resolvedDefinitions) &&
-            isRecord(siblingDefinitions) &&
+        const definitions = isObjectOrArray(resolvedDefinitions) &&
+            isObjectOrArray(siblingDefinitions) &&
             resolvedDefinitions !== siblingDefinitions
           ? { ...siblingDefinitions, ...resolvedDefinitions }
           : resolvedDefinitions ?? siblingDefinitions;
@@ -682,7 +683,7 @@ export const resolveCfcSchemaRefsOrThrow = (
   schemaObj: JSONSchemaObj,
   fullSchema: JSONSchema = schemaObj,
 ): JSONSchema => {
-  if (!isRecord(fullSchema)) {
+  if (!isObjectOrArray(fullSchema)) {
     throw new Error("Found $ref without fullSchema object");
   }
   const resolved = resolveCfcSchemaRefs(schemaObj, fullSchema);

--- a/packages/runner/src/cfc/schema-sanitization.ts
+++ b/packages/runner/src/cfc/schema-sanitization.ts
@@ -18,12 +18,13 @@ import {
 import { schemaTypeOfFabricPrimitive } from "@commonfabric/data-model/fabric-primitives";
 import { deepFrozenCloneAndInternSchema } from "@commonfabric/data-model/schema-hash";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import {
   hasOwnEnumerableDataProperty,
   isCellKind,
   isSchemaScope,
 } from "../scope.ts";
+import { isSubschema } from "../schema-walk.ts";
 import { uniqueCfcAtoms } from "./observation.ts";
 import {
   cfcSchemaChildRoot,
@@ -101,7 +102,7 @@ export const isPromptInjectionMaterialRiskAtom = (atom: unknown): boolean => {
   if (typeof atom === "string") {
     return PROMPT_INJECTION_RISK_KINDS.has(atom);
   }
-  return isRecord(atom) &&
+  return isObjectOrArray(atom) &&
     atom.type === CFC_ATOM_TYPE.Caveat &&
     typeof atom.kind === "string" &&
     PROMPT_INJECTION_RISK_KINDS.has(atom.kind);
@@ -183,7 +184,7 @@ const mergeIfc = (
     instructionInert: boolean;
   },
 ): Record<string, unknown> => {
-  const existingIfc = isRecord(schema.ifc) ? schema.ifc : {};
+  const existingIfc = isObjectOrArray(schema.ifc) ? schema.ifc : {};
   const retainedConfidentiality = instructionInert
     ? dischargeMaterialRiskAtoms(observedConfidentiality)
     : uniqueAtoms(observedConfidentiality);
@@ -258,7 +259,7 @@ export const resolveSchemaForValidation = (
   schema: JSONSchema,
   fullSchema: JSONSchema,
 ): JSONSchema =>
-  isRecord(schema) && typeof schema.$ref === "string"
+  isObjectOrArray(schema) && typeof schema.$ref === "string"
     ? resolveCfcSchemaRefs(schema, fullSchema) ?? false
     : schema;
 
@@ -273,7 +274,7 @@ const annotateSchema = (
   }
 
   const schemaRoot = cfcSchemaChildRoot(schema, fullSchema);
-  const rootKey = isRecord(schemaRoot) ? schemaRoot : schema;
+  const rootKey = isObjectOrArray(schemaRoot) ? schemaRoot : schema;
 
   // $ref cycle guard: resolveSchemaRefs only detects cycles within a single
   // call, but annotateSchema recurses across resolutions. A local ref string
@@ -459,7 +460,7 @@ const stripRequiredFields = (schema: JSONSchema): JSONSchema => {
   const { required: _required, ...rest } = schema as any;
   const result: Record<string, unknown> = { ...rest };
 
-  if (isRecord(result.properties)) {
+  if (isObjectOrArray(result.properties)) {
     result.properties = Object.fromEntries(
       Object.entries(result.properties).map(([key, value]) => [
         key,
@@ -769,7 +770,7 @@ const claimDefinitionScopes = (
   let claimed: Set<DefinitionKey> | undefined;
   for (const key of DEFINITION_KEYS) {
     const definitions = schema[key];
-    if (!isRecord(definitions) || Array.isArray(definitions)) continue;
+    if (!isObjectNotArray(definitions)) continue;
     let walked = context.walkedDefinitionsByRoot.get(rootKey);
     if (walked?.has(definitions)) continue;
     if (!walked) {
@@ -812,13 +813,13 @@ const validateSchemaDefinitionInternal = (
   path: string,
   context: SchemaDefinitionContext,
 ): string | undefined => {
-  if (typeof schema === "boolean") return undefined;
-  if (!isRecord(schema) || Array.isArray(schema)) {
+  if (!isSubschema(schema)) {
     return `${path}: schema must be an object or boolean`;
   }
+  if (typeof schema === "boolean") return undefined;
 
   const schemaRoot = cfcSchemaChildRoot(schema, fullSchema);
-  const rootKey = isRecord(schemaRoot) ? schemaRoot : schema;
+  const rootKey = isObjectOrArray(schemaRoot) ? schemaRoot : schema;
   if (context.provenByRoot.get(rootKey)?.has(schema)) return undefined;
   let active = context.activeByRoot.get(rootKey);
   if (active?.has(schema)) {
@@ -897,7 +898,7 @@ const validateSchemaDefinitionInternal = (
       for (let index = 0; index < schema.asCell.length; index++) {
         const entry = schema.asCell[index] as unknown;
         if (isCellKind(entry)) continue;
-        if (!isRecord(entry) || Array.isArray(entry)) {
+        if (!isObjectNotArray(entry)) {
           return `${path}.asCell[${index}]: must be a cell kind or descriptor`;
         }
         if (!hasOwnEnumerableDataProperty(entry, "kind")) {
@@ -931,7 +932,7 @@ const validateSchemaDefinitionInternal = (
     ) {
       const value = schema[key];
       if (value === undefined) continue;
-      if (!isRecord(value) || Array.isArray(value)) {
+      if (!isObjectNotArray(value)) {
         return `${path}.${key}: must be an object of schemas`;
       }
     }
@@ -951,8 +952,7 @@ const validateSchemaDefinitionInternal = (
     }
     if (schema.dependentRequired !== undefined) {
       if (
-        !isRecord(schema.dependentRequired) ||
-        Array.isArray(schema.dependentRequired)
+        !isObjectNotArray(schema.dependentRequired)
       ) {
         return `${path}.dependentRequired: must be an object`;
       }
@@ -1107,7 +1107,7 @@ const validateSchemaDefinitionInternal = (
     for (const key of claimedDefinitions ?? []) {
       if (settledDefinitions.has(key)) continue;
       const definitions = schema[key];
-      if (isRecord(definitions)) {
+      if (isObjectOrArray(definitions)) {
         releaseCutDefinitionScope(rootKey, definitions, context, provenLogMark);
       }
     }
@@ -1504,11 +1504,11 @@ const validateAgainstSchemaInternal = (
 ): SchemaValidationFailure | undefined => {
   if (schema === true) return undefined;
   if (schema === false) return mismatch("schema rejects all values");
-  if (!isRecord(schema) || Array.isArray(schema)) {
+  if (!isObjectNotArray(schema)) {
     return indeterminate("schema must be an object or boolean");
   }
   const schemaRoot = cfcSchemaChildRoot(schema, fullSchema);
-  const rootKey = isRecord(schemaRoot) ? schemaRoot : schema;
+  const rootKey = isObjectOrArray(schemaRoot) ? schemaRoot : schema;
   if (!markSchemaValueActive(rootKey, schema, value, context)) {
     return indeterminate("recursive schema validation made no progress");
   }

--- a/packages/runner/src/cfc/structured-result.ts
+++ b/packages/runner/src/cfc/structured-result.ts
@@ -1,5 +1,5 @@
 import type { JSONSchema } from "@commonfabric/api";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { cfcOpaqueLinkForPath } from "./observation.ts";
 import {
   cfcObjectSchemaIsClosed,
@@ -31,7 +31,7 @@ const schemaAllowsRawString = (
   fullSchema: JSONSchema,
 ): boolean => {
   const resolved = resolveSchemaForValidation(schema, fullSchema);
-  if (!isRecord(resolved)) {
+  if (!isObjectOrArray(resolved)) {
     return false;
   }
   if (Array.isArray(resolved.enum)) {
@@ -64,8 +64,8 @@ const schemaAllowsRawString = (
 const schemaDirectlyDeclaresOpaqueLinkObject = (
   schema: Record<string, unknown>,
 ): boolean =>
-  isRecord(schema.properties) &&
-  isRecord(schema.properties["@link"]) &&
+  isObjectOrArray(schema.properties) &&
+  isObjectOrArray(schema.properties["@link"]) &&
   schema.properties["@link"].type === "string" &&
   Array.isArray(schema.required) &&
   schema.required.includes("@link") &&
@@ -81,7 +81,7 @@ const matchingBranches = (
   }
   return branches
     .filter((branch): branch is JSONSchema =>
-      (typeof branch === "boolean" || isRecord(branch)) &&
+      (typeof branch === "boolean" || isObjectOrArray(branch)) &&
       validateAgainstSchema(branch, value, fullSchema) === undefined
     )
     .map((branch) => resolveSchemaForValidation(branch, fullSchema));
@@ -93,7 +93,7 @@ const schemaAcceptsOpaqueLinkObject = (
   fullSchema: JSONSchema,
 ): boolean => {
   const resolved = resolveSchemaForValidation(schema, fullSchema);
-  if (!isRecord(resolved)) {
+  if (!isObjectOrArray(resolved)) {
     return false;
   }
   if (validateAgainstSchema(resolved, value, fullSchema) !== undefined) {
@@ -121,7 +121,7 @@ const schemaAcceptsOpaqueLinkObject = (
 const valueIsOpaqueLinkObject = (
   value: unknown,
 ): value is { "@link": string } =>
-  isRecord(value) &&
+  isObjectOrArray(value) &&
   typeof value["@link"] === "string" &&
   Object.keys(value).length === 1;
 
@@ -134,7 +134,7 @@ const matchingBranch = (
     return undefined;
   }
   const branch = branches.find((branch): branch is JSONSchema =>
-    (typeof branch === "boolean" || isRecord(branch)) &&
+    (typeof branch === "boolean" || isObjectOrArray(branch)) &&
     validateAgainstSchema(branch, value, fullSchema) === undefined
   );
   return branch === undefined
@@ -143,7 +143,7 @@ const matchingBranch = (
 };
 
 const isEmptySchemaObject = (schema: JSONSchema): boolean =>
-  isRecord(schema) && Object.keys(schema).length === 0;
+  isObjectOrArray(schema) && Object.keys(schema).length === 0;
 
 const combineAllOf = (schemas: readonly JSONSchema[]): JSONSchema => {
   const constrained = schemas.filter((schema) =>
@@ -175,7 +175,7 @@ const schemaForValue = (
   fullSchema: JSONSchema,
 ): JSONSchema => {
   const resolved = resolveSchemaForValidation(schema, fullSchema);
-  if (!isRecord(resolved)) {
+  if (!isObjectOrArray(resolved)) {
     return resolved;
   }
   let base: JSONSchema = resolved;
@@ -199,20 +199,20 @@ const childSchemaForKey = (
   fullSchema: JSONSchema,
 ): JSONSchema => {
   const resolved = resolveSchemaForValidation(schema, fullSchema);
-  if (!isRecord(resolved)) {
+  if (!isObjectOrArray(resolved)) {
     return true;
   }
   const childSchemas: JSONSchema[] = [];
-  if (isRecord(resolved.properties)) {
+  if (isObjectOrArray(resolved.properties)) {
     const child = resolved.properties[key];
-    if (typeof child === "boolean" || isRecord(child)) {
+    if (typeof child === "boolean" || isObjectOrArray(child)) {
       childSchemas.push(child);
     }
   }
   if (
-    !(isRecord(resolved.properties) && key in resolved.properties) &&
+    !(isObjectOrArray(resolved.properties) && key in resolved.properties) &&
     (typeof resolved.additionalProperties === "boolean" ||
-      isRecord(resolved.additionalProperties))
+      isObjectOrArray(resolved.additionalProperties))
   ) {
     childSchemas.push(resolved.additionalProperties);
   }
@@ -233,10 +233,10 @@ const knownPropertyNames = (
 ): Set<string> => {
   const resolved = resolveSchemaForValidation(schema, fullSchema);
   const known = new Set<string>();
-  if (!isRecord(resolved)) {
+  if (!isObjectOrArray(resolved)) {
     return known;
   }
-  if (isRecord(resolved.properties)) {
+  if (isObjectOrArray(resolved.properties)) {
     for (const key of Object.keys(resolved.properties)) {
       known.add(key);
     }
@@ -263,7 +263,7 @@ const itemSchemaForIndex = (
 ): JSONSchema => {
   const resolved = resolveSchemaForValidation(schema, fullSchema);
   const itemSchemas: JSONSchema[] = [];
-  if (isRecord(resolved)) {
+  if (isObjectOrArray(resolved)) {
     // 2020-12 array semantics: a tuple slot governs its exact index; the
     // uniform `items` schema governs only the indices past the slots.
     // Collecting only `items` let tuple elements sanitize against an
@@ -273,11 +273,11 @@ const itemSchemaForIndex = (
       : undefined;
     if (prefixItems !== undefined && index < prefixItems.length) {
       const slot = prefixItems[index];
-      if (typeof slot === "boolean" || isRecord(slot)) {
+      if (typeof slot === "boolean" || isObjectOrArray(slot)) {
         itemSchemas.push(slot);
       }
     } else if (
-      typeof resolved.items === "boolean" || isRecord(resolved.items)
+      typeof resolved.items === "boolean" || isObjectOrArray(resolved.items)
     ) {
       itemSchemas.push(resolved.items);
     }
@@ -295,7 +295,7 @@ const itemSchemaForIndex = (
 
 // TODO(danfuzz): Latent — schemas don't admit `Fabric*` values on this path
 // today, but will in the not-too-distant future; at that point this guard-less
-// `isRecord`-walk fails (a `FabricPrimitive` is decomposed, a `FabricInstance`
+// `isObjectOrArray`-walk fails (a `FabricPrimitive` is decomposed, a `FabricInstance`
 // is walked by internal slots rather than codec contents). Mark ahead of that.
 const sanitizeValueWithOpaqueLinks = (
   value: unknown,
@@ -329,7 +329,7 @@ const sanitizeValueWithOpaqueLinks = (
     });
     return { value: items, linkedStringCount };
   }
-  if (isRecord(value)) {
+  if (isObjectOrArray(value)) {
     if (
       valueIsOpaqueLinkObject(value) &&
       schemaAcceptsOpaqueLinkObject(schema, value, fullSchema)

--- a/packages/runner/src/cfc/trust.ts
+++ b/packages/runner/src/cfc/trust.ts
@@ -1,7 +1,7 @@
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import type { CfcAtom } from "@commonfabric/api/cfc";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 import { type AtomPattern, matchAtomPattern } from "./atom-pattern.ts";
 
 /**
@@ -124,7 +124,7 @@ const requireEntryRecord = (
   value: unknown,
   where: string,
 ): Record<string, unknown> => {
-  if (!isRecord(value) || Array.isArray(value)) {
+  if (!isObjectNotArray(value)) {
     throw new Error(`cfcTrustConfig: ${where} must be an object`);
   }
   return value as Record<string, unknown>;

--- a/packages/runner/src/cfc/ui-contract.ts
+++ b/packages/runner/src/cfc/ui-contract.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import type { CellScope, FabricValue, JSONSchema } from "../builder/types.ts";
 import { type NormalizedFullLink, parseLink } from "../link-utils.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
@@ -98,12 +98,12 @@ const rendererTrustedEvents = new WeakSet<object>();
 const isTrustedDomProvenance = (
   provenance: unknown,
 ): provenance is TrustedDomProvenance =>
-  isRecord(provenance) &&
+  isObjectOrArray(provenance) &&
   provenance.origin === "dom" &&
   provenance.trusted === true;
 
 export const markRendererTrustedEvent = (event: unknown): void => {
-  if (isRecord(event)) {
+  if (isObjectOrArray(event)) {
     rendererTrustedEvents.add(event);
   }
 };
@@ -113,16 +113,16 @@ export const propagateRendererTrustedEvent = (
   target: unknown,
 ): void => {
   if (
-    isRecord(source) &&
+    isObjectOrArray(source) &&
     rendererTrustedEvents.has(source) &&
-    isRecord(target)
+    isObjectOrArray(target)
   ) {
     rendererTrustedEvents.add(target);
   }
 };
 
 export const isRendererTrustedEvent = (event: unknown): boolean =>
-  isRecord(event) && rendererTrustedEvents.has(event);
+  isObjectOrArray(event) && rendererTrustedEvents.has(event);
 
 const trustRequirementsFromContract = (
   contract: Record<string, unknown>,
@@ -149,7 +149,7 @@ const resolveLocalSchemaRef = (
   root: JSONSchema | undefined,
   seenRefs: Set<string>,
 ): JSONSchema | undefined => {
-  if (!isRecord(schema) || typeof schema.$ref !== "string") {
+  if (!isObjectOrArray(schema) || typeof schema.$ref !== "string") {
     return schema;
   }
   const ref = schema.$ref;
@@ -158,7 +158,7 @@ const resolveLocalSchemaRef = (
   }
   seenRefs.add(ref);
 
-  if (!isRecord(root)) {
+  if (!isObjectOrArray(root)) {
     return schema;
   }
 
@@ -175,8 +175,8 @@ const uiContractFromSchemaInternal = (
     return uiContractFromSchemaInternal(resolvedSchema, root, seenRefs);
   }
   if (
-    !isRecord(resolvedSchema) || !isRecord(resolvedSchema.ifc) ||
-    !isRecord(resolvedSchema.ifc.uiContract)
+    !isObjectOrArray(resolvedSchema) || !isObjectOrArray(resolvedSchema.ifc) ||
+    !isObjectOrArray(resolvedSchema.ifc.uiContract)
   ) {
     return undefined;
   }
@@ -226,11 +226,13 @@ const uiContractsFromSchemaInternal = (
       branchRefs,
     );
   }
-  if (!isRecord(resolvedSchema)) {
+  if (!isObjectOrArray(resolvedSchema)) {
     return [];
   }
 
-  const childRoot = isRecord(resolvedSchema.$defs) ? resolvedSchema : root;
+  const childRoot = isObjectOrArray(resolvedSchema.$defs)
+    ? resolvedSchema
+    : root;
   const entries: UiContractEntry[] = [];
   const contract = uiContractFromSchemaInternal(
     resolvedSchema,
@@ -241,11 +243,11 @@ const uiContractsFromSchemaInternal = (
     entries.push(uiContractEntry([...path], contract, resolvedSchema));
   }
 
-  const hasProperties = isRecord(resolvedSchema.properties);
+  const hasProperties = isObjectOrArray(resolvedSchema.properties);
   const hasCompoundSchemas = Array.isArray(resolvedSchema.anyOf) ||
     Array.isArray(resolvedSchema.oneOf) ||
     Array.isArray(resolvedSchema.allOf);
-  const hasItems = isRecord(resolvedSchema.items) ||
+  const hasItems = isObjectOrArray(resolvedSchema.items) ||
     typeof resolvedSchema.items === "boolean";
   // prefixItems counts as children too (PR #4969 review): an unknown-typed
   // tuple with a contract-bearing $defs entry must not mint that contract
@@ -259,7 +261,7 @@ const uiContractsFromSchemaInternal = (
     !hasItems &&
     !hasPrefixItems &&
     resolvedSchema.type === "unknown" &&
-    isRecord(resolvedSchema.$defs)
+    isObjectOrArray(resolvedSchema.$defs)
   ) {
     const definitionContracts = Object.values(resolvedSchema.$defs)
       .flatMap((definition) =>
@@ -312,7 +314,7 @@ const uiContractsFromSchemaInternal = (
   // precise "past the slots" representation needs a path grammar beyond
   // `*`.
   if (
-    isRecord(resolvedSchema.items) ||
+    isObjectOrArray(resolvedSchema.items) ||
     typeof resolvedSchema.items === "boolean"
   ) {
     entries.push(
@@ -357,7 +359,7 @@ export const trustedEventProvenanceMatchesUiContract = (
     contract.trustedPattern !== undefined ||
     (contract.requiredEventIntegrity?.length ?? 0) > 0
   ) {
-    if (!isRecord(provenance.ui)) {
+    if (!isObjectOrArray(provenance.ui)) {
       return false;
     }
     if (
@@ -393,10 +395,10 @@ export const recordedTrustedEventProvenanceMatchesUiContract = (
   if (!trustedEventProvenanceMatchesUiContract(provenance, contract)) {
     return false;
   }
-  const dataset = isRecord(provenance) && isRecord(provenance.ui)
+  const dataset = isObjectOrArray(provenance) && isObjectOrArray(provenance.ui)
     ? provenance.ui.uiContractDataset
     : undefined;
-  if (!isRecord(dataset)) {
+  if (!isObjectOrArray(dataset)) {
     return false;
   }
 
@@ -417,7 +419,7 @@ export const trustedEventMatchesUiContract = (
   event: unknown,
   contract: UiContract | undefined,
 ): boolean => {
-  if (contract === undefined || !isRecord(event)) {
+  if (contract === undefined || !isObjectOrArray(event)) {
     return false;
   }
   const serializedEvent = event as SerializedTrustedEvent;
@@ -451,13 +453,13 @@ const trustedEventMatchCandidates = (event: unknown): unknown[] => {
 
   for (let index = 0; index < candidates.length; index++) {
     const candidate = candidates[index];
-    if (!isRecord(candidate)) {
+    if (!isObjectOrArray(candidate)) {
       continue;
     }
     if ("$event" in candidate) {
       add(candidate.$event);
     }
-    if (isRecord(candidate.value) && "$event" in candidate.value) {
+    if (isObjectOrArray(candidate.value) && "$event" in candidate.value) {
       add(candidate.value.$event);
     }
   }
@@ -553,7 +555,7 @@ const eventEnvelopePayloads = (
   };
 
   addPayload(event);
-  if (isRecord(event) && "value" in event) {
+  if (isObjectOrArray(event) && "value" in event) {
     addPayload(event.value);
   }
   try {
@@ -598,7 +600,7 @@ const collectContextLinks = (
     }
     return;
   }
-  if (!isRecord(value) && !Array.isArray(value)) {
+  if (!isObjectOrArray(value)) {
     return;
   }
   if (seen.has(value)) {
@@ -634,7 +636,9 @@ const contractCandidatesFromEventContext = (
 ): UiContract[] => {
   const contracts: UiContract[] = [];
   for (const payload of eventEnvelopePayloads(event)) {
-    if (!isRecord(payload.value) || !isRecord(payload.value.$ctx)) {
+    if (
+      !isObjectOrArray(payload.value) || !isObjectOrArray(payload.value.$ctx)
+    ) {
       continue;
     }
     const links: NormalizedFullLink[] = [];

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -1,5 +1,5 @@
 import { getLogger } from "@commonfabric/utils/logger";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { CFC_COMPILED_BY_ATOM } from "@commonfabric/api/cfc";
 import type { PatternCoverageSpan } from "@commonfabric/ts-transformers";
 import { normalize } from "@std/path/posix";
@@ -839,7 +839,7 @@ export function writeSourceDocs(
         ...(delegatedModuleIdentities.length > 0
           ? { delegatedModuleIdentities }
           : {}),
-        ...(isRecord(existingAnnotations)
+        ...(isObjectOrArray(existingAnnotations)
           ? { annotations: existingAnnotations }
           : {}),
       } as StoredSourceDoc);
@@ -942,7 +942,9 @@ export function readLoadedSourceClosure(
       ...(delegatedModuleIdentities.length > 0
         ? { delegatedModuleIdentities }
         : {}),
-      ...(isRecord(doc.annotations) ? { annotations: doc.annotations } : {}),
+      ...(isObjectOrArray(doc.annotations)
+        ? { annotations: doc.annotations }
+        : {}),
     });
     for (const child of childDocs) {
       if (!out.has(child.doc.identity)) queue.push(child);
@@ -1177,7 +1179,7 @@ function storedCoverageSpans(
   if (!Array.isArray(spans)) return undefined;
   const out: PatternCoverageSpan[] = [];
   for (const span of spans) {
-    if (!isRecord(span)) return undefined;
+    if (!isObjectOrArray(span)) return undefined;
     const { fileName, id, kind, startLine, endLine, startColumn, endColumn } =
       span;
     if (

--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -12,7 +12,7 @@ import {
   entityRefFromString,
   isEntityRef,
 } from "@commonfabric/data-model/cell-rep";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { isReactive } from "./builder/types.ts";
 import {
   getCellOrThrow,
@@ -180,7 +180,7 @@ export function createRef(
       // answer. Two cells of one document derive two ids.
       return traverse(encodableFormOf(obj));
     } else if (Array.isArray(obj)) return obj.map(traverse);
-    else if (isRecord(obj)) {
+    else if (isObjectOrArray(obj)) {
       return Object.fromEntries(
         Object.entries(obj).map(([key, value]) => [key, traverse(value)]),
       );

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -1,4 +1,4 @@
-import { isObject, isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import type { CfcConfClause } from "./cfc/clause.ts";
 import type { CfcAtom } from "@commonfabric/api/cfc";
 import { forEachSubschema } from "./schema-walk.ts";
@@ -175,7 +175,7 @@ export const schemaIfcOverlapsPath = (
       return false;
     }
     if (
-      isRecord(current.ifc) &&
+      isObjectOrArray(current.ifc) &&
       labelHasValues(current.ifc) &&
       schemaPathsOverlap(path, sourcePath)
     ) {
@@ -295,7 +295,7 @@ const stripCfcLabelViewFromPrimitiveLink = (value: unknown): unknown => {
 const _toleratesMissingCache = new WeakMap<object, boolean>();
 function schemaToleratesMissing(schema: JSONSchema | undefined): boolean {
   if (schema === undefined) return true;
-  if (!isRecord(schema)) return true;
+  if (!isObjectOrArray(schema)) return true;
   // Schemas are identity-stable (interned / deep-frozen) on the paths that
   // reach here, mirroring traverse's own ref cache — memoize the verdict so
   // per-row write loops don't re-resolve refs (a CI-visible cost otherwise).
@@ -314,10 +314,10 @@ function computeToleratesMissing(schema: JSONSchema): boolean {
   // does not make the slot tolerant, while `default: 0/""/false` do. Judged
   // on the resolved schema so a default carried by the $defs target counts.
   let resolved: JSONSchema | undefined = schema;
-  if (isRecord(schema) && "$ref" in schema) {
+  if (isObjectOrArray(schema) && "$ref" in schema) {
     resolved = resolveSchemaRefsCanonical(schema as JSONSchemaObj) ?? schema;
   }
-  if (isRecord(resolved) && resolved.default != undefined) return true;
+  if (isObjectOrArray(resolved) && resolved.default != undefined) return true;
   // Type tolerance judged with the read side's own matcher (schemaAcceptsType
   // wraps the logic extracted from SchemaObjectTraverser.isValidType,
   // including $ref resolution and allOf/anyOf/oneOf).
@@ -605,7 +605,7 @@ export function normalizeAndDiff(
     if (
       state.nextAnchorId !== undefined &&
       isArrayElement &&
-      isObject(newValue) &&
+      isObjectNotArray(newValue) &&
       !(newValue instanceof FabricSpecialObject) &&
       !isCellLink(newValue) &&
       seenLink.path.length > 0
@@ -766,9 +766,11 @@ export function normalizeAndDiff(
     // re-derivations serialize the same cell again but find the doc present
     // and leave user edits alone.
     const cellSchema = newValue.schema;
-    const seedDefault = isRecord(cellSchema) ? cellSchema.default : undefined;
+    const seedDefault = isObjectOrArray(cellSchema)
+      ? cellSchema.default
+      : undefined;
     const seedTarget = seedDefault !== undefined &&
-        !(isRecord(seedDefault) &&
+        !(isObjectOrArray(seedDefault) &&
           (seedDefault as Record<string, unknown>).$stream === true)
       ? newValue.getAsNormalizedFullLink()
       : undefined;
@@ -1176,7 +1178,7 @@ export function normalizeAndDiff(
   if (
     state.nextAnchorId !== undefined &&
     isArrayElement &&
-    isObject(newValue) &&
+    isObjectNotArray(newValue) &&
     !(newValue instanceof FabricSpecialObject) &&
     !isCellLink(newValue)
   ) {
@@ -1370,7 +1372,7 @@ export function normalizeAndDiff(
   // leaves alike) are atomic from this layer's perspective: their
   // own-enumerable properties are implementation details, not
   // user-visible structure, and iterating them via the generic
-  // `isRecord` branch below would walk wrapper-internal fields (or, for a
+  // `isObjectOrArray` branch below would walk wrapper-internal fields (or, for a
   // primitive whose state is private, flatten it to `{}`), which
   // is meaningless at the change-emission level. Emit a single change at
   // this link with the value as-is — the storage layer's JSON encoding handles
@@ -1416,28 +1418,28 @@ export function normalizeAndDiff(
   }
 
   // Handle objects
-  if (isRecord(newValue)) {
+  if (isObjectOrArray(newValue)) {
     diffLogger.debug(
       "diff",
       () => `[BRANCH_OBJECT] Processing object at path=${pathStr}`,
     );
     // If the current value is not a (regular) object, set it to an empty object.
     // Note that the alias case is handled above.
-    // We use `isObject` (not `isRecord`) here deliberately: `isRecord` is true
-    // for arrays (`typeof [] === "object"`), whereas `isObject` excludes them.
+    // We use `isObjectNotArray` (not `isObjectOrArray`) here deliberately: `isObjectOrArray` is true
+    // for arrays (`typeof [] === "object"`), whereas `isObjectNotArray` excludes them.
     // Resetting on an array→object transition is required; otherwise per-key
     // writes land in a slot whose stored parent is still an array and storage
     // rejects them with a TypeMismatchError. This mirrors the array branch
     // above, which resets a mismatched container via `value: []`.
     //
-    // TODO(danfuzz): `isObject` is also true for a `FabricSpecialObject`, so
+    // TODO(danfuzz): `isObjectNotArray` is also true for a `FabricSpecialObject`, so
     // a stored special object (which reaches storage whole via this
     // function's `FabricSpecialObject` branch above) is treated as an
     // existing plain record: no reset is emitted, its zero keys yield no
     // removals, and the per-key child writes land in slots whose stored
     // parent is still the special object. The special-object→object
     // transition wants the same reset the array→object one gets.
-    if (!isObject(currentValue) || isPrimitiveCellLink(currentValue)) {
+    if (!isObjectNotArray(currentValue) || isPrimitiveCellLink(currentValue)) {
       diffLogger.debug(
         "diff",
         () =>
@@ -1471,7 +1473,7 @@ export function normalizeAndDiff(
     // still reject. A missed warn is acceptable for a lint; asserting
     // requiredness where there is none is not.
     const resolvedParentSchema = resolveSchema(link.schema);
-    const requiredProps = isRecord(resolvedParentSchema)
+    const requiredProps = isObjectOrArray(resolvedParentSchema)
       ? new Set(
         Array.isArray(resolvedParentSchema.required)
           ? (resolvedParentSchema.required as readonly string[])
@@ -1540,10 +1542,10 @@ export function normalizeAndDiff(
     // property values and diverges on circular values + recursive $ref
     // schemas; only the top-level property names are needed here.)
     const eagerScopedKeys = new Set<string>();
-    const schemaProperties = isRecord(resolvedParentSchema)
+    const schemaProperties = isObjectOrArray(resolvedParentSchema)
       ? resolvedParentSchema.properties
       : undefined;
-    if (isRecord(schemaProperties)) {
+    if (isObjectOrArray(schemaProperties)) {
       // `Object.keys`, not `for...in`: the latter walks the prototype chain
       // too, and these are the schema's OWN declared property names.
       for (const key of Object.keys(schemaProperties)) {

--- a/packages/runner/src/data-uri.ts
+++ b/packages/runner/src/data-uri.ts
@@ -28,7 +28,7 @@ import {
   FabricPrimitive,
   type FabricValue,
 } from "@commonfabric/data-model/fabric-value";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { refuseFabricInstance } from "./fabric-special-object.ts";
 import { type Cell, isCell } from "./cell.ts";
 import { isPrimitiveCellLink, type NormalizedLink } from "./link-types.ts";
@@ -85,7 +85,7 @@ export function dataUriFromValueWithResolvedLinks(
     value: FabricValue,
     seen: Set<object>,
   ): FabricValue {
-    if (!isRecord(value)) return value;
+    if (!isObjectOrArray(value)) return value;
     if (seen.has(value)) {
       throw new Error(`Cycle detected when creating data URI`);
     }
@@ -128,7 +128,7 @@ export function dataUriFromValueWithResolvedLinks(
           }
         }
         return next ?? value;
-      } else { // isObject
+      } else { // not an array
         let next: Record<string, FabricValue> | undefined;
         for (const [key, entry] of Object.entries(value)) {
           const rewritten = traverseAndAddBaseIdToRelativeLinks(entry, seen);
@@ -253,7 +253,7 @@ export function findAndInlineDataUriLinks(value: any): any {
     }
     return next ?? value;
   } else if (value instanceof FabricPrimitive) {
-    // A leaf, and `isRecord`, so it leaves ahead of the record branch below.
+    // A leaf, and `isObjectOrArray`, so it leaves ahead of the record branch below.
     // It holds no link to inline, so returning it whole is the answer rather
     // than an omission.
     return value;
@@ -278,7 +278,7 @@ export function findAndInlineDataUriLinks(value: any): any {
     // at which point this becomes a walk rather than a refusal -- the same gap
     // marked at the sibling walk in `dataUriFromValueWithResolvedLinks()`.
     refuseFabricInstance(value, "when inlining `data:` URI links");
-  } else if (isRecord(value)) {
+  } else if (isObjectOrArray(value)) {
     let next: Record<string, unknown> | undefined;
     for (const [key, entry] of Object.entries(value)) {
       const inlined = findAndInlineDataUriLinks(entry);

--- a/packages/runner/src/ensure-piece-running.ts
+++ b/packages/runner/src/ensure-piece-running.ts
@@ -1,5 +1,5 @@
 import { getLogger } from "@commonfabric/utils/logger";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import type { Cell } from "./cell.ts";
 import { getMetaLink, type NormalizedFullLink } from "./link-utils.ts";
 import type { Runtime } from "./runtime.ts";
@@ -15,7 +15,7 @@ function readPatternIdentity(
 ): { identity: string; symbol: string } | undefined {
   const raw = cell.getMetaRaw("patternIdentity");
   if (
-    isRecord(raw) && typeof raw.identity === "string" &&
+    isObjectOrArray(raw) && typeof raw.identity === "string" &&
     typeof raw.symbol === "string"
   ) {
     return { identity: raw.identity, symbol: raw.symbol };

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { isLinkRef, linkRefPayload } from "@commonfabric/data-model/cell-rep";
 import {
   type CellScope,
@@ -137,7 +137,7 @@ export function isPrimitiveCellLink(
 }
 
 export function isNormalizedLink(value: any): value is NormalizedLink {
-  if (!isRecord(value)) return false;
+  if (!isObjectOrArray(value)) return false;
   const { path, id, space, scope } = value;
   return Array.isArray(path) &&
     (typeof id === "string" || id === undefined) &&
@@ -158,7 +158,7 @@ export function isNormalizedLink(value: any): value is NormalizedLink {
  */
 export function isNormalizedFullLink(value: any): value is NormalizedFullLink {
   return (
-    isRecord(value) &&
+    isObjectOrArray(value) &&
     typeof value.id === "string" &&
     typeof value.space === "string" &&
     (value.scope === "space" || value.scope === "user" ||
@@ -193,7 +193,8 @@ export function isWriteRedirectLink(
  * to point to an actual cell. In data they are plain values.
  */
 export function isAliasBinding(value: any): value is AliasBinding {
-  return isRecord(value) && "$alias" in value && isRecord(value.$alias) &&
+  return isObjectOrArray(value) && "$alias" in value &&
+    isObjectOrArray(value.$alias) &&
     Array.isArray(value.$alias.path) &&
     (value.$alias.partialCause !== undefined ||
       value.$alias.cell === "result" || value.$alias.cell === "argument");

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -1,5 +1,5 @@
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { isNontrivialSchema } from "@commonfabric/data-model/schema-utils";
 import { deepFreeze, isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import {
@@ -555,7 +555,7 @@ function schemaLosesStreamCellMarker(
   schema: unknown,
   context: SanitizeContext,
 ): boolean {
-  if (context.keepAsCell === KeepAsCell.All || !isRecord(schema)) {
+  if (context.keepAsCell === KeepAsCell.All || !isObjectOrArray(schema)) {
     return false;
   }
 
@@ -576,9 +576,9 @@ function removeStrippedStreamPropertiesFromRequired(
   result: unknown,
   context: SanitizeContext,
 ): void {
-  if (!isRecord(originalSchema) || !isRecord(result)) return;
+  if (!isObjectOrArray(originalSchema) || !isObjectOrArray(result)) return;
   const properties = originalSchema.properties;
-  if (!isRecord(properties)) return;
+  if (!isObjectOrArray(properties)) return;
   if (!Array.isArray(result.required)) return;
 
   const required = result.required.filter((property) =>
@@ -655,7 +655,7 @@ export function getStableInternalPathSegment(
   }
 
   if (cause !== undefined) {
-    if (isRecord(cause) && "stream" in cause) {
+    if (isObjectOrArray(cause) && "stream" in cause) {
       return `stream:${formatStableCauseSegment(cause.stream as JSONValue)}`;
     }
     return formatStableCauseSegment(cause as JSONValue);

--- a/packages/runner/src/path-utils.ts
+++ b/packages/runner/src/path-utils.ts
@@ -1,5 +1,5 @@
 import { valueEqual } from "@commonfabric/data-model/fabric-value";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 
 /**
  * Read one path segment out of a data container WITHOUT falling through to the
@@ -19,7 +19,7 @@ import { isRecord } from "@commonfabric/utils/types";
  * Primitives need none either, and must not be excluded. `Object.hasOwn()`
  * coerces with `ToObject`, so it answers `true` for a string's `length` and its
  * indices — genuinely own — and `false` for `toUpperCase`/`toString`, which
- * live on `String.prototype`. Bailing out on everything non-`isRecord` would
+ * live on `String.prototype`. Bailing out on everything non-`isObjectOrArray` would
  * lose `getValueAtPath("abc", ["length"])`, which callers rely on to
  * reconstruct write details over primitive subtrees; indexing unconditionally,
  * as this did before, would hand back the prototype methods. `Object.hasOwn`
@@ -87,7 +87,7 @@ export function getValueAtPath(obj: any, path: readonly PropertyKey[]): any {
 export function hasValueAtPath(obj: any, path: PropertyKey[]): boolean {
   let current = obj;
   for (const key of path) {
-    if (!isRecord(current) || !Object.hasOwn(current, key as string)) {
+    if (!isObjectOrArray(current) || !Object.hasOwn(current, key as string)) {
       return false;
     }
     current = (current as Record<PropertyKey, unknown>)[key];

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import {
   FabricInstance,
@@ -100,7 +100,9 @@ const foldDeclaredScopeIntoLinkSchema = (
   authoredRootSchema: JSONSchema | undefined,
   path: readonly string[],
 ): NormalizedFullLink => {
-  if (authoredRootSchema === undefined || !isRecord(link.schema)) return link;
+  if (authoredRootSchema === undefined || !isObjectOrArray(link.schema)) {
+    return link;
+  }
   if (ContextualFlowControl.getSchemaScopeCap(link.schema) !== undefined) {
     return link;
   }
@@ -130,7 +132,7 @@ const scopedLinkForPath = (
 
   for (const key of path) {
     childSchema = ContextualFlowControl.getSchemaAtPath(schema, [key]);
-    if (isRecord(childSchema) && isCellScope(childSchema.scope)) {
+    if (isObjectOrArray(childSchema) && isCellScope(childSchema.scope)) {
       scope = childSchema.scope;
     }
     schema = childSchema;
@@ -140,7 +142,7 @@ const scopedLinkForPath = (
   const linkSchema = finalSchema === undefined
     ? undefined
     : sanitizeAliasSchemaForBinding(finalSchema);
-  if (isRecord(linkSchema)) {
+  if (isObjectOrArray(linkSchema)) {
     if (isCellScope(linkSchema.scope)) {
       scope = linkSchema.scope;
     }
@@ -357,7 +359,7 @@ function sendValueToBindingInner<T>(
     // guard-less walk keys a live `FabricValue` against the binding shape (a
     // `FabricPrimitive` is decomposed, a `FabricInstance` is walked by internal
     // slots rather than codec contents). Mark ahead of that.
-  } else if (isRecord(binding) && isRecord(value)) {
+  } else if (isObjectOrArray(binding) && isObjectOrArray(value)) {
     for (const key of Object.keys(binding)) {
       if (key in value) {
         sendValueToBindingInner(
@@ -370,7 +372,7 @@ function sendValueToBindingInner<T>(
         );
       }
     }
-  } else if (!isRecord(binding) || Object.keys(binding).length !== 0) {
+  } else if (!isObjectOrArray(binding) || Object.keys(binding).length !== 0) {
     // `Object.is`, not `===`: a constant `NaN` binding legitimately matches a
     // produced `NaN`, and `0` vs `-0` is a genuine mismatch.
     if (!Object.is(binding, value)) {
@@ -570,7 +572,7 @@ export function unwrapOneLevelAndBindToDoc<T extends FabricExecValue>(
       }
       // Nothing rebound, so the original is the answer.
       return converted ?? binding;
-    } else if (isRecord(binding)) {
+    } else if (isObjectOrArray(binding)) {
       // Copy lazily, as the array branch does: allocate only once a value
       // actually converts to something else, so the shared path — the common
       // one, and the majority of nodes — allocates nothing at all. (Compare
@@ -617,9 +619,9 @@ export function opaqueArgumentKeys(
   argumentSchema: JSONSchema | undefined,
 ): Set<string> {
   const keys = new Set<string>();
-  if (!isRecord(argumentSchema)) return keys;
+  if (!isObjectOrArray(argumentSchema)) return keys;
   const properties = argumentSchema.properties;
-  if (!isRecord(properties)) return keys;
+  if (!isObjectOrArray(properties)) return keys;
   for (const [key, propSchema] of Object.entries(properties)) {
     const isOpaque = ContextualFlowControl.getAsCellValues(
       propSchema as JSONSchema,
@@ -700,7 +702,7 @@ export function findAllWriteRedirectCells<T>(
     } else if (Array.isArray(binding)) {
       // If the binding is an array, recurse into each element.
       for (const value of binding) find(value, baseCell);
-      // A `FabricPrimitive` reaches the `isRecord` branch below, and is
+      // A `FabricPrimitive` reaches the `isObjectOrArray` branch below, and is
       // harmless there. This walk collects write-redirect links, and a
       // primitive is an opaque scalar: it can contain no redirect, and its
       // state lives in private fields, so `Object.values()` yields nothing and
@@ -710,14 +712,14 @@ export function findAllWriteRedirectCells<T>(
       // TODO(danfuzz): Latent — a `FabricInstance` is not harmless in the same
       // way. It is a container reached by its codec contents rather than by
       // property name, so a write redirect nested inside one is missed here.
-    } else if (isRecord(binding) && !isCellLink(binding)) {
+    } else if (isObjectOrArray(binding) && !isCellLink(binding)) {
       // If the binding is an object, recurse into each value.
       for (const value of Object.values(binding)) find(value, baseCell);
     }
   }
   if (
     skipTopLevelKeys !== undefined && skipTopLevelKeys.size > 0 &&
-    isRecord(binding) && !isCellLink(binding) && !isAliasBinding(binding)
+    isObjectOrArray(binding) && !isCellLink(binding) && !isAliasBinding(binding)
   ) {
     // Drop the named top-level argument keys (opaque forwarded references)
     // before traversing — they must not contribute to declared reads.

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -58,7 +58,7 @@ import {
   pinnedIdentity,
 } from "./sandbox/fabric-import-specifier.ts";
 import { fromURI, toURI } from "./uri-utils.ts";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { interleaveCompileYield } from "./harness/compile-interleave.ts";
 
 const logger = getLogger("pattern-manager");
@@ -2219,7 +2219,7 @@ export class PatternManager {
       );
       const current = cell.get();
       const annotations = {
-        ...(isRecord(current?.annotations) ? current!.annotations : {}),
+        ...(isObjectOrArray(current?.annotations) ? current!.annotations : {}),
         [key]: link,
       };
       cell.key("annotations").set(annotations);

--- a/packages/runner/src/piece-helpers.ts
+++ b/packages/runner/src/piece-helpers.ts
@@ -4,7 +4,7 @@ import {
 } from "@commonfabric/data-model/cell-rep";
 // Relative import (not "@commonfabric/utils/types") for the same rollup
 // reason as traverse.ts.
-import { isRecord } from "../../utils/src/types.ts";
+import { isObjectOrArray } from "../../utils/src/types.ts";
 import { getLogger } from "../../utils/src/logger.ts";
 import { type Cell, isCell, isStream } from "./cell.ts";
 import { isSigilLink } from "./link-types.ts";
@@ -145,7 +145,8 @@ export function schemaWithScopedLinkRequiredsRelaxed(
   tx?: IExtendedStorageTransaction,
 ): JSONSchema | undefined {
   if (
-    !isRecord(schema) || !isRecord(rawValue) || isSigilLink(rawValue) ||
+    !isObjectOrArray(schema) || !isObjectOrArray(rawValue) ||
+    isSigilLink(rawValue) ||
     Array.isArray(rawValue)
   ) {
     return schema;
@@ -219,7 +220,7 @@ export function schemaWithScopedLinkRequiredsRelaxed(
   }
 
   let properties = schema.properties;
-  if (isRecord(properties)) {
+  if (isObjectOrArray(properties)) {
     let newProperties: Record<string, JSONSchema> | undefined;
     for (const [key, propSchema] of Object.entries(properties)) {
       const propValue = (rawValue as Record<string, unknown>)[key];
@@ -313,7 +314,7 @@ export function isLegacyPieceRegistryRoot(
   const patternIdentity = root.getMetaRaw("patternIdentity");
   const patternSource = root.getMetaRaw("patternSource");
   if (
-    !isRecord(patternIdentity) ||
+    !isObjectOrArray(patternIdentity) ||
     typeof patternIdentity.identity !== "string" ||
     typeof patternIdentity.symbol !== "string" ||
     (patternSource !== undefined &&

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -1,6 +1,6 @@
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { FabricPrimitive } from "@commonfabric/data-model/fabric-value";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { getTopFrame } from "./builder/pattern.ts";
 import { isStreamValue } from "./builder/types.ts";
@@ -259,7 +259,7 @@ function createViewProxy<T>(
   // check depends on a specific field's VALUE. Register an explicit read of
   // `$stream` when present, so a value flipping into/out of a stream marker
   // re-triggers consumers. [review: ubik2]
-  if (isRecord(value) && "$stream" in value) {
+  if (isObjectOrArray(value) && "$stream" in value) {
     viewTx.readValueOrThrow({ ...link, path: [...link.path, "$stream"] });
   }
 
@@ -277,7 +277,7 @@ function createViewProxy<T>(
   // directly, exactly as for JS primitives above; wrapping one in a live proxy
   // serves no purpose and would leak that proxy into any consumer that
   // deep-clones or freezes the surrounding value (e.g. schema interning).
-  if (!isRecord(value) || value instanceof FabricPrimitive) {
+  if (!isObjectOrArray(value) || value instanceof FabricPrimitive) {
     // The SHAPE_READ above tracks only the container's shape, but a
     // FabricPrimitive is an atomic VALUE the consumer materializes here (handed
     // back directly, like a JS primitive), not a container whose shape it
@@ -688,7 +688,7 @@ function createViewProxy<T>(
     },
     ownKeys: () => {
       const current = readTx().readValueOrThrow(link, SHAPE_READ);
-      const keys = isRecord(current) || Array.isArray(current)
+      const keys = isObjectOrArray(current) || Array.isArray(current)
         ? Reflect.ownKeys(current)
         : Reflect.ownKeys(value);
       if (Array.isArray(proxyTarget)) {
@@ -771,7 +771,7 @@ function createViewProxy<T>(
       // (loom CT-1949). The `has` trap below keeps `in` -- there it is correct,
       // being the `in` operator's own trap.
       if (
-        (isRecord(current) || Array.isArray(current)) &&
+        (isObjectOrArray(current) || Array.isArray(current)) &&
         Object.hasOwn(current, prop)
       ) {
         return {
@@ -797,7 +797,7 @@ function createViewProxy<T>(
         return prop in value;
       }
       const current = readTx().readValueOrThrow(link, SHAPE_READ);
-      if (isRecord(current) || Array.isArray(current)) {
+      if (isObjectOrArray(current) || Array.isArray(current)) {
         // Probing whether a numeric index is present (`n in arr`) observes the
         // array's key set: for a dense array the answer is `n < length`, but a
         // sparse array has holes, so the answer depends on whether index `n` is
@@ -901,7 +901,7 @@ const createProxyForArrayValue = (
 };
 
 function isProxyForArrayValue(value: any): value is ProxyForArrayValue {
-  return isRecord(value) && originalIndex in value;
+  return isObjectOrArray(value) && originalIndex in value;
 }
 
 /**
@@ -923,7 +923,7 @@ export function getCellOrThrow<T = any>(value: any): Cell<T> {
  * @returns {boolean}
  */
 export function isCellResult(value: any): value is CellResult<any> {
-  return isRecord(value) &&
+  return isObjectOrArray(value) &&
     typeof (value as Partial<BackToCellInternals>)[toCell] === "function";
 }
 

--- a/packages/runner/src/reactive-dependencies.ts
+++ b/packages/runner/src/reactive-dependencies.ts
@@ -1,4 +1,4 @@
-import { isPlainContainer, isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray, isPlainContainer } from "@commonfabric/utils/types";
 import {
   type FabricValue,
   valueEqual,
@@ -142,15 +142,15 @@ export function determineTriggeredActions(
 
   // *LastObject: Last key-able object along currentPath
   //
-  // TODO(danfuzz): `isRecord` counts a `FabricSpecialObject` as key-able, so
+  // TODO(danfuzz): `isObjectOrArray` counts a `FabricSpecialObject` as key-able, so
   // the descent below indexes into one: every key reads `undefined` (or, via
   // the prototype chain, an accessor result) on both the before and after
   // side, so a subscriber path continuing below a `FabricInstance` compares
   // equal-by-vacancy and its action never triggers, however the instance's
   // contents changed. The `shallowEqual` marker at the bottom of this file
   // covers the leaf comparison; this is the descent's half of the same gap.
-  let beforeLastObject = isRecord(before) ? 0 : -1;
-  let afterLastObject = isRecord(after) ? 0 : -1;
+  let beforeLastObject = isObjectOrArray(before) ? 0 : -1;
+  let afterLastObject = isObjectOrArray(after) ? 0 : -1;
 
   while (subscribers.length > 0) {
     // Pull the next path from the queue
@@ -170,12 +170,12 @@ export function determineTriggeredActions(
     for (let i = overlap; i < targetPath.length; i++) {
       if (i <= beforeLastObject) {
         beforeValues[i + 1] = (beforeValues[i] as Keyable)[targetPath[i]!];
-        if (isRecord(beforeValues[i + 1])) beforeLastObject = i + 1;
+        if (isObjectOrArray(beforeValues[i + 1])) beforeLastObject = i + 1;
         else beforeLastObject = i;
       }
       if (i <= afterLastObject) {
         afterValues[i + 1] = (afterValues[i] as Keyable)[targetPath[i]!];
-        if (isRecord(afterValues[i + 1])) afterLastObject = i + 1;
+        if (isObjectOrArray(afterValues[i + 1])) afterLastObject = i + 1;
         else afterLastObject = i;
       }
     }

--- a/packages/runner/src/runner-utils.ts
+++ b/packages/runner/src/runner-utils.ts
@@ -8,7 +8,7 @@ import {
 import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import {
   isModule,
   type JSONSchema,
@@ -301,9 +301,9 @@ function extractDefaultValuesInternal(
       (canonical.type === "object" ||
         Array.isArray(canonical.type) && canonical.type.includes("object")) &&
       canonical.properties &&
-      isRecord(canonical.properties)
+      isObjectOrArray(canonical.properties)
     ) {
-      // TODO(danfuzz): `isRecord` admits a `FabricSpecialObject`, so a
+      // TODO(danfuzz): `isObjectOrArray` admits a `FabricSpecialObject`, so a
       // fabric-valued `default` under an object-with-properties schema skips
       // this scalar return and proceeds below: `shallowMutableClone` returns
       // a `FabricPrimitive` by identity (it is inherently frozen), so the
@@ -313,12 +313,12 @@ function extractDefaultValuesInternal(
       // default. Wants a `FabricSpecialObject` test taking this return.
       if (
         Object.hasOwn(canonical, "default") &&
-        !isRecord(canonical.default)
+        !isObjectOrArray(canonical.default)
       ) {
         return canonical.default;
       }
       const hasObjectDefault = Object.hasOwn(canonical, "default") &&
-        isRecord(canonical.default);
+        isObjectOrArray(canonical.default);
       // Mutable top-level copy of the schema default, so injecting top-level
       // property defaults below doesn't mutate the schema's own default object.
       // Only top-level keys are written here, and the result is normalized
@@ -327,7 +327,7 @@ function extractDefaultValuesInternal(
       // children as inexpensive defense-in-depth against accidental deeper
       // mutation of the shared default.
       const obj = shallowMutableClone(
-        isRecord(canonical.default) ? canonical.default : {},
+        isObjectOrArray(canonical.default) ? canonical.default : {},
       ) as Record<string, FabricValue>;
       for (
         const [propKey, propSchema] of Object.entries(canonical.properties)
@@ -379,7 +379,7 @@ export function mergeObjects<T>(
   const result: Record<string, unknown> = {};
 
   for (const obj of objects) {
-    if (!isRecord(obj) || Array.isArray(obj) || isCellLink(obj)) {
+    if (!isObjectNotArray(obj) || isCellLink(obj)) {
       return obj as T;
     }
 
@@ -388,7 +388,7 @@ export function mergeObjects<T>(
       seen.add(key);
       const merged = mergeObjects<T[keyof T]>(
         ...objects.map((entry) =>
-          isRecord(entry) && Object.hasOwn(entry, key)
+          isObjectOrArray(entry) && Object.hasOwn(entry, key)
             ? (entry as Record<string, unknown>)[key] as T[keyof T]
             : undefined
         ),

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -16,7 +16,11 @@ import { ContextualFlowControl } from "./cfc.ts";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { getLogger } from "@commonfabric/utils/logger";
-import { isPlainObject, isRecord } from "@commonfabric/utils/types";
+import {
+  isObjectNotArray,
+  isObjectOrArray,
+  isPlainObject,
+} from "@commonfabric/utils/types";
 import { BoundedKeyMap } from "@commonfabric/utils/cache";
 import { PatternManager } from "./pattern-manager.ts";
 import { rendererVDOMSchema } from "./schemas.ts";
@@ -266,7 +270,7 @@ function schedulerActionInstanceKey(parts: {
 function schemaCellScope(
   schema: JSONSchema | undefined,
 ): CellScope | undefined {
-  return isRecord(schema) && isCellScope(schema.scope)
+  return isObjectOrArray(schema) && isCellScope(schema.scope)
     ? schema.scope
     : undefined;
 }
@@ -377,7 +381,7 @@ const recordOutputSchemaPolicyInputs = (
     return;
   }
 
-  // A `FabricInstance` is refused. `isRecord` admits one, and its enumerable
+  // A `FabricInstance` is refused. `isObjectOrArray` admits one, and its enumerable
   // properties are empty, so descent would stop without reaching its codec
   // contents -- and a write-redirect link nested inside one would record no
   // `kind: "schema"` entry.
@@ -400,7 +404,7 @@ const recordOutputSchemaPolicyInputs = (
     );
   }
 
-  if (isRecord(outputBinding) && !isCellLink(outputBinding)) {
+  if (isObjectOrArray(outputBinding) && !isCellLink(outputBinding)) {
     for (const [key, child] of Object.entries(outputBinding)) {
       recordOutputSchemaPolicyInputs(
         tx,
@@ -477,10 +481,10 @@ const recordRawBuiltinBindingSchemaPolicyInputs = (
   }
 
   // TODO(danfuzz): same gap as `recordOutputSchemaPolicyInputs()` above:
-  // `isRecord` admits a `FabricSpecialObject`, whose empty entries end the
+  // `isObjectOrArray` admits a `FabricSpecialObject`, whose empty entries end the
   // descent, so a link inside a `FabricInstance`'s codec contents records no
   // policy input. Fails closed, as there.
-  if (isRecord(outputBinding) && !isCellLink(outputBinding)) {
+  if (isObjectOrArray(outputBinding) && !isCellLink(outputBinding)) {
     for (const child of Object.values(outputBinding)) {
       recordRawBuiltinBindingSchemaPolicyInputs(
         tx,
@@ -601,12 +605,12 @@ export function firstResolvedOutputRedirect(
     }
     return undefined;
   }
-  // TODO(danfuzz): `isRecord` admits a `FabricSpecialObject`, whose empty
+  // TODO(danfuzz): `isObjectOrArray` admits a `FabricSpecialObject`, whose empty
   // entries end the descent, so a write-redirect link inside a
   // `FabricInstance`'s codec contents is invisible here. The caller then
   // sees no redirect and silently skips the sub-pattern's owned-cell
   // pre-sync keyed off it.
-  if (isRecord(binding) && !isCellLink(binding)) {
+  if (isObjectOrArray(binding) && !isCellLink(binding)) {
     for (const child of Object.values(binding)) {
       const found = firstResolvedOutputRedirect(runtime, tx, child, baseCell);
       if (found) return found;
@@ -715,7 +719,7 @@ const recordSetupProjectionPolicyInputs = (
     );
   }
 
-  if (isRecord(projection) && !isCellLink(projection)) {
+  if (isObjectOrArray(projection) && !isCellLink(projection)) {
     for (const [key, child] of Object.entries(projection)) {
       recordSetupProjectionPolicyInputs(
         tx,
@@ -977,14 +981,17 @@ function closedWorldEventRejection(
   runtimeInjectedEventKeys?: readonly string[],
 ): string | undefined {
   if (event === undefined) return undefined;
-  if (!isRecord(argumentSchema) || !isRecord(argumentSchema.properties)) {
+  if (
+    !isObjectOrArray(argumentSchema) ||
+    !isObjectOrArray(argumentSchema.properties)
+  ) {
     return undefined;
   }
   const eventSchema = argumentSchema.properties.$event;
-  if (!isRecord(eventSchema)) return undefined;
+  if (!isObjectOrArray(eventSchema)) return undefined;
   const refTarget = localRefTarget(eventSchema, argumentSchema);
   const closed = eventSchema.additionalProperties === false ||
-    (isRecord(refTarget) && refTarget.additionalProperties === false);
+    (isObjectOrArray(refTarget) && refTarget.additionalProperties === false);
   if (!closed) return undefined;
 
   // The runtime itself merges keys into some payloads — the LLM tool-call
@@ -1013,10 +1020,10 @@ function closedWorldEventRejection(
   if (
     runtimeInjectedEventKeys !== undefined &&
     runtimeInjectedEventKeys.length > 0 &&
-    isRecord(event)
+    isObjectOrArray(event)
   ) {
     const declaredProperties =
-      isRecord(refTarget) && isRecord(refTarget.properties)
+      isObjectOrArray(refTarget) && isObjectOrArray(refTarget.properties)
         ? refTarget.properties
         : undefined;
     const rest = { ...(event as Record<string, unknown>) };
@@ -1046,9 +1053,10 @@ function closedWorldEventRejection(
     );
     if (cacheable) relaxedHandlerSchemaCache.set(argumentSchema, relaxedRoot);
   }
-  const relaxedEvent = isRecord(relaxedRoot) && isRecord(relaxedRoot.properties)
-    ? relaxedRoot.properties.$event
-    : undefined;
+  const relaxedEvent =
+    isObjectOrArray(relaxedRoot) && isObjectOrArray(relaxedRoot.properties)
+      ? relaxedRoot.properties.$event
+      : undefined;
   if (relaxedEvent === undefined) return undefined;
 
   const failure = validateSchemaValue(relaxedEvent, payload, relaxedRoot, {
@@ -1088,7 +1096,7 @@ function overlayUnresolvedLinkPlaceholders(
     }
     return result ?? materialized;
   }
-  if (isRecord(raw) && isRecord(materialized)) {
+  if (isObjectOrArray(raw) && isObjectOrArray(materialized)) {
     let result: Record<string, unknown> | undefined;
     for (const [key, rawChild] of Object.entries(raw)) {
       const child = overlayUnresolvedLinkPlaceholders(
@@ -1774,7 +1782,7 @@ export class Runner {
     });
     if (
       options.preserveName &&
-      isRecord(previousResult) &&
+      isObjectOrArray(previousResult) &&
       previousResult[NAME]
     ) {
       result = { ...result, [NAME]: previousResult[NAME] };
@@ -1869,7 +1877,7 @@ export class Runner {
         // a probe read of the not-yet-loaded value would otherwise enter the
         // commit's conflict set and lose to the durable value when it streams
         // in, reverting the whole instantiation commit.
-        const schemaDefault = isRecord(descriptor.schema)
+        const schemaDefault = isObjectOrArray(descriptor.schema)
           ? descriptor.schema.default as JSONValue | undefined
           : undefined;
         if (schemaDefault !== undefined) {
@@ -3931,8 +3939,8 @@ export class Runner {
 
       if (link) {
         promises.add(this.runtime.getCellFromLink(link).sync());
-      } else if (isRecord(value)) {
-        // TODO(danfuzz): `isRecord` admits a `FabricSpecialObject`, and
+      } else if (isObjectOrArray(value)) {
+        // TODO(danfuzz): `isObjectOrArray` admits a `FabricSpecialObject`, and
         // `for..in` sees none of its state, so a link nested in a
         // `FabricInstance`'s codec contents is never synced here — the cold
         // target this pre-sync exists to warm.
@@ -4054,9 +4062,9 @@ export class Runner {
     // first locally computed, then conflicts on write and only then properly
     // received from the server.
     if (
-      isRecord(pattern.result) &&
+      isObjectOrArray(pattern.result) &&
       pattern.result[UI] &&
-      (!isRecord(pattern.resultSchema) ||
+      (!isObjectOrArray(pattern.resultSchema) ||
         !pattern.resultSchema.properties?.[UI])
     ) {
       cells.push(resultCell.key(UI).asSchema(rendererVDOMSchema));
@@ -4132,8 +4140,8 @@ export class Runner {
                 )
               ),
           );
-        } else if (isRecord(value)) {
-          // TODO(danfuzz): `isRecord` admits a `FabricSpecialObject`, and
+        } else if (isObjectOrArray(value)) {
+          // TODO(danfuzz): `isObjectOrArray` admits a `FabricSpecialObject`, and
           // `for..in` sees none of its state, so a link inside a
           // `FabricInstance` held in a raw argument value is never pre-synced
           // — a cold target can then enter the commit basis, the exact
@@ -4746,7 +4754,10 @@ export class Runner {
     event: unknown,
     depTx: IExtendedStorageTransaction,
   ): void {
-    if (!isRecord(argumentSchema) || !isRecord(argumentSchema.properties)) {
+    if (
+      !isObjectOrArray(argumentSchema) ||
+      !isObjectOrArray(argumentSchema.properties)
+    ) {
       return;
     }
     const eventSchema = argumentSchema.properties.$event;
@@ -4799,7 +4810,7 @@ export class Runner {
       currentValue: unknown,
       path: readonly string[],
     ): void => {
-      if (!isRecord(schema)) return;
+      if (!isObjectOrArray(schema)) return;
       const pathKey = JSON.stringify(path);
       const seenPaths = seen.get(schema);
       if (seenPaths?.has(pathKey)) return;
@@ -4865,7 +4876,7 @@ export class Runner {
       forEachSubschema(schema as JSONSchema, (child, keyword, key, index) => {
         switch (keyword) {
           case "properties":
-            if (isRecord(currentValue)) {
+            if (isObjectOrArray(currentValue)) {
               visit(child, currentValue[key!], [...path, key!]);
             }
             return;
@@ -4890,9 +4901,9 @@ export class Runner {
             }
             return;
           case "additionalProperties":
-            if (isRecord(currentValue) && !Array.isArray(currentValue)) {
+            if (isObjectNotArray(currentValue)) {
               // Covers only the keys `properties` does not declare.
-              const declaredKeys = isRecord(schema.properties)
+              const declaredKeys = isObjectOrArray(schema.properties)
                 ? new Set(Object.keys(schema.properties))
                 : undefined;
               for (const [k, v] of Object.entries(currentValue)) {
@@ -4916,7 +4927,7 @@ export class Runner {
 
   private moduleHasOpaqueResult(module: Module): boolean {
     const resultSchema = module.resultSchema;
-    return isRecord(resultSchema) &&
+    return isObjectOrArray(resultSchema) &&
       Array.isArray(resultSchema.asCell) &&
       resultSchema.asCell.includes("opaque");
   }
@@ -4933,7 +4944,7 @@ export class Runner {
     const schemaWithRootDefinitions = (
       schema: JSONSchema | undefined,
     ): JSONSchema | undefined => {
-      if (!isRecord(schema) || !isRecord(rootSchema)) {
+      if (!isObjectOrArray(schema) || !isObjectOrArray(rootSchema)) {
         return schema;
       }
       return {
@@ -4965,7 +4976,7 @@ export class Runner {
       if (isCellLink(currentValue)) {
         return;
       }
-      if (!isRecord(schema)) return;
+      if (!isObjectOrArray(schema)) return;
       const seenValues = seen.get(schema) ?? new Set<unknown>();
       if (seenValues.has(currentValue)) return;
       seenValues.add(currentValue);
@@ -4990,7 +5001,7 @@ export class Runner {
           "when collecting scheduler read links from an argument",
         );
       }
-      if (isRecord(schema.properties) && isRecord(currentValue)) {
+      if (isObjectOrArray(schema.properties) && isObjectOrArray(currentValue)) {
         for (const [key, propertySchema] of Object.entries(schema.properties)) {
           visit(propertySchema, currentValue[key]);
         }
@@ -5015,9 +5026,9 @@ export class Runner {
       }
       if (
         schema.additionalProperties !== undefined &&
-        isRecord(currentValue)
+        isObjectOrArray(currentValue)
       ) {
-        const declaredKeys = isRecord(schema.properties)
+        const declaredKeys = isObjectOrArray(schema.properties)
           ? new Set(Object.keys(schema.properties))
           : undefined;
         for (const [key, propertyValue] of Object.entries(currentValue)) {
@@ -5176,7 +5187,7 @@ export class Runner {
     streamLink?: NormalizedFullLink;
     eventTarget?: { link?: NormalizedFullLink; value: FabricValue };
   } {
-    if (!isRecord(inputs) || !("$event" in inputs)) return {};
+    if (!isObjectOrArray(inputs) || !("$event" in inputs)) return {};
 
     // Sigil-only: `$event` is builder-generated and always unwraps to a sigil
     // link; a residual `$alias` here could only be an embedded pattern's
@@ -6002,7 +6013,7 @@ export class Runner {
           // is an ambient local read (it may kick off, but never await, a
           // sync); guard each access so one lazy read failing doesn't abort
           // the rest of the presync.
-          if (!isRecord(value)) return;
+          if (!isObjectOrArray(value)) return;
           if (seen.has(value)) return;
           seen.add(value);
           for (const key of Object.keys(value)) {
@@ -6096,7 +6107,7 @@ export class Runner {
       schedulerRehydration,
     }: JavaScriptNodeContext,
   ): void {
-    if (isRecord(inputs) && "$event" in inputs) {
+    if (isObjectOrArray(inputs) && "$event" in inputs) {
       throw new Error(
         "Handler used as lift, because $stream: true was overwritten",
       );
@@ -6552,10 +6563,10 @@ export class Runner {
   ): unknown {
     const invoke = () => {
       if (module.wrapper === "handler") {
-        const event = isRecord(argument) && "$event" in argument
+        const event = isObjectOrArray(argument) && "$event" in argument
           ? argument.$event
           : undefined;
-        const context = isRecord(argument) && "$ctx" in argument
+        const context = isObjectOrArray(argument) && "$ctx" in argument
           ? argument.$ctx
           : undefined;
         return fn(event, context);
@@ -6636,9 +6647,9 @@ export class Runner {
     ) {
       return;
     }
-    if (!isRecord(inputBindings)) return;
+    if (!isObjectOrArray(inputBindings)) return;
     const op = (inputBindings as Record<string, unknown>).op;
-    if (!isRecord(op)) return;
+    if (!isObjectOrArray(op)) return;
     let ref = this.runtime.patternManager.getArtifactEntryRef(
       op as unknown as object,
     );
@@ -7341,7 +7352,7 @@ export function getPieceSourceRevisions(
   const revisions: PieceSourceRevision[] = [];
   const revisionIds = new Set<string>();
   for (const value of raw) {
-    if (!isRecord(value)) {
+    if (!isObjectOrArray(value)) {
       throw new Error("piece source history is invalid");
     }
     const pattern = asPatternIdentityRef(value.pattern);
@@ -7677,7 +7688,7 @@ export function asPatternIdentityRef(
   raw: unknown,
 ): { identity: string; symbol: string } | undefined {
   if (
-    isRecord(raw) && typeof raw.identity === "string" &&
+    isObjectOrArray(raw) && typeof raw.identity === "string" &&
     typeof raw.symbol === "string"
   ) {
     return { identity: raw.identity, symbol: raw.symbol };

--- a/packages/runner/src/scheduler/diagnostics.ts
+++ b/packages/runner/src/scheduler/diagnostics.ts
@@ -1,5 +1,5 @@
 import type { MemorySpace } from "@commonfabric/memory/interface";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { getTopFrame } from "../builder/pattern.ts";
 import { type Frame } from "../builder/types.ts";
 import {
@@ -99,7 +99,7 @@ function formatTelemetryLink(link: NormalizedFullLink): string {
 }
 
 function getOptionalName(value: unknown): string | undefined {
-  if (!isRecord(value)) return undefined;
+  if (!isObjectOrArray(value)) return undefined;
   const debugName = value.debugName;
   if (typeof debugName === "string") return debugName;
   const name = value.name;
@@ -161,7 +161,7 @@ export function summarizeTriggerTraceValue(
   if (Array.isArray(value)) {
     return { kind: "array", size: value.length };
   }
-  if (isRecord(value)) {
+  if (isObjectOrArray(value)) {
     return { kind: "object", size: Object.keys(value).length };
   }
   return { kind: "other", preview: Object.prototype.toString.call(value) };
@@ -191,15 +191,15 @@ export function getPieceMetadataFromFrame(frame?: Frame): {
   // cycle) and fall back to the in-hand pattern's entry ref when the cell has no
   // stored pointer (a keyless run()).
   const storedIdentity = resultCell.getMetaRaw("patternIdentity");
-  result.patternId =
-    (isRecord(storedIdentity) && typeof storedIdentity.identity === "string"
-      ? storedIdentity.identity
-      : undefined) ??
-      (frame?.unsafe_binding?.pattern
-        ? frame.runtime?.patternManager.getArtifactEntryRef(
-          frame.unsafe_binding.pattern,
-        )?.identity
-        : undefined);
+  result.patternId = (isObjectOrArray(storedIdentity) &&
+      typeof storedIdentity.identity === "string"
+    ? storedIdentity.identity
+    : undefined) ??
+    (frame?.unsafe_binding?.pattern
+      ? frame.runtime?.patternManager.getArtifactEntryRef(
+        frame.unsafe_binding.pattern,
+      )?.identity
+      : undefined);
   result.space = resultCell.space;
   // The FULL sourceURI, scheme included. All consumers are display (error
   // strings, console-log prefixes), and keeping the scheme means ids copied

--- a/packages/runner/src/scheduler/wake-shaping.ts
+++ b/packages/runner/src/scheduler/wake-shaping.ts
@@ -1,5 +1,5 @@
 import { getLogger } from "@commonfabric/utils/logger";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { type NormalizedFullLink } from "../link-utils.ts";
 import {
   isRendererTrustedEvent,
@@ -299,7 +299,7 @@ const CLOCK_FIELD_NAMES = new Set(["timestamp", "timeStamp"]);
 
 function hasClockFieldDeep(value: unknown): boolean {
   if (Array.isArray(value)) return value.some(hasClockFieldDeep);
-  if (isRecord(value)) {
+  if (isObjectOrArray(value)) {
     for (const [key, child] of Object.entries(value)) {
       if (CLOCK_FIELD_NAMES.has(key)) return true;
       if (hasClockFieldDeep(child)) return true;
@@ -310,7 +310,7 @@ function hasClockFieldDeep(value: unknown): boolean {
 
 function scrubClockFields(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(scrubClockFields);
-  if (isRecord(value)) {
+  if (isObjectOrArray(value)) {
     const out: Record<string, unknown> = {};
     for (const [key, child] of Object.entries(value)) {
       if (CLOCK_FIELD_NAMES.has(key)) continue;
@@ -332,7 +332,7 @@ function scrubClockFields(value: unknown): unknown {
  * Returns the same reference when there is nothing to strip.
  */
 export function stripClockFields(event: unknown): unknown {
-  if (!isRecord(event)) return event;
+  if (!isObjectOrArray(event)) return event;
   if (!hasClockFieldDeep(event)) return event;
   return scrubClockFields(event);
 }

--- a/packages/runner/src/schema-view.ts
+++ b/packages/runner/src/schema-view.ts
@@ -42,7 +42,7 @@ import type {
 } from "@commonfabric/api";
 import { FabricPrimitive } from "@commonfabric/data-model/fabric-value";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { ContextualFlowControl } from "./cfc.ts";
 import {
@@ -127,7 +127,7 @@ const EXCLUDED_REJECTED: JSONSchema = Object.freeze({
 });
 
 const isExcluded = (schema: JSONSchema): boolean =>
-  isRecord(schema) &&
+  isObjectOrArray(schema) &&
   (schema.$comment === "emptyProperties" ||
     schema.$comment === "missingProperty" ||
     schema.$comment === "rejectedProperty");
@@ -195,12 +195,14 @@ const branchWithOuter = (
 ): JSONSchema => {
   const { anyOf: _anyOf, oneOf: _oneOf, ...outer } = schema;
   const combined = combineSchema(outer as JSONSchemaObj, branch);
-  if (!isRecord(combined) || !isRecord(schema.$defs)) return combined;
+  if (!isObjectOrArray(combined) || !isObjectOrArray(schema.$defs)) {
+    return combined;
+  }
   return {
     ...combined as JSONSchemaObj,
     $defs: {
       ...schema.$defs,
-      ...(isRecord(combined.$defs) ? combined.$defs : {}),
+      ...(isObjectOrArray(combined.$defs) ? combined.$defs : {}),
     },
   };
 };
@@ -217,7 +219,7 @@ const branchWithOuter = (
  * same answer, decided on the schema instead.
  */
 const preferAsCellBranch = (schema: JSONSchema): JSONSchema => {
-  if (!isRecord(schema)) return schema;
+  if (!isObjectOrArray(schema)) return schema;
   const branches = schema.anyOf ?? schema.oneOf;
   if (!Array.isArray(branches)) return schema;
   const resolved = branches.map((branch) => resolveBranch(branch, schema));
@@ -250,9 +252,9 @@ const resolveBranch = (
   branch: JSONSchema,
   parent: JSONSchemaObj,
 ): JSONSchema => {
-  if (!isRecord(branch) || !("$ref" in branch)) return branch;
+  if (!isObjectOrArray(branch) || !("$ref" in branch)) return branch;
   const roots = [
-    ...(isRecord(parent.$defs)
+    ...(isObjectOrArray(parent.$defs)
       ? [{ $defs: parent.$defs } as JSONSchemaObj]
       : []),
     branch as JSONSchemaObj,
@@ -267,7 +269,9 @@ const resolveBranch = (
       // matches everything and `false` matches nothing, which is what the
       // definition said. Only exhausting the roots is a failure, and the
       // resolver throws rather than returning a boolean for that.
-      if (isRecord(resolved) || typeof resolved === "boolean") return resolved;
+      if (isObjectOrArray(resolved) || typeof resolved === "boolean") {
+        return resolved;
+      }
     } catch {
       // Try the next root; the warning below covers exhausting them.
     }
@@ -293,7 +297,7 @@ const narrowForValue = (
   schema: JSONSchema | undefined,
   value: FabricValue,
 ): JSONSchema | undefined => {
-  if (!isRecord(schema)) return schema;
+  if (!isObjectOrArray(schema)) return schema;
   const rawBranches = schema.anyOf ?? schema.oneOf;
   if (!Array.isArray(rawBranches) || rawBranches.length === 0) return schema;
   // Resolve `$ref` branches against this schema's own `$defs` first. A branch
@@ -321,7 +325,7 @@ const narrowForValue = (
 };
 
 const requiredKeys = (schema: JSONSchema | undefined): readonly string[] =>
-  isRecord(schema) && Array.isArray(schema.required)
+  isObjectOrArray(schema) && Array.isArray(schema.required)
     ? schema.required as string[]
     : [];
 
@@ -337,7 +341,7 @@ const childSchema = (
     EXCLUDED_EMPTY,
     EXCLUDED_MISSING,
   );
-  if (narrowed !== false || !isRecord(schema)) {
+  if (narrowed !== false || !isObjectOrArray(schema)) {
     return preferAsCellBranch(narrowed);
   }
   // `schemaAtPath` decides which children exist from the schema's `type`, so a
@@ -346,7 +350,9 @@ const childSchema = (
   // subschema is right there, so read it directly rather than refuse. Losing it
   // costs more than a refusal: the child's `asCell` marker goes with it, and
   // the reader gets a plain view where the pattern declared a `Cell`.
-  if (isRecord(schema.properties) && Object.hasOwn(schema.properties, key)) {
+  if (
+    isObjectOrArray(schema.properties) && Object.hasOwn(schema.properties, key)
+  ) {
     const declared = (schema.properties as Record<string, JSONSchema>)[key];
     // Except where the subschema is `false`, which turns the child down rather
     // than describing one to read through.
@@ -359,16 +365,18 @@ const childSchema = (
   // has turned this key down. Without `additionalProperties` the same shape
   // reaches `schemaAtPath` as a missing property rather than as `false`, and an
   // eager read drops the property either way.
-  if (isRecord(schema.properties) && schema.additionalProperties === false) {
+  if (
+    isObjectOrArray(schema.properties) && schema.additionalProperties === false
+  ) {
     return EXCLUDED_REJECTED;
   }
   return false;
 };
 
 const declaredDefault = (schema: JSONSchema): FabricValue | undefined => {
-  if (!isRecord(schema)) return undefined;
+  if (!isObjectOrArray(schema)) return undefined;
   const resolved = ContextualFlowControl.resolveSchemaRefs(schema);
-  return isRecord(resolved)
+  return isObjectOrArray(resolved)
     ? resolved.default as FabricValue | undefined
     : undefined;
 };
@@ -385,7 +393,7 @@ const declaredDefault = (schema: JSONSchema): FabricValue | undefined => {
 const defaultForAbsentValue = (
   schema: JSONSchema | undefined,
 ): FabricValue | undefined =>
-  isRecord(schema) ? declaredDefault(schema) : undefined;
+  isObjectOrArray(schema) ? declaredDefault(schema) : undefined;
 
 /**
  * Build a view over `value` at `link`, or report that the data does not match.
@@ -473,7 +481,7 @@ export function materializeSchemaView(
   }
 
   const actualType = jsonTypeOf(value);
-  if (isRecord(schema) && schema.type !== undefined) {
+  if (isObjectOrArray(schema) && schema.type !== undefined) {
     if (!typeAccepts(schema.type, actualType)) {
       return mismatch(
         `expected ${JSON.stringify(schema.type)}, found ${actualType}`,
@@ -486,7 +494,7 @@ export function materializeSchemaView(
   // `required: ["length"]` — so the check is prototype-chain membership with
   // the brand exemption, which is what an eager read applies before letting one
   // through.
-  if (value instanceof FabricPrimitive && isRecord(schema)) {
+  if (value instanceof FabricPrimitive && isObjectOrArray(schema)) {
     if (opaqueLeafMissesRequired(schema, value)) {
       return mismatch("opaque leaf is missing a required property");
     }
@@ -494,7 +502,7 @@ export function materializeSchemaView(
 
   // A primitive, and a `FabricPrimitive` with it, is a leaf: the type check
   // above is the whole of what a schema says about it.
-  if (!isRecord(value) || value instanceof FabricPrimitive) {
+  if (!isObjectOrArray(value) || value instanceof FabricPrimitive) {
     // The caller read this document without telling the scheduler — the eager
     // traverser registers its own reads as it walks, and so does a view. Same
     // granularity it uses: non-recursive, which a write at this path still
@@ -554,7 +562,7 @@ const visibleKeys = (
   const keys = Object.keys(value).filter((key) =>
     !isExcluded(childSchema(schema, key))
   );
-  if (isRecord(schema) && isRecord(schema.properties)) {
+  if (isObjectOrArray(schema) && isObjectOrArray(schema.properties)) {
     for (const key of Object.keys(schema.properties)) {
       if (Object.hasOwn(value, key)) continue;
       if (declaredDefault(childSchema(schema, key)) === undefined) continue;
@@ -762,7 +770,7 @@ function createArrayView(
     // carries its own identity, and an `asCell` item is a handle whose link is
     // the point of it.
     if (
-      isRecord(item) && !Array.isArray(item) && !isSigilLink(item) &&
+      isObjectNotArray(item) && !isSigilLink(item) &&
       !SchemaObjectTraverser.hasAsCell(itemSchema)
     ) {
       // The read still belongs to the slot, and recursively: the identity is

--- a/packages/runner/src/schema-walk.ts
+++ b/packages/runner/src/schema-walk.ts
@@ -43,7 +43,11 @@
  */
 
 import type { JSONSchema, JSONSchemaObj } from "@commonfabric/api";
-import { isRecord } from "@commonfabric/utils/types";
+import {
+  isBoolean,
+  isObjectNotArray,
+  isObjectOrArray,
+} from "@commonfabric/utils/types";
 import { getLogger } from "@commonfabric/utils/logger";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 
@@ -107,14 +111,15 @@ export type SubschemaKeyword =
 
 /**
  * Everything a schema can be: `true`, `false`, or an object that is not an
- * array. This is the test `validateSchemaDefinition` applies to a subschema,
- * which rejects the pre-2019 tuple spelling of `items` along with everything
- * else an array could mean there. See the module docstring for how the walk
- * treats a value that fails it.
+ * array. Rejecting the array rejects the pre-2019 tuple spelling of `items`
+ * along with everything else an array could mean in a subschema position. See
+ * the module docstring for how the walk treats a value that fails this.
+ *
+ * `validateSchemaDefinition` gates an authored schema on the same question and
+ * calls this to ask it, so what the two admit cannot drift apart.
  */
 export function isSubschema(value: unknown): value is JSONSchema {
-  return typeof value === "boolean" ||
-    (isRecord(value) && !Array.isArray(value));
+  return isBoolean(value) || isObjectNotArray(value);
 }
 
 export interface SchemaWalkOptions {
@@ -241,7 +246,7 @@ const holdsSubschemaRecord = (
   keyword: SubschemaKeyword,
   parent: JSONSchema,
 ): value is Readonly<Record<string, unknown>> => {
-  if (isRecord(value)) return true;
+  if (isObjectOrArray(value)) return true;
   warnNotSchema(
     "an object of named schemas",
     keyword,
@@ -268,7 +273,7 @@ export function forEachSubschema(
   visit: SubschemaVisitor,
   opts: SchemaWalkOptions = {},
 ): boolean {
-  if (!isRecord(schema)) return false;
+  if (!isObjectOrArray(schema)) return false;
   const node = schema as JSONSchemaObj;
   for (const keyword of singleKeywordsFor(opts)) {
     const child = node[keyword];
@@ -328,7 +333,7 @@ export function* subschemaEdges(
   schema: JSONSchema,
   opts: SchemaWalkOptions = {},
 ): Generator<SubschemaEdge> {
-  if (!isRecord(schema)) return;
+  if (!isObjectOrArray(schema)) return;
   const node = schema as JSONSchemaObj;
   for (const keyword of singleKeywordsFor(opts)) {
     const child = node[keyword];
@@ -488,7 +493,7 @@ export function walkSchema(
     // The root and a `resolveRef` result come straight from the caller; every
     // other node arrives already filtered by `forEachSubschema`.
     if (!isSubschema(schema)) return;
-    const record = isRecord(schema);
+    const record = isObjectOrArray(schema);
     if (!record && !opts.visitBooleans) return;
     const control = visit({ schema, path, ...edge, parent });
     if (control === "stop") {

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -1,7 +1,11 @@
 import { AnyCellWrapping } from "@commonfabric/api";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { getLogger } from "@commonfabric/utils/logger";
-import { isReadonlyRecord, isRecord } from "@commonfabric/utils/types";
+import {
+  isObjectNotArray,
+  isObjectOrArray,
+  isReadonlyObjectOrArray,
+} from "@commonfabric/utils/types";
 import { storedCfcMetadataAppliesToPath } from "./cfc/metadata.ts";
 import { ContextualFlowControl } from "./cfc.ts";
 import { type JSONSchema, type SchemaScope } from "./builder/types.ts";
@@ -131,7 +135,7 @@ const asCellCompoundCandidates = (
       const resolved = resolveSchema(branchWithDefs) ?? branchWithDefs;
       const merged = combineSchema(baseSchema as JSONSchemaObj, resolved);
       if (
-        isRecord(merged) &&
+        isObjectOrArray(merged) &&
         ContextualFlowControl.getAsCellValues(merged).length > 0
       ) {
         candidates.push(merged as JSONSchemaObj);
@@ -186,7 +190,7 @@ export type CellViewRef = {
 
 const isCellViewRef = (
   ref: NormalizedFullLink | CellViewRef,
-): ref is CellViewRef => isRecord(ref) && "link" in ref;
+): ref is CellViewRef => isObjectOrArray(ref) && "link" in ref;
 
 const isPrefix = (
   prefix: readonly string[],
@@ -214,7 +218,7 @@ const containsLocalRef = (
   schema: JSONSchema,
   seen: Set<JSONSchema> = new Set(),
 ): boolean => {
-  if (!isRecord(schema) || seen.has(schema)) {
+  if (!isObjectOrArray(schema) || seen.has(schema)) {
     return false;
   }
   seen.add(schema);
@@ -237,9 +241,9 @@ const branchWithParentDefs = (
   branch: JSONSchema,
 ): JSONSchema => {
   if (
-    !isRecord(branch) ||
+    !isObjectOrArray(branch) ||
     branch.$defs !== undefined ||
-    !isRecord(parent.$defs) ||
+    !isObjectOrArray(parent.$defs) ||
     !containsLocalRef(branch)
   ) {
     return branch;
@@ -310,7 +314,7 @@ const matchesConcreteValue = (
     ).length === 1;
   }
 
-  if (isRecord(value) && isRecord(resolved.properties)) {
+  if (isObjectOrArray(value) && isObjectOrArray(resolved.properties)) {
     return Object.entries(resolved.properties).every(([key, childSchema]) =>
       value[key] === undefined ||
       matchesConcreteValue(
@@ -420,7 +424,7 @@ export function resolveSchema(
       );
       return false;
     }
-    if (!isRecord(resolved)) {
+    if (!isObjectOrArray(resolved)) {
       // For boolean schema or the default `{}` schema, we don't have any
       // meaningful information in the schema, so just return undefined.
       return undefined;
@@ -467,7 +471,7 @@ export function resolveSchemaForValue(
   const resolved = resolveSchema(schema);
   if (
     resolved === undefined || typeof resolved === "boolean" ||
-    !isRecord(resolved)
+    !isObjectOrArray(resolved)
   ) {
     return resolved;
   }
@@ -481,11 +485,11 @@ export function resolveSchemaForValue(
       resolved;
   }
 
-  if (!isRecord(narrowed)) {
+  if (!isObjectOrArray(narrowed)) {
     return narrowed;
   }
 
-  if (!isRecord(value) || !isRecord(narrowed.properties)) {
+  if (!isObjectOrArray(value) || !isObjectOrArray(narrowed.properties)) {
     return narrowed;
   }
 
@@ -547,10 +551,10 @@ export function schemaHasIfc(
   const context: SchemaHasIfcContext = { seenByRoot: new WeakMap() };
   if (seen.size > 0) {
     const initialRoot = cfcSchemaChildRoot(schema, fullSchema ?? schema);
-    const rootKey = isRecord(initialRoot) ? initialRoot : schema;
+    const rootKey = isObjectOrArray(initialRoot) ? initialRoot : schema;
     const initialSeen = new WeakSet<object>();
     for (const item of seen) {
-      if (isRecord(item)) initialSeen.add(item);
+      if (isObjectOrArray(item)) initialSeen.add(item);
     }
     context.seenByRoot.set(rootKey, initialSeen);
   }
@@ -569,7 +573,7 @@ function _schemaHasIfcUncached(
   context: SchemaHasIfcContext,
 ): boolean {
   const schemaRoot = cfcSchemaChildRoot(schema, fullSchema ?? schema);
-  const rootKey = isRecord(schemaRoot) ? schemaRoot : schema;
+  const rootKey = isObjectOrArray(schemaRoot) ? schemaRoot : schema;
   let seen = context.seenByRoot.get(rootKey);
   if (seen?.has(schema)) return false;
   if (!seen) {
@@ -581,7 +585,7 @@ function _schemaHasIfcUncached(
   const resolved = typeof schema.$ref === "string"
     ? ContextualFlowControl.resolveSchemaRefs(schema, schemaRoot)
     : schema;
-  if (resolved === true || resolved === false || !isRecord(resolved)) {
+  if (resolved === true || resolved === false || !isObjectOrArray(resolved)) {
     return false;
   }
   const childFullSchema = cfcSchemaChildRoot(
@@ -603,7 +607,8 @@ function _schemaHasIfcUncached(
   return forEachSubschema(
     resolved,
     (child) =>
-      isRecord(child) && _schemaHasIfcUncached(child, childFullSchema, context),
+      isObjectOrArray(child) &&
+      _schemaHasIfcUncached(child, childFullSchema, context),
   );
 }
 
@@ -659,7 +664,7 @@ export function processDefaultValue(
   if (!schema) return defaultValue;
 
   let resolvedSchema = resolveSchema(schema);
-  if (!isRecord(resolvedSchema)) {
+  if (!isObjectOrArray(resolvedSchema)) {
     // For primitive types, return as is
     return annotateWithBackToCellSymbols(
       defaultValue,
@@ -746,8 +751,7 @@ export function processDefaultValue(
 
   // Handle object type defaults
   if (
-    resolvedSchema?.type === "object" && isRecord(defaultValue) &&
-    !Array.isArray(defaultValue)
+    resolvedSchema?.type === "object" && isObjectNotArray(defaultValue)
   ) {
     const result: Record<string, any> = {};
     const processedKeys = new Set<string>();
@@ -759,13 +763,13 @@ export function processDefaultValue(
           resolvedSchema,
           [key],
         );
-        const propSchema =
-          (isRecord(rawPropSchema) && typeof rawPropSchema.$ref === "string")
-            ? ContextualFlowControl.resolveSchemaRefs(
-              rawPropSchema,
-              resolvedSchema,
-            )
-            : rawPropSchema;
+        const propSchema = (isObjectOrArray(rawPropSchema) &&
+            typeof rawPropSchema.$ref === "string")
+          ? ContextualFlowControl.resolveSchemaRefs(
+            rawPropSchema,
+            resolvedSchema,
+          )
+          : rawPropSchema;
         // `Object.hasOwn`, not `in`: `key` is a schema-declared property NAME,
         // and `defaultValue` is data. `in` walks the prototype chain, so a
         // schema property called `toString` or `valueOf` matched every object
@@ -780,7 +784,7 @@ export function processDefaultValue(
             rebaseCfcLabelView(cfcLabelView, [key]),
           );
           processedKeys.add(key);
-        } else if (isRecord(propSchema)) {
+        } else if (isObjectOrArray(propSchema)) {
           const asCellValues = ContextualFlowControl.getAsCellValues(
             propSchema,
           );
@@ -937,7 +941,7 @@ export function mergeDefaults(
 
   // TODO(seefeld): What's the right thing to do for arrays?
   //
-  // TODO(danfuzz): `isReadonlyRecord` admits a `FabricSpecialObject` on
+  // TODO(danfuzz): `isReadonlyObjectOrArray` admits a `FabricSpecialObject` on
   // either side, and the spread copies zero properties from one, so a
   // fabric-valued default here merges to `{}` (or silently drops the other
   // side's contribution). Reachable: the schema generator emits
@@ -946,7 +950,8 @@ export function mergeDefaults(
   // schema takes the spread arm. Wants a `FabricSpecialObject` test choosing
   // the `defaultValue` arm.
   const mergedDefault = base.type === "object" &&
-      isReadonlyRecord(base.default) && isReadonlyRecord(defaultValue)
+      isReadonlyObjectOrArray(base.default) &&
+      isReadonlyObjectOrArray(defaultValue)
     ? { ...base.default, ...defaultValue } as JSONValue
     : defaultValue as JSONValue;
 
@@ -972,7 +977,7 @@ function annotateWithBackToCellSymbols(
   cfcLabelView?: CfcLabelView,
 ) {
   if (
-    !isRecord(value) || isCell(value) ||
+    !isObjectOrArray(value) || isCell(value) ||
     value instanceof FabricPrimitive
   ) {
     // We only possibly annotate plain objects or arrays that _aren't_ cells.
@@ -1280,7 +1285,7 @@ export function validateAndTransform(
   // notify the scheduler for shallow reads as they occur.
   const value = readValueAtResolvedLink(tx, resolvedValueLink, address);
   const doc = { address, value: value };
-  const valueSelectedSchema = isRecord(effectiveSchema)
+  const valueSelectedSchema = isObjectOrArray(effectiveSchema)
     ? asCellCompoundSchemaForValue(effectiveSchema, value)
     : undefined;
   // If we have a ref with a schema, use that; otherwise, use the link's schema
@@ -1522,7 +1527,7 @@ class TransformObjectCreator
         false,
         this.labelViewFor(link),
       );
-    } else if (isRecord(link.schema)) {
+    } else if (isObjectOrArray(link.schema)) {
       const schema = asCellCompoundSchemaForValue(link.schema, value) ??
         link.schema;
       const asCellValues = ContextualFlowControl.getAsCellValues(schema);
@@ -1589,7 +1594,7 @@ class TransformObjectCreator
       // If we're an object, we may be missing some properties that have a
       // default.
       if (
-        isRecord(value) && !Array.isArray(value) &&
+        isObjectNotArray(value) &&
         schema.properties !== undefined
       ) {
         // Ensure value is mutable before injecting default properties.
@@ -1605,7 +1610,7 @@ class TransformObjectCreator
           JSONSchema,
         ][];
         for (const [propName, propSchema] of propertyEntries) {
-          if (isRecord(propSchema) && propSchema.default !== undefined) {
+          if (isObjectOrArray(propSchema) && propSchema.default !== undefined) {
             const valueObj = value as Record<string, any>;
             if (valueObj[propName] === undefined) {
               valueObj[propName] = processDefaultValue(
@@ -1652,14 +1657,14 @@ export function generateHandlerSchema(
   }
   const mergedDefs: Record<string, JSONSchema> = {};
   const mergedDefinitions: Record<string, JSONSchema> = {};
-  if (isRecord(eventSchema)) {
+  if (isObjectOrArray(eventSchema)) {
     // extract $defs and definitions and remove them from eventSchema
     const { $defs, definitions, ...rest } = eventSchema;
     eventSchema = rest;
     Object.assign(mergedDefs, $defs);
     Object.assign(mergedDefinitions, definitions);
   }
-  if (isRecord(stateSchema)) {
+  if (isObjectOrArray(stateSchema)) {
     // extract $defs and definitions and remove them from stateSchema
     const { $defs, definitions, ...rest } = stateSchema;
     stateSchema = rest;
@@ -1708,7 +1713,7 @@ function unwrapAsCellSchema(schema: JSONSchemaObj): JSONSchemaObj {
 }
 
 function removeAsCellFromSchema(schema: JSONSchema): JSONSchema {
-  if (isRecord(schema)) {
+  if (isObjectOrArray(schema)) {
     const { asCell: _c, ...restSchema } = schema;
     return restSchema;
   }

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { getLogger } from "@commonfabric/utils/logger";
 import {
@@ -1192,7 +1192,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     // one concrete thing — no wildcards, no empty identifiers, no non-string
     // path segments. A rejected marker leaves the gate fully in force.
     if (
-      !isRecord(exemption) ||
+      !isObjectOrArray(exemption) ||
       typeof exemption.space !== "string" || exemption.space.length === 0 ||
       typeof exemption.id !== "string" || exemption.id.length === 0 ||
       !Array.isArray(exemption.path) ||
@@ -1748,7 +1748,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
           ...address,
           path: lastExistingPath,
         }, { meta: ignoreReadForScheduling });
-        if (!isRecord(currentValue)) {
+        if (!isObjectOrArray(currentValue)) {
           // This should have already been caught as type mismatch error
           throw new Error(
             `Value at path ${address.path.join("/")} is not an object`,

--- a/packages/runner/src/storage/selector-tracker.ts
+++ b/packages/runner/src/storage/selector-tracker.ts
@@ -4,7 +4,7 @@ import { hashSchema, internSchema } from "@commonfabric/data-model/schema-hash";
 import { schemaWithProperties } from "@commonfabric/data-model/schema-utils";
 import type { FabricValue, SchemaPathSelector } from "@commonfabric/api";
 import type { Result, Unit } from "@commonfabric/memory/interface";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import type { JSONSchema } from "../builder/types.ts";
 import { ContextualFlowControl } from "../cfc.ts";
 import { BaseMemoryAddress, MapSetStringToStrings } from "../traverse.ts";
@@ -129,7 +129,7 @@ export class SelectorTracker<T = Result<Unit, Error>> {
       ? SelectorTracker.getStandardSchema(selector.schema)
       : false;
     const newSchemaHash = newSchema === false ? false : hashSchema(newSchema);
-    const newSchemaObj = isRecord(newSchema) ? newSchema : undefined;
+    const newSchemaObj = isObjectOrArray(newSchema) ? newSchema : undefined;
     // Constant across the candidate loop; hoisted so the $defs-insensitive
     // comparison below doesn't recompute it per tracked selector.
     let newSchemaRefCount: number | undefined;
@@ -164,7 +164,7 @@ export class SelectorTracker<T = Result<Unit, Error>> {
           const promiseKey = `${toKey(address)}?${selectorRef}`;
           return [existingSelector, this.selectorPromises.get(promiseKey)!];
         } else {
-          const sortedSubSchemaObj = isRecord(sortedSubSchema)
+          const sortedSubSchemaObj = isObjectOrArray(sortedSubSchema)
             ? sortedSubSchema
             : undefined;
           if (newSchemaObj && sortedSubSchemaObj) {
@@ -243,7 +243,7 @@ export class SelectorTracker<T = Result<Unit, Error>> {
     schema: JSONSchema,
     schemaHash: string | false,
   ): boolean {
-    return isRecord(schema) && Array.isArray(schema.anyOf) &&
+    return isObjectOrArray(schema) && Array.isArray(schema.anyOf) &&
       (schema.anyOf.some((item) =>
         SelectorTracker.#anyOfItemHashes(schema, item).includes(
           schemaHash as string,
@@ -285,7 +285,7 @@ export class SelectorTracker<T = Result<Unit, Error>> {
       );
       hashes.push(hashSchema(current));
     }
-    if (isRecord(current) && current.$ref !== undefined) {
+    if (isObjectOrArray(current) && current.$ref !== undefined) {
       hashes.push(
         hashSchema(
           SelectorTracker.getStandardSchema(
@@ -331,7 +331,7 @@ export class SelectorTracker<T = Result<Unit, Error>> {
       return byContent;
     }
     // TODO(danfuzz): this rebuild filters by key name only, so it also
-    // rebuilds `default`/`examples` VALUES: `isRecord` admits a
+    // rebuilds `default`/`examples` VALUES: `isObjectOrArray` admits a
     // `FabricSpecialObject` and `Object.entries` sees none of its state, so
     // a fabric-valued default standardizes to `{}` — losing the value in the
     // interned schema and making two schemas that differ only in such a
@@ -340,7 +340,7 @@ export class SelectorTracker<T = Result<Unit, Error>> {
     const traverse = (
       value: Readonly<any>,
     ): FabricValue => {
-      if (isRecord(value)) {
+      if (isObjectOrArray(value)) {
         if (Array.isArray(value)) {
           return value.map((val) => traverse(val));
         } else {

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import {
   type FabricPlainObject,
   type FabricValue,
@@ -194,13 +194,13 @@ export const resolve = (
 
   while (++at < path.length) {
     const key = path[at];
-    // TODO(danfuzz): `isRecord` admits a `FabricSpecialObject`, so descending
+    // TODO(danfuzz): `isObjectOrArray` admits a `FabricSpecialObject`, so descending
     // into one lands in this arm and reads `undefined` instead of reaching
     // the `TypeMismatchError` arm below the way a scalar does. The caller
     // then treats the slot as absent-but-writable, and a path into a
     // `FabricInstance`'s codec contents reads as missing rather than being
     // refused or resolved.
-    if (isRecord(value)) {
+    if (isObjectOrArray(value)) {
       const record = value as FabricPlainObject;
       value = Object.hasOwn(record, key) ? record[key] : undefined;
     } else {

--- a/packages/runner/src/storage/transaction/mutable-path-write.ts
+++ b/packages/runner/src/storage/transaction/mutable-path-write.ts
@@ -18,7 +18,7 @@ import {
   valueEqual,
 } from "@commonfabric/data-model/fabric-value";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import type {
   IMemoryAddress,
   ITypeMismatchError,
@@ -47,7 +47,7 @@ export type MutablePathWriteOptions = {
 export const isContainerValue = (
   value: FabricValue | undefined,
 ): value is Record<string, FabricValue> | FabricValue[] =>
-  Array.isArray(value) || isRecord(value);
+  Array.isArray(value) || isObjectOrArray(value);
 
 export const getValueTypeName = (value: FabricValue | undefined): string => {
   if (value === null) {

--- a/packages/runner/src/storage/v2-path.ts
+++ b/packages/runner/src/storage/v2-path.ts
@@ -1,6 +1,6 @@
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import type { FabricValue } from "@commonfabric/api";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 
 export type ReadPathOptions = {
   allowArrayLength?: boolean;
@@ -45,7 +45,7 @@ export const hasValueAtPath = (
       current = current[index];
       continue;
     }
-    if (!isRecord(current)) {
+    if (!isObjectOrArray(current)) {
       return false;
     }
     const record = current as Record<string, unknown>;
@@ -79,7 +79,7 @@ export const readValueAtPath = (
       current = current[index];
       continue;
     }
-    if (!isRecord(current)) {
+    if (!isObjectOrArray(current)) {
       return undefined;
     }
     const record = current as Record<string, unknown>;

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -21,7 +21,7 @@ import {
 import { PathKeyMap } from "@commonfabric/utils/path-key-map";
 import type { FabricValue } from "@commonfabric/api";
 import { getLogger } from "@commonfabric/utils/logger";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import type {
   Activity,
   ChangeGroup,
@@ -283,8 +283,7 @@ const collapseEmptyJsonDocumentEnvelope = (
 ): FabricValue | undefined => {
   if (
     value === undefined ||
-    !isRecord(value) ||
-    Array.isArray(value) ||
+    !isObjectNotArray(value) ||
     Object.keys(value).length > 0
   ) {
     return value;
@@ -352,7 +351,7 @@ const inspectPath = (
       continue;
     }
 
-    if (isRecord(current)) {
+    if (isObjectOrArray(current)) {
       current = current[segment];
       continue;
     }
@@ -373,7 +372,7 @@ const inspectPath = (
 const schedulerObservationCommitSpace = (
   observation: unknown,
 ): MemorySpace | undefined => {
-  if (!isRecord(observation)) {
+  if (!isObjectOrArray(observation)) {
     return undefined;
   }
   if (typeof observation.ownerSpace === "string") {
@@ -386,7 +385,7 @@ const schedulerObservationCommitSpace = (
       continue;
     }
     for (const address of addresses) {
-      if (!isRecord(address) || typeof address.space !== "string") {
+      if (!isObjectOrArray(address) || typeof address.space !== "string") {
         continue;
       }
       return address.space as MemorySpace;
@@ -733,7 +732,7 @@ const isSubsumedByTailSplice = (
     Number(childSegment) >= spliceCandidate.tailSpliceStartIndex;
 };
 
-// TODO(danfuzz): `isRecord` admits a `FabricSpecialObject` on both sides, so
+// TODO(danfuzz): `isObjectOrArray` admits a `FabricSpecialObject` on both sides, so
 // two special objects — or one against a plain `{}` — compare by their empty
 // key sets and report "unchanged" without ever reaching the fabric-aware
 // `valueEqual` fallback. An in-place fabric change at an ancestor prefix then
@@ -743,7 +742,7 @@ const shallowStructureChanged = (
   before: FabricValue | undefined,
   after: FabricValue | undefined,
 ): boolean => {
-  if (isRecord(before) && isRecord(after)) {
+  if (isObjectOrArray(before) && isObjectOrArray(after)) {
     const beforeKeys = Object.keys(before);
     const afterKeys = Object.keys(after);
     if (beforeKeys.length !== afterKeys.length) {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -44,7 +44,7 @@ import {
 import type { AppliedCommit } from "@commonfabric/memory/v2/engine";
 import { BoundedKeyMap } from "@commonfabric/utils/cache";
 import { getLogger } from "@commonfabric/utils/logger";
-import { isObject, isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import type { Cell } from "../cell.ts";
 import type { JSONSchema } from "../builder/types.ts";
 import { ContextualFlowControl } from "../cfc.ts";
@@ -267,7 +267,7 @@ const activeCommitPreconditions = (
     );
 
 const toExplicitDocument = (value: FabricValue): EntityDocument => {
-  if (!isObject(value)) {
+  if (!isObjectNotArray(value)) {
     throw new Error(
       "memory v2 transactions require explicit full-document roots",
     );
@@ -1461,7 +1461,7 @@ export class StorageManager implements IStorageManager {
     space: MemorySpace,
     document: EntityDocument | undefined,
   ): Promise<Error | undefined> {
-    const cfc = isRecord(document?.cfc) ? document.cfc : undefined;
+    const cfc = isObjectOrArray(document?.cfc) ? document.cfc : undefined;
     const schemaHash = cfc?.schemaHash;
     if (typeof schemaHash !== "string" || schemaHash.length === 0) {
       return undefined;
@@ -1551,7 +1551,7 @@ export class StorageManager implements IStorageManager {
   ): Promise<void> {
     let value: unknown = valueFromDataUri(id);
     for (const segment of [...cell.path.map(String)]) {
-      if (!isRecord(value) && !Array.isArray(value)) {
+      if (!isObjectOrArray(value)) {
         return;
       }
       value = (value as Record<string, unknown>)[segment];
@@ -1629,12 +1629,12 @@ export class StorageManager implements IStorageManager {
       return;
     }
 
-    // TODO(danfuzz): `isRecord` admits a `FabricSpecialObject`, whose
+    // TODO(danfuzz): `isObjectOrArray` admits a `FabricSpecialObject`, whose
     // `Object.keys` are empty, so a cell link held inside a `FabricInstance`
     // reconstructed from the data URI is never found here and its target
     // document is never synced — the later read finds it absent. (A
     // `FabricPrimitive` ends the walk harmlessly; it is a leaf.)
-    if (isRecord(value)) {
+    if (isObjectOrArray(value)) {
       for (const key of Object.keys(value)) {
         const child = value[key];
         if (

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -28,8 +28,8 @@ import { deepEqual } from "@commonfabric/utils/deep-equal";
 import {
   type Immutable,
   isBoolean,
-  isObject,
-  isRecord,
+  isObjectNotArray,
+  isObjectOrArray,
   isString,
 } from "../../utils/src/types.ts";
 import { getLogger } from "../../utils/src/logger.ts";
@@ -390,7 +390,7 @@ function plainArrayItems(schema: JSONSchemaObj): JSONSchema | undefined {
 function plainObjectProperties(
   schema: JSONSchemaObj,
 ): Record<string, JSONSchema> | undefined {
-  return schema.type === "object" && isRecord(schema.properties) &&
+  return schema.type === "object" && isObjectOrArray(schema.properties) &&
       Object.keys(schema).length === 2
     ? schema.properties as Record<string, JSONSchema>
     : undefined;
@@ -404,7 +404,7 @@ function preparePlainSchemaPlan(
   schema: JSONSchema,
   seen: Set<JSONSchemaObj> = new Set(),
 ): PlainSchemaPlan | undefined {
-  if (!isRecord(schema)) return undefined;
+  if (!isObjectOrArray(schema)) return undefined;
 
   const cacheable = isInternedSchema(schema);
   if (cacheable) {
@@ -431,7 +431,7 @@ function preparePlainSchemaPlan(
     if (items !== undefined) plan = { kind: "array", schema, items };
   } else if (
     keys.length === 2 && schema.type === "object" &&
-    isRecord(schema.properties)
+    isObjectOrArray(schema.properties)
   ) {
     const properties = new Map<string, PlainSchemaPlan>();
     let valid = true;
@@ -1347,14 +1347,14 @@ export function mergeAnyOfMatches<T>(
   if (matches.length > 1) {
     // If all our matches are non-array objects, merge the properties.
     //
-    // TODO(danfuzz): `isObject` admits a `FabricSpecialObject`, whose state
+    // TODO(danfuzz): `isObjectNotArray` admits a `FabricSpecialObject`, whose state
     // lives in private fields, so `Object.assign` copies nothing from it: a
     // `FabricPrimitive` that matches more than one branch (say, an `anyOf` of
     // its specific type name and `"object"`, which the subtype rule also
     // accepts) merges to a plain `{}` and the value is lost. The merge wants
     // a `FabricSpecialObject` test ahead of this point, returning the value
     // whole rather than merging it.
-    if (matches.every((v) => isObject(v))) {
+    if (matches.every((v) => isObjectNotArray(v))) {
       const unified: Record<string, T> = {};
       for (const match of matches) {
         Object.assign(unified, match);
@@ -1479,7 +1479,7 @@ export abstract class BaseObjectTraverser {
       }
       doc.value.forEach((item, index) => {
         const itemDefault =
-          isRecord(defaultValue) && Array.isArray(defaultValue) &&
+          isObjectOrArray(defaultValue) && Array.isArray(defaultValue) &&
             index < defaultValue.length
             ? defaultValue[index]
             : undefined;
@@ -1550,7 +1550,7 @@ export abstract class BaseObjectTraverser {
       // that is read back through here), so unlike the schema-`default`
       // paths it cannot fail loudly yet: the instance leafs through whole.
       return doc.value;
-    } else if (isRecord(doc.value)) {
+    } else if (isObjectOrArray(doc.value)) {
       // First, see if we need special handling
       if (isSigilLink(doc.value)) {
         // Check coverage before getAtPath/followPointer adds this link target
@@ -1615,7 +1615,7 @@ export abstract class BaseObjectTraverser {
           };
           const val = this.traverseDAG(
             itemDoc,
-            isRecord(defaultValue) && !Array.isArray(defaultValue)
+            isObjectNotArray(defaultValue)
               ? (defaultValue as JSONObject)[k]
               : undefined,
           )!;
@@ -1870,8 +1870,8 @@ export function getAtPath(
         },
         value: curDoc.value.length,
       };
-    } else if (isRecord(curDoc.value) && part in curDoc.value) {
-      // TODO(danfuzz): `isRecord` admits a `FabricSpecialObject`, and `in`
+    } else if (isObjectOrArray(curDoc.value) && part in curDoc.value) {
+      // TODO(danfuzz): `isObjectOrArray` admits a `FabricSpecialObject`, and `in`
       // consults the prototype chain, so this arm descends a special object
       // by its class surface rather than its codec contents: on a
       // `FabricError` (live traffic — the fetch builtins store one),
@@ -2237,7 +2237,7 @@ function loadMetaLinkedDoc(
   schemaTracker: MapSet<string, SchemaPathSelector>,
 ): MetaLinkedDoc[] {
   const targetObj = valueEntry.value as Immutable<JSONObject>;
-  if (!isRecord(targetObj) || !(meta in targetObj)) return [];
+  if (!isObjectOrArray(targetObj) || !(meta in targetObj)) return [];
   const loaded = [];
   // The internal meta field contains a list of objects with links instead
   if (meta === "internal") {
@@ -2249,7 +2249,7 @@ function loadMetaLinkedDoc(
       return [];
     }
     for (const manifestEntry of targetObj["internal"]) {
-      if (!isRecord(manifestEntry)) {
+      if (!isObjectOrArray(manifestEntry)) {
         logger.warn(
           "traverse",
           () => ["Invalid internal manifest entry in", valueEntry.address],
@@ -2323,7 +2323,7 @@ function loadMetaLinkedDocFromLink(
 }
 
 function cfcMetaToSigilLink(obj: unknown): SigilLink | undefined {
-  if (isRecord(obj) && "schemaHash" in obj) {
+  if (isObjectOrArray(obj) && "schemaHash" in obj) {
     const schemaHash = obj["schemaHash"];
     if (typeof schemaHash === "string" && schemaHash.length > 0) {
       return linkRefFrom<CellLinkRefPayload>({ id: `cid:${schemaHash}` });
@@ -2347,7 +2347,7 @@ function traverseMetaLinkedDoc(
   ) {
     return;
   }
-  if (!isRecord(doc.value) || !("value" in doc.value)) {
+  if (!isObjectOrArray(doc.value) || !("value" in doc.value)) {
     return;
   }
 
@@ -2459,7 +2459,7 @@ function _mergeSchemaFlagsUncached(
   flagSchema: JSONSchema,
   schema: JSONSchema,
 ) {
-  if (isRecord(flagSchema) && flagSchema.asCell !== undefined) {
+  if (isObjectOrArray(flagSchema) && flagSchema.asCell !== undefined) {
     // we want to preserve asCell -- if set, this will override the value in
     // the schema
     return schemaWithProperties(schema, { asCell: flagSchema.asCell });
@@ -2598,7 +2598,7 @@ function _combineSchemaUncached(
     return mergeSchemaFlags(parentSchema, linkSchema);
   } else if (ContextualFlowControl.isTrueSchema(linkSchema)) {
     return mergeSchemaFlags(linkSchema, parentSchema);
-  } else if (isRecord(linkSchema) && isRecord(parentSchema)) {
+  } else if (isObjectOrArray(linkSchema) && isObjectOrArray(parentSchema)) {
     if (
       schemaTypesAreDisjoint(parentSchema.type, linkSchema.type)
     ) return false;
@@ -3231,7 +3231,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
     // Track both the unresolved version of our schema (possibly with top
     // level $ref) and the resolved version.
     let resolved: JSONSchema | undefined = schema;
-    if (isRecord(schema) && "$ref" in schema) {
+    if (isObjectOrArray(schema) && "$ref" in schema) {
       // Handle any top-level $ref in the schema
       resolved = resolveSchemaRefsCanonical(schema);
       if (resolved === undefined) {
@@ -3242,7 +3242,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
         return fail(TRAVERSE_FAILURES.schemaRefResolution);
       }
     }
-    if (isRecord(resolved)) {
+    if (isObjectOrArray(resolved)) {
       if (
         doc.value === undefined && resolved.default !== undefined &&
         (resolved.anyOf || resolved.oneOf || resolved.allOf)
@@ -3310,7 +3310,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
         const prepared = prepareAnyOf(resolved, resolved.anyOf);
         const valueIsLink = isSigilLink(doc.value);
         const actualType = getJsonType(doc.value);
-        const valueIsRecord = isRecord(doc.value);
+        const valueIsRecord = isObjectOrArray(doc.value);
         for (const branch of prepared) {
           this.anyOfBranches++;
           if (branch.optionIsFalse) {
@@ -3499,7 +3499,9 @@ export class SchemaObjectTraverser<V extends FabricValue>
       ContextualFlowControl.isTrueSchema(resolved) &&
       !SchemaObjectTraverser.hasAsCell(resolved)
     ) {
-      const defaultValue = isRecord(resolved) ? resolved["default"] : undefined;
+      const defaultValue = isObjectOrArray(resolved)
+        ? resolved["default"]
+        : undefined;
       // A value of true or {} means we match anything.
       // Resolve the rest of the doc, and return
       this.tx.read(doc.address, READ_FOR_SCHEDULING); // recursively read this doc
@@ -3526,7 +3528,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
     ) {
       // This value rejects all objects - just return
       return fail(TRAVERSE_FAILURES.falseSchema);
-    } else if (!isRecord(resolved)) {
+    } else if (!isObjectOrArray(resolved)) {
       logger.warn(
         "traverse",
         () => ["Invalid schema is not an object", resolved],
@@ -3644,7 +3646,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
         `Cannot yet handle \`${doc.value.constructor.name}\` (a ` +
           "`FabricInstance`) in schema traversal.",
       );
-    } else if (isRecord(doc.value)) {
+    } else if (isObjectOrArray(doc.value)) {
       const valid = this.isValidType(schemaObj, "object");
       if (valid === TypeValidity.False) {
         return fail(TRAVERSE_FAILURES.invalidType);
@@ -3808,7 +3810,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
           "`FabricInstance`) in plain-schema traversal.",
       );
     }
-    if (!isRecord(doc.value)) return fail(TRAVERSE_FAILURES.invalidType);
+    if (!isObjectOrArray(doc.value)) return fail(TRAVERSE_FAILURES.invalidType);
 
     const newValue: Record<string, FabricValue> = {};
     const newLink = link ?? getNormalizedLink(doc.address, plan.schema);
@@ -4176,7 +4178,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
           );
         }
       } else if (
-        isRecord(item) &&
+        isObjectOrArray(item) &&
         !SchemaObjectTraverser.hasAsCell(curSelector.schema)
       ) {
         // We create an element link, but this is just to establish the id if we encounter
@@ -4311,7 +4313,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
       // cell.get will ignore these properties, while the query system will
       // include their raw value (and will not follow links).
       if (
-        isRecord(propSchema) && (
+        isObjectOrArray(propSchema) && (
           propSchema.$comment === "emptyProperties" ||
           propSchema.$comment === "missingProperty"
         )
@@ -4363,7 +4365,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
     }
 
     // Apply defaults from our schema
-    if (isRecord(schema) && schema.properties) {
+    if (isObjectOrArray(schema) && schema.properties) {
       for (const propKey of Object.keys(schema.properties)) {
         // `Object.hasOwn`, not `in`: `propKey` is a schema-declared property
         // NAME and `filteredObj` is data. `in` walks the prototype chain, so a
@@ -4376,11 +4378,11 @@ export class SchemaObjectTraverser<V extends FabricValue>
         const subSchema = ContextualFlowControl.getSchemaAtPath(schema, [
           propKey,
         ]);
-        if (!isRecord(subSchema)) {
+        if (!isObjectOrArray(subSchema)) {
           continue;
         }
         const propSchema = ContextualFlowControl.resolveSchemaRefs(subSchema);
-        if (!isRecord(propSchema) || propSchema.default == undefined) {
+        if (!isObjectOrArray(propSchema) || propSchema.default == undefined) {
           continue;
         }
         const propAddress = {
@@ -4417,7 +4419,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
     }
 
     // Check that all required fields are present
-    if (isRecord(schema) && "required" in schema) {
+    if (isObjectOrArray(schema) && "required" in schema) {
       const required = schema["required"] as string[];
       if (Array.isArray(required)) {
         for (const requiredProperty of required) {
@@ -4617,7 +4619,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
     doc: IMemorySpaceValueAttestation,
     schema: JSONSchema,
   ): FabricValue {
-    if (isRecord(schema) && schema.default !== undefined) {
+    if (isObjectOrArray(schema) && schema.default !== undefined) {
       const link = getNormalizedLink(doc.address, schema);
       return this.objectCreator.applyDefault(link, schema.default);
     }
@@ -4714,7 +4716,7 @@ export function canBranchMatch(
   // For plain object values, check missing required properties.
   // Const/enum checks are omitted — property values may contain unresolved
   // links that would match after link resolution during traversal.
-  if (isRecord(value)) {
+  if (isObjectOrArray(value)) {
     if (
       schemaTypeIncludesObject(resolved.type) &&
       Array.isArray(resolved.required)
@@ -4800,7 +4802,7 @@ function getPlainJsonType(
   if (value instanceof FabricPrimitive) {
     return schemaTypeOfFabricPrimitive(value);
   }
-  if (isObject(value)) return "object";
+  if (isObjectNotArray(value)) return "object";
   return null;
 }
 
@@ -4856,7 +4858,7 @@ function _mergeAnyOfBranchSchemasUncached(
   const resolvedBranches: JSONSchemaObj[] = [];
   for (const branch of branches) {
     const merged = mergeSchemaOption(outerSchema, branch);
-    if (!isRecord(merged)) return null;
+    if (!isObjectOrArray(merged)) return null;
     // Must be object type or unspecified (compatible with object)
     // type can be a string or an array of strings
     if (merged.type !== undefined) {
@@ -4874,7 +4876,7 @@ function _mergeAnyOfBranchSchemasUncached(
 
   for (const branch of resolvedBranches) {
     // Collect properties
-    if (isRecord(branch.properties)) {
+    if (isObjectOrArray(branch.properties)) {
       for (const [k, v] of Object.entries(branch.properties)) {
         let arr = allProps.get(k);
         if (!arr) {
@@ -4893,7 +4895,7 @@ function _mergeAnyOfBranchSchemasUncached(
     }
 
     // Merge $defs
-    if (isRecord(branch.$defs)) {
+    if (isObjectOrArray(branch.$defs)) {
       mergedDefs ??= {};
       Object.assign(mergedDefs, branch.$defs);
     }
@@ -4902,7 +4904,7 @@ function _mergeAnyOfBranchSchemasUncached(
     if (
       branch.additionalProperties === undefined ||
       branch.additionalProperties === true ||
-      (isRecord(branch.additionalProperties))
+      (isObjectOrArray(branch.additionalProperties))
     ) {
       anyAllowsAdditional = true;
     }
@@ -5007,7 +5009,7 @@ function schemaTypeValidity(
   valueType: JSONSchemaTypes,
 ): TypeValidity {
   let resolved: JSONSchema | undefined = schema;
-  if (isRecord(schema) && "$ref" in schema) {
+  if (isObjectOrArray(schema) && "$ref" in schema) {
     // Handle any top-level $ref in the schema
     resolved = resolveSchemaRefsCanonical(schema);
     if (resolved === undefined) {
@@ -5163,7 +5165,7 @@ export function schemaAcceptsType(
 
 function schemaWithDefs(parent: JSONSchemaObj, option: JSONSchema): JSONSchema {
   // We need to preserve any parent $defs in the branch
-  if (!parent.$defs || !isRecord(option)) {
+  if (!parent.$defs || !isObjectOrArray(option)) {
     return option;
   }
   return {

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -181,7 +181,7 @@ describe("Cell", () => {
     // `Cell.set` pre-resolves its top-level link, so to exercise
     // `normalizeAndDiff`'s redirect-resolution branch we need the redirect
     // at a nested key — that's the path it actually fires on, during the
-    // per-key recursion in the `isRecord(newValue)` branch.
+    // per-key recursion in the `isObjectOrArray(newValue)` branch.
     const parent = rt.getCell<{ slot: unknown }>(
       space,
       "nested redirect parent",

--- a/packages/runner/test/cfc-concept-floor.test.ts
+++ b/packages/runner/test/cfc-concept-floor.test.ts
@@ -205,7 +205,7 @@ describe("CFC concept-level integrity floors (D5)", () => {
     });
 
     it("does not treat a Concept-shaped ARRAY as a concept guard (cubic P2)", () => {
-      // `isRecord` admits arrays (`typeof [] === "object"`), so an array
+      // `isObjectOrArray` admits arrays (`typeof [] === "object"`), so an array
       // carrying own `type`/`uri` properties previously routed to trust-closure
       // satisfaction. The canonical Concept atom is an OBJECT; a Concept-shaped
       // array is not the canonical shape and must fail closed to ordinary

--- a/packages/runner/test/cfc-label-view.test.ts
+++ b/packages/runner/test/cfc-label-view.test.ts
@@ -1478,7 +1478,7 @@ describe("redactSigilCfcLabelViewsForDisplay", () => {
     ).toBeDefined();
   });
 
-  // A `FabricSpecialObject` is `isRecord`, so it reaches the record branch
+  // A `FabricSpecialObject` is `isObjectOrArray`, so it reaches the record branch
   // rather than the leaf return. What keeps it whole is the copy-on-write
   // gate: such a value has zero enumerable own properties, so no member can
   // come back changed, `changed` stays false, and the original goes back by

--- a/packages/runner/test/cfc-policy.test.ts
+++ b/packages/runner/test/cfc-policy.test.ts
@@ -195,7 +195,7 @@ describe("CFC policy records (B2a)", () => {
         /must be an object/,
       ],
       [
-        // A Map passes `isRecord` but exposes no own string keys, so
+        // A Map passes `isObjectOrArray` but exposes no own string keys, so
         // field-by-field validation would read no guards — must fail closed
         // (cubic P1 on #4562).
         "Map-shaped record",

--- a/packages/runner/test/data-uri-inlining.test.ts
+++ b/packages/runner/test/data-uri-inlining.test.ts
@@ -337,7 +337,7 @@ describe("data URI inlining", () => {
     });
 
     describe("special objects", () => {
-      // A `FabricSpecialObject` is `isRecord`, so it reaches the record branch
+      // A `FabricSpecialObject` is `isObjectOrArray`, so it reaches the record branch
       // rather than the leaf return. What keeps it whole is that the branch
       // only clones when an entry inlines to something new, and a special
       // object has zero enumerable own properties: the loop body never runs,

--- a/packages/runner/test/merge-defaults.test.ts
+++ b/packages/runner/test/merge-defaults.test.ts
@@ -80,7 +80,7 @@ describe("mergeDefaults", () => {
       expect(result.default).toBe(null);
     });
 
-    it("should spread-merge when defaultValue is an array (arrays pass isRecord)", () => {
+    it("should spread-merge when defaultValue is an array (arrays pass isObjectOrArray)", () => {
       // Arrays are records in JS, so they hit the merge path.
       // This is a known quirk — see the TODO in mergeDefaults.
       const schema: JSONSchema = {
@@ -196,7 +196,7 @@ describe("mergeDefaults", () => {
         properties: { a: { type: "number" } },
       };
       const result = expectNontrivial(mergeDefaults(schema, { a: 42 }));
-      // No existing default to merge with, so isRecord(result.default) is
+      // No existing default to merge with, so isObjectOrArray(result.default) is
       // false on the first pass — falls through to simple assignment.
       expect(result.default).toEqual({ a: 42 });
     });

--- a/packages/runner/test/patterns-default-array-materialization.test.ts
+++ b/packages/runner/test/patterns-default-array-materialization.test.ts
@@ -7,7 +7,7 @@
 // items:{$ref:T}}` (the populated branch). Both branches can match a
 // populated array. Before the fix in `packages/runner/src/traverse.ts`,
 // `mergeAnyOfMatches` ran `Object.assign({}, …branches)` for multi-match
-// anyOf results because arrays satisfy `isRecord`; two array branches
+// anyOf results because arrays satisfy `isObjectOrArray`; two array branches
 // collapsed to `{ "0": …, "1": … }`, dropping `.map` and crashing the
 // derive callback with `TypeError: rooms.map is not a function`. Fix
 // preserves array-ness when all matches are arrays.

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -2112,7 +2112,7 @@ describe("mergeAnyOfMatches", () => {
   // CT-1562 / B2: when an anyOf produces multiple successful matches and all
   // of them are arrays, the current `Object.assign({}, ...arrays)` merge
   // strips array-ness, returning `{ "0": …, "1": … }` instead of `[…, …]`.
-  // Arrays satisfy `isRecord` (typeof [] === "object" && [] !== null), so
+  // Arrays satisfy `isObjectOrArray` (typeof [] === "object" && [] !== null), so
   // the object-merge branch fires erroneously.
   //
   // The existing object-merge semantic is intentional for object branches

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -29,7 +29,7 @@ import {
   FabricSpecialObject,
   type FabricValue,
 } from "@commonfabric/data-model/fabric-value";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import { InitializedRuntimeConnection } from "./client/connection.ts";
 import { getLogger } from "@commonfabric/utils/logger";
 
@@ -503,7 +503,7 @@ export class CellHandle<T = unknown> {
       return value.map((item) => CellHandle.deserialize(base, item));
     }
 
-    if (isRecord(value)) {
+    if (isObjectOrArray(value)) {
       const reference = parseAsCellRef(
         value as JSONValue | undefined,
         base.ref(),
@@ -562,7 +562,7 @@ export class CellHandle<T = unknown> {
       );
     }
 
-    if (isRecord(value)) {
+    if (isObjectOrArray(value)) {
       return Object.fromEntries(
         Object.entries(value).map((
           [key, member],
@@ -638,8 +638,8 @@ function applyValue(
   }
 
   // For plain objects, recursively apply to each property
-  if (isRecord(current)) {
-    const prevRecord = (isRecord(previous) && !Array.isArray(previous))
+  if (isObjectOrArray(current)) {
+    const prevRecord = (isObjectNotArray(previous))
       ? previous as Record<string, unknown>
       : {};
     const result: Record<string, unknown> = {};

--- a/packages/runtime-client/protocol/guards.ts
+++ b/packages/runtime-client/protocol/guards.ts
@@ -1,5 +1,5 @@
 import { isDID } from "@commonfabric/identity";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import {
   CellRef,
   CellUpdateNotification,
@@ -22,7 +22,7 @@ import {
 } from "./types.ts";
 
 export function isCellRef(value: unknown): value is CellRef {
-  if (!isRecord(value)) return false;
+  if (!isObjectOrArray(value)) return false;
   return Array.isArray(value.path) && typeof value.id === "string" &&
     !!value.id &&
     isDID(value.space);
@@ -32,7 +32,7 @@ export function isInitializationData(
   value: unknown,
 ): value is InitializationData {
   return (
-    isRecord(value) &&
+    isObjectOrArray(value) &&
     typeof value.apiUrl === "string" && !!value.identity &&
     typeof value.spaceDid === "string"
   );
@@ -40,7 +40,7 @@ export function isInitializationData(
 
 export function isIPCClientRequest(value: unknown): value is IPCClientRequest {
   return (
-    isRecord(value) &&
+    isObjectOrArray(value) &&
     typeof value.type === "string" &&
     Object.values(RequestType).includes(
       value.type as RequestType,
@@ -50,7 +50,7 @@ export function isIPCClientRequest(value: unknown): value is IPCClientRequest {
 
 export function isIPCClientMessage(value: unknown): value is IPCClientMessage {
   return (
-    isRecord(value) &&
+    isObjectOrArray(value) &&
     typeof value.msgId === "number" &&
     isIPCClientRequest(value.data)
   );
@@ -60,7 +60,7 @@ export function isIPCClientNotification(
   value: unknown,
 ): value is IPCClientNotification {
   return (
-    isRecord(value) &&
+    isObjectOrArray(value) &&
     typeof value.type === "string" &&
     Object.values(ClientNotificationType).includes(
       value.type as ClientNotificationType,
@@ -78,7 +78,7 @@ export function isIPCRemoteResponse(
   value: unknown,
 ): value is IPCRemoteResponse {
   return (
-    isRecord(value) &&
+    isObjectOrArray(value) &&
     typeof value.msgId === "number" &&
     ("error" in value ? typeof value.error === "string" : true)
   );
@@ -97,7 +97,7 @@ export function isCellUpdateNotification(
   value: unknown,
 ): value is CellUpdateNotification {
   return (
-    isRecord(value) &&
+    isObjectOrArray(value) &&
     value.type === NotificationType.CellUpdate &&
     typeof value.cell === "object" &&
     "value" in value
@@ -108,7 +108,7 @@ export function isConsoleNotification(
   value: unknown,
 ): value is ConsoleNotification {
   return (
-    isRecord(value) &&
+    isObjectOrArray(value) &&
     value.type === NotificationType.ConsoleMessage &&
     typeof value.method === "string" &&
     Array.isArray(value.args)
@@ -119,9 +119,9 @@ export function isNavigateRequestNotification(
   value: unknown,
 ): value is NavigateRequestNotification {
   return (
-    isRecord(value) &&
+    isObjectOrArray(value) &&
     value.type === NotificationType.NavigateRequest &&
-    isRecord(value.targetCellRef)
+    isObjectOrArray(value.targetCellRef)
   );
 }
 
@@ -129,7 +129,7 @@ export function isErrorNotification(
   value: unknown,
 ): value is ErrorNotification {
   return (
-    isRecord(value) &&
+    isObjectOrArray(value) &&
     value.type === NotificationType.ErrorReport &&
     typeof value.message === "string"
   );
@@ -139,7 +139,7 @@ export function isTelemetryNotification(
   value: unknown,
 ): value is TelemetryNotification {
   return (
-    isRecord(value) &&
+    isObjectOrArray(value) &&
     value.type === NotificationType.Telemetry &&
     typeof value.marker === "object"
   );
@@ -149,7 +149,7 @@ export function isPendingWritesNotification(
   value: unknown,
 ): value is PendingWritesNotification {
   return (
-    isRecord(value) &&
+    isObjectOrArray(value) &&
     value.type === NotificationType.PendingWritesChanged &&
     typeof value.pending === "boolean"
   );
@@ -159,7 +159,7 @@ export function isVDomBatchNotification(
   value: unknown,
 ): value is VDomBatchNotification {
   return (
-    isRecord(value) &&
+    isObjectOrArray(value) &&
     value.type === NotificationType.VDomBatch &&
     typeof value.batchId === "number" &&
     Array.isArray(value.ops)

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -1,5 +1,5 @@
 import ts from "typescript";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import {
   type CellWrapperKind,
   getCellBrand,
@@ -103,7 +103,7 @@ const applyScopeToAsCellEntry = (
   if (typeof entry === "string") {
     return { kind: entry, scope };
   }
-  if (isRecord(entry)) {
+  if (isObjectOrArray(entry)) {
     return { ...entry, scope };
   }
   return entry;
@@ -1327,7 +1327,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     switch (aliasName) {
       case "Cfc": {
         const payload = readValue(1);
-        return isRecord(payload) ? { ...payload } : undefined;
+        return isObjectOrArray(payload) ? { ...payload } : undefined;
       }
       case "Confidential":
         return { confidentiality: readValue(1) };
@@ -1586,7 +1586,7 @@ export class CommonFabricFormatter implements TypeFormatter {
       return schema === false ? { not: true, ifc } : { ifc };
     }
 
-    const existingIfc = isRecord(schema.ifc) ? schema.ifc : {};
+    const existingIfc = isObjectOrArray(schema.ifc) ? schema.ifc : {};
     return {
       ...schema,
       ifc: {

--- a/packages/schema-generator/src/formatters/intersection-formatter.ts
+++ b/packages/schema-generator/src/formatters/intersection-formatter.ts
@@ -7,7 +7,7 @@ import type { GenerationContext, TypeFormatter } from "../interface.ts";
 import type { SchemaGenerator } from "../schema-generator.ts";
 import { cloneSchemaDefinition, getNativeTypeSchema } from "../type-utils.ts";
 import { getLogger } from "@commonfabric/utils/logger";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { attachDocTags, extractDocFromType } from "../doc-utils.ts";
 import { isCellType } from "../typescript/cell-brand.ts";
 
@@ -183,7 +183,7 @@ export class IntersectionFormatter implements TypeFormatter {
         for (const [key, value] of Object.entries(objSchema.properties)) {
           const existing = mergedProps[key];
           if (existing) {
-            if (isRecord(existing) && isRecord(value)) {
+            if (isObjectOrArray(existing) && isObjectOrArray(value)) {
               const aDesc = typeof existing.description === "string"
                 ? existing.description as string
                 : undefined;
@@ -271,7 +271,7 @@ export class IntersectionFormatter implements TypeFormatter {
     },
   ): MutableJSONSchemaObj {
     const { schema, docTexts, documentedSources, missingSources } = data;
-    if (!isRecord(schema)) return schema;
+    if (!isObjectOrArray(schema)) return schema;
 
     const uniqueDocTexts = docTexts.filter((doc, index, arr) =>
       arr.indexOf(doc) === index

--- a/packages/schema-generator/src/formatters/object-formatter.ts
+++ b/packages/schema-generator/src/formatters/object-formatter.ts
@@ -29,7 +29,7 @@ import {
   symbolHasDeprecatedTag,
 } from "../doc-utils.ts";
 import { getLogger } from "@commonfabric/utils/logger";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 
 const logger = getLogger("schema-generator.object", {
   enabled: true,
@@ -330,7 +330,7 @@ export class ObjectFormatter implements TypeFormatter {
         context,
         propTypeNode,
       );
-      if (isRecord(generated)) {
+      if (isObjectOrArray(generated)) {
         attachDeprecatedStreamMark(
           generated as Record<string, unknown>,
           prop,
@@ -339,7 +339,7 @@ export class ObjectFormatter implements TypeFormatter {
       }
       // Attach property description from JSDoc (if any)
       const { text, all } = extractDocFromSymbolAndDecls(prop, checker);
-      if (text && isRecord(generated)) {
+      if (text && isObjectOrArray(generated)) {
         const conflicts = all.filter((s) => s && s !== text);
         (generated as Record<string, unknown>).description = text;
         attachDocTags(generated as Record<string, unknown>, text);
@@ -398,7 +398,7 @@ export class ObjectFormatter implements TypeFormatter {
           }
         }
       }
-      if (foundDocs.length > 0 && isRecord(apSchema)) {
+      if (foundDocs.length > 0 && isObjectOrArray(apSchema)) {
         (apSchema as Record<string, unknown>).description = foundDocs[0]!;
         attachDocTags(apSchema as Record<string, unknown>, foundDocs[0]!);
         if (foundDocs.length > 1) {

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -15,7 +15,7 @@ import {
   resolveWrapperNode,
   TypeWithInternals,
 } from "../type-utils.ts";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { dedupeByValueEqual } from "../value-equality.ts";
 
@@ -618,7 +618,7 @@ export class UnionFormatter implements TypeFormatter {
       return schemas[0]!;
     }
     const nullSchema = schemas.find((schema) =>
-      isRecord(schema) && schema.type === "null"
+      isObjectOrArray(schema) && schema.type === "null"
     );
     const nonNullSchemas = schemas.filter((schema) => schema !== nullSchema);
     if (nullSchema && nonNullSchemas.length === 1) {
@@ -674,7 +674,7 @@ export class UnionFormatter implements TypeFormatter {
     rootDefs?: Record<string, unknown>,
   ): MutableJSONSchema {
     const withDefault = this.applySchemaDefault(schema, defaultValue);
-    if (!this.isDefaultObject(defaultValue) || !isRecord(withDefault)) {
+    if (!this.isDefaultObject(defaultValue) || !isObjectOrArray(withDefault)) {
       return withDefault;
     }
 
@@ -693,11 +693,11 @@ export class UnionFormatter implements TypeFormatter {
     rootDefs?: Record<string, unknown>,
     targetSchema?: MutableJSONSchema,
   ): MutableJSONSchemaObj {
-    const properties = isRecord(schema.properties)
+    const properties = isObjectOrArray(schema.properties)
       ? { ...schema.properties }
       : {};
     const targetProperties = this.getObjectTargetProperties(
-      isRecord(targetSchema) ? targetSchema : schema,
+      isObjectOrArray(targetSchema) ? targetSchema : schema,
       rootDefs,
     );
 
@@ -735,7 +735,7 @@ export class UnionFormatter implements TypeFormatter {
     targetSchema?: MutableJSONSchema,
   ): MutableJSONSchema {
     const withDefault = this.applySchemaDefault(schema ?? true, defaultValue);
-    if (!this.isDefaultObject(defaultValue) || !isRecord(withDefault)) {
+    if (!this.isDefaultObject(defaultValue) || !isObjectOrArray(withDefault)) {
       return withDefault;
     }
 
@@ -758,7 +758,7 @@ export class UnionFormatter implements TypeFormatter {
     }
     seen.add(schema);
 
-    if (isRecord(schema.properties)) {
+    if (isObjectOrArray(schema.properties)) {
       return schema.properties;
     }
 
@@ -770,7 +770,7 @@ export class UnionFormatter implements TypeFormatter {
     if (Array.isArray(schema.anyOf)) {
       const candidates = schema.anyOf
         .map((option) =>
-          isRecord(option)
+          isObjectOrArray(option)
             ? this.getObjectTargetProperties(
               option as MutableJSONSchemaObj,
               rootDefs,
@@ -804,20 +804,22 @@ export class UnionFormatter implements TypeFormatter {
 
     const defs = this.getSchemaDefs(schema) ?? rootDefs;
     const resolved = defs?.[schema.$ref.slice(prefix.length)];
-    return isRecord(resolved) ? resolved as MutableJSONSchemaObj : undefined;
+    return isObjectOrArray(resolved)
+      ? resolved as MutableJSONSchemaObj
+      : undefined;
   }
 
   private getSchemaDefs(
     schema: MutableJSONSchemaObj,
   ): Record<string, unknown> | undefined {
-    if (isRecord(schema.$defs)) {
+    if (isObjectOrArray(schema.$defs)) {
       return schema.$defs;
     }
-    return isRecord(schema.definitions) ? schema.definitions : undefined;
+    return isObjectOrArray(schema.definitions) ? schema.definitions : undefined;
   }
 
   private isDefaultObject(value: unknown): value is Record<string, unknown> {
-    return isRecord(value) && !Array.isArray(value);
+    return isObjectNotArray(value);
   }
 
   private extractDefaultValueFromNode(
@@ -1056,7 +1058,7 @@ export class UnionFormatter implements TypeFormatter {
     }
     // See if we can merge into one of the anyOf options
     const matchingTypeIdx = anyOf.findIndex((option) =>
-      isRecord(option) &&
+      isObjectOrArray(option) &&
       PRIMITIVE_SCHEMA_KEY_SET.isSupersetOf(new Set(Object.keys(option))) &&
       "type" in option && option.type === cur.type
     );
@@ -1067,7 +1069,8 @@ export class UnionFormatter implements TypeFormatter {
       new Set(Object.keys(cur)),
     );
     if (
-      isRecord(cur) && Array.isArray(cur.enum) && isRecord(matchingType) &&
+      isObjectOrArray(cur) && Array.isArray(cur.enum) &&
+      isObjectOrArray(matchingType) &&
       Array.isArray(matchingType.enum)
     ) {
       // Add our enum values to their enum values, and keep the same type.
@@ -1093,7 +1096,7 @@ export class UnionFormatter implements TypeFormatter {
           enum: mergedEnum.toSorted(),
         };
       }
-    } else if (isRecord(matchingType)) {
+    } else if (isObjectOrArray(matchingType)) {
       // If either entry is missing an enum, we can have any value of that type, so clear enum
       const { enum: _dropped, ...rest } = matchingType;
       anyOf[matchingTypeIdx] = rest;
@@ -1102,14 +1105,14 @@ export class UnionFormatter implements TypeFormatter {
     ) {
       // If cur is a primitive non-enum with a known type, we can merge with any existing non-enum primitive
       const matchingNonEnumIdx = anyOf.findIndex((option) =>
-        isRecord(option) &&
+        isObjectOrArray(option) &&
         PRIMITIVE_SCHEMA_KEY_SET.isSupersetOf(new Set(Object.keys(option))) &&
         option.enum === undefined
       );
       const matchingNonEnum = matchingNonEnumIdx !== -1
         ? anyOf[matchingNonEnumIdx]
         : undefined;
-      if (isRecord(matchingNonEnum) && matchingNonEnumIdx !== -1) {
+      if (isObjectOrArray(matchingNonEnum) && matchingNonEnumIdx !== -1) {
         const curTypes = Array.isArray(cur.type) ? cur.type : [cur.type];
         const matchingNonEnumTypes = matchingNonEnum.type === undefined
           ? []
@@ -1155,7 +1158,7 @@ export class UnionFormatter implements TypeFormatter {
     }
 
     // Recursively normalize properties
-    if ("properties" in schema && isRecord(schema.properties)) {
+    if ("properties" in schema && isObjectOrArray(schema.properties)) {
       const props: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(schema.properties)) {
         props[key] = this.normalizeSchemaForComparison(
@@ -1211,12 +1214,12 @@ export class UnionFormatter implements TypeFormatter {
     }
 
     // Recursively merge properties
-    if ("properties" in first && isRecord(first.properties)) {
+    if ("properties" in first && isObjectOrArray(first.properties)) {
       const props: Record<string, MutableJSONSchema> = {};
       for (const key of Object.keys(first.properties)) {
         const propSchemas = schemas
           .map((s) =>
-            isRecord(s) && isRecord(s.properties)
+            isObjectOrArray(s) && isObjectOrArray(s.properties)
               ? s.properties[key]
               : undefined
           )
@@ -1233,7 +1236,7 @@ export class UnionFormatter implements TypeFormatter {
     if ("items" in first && first.items !== undefined) {
       const itemSchemas = schemas
         .map((s) =>
-          isRecord(s) && "items" in s && s.items !== undefined
+          isObjectOrArray(s) && "items" in s && s.items !== undefined
             ? s.items
             : undefined
         )

--- a/packages/schema-generator/src/schema-generator.ts
+++ b/packages/schema-generator/src/schema-generator.ts
@@ -1,5 +1,5 @@
 import ts from "typescript";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 
 import type {
   MutableJSONSchema,
@@ -596,10 +596,12 @@ export class SchemaGenerator {
     if (typeof schema !== "object") return schema;
 
     const docInfo = extractDocFromType(type, context.typeChecker);
-    if (docInfo.firstDoc && isRecord(schema) && !("description" in schema)) {
+    if (
+      docInfo.firstDoc && isObjectOrArray(schema) && !("description" in schema)
+    ) {
       (schema as Record<string, unknown>).description = docInfo.firstDoc;
     }
-    if (isRecord(schema) && typeof schema.description === "string") {
+    if (isObjectOrArray(schema) && typeof schema.description === "string") {
       attachDocTags(schema as Record<string, unknown>, schema.description);
     }
     return schema;

--- a/packages/schema-generator/src/ui-contract.ts
+++ b/packages/schema-generator/src/ui-contract.ts
@@ -3,7 +3,7 @@ import type {
   MutableJSONSchema,
   MutableJSONSchemaObj,
 } from "@commonfabric/api";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import type { GenerationContext, UiContractHint } from "./interface.ts";
 
 type EmittedUiContract = NonNullable<
@@ -45,7 +45,7 @@ export function attachUiContract(
       : { ifc: { uiContract } };
   }
 
-  const existingIfc = isRecord(schema.ifc) ? schema.ifc : {};
+  const existingIfc = isObjectOrArray(schema.ifc) ? schema.ifc : {};
   return {
     ...schema,
     ifc: {

--- a/packages/schema-generator/test/utils.ts
+++ b/packages/schema-generator/test/utils.ts
@@ -1,6 +1,6 @@
 import ts from "typescript";
 import { StaticCache } from "@commonfabric/static";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { FabricPrimitive } from "@commonfabric/data-model/fabric-value";
 import type { JSONSchemaObj } from "@commonfabric/api";
 
@@ -460,7 +460,7 @@ function normalizeAnyOf(node: any): any {
   if (node.anyOf.length === 2) {
     const a = node.anyOf[0];
     const b = node.anyOf[1];
-    const isNull = (x: any) => isRecord(x) && x.type === "null";
+    const isNull = (x: any) => isObjectOrArray(x) && x.type === "null";
     if (isNull(b) && !isNull(a)) {
       node.anyOf = [b, a];
     }
@@ -491,7 +491,7 @@ function deepCanonicalize(node: unknown): unknown {
   // descend into. There is no faithful way to do that through `Object.entries`
   // either, so a `FabricInstance` still flattens to `{}` here. Handling it is
   // left for when the golden path needs to carry one.
-  if (!isRecord(node) || node instanceof FabricPrimitive) return node;
+  if (!isObjectOrArray(node) || node instanceof FabricPrimitive) return node;
 
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(node)) {

--- a/packages/shell/src/lib/debug-utils.ts
+++ b/packages/shell/src/lib/debug-utils.ts
@@ -20,7 +20,7 @@ import type {
 } from "@commonfabric/runtime-client";
 import type { DID } from "@commonfabric/identity";
 import { hasEntityUriScheme } from "@commonfabric/runner/entity-kind";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import type { MetaField } from "@commonfabric/api";
 import { createVDomDebugHelpers, viewSettled } from "@commonfabric/html/debug";
 
@@ -251,13 +251,13 @@ export function summarizeDebugValue(value: unknown): DebugValueSummary {
   if (Array.isArray(value)) {
     return { kind: "array", length: value.length };
   }
-  if (!isRecord(value)) {
+  if (!isObjectOrArray(value)) {
     return { kind: "other", preview: Object.prototype.toString.call(value) };
   }
 
   const topKeys = Object.keys(value).slice(0, 12);
   const looksLike: string[] = [];
-  const internal = isRecord(value.internal) ? value.internal : undefined;
+  const internal = isObjectOrArray(value.internal) ? value.internal : undefined;
   const internalKeys = internal
     ? Object.keys(internal).slice(0, 12)
     : undefined;
@@ -280,7 +280,7 @@ export function summarizeDebugValue(value: unknown): DebugValueSummary {
   if ("$UI" in value) {
     looksLike.push("ui-result");
     const ui = value.$UI;
-    if (isRecord(ui) && Array.isArray(ui.children)) {
+    if (isObjectOrArray(ui) && Array.isArray(ui.children)) {
       summary.uiChildCount = ui.children.length;
     }
   }

--- a/packages/shell/src/views/DebuggerView.ts
+++ b/packages/shell/src/views/DebuggerView.ts
@@ -6,7 +6,7 @@ import type {
   RuntimeTelemetryMarkerResult,
   TimingStats,
 } from "@commonfabric/runtime-client";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import type { DebuggerController } from "../lib/debugger-controller.ts";
 import "./SchedulerGraphView.ts"; // Register x-scheduler-graph component
 import type { Logger, LoggerBreakdown } from "@commonfabric/utils/logger";
@@ -1127,9 +1127,9 @@ export class XDebuggerView extends LitElement {
       const handlerId = typeof eventData.handlerId === "string"
         ? eventData.handlerId
         : undefined;
-      const info = isRecord(eventData.actionInfo)
+      const info = isObjectOrArray(eventData.actionInfo)
         ? eventData.actionInfo
-        : isRecord(eventData.handlerInfo)
+        : isObjectOrArray(eventData.handlerInfo)
         ? eventData.handlerInfo
         : undefined;
 
@@ -1193,8 +1193,8 @@ export class XDebuggerView extends LitElement {
       }
     } else if (type === "cell.update") {
       const change = (rest as Record<string, unknown>).change;
-      if (isRecord(change)) {
-        if (isRecord(change.address)) {
+      if (isObjectOrArray(change)) {
+        if (isObjectOrArray(change.address)) {
           if (change.address?.id) {
             details.push(html`
               <div class="event-detail">

--- a/packages/toolshed/routes/integrations/plaid-oauth/plaid-oauth.error.test.ts
+++ b/packages/toolshed/routes/integrations/plaid-oauth/plaid-oauth.error.test.ts
@@ -1,0 +1,40 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { plaidErrorFrom } from "./plaid-oauth.error.ts";
+
+describe("plaid-oauth.error", () => {
+  describe("plaidErrorFrom()", () => {
+    it("returns the error document an SDK rejection carries", () => {
+      const document = {
+        error_message: "the item is no longer valid",
+        error_code: "ITEM_LOGIN_REQUIRED",
+        error_type: "ITEM_ERROR",
+        display_message: "Please sign in again",
+      };
+
+      expect(plaidErrorFrom({ response: { data: document } })).toBe(document);
+    });
+
+    it("returns `undefined` for a thrown value that is not an object", () => {
+      expect(plaidErrorFrom(new Error("boom").message)).toBe(undefined);
+      expect(plaidErrorFrom(undefined)).toBe(undefined);
+      expect(plaidErrorFrom(null)).toBe(undefined);
+    });
+
+    it("returns `undefined` for a transport failure with no response", () => {
+      expect(plaidErrorFrom(new Error("connection reset"))).toBe(undefined);
+      expect(plaidErrorFrom({ response: undefined })).toBe(undefined);
+    });
+
+    it("returns `undefined` for a response carrying no document", () => {
+      expect(plaidErrorFrom({ response: {} })).toBe(undefined);
+      expect(plaidErrorFrom({ response: { data: null } })).toBe(undefined);
+      expect(plaidErrorFrom({ response: { data: "" } })).toBe(undefined);
+    });
+
+    it("returns `undefined` for an array in either position", () => {
+      expect(plaidErrorFrom([])).toBe(undefined);
+      expect(plaidErrorFrom({ response: [] })).toBe(undefined);
+    });
+  });
+});

--- a/packages/toolshed/routes/integrations/plaid-oauth/plaid-oauth.error.ts
+++ b/packages/toolshed/routes/integrations/plaid-oauth/plaid-oauth.error.ts
@@ -1,0 +1,20 @@
+import type { PlaidError } from "plaid";
+import { isObjectNotArray } from "@commonfabric/utils/types";
+
+/**
+ * The Plaid error document carried by a failed SDK call, or `undefined` when
+ * the thrown value carries none.
+ *
+ * The SDK rejects with an axios error whose `response.data` holds the document.
+ * Anything else reaching a handler's `catch` carries no such document: a
+ * `TypeError` raised by the handler's own code, or a transport failure that
+ * never produced a response. A caller getting `undefined` has nothing more
+ * specific to report than the thrown value's own message.
+ */
+export const plaidErrorFrom = (error: unknown): PlaidError | undefined => {
+  if (!isObjectNotArray(error)) return undefined;
+  const response = error.response;
+  if (!isObjectNotArray(response)) return undefined;
+  const data = response.data;
+  return data ? data as PlaidError : undefined;
+};

--- a/packages/toolshed/routes/integrations/plaid-oauth/plaid-oauth.handlers.ts
+++ b/packages/toolshed/routes/integrations/plaid-oauth/plaid-oauth.handlers.ts
@@ -30,7 +30,7 @@ import {
   Transaction,
   TransactionsSyncRequest,
 } from "plaid";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 
 /**
  * Plaid Create Link Token Handler
@@ -85,7 +85,10 @@ export const createLinkToken: AppRouteHandler<CreateLinkTokenRoute> = async (
     logger.error({ error }, "Failed to create link token");
 
     // Extract Plaid error details if available
-    if (isRecord(error) && isRecord(error.response) && error.response.data) {
+    if (
+      isObjectOrArray(error) && isObjectOrArray(error.response) &&
+      error.response.data
+    ) {
       const plaidError = error.response.data as PlaidError;
       return c.json({
         error: plaidError.error_message || "Failed to create link token",

--- a/packages/toolshed/routes/integrations/plaid-oauth/plaid-oauth.handlers.ts
+++ b/packages/toolshed/routes/integrations/plaid-oauth/plaid-oauth.handlers.ts
@@ -26,11 +26,10 @@ import env from "@/env.ts";
 import {
   CountryCode,
   LinkTokenCreateRequest,
-  PlaidError,
   Transaction,
   TransactionsSyncRequest,
 } from "plaid";
-import { isObjectOrArray } from "@commonfabric/utils/types";
+import { plaidErrorFrom } from "./plaid-oauth.error.ts";
 
 /**
  * Plaid Create Link Token Handler
@@ -85,11 +84,8 @@ export const createLinkToken: AppRouteHandler<CreateLinkTokenRoute> = async (
     logger.error({ error }, "Failed to create link token");
 
     // Extract Plaid error details if available
-    if (
-      isObjectOrArray(error) && isObjectOrArray(error.response) &&
-      error.response.data
-    ) {
-      const plaidError = error.response.data as PlaidError;
+    const plaidError = plaidErrorFrom(error);
+    if (plaidError) {
       return c.json({
         error: plaidError.error_message || "Failed to create link token",
         error_code: plaidError.error_code,

--- a/packages/utils/src/deep-equal.ts
+++ b/packages/utils/src/deep-equal.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "./types.ts";
+import { isObjectOrArray } from "./types.ts";
 
 /**
  * Performs a deep equality comparison between two values.
@@ -26,7 +26,7 @@ import { isRecord } from "./types.ts";
 export function deepEqual(a: any, b: any): boolean {
   if (Object.is(a, b)) return true;
 
-  if (!(isRecord(a) && isRecord(b))) {
+  if (!(isObjectOrArray(a) && isObjectOrArray(b))) {
     return false;
   }
 

--- a/packages/utils/src/equal-ignoring-symbols.ts
+++ b/packages/utils/src/equal-ignoring-symbols.ts
@@ -1,11 +1,11 @@
 import { expect } from "@std/expect";
 import type { Async, Expected } from "@std/expect";
-import { isRecord } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 
 /**
  * Strips all symbol properties from an object, recursively.
  *
- * TODO(danfuzz): `isRecord` admits a `FabricSpecialObject`, and the
+ * TODO(danfuzz): `isObjectOrArray` admits a `FabricSpecialObject`, and the
  * `Object.keys` rebuild renders one as `{}` — on BOTH sides of the matchers
  * below, so a test asserting on cell-read values judges any two same-shaped
  * values with differing fabric contents equal, and its failure diff prints
@@ -14,7 +14,7 @@ import { isRecord } from "@commonfabric/utils/types";
  * classes hold no own symbol properties to strip).
  */
 export function stripSymbols(obj: unknown): unknown {
-  if (!isRecord(obj)) return obj;
+  if (!isObjectOrArray(obj)) return obj;
 
   // Handle arrays
   if (Array.isArray(obj)) {

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -53,8 +53,8 @@
  * `typeof [] === "object"`, so a predicate named only for "object" leaves a
  * reader guessing whether an array passes it, and a reader who guesses wrong
  * writes the wrong branch. Each name below settles the question in its own
- * final word. They are listed loosest test first, and each accepts a subset of
- * the one above it except where noted:
+ * final word. They are listed loosest test first, each accepting a subset of
+ * what the one above it accepts:
  *
  * * `isObjectOrArray()` -- any non-`null` value whose `typeof` is `"object"`.
  *   Arrays, `Date`s, `Map`s, other class instances, and null-prototype objects

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -6,9 +6,10 @@
  * `isNumber()`, `isFunction()` -- and says everything there is to say about the
  * value, so its `false` branch is exactly as trustworthy as its `true` branch.
  *
- * The other kind is *structural*: `isPlainObject()` and `isPlainContainer()`
- * here, and `isInertArray()`, `isArrayWithOnlyIndexProperties()`, and
- * `isInertPlainObject()` in the sibling `arrays` and `objects` modules. Each of
+ * The other kind is *structural*: `isObjectNotArray()`, `isPlainObject()` and
+ * `isPlainContainer()` here, and `isInertArray()`,
+ * `isArrayWithOnlyIndexProperties()`, and `isInertPlainObject()` in the sibling
+ * `arrays` and `objects` modules. Each of
  * those checks strictly more than the type it narrows to can express, and
  * deliberately so: each narrows to the weakest type that stays true however the
  * value is treated afterwards, never to the property it actually checks. A
@@ -46,14 +47,56 @@
  * would not be assignable, and TypeScript would intersect the two instead: the
  * resulting `readonly number[] & unknown[]` accepts writes, which is how a
  * mutable target launders `readonly` away.
+ *
+ * ## Every object-shape predicate answers the array question in its name
+ *
+ * `typeof [] === "object"`, so a predicate named only for "object" leaves a
+ * reader guessing whether an array passes it, and a reader who guesses wrong
+ * writes the wrong branch. Each name below settles the question in its own
+ * final word. They are listed loosest test first, and each accepts a subset of
+ * the one above it except where noted:
+ *
+ * * `isObjectOrArray()` -- any non-`null` value whose `typeof` is `"object"`.
+ *   Arrays, `Date`s, `Map`s, other class instances, and null-prototype objects
+ *   all pass.
+ * * `isObjectNotArray()` -- the same question with arrays removed. Class
+ *   instances still pass.
+ * * `isPlainObject()` -- rooted at `Object.prototype`, or at `null` unless the
+ *   caller asks for the narrower question. Class instances do not pass.
+ * * `isInertPlainObject()`, in the sibling `objects` module -- rooted at
+ *   `Object.prototype` exactly, with every own property an enumerable
+ *   string-keyed data property.
+ *
+ * Two more sit outside that chain. `isPlainContainer()` is `isPlainObject()`
+ * widened to admit arrays again, for a caller whose next move is member access
+ * by property name or by array index. `isInstance()` is the complement of the
+ * plain objects among the non-array ones: a prototype that is neither
+ * `Object.prototype` nor `null`.
+ *
+ * What a predicate narrows to is a separate matter from what its name says.
+ * `isObjectOrArray()` narrows to `Record<string, unknown>`, and an array
+ * satisfies that as far as reading a property by name goes. The name is what
+ * tells a caller an array can be the thing it is now holding; the type does
+ * not.
+ *
+ * `@commonfabric/data-model` asks the first of these questions of a value the
+ * type system already says is a `FabricValue`, and spells it
+ * `isFabricObjectOrArray()` for the same reason.
  */
 
 /**
- * Predicate for narrowing a mutable string-keyed record type.
+ * Indicates whether a value is a non-`null` value whose `typeof` is `"object"`.
+ * This is the loosest of the object-shape questions: an array passes, as does
+ * any class instance and any null-prototype object.
+ *
+ * The narrowed type is mutable, and is a string-keyed record because reading a
+ * property by name is what callers do with the result. An array reaching such a
+ * caller is read the same way, its indices being property names like any other.
+ *
  * @param value - The value to check
- * @returns True if the value is a record object
+ * @returns True if the value is a non-`null` object, array included
  */
-export function isRecord(
+export function isObjectOrArray(
   value: unknown,
 ): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -65,11 +108,15 @@ export function isRecord(
 export type ReadonlyRecord = Readonly<Record<string, unknown>>;
 
 /**
- * Predicate for narrowing a read-only record type, including frozen values.
+ * The `isObjectOrArray()` question asked on behalf of a caller that only reads:
+ * the same test, narrowing to a read-only record so a frozen value keeps its
+ * protection.
  * @param value - The value to check
- * @returns True if the value is a record object
+ * @returns True if the value is a non-`null` object, array included
  */
-export function isReadonlyRecord(value: unknown): value is ReadonlyRecord {
+export function isReadonlyObjectOrArray(
+  value: unknown,
+): value is ReadonlyRecord {
   return typeof value === "object" && value !== null;
 }
 
@@ -90,7 +137,7 @@ export function isFunction(
  * @returns True if the value is an instance
  */
 export function isInstance(value: unknown): boolean {
-  if (!isObject(value)) return false;
+  if (!isObjectNotArray(value)) return false;
 
   const proto = Object.getPrototypeOf(value);
 
@@ -98,25 +145,23 @@ export function isInstance(value: unknown): boolean {
 }
 
 /**
- * Indicates whether a value is a non-array, non-`null` `object` type.
+ * Indicates whether a value is a non-`null` value whose `typeof` is `"object"`
+ * and which is not an array. Class instances pass; for the narrower question
+ * that rejects those, see `isPlainObject()`.
+ *
+ * This is a structural predicate, so it narrows in one direction only, and is
+ * overloaded accordingly; see the module header for what that means and why.
+ * A `false` result means the value was not established to be a non-array
+ * object, which is weaker than saying it is one of the things the check
+ * rejects.
+ *
  * @param value - The value to check
- * @returns True if the value is an object (not array or null)
+ * @returns True if the value is a non-`null` object other than an array
  */
-export function isObject(value: unknown): boolean {
+export function isObjectNotArray(value: ReadonlyRecord): boolean;
+export function isObjectNotArray(value: unknown): value is ReadonlyRecord;
+export function isObjectNotArray(value: unknown): boolean {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-/**
- * Narrowing for a non-array/non-null `object` type.
- * @param value - The value to check
- * @returns if the value is an object (not array or null) or throws if it is not
- */
-export function assertIsObject(value: unknown): asserts value is object {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new Error(
-      "Assertion that value is a non-array/non-null object failed",
-    );
-  }
 }
 
 /**

--- a/packages/utils/test/narrowing.test.ts
+++ b/packages/utils/test/narrowing.test.ts
@@ -17,6 +17,7 @@ import {
 } from "@commonfabric/utils/arrays";
 import { isInertPlainObject } from "@commonfabric/utils/objects";
 import {
+  isObjectNotArray,
   isPlainContainer,
   isPlainObject,
   type ReadonlyRecord,
@@ -86,6 +87,20 @@ describe("structural predicate narrowing", () => {
         throw new Error("Expected an inert array.");
       }
       expect(array.length).toBe(1);
+    });
+
+    it("narrows `unknown` for `isObjectNotArray()`", () => {
+      // Narrowing is the whole reason this predicate is not just a `boolean`
+      // check. Without it a caller wanting the array case excluded has to
+      // reach for `isObjectOrArray()` and re-derive `!Array.isArray()` beside
+      // it, which is how the same test ends up written out in several places.
+      const value: unknown = { a: 1 };
+
+      if (isObjectNotArray(value)) {
+        expect(Object.keys(value)).toEqual(["a"]);
+      } else {
+        throw new Error("Expected a non-array object.");
+      }
     });
 
     it("narrows `unknown` for `isPlainContainer()`", () => {
@@ -177,6 +192,20 @@ describe("structural predicate narrowing", () => {
       expect(record.inherited).toBe(1);
     });
 
+    it("keeps a record usable after a `false` result from `isObjectNotArray()`", () => {
+      // An array reaching a caller whose declared type says record. The check
+      // rejects it for being an array, which is a fact about the value that
+      // `ReadonlyRecord` cannot carry, so the `false` branch has to keep the
+      // type the caller arrived with.
+      const record = [1, 2, 3] as unknown as ReadonlyRecord;
+
+      if (isObjectNotArray(record)) {
+        throw new Error("Expected an array to be rejected.");
+      }
+
+      expect(record.length).toBe(3);
+    });
+
     it("keeps a container usable after a `false` result", () => {
       const container: ReadonlyRecord = new Date() as unknown as ReadonlyRecord;
 
@@ -223,6 +252,21 @@ describe("structural predicate narrowing", () => {
       // `readonly` array is -- `ReadonlyRecord` assigns happily to
       // `Record<string, unknown>`. Only a write catches it, so the assertion
       // lives in a function that is never called, the value being frozen.
+      const _assertReadOnly = () => {
+        // @ts-expect-error The narrowed type confers read access, not write.
+        value.a = 2;
+      };
+
+      expect(value.a).toBe(1);
+    });
+
+    it("narrows `unknown` to a read-only record for `isObjectNotArray()` too", () => {
+      const value: unknown = Object.freeze({ a: 1 });
+
+      if (!isObjectNotArray(value)) {
+        throw new Error("Expected a frozen plain object to be a non-array.");
+      }
+
       const _assertReadOnly = () => {
         // @ts-expect-error The narrowed type confers read access, not write.
         value.a = 2;

--- a/packages/utils/test/types.test.ts
+++ b/packages/utils/test/types.test.ts
@@ -6,11 +6,11 @@ import {
   isFunction,
   isInstance,
   isNumber,
-  isObject,
+  isObjectNotArray,
+  isObjectOrArray,
   isPlainContainer,
   isPlainObject,
-  isReadonlyRecord,
-  isRecord,
+  isReadonlyObjectOrArray,
   isString,
   isUnsafeObjectKey,
   Mutable,
@@ -70,45 +70,45 @@ describe("types", () => {
     });
   });
 
-  describe("isRecord()", () => {
+  describe("isObjectOrArray()", () => {
     it("returns `true` for plain objects", () => {
-      expect(isRecord({})).toBe(true);
-      expect(isRecord({ a: 1 })).toBe(true);
+      expect(isObjectOrArray({})).toBe(true);
+      expect(isObjectOrArray({ a: 1 })).toBe(true);
     });
 
     it("returns `true` for arrays", () => {
-      expect(isRecord([])).toBe(true);
-      expect(isRecord([1, 2, 3])).toBe(true);
+      expect(isObjectOrArray([])).toBe(true);
+      expect(isObjectOrArray([1, 2, 3])).toBe(true);
     });
 
     it("returns `true` for class instances", () => {
-      expect(isRecord(new Date())).toBe(true);
-      expect(isRecord(new Map())).toBe(true);
+      expect(isObjectOrArray(new Date())).toBe(true);
+      expect(isObjectOrArray(new Map())).toBe(true);
     });
 
     it("returns `false` for `null`", () => {
-      expect(isRecord(null)).toBe(false);
+      expect(isObjectOrArray(null)).toBe(false);
     });
 
     it("returns `false` for primitives", () => {
-      expect(isRecord(undefined)).toBe(false);
-      expect(isRecord(42)).toBe(false);
-      expect(isRecord("string")).toBe(false);
-      expect(isRecord(true)).toBe(false);
-      expect(isRecord(Symbol("test"))).toBe(false);
+      expect(isObjectOrArray(undefined)).toBe(false);
+      expect(isObjectOrArray(42)).toBe(false);
+      expect(isObjectOrArray("string")).toBe(false);
+      expect(isObjectOrArray(true)).toBe(false);
+      expect(isObjectOrArray(Symbol("test"))).toBe(false);
     });
 
     it("returns `false` for functions", () => {
-      expect(isRecord(() => {})).toBe(false);
+      expect(isObjectOrArray(() => {})).toBe(false);
     });
   });
 
-  describe("isReadonlyRecord()", () => {
+  describe("isReadonlyObjectOrArray()", () => {
     it("returns `true` for frozen records", () => {
-      expect(isReadonlyRecord(Object.freeze({ a: 1 }))).toBe(true);
+      expect(isReadonlyObjectOrArray(Object.freeze({ a: 1 }))).toBe(true);
     });
 
-    it("has the same runtime domain as `isRecord()`", () => {
+    it("has the same runtime domain as `isObjectOrArray()`", () => {
       for (
         const value of [
           {},
@@ -123,7 +123,7 @@ describe("types", () => {
           () => {},
         ]
       ) {
-        expect(isReadonlyRecord(value)).toBe(isRecord(value));
+        expect(isReadonlyObjectOrArray(value)).toBe(isObjectOrArray(value));
       }
     });
   });
@@ -196,35 +196,35 @@ describe("types", () => {
     });
   });
 
-  describe("isObject()", () => {
+  describe("isObjectNotArray()", () => {
     it("returns `true` for plain objects", () => {
-      expect(isObject({})).toBe(true);
-      expect(isObject({ a: 1 })).toBe(true);
+      expect(isObjectNotArray({})).toBe(true);
+      expect(isObjectNotArray({ a: 1 })).toBe(true);
     });
 
     it("returns `true` for class instances", () => {
-      expect(isObject(new Date())).toBe(true);
-      expect(isObject(new Map())).toBe(true);
+      expect(isObjectNotArray(new Date())).toBe(true);
+      expect(isObjectNotArray(new Map())).toBe(true);
     });
 
     it("returns `false` for arrays", () => {
-      expect(isObject([])).toBe(false);
-      expect(isObject([1, 2, 3])).toBe(false);
+      expect(isObjectNotArray([])).toBe(false);
+      expect(isObjectNotArray([1, 2, 3])).toBe(false);
     });
 
     it("returns `false` for `null`", () => {
-      expect(isObject(null)).toBe(false);
+      expect(isObjectNotArray(null)).toBe(false);
     });
 
     it("returns `false` for primitives", () => {
-      expect(isObject(undefined)).toBe(false);
-      expect(isObject(42)).toBe(false);
-      expect(isObject("string")).toBe(false);
-      expect(isObject(true)).toBe(false);
+      expect(isObjectNotArray(undefined)).toBe(false);
+      expect(isObjectNotArray(42)).toBe(false);
+      expect(isObjectNotArray("string")).toBe(false);
+      expect(isObjectNotArray(true)).toBe(false);
     });
 
     it("returns `false` for functions", () => {
-      expect(isObject(() => {})).toBe(false);
+      expect(isObjectNotArray(() => {})).toBe(false);
     });
   });
 


### PR DESCRIPTION
`typeof [] === "object"`, so a predicate named for "object" alone leaves a reader guessing whether an array passes it, and the two predicates in `utils/types` that answer that question were named the wrong way round. `isRecord()` was the loosest test in the module -- every non-null object, arrays and class instances included -- under the most specific-sounding name in the family, "record" being what this system elsewhere calls a string-keyed plain object. `isObject()` was the one that actually excluded arrays.

The cost was not hypothetical. `data-updating.ts` carries a five-line comment whose whole job is to warn that `isRecord` admits arrays and `isObject` does not. Eight runner tests carry a sentence apiece saying the same thing. `data-model` invented `isFabricObjectOrArray()` rather than reuse the name, and its docstring gives the reason in as many words: the name spells out the array case because "object" alone reads as excluding it. That is the rule this change applies to the other two:

* `isRecord()` becomes `isObjectOrArray()`, matching `data-model`'s spelling of the same question.
* `isReadonlyRecord()` becomes `isReadonlyObjectOrArray()`.
* `isObject()` becomes `isObjectNotArray()`.

Neither new name is the old name of the other predicate, so no call site keeps compiling with its meaning quietly changed; every one of them had to be visited. The `ReadonlyRecord` type keeps its name, which was never the misleading part.

`isObject()` also returned a bare `boolean` where its sibling narrowed, which is what turned the naming problem into duplicated code. A caller needing the array case excluded *and* a narrowed type could not use it, so they wrote `isRecord(x) && !Array.isArray(x)` instead -- 49 times across the tree, in `llm`, `cli`, `cf-harness`, `memory`, `runtime-client`, `schema-generator` and throughout `runner`. Two of those had drifted into `!isRecord(x) && !Array.isArray(x)`, where the second half can never be reached because the first already rejects every array; both are now the single test they meant. `isObjectNotArray()` narrows, with the overload pair the module header prescribes so a caller that already knows the shape keeps a usable `false` branch, and the 49 sites call it.

The most recent copy of that pattern was `isSubschema()` in the schema walk, which is where a reviewer noticed the redundancy. It now asks `isObjectNotArray()`. The definition validator in `schema-sanitization` was spelling out a third copy of the same test, one line away from the error message that describes it; the walk's docstring claimed the two agreed. They agree now because the validator calls `isSubschema()`.

`assertIsObject()` had no callers and no tests, and is deleted rather than renamed.

The narrowing contract of the new predicate is pinned in `utils/test/narrowing.test.ts` alongside its siblings: that `unknown` narrows through it, that a caller holding a record type survives a `false` result rather than collapsing to `never`, and that a frozen value does not come back writable.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

