### PR TITLE
fix(cli): restore the predicate rename in cell-selection

### DIFF
--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -1058,12 +1058,12 @@ function schemaAtLocalRef(
   if (pointer !== "" && !pointer.startsWith("/")) return undefined;
   let current: unknown = root;
   for (const segment of pointer.split("/").slice(1)) {
-    if (!isRecord(current)) return undefined;
+    if (!isObjectOrArray(current)) return undefined;
     const key = segment.replaceAll("~1", "/").replaceAll("~0", "~");
     current = (current as Record<string, unknown>)[key];
   }
   return current === undefined || typeof current === "boolean" ||
-      isRecord(current)
+      isObjectOrArray(current)
     ? current as JSONSchema | undefined
     : undefined;
 }
@@ -1138,7 +1138,7 @@ function derivePosition(
 
   if (schema.type === "object" || schema.properties !== undefined) {
     const declared = schema.properties;
-    if (!isRecord(declared)) return DERIVED_WHOLE;
+    if (!isObjectNotArray(declared)) return DERIVED_WHOLE;
     const properties: Record<string, unknown> = {};
     let cut = false;
     for (const [key, child] of Object.entries(declared)) {
@@ -2521,7 +2521,7 @@ function markersHeldBy(
     const properties: Record<string, LinkMarkers> = {};
     for (const [key, child] of Object.entries(markers.properties)) {
       const below = held.flatMap((value) =>
-        isRecord(value) && !Array.isArray(value) && key in value
+        isObjectNotArray(value) && key in value
           ? [(value as Record<string, unknown>)[key]]
           : []
       );


### PR DESCRIPTION
## Why

**`main` does not currently type-check.** `deno check packages/cli/lib/cell-selection.ts` on a clean checkout fails with 7 errors, and every open PR touching `packages/cli` is red for a reason its author did not cause — including #5757.

Two PRs merged five minutes apart, neither able to see the other:

- **#5740** (20:37) added four `isRecord` call sites in `cell-selection.ts`.
- **#5762** (20:42) renamed `isRecord` to `isObjectOrArray` / `isObjectNotArray` and rewrote every call site *it* could see.

#5762's branch predated #5740, so it converted the import and the sites that existed when it was written. Git merged both cleanly — they touch different lines — leaving a file that imports `isObjectNotArray, isObjectOrArray` at line 21 and calls `isRecord` at 1061, 1066, 1141 and 2524.

This is a semantic conflict that no textual merge could have caught. Neither PR was wrong; the pair was.

## What Changed

Four call sites, and **the rename is not mechanical** — #5762's own message notes `isRecord` was the loosest of the predicates, admitting arrays. A blind substitution of `isObjectNotArray` would have silently changed behaviour at two of them.

| Site | Now | Why |
| --- | --- | --- |
| JSON-pointer walk guard | `isObjectOrArray` | A pointer may legitimately traverse an array (`allOf/0`); preserves the old looseness |
| JSON-pointer result | `isObjectOrArray` | Same test, same reason |
| `schema.properties` guard | `isObjectNotArray` | A properties map is never an array — and this restores the narrowing that `TS2345` lost |
| marker-walk guard | `isObjectNotArray` | Was literally `isRecord(v) && !Array.isArray(v)`; the new predicate says it once |

Confirmed the blast radius is one file: two dozen files still call `isRecord`, and every one has its own local binding. Only `cell-selection.ts` depended on the import #5762 rewrote.

## Test plan

- `deno check packages/cli/lib/cell-selection.ts` → **rc=0** (was rc=1, 7 errors)
- `deno check packages/cli/lib/callable.ts` → **rc=0**
- `deno task check` → **rc=0**
- `cd packages/cli && deno task test` → **rc=0**, 1673 + 174 passed, 0 failed
- `deno fmt --check`, `deno lint` → **rc=0**

The suite covered the changed code rather than merely exiting zero: `cf piece get transforms` ran 105 times, the cyclic-readback suite 14, `declaredResultProjection` 14.

## Worth noting

`packages/cli/lib` is absent from the hand-maintained list in `tasks/check.sh`, so `deno task check` is green on broken `main` and was not what caught this. CI's separate codebase type-check was. That gap is why the window existed between the two merges and now.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

