### PR TITLE
test(generated-patterns): drop latency sleep from ct-1334 fetch mock

### DIFF
--- a/packages/generated-patterns/integration/patterns/ct-1334-fetchjson-derive-subpattern.test.ts
+++ b/packages/generated-patterns/integration/patterns/ct-1334-fetchjson-derive-subpattern.test.ts
@@ -14,7 +14,7 @@ let originalFetch: typeof globalThis.fetch;
 describe("CT-1334: fetchJson + computed inside sub-pattern (transformed)", () => {
   beforeEach(() => {
     originalFetch = globalThis.fetch;
-    globalThis.fetch = async (
+    globalThis.fetch = (
       input: string | URL | Request,
       _init?: RequestInit,
     ) => {
@@ -26,19 +26,20 @@ describe("CT-1334: fetchJson + computed inside sub-pattern (transformed)", () =>
 
       // Only mock our test endpoint
       if (url.includes("localhost:59999/api/contacts")) {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-        return new Response(
-          JSON.stringify({
-            connections: [
-              { name: "Alice" },
-              { name: "Bob" },
-              { name: "Carol" },
-            ],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              connections: [
+                { name: "Alice" },
+                { name: "Bob" },
+                { name: "Carol" },
+              ],
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
         );
       }
 


### PR DESCRIPTION
The CT-1334 pattern-harness test mocked globalThis.fetch with an async arrow that, for the test endpoint, awaited a ten-millisecond timer before returning the fake Response. The timer was there to simulate network latency, so it is not the usual sleep-as-a-wait anti-pattern; but it is still a fixed wall-clock delay, which this repository bans in tests, and nothing the test verifies depends on it.

The delay was not load-bearing. The runner's fetchJson builtin is asynchronous on its own account: it enqueues the request as a post-commit effect, claims a cross-tab mutex through a promise, awaits the response body parse, and awaits the scheduler going idle before it writes the parsed result and the pending flag back into the cells the sub-pattern's computed() projection observes. The pattern harness never observes any ordering against the fetch; it polls the result cell until it converges on the expected value. So the derive-across-fetch reactivity is exercised the same whether the mock resolves on a later timer turn or immediately.

Remove the timer entirely and drop the now-pointless async keyword, returning Promise.resolve(new Response(...)) for the mocked endpoint. The mock stays asynchronous, as globalThis.fetch must, but carries no wall-clock floor, and teardown no longer has a pending timer for --trace-leaks to account for. The test passes repeatedly, and deno fmt, deno lint, and deno check are clean on the file.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

