### PR TITLE
refactor(data-model): name the JSON entry points for the `native` family

### DIFF
--- a/docs/specs/pattern-construction/node-factory-shipping.md
+++ b/docs/specs/pattern-construction/node-factory-shipping.md
@@ -480,7 +480,7 @@ Every runner exposure path uses this chokepoint: schema-driven `asFactory`
 reads, recursive Cell/query result materialization, graph binding and dynamic
 module dispatch, and CLI/FUSE/tool adapters. Transformed symbolic invocation
 may pass a cell to the same hook after resolving its value. Context-free
-`valueFromJson()` remains the intentional shell-returning boundary.
+`fabricFromJsonValue()` remains the intentional shell-returning boundary.
 
 Materialization returns another function, not a wrapper object, and preserves
 the canonical codec state for reserialization.

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -2817,20 +2817,20 @@ recognizer for text in it, live one layer down in
  * JSON-embedded encoding, prefixed with the format-identifying tag
  * `fvj1:`.
  */
-export function jsonFromValue(value: FabricValue): string;
+export function jsonFromFabricValue(value: FabricValue): string;
 
 /**
  * Decodes a string in the `FabricValue` JSON-embedded encoding format. If
  * `context` is omitted, a shared decode-framed empty context is
  * substituted, which throws if any reconstruction is needed.
  */
-export function valueFromJson(
+export function fabricFromJsonValue(
   json: string,
   context?: ReconstructionContext,
 ): FabricValue;
 
 /**
- * Like `valueFromJson()`, except the decoded result is expected to be a
+ * Like `fabricFromJsonValue()`, except the decoded result is expected to be a
  * plain object. Throws if it turns out to be something else.
  */
 export function plainObjectFromJson<T extends object = object>(
@@ -2856,9 +2856,10 @@ time and reuses it for all encode/decode operations.
 The `memory` package wraps these at its serialization boundary
 (`packages/memory/v2.ts`):
 
-- **Write path:** `encodeMemoryBoundary(value)` calls `jsonFromValue(value)`.
+- **Write path:** `encodeMemoryBoundary(value)` calls
+  `jsonFromFabricValue(value)`.
 - **Read path:** `decodeMemoryBoundary(source)` calls
-  `valueFromJson(source, context)` with a memory `ReconstructionContext`.
+  `fabricFromJsonValue(source, context)` with a memory `ReconstructionContext`.
 
 ### 4.9 Fabric Value Conversion
 

--- a/packages/cli/test/inspect-remote.test.ts
+++ b/packages/cli/test/inspect-remote.test.ts
@@ -11,7 +11,7 @@ import { Database } from "@db/sqlite";
 import { ValidationError } from "@cliffy/command";
 import { Identity } from "@commonfabric/identity";
 import { defaultCacheDir } from "@commonfabric/state-inspector";
-import { jsonFromValue } from "@commonfabric/data-model/codecs";
+import { jsonFromFabricValue } from "@commonfabric/data-model/codecs";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { inspect } from "../commands/inspect.ts";
 
@@ -66,7 +66,7 @@ async function buildDbBytes(): Promise<Uint8Array> {
   db.prepare(
     `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
      VALUES ('of:a', 1, 0, 'set', ?, 1)`,
-  ).run(jsonFromValue({
+  ).run(jsonFromFabricValue({
     value: {
       n: 1,
       deep,
@@ -84,7 +84,7 @@ async function buildDbBytes(): Promise<Uint8Array> {
     `INSERT INTO revision
        (id, scope_key, seq, op_index, op, data, commit_seq)
      VALUES ('of:a', 'user:did%3Akey%3AzInspector', 1, 0, 'set', ?, 1)`,
-  ).run(jsonFromValue({
+  ).run(jsonFromFabricValue({
     value: {
       n: 2,
       deep,
@@ -107,7 +107,7 @@ async function buildDbBytes(): Promise<Uint8Array> {
   db.prepare(
     `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
      VALUES ('of:a', 2, 0, 'set', ?, 2)`,
-  ).run(jsonFromValue({
+  ).run(jsonFromFabricValue({
     value: {
       n: 1,
       deep,

--- a/packages/data-model/bench/codec-json.bench.ts
+++ b/packages/data-model/bench/codec-json.bench.ts
@@ -25,7 +25,7 @@
  * iteration anyway, which most of these are.
  */
 
-import { jsonFromValue, valueFromJson } from "../src/codecs.ts";
+import { fabricFromJsonValue, jsonFromFabricValue } from "../src/codecs.ts";
 import type { FabricValue } from "../src/interface.ts";
 import { FabricBytes } from "../src/fabric-primitives/FabricBytes.ts";
 import { FabricEpochNsec } from "../src/fabric-primitives/FabricEpochNsec.ts";
@@ -218,12 +218,20 @@ const OBJECTS = SIZES.map((size) => [size, makeObject(size)] as const);
 const OMNIBUSES = [10, 100, 1000].map((n) => [n, makeOmnibus(n)] as const);
 
 /** Encoded forms, for the decode direction. */
-const SINGLES_JSON = SINGLES.map(([n, v]) => [n, jsonFromValue(v)] as const);
-const ARRAYS_JSON = ARRAYS.map(([n, v]) => [n, jsonFromValue(v)] as const);
-const SPARSE_JSON = SPARSE.map(([n, v]) => [n, jsonFromValue(v)] as const);
-const OBJECTS_JSON = OBJECTS.map(([n, v]) => [n, jsonFromValue(v)] as const);
+const SINGLES_JSON = SINGLES.map(([n, v]) =>
+  [n, jsonFromFabricValue(v)] as const
+);
+const ARRAYS_JSON = ARRAYS.map(([n, v]) =>
+  [n, jsonFromFabricValue(v)] as const
+);
+const SPARSE_JSON = SPARSE.map(([n, v]) =>
+  [n, jsonFromFabricValue(v)] as const
+);
+const OBJECTS_JSON = OBJECTS.map(([n, v]) =>
+  [n, jsonFromFabricValue(v)] as const
+);
 const OMNIBUSES_JSON = OMNIBUSES.map(([n, v]) =>
-  [n, jsonFromValue(v)] as const
+  [n, jsonFromFabricValue(v)] as const
 );
 
 /** Zero-pads a size, so that group keys sort by magnitude. */
@@ -236,10 +244,10 @@ function groupKey(prefix: string, size: number): string {
 // since the single-value groups are measured first and are the shortest.
 for (let i = 0; i < 50; i++) {
   for (const [, value] of SINGLES) {
-    valueFromJson(jsonFromValue(value));
+    fabricFromJsonValue(jsonFromFabricValue(value));
   }
-  valueFromJson(jsonFromValue(ARRAYS[2]![1]));
-  valueFromJson(jsonFromValue(OBJECTS[2]![1]));
+  fabricFromJsonValue(jsonFromFabricValue(ARRAYS[2]![1]));
+  fabricFromJsonValue(jsonFromFabricValue(OBJECTS[2]![1]));
 }
 
 //
@@ -252,7 +260,7 @@ for (const [name, value] of SINGLES) {
     group: `single-${name}`,
     baseline: true,
     fn() {
-      jsonFromValue(value);
+      jsonFromFabricValue(value);
     },
   });
 }
@@ -262,7 +270,7 @@ for (const [name, json] of SINGLES_JSON) {
     name: `decode single-${name}`,
     group: `single-${name}`,
     fn() {
-      valueFromJson(json);
+      fabricFromJsonValue(json);
     },
   });
 }
@@ -277,7 +285,7 @@ for (const [size, value] of ARRAYS) {
     group: groupKey("array", size),
     baseline: true,
     fn() {
-      jsonFromValue(value);
+      jsonFromFabricValue(value);
     },
   });
 }
@@ -287,7 +295,7 @@ for (const [size, json] of ARRAYS_JSON) {
     name: `decode ${groupKey("array", size)}`,
     group: groupKey("array", size),
     fn() {
-      valueFromJson(json);
+      fabricFromJsonValue(json);
     },
   });
 }
@@ -302,7 +310,7 @@ for (const [size, value] of SPARSE) {
     group: groupKey("sparse", size),
     baseline: true,
     fn() {
-      jsonFromValue(value);
+      jsonFromFabricValue(value);
     },
   });
 }
@@ -312,7 +320,7 @@ for (const [size, json] of SPARSE_JSON) {
     name: `decode ${groupKey("sparse", size)}`,
     group: groupKey("sparse", size),
     fn() {
-      valueFromJson(json);
+      fabricFromJsonValue(json);
     },
   });
 }
@@ -327,7 +335,7 @@ for (const [size, value] of OBJECTS) {
     group: groupKey("object", size),
     baseline: true,
     fn() {
-      jsonFromValue(value);
+      jsonFromFabricValue(value);
     },
   });
 }
@@ -337,7 +345,7 @@ for (const [size, json] of OBJECTS_JSON) {
     name: `decode ${groupKey("object", size)}`,
     group: groupKey("object", size),
     fn() {
-      valueFromJson(json);
+      fabricFromJsonValue(json);
     },
   });
 }
@@ -352,7 +360,7 @@ for (const [leaves, value] of OMNIBUSES) {
     group: groupKey("omnibus", leaves),
     baseline: true,
     fn() {
-      jsonFromValue(value);
+      jsonFromFabricValue(value);
     },
   });
 }
@@ -362,7 +370,7 @@ for (const [leaves, json] of OMNIBUSES_JSON) {
     name: `decode ${groupKey("omnibus", leaves)}`,
     group: groupKey("omnibus", leaves),
     fn() {
-      valueFromJson(json);
+      fabricFromJsonValue(json);
     },
   });
 }

--- a/packages/data-model/src/codecs.ts
+++ b/packages/data-model/src/codecs.ts
@@ -73,7 +73,7 @@ const jsonCodecEngine = newDefaultJsonCodecEngine();
  * singleton (`shouldDeepFreeze` is `true`); only the `getCell()` throw
  * message is decode-framed, so an unexpected cell reference during a
  * context-less decode produces a message that names the situation. This
- * single instance covers both public entry points (`valueFromJson()` and
+ * single instance covers both public entry points (`fabricFromJsonValue()` and
  * `plainObjectFromJson()`, the latter delegating to the former).
  */
 const JSON_DECODE_EMPTY_CONTEXT = Object.freeze(
@@ -87,7 +87,7 @@ const JSON_DECODE_EMPTY_CONTEXT = Object.freeze(
  * Encodes a fabric value to a JSON string in the standard `FabricValue`
  * JSON-embedded encoding, prefixed with the format-identifying tag `fvj1:`.
  */
-export function jsonFromValue(value: FabricValue): string {
+export function jsonFromFabricValue(value: FabricValue): string {
   return jsonCodecEngine.encode(value);
 }
 
@@ -95,14 +95,14 @@ export function jsonFromValue(value: FabricValue): string {
  * Decodes a string in the `FabricValue` JSON-embedded encoding format, which is
  * expected to be a plain object. Throws if it turns out to be something else.
  * If `context` is omitted, a shared decode-framed empty context is
- * substituted (via `valueFromJson()`), which throws if any reconstruction
+ * substituted (via `fabricFromJsonValue()`), which throws if any reconstruction
  * is needed.
  */
 export function plainObjectFromJson<T extends object = object>(
   json: string,
   context?: ReconstructionContext,
 ): T {
-  const result = valueFromJson(json, context);
+  const result = fabricFromJsonValue(json, context);
 
   if ((result === null) || (typeof result !== "object")) {
     throw new Error(
@@ -127,7 +127,7 @@ export function plainObjectFromJson<T extends object = object>(
  * (`JSON_DECODE_EMPTY_CONTEXT`) is substituted, which throws if any
  * reconstruction is needed.
  */
-export function valueFromJson(
+export function fabricFromJsonValue(
   json: string,
   context?: ReconstructionContext | undefined,
 ): FabricValue {

--- a/packages/data-model/src/data-uri-codec.ts
+++ b/packages/data-model/src/data-uri-codec.ts
@@ -11,7 +11,7 @@ import {
   toUnpaddedBase64urlFromText,
 } from "@commonfabric/utils/base64url";
 import { EmptyReconstructionContext } from "./codec-common/index.ts";
-import { jsonFromValue, valueFromJson } from "./codecs.ts";
+import { fabricFromJsonValue, jsonFromFabricValue } from "./codecs.ts";
 import type { FabricValue } from "./fabric-value.ts";
 
 /**
@@ -65,7 +65,7 @@ export function isFabricDataUri(id: string): boolean {
  * other preparation of `value`; callers hand it a ready `FabricValue`.
  */
 export function dataUriFromValue(value: FabricValue): UriString {
-  const payload = toUnpaddedBase64urlFromText(jsonFromValue(value));
+  const payload = toUnpaddedBase64urlFromText(jsonFromFabricValue(value));
   return `data:${DATA_URI_MEDIA_TYPE},${payload}` as UriString;
 }
 
@@ -150,7 +150,7 @@ export function extractDataUriPayloadText(
  *   it is empty or is bare JSON.
  */
 export function valueFromDataUriPayloadText(text: string): FabricValue {
-  return valueFromJson(text, dataUriReconstructionContext);
+  return fabricFromJsonValue(text, dataUriReconstructionContext);
 }
 
 /**

--- a/packages/data-model/test/codec-json/impl.test.ts
+++ b/packages/data-model/test/codec-json/impl.test.ts
@@ -13,7 +13,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { seemsLikeJsonEncodedFabricValue } from "@/codec-json/impl.ts";
-import { jsonFromValue } from "@/codecs.ts";
+import { jsonFromFabricValue } from "@/codecs.ts";
 
 describe("impl", () => {
   describe("seemsLikeJsonEncodedFabricValue", () => {
@@ -27,8 +27,8 @@ describe("impl", () => {
       expect(seemsLikeJsonEncodedFabricValue("fvj1:")).toBe(true);
     });
 
-    it("recognizes the actual output of `jsonFromValue()` (round-trip check)", () => {
-      const encoded = jsonFromValue({ a: 1, b: 42n });
+    it("recognizes the actual output of `jsonFromFabricValue()` (round-trip check)", () => {
+      const encoded = jsonFromFabricValue({ a: 1, b: 42n });
       expect(seemsLikeJsonEncodedFabricValue(encoded)).toBe(true);
     });
 

--- a/packages/data-model/test/codecs.test.ts
+++ b/packages/data-model/test/codecs.test.ts
@@ -18,9 +18,9 @@ import { expect } from "@std/expect";
 
 import {
   createDefaultJsonRegistry,
-  jsonFromValue,
+  fabricFromJsonValue,
+  jsonFromFabricValue,
   plainObjectFromJson,
-  valueFromJson,
 } from "@/codecs.ts";
 import { seemsLikeJsonEncodedFabricValue } from "@/codec-json/impl.ts";
 import { JsonCodecEngine } from "@/codec-json/JsonCodecEngine.ts";
@@ -42,7 +42,7 @@ const mockRuntime = new MockRuntime();
 
 /** Encodes and then decodes a value, per the current dispatch configuration. */
 function roundTrip(value: FabricValue): FabricValue {
-  return valueFromJson(jsonFromValue(value), mockRuntime);
+  return fabricFromJsonValue(jsonFromFabricValue(value), mockRuntime);
 }
 
 /**
@@ -50,7 +50,7 @@ function roundTrip(value: FabricValue): FabricValue {
  * compared as parsed structure, after stripping the modern encoding prefix.
  */
 function expectWireFormat(value: FabricValue, expected: unknown): void {
-  const json = jsonFromValue(value);
+  const json = jsonFromFabricValue(value);
   expect(seemsLikeJsonEncodedFabricValue(json)).toBe(true);
   expect(
     JSON.parse(JsonCodecEngine.unwrapEncodedValueForTesting(json)),
@@ -81,22 +81,22 @@ describe("codecs", () => {
     expect(roundTrip(42n)).toBe(42n);
   });
 
-  it("`jsonFromValue()` encodes `undefined` to tagged JSON", () => {
+  it("`jsonFromFabricValue()` encodes `undefined` to tagged JSON", () => {
     expectWireFormat(undefined, { "/Undefined@1": null });
   });
 
-  it("`jsonFromValue()` encodes `bigint` to tagged JSON", () => {
+  it("`jsonFromFabricValue()` encodes `bigint` to tagged JSON", () => {
     expectWireFormat(42n, { "/BigInt@1": "Kg" });
   });
 
-  it("`valueFromJson()` decodes tagged `undefined`", () => {
+  it("`fabricFromJsonValue()` decodes tagged `undefined`", () => {
     const json = 'fvj1:{"\/Undefined@1":null}';
-    expect(valueFromJson(json, mockRuntime)).toBe(undefined);
+    expect(fabricFromJsonValue(json, mockRuntime)).toBe(undefined);
   });
 
-  it("`valueFromJson()` decodes tagged `bigint`", () => {
+  it("`fabricFromJsonValue()` decodes tagged `bigint`", () => {
     const json = 'fvj1:{"\/BigInt@1":"Kg"}';
-    expect(valueFromJson(json, mockRuntime)).toBe(42n);
+    expect(fabricFromJsonValue(json, mockRuntime)).toBe(42n);
   });
 
   it("round-trips plain objects", () => {
@@ -114,10 +114,10 @@ describe("codecs", () => {
   });
 
   it("JSON-safe primitives stringify normally (under the encoding prefix)", () => {
-    expect(jsonFromValue(42)).toBe("fvj1:42");
-    expect(jsonFromValue("hello")).toBe('fvj1:"hello"');
-    expect(jsonFromValue(true)).toBe("fvj1:true");
-    expect(jsonFromValue(null)).toBe("fvj1:null");
+    expect(jsonFromFabricValue(42)).toBe("fvj1:42");
+    expect(jsonFromFabricValue("hello")).toBe('fvj1:"hello"');
+    expect(jsonFromFabricValue(true)).toBe("fvj1:true");
+    expect(jsonFromFabricValue(null)).toBe("fvj1:null");
   });
 
   describe("edge case", () => {
@@ -234,28 +234,30 @@ describe("codecs", () => {
     });
   });
 
-  describe("`valueFromJson()` without a runtime argument", () => {
+  describe("`fabricFromJsonValue()` without a runtime argument", () => {
     it("decodes a plain object", () => {
-      expect(valueFromJson('fvj1:{"a":1}')).toEqual({ a: 1 });
+      expect(fabricFromJsonValue('fvj1:{"a":1}')).toEqual({ a: 1 });
     });
 
     it("decodes a primitive", () => {
-      expect(valueFromJson("fvj1:42")).toBe(42);
+      expect(fabricFromJsonValue("fvj1:42")).toBe(42);
     });
 
     it("decodes tagged values that don't need cell reconstruction", () => {
-      expect(valueFromJson('fvj1:{"\/Undefined@1":null}')).toBe(undefined);
-      expect(valueFromJson('fvj1:{"\/BigInt@1":"Kg"}')).toBe(42n);
+      expect(fabricFromJsonValue('fvj1:{"\/Undefined@1":null}')).toBe(
+        undefined,
+      );
+      expect(fabricFromJsonValue('fvj1:{"\/BigInt@1":"Kg"}')).toBe(42n);
     });
 
     it("explicit `undefined` runtime is equivalent to omission", () => {
-      expect(valueFromJson('fvj1:{"a":1}', undefined)).toEqual({ a: 1 });
+      expect(fabricFromJsonValue('fvj1:{"a":1}', undefined)).toEqual({ a: 1 });
     });
   });
 
   describe("plainObjectFromJson", () => {
     it("returns the decoded plain object", () => {
-      const json = jsonFromValue({ a: 1, b: 42n });
+      const json = jsonFromFabricValue({ a: 1, b: 42n });
       const result = plainObjectFromJson<{ a: number; b: bigint }>(json);
       expect(result.a).toBe(1);
       expect(result.b).toBe(42n);
@@ -263,18 +265,18 @@ describe("codecs", () => {
 
     it("throws on a class instance (`FabricError`)", () => {
       const err = FabricError.fromNativeError(new Error("test"));
-      const json = jsonFromValue(err);
+      const json = jsonFromFabricValue(err);
       expect(() => plainObjectFromJson(json)).toThrow(/instance/);
     });
 
     it("throws on an array", () => {
-      const json = jsonFromValue(["whoops"]);
+      const json = jsonFromFabricValue(["whoops"]);
       expect(() => plainObjectFromJson(json)).toThrow(/array/);
     });
 
     for (const prim of [null, 123, "florp", true]) {
       it(`throws on primitive \`${prim}\``, () => {
-        const json = jsonFromValue(prim);
+        const json = jsonFromFabricValue(prim);
         expect(() => plainObjectFromJson(json)).toThrow(/primitive/);
       });
     }

--- a/packages/data-model/test/data-uri-codec.test.ts
+++ b/packages/data-model/test/data-uri-codec.test.ts
@@ -26,7 +26,7 @@ import {
   JsonCodecEngine,
   seemsLikeJsonEncodedFabricValue,
 } from "@/codec-json/index.ts";
-import { jsonFromValue } from "@/codecs.ts";
+import { jsonFromFabricValue } from "@/codecs.ts";
 import {
   DATA_URI_MEDIA_TYPE,
   dataUriFromValue,
@@ -93,7 +93,7 @@ describe("data-uri-codec", () => {
       for (const value of values) {
         const uri = dataUriFromValue(value);
         expect(uri.slice(uri.indexOf(",") + 1)).toBe(
-          toUnpaddedBase64url(textEncoder.encode(jsonFromValue(value))),
+          toUnpaddedBase64url(textEncoder.encode(jsonFromFabricValue(value))),
         );
       }
     });
@@ -182,14 +182,16 @@ describe("data-uri-codec", () => {
 
   describe("valueFromDataUriPayloadText", () => {
     it("decodes encoded payload text of every top-level shape", () => {
-      expect(valueFromDataUriPayloadText(jsonFromValue({ b: 1, a: [true] })))
+      expect(
+        valueFromDataUriPayloadText(jsonFromFabricValue({ b: 1, a: [true] })),
+      )
         .toEqual({ b: 1, a: [true] });
-      expect(valueFromDataUriPayloadText(jsonFromValue([1, 2, 3])))
+      expect(valueFromDataUriPayloadText(jsonFromFabricValue([1, 2, 3])))
         .toEqual([1, 2, 3]);
-      expect(valueFromDataUriPayloadText(jsonFromValue("plain"))).toBe(
+      expect(valueFromDataUriPayloadText(jsonFromFabricValue("plain"))).toBe(
         "plain",
       );
-      expect(valueFromDataUriPayloadText(jsonFromValue(null))).toBe(null);
+      expect(valueFromDataUriPayloadText(jsonFromFabricValue(null))).toBe(null);
     });
 
     it("throws given historical bare-JSON payload text", () => {
@@ -207,7 +209,9 @@ describe("data-uri-codec", () => {
 
     it("decodes encoded-`FabricValue` payload text", () => {
       const value = { value: { b: 1, a: [true, null, "x"] } };
-      expect(valueFromDataUriPayloadText(jsonFromValue(value))).toEqual(value);
+      expect(valueFromDataUriPayloadText(jsonFromFabricValue(value))).toEqual(
+        value,
+      );
     });
 
     it("throws given invalid payload text past the codec tag", () => {
@@ -236,7 +240,7 @@ describe("data-uri-codec", () => {
     // form is not.
     it("throws given the `application/json` media type", () => {
       const payload = toUnpaddedBase64url(
-        new TextEncoder().encode(jsonFromValue({ a: 1 })),
+        new TextEncoder().encode(jsonFromFabricValue({ a: 1 })),
       );
       expect(() => valueFromDataUri(`data:application/json,${payload}`))
         .toThrow(/Invalid URI/);
@@ -246,7 +250,7 @@ describe("data-uri-codec", () => {
     // fails the media-type check.
     it("throws given header parameters (charset, base64)", () => {
       const payload = toUnpaddedBase64url(
-        new TextEncoder().encode(jsonFromValue({})),
+        new TextEncoder().encode(jsonFromFabricValue({})),
       );
       expect(() =>
         valueFromDataUri(
@@ -268,7 +272,7 @@ describe("data-uri-codec", () => {
     });
 
     it("throws given a percent-encoded payload", () => {
-      const payload = encodeURIComponent(jsonFromValue({ a: 1 }));
+      const payload = encodeURIComponent(jsonFromFabricValue({ a: 1 }));
       expect(() =>
         valueFromDataUri(
           `data:${DATA_URI_MEDIA_TYPE},${payload}`,
@@ -293,26 +297,26 @@ describe("data-uri-codec", () => {
     describe("encoded-`FabricValue` payloads", () => {
       it("decodes a payload", () => {
         const value = { value: { b: 1, a: [true, null, "x"] } };
-        expect(valueFromDataUri(uriOf(jsonFromValue(value)))).toEqual(
+        expect(valueFromDataUri(uriOf(jsonFromFabricValue(value)))).toEqual(
           value,
         );
       });
 
       it("decodes non-ASCII text", () => {
         const value = { value: "città" };
-        expect(valueFromDataUri(uriOf(jsonFromValue(value))))
+        expect(valueFromDataUri(uriOf(jsonFromFabricValue(value))))
           .toEqual(value);
       });
 
       it("decodes a non-object payload", () => {
-        expect(valueFromDataUri(uriOf(jsonFromValue([1, 2, 3]))))
+        expect(valueFromDataUri(uriOf(jsonFromFabricValue([1, 2, 3]))))
           .toEqual([1, 2, 3]);
-        expect(valueFromDataUri(uriOf(jsonFromValue("plain"))))
+        expect(valueFromDataUri(uriOf(jsonFromFabricValue("plain"))))
           .toBe("plain");
       });
 
       it("preserves non-finite numbers and negative zero", () => {
-        const uri = uriOf(jsonFromValue({ value: [NaN, -0, Infinity] }));
+        const uri = uriOf(jsonFromFabricValue({ value: [NaN, -0, Infinity] }));
         const result = valueFromDataUri(uri);
         expect(Object.is(result.value[0], NaN)).toBe(true);
         expect(Object.is(result.value[1], -0)).toBe(true);
@@ -326,13 +330,15 @@ describe("data-uri-codec", () => {
         const value = {
           value: { "/": { "link@1": { id: "of:xyz", path: ["a"] } } },
         };
-        expect(valueFromDataUri(uriOf(jsonFromValue(value)))).toEqual(
+        expect(valueFromDataUri(uriOf(jsonFromFabricValue(value)))).toEqual(
           value,
         );
       });
 
       it("returns deep-frozen results", () => {
-        const uri = uriOf(jsonFromValue({ value: { nested: { deep: [1] } } }));
+        const uri = uriOf(
+          jsonFromFabricValue({ value: { nested: { deep: [1] } } }),
+        );
         const result = valueFromDataUri(uri);
         expect(Object.isFrozen(result)).toBe(true);
         expect(Object.isFrozen(result.value)).toBe(true);
@@ -342,7 +348,7 @@ describe("data-uri-codec", () => {
       it("stops the payload at a raw query or fragment delimiter", () => {
         // base64url never contains `?` or `#`; raw ones delimit a
         // query/fragment per the URL grammar.
-        const uri = uriOf(jsonFromValue({ a: 1 }));
+        const uri = uriOf(jsonFromFabricValue({ a: 1 }));
         expect(valueFromDataUri(`${uri}#frag`)).toEqual({ a: 1 });
         expect(valueFromDataUri(`${uri}?q=1`)).toEqual({ a: 1 });
       });

--- a/packages/data-model/test/fabric-instances/FabricLink.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricLink.test.ts
@@ -34,7 +34,7 @@ import { CODEC } from "@/codec-interface/interface.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/codec-interface/EmptyReconstructionContext.ts";
 import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
-import { jsonFromValue, valueFromJson } from "@/codecs.ts";
+import { fabricFromJsonValue, jsonFromFabricValue } from "@/codecs.ts";
 import { hashOf } from "@/value-hash.ts";
 
 describe("FabricLink", () => {
@@ -233,14 +233,16 @@ describe("FabricLink", () => {
 
   // Free functions exercising `FabricLink` rather than members of the class
   // itself, so they live directly under the class `describe()`.
-  describe("round-trip via `jsonFromValue()` / `valueFromJson()`", () => {
+  describe("round-trip via `jsonFromFabricValue()` / `fabricFromJsonValue()`", () => {
     it("round-trips a `FabricLink`, including a nested schema", () => {
       const original = new FabricLink({
         id: "fid1:abc",
         path: ["a", "b"],
         schema: { type: "object", properties: { x: { type: "number" } } },
       });
-      const restored = valueFromJson(jsonFromValue(original)) as FabricLink;
+      const restored = fabricFromJsonValue(
+        jsonFromFabricValue(original),
+      ) as FabricLink;
       expect(restored).toBeInstanceOf(FabricLink);
       expect(restored.payload).toEqual(original.payload);
     });

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -34,7 +34,7 @@ import {
   tagFromNativeClass,
   tagFromNativeValue,
 } from "@/native-type-tags.ts";
-import { jsonFromValue, valueFromJson } from "@/codecs.ts";
+import { fabricFromJsonValue, jsonFromFabricValue } from "@/codecs.ts";
 import { hashOf } from "@/value-hash.ts";
 
 describe("FabricRegExp", () => {
@@ -239,10 +239,12 @@ describe("FabricRegExp", () => {
   // The following exercise free functions' handling of `FabricRegExp` /
   // `RegExp` rather than members of the class itself, so they live directly
   // under the class `describe()` (the cross-cutting carve-out).
-  describe("round-trip via `jsonFromValue()` / `valueFromJson()`", () => {
+  describe("round-trip via `jsonFromFabricValue()` / `fabricFromJsonValue()`", () => {
     it("round-trips a `FabricRegExp`", () => {
       const original = new FabricRegExp(/hello\s+world/gim);
-      const restored = valueFromJson(jsonFromValue(original)) as FabricRegExp;
+      const restored = fabricFromJsonValue(
+        jsonFromFabricValue(original),
+      ) as FabricRegExp;
       expect(restored).toBeInstanceOf(FabricRegExp);
       expect(restored.source).toBe(original.source);
       expect(restored.flags).toBe(original.flags);
@@ -253,7 +255,9 @@ describe("FabricRegExp", () => {
       const flagSets = ["", "g", "i", "m", "s", "u", "y", "d", "gi", "gims"];
       for (const flags of flagSets) {
         const original = new FabricRegExp(new RegExp("test", flags));
-        const restored = valueFromJson(jsonFromValue(original)) as FabricRegExp;
+        const restored = fabricFromJsonValue(
+          jsonFromFabricValue(original),
+        ) as FabricRegExp;
         expect(restored.flags).toBe(original.flags);
         expect(restored.flavor).toBe("es2025");
       }
@@ -261,7 +265,9 @@ describe("FabricRegExp", () => {
 
     it("round-trips a non-`es2025` flavor faithfully (source/flags/flavor)", () => {
       const original = new FabricRegExp("pcre2", "ab+c", "g");
-      const restored = valueFromJson(jsonFromValue(original)) as FabricRegExp;
+      const restored = fabricFromJsonValue(
+        jsonFromFabricValue(original),
+      ) as FabricRegExp;
       expect(restored.source).toBe("ab+c");
       expect(restored.flags).toBe("g");
       expect(restored.flavor).toBe("pcre2");

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -2,7 +2,10 @@ import {
   type EntityRef,
   getModernCellRepConfig,
 } from "@commonfabric/data-model/cell-rep";
-import { jsonFromValue, valueFromJson } from "@commonfabric/data-model/codecs";
+import {
+  fabricFromJsonValue,
+  jsonFromFabricValue,
+} from "@commonfabric/data-model/codecs";
 import { internPathSelector } from "@commonfabric/data-model/schema-utils";
 import type {
   FabricPlainObject,
@@ -1115,7 +1118,7 @@ export const wireMemoryProtocolFlags = (
  * stops holding.
  */
 export const encodeMemoryBoundary = (value: FabricValue): string =>
-  jsonFromValue(value);
+  jsonFromFabricValue(value);
 
 export const commitPreconditionValueHash = (value: FabricValue): string =>
   hashStringOf(encodeMemoryBoundary(value));
@@ -1123,7 +1126,7 @@ export const commitPreconditionValueHash = (value: FabricValue): string =>
 export const decodeMemoryBoundary = <Value extends FabricValue = FabricValue>(
   source: string,
 ): Value & FabricValue => {
-  const decoded = valueFromJson(
+  const decoded = fabricFromJsonValue(
     source,
     memoryReconstructionContext,
   );

--- a/packages/memory/v2/patch.ts
+++ b/packages/memory/v2/patch.ts
@@ -21,7 +21,7 @@ const MAX_ARRAY_INDEX = 2 ** 32 - 2;
  * `structuredClone()` MUST NOT be used here: it silently demotes class
  * instances to plain objects. A demoted `FabricError` then fails the
  * `value instanceof FabricInstance` check in the wire/persistence codec
- * (`jsonFromValue`/`FabricInstanceHandler`), so it is serialized
+ * (`jsonFromFabricValue()`/`FabricInstanceHandler`), so it is serialized
  * generically and its wrapped native `Error` -- whose `message`/`stack`
  * are non-enumerable -- collapses to `{}`, losing the error entirely.
  *

--- a/packages/runner/test/attestation-data-uri.test.ts
+++ b/packages/runner/test/attestation-data-uri.test.ts
@@ -8,7 +8,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { JsonCodecEngine } from "@commonfabric/data-model/codec-json";
-import { jsonFromValue } from "@commonfabric/data-model/codecs";
+import { jsonFromFabricValue } from "@commonfabric/data-model/codecs";
 import { toUnpaddedBase64url } from "@commonfabric/utils/base64url";
 import { DATA_URI_MEDIA_TYPE } from "@commonfabric/data-model/data-uri-codec";
 import { load } from "../src/storage/transaction/attestation.ts";
@@ -28,7 +28,7 @@ describe("attestation `load()` of `data:` URIs", () => {
   });
 
   it("synthesizes the document around the decoded value", () => {
-    const { ok, error } = load({ id: uriOf(jsonFromValue({ x: 1 })) });
+    const { ok, error } = load({ id: uriOf(jsonFromFabricValue({ x: 1 })) });
     expect(error).toBeUndefined();
     expect(ok!.value).toEqual({ value: { x: 1 } });
     expect(ok!.address.path).toEqual([]);
@@ -37,14 +37,14 @@ describe("attestation `load()` of `data:` URIs", () => {
 
   it("loads an encoded-`FabricValue` payload", () => {
     const value = { b: 1, a: [true, null, "x"] };
-    const { ok, error } = load({ id: uriOf(jsonFromValue(value)) });
+    const { ok, error } = load({ id: uriOf(jsonFromFabricValue(value)) });
     expect(error).toBeUndefined();
     expect(ok!.value).toEqual({ value });
   });
 
   it("preserves non-finite numbers in an encoded payload", () => {
     const { ok, error } = load({
-      id: uriOf(jsonFromValue([NaN, -0, Infinity])),
+      id: uriOf(jsonFromFabricValue([NaN, -0, Infinity])),
     });
     expect(error).toBeUndefined();
     const items = (ok!.value as { value: number[] }).value;
@@ -72,7 +72,9 @@ describe("attestation `load()` of `data:` URIs", () => {
   it("rejects the `application/json` media type", () => {
     const { ok, error } = load({
       id: `data:application/json,${
-        toUnpaddedBase64url(new TextEncoder().encode(jsonFromValue({ a: 1 })))
+        toUnpaddedBase64url(
+          new TextEncoder().encode(jsonFromFabricValue({ a: 1 })),
+        )
       }` as URI,
     });
     expect(ok).toBeUndefined();
@@ -96,7 +98,7 @@ describe("attestation `load()` of `data:` URIs", () => {
   // media type (this format has no parameters).
   it("errors on a parameterized header", () => {
     const payload = toUnpaddedBase64url(
-      new TextEncoder().encode(jsonFromValue({ a: 1 })),
+      new TextEncoder().encode(jsonFromFabricValue({ a: 1 })),
     );
     const { ok, error } = load({
       id: `data:${DATA_URI_MEDIA_TYPE};base64,${payload}` as URI,
@@ -110,7 +112,7 @@ describe("attestation `load()` of `data:` URIs", () => {
   it("errors on a percent-encoded payload", () => {
     const { ok, error } = load({
       id: `data:${DATA_URI_MEDIA_TYPE},${
-        encodeURIComponent(jsonFromValue({ a: 1 }))
+        encodeURIComponent(jsonFromFabricValue({ a: 1 }))
       }` as URI,
     });
     expect(ok).toBeUndefined();

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -1256,7 +1256,7 @@ describe(`Cell result-meta round-trip`, () => {
       // Commit, then start a fresh tx. This forces the `path: ["result"]`
       // read to go through the storage layer (rather than the in-tx
       // novelty cache, which short-circuits serialization), so
-      // `valueFromJson` runs as the actual decode step.
+      // `fabricFromJsonValue()` runs as the actual decode step.
       await tx.commit();
       tx = runtime.edit();
 

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -4,7 +4,10 @@ import {
   assertExists,
   assertStrictEquals,
 } from "@std/assert";
-import { jsonFromValue, valueFromJson } from "@commonfabric/data-model/codecs";
+import {
+  fabricFromJsonValue,
+  jsonFromFabricValue,
+} from "@commonfabric/data-model/codecs";
 import { FabricEpochNsec } from "@commonfabric/data-model/fabric-primitives";
 import { Identity } from "@commonfabric/identity";
 import type { FabricValue } from "@commonfabric/api";
@@ -418,13 +421,13 @@ class ScriptedModelTransport extends ScriptedSessionTransport {
   // The commit payloads carry full FabricValues; decode with a context that
   // FAILS on cell reconstruction rather than the default memory context.
   protected override decode(payload: string): ScriptedTransportMessage {
-    return valueFromJson(
+    return fabricFromJsonValue(
       payload,
       testReconstructionContext,
     ) as ScriptedTransportMessage;
   }
   protected override encode(message: unknown): string {
-    return jsonFromValue(message as FabricValue);
+    return jsonFromFabricValue(message as FabricValue);
   }
 
   // The harness owns teardown; closing the session must not signal a

--- a/packages/runner/test/scheduler-observation-capability-skew.test.ts
+++ b/packages/runner/test/scheduler-observation-capability-skew.test.ts
@@ -23,7 +23,10 @@
  */
 
 import { assertEquals } from "@std/assert";
-import { jsonFromValue, valueFromJson } from "@commonfabric/data-model/codecs";
+import {
+  fabricFromJsonValue,
+  jsonFromFabricValue,
+} from "@commonfabric/data-model/codecs";
 import { EmptyReconstructionContext } from "@commonfabric/data-model/codec-common";
 import { Identity } from "@commonfabric/identity";
 import type { FabricValue } from "@commonfabric/api";
@@ -80,7 +83,7 @@ class FlagOffServerTransport implements MemoryV2Client.Transport {
 
   send(payload: string): Promise<void> {
     // Decoded wire payload, asserted to the shape this fake expects.
-    const message = valueFromJson(
+    const message = fabricFromJsonValue(
       payload,
       reconstructionContext,
     ) as unknown as {
@@ -197,7 +200,7 @@ class FlagOffServerTransport implements MemoryV2Client.Transport {
   }
 
   private respond(message: unknown): void {
-    this.#receiver(jsonFromValue(message as FabricValue));
+    this.#receiver(jsonFromFabricValue(message as FabricValue));
   }
 }
 

--- a/packages/schema-generator/test/fixtures-runner.test.ts
+++ b/packages/schema-generator/test/fixtures-runner.test.ts
@@ -9,7 +9,10 @@ import {
   defineFixtureSuite,
 } from "@commonfabric/test-support/fixture-runner";
 import { JsonCodecEngine } from "@commonfabric/data-model/codec-json";
-import { jsonFromValue, valueFromJson } from "@commonfabric/data-model/codecs";
+import {
+  fabricFromJsonValue,
+  jsonFromFabricValue,
+} from "@commonfabric/data-model/codecs";
 import {
   FabricPrimitive,
   type FabricValue,
@@ -195,7 +198,7 @@ async function runSchemaTransform(inputPath: string): Promise<SchemaResult> {
 function encodeGolden(value: unknown): string {
   const body = JSON.parse(
     JsonCodecEngine.unwrapEncodedValueForTesting(
-      jsonFromValue(value as FabricValue),
+      jsonFromFabricValue(value as FabricValue),
     ),
   );
   return JSON.stringify(body, null, 2) + "\n";
@@ -203,7 +206,7 @@ function encodeGolden(value: unknown): string {
 
 /** Inverse of {@link encodeGolden}. */
 function decodeGolden(text: string): unknown {
-  return valueFromJson(
+  return fabricFromJsonValue(
     JsonCodecEngine.wrapEncodedValueForTesting(text.trim()),
   );
 }

--- a/packages/state-inspector/decode.ts
+++ b/packages/state-inspector/decode.ts
@@ -3,7 +3,7 @@
 // Stored payloads (`revision.data`, `commit.original`, …) come in TWO at-rest
 // formats, BOTH seen in real DBs:
 //   - modern: a `data-model` codec-json envelope, carrying that codec's prefix
-//     (decode via valueFromJson)
+//     (decode via `fabricFromJsonValue()`)
 //   - legacy: plain JSON
 // In both, links/refs/streams appear as plain-data sigils:
 //   link   { "/": { "link@1": { id, space?, path?, scope?, schema? } } }
@@ -15,7 +15,7 @@
 // `/quote`-escaped literals, so a context-less decode is inert.
 
 import { seemsLikeJsonEncodedFabricValue } from "@commonfabric/data-model/codec-json";
-import { valueFromJson } from "@commonfabric/data-model/codecs";
+import { fabricFromJsonValue } from "@commonfabric/data-model/codecs";
 import { FabricLink } from "@commonfabric/data-model/fabric-instances";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
@@ -24,7 +24,7 @@ import { isPlainObject } from "@commonfabric/utils/types";
 /** Decode a stored payload string, routing the `data-model` codec envelope. */
 export function decodeStored(data: string): unknown {
   return seemsLikeJsonEncodedFabricValue(data)
-    ? valueFromJson(data)
+    ? fabricFromJsonValue(data)
     : JSON.parse(data);
 }
 
@@ -87,11 +87,12 @@ export function parseSigilLink(v: Json): DecodedLink | null {
 
 /**
  * A link in EITHER at-rest form: the legacy `{ "/": { "link@N": … } }` sigil, or
- * a modern `FabricLink` instance (which `valueFromJson` can restore from a
- * codec envelope). Detected by class — `cell-rep`'s `isLinkRef` is gated on a
- * global modern-mode flag the inspector doesn't set, so we check `FabricLink`
- * directly and read its `.payload`. Without this, a modern link is an opaque
- * instance with no enumerable keys and vanishes from links/lineage/graph.
+ * a modern `FabricLink` instance (which `fabricFromJsonValue()` can restore
+ * from a codec envelope). Detected by class — `cell-rep`'s `isLinkRef` is gated
+ * on a global modern-mode flag the inspector doesn't set, so we check
+ * `FabricLink` directly and read its `.payload`. Without this, a modern link is
+ * an opaque instance with no enumerable keys and vanishes from
+ * links/lineage/graph.
  */
 export function decodedLinkOf(v: Json): DecodedLink | null {
   const sigil = parseSigilLink(v);

--- a/packages/state-inspector/test/cli.test.ts
+++ b/packages/state-inspector/test/cli.test.ts
@@ -6,7 +6,7 @@
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { expect } from "@std/expect";
 import { Database } from "@db/sqlite";
-import { jsonFromValue } from "@commonfabric/data-model/codecs";
+import { jsonFromFabricValue } from "@commonfabric/data-model/codecs";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 
 import { main } from "../cli.ts";
@@ -53,7 +53,7 @@ function seed(path: string) {
     "of:a",
     1,
     "set",
-    jsonFromValue({
+    jsonFromFabricValue({
       value: {
         n: 1,
         deep,

--- a/packages/state-inspector/test/convergence.test.ts
+++ b/packages/state-inspector/test/convergence.test.ts
@@ -5,7 +5,7 @@
 import { assert, assertEquals } from "@std/assert";
 import { Database } from "@db/sqlite";
 import type { FabricValue } from "@commonfabric/api";
-import { jsonFromValue } from "@commonfabric/data-model/codecs";
+import { jsonFromFabricValue } from "@commonfabric/data-model/codecs";
 
 import {
   convergence,
@@ -68,7 +68,7 @@ function makeSpace(
   entries.forEach((e, i) => {
     const seq = i + 1;
     commit.run(seq, `session-${i}`, 1, JSON.stringify({ seq }));
-    rev.run(e.id, seq, jsonFromValue({ value: e.value }), seq);
+    rev.run(e.id, seq, jsonFromFabricValue({ value: e.value }), seq);
   });
   db.close();
 }

--- a/packages/state-inspector/test/decode.test.ts
+++ b/packages/state-inspector/test/decode.test.ts
@@ -10,7 +10,7 @@ import {
   FabricLink,
 } from "@commonfabric/data-model/fabric-instances";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import { jsonFromValue } from "@commonfabric/data-model/codecs";
+import { jsonFromFabricValue } from "@commonfabric/data-model/codecs";
 import {
   resetModernCellRepConfig,
   setModernCellRepConfig,
@@ -44,7 +44,9 @@ Deno.test("decode: a modern encoded link round-trips to a recognized link", () =
   setModernCellRepConfig(true);
   let encoded: string;
   try {
-    encoded = jsonFromValue({ value: { ref: new FabricLink({ id: "of:x" }) } });
+    encoded = jsonFromFabricValue({
+      value: { ref: new FabricLink({ id: "of:x" }) },
+    });
   } finally {
     resetModernCellRepConfig();
   }

--- a/packages/state-inspector/test/entities.test.ts
+++ b/packages/state-inspector/test/entities.test.ts
@@ -7,7 +7,7 @@
 
 import { assert, assertEquals } from "@std/assert";
 import { Database } from "@db/sqlite";
-import { jsonFromValue } from "@commonfabric/data-model/codecs";
+import { jsonFromFabricValue } from "@commonfabric/data-model/codecs";
 
 import { openSpace } from "../db.ts";
 import { listCommits } from "../queries.ts";
@@ -50,7 +50,7 @@ function seed(path: string) {
   const session = "session:did:key:zSpaceAAAA:11111111-2222-3333";
 
   // Commit 1: original stored codec-encoded with 2 ops and 1 confirmed read.
-  const original = jsonFromValue({
+  const original = jsonFromFabricValue({
     localSeq: 1,
     operations: [{ op: "set" }, { op: "patch" }],
     reads: { confirmed: [{ id: "x" }], pending: [] },

--- a/packages/state-inspector/test/timetravel.test.ts
+++ b/packages/state-inspector/test/timetravel.test.ts
@@ -4,7 +4,7 @@
 
 import { assert, assertEquals, assertThrows } from "@std/assert";
 import { Database } from "@db/sqlite";
-import { jsonFromValue } from "@commonfabric/data-model/codecs";
+import { jsonFromFabricValue } from "@commonfabric/data-model/codecs";
 
 import { openSpace } from "../db.ts";
 import {
@@ -52,7 +52,7 @@ function seed(path: string) {
     "of:A",
     1,
     "set",
-    jsonFromValue({
+    jsonFromFabricValue({
       value: {
         count: 0,
         title: "a",
@@ -69,7 +69,7 @@ function seed(path: string) {
     "of:E",
     1,
     "set",
-    jsonFromValue({ value: { n: 1, m: 1 } }),
+    jsonFromFabricValue({ value: { n: 1, m: 1 } }),
     1,
   );
   // commit 2: create B and encounter an invalid E patch
@@ -112,7 +112,7 @@ function seed(path: string) {
     "of:E",
     4,
     "set",
-    jsonFromValue({ value: { n: 10, m: 10 } }),
+    jsonFromFabricValue({ value: { n: 10, m: 10 } }),
     4,
   );
   // commit 5: a patch after the set can be reconstructed

--- a/tasks/pattern-compat-lib.ts
+++ b/tasks/pattern-compat-lib.ts
@@ -23,7 +23,10 @@ import { type JSONSchema, type Pattern } from "@commonfabric/runner";
 import { validateSchemaDefinition } from "@commonfabric/runner/cfc";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { JsonCodecEngine } from "@commonfabric/data-model/codec-json";
-import { jsonFromValue, valueFromJson } from "@commonfabric/data-model/codecs";
+import {
+  fabricFromJsonValue,
+  jsonFromFabricValue,
+} from "@commonfabric/data-model/codecs";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { assertPatternSchemasBackwardCompatible } from "../packages/piece/src/schema-compatibility.ts";
 
@@ -156,7 +159,7 @@ export interface StoredBaseline extends PatternContract {
 export function encodeBaseline(stored: StoredBaseline): string {
   const body = JSON.parse(
     JsonCodecEngine.unwrapEncodedValueForTesting(
-      jsonFromValue(stored as unknown as FabricValue),
+      jsonFromFabricValue(stored as unknown as FabricValue),
     ),
   );
   return `${JSON.stringify(body, null, 2)}\n`;
@@ -164,7 +167,7 @@ export function encodeBaseline(stored: StoredBaseline): string {
 
 /** Inverse of {@link encodeBaseline}. */
 export function decodeBaseline(text: string): StoredBaseline {
-  return valueFromJson(
+  return fabricFromJsonValue(
     JsonCodecEngine.wrapEncodedValueForTesting(text.trim()),
   ) as unknown as StoredBaseline;
 }


### PR DESCRIPTION
`jsonFromValue()` and `valueFromJson()` become `jsonFromFabricValue()` and
`fabricFromJsonValue()`, matching the `<target>From<Source>Value` shape that
`fabricFromNativeValue()` and `nativeFromFabricValue()` establish.

Qualifying both sides is what does the work. With one half left bare,
`valueFromJson()` reads as "a value from JSON" — naming the format being
crossed rather than the form being converted. With `json` sitting against
`value` it can only be a modifier, so a *JSON value* is this textual form
exactly as a *native value* is a plain JavaScript one.

I (agent working on behalf of @danfuzz) did the rename mechanically, but four
things around it were not mechanical and are worth a reviewer's eye:

- **Import order.** Ten sites had the two names sorted by their old spelling;
  they are re-sorted alphabetically under the new one.
- **Line width.** The longer names push prose past 80 columns. `deno fmt`
  rewraps code but not comment prose or Markdown, so a spec bullet and the
  `state-inspector/decode.ts` doc comment are rewrapped by hand. Over-80
  `it()` description strings are left alone, being pre-existing practice in
  those files.
- **Trailing parens.** Four comments named these functions bare; per the
  repository's comment style they now carry `()`. Everything still bare after
  the sweep is an import specifier.
- **`docs/history/` is untouched.** The 2026-08 data-URI-mint document still
  says `jsonFromValue()`, which is what was true when it was written.

`plainObjectFromJson()` has the same bare half and is deliberately left alone:
"plain object" is not a `<source>Value` the way `fabric`, `json` and `native`
are, so aligning it is a separate question rather than part of this sweep.

## Verification

Repo-wide `deno fmt --check`, `deno lint`, `deno task check`,
`deno task check-docs` (549 blocks) and `deno task check-skill-facts` all pass.
Package suites for every package this touches pass: `data-model` (54),
`state-inspector` (102), `schema-generator` (55), `memory` (495), `cli` (174),
`runner` (1200). `tasks/pattern-compat-lib.ts` and
`packages/data-model/bench/codec-json.bench.ts` were type-checked explicitly,
since `deno task check` covers neither.

## Coverage debt accepted, and why

The coverage gate charges this PR two lines it did not write:
`packages/memory/v2/client.ts` 1101 and 1102. That file is not in this diff —
the only `memory` files here are `v2.ts` and `v2/patch.ts`, and both changed by
rename alone. Those two lines flap on `main`, so the gate compares a run that
happened to cover them against one that happened not to, and whichever PR is
measured in between fails.

Accepted with the narrow per-metric marker rather than the broad reset, so the
acceptance covers this one group and nothing else:

```text
ACCEPT_COVERAGE_DEBT: coverage-debt: packages/memory uncovered lines = 643 lines
```

The flake itself is worth fixing, and a follow-on PR will take it up per the
agent prompt in the coverage bot's comment. `docs/development/COVERAGE.md`,
under "What the check says when the regression is not the pull request's", is
explicit that this PR is not the place for that fix and should not wait on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vyoNfY94Mn4biMaEz3gni


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


