### PR TITLE
docs(plans): the index and the interfaces section catch up to the posture

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -77,9 +77,11 @@ a record: archive it to `docs/history/plans/` following the procedure in
   already accepts link values; the outer gates never got the option.
 - [Designing verbs so they can change](verb-evolution.md) records how verbs are
   declared so that adding to and changing them later is possible: verbs are
-  promises and their names are permanent, a holder declares only what it uses,
-  an optional member's maybe is resolved once at binding, and an output change
-  gets a new verb name. It states what the update gate enforces today, what
+  promises and their names are stable by default — an owner may break their
+  own pattern deliberately, so what a caller holds is a commitment rather than
+  a guarantee — a holder declares only what it uses, an optional member's
+  maybe is resolved once at binding, and an output change gets a new verb
+  name. It states what the update gate enforces today, what
   the transformer and authoring tools should carry so a one-off author never
   has to learn a rule, and the open stream — named versioned interfaces,
   per-piece upgrade policy, migrations that run code — that everything else

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -152,8 +152,8 @@ Six requirements, each load-bearing in the design that follows.
 4. **Put the uncertainty in one place.** Old pieces make uncertainty
    unavoidable, but it can be placed. The livable designs concentrate it at
    the moment a caller first takes hold of a piece — establish what it is
-   holding once, rely on a guarantee from then on. The miserable designs
-   spread it across every call site.
+   holding once, and work against what that established from then on. The
+   miserable designs spread it across every call site.
 
 5. **Hold across authors.** Patterns by one party will depend on contracts
    offered by another's. Those contracts cannot be made unbreakable — an
@@ -236,10 +236,12 @@ An interface here is a named set of field and verb contracts, carrying a
 version, separate from any one pattern: "Notes, version 2" is a
 first-class thing. A pattern declares which interfaces it provides —
 usually several, none of them the whole of its shape — and consumers
-declare the minimum version they accept. Binding checks once; after that
-the caller holds a guarantee. The name is what shape cannot be: a claim
-about meaning. Declaring "Notes v2" says `append` does what Notes means by
-it, which no structural demand can say.
+declare the minimum version they accept. Binding checks once, and the caller
+works against the version it bound to rather than re-checking at every call
+— which places the uncertainty without pretending the provider can never
+move. The name is what shape cannot be: a claim about meaning. Declaring
+"Notes v2" says `append` does what Notes means by it, which no structural
+demand can say.
 
 Who defines one is worth pinning down, because it is the consumer who
 knows what it needs — and that knowledge stays where it is: the structural
@@ -294,7 +296,7 @@ declare const activityLog: { logEvent?: Stream<{ text: string }> };
 // Never this: when the verb is absent, nothing happens and nothing says so.
 activityLog.logEvent?.send({ text: "started" });
 
-// Resolve once, into a guarantee or a failure someone can act on.
+// Resolve once, into something callable or a failure someone can act on.
 const logEvent = activityLog.logEvent;
 if (logEvent === undefined) {
   throw new Error("activity log predates logEvent; Notes v2 required");


### PR DESCRIPTION
## Why

[#5682](https://github.com/commontoolsinc/labs/pull/5682) changed the plan's
core claim — names are stable by default, an owner may deliberately break
their own pattern, and what a caller holds is a commitment rather than a
guarantee. Two places kept asserting the older, stronger version, and cubic
caught them two seconds before that PR merged.

`docs/plans/README.md` summarized the plan as "verbs are promises and their
names are permanent" — now the opposite of what the plan says. A live
document's index entry has to move with it in the same change; this one
didn't, so main currently has an index contradicting the document it indexes.

The named-interfaces section still said a caller "holds a guarantee" after
binding, using the exact word the rest of the document now reserves for the
durable claim it declines to make.

## What Changed

- **`docs/plans/README.md`**: the entry now says names are stable by default,
  that an owner may break their own pattern deliberately, and that a caller
  holds a commitment rather than a guarantee.
- **`docs/plans/verb-evolution.md`**: binding is described by what it does —
  the caller stops re-checking at every call — without implying the provider
  can never move. Requirement 4 and the optional-resolution example's comment
  drop the same overloaded word.

No design change. This is the vocabulary #5682 settled, applied to the three
spots it missed.

## Test plan

- `deno task check-docs plans` — passes.
- `deno task docs-links --orphan` — clean.
- `deno fmt --check` — clean across 4474 files.
- Added prose lines wrap at 80 columns.
- `grep -n guarantee` over both files: the only remaining use is the sentence
  that draws the distinction on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

