### PR TITLE
Expose schema-declared labels in cf piece get-label

### DIFF
--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -26,8 +26,10 @@ import {
 import {
   type CfcLabelView,
   cfcLabelViewForCellWithStatus,
+  cfcLabelViewFromSchema,
   getCarriedCfcLabelView,
   type IFCLabel,
+  mergeCfcLabelViews,
   redactCaveatSourcesForDisplay,
   validateSchemaValue,
 } from "@commonfabric/runner/cfc";
@@ -230,7 +232,16 @@ function cfcLabelViewForCommand(
     const location = path.length === 0 ? "<root>" : path.join("/");
     throw new Error(`Could not read CFC labels at "${location}".`);
   }
-  return view === undefined ? null : redactCaveatSourcesForDisplay(view);
+  const schema = isObjectOrArray(cell)
+    ? cell.schema as JSONSchema | undefined
+    : undefined;
+  const effectiveView = mergeCfcLabelViews([
+    view,
+    cfcLabelViewFromSchema(schema),
+  ]);
+  return effectiveView === undefined
+    ? null
+    : redactCaveatSourcesForDisplay(effectiveView);
 }
 
 /** A `cf piece get` path that lands ON a verb. Reading a verb returns the

--- a/packages/cli/test/piece-label.test.ts
+++ b/packages/cli/test/piece-label.test.ts
@@ -204,6 +204,53 @@ describe("cf piece CFC labels", () => {
     ).toEqual(updated);
   });
 
+  it("returns labels declared only by the selected cell schema", async () => {
+    const schemaOnlyRoot = root.asSchema({
+      type: "object",
+      ifc: {
+        confidentiality: ["workspace"],
+        observes: "shape",
+      },
+      properties: {
+        body: {
+          type: "string",
+          ifc: { integrity: ["reviewed"] },
+        },
+      },
+      required: ["body"],
+    });
+    const schemaOnlyDeps = {
+      ...deps,
+      loadPieces: () =>
+        Promise.resolve({
+          runtime,
+          get: () =>
+            Promise.resolve({
+              input: { getCell: () => Promise.resolve(schemaOnlyRoot) },
+              result: { getCell: () => Promise.resolve(schemaOnlyRoot) },
+            }),
+          synced: () => Promise.resolve(),
+        }),
+    };
+
+    expect(
+      await getCellCfcLabel(pieceConfig, [], {}, schemaOnlyDeps as never),
+    ).toEqual({
+      version: 1,
+      entries: [
+        {
+          path: [],
+          label: { confidentiality: ["workspace"] },
+          observes: "shape",
+        },
+        {
+          path: ["body"],
+          label: { integrity: ["reviewed"] },
+        },
+      ],
+    });
+  });
+
   it("requires a transaction and an existing value for a CFC schema update", async () => {
     expect(() =>
       root.key("body").asSchema({

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -40,6 +40,7 @@ export {
   rebaseCfcLabelView,
   redactCaveatSourcesForDisplay,
 } from "./label-view.ts";
+export { cfcLabelViewFromSchema } from "./schema-label-view.ts";
 export type {
   AttemptedWrite,
   CfcAddress,

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -27,7 +27,6 @@ import type { FabricValue } from "@commonfabric/api";
 import type { MemorySpace, URI } from "@commonfabric/memory/interface";
 import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import type { JSONSchema } from "../builder/types.ts";
-import { forEachSubschema } from "../schema-walk.ts";
 import { arrayMatchesPositionally } from "../schema-match.ts";
 import { normalizeCellScope } from "../scope.ts";
 import { ignoreReadForScheduling } from "../scheduler.ts";
@@ -50,7 +49,6 @@ import {
 import { getValueAtPath, setValueAtPath } from "../path-utils.ts";
 import { encodePointer } from "../../../memory/v2/path.ts";
 import { ContextualFlowControl } from "../cfc.ts";
-import { cfcSchemaChildRoot, resolveCfcSchemaRefRoot } from "./schema-refs.ts";
 import { atomPropagationClass } from "./atom-classes.ts";
 import {
   canonicalizeCfcMetadata,
@@ -97,6 +95,7 @@ import {
   readConsumesEntry,
   type ReadObservationShape,
 } from "./observation-classes.ts";
+import { cfcSchemaEntries } from "./schema-label-view.ts";
 import { mergeCfcSchemaEnvelopes } from "./schema-merge.ts";
 import {
   CFC_SCHEMA_MIGRATION_INCOMPATIBLE_REASON,
@@ -2096,157 +2095,6 @@ export const gatedSinkRequestExists = (
   );
 };
 
-interface IfcSchemaVisit {
-  root: object;
-  schema: object;
-  parent?: IfcSchemaVisit;
-}
-
-const walkIfcSchema = (
-  schema: JSONSchema,
-  path: readonly string[] = [],
-  entries: Array<
-    {
-      path: readonly string[];
-      label: IFCLabel;
-      schema: JSONSchema;
-      // Document carrying the `$defs` that resolves refs inside `schema`.
-      // `schema` is the bare ifc node (no `$defs` of its own), so value-condition
-      // refs only resolve against this root — thread it to the policy matcher.
-      root: JSONSchema;
-    }
-  > = [],
-  root: JSONSchema = schema,
-  active?: IfcSchemaVisit,
-): typeof entries => {
-  if (typeof schema === "boolean") {
-    return entries;
-  }
-  const schemaRoot = cfcSchemaChildRoot(schema, root);
-  const rootKey = isObjectOrArray(schemaRoot) ? schemaRoot : schema;
-  for (let cursor = active; cursor !== undefined; cursor = cursor.parent) {
-    if (cursor.root === rootKey && cursor.schema === schema) return entries;
-  }
-  const nextActive = { root: rootKey, schema, parent: active };
-
-  {
-    const resolved = typeof schema.$ref === "string"
-      ? ContextualFlowControl.resolveSchemaRefs(schema, schemaRoot) ?? schema
-      : schema;
-    if (typeof resolved === "boolean") {
-      return entries;
-    }
-
-    const childRoot = cfcSchemaChildRoot(
-      resolved,
-      typeof schema.$ref === "string"
-        ? resolveCfcSchemaRefRoot(schema, schemaRoot)
-        : schemaRoot,
-    );
-    if (resolved.ifc !== undefined) {
-      entries.push({
-        path,
-        label: {
-          integrity: resolved.ifc.integrity
-            ? [...resolved.ifc.integrity]
-            : undefined,
-          confidentiality: resolved.ifc.confidentiality
-            ? [...resolved.ifc.confidentiality]
-            : undefined,
-        },
-        schema: resolved,
-        root: childRoot,
-      });
-    }
-
-    // Keyword descent via the shared walk, so the vocabulary cannot silently
-    // drift from schema-walk's (a missed keyword here fails open:
-    // under-tainting). The visitor owns the path rule per keyword — that
-    // part is this walker's semantics, not the walk's.
-    //
-    // Record-only `additionalProperties` descends as the same `*` segment
-    // arrays get from `items` (template-population §4) — RESTRICTED to
-    // record-only objects (no NAMED property). The restriction is
-    // load-bearing: `isPrefix`'s `*` matches ANY segment, but
-    // `additionalProperties` semantically covers only keys NOT listed under
-    // `properties` (schemaAtPath consults it only on a properties miss), so
-    // an unrestricted `*` entry from a mixed schema would over-taint the
-    // named fields. Mixed fixed-plus-record-tail schemas therefore mint no
-    // `*` entry (expressing them needs exclusion semantics §3.3 forbids).
-    // An EMPTY `properties` object is still record-only — it names no key,
-    // so every key is a properties miss and `additionalProperties` covers
-    // all of them; schema helpers routinely emit that wrapper shape, and
-    // skipping it would silently drop the declared map label (codex/cubic
-    // review on this PR).
-    const recordOnly = resolved.properties === undefined ||
-      Object.keys(resolved.properties).length === 0;
-    // `items` keeps its `*` entry even beside `prefixItems` (PR #4969
-    // review). The `*` matches ANY index — including the tuple slots — so
-    // the mixed tuple-plus-rest shape over-taints the slots with the rest
-    // labels; but the alternative (minting nothing, as additionalProperties
-    // does beside named properties) silently DROPS the tail elements'
-    // declared labels — fail-open, strictly worse than over-taint.
-    // Expressing "every index past the slots" precisely needs a path
-    // grammar beyond `*`; until then the wildcard stays. The record-side
-    // no-mint rule is unchanged: there the `*` entry would misassign
-    // through schemaAtPath's properties-first resolution, a trade that
-    // predates tuple support.
-    forEachSubschema(resolved, (child, keyword, key, index) => {
-      switch (keyword) {
-        case "properties":
-          walkIfcSchema(child, [...path, key!], entries, childRoot, nextActive);
-          break;
-        case "anyOf":
-        case "oneOf":
-        case "allOf":
-          walkIfcSchema(child, path, entries, childRoot, nextActive);
-          break;
-        case "items":
-          walkIfcSchema(child, [...path, "*"], entries, childRoot, nextActive);
-          break;
-        case "prefixItems":
-          // Tuple slots mint at their concrete index — unlike `items`' `*`
-          // entry, a slot label applies to exactly that position.
-          walkIfcSchema(
-            child,
-            [...path, String(index!)],
-            entries,
-            childRoot,
-            nextActive,
-          );
-          break;
-        case "additionalProperties":
-          if (recordOnly) {
-            walkIfcSchema(
-              child,
-              [...path, "*"],
-              entries,
-              childRoot,
-              nextActive,
-            );
-          }
-          break;
-        case "not":
-          // Negation describes what the value must NOT be. Minting
-          // label/policy entries from it would enforce an author's negated
-          // branch as if it labeled real data — deliberately skipped (unlike
-          // joinSchema, where unioning `not` atoms into the LUB is a safe
-          // over-taint).
-          break;
-        default:
-          // A keyword schema-walk knows but this walker has no path rule
-          // for: descend at the parent's own path — labels join at the
-          // position (over-taint, fail-safe) rather than being silently
-          // dropped (under-taint, fail-open). Give new keywords an explicit
-          // case above.
-          walkIfcSchema(child, path, entries, childRoot, nextActive);
-          break;
-      }
-    });
-    return entries;
-  }
-};
-
 const policyOnlySchema = (schema: JSONSchema): JSONSchema => {
   if (!isObjectOrArray(schema) || !isObjectOrArray(schema.ifc)) {
     return {};
@@ -2277,7 +2125,7 @@ const storedSchemaClaimsForLinkWrites = (
   const targetPaths = inputs.map((input) =>
     canonicalizeLogicalPath(input.target.path)
   );
-  for (const entry of walkIfcSchema(schema)) {
+  for (const entry of cfcSchemaEntries(schema)) {
     if (
       !targetPaths.some((targetPath) => pathsOverlap(targetPath, entry.path))
     ) {
@@ -2445,7 +2293,7 @@ const projectionClaimSpec = (
 
 // A schema-entry path (a `pathKey` — the canonical pointer encoding) parsed
 // back to segments. Entry paths use "*" for array-item / record-value
-// positions (walkIfcSchema).
+// positions (`cfcSchemaEntries()`).
 const entryPathFromKey = (key: string): readonly string[] =>
   key === "" ? [] : key.slice(1).split("/").map(decodePointerSegment);
 
@@ -3044,8 +2892,9 @@ export const wildcardPolicyMatchesValue = (
   },
   schema: JSONSchema | undefined,
   value: unknown,
-  // Schema document that resolves `$ref`s inside `schema`. walkIfcSchema
-  // captures an ifc node WITHOUT the document's `$defs` (those live on the
+  // Schema document that resolves `$ref`s inside `schema`.
+  // `cfcSchemaEntries()` captures an ifc node without the document's
+  // `$defs` (those live on the
   // outer root), so a value-condition ref like `items: {$ref: "#/$defs/X"}`
   // only resolves when the root carrying `$defs` is threaded in. Without it the
   // ref is spuriously unevaluable and the entry would fail closed on a perfectly
@@ -3098,7 +2947,8 @@ const ifcEntryAppliesToAttemptedWrite = (
   path: readonly string[],
   schema?: JSONSchema,
   // Document root that resolves `$ref`s inside `schema` (see
-  // wildcardPolicyMatchesValue). Threaded from walkIfcSchema entries, whose
+  // `wildcardPolicyMatchesValue()`). Threaded from
+  // `cfcSchemaEntries()` entries, whose
   // captured ifc node lacks the document's `$defs`.
   root?: JSONSchema,
 ): boolean => {
@@ -3625,7 +3475,7 @@ const verifyInputRequirements = (
     provenance.clockLessReads = clockLessReads;
   }
 
-  for (const entry of walkIfcSchema(schema)) {
+  for (const entry of cfcSchemaEntries(schema)) {
     if (
       !ifcEntryAppliesToAttemptedWrite(
         tx,
@@ -3909,7 +3759,7 @@ const verifyExactCopyRequirements = (
   },
   schema: JSONSchema,
 ): string | undefined => {
-  for (const entry of walkIfcSchema(schema)) {
+  for (const entry of cfcSchemaEntries(schema)) {
     const sourcePath = exactCopySourcePath(entry.schema);
     if (sourcePath === undefined) {
       continue;
@@ -3972,7 +3822,7 @@ const verifyProjectionRequirements = (
   },
   schema: JSONSchema,
 ): string | undefined => {
-  for (const entry of walkIfcSchema(schema)) {
+  for (const entry of cfcSchemaEntries(schema)) {
     const claim = projectionClaimSpec(entry.schema);
     if (claim === undefined) {
       continue;
@@ -4319,7 +4169,7 @@ const persistedLabelFromSchemaAtPath = (
   owningSpace: MemorySpace,
 ): IFCLabel | undefined => {
   const logicalPath = canonicalizeLogicalPath(path);
-  const entries = walkIfcSchema(schema);
+  const entries = cfcSchemaEntries(schema);
   let match:
     | { path: readonly string[]; label: IFCLabel; schema: JSONSchema }
     | undefined;
@@ -4379,7 +4229,9 @@ const rootLabelFromSchema = (
   if (schema === undefined) {
     return {};
   }
-  const root = walkIfcSchema(schema).find((entry) => entry.path.length === 0);
+  const root = cfcSchemaEntries(schema).find((entry) =>
+    entry.path.length === 0
+  );
   return root === undefined
     ? {}
     : derivePersistedLabel(tx, root.schema, root.label, undefined, owningSpace);
@@ -5127,7 +4979,7 @@ const verifyWriteFloor = (
   // principal are tx-wide. Concept floors on the written value resolve through
   // it; plain floors ignore it (Epic D5).
   const trust = cfcFloorTrustContext(tx);
-  const entries = walkIfcSchema(schema);
+  const entries = cfcSchemaEntries(schema);
   const entryLabels = new Map<string, IFCLabel>(
     entries.map((entry) => [pathKey(entry.path), entry.label]),
   );
@@ -5667,7 +5519,7 @@ export const prepareBoundaryCommit = (
     }
 
     const schemaAndHash = internSchema(mergedSchema, true);
-    const mergedSchemaEntries = walkIfcSchema(schemaAndHash.schema);
+    const mergedSchemaEntries = cfcSchemaEntries(schemaAndHash.schema);
     const mergedSchemaEntryLabels = new Map<string, IFCLabel>(
       mergedSchemaEntries.map((entry) => [
         pathKey(entry.path),

--- a/packages/runner/src/cfc/schema-label-view.ts
+++ b/packages/runner/src/cfc/schema-label-view.ts
@@ -62,10 +62,10 @@ export const cfcSchemaEntries = (
     entries.push({
       path,
       label: {
-        integrity: resolved.ifc.integrity
+        integrity: Array.isArray(resolved.ifc.integrity)
           ? [...resolved.ifc.integrity]
           : undefined,
-        confidentiality: resolved.ifc.confidentiality
+        confidentiality: Array.isArray(resolved.ifc.confidentiality)
           ? [...resolved.ifc.confidentiality]
           : undefined,
       },

--- a/packages/runner/src/cfc/schema-label-view.ts
+++ b/packages/runner/src/cfc/schema-label-view.ts
@@ -46,9 +46,9 @@ export const cfcSchemaEntries = (
   const nextActive = { root: rootKey, schema, parent: active };
 
   const resolved = typeof schema.$ref === "string"
-    ? ContextualFlowControl.resolveSchemaRefs(schema, schemaRoot) ?? schema
+    ? ContextualFlowControl.resolveSchemaRefs(schema, schemaRoot)
     : schema;
-  if (typeof resolved === "boolean") {
+  if (resolved === undefined || typeof resolved === "boolean") {
     return entries;
   }
 
@@ -58,7 +58,7 @@ export const cfcSchemaEntries = (
       ? resolveCfcSchemaRefRoot(schema, schemaRoot)
       : schemaRoot,
   );
-  if (resolved.ifc !== undefined) {
+  if (isObjectOrArray(resolved.ifc)) {
     entries.push({
       path,
       label: {
@@ -75,7 +75,8 @@ export const cfcSchemaEntries = (
   }
 
   const recordOnly = resolved.properties === undefined ||
-    Object.keys(resolved.properties).length === 0;
+    (isObjectOrArray(resolved.properties) &&
+      Object.keys(resolved.properties).length === 0);
   forEachSubschema(resolved, (child, keyword, key, index) => {
     switch (keyword) {
       case "properties":

--- a/packages/runner/src/cfc/schema-label-view.ts
+++ b/packages/runner/src/cfc/schema-label-view.ts
@@ -1,0 +1,168 @@
+import type { JSONSchema } from "@commonfabric/api";
+import { isObjectOrArray } from "@commonfabric/utils/types";
+import { ContextualFlowControl } from "../cfc.ts";
+import { forEachSubschema, isSubschema } from "../schema-walk.ts";
+import { cfcSchemaChildRoot, resolveCfcSchemaRefRoot } from "./schema-refs.ts";
+import { type CfcLabelView, mergeCfcLabelViews } from "./label-view-state.ts";
+import type { IFCLabel, LabelObservationClass } from "./types.ts";
+
+/** One `ifc` declaration found while walking a CFC schema. */
+export interface CfcSchemaEntry {
+  readonly path: readonly string[];
+  readonly label: IFCLabel;
+  readonly schema: JSONSchema;
+  /** The schema document that resolves local references inside `.schema`. */
+  readonly root: JSONSchema;
+}
+
+interface IfcSchemaVisit {
+  root: object;
+  schema: object;
+  parent?: IfcSchemaVisit;
+}
+
+/**
+ * Return every `ifc` declaration in a schema at its logical value path.
+ *
+ * Compound schemas contribute at their current path. Array items and
+ * record-only additional properties use a wildcard path. Tuple entries use
+ * their concrete index. Negated schemas do not describe labels on real data.
+ */
+export const cfcSchemaEntries = (
+  schema: JSONSchema,
+  path: readonly string[] = [],
+  entries: CfcSchemaEntry[] = [],
+  root: JSONSchema = schema,
+  active?: IfcSchemaVisit,
+): CfcSchemaEntry[] => {
+  if (!isSubschema(schema) || typeof schema === "boolean") {
+    return entries;
+  }
+  const schemaRoot = cfcSchemaChildRoot(schema, root);
+  const rootKey = isObjectOrArray(schemaRoot) ? schemaRoot : schema;
+  for (let cursor = active; cursor !== undefined; cursor = cursor.parent) {
+    if (cursor.root === rootKey && cursor.schema === schema) return entries;
+  }
+  const nextActive = { root: rootKey, schema, parent: active };
+
+  const resolved = typeof schema.$ref === "string"
+    ? ContextualFlowControl.resolveSchemaRefs(schema, schemaRoot) ?? schema
+    : schema;
+  if (typeof resolved === "boolean") {
+    return entries;
+  }
+
+  const childRoot = cfcSchemaChildRoot(
+    resolved,
+    typeof schema.$ref === "string"
+      ? resolveCfcSchemaRefRoot(schema, schemaRoot)
+      : schemaRoot,
+  );
+  if (resolved.ifc !== undefined) {
+    entries.push({
+      path,
+      label: {
+        integrity: resolved.ifc.integrity
+          ? [...resolved.ifc.integrity]
+          : undefined,
+        confidentiality: resolved.ifc.confidentiality
+          ? [...resolved.ifc.confidentiality]
+          : undefined,
+      },
+      schema: resolved,
+      root: childRoot,
+    });
+  }
+
+  const recordOnly = resolved.properties === undefined ||
+    Object.keys(resolved.properties).length === 0;
+  forEachSubschema(resolved, (child, keyword, key, index) => {
+    switch (keyword) {
+      case "properties":
+        cfcSchemaEntries(
+          child,
+          [...path, key!],
+          entries,
+          childRoot,
+          nextActive,
+        );
+        break;
+      case "anyOf":
+      case "oneOf":
+      case "allOf":
+        cfcSchemaEntries(child, path, entries, childRoot, nextActive);
+        break;
+      case "items":
+        // The wildcard covers tuple positions and the rest schema when
+        // `.prefixItems` is present.
+        cfcSchemaEntries(
+          child,
+          [...path, "*"],
+          entries,
+          childRoot,
+          nextActive,
+        );
+        break;
+      case "prefixItems":
+        cfcSchemaEntries(
+          child,
+          [...path, String(index!)],
+          entries,
+          childRoot,
+          nextActive,
+        );
+        break;
+      case "additionalProperties":
+        // A wildcard cannot express "all properties except the named ones".
+        // It is exact only when the schema declares no named properties.
+        if (recordOnly) {
+          cfcSchemaEntries(
+            child,
+            [...path, "*"],
+            entries,
+            childRoot,
+            nextActive,
+          );
+        }
+        break;
+      case "not":
+        // A negated schema does not describe declarations on real data.
+        break;
+      default:
+        // Unknown structural keywords contribute at the current position.
+        cfcSchemaEntries(child, path, entries, childRoot, nextActive);
+        break;
+    }
+  });
+  return entries;
+};
+
+const declaredObservationClass = (
+  schema: JSONSchema,
+): LabelObservationClass | undefined => {
+  const observes = isObjectOrArray(schema) && isObjectOrArray(schema.ifc)
+    ? schema.ifc.observes
+    : undefined;
+  return observes === "value" || observes === "shape" ||
+      observes === "enumerate" || observes === "followRef"
+    ? observes
+    : undefined;
+};
+
+/** Return the label view declared by a schema. */
+export const cfcLabelViewFromSchema = (
+  schema: JSONSchema | undefined,
+): CfcLabelView | undefined => {
+  if (schema === undefined) return undefined;
+  const entries = cfcSchemaEntries(schema).map((entry) => {
+    const observes = declaredObservationClass(entry.schema);
+    return {
+      path: entry.path,
+      label: entry.label,
+      ...(observes === undefined ? {} : { observes }),
+    };
+  });
+  return mergeCfcLabelViews([
+    entries.length === 0 ? undefined : { version: 1, entries },
+  ]);
+};

--- a/packages/runner/src/cfc/schema-label-view.ts
+++ b/packages/runner/src/cfc/schema-label-view.ts
@@ -46,9 +46,9 @@ export const cfcSchemaEntries = (
   const nextActive = { root: rootKey, schema, parent: active };
 
   const resolved = typeof schema.$ref === "string"
-    ? ContextualFlowControl.resolveSchemaRefs(schema, schemaRoot)
+    ? ContextualFlowControl.resolveSchemaRefs(schema, schemaRoot) ?? schema
     : schema;
-  if (resolved === undefined || typeof resolved === "boolean") {
+  if (typeof resolved === "boolean") {
     return entries;
   }
 

--- a/packages/runner/test/cfc-label-view.test.ts
+++ b/packages/runner/test/cfc-label-view.test.ts
@@ -100,11 +100,17 @@ describe("CFC label view helpers", () => {
     expect(cfcLabelViewFromSchema(null as never)).toBeUndefined();
   });
 
-  it("ignores declarations beside an unresolved schema reference", () => {
+  it("keeps declarations beside an unresolved schema reference", () => {
     expect(cfcLabelViewFromSchema({
       $ref: "#/$defs/Missing",
       ifc: { confidentiality: ["workspace"] },
-    })).toBeUndefined();
+    })).toEqual({
+      version: 1,
+      entries: [{
+        path: [],
+        label: { confidentiality: ["workspace"] },
+      }],
+    });
   });
 
   it("ignores an IFC block that is not an object", () => {

--- a/packages/runner/test/cfc-label-view.test.ts
+++ b/packages/runner/test/cfc-label-view.test.ts
@@ -117,6 +117,15 @@ describe("CFC label view helpers", () => {
     expect(cfcLabelViewFromSchema({ ifc: null } as never)).toBeUndefined();
   });
 
+  it("ignores IFC label fields that are not arrays", () => {
+    expect(cfcLabelViewFromSchema({
+      ifc: { confidentiality: 7, integrity: { trusted: true } },
+    } as never)).toBeUndefined();
+    expect(cfcLabelViewFromSchema({
+      ifc: { integrity: "trusted" },
+    } as never)).toBeUndefined();
+  });
+
   it("ignores a properties value that is not an object", () => {
     expect(cfcLabelViewFromSchema({
       ifc: { confidentiality: ["workspace"] },

--- a/packages/runner/test/cfc-label-view.test.ts
+++ b/packages/runner/test/cfc-label-view.test.ts
@@ -6,6 +6,7 @@ import {
   cfcLabelViewForCell,
   cfcLabelViewFromMetadata,
 } from "../src/cfc/label-view.ts";
+import { cfcLabelViewFromSchema } from "../src/cfc/schema-label-view.ts";
 import {
   redactSigilCfcLabelViewsForDisplay,
   stripSigilCfcLabelViews,
@@ -58,6 +59,45 @@ describe("CFC label view helpers", () => {
         },
       ],
     });
+  });
+
+  it("collects declared labels from schema paths and local references", () => {
+    expect(cfcLabelViewFromSchema({
+      type: "object",
+      ifc: {
+        confidentiality: ["workspace"],
+        maxConfidentiality: ["workspace"],
+      },
+      properties: {
+        items: {
+          type: "array",
+          items: { $ref: "#/$defs/Reviewed" },
+        },
+      },
+      $defs: {
+        Reviewed: {
+          type: "string",
+          ifc: { integrity: ["reviewed"], observes: "value" },
+        },
+      },
+    })).toEqual({
+      version: 1,
+      entries: [
+        {
+          path: [],
+          label: { confidentiality: ["workspace"] },
+        },
+        {
+          path: ["items", "*"],
+          label: { integrity: ["reviewed"] },
+          observes: "value",
+        },
+      ],
+    });
+  });
+
+  it("ignores a root value that is not a schema", () => {
+    expect(cfcLabelViewFromSchema(null as never)).toBeUndefined();
   });
 
   it("rebases wildcard label paths onto concrete array item paths", () => {

--- a/packages/runner/test/cfc-label-view.test.ts
+++ b/packages/runner/test/cfc-label-view.test.ts
@@ -100,6 +100,30 @@ describe("CFC label view helpers", () => {
     expect(cfcLabelViewFromSchema(null as never)).toBeUndefined();
   });
 
+  it("ignores declarations beside an unresolved schema reference", () => {
+    expect(cfcLabelViewFromSchema({
+      $ref: "#/$defs/Missing",
+      ifc: { confidentiality: ["workspace"] },
+    })).toBeUndefined();
+  });
+
+  it("ignores an IFC block that is not an object", () => {
+    expect(cfcLabelViewFromSchema({ ifc: null } as never)).toBeUndefined();
+  });
+
+  it("ignores a properties value that is not an object", () => {
+    expect(cfcLabelViewFromSchema({
+      ifc: { confidentiality: ["workspace"] },
+      properties: null,
+    } as never)).toEqual({
+      version: 1,
+      entries: [{
+        path: [],
+        label: { confidentiality: ["workspace"] },
+      }],
+    });
+  });
+
   it("rebases wildcard label paths onto concrete array item paths", () => {
     const metadata: CfcMetadata = {
       version: 1,


### PR DESCRIPTION
The label inspection command only read persisted and carried CFC metadata. A piece whose labels existed only in its durable schema therefore reported null even though the declaration governed the piece.

Extract the CFC schema walk used by persistence into a shared helper. Build a label view from that walk and merge it with stored and carried labels at the CLI inspection boundary. This keeps schema references, compound schemas, tuple positions, and wildcard paths aligned with persistence.

Use the central schema predicate at the helper boundary so malformed stored schema roots contribute no label view instead of throwing.

Cover schema-only root and nested labels through the CLI. Cover local schema references and malformed roots in the runner helper.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

