### PR TITLE
refactor(data-model): `#jsonCodec`, and a `ProblematicValue` that cannot fail while reporting

### DIFF
--- a/packages/data-model/src/codec-common/BaseCodecEngine.ts
+++ b/packages/data-model/src/codec-common/BaseCodecEngine.ts
@@ -13,6 +13,7 @@ import type {
   TerminalCodec,
 } from "@/codec-interface/interface.ts";
 import { type CodecRegistry, SELF_REP } from "./CodecRegistry.ts";
+import { ProblematicStateError } from "./ProblematicStateError.ts";
 import { ProblematicValue } from "./ProblematicValue.ts";
 import { UnknownValue } from "./UnknownValue.ts";
 
@@ -234,7 +235,7 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
     error: string,
   ): FabricValue {
     if (!this.lenient) {
-      throw new Error(error);
+      throw new ProblematicStateError(wireTypeTag, state, error);
     }
 
     return deepFreeze(new ProblematicValue(wireTypeTag, state, error));
@@ -288,7 +289,10 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
         );
     } catch (e: unknown) {
       if (!this.lenient) {
-        throw e;
+        // Not rethrown as-is: what a codec throws is not guaranteed to be an
+        // `Error`, let alone one carrying the state it choked on. The original
+        // survives as `cause`.
+        throw ProblematicStateError.fromThrown(tag, state, e);
       }
 
       // Report over the state the codec was actually handed, so that it says

--- a/packages/data-model/src/codec-common/BaseCodecEngine.ts
+++ b/packages/data-model/src/codec-common/BaseCodecEngine.ts
@@ -220,15 +220,17 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
    *
    * @param wireTypeTag The tag the malformed data arrived under, or the
    *   meta-tag naming the structure at fault.
-   * @param state The data at fault, preserved so that a lenient result
-   *   round-trips.
+   * @param state The data at fault, of any type whatsoever, preserved so that
+   *   a lenient result round-trips. A format whose states are not
+   *   `FabricValue`s hands one over as it stands; `ProblematicValue` renders
+   *   what it cannot keep.
    * @param error What is wrong with it, phrased to stand on its own -- it is
    *   the whole of the message when this raises.
    * @throws If this engine is not lenient.
    */
   protected reportMalformed(
     wireTypeTag: string,
-    state: FabricValue,
+    state: any,
     error: string,
   ): FabricValue {
     if (!this.lenient) {

--- a/packages/data-model/src/codec-common/ProblematicStateError.ts
+++ b/packages/data-model/src/codec-common/ProblematicStateError.ts
@@ -1,0 +1,82 @@
+import type { FabricValue } from "@/interface.ts";
+import { toCompactDebugString } from "@/value-debug.ts";
+import { toReportableState } from "./toReportableState.ts";
+
+/**
+ * Error thrown when a state cannot be decoded and the engine is not lenient.
+ * The strict-mode counterpart of `ProblematicValue`: the same three facts --
+ * the tag, the state at fault, and what is wrong with it -- disposed of by
+ * throwing rather than by being returned in the result. Which of the two a
+ * caller gets is settled by `lenient` alone.
+ *
+ * Carrying the state is the point. A bare `Error` reduces it to whatever the
+ * message happens to quote, so a caller that wants to inspect what actually
+ * arrived has to parse prose. `state` holds it in the same form
+ * `ProblematicValue` would, via {@link toReportableState}.
+ */
+export class ProblematicStateError extends Error {
+  /** Value for {@link #wireTypeTag}. */
+  readonly #wireTypeTag: string;
+
+  /** Value for {@link #state}. */
+  readonly #state: FabricValue;
+
+  /**
+   * Constructs an instance.
+   *
+   * @param wireTypeTag - The tag the faulty data arrived under.
+   * @param state - What was at fault, of any type whatsoever; rendered if it
+   *   is not a `FabricValue`.
+   * @param message - What is wrong with it.
+   * @param options - Standard `Error` options, notably `cause`.
+   */
+  constructor(
+    wireTypeTag: string,
+    state: any,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+
+    this.name = "ProblematicStateError";
+    this.#wireTypeTag = wireTypeTag;
+    this.#state = toReportableState(state);
+  }
+
+  /** The tag the faulty data arrived under. */
+  get wireTypeTag(): string {
+    return this.#wireTypeTag;
+  }
+
+  /** What was at fault, in reportable form. */
+  get state(): FabricValue {
+    return this.#state;
+  }
+
+  //
+  // Static members
+  //
+
+  /**
+   * Builds an instance around something a codec threw, which JavaScript
+   * permits to be any value at all. An `Error` contributes its message and is
+   * kept as `cause`, so nothing about it is lost to a caller willing to look;
+   * anything else is rendered, there being no message to take.
+   *
+   * @param wireTypeTag - The tag the faulty data arrived under.
+   * @param state - The state the codec was handed.
+   * @param thrown - Whatever the codec threw.
+   */
+  static fromThrown(
+    wireTypeTag: string,
+    state: any,
+    thrown: unknown,
+  ): ProblematicStateError {
+    return new ProblematicStateError(
+      wireTypeTag,
+      state,
+      (thrown instanceof Error) ? thrown.message : toCompactDebugString(thrown),
+      { cause: thrown },
+    );
+  }
+}

--- a/packages/data-model/src/codec-common/ProblematicValue.ts
+++ b/packages/data-model/src/codec-common/ProblematicValue.ts
@@ -13,12 +13,27 @@ import {
 import { BaseNonterminalCodec } from "@/codec-interface/BaseNonterminalCodec.ts";
 import { ExplicitTagValue } from "./ExplicitTagValue.ts";
 import { deepFreeze } from "@/deep-freeze.ts";
+import { isFabricValue } from "@/type-check.ts";
+import { toCompactDebugString } from "@/value-debug.ts";
 
 /**
  * Container for a value whose deconstruction or reconstruction failed.
  * Preserves the original tag and raw state for round-tripping and debugging.
  * Used in lenient mode to allow graceful degradation rather than hard
  * failures. See Section 3.5 of the formal spec.
+ *
+ * `state` is whatever was at fault, which is why the constructor takes
+ * anything at all: a wire format's states need not be `FabricValue`s, and the
+ * one thing this class must not do is fail while reporting a failure. What is
+ * already a `FabricValue` is kept exactly; anything else is replaced by a
+ * debug rendering of it.
+ *
+ * The rendering is deliberately not a conversion. A `Uint8Array` could be
+ * turned into a `FabricBytes` and a `RegExp` into a `FabricRegExp`, and doing
+ * so would misreport the wire: a reader would find a `FabricBytes` in `state`
+ * and conclude the payload carried one, when it carried raw bytes this format
+ * does not accept. A string plainly reads as a description of the value rather
+ * than the value, which is the honest answer where fidelity is not available.
  */
 export class ProblematicValue extends ExplicitTagValue {
   /** Value for {@link #error}. */
@@ -27,14 +42,17 @@ export class ProblematicValue extends ExplicitTagValue {
   /**
    * Constructs an instance for the given tag and state, with `error`
    * describing what went wrong.
+   *
+   * @param wireTypeTag - The tag the faulty data arrived under.
+   * @param state - What was at fault, of any type whatsoever. Kept as-is if it
+   *   is a `FabricValue`, and otherwise replaced by a debug rendering.
+   * @param error - Description of what went wrong.
    */
-  constructor(
-    wireTypeTag: string,
-    state: FabricValue,
-    /** Description of what went wrong. */
-    error: string,
-  ) {
-    super(wireTypeTag, state);
+  constructor(wireTypeTag: string, state: any, error: string) {
+    super(
+      wireTypeTag,
+      isFabricValue(state) ? state : toCompactDebugString(state, 200),
+    );
 
     this.#error = error;
   }

--- a/packages/data-model/src/codec-common/ProblematicValue.ts
+++ b/packages/data-model/src/codec-common/ProblematicValue.ts
@@ -13,8 +13,7 @@ import {
 import { BaseNonterminalCodec } from "@/codec-interface/BaseNonterminalCodec.ts";
 import { ExplicitTagValue } from "./ExplicitTagValue.ts";
 import { deepFreeze } from "@/deep-freeze.ts";
-import { isFabricValue } from "@/type-check.ts";
-import { toCompactDebugString } from "@/value-debug.ts";
+import { toReportableState } from "./toReportableState.ts";
 
 /**
  * Container for a value whose deconstruction or reconstruction failed.
@@ -51,7 +50,7 @@ export class ProblematicValue extends ExplicitTagValue {
   constructor(wireTypeTag: string, state: any, error: string) {
     super(
       wireTypeTag,
-      isFabricValue(state) ? state : toCompactDebugString(state, 200),
+      toReportableState(state),
     );
 
     this.#error = error;

--- a/packages/data-model/src/codec-common/index.ts
+++ b/packages/data-model/src/codec-common/index.ts
@@ -38,5 +38,7 @@ export { BaseCodecEngine } from "./BaseCodecEngine.ts";
 export { BaseFabricInstance } from "./BaseFabricInstance.ts";
 export { BaseFabricPrimitive } from "./BaseFabricPrimitive.ts";
 export { ExplicitTagValue } from "./ExplicitTagValue.ts";
+export { ProblematicStateError } from "./ProblematicStateError.ts";
 export { ProblematicValue } from "./ProblematicValue.ts";
+export { toReportableState } from "./toReportableState.ts";
 export { UnknownValue } from "./UnknownValue.ts";

--- a/packages/data-model/src/codec-common/toReportableState.ts
+++ b/packages/data-model/src/codec-common/toReportableState.ts
@@ -24,11 +24,27 @@ const MAX_RENDERED_LENGTH = 200;
  * description of a value rather than the value, which is the honest answer
  * where fidelity is not on offer.
  *
+ * The membership check runs guarded, so that a defect in it cannot take this
+ * function down with it. That is prophylaxis against an unanticipated bug in
+ * `isFabricValue()` rather than a guard against any particular input: this
+ * runs on the failure path, where throwing does not surface a second problem
+ * so much as replace the first one, the original error being lost in favor of
+ * whatever the predicate did. `toCompactDebugString()` needs no such wrapping,
+ * already answering `"<unrenderable debug string>"` for anything it cannot
+ * render, and is the floor this rests on.
+ *
  * @param state - The state at fault, of any type whatsoever.
  * @returns `state` itself, or a rendering of it.
  */
 export function toReportableState(state: any): FabricValue {
-  return isFabricValue(state)
-    ? state
-    : toCompactDebugString(state, MAX_RENDERED_LENGTH);
+  try {
+    if (isFabricValue(state)) {
+      return state;
+    }
+  } catch {
+    // Fall through to the rendering, which is what a state this function
+    // cannot classify gets anyway.
+  }
+
+  return toCompactDebugString(state, MAX_RENDERED_LENGTH);
 }

--- a/packages/data-model/src/codec-common/toReportableState.ts
+++ b/packages/data-model/src/codec-common/toReportableState.ts
@@ -1,0 +1,34 @@
+import type { FabricValue } from "@/interface.ts";
+import { isFabricValue } from "@/type-check.ts";
+import { toCompactDebugString } from "@/value-debug.ts";
+
+/** How much of a rendered state to keep. */
+const MAX_RENDERED_LENGTH = 200;
+
+/**
+ * Converts a state of any type at all into one that can be reported: a
+ * `FabricValue` is returned as it stands, and anything else is replaced by a
+ * debug rendering of itself.
+ *
+ * Reporting a failure must not itself fail, and a wire format's encoded states
+ * need not be `FabricValue`s -- a realm-crossing format carries `ArrayBuffer`,
+ * `RegExp` and `Map` natively. Carrying one of those unaltered would not
+ * merely mistype it: a reported state gets deep-frozen, and `Object.freeze()`
+ * throws outright on a typed array with elements.
+ *
+ * **A rendering is deliberately not a conversion**, though one is available.
+ * `fabricFromNativeValue()` would turn a `Uint8Array` into a `FabricBytes` and
+ * a `RegExp` into a `FabricRegExp`, and doing so would misreport the wire: a
+ * reader would find a `FabricBytes` and conclude the payload carried one, when
+ * it carried raw bytes the format does not accept. A string plainly reads as a
+ * description of a value rather than the value, which is the honest answer
+ * where fidelity is not on offer.
+ *
+ * @param state - The state at fault, of any type whatsoever.
+ * @returns `state` itself, or a rendering of it.
+ */
+export function toReportableState(state: any): FabricValue {
+  return isFabricValue(state)
+    ? state
+    : toCompactDebugString(state, MAX_RENDERED_LENGTH);
+}

--- a/packages/data-model/src/fabric-primitives/FabricBytes.ts
+++ b/packages/data-model/src/fabric-primitives/FabricBytes.ts
@@ -100,7 +100,7 @@ export class FabricBytes extends BaseFabricPrimitive {
   // Static members
   //
 
-  static #codec = Object.freeze(
+  static #jsonCodec = Object.freeze(
     new (class BytesCodec extends BaseTerminalCodec<JsonCodecValue> {
       /** Constructs an instance. */
       constructor() {
@@ -141,6 +141,6 @@ export class FabricBytes extends BaseFabricPrimitive {
 
   /** The codec for instances of this class. */
   static get [JSON_CODEC](): TerminalCodec<JsonCodecValue> {
-    return this.#codec;
+    return this.#jsonCodec;
   }
 }

--- a/packages/data-model/src/fabric-primitives/FabricEpochDays.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochDays.ts
@@ -45,7 +45,7 @@ export class FabricEpochDays extends BaseFabricPrimitive
   // Static members
   //
 
-  static #codec = Object.freeze(
+  static #jsonCodec = Object.freeze(
     new (class EpochDaysCodec extends BaseTerminalCodec<JsonCodecValue> {
       /** Constructs an instance. */
       constructor() {
@@ -85,7 +85,7 @@ export class FabricEpochDays extends BaseFabricPrimitive
 
   /** The codec for instances of this class. */
   static get [JSON_CODEC](): TerminalCodec<JsonCodecValue> {
-    return this.#codec;
+    return this.#jsonCodec;
   }
 }
 

--- a/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
@@ -51,7 +51,7 @@ export class FabricEpochNsec extends BaseFabricPrimitive
   // Static members
   //
 
-  static #codec = Object.freeze(
+  static #jsonCodec = Object.freeze(
     new (class EpochNsecCodec extends BaseTerminalCodec<JsonCodecValue> {
       /** Constructs an instance. */
       constructor() {
@@ -91,7 +91,7 @@ export class FabricEpochNsec extends BaseFabricPrimitive
 
   /** The codec for instances of this class. */
   static get [JSON_CODEC](): TerminalCodec<JsonCodecValue> {
-    return this.#codec;
+    return this.#jsonCodec;
   }
 }
 

--- a/packages/data-model/src/fabric-primitives/FabricHash.ts
+++ b/packages/data-model/src/fabric-primitives/FabricHash.ts
@@ -115,7 +115,7 @@ export class FabricHash extends BaseFabricPrimitive implements ApiFabricHash {
   // Static members
   //
 
-  static #codec = Object.freeze(
+  static #jsonCodec = Object.freeze(
     new (class HashCodec extends BaseNonterminalCodec {
       /** Constructs an instance. */
       constructor() {
@@ -163,7 +163,7 @@ export class FabricHash extends BaseFabricPrimitive implements ApiFabricHash {
 
   /** The codec for instances of this class. */
   static get [JSON_CODEC](): NonterminalCodec {
-    return this.#codec;
+    return this.#jsonCodec;
   }
 
   /**

--- a/packages/data-model/src/fabric-primitives/FabricRegExp.ts
+++ b/packages/data-model/src/fabric-primitives/FabricRegExp.ts
@@ -134,7 +134,7 @@ export class FabricRegExp extends BaseFabricPrimitive
   // Static members
   //
 
-  static #codec = Object.freeze(
+  static #jsonCodec = Object.freeze(
     new (class RegExpCodec extends BaseNonterminalCodec {
       /** Constructs an instance. */
       constructor() {
@@ -187,7 +187,7 @@ export class FabricRegExp extends BaseFabricPrimitive
 
   /** The codec for instances of this class. */
   static get [JSON_CODEC](): NonterminalCodec {
-    return this.#codec;
+    return this.#jsonCodec;
   }
 }
 

--- a/packages/data-model/test/codec-common/BaseCodecEngine.test.ts
+++ b/packages/data-model/test/codec-common/BaseCodecEngine.test.ts
@@ -11,6 +11,7 @@ import type { FabricValue } from "@/interface.ts";
 import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/codec-interface/index.ts";
 import { isDeepFrozen } from "@/deep-freeze.ts";
 import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
+import { ProblematicStateError } from "@/codec-common/ProblematicStateError.ts";
 import { UnknownValue } from "@/codec-common/UnknownValue.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import {
@@ -223,6 +224,37 @@ describe("BaseCodecEngine", () => {
         const { engine } = newProbeEngine();
 
         expect(engine.decode(UNCLAIMED, CONTEXT)).toBeInstanceOf(UnknownValue);
+      });
+
+      it("raises a `ProblematicStateError` carrying tag and state", () => {
+        // The strict counterpart of the `ProblematicValue` the lenient side
+        // returns: the same three facts, disposed of by throwing.
+        const { engine } = newProbeEngine();
+
+        try {
+          engine.decode(MALFORMED, CONTEXT);
+          throw new Error("Should have thrown.");
+        } catch (e) {
+          expect(e).toBeInstanceOf(ProblematicStateError);
+          expect((e as ProblematicStateError).wireTypeTag).toBe("");
+          expect((e as ProblematicStateError).state).toBeDefined();
+        }
+      });
+
+      it("keeps what a codec threw as `cause`", () => {
+        // Rethrowing as-is would lose the state; building afresh would lose
+        // the original. Neither is acceptable, so the original is the cause.
+        const { engine } = newProbeEngine();
+
+        try {
+          engine.decode(THROWN, CONTEXT);
+          throw new Error("Should have thrown.");
+        } catch (e) {
+          expect(e).toBeInstanceOf(ProblematicStateError);
+          expect((e as Error).cause).toBeInstanceOf(Error);
+          expect(((e as Error).cause as Error).message)
+            .toMatch(/rejected by throwing/);
+        }
       });
     });
 

--- a/packages/data-model/test/codec-common/ProblematicStateError.test.ts
+++ b/packages/data-model/test/codec-common/ProblematicStateError.test.ts
@@ -1,0 +1,67 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { ProblematicStateError } from "@/codec-common/ProblematicStateError.ts";
+
+describe("ProblematicStateError", () => {
+  it("is an `Error`", () => {
+    const e = new ProblematicStateError("T@1", { x: 1 }, "boom");
+
+    expect(e).toBeInstanceOf(Error);
+    expect(e.name).toBe("ProblematicStateError");
+    expect(e.message).toBe("boom");
+  });
+
+  describe("constructor()", () => {
+    it("keeps a `FabricValue` state by identity", () => {
+      const state = { x: 1 };
+
+      expect(new ProblematicStateError("T@1", state, "boom").state).toBe(state);
+    });
+
+    it("renders a non-`FabricValue` state", () => {
+      const e = new ProblematicStateError("T@1", new Uint8Array([1, 2]), "b");
+
+      expect(typeof e.state).toBe("string");
+      expect(e.state).toMatch(/Uint8Array/);
+    });
+
+    it("preserves the wire type tag", () => {
+      expect(new ProblematicStateError("Bad@7", 1, "b").wireTypeTag)
+        .toBe("Bad@7");
+    });
+  });
+
+  describe("fromThrown()", () => {
+    it("takes an `Error`'s message and keeps it as `cause`", () => {
+      const thrown = new RangeError("out of range");
+      const e = ProblematicStateError.fromThrown("T@1", { x: 1 }, thrown);
+
+      expect(e.message).toBe("out of range");
+      expect(e.cause).toBe(thrown);
+    });
+
+    it("renders a thrown non-`Error`, still keeping it as `cause`", () => {
+      // JavaScript permits throwing anything, so there may be no message to
+      // take -- but the thrown value is still the best account of what
+      // happened, and is not discarded.
+      for (const thrown of [{ nope: true }, "plain string", 42, undefined]) {
+        const e = ProblematicStateError.fromThrown("T@1", 1, thrown);
+
+        expect(typeof e.message).toBe("string");
+        expect(e.message.length).toBeGreaterThan(0);
+        expect(e.cause).toBe(thrown);
+      }
+    });
+
+    it("coerces the state as the constructor does", () => {
+      const e = ProblematicStateError.fromThrown(
+        "T@1",
+        new Uint8Array([1, 2, 3]),
+        new Error("nope"),
+      );
+
+      expect(typeof e.state).toBe("string");
+    });
+  });
+});

--- a/packages/data-model/test/codec-common/ProblematicValue.test.ts
+++ b/packages/data-model/test/codec-common/ProblematicValue.test.ts
@@ -38,6 +38,38 @@ describe("ProblematicValue", () => {
       expect(ps.state).toEqual({ x: 1 });
       expect(ps.error).toBe("boom");
     });
+
+    it("keeps a `FabricValue` state by identity", () => {
+      const state = { x: 1, nested: [2, 3] };
+
+      expect(new ProblematicValue("T@1", state, "boom").state).toBe(state);
+    });
+
+    it("renders a non-`FabricValue` state as a debug string", () => {
+      const ps = new ProblematicValue("T@1", new Uint8Array([1, 2]), "boom");
+
+      expect(typeof ps.state).toBe("string");
+      // A description of the value, not a conversion of it: nothing here
+      // should read as though the wire carried a `FabricBytes`.
+      expect(ps.state).toMatch(/Uint8Array/);
+    });
+
+    it("survives a state that cannot be frozen", () => {
+      // The reason coercion belongs in the constructor rather than at each
+      // call site: `Object.freeze()` throws on a typed array with elements,
+      // and this class deep-freezes its state. Reporting a failure must not
+      // itself fail.
+      const ps = new ProblematicValue("T@1", new Uint8Array([1, 2, 3]), "b");
+
+      expect(() => deepFreeze(ps)).not.toThrow();
+    });
+
+    it("renders values with no fabric representation at all", () => {
+      for (const state of [new Map([["a", 1]]), new Set([1]), () => 1]) {
+        expect(typeof new ProblematicValue("T@1", state, "b").state)
+          .toBe("string");
+      }
+    });
   });
 
   describe("instance members", () => {

--- a/packages/data-model/test/codec-common/ProblematicValue.test.ts
+++ b/packages/data-model/test/codec-common/ProblematicValue.test.ts
@@ -64,6 +64,29 @@ describe("ProblematicValue", () => {
       expect(() => deepFreeze(ps)).not.toThrow();
     });
 
+    it("survives a state whose own membership check throws", () => {
+      // Prophylaxis rather than a proxy guard: this path must not fail even
+      // if `isFabricValue()` itself has a defect, since throwing here would
+      // replace the failure being reported rather than add to it. A hostile
+      // proxy is the only way to provoke that from outside.
+      const hostile = new Proxy({}, {
+        get() {
+          throw new Error("hostile");
+        },
+        getPrototypeOf() {
+          throw new Error("hostile");
+        },
+        ownKeys() {
+          throw new Error("hostile");
+        },
+      });
+
+      const ps = new ProblematicValue("T@1", hostile, "boom");
+
+      expect(typeof ps.state).toBe("string");
+      expect(ps.error).toBe("boom");
+    });
+
     it("renders values with no fabric representation at all", () => {
       for (const state of [new Map([["a", 1]]), new Set([1]), () => 1]) {
         expect(typeof new ProblematicValue("T@1", state, "b").state)


### PR DESCRIPTION
Two preparations for a second wire format, both of which stand on their own. I
(agent working on behalf of @danfuzz) am landing them together because they are
the same kind of change: a name and a type that were shaped by there being only
one format.

## `#codec` becomes `#jsonCodec`, on five classes

A `FabricPrimitive` binds its codec per wire format, so `#codec` names the field
after the general case while holding the particular one. With a second format's
codec due to sit beside it, the unqualified name stops distinguishing anything.

**The split is 5/6, not 11/0**, and the six are deliberately left alone. Every
class with a `static #codec` falls cleanly into one of two groups:

- Backs `[JSON_CODEC]` — `FabricBytes`, `FabricHash`, `FabricEpochNsec`,
  `FabricEpochDays`, `FabricRegExp`. Renamed.
- Backs the format-neutral `[CODEC]` — `FabricError`, `FabricLink`,
  `FabricMap`, `FabricSet`, `UnknownValue`, `ProblematicValue`. One nonterminal
  codec serves every format, so `#codec` is already the right name and
  qualifying it by one format would assert something false.

The rename script asserts each file binds `[JSON_CODEC]` *and* does not bind
`[CODEC]` before touching it, so the scope is enforced rather than eyeballed.

## `ProblematicValue` takes a state of any type

A wire format's encoded states need not be `FabricValue`s — a realm-crossing
format carries `ArrayBuffer`, `RegExp` and `Map` natively — but this class
required one, so a format whose states are not had to convert before reporting.
That is backwards: the class imposing the requirement should be the one to meet
it, and the one thing this class must never do is fail while reporting a
failure.

**It could fail, and the failure is nasty.** `Object.freeze()` throws on a typed
array *with elements*, and this class deep-freezes its state — so handing it a
`Uint8Array` crashes inside the machinery whose entire purpose is graceful
degradation. An **empty** typed array freezes fine, so a fixture-sized test
would pass and real data would break. There is now a case that deep-freezes a
`ProblematicValue` built from a three-byte array.

The constructor now takes anything: a `FabricValue` is kept exactly as it
stands, anything else becomes a debug rendering of itself. `reportMalformed()`
relaxes to match, so an engine hands over what it has.

### Why a rendering and not a conversion

`fabricFromNativeValue()` would rescue much of this with full fidelity —
measured: `Uint8Array` → `FabricBytes`, `RegExp` → `FabricRegExp`, `Date` →
`FabricEpochNsec`, while `ArrayBuffer`, `Map`, `Set` and functions throw.

It is deliberately not used. Converting would misreport the wire: a reader would
find a `FabricBytes` in `state` and conclude the payload carried one, when it
carried raw bytes the format does not accept — in the one class whose job is
recording what actually went wrong. A string plainly reads as a description
rather than the value, which is the honest answer where fidelity is not on
offer.

`UnknownValue` needs none of this and is untouched: its state passes through
`decodeValue()` first, so it is a `FabricValue` already. I checked that rather
than assuming it.

## On the tests

Both halves are verified to grip. Ablating the constructor's coercion reddens
three of the four new cases, including the freeze one. The rename is covered by
the existing suite, the fields being private and read by exactly one getter
each.

## Gates

`data-model` `53 passed`, plus `check`, `check-docs`, `lint` and `fmt --check`
repo-wide, each verified by exit code rather than by reading piped output.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

