### PR TITLE
docs(common): the circling readback already derives its declared-result bound

### DIFF
--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -347,15 +347,17 @@ position renders the address and suppresses the fetch without consulting a
 source schema at all. What a declared result would add is that `cf` could
 derive the selection instead of the caller supplying it.
 
-One case already derives it: a create that returns its piece from inside the
-container holding it — `addChild` under an epic — hands back a value that
-reaches itself, which plain JSON cannot spell. There the readback bounds the
-result with the verb's own declared result and renders the position that
-closes the circle as an address, the same rendering a `$link` marker asks for
-by hand; with no declared result to bound it, the call refuses with a message
-instead of a stack trace.
+One case already works this way. `addChild` hands back the child it created,
+and the child's `parent` points back at the item that holds it. That loop
+means the result cannot be written out as plain JSON at all. So `cf` falls
+back on the verb's declared result and renders that shape instead: the
+child's fields come through as usual, and `parent` — the position where the
+loop would start again — comes through as an address, the same address a
+`$link` marker would have produced. If the verb declares no result, there is
+nothing to fall back on, and the call fails with a clear message rather than
+a stack trace.
 [A result that points back at its container](verbs-over-the-cli.md#a-result-that-points-back-at-its-container)
-walks the exchange.
+shows the full exchange.
 
 ## 5. Read the tree back, bounded **[today]**
 

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -347,6 +347,16 @@ position renders the address and suppresses the fetch without consulting a
 source schema at all. What a declared result would add is that `cf` could
 derive the selection instead of the caller supplying it.
 
+One case already derives it: a create that returns its piece from inside the
+container holding it — `addChild` under an epic — hands back a value that
+reaches itself, which plain JSON cannot spell. There the readback bounds the
+result with the verb's own declared result and renders the position that
+closes the circle as an address, the same rendering a `$link` marker asks for
+by hand; with no declared result to bound it, the call refuses with a message
+instead of a stack trace.
+[A result that points back at its container](verbs-over-the-cli.md#a-result-that-points-back-at-its-container)
+walks the exchange.
+
 ## 5. Read the tree back, bounded **[today]**
 
 ```bash


### PR DESCRIPTION
## Why

Section 4 of the verb-session walkthrough closes on what a declared result *would* add: `cf` deriving the selection instead of the caller supplying it. Since #5740, one case does exactly that — a returned piece that reaches itself (`addChild`'s item carrying `parent`) cannot render as plain JSON, so the readback bounds the result with the verb's own declared result and renders the position that closes the circle as an address. The future tense had gone half-stale.

## What

One paragraph at the end of §4 saying the derivation already happens for the circling readback — including the refusal when no declared result bounds it — cross-linked to ["A result that points back at its container"](https://github.com/commontoolsinc/labs/blob/main/docs/common/verbs-over-the-cli.md#a-result-that-points-back-at-its-container), the section #5740 added for it.

## Verification

- `deno task check-docs`: all 550 blocks pass.
- The behavior itself: `verb-session-gaps.sh` step 11, 21 passed / 0 failed against a local toolshed at current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

