### PR TITLE
test(patterns): make multi-runtime settle() wait on real delivery

### DIFF
--- a/packages/memory/v2/standalone.ts
+++ b/packages/memory/v2/standalone.ts
@@ -99,6 +99,18 @@ export class StandaloneMemoryServer {
     return new StandaloneMemoryServer(memory, http);
   }
 
+  /**
+   * Drain the underlying memory server: apply every received commit, run
+   * post-commit scheduler bookkeeping, and flush all pending subscription
+   * fan-out so every frame the server owes its subscribers has been sent.
+   * A passthrough to `MemoryServer.Server.idle()`; multi-runtime test harnesses
+   * call it as the deterministic "the server has published everything" barrier
+   * in place of a fixed delay.
+   */
+  async idle(): Promise<void> {
+    await this.#memory.idle();
+  }
+
   async close(): Promise<void> {
     await this.#http.shutdown();
     await this.#memory.close();

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -276,6 +276,15 @@ export class MultiRuntimeSession {
     await this.#client.call("idle");
   }
 
+  /**
+   * Force an ordered-after round trip on this runtime's open space connections,
+   * so any subscription fan-out the server has already sent has landed here.
+   * See `MultiRuntimeHarness.settle`.
+   */
+  async barrier(): Promise<void> {
+    await this.#client.call("barrier");
+  }
+
   /** Capture scheduler graph, settle stats history, and action run trace. */
   async diagnostics(): Promise<RuntimeDiagnosticsSnapshot> {
     return await this.#client.call("diagnostics") as RuntimeDiagnosticsSnapshot;
@@ -404,12 +413,32 @@ export class MultiRuntimeHarness {
     return session;
   }
 
-  /** Let all runtimes finish local work and exchange pending sync traffic. */
+  /**
+   * Let all runtimes finish local work and exchange pending sync traffic. Each
+   * round is one full cross-runtime hop, driven by real completion signals
+   * rather than a timer:
+   *
+   * 1. Every runtime settles its own reactivity and flushes its pending commits
+   *    to the server (`session.idle`).
+   * 2. The in-process server drains: it applies every commit it has received
+   *    and sends all pending subscription fan-out (`server.idle`).
+   * 3. Every runtime forces an ordered-after round trip on its open space
+   *    connections (`session.barrier`). Because a WebSocket delivers a
+   *    connection's frames in order, the fan-out the server just sent has been
+   *    received and applied by the time each round trip's response returns.
+   * 4. Every runtime settles again, so a foreign write that just arrived and
+   *    re-derives local cells has its recompute run before this round ends.
+   *
+   * With a running toolshed (when `apiUrl` was passed) there is no in-process
+   * server handle for step 2; the barrier in step 3 still pulls in whatever the
+   * toolshed has sent, and successive rounds converge.
+   */
   async settle(rounds = 2): Promise<void> {
     for (let i = 0; i < rounds; i++) {
       await Promise.all(this.sessions.map((session) => session.idle()));
-      // Give subscription pushes a macrotask to land before the next round.
-      await new Promise((resolve) => setTimeout(resolve, 25));
+      await this.#server?.idle();
+      await Promise.all(this.sessions.map((session) => session.barrier()));
+      await Promise.all(this.sessions.map((session) => session.idle()));
     }
   }
 

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -432,6 +432,15 @@ const handlers: Record<
     return {};
   },
 
+  // Force an ordered-after round trip on every open space connection, so any
+  // subscription fan-out the server has already sent has been received and
+  // applied by this runtime before returning. The harness's cross-runtime
+  // delivery barrier (see MultiRuntimeHarness.settle).
+  async barrier() {
+    await controller().runtime.storageManager.pullOpenSpacesToHead();
+    return {};
+  },
+
   async diagnostics() {
     await idle();
     const scheduler = controller().runtime.scheduler;

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -167,6 +167,20 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
   synced(): Promise<void>;
 
   /**
+   * Issue an ordered-after round trip on every open space connection, so that
+   * any subscription fan-out the server has already sent has been received and
+   * applied before this resolves. Unlike `synced()`, which waits only on this
+   * replica's own pending syncs and commits, this waits on the delivery of a
+   * peer's committed writes that the server has begun fanning out. A WebSocket
+   * delivers a connection's frames in order, so a fresh round trip on that
+   * connection cannot resolve ahead of fan-out the server sent earlier on it.
+   * Multi-runtime test harnesses use it to make one runtime observe another's
+   * committed state deterministically; a manager with no open remote
+   * connection resolves immediately.
+   */
+  pullOpenSpacesToHead(): Promise<void>;
+
+  /**
    * A throwable `AuthorizationError` when `space` is under a permanent
    * authorization denial (an ACL shortfall, an audience or protocol mismatch),
    * or undefined when it is authorized or was never opened. Scoped to one space

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1192,6 +1192,14 @@ export class StorageManager implements IStorageManager {
     return promise;
   }
 
+  async pullOpenSpacesToHead(): Promise<void> {
+    await Promise.all(
+      [...this.#providers.values()].map((provider) =>
+        provider.pullToServerHead()
+      ),
+    );
+  }
+
   /**
    * A throwable `AuthorizationError` when `space` is under a permanent
    * authorization denial (an ACL shortfall, an audience or protocol mismatch),
@@ -1857,6 +1865,10 @@ class Provider implements IStorageProvider {
     return this.followReplacement((replica) => replica.entityIdExists(id));
   }
 
+  pullToServerHead(): Promise<void> {
+    return this.followReplacement((replica) => replica.pullToServerHead());
+  }
+
   listSchedulerActionSnapshots(
     query: SchedulerActionSnapshotQuery = {},
   ): Promise<SchedulerSnapshotListResult> {
@@ -2350,6 +2362,19 @@ class SpaceReplica implements ISpaceReplica {
       return undefined;
     }
     return (await session.entityIdExists(id))?.exists;
+  }
+
+  async pullToServerHead(): Promise<void> {
+    const { session } = await this.activeSessionHandle();
+    // An empty-root graph query fetches no document but still crosses the wire
+    // and returns the server's current sequence. Because a WebSocket delivers a
+    // connection's frames in order, any subscription fan-out the server has
+    // already sent on this connection has been received and applied by the time
+    // this response arrives — so the round trip doubles as a "this replica has
+    // caught up to everything the server had sent" barrier. `graph.query` is an
+    // unconditional round trip (it cannot be answered from the local replica),
+    // unlike the entity-id listing calls, which a server may decline by flag.
+    await session.queryGraph({ roots: [] });
   }
 
   /**

--- a/packages/runner/test/storage-pull-open-spaces.test.ts
+++ b/packages/runner/test/storage-pull-open-spaces.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import type * as MemoryV2Server from "@commonfabric/memory/v2/server";
+
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { Runtime } from "../src/runtime.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
+
+// `pullOpenSpacesToHead()` is the client half of the multi-runtime settle
+// barrier: it issues an unconditional `graph.query` round trip on every open
+// space connection, so subscription fan-out the server has already sent has
+// been received and applied before it resolves. The server holds fan-out
+// manually here, so a second replica is provably stale until the write is
+// published; the barrier is then what carries the published write into it.
+//
+// The deterministic cross-realm ordering guarantee this exploits (a WebSocket
+// delivers a connection's frames in order) is exercised end to end by the
+// packages/patterns multi-runtime integration suite, over real worker realms
+// and a real socket. This test pins the method's functional contract.
+
+const signer = await Identity.fromPassphrase("storage-pull-open-spaces");
+const space = signer.did();
+
+const stringListSchema = {
+  type: "array",
+  items: { type: "string" },
+  // deno-lint-ignore no-explicit-any
+} as any;
+
+describe("StorageManager.pullOpenSpacesToHead", () => {
+  let server: MemoryV2Server.Server;
+  let storage1: EmulatedStorageManager;
+  let storage2: EmulatedStorageManager;
+
+  beforeEach(() => {
+    server = newSharedServer({ subscriptionRefreshDelayMs: "manual" });
+    storage1 = EmulatedStorageManager.connectTo(server, { as: signer });
+    storage2 = EmulatedStorageManager.connectTo(server, { as: signer });
+  });
+
+  afterEach(async () => {
+    await storage1?.close();
+    await storage2?.close();
+    await server?.close();
+  });
+
+  it("carries a peer's published write into a watching replica", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage2,
+    });
+    try {
+      // rt2 watches the cell, so the server has a subscriber to fan out to.
+      const cell2 = rt2.getCell<string[]>(
+        space,
+        "shared-list",
+        stringListSchema,
+      );
+      await cell2.sync();
+
+      // rt1 commits a write. The commit reaches the server, but fan-out is held
+      // (manual mode), so rt2 stays stale even after settling itself.
+      const tx = rt1.edit();
+      rt1.getCell<string[]>(space, "shared-list", stringListSchema, tx)
+        .set(["A"]);
+      await tx.commit({ resolveAt: "verdict" });
+      await storage1.synced();
+      await rt2.idle();
+      expect(cell2.get()).toBeUndefined();
+
+      // Publish the fan-out, then converge rt2 through the barrier alone.
+      await server.idle();
+      await storage2.pullOpenSpacesToHead();
+      await rt2.idle();
+      expect(cell2.get()).toEqual(["A"]);
+    } finally {
+      await rt1.dispose();
+      await rt2.dispose();
+    }
+  });
+});


### PR DESCRIPTION
The shared multi-runtime harness settled the runtimes it drives by idling each one and then sleeping for a fixed 25 milliseconds, on the theory that a macrotask is long enough for the storage server's subscription fan-out to cross to the other in-process runtimes before the next round. That is the exact shape the repository forbids: the delay is both a floor on every settle and a guess that a slower machine or a paused VM can outrun, and nothing in the assertion depends on the guess having been long enough.

Replace the sleep with a deterministic barrier built from real completion signals. Each settle round now runs four steps: every runtime idles (flushing its commits to the server), the in-process server drains, every runtime forces an ordered-after round trip, and every runtime idles again to settle reactivity on whatever just arrived.

The two new signals close the two halves of the former guess. The server side gains StandaloneMemoryServer.idle(), a passthrough to the memory server's own idle() that applies every received commit and flushes all pending subscription fan-out, so the server has provably sent every frame it owes before the round continues. The client side gains pullOpenSpacesToHead() on the storage manager, which issues an unconditional graph query on each open space connection. Because a WebSocket delivers a connection's frames in order, that query's response cannot arrive before fan-out the server sent earlier on the same connection, and the client applies an inbound fan-out frame within the receiving message task; so once the round trip resolves, every runtime has received and applied whatever the server had published. The query uses an empty root set, which crosses the wire and returns the server's current sequence without fetching any document; graph query is chosen over the entity-id listing calls because it round trips unconditionally rather than being gated behind a server capability flag.

Callers are unchanged. Explicit round counts still mean the same number of cross-runtime hops, and waitFor's single-round settle still converges one step per poll. With a running toolshed there is no in-process server handle for the drain step; the client barrier still pulls in whatever the toolshed has sent and successive rounds converge.

Add a direct unit test for the new storage-manager method. Two replicas of one space share a memory server whose fan-out is held manually. One replica commits a write; with fan-out held, the other stays provably stale even after settling itself. The server then publishes, and the barrier alone carries the published write into the watching replica. The test is load-bearing on both halves: removing the publish, or removing the barrier round trip, each leaves the second replica stale and fails the assertion. Over the loopback transport the delivery ordering matches the real socket the multi-runtime integration suite uses, so the unit test reproduces the property without a real network.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

