### PR TITLE
docs(plans): the three verb design documents agree on what the gate checks

### DIFF
--- a/docs/plans/pattern-verb-contract.md
+++ b/docs/plans/pattern-verb-contract.md
@@ -378,16 +378,27 @@ number of records returned from a large array remains deferred, blocking
 nothing. It is adjacent CLI work for when board scale demands it, not an ask on
 any workstream in this implementation plan.
 
-**A set of verbs wants to be a structural interface, and the machinery for that
-already exists.** Schemas are the type system, so a verb set is a schema
-fragment and conformance is a subset check the repo already computes
-(`schemaSubsetIssue`). Its variance is already correct for the purpose: an
-implementer must accept at least the declared payload and return at most the
-declared result, which is exactly the argument/result direction pair above.
-Interface conformance and schema evolution are the same rule — evolution is
-conformance to one's past self. So no type machinery needs building, and any
-explicit interface mechanism (nominal declaration, discovery *by* interface) is
-deferred until a concrete need appears.
+**A set of verbs is checkable as a structural interface with the machinery that
+exists.** Schemas are the type system, so a verb set is a schema fragment and
+conformance is a subset check the repo already computes (`schemaSubsetIssue`,
+`packages/piece/src/schema-compatibility.ts`). Its variance is already correct
+for the purpose: an implementer must accept at least the declared payload and
+return at most the declared result, which is exactly the argument/result
+direction pair above. Interface conformance and schema evolution are the same
+rule — evolution is conformance to one's past self.
+
+That covers the structural half and stops there.
+[Designing verbs so they can change](verb-evolution.md) is the design of record
+for what a verb's interface is and how it changes, and it puts an explicit
+interface mechanism — **named, versioned interfaces**, with nominal
+declaration and discovery by interface — on the road rather than in reserve,
+because a name is a claim about meaning that no structural demand can make.
+It is also the most machinery of anything in that design: an identity, a
+registry, a place in the shape, a member-to-field mapping, and a
+compatibility rule of its own, where what a version bump means and how a
+declared minimum resolves against what a piece provides are both still to be
+designed. So the subset check is the default and the interim, not an argument
+that the named mechanism is unnecessary.
 
 What is **not** yet true is the premise all of that rests on: that a piece's
 verbs can be identified from its schema. Verb-ness has three independent
@@ -616,56 +627,72 @@ pattern to follow rather than in the runtime.
 A verb's result schema declares whether it carries a live piece reference or a
 self-contained snapshot — the pattern knows which is meaningful for that verb.
 
-The result schema is part of the piece's public contract, and the repo already
-checks pattern schema evolution: `assertPatternSchemasBackwardCompatible`
+The repo checks **a pattern's own** schema evolution:
+`assertPatternSchemasBackwardCompatible`
 (`packages/piece/src/schema-compatibility.ts`) runs on every `setsrc` unless
 `--dangerously-allow-incompatible-schema` is passed
-(`packages/piece/src/ops/piece-controller.ts`). It checks arguments
-and results in **opposite directions**:
+(`dangerouslyAllowIncompatibleSchema`,
+`packages/piece/src/ops/piece-controller.ts`). It compares four schemas and no
+others — the previous and candidate `Pattern`'s `argumentSchema` and
+`resultSchema` — and it compares the two roles in **opposite directions**:
 
 - **Arguments**: previous ⊆ candidate. Inputs may widen but not narrow; a new
   required field is incompatible.
 - **Results**: candidate ⊆ previous. Results may narrow freely — but *adding* a
   result field is only compatible if the previous schema was open-world.
 
-That second direction matters here: a declared result is easier to shrink than
-to extend, so the result shape wants to be right early, or deliberately
-open-world. The `Invocation` shape is the first schema this applies to — it
-must be authored open-world so protocol fields such as a payload digest or
-retention metadata can be added later.
+That second direction matters here: a pattern's declared result is easier to
+shrink than to extend, so the result shape wants to be right early, or
+deliberately open-world. The `Invocation` shape is the first schema this
+applies to — it must be authored open-world so protocol fields such as a
+payload digest or retention metadata can be added later.
 
 "Results may narrow freely" governs *values*, not *named fields*. Removing a
 named property is rejected outright in either direction — `objectSubsetIssue`
 returns "existing result field was removed" whenever the comparison is an
 evolution, on the stated principle that "pattern evolution preserves named
 fields as part of the public contract, even when the candidate object is
-otherwise open" (`packages/piece/src/schema-compatibility.ts`). A
-verb's `asCell` marker is pinned the same way: it is a semantic extension key
-compared for exact equality, so a field cannot change
-between data and verb across a deploy. Verb names and their verb-ness are
-therefore already a contract with teeth, before this document adds any rule.
+otherwise open" (`objectSubsetIssue`,
+`packages/piece/src/schema-compatibility.ts`). The removed-field check
+recurses, so a nested removal is rejected on a nested path
+(`result.topic.title: existing result field was removed`) exactly as a flat one
+is. Adding a **required** field is rejected at any depth unless it carries a
+default; adding an **optional** one is allowed at any depth; narrowing a
+*value* type is allowed at any depth. Nesting a pattern's result under a single
+key therefore buys it nothing: "results may narrow freely" is true of values
+and never of names, at every depth.
 
-The practical consequence for verb results: **every name a result publishes is
-permanent regardless of depth, and every later addition must be optional.**
+A verb's `asCell` marker is pinned the same way: it is a semantic extension key
+compared for exact equality (`SEMANTIC_EXTENSION_KEYS`,
+`packages/piece/src/schema-compatibility.ts`), so a field cannot change between
+data and verb across a deploy. Verb names and their verb-ness are therefore
+already a contract with teeth, before this document adds any rule.
 
-An earlier revision of this paragraph advised nesting the value under a single
-key so that "only that key is permanent and everything beneath it is free to
-narrow". Measured against `assertPatternSchemasBackwardCompatible`, that is not
-what the checker does. The removed-field check recurses, so a nested removal is
-rejected on a nested path (`result.topic.title: existing result field was
-removed`) exactly as a flat one is. Adding a **required** field is rejected at
-any depth unless it carries a default; adding an **optional** one is allowed at
-any depth; narrowing a *value* type is allowed at any depth. Nesting changes
-none of it.
+**What a verb hands back sits outside all of it.** A verb's declared result
+travels on `module.resultSchema` — the `CELL_RESULT_TYPE` doc comment
+(`packages/api/index.ts`) states this, and `declaredVerbResults`
+(`packages/cli/lib/piece.ts`) is what reads it back off a piece's compiled
+graph — while the comparison above sees only `Pattern.argumentSchema` and
+`Pattern.resultSchema`. There a verb is a property carrying its
+`asCell: ["stream"]` marker and a reference to its event schema, and nothing
+about its output. So no gate compares a verb's result across a deploy:
+renaming a field of what a verb returns passes every check and breaks its
+callers silently.
 
-"Results may narrow freely" is therefore true of values and never of names,
-which is the distinction the earlier wording blurred. Publish as few names as
-the verb can live with, and make every later addition optional. An envelope
-remains a reasonable readability choice — the llm-dialog tool path returns a
-single-key shape from both of its branches, an `@resultLocation` link, the
-value, and its schema together (both `"@resultLocation"` sites in
-`handleInvoke`, `packages/runner/src/builtins/llm-dialog.ts`) — just not for
-the evolution reason previously given.
+The advice stands; its enforcement does not. Publish as few names as the verb
+can live with, and treat **every name a verb's result publishes as permanent
+regardless of depth, with every later addition optional** — a discipline the
+author and review hold, not one the update gate holds for them.
+[Designing verbs so they can change](verb-evolution.md) is the design of record
+for how a verb's interface changes, and it carries the same rule to its
+conclusion: because nothing checks an output, a change to what a verb hands
+back is treated exactly like a rename and gets a new verb name, until
+Fabric-types records outputs in the shape and a check replaces the convention.
+
+An envelope remains a reasonable readability choice — the llm-dialog tool path
+returns a single-key shape from both of its branches, an `@resultLocation`
+link, the value, and its schema together (both `"@resultLocation"` sites in
+`handleInvoke`, `packages/runner/src/builtins/llm-dialog.ts`).
 
 ### Authoring
 

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -76,11 +76,21 @@ listed here because it shapes how much the gate can be trusted while open.
 
 **A verb's output is not checked at all.** The shape records a verb's input
 and discards its output, so renaming a field of what a verb hands back
-passes every check and breaks callers silently. This is a deliberate
-deferral: recording outputs now would commit to a format that
-**Fabric-types** — the planned design stream that gives verbs declared,
-checkable result types in the shape — is expected to replace. Until it
-lands, output changes are governed by convention alone.
+passes every check and breaks callers silently. The deferral is narrower
+than "recording outputs": what would commit to a format **Fabric-types** —
+the planned design stream that gives verbs declared, checkable result types
+in the shape — is expected to replace is recording an output *in the durable
+shape*. Recording one at all is already done. A verb's declared result
+travels on `module.resultSchema`, a module field that enters no durable
+schema and that no baseline under `packages/patterns/baselines/` records,
+which is what made that road passable while the durable one was not; and it
+is resolvable per deployed piece, because `cf piece verbs` publishes it as a
+row's `outputSchema` and `cf piece call <verb> --help` publishes it for a
+single verb (`listPieceCallables`, `declaredVerbResults` and
+`withDeclaredResult`, `packages/cli/lib/piece.ts`). What is still deferred is
+the durable record and the comparison it would feed: nothing holds one
+deploy's output beside the next, so output changes are governed by convention
+alone.
 
 The same gate also governs the *holder* — what a pattern may change about
 what it demands from the pieces it stores — and there is the fourth bad
@@ -356,7 +366,13 @@ down, and read the cells. Five kinds of demand are reachable: embedding the
 provider's whole **Output** type (today's default), a narrow demand naming
 **fields only**, one naming a **required verb**, one naming an **optional
 verb**, and a **versioned** interface demand. Probing callers are omitted —
-they bind late and survive every row.
+they bind late and survive every *evolution* row, which is what the table
+scores. What late binding does not survive is an enumeration defect: [#5698]
+measures 8 callable verbs across 4 files that `cf piece verbs` and
+tab-completion both miss, because candidate names are built from the declared
+result type rather than from what the piece stores. A probing caller is
+therefore only as good as the listing it probes, and absence from one today
+is ambiguous between deprecated, retired, and never enumerated.
 
 | Provider evolution | Full Output | Fields only | Req. verb | Opt. verb | Versioned |
 | --- | --- | --- | --- | --- | --- |
@@ -516,7 +532,13 @@ in practice — is for whoever builds it to settle.
 
 Retirement policy is guesswork without usage data; deprecation windows work
 in other systems because usage is observable. The planned invocation-record
-work is the natural place for this to ride. Counting also sees past the
+work is the natural place for this to ride, and that work —
+[retention and CFC execution provenance](retention-and-provenance.md) — is
+**gated on a CFC review that has not happened**, with nothing behind the gate
+started. So call-count-driven retirement is not near-term at any price: its
+carrier waits on a review rather than on a queue position.
+
+Counting also sees past the
 blast-radius horizon: a call executes against the provider's piece, in the
 provider's space, so invocation records catch the cross-space and
 third-party callers no static enumeration can reach. The two signals are
@@ -609,9 +631,15 @@ person, a recipe for a tool. Where it lives matters most: askable of the
 piece itself, so an agent watching a holding piece's errors can ask the
 held piece for upgrade instructions and decide whether to apply them. The
 channel exists — the shape already lifts deprecation out of JSDoc into
-listings. Scoped acknowledgment is the natural place to ask for it: a
-deliberate break proceeds when it says what those it breaks should do
-instead.
+listings — and it carries a named precondition, because that channel is the
+listing surface: while [#5698] holds, the listing omits verbs the piece
+really has, and instructions served over a surface that drops their subject
+arrive incomplete. Closing that enumeration gap is on this direction's
+critical path; where it sits in the order is the owner of
+[the verbs implementation plan](verbs-implementation.md) to decide, not this
+document. Scoped acknowledgment is the natural place to ask for the
+instructions themselves: a deliberate break proceeds when it says what those
+it breaks should do instead.
 
 The anchors are the systems that permit breakage and manage it rather than
 forbid it. Kubernetes deprecates an API, keeps serving it for a published
@@ -635,14 +663,32 @@ Five smaller calls belong to whoever does the work:
   recorded shapes under `packages/patterns/baselines/` that updates are
   checked against), and how it is sequenced against the append-only
   baselines gate.
-- Whether an interim output check is possible before Fabric-types, given
-  that the shape discards verb outputs today.
+- Where an interim output check runs before Fabric-types, and what it does
+  on a mismatch. Availability is not the question: a verb's declared result
+  resolves from a deployed piece's compiled graph and from a candidate's, so
+  a comparison has both of its sides. `setPattern`
+  (`packages/piece/src/ops/piece-controller.ts`) loads the deployed pattern
+  and compiles the candidate before it asserts compatibility, so both graphs
+  are in hand at that point. What is **not** established is what comparing
+  them costs there, or what a graph compiled before `module.resultSchema`
+  existed offers to compare against — so the site (`setsrc`, a pre-deploy
+  report, a lint) and the response (refuse, warn, record) are both open, and
+  none of them should be priced as cheap before that is measured.
 - Whether a version bump is author-declared or derived from the shape diff;
   the Versioned column's red rows depend on the answer.
 - When the `Demand<T>` marker grows interface and version fields: the
   growth is free — annotation values are never compared across updates —
   but only until a binding check reads them, at which point the key stops
-  being annotation-neutral. A real design step, not an extension.
+  being annotation-neutral. A real design step, not an extension — and a
+  two-registry one. [#5746] adds `demand` to `ANNOTATION_KEYS`
+  (`packages/piece/src/schema-compatibility.ts`), and item 2 of
+  [the verbs implementation plan](verbs-implementation.md) derives the
+  projection reader's *tolerated* keys from that same set, so a key
+  reclassified out of it lands in projection's *refused* tier by default and
+  starts rejecting reads that carry it. Whoever reclassifies `demand`
+  changes both registries deliberately, which is what keeping them siblings
+  rather than one list is for.
 
 [#5663]: https://github.com/commontoolsinc/labs/issues/5663
+[#5698]: https://github.com/commontoolsinc/labs/issues/5698
 [#5746]: https://github.com/commontoolsinc/labs/pull/5746

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -538,13 +538,12 @@ work is the natural place for this to ride, and that work —
 started. So call-count-driven retirement is not near-term at any price: its
 carrier waits on a review rather than on a queue position.
 
-Counting also sees past the
-blast-radius horizon: a call executes against the provider's piece, in the
-provider's space, so invocation records catch the cross-space and
-third-party callers no static enumeration can reach. The two signals are
-complementary and both partial — enumeration sees recorded demands within
-its horizon, dormant holders included; counting sees live callers beyond
-it, and misses anyone who has not called lately.
+Counting also sees past the blast-radius horizon: a call executes against the
+provider's piece, in the provider's space, so invocation records catch the
+cross-space and third-party callers no static enumeration can reach. The two
+signals are complementary and both partial — enumeration sees recorded
+demands within its horizon, dormant holders included; counting sees live
+callers beyond it, and misses anyone who has not called lately.
 
 ## The longer arc
 

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -10,6 +10,8 @@ and
 
 **The designs are unchanged and are not restated here.**
 [The pattern verb contract](pattern-verb-contract.md) says what a verb is.
+[Designing verbs so they can change](verb-evolution.md) is the design of record
+for how a verb's interface changes once pieces are deployed against it.
 [Reading Fabric data](fabric-read-model.md) and the two documents it points at
 say how a caller reads. Read those for reasoning; read this for order.
 
@@ -62,6 +64,7 @@ a driver needs to know what is already moving before scheduling anything new.
 | PR | What | State |
 | --- | --- | --- |
 | #5307 | closed-world verb event schemas | **ruled against** on #5589 and in review. Retreating leaves nothing to land — the emission and the goldens and baselines recording it are the whole branch — so this closes rather than merges |
+| #5746 | the `Demand<T>` marker and the foreign-output embedding warning, prototyping the demand substrate in [designing verbs so they can change](verb-evolution.md) | open. It edits `packages/ts-transformers/src/transformers/schema-injection.ts`, which is the file item 11's fourth part edits, so the one-file rule queues the two rather than running them in parallel — a driver picking up item 11 schedules against this branch before starting. It also adds `demand` to `ANNOTATION_KEYS` (`packages/piece/src/schema-compatibility.ts`), the set item 2 derives its tolerated tier from |
 
 **Most of the read layer has landed.** #5309, #5459, #5468, #5470, #5497 and
 #5500 are on main. #5458 is closed rather than merged because its rename was

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -163,11 +163,12 @@ reader keeps deriving `required` from the source schema, and that derivation
 must survive the item intact.
 
 *Three things the coupling to the compatibility checker has to respect.*
-**Derivation is not one-to-one:** 3 of `ANNOTATION_KEYS`' 12 members —
-`default`, `$defs`, `definitions` — are refused by projection on purpose, so the
-relation is `ANNOTATION_KEYS` minus a stated exception set, and a fallback test
-asserting plain non-refusal of every annotation key would be red the day it is
-written. It asserts the exception relation in both directions instead.
+**Derivation is not one-to-one:** three members of `ANNOTATION_KEYS` —
+`default`, `$defs`, `definitions` — are refused by projection on purpose, so
+the relation is `ANNOTATION_KEYS` minus a stated exception set, whatever that
+set grows to, and a fallback test asserting plain non-refusal of every
+annotation key would be red the day it is written. It asserts the exception
+relation in both directions instead.
 **The validation half must not derive:** the checker's `handled` set is a union
 including `allOf`, `if`/`then`/`else`, `patternProperties`, `asCell`, `ifc` and
 `scope`, every one of which projection refuses deliberately — so derive the


### PR DESCRIPTION
## Why

Three live design documents had drifted apart on one load-bearing fact, and
the drift was pointed the wrong way: `docs/plans/pattern-verb-contract.md`
told a reader the repo already checks a verb's declared result across a
deploy, and derived its result-authoring rule from that check. It does not.
`assertPatternSchemasBackwardCompatible`
(`packages/piece/src/schema-compatibility.ts`) compares exactly four schemas
— the previous and candidate `Pattern`'s `argumentSchema` and `resultSchema`
— while a verb's declared result travels on `module.resultSchema`
(`CELL_RESULT_TYPE`'s doc comment, `packages/api/index.ts`, states this, and
`packages/ts-transformers/test/fixtures/handler-schema/stream-declared-result.expected.jsx`
pins the boundary deliberately). An author following the contract would have
believed a gate was protecting verb outputs that has never seen one.

The other four documents' worth of drift is the same shape one layer out:
`verb-evolution.md` is now the design of record for how a verb's interface
changes, and neither of the other two named it; and `verb-evolution.md`
itself still carried a premise that #5501, #5629 and #5717 have since
retired, plus two claims that lean on the verb listing being complete, which
#5698 measures as false.

Nothing here changes a decision. Every edit either corrects a mechanism
claim against the code, or points a document at the newer design instead of
contradicting it.

## What changed

Split so the factual half can be accepted quickly and the judgement half
argued with separately.

### Factual corrections — each verified against the code named

1. **`pattern-verb-contract.md`, "Results and schema evolution."** The gate's
   scope is stated as what it is (four schemas, both properties of
   `Pattern`), and a new paragraph states that a verb's declared result is
   outside it: `module.resultSchema`, read back by `declaredVerbResults`
   (`packages/cli/lib/piece.ts`). The authoring rule — publish few names,
   treat them as permanent, keep later additions optional — is kept and
   re-grounded as convention, cross-referencing `verb-evolution.md` as the
   design of record.

2. **`verbs-implementation.md`, opening pointer.** Adds `verb-evolution.md`
   beside the contract and the read documents.

3. **`verbs-implementation.md`, open-PR table.** Adds #5746. Verified against
   its current file list: it edits
   `packages/ts-transformers/src/transformers/schema-injection.ts`, the file
   item 11's fourth part edits, so the plan's own one-file rule queues the
   two. It also adds `demand` to `ANNOTATION_KEYS`, the set item 2 derives
   its tolerated tier from.

4. **`verb-evolution.md`, "The problem."** "Recording outputs" and "recording
   outputs in the durable shape" have come apart. A module field enters no
   durable schema and no baseline under `packages/patterns/baselines/`
   records it (item 1, #5501), and the value is served per deployed piece by
   `cf piece verbs` (item 10, #5629) and `piece call --help` (step 6, #5717)
   — `listPieceCallables`, `declaredVerbResults`, `withDeclaredResult`,
   `packages/cli/lib/piece.ts`. Only the durable record and the comparison it
   would feed are still deferred.

5. **`verb-evolution.md`, "Verb calls are counted."** Names the gate: the
   invocation-record work is `retention-and-provenance.md`, gated on a CFC
   review that has not happened, with nothing started behind it. So
   call-count-driven retirement is not near-term at any price.

6. **`verb-evolution.md`, fifth smaller call.** `ANNOTATION_KEYS` now has two
   consumers — #5746 puts `demand` in it, and item 2 derives projection's
   *tolerated* tier from it — so reclassifying `demand` when a binding check
   reads it would drop it into projection's *refused* tier by default.
   Recorded as a two-registry change. No scheduling, and #5753's branch is
   untouched.

### Re-framings — judgement calls, argue with these

7. **`pattern-verb-contract.md`, "Discovery."** "No type machinery needs
   building, and any explicit interface mechanism is deferred" is replaced by
   a pointer to `verb-evolution.md`'s named, versioned interfaces, which that
   document calls the most machinery of anything in it. The structural subset
   check keeps its place as the default and the interim.

8. **`verb-evolution.md`, the cross product.** "Probing callers … survive
   every row" gains its caveat: they survive every *evolution* row, which is
   what the table scores, but not an enumeration defect. #5698 measures 8
   callable verbs across 4 files invisible to `cf piece verbs` and to
   tab-completion, so absence from a listing today is ambiguous between
   deprecated, retired, and never enumerated.

9. **`verb-evolution.md`, the upgrade-instruction direction.** The channel
   rides the listing surface, so #5698 is named as a precondition on its
   critical path. Deliberately not sequenced — where it sits in the order is
   the plan owner's call, and the text says so.

10. **`verb-evolution.md`, the interim-output-check open call.** Re-framed
    from "is a check possible" to "where does it run and what does it do on a
    mismatch", since both sides of the comparison now exist. **It does not
    claim a `setsrc`-time check is cheap** — see the note below.

## What I verified, and the one gap I marked

Verified by reading the code: the gate's four-schema comparison; `Pattern`
carrying only `argumentSchema`/`resultSchema`; `module.resultSchema` as the
verb result's home; `objectSubsetIssue`'s recursion and its removed-field
message; `SEMANTIC_EXTENSION_KEYS` exact-equality pinning; baselines
recording exactly `argumentSchema` and `resultSchema`; the listing and help
paths serving `outputSchema`; #5746's file list and its `ANNOTATION_KEYS`
addition; #5753 deriving tier T from `ANNOTATION_KEYS` minus three
exceptions; #5698's measurement; and `retention-and-provenance.md`'s CFC
gate.

One instruction I went one step past, deliberately: I was told to treat
"whether `setsrc` holds both graphs at once" as unverified. Reading
`setPattern` (`packages/piece/src/ops/piece-controller.ts`) shows it loads
the deployed pattern through `#loadCurrentPattern` → `loadPatternByIdentity`
and compiles the candidate through `compileProgram`, both before the
compatibility assertion, and both are `Pattern` values carrying `nodes`. So
availability is established and the document says so. What the document
explicitly marks as **not** established is the cost of comparing them there,
and what a graph compiled before `module.resultSchema` existed offers to
compare against. Nothing is priced as cheap.

## Test plan

Documentation only; no source file changed. `docs/` is excluded from
`deno fmt`, so no formatting evidence is claimed — prose is hand-wrapped to
80 columns.

- `deno task check-docs` — exit 0 (550 code blocks)
- `deno task check-skill-facts` — exit 0 (45 documents)
- `deno task check-conflict-markers` — exit 0
- `deno task docs-links --orphan` — exit 0, no orphans

**Merge-order note.** #5753 also edits `docs/plans/verbs-implementation.md`,
in the item 2 region (hunks at lines 48, 123-174, 372); this branch's edits
land at lines 11-14 and in the open-PR table, so the two do not overlap
textually. Whoever merges second should still glance at the item 2 wording,
since both branches describe the `ANNOTATION_KEYS` coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

