### PR TITLE
fix(cli): anchor walkthrough piece-id extraction to `piece new --quiet` stdout

### DIFF
--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -48,7 +48,11 @@ say "space $SPACE · nothing here was written for this pattern"
 
 act "1 · Arrive by name"
 say "A slug is a name in the space. After this, no fid appears again."
-BOARD=$($CF piece new "$FIXTURE" $ARGS 2>&1 | grep -oE 'fid1:[A-Za-z0-9_-]+' | head -1)
+# --quiet makes the piece id stdout's only line; stderr is dropped and the
+# grep anchored so a compile warning carrying a fid1: token cannot be taken
+# for the deploy's id.
+BOARD=$($CF piece new --quiet "$FIXTURE" $ARGS 2>/dev/null |
+  grep -oE '^fid1:[A-Za-z0-9_-]+' | head -1)
 $CF piece set-slug board "$BOARD" $ARGS >/dev/null 2>&1
 printf '\n%s   $ cf piece new tracker.tsx --slug board%s\n' "$C" "$N"
 printf '     %s\n' "$BOARD"

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -97,11 +97,16 @@ EPIC=$(echo "$R" | jq -r '.links["/item"].id // empty' | sed 's/^of://')
 if [ -n "$EPIC" ]; then ok "the result names its document: $EPIC"; else
   bad "no link for /item"
 fi
-# The receiver axis: call the verb ON the thing you were just handed.
+# The receiver axis: call the verb ON the thing you were just handed. The
+# children count below proves the writes landed; each call's exit code is
+# checked too, because the readback runs after the write commits — a readback
+# failure leaves the count intact, and only the exit code shows it.
 $CF piece call --quiet --piece "$EPIC" $ARGS \
-  addChild '{"title":"Session cookies"}' >/dev/null 2>&1
+  addChild '{"title":"Session cookies"}' >/dev/null 2>&1 ||
+  bad "addChild (Session cookies) exited nonzero"
 $CF piece call --quiet --piece "$EPIC" $ARGS \
-  addChild '{"title":"CSRF tokens"}' >/dev/null 2>&1
+  addChild '{"title":"CSRF tokens"}' >/dev/null 2>&1 ||
+  bad "addChild (CSRF tokens) exited nonzero"
 KIDS=$($CF piece get --quiet --piece "$EPIC" children $ARGS \
   --schema '{"type":"array","items":{"type":"object","properties":{"title":true}}}' \
   2>/dev/null)
@@ -153,8 +158,10 @@ AT=$(echo "$N" | jq -r '.result.note.at // 0')
   bad "no pattern-stamped time on the note"
 
 step "8. Finishing reports what the caller could not know"
+# Exit code checked for the same reason as step 4's creates.
 $CF piece call --quiet --piece "$KID" $ARGS \
-  addChild '{"title":"Rotate signing key"}' >/dev/null 2>&1
+  addChild '{"title":"Rotate signing key"}' >/dev/null 2>&1 ||
+  bad "addChild (Rotate signing key) exited nonzero"
 # Unshaped: a PROJECTED read of this path fails once `finish` has run, while
 # the same path unshaped resolves fine. Counting is all this step needs.
 DIRECT=$($CF piece get --quiet --piece "$EPIC" children $ARGS --step 2>/dev/null |

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -58,8 +58,11 @@ echo "SPACE=$SPACE"
 START=$(date +%s)
 
 step "1. Arrive by name, not by fid"
-BOARD=$($CF piece new "$FIXTURE" $ARGS 2>&1 |
-  grep -oE 'fid1:[A-Za-z0-9_-]+' | head -1)
+# --quiet makes the piece id stdout's only line; stderr is dropped and the
+# grep anchored so a compile warning carrying a fid1: token cannot be taken
+# for the deploy's id.
+BOARD=$($CF piece new --quiet "$FIXTURE" $ARGS 2>/dev/null |
+  grep -oE '^fid1:[A-Za-z0-9_-]+' | head -1)
 if [ -n "$BOARD" ]; then ok "deployed $BOARD"; else
   bad "deploy failed"
   exit 1

--- a/packages/cli/integration/verbs-over-the-cli.sh
+++ b/packages/cli/integration/verbs-over-the-cli.sh
@@ -67,8 +67,11 @@ export EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=true
 START=$(date +%s)
 
 step "1. Deploy the fixture"
-BOARD=$($CF piece new "$FIXTURE" $ARGS 2>&1 |
-  grep -oE 'fid1:[A-Za-z0-9_-]+' | head -1)
+# --quiet makes the piece id stdout's only line; stderr is dropped and the
+# grep anchored so a compile warning carrying a fid1: token cannot be taken
+# for the deploy's id.
+BOARD=$($CF piece new --quiet "$FIXTURE" $ARGS 2>/dev/null |
+  grep -oE '^fid1:[A-Za-z0-9_-]+' | head -1)
 if [ -n "$BOARD" ]; then ok "deployed $BOARD"; else
   bad "deploy failed"
   exit 1


### PR DESCRIPTION
## Problem

The three verb walkthrough scripts extracted a freshly deployed piece id by grepping MERGED stdout+stderr for the first `fid1:` token:

```bash
BOARD=$($CF piece new "$FIXTURE" $ARGS 2>&1 | grep -oE 'fid1:[A-Za-z0-9_-]+' | head -1)
```

Any stderr line carrying a `fid1:` token that prints before the deploy output becomes the "piece id", and every downstream step then targets a nonexistent piece. This bit on #5746: a transformer warning prints the compiler's virtual source path, which begins with the module's `fid1:` id — step 1 "passed" with the wrong id and the walkthrough failed its other 34 steps with empty JSON and `initial_sync → failed` (run 31659621269; rerun identical). That PR worked around it in its fixture; this PR fixes the extraction itself.

## Fix

`cf piece new` already has the structured output the scripts need: under `--quiet` the bare piece id is stdout's only line (`render(pieceId)`), the NEXT-STEPS hint rides `hint()` on stderr and is suppressed, and compile warnings ride the logger's warn sink on stderr (the CLI's default log floor). So all three scripts now use, identically:

```bash
BOARD=$($CF piece new --quiet "$FIXTURE" $ARGS 2>/dev/null |
  grep -oE '^fid1:[A-Za-z0-9_-]+' | head -1)
```

Three independent layers: `--quiet` makes the id stdout's only line; stderr never enters the pipeline, so a warning cannot be captured no matter when it prints; the `^` anchor means only a line that IS a piece id can match. An empty result still trips each script's existing deploy-failed guard.

## Verification

Against a fresh local toolshed:

- Stream probe: `cf piece new --quiet` with stdout/stderr captured separately prints exactly one stdout line — the id — and nothing else.
- `verbs-over-the-cli.sh` (the CI-run script): **44 passed, 0 failed**.
- `verb-session-demo.sh`: exit 0; the slug set from the extracted id resolves in act 2, which only works if the id addressed the real piece.
- `verb-session-gaps.sh`: 19 passed, 2 failed — the 2 failures (step 11, `addChild` readback) reproduce byte-identically with this change stashed, so they are pre-existing on main and unrelated to this PR (CI does not run this script; being investigated separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Second commit: assert the setup addChild calls' exit codes

The step-11 incident (#5767's window) exposed a masking pattern in the same script: steps 4 and 8 run `addChild` for setup and assert only the effect — the children count — while discarding the calls' exit codes. A broken readback exits nonzero *after* the write lands, so the count stays right and steps 1–10 stay green; during the #5740×#5762 window every one of those calls was failing and nothing said so until step 11 checked a readback on purpose. Each setup call now fails its step on a nonzero exit.

The branch is also rebased onto current main (it was based on 572a477c2, inside that window). Re-verified on the rebased branch against a local toolshed: gaps **21 passed / 0 failed**, demo **exit 0**, walkthrough **44 passed / 0 failed**.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


