### PR TITLE
test(cli): point the gap-harness note at the script it delegates to

### DIFF
--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -1037,13 +1037,11 @@ run_verbs_walkthrough() {
   echo "Successfully ran the verb-result walkthrough for ${API_URL}."
 }
 
-# The gap harness beside the walkthrough: what does NOT work yet, asserted as
-# gaps that fail loudly the day a capability arrives. Running it here is what
-# makes that announcement automatic — a gap script nobody runs announces
-# nothing. Same delegation rationale as above: the standalone script is the
-# artifact docs/common/verb-session-walkthrough.md documents, so the
-# documented thing is the tested one. It deploys its own fixture and takes its
-# own space.
+# The gap harness beside the walkthrough: what does NOT work yet, asserted so
+# it fails the day a capability arrives — its own header says what and why.
+# Running it here is what makes that announcement automatic: a gap script
+# nobody runs announces nothing. Same delegation rationale as above; it
+# deploys its own fixture and takes its own space.
 run_verb_session_gaps() {
   echo "Running the verb-session gap harness..."
   API_URL="$API_URL" bash "$SCRIPT_DIR/verb-session-gaps.sh" ||


### PR DESCRIPTION
## Why

#5793 landed the gap harness in the piece-call section on its own — the wiring this PR originally carried. What survives here is the note beside `run_verb_session_gaps`, which has two problems this PR's review already named on identical text:

- It claims the standalone script is "the artifact `docs/common/verb-session-walkthrough.md` documents", and the walkthrough never names the script — it refers to its scripts only as "the two scripts beside it". A reader who follows the claim finds no citation (the coherence issue cubic flagged on this PR's earlier wording of the same sentence).
- It restates what the harness asserts, which is the script header's job — the drift risk @mpsalisbury's review pointed at.

## What changed

One comment. It keeps what running the harness *here* adds — a gap script nobody runs announces nothing; this section is what makes the announcement automatic — and points at the script's own header for what it asserts and why. No behavior change.

## Test plan

`bash -n` passes; the section's own CI job (core-piece-call) runs the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)