### PR TITLE
fix(runner): make a list coordinator's setup writes a debt, not a flag

### DIFF
--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -361,7 +361,7 @@ its own track.
 | # | Step | Delivers | After | Why here |
 | --- | --- | --- | --- | --- |
 | 1 | The doubly-linked tracker fixture and its walkthrough | **on main** (#5639, #5631) — repro for #5577, #5632, #5633, #5637; item 11's subject | — | Five things verify against a piece that holds a back-reference, and none could be demonstrated until one existed. `verb-session-gaps.sh` is where they are asserted, and several of its assertions expect a gap and fail loudly the day it closes — so a capability arriving announces itself instead of quietly turning a check green. The script states its own count; repeating it here only creates a second place to be wrong |
-| 2 | A projected read survives a handler | #5633 — **handed off, owned by the runner** | 1 | Breaks call-then-read-shaped, which is the loop items 4, 5, 10 and #5577 all demonstrate against. Diagnose before estimating: if it sits in runner materialization rather than the read path, it moves after step 7 rather than holding the line |
+| 2 | A projected read survives a handler | #5633 — **in review** (#5764) | 1 | Breaks call-then-read-shaped, which is the loop items 4, 5, 10 and #5577 all demonstrate against. Diagnose before estimating: if it sits in runner materialization rather than the read path, it moves after step 7 rather than holding the line |
 | 3 | Listing rows carry a handler's declared result | **on main** (#5629) — item 10, #5619 | — | The consumer half of item 1 |
 | 4 | The forced-stream fallback stops inventing verbs | **on main** (#5683) — #5576, #5662 | 3 | Same file as step 3, which has landed, so this is the front of the queue. It narrows the listing, so sweep the open branches for writers first |
 | 5 | The help page stops claiming a verb returns nothing | **on main** (#5680) — #5558, first half | — | `Output: No output on success.` is wrong for a declared verb. Asserting there is no output is worse than saying nothing, and stopping it needs no schema and no decision, which is why it precedes the half that does |
@@ -540,7 +540,7 @@ from a plan is one nobody schedules, which is the whole reason for this table.
 
 | Issue | What | Attaches at |
 | --- | --- | --- |
-| #5633 | a projected read fails on the SECOND read of the same source and schema; the handler is a red herring | **owned by the runner** — the container's result link is not re-issued after a stale-basis retry. #5706 is why it reproduces every time |
+| #5633 | a projected read fails on the SECOND read of the same source and schema; the handler is a red herring | **in review** (#5764) — a list coordinator owes the setup writes a lost commit discarded, its result container's links among them. #5706, which is why it reproduces every time, stands |
 | #5576 | `cf piece verbs` lists data fields as handlers, so discovery reports what cannot be called | **fixed** by #5683, with #5662 |
 | #5698 | `cf piece verbs` returns nothing for a piece whose declared result type omits its verbs, though they are callable | the other direction of the same surface: 8 verbs invisible to the listing AND to tab-completion |
 | #5706 | a shaped read permanently writes to the user's space — per-element sub-patterns land at space scope | runner-owned, beside #5633 |

--- a/docs/specs/space-model/5-transactions.md
+++ b/docs/specs/space-model/5-transactions.md
@@ -46,6 +46,17 @@ discard; undoing it there can stop the work converging at all.
 `storage/rejection.ts` classifies the outcomes, so a callback acts only on the
 ones no re-run follows.
 
+That exception covers the bookkeeping, not the writes. Every outcome that
+delivers an error discards what the transaction staged, a stale basis included,
+so a record saying those writes are in place is wrong however the transaction
+failed. Such a record is not state to discard but a debt to mark: the callback
+says the writes are owed, and the next run issues them again against the
+bookkeeping it kept. A callback that only tears state down, under the outcomes
+with no re-run behind them, leaves the re-run trusting writes that never landed.
+The list coordinators are the case this rule exists for — a per-element pattern
+run and the links that make a result container reachable are both writes the
+coordinator remembers making.
+
 External side effects belong in the post-commit outbox instead, which runs only
 after a successful commit.
 

--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -31,6 +31,7 @@ import type { NormalizedFullLink } from "../link-types.ts";
 import { listResultSchema } from "./list-result-schema.ts";
 import { inferListOpArgumentUsage } from "./list-op-argument-usage.ts";
 import { setPatternCell, setResultCell } from "../result-utils.ts";
+import { issueResultContainerSetup } from "./list-result-container.ts";
 import {
   narrowestCellScope,
   outputSpotFromBinding,
@@ -39,6 +40,7 @@ import {
 import { resolveOpPattern } from "./op-pattern-ref.ts";
 import {
   type ElementRun,
+  type SetupRecord,
   trackListSetupRollback,
 } from "./list-element-rollback.ts";
 import {
@@ -89,6 +91,22 @@ export function filter(
   awaitSync?: boolean,
 ): RawBuiltinReturnType {
   let result: Cell<any[]> | undefined;
+
+  // Whether the writes that make `result` reachable are owed. The coordinator
+  // keeps the container across reconciles, so one that stages those writes and
+  // then does not commit leaves it holding a container nothing links to; the
+  // next reconcile issues them again. See list-element-rollback.ts.
+  const containerSetup: SetupRecord = { needsSetup: false };
+
+  // An element's links back to this coordinator. They are setup writes like the
+  // element's pattern run: issued when the element is created, and again when
+  // the transaction carrying them did not commit. Without them the element's
+  // document names no owning piece, so nothing can start that piece for an
+  // event addressed to it.
+  const linkElementCell = (cell: Cell<any>): void => {
+    setResultCell(cell, parentCell);
+    setPatternCell(cell, parentCell.key("pattern"));
+  };
 
   // Identity-based tracking: maps element address key → element run.
   // resultCell holds the predicate boolean for this element.
@@ -223,11 +241,11 @@ export function filter(
       argumentUsage.usesParams ? inputsCell.key("params") : undefined,
     ]);
 
+    // Whether this reconcile issues the container's links: a container it
+    // mints needs them, and one whose last issuance did not commit owes them.
+    let issueLinks = containerSetup.needsSetup;
     if (!result || result.getAsNormalizedFullLink().scope !== outputScope) {
       const previousResult = result;
-      rollback.resultReplaced(() => {
-        result = previousResult;
-      });
       const resultSchema = listResultSchema();
       // CT-1623: identify the result container by the reserved output spot
       // (stable, program-independent). See map.ts for rationale.
@@ -244,15 +262,30 @@ export function filter(
         tx,
       );
       const boundResult = scopedCell(runtime, tx, baseResult, outputScope);
-      // Link this cell to the parent cell
-      setResultCell(boundResult, parentCell);
-      // Link the new result cells to the pattern cell too
-      setPatternCell(boundResult, parentCell.key("pattern"));
-      sendResult(tx, boundResult);
       // The container outlives this reconcile's transaction; a cell bound to
       // it would pin the settled transaction and its journal for the life of
       // the coordinator. Rebind per use instead.
       result = boundResult.withTx();
+      const installedResult = result;
+      // Give back only what this reconcile installed. An overlapping reconcile
+      // that has already replaced the container owns it, and its bookkeeping
+      // matches durable writes of its own.
+      rollback.resultReplaced(() => {
+        if (result === installedResult) result = previousResult;
+      });
+      issueLinks = true;
+    }
+    // A container this coordinator holds is reachable only through the links
+    // below, and the reconcile that last issued them may not have committed.
+    if (issueLinks) {
+      issueResultContainerSetup(
+        tx,
+        result.withTx(tx),
+        parentCell,
+        sendResult,
+        rollback,
+        containerSetup,
+      );
     }
     // The coordinator's view of the result container is links-only
     // (RESULT_PRESENCE_SCHEMA): get() probes presence and set() diffs
@@ -424,6 +457,13 @@ export function filter(
                 awaitSyncBeforeInitialRun: elementAwaitSync,
               },
             );
+            // The whole setup, every time, because issuing it takes the debt
+            // for it: an overlapping reconcile that wrote the links and has
+            // not settled hands them to this one, and a partial issuance would
+            // leave nobody owing them. Links already durable cost a
+            // comparison, since a write of the value a leaf already holds does
+            // not reach storage.
+            linkElementCell(existing.resultCell.withTx(tx));
             rollback.setupIssued(existing);
           }
         }
@@ -451,10 +491,7 @@ export function filter(
             awaitSyncBeforeInitialRun: elementAwaitSync,
           },
         );
-        // Link these individual cells to the top cell
-        setResultCell(boundResultCell, parentCell);
-        // Link the new result cells to the pattern cell too
-        setPatternCell(boundResultCell, parentCell.key("pattern"));
+        linkElementCell(boundResultCell);
 
         const entry = { resultCell, lastIndex: i, needsSetup: false };
         elementRuns.set(elementKey, entry);

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -30,7 +30,8 @@ import type { RawBuiltinReturnType } from "../module.ts";
 import type { NormalizedFullLink } from "../link-types.ts";
 import { listResultSchema } from "./list-result-schema.ts";
 import { inferListOpArgumentUsage } from "./list-op-argument-usage.ts";
-import { setPatternCell, setResultCell } from "../result-utils.ts";
+import { setPatternCell } from "../result-utils.ts";
+import { issueResultContainerSetup } from "./list-result-container.ts";
 import {
   narrowestCellScope,
   outputSpotFromBinding,
@@ -39,6 +40,7 @@ import {
 import { resolveOpPattern } from "./op-pattern-ref.ts";
 import {
   type ElementRun,
+  type SetupRecord,
   trackListSetupRollback,
 } from "./list-element-rollback.ts";
 import {
@@ -109,6 +111,19 @@ export function flatMap(
   awaitSync?: boolean,
 ): RawBuiltinReturnType {
   let result: Cell<any[]> | undefined;
+
+  // Whether the writes that make `result` reachable are owed. The coordinator
+  // keeps the container across reconciles, so one that stages those writes and
+  // then does not commit leaves it holding a container nothing links to; the
+  // next reconcile issues them again. See list-element-rollback.ts.
+  const containerSetup: SetupRecord = { needsSetup: false };
+
+  // An element's link back to this coordinator's pattern. It is a setup write
+  // like the element's own run: issued when the element is created, and again
+  // when the transaction carrying it did not commit.
+  const linkElementCell = (cell: Cell<any>): void => {
+    setPatternCell(cell, parentCell.key("pattern"));
+  };
 
   // Identity-based tracking: maps element address key → element run.
   // resultCell holds the per-element result array.
@@ -233,11 +248,11 @@ export function flatMap(
       argumentUsage.usesParams ? inputsCell.key("params") : undefined,
     ]);
 
+    // Whether this reconcile issues the container's links: a container it
+    // mints needs them, and one whose last issuance did not commit owes them.
+    let issueLinks = containerSetup.needsSetup;
     if (!result || result.getAsNormalizedFullLink().scope !== outputScope) {
       const previousResult = result;
-      rollback.resultReplaced(() => {
-        result = previousResult;
-      });
       const resultSchema = listResultSchema();
       // CT-1623: identify the result container by the reserved output spot
       // (stable, program-independent). See map.ts for rationale.
@@ -254,15 +269,30 @@ export function flatMap(
         tx,
       );
       const boundResult = scopedCell(runtime, tx, baseResult, outputScope);
-      // Link this cell to the parent cell
-      setResultCell(boundResult, parentCell);
-      // Link the new result cells to the pattern cell too
-      setPatternCell(boundResult, parentCell.key("pattern"));
-      sendResult(tx, boundResult);
       // The container outlives this reconcile's transaction; a cell bound to
       // it would pin the settled transaction and its journal for the life of
       // the coordinator. Rebind per use instead.
       result = boundResult.withTx();
+      const installedResult = result;
+      // Give back only what this reconcile installed. An overlapping reconcile
+      // that has already replaced the container owns it, and its bookkeeping
+      // matches durable writes of its own.
+      rollback.resultReplaced(() => {
+        if (result === installedResult) result = previousResult;
+      });
+      issueLinks = true;
+    }
+    // A container this coordinator holds is reachable only through the links
+    // below, and the reconcile that last issued them may not have committed.
+    if (issueLinks) {
+      issueResultContainerSetup(
+        tx,
+        result.withTx(tx),
+        parentCell,
+        sendResult,
+        rollback,
+        containerSetup,
+      );
     }
     // The coordinator's view of the result container is links-only
     // (RESULT_PRESENCE_SCHEMA): get() probes presence and set() diffs
@@ -431,6 +461,13 @@ export function flatMap(
                 awaitSyncBeforeInitialRun: elementAwaitSync,
               },
             );
+            // The whole setup, every time, because issuing it takes the debt
+            // for it: an overlapping reconcile that wrote the links and has
+            // not settled hands them to this one, and a partial issuance would
+            // leave nobody owing them. Links already durable cost a
+            // comparison, since a write of the value a leaf already holds does
+            // not reach storage.
+            linkElementCell(existing.resultCell.withTx(tx));
             rollback.setupIssued(existing);
           }
         }
@@ -458,8 +495,7 @@ export function flatMap(
             awaitSyncBeforeInitialRun: elementAwaitSync,
           },
         );
-        // Link the new result cells to the pattern cell too
-        setPatternCell(boundResultCell, parentCell.key("pattern"));
+        linkElementCell(boundResultCell);
         const entry = { resultCell, lastIndex: i, needsSetup: false };
         elementRuns.set(elementKey, entry);
         rollback.created(elementKey, entry);

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -118,9 +118,10 @@ export function flatMap(
   // next reconcile issues them again. See list-element-rollback.ts.
   const containerSetup: SetupRecord = { needsSetup: false };
 
-  // An element's link back to this coordinator's pattern. It is a setup write
-  // like the element's own run: issued when the element is created, and again
-  // when the transaction carrying it did not commit.
+  // An element's link naming the pattern this coordinator runs, written when
+  // the parent carries a pattern to name. It is a setup write like the
+  // element's own run: issued when the element is created, and again when the
+  // transaction carrying it did not commit.
   const linkElementCell = (cell: Cell<any>): void => {
     setPatternCell(cell, parentCell.key("pattern"));
   };

--- a/packages/runner/src/builtins/list-element-rollback.ts
+++ b/packages/runner/src/builtins/list-element-rollback.ts
@@ -7,26 +7,33 @@ import {
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 
 /**
- * The per-element bookkeeping a list coordinator keeps across reconciles.
+ * The record of one set of setup writes a list coordinator has issued.
  *
- * `needsSetup` says the element's setup writes are not known to be durable, so
- * the next reconcile issues them again. Issuing them clears it, and the
- * rollback below sets it again when the reconcile carrying them does not become
- * durable.
+ * `needsSetup` says those writes are not known to be durable, so the next
+ * reconcile issues them again. Issuing them clears it, and the rollback below
+ * sets it again when the reconcile carrying them does not become durable. A
+ * coordinator keeps one of these per element, and one for the result container
+ * it hands to its output binding.
  */
-export type ElementRun = {
+export type SetupRecord = {
+  needsSetup: boolean;
+  /** The reconcile that last issued these setup writes. */
+  setupIssuance?: object;
+};
+
+/**
+ * The per-element bookkeeping a list coordinator keeps across reconciles.
+ */
+export type ElementRun = SetupRecord & {
   resultCell: Cell<any>;
   lastIndex: number;
-  needsSetup: boolean;
-  /** The reconcile that last issued this element's setup writes. */
-  setupIssuance?: object;
 };
 
 export interface ListSetupRollback {
   /** An entry this reconcile added to the coordinator's element map. */
   created(elementKey: string, entry: ElementRun): void;
-  /** Setup writes this reconcile staged for an entry that already existed. */
-  setupIssued(entry: ElementRun): void;
+  /** Setup writes this reconcile staged against a record it already had. */
+  setupIssued(record: SetupRecord): void;
   /** An index this reconcile moved, with the value it moved away from. */
   indexChanged(entry: ElementRun, previousIndex: number): void;
   /** A result container this reconcile installed, with a restore for the old one. */
@@ -52,10 +59,14 @@ export interface ListSetupRollback {
  * has no such re-run behind it, so the record has to go.
  *
  * The setup writes themselves are what the re-run has to re-issue, and every
- * failed outcome loses them, stale basis included. Marking the entry as needing
- * setup again is therefore the one undo that applies to all of them: an element
- * whose entry survives is set up again by the next reconcile, rather than
- * reading as undefined for as long as the coordinator lives.
+ * failed outcome loses them, stale basis included. Marking the record as
+ * needing setup again is therefore the one undo that applies to all of them: an
+ * element whose entry survives is set up again by the next reconcile, rather
+ * than reading as undefined for as long as the coordinator lives. The result
+ * container's own links are setup writes of the same kind — the coordinator
+ * keeps the container in memory, so a reconcile that loses those links leaves
+ * a container nothing points at — and they are marked and re-issued the same
+ * way.
  *
  * Each undo checks that the state it is about to revert is still the state this
  * reconcile installed. An overlapping reconcile that has already moved the same
@@ -67,7 +78,7 @@ export function trackListSetupRollback(
   elementRuns: Map<string, ElementRun>,
 ): ListSetupRollback {
   const created = new Map<string, ElementRun>();
-  const setUp = new Set<ElementRun>();
+  const setUp = new Set<SetupRecord>();
   const indexChanges = new Map<
     ElementRun,
     { from: number; to: number }
@@ -82,10 +93,10 @@ export function trackListSetupRollback(
   // has nothing to restore.
   const issuance = {};
 
-  const markSetupIssued = (entry: ElementRun): void => {
-    entry.setupIssuance = issuance;
-    setUp.add(entry);
-    entry.needsSetup = false;
+  const markSetupIssued = (record: SetupRecord): void => {
+    record.setupIssuance = issuance;
+    setUp.add(record);
+    record.needsSetup = false;
   };
 
   const registerRollback = (): void => {
@@ -93,9 +104,9 @@ export function trackListSetupRollback(
     registered = true;
     tx.addCommitCallback((_settledTx, result) => {
       if (!result.error) return;
-      for (const entry of setUp) {
-        if (entry.setupIssuance !== issuance) continue;
-        entry.needsSetup = true;
+      for (const record of setUp) {
+        if (record.setupIssuance !== issuance) continue;
+        record.needsSetup = true;
       }
       if (
         isConflictRejection(result.error) ||
@@ -140,8 +151,8 @@ export function trackListSetupRollback(
       markSetupIssued(entry);
       registerRollback();
     },
-    setupIssued(entry) {
-      markSetupIssued(entry);
+    setupIssued(record) {
+      markSetupIssued(record);
       registerRollback();
     },
     indexChanged(entry, previousIndex) {

--- a/packages/runner/src/builtins/list-result-container.ts
+++ b/packages/runner/src/builtins/list-result-container.ts
@@ -1,0 +1,35 @@
+import type { Cell } from "../cell.ts";
+import type { IExtendedStorageTransaction } from "../storage/interface.ts";
+import { setPatternCell, setResultCell } from "../result-utils.ts";
+import type {
+  ListSetupRollback,
+  SetupRecord,
+} from "./list-element-rollback.ts";
+
+/**
+ * Issue the writes that make a list coordinator's result container reachable:
+ * the container's `result` and `pattern` meta, and the link the coordinator
+ * hands to its output binding.
+ *
+ * A coordinator mints a container and then keeps it in memory across reconciles,
+ * so these writes are setup in the same sense an element's pattern run is: the
+ * reconcile that stages them and does not commit loses them while the
+ * coordinator carries on holding the container. A container nothing links to
+ * reads as undefined for as long as the coordinator lives, so the record passed
+ * here says whether they are owed, and the next reconcile issues them again
+ * against the container already in hand. See list-element-rollback.ts for the
+ * undo contract.
+ */
+export function issueResultContainerSetup(
+  tx: IExtendedStorageTransaction,
+  container: Cell<any>,
+  parentCell: Cell<any>,
+  sendResult: (tx: IExtendedStorageTransaction, result: any) => void,
+  rollback: ListSetupRollback,
+  setup: SetupRecord,
+): void {
+  setResultCell(container, parentCell);
+  setPatternCell(container, parentCell.key("pattern"));
+  sendResult(tx, container);
+  rollback.setupIssued(setup);
+}

--- a/packages/runner/src/builtins/list-result-container.ts
+++ b/packages/runner/src/builtins/list-result-container.ts
@@ -8,8 +8,9 @@ import type {
 
 /**
  * Issue the writes that make a list coordinator's result container reachable:
- * the container's `result` and `pattern` meta, and the link the coordinator
- * hands to its output binding.
+ * the container's `result` meta, the link the coordinator hands to its output
+ * binding, and the container's `pattern` meta when the parent carries a pattern
+ * to name — a parent with none leaves nothing to write and nothing owed.
  *
  * A coordinator mints a container and then keeps it in memory across reconciles,
  * so these writes are setup in the same sense an element's pattern run is: the

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -34,6 +34,7 @@ import { outputSpotFromBinding } from "./scope-policy.ts";
 import { listResultSchema } from "./list-result-schema.ts";
 import { inferListOpArgumentUsage } from "./list-op-argument-usage.ts";
 import { setPatternCell, setResultCell } from "../result-utils.ts";
+import { issueResultContainerSetup } from "./list-result-container.ts";
 import { exposedResultCell, scopedCell } from "./scope-policy.ts";
 import { resolveLink } from "../link-resolution.ts";
 import { listElementLink } from "./list-element-link.ts";
@@ -48,6 +49,7 @@ import {
 import { resolveOpPattern } from "./op-pattern-ref.ts";
 import {
   type ElementRun,
+  type SetupRecord,
   trackListSetupRollback,
 } from "./list-element-rollback.ts";
 import { getLogger } from "@commonfabric/utils/logger";
@@ -94,6 +96,22 @@ export function map(
   awaitSync?: boolean,
 ): RawBuiltinReturnType {
   let result: Cell<any[]> | undefined;
+
+  // Whether the writes that make `result` reachable are owed. The coordinator
+  // keeps the container across reconciles, so one that stages those writes and
+  // then does not commit leaves it holding a container nothing links to; the
+  // next reconcile issues them again. See list-element-rollback.ts.
+  const containerSetup: SetupRecord = { needsSetup: false };
+
+  // An element's links back to this coordinator. They are setup writes like the
+  // element's pattern run: issued when the element is created, and again when
+  // the transaction carrying them did not commit. Without them the element's
+  // document names no owning piece, so nothing can start that piece for an
+  // event addressed to it.
+  const linkElementCell = (cell: Cell<any>): void => {
+    setResultCell(cell, parentCell);
+    setPatternCell(cell, parentCell.key("pattern"));
+  };
 
   // Identity-based tracking: maps element address key → { resultCell, lastIndex }
   // for reuse across position changes. We pass list[i] directly each time, so
@@ -209,11 +227,11 @@ export function map(
     const opPattern = resolveOpPattern(runtime, op.getRaw(), "map");
     const argumentUsage = inferListOpArgumentUsage(opPattern);
 
+    // Whether this reconcile issues the container's links: a container it
+    // mints needs them, and one whose last issuance did not commit owes them.
+    let issueLinks = containerSetup.needsSetup;
     if (!result || result.getAsNormalizedFullLink().scope !== listScope) {
       const previousResult = result;
-      rollback.resultReplaced(() => {
-        result = previousResult;
-      });
       const resultSchema = listResultSchema(opPattern.resultSchema);
       // CT-1623: identify the result container by the reserved output spot —
       // the fully-resolved write-redirect target the runner supplies as the
@@ -235,14 +253,30 @@ export function map(
         tx,
       );
       const boundResult = scopedCell(runtime, tx, baseResult, listScope);
-      setResultCell(boundResult, parentCell);
-      // Link the new result cells to the pattern cell too
-      setPatternCell(boundResult, parentCell.key("pattern"));
-      sendResult(tx, boundResult);
       // The container outlives this reconcile's transaction; a cell bound to
       // it would pin the settled transaction and its journal for the life of
       // the coordinator. Rebind per use instead.
       result = boundResult.withTx();
+      const installedResult = result;
+      // Give back only what this reconcile installed. An overlapping reconcile
+      // that has already replaced the container owns it, and its bookkeeping
+      // matches durable writes of its own.
+      rollback.resultReplaced(() => {
+        if (result === installedResult) result = previousResult;
+      });
+      issueLinks = true;
+    }
+    // A container this coordinator holds is reachable only through the links
+    // below, and the reconcile that last issued them may not have committed.
+    if (issueLinks) {
+      issueResultContainerSetup(
+        tx,
+        result.withTx(tx),
+        parentCell,
+        sendResult,
+        rollback,
+        containerSetup,
+      );
     }
     // The coordinator's view of the result container is links-only
     // (RESULT_PRESENCE_SCHEMA): get() probes presence and set() diffs
@@ -392,6 +426,12 @@ export function map(
               awaitSyncBeforeInitialRun: elementAwaitSync,
             },
           );
+          // The whole setup, every time, because issuing it takes the debt for
+          // it: an overlapping reconcile that wrote the links and has not
+          // settled hands them to this one, and a partial issuance would leave
+          // nobody owing them. Links already durable cost a comparison, since
+          // a write of the value a leaf already holds does not reach storage.
+          linkElementCell(existing.resultCell.withTx(tx));
           rollback.setupIssued(existing);
         }
         existing.lastIndex = i;
@@ -419,10 +459,7 @@ export function map(
             awaitSyncBeforeInitialRun: elementAwaitSync,
           },
         );
-        // Link these individual cells to the top cell
-        setResultCell(boundResultCell, parentCell);
-        // Link the new result cells to the pattern cell too
-        setPatternCell(boundResultCell, parentCell.key("pattern"));
+        linkElementCell(boundResultCell);
         const entry = { resultCell, lastIndex: i, needsSetup: false };
         elementRuns.set(elementKey, entry);
         rollback.created(elementKey, entry);

--- a/packages/runner/test/list-container-link-reissue.test.ts
+++ b/packages/runner/test/list-container-link-reissue.test.ts
@@ -1,0 +1,405 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import type { Signer } from "@commonfabric/memory/interface";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import {
+  type Options,
+  type SessionFactory,
+  StorageManager,
+} from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { Cell } from "../src/cell.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import type { NormalizedFullLink } from "../src/link-types.ts";
+import {
+  TEST_MEMORY_SERVER_AUTH,
+  testPrincipalSessionOpenAuthFactory,
+} from "./memory-v2-test-utils.ts";
+import { resolveLink } from "../src/link-resolution.ts";
+import { isRawBuiltinResult, raw } from "../src/module.ts";
+import { map } from "../src/builtins/map.ts";
+import { filter } from "../src/builtins/filter.ts";
+import { flatMap } from "../src/builtins/flatmap.ts";
+
+// A list coordinator reaches its result container two ways, and only one of
+// them is re-issued when a reconcile has to run again.
+//
+// `sendResult` writes the link from the node's output spot to the container it
+// mints, and the reconcile that mints the container is the only one that calls
+// it: every later reconcile takes the `result` the coordinator already holds in
+// memory and writes the container's VALUE alone. The per-element setup writes
+// have a ledger for exactly this — `trackListSetupRollback` marks each element
+// `needsSetup` when the transaction carrying its writes fails, stale basis
+// included, so the next reconcile issues them again. The container link has no
+// such ledger, so a first reconcile whose commit is rejected leaves the
+// coordinator holding a container that nothing points at, and every retry
+// commits the container's value without the link. The output spot then reads
+// `undefined` for as long as the coordinator lives.
+//
+// Each coordinator gets the same two runs, differing only in whether its first
+// reconcile commits, so the rejection is what they isolate:
+//
+//   1. Runtime A builds the durable aggregate, then empties the node's output
+//      spot. That is the state a session starts in when the spot is a fresh
+//      holder over a container that persists at space scope: the container and
+//      its per-element runs are durable, and the link to them is not.
+//   2. Runtime B resumes over that state. On a COLD replica the container is
+//      unreachable from the emptied spot, so B never loads it, and the
+//      coordinator's first reconcile reads it as absent — a confirmed read at
+//      seq 0 against a document the server holds at a later seq, which the
+//      server rejects as a stale basis. Nothing here is timed: whether B holds
+//      the container is decided by whether anything links to it, so the
+//      rejection is a property of the arrangement rather than of the schedule.
+//   3. On a WARM replica B already holds every document, the same first
+//      reconcile commits, and the link comes back. That control is what pins
+//      the rejection, rather than the emptied spot, as the cause.
+//
+// `map` is the coordinator issue #5633 (CT-1989) traced; `filter` and `flatMap`
+// carry the same guard and the same single `sendResult` call site.
+
+const signer = await Identity.fromPassphrase("list container link reissue");
+const space = signer.did();
+
+class SharedSessionFactory implements SessionFactory {
+  constructor(private readonly getServer: () => MemoryV2Server.Server) {}
+  async create(spaceId: string, sgnr?: Signer) {
+    const client = await MemoryV2Client.connect({
+      transport: MemoryV2Client.loopback(this.getServer()),
+    });
+    const session = await client.mount(
+      spaceId,
+      {},
+      testPrincipalSessionOpenAuthFactory(sgnr),
+    );
+    return { client, session };
+  }
+}
+
+class SharedServerStorageManager extends StorageManager {
+  static make(
+    as: Identity,
+    server: MemoryV2Server.Server,
+  ): SharedServerStorageManager {
+    return new SharedServerStorageManager(
+      { as, memoryHost: new URL("memory://") } as Options,
+      server,
+    );
+  }
+  private constructor(options: Options, server: MemoryV2Server.Server) {
+    super(options, new SharedSessionFactory(() => server));
+  }
+  override registerSpaceHost(): boolean {
+    return false;
+  }
+}
+
+const makeServer = () =>
+  new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
+  });
+
+/** How one reconcile of the coordinator under test went. */
+type ReconcileRecord = {
+  attempt: number;
+  /** Whether this reconcile called `sendResult`, the container link's only writer. */
+  issuedLink: boolean;
+  outcome: string;
+};
+
+// The three list builtins, each with a program whose aggregate the coordinator
+// owns and the value that aggregate holds once it has converged.
+const COORDINATORS = [
+  {
+    name: "map",
+    // deno-lint-ignore no-explicit-any
+    implementation: map as any,
+    body: "items.map((n) => n * 2)",
+    expected: [2, 4, 6],
+  },
+  {
+    name: "filter",
+    // deno-lint-ignore no-explicit-any
+    implementation: filter as any,
+    body: "items.filter((n) => n > 1)",
+    expected: [2, 3],
+  },
+  {
+    name: "flatMap",
+    // deno-lint-ignore no-explicit-any
+    implementation: flatMap as any,
+    body: "items.flatMap((n) => n * 2)",
+    expected: [2, 4, 6],
+  },
+] as const;
+
+const programFor = (body: string): RuntimeProgram => ({
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { pattern } from 'commonfabric';",
+      "export default pattern<{ items: number[] }>(({ items }) => {",
+      `  return { aggregate: ${body} };`,
+      "});",
+    ].join("\n"),
+  }],
+});
+
+/**
+ * Re-register a list builtin so the test can see how many times the
+ * coordinator issued its container link and how each reconcile's transaction
+ * settled. The coordinator, its rollback bookkeeping and its writes are the
+ * real ones; only the reporting is added.
+ */
+function observeCoordinator(
+  runtime: Runtime,
+  ref: string,
+  // deno-lint-ignore no-explicit-any
+  implementation: any,
+): { issued: Cell<unknown[]>[]; log: ReconcileRecord[] } {
+  const issued: Cell<unknown[]>[] = [];
+  const log: ReconcileRecord[] = [];
+  runtime.moduleRegistry.addModuleByRef(
+    ref,
+    raw((
+      inputsCell,
+      sendResult,
+      addCancel,
+      cause,
+      parentCell,
+      rt,
+      outputBinding,
+      awaitSync,
+      // deno-lint-ignore no-explicit-any
+    ): any => {
+      const built = implementation(
+        inputsCell,
+        // deno-lint-ignore no-explicit-any
+        (tx: IExtendedStorageTransaction, value: any) => {
+          issued.push(value as Cell<unknown[]>);
+          sendResult(tx, value);
+        },
+        addCancel,
+        cause,
+        parentCell,
+        rt,
+        outputBinding,
+        awaitSync,
+      );
+      const action = isRawBuiltinResult(built) ? built.action : built;
+      let attempts = 0;
+      const observed = (tx: IExtendedStorageTransaction) => {
+        const attempt = ++attempts;
+        const before = issued.length;
+        action(tx);
+        const issuedLink = issued.length > before;
+        tx.addCommitCallback((_settled, result) => {
+          log.push({
+            attempt,
+            issuedLink,
+            outcome: result.error ? `rejected:${result.error.name}` : "commits",
+          });
+        });
+      };
+      return isRawBuiltinResult(built)
+        ? { ...built, action: observed }
+        : observed;
+      // deno-lint-ignore no-explicit-any
+    }) as any,
+  );
+  return { issued, log };
+}
+
+type ResumeOutcome = {
+  aggregate: unknown;
+  container: unknown;
+  issuedCount: number;
+  log: ReconcileRecord[];
+};
+
+/**
+ * Build the aggregate in one runtime, empty the node's output spot, and resume
+ * in a second runtime. `replica` decides what that second runtime knows when
+ * its coordinator first reconciles: a `warm` replica already holds the
+ * container and its per-element runs, so the reconcile commits; a `cold` one
+ * has never seen them — nothing links to them while the spot is empty — so the
+ * reconcile reads them as absent and the server rejects its commit against its
+ * own later sequence numbers.
+ */
+async function resumeOverEmptiedSpot(
+  coordinator: typeof COORDINATORS[number],
+  cellId: string,
+  { replica }: { replica: "warm" | "cold" },
+): Promise<ResumeOutcome> {
+  const program = programFor(coordinator.body);
+  const server = makeServer();
+  const sm1 = SharedServerStorageManager.make(signer, server);
+  const sm2 = replica === "warm"
+    ? sm1
+    : SharedServerStorageManager.make(signer, server);
+
+  const rt1 = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: sm1,
+  });
+  let spotLink: NormalizedFullLink;
+  let containerLink: NormalizedFullLink;
+  try {
+    const compiled = await rt1.patternManager.compilePattern(program, {
+      space,
+    });
+    const tx0 = rt1.edit();
+    const rc1 = rt1.getCell<Record<string, unknown>>(
+      space,
+      cellId,
+      compiled.resultSchema,
+      tx0,
+    );
+    rt1.run(tx0, compiled, { items: [1, 2, 3] }, rc1);
+    expect((await tx0.commit()).error).toBeUndefined();
+    await rc1.pull();
+    await rt1.settled();
+    await rt1.patternManager.flushCompileCacheWrites();
+    await sm1.synced();
+    expect(
+      rc1.key("aggregate").getAsQueryResult(),
+      "the first runtime built the aggregate",
+    ).toEqual(coordinator.expected);
+
+    // The node's output spot, and the container it points at. The spot is the
+    // write-redirect target of the aggregate key; `sendResult` writes the
+    // container's link into it, and nothing else ever does.
+    const probeTx = rt1.edit();
+    spotLink = resolveLink(
+      rt1,
+      probeTx,
+      rc1.key("aggregate").getAsNormalizedFullLink(),
+      "writeRedirect",
+    );
+    containerLink = rc1.key("aggregate").resolveAsCell()
+      .getAsNormalizedFullLink();
+    probeTx.abort("output spot probe");
+
+    // Empty the spot, leaving the container and its per-element runs durable.
+    const clearTx = rt1.edit();
+    rt1.getCellFromLink(spotLink, undefined, clearTx).setRaw(undefined);
+    rt1.prepareTxForCommit(clearTx);
+    expect((await clearTx.commit()).error).toBeUndefined();
+    await rt1.settled();
+    await sm1.synced();
+    expect(
+      rc1.key("aggregate").getAsQueryResult(),
+      "the aggregate is unreachable while the spot is empty",
+    ).toBeUndefined();
+  } finally {
+    await rt1.dispose({ closeStorage: false });
+  }
+
+  const rt2 = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: sm2,
+  });
+  const { issued, log } = observeCoordinator(
+    rt2,
+    coordinator.name,
+    coordinator.implementation,
+  );
+  try {
+    const compiled2 = await rt2.patternManager.compilePattern(program, {
+      space,
+    });
+    const tx = rt2.edit();
+    const rc2 = rt2.getCell<Record<string, unknown>>(
+      space,
+      cellId,
+      compiled2.resultSchema,
+      tx,
+    );
+    expect((await tx.commit()).error).toBeUndefined();
+
+    expect(await rt2.start(rc2)).toBe(true);
+    await rc2.pull();
+    await rt2.settled();
+
+    return {
+      aggregate: await rc2.key("aggregate").pull(),
+      container: await rt2.getCellFromLink<unknown[]>(containerLink).pull(),
+      issuedCount: issued.length,
+      log,
+    };
+  } finally {
+    await rt2.dispose({ closeStorage: false });
+    await sm1.close();
+    if (sm2 !== sm1) await sm2.close();
+    await server.close();
+  }
+}
+
+describe("list container link reissue", () => {
+  for (const coordinator of COORDINATORS) {
+    describe(coordinator.name, () => {
+      it("re-issues the container link when its first reconcile commits", async () => {
+        const outcome = await resumeOverEmptiedSpot(
+          coordinator,
+          `${coordinator.name} link control`,
+          { replica: "warm" },
+        );
+
+        expect(
+          outcome.log[0],
+          "the first reconcile issued the container link and committed",
+        ).toEqual({ attempt: 1, issuedLink: true, outcome: "commits" });
+        expect(
+          outcome.aggregate,
+          "the aggregate is reachable again through the re-issued link",
+        ).toEqual(coordinator.expected);
+      });
+
+      it("re-issues the container link when its first reconcile is rejected on a stale basis", async () => {
+        const outcome = await resumeOverEmptiedSpot(
+          coordinator,
+          `${coordinator.name} link regression`,
+          { replica: "cold" },
+        );
+
+        // The scenario this test exists to cover: the reconcile that issued the
+        // link lost its commit, and a later one converged without it.
+        expect(
+          outcome.log[0],
+          "the first reconcile issued the container link and was rejected on a stale basis",
+        ).toEqual({
+          attempt: 1,
+          issuedLink: true,
+          outcome: "rejected:ConflictError",
+        });
+        expect(
+          outcome.log.some((record) => record.outcome === "commits"),
+          "a later reconcile committed",
+        ).toBe(true);
+        expect(
+          outcome.container,
+          "the converged reconcile committed the container's value",
+        ).toEqual(coordinator.expected);
+
+        // `sendResult` is the container link's only writer, so the retry that
+        // carries the container's value has to carry the link too.
+        expect(
+          outcome.issuedCount,
+          "the container link is issued again by the reconcile that replaces the rejected one",
+        ).toBeGreaterThan(1);
+        expect(
+          outcome.aggregate,
+          "the aggregate is reachable through the re-issued link",
+        ).toEqual(coordinator.expected);
+      });
+    });
+  }
+});

--- a/packages/runner/test/list-element-issuance-ownership.test.ts
+++ b/packages/runner/test/list-element-issuance-ownership.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { Runtime } from "../src/runtime.ts";
+import { getMetaLink } from "../src/link-utils.ts";
+import type { Cell } from "../src/cell.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("list element issuance ownership");
+const space = signer.did();
+
+// Two runs of one map coordinator overlap. The first creates a new element and
+// writes that element's links back to the coordinator; before it commits, a
+// second run moves the same element to a new index, re-runs its pattern without
+// re-writing its links, and takes over the element's setup record. The first
+// run is then rejected on a stale basis.
+//
+// The pair differs in one step: whether the overlapping run happens. The
+// control lets the rejected run's retry converge on its own.
+
+type Outcome = {
+  rejection: string | undefined;
+  aggregate: unknown;
+  /** Ids of element documents left without a `result` meta. */
+  missing: string[];
+  /** The element the held reconcile created. */
+  createdId: string | undefined;
+};
+
+describe("list element issuance ownership", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  async function run(
+    label: string,
+    { overlap, listOp }: { overlap: boolean; listOp: string },
+  ): Promise<Outcome> {
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const tagIndex = lift(
+      (input: { element: number; index: number }) =>
+        listOp === "filterWithPattern"
+          ? (input.element + input.index) % 2 === 0
+          : input.element * 100 + input.index,
+    );
+    // No explicit argument schema: legacy mode reports every argument as used,
+    // so usesIndex is true and a reused element that moves re-runs its op.
+    // deno-lint-ignore no-explicit-any
+    const op = pattern(({ element, index }: any) =>
+      tagIndex({ element, index })
+    );
+
+    const setupTx = runtime.edit();
+    const cellA = runtime.getCell<number>(
+      space,
+      `${label}-a`,
+      undefined,
+      setupTx,
+    );
+    cellA.withTx(setupTx).set(1);
+    const cellB = runtime.getCell<number>(
+      space,
+      `${label}-b`,
+      undefined,
+      setupTx,
+    );
+    cellB.withTx(setupTx).set(2);
+    const cellC = runtime.getCell<number>(
+      space,
+      `${label}-c`,
+      undefined,
+      setupTx,
+    );
+    cellC.withTx(setupTx).set(3);
+
+    const mapPattern = pattern<{ values: number[] }>(({ values }) => ({
+      values,
+      tagged: (values as unknown as Record<string, any>)[listOp](
+        // deno-lint-ignore no-explicit-any
+        op as any,
+        {},
+      ),
+    }));
+    const resultCell = runtime.getCell<
+      { values: number[]; tagged: number[] }
+    >(space, label, undefined, setupTx);
+    const result = runtime.run(setupTx, mapPattern, {
+      values: [cellA, cellB],
+    }, resultCell);
+    expect((await setupTx.commit()).error).toBeUndefined();
+
+    const stopReading = result.key("tagged").sink(() => {});
+    const originalRun = runtime.runner.run;
+    const elementCells: Cell<any>[] = [];
+    let armed = false;
+    let createdIndex = -1;
+    const heldReconcile = Promise.withResolvers<void>();
+    const captured = Promise.withResolvers<void>();
+    let sourceAction: unknown;
+    let rejection: { name?: string } | undefined;
+
+    runtime.runner.run = ((...args: Parameters<typeof originalRun>) => {
+      const ran = Reflect.apply(originalRun, runtime.runner, args);
+      const options = args[4] as
+        | { doNotUpdateOnPatternChange?: boolean }
+        | undefined;
+      if (options?.doNotUpdateOnPatternChange !== true) return ran;
+      elementCells.push(args[3] as Cell<any>);
+      if (!armed) return ran;
+      armed = false;
+      // The first per-element run of the held reconcile is the newly created
+      // element at index 0.
+      createdIndex = elementCells.length - 1;
+      const reconcileTx = args[0] as IExtendedStorageTransaction;
+      sourceAction =
+        (reconcileTx as unknown as { tx: { sourceAction?: unknown } }).tx
+          .sourceAction;
+      reconcileTx.addCommitCallback((_settled, res) => {
+        rejection = res.error;
+      });
+      const originalCommit = reconcileTx.commit.bind(reconcileTx);
+      reconcileTx.commit =
+        (() =>
+          heldReconcile.promise.then(() =>
+            originalCommit()
+          )) as typeof reconcileTx.commit;
+      captured.resolve();
+      return ran;
+    }) as typeof runtime.runner.run;
+
+    try {
+      await runtime.scheduler.idleWithPendingCommits();
+
+      armed = true;
+      const addTx = runtime.edit();
+      result.withTx(addTx).key("values").set([cellC, cellA, cellB]);
+      expect((await addTx.commit()).error).toBeUndefined();
+      await captured.promise;
+      expect(sourceAction).toBeDefined();
+
+      if (overlap) {
+        // A second reconcile for the same coordinator while the first is still
+        // awaiting its commit: C already exists in the coordinator's memory and
+        // its index moves, so this reconcile re-runs C's pattern without
+        // re-writing C's links, and takes over C's setup record.
+        const moveTx = runtime.edit();
+        result.withTx(moveTx).key("values").set([cellA, cellC, cellB]);
+        expect((await moveTx.commit()).error).toBeUndefined();
+        // deno-lint-ignore no-explicit-any
+        await runtime.scheduler.run(sourceAction as any);
+      }
+
+      heldReconcile.resolve();
+      await runtime.scheduler.idleWithPendingCommits();
+
+      const aggregate = await result.key("tagged").pull();
+      const probeTx = runtime.edit();
+      try {
+        const seen = new Set<string>();
+        const missing: string[] = [];
+        for (const cell of elementCells) {
+          const id = cell.getAsNormalizedFullLink().id;
+          if (seen.has(id)) continue;
+          seen.add(id);
+          if (getMetaLink(cell.withTx(probeTx), "result") === undefined) {
+            missing.push(id);
+          }
+        }
+        return {
+          rejection: rejection?.name,
+          aggregate,
+          missing,
+          createdId: createdIndex < 0
+            ? undefined
+            : elementCells[createdIndex].getAsNormalizedFullLink().id,
+        };
+      } finally {
+        probeTx.abort("element link probe");
+      }
+    } finally {
+      runtime.runner.run = originalRun;
+      heldReconcile.resolve();
+      stopReading();
+    }
+  }
+
+  for (
+    const [name, listOp] of [
+      ["map", "mapWithPattern"],
+      ["filter", "filterWithPattern"],
+    ] as const
+  ) {
+    it(`re-links a created ${name} element when its rejected reconcile retries alone`, async () => {
+      const outcome = await run(`probe-control-${name}`, {
+        overlap: false,
+        listOp,
+      });
+
+      expect(outcome.rejection, "the held reconcile lost its commit").toBe(
+        "StorageTransactionInconsistent",
+      );
+      expect(
+        outcome.missing,
+        "every element names the piece that owns it",
+      ).toEqual([]);
+    });
+
+    it(`re-links a created ${name} element when an overlapping reconcile moves it`, async () => {
+      const outcome = await run(`probe-overlap-${name}`, {
+        overlap: true,
+        listOp,
+      });
+
+      expect(outcome.rejection, "the held reconcile lost its commit").toBe(
+        "StorageTransactionInconsistent",
+      );
+      expect(
+        outcome.missing,
+        "every element names the piece that owns it",
+      ).toEqual([]);
+      expect(outcome.createdId).toBeDefined();
+    });
+  }
+});

--- a/packages/runner/test/list-element-rollback.test.ts
+++ b/packages/runner/test/list-element-rollback.test.ts
@@ -3,12 +3,14 @@ import { expect } from "@std/expect";
 
 import { Identity } from "@commonfabric/identity";
 import type { Cell } from "../src/cell.ts";
+import { getMetaLink } from "../src/link-utils.ts";
 import { Runtime as RuntimeClass } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import type { Runtime } from "../src/runtime.ts";
 import {
   type ElementRun,
+  type SetupRecord,
   trackListSetupRollback,
 } from "../src/builtins/list-element-rollback.ts";
 import type {
@@ -380,6 +382,81 @@ describe("list element rollback", () => {
     expect(entry.lastIndex).toBe(9);
   });
 
+  for (
+    const [label, outcome] of [
+      ["a conflict", conflict],
+      ["a local inconsistency", inconsistent],
+      ["an abort", aborted],
+    ] as const
+  ) {
+    it(`owes the result container its links through ${label}`, () => {
+      const tx = createSettleableTx();
+      const rollback = trackListSetupRollback(
+        tx,
+        createStoppingRuntime().runtime,
+        new Map<string, ElementRun>(),
+      );
+
+      const container: SetupRecord = { needsSetup: true };
+      rollback.setupIssued(container);
+      expect(container.needsSetup).toBe(false);
+
+      tx.settle(outcome);
+
+      // The container survives a stale basis while its links do not, so the
+      // re-run has to issue them again against the container it still holds.
+      expect(container.needsSetup).toBe(true);
+    });
+  }
+
+  it("leaves the result container linked when its reconcile commits", () => {
+    const tx = createSettleableTx();
+    const rollback = trackListSetupRollback(
+      tx,
+      createStoppingRuntime().runtime,
+      new Map<string, ElementRun>(),
+    );
+
+    const container: SetupRecord = { needsSetup: true };
+    rollback.setupIssued(container);
+
+    tx.settle(committed);
+
+    expect(container.needsSetup).toBe(false);
+  });
+
+  it("leaves a result container a later reconcile replaced", () => {
+    const older = createSettleableTx();
+    const newer = createSettleableTx();
+    const elementRuns = new Map<string, ElementRun>();
+    const { runtime } = createStoppingRuntime();
+    const olderRollback = trackListSetupRollback(older, runtime, elementRuns);
+    const newerRollback = trackListSetupRollback(newer, runtime, elementRuns);
+
+    // The shape of the container install in map/filter/flatMap: each reconcile
+    // captures the container it replaced and the one it installed, and gives
+    // back only what it installed.
+    let container = "first";
+    const previousForOlder = container;
+    container = "older";
+    const installedByOlder = container;
+    olderRollback.resultReplaced(() => {
+      if (container === installedByOlder) container = previousForOlder;
+    });
+
+    const previousForNewer = container;
+    container = "newer";
+    const installedByNewer = container;
+    newerRollback.resultReplaced(() => {
+      if (container === installedByNewer) container = previousForNewer;
+    });
+
+    newer.settle(committed);
+    older.settle(aborted);
+
+    expect(container).toBe("newer");
+  });
+
   it("restores a result container it installed", () => {
     const tx = createSettleableTx();
     const rollback = trackListSetupRollback(
@@ -595,6 +672,56 @@ describe("a list coordinator whose first reconcile is discarded", () => {
     };
   }
 
+  // Land a write on a document the first reconcile touched, at the moment that
+  // reconcile commits, so its commit is rejected against a basis that moved
+  // underneath it. Unlike an abort, this rejection is one the scheduler
+  // recovers from by re-running the same reconcile, which is what has to
+  // re-issue the writes the rejected transaction carried.
+  function unsettleFirstElementSetup(): {
+    restore(): void;
+    rejection(): { name?: string } | undefined;
+    elementCells(): Cell<any>[];
+  } {
+    const originalRun = runtime.runner.run;
+    const elementCells: Cell<any>[] = [];
+    let rejection: { name?: string } | undefined;
+    let setups = 0;
+    runtime.runner.run = ((...args: Parameters<typeof originalRun>) => {
+      const run = Reflect.apply(originalRun, runtime.runner, args);
+      const options = args[4] as
+        | { doNotUpdateOnPatternChange?: boolean }
+        | undefined;
+      if (options?.doNotUpdateOnPatternChange !== true) return run;
+      setups++;
+      const elementResult = args[3] as Cell<any>;
+      elementCells.push(elementResult);
+      if (setups !== 1) return run;
+      const reconcileTx = args[0];
+      if (reconcileTx === undefined) {
+        throw new Error("element setup had no transaction");
+      }
+      reconcileTx.addCommitCallback((_settledTx, result) => {
+        rejection = result.error;
+      });
+      const originalCommit = reconcileTx.commit.bind(reconcileTx);
+      reconcileTx.commit = ((
+        ...commitArgs: Parameters<typeof originalCommit>
+      ) => {
+        const moved = runtime.edit();
+        elementResult.withTx(moved).setRaw("moved under the reconcile");
+        return moved.commit().then(() => originalCommit(...commitArgs));
+      }) as typeof reconcileTx.commit;
+      return run;
+    }) as typeof runtime.runner.run;
+    return {
+      restore: () => {
+        runtime.runner.run = originalRun;
+      },
+      rejection: () => rejection,
+      elementCells: () => elementCells,
+    };
+  }
+
   async function runListPattern(
     listOp: ListOp,
     opBody: (element: any) => any,
@@ -628,14 +755,17 @@ describe("a list coordinator whose first reconcile is discarded", () => {
     return result;
   }
 
+  // `backLinksElements` says the coordinator writes the `result` meta that
+  // names an element's owning piece. flatMap links its elements to the pattern
+  // alone, so it has no such link to lose.
   for (
-    const [name, listOp, opBody, expected] of [
-      ["map", "mapWithPattern", (value: number) => value * 2, [6]],
-      ["filter", "filterWithPattern", (value: number) => value > 1, [3]],
+    const [name, listOp, opBody, expected, backLinksElements] of [
+      ["map", "mapWithPattern", (value: number) => value * 2, [6], true],
+      ["filter", "filterWithPattern", (value: number) => value > 1, [3], true],
       ["flatMap", "flatMapWithPattern", (value: number) => [value, value], [
         3,
         3,
-      ]],
+      ], false],
     ] as const
   ) {
     it(`rebuilds a ${name} element and its container`, async () => {
@@ -656,6 +786,67 @@ describe("a list coordinator whose first reconcile is discarded", () => {
         }
       } finally {
         abort.restore();
+      }
+    });
+
+    if (backLinksElements) {
+      it(`re-links a ${name} element to its coordinator when the first reconcile is stale`, async () => {
+        const unsettle = unsettleFirstElementSetup();
+        try {
+          const result = await runListPattern(
+            listOp,
+            opBody,
+            `stale first reconcile element links ${name}`,
+          );
+          const stopReading = result.key("derived").sink(() => {});
+          try {
+            await runtime.scheduler.idleWithPendingCommits();
+            expect(unsettle.rejection()?.name).toBe(
+              "StorageTransactionInconsistent",
+            );
+            // The element's own document names the piece that owns it. A
+            // reader that loses this link cannot start that piece for an event
+            // addressed to the element.
+            const element = unsettle.elementCells()[0];
+            const probeTx = runtime.edit();
+            try {
+              expect(getMetaLink(element.withTx(probeTx), "result"))
+                .toBeDefined();
+            } finally {
+              probeTx.abort("element link probe");
+            }
+          } finally {
+            stopReading();
+          }
+        } finally {
+          unsettle.restore();
+        }
+      });
+    }
+
+    it(`re-links a ${name} container when the first reconcile is stale`, async () => {
+      const unsettle = unsettleFirstElementSetup();
+      try {
+        const result = await runListPattern(
+          listOp,
+          opBody,
+          `stale first reconcile ${name}`,
+        );
+        const stopReading = result.key("derived").sink(() => {});
+        try {
+          await runtime.scheduler.idleWithPendingCommits();
+          // The premise: the reconcile was rejected on its basis, not on
+          // anything else, so the scheduler re-ran it and the re-run is what
+          // has to make the container reachable again.
+          expect(unsettle.rejection()?.name).toBe(
+            "StorageTransactionInconsistent",
+          );
+          expect(await result.key("derived").pull()).toEqual([...expected]);
+        } finally {
+          stopReading();
+        }
+      } finally {
+        unsettle.restore();
       }
     });
   }


### PR DESCRIPTION
A list coordinator — map, filter, or flatMap — writes two kinds of setup through its reconcile's transaction, and remembers in plain memory that it has. It mints a result container, writes that container's `result` and `pattern` meta, and hands the container's link to the node's output binding; and for each element it starts a pattern run and writes two links naming the coordinator that owns the element. Both kinds of memory outlive a transaction that never commits, and the writes do not.

The container was the visible failure. Its links were issued inside the guard that mints it, and that guard asks only whether the coordinator already holds a container of the right scope. So a reconcile whose commit was rejected left the coordinator holding a container nothing points at, and every later reconcile skipped the guard, wrote the container's value again, and never wrote a link to it. Reading that coordinator's result returned undefined from then on, for as long as the coordinator lived. A stale basis is the rejection that bites: the scheduler recovers from one by re-running the same reconcile, and that re-run is exactly the one that skips the links.

The element setup already had the shape of the answer. An element carries a record saying its setup writes are not known to be durable; every failed outcome sets it, a stale basis included, because every failed outcome discards what the transaction staged. The next reconcile issues those writes again against the bookkeeping it kept, rather than tearing the bookkeeping down and rebuilding what the last attempt discarded. That record is now shared: the container has one too, the three coordinators issue its links through one function that cannot be called without taking the debt for them, and a reconcile that finds them owed issues them again against the container already in hand.

Two more losses of the same kind travel with it. An element's links were never re-issued at all, so an element whose creating transaction was rejected re-ran its pattern but permanently lacked the `result` meta naming its owning piece — the state a reader follows to decide which piece to start for an event addressed to that element. And issuing setup takes the debt for it, so a reconcile that issues must write everything the record covers: one that re-ran only an element's pattern, for an index move, took the debt for links it had not written, and an overlapping reconcile that had written them then found the record owned by someone else and left it alone. Every issuance is now the whole setup. An element whose links are already durable costs a comparison rather than a write, because a write of the value a leaf already holds does not reach storage.

The container restore now gives back only the container this reconcile installed, which is the check the other two undos in the rollback already make and the module's doc comment already claims for all of them.

flatMap writes its elements no link back to its own result, at creation or otherwise, so it has no such link to lose. Giving it one would change what every flatMap element's document holds, which is a decision about metadata rather than a transaction that lost its writes, so it is left as it is and the tests say which coordinators the element case covers.

The settle-outcome specification said a stale basis calls for no compensation. That is true of the bookkeeping and false of the writes, and the gap is what made this reachable. It now says which is which: a record stating that writes are in place is wrong however the transaction failed, so the callback marks it as owed rather than discarding it.

The tests come in three layers. The rollback record is driven directly for each settle outcome and each ownership case. Each coordinator is driven through a first reconcile whose commit is rejected against a basis that moved underneath it, asserting the rejection was a stale basis before asserting the result reads and the element keeps its link. And two runtimes over one server resume a cold replica across an emptied output spot, where the rejection is a real cross-replica conflict and the container link is counted rather than inferred; that pair has a matched control whose first reconcile commits, so a failure can only be about the rejection.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

