### PR TITLE
fix(data-model): carry the state on every strict-mode failure, and stop re-wrapping

### DIFF
--- a/packages/data-model/src/codec-common/BaseCodecEngine.ts
+++ b/packages/data-model/src/codec-common/BaseCodecEngine.ts
@@ -312,7 +312,11 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
       // nothing about what a caller wants. `lenient` is what says that, so
       // this instance settles both into the same answer: a strict decode
       // fails, whichever way the codec spelled it.
-      throw new Error(`\`${tag}\`: ${decoded.error}`);
+      throw new ProblematicStateError(
+        tag,
+        decoded.state,
+        `\`${tag}\`: ${decoded.error}`,
+      );
     }
 
     // A codec's `decode()` promises deep-frozen results rather than relying on

--- a/packages/data-model/src/codec-common/BaseCodecEngine.ts
+++ b/packages/data-model/src/codec-common/BaseCodecEngine.ts
@@ -289,9 +289,11 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
         );
     } catch (e: unknown) {
       if (!this.lenient) {
-        // Not rethrown as-is: what a codec throws is not guaranteed to be an
-        // `Error`, let alone one carrying the state it choked on. The original
-        // survives as `cause`.
+        // Normalized rather than rethrown: what a codec throws is not
+        // guaranteed to be an `Error`, let alone one naming the state it
+        // choked on. `fromThrown()` answers with one that does -- the thrown
+        // value itself where it already qualifies, and otherwise a fresh one
+        // holding it as `cause`.
         throw ProblematicStateError.fromThrown(tag, state, e);
       }
 

--- a/packages/data-model/src/codec-common/BaseCodecEngine.ts
+++ b/packages/data-model/src/codec-common/BaseCodecEngine.ts
@@ -291,7 +291,7 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
       if (!this.lenient) {
         // Normalized rather than rethrown: what a codec throws is not
         // guaranteed to be an `Error`, let alone one naming the state it
-        // choked on. `fromThrown()` answers with one that does -- the thrown
+        // choked on. `fromThrown()` returns one that does -- the thrown
         // value itself where it already qualifies, and otherwise a fresh one
         // holding it as `cause`.
         throw ProblematicStateError.fromThrown(tag, state, e);
@@ -314,11 +314,7 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
       // nothing about what a caller wants. `lenient` is what says that, so
       // this instance settles both into the same answer: a strict decode
       // fails, whichever way the codec spelled it.
-      throw new ProblematicStateError(
-        tag,
-        decoded.state,
-        `\`${tag}\`: ${decoded.error}`,
-      );
+      throw new ProblematicStateError(tag, decoded.state, decoded.error);
     }
 
     // A codec's `decode()` promises deep-frozen results rather than relying on

--- a/packages/data-model/src/codec-common/BaseFabricInstance.ts
+++ b/packages/data-model/src/codec-common/BaseFabricInstance.ts
@@ -47,7 +47,7 @@ export const DEEP_FREEZE: unique symbol = Symbol("data-model.deepFreeze");
  * concrete subclasses.
  *
  * Unlike `[DEEP_FREEZE]`, this method is side-effect-free and never throws:
- * a not-in-canonical-deep-frozen-form instance answers `false`, it does not
+ * an instance not in canonical deep-frozen form returns `false`, it does not
  * crash. (`[DEEP_FREEZE]` is a mutator and uses "death before confusion" on
  * a malformed internal slot; a status check must not.)
  */
@@ -225,7 +225,7 @@ export abstract class BaseFabricInstance extends FabricInstance {
    * actively enforced rather than silently skipped.
    *
    * This uses "death before confusion" on the mismatch: rather than quietly
-   * answer `false` for a direct `FabricInstance` subclass (which would let it
+   * return `false` for a direct `FabricInstance` subclass (which would let it
    * bypass its freeze protocol and be cached as deep-frozen while only
    * shallow-frozen), it throws, surfacing the broken subclass at the point of
    * use. The throw is intentional despite the predicate-style name.

--- a/packages/data-model/src/codec-common/ProblematicStateError.ts
+++ b/packages/data-model/src/codec-common/ProblematicStateError.ts
@@ -72,9 +72,21 @@ export class ProblematicStateError extends Error {
     state: any,
     thrown: unknown,
   ): ProblematicStateError {
+    const reportable = toReportableState(state);
+
+    if (
+      (thrown instanceof ProblematicStateError) &&
+      (thrown.wireTypeTag === wireTypeTag) && (thrown.state === reportable)
+    ) {
+      // Already an account of this same failure. Wrapping it would say
+      // nothing the original does not, at the cost of a `cause` chain a
+      // reader has to walk to reach the message that matters.
+      return thrown;
+    }
+
     return new ProblematicStateError(
       wireTypeTag,
-      state,
+      reportable,
       (thrown instanceof Error) ? thrown.message : toCompactDebugString(thrown),
       { cause: thrown },
     );

--- a/packages/data-model/src/codec-common/ProblematicStateError.ts
+++ b/packages/data-model/src/codec-common/ProblematicStateError.ts
@@ -58,7 +58,7 @@ export class ProblematicStateError extends Error {
   //
 
   /**
-   * Answers with an instance accounting for something a codec threw, which
+   * Returns an instance accounting for something a codec threw, which
    * JavaScript permits to be any value at all. An `Error` contributes its
    * message and is kept as `cause`, so nothing about it is lost to a caller
    * willing to look; anything else is rendered, there being no message to

--- a/packages/data-model/src/codec-common/ProblematicStateError.ts
+++ b/packages/data-model/src/codec-common/ProblematicStateError.ts
@@ -58,10 +58,14 @@ export class ProblematicStateError extends Error {
   //
 
   /**
-   * Builds an instance around something a codec threw, which JavaScript
-   * permits to be any value at all. An `Error` contributes its message and is
-   * kept as `cause`, so nothing about it is lost to a caller willing to look;
-   * anything else is rendered, there being no message to take.
+   * Answers with an instance accounting for something a codec threw, which
+   * JavaScript permits to be any value at all. An `Error` contributes its
+   * message and is kept as `cause`, so nothing about it is lost to a caller
+   * willing to look; anything else is rendered, there being no message to
+   * take.
+   *
+   * Where `thrown` is already an instance bearing this same tag and state, it
+   * is returned as it stands rather than wrapped.
    *
    * @param wireTypeTag - The tag the faulty data arrived under.
    * @param state - The state the codec was handed.

--- a/packages/data-model/test/codec-common/BaseCodecEngine.test.ts
+++ b/packages/data-model/test/codec-common/BaseCodecEngine.test.ts
@@ -226,6 +226,29 @@ describe("BaseCodecEngine", () => {
         expect(engine.decode(UNCLAIMED, CONTEXT)).toBeInstanceOf(UnknownValue);
       });
 
+      it("carries tag and state however the codec spelled the rejection", () => {
+        // Throwing and returning a `ProblematicValue` are the codec author's
+        // choice and say nothing about what a caller wants, so a strict
+        // failure must look the same either way. It did not: the returned
+        // form used to become a bare `Error`.
+        const { engine } = newProbeEngine();
+
+        for (
+          const [label, wire] of [["threw", THROWN], [
+            "returned",
+            RETURNED,
+          ]] as const
+        ) {
+          try {
+            engine.decode(wire, CONTEXT);
+            throw new Error(`Should have thrown (${label}).`);
+          } catch (e) {
+            expect(e).toBeInstanceOf(ProblematicStateError);
+            expect((e as ProblematicStateError).state).toBe("x");
+          }
+        }
+      });
+
       it("raises a `ProblematicStateError` carrying tag and state", () => {
         // The strict counterpart of the `ProblematicValue` the lenient side
         // returns: the same three facts, disposed of by throwing.

--- a/packages/data-model/test/codec-common/ProblematicStateError.test.ts
+++ b/packages/data-model/test/codec-common/ProblematicStateError.test.ts
@@ -54,6 +54,39 @@ describe("ProblematicStateError", () => {
       }
     });
 
+    it("returns the thrown one when it already says the same thing", () => {
+      // Re-wrapping would add a `cause` chain a reader has to walk to reach
+      // the message that matters, and say nothing the original does not.
+      const inner = new ProblematicStateError("T@1", { x: 1 }, "boom");
+      const state = inner.state;
+
+      expect(ProblematicStateError.fromThrown("T@1", state, inner))
+        .toBe(inner);
+    });
+
+    it("wraps when the tag differs", () => {
+      const inner = new ProblematicStateError("T@1", { x: 1 }, "boom");
+
+      const outer = ProblematicStateError.fromThrown(
+        "Other@1",
+        inner.state,
+        inner,
+      );
+
+      expect(outer).not.toBe(inner);
+      expect(outer.wireTypeTag).toBe("Other@1");
+      expect(outer.cause).toBe(inner);
+    });
+
+    it("wraps when the state differs", () => {
+      const inner = new ProblematicStateError("T@1", { x: 1 }, "boom");
+
+      const outer = ProblematicStateError.fromThrown("T@1", { x: 2 }, inner);
+
+      expect(outer).not.toBe(inner);
+      expect(outer.cause).toBe(inner);
+    });
+
     it("coerces the state as the constructor does", () => {
       const e = ProblematicStateError.fromThrown(
         "T@1",

--- a/packages/data-model/test/codec-common/probe-engine.ts
+++ b/packages/data-model/test/codec-common/probe-engine.ts
@@ -198,11 +198,11 @@ export class ThrowingCodec extends BaseTerminalCodec<ProbeValue> {
   }
 
   decode(
-    typeTag: string,
+    _typeTag: string,
     _state: ProbeValue,
     _context: ReconstructionContext,
   ): FabricValue {
-    throw new Error(`${typeTag}: rejected by throwing`);
+    throw new Error("rejected by throwing");
   }
 }
 

--- a/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
@@ -33,6 +33,7 @@ import {
 import { FabricInstance, type FabricValue } from "@/interface.ts";
 import { JSON_FORMAT, type JsonCodecValue } from "@/codec-json/interface.ts";
 import { UnknownValue } from "@/codec-common/UnknownValue.ts";
+import { ProblematicStateError } from "@/codec-common/ProblematicStateError.ts";
 import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
 import {
   BaseFabricInstance,
@@ -342,22 +343,42 @@ describe("JsonCodecEngine", () => {
       );
     });
 
-    it("throws a codec's rejection when not lenient, tag named", () => {
+    it("throws a codec's rejection when not lenient, tag borne", () => {
       // The same rejection, through a strict engine. `BigInt@1` reports by
       // RETURNING a `ProblematicValue` rather than throwing, and the engine
       // settles the two reporting styles into one answer.
       const jsonCodecEngine = newDefaultJsonCodecEngine();
 
       expect(jsonCodecEngine.lenient).toBe(false);
-      expect(() =>
+
+      try {
         jsonCodecEngine.decode(
           JsonCodecEngine.wrapEncodedValueForTesting(
             JSON.stringify({ "/BigInt@1": { "/Undefined@1": "bad" } }),
             true, // Undecodable on purpose; that is what this test is about.
           ),
           new TestReconstructionContext(),
-        )
-      ).toThrow(/`BigInt@1`: bigint: expected string state/);
+        );
+        throw new Error("Should have thrown.");
+      } catch (e) {
+        expect(e).toBeInstanceOf(ProblematicStateError);
+        expect((e as ProblematicStateError).wireTypeTag).toBe("BigInt@1");
+
+        // The tag rides on the error rather than being spliced into the
+        // message, so the codec's own words reach a caller unaltered. Taken
+        // from the lenient run rather than restated here, so that this
+        // compares the two dispositions of one rejection.
+        const lenient = newDefaultJsonCodecEngine({ lenient: true }).decode(
+          JsonCodecEngine.wrapEncodedValueForTesting(
+            JSON.stringify({ "/BigInt@1": { "/Undefined@1": "bad" } }),
+            true,
+          ),
+          new TestReconstructionContext(),
+        );
+
+        expect(lenient).toBeInstanceOf(ProblematicValue);
+        expect((e as Error).message).toBe((lenient as ProblematicValue).error);
+      }
     });
 
     it("hands a nonterminal codec state that has been expanded", () => {


### PR DESCRIPTION
Two follow-ups to #5770, one a live defect on `main` and one a shape
correction. I (agent working on behalf of @danfuzz) found the first while
converting the realm codecs on a downstream branch; @danfuzz spotted the
second.

## The strict path discarded the state, depending on how a codec spelled itself

`BaseCodecEngine` has **three** strict-mode exits. #5770 converted two.
`reportMalformed()` and the codec-throw catch both raise a
`ProblematicStateError` carrying the state; the branch that turns a codec's
*returned* `ProblematicValue` into a throw still raised a bare `Error`.

Measured on `main`, through the probe engine:

```
codec THREW     -> ProblematicStateError   state=x
codec RETURNED  -> Error                   state=undefined
```

So what a strict caller got depended on the codec author's choice of spelling —
which is precisely the distinction `lenient` exists to erase, and which #5770's
own rationale says should not be visible.

**Reachable on the ordinary JSON path**, no second wire format involved:
strict-decoding `{"/Hash@1": "not an object"}` lands here, because
`FabricHash`'s JSON codec reports by returning a `ProblematicValue` rather than
throwing. Same result — plain `Error`, no `state`.

**Why review missed it.** The existing case at that site,
`turns a ProblematicValue a codec returned into a throw`, asserts only
`.toThrow(/rejected by returning/)`. Nothing about the class or the state, so
converting the other two sites left it green. The new case drives both
spellings through one loop and asserts class and state on each, which is what
makes them comparable rather than merely both-throwing.

## `fromThrown()` re-wrapped an account of the same failure

Given a `ProblematicStateError` already bearing the tag and state it would
construct, it built a second one around it — saying nothing the original does
not, at the cost of a `cause` chain a reader has to walk to reach the message
that matters. It now returns the original.

**This is the helper being right rather than a bug being fixed**, and worth
saying plainly: nothing in this package can reach it today, since our codecs do
not re-enter the engine (`FabricError` calls a codec directly, not the walk).
The two wrapping cases — differing tag, differing state — are pinned alongside
the identity case, so the check cannot quietly become unconditional and start
swallowing genuinely different failures.

## Verification

Each fix is ablated independently and reddens only its own case: reverting the
third exit to `new Error(...)` fails the both-spellings case, and dropping the
identity check fails the no-rewrap case.

`data-model` green, plus `check`, `check-docs`, `lint` and `fmt --check`, each
by exit code.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

