### PR TITLE
refactor(data-model,utils): the class-convention cases a body-only census could not see

### DIFF
--- a/packages/data-model/src/value-clone.ts
+++ b/packages/data-model/src/value-clone.ts
@@ -294,23 +294,59 @@ export type CloneForMutationErrorKind =
  * unsuitable for producing a mutable handle. Carries structured fields so
  * the caller can preserve typed error info rather than parsing the
  * message.
- *
- * - `kind` — categorical reason (see {@link CloneForMutationErrorKind}).
- * - `pathIndex` — the path index at which the error occurred, or `-1`
- *   for root-level errors.
- * - `valueKind` — debug-string kind of the offending value (matches
- *   `toDebugKindString()`).
  */
 export class CloneForMutationError extends Error {
-  /** Constructs an instance describing one clone-for-mutation failure. */
+  /** Value for {@link #kind}. */
+  readonly #kind: CloneForMutationErrorKind;
+
+  /** Value for {@link #pathIndex}. */
+  readonly #pathIndex: number;
+
+  /** Value for {@link #valueKind}. */
+  readonly #valueKind: string;
+
+  /**
+   * Constructs an instance describing one clone-for-mutation failure.
+   *
+   * @param kind - Categorical reason.
+   * @param pathIndex - The path index at which the error occurred, or `-1`
+   *   for a root-level error.
+   * @param valueKind - Debug-string kind of the offending value.
+   * @param message - What is wrong.
+   */
   constructor(
-    readonly kind: CloneForMutationErrorKind,
-    readonly pathIndex: number,
-    readonly valueKind: string,
+    kind: CloneForMutationErrorKind,
+    pathIndex: number,
+    valueKind: string,
     message: string,
   ) {
     super(message);
+
     this.name = "CloneForMutationError";
+    this.#kind = kind;
+    this.#pathIndex = pathIndex;
+    this.#valueKind = valueKind;
+  }
+
+  /** Categorical reason. See {@link CloneForMutationErrorKind}. */
+  get kind(): CloneForMutationErrorKind {
+    return this.#kind;
+  }
+
+  /**
+   * The path index at which the error occurred, or `-1` for a root-level
+   * error.
+   */
+  get pathIndex(): number {
+    return this.#pathIndex;
+  }
+
+  /**
+   * Debug-string kind of the offending value, matching
+   * `toDebugKindString()`.
+   */
+  get valueKind(): string {
+    return this.#valueKind;
   }
 }
 

--- a/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
@@ -76,7 +76,7 @@ class UnregisteredInstance extends BaseFabricInstance {
     return "Unregistered@1";
   }
 
-  // The encode-side mandate guard fires before either of these is reached, so
+  // The encode-side mandate guard fires before any of these are reached, so
   // they are throwing stubs.
   [DEEP_FREEZE](_subFreeze: (value: FabricValue) => FabricValue): FabricValue {
     throw new Error("not implemented");
@@ -88,13 +88,12 @@ class UnregisteredInstance extends BaseFabricInstance {
     throw new Error("not implemented");
   }
 
-  protected [SHALLOW_UNFROZEN_CLONE](): FabricInstance {
-    return new UnregisteredInstance();
-  }
-
-  // Also unreachable, for the same reason.
   protected [DEEP_CLONE_CORE](_frozen: boolean): FabricInstance {
     throw new Error("not implemented");
+  }
+
+  protected [SHALLOW_UNFROZEN_CLONE](): FabricInstance {
+    return new UnregisteredInstance();
   }
 }
 

--- a/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
@@ -76,16 +76,8 @@ class UnregisteredInstance extends BaseFabricInstance {
     return "Unregistered@1";
   }
 
-  protected [SHALLOW_UNFROZEN_CLONE](): FabricInstance {
-    return new UnregisteredInstance();
-  }
-
-  // The encode-side mandate guard fires before any of these are reached, so
+  // The encode-side mandate guard fires before either of these is reached, so
   // they are throwing stubs.
-  protected [DEEP_CLONE_CORE](_frozen: boolean): FabricInstance {
-    throw new Error("not implemented");
-  }
-
   [DEEP_FREEZE](_subFreeze: (value: FabricValue) => FabricValue): FabricValue {
     throw new Error("not implemented");
   }
@@ -93,6 +85,15 @@ class UnregisteredInstance extends BaseFabricInstance {
   [IS_DEEP_FROZEN](
     _subIsDeepFrozen: (value: FabricValue) => boolean,
   ): boolean {
+    throw new Error("not implemented");
+  }
+
+  protected [SHALLOW_UNFROZEN_CLONE](): FabricInstance {
+    return new UnregisteredInstance();
+  }
+
+  // Also unreachable, for the same reason.
+  protected [DEEP_CLONE_CORE](_frozen: boolean): FabricInstance {
     throw new Error("not implemented");
   }
 }
@@ -216,14 +217,6 @@ describe("JsonCodecEngine", () => {
         return PROBE_TAG;
       }
 
-      protected [SHALLOW_UNFROZEN_CLONE](): FabricInstance {
-        return new ProbeInstance();
-      }
-
-      protected [DEEP_CLONE_CORE](_frozen: boolean): FabricInstance {
-        return new ProbeInstance();
-      }
-
       [DEEP_FREEZE](
         _subFreeze: (value: FabricValue) => FabricValue,
       ): FabricValue {
@@ -234,6 +227,14 @@ describe("JsonCodecEngine", () => {
         _subIsDeepFrozen: (value: FabricValue) => boolean,
       ): boolean {
         return true;
+      }
+
+      protected [SHALLOW_UNFROZEN_CLONE](): FabricInstance {
+        return new ProbeInstance();
+      }
+
+      protected [DEEP_CLONE_CORE](_frozen: boolean): FabricInstance {
+        return new ProbeInstance();
       }
     }
 

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -966,6 +966,10 @@ export class Logger {
     this.#flags.clear();
   }
 
+  //
+  // Private helpers
+  //
+
   /** Increments the count for a specific message key and log level. */
   #incrementKeyCount(key: string, level: ActiveLogLevel): void {
     // Skip reserved key name "total" to prevent corruption of breakdown totals

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -381,6 +381,17 @@ class TimingDataStore {
     };
   }
 
+  /** Resets all timing data. */
+  reset(): void {
+    this.#count = 0;
+    this.#min = Infinity;
+    this.#max = -Infinity;
+    this.#totalTime = 0;
+    this.#lastTime = 0;
+    this.#lastTimestamp = 0;
+    this.#samples = [];
+  }
+
   /**
    * Returns the CDF (cumulative distribution function) of `sorted`, as
    * points where `(x, y)` means that a `y` fraction of the samples are at
@@ -393,17 +404,6 @@ class TimingDataStore {
       x,
       y: (i + 1) / sorted.length,
     }));
-  }
-
-  /** Resets all timing data. */
-  reset(): void {
-    this.#count = 0;
-    this.#min = Infinity;
-    this.#max = -Infinity;
-    this.#totalTime = 0;
-    this.#lastTime = 0;
-    this.#lastTimestamp = 0;
-    this.#samples = [];
   }
 }
 
@@ -655,6 +655,40 @@ export class Logger {
     return result;
   }
 
+  /**
+   * Returns all timing statistics for this logger.
+   * Returns a flat map with "/" joined keys.
+   */
+  get timeStats(): Record<string, TimingStats> {
+    const result: Record<string, TimingStats> = {};
+    for (const [key, store] of this.#timingsByKey) {
+      result[key] = store.getStats();
+    }
+    return result;
+  }
+
+  /**
+   * All active flags, as a record from flag name to a record from id to
+   * metadata. The metadata is whatever was passed to `flag()`, or `null` when
+   * none was. A flag name with no active id is omitted entirely.
+   */
+  get flags(): Record<string, Record<string, Record<string, unknown> | null>> {
+    const result: Record<
+      string,
+      Record<string, Record<string, unknown> | null>
+    > = {};
+    for (const [name, group] of this.#flags) {
+      if (group.size > 0) {
+        const entries: Record<string, Record<string, unknown> | null> = {};
+        for (const [id, value] of group) {
+          entries[id] = value === true ? null : value;
+        }
+        result[name] = entries;
+      }
+    }
+    return result;
+  }
+
   /** Resets all call counts to zero, both the overall and the by-key ones. */
   resetCounts(): void {
     this.#counts.debug = 0;
@@ -663,70 +697,6 @@ export class Logger {
     this.#counts.error = 0;
     this.#countsByKey = {};
     this.#lastLoggedAt = 0;
-  }
-
-  /** Increments the count for a specific message key and log level. */
-  #incrementKeyCount(key: string, level: ActiveLogLevel): void {
-    // Skip reserved key name "total" to prevent corruption of breakdown totals
-    if (key === "total") {
-      console.warn(
-        `[Logger] Message key \`total\` is reserved and cannot be used. ` +
-          `Please use a different key.`,
-      );
-      return;
-    }
-    if (!this.#countsByKey[key]) {
-      this.#countsByKey[key] = { debug: 0, info: 0, warn: 0, error: 0 };
-    }
-    this.#countsByKey[key][level]++;
-  }
-
-  /**
-   * Logs the count summary, if incrementing the counter has just carried the
-   * total past another multiple of the configured threshold.
-   */
-  #maybeLogCountSummary(): void {
-    // Skip if disabled or logCountEvery is 0
-    if (this.#logCountEvery === 0) return;
-
-    const total = this.counts.total;
-    const threshold = Math.floor(total / this.#logCountEvery);
-
-    // Check if we've crossed a new threshold
-    if (threshold > this.#lastLoggedAt) {
-      this.#lastLoggedAt = threshold;
-
-      // Only log if debug level is enabled
-      if (shouldLog("debug", this.#level)) {
-        const { prefix, color } = this.#getLogFormat("debug");
-        const moduleName = this.#moduleName || "logger";
-        const message =
-          `${moduleName}: ${total} log calls made (debug: ${this.#counts.debug}, info: ${this.#counts.info}, warn: ${this.#counts.warn}, error: ${this.#counts.error})`;
-        console.debug(prefix, color, message);
-      }
-    }
-  }
-
-  /** Returns the prefix and color for a log level. */
-  #getLogFormat(
-    level: ActiveLogLevel,
-  ): { prefix: string; color: string } {
-    const levelUpper = level.toUpperCase();
-    const timestamp = getTimeStamp();
-
-    if (this.#moduleName) {
-      const prefix = `%c[${levelUpper}][${this.#moduleName}::${timestamp}]`;
-      const color = LOG_COLORS[
-        `tagged${
-          levelUpper.charAt(0) + level.slice(1)
-        }` as keyof typeof LOG_COLORS
-      ];
-      return { prefix, color };
-    } else {
-      const prefix = `%c[${levelUpper}][${timestamp}]`;
-      const color = LOG_COLORS[level];
-      return { prefix, color };
-    }
   }
 
   /** Logs a debug message. */
@@ -892,23 +862,6 @@ export class Logger {
   }
 
   /**
-   * Records timing against the full key path only, with no rollup to the
-   * shorter paths.
-   */
-  #recordTime(elapsed: number, keys: string[]): void {
-    const path = keys.join("/");
-    let store = this.#timingsByKey.get(path);
-    if (!store) {
-      store = new TimingDataStore();
-      if (this.#timingBaselineActive) {
-        store.setBaseline();
-      }
-      this.#timingsByKey.set(path, store);
-    }
-    store.record(elapsed);
-  }
-
-  /**
    * Returns timing statistics for a specific key path.
    * Accepts either separate key segments or a single "/" joined path.
    *
@@ -920,18 +873,6 @@ export class Logger {
     const keyPath = keys.join("/");
     const store = this.#timingsByKey.get(keyPath);
     return store?.getStats();
-  }
-
-  /**
-   * Returns all timing statistics for this logger.
-   * Returns a flat map with "/" joined keys.
-   */
-  get timeStats(): Record<string, TimingStats> {
-    const result: Record<string, TimingStats> = {};
-    for (const [key, store] of this.#timingsByKey) {
-      result[key] = store.getStats();
-    }
-    return result;
   }
 
   /** Resets all timing statistics for this logger. */
@@ -1020,31 +961,90 @@ export class Logger {
     }
   }
 
-  /**
-   * All active flags, as a record from flag name to a record from id to
-   * metadata. The metadata is whatever was passed to `flag()`, or `null` when
-   * none was. A flag name with no active id is omitted entirely.
-   */
-  get flags(): Record<string, Record<string, Record<string, unknown> | null>> {
-    const result: Record<
-      string,
-      Record<string, Record<string, unknown> | null>
-    > = {};
-    for (const [name, group] of this.#flags) {
-      if (group.size > 0) {
-        const entries: Record<string, Record<string, unknown> | null> = {};
-        for (const [id, value] of group) {
-          entries[id] = value === true ? null : value;
-        }
-        result[name] = entries;
-      }
-    }
-    return result;
-  }
-
   /** Resets all flags for this logger. */
   resetFlags(): void {
     this.#flags.clear();
+  }
+
+  /** Increments the count for a specific message key and log level. */
+  #incrementKeyCount(key: string, level: ActiveLogLevel): void {
+    // Skip reserved key name "total" to prevent corruption of breakdown totals
+    if (key === "total") {
+      console.warn(
+        `[Logger] Message key \`total\` is reserved and cannot be used. ` +
+          `Please use a different key.`,
+      );
+      return;
+    }
+    if (!this.#countsByKey[key]) {
+      this.#countsByKey[key] = { debug: 0, info: 0, warn: 0, error: 0 };
+    }
+    this.#countsByKey[key][level]++;
+  }
+
+  /**
+   * Logs the count summary, if incrementing the counter has just carried the
+   * total past another multiple of the configured threshold.
+   */
+  #maybeLogCountSummary(): void {
+    // Skip if disabled or logCountEvery is 0
+    if (this.#logCountEvery === 0) return;
+
+    const total = this.counts.total;
+    const threshold = Math.floor(total / this.#logCountEvery);
+
+    // Check if we've crossed a new threshold
+    if (threshold > this.#lastLoggedAt) {
+      this.#lastLoggedAt = threshold;
+
+      // Only log if debug level is enabled
+      if (shouldLog("debug", this.#level)) {
+        const { prefix, color } = this.#getLogFormat("debug");
+        const moduleName = this.#moduleName || "logger";
+        const message =
+          `${moduleName}: ${total} log calls made (debug: ${this.#counts.debug}, info: ${this.#counts.info}, warn: ${this.#counts.warn}, error: ${this.#counts.error})`;
+        console.debug(prefix, color, message);
+      }
+    }
+  }
+
+  /** Returns the prefix and color for a log level. */
+  #getLogFormat(
+    level: ActiveLogLevel,
+  ): { prefix: string; color: string } {
+    const levelUpper = level.toUpperCase();
+    const timestamp = getTimeStamp();
+
+    if (this.#moduleName) {
+      const prefix = `%c[${levelUpper}][${this.#moduleName}::${timestamp}]`;
+      const color = LOG_COLORS[
+        `tagged${
+          levelUpper.charAt(0) + level.slice(1)
+        }` as keyof typeof LOG_COLORS
+      ];
+      return { prefix, color };
+    } else {
+      const prefix = `%c[${levelUpper}][${timestamp}]`;
+      const color = LOG_COLORS[level];
+      return { prefix, color };
+    }
+  }
+
+  /**
+   * Records timing against the full key path only, with no rollup to the
+   * shorter paths.
+   */
+  #recordTime(elapsed: number, keys: string[]): void {
+    const path = keys.join("/");
+    let store = this.#timingsByKey.get(path);
+    if (!store) {
+      store = new TimingDataStore();
+      if (this.#timingBaselineActive) {
+        store.setBaseline();
+      }
+      this.#timingsByKey.set(path, store);
+    }
+    store.record(elapsed);
   }
 
   /** Returns the total count of all log calls, over all four levels. */


### PR DESCRIPTION
A second pass over the five packages already swept for the `Classes` rules in
`docs/development/DEVELOPMENT.md` — `leb128`, `pure-json`, `content-hash`,
`utils`, `data-model`. I (agent working on behalf of @danfuzz) re-ran the sweep
with an AST census rather than a grep, so nested and expression classes are
visible: 137 classes, 66 of them nested.

Three things came back.

### `CloneForMutationError` exposes three enumerable properties

`value-clone.ts` took `kind`, `pathIndex` and `valueKind` as `readonly`
constructor parameter properties. Those are field declarations in disguise, so
an exported class carried three enumerable own properties — the case the rule
names explicitly, and the one nothing found earlier, because every tool built
for the first sweep keyed on field declarations in the class *body*.

The conformant model was already in the same package: `ProblematicStateError`
holds the identical shape — an exported `Error` carrying structured facts — as
`#` fields behind getters. This class now matches it. Both consumers
(`memory/v2/patch.ts`, `runner/.../mutable-path-write.ts`) only read the three
values, so nothing about how they are reached changes.

### Two test probes ordered protected ahead of public

`UnregisteredInstance` and `ProbeInstance` in `JsonCodecEngine.test.ts` each
implemented protected `[DEEP_CLONE_CORE]` before public `[DEEP_FREEZE]`, where
`BaseFabricInstance` declares them the other way round.

### `logger.ts` conforms rather than staying exempt

`Logger` and `TimingDataStore` interleaved private helpers with their public
callers, and `Logger` placed two getters after neighboring methods. Both now
follow the group-5 order.

Worth knowing for review: the class no longer needs the reshuffle it once
would have. Its group-level order is already correct, so the whole of this is
six moves — two getters up, four private methods down, and `#calculateCDF`
below `reset()`. The `Timing methods`, `Baseline methods` and `Flag methods`
markers stay put and still head the public methods they name.

**The `logger.ts` commit is a pure move**, verified by comparing the sorted
line multiset before against after — identical, with the check itself shown
able to report a difference.

### What the census raised and this change deliberately leaves alone

- `FabricSpecialObject`'s brand is a `declare` field. It emits no runtime
  member, so it is not a property at all.
- `this.name = "..."` in the two `Error` subclasses is the house idiom;
  `ProblematicStateError` does the same.

The nested classes turned out to be clean — all 55 of `data-model`'s, which
was the gap most likely to be hiding something. Validated rather than assumed:
zero TS `private` anywhere in the five (an independent grep agrees), all 35
static fields `#`-named, and no `Object.assign(this)`, `defineProperty(this)`
or post-hoc `Foo.bar =`.

The census was calibrated before it was believed: `DEVELOPMENT.md`'s own
`Fryer` example reads clean, seeded violations of each axis are caught, and
inserting a public method above a constructor in `BaseCodecEngine.ts` turned a
0 into 8 findings.

### Gates

`deno task check`, `deno lint` and `deno fmt --check` all exit 0. Package
suites: `utils` 99 passed, `data-model` 54 passed (2404 steps), and both
consumers of the changed type — `memory` 495 passed, `runner` 1197 passed
(6440 steps). `check-docs` is not implicated; no document mentions any changed
name.


### Two follow-ups from review

Gathering `Logger`'s private methods at the end left them under the
`Flag methods` marker, which then headed log formatting, timing and counting
alongside the two members it names — a marker's scope runs to the next one, so
navigating the class by its markers led to the wrong place. A `Private helpers`
marker bounds `Flag methods` to `flag()` and `resetFlags()`.

`UnregisteredInstance`'s two protected members swapped, so all three throwing
stubs sit under the one note again rather than having it split around the
member between them. That makes the whole test file a pure move as well.

One consequence worth stating plainly: `console.log(err)` and Deno's inspector
no longer surface `kind`, `pathIndex` and `valueKind` on a
`CloneForMutationError`, prototype getters not being shown where own properties
were. Both consumers rebuild a domain error from the values before anything is
logged, so nothing functional turns on it, but it is a change in what a
breakpoint shows. `this.name` remains an own enumerable property, here as in
`ProblematicStateError`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


