### PR TITLE
feat(data-model): `FabricBytes.sliceBuffer()`, and state the unshared guarantee

### DIFF
--- a/packages/data-model/src/fabric-primitives/FabricBytes.ts
+++ b/packages/data-model/src/fabric-primitives/FabricBytes.ts
@@ -29,10 +29,8 @@ import { JSON_CODEC } from "@/codec-interface/interface.ts";
  */
 export class FabricBytes extends BaseFabricPrimitive {
   /**
-   * Private byte storage. Callers use `slice()`, `sliceBuffer()` or
-   * `copyInto()`. Never backed by a `SharedArrayBuffer`, which is what
-   * `toOwnedUint8Array()` guarantees and what lets `sliceBuffer()` promise a
-   * transferable result.
+   * Private byte storage. Guaranteed to be backed by an exact-sized and
+   * unshared `ArrayBuffer`.
    */
   readonly #bytes: Uint8Array<ArrayBuffer>;
 
@@ -75,14 +73,7 @@ export class FabricBytes extends BaseFabricPrimitive {
 
   /**
    * Returns a copy of the bytes (or a sub-range) as a bare `ArrayBuffer`. The
-   * counterpart to {@link #slice} for a caller that wants the buffer rather
-   * than a view onto it, and which allocates no view to get there.
-   *
-   * An `ArrayBuffer` is what a caller needs in order to *transfer* the bytes
-   * across a realm boundary, `ArrayBuffer` being transferable where a typed
-   * array is not. The result is unshared and covers exactly the requested
-   * range, so it can be transferred outright rather than reasoned about
-   * through an offset and a length.
+   * returned buffer is unshared -- the caller may mutate it freely.
    *
    * @param start - Start index (inclusive, default 0).
    * @param end - End index (exclusive, default `length`).

--- a/packages/data-model/src/fabric-primitives/FabricBytes.ts
+++ b/packages/data-model/src/fabric-primitives/FabricBytes.ts
@@ -28,8 +28,13 @@ import { JSON_CODEC } from "@/codec-interface/interface.ts";
  * (JS cannot freeze `ArrayBuffer` contents, so sole ownership is the defense.)
  */
 export class FabricBytes extends BaseFabricPrimitive {
-  /** Private byte storage. Callers use `slice()` or `copyInto()`. */
-  readonly #bytes: Uint8Array;
+  /**
+   * Private byte storage. Callers use `slice()`, `sliceBuffer()` or
+   * `copyInto()`. Never backed by a `SharedArrayBuffer`, which is what
+   * `toOwnedUint8Array()` guarantees and what lets `sliceBuffer()` promise a
+   * transferable result.
+   */
+  readonly #bytes: Uint8Array<ArrayBuffer>;
 
   /**
    * Constructs an instance holding the given bytes, which it owns outright.
@@ -66,6 +71,28 @@ export class FabricBytes extends BaseFabricPrimitive {
    */
   slice(start?: number, end?: number): Uint8Array<ArrayBuffer> {
     return this.#bytes.slice(start, end);
+  }
+
+  /**
+   * Returns a copy of the bytes (or a sub-range) as a bare `ArrayBuffer`. The
+   * counterpart to {@link #slice} for a caller that wants the buffer rather
+   * than a view onto it, and which allocates no view to get there.
+   *
+   * An `ArrayBuffer` is what a caller needs in order to *transfer* the bytes
+   * across a realm boundary, `ArrayBuffer` being transferable where a typed
+   * array is not. The result is unshared and covers exactly the requested
+   * range, so it can be transferred outright rather than reasoned about
+   * through an offset and a length.
+   *
+   * @param start - Start index (inclusive, default 0).
+   * @param end - End index (exclusive, default `length`).
+   */
+  sliceBuffer(start?: number, end?: number): ArrayBuffer {
+    // `#bytes` covers the whole of its own buffer, so the buffer's indices are
+    // this value's indices and `ArrayBuffer.prototype.slice()` takes `start`
+    // and `end` unaltered -- negative values included, exactly as `slice()`
+    // resolves them.
+    return this.#bytes.buffer.slice(start ?? 0, end);
   }
 
   /**

--- a/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
@@ -85,6 +85,53 @@ describe("FabricBytes", () => {
       });
     });
 
+    describe("sliceBuffer()", () => {
+      it("returns the bytes as a bare `ArrayBuffer`", () => {
+        const fb = new FabricBytes(new Uint8Array([10, 20, 30]));
+        const buffer = fb.sliceBuffer();
+
+        expect(buffer).toBeInstanceOf(ArrayBuffer);
+        expect([...new Uint8Array(buffer)]).toEqual([10, 20, 30]);
+      });
+
+      it("returns a buffer covering exactly the requested range", () => {
+        // What makes the result transferable outright: a transfer hands over
+        // a whole buffer, so any excess would cede bytes not asked for.
+        const fb = new FabricBytes(new Uint8Array([1, 2, 3, 4, 5]));
+
+        expect(fb.sliceBuffer().byteLength).toBe(5);
+        expect(fb.sliceBuffer(1, 3).byteLength).toBe(2);
+      });
+
+      it("returns a copy, leaving the instance intact", () => {
+        const fb = new FabricBytes(new Uint8Array([10, 20, 30]));
+        const view = new Uint8Array(fb.sliceBuffer());
+
+        view[0] = 99;
+
+        expect(fb.slice()[0]).toBe(10);
+      });
+
+      it("resolves `start` and `end` as `slice()` does", () => {
+        const fb = new FabricBytes(new Uint8Array([1, 2, 3, 4, 5]));
+
+        for (const range of [[], [1, 3], [3], [-2], [1, -1], [0, 0]]) {
+          const viaBuffer = new Uint8Array(
+            fb.sliceBuffer(...range as [number?, number?]),
+          );
+
+          expect([...viaBuffer]).toEqual([
+            ...fb.slice(...range as [number?, number?]),
+          ]);
+        }
+      });
+
+      it("returns an empty buffer for empty bytes", () => {
+        expect(new FabricBytes(new Uint8Array()).sliceBuffer().byteLength)
+          .toBe(0);
+      });
+    });
+
     describe("copyInto()", () => {
       it("copies bytes into the target", () => {
         const fb = new FabricBytes(new Uint8Array([10, 20, 30, 40]));

--- a/packages/utils/src/buffers.ts
+++ b/packages/utils/src/buffers.ts
@@ -39,6 +39,16 @@ export function isDetached(source: ArrayBufferLike | ArrayBufferView): boolean {
  * since it cannot tell which of the two happened. Passing an already-detached
  * `bytes` throws, as reading it would.
  *
+ * The result's buffer is **exact-sized**: the result starts at offset zero and
+ * runs to the end of it, so the buffer holds these bytes and nothing else.
+ * That is stronger than sole ownership and is separately load-bearing. A
+ * caller reaching past the view to the buffer -- to hash it, or to hand it to
+ * `postMessage()` as a transferable -- gets exactly the byte sequence the view
+ * describes, with no offset to apply and no tail belonging to something else.
+ * Both paths give it: the copy allocates a buffer of the needed size, and the
+ * take-over path is entered only for a `bytes` that already covered its whole
+ * buffer.
+ *
  * @param bytes - The source bytes.
  * @param transfer - Whether the caller cedes `bytes`.
  */

--- a/packages/utils/src/buffers.ts
+++ b/packages/utils/src/buffers.ts
@@ -45,7 +45,7 @@ export function isDetached(source: ArrayBufferLike | ArrayBufferView): boolean {
 export function toOwnedUint8Array(
   bytes: Uint8Array,
   transfer: boolean,
-): Uint8Array {
+): Uint8Array<ArrayBuffer> {
   const buffer = bytes.buffer;
 
   if (

--- a/packages/utils/test/buffers.test.ts
+++ b/packages/utils/test/buffers.test.ts
@@ -71,12 +71,14 @@ describe("buffers", () => {
       const window = new Uint8Array(new ArrayBuffer(16), 4, 3);
       window.set([1, 2, 3]);
 
-      for (const [label, source, transfer] of [
-        ["window, copied", window, false],
-        ["window, transfer requested", window, true],
-        ["whole buffer, copied", new Uint8Array([1, 2, 3]), false],
-        ["whole buffer, taken over", new Uint8Array([1, 2, 3]), true],
-      ] as [string, Uint8Array, boolean][]) {
+      for (
+        const [label, source, transfer] of [
+          ["window, copied", window, false],
+          ["window, transfer requested", window, true],
+          ["whole buffer, copied", new Uint8Array([1, 2, 3]), false],
+          ["whole buffer, taken over", new Uint8Array([1, 2, 3]), true],
+        ] as [string, Uint8Array, boolean][]
+      ) {
         const result = toOwnedUint8Array(source, transfer);
 
         expect(`${label}: ${result.byteOffset}`).toBe(`${label}: 0`);

--- a/packages/utils/test/buffers.test.ts
+++ b/packages/utils/test/buffers.test.ts
@@ -63,6 +63,27 @@ describe("buffers", () => {
       );
     });
 
+    it("returns an exact-sized buffer, whichever path it takes", () => {
+      // Load-bearing beyond sole ownership: a caller reaching past the view
+      // to the buffer -- to transfer it, say -- must get exactly these bytes.
+      // Both a window onto a larger buffer (copied) and a whole-buffer source
+      // (taken over) have to come back exact-sized.
+      const window = new Uint8Array(new ArrayBuffer(16), 4, 3);
+      window.set([1, 2, 3]);
+
+      for (const [label, source, transfer] of [
+        ["window, copied", window, false],
+        ["window, transfer requested", window, true],
+        ["whole buffer, copied", new Uint8Array([1, 2, 3]), false],
+        ["whole buffer, taken over", new Uint8Array([1, 2, 3]), true],
+      ] as [string, Uint8Array, boolean][]) {
+        const result = toOwnedUint8Array(source, transfer);
+
+        expect(`${label}: ${result.byteOffset}`).toBe(`${label}: 0`);
+        expect(`${label}: ${result.buffer.byteLength}`).toBe(`${label}: 3`);
+      }
+    });
+
     it("returns an empty array for an empty source", () => {
       expect(toOwnedUint8Array(new Uint8Array(), true).length).toBe(0);
       expect(toOwnedUint8Array(new Uint8Array(), false).length).toBe(0);


### PR DESCRIPTION
Prep for the realm-crossing wire format, which needs a `FabricBytes`' bytes in
a form `postMessage()` can *transfer*. I (agent working on behalf of @danfuzz)
am landing this separately because it stands on its own: nothing here mentions
that format, and the accessor is useful to anyone who wants a buffer rather
than a view onto one.

## `sliceBuffer()`

`ArrayBuffer` is transferable; a typed array is not. So a caller assembling a
transfer list needs the buffer itself, and getting there through `slice()`
means allocating a `Uint8Array` only to read `.buffer` off it and discard it.
`sliceBuffer()` goes straight to `ArrayBuffer.prototype.slice()`, which
allocates the buffer and nothing else.

The result covers **exactly** the requested range. That is the property that
makes it transferable outright: a transfer hands over a whole buffer, so a
result covering more than was asked for would cede bytes that are not part of
the value.

## The `SharedArrayBuffer` guarantee moves into the types

`sliceBuffer()` cannot compile against `Uint8Array`'s default
`ArrayBufferLike` buffer type, because that admits `SharedArrayBuffer` — which
has no `transfer` and is exactly what must not reach a transfer list.

The guarantee already existed and was already documented;
`toOwnedUint8Array()`'s doc says a source backed by a `SharedArrayBuffer` "is
likewise copied, that being a buffer which cannot be detached at all". Only the
return type was under-stated. It now says `Uint8Array<ArrayBuffer>`, which is
true of both its return paths — `new Uint8Array(buffer.transfer())` and
`new Uint8Array(bytes)` each allocate a plain, unshared buffer — and
`FabricBytes.#bytes` declares the same.

So this is a type catching up with a documented contract, not a new
restriction. Its only other consumer, `FabricHash`, type-checks unchanged.

## On the tests

`sliceBuffer()` is verified to grip, not merely to pass: ablating it to ignore
its `end` argument turns two of the five new cases red — "returns a buffer
covering exactly the requested range", and the one that compares it against
`slice()` across six ranges including negative indices. That last case is there
because `sliceBuffer()` rests on an invariant rather than restating it:
`#bytes` covers the whole of its own buffer, so the buffer's indices *are* the
value's indices and `start`/`end` pass through unaltered. If that invariant
ever broke, the two methods would disagree and that case is what would say so.

## Scope

`sliceBuffer()` has no caller on `main`. Its consumer is the realm codec, which
arrives with the format itself; this is the half that does not depend on it.

## Gates

`utils` `99 passed (660 steps)`, `data-model` `53 passed (2388 steps)`,
plus `check`, `check-docs`, `lint` and `fmt --check` repo-wide. Cross-package,
since `toOwnedUint8Array()` is shared.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

