### PR TITLE
fix(cli): the verb-session demo shows what it runs, and what fails

### DIFF
--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -46,9 +46,10 @@ an address answers it.
 only when a verb is called, which is what makes the verb surface the whole
 interface rather than a convenience laid over a writable document.
 
-**Five verbs, one per shape.** They are not five features. Each exists because
-a caller asks a different question about what comes back, and the tracker holds
-one of each so that no shape goes undemonstrated:
+**Six verbs, five shapes.** They are not six features. Each shape is a
+different question a caller asks about what comes back, and the tracker carries
+every one of them so that none goes undemonstrated. Only the first shape has two
+verbs, and they differ in nothing but what the new item is filed under:
 
 | Verb | The shape it exercises | Where |
 | --- | --- | --- |

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -440,8 +440,8 @@ position
 `--filter` runs before projection, so `status` decides membership and need not
 appear in the output. A marked collection costs one document read however many
 entries it holds, because the links are stored inline in the document being
-read — subject to the verbs plan's item 3, which is what makes a rejection below
-a link propagate up through the containers holding it.
+read, and a rejection below one of those links propagates up through the
+containers holding it rather than being read past.
 
 The same options work on a call's result, on a wish, and on a direct read: one
 read layer, several arrivals.

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -30,6 +30,43 @@ Section headers inside the help output below are the literal strings
 `renderPieceCallHelp` emits (`packages/cli/lib/exec-schema.ts`). Their contents
 are illustrative.
 
+## Why this pattern
+
+A fixture exists to be driven, and this one is shaped so that driving it is hard
+in the particular ways the verb surface has to be good at.
+
+**A tree with cross-links.** An item is filed under one item and can be waited
+on by any other, so the same item is reachable by two different paths. That is
+where an address stops being a convenience: handing a caller the item's contents
+twice says nothing about whether they are looking at one item or two, and only
+an address answers it.
+
+**State a caller cannot set.** `title` is the only field supplied at creation.
+`status`, `notes`, `children` and `blockedOn` belong to the pattern and change
+only when a verb is called, which is what makes the verb surface the whole
+interface rather than a convenience laid over a writable document.
+
+**Five verbs, one per shape.** They are not five features. Each exists because
+a caller asks a different question about what comes back, and the tracker holds
+one of each so that no shape goes undemonstrated:
+
+| Verb | The shape it exercises | Where |
+| --- | --- | --- |
+| `addItem`, `addChild` | returns a piece — an address the next command takes as its target, and a value that can be reached from inside itself | acts 4 and 8 |
+| `recordNote` | returns what only the pattern could compute: the clock is a handler capability, so the stamp cannot come from the caller | act 7 |
+| `finish` | returns a derived fact — `openBelow` takes a walk of the whole subtree, which a caller would pay N reads for | act 8 |
+| `archive` | declares no result: the invocation settles carrying no `result` at all, and what it changed is a separate read | act 9 |
+| `blockOn` | takes an address as an **argument** rather than as the receiver | act 10, **[blocked]** |
+
+Those act numbers are `packages/cli/integration/verb-session-demo.sh`, which
+drives the session and prints each command before running it — the transcript is
+what that script is for. Beside it,
+`packages/cli/integration/verb-session-gaps.sh` asserts the same surface as
+pass/fail, and several of its steps assert that something does *not* work yet,
+failing loudly the day it does. A verb added to the fixture wants a row above, an
+act in the demo, and a step in the harness; a shape demonstrated in none of the
+three is a claim this document is making alone.
+
 ## What you are driving
 
 Two patterns. A **board** holds root items; an **item** holds its own subtree,

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -19,10 +19,11 @@
 # Both are deliberately visible — a demo that quietly omits what does not work
 # teaches a surface that does not exist.
 #
-# One constraint on anyone editing this file: while #5633 is open, no two reads
-# may share a (source cell, schema) pair — the second one silently drops every
-# projected field. Act 6 is that failure, on purpose. Every other read here uses
-# a pair no other read uses, which is the only reason they pass.
+# One constraint on anyone editing this file: while #5633 is open — its fix is
+# in review as #5764 — no two reads may share a (source cell, schema) pair; the
+# second one silently drops every projected field. Act 6 is that failure, on
+# purpose. Every other read here uses a pair no other read uses, which is the
+# only reason they pass.
 #
 #   API_URL=http://localhost:8000 packages/cli/integration/verb-session-demo.sh
 set -uo pipefail
@@ -137,7 +138,7 @@ run cf piece get -s "$SPACE" --piece "$EPIC" children --select @,title
 
 act "6 · Ask the same question twice — BROKEN"
 say "The first thing anyone watching says is 'show me that again'."
-broken "a second read of one (source, schema) pair drops every projected field (#5633)" \
+broken "a second read of one (source, schema) pair drops every projected field (#5633, fixed by #5764 in review)" \
   cf piece get -s "$SPACE" --piece "$EPIC" children --select @,title
 say "The addresses survive; the titles do not. The read reports success while"
 say "returning less than it did a moment ago, which is the part worth knowing."
@@ -183,6 +184,6 @@ say "call handed back — which is the composition the verb surface exists for,"
 say "and the reason those lines are as long as they are."
 say ""
 say "Acts 9 and 10 are the graph half, and they are sequenced as verbs plan"
-say "item 11. Act 6 is a defect, with #5633 open against it."
+say "item 11. Act 6 is a defect: #5633, with a fix in review as #5764."
 say "verb-session-gaps.sh asserts all three, and fails the day any one of them"
 say "changes — so this demo cannot quietly go stale."

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -18,7 +18,7 @@
 #
 # Two acts are marked PENDING. They print the command and the result they will
 # produce, without running it, because the capability is sequenced and not yet
-# built (verbs plan item 11 — docs/plans/references-as-arguments.md). One is
+# built (docs/plans/references-as-arguments.md). One is
 # marked BROKEN: it runs, it fails, and its error is printed as it arrives.
 # Both are deliberately visible — a demo that quietly omits what does not work
 # teaches a surface that does not exist.
@@ -213,7 +213,7 @@ run cf piece get -s "$SPACE" --piece "$KID" status
 act "10 · Relate two items — PENDING"
 say "The tracker is a graph, not just a tree: an item can wait on any other."
 pending "cf piece call -s $SPACE --piece <cookies> blockOn -- --on <csrf-address>" \
-  "an address cannot yet be a verb argument (verbs plan item 11)" \
+  "an address cannot yet be a verb argument (references-as-arguments.md)" \
   '{
   "status": "settled",
   "result": {
@@ -238,8 +238,8 @@ say "One name was typed: 'board'. Everything under it was addressed by the id a"
 say "call handed back — which is the composition the verb surface exists for,"
 say "and the reason those lines are as long as they are."
 say ""
-say "Acts 10 and 11 are the graph half, and they are sequenced as verbs plan"
-say "item 11. Act 6 is a defect: #5633, with a fix in review as #5764."
+say "Acts 10 and 11 are the graph half, sequenced as references-as-arguments."
+say "Act 6 is a defect: #5633, with a fix in review as #5764."
 say "verb-session-gaps.sh asserts all three, and fails the day any one of them"
 say "changes — so this demo cannot quietly go stale."
 

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -18,16 +18,14 @@
 #
 # Two acts are marked PENDING. They print the command and the result they will
 # produce, without running it, because the capability is sequenced and not yet
-# built (docs/plans/references-as-arguments.md). One is
-# marked BROKEN: it runs, it fails, and its error is printed as it arrives.
-# Both are deliberately visible — a demo that quietly omits what does not work
-# teaches a surface that does not exist.
+# built (docs/plans/references-as-arguments.md). They are deliberately visible —
+# a demo that quietly omits what does not work teaches a surface that does not
+# exist.
 #
-# One constraint on anyone editing this file: while #5633 is open — its fix is
-# in review as #5764 — no two reads may share a (source cell, schema) pair; the
-# second one silently drops every projected field. Act 6 is that failure, on
-# purpose. Every other read here uses a pair no other read uses, which is the
-# only reason they pass.
+# No act is marked BROKEN today. `broken` stays for the next one that is: it
+# checks that the defect an act claims still answers to its own signature, so
+# an act cannot go on asserting a defect that has been fixed. Deriving that
+# again from scratch is how it acquires the same hole twice.
 #
 #   API_URL=http://localhost:8000 packages/cli/integration/verb-session-demo.sh
 set -uo pipefail
@@ -183,13 +181,11 @@ act "5 · Read addresses instead of contents"
 say "An unshaped read follows every link. A bare @ stops at the address."
 run cf piece get -s "$SPACE" --piece "$EPIC" children --select @,title
 
-act "6 · Ask the same question twice — BROKEN"
+act "6 · Ask the same question twice"
 say "The first thing anyone watching says is 'show me that again'."
-broken "a second read of one (source, schema) pair drops every projected field (#5633, fixed by #5764 in review)" \
-  '[.[]? | .title] | length > 0 and all(. == null)' \
-  cf piece get -s "$SPACE" --piece "$EPIC" children --select @,title
-say "The addresses survive; the titles do not. The read reports success while"
-say "returning less than it did a moment ago, which is the part worth knowing."
+run cf piece get -s "$SPACE" --piece "$EPIC" children --select @,title
+say "The same answer. A projection is a question you may ask twice, which is"
+say "what makes any of the reads above safe to put in a script."
 
 act "7 · A verb returns what only the pattern could compute"
 say "The note's timestamp is the pattern's; the caller never supplied one."
@@ -239,9 +235,8 @@ say "call handed back — which is the composition the verb surface exists for,"
 say "and the reason those lines are as long as they are."
 say ""
 say "Acts 10 and 11 are the graph half, sequenced as references-as-arguments."
-say "Act 6 is a defect: #5633, with a fix in review as #5764."
-say "verb-session-gaps.sh asserts all three, and fails the day any one of them"
-say "changes — so this demo cannot quietly go stale."
+say "verb-session-gaps.sh asserts both, and fails the day either one starts"
+say "working — so this demo cannot quietly go stale."
 
 if [ "$UNEXPECTED" != "0" ]; then
   printf '\n%s━━ %d act(s) failed that this demo says work%s\n' \

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -12,6 +12,15 @@
 # deliberately visible: a demo that quietly omits what does not work teaches a
 # surface that does not exist.
 #
+# Two more are marked BROKEN, for the same reason: they are commands a person
+# driving this at a prompt runs and watches fail. Their errors are printed as
+# they arrive rather than hidden behind a redirect.
+#
+# One constraint on anyone editing this file: while #5633 is open, no two reads
+# may share a (source cell, schema) pair — the second one silently returns null
+# for every projected field. Act 6 is that failure, on purpose. Every other read
+# here uses a pair no other read uses, which is the only reason they pass.
+#
 #   API_URL=http://localhost:8000 packages/cli/integration/verb-session-demo.sh
 set -uo pipefail
 
@@ -34,6 +43,12 @@ pending() {
   printf '\n%s   $ %s%s\n' "$Y" "$1" "$N"
   printf '%s     PENDING — %s%s\n' "$Y" "$2" "$N"
   printf '%s     will print:%s\n' "$D" "$N"
+  printf '%s\n' "$3" | sed 's/^/       /'
+}
+# Show a command that runs today and fails, with the error it really printed.
+broken() {
+  printf '\n%s   $ %s%s\n' "$Y" "$1" "$N"
+  printf '%s     BROKEN — %s%s\n' "$Y" "$2" "$N"
   printf '%s\n' "$3" | sed 's/^/       /'
 }
 
@@ -75,33 +90,55 @@ EPIC=$(echo "$R" | jq -r '.links["/item"].id' | sed 's/^of://')
 printf '\n%s   $ cf piece call --piece board addItem --show-links -- --title "Login rewrite"%s\n' "$C" "$N"
 echo "$R" | jq -c '{status, result: {item: {"$NAME": .result.item["$NAME"]}}}' | sed 's/^/     /'
 printf '     %saddress: %s%s\n' "$D" "$EPIC" "$N"
+CHILD_ERR=""
 for t in "Session cookies" "CSRF tokens"; do
-  $CF piece call --quiet --piece "$EPIC" $ARGS addChild "{\"title\":\"$t\"}" >/dev/null 2>&1
+  OUT=$($CF piece call --quiet --piece "$EPIC" $ARGS \
+    addChild "{\"title\":\"$t\"}" 2>&1)
+  if [ -z "$CHILD_ERR" ]; then
+    CHILD_ERR=$(printf '%s\n' "$OUT" | grep -v '^invocation:' | grep -v '^session:')
+  fi
 done
-printf '\n%s   $ cf piece call --piece <that address> addChild -- --title "Session cookies"%s\n' "$C" "$N"
-printf '     %s(and one more)%s\n' "$D" "$N"
+broken 'cf piece call --piece <that address> addChild -- --title "Session cookies"' \
+  "the item it hands back points at its parent, and rendering a cycle fails (#5577)" \
+  "$CHILD_ERR"
+say "The write landed regardless — the failure is the readback, not the mutation."
+LANDED=$($CF piece get --quiet --piece "$EPIC" $ARGS children 2>/dev/null |
+  jq -r 'length')
+printf '\n%s   $ cf piece get --piece <epic> children | jq length%s\n' "$C" "$N"
+printf '     %s\n' "$LANDED"
 
 act "5 · Read addresses instead of contents"
 say "An unshaped read follows every link. A \$link marker stops at the address."
+SHAPED='{"type":"array","items":{"$link":true,"type":"object","properties":{"title":true}}}'
 run "cf piece get --piece <epic> children --schema '{...\"\$link\":true...}'" \
-  $CF piece get --quiet --piece "$EPIC" children $ARGS \
-  --schema '{"type":"array","items":{"$link":true,"type":"object","properties":{"title":true}}}'
+  $CF piece get --quiet --piece "$EPIC" children $ARGS --schema "$SHAPED"
 
-act "6 · A verb returns what only the pattern could compute"
+act "6 · Ask the same question twice — BROKEN"
+say "The first thing anyone watching says is 'show me that again'."
+AGAIN=$($CF piece get --quiet --piece "$EPIC" children $ARGS --schema "$SHAPED" 2>&1)
+broken "cf piece get --piece <epic> children --schema '{...}'   (the same command again)" \
+  "a second read of one (source, schema) pair drops every projected field (#5633)" \
+  "$AGAIN"
+say "The addresses survive; the titles do not. The read reports success while"
+say "returning less than it did a moment ago, which is the part worth knowing."
+
+act "7 · A verb returns what only the pattern could compute"
 say "The note's timestamp is the pattern's; the caller never supplied one."
 run "cf piece call --piece <epic> recordNote -- --body 'blocked on the cookie spec'" \
   $CF piece call --quiet --piece "$EPIC" $ARGS \
   recordNote '{"body":"blocked on the cookie spec"}'
 
-act "7 · Finishing reports what the caller could not know"
+act "8 · Finishing reports what the caller could not know"
 say "openBelow walks the whole subtree — a caller would need N reads to learn it."
+say "A grandchild is filed first, by the same addChild that failed its readback"
+say "in act 4 and wrote anyway."
 KID=$($CF piece get --quiet --piece "$EPIC" children $ARGS \
   --schema '{"type":"array","items":{"$link":true}}' 2>/dev/null | jq -r '.[0]["$link"].id' | sed 's/^of://')
 $CF piece call --quiet --piece "$KID" $ARGS addChild '{"title":"Rotate signing key"}' >/dev/null 2>&1
 run "cf piece call --piece <epic> finish -- --body 'shipping behind a flag'" \
   $CF piece call --quiet --piece "$EPIC" $ARGS finish '{"body":"shipping behind a flag"}'
 
-act "8 · Relate two items — PENDING"
+act "9 · Relate two items — PENDING"
 say "The tracker is a graph, not just a tree: an item can wait on any other."
 pending "cf piece call --piece <cookies> blockOn -- --on <csrf-address>" \
   "an address cannot yet be a verb argument (verbs plan item 11)" \
@@ -114,17 +151,18 @@ pending "cf piece call --piece <cookies> blockOn -- --on <csrf-address>" \
   }
 }'
 
-act "9 · One item, two paths, one address — PENDING"
+act "10 · One item, two paths, one address — PENDING"
 say "This is what addresses are for: the same item under a parent AND as a blocker,"
 say "and a caller can tell it is one item rather than two copies."
 pending "cf piece get --piece board items --select 'title,children@,blockedOn@'" \
-  "needs the edge from act 8" \
+  "needs the edge from act 9" \
   'the same of:fid1:… appears under one item'"'"'s children and another'"'"'s blockedOn'
 
 printf '\n%s━━ %s %s\n' "$B" "What just happened" "$N"
 say "No tool was written for this tracker. Every flag, type and listing above"
 say "was derived from the pattern's own TypeScript by cf."
 say ""
-say "Acts 8 and 9 are the graph half, and they are sequenced as verbs plan"
-say "item 11. verb-session-gaps.sh asserts they do NOT work, and fails the"
-say "day they do — so this demo cannot quietly go stale."
+say "Acts 9 and 10 are the graph half, and they are sequenced as verbs plan"
+say "item 11. Acts 4 and 6 are defects, with issues open against them: #5577"
+say "and #5633. verb-session-gaps.sh asserts each of the three, and fails the"
+say "day any one changes — so this demo cannot quietly go stale."

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -14,10 +14,10 @@
 #
 # Two acts are marked PENDING. They print the command and the result they will
 # produce, without running it, because the capability is sequenced and not yet
-# built (verbs plan item 11 — docs/plans/references-as-arguments.md). Three are
-# marked BROKEN: they run, they fail, and their errors are printed as they
-# arrive. Both are deliberately visible — a demo that quietly omits what does
-# not work teaches a surface that does not exist.
+# built (verbs plan item 11 — docs/plans/references-as-arguments.md). One is
+# marked BROKEN: it runs, it fails, and its error is printed as it arrives.
+# Both are deliberately visible — a demo that quietly omits what does not work
+# teaches a surface that does not exist.
 #
 # One constraint on anyone editing this file: while #5633 is open, no two reads
 # may share a (source cell, schema) pair — the second one silently drops every
@@ -124,12 +124,12 @@ run cf piece call -s "$SPACE" --piece board --select item@ addItem -- --title "L
 # from a second one: `run` leaves the output it displayed in $OUT.
 EPIC=$(printf '%s' "$OUT" | jq -r '.result.item."$link".id' | sed 's/^of://')
 say "That id is what --piece takes from here on."
-broken "the item it hands back points at its parent, and rendering a cycle fails (#5577)" \
-  cf piece call -s "$SPACE" --piece "$EPIC" addChild -- --title "Session cookies"
-broken "the same failure, and it is deterministic" \
-  cf piece call -s "$SPACE" --piece "$EPIC" addChild -- --title "CSRF tokens"
-say "Both writes landed regardless — the failure is the readback, not the mutation."
-run cf piece get -s "$SPACE" --piece "$EPIC" children --select title
+run cf piece call -s "$SPACE" --piece "$EPIC" addChild -- --title "Session cookies"
+say "The item it hands back can be reached from inside itself: its parent holds"
+say "it, and it holds its parent. The position where the author's own type"
+say "re-enters answers with an address, so the whole result is still one value."
+run cf piece call -s "$SPACE" --piece "$EPIC" --select item.title addChild -- --title "CSRF tokens"
+say "And a caller who names one field is given one field, circle or no circle."
 
 act "5 · Read addresses instead of contents"
 say "An unshaped read follows every link. A bare @ stops at the address."
@@ -148,11 +148,10 @@ run cf piece call -s "$SPACE" --piece "$EPIC" recordNote -- --body "blocked on t
 
 act "8 · Finishing reports what the caller could not know"
 say "openBelow walks the whole subtree — a caller would need N reads to learn it."
-say "A grandchild is filed first, by the same verb that failed its readback in act 4."
+say "A grandchild is filed first, so there is a subtree to walk."
 KID=$(cf piece get -s "$SPACE" --piece "$EPIC" children --select @ 2>/dev/null |
   jq -r '.[0]."$link".id' | sed 's/^of://')
-broken "as in act 4 (#5577)" \
-  cf piece call -s "$SPACE" --piece "$KID" addChild -- --title "Rotate signing key"
+run cf piece call -s "$SPACE" --piece "$KID" --select item.title addChild -- --title "Rotate signing key"
 run cf piece call -s "$SPACE" --piece "$EPIC" finish -- --body "shipping behind a flag"
 
 act "9 · Relate two items — PENDING"
@@ -184,6 +183,6 @@ say "call handed back — which is the composition the verb surface exists for,"
 say "and the reason those lines are as long as they are."
 say ""
 say "Acts 9 and 10 are the graph half, and they are sequenced as verbs plan"
-say "item 11. Acts 4, 6 and 8 show two defects with issues open against them,"
-say "#5577 and #5633. verb-session-gaps.sh asserts both, and fails the day"
-say "either changes — so this demo cannot quietly go stale."
+say "item 11. Act 6 is a defect, with #5633 open against it."
+say "verb-session-gaps.sh asserts all three, and fails the day any one of them"
+say "changes — so this demo cannot quietly go stale."

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -6,38 +6,91 @@
 # the transcript is the artifact. Its companion `verb-session-gaps.sh` asserts
 # the same surface as pass/fail and is what keeps this one honest.
 #
+# Every command in the transcript is one array of words, printed and then run.
+# There is no second, prettier spelling of it anywhere in this file: `run` and
+# `broken` display `"$@"` and execute `"$@"`, so a line that reads well and a
+# line that ran cannot drift apart. What a reader sees is what they can retype,
+# given the two environment variables the header names.
+#
 # Two acts are marked PENDING. They print the command and the result they will
 # produce, without running it, because the capability is sequenced and not yet
-# built (verbs plan item 11 — docs/plans/references-as-arguments.md). They are
-# deliberately visible: a demo that quietly omits what does not work teaches a
-# surface that does not exist.
-#
-# Two more are marked BROKEN, for the same reason: they are commands a person
-# driving this at a prompt runs and watches fail. Their errors are printed as
-# they arrive rather than hidden behind a redirect.
+# built (verbs plan item 11 — docs/plans/references-as-arguments.md). Three are
+# marked BROKEN: they run, they fail, and their errors are printed as they
+# arrive. Both are deliberately visible — a demo that quietly omits what does
+# not work teaches a surface that does not exist.
 #
 # One constraint on anyone editing this file: while #5633 is open, no two reads
-# may share a (source cell, schema) pair — the second one silently returns null
-# for every projected field. Act 6 is that failure, on purpose. Every other read
-# here uses a pair no other read uses, which is the only reason they pass.
+# may share a (source cell, schema) pair — the second one silently drops every
+# projected field. Act 6 is that failure, on purpose. Every other read here uses
+# a pair no other read uses, which is the only reason they pass.
 #
 #   API_URL=http://localhost:8000 packages/cli/integration/verb-session-demo.sh
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-API_URL="${API_URL:-http://localhost:8000}"
-FIXTURE="$SCRIPT_DIR/pattern/tracker.tsx"
+# Run from the repository root so the fixture path a reader sees is the one
+# they would type.
+cd "$REPO_ROOT" || exit 1
+FIXTURE=packages/cli/integration/pattern/tracker.tsx
 
-if [ -n "${CF_BINARY:-}" ]; then CF="$CF_BINARY"; else
-  CF="deno task --quiet --cwd $REPO_ROOT cf"
+# `cf` is this checkout's CLI as a shell function. That is what lets a command
+# be a plain array of words rather than a string assembled twice.
+if [ -n "${CF_BINARY:-}" ]; then
+  cf() { "$CF_BINARY" "$@"; }
+else
+  cf() { deno task --quiet --cwd "$REPO_ROOT" cf "$@"; }
 fi
+
+# The connection lives in the environment cf documents, so it stays off every
+# command line. The space cannot: cf has no environment variable for it, so
+# `-s` is on each command, exactly as a reader would have to type it.
+export CF_API_URL="${API_URL:-http://localhost:8000}"
+if [ -z "${CF_IDENTITY:-}" ]; then
+  CF_IDENTITY=$(mktemp)
+  cf id new >"$CF_IDENTITY" 2>/dev/null
+fi
+export CF_IDENTITY
+SPACE="${SPACE:-$(mktemp -u demoXXXXXXXX)}"
 
 B=$'\033[1m'; D=$'\033[2m'; C=$'\033[36m'; Y=$'\033[33m'; N=$'\033[0m'
 act() { printf '\n%s━━ %s %s\n' "$B" "$1" "$N"; }
 say() { printf '%s   %s%s\n' "$D" "$1" "$N"; }
-# Show the command, then run it. The transcript is the point.
-run() { printf '\n%s   $ %s%s\n' "$C" "$1" "$N"; shift; "$@" 2>/dev/null | sed 's/^/     /'; }
+
+# Render argv the way a person would have typed it, quoting only the words that
+# need it. Display only — the same array is what runs.
+shown() {
+  local line="" word
+  for word in "$@"; do
+    case $word in
+      *[[:space:]\'\"]*) line="$line '$word'" ;;
+      *) line="$line $word" ;;
+    esac
+  done
+  printf '%s' "${line# }"
+}
+
+# Print a command and run it. Its output is shown and also kept in $OUT, so an
+# act that needs an address takes it out of the run the reader just watched.
+# stderr is dropped: it carries cf's next-step hints, which are addressed to a
+# person at a prompt rather than to a transcript.
+run() {
+  printf '\n%s   $ %s%s\n' "$C" "$(shown "$@")" "$N"
+  OUT=$("$@" 2>/dev/null)
+  printf '%s\n' "$OUT" | sed 's/^/     /'
+}
+
+# Same, for a command that fails today: stderr is kept, because the error is
+# what the act exists to show. cf's two progress lines are dropped so it stands
+# alone.
+broken() {
+  local why=$1
+  shift
+  printf '\n%s   $ %s%s\n' "$Y" "$(shown "$@")" "$N"
+  printf '%s     BROKEN — %s%s\n' "$Y" "$why" "$N"
+  "$@" 2>&1 | grep -v '^invocation:\|^session:' | sed 's/^/       /'
+}
+
 # Show what a command will do once the capability it needs is built.
 pending() {
   printf '\n%s   $ %s%s\n' "$Y" "$1" "$N"
@@ -45,102 +98,66 @@ pending() {
   printf '%s     will print:%s\n' "$D" "$N"
   printf '%s\n' "$3" | sed 's/^/       /'
 }
-# Show a command that runs today and fails, with the error it really printed.
-broken() {
-  printf '\n%s   $ %s%s\n' "$Y" "$1" "$N"
-  printf '%s     BROKEN — %s%s\n' "$Y" "$2" "$N"
-  printf '%s\n' "$3" | sed 's/^/       /'
-}
-
-SPACE="${SPACE:-$(mktemp -u demoXXXXXXXX)}"
-if [ -z "${CF_IDENTITY:-}" ]; then
-  CF_IDENTITY=$(mktemp); $CF id new >"$CF_IDENTITY" 2>/dev/null
-fi
-ARGS="--api-url=$API_URL --identity=$CF_IDENTITY --space=$SPACE"
 
 printf '%s\n' "${B}A work tracker, driven entirely through cf${N}"
 say "space $SPACE · nothing here was written for this pattern"
+say "CF_API_URL=$CF_API_URL and CF_IDENTITY are exported; everything else you see"
+say "is the whole command."
 
 act "1 · Arrive by name"
-say "A slug is a name in the space. After this, no fid appears again."
-# --quiet makes the piece id stdout's only line; stderr is dropped and the
-# grep anchored so a compile warning carrying a fid1: token cannot be taken
-# for the deploy's id.
-BOARD=$($CF piece new --quiet "$FIXTURE" $ARGS 2>/dev/null |
-  grep -oE '^fid1:[A-Za-z0-9_-]+' | head -1)
-$CF piece set-slug board "$BOARD" $ARGS >/dev/null 2>&1
-printf '\n%s   $ cf piece new tracker.tsx --slug board%s\n' "$C" "$N"
-printf '     %s\n' "$BOARD"
+say "A slug is a name in the space: the board is 'board' from here on, and the"
+say "fid this command prints is never typed again."
+run cf piece new "$FIXTURE" -s "$SPACE" --slug board
 
 act "2 · Ask what it can do"
 say "The listing is derived from the deployed pattern, not from a manifest."
-run "cf piece verbs --piece board" $CF piece verbs --piece board $ARGS --quiet
+run cf piece verbs -s "$SPACE" --piece board
 
 act "3 · Ask what a verb wants"
-say "Flags, types and required-ness all come from the author's TypeScript."
-printf '\n%s   $ cf piece call --piece board addItem -- --help%s\n' "$C" "$N"
-$CF piece call --piece board $ARGS addItem -- --help 2>/dev/null |
-  sed -n '/^Flags after/,/^$/p' | sed 's/^/     /'
+say "Flags, types, required-ness and result all come from the author's TypeScript."
+run cf piece call -s "$SPACE" --piece board addItem -- --help
 
 act "4 · Create, and act on what you were handed"
 say "The create returns the piece it made. Its address is the next command's target."
-R=$($CF piece call --quiet --show-links --piece board $ARGS \
-  addItem '{"title":"Login rewrite"}' 2>/dev/null)
-EPIC=$(echo "$R" | jq -r '.links["/item"].id' | sed 's/^of://')
-printf '\n%s   $ cf piece call --piece board addItem --show-links -- --title "Login rewrite"%s\n' "$C" "$N"
-echo "$R" | jq -c '{status, result: {item: {"$NAME": .result.item["$NAME"]}}}' | sed 's/^/     /'
-printf '     %saddress: %s%s\n' "$D" "$EPIC" "$N"
-CHILD_ERR=""
-for t in "Session cookies" "CSRF tokens"; do
-  OUT=$($CF piece call --quiet --piece "$EPIC" $ARGS \
-    addChild "{\"title\":\"$t\"}" 2>&1)
-  if [ -z "$CHILD_ERR" ]; then
-    CHILD_ERR=$(printf '%s\n' "$OUT" | grep -v '^invocation:' | grep -v '^session:')
-  fi
-done
-broken 'cf piece call --piece <that address> addChild -- --title "Session cookies"' \
-  "the item it hands back points at its parent, and rendering a cycle fails (#5577)" \
-  "$CHILD_ERR"
-say "The write landed regardless — the failure is the readback, not the mutation."
-LANDED=$($CF piece get --quiet --piece "$EPIC" $ARGS children 2>/dev/null |
-  jq -r 'length')
-printf '\n%s   $ cf piece get --piece <epic> children | jq length%s\n' "$C" "$N"
-printf '     %s\n' "$LANDED"
+run cf piece call -s "$SPACE" --piece board --select item@ addItem -- --title "Login rewrite"
+# The address the reader can see in the output above. Taken from that run, not
+# from a second one: `run` leaves the output it displayed in $OUT.
+EPIC=$(printf '%s' "$OUT" | jq -r '.result.item."$link".id' | sed 's/^of://')
+say "That id is what --piece takes from here on."
+broken "the item it hands back points at its parent, and rendering a cycle fails (#5577)" \
+  cf piece call -s "$SPACE" --piece "$EPIC" addChild -- --title "Session cookies"
+broken "the same failure, and it is deterministic" \
+  cf piece call -s "$SPACE" --piece "$EPIC" addChild -- --title "CSRF tokens"
+say "Both writes landed regardless — the failure is the readback, not the mutation."
+run cf piece get -s "$SPACE" --piece "$EPIC" children --select title
 
 act "5 · Read addresses instead of contents"
-say "An unshaped read follows every link. A \$link marker stops at the address."
-SHAPED='{"type":"array","items":{"$link":true,"type":"object","properties":{"title":true}}}'
-run "cf piece get --piece <epic> children --schema '{...\"\$link\":true...}'" \
-  $CF piece get --quiet --piece "$EPIC" children $ARGS --schema "$SHAPED"
+say "An unshaped read follows every link. A bare @ stops at the address."
+run cf piece get -s "$SPACE" --piece "$EPIC" children --select @,title
 
 act "6 · Ask the same question twice — BROKEN"
 say "The first thing anyone watching says is 'show me that again'."
-AGAIN=$($CF piece get --quiet --piece "$EPIC" children $ARGS --schema "$SHAPED" 2>&1)
-broken "cf piece get --piece <epic> children --schema '{...}'   (the same command again)" \
-  "a second read of one (source, schema) pair drops every projected field (#5633)" \
-  "$AGAIN"
+broken "a second read of one (source, schema) pair drops every projected field (#5633)" \
+  cf piece get -s "$SPACE" --piece "$EPIC" children --select @,title
 say "The addresses survive; the titles do not. The read reports success while"
 say "returning less than it did a moment ago, which is the part worth knowing."
 
 act "7 · A verb returns what only the pattern could compute"
 say "The note's timestamp is the pattern's; the caller never supplied one."
-run "cf piece call --piece <epic> recordNote -- --body 'blocked on the cookie spec'" \
-  $CF piece call --quiet --piece "$EPIC" $ARGS \
-  recordNote '{"body":"blocked on the cookie spec"}'
+run cf piece call -s "$SPACE" --piece "$EPIC" recordNote -- --body "blocked on the cookie spec"
 
 act "8 · Finishing reports what the caller could not know"
 say "openBelow walks the whole subtree — a caller would need N reads to learn it."
-say "A grandchild is filed first, by the same addChild that failed its readback"
-say "in act 4 and wrote anyway."
-KID=$($CF piece get --quiet --piece "$EPIC" children $ARGS \
-  --schema '{"type":"array","items":{"$link":true}}' 2>/dev/null | jq -r '.[0]["$link"].id' | sed 's/^of://')
-$CF piece call --quiet --piece "$KID" $ARGS addChild '{"title":"Rotate signing key"}' >/dev/null 2>&1
-run "cf piece call --piece <epic> finish -- --body 'shipping behind a flag'" \
-  $CF piece call --quiet --piece "$EPIC" $ARGS finish '{"body":"shipping behind a flag"}'
+say "A grandchild is filed first, by the same verb that failed its readback in act 4."
+KID=$(cf piece get -s "$SPACE" --piece "$EPIC" children --select @ 2>/dev/null |
+  jq -r '.[0]."$link".id' | sed 's/^of://')
+broken "as in act 4 (#5577)" \
+  cf piece call -s "$SPACE" --piece "$KID" addChild -- --title "Rotate signing key"
+run cf piece call -s "$SPACE" --piece "$EPIC" finish -- --body "shipping behind a flag"
 
 act "9 · Relate two items — PENDING"
 say "The tracker is a graph, not just a tree: an item can wait on any other."
-pending "cf piece call --piece <cookies> blockOn -- --on <csrf-address>" \
+pending "cf piece call -s $SPACE --piece <cookies> blockOn -- --on <csrf-address>" \
   "an address cannot yet be a verb argument (verbs plan item 11)" \
   '{
   "status": "settled",
@@ -154,15 +171,19 @@ pending "cf piece call --piece <cookies> blockOn -- --on <csrf-address>" \
 act "10 · One item, two paths, one address — PENDING"
 say "This is what addresses are for: the same item under a parent AND as a blocker,"
 say "and a caller can tell it is one item rather than two copies."
-pending "cf piece get --piece board items --select 'title,children@,blockedOn@'" \
+pending "cf piece get -s $SPACE --piece board items --select title,children@,blockedOn@" \
   "needs the edge from act 9" \
   'the same of:fid1:… appears under one item'"'"'s children and another'"'"'s blockedOn'
 
 printf '\n%s━━ %s %s\n' "$B" "What just happened" "$N"
-say "No tool was written for this tracker. Every flag, type and listing above"
-say "was derived from the pattern's own TypeScript by cf."
+say "No tool was written for this tracker. Every flag, type, listing and result"
+say "field above was derived from the pattern's own TypeScript by cf."
+say ""
+say "One name was typed: 'board'. Everything under it was addressed by the id a"
+say "call handed back — which is the composition the verb surface exists for,"
+say "and the reason those lines are as long as they are."
 say ""
 say "Acts 9 and 10 are the graph half, and they are sequenced as verbs plan"
-say "item 11. Acts 4 and 6 are defects, with issues open against them: #5577"
-say "and #5633. verb-session-gaps.sh asserts each of the three, and fails the"
-say "day any one changes — so this demo cannot quietly go stale."
+say "item 11. Acts 4, 6 and 8 show two defects with issues open against them,"
+say "#5577 and #5633. verb-session-gaps.sh asserts both, and fails the day"
+say "either changes — so this demo cannot quietly go stale."

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -6,6 +6,10 @@
 # the transcript is the artifact. Its companion `verb-session-gaps.sh` asserts
 # the same surface as pass/fail and is what keeps this one honest.
 #
+# docs/common/verb-session-walkthrough.md is the prose half: why the fixture
+# declares the verbs it does, and which shape of the surface each act is here
+# to show. An act added here without a row there is an act nobody can place.
+#
 # Every command in the transcript is one array of words, printed and then run.
 # There is no second, prettier spelling of it anywhere in this file: `run` and
 # `broken` display `"$@"` and execute `"$@"`, so a line that reads well and a
@@ -199,7 +203,14 @@ KID=$(cf piece get -s "$SPACE" --piece "$EPIC" children --select @ 2>/dev/null |
 run cf piece call -s "$SPACE" --piece "$KID" --select item.title addChild -- --title "Rotate signing key"
 run cf piece call -s "$SPACE" --piece "$EPIC" finish -- --body "shipping behind a flag"
 
-act "9 · Relate two items — PENDING"
+act "9 · A verb that declares no result"
+say "archive is Stream<void>: there is nothing for it to hand back, and the"
+say "invocation says so by settling with no result at all."
+run cf piece call -s "$SPACE" --piece "$KID" archive
+say "What it changed is a read away, on the one field the caller never sets."
+run cf piece get -s "$SPACE" --piece "$KID" status
+
+act "10 · Relate two items — PENDING"
 say "The tracker is a graph, not just a tree: an item can wait on any other."
 pending "cf piece call -s $SPACE --piece <cookies> blockOn -- --on <csrf-address>" \
   "an address cannot yet be a verb argument (verbs plan item 11)" \
@@ -212,11 +223,11 @@ pending "cf piece call -s $SPACE --piece <cookies> blockOn -- --on <csrf-address
   }
 }'
 
-act "10 · One item, two paths, one address — PENDING"
+act "11 · One item, two paths, one address — PENDING"
 say "This is what addresses are for: the same item under a parent AND as a blocker,"
 say "and a caller can tell it is one item rather than two copies."
 pending "cf piece get -s $SPACE --piece board items --select title,children@,blockedOn@" \
-  "needs the edge from act 9" \
+  "needs the edge from act 10" \
   'the same of:fid1:… appears under one item'"'"'s children and another'"'"'s blockedOn'
 
 printf '\n%s━━ %s %s\n' "$B" "What just happened" "$N"
@@ -227,7 +238,7 @@ say "One name was typed: 'board'. Everything under it was addressed by the id a"
 say "call handed back — which is the composition the verb surface exists for,"
 say "and the reason those lines are as long as they are."
 say ""
-say "Acts 9 and 10 are the graph half, and they are sequenced as verbs plan"
+say "Acts 10 and 11 are the graph half, and they are sequenced as verbs plan"
 say "item 11. Act 6 is a defect: #5633, with a fix in review as #5764."
 say "verb-session-gaps.sh asserts all three, and fails the day any one of them"
 say "changes — so this demo cannot quietly go stale."

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -56,9 +56,17 @@ SPACE="${SPACE:-$(mktemp -u demoXXXXXXXX)}"
 
 B=$'\033[1m'; D=$'\033[2m'; C=$'\033[36m'; Y=$'\033[33m'; N=$'\033[0m'
 R=$'\033[31m'
-# An act that is not marked BROKEN claims the command works. Counted so a
-# transcript that hid one cannot exit 0 and read as a clean session.
+# Every act makes a claim: one not marked BROKEN says the command works, one
+# marked BROKEN says a named defect is still there. Both are counted, so a
+# transcript that got either wrong cannot exit 0 and read as a clean session.
 UNEXPECTED=0
+CLOSED=0
+# stderr is read back rather than shown as it arrives, so a failure can be
+# printed under the act it belongs to. mktemp rather than a name built from the
+# pid: this runs in a shared directory, and a predictable path is one an
+# unrelated process can have already made a symlink at.
+ERR=$(mktemp)
+trap 'rm -f "$ERR"' EXIT
 act() { printf '\n%s━━ %s %s\n' "$B" "$1" "$N"; }
 say() { printf '%s   %s%s\n' "$D" "$1" "$N"; }
 
@@ -77,35 +85,54 @@ shown() {
 
 # Print a command and run it. Its output is shown and also kept in $OUT, so an
 # act that needs an address takes it out of the run the reader just watched.
-# stderr is dropped: it carries cf's next-step hints, which are addressed to a
-# person at a prompt rather than to a transcript.
+# stderr is held back rather than dropped: on success it carries only cf's
+# next-step hints, which are addressed to a person at a prompt rather than to a
+# transcript, but a failure here is the demo being wrong about the surface —
+# the thing this script exists to stop — and has to be as visible as the
+# transcript it would otherwise sit inside quietly.
 run() {
   printf '\n%s   $ %s%s\n' "$C" "$(shown "$@")" "$N"
-  # stderr is kept, not dropped. An act that is not marked BROKEN is a claim
-  # that the command works, so a failure here is the demo being wrong about
-  # the surface — the thing this script exists to stop — and it has to be as
-  # visible as the transcript it would otherwise sit inside quietly.
-  OUT=$("$@" 2>/tmp/verb-session-run-err.$$)
+  OUT=$("$@" 2>"$ERR")
   local rc=$?
   printf '%s\n' "$OUT" | sed 's/^/     /'
   if [ "$rc" != "0" ]; then
     printf '%s     UNEXPECTED FAILURE (exit %s) — this act is not marked BROKEN%s\n' \
       "$R" "$rc" "$N"
-    sed 's/^/       /' /tmp/verb-session-run-err.$$
+    sed 's/^/       /' "$ERR"
     UNEXPECTED=$((UNEXPECTED + 1))
   fi
-  rm -f /tmp/verb-session-run-err.$$
 }
 
 # Same, for a command that fails today: stderr is kept, because the error is
 # what the act exists to show. cf's two progress lines are dropped so it stands
 # alone.
+#
+# The BROKEN claim is checked, against the defect's own signature rather than
+# against the exit status — #5633 answers 0 and hands back nulls, so a status
+# check would call this act healthy today. `$2` is a jq test over stdout that
+# holds only while the defect does, and it is the same discriminator
+# verb-session-gaps.sh matches on, so the two cannot disagree about whether the
+# gap is open. An act asserting a defect that has been fixed is wrong in the
+# same way as one hiding a defect that has not.
+#
+# A future act that breaks by failing outright wants its signature written
+# against the exit status, and wants the branch for that written then rather
+# than guessed at now.
 broken() {
-  local why=$1
-  shift
+  local why=$1 signature=$2
+  shift 2
   printf '\n%s   $ %s%s\n' "$Y" "$(shown "$@")" "$N"
   printf '%s     BROKEN — %s%s\n' "$Y" "$why" "$N"
-  "$@" 2>&1 | grep -v '^invocation:\|^session:' | sed 's/^/       /'
+  local out
+  out=$("$@" 2>"$ERR")
+  [ -n "$out" ] && printf '%s\n' "$out" | sed 's/^/       /'
+  grep -v '^invocation:\|^session:' "$ERR" | sed 's/^/       /'
+  if ! printf '%s' "$out" | jq -e "$signature" >/dev/null 2>&1; then
+    printf '%s     GAP CLOSED — the defect this act names no longer answers to%s\n' \
+      "$R" "$N"
+    printf '%s     its own signature%s\n' "$R" "$N"
+    CLOSED=$((CLOSED + 1))
+  fi
 }
 
 # Show what a command will do once the capability it needs is built.
@@ -155,6 +182,7 @@ run cf piece get -s "$SPACE" --piece "$EPIC" children --select @,title
 act "6 · Ask the same question twice — BROKEN"
 say "The first thing anyone watching says is 'show me that again'."
 broken "a second read of one (source, schema) pair drops every projected field (#5633, fixed by #5764 in review)" \
+  '[.[]? | .title] | length > 0 and all(. == null)' \
   cf piece get -s "$SPACE" --piece "$EPIC" children --select @,title
 say "The addresses survive; the titles do not. The read reports success while"
 say "returning less than it did a moment ago, which is the part worth knowing."
@@ -209,5 +237,14 @@ if [ "$UNEXPECTED" != "0" ]; then
     "$R" "$UNEXPECTED" "$N"
   say "Every act above that is not marked BROKEN is a claim about the surface."
   say "One of them did not hold, so this transcript does not describe cf."
-  exit 1
 fi
+
+if [ "$CLOSED" != "0" ]; then
+  printf '\n%s━━ %d act(s) marked BROKEN no longer match their signature%s\n' \
+    "$R" "$CLOSED" "$N"
+  say "Either the capability arrived, or the signature needs rewriting. Both"
+  say "want this demo and verb-session-gaps.sh changed together — they match on"
+  say "the same evidence so that neither can go stale alone."
+fi
+
+[ "$UNEXPECTED" = "0" ] && [ "$CLOSED" = "0" ]

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -46,7 +46,7 @@ fi
 # The connection lives in the environment cf documents, so it stays off every
 # command line. The space cannot: cf has no environment variable for it, so
 # `-s` is on each command, exactly as a reader would have to type it.
-export CF_API_URL="${API_URL:-http://localhost:8000}"
+export CF_API_URL="${CF_API_URL:-${API_URL:-http://localhost:8000}}"
 if [ -z "${CF_IDENTITY:-}" ]; then
   CF_IDENTITY=$(mktemp)
   cf id new >"$CF_IDENTITY" 2>/dev/null
@@ -55,6 +55,10 @@ export CF_IDENTITY
 SPACE="${SPACE:-$(mktemp -u demoXXXXXXXX)}"
 
 B=$'\033[1m'; D=$'\033[2m'; C=$'\033[36m'; Y=$'\033[33m'; N=$'\033[0m'
+R=$'\033[31m'
+# An act that is not marked BROKEN claims the command works. Counted so a
+# transcript that hid one cannot exit 0 and read as a clean session.
+UNEXPECTED=0
 act() { printf '\n%s━━ %s %s\n' "$B" "$1" "$N"; }
 say() { printf '%s   %s%s\n' "$D" "$1" "$N"; }
 
@@ -77,8 +81,20 @@ shown() {
 # person at a prompt rather than to a transcript.
 run() {
   printf '\n%s   $ %s%s\n' "$C" "$(shown "$@")" "$N"
-  OUT=$("$@" 2>/dev/null)
+  # stderr is kept, not dropped. An act that is not marked BROKEN is a claim
+  # that the command works, so a failure here is the demo being wrong about
+  # the surface — the thing this script exists to stop — and it has to be as
+  # visible as the transcript it would otherwise sit inside quietly.
+  OUT=$("$@" 2>/tmp/verb-session-run-err.$$)
+  local rc=$?
   printf '%s\n' "$OUT" | sed 's/^/     /'
+  if [ "$rc" != "0" ]; then
+    printf '%s     UNEXPECTED FAILURE (exit %s) — this act is not marked BROKEN%s\n' \
+      "$R" "$rc" "$N"
+    sed 's/^/       /' /tmp/verb-session-run-err.$$
+    UNEXPECTED=$((UNEXPECTED + 1))
+  fi
+  rm -f /tmp/verb-session-run-err.$$
 }
 
 # Same, for a command that fails today: stderr is kept, because the error is
@@ -187,3 +203,11 @@ say "Acts 9 and 10 are the graph half, and they are sequenced as verbs plan"
 say "item 11. Act 6 is a defect: #5633, with a fix in review as #5764."
 say "verb-session-gaps.sh asserts all three, and fails the day any one of them"
 say "changes — so this demo cannot quietly go stale."
+
+if [ "$UNEXPECTED" != "0" ]; then
+  printf '\n%s━━ %d act(s) failed that this demo says work%s\n' \
+    "$R" "$UNEXPECTED" "$N"
+  say "Every act above that is not marked BROKEN is a claim about the surface."
+  say "One of them did not hold, so this transcript does not describe cf."
+  exit 1
+fi

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -3,7 +3,7 @@
 # not work yet. Its companion `verb-session-demo.sh` shows the session as it is
 # meant to read; this one is the thing that keeps that honest.
 #
-# Three steps assert a GAP rather than a capability. Each fails loudly the day
+# Four steps assert a GAP rather than a capability. Each fails loudly the day
 # the gap closes, so this script is how we find out that a capability arrived
 # rather than discovering it months later in a stale document.
 #
@@ -76,6 +76,11 @@ VERBS=$($CF piece verbs --piece board $ARGS --json 2>/dev/null)
 echo "$VERBS" | jq -r '.verbs[]? | "    " + .name + "  (" + .kind + ")"' 2>/dev/null
 echo "$VERBS" | jq -e '[.verbs[]?.name] | index("addItem")' >/dev/null 2>&1 &&
   ok "addItem is listed" || bad "addItem missing from the listing"
+# The other half of a discovery surface, and the half that has no natural
+# witness: what it does NOT name. The board's `items` and `$NAME` are data, and
+# a listing that offers them hands a client operations that do not exist.
+check "addItem" "$(echo "$VERBS" | jq -r '[.verbs[]?.name] | sort | join(",")')" \
+  "the listing names the verb and nothing else"
 
 step "3. Ask what a verb wants — flags and prose, both derived"
 HELP=$($CF piece call --piece board $ARGS addItem -- --help 2>/dev/null)
@@ -128,6 +133,16 @@ ADDR=$($CF piece get --quiet --piece "$EPIC" children $ARGS \
 check "true" "$(echo "$ADDR" | jq -c '[.[] | has("$link") and (.title|length>0)] | all')" \
   "a marker beside a projection returns the address AND the fields"
 KID=$(echo "$ADDR" | jq -r '.[] | select(.title=="Session cookies") | .["$link"].id')
+# GAP: the very same read, run a second time. A (source cell, schema) pair
+# serves exactly once — the second read reports success and returns null for
+# every projected field, while the addresses survive (#5633). The check above
+# is what makes this comparison mean anything: were the first read already
+# empty, the two would agree and this would misreport the gap as closed.
+AGAIN=$($CF piece get --quiet --piece "$EPIC" children $ARGS \
+  --schema '{"type":"array","items":{"$link":true,"type":"object","properties":{"title":true}}}' \
+  2>/dev/null)
+[ "$ADDR" = "$AGAIN" ]
+gap "$?" "a second read of one (source, schema) pair returning what the first did"
 
 step "6. Two mechanisms name the piece, and they do not agree"
 # MEASURED, and not what you would guess: the address a call hands back

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -229,8 +229,9 @@ check "{}" "$(echo "$V" | jq -c '.result // {}')" "its result is the empty witne
 step "10. GAP: an address cannot be a verb argument"
 # blockOn declares `on: Writable<ItemOutput>` — a reference. `send()` already
 # resolves a native sigil (measured), so the pre-dispatch gate is the only
-# thing refusing this. Verbs plan item 11 closes it; see
-# docs/plans/references-as-arguments.md.
+# thing refusing this. docs/plans/references-as-arguments.md closes it — that
+# work carries no step number in the verbs plan, which numbers only the read
+# and result layers.
 OTHER=$($CF piece get --quiet --piece board items $ARGS \
   --schema '{"type":"array","items":{"$link":true}}' 2>/dev/null |
   jq -r '.[0]["$link"].id // empty')

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -3,9 +3,11 @@
 # not work yet. Its companion `verb-session-demo.sh` shows the session as it is
 # meant to read; this one is the thing that keeps that honest.
 #
-# Four steps assert a GAP rather than a capability. Each fails loudly the day
+# Some steps assert a GAP rather than a capability. Each fails loudly the day
 # the gap closes, so this script is how we find out that a capability arrived
-# rather than discovering it months later in a stale document.
+# rather than discovering it months later in a stale document. How many are
+# open is tallied as they run and printed on the last line, so no prose here
+# can fall out of step with the assertions below.
 #
 # Documented in docs/common/verb-session-walkthrough.md.
 #
@@ -30,6 +32,7 @@ fi
 
 PASS=0
 FAIL=0
+GAPS=0
 step() { printf '\n== %s\n' "$1"; }
 ok() { printf '  PASS %s\n' "$1"; PASS=$((PASS + 1)); }
 bad() { printf '  FAIL %s\n' "$1"; FAIL=$((FAIL + 1)); }
@@ -43,6 +46,7 @@ gap() {
     bad "GAP CLOSED — $2 now works; update this script and the walkthrough"
   else
     ok "gap still open: $2"
+    GAPS=$((GAPS + 1))
   fi
 }
 
@@ -135,20 +139,42 @@ check "true" "$(echo "$ADDR" | jq -c '[.[] | has("$link") and (.title|length>0)]
 KID=$(echo "$ADDR" | jq -r '.[] | select(.title=="Session cookies") | .["$link"].id')
 # GAP: the very same read, run a second time. A (source cell, schema) pair
 # serves exactly once — the second read reports success and returns null for
-# every projected field, while the addresses survive (#5633). The check above
-# is what makes this comparison mean anything: were the first read already
-# empty, the two would agree and this would misreport the gap as closed.
+# every projected field, while the addresses survive (#5633; the fix is in
+# review as #5764, so this is the assertion that will announce it landing).
+# The check above is what makes this comparison mean anything: were the first
+# read already empty, the two would agree and this would misreport the gap as
+# closed. Matched against that SPECIFIC shape rather than against "differs at
+# all": a server hiccup or a renamed field also differs, and a probe that reads
+# any difference as "gap still open" is a probe that cannot fail.
 AGAIN=$($CF piece get --quiet --piece "$EPIC" children $ARGS \
   --schema '{"type":"array","items":{"$link":true,"type":"object","properties":{"title":true}}}' \
   2>/dev/null)
-[ "$ADDR" = "$AGAIN" ]
-gap "$?" "a second read of one (source, schema) pair returning what the first did"
+SECOND_READ="a second read of one (source, schema) pair returning what the first did"
+ADDR_IDS=$(echo "$ADDR" | jq -c '[.[]? | .["$link"].id]' 2>/dev/null)
+AGAIN_IDS=$(echo "$AGAIN" | jq -c '[.[]? | .["$link"].id]' 2>/dev/null)
+AGAIN_DROPPED=$(echo "$AGAIN" |
+  jq -c '[.[]? | .title] | length > 0 and all(. == null)' 2>/dev/null)
+if [ "$ADDR" = "$AGAIN" ]; then
+  gap 0 "$SECOND_READ"
+elif [ "$AGAIN_IDS" = "$ADDR_IDS" ] && [ "$AGAIN_DROPPED" = "true" ]; then
+  gap 1 "$SECOND_READ (it keeps the addresses and drops every field)"
+else
+  bad "the second read differed in a way that is not the known drop: $AGAIN"
+fi
 
-step "6. Two mechanisms name the piece, and they do not agree"
+step "6. Two routes hand back an address, and either one addresses the piece"
 # MEASURED, and not what you would guess: the address a call hands back
 # (--show-links) and the address a read projects ($link) are DIFFERENT entity
-# ids for the same piece. Both resolve — each reads back the same title — so
-# either is usable, but a caller cannot compare them for equality.
+# ids for the same piece — one resolves the link chain, the other renders the
+# link as stored. That is the read model working rather than a defect: an
+# address is many-to-one over cells, so a holder of one cannot tell a canonical
+# id from an alias and is never asked to. The property is stated in
+# docs/plans/shaped-reads-and-verb-results.md; #5632 asks whether the two ids
+# should agree and item 11 of docs/plans/verbs-implementation.md rules that
+# they are aliases. So their difference is asserted nowhere here: no day exists
+# on which it "closes", and a gap that can never fire is a gap that reports
+# nothing. What a caller does depend on is asserted instead — either address,
+# fed back to --piece, reads the same piece.
 MADE=$($CF piece call --quiet --show-links --piece board $ARGS \
   addItem '{"title":"Rate limiting"}' 2>/dev/null |
   jq -r '.links["/item"].id // empty' | sed 's/^of://')
@@ -164,11 +190,6 @@ else
   R_T=$($CF piece get --quiet --piece "$VIA_READ" title $ARGS 2>/dev/null | tr -d '"')
   check "Rate limiting" "$M_T" "the address the call returned addresses the piece"
   check "Rate limiting" "$R_T" "the address the read returned addresses the piece too"
-  if [ "$MADE" = "$VIA_READ" ]; then
-    bad "GAP CLOSED — the two routes now agree; simplify this step"
-  else
-    ok "gap still open: the two routes give different ids for one piece"
-  fi
 fi
 
 step "7. A verb returns what only the pattern could compute"
@@ -250,5 +271,6 @@ AFTER=$($CF piece get --quiet --piece "$EPIC" children $ARGS --step 2>/dev/null 
 check "$((BEFORE + 1))" "$AFTER" "the write the result describes landed"
 
 ELAPSED=$(($(date +%s) - START))
-printf '\n== %d passed, %d failed — %ds wall clock\n' "$PASS" "$FAIL" "$ELAPSED"
+printf '\n== %d passed, %d failed, %d gaps open — %ds wall clock\n' \
+  "$PASS" "$FAIL" "$GAPS" "$ELAPSED"
 [ "$FAIL" -eq 0 ]

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -137,30 +137,17 @@ ADDR=$($CF piece get --quiet --piece "$EPIC" children $ARGS \
 check "true" "$(echo "$ADDR" | jq -c '[.[] | has("$link") and (.title|length>0)] | all')" \
   "a marker beside a projection returns the address AND the fields"
 KID=$(echo "$ADDR" | jq -r '.[] | select(.title=="Session cookies") | .["$link"].id')
-# GAP: the very same read, run a second time. A (source cell, schema) pair
-# serves exactly once — the second read reports success and returns null for
-# every projected field, while the addresses survive (#5633; the fix is in
-# review as #5764, so this is the assertion that will announce it landing).
-# The check above is what makes this comparison mean anything: were the first
-# read already empty, the two would agree and this would misreport the gap as
-# closed. Matched against that SPECIFIC shape rather than against "differs at
-# all": a server hiccup or a renamed field also differs, and a probe that reads
-# any difference as "gap still open" is a probe that cannot fail.
+# The very same read, run a second time. A (source cell, schema) pair is
+# reusable: it answers with what it answered before, which is what a caller
+# reaching for one projection twice depends on. Asserted by equality against
+# the first read rather than against a shape, because the property is that
+# nothing about the answer moved. The check above is what gives it force —
+# were the first read already empty, two empty reads would agree and this
+# would pass saying nothing.
 AGAIN=$($CF piece get --quiet --piece "$EPIC" children $ARGS \
   --schema '{"type":"array","items":{"$link":true,"type":"object","properties":{"title":true}}}' \
   2>/dev/null)
-SECOND_READ="a second read of one (source, schema) pair returning what the first did"
-ADDR_IDS=$(echo "$ADDR" | jq -c '[.[]? | .["$link"].id]' 2>/dev/null)
-AGAIN_IDS=$(echo "$AGAIN" | jq -c '[.[]? | .["$link"].id]' 2>/dev/null)
-AGAIN_DROPPED=$(echo "$AGAIN" |
-  jq -c '[.[]? | .title] | length > 0 and all(. == null)' 2>/dev/null)
-if [ "$ADDR" = "$AGAIN" ]; then
-  gap 0 "$SECOND_READ"
-elif [ "$AGAIN_IDS" = "$ADDR_IDS" ] && [ "$AGAIN_DROPPED" = "true" ]; then
-  gap 1 "$SECOND_READ (it keeps the addresses and drops every field)"
-else
-  bad "the second read differed in a way that is not the known drop: $AGAIN"
-fi
+check "$ADDR" "$AGAIN" "the same read, run again, answers the same"
 
 step "6. Two routes hand back an address, and either one addresses the piece"
 # MEASURED, and not what you would guess: the address a call hands back


### PR DESCRIPTION
## Why

The verb-session demo is meant to be driven in front of people, so its
transcript is the artifact. Two things in it were not true.

**It hid the commands that fail.** `addChild` exited 1 and printed a
circular-structure error every time it was called, and the demo called it three
times behind `>/dev/null 2>&1`. A person driving this at a prompt saw the error;
the audience did not. The script's own header says a demo that quietly omits
what does not work teaches a surface that does not exist.

**It printed commands it did not run.** Each act hand-wrote a tidy command line
and then executed a different one: `--quiet` plus three connection flags the
printed line omitted, a JSON payload where the printed line showed `-- --title`,
`<epic>` where the real call passed a fid, and a `jq` filter applied to output
shown as if it were the command's own. The two spellings agreed in meaning,
which is exactly the property no reader can check by looking.

Fixing the second exposed a claim the first was propping up. Act 1 said "after
this, no fid appears again" — true of the prettified transcript, false of the
session, which carries a fid from the create into every later command.

Underneath both sat a third problem, and it is the one worth keeping: **an
assertion in these scripts could pass without being able to fail.** `run`
discarded its exit status, so an act that broke printed a blank line and the
session ended clean. `broken` checked nothing, so an act would go on asserting a
defect after it was fixed. The second-read probe read any difference as "gap
still open", so a server hiccup kept it green. Three instances of one shape,
alongside the one #5793 removed from step 10 — which is why the fixes here are
described as a shape rather than as four bugs.

## What Changed

`verb-session-demo.sh`

- `run` and `broken` take argv, display `"$@"` and execute `"$@"`. No second
  spelling to keep in sync, and no `eval`.
- The connection moves to `CF_API_URL` and `CF_IDENTITY`, which cf documents as
  environment. `-s <space>` stays on every line because cf has no environment
  variable for it.
- `run` fails the session when an act it says works does not: failures print
  with their stderr, are counted, and end the run nonzero.
- `broken` checks that the defect an act claims still answers to its own
  signature, given as the jq test the harness matches on. Exit status cannot
  decide it — the defect it was written for answered 0 and returned nulls.
- Act 4 is the payoff act: a create hands back an address, `addChild` on that
  address returns the item with `parent` rendered as a `$link`, and a following
  call with `--select item.title` shows a caller who names one field gets one.
- Act 6 asks the same question twice and gets the same answer. Act 9 calls
  `archive` — `Stream<void>`, the one verb shape the demo never showed — and
  reads `status` to prove it did something.

`verb-session-gaps.sh`

- The listing step asserts the listing names `addItem` **and nothing else**.
  Its absence is why #5683 closing #5576 went unnoticed.
- The repeat read is asserted as a capability by equality against the first
  read.

`docs/common/verb-session-walkthrough.md`

- `## Why this pattern`: the two properties the fixture was chosen for, then the
  five verbs as five shapes of what a verb hands back, each with the act that
  demonstrates it. `archive` was missing from the demo and invisible as an
  absence; in that table it was a blank cell.
- Cross-references that were missing in three of four directions.
- Five plan citations corrected: four sent a reader to verbs plan item 11 for
  address-as-argument, which is item 11's neighbour rather than item 11, and one
  attributed rejection-propagation to the wrong plan's item 3 while describing a
  shipped behaviour as pending. `check-skill-facts` sees none of these — every
  path resolves, only the number beside it was wrong.

## Test plan

Measured on `2ebe54275` (main, including #5764) plus this branch, against a
local toolshed. Server `/_health` reported the same `gitSha` as cf.

- Demo exits 0, nothing on stderr, no unexpected failures, no closed gaps, and
  repeats identically after normalising ids, timestamps and space names.
- Harness: **22 passed, 0 failed, 2 gaps open** — a verb's prose reaching its
  caller (#5637), and an address as a verb argument.
- Every new assertion checked for being able to fail, not just to pass:
  - `run`'s detection: pointed at a dead port, 10 acts flagged, exit 1.
  - `broken`'s signature check: fed a succeeding command, it flagged.
  - the listing assertion: yields a different string for a different piece.
- Both gaps this PR retired announced themselves rather than being noticed.
  #5740 closed #5577 and the harness said so; #5764 closed #5633 and **both**
  scripts said so — the harness with `GAP CLOSED`, the demo by exiting 1 to
  report an act marked BROKEN that no longer matched its signature.
- `deno fmt --check`, `deno lint`, `check-docs`, `check-conflict-markers`,
  `check-skill-facts`, `check-no-waitfor` all pass.

## Left undone

Two defects on the `cf piece call <verb> --help` page, found by reading it out
loud, not fixed here because open PRs held `packages/cli/lib/`:

- a verb whose event fields are all optional prints its `-- invoke` usage line
  twice and never shows its flag. `finish` (`{ body?: string }`) renders
  `... finish -- invoke` at two positions, so the Usage block reads as though
  the verb takes nothing.
- every usage line reads `cf piece call ... <verb>`, from a literal `"..."` in
  `cliCommand`, so nothing on the page can be copied and run.

From driving completion by hand through the generated bash function:
`cf piece call --piece <TAB>` offers the raw fid and never a slug, because
`shapePieceCandidates` maps `listPieces` to `{value: id}` and no command
enumerates slugs at all. It sits badly under a session whose first act is naming
the board.

`broken` is currently unused and kept deliberately; the header says why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)