### PR TITLE
feat(cf-harness): add strict local Loom host boundary

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -166,6 +166,10 @@ What is not done yet:
   - what caused a gateway request, reported on the request
 - [src/interactive-chat-stdio.ts](src/interactive-chat-stdio.ts)
   - NDJSON stdio transport for the interactive chat protocol
+- [src/loom-local-host.ts](src/loom-local-host.ts)
+  - strict, fixed-owner host factory for local single-user Loom
+- [src/loom-local-host-main.ts](src/loom-local-host-main.ts)
+  - one batch/interactive executable boundary for Loom-owned runs
 - [src/sqlite-session-store.ts](src/sqlite-session-store.ts)
   - SQLite-backed interactive chat session, turn, and event persistence
 - [src/artifacts.ts](src/artifacts.ts)
@@ -313,8 +317,45 @@ silently substituted.
 
 ### Loom subscription binding
 
-Loom support uses the same `openai-codex` protocol and model client, but never
-the local filesystem credential store. A trusted Loom host must:
+Local single-user Loom uses the exported `createLoomLocalCfHarnessHost()`
+factory and the package entrypoint in `src/loom-local-host-main.ts`. The host
+requires an explicit, absolute, normalized `CF_HARNESS_HOME`; strictly resolves
+the persisted provider from that home's `config.json`; and fixes the credential
+owner to `local`. It uses that same home's `auth.json` only through cf-harness's
+credential-store and resolver APIs. It never reads or imports the ordinary Codex
+CLI login.
+
+```bash
+CF_HARNESS_HOME=/canonical/private/home \
+  deno run --no-lock -A src/loom-local-host-main.ts batch -- \
+  --workspace ../.. --prompt "Summarize this workspace."
+
+CF_HARNESS_HOME=/canonical/private/home \
+  deno run --no-lock -A src/loom-local-host-main.ts interactive -- \
+  --chat-session-db /private/runtime/chat.sqlite
+```
+
+The entrypoint serves both execution shapes. It rejects missing or invalid
+provider configuration instead of applying the historical gateway default. Codex
+preflight reads bounded connection health without refreshing; an expired
+credential refreshes only in the serialized resolver immediately before model
+traffic. Disconnected and reconnect-required Codex configurations return
+`provider-auth-required` without contacting Codex or the gateway. Resumed runs
+must match the recorded provider, model, fixed owner, auth source, and an opaque
+digest of the canonical home. The path itself is never written to provider
+binding metadata. Runs and durable chat sessions created before this complete
+binding existed are deliberately not resumable through the local adapter; it
+fails closed instead of guessing which credential home or billing route created
+them.
+
+Batch startup failures are one `cf-harness.host-failure` JSON object on stderr.
+Interactive startup failures remain on the NDJSON chat protocol so hosts that do
+not consume stderr still receive the stable provider error code. Run state,
+manifests, reports, child manifests, and structured batch results record only
+provider, the non-secret auth-source label, and the fixed owner reference.
+
+Hosted or multi-user Loom must not reuse this single-user adapter. A trusted
+multi-user host must instead:
 
 - require the initiating user to connect ChatGPT/Codex explicitly;
 - put `modelProvider: "openai-codex"` and a `cf-harness.credential-owner-ref` in
@@ -333,7 +374,7 @@ interactive service processes, inject the owner-bound client through
 `credentialOwner`. The service constructor rejects Codex without this fixed
 process owner. Do not accept an owner or token through the NDJSON request.
 
-This package provides the Loom integration seam; the Loom host still must
+The multi-user library seam remains available, but its host still must
 authenticate the initiating principal, enforce workspace policy, and prove
 cross-user isolation before product rollout.
 

--- a/packages/cf-harness/deno.jsonc
+++ b/packages/cf-harness/deno.jsonc
@@ -13,6 +13,8 @@
     "./prompt-loop": "./src/prompt-loop.ts",
     "./interactive-chat-service": "./src/interactive-chat-service.ts",
     "./interactive-chat-stdio": "./src/interactive-chat-stdio.ts",
+    "./loom-local-host": "./src/loom-local-host.ts",
+    "./loom-local-host-main": "./src/loom-local-host-main.ts",
     "./session-store": "./src/session-store.ts",
     "./sqlite-session-store": "./src/sqlite-session-store.ts",
     "./subagent-return": "./src/subagent-return.ts",

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -43,12 +43,15 @@ import {
   type PromptSlotRole,
 } from "./contracts/prompt-slot.ts";
 import {
+  bindLoomLocalRunManifest,
   HARNESS_CREDENTIAL_OWNER_REF_TYPE,
   type HarnessCredentialOwnerRef,
   harnessCredentialOwnersEqual,
   type HarnessRunManifest,
+  type LoomLocalHostBinding,
   parseLoomRunManifestJson,
 } from "./contracts/run-manifest.ts";
+import type { HarnessFetch } from "./contracts/http-fetch.ts";
 import {
   DEFAULT_SUBAGENT_PROFILE,
   getHarnessSubagentProfileConfig,
@@ -290,7 +293,7 @@ export interface CfHarnessCliCapabilities {
     persistentProviderConfig: true;
     structuredAuthControl: true;
     credentialHealth: true;
-    loomLocalOwnerBinding: false;
+    loomLocalOwnerBinding: true;
     runPattern: true;
   };
 }
@@ -299,6 +302,33 @@ export interface CfHarnessCliIO {
   stdout(text: string): void;
   stderr(text: string): void;
 }
+
+export interface CfHarnessHostFailure {
+  type: "cf-harness.host-failure";
+  version: 1;
+  ok: false;
+  error: {
+    code: HarnessControlErrorCode;
+    message: string;
+  };
+}
+
+export const createCfHarnessHostFailure = (
+  error: unknown,
+): CfHarnessHostFailure => {
+  const controlError = error instanceof HarnessControlError
+    ? error
+    : new HarnessControlError(
+      "internal-error",
+      "The local cf-harness host operation failed",
+    );
+  return {
+    type: "cf-harness.host-failure",
+    version: 1,
+    ok: false,
+    error: { code: controlError.code, message: controlError.message },
+  };
+};
 
 export type CfHarnessCliSignal = "SIGINT" | "SIGTERM";
 
@@ -309,6 +339,10 @@ export type CfHarnessCliSignalHandler = (
 export interface RunCfHarnessCliDependencies {
   cwd?: string;
   env?: Record<string, string | undefined>;
+  /** Trusted, fixed binding supplied only by the dedicated local Loom host. */
+  loomLocalHostBinding?: LoomLocalHostBinding;
+  fetchFn?: HarnessFetch;
+  structuredHostFailures?: boolean;
   /**
    * What caused this run, reported on every gateway request it makes.
    * Resolved from the process when absent.
@@ -595,7 +629,7 @@ export const createCfHarnessCliCapabilities = (): CfHarnessCliCapabilities => ({
     persistentProviderConfig: true,
     structuredAuthControl: true,
     credentialHealth: true,
-    loomLocalOwnerBinding: false,
+    loomLocalOwnerBinding: true,
     runPattern: true,
   },
 });
@@ -1742,11 +1776,13 @@ const createSelectedModelClient = async (options: {
       store,
       ownerKey: credentialOwnerKey,
       credentialOwner: options.credentialOwner,
+      fetchFn: options.deps.fetchFn,
     });
   }
   return new OpenAICodexResponsesClient({
     credentialResolver: resolver!,
     credentialOwner: options.credentialOwner,
+    fetchFn: options.deps.fetchFn,
   });
 };
 
@@ -2022,6 +2058,9 @@ export interface CfHarnessBatchResult {
   run_id: string;
   status: string;
   model: string;
+  model_provider?: HarnessModelProviderId;
+  model_auth_source?: string;
+  credential_owner?: HarnessCredentialOwnerRef;
   usage?: HarnessModelUsage;
   artifact_root?: string;
   transcript_path?: string;
@@ -2109,6 +2148,15 @@ export const createCfHarnessBatchResult = (
   run_id: result.runState.runId,
   status: result.runState.status,
   model: result.model,
+  ...(result.runState.modelProvider !== undefined
+    ? { model_provider: result.runState.modelProvider }
+    : {}),
+  ...(result.runState.modelAuthSource !== undefined
+    ? { model_auth_source: result.runState.modelAuthSource }
+    : {}),
+  ...(result.runState.credentialOwner !== undefined
+    ? { credential_owner: structuredClone(result.runState.credentialOwner) }
+    : {}),
   ...((result.totalUsage ?? result.usage) !== undefined
     ? { usage: result.totalUsage ?? result.usage }
     : {}),
@@ -2351,6 +2399,21 @@ const parseCfHarnessCliControlArgs = (
       h: "help",
     },
   });
+};
+
+export type CfHarnessCliInformationalControl =
+  | "help"
+  | "describe-capabilities";
+
+/** Classifies global controls that do not inspect provider or auth state. */
+export const cfHarnessCliInformationalControl = (
+  argv: readonly string[],
+): CfHarnessCliInformationalControl | undefined => {
+  if (cfHarnessCliCommandName(argv) !== "prompt") return undefined;
+  const args = parseCfHarnessCliControlArgs(argv);
+  if (args.help) return "help";
+  if (args["describe-capabilities"]) return "describe-capabilities";
+  return undefined;
 };
 
 const defaultOpenUrl = async (url: string): Promise<void> => {
@@ -2742,12 +2805,12 @@ export const runCfHarnessCli = async (
     if (modelsResult !== undefined) return modelsResult;
     const whoamiResult = runCfHarnessWhoamiCommand(argv, deps, io);
     if (whoamiResult !== undefined) return whoamiResult;
-    const controlArgs = parseCfHarnessCliControlArgs(argv);
-    if (controlArgs.help) {
+    const informationalControl = cfHarnessCliInformationalControl(argv);
+    if (informationalControl === "help") {
       io.stdout(formatCfHarnessCliUsage());
       return 0;
     }
-    if (controlArgs["describe-capabilities"]) {
+    if (informationalControl === "describe-capabilities") {
       io.stdout(
         `${JSON.stringify(createCfHarnessCliCapabilities(), null, 2)}\n`,
       );
@@ -2765,10 +2828,24 @@ export const runCfHarnessCli = async (
     const readTextFile = deps.readTextFile ?? Deno.readTextFile;
     const startedAt = Date.now();
     let result: HarnessPromptLoopResult;
-    const runManifest = await readRunManifest(
+    let runManifest = await readRunManifest(
       parsed.runManifestPath,
       readTextFile,
     );
+    if (deps.loomLocalHostBinding !== undefined) {
+      try {
+        runManifest = bindLoomLocalRunManifest(
+          runManifest,
+          deps.loomLocalHostBinding,
+          parsed.model,
+        );
+      } catch (error) {
+        throw new HarnessControlError(
+          "provider-mismatch",
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    }
     const promptSlotBinding = runManifest?.promptSlot ??
       createCliPromptSlotBinding({
         kernelName: "cf-harness",
@@ -2854,6 +2931,16 @@ export const runCfHarnessCli = async (
         );
       }
       const recordedRunManifest = artifacts.runState.runManifest;
+      if (
+        runManifest?.model !== undefined &&
+        artifacts.runState.model !== undefined &&
+        runManifest.model !== artifacts.runState.model
+      ) {
+        throw new HarnessControlError(
+          "provider-mismatch",
+          `resume model mismatch: run uses ${artifacts.runState.model}, requested manifest uses ${runManifest.model}`,
+        );
+      }
       const credentialOwner = recordedRunManifest?.credentialOwner ??
         localCredentialOwner(artifacts.runState.credentialOwnerKey ?? "local");
       if (
@@ -2972,6 +3059,7 @@ export const runCfHarnessCli = async (
           ? { apiKey: parsed.apiKey, apiKeySource: parsed.apiKeySource }
           : {}),
         ...(modelClient !== undefined ? { modelClient } : {}),
+        ...(deps.fetchFn !== undefined ? { fetchFn: deps.fetchFn } : {}),
         ...(parsed.reasoningEffort !== undefined
           ? { reasoningEffort: parsed.reasoningEffort }
           : {}),
@@ -3115,6 +3203,7 @@ export const runCfHarnessCli = async (
           ? { apiKey: parsed.apiKey, apiKeySource: parsed.apiKeySource }
           : {}),
         ...(modelClient !== undefined ? { modelClient } : {}),
+        ...(deps.fetchFn !== undefined ? { fetchFn: deps.fetchFn } : {}),
         ...(parsed.reasoningEffort !== undefined
           ? { reasoningEffort: parsed.reasoningEffort }
           : {}),
@@ -3190,7 +3279,20 @@ export const runCfHarnessCli = async (
     }
     return 0;
   } catch (error) {
-    io.stderr(`${error instanceof Error ? error.message : String(error)}\n`);
+    const hostError = deps.structuredHostFailures &&
+        !(error instanceof HarnessControlError)
+      ? new HarnessControlError(
+        activeEngine === undefined ? "invalid-request" : "internal-error",
+        activeEngine === undefined
+          ? "The cf-harness request is invalid"
+          : "The local cf-harness host operation failed",
+      )
+      : error;
+    io.stderr(
+      deps.structuredHostFailures
+        ? `${JSON.stringify(createCfHarnessHostFailure(hostError))}\n`
+        : `${error instanceof Error ? error.message : String(error)}\n`,
+    );
     return 1;
   } finally {
     signalCleanup?.();

--- a/packages/cf-harness/src/config.ts
+++ b/packages/cf-harness/src/config.ts
@@ -3,7 +3,11 @@ import {
   isCfcEnforcementMode,
 } from "@commonfabric/runner/cfc";
 import type { HarnessCfcEnforcementModeSource } from "./contracts/cfc-policy-snapshot.ts";
-import type { HarnessRunManifest } from "./contracts/run-manifest.ts";
+import {
+  type HarnessCredentialOwnerRef,
+  harnessCredentialOwnersEqual,
+  type HarnessRunManifest,
+} from "./contracts/run-manifest.ts";
 import type {
   HarnessAllowedSkillScript,
   HarnessSkillScriptExecutionTarget,
@@ -31,11 +35,18 @@ export interface HarnessFabricSessionConfig {
 export type HarnessModelProviderId =
   | "openai-compatible-gateway"
   | "openai-codex";
-export type HarnessModelAuthSource = "api-key" | "none" | "owner-bound-oauth";
+export type HarnessModelAuthSource =
+  | "api-key"
+  | "none"
+  | "owner-bound-oauth"
+  | "cf-harness-local-store";
 
 interface HarnessCommonConfig {
   cwd?: string;
   model?: string;
+  modelAuthSource?: HarnessModelAuthSource;
+  credentialOwner?: HarnessCredentialOwnerRef;
+  harnessHomeIdentity?: string;
   skillsRoot?: string;
   allowedSkillScripts?: readonly HarnessAllowedSkillScript[];
   skillScriptExecutionTarget: HarnessSkillScriptExecutionTarget;
@@ -79,6 +90,9 @@ export type ResolvedHarnessConfig =
 export interface ResolveHarnessConfigOptions {
   modelProvider?: HarnessModelProviderId;
   credentialOwnerKey?: string;
+  credentialOwner?: HarnessCredentialOwnerRef;
+  modelAuthSource?: HarnessModelAuthSource;
+  harnessHomeIdentity?: string;
   gatewayBaseUrl?: string;
   gatewayAuthMode?: HarnessGatewayAuthMode;
   gatewayAuthModeOverride?: string | HarnessGatewayAuthMode;
@@ -195,6 +209,32 @@ export const resolveHarnessConfig = (
 ): ResolvedHarnessConfig => {
   const modelProvider = options.modelProvider ?? "openai-compatible-gateway";
   if (
+    options.credentialOwner !== undefined &&
+    options.runManifest?.credentialOwner !== undefined &&
+    !harnessCredentialOwnersEqual(
+      options.credentialOwner,
+      options.runManifest.credentialOwner,
+    )
+  ) {
+    throw new Error(
+      "configured credential owner does not match run manifest credential owner",
+    );
+  }
+  const credentialOwner = options.credentialOwner ??
+    options.runManifest?.credentialOwner;
+  const harnessHomeIdentity = options.harnessHomeIdentity ??
+    options.runManifest?.harnessHomeIdentity;
+  const modelAuthSource = options.modelAuthSource ??
+    options.runManifest?.modelAuthSource;
+  if (
+    credentialOwner !== undefined && options.credentialOwnerKey !== undefined &&
+    credentialOwner.ownerKey !== options.credentialOwnerKey
+  ) {
+    throw new Error(
+      "credential owner reference does not match configured credential owner key",
+    );
+  }
+  if (
     modelProvider === "openai-codex" &&
     (options.gatewayBaseUrl !== undefined ||
       options.gatewayAuthMode !== undefined ||
@@ -207,6 +247,9 @@ export const resolveHarnessConfig = (
   const common: HarnessCommonConfig = {
     ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
     ...(options.model !== undefined ? { model: options.model } : {}),
+    ...(modelAuthSource !== undefined ? { modelAuthSource } : {}),
+    ...(credentialOwner !== undefined ? { credentialOwner } : {}),
+    ...(harnessHomeIdentity !== undefined ? { harnessHomeIdentity } : {}),
     ...(options.skillsRoot !== undefined
       ? { skillsRoot: options.skillsRoot }
       : {}),
@@ -237,7 +280,8 @@ export const resolveHarnessConfig = (
     return {
       ...common,
       modelProvider,
-      credentialOwnerKey: options.credentialOwnerKey ?? "local",
+      credentialOwnerKey: options.credentialOwnerKey ??
+        credentialOwner?.ownerKey ?? "local",
       gatewayBaseUrl: normalizeGatewayBaseUrl(DEFAULT_GATEWAY_BASE_URL),
       gatewayAuthMode: "bearer",
     };

--- a/packages/cf-harness/src/contracts/interactive-chat.ts
+++ b/packages/cf-harness/src/contracts/interactive-chat.ts
@@ -2,6 +2,7 @@ import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import type { HarnessBrowserAccessLease } from "./browser-access.ts";
 import type { HarnessImageAttachment } from "./image.ts";
 import type { PromptSlotBinding } from "./prompt-slot.ts";
+import type { LoomLocalHostBinding } from "./run-manifest.ts";
 import {
   type BuiltinToolId,
   DEFAULT_PARENT_TOOL_IDS,
@@ -245,6 +246,10 @@ export interface HarnessChatError {
     | "session_closed"
     | "browser_access_required"
     | "policy_denied"
+    | "provider-configuration-required"
+    | "provider-auth-required"
+    | "provider-mismatch"
+    | "provider-unavailable"
     | "internal_error";
   message: string;
   retryable?: boolean;
@@ -294,6 +299,7 @@ export interface HarnessChatSessionStatus {
   workspace?: HarnessChatWorkspace;
   context?: HarnessChatContext;
   model?: string;
+  loomLocalHostBinding?: LoomLocalHostBinding;
   harnessRunId?: string;
   artifactRoot?: string;
   capabilities: HarnessChatCapabilities;
@@ -449,6 +455,7 @@ export interface CreateHarnessChatSessionStatusOptions {
   workspace?: HarnessChatWorkspace;
   context?: HarnessChatContext;
   model?: string;
+  loomLocalHostBinding?: LoomLocalHostBinding;
   harnessRunId?: string;
   artifactRoot?: string;
   capabilities?: Partial<HarnessChatCapabilities>;
@@ -473,6 +480,9 @@ export const createHarnessChatSessionStatus = (
       : {}),
     ...(options.context !== undefined ? { context: options.context } : {}),
     ...(options.model !== undefined ? { model: options.model } : {}),
+    ...(options.loomLocalHostBinding !== undefined
+      ? { loomLocalHostBinding: structuredClone(options.loomLocalHostBinding) }
+      : {}),
     ...(options.harnessRunId !== undefined
       ? { harnessRunId: options.harnessRunId }
       : {}),

--- a/packages/cf-harness/src/contracts/run-manifest.ts
+++ b/packages/cf-harness/src/contracts/run-manifest.ts
@@ -49,7 +49,14 @@ export interface LoomRunManifest {
   capabilityProfile?: string;
   model?: string;
   modelProvider?: "openai-compatible-gateway" | "openai-codex";
+  modelAuthSource?:
+    | "api-key"
+    | "none"
+    | "owner-bound-oauth"
+    | "cf-harness-local-store";
   credentialOwner?: HarnessCredentialOwnerRef;
+  /** Opaque digest identifying the canonical host-owned credential home. */
+  harnessHomeIdentity?: string;
   workspace?: LoomRunManifestWorkspace;
   promptSlot?: PromptSlotBinding;
   cfc?: LoomRunManifestCfc;
@@ -57,6 +64,71 @@ export interface LoomRunManifest {
 }
 
 export type HarnessRunManifest = LoomRunManifest;
+
+export interface LoomLocalHostBinding {
+  source: "loom";
+  modelProvider: "openai-compatible-gateway" | "openai-codex";
+  modelAuthSource:
+    | "api-key"
+    | "none"
+    | "cf-harness-local-store";
+  credentialOwner: HarnessCredentialOwnerRef;
+  harnessHomeIdentity: string;
+}
+
+const assertOptionalBindingField = <T>(
+  label: string,
+  current: T | undefined,
+  expected: T,
+  equal: (left: T, right: T) => boolean = Object.is,
+): void => {
+  if (current !== undefined && !equal(current, expected)) {
+    throw new Error(`Loom-local ${label} does not match the host binding`);
+  }
+};
+
+/** Adds the trusted local host binding without overwriting caller metadata. */
+export const bindLoomLocalRunManifest = (
+  input: HarnessRunManifest | undefined,
+  binding: LoomLocalHostBinding,
+  model?: string,
+): HarnessRunManifest => {
+  assertOptionalBindingField(
+    "provider",
+    input?.modelProvider,
+    binding.modelProvider,
+  );
+  assertOptionalBindingField(
+    "auth source",
+    input?.modelAuthSource,
+    binding.modelAuthSource,
+  );
+  assertOptionalBindingField(
+    "credential owner",
+    input?.credentialOwner,
+    binding.credentialOwner,
+    harnessCredentialOwnersEqual,
+  );
+  assertOptionalBindingField(
+    "harness home",
+    input?.harnessHomeIdentity,
+    binding.harnessHomeIdentity,
+  );
+  if (model !== undefined) {
+    assertOptionalBindingField("model", input?.model, model);
+  }
+  return {
+    ...(input ?? {}),
+    type: LOOM_RUN_MANIFEST_TYPE,
+    version: 1,
+    source: "loom",
+    modelProvider: binding.modelProvider,
+    modelAuthSource: binding.modelAuthSource,
+    credentialOwner: structuredClone(binding.credentialOwner),
+    harnessHomeIdentity: binding.harnessHomeIdentity,
+    ...(model !== undefined ? { model } : {}),
+  };
+};
 
 const isJsonObject = (input: unknown): input is Record<string, unknown> =>
   isObjectNotArray(input);
@@ -142,6 +214,11 @@ export const normalizeLoomRunManifest = (
       `unsupported run manifest version: ${String(input.version)}`,
     );
   }
+  if (input.source !== undefined && input.source !== "loom") {
+    throw new Error(
+      `unsupported run manifest source: ${String(input.source)}`,
+    );
+  }
   const promptSlot = input.promptSlot === undefined
     ? undefined
     : normalizePromptSlotBinding(input.promptSlot);
@@ -154,6 +231,25 @@ export const normalizeLoomRunManifest = (
     throw new Error(
       `unsupported run manifest modelProvider: ${String(input.modelProvider)}`,
     );
+  }
+  if (
+    input.modelAuthSource !== undefined &&
+    input.modelAuthSource !== "api-key" && input.modelAuthSource !== "none" &&
+    input.modelAuthSource !== "owner-bound-oauth" &&
+    input.modelAuthSource !== "cf-harness-local-store"
+  ) {
+    throw new Error(
+      `unsupported run manifest modelAuthSource: ${
+        String(input.modelAuthSource)
+      }`,
+    );
+  }
+  if (
+    input.harnessHomeIdentity !== undefined &&
+    (typeof input.harnessHomeIdentity !== "string" ||
+      !/^sha256:[A-Za-z0-9._-]+$/.test(input.harnessHomeIdentity))
+  ) {
+    throw new Error("invalid run manifest harnessHomeIdentity");
   }
   const credentialOwner = normalizeCredentialOwnerRef(input.credentialOwner);
   return {

--- a/packages/cf-harness/src/contracts/run-report.ts
+++ b/packages/cf-harness/src/contracts/run-report.ts
@@ -21,6 +21,7 @@ import type {
   HarnessModelAuthSource,
   HarnessModelProviderId,
 } from "../config.ts";
+import type { HarnessCredentialOwnerRef } from "./run-manifest.ts";
 
 export type HarnessToolPolicyDecision = "allowed" | "warned" | "denied";
 export type HarnessToolExecutionStatus = "completed" | "failed" | "not-run";
@@ -106,6 +107,8 @@ export interface HarnessRunReport {
   cacheAffinity?: "run" | "custom";
   modelProvider?: HarnessModelProviderId;
   modelAuthSource?: HarnessModelAuthSource;
+  credentialOwner?: HarnessCredentialOwnerRef;
+  harnessHomeIdentity?: string;
   modelTurns: number;
   /** Usage from model turns executed directly by this run. */
   usage?: HarnessModelUsage;
@@ -163,6 +166,8 @@ export interface CreateHarnessRunReportOptions {
     toolOutputs: ToolResultRef[];
     modelProvider?: HarnessModelProviderId;
     modelAuthSource?: HarnessModelAuthSource;
+    credentialOwner?: HarnessCredentialOwnerRef;
+    harnessHomeIdentity?: string;
     subagentRuns?: HarnessSubagentRunRef[];
   };
   model: string;
@@ -309,6 +314,12 @@ export const createHarnessRunReport = (
       ? { modelAuthSource: options.runState.modelAuthSource }
       : options.runState.modelProvider === "openai-codex"
       ? { modelAuthSource: "owner-bound-oauth" as const }
+      : {}),
+    ...(options.runState.credentialOwner !== undefined
+      ? { credentialOwner: structuredClone(options.runState.credentialOwner) }
+      : {}),
+    ...(options.runState.harnessHomeIdentity !== undefined
+      ? { harnessHomeIdentity: options.runState.harnessHomeIdentity }
       : {}),
     modelTurns: options.modelTurns,
     ...(options.usage !== undefined ? { usage: options.usage } : {}),

--- a/packages/cf-harness/src/contracts/subagent.ts
+++ b/packages/cf-harness/src/contracts/subagent.ts
@@ -5,7 +5,11 @@ import {
   type LLMNativeModelToolId,
 } from "@commonfabric/llm/types";
 import type { HarnessFailureRecord } from "../diagnostics.ts";
-import type { HarnessModelProviderId } from "../config.ts";
+import type {
+  HarnessModelAuthSource,
+  HarnessModelProviderId,
+} from "../config.ts";
+import type { HarnessCredentialOwnerRef } from "./run-manifest.ts";
 import type {
   HarnessAllowedSkillScript,
   HarnessSkillScriptExecutionTarget,
@@ -201,6 +205,9 @@ export interface HarnessSubagentRunManifest {
   depth: 1;
   cfcEnforcementMode: CfcEnforcementMode;
   modelProvider?: HarnessModelProviderId;
+  modelAuthSource?: HarnessModelAuthSource;
+  credentialOwner?: HarnessCredentialOwnerRef;
+  harnessHomeIdentity?: string;
   model: string;
   modelSource?: HarnessSubagentModelSource;
   allowedToolIds: readonly BuiltinToolId[];

--- a/packages/cf-harness/src/control-errors.ts
+++ b/packages/cf-harness/src/control-errors.ts
@@ -5,12 +5,10 @@ export type HarnessControlErrorCode =
   | "provider-auth-required"
   | "provider-mismatch"
   | "provider-unavailable"
+  | "internal-error"
   | "operation-canceled";
 
-/**
- * A machine-classifiable provider failure whose message and cause graph are
- * safe to persist in run metadata or return from a control command.
- */
+/** A machine-classifiable, bounded failure safe to return at host boundaries. */
 export class HarnessControlError extends Error {
   constructor(
     readonly code: HarnessControlErrorCode,

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -43,6 +43,7 @@ import {
 import type { HarnessCfcPolicySnapshot } from "./contracts/cfc-policy-snapshot.ts";
 import type { HarnessHandleTable } from "./contracts/handle-table.ts";
 import { assertValidHarnessHandleTable } from "./handle-table.ts";
+import { harnessCredentialOwnersEqual } from "./contracts/run-manifest.ts";
 import {
   createHarnessPolicyDecisionRecord,
   type HarnessPolicyDecisionRecord,
@@ -363,6 +364,45 @@ export class CfHarnessEngine {
         `resumed openai-codex run model ${options.runState.model} does not match requested model ${options.model}`,
       );
     }
+    const recordedOwner = options.runState?.credentialOwner ??
+      options.runState?.runManifest?.credentialOwner;
+    const requestedOwner = options.credentialOwner ??
+      options.runManifest?.credentialOwner;
+    if (
+      options.runState !== undefined && recordedOwner !== undefined &&
+      requestedOwner !== undefined &&
+      !harnessCredentialOwnersEqual(recordedOwner, requestedOwner)
+    ) {
+      throw new Error(
+        "resumed run credential owner does not match requested credential owner",
+      );
+    }
+    const recordedHomeIdentity = options.runState?.harnessHomeIdentity ??
+      options.runState?.runManifest?.harnessHomeIdentity;
+    const requestedHomeIdentity = options.harnessHomeIdentity ??
+      options.runManifest?.harnessHomeIdentity;
+    if (
+      options.runState !== undefined && recordedHomeIdentity !== undefined &&
+      requestedHomeIdentity !== undefined &&
+      recordedHomeIdentity !== requestedHomeIdentity
+    ) {
+      throw new Error(
+        "resumed run harness home does not match requested harness home",
+      );
+    }
+    const recordedAuthSource = options.runState?.modelAuthSource ??
+      options.runState?.runManifest?.modelAuthSource;
+    const requestedAuthSource = options.modelAuthSource ??
+      options.runManifest?.modelAuthSource;
+    if (
+      options.runState !== undefined && recordedAuthSource !== undefined &&
+      requestedAuthSource !== undefined &&
+      recordedAuthSource !== requestedAuthSource
+    ) {
+      throw new Error(
+        "resumed run model auth source does not match requested model auth source",
+      );
+    }
     if (
       options.runState !== undefined && recordedProvider === "openai-codex" &&
       options.runState.credentialOwnerKey !== undefined &&
@@ -386,6 +426,15 @@ export class CfHarnessEngine {
           credentialOwnerKey: options.runState.credentialOwnerKey ??
             options.credentialOwnerKey,
         }
+        : {}),
+      ...(options.runState !== undefined && recordedOwner !== undefined
+        ? { credentialOwner: recordedOwner }
+        : {}),
+      ...(options.runState !== undefined && recordedHomeIdentity !== undefined
+        ? { harnessHomeIdentity: recordedHomeIdentity }
+        : {}),
+      ...(options.runState !== undefined && recordedAuthSource !== undefined
+        ? { modelAuthSource: recordedAuthSource }
         : {}),
     });
     const runId = options.runState?.runId ?? options.runId ??
@@ -475,12 +524,15 @@ export class CfHarnessEngine {
         currentDir,
         model: this.config.model,
         modelProvider: this.config.modelProvider,
-        modelAuthSource: this.config.modelProvider === "openai-codex"
-          ? "owner-bound-oauth"
-          : this.config.gatewayAuthMode === "none"
-          ? "none"
-          : "api-key",
+        modelAuthSource: this.config.modelAuthSource ??
+          (this.config.modelProvider === "openai-codex"
+            ? "owner-bound-oauth"
+            : this.config.gatewayAuthMode === "none"
+            ? "none"
+            : "api-key"),
         credentialOwnerKey: this.config.credentialOwnerKey,
+        credentialOwner: this.config.credentialOwner,
+        harnessHomeIdentity: this.config.harnessHomeIdentity,
         artifactRoot: this.artifactStore?.runRoot,
         runManifest: this.config.runManifest,
         runManifestPath: this.config.runManifestPath,

--- a/packages/cf-harness/src/index.ts
+++ b/packages/cf-harness/src/index.ts
@@ -4,6 +4,7 @@ export * from "./engine.ts";
 export * from "./prompt-loop.ts";
 export * from "./interactive-chat-service.ts";
 export * from "./interactive-chat-stdio.ts";
+export * from "./loom-local-host.ts";
 export * from "./session-store.ts";
 export * from "./structured-result.ts";
 export * from "./subagent-return.ts";

--- a/packages/cf-harness/src/interactive-chat-service.ts
+++ b/packages/cf-harness/src/interactive-chat-service.ts
@@ -33,6 +33,7 @@ import { BROWSER_SUBAGENT_PROFILE } from "./contracts/subagent.ts";
 import {
   type HarnessCredentialOwnerRef,
   harnessCredentialOwnersEqual,
+  type LoomLocalHostBinding,
 } from "./contracts/run-manifest.ts";
 import type {
   HarnessAssistantTranscriptMessage,
@@ -40,6 +41,7 @@ import type {
   HarnessTranscriptMessage,
 } from "./contracts/transcript.ts";
 import type { HarnessChatSessionStore } from "./session-store.ts";
+import { HarnessControlError } from "./control-errors.ts";
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -157,6 +159,107 @@ const sessionClosedError = (
     message: `chat session is closed: ${sessionId}`,
   });
 
+const providerMismatchError = (
+  requestId: string,
+  message: string,
+): HarnessChatErrorResponse =>
+  createHarnessChatErrorResponse(requestId, {
+    code: "provider-mismatch",
+    message,
+  });
+
+const isLoomLocalHostBinding = (
+  value: unknown,
+): value is LoomLocalHostBinding => {
+  if (!isRecord(value) || value.source !== "loom") {
+    return false;
+  }
+  if (
+    value.modelProvider !== "openai-compatible-gateway" &&
+    value.modelProvider !== "openai-codex"
+  ) {
+    return false;
+  }
+  if (
+    value.modelAuthSource !== "api-key" &&
+    value.modelAuthSource !== "none" &&
+    value.modelAuthSource !== "cf-harness-local-store"
+  ) {
+    return false;
+  }
+  const owner = value.credentialOwner;
+  return isRecord(owner) &&
+    owner.type === "cf-harness.credential-owner-ref" && owner.version === 1 &&
+    typeof owner.ownerKey === "string" && owner.ownerKey.length > 0 &&
+    (owner.tenantKey === undefined || typeof owner.tenantKey === "string") &&
+    typeof value.harnessHomeIdentity === "string" &&
+    value.harnessHomeIdentity.length > 0;
+};
+
+const loomLocalHostBindingFromPromptLoopOptions = (
+  options: CreateHarnessPromptLoopOptions,
+): LoomLocalHostBinding | undefined => {
+  const manifest = options.runManifest;
+  if (!isLoomLocalHostBinding(manifest)) {
+    return undefined;
+  }
+  const binding: LoomLocalHostBinding = {
+    source: "loom",
+    modelProvider: manifest.modelProvider,
+    modelAuthSource: manifest.modelAuthSource,
+    credentialOwner: structuredClone(manifest.credentialOwner),
+    harnessHomeIdentity: manifest.harnessHomeIdentity,
+  };
+  if (
+    options.modelProvider !== binding.modelProvider
+  ) {
+    throw new Error(
+      "interactive service provider does not match its Loom-local run manifest",
+    );
+  }
+  if (
+    options.modelAuthSource !== undefined &&
+    options.modelAuthSource !== binding.modelAuthSource
+  ) {
+    throw new Error(
+      "interactive service auth source does not match its Loom-local run manifest",
+    );
+  }
+  if (
+    options.credentialOwner !== undefined &&
+    !harnessCredentialOwnersEqual(
+      options.credentialOwner,
+      binding.credentialOwner,
+    )
+  ) {
+    throw new Error(
+      "interactive service credential owner does not match its Loom-local run manifest",
+    );
+  }
+  if (
+    options.harnessHomeIdentity !== undefined &&
+    options.harnessHomeIdentity !== binding.harnessHomeIdentity
+  ) {
+    throw new Error(
+      "interactive service harness home does not match its Loom-local run manifest",
+    );
+  }
+  return binding;
+};
+
+const loomLocalHostBindingsEqual = (
+  expected: LoomLocalHostBinding,
+  actual: unknown,
+): boolean =>
+  isLoomLocalHostBinding(actual) &&
+  expected.source === actual.source &&
+  expected.modelProvider === actual.modelProvider &&
+  expected.modelAuthSource === actual.modelAuthSource &&
+  harnessCredentialOwnersEqual(
+    expected.credentialOwner,
+    actual.credentialOwner,
+  ) && expected.harnessHomeIdentity === actual.harnessHomeIdentity;
+
 const browserAccessRequiredError = (
   requestId: string,
 ): HarnessChatErrorResponse =>
@@ -193,6 +296,22 @@ const interruptedTurnError = (
     priorStatus,
   },
 });
+
+const chatTurnError = (error: unknown): HarnessChatError => {
+  if (
+    error instanceof HarnessControlError &&
+    (error.code === "provider-configuration-required" ||
+      error.code === "provider-auth-required" ||
+      error.code === "provider-mismatch" ||
+      error.code === "provider-unavailable")
+  ) {
+    return { code: error.code, message: error.message };
+  }
+  return {
+    code: "internal_error",
+    message: error instanceof Error ? error.message : String(error),
+  };
+};
 
 const isTerminalTurnStatus = (
   status: HarnessChatTurnStatus["status"],
@@ -298,6 +417,8 @@ const fileChangeFromToolMessage = (
 
 export class HarnessInteractiveChatService {
   readonly #basePromptLoopOptions: CreateHarnessPromptLoopOptions;
+  readonly #loomLocalHostBinding?: LoomLocalHostBinding;
+  readonly #loomLocalHostModel?: string;
   readonly #createPromptLoop: HarnessInteractivePromptLoopFactory;
   readonly #now: () => string;
   readonly #randomUUID: () => string;
@@ -311,6 +432,23 @@ export class HarnessInteractiveChatService {
 
   constructor(options: CreateHarnessInteractiveChatServiceOptions = {}) {
     this.#basePromptLoopOptions = options.basePromptLoopOptions ?? {};
+    this.#loomLocalHostBinding = loomLocalHostBindingFromPromptLoopOptions(
+      this.#basePromptLoopOptions,
+    );
+    const manifestModel = this.#basePromptLoopOptions.runManifest?.model;
+    if (
+      this.#loomLocalHostBinding !== undefined &&
+      this.#basePromptLoopOptions.model !== undefined &&
+      manifestModel !== undefined &&
+      this.#basePromptLoopOptions.model !== manifestModel
+    ) {
+      throw new Error(
+        "interactive service model does not match its Loom-local run manifest",
+      );
+    }
+    this.#loomLocalHostModel = this.#loomLocalHostBinding === undefined
+      ? undefined
+      : this.#basePromptLoopOptions.model ?? manifestModel;
     const codexConfigured =
       this.#basePromptLoopOptions.modelProvider === "openai-codex" ||
       this.#basePromptLoopOptions.modelClient?.providerId === "openai-codex";
@@ -637,12 +775,32 @@ export class HarnessInteractiveChatService {
     if (this.#sessions.has(sessionId)) {
       return sessionExistsError(requestId, sessionId);
     }
+    if (
+      this.#loomLocalHostModel !== undefined && params.model !== undefined &&
+      params.model !== this.#loomLocalHostModel
+    ) {
+      return providerMismatchError(
+        requestId,
+        "chat session model does not match the local Loom host binding",
+      );
+    }
+    const model = this.#loomLocalHostModel ?? params.model;
+    if (
+      this.#loomLocalHostBinding !== undefined &&
+      (model === undefined || model.trim() === "")
+    ) {
+      return providerMismatchError(
+        requestId,
+        "local Loom chat sessions require a durable model binding",
+      );
+    }
     const session = createHarnessChatSessionStatus({
       sessionId,
       createdAt: this.#now(),
       workspace: params.workspace,
       context: params.context,
-      model: params.model,
+      model,
+      loomLocalHostBinding: this.#loomLocalHostBinding,
       artifactRoot: params.artifactRoot,
       capabilities: params.capabilities,
       policy: resolveHarnessChatPolicy(params.policy, params.context),
@@ -674,6 +832,36 @@ export class HarnessInteractiveChatService {
     const record = this.#sessions.get(params.sessionId);
     if (record === undefined) {
       return sessionNotFoundError(requestId, params.sessionId);
+    }
+    if (this.#loomLocalHostBinding !== undefined) {
+      if (
+        !loomLocalHostBindingsEqual(
+          this.#loomLocalHostBinding,
+          record.status.loomLocalHostBinding,
+        )
+      ) {
+        return providerMismatchError(
+          requestId,
+          "durable chat session does not match the local Loom host binding",
+        );
+      }
+      if (
+        record.status.model === undefined || record.status.model.trim() === ""
+      ) {
+        return providerMismatchError(
+          requestId,
+          "durable chat session is missing its model binding",
+        );
+      }
+      if (
+        this.#loomLocalHostModel !== undefined &&
+        record.status.model !== this.#loomLocalHostModel
+      ) {
+        return providerMismatchError(
+          requestId,
+          "durable chat session model does not match the local Loom host binding",
+        );
+      }
     }
     if (record.status.status === "closed") {
       return sessionClosedError(requestId, params.sessionId);
@@ -926,10 +1114,7 @@ export class HarnessInteractiveChatService {
       await this.#emit(session.sessionId, turnId, {
         kind: "turn_failed",
         turnId,
-        error: {
-          code: "internal_error",
-          message: error instanceof Error ? error.message : String(error),
-        },
+        error: chatTurnError(error),
       });
     }
   }
@@ -948,6 +1133,15 @@ export class HarnessInteractiveChatService {
         ? { cwd: session.workspace.cwd }
         : {}),
       ...(session.model !== undefined ? { model: session.model } : {}),
+      ...(this.#loomLocalHostBinding !== undefined &&
+          session.model !== undefined
+        ? {
+          runManifest: {
+            ...this.#basePromptLoopOptions.runManifest!,
+            model: session.model,
+          },
+        }
+        : {}),
       ...(session.artifactRoot !== undefined
         ? { artifactRoot: session.artifactRoot }
         : {}),

--- a/packages/cf-harness/src/interactive-chat-stdio.ts
+++ b/packages/cf-harness/src/interactive-chat-stdio.ts
@@ -89,6 +89,8 @@ Environment:
   ${CHAT_MAX_IN_MEMORY_EVENTS_ENV}       Default in-memory event retention cap
 `;
 
+export const harnessInteractiveChatStdioUsageText = (): string => usageText;
+
 const nonEmptyOptionValue = (
   name: string,
   value: string | undefined,
@@ -575,7 +577,9 @@ export const runHarnessInteractiveChatStdioCli = async (
 ): Promise<void> => {
   const options = parseHarnessInteractiveChatStdioCliOptions(args);
   if (options.help) {
-    await Deno.stderr.write(new TextEncoder().encode(usageText));
+    await Deno.stderr.write(
+      new TextEncoder().encode(harnessInteractiveChatStdioUsageText()),
+    );
     return;
   }
   await runHarnessInteractiveChatStdio(options);

--- a/packages/cf-harness/src/loom-local-host-main.ts
+++ b/packages/cf-harness/src/loom-local-host-main.ts
@@ -1,0 +1,59 @@
+import { createCfHarnessHostFailure } from "./cli.ts";
+import {
+  createLoomLocalCfHarnessHost,
+  runLoomLocalInteractiveFailureStdio,
+} from "./loom-local-host.ts";
+import { HarnessControlError } from "./control-errors.ts";
+
+const writeStderr = (value: unknown): void => {
+  Deno.stderr.writeSync(
+    new TextEncoder().encode(`${JSON.stringify(value)}\n`),
+  );
+};
+
+export const runLoomLocalCfHarnessHostMain = async (
+  args: readonly string[] = Deno.args,
+  env: Record<string, string | undefined> = Deno.env.toObject(),
+): Promise<number> => {
+  const mode = args[0];
+  const forwarded = args[1] === "--" ? args.slice(2) : args.slice(1);
+  if (mode !== "batch" && mode !== "interactive") {
+    writeStderr(createCfHarnessHostFailure(
+      new HarnessControlError(
+        "invalid-request",
+        "usage: loom-local-host-main.ts batch|interactive [--] [options]",
+      ),
+    ));
+    return 1;
+  }
+  const harnessHome = env.CF_HARNESS_HOME;
+  if (harnessHome === undefined) {
+    const error = new HarnessControlError(
+      "provider-configuration-required",
+      "CF_HARNESS_HOME is required by the local Loom host",
+    );
+    if (mode === "interactive") {
+      await runLoomLocalInteractiveFailureStdio(error);
+    } else {
+      writeStderr(createCfHarnessHostFailure(error));
+    }
+    return 1;
+  }
+  try {
+    const host = await createLoomLocalCfHarnessHost({ harnessHome, env });
+    if (mode === "batch") return await host.runBatch(forwarded);
+    await host.runInteractive(forwarded);
+    return 0;
+  } catch (error) {
+    if (mode === "interactive") {
+      await runLoomLocalInteractiveFailureStdio(error);
+    } else {
+      writeStderr(createCfHarnessHostFailure(error));
+    }
+    return 1;
+  }
+};
+
+if (import.meta.main) {
+  Deno.exit(await runLoomLocalCfHarnessHostMain());
+}

--- a/packages/cf-harness/src/loom-local-host.ts
+++ b/packages/cf-harness/src/loom-local-host.ts
@@ -1,0 +1,681 @@
+import { isAbsolute, resolve } from "@std/path";
+import {
+  type HarnessRunArtifacts,
+  readHarnessRunArtifacts,
+} from "./artifacts.ts";
+import {
+  defaultHarnessCredentialStorePath,
+  FileHarnessCredentialStore,
+  type HarnessCredentialStore,
+} from "./auth/credential-store.ts";
+import {
+  OpenAICodexAuthService,
+  OpenAICodexCredentialResolver,
+} from "./auth/openai-codex.ts";
+import {
+  defaultHarnessProviderSettingsPath,
+  FileHarnessProviderSettingsStore,
+  resolveHarnessModelProviderPreference,
+} from "./auth/provider-settings.ts";
+import {
+  cfHarnessCliInformationalControl,
+  type CfHarnessCliIO,
+  type CfHarnessHostFailure,
+  createCfHarnessHostFailure,
+  runCfHarnessCli,
+  type RunCfHarnessCliDependencies,
+} from "./cli.ts";
+import type {
+  HarnessGatewayAuthMode,
+  HarnessModelProviderId,
+} from "./config.ts";
+import { HarnessControlError } from "./control-errors.ts";
+import {
+  createHarnessChatErrorResponse,
+  type HarnessChatError,
+} from "./contracts/interactive-chat.ts";
+import type { HarnessFetch } from "./contracts/http-fetch.ts";
+import {
+  HARNESS_CREDENTIAL_OWNER_REF_TYPE,
+  harnessCredentialOwnersEqual,
+  type LoomLocalHostBinding,
+  type LoomRunManifest,
+} from "./contracts/run-manifest.ts";
+import {
+  harnessInteractiveChatStdioUsageText,
+  parseHarnessInteractiveChatStdioCliOptions,
+  runHarnessInteractiveChatStdio,
+  type RunHarnessInteractiveChatStdioOptions,
+} from "./interactive-chat-stdio.ts";
+import { OpenAICodexResponsesClient } from "./model/openai-codex-responses.ts";
+
+export const LOOM_LOCAL_CREDENTIAL_OWNER = {
+  type: HARNESS_CREDENTIAL_OWNER_REF_TYPE,
+  version: 1,
+  ownerKey: "local",
+} as const;
+
+export const LOOM_LOCAL_AUTH_SOURCE = "cf-harness-local-store" as const;
+
+const CODEX_INCOMPATIBLE_ENV_KEYS = [
+  "CF_HARNESS_API_KEY",
+  "OPENAI_API_KEY",
+  "CF_HARNESS_GATEWAY_BASE_URL",
+  "CF_HARNESS_GATEWAY_AUTH_MODE",
+  "CF_HARNESS_PROMPT_CACHE_MODE",
+] as const;
+
+const nonEmpty = (value: string | undefined): string | undefined =>
+  value === undefined || value.trim() === "" ? undefined : value;
+
+const canonicalHarnessHome = async (input: string): Promise<string> => {
+  if (input.trim() === "" || !isAbsolute(input)) {
+    throw new HarnessControlError(
+      "provider-configuration-required",
+      "CF_HARNESS_HOME must be an absolute canonical path",
+    );
+  }
+  const canonical = resolve(input);
+  if (canonical !== input) {
+    throw new HarnessControlError(
+      "provider-configuration-required",
+      "CF_HARNESS_HOME must already be normalized",
+    );
+  }
+  try {
+    const real = await Deno.realPath(canonical);
+    if (!(await Deno.stat(real)).isDirectory) {
+      throw new Error("not a directory");
+    }
+    return real;
+  } catch {
+    throw new HarnessControlError(
+      "provider-configuration-required",
+      "CF_HARNESS_HOME must resolve to an existing directory",
+    );
+  }
+};
+
+const homeIdentity = async (home: string): Promise<string> => {
+  const bytes = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(home),
+  );
+  return `sha256:${
+    [...new Uint8Array(bytes)].map((value) =>
+      value.toString(16).padStart(2, "0")
+    ).join("")
+  }`;
+};
+
+interface ParsedBindingArgs {
+  resumeRun?: string;
+  modelProvider?: HarnessModelProviderId;
+  model?: string;
+  gatewayAuthMode?: HarnessGatewayAuthMode;
+  hasGatewayOptions: boolean;
+}
+
+const optionValue = (
+  argv: readonly string[],
+  index: number,
+  name: string,
+): { value: string; consumed: number } => {
+  const argument = argv[index];
+  const prefix = `${name}=`;
+  if (argument.startsWith(prefix)) {
+    const value = argument.slice(prefix.length);
+    if (value.trim() === "") throw new Error(`${name} requires a value`);
+    return { value, consumed: 0 };
+  }
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+  return { value, consumed: 1 };
+};
+
+const parseBindingArgs = (argv: readonly string[]): ParsedBindingArgs => {
+  let resumeRun: string | undefined;
+  let modelProvider: HarnessModelProviderId | undefined;
+  let model: string | undefined;
+  let parsedGatewayAuthMode: HarnessGatewayAuthMode | undefined;
+  let hasGatewayOptions = false;
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--") {
+      if (index === 0) continue;
+      break;
+    }
+    if (
+      argument === "--gateway-base-url" ||
+      argument.startsWith("--gateway-base-url=")
+    ) {
+      hasGatewayOptions = true;
+      const parsed = optionValue(argv, index, "--gateway-base-url");
+      index += parsed.consumed;
+      continue;
+    }
+    if (
+      argument === "--prompt-cache-mode" ||
+      argument.startsWith("--prompt-cache-mode=")
+    ) {
+      hasGatewayOptions = true;
+      const parsed = optionValue(argv, index, "--prompt-cache-mode");
+      index += parsed.consumed;
+      continue;
+    }
+    if (
+      argument === "--gateway-auth-mode" ||
+      argument.startsWith("--gateway-auth-mode=")
+    ) {
+      hasGatewayOptions = true;
+      if (parsedGatewayAuthMode !== undefined) {
+        throw new Error("duplicate --gateway-auth-mode");
+      }
+      const parsed = optionValue(argv, index, "--gateway-auth-mode");
+      index += parsed.consumed;
+      if (parsed.value !== "bearer" && parsed.value !== "none") {
+        throw new Error("--gateway-auth-mode must be bearer or none");
+      }
+      parsedGatewayAuthMode = parsed.value;
+      continue;
+    }
+    for (const name of ["--resume-run", "--model-provider", "--model"]) {
+      if (argument !== name && !argument.startsWith(`${name}=`)) continue;
+      const parsed = optionValue(argv, index, name);
+      index += parsed.consumed;
+      if (name === "--resume-run") {
+        if (resumeRun !== undefined) throw new Error("duplicate --resume-run");
+        resumeRun = parsed.value;
+      } else if (name === "--model") {
+        if (model !== undefined) throw new Error("duplicate --model");
+        model = parsed.value;
+      } else {
+        if (modelProvider !== undefined) {
+          throw new Error("duplicate --model-provider");
+        }
+        if (
+          parsed.value !== "openai-compatible-gateway" &&
+          parsed.value !== "openai-codex"
+        ) {
+          throw new Error("unsupported --model-provider");
+        }
+        modelProvider = parsed.value;
+      }
+      break;
+    }
+  }
+  return {
+    ...(resumeRun !== undefined ? { resumeRun } : {}),
+    ...(modelProvider !== undefined ? { modelProvider } : {}),
+    ...(model !== undefined ? { model } : {}),
+    ...(parsedGatewayAuthMode !== undefined
+      ? { gatewayAuthMode: parsedGatewayAuthMode }
+      : {}),
+    hasGatewayOptions,
+  };
+};
+
+const gatewayAuthMode = (
+  env: Record<string, string | undefined>,
+): HarnessGatewayAuthMode => {
+  const raw = nonEmpty(env.CF_HARNESS_GATEWAY_AUTH_MODE);
+  if (raw === undefined || raw === "bearer") return "bearer";
+  if (raw === "none") return "none";
+  throw new HarnessControlError(
+    "provider-configuration-required",
+    "CF_HARNESS_GATEWAY_AUTH_MODE must be bearer or none",
+  );
+};
+
+const bindingFromRecordedRun = (
+  artifacts: HarnessRunArtifacts,
+  expectedHomeIdentity: string,
+): LoomLocalHostBinding => {
+  const state = artifacts.runState;
+  const manifest = state.runManifest;
+  const provider = state.modelProvider;
+  const model = state.model;
+  const authSource = state.modelAuthSource;
+  const owner = state.credentialOwner;
+  const recordedHome = state.harnessHomeIdentity;
+  const manifestProvider = manifest?.modelProvider;
+  const manifestModel = manifest?.model;
+  const manifestAuthSource = manifest?.modelAuthSource;
+  const manifestOwner = manifest?.credentialOwner;
+  const manifestHome = manifest?.harnessHomeIdentity;
+  if (
+    manifest?.source !== "loom" ||
+    (provider !== "openai-compatible-gateway" &&
+      provider !== "openai-codex") ||
+    manifestProvider !== provider ||
+    typeof model !== "string" || model.trim() === "" ||
+    manifestModel !== model ||
+    (authSource !== "api-key" && authSource !== "none" &&
+      authSource !== LOOM_LOCAL_AUTH_SOURCE) ||
+    manifestAuthSource !== authSource ||
+    owner === undefined || manifestOwner === undefined ||
+    !harnessCredentialOwnersEqual(owner, manifestOwner) ||
+    recordedHome === undefined || manifestHome !== recordedHome ||
+    (state.credentialOwnerKey !== undefined &&
+      state.credentialOwnerKey !== owner.ownerKey) ||
+    !harnessCredentialOwnersEqual(owner, LOOM_LOCAL_CREDENTIAL_OWNER) ||
+    recordedHome !== expectedHomeIdentity ||
+    (provider === "openai-codex" && authSource !== LOOM_LOCAL_AUTH_SOURCE) ||
+    (provider === "openai-compatible-gateway" &&
+      authSource !== "api-key" && authSource !== "none")
+  ) {
+    throw new HarnessControlError(
+      "provider-mismatch",
+      "resumed run does not match the local Loom provider binding",
+    );
+  }
+  return {
+    source: "loom",
+    modelProvider: provider,
+    modelAuthSource: authSource,
+    credentialOwner: LOOM_LOCAL_CREDENTIAL_OWNER,
+    harnessHomeIdentity: expectedHomeIdentity,
+  };
+};
+
+const assertRequestedBinding = (
+  parsed: ParsedBindingArgs,
+  binding: LoomLocalHostBinding,
+  recordedModel?: string,
+): void => {
+  if (
+    parsed.modelProvider !== undefined &&
+    parsed.modelProvider !== binding.modelProvider
+  ) {
+    throw new HarnessControlError(
+      "provider-mismatch",
+      `requested provider ${parsed.modelProvider} does not match ${binding.modelProvider}`,
+    );
+  }
+  if (
+    recordedModel !== undefined && parsed.model !== undefined &&
+    parsed.model !== recordedModel
+  ) {
+    throw new HarnessControlError(
+      "provider-mismatch",
+      `requested model ${parsed.model} does not match resumed model ${recordedModel}`,
+    );
+  }
+  if (binding.modelProvider === "openai-codex" && parsed.hasGatewayOptions) {
+    throw new HarnessControlError(
+      "provider-mismatch",
+      "gateway options cannot be used with the local Loom Codex binding",
+    );
+  }
+};
+
+export interface CreateLoomLocalCfHarnessHostOptions {
+  harnessHome: string;
+  env?: Record<string, string | undefined>;
+  credentialStore?: HarnessCredentialStore;
+  providerSettingsStore?: Pick<FileHarnessProviderSettingsStore, "inspect">;
+  readRunArtifacts?: typeof readHarnessRunArtifacts;
+  fetchFn?: HarnessFetch;
+  interactiveStdioRunner?: (
+    options: RunHarnessInteractiveChatStdioOptions,
+  ) => Promise<void>;
+  cliDependencies?: Omit<
+    RunCfHarnessCliDependencies,
+    | "env"
+    | "loomLocalHostBinding"
+    | "credentialStore"
+    | "providerSettingsStore"
+    | "openAICodexCredentialResolver"
+    | "fetchFn"
+    | "structuredHostFailures"
+  >;
+}
+
+export interface LoomLocalCfHarnessHost {
+  readonly harnessHomeIdentity: string;
+  runBatch(argv: readonly string[]): Promise<number>;
+  runInteractive(args?: readonly string[]): Promise<void>;
+}
+
+/** Creates the fixed-owner execution boundary used by local single-user Loom. */
+export const createLoomLocalCfHarnessHost = async (
+  options: CreateLoomLocalCfHarnessHostOptions,
+): Promise<LoomLocalCfHarnessHost> => {
+  const harnessHome = await canonicalHarnessHome(options.harnessHome);
+  const identity = await homeIdentity(harnessHome);
+  const processEnv = { ...(options.env ?? Deno.env.toObject()) };
+  if (nonEmpty(processEnv.CF_HARNESS_MODEL_PROVIDER) !== undefined) {
+    throw new HarnessControlError(
+      "provider-configuration-required",
+      "local Loom runs do not accept CF_HARNESS_MODEL_PROVIDER overrides",
+    );
+  }
+  processEnv.CF_HARNESS_HOME = harnessHome;
+  processEnv.HOME = undefined;
+  processEnv.CF_HARNESS_MODEL_PROVIDER = undefined;
+  const providerStore = options.providerSettingsStore ??
+    new FileHarnessProviderSettingsStore({
+      path: defaultHarnessProviderSettingsPath(harnessHome),
+    });
+  const credentialStore = options.credentialStore ??
+    new FileHarnessCredentialStore({
+      path: defaultHarnessCredentialStorePath(harnessHome),
+    });
+  const readArtifacts = options.readRunArtifacts ?? readHarnessRunArtifacts;
+
+  const configuredProvider = async (): Promise<HarnessModelProviderId> =>
+    (await resolveHarnessModelProviderPreference({
+      store: providerStore,
+      strict: true,
+    })).provider;
+
+  const preflightCodex = async (): Promise<OpenAICodexCredentialResolver> => {
+    let status;
+    try {
+      status = await new OpenAICodexAuthService(
+        credentialStore,
+        LOOM_LOCAL_CREDENTIAL_OWNER.ownerKey,
+      ).status();
+    } catch {
+      throw new HarnessControlError(
+        "provider-unavailable",
+        "cf-harness Codex credential status could not be read",
+      );
+    }
+    if (status.status === "disconnected") {
+      throw new HarnessControlError(
+        "provider-auth-required",
+        "cf-harness Codex is not connected; connect it in Loom Settings → Harnesses",
+      );
+    }
+    if (status.status === "reconnect-required") {
+      throw new HarnessControlError(
+        "provider-auth-required",
+        "cf-harness Codex must be reconnected in Loom Settings → Harnesses",
+      );
+    }
+    return new OpenAICodexCredentialResolver({
+      store: credentialStore,
+      ownerKey: LOOM_LOCAL_CREDENTIAL_OWNER.ownerKey,
+      credentialOwner: LOOM_LOCAL_CREDENTIAL_OWNER,
+      fetchFn: options.fetchFn,
+    });
+  };
+
+  const resolveBinding = async (
+    argv: readonly string[],
+  ): Promise<
+    {
+      binding: LoomLocalHostBinding;
+      resolver?: OpenAICodexCredentialResolver;
+      artifacts?: HarnessRunArtifacts;
+      forcedGatewayAuthMode?: HarnessGatewayAuthMode;
+    }
+  > => {
+    let parsed: ParsedBindingArgs;
+    try {
+      parsed = parseBindingArgs(argv);
+    } catch (error) {
+      throw new HarnessControlError(
+        "invalid-request",
+        error instanceof Error ? error.message : "invalid host arguments",
+      );
+    }
+    const persistedProvider = await configuredProvider();
+    let binding: LoomLocalHostBinding;
+    let recordedModel: string | undefined;
+    let artifacts: HarnessRunArtifacts | undefined;
+    let forcedGatewayAuthMode: HarnessGatewayAuthMode | undefined;
+    if (parsed.resumeRun !== undefined) {
+      artifacts = await readArtifacts(resolve(
+        options.cliDependencies?.cwd ?? Deno.cwd(),
+        parsed.resumeRun,
+      ));
+      binding = bindingFromRecordedRun(artifacts, identity);
+      recordedModel = artifacts.runState.model;
+      if (binding.modelProvider === "openai-compatible-gateway") {
+        forcedGatewayAuthMode = binding.modelAuthSource === "none"
+          ? "none"
+          : "bearer";
+        if (
+          parsed.gatewayAuthMode !== undefined &&
+          parsed.gatewayAuthMode !== forcedGatewayAuthMode
+        ) {
+          throw new HarnessControlError(
+            "provider-mismatch",
+            "requested gateway auth mode does not match the resumed run",
+          );
+        }
+      }
+    } else {
+      const provider = persistedProvider;
+      const authMode = provider === "openai-compatible-gateway"
+        ? parsed.gatewayAuthMode ?? gatewayAuthMode(processEnv)
+        : undefined;
+      binding = {
+        source: "loom",
+        modelProvider: provider,
+        modelAuthSource: provider === "openai-codex"
+          ? LOOM_LOCAL_AUTH_SOURCE
+          : authMode === "none"
+          ? "none"
+          : "api-key",
+        credentialOwner: LOOM_LOCAL_CREDENTIAL_OWNER,
+        harnessHomeIdentity: identity,
+      };
+    }
+    assertRequestedBinding(parsed, binding, recordedModel);
+    const resolver = binding.modelProvider === "openai-codex"
+      ? await preflightCodex()
+      : undefined;
+    return {
+      binding,
+      ...(resolver !== undefined ? { resolver } : {}),
+      ...(artifacts !== undefined ? { artifacts } : {}),
+      ...(forcedGatewayAuthMode !== undefined ? { forcedGatewayAuthMode } : {}),
+    };
+  };
+
+  const cliEnv = (
+    provider: HarnessModelProviderId,
+  ): Record<string, string | undefined> => {
+    const env = { ...processEnv };
+    if (provider === "openai-codex") {
+      for (const key of CODEX_INCOMPATIBLE_ENV_KEYS) env[key] = undefined;
+    }
+    return env;
+  };
+
+  return {
+    harnessHomeIdentity: identity,
+    async runBatch(argv: readonly string[]): Promise<number> {
+      if (cfHarnessCliInformationalControl(argv) !== undefined) {
+        return await runCfHarnessCli(argv, {
+          ...options.cliDependencies,
+          env: processEnv,
+          structuredHostFailures: true,
+        });
+      }
+      let resolved;
+      try {
+        resolved = await resolveBinding(argv);
+      } catch (error) {
+        const io = options.cliDependencies?.io ?? defaultHostIo();
+        io.stderr(`${JSON.stringify(createCfHarnessHostFailure(error))}\n`);
+        return 1;
+      }
+      let args = parsedProviderPresent(argv)
+        ? [...argv]
+        : ["--model-provider", resolved.binding.modelProvider, ...argv];
+      if (
+        resolved.forcedGatewayAuthMode !== undefined &&
+        !bindingOptionPresent(args, "--gateway-auth-mode")
+      ) {
+        args = [
+          "--gateway-auth-mode",
+          resolved.forcedGatewayAuthMode,
+          ...args,
+        ];
+      }
+      return await runCfHarnessCli(args, {
+        ...options.cliDependencies,
+        ...(resolved.artifacts !== undefined
+          ? { readRunArtifacts: () => Promise.resolve(resolved.artifacts!) }
+          : {}),
+        env: cliEnv(resolved.binding.modelProvider),
+        loomLocalHostBinding: resolved.binding,
+        credentialStore,
+        ...(resolved.resolver !== undefined
+          ? { openAICodexCredentialResolver: resolved.resolver }
+          : {}),
+        ...(options.fetchFn !== undefined ? { fetchFn: options.fetchFn } : {}),
+        structuredHostFailures: true,
+      });
+    },
+    async runInteractive(args: readonly string[] = []): Promise<void> {
+      const parsed = parseHarnessInteractiveChatStdioCliOptions(
+        args,
+        processEnv,
+      );
+      if (parsed.help) {
+        Deno.stderr.writeSync(
+          new TextEncoder().encode(harnessInteractiveChatStdioUsageText()),
+        );
+        return;
+      }
+      const provider = await configuredProvider();
+      const binding: LoomLocalHostBinding = {
+        source: "loom",
+        modelProvider: provider,
+        modelAuthSource: provider === "openai-codex"
+          ? LOOM_LOCAL_AUTH_SOURCE
+          : gatewayAuthMode(processEnv) === "none"
+          ? "none"
+          : "api-key",
+        credentialOwner: LOOM_LOCAL_CREDENTIAL_OWNER,
+        harnessHomeIdentity: identity,
+      };
+      const resolver = provider === "openai-codex"
+        ? await preflightCodex()
+        : undefined;
+      const runManifest: LoomRunManifest = {
+        type: "cf-harness.loom-run-manifest",
+        version: 1,
+        ...binding,
+      };
+      const modelClient = resolver === undefined
+        ? undefined
+        : new OpenAICodexResponsesClient({
+          credentialResolver: resolver,
+          credentialOwner: LOOM_LOCAL_CREDENTIAL_OWNER,
+          fetchFn: options.fetchFn,
+        });
+      await (options.interactiveStdioRunner ?? runHarnessInteractiveChatStdio)({
+        ...(parsed.sessionDbPath !== undefined
+          ? { sessionDbPath: parsed.sessionDbPath }
+          : {}),
+        ...(parsed.maxInMemoryEvents !== undefined
+          ? { maxInMemoryEvents: parsed.maxInMemoryEvents }
+          : {}),
+        credentialOwner: LOOM_LOCAL_CREDENTIAL_OWNER,
+        basePromptLoopOptions: {
+          modelProvider: provider,
+          modelAuthSource: binding.modelAuthSource,
+          credentialOwner: LOOM_LOCAL_CREDENTIAL_OWNER,
+          credentialOwnerKey: LOOM_LOCAL_CREDENTIAL_OWNER.ownerKey,
+          harnessHomeIdentity: identity,
+          runManifest,
+          ...(provider === "openai-compatible-gateway"
+            ? {
+              gatewayBaseUrl: processEnv.CF_HARNESS_GATEWAY_BASE_URL,
+              gatewayAuthMode: gatewayAuthMode(processEnv),
+              apiKey: processEnv.CF_HARNESS_API_KEY ??
+                processEnv.OPENAI_API_KEY,
+              fetchFn: options.fetchFn,
+            }
+            : { modelClient }),
+        },
+      });
+    },
+  };
+};
+
+const bindingOptionPresent = (
+  argv: readonly string[],
+  name: string,
+): boolean => {
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--" && index !== 0) return false;
+    if (argument === name || argument.startsWith(`${name}=`)) return true;
+  }
+  return false;
+};
+
+const parsedProviderPresent = (argv: readonly string[]): boolean =>
+  bindingOptionPresent(argv, "--model-provider");
+
+const defaultHostIo = (): CfHarnessCliIO => ({
+  stdout: (text) => Deno.stdout.writeSync(new TextEncoder().encode(text)),
+  stderr: (text) => Deno.stderr.writeSync(new TextEncoder().encode(text)),
+});
+
+const chatError = (failure: CfHarnessHostFailure): HarnessChatError => ({
+  code: failure.error.code === "provider-configuration-required" ||
+      failure.error.code === "provider-auth-required" ||
+      failure.error.code === "provider-mismatch" ||
+      failure.error.code === "provider-unavailable"
+    ? failure.error.code
+    : failure.error.code === "internal-error"
+    ? "internal_error"
+    : "internal_error",
+  message: failure.error.message,
+});
+
+/** Keeps the interactive protocol alive long enough to return startup blockers. */
+export const runLoomLocalInteractiveFailureStdio = async (
+  error: unknown,
+  options: {
+    input?: ReadableStream<Uint8Array>;
+    output?: WritableStream<Uint8Array>;
+  } = {},
+): Promise<void> => {
+  const failure = createCfHarnessHostFailure(error);
+  const reader = (options.input ?? Deno.stdin.readable).getReader();
+  const writer = (options.output ?? Deno.stdout.writable).getWriter();
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let buffered = "";
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      buffered += decoder.decode(value, { stream: !done });
+      let newline;
+      while ((newline = buffered.indexOf("\n")) >= 0) {
+        const line = buffered.slice(0, newline).trim();
+        buffered = buffered.slice(newline + 1);
+        if (line === "") continue;
+        let requestId = "invalid";
+        try {
+          const parsed = JSON.parse(line) as Record<string, unknown>;
+          if (typeof parsed.requestId === "string") {
+            requestId = parsed.requestId;
+          }
+        } catch {
+          // The typed host failure is more useful than a second parse failure.
+        }
+        const response = createHarnessChatErrorResponse(
+          requestId,
+          chatError(failure),
+        );
+        await writer.write(encoder.encode(`${JSON.stringify(response)}\n`));
+      }
+      if (done) break;
+    }
+  } finally {
+    reader.releaseLock();
+    writer.releaseLock();
+  }
+};

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -113,6 +113,7 @@ import type {
   HarnessModelUsage,
 } from "./model/client.ts";
 import { OpenAICompatibleGatewayModelClient } from "./model/openai-compatible-gateway.ts";
+import { HarnessControlError } from "./control-errors.ts";
 import { sumHarnessModelUsage } from "./model/usage.ts";
 
 const DEFAULT_MAX_MODEL_TURNS = 8;
@@ -2109,29 +2110,47 @@ export class CfHarnessPromptLoop {
     try {
       while (modelTurns < maxModelTurns) {
         modelTurns += 1;
-        const response = await this.modelClient.complete({
-          model,
-          transcript,
-          tools: BUILTIN_TOOLS.filter((tool) =>
-            this.#allowedToolIds.has(tool.descriptor.toolId)
-          ).map((tool) => tool.descriptor),
-          nativeModelToolIds: this.#nativeModelToolIds,
-          runId: this.engine.getRunState().runId,
-          ...(this.#cacheAffinityKey !== undefined
-            ? { cacheAffinityKey: this.#cacheAffinityKey }
-            : {}),
-          ...(this.#promptCacheMode !== undefined
-            ? { promptCacheMode: this.#promptCacheMode }
-            : {}),
-          ...(this.#reasoningEffort !== undefined
-            ? { reasoningEffort: this.#reasoningEffort }
-            : {}),
-          ...(this.#compactThreshold !== undefined
-            ? { compactThreshold: this.#compactThreshold }
-            : {}),
-          signal: options.signal,
-          onAttempt: recordModelAttempt,
-        });
+        let response;
+        try {
+          response = await this.modelClient.complete({
+            model,
+            transcript,
+            tools: BUILTIN_TOOLS.filter((tool) =>
+              this.#allowedToolIds.has(tool.descriptor.toolId)
+            ).map((tool) => tool.descriptor),
+            nativeModelToolIds: this.#nativeModelToolIds,
+            runId: this.engine.getRunState().runId,
+            ...(this.#cacheAffinityKey !== undefined
+              ? { cacheAffinityKey: this.#cacheAffinityKey }
+              : {}),
+            ...(this.#promptCacheMode !== undefined
+              ? { promptCacheMode: this.#promptCacheMode }
+              : {}),
+            ...(this.#reasoningEffort !== undefined
+              ? { reasoningEffort: this.#reasoningEffort }
+              : {}),
+            ...(this.#compactThreshold !== undefined
+              ? { compactThreshold: this.#compactThreshold }
+              : {}),
+            signal: options.signal,
+            onAttempt: recordModelAttempt,
+          });
+        } catch (error) {
+          const localGateway = this.engine.config.modelProvider ===
+              "openai-compatible-gateway" &&
+            this.engine.config.runManifest?.harnessHomeIdentity !== undefined;
+          if (
+            localGateway && !(error instanceof HarnessControlError) &&
+            options.signal?.aborted !== true &&
+            !(error instanceof DOMException && error.name === "AbortError")
+          ) {
+            throw new HarnessControlError(
+              "provider-unavailable",
+              "The configured cf-harness gateway request failed",
+            );
+          }
+          throw error;
+        }
         if (response.usage !== undefined) {
           modelUsage.push({
             modelTurn: modelTurns,
@@ -3016,6 +3035,15 @@ export class CfHarnessPromptLoop {
       depth: 1,
       cfcEnforcementMode: parentRunState.cfcEnforcementMode,
       modelProvider,
+      ...(parentRunState.modelAuthSource !== undefined
+        ? { modelAuthSource: parentRunState.modelAuthSource }
+        : {}),
+      ...(parentRunState.credentialOwner !== undefined
+        ? { credentialOwner: structuredClone(parentRunState.credentialOwner) }
+        : {}),
+      ...(parentRunState.harnessHomeIdentity !== undefined
+        ? { harnessHomeIdentity: parentRunState.harnessHomeIdentity }
+        : {}),
       model: childModel.model,
       modelSource: childModel.source,
       allowedToolIds: [...profileConfig.allowedToolIds],

--- a/packages/cf-harness/src/run-state.ts
+++ b/packages/cf-harness/src/run-state.ts
@@ -12,7 +12,10 @@ import type {
   HarnessPolicyDecisionRecord,
   HarnessPolicyTrace,
 } from "./contracts/policy-trace.ts";
-import type { HarnessRunManifest } from "./contracts/run-manifest.ts";
+import type {
+  HarnessCredentialOwnerRef,
+  HarnessRunManifest,
+} from "./contracts/run-manifest.ts";
 import type { PromptSlotBinding } from "./contracts/prompt-slot.ts";
 import type {
   HarnessSkillActivations,
@@ -63,6 +66,8 @@ export interface HarnessRunState {
   modelProvider?: HarnessModelProviderId;
   modelAuthSource?: HarnessModelAuthSource;
   credentialOwnerKey?: string;
+  credentialOwner?: HarnessCredentialOwnerRef;
+  harnessHomeIdentity?: string;
   artifactRoot?: string;
   runManifest?: HarnessRunManifest;
   runManifestPath?: string;
@@ -106,6 +111,8 @@ export interface CreateHarnessRunStateOptions {
   modelProvider?: HarnessModelProviderId;
   modelAuthSource?: HarnessModelAuthSource;
   credentialOwnerKey?: string;
+  credentialOwner?: HarnessCredentialOwnerRef;
+  harnessHomeIdentity?: string;
   artifactRoot?: string;
   runManifest?: HarnessRunManifest;
   runManifestPath?: string;
@@ -161,6 +168,12 @@ export const createHarnessRunState = (
       : {}),
     ...(options.credentialOwnerKey !== undefined
       ? { credentialOwnerKey: options.credentialOwnerKey }
+      : {}),
+    ...(options.credentialOwner !== undefined
+      ? { credentialOwner: structuredClone(options.credentialOwner) }
+      : {}),
+    ...(options.harnessHomeIdentity !== undefined
+      ? { harnessHomeIdentity: options.harnessHomeIdentity }
       : {}),
     ...(options.artifactRoot !== undefined
       ? { artifactRoot: options.artifactRoot }

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -10,6 +10,7 @@ import {
   buildCfHarnessBaseSystemPrompt,
   buildCfHarnessBatchSystemPrompt,
   buildCfHarnessOperatorSystemPrompt,
+  cfHarnessCliInformationalControl,
   type CfHarnessCliIO,
   type CfHarnessCliSignalHandler,
   createCfHarnessBatchResult,
@@ -1700,6 +1701,36 @@ Deno.test("runCfHarnessCli prints usage for help", async () => {
   assertEquals(stderr, []);
 });
 
+Deno.test("cfHarnessCliInformationalControl mirrors global control parsing", () => {
+  assertEquals(cfHarnessCliInformationalControl(["--help"]), "help");
+  assertEquals(cfHarnessCliInformationalControl(["-h"]), "help");
+  assertEquals(
+    cfHarnessCliInformationalControl(["--describe-capabilities"]),
+    "describe-capabilities",
+  );
+  assertEquals(
+    cfHarnessCliInformationalControl([
+      "--describe-capabilities",
+      "--help",
+    ]),
+    "help",
+  );
+  assertEquals(cfHarnessCliInformationalControl(["--", "--help"]), "help");
+  assertEquals(
+    cfHarnessCliInformationalControl([
+      "--output-mode",
+      "batch",
+      "--",
+      "--help",
+    ]),
+    undefined,
+  );
+  assertEquals(
+    cfHarnessCliInformationalControl(["config", "inspect", "--help"]),
+    undefined,
+  );
+});
+
 Deno.test("runCfHarnessCli prints machine-readable capabilities", async () => {
   const { io, stdout, stderr } = createIoBuffers();
   const exitCode = await runCfHarnessCli(["--describe-capabilities"], { io });
@@ -1736,7 +1767,7 @@ Deno.test("runCfHarnessCli prints machine-readable capabilities", async () => {
   assertEquals(capabilities.features.persistentProviderConfig, true);
   assertEquals(capabilities.features.structuredAuthControl, true);
   assertEquals(capabilities.features.credentialHealth, true);
-  assertEquals(capabilities.features.loomLocalOwnerBinding, false);
+  assertEquals(capabilities.features.loomLocalOwnerBinding, true);
 });
 
 Deno.test("installCfHarnessSignalHandlers terminalizes the active run before exiting", async () => {
@@ -5400,4 +5431,55 @@ Deno.test("parseCfHarnessCliArgs validates --compact-threshold", async () => {
       "--compact-threshold requires a non-negative integer token count",
     );
   }
+});
+
+Deno.test("local Loom binding conflicts become structured provider mismatches before execution", async () => {
+  const buffers = createIoBuffers();
+  let promptLoopsCreated = 0;
+  let providerRequests = 0;
+  const exitCode = await runCfHarnessCli(
+    ["--run-manifest", "/tmp/loom-run-manifest.json", "hello"],
+    {
+      cwd: "/tmp/project",
+      env: {},
+      io: buffers.io,
+      structuredHostFailures: true,
+      loomLocalHostBinding: {
+        source: "loom",
+        modelProvider: "openai-codex",
+        modelAuthSource: "cf-harness-local-store",
+        credentialOwner: {
+          type: "cf-harness.credential-owner-ref",
+          version: 1,
+          ownerKey: "local",
+        },
+        harnessHomeIdentity: "sha256:local-home",
+      },
+      readTextFile: () =>
+        Promise.resolve(JSON.stringify({
+          type: "cf-harness.loom-run-manifest",
+          version: 1,
+          source: "loom",
+          modelProvider: "openai-compatible-gateway",
+        })),
+      createPromptLoop: () => {
+        promptLoopsCreated += 1;
+        throw new Error("must not construct a prompt loop");
+      },
+      fetchFn: () => {
+        providerRequests += 1;
+        return Promise.reject(new Error("must not request a provider"));
+      },
+    },
+  );
+
+  assertEquals(exitCode, 1);
+  assertEquals(promptLoopsCreated, 0);
+  assertEquals(providerRequests, 0);
+  assertEquals(buffers.stdout, []);
+  assertEquals(buffers.stderr.length, 1);
+  const failure = JSON.parse(buffers.stderr[0]);
+  assertEquals(failure.type, "cf-harness.host-failure");
+  assertEquals(failure.error.code, "provider-mismatch");
+  assertStringIncludes(failure.error.message, "provider");
 });

--- a/packages/cf-harness/test/config.test.ts
+++ b/packages/cf-harness/test/config.test.ts
@@ -212,6 +212,41 @@ Deno.test("resolveHarnessConfig preserves legacy gateway fields for openai-codex
   );
 });
 
+Deno.test("resolveHarnessConfig requires exact explicit and manifest credential owners", () => {
+  const runManifest = {
+    type: "cf-harness.loom-run-manifest" as const,
+    version: 1 as const,
+    source: "loom" as const,
+    credentialOwner: {
+      type: "cf-harness.credential-owner-ref" as const,
+      version: 1 as const,
+      ownerKey: "local",
+      tenantKey: "tenant-a",
+    },
+  };
+  assertThrows(
+    () =>
+      resolveHarnessConfig({
+        credentialOwner: {
+          type: "cf-harness.credential-owner-ref",
+          version: 1,
+          ownerKey: "local",
+          tenantKey: "tenant-b",
+        },
+        runManifest,
+      }),
+    Error,
+    "does not match run manifest",
+  );
+  assertEquals(
+    resolveHarnessConfig({
+      credentialOwner: runManifest.credentialOwner,
+      runManifest,
+    }).credentialOwner,
+    runManifest.credentialOwner,
+  );
+});
+
 Deno.test("resolveHarnessConfig accepts an explicit mode override string", () => {
   const config = resolveHarnessConfig({
     inheritedCfcEnforcementMode: "disabled",

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -1139,8 +1139,14 @@ Deno.test("CfHarnessEngine keeps a resumed run's recorded provider authoritative
     cfcEnforcementMode: "disabled",
     currentDir: "/workspace",
     modelProvider: "openai-codex",
-    modelAuthSource: "owner-bound-oauth",
+    modelAuthSource: "cf-harness-local-store",
     credentialOwnerKey: "loom:user-1",
+    credentialOwner: {
+      type: "cf-harness.credential-owner-ref",
+      version: 1,
+      ownerKey: "loom:user-1",
+    },
+    harnessHomeIdentity: "sha256:home-one",
     policyEvents: [],
     toolOutputs: [],
     failureRecords: [],
@@ -1152,6 +1158,9 @@ Deno.test("CfHarnessEngine keeps a resumed run's recorded provider authoritative
   });
   assertEquals(resumed.config.modelProvider, "openai-codex");
   assertEquals(resumed.config.credentialOwnerKey, "loom:user-1");
+  assertEquals(resumed.config.modelAuthSource, "cf-harness-local-store");
+  assertEquals(resumed.config.credentialOwner, runState.credentialOwner);
+  assertEquals(resumed.config.harnessHomeIdentity, "sha256:home-one");
 
   assertThrows(
     () =>
@@ -1173,6 +1182,40 @@ Deno.test("CfHarnessEngine keeps a resumed run's recorded provider authoritative
       }),
     Error,
     "credential owner does not match",
+  );
+  assertThrows(
+    () =>
+      new CfHarnessEngine({
+        sandboxRuntime: new FakeSandboxRuntime(),
+        runState,
+        credentialOwner: {
+          type: "cf-harness.credential-owner-ref",
+          version: 1,
+          ownerKey: "loom:user-2",
+        },
+      }),
+    Error,
+    "credential owner does not match",
+  );
+  assertThrows(
+    () =>
+      new CfHarnessEngine({
+        sandboxRuntime: new FakeSandboxRuntime(),
+        runState,
+        harnessHomeIdentity: "sha256:home-two",
+      }),
+    Error,
+    "harness home does not match",
+  );
+  assertThrows(
+    () =>
+      new CfHarnessEngine({
+        sandboxRuntime: new FakeSandboxRuntime(),
+        runState,
+        modelAuthSource: "owner-bound-oauth",
+      }),
+    Error,
+    "auth source does not match",
   );
 });
 

--- a/packages/cf-harness/test/interactive-chat-service.test.ts
+++ b/packages/cf-harness/test/interactive-chat-service.test.ts
@@ -14,6 +14,7 @@ import {
   HarnessInteractiveChatService,
   type HarnessInteractivePromptLoopFactory,
 } from "../src/interactive-chat-service.ts";
+import { HarnessControlError } from "../src/control-errors.ts";
 import type {
   CreateHarnessPromptLoopOptions,
   HarnessPromptLoopResult,
@@ -292,6 +293,169 @@ Deno.test("interactive Codex services require one matching process owner", () =>
     Error,
     "full owner binding",
   );
+});
+
+Deno.test("Loom-local interactive services require an explicit matching provider", () => {
+  const credentialOwner = {
+    type: "cf-harness.credential-owner-ref" as const,
+    version: 1 as const,
+    ownerKey: "local",
+  };
+  assertThrows(
+    () =>
+      new HarnessInteractiveChatService({
+        credentialOwner,
+        basePromptLoopOptions: {
+          modelAuthSource: "cf-harness-local-store",
+          credentialOwner,
+          credentialOwnerKey: credentialOwner.ownerKey,
+          harnessHomeIdentity: "sha256:opaque-home",
+          runManifest: {
+            type: "cf-harness.loom-run-manifest",
+            version: 1,
+            source: "loom",
+            modelProvider: "openai-codex",
+            modelAuthSource: "cf-harness-local-store",
+            credentialOwner,
+            harnessHomeIdentity: "sha256:opaque-home",
+          },
+        },
+      }),
+    Error,
+    "provider does not match",
+  );
+});
+
+Deno.test("Loom-local interactive services reject mismatched binding fields", () => {
+  const credentialOwner = {
+    type: "cf-harness.credential-owner-ref" as const,
+    version: 1 as const,
+    ownerKey: "local",
+    tenantKey: "tenant-a",
+  };
+  const manifest = {
+    type: "cf-harness.loom-run-manifest" as const,
+    version: 1 as const,
+    source: "loom" as const,
+    modelProvider: "openai-compatible-gateway" as const,
+    modelAuthSource: "api-key" as const,
+    credentialOwner,
+    harnessHomeIdentity: "sha256:home-a",
+    model: "gpt-a",
+  };
+  const baseOptions = (
+    overrides: Partial<CreateHarnessPromptLoopOptions>,
+  ): CreateHarnessPromptLoopOptions => ({
+    modelProvider: manifest.modelProvider,
+    modelAuthSource: manifest.modelAuthSource,
+    credentialOwner,
+    credentialOwnerKey: credentialOwner.ownerKey,
+    harnessHomeIdentity: manifest.harnessHomeIdentity,
+    model: manifest.model,
+    runManifest: manifest,
+    ...overrides,
+  });
+  const cases: Array<{
+    overrides: Partial<CreateHarnessPromptLoopOptions>;
+    message: string;
+  }> = [
+    {
+      overrides: { modelAuthSource: "none" },
+      message: "auth source does not match",
+    },
+    {
+      overrides: {
+        credentialOwner: { ...credentialOwner, tenantKey: "tenant-b" },
+      },
+      message: "credential owner does not match",
+    },
+    {
+      overrides: { harnessHomeIdentity: "sha256:home-b" },
+      message: "harness home does not match",
+    },
+    { overrides: { model: "gpt-b" }, message: "model does not match" },
+  ];
+
+  for (const testCase of cases) {
+    assertThrows(
+      () =>
+        new HarnessInteractiveChatService({
+          basePromptLoopOptions: baseOptions(testCase.overrides),
+        }),
+      Error,
+      testCase.message,
+    );
+  }
+});
+
+Deno.test("Loom-local interactive sessions require a matching durable model", async () => {
+  const credentialOwner = {
+    type: "cf-harness.credential-owner-ref" as const,
+    version: 1 as const,
+    ownerKey: "local",
+  };
+  const binding = {
+    source: "loom" as const,
+    modelProvider: "openai-compatible-gateway" as const,
+    modelAuthSource: "none" as const,
+    credentialOwner,
+    harnessHomeIdentity: "sha256:home-a",
+  };
+  const fixedModelService = new HarnessInteractiveChatService({
+    basePromptLoopOptions: {
+      ...binding,
+      model: "gpt-fixed",
+      runManifest: {
+        type: "cf-harness.loom-run-manifest",
+        version: 1,
+        ...binding,
+        model: "gpt-fixed",
+      },
+    },
+  });
+  const fixedModel = await fixedModelService.startSession("req-fixed", {
+    sessionId: "session-fixed",
+    workspace: { hostPath: "/workspace" },
+    model: "gpt-requested",
+  });
+  assertEquals(fixedModel.ok, false);
+  assertEquals(
+    fixedModel.ok === false ? fixedModel.error.code : undefined,
+    "provider-mismatch",
+  );
+  assertEquals(fixedModelService.status().sessions, []);
+
+  const missingModelService = new HarnessInteractiveChatService({
+    basePromptLoopOptions: {
+      ...binding,
+      runManifest: {
+        type: "cf-harness.loom-run-manifest",
+        version: 1,
+        ...binding,
+      },
+    },
+  });
+  for (
+    const testCase of [
+      { requestId: "req-missing" },
+      { requestId: "req-blank", model: "  " },
+    ]
+  ) {
+    const response = await missingModelService.startSession(
+      testCase.requestId,
+      {
+        sessionId: testCase.requestId,
+        workspace: { hostPath: "/workspace" },
+        ...(testCase.model !== undefined ? { model: testCase.model } : {}),
+      },
+    );
+    assertEquals(response.ok, false);
+    assertEquals(
+      response.ok === false ? response.error.code : undefined,
+      "provider-mismatch",
+    );
+  }
+  assertEquals(missingModelService.status().sessions, []);
 });
 
 Deno.test("interactive service forces comment-thread turns to read-only prompt-loop options", async () => {
@@ -1264,4 +1428,40 @@ Deno.test("interactive service terminalizes prompt-loop setup failures", async (
   assertEquals(second.ok, true);
   await service.waitForTurn("session-1", "turn-2");
   assertEquals(service.status("session-1").sessions[0].status, "idle");
+});
+
+Deno.test("interactive service preserves every typed provider blocker", async () => {
+  for (
+    const code of [
+      "provider-configuration-required",
+      "provider-auth-required",
+      "provider-mismatch",
+      "provider-unavailable",
+    ] as const
+  ) {
+    const service = new HarnessInteractiveChatService({
+      createPromptLoop: () => ({
+        runTranscript: () =>
+          Promise.reject(
+            new HarnessControlError(code, `provider blocker: ${code}`),
+          ),
+      }),
+      now: nextIsoNow(),
+    });
+    await service.startSession("req-1", {
+      sessionId: `session-${code}`,
+      workspace: { hostPath: "/workspace" },
+    });
+    await service.startTurn("req-2", {
+      sessionId: `session-${code}`,
+      turnId: `turn-${code}`,
+      input: { text: "Start" },
+    });
+    await service.waitForTurn(`session-${code}`, `turn-${code}`);
+
+    assertEquals(
+      service.listTurns({ sessionId: `session-${code}` }).turns[0].turn.error,
+      { code, message: `provider blocker: ${code}` },
+    );
+  }
 });

--- a/packages/cf-harness/test/interactive-chat-stdio.test.ts
+++ b/packages/cf-harness/test/interactive-chat-stdio.test.ts
@@ -23,6 +23,7 @@ import {
   parseHarnessInteractiveChatStdioCliOptions,
   runHarnessInteractiveChatNdjsonTransport,
   runHarnessInteractiveChatStdio,
+  runHarnessInteractiveChatStdioCli,
 } from "../src/interactive-chat-stdio.ts";
 import type { HarnessPromptLoopResult } from "../src/prompt-loop.ts";
 
@@ -1154,4 +1155,8 @@ Deno.test("interactive NDJSON transport rejects invalid Browser Access profile m
     "ok" in response && response.ok === false ? response.error.code : "",
     "invalid_request",
   );
+});
+
+Deno.test("interactive stdio CLI help returns without starting the transport", async () => {
+  assertEquals(await runHarnessInteractiveChatStdioCli(["--help"]), undefined);
 });

--- a/packages/cf-harness/test/loom-local-host-controls.test.ts
+++ b/packages/cf-harness/test/loom-local-host-controls.test.ts
@@ -1,0 +1,198 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { fromFileUrl } from "@std/path";
+import { InMemoryHarnessCredentialStore } from "../src/auth/credential-store.ts";
+import type { CfHarnessCliIO } from "../src/cli.ts";
+import {
+  createCfHarnessCliCapabilities,
+  formatCfHarnessCliUsage,
+} from "../src/cli.ts";
+import { createLoomLocalCfHarnessHost } from "../src/loom-local-host.ts";
+import { runLoomLocalCfHarnessHostMain } from "../src/loom-local-host-main.ts";
+
+const ioBuffers = (): {
+  io: CfHarnessCliIO;
+  stdout: string[];
+  stderr: string[];
+} => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    io: {
+      stdout: (text) => stdout.push(text),
+      stderr: (text) => stderr.push(text),
+    },
+    stdout,
+    stderr,
+  };
+};
+
+Deno.test("local Loom batch informational controls bypass provider and auth state", async () => {
+  const controls: Array<{
+    args: readonly string[];
+    expected: "help" | "capabilities";
+  }> = [
+    { args: ["--help"], expected: "help" },
+    { args: ["-h"], expected: "help" },
+    { args: ["--describe-capabilities"], expected: "capabilities" },
+    { args: ["--", "--help"], expected: "help" },
+  ];
+
+  for (const testCase of controls) {
+    const home = await Deno.makeTempDir();
+    let providerReads = 0;
+    let credentialReads = 0;
+    let providerRequests = 0;
+    const credentials = new InMemoryHarnessCredentialStore();
+    const originalGetRecord = credentials.getRecord.bind(credentials);
+    credentials.getRecord = (...args) => {
+      credentialReads += 1;
+      return originalGetRecord(...args);
+    };
+    const io = ioBuffers();
+    const host = await createLoomLocalCfHarnessHost({
+      harnessHome: home,
+      env: {},
+      credentialStore: credentials,
+      providerSettingsStore: {
+        inspect: () => {
+          providerReads += 1;
+          return Promise.reject(new Error("provider state must not be read"));
+        },
+      },
+      fetchFn: () => {
+        providerRequests += 1;
+        return Promise.reject(new Error("provider traffic must not occur"));
+      },
+      cliDependencies: { cwd: home, io: io.io },
+    });
+
+    assertEquals(await host.runBatch(testCase.args), 0);
+    assertEquals(io.stderr, []);
+    assertEquals(providerReads, 0);
+    assertEquals(credentialReads, 0);
+    assertEquals(providerRequests, 0);
+    if (testCase.expected === "help") {
+      assertEquals(io.stdout, [formatCfHarnessCliUsage()]);
+    } else {
+      assertEquals(
+        JSON.parse(io.stdout.join("")),
+        createCfHarnessCliCapabilities(),
+      );
+    }
+  }
+});
+
+Deno.test("local Loom batch control-looking prompt text does not bypass binding", async () => {
+  const home = await Deno.makeTempDir();
+  const io = ioBuffers();
+  const host = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {},
+    providerSettingsStore: {
+      inspect: () => Promise.resolve({ state: "missing" as const }),
+    },
+    cliDependencies: { cwd: home, io: io.io },
+  });
+
+  assertEquals(
+    await host.runBatch(["--output-mode", "batch", "--", "--help"]),
+    1,
+  );
+  assertEquals(io.stdout, []);
+  assertEquals(
+    JSON.parse(io.stderr.join("")).error.code,
+    "provider-configuration-required",
+  );
+});
+
+Deno.test("local Loom batch executable exposes help and capabilities before setup", async () => {
+  const entrypoint = fromFileUrl(
+    new URL("../src/loom-local-host-main.ts", import.meta.url),
+  );
+  for (const control of ["--help", "--describe-capabilities"] as const) {
+    const home = await Deno.makeTempDir();
+    const result = await new Deno.Command(Deno.execPath(), {
+      args: [
+        "run",
+        "--quiet",
+        "--no-lock",
+        "-A",
+        entrypoint,
+        "batch",
+        "--",
+        control,
+      ],
+      env: {
+        CF_HARNESS_HOME: home,
+        CF_HARNESS_MODEL_PROVIDER: "",
+      },
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    const stdout = new TextDecoder().decode(result.stdout);
+    const stderr = new TextDecoder().decode(result.stderr);
+
+    assertEquals(result.code, 0, control);
+    assertEquals(stderr, "", control);
+    if (control === "--help") {
+      assertStringIncludes(stdout, "Usage:");
+      assertStringIncludes(stdout, "--describe-capabilities");
+    } else {
+      assertEquals(JSON.parse(stdout), createCfHarnessCliCapabilities());
+    }
+  }
+});
+
+Deno.test("local Loom interactive executable reports a missing dedicated home on its protocol", async () => {
+  const entrypoint = fromFileUrl(
+    new URL("../src/loom-local-host-main.ts", import.meta.url),
+  );
+  const coverageDir = Deno.env.get("DENO_COVERAGE_DIR");
+  const result = await new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--quiet",
+      "--no-lock",
+      "-A",
+      entrypoint,
+      "interactive",
+    ],
+    clearEnv: true,
+    env: coverageDir === undefined ? {} : { DENO_COVERAGE_DIR: coverageDir },
+    stdin: "null",
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+
+  assertEquals(result.code, 1);
+  assertEquals(new TextDecoder().decode(result.stdout), "");
+  assertEquals(new TextDecoder().decode(result.stderr), "");
+});
+
+Deno.test("local Loom host main classifies startup and batch routing failures in process", async () => {
+  const home = await Deno.makeTempDir();
+
+  assertEquals(await runLoomLocalCfHarnessHostMain(["unknown"], {}), 1);
+  assertEquals(await runLoomLocalCfHarnessHostMain(["batch"], {}), 1);
+  assertEquals(
+    await runLoomLocalCfHarnessHostMain(
+      ["batch", "--", "--help"],
+      { CF_HARNESS_HOME: home, CF_HARNESS_MODEL_PROVIDER: "" },
+    ),
+    0,
+  );
+  assertEquals(
+    await runLoomLocalCfHarnessHostMain(
+      ["interactive", "--", "--help"],
+      { CF_HARNESS_HOME: home, CF_HARNESS_MODEL_PROVIDER: "" },
+    ),
+    0,
+  );
+  assertEquals(
+    await runLoomLocalCfHarnessHostMain(
+      ["batch", "--", "--prompt", "hello"],
+      { CF_HARNESS_HOME: "relative/home" },
+    ),
+    1,
+  );
+});

--- a/packages/cf-harness/test/loom-local-host-interactive.test.ts
+++ b/packages/cf-harness/test/loom-local-host-interactive.test.ts
@@ -1,0 +1,575 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+import { readHarnessRunArtifacts } from "../src/artifacts.ts";
+import { InMemoryHarnessCredentialStore } from "../src/auth/credential-store.ts";
+import type { HarnessProviderSettingsState } from "../src/auth/provider-settings.ts";
+import type { HarnessModelProviderId } from "../src/config.ts";
+import {
+  HARNESS_CHAT_PROTOCOL_VERSION,
+  HARNESS_CHAT_REQUEST_TYPE,
+  type HarnessChatEventEnvelope,
+  type HarnessChatResponse,
+} from "../src/contracts/interactive-chat.ts";
+import {
+  createLoomLocalCfHarnessHost,
+  runLoomLocalInteractiveFailureStdio,
+} from "../src/loom-local-host.ts";
+import {
+  runHarnessInteractiveChatStdio,
+  type RunHarnessInteractiveChatStdioOptions,
+} from "../src/interactive-chat-stdio.ts";
+
+type InteractiveEnvelope = HarnessChatEventEnvelope | HarnessChatResponse;
+
+const providerStore = (state: HarnessProviderSettingsState) => ({
+  inspect: () => Promise.resolve(state),
+});
+
+const configured = (provider: HarnessModelProviderId) =>
+  providerStore({
+    state: "configured",
+    settings: { version: 1, modelProvider: provider },
+  });
+
+const encodeInput = (lines: readonly string[]): ReadableStream<Uint8Array> => {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const line of lines) controller.enqueue(encoder.encode(`${line}\n`));
+      controller.close();
+    },
+  });
+};
+
+const captureOutput = (): {
+  output: WritableStream<Uint8Array>;
+  envelopes: () => InteractiveEnvelope[];
+} => {
+  const decoder = new TextDecoder();
+  let text = "";
+  return {
+    output: new WritableStream({
+      write(chunk) {
+        text += decoder.decode(chunk, { stream: true });
+      },
+      close() {
+        text += decoder.decode();
+      },
+    }),
+    envelopes: () =>
+      text.split("\n").filter((line) => line.trim() !== "").map((line) =>
+        JSON.parse(line) as InteractiveEnvelope
+      ),
+  };
+};
+
+const statusRequest = (requestId: string): string =>
+  JSON.stringify({
+    type: HARNESS_CHAT_REQUEST_TYPE,
+    protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+    requestId,
+    method: "status",
+    params: {},
+  });
+
+const turnRequests = (workspace: string, artifactRoot?: string): string[] => [
+  JSON.stringify({
+    type: HARNESS_CHAT_REQUEST_TYPE,
+    protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+    requestId: "start-session",
+    method: "start_session",
+    params: {
+      sessionId: "session-1",
+      workspace: { hostPath: workspace },
+      model: "gpt-5.6-terra",
+      ...(artifactRoot !== undefined ? { artifactRoot } : {}),
+      policy: {
+        type: "cf-harness.chat-policy",
+        toolMode: "workspace-write",
+        allowedToolIds: [],
+        allowedSubagentProfiles: [],
+        cfcEnforcementMode: "disabled",
+      },
+    },
+  }),
+  JSON.stringify({
+    type: HARNESS_CHAT_REQUEST_TYPE,
+    protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+    requestId: "start-turn",
+    method: "start_turn",
+    params: {
+      sessionId: "session-1",
+      turnId: "turn-1",
+      input: { text: "hello" },
+    },
+  }),
+];
+
+const protocolRunner = (
+  lines: readonly string[],
+  capture: ReturnType<typeof captureOutput>,
+) =>
+(options: RunHarnessInteractiveChatStdioOptions): Promise<void> =>
+  runHarnessInteractiveChatStdio({
+    ...options,
+    input: encodeInput(lines),
+    output: capture.output,
+  });
+
+const completedTurn = (envelopes: readonly InteractiveEnvelope[]): boolean =>
+  envelopes.some((envelope) =>
+    "event" in envelope && envelope.event.kind === "turn_completed"
+  );
+
+const codexCompletion = (): Response =>
+  new Response(
+    `data: ${
+      JSON.stringify({
+        type: "response.completed",
+        response: {
+          id: "resp_interactive",
+          status: "completed",
+          output: [{
+            type: "message",
+            id: "msg_interactive",
+            role: "assistant",
+            content: [{ type: "output_text", text: "codex interactive" }],
+          }],
+        },
+      })
+    }\n\n`,
+    { status: 200, headers: { "content-type": "text/event-stream" } },
+  );
+
+const gatewayCompletion = (): Response =>
+  new Response(
+    JSON.stringify({
+      id: "resp_gateway_interactive",
+      object: "response",
+      status: "completed",
+      output: [{
+        type: "message",
+        id: "msg_gateway_interactive",
+        role: "assistant",
+        status: "completed",
+        content: [{
+          type: "output_text",
+          text: "gateway interactive",
+          annotations: [],
+        }],
+      }],
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+
+const onlyRunRoot = async (artifactRoot: string): Promise<string> => {
+  const entries: string[] = [];
+  for await (const entry of Deno.readDir(artifactRoot)) {
+    if (entry.isDirectory) entries.push(entry.name);
+  }
+  assertEquals(entries.length, 1);
+  return join(artifactRoot, entries[0]);
+};
+
+Deno.test("local Loom interactive stdio sends Codex traffic without gateway fallback", async () => {
+  const home = await Deno.makeTempDir();
+  const workspace = await Deno.makeTempDir();
+  const credentials = new InMemoryHarnessCredentialStore();
+  await credentials.set("local", "openai-codex", {
+    type: "oauth",
+    providerId: "openai-codex",
+    accessToken: "access-secret",
+    refreshToken: "refresh-secret",
+    expiresAt: Date.now() + 60 * 60_000,
+    accountId: "account-secret",
+  });
+  let codexRequests = 0;
+  let gatewayRequests = 0;
+  const capture = captureOutput();
+  const host = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {
+      CF_HARNESS_GATEWAY_BASE_URL: "https://gateway.invalid/",
+      CF_HARNESS_GATEWAY_AUTH_MODE: "none",
+      CF_HARNESS_API_KEY: "gateway-secret",
+    },
+    credentialStore: credentials,
+    providerSettingsStore: configured("openai-codex"),
+    fetchFn: (input) => {
+      if (String(input).includes("chatgpt.com/backend-api/codex/responses")) {
+        codexRequests += 1;
+        return Promise.resolve(codexCompletion());
+      }
+      gatewayRequests += 1;
+      return Promise.reject(new Error("unexpected gateway request"));
+    },
+    interactiveStdioRunner: protocolRunner(turnRequests(workspace), capture),
+  });
+
+  await host.runInteractive([]);
+
+  assertEquals(codexRequests, 1);
+  assertEquals(gatewayRequests, 0);
+  assertEquals(completedTurn(capture.envelopes()), true);
+});
+
+Deno.test("local Loom interactive stdio reports credential loss after preflight before traffic", async () => {
+  const home = await Deno.makeTempDir();
+  const workspace = await Deno.makeTempDir();
+  const credentials = new InMemoryHarnessCredentialStore();
+  await credentials.set("local", "openai-codex", {
+    type: "oauth",
+    providerId: "openai-codex",
+    accessToken: "access-secret",
+    refreshToken: "refresh-secret",
+    expiresAt: Date.now() + 60 * 60_000,
+    accountId: "account-secret",
+  });
+  let providerRequests = 0;
+  const capture = captureOutput();
+  const host = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {},
+    credentialStore: credentials,
+    providerSettingsStore: configured("openai-codex"),
+    fetchFn: () => {
+      providerRequests += 1;
+      return Promise.reject(new Error("must not request"));
+    },
+    interactiveStdioRunner: async (options) => {
+      await credentials.delete("local", "openai-codex");
+      await runHarnessInteractiveChatStdio({
+        ...options,
+        input: encodeInput(turnRequests(workspace)),
+        output: capture.output,
+      });
+    },
+  });
+
+  await host.runInteractive([]);
+
+  const errors = capture.envelopes().flatMap((envelope) =>
+    "event" in envelope && envelope.event.kind === "turn_failed"
+      ? [envelope.event.error]
+      : []
+  );
+  assertEquals(errors, [{
+    code: "provider-auth-required",
+    message: "OpenAI Codex is not connected for this credential owner",
+  }]);
+  assertEquals(providerRequests, 0);
+});
+
+Deno.test("local Loom interactive artifacts bind their selected model and resume for both providers", async () => {
+  for (
+    const provider of [
+      "openai-compatible-gateway",
+      "openai-codex",
+    ] as const
+  ) {
+    const home = await Deno.makeTempDir();
+    const workspace = await Deno.makeTempDir();
+    const artifactRoot = await Deno.makeTempDir();
+    const credentials = new InMemoryHarnessCredentialStore();
+    if (provider === "openai-codex") {
+      await credentials.set("local", "openai-codex", {
+        type: "oauth",
+        providerId: "openai-codex",
+        accessToken: "access-secret",
+        refreshToken: "refresh-secret",
+        expiresAt: Date.now() + 60 * 60_000,
+        accountId: "account-secret",
+      });
+    }
+    let providerRequests = 0;
+    let wrongProviderRequests = 0;
+    const fetchFn = (input: Request | URL | string): Promise<Response> => {
+      const isCodex = String(input).includes(
+        "chatgpt.com/backend-api/codex/responses",
+      );
+      if (isCodex !== (provider === "openai-codex")) {
+        wrongProviderRequests += 1;
+        return Promise.reject(new Error("unexpected provider route"));
+      }
+      providerRequests += 1;
+      return Promise.resolve(
+        provider === "openai-codex" ? codexCompletion() : gatewayCompletion(),
+      );
+    };
+    const env = provider === "openai-codex"
+      ? {
+        CF_HARNESS_GATEWAY_BASE_URL: "https://must-not-be-used.invalid/",
+        CF_HARNESS_GATEWAY_AUTH_MODE: "none",
+      }
+      : {
+        CF_HARNESS_GATEWAY_BASE_URL: "https://gateway.example/",
+        CF_HARNESS_GATEWAY_AUTH_MODE: "none",
+      };
+    const capture = captureOutput();
+    const host = await createLoomLocalCfHarnessHost({
+      harnessHome: home,
+      env,
+      credentialStore: credentials,
+      providerSettingsStore: configured(provider),
+      fetchFn,
+      interactiveStdioRunner: protocolRunner(
+        turnRequests(workspace, artifactRoot),
+        capture,
+      ),
+    });
+
+    await host.runInteractive([]);
+    assertEquals(completedTurn(capture.envelopes()), true, provider);
+    const runRoot = await onlyRunRoot(artifactRoot);
+    const artifacts = await readHarnessRunArtifacts(runRoot);
+    const persistedManifest = JSON.parse(
+      await Deno.readTextFile(join(runRoot, "run-manifest.json")),
+    );
+    assertEquals(artifacts.runState.model, "gpt-5.6-terra", provider);
+    assertEquals(
+      artifacts.runState.runManifest?.model,
+      "gpt-5.6-terra",
+      provider,
+    );
+    assertEquals(persistedManifest.model, "gpt-5.6-terra", provider);
+    assertEquals(artifacts.runState.modelProvider, provider, provider);
+    assertEquals(
+      artifacts.runState.runManifest?.modelProvider,
+      provider,
+      provider,
+    );
+
+    const resumeStdout: string[] = [];
+    const resumeStderr: string[] = [];
+    const resumeHost = await createLoomLocalCfHarnessHost({
+      harnessHome: home,
+      env,
+      credentialStore: credentials,
+      providerSettingsStore: configured(provider),
+      fetchFn,
+      cliDependencies: {
+        cwd: workspace,
+        io: {
+          stdout: (text) => resumeStdout.push(text),
+          stderr: (text) => resumeStderr.push(text),
+        },
+      },
+    });
+    assertEquals(
+      await resumeHost.runBatch([
+        "--resume-run",
+        runRoot,
+        "--output-mode",
+        "batch",
+      ]),
+      0,
+      provider,
+    );
+    assertEquals(providerRequests, 2, provider);
+    assertEquals(wrongProviderRequests, 0, provider);
+    assertEquals(resumeStdout.length, 1, provider);
+    assertEquals(resumeStderr, [], provider);
+  }
+});
+
+Deno.test("local Loom interactive stdio sends gateway traffic without credential reads", async () => {
+  const home = await Deno.makeTempDir();
+  const workspace = await Deno.makeTempDir();
+  const credentials = new InMemoryHarnessCredentialStore();
+  const originalGetRecord = credentials.getRecord.bind(credentials);
+  let credentialReads = 0;
+  credentials.getRecord = (...args) => {
+    credentialReads += 1;
+    return originalGetRecord(...args);
+  };
+  let gatewayRequests = 0;
+  let codexRequests = 0;
+  const capture = captureOutput();
+  const host = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {
+      CF_HARNESS_GATEWAY_BASE_URL: "https://gateway.example/",
+      CF_HARNESS_GATEWAY_AUTH_MODE: "none",
+    },
+    credentialStore: credentials,
+    providerSettingsStore: configured("openai-compatible-gateway"),
+    fetchFn: (input) => {
+      if (String(input).includes("chatgpt.com")) {
+        codexRequests += 1;
+        return Promise.reject(new Error("unexpected Codex request"));
+      }
+      gatewayRequests += 1;
+      return Promise.resolve(gatewayCompletion());
+    },
+    interactiveStdioRunner: protocolRunner(turnRequests(workspace), capture),
+  });
+
+  await host.runInteractive([]);
+
+  assertEquals(gatewayRequests, 1);
+  assertEquals(codexRequests, 0);
+  assertEquals(credentialReads, 0);
+  assertEquals(completedTurn(capture.envelopes()), true);
+});
+
+Deno.test("local Loom interactive startup blockers use protocol errors before traffic", async () => {
+  const reconnectCredentials = new InMemoryHarnessCredentialStore();
+  await reconnectCredentials.updateRecord("local", "openai-codex", () => ({
+    credential: {
+      type: "oauth",
+      providerId: "openai-codex",
+      accessToken: "expired-secret",
+      refreshToken: "revoked-secret",
+      expiresAt: 0,
+      accountId: "account-secret",
+    },
+    health: { status: "reconnect-required", reason: "revoked" },
+  }));
+  const cases: Array<{
+    name: string;
+    settings: HarnessProviderSettingsState;
+    credentials?: InMemoryHarnessCredentialStore;
+    code: string;
+  }> = [
+    {
+      name: "missing config",
+      settings: { state: "missing" },
+      code: "provider-configuration-required",
+    },
+    {
+      name: "invalid config",
+      settings: { state: "invalid", detail: "invalid JSON" },
+      code: "provider-configuration-required",
+    },
+    {
+      name: "disconnected Codex",
+      settings: {
+        state: "configured",
+        settings: { version: 1, modelProvider: "openai-codex" },
+      },
+      credentials: new InMemoryHarnessCredentialStore(),
+      code: "provider-auth-required",
+    },
+    {
+      name: "reconnect-required Codex",
+      settings: {
+        state: "configured",
+        settings: { version: 1, modelProvider: "openai-codex" },
+      },
+      credentials: reconnectCredentials,
+      code: "provider-auth-required",
+    },
+  ];
+
+  for (const testCase of cases) {
+    const home = await Deno.makeTempDir();
+    let requests = 0;
+    let runnerCalls = 0;
+    const host = await createLoomLocalCfHarnessHost({
+      harnessHome: home,
+      env: {},
+      credentialStore: testCase.credentials,
+      providerSettingsStore: providerStore(testCase.settings),
+      fetchFn: () => {
+        requests += 1;
+        return Promise.reject(new Error("must not request"));
+      },
+      interactiveStdioRunner: () => {
+        runnerCalls += 1;
+        return Promise.resolve();
+      },
+    });
+    const capture = captureOutput();
+    try {
+      await host.runInteractive([]);
+      throw new Error(`${testCase.name} unexpectedly started`);
+    } catch (error) {
+      await runLoomLocalInteractiveFailureStdio(error, {
+        input: encodeInput([statusRequest(`status-${testCase.name}`)]),
+        output: capture.output,
+      });
+    }
+    const response = capture.envelopes()[0];
+    assertEquals("ok" in response && response.ok, false, testCase.name);
+    assertEquals(
+      "ok" in response && !response.ok ? response.error.code : undefined,
+      testCase.code,
+      testCase.name,
+    );
+    assertEquals(requests, 0, testCase.name);
+    assertEquals(runnerCalls, 0, testCase.name);
+  }
+});
+
+Deno.test("local Loom interactive entrypoint returns disconnected Codex on stdout protocol", async () => {
+  const home = await Deno.makeTempDir();
+  await Deno.writeTextFile(
+    `${home}/config.json`,
+    JSON.stringify({ version: 1, modelProvider: "openai-codex" }),
+    { mode: 0o600 },
+  );
+  const requestId = "entrypoint-disconnected";
+  const child = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--quiet",
+      "--no-lock",
+      "-A",
+      fromFileUrl(new URL("../src/loom-local-host-main.ts", import.meta.url)),
+      "interactive",
+    ],
+    env: {
+      CF_HARNESS_HOME: home,
+      CF_HARNESS_MODEL_PROVIDER: "",
+    },
+    stdin: "piped",
+    stdout: "piped",
+    stderr: "piped",
+  }).spawn();
+  const writer = child.stdin.getWriter();
+  await writer.write(new TextEncoder().encode(`${statusRequest(requestId)}\n`));
+  await writer.close();
+  const result = await child.output();
+  const response = JSON.parse(
+    new TextDecoder().decode(result.stdout),
+  ) as HarnessChatResponse;
+
+  assertEquals(result.code, 1);
+  assertEquals(response.requestId, requestId);
+  assertEquals(response.ok, false);
+  assertEquals(
+    response.ok ? undefined : response.error.code,
+    "provider-auth-required",
+  );
+  assertEquals(new TextDecoder().decode(result.stderr), "");
+});
+
+Deno.test("local Loom interactive help does not require provider configuration or authentication", async () => {
+  const home = await Deno.makeTempDir();
+  const result = await new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--quiet",
+      "--no-lock",
+      "-A",
+      fromFileUrl(new URL("../src/loom-local-host-main.ts", import.meta.url)),
+      "interactive",
+      "--help",
+    ],
+    env: {
+      CF_HARNESS_HOME: home,
+      CF_HARNESS_MODEL_PROVIDER: "",
+    },
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+
+  const stderr = new TextDecoder().decode(result.stderr);
+  assertEquals(result.code, 0);
+  assertEquals(new TextDecoder().decode(result.stdout), "");
+  assertStringIncludes(stderr, "Usage:");
+  assertStringIncludes(stderr, "--chat-session-db");
+  assertStringIncludes(stderr, "--chat-max-in-memory-events");
+  assertEquals(stderr.includes("provider-configuration-required"), false);
+  assertEquals(stderr.includes("provider-auth-required"), false);
+});

--- a/packages/cf-harness/test/loom-local-host.test.ts
+++ b/packages/cf-harness/test/loom-local-host.test.ts
@@ -1,0 +1,1516 @@
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { fromFileUrl } from "@std/path";
+import { InMemoryHarnessCredentialStore } from "../src/auth/credential-store.ts";
+import type { HarnessProviderSettingsState } from "../src/auth/provider-settings.ts";
+import type { CfHarnessCliIO } from "../src/cli.ts";
+import type { HarnessModelProviderId } from "../src/config.ts";
+import type { HarnessRunArtifacts } from "../src/artifacts.ts";
+import {
+  createLoomLocalCfHarnessHost,
+  LOOM_LOCAL_AUTH_SOURCE,
+  LOOM_LOCAL_CREDENTIAL_OWNER,
+  runLoomLocalInteractiveFailureStdio,
+} from "../src/loom-local-host.ts";
+import { HarnessControlError } from "../src/control-errors.ts";
+import type {
+  CreateHarnessPromptLoopOptions,
+  HarnessPromptLoopResult,
+} from "../src/prompt-loop.ts";
+import type { RunHarnessInteractiveChatStdioOptions } from "../src/interactive-chat-stdio.ts";
+
+const providerStore = (state: HarnessProviderSettingsState) => ({
+  inspect: () => Promise.resolve(state),
+});
+
+const configured = (provider: HarnessModelProviderId) =>
+  providerStore({
+    state: "configured",
+    settings: { version: 1, modelProvider: provider },
+  });
+
+const ioBuffers = (): {
+  io: CfHarnessCliIO;
+  stdout: string[];
+  stderr: string[];
+} => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    io: {
+      stdout: (text) => stdout.push(text),
+      stderr: (text) => stderr.push(text),
+    },
+    stdout,
+    stderr,
+  };
+};
+
+const sseCompletion = (): Response =>
+  new Response(
+    `data: ${
+      JSON.stringify({
+        type: "response.completed",
+        response: {
+          id: "resp_local",
+          status: "completed",
+          output: [{
+            type: "message",
+            id: "msg_local",
+            role: "assistant",
+            content: [{ type: "output_text", text: "local response" }],
+          }],
+        },
+      })
+    }\n\n`,
+    { status: 200, headers: { "content-type": "text/event-stream" } },
+  );
+
+const jwt = (accountId: string): string => {
+  const encode = (value: unknown) =>
+    btoa(JSON.stringify(value)).replaceAll("+", "-").replaceAll("/", "_")
+      .replace(/=+$/, "");
+  return `${encode({ alg: "none" })}.${
+    encode({
+      "https://api.openai.com/auth": { chatgpt_account_id: accountId },
+    })
+  }.`;
+};
+
+const completedResult = (
+  options: CreateHarnessPromptLoopOptions,
+  text: string,
+): HarnessPromptLoopResult => ({
+  model: options.model ?? "gpt-5.6-terra",
+  finalAssistantText: text,
+  transcript: [
+    { role: "user", content: "hello" },
+    { role: "assistant", content: text },
+  ],
+  modelTurns: 1,
+  runState: options.engine!.getRunState(),
+});
+
+const localRunArtifacts = (options: {
+  harnessHomeIdentity: string;
+  provider?: HarnessModelProviderId;
+  authSource?: "api-key" | "none" | typeof LOOM_LOCAL_AUTH_SOURCE;
+  model?: string;
+  source?: string;
+}): HarnessRunArtifacts => {
+  const provider = options.provider ?? "openai-compatible-gateway";
+  const authSource = options.authSource ??
+    (provider === "openai-codex" ? LOOM_LOCAL_AUTH_SOURCE : "none");
+  const model = options.model ?? "gpt-5.6-terra";
+  return {
+    runRoot: "/runs/one",
+    runStatePath: "/runs/one/run-state.json",
+    runState: {
+      runId: "one",
+      status: "completed",
+      createdAt: "2026-08-13T00:00:00Z",
+      updatedAt: "2026-08-13T00:00:01Z",
+      cfcEnforcementMode: "disabled",
+      currentDir: "/workspace",
+      model,
+      modelProvider: provider,
+      modelAuthSource: authSource,
+      credentialOwnerKey: "local",
+      credentialOwner: LOOM_LOCAL_CREDENTIAL_OWNER,
+      harnessHomeIdentity: options.harnessHomeIdentity,
+      runManifest: {
+        type: "cf-harness.loom-run-manifest",
+        version: 1,
+        source: (options.source ?? "loom") as "loom",
+        model,
+        modelProvider: provider,
+        modelAuthSource: authSource,
+        credentialOwner: LOOM_LOCAL_CREDENTIAL_OWNER,
+        harnessHomeIdentity: options.harnessHomeIdentity,
+      },
+      policyEvents: [],
+      toolOutputs: [],
+    },
+    transcript: [{ role: "user", content: "resume me" }],
+  };
+};
+
+Deno.test("local Loom host sends authenticated Codex traffic and never gateway traffic", async () => {
+  const home = await Deno.makeTempDir();
+  const workspace = await Deno.makeTempDir();
+  const credentials = new InMemoryHarnessCredentialStore();
+  await credentials.set("local", "openai-codex", {
+    type: "oauth",
+    providerId: "openai-codex",
+    accessToken: "access-secret",
+    refreshToken: "refresh-secret",
+    expiresAt: Date.now() + 60 * 60_000,
+    accountId: "account-secret",
+  });
+  let codexRequests = 0;
+  let gatewayRequests = 0;
+  let observed: CreateHarnessPromptLoopOptions | undefined;
+  let batchResultJson = "";
+  const io = ioBuffers();
+  const host = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {
+      CF_HARNESS_GATEWAY_BASE_URL: "https://gateway.invalid/",
+      CF_HARNESS_GATEWAY_AUTH_MODE: "none",
+      CF_HARNESS_API_KEY: "gateway-secret",
+      CF_HARNESS_PROMPT_CACHE_MODE: "explicit",
+    },
+    credentialStore: credentials,
+    providerSettingsStore: configured("openai-codex"),
+    fetchFn: (input) => {
+      if (String(input).includes("chatgpt.com/backend-api/codex/responses")) {
+        codexRequests += 1;
+        return Promise.resolve(sseCompletion());
+      }
+      gatewayRequests += 1;
+      return Promise.reject(new Error("unexpected gateway request"));
+    },
+    cliDependencies: {
+      cwd: workspace,
+      io: io.io,
+      writeTextFile: (_path, text) => {
+        batchResultJson = text;
+        return Promise.resolve();
+      },
+      createPromptLoop: (options) => {
+        observed = options;
+        return {
+          runPrompt: async () => {
+            const response = await options.modelClient!.complete({
+              model: options.model ?? "gpt-5.6-terra",
+              transcript: [{ role: "user", content: "hello" }],
+              tools: [],
+              nativeModelToolIds: [],
+              runId: options.engine!.getRunState().runId,
+            });
+            return completedResult(options, response.assistant.content);
+          },
+          runTranscript: () => Promise.reject(new Error("unexpected resume")),
+        };
+      },
+    },
+  });
+
+  assertEquals(
+    await host.runBatch([
+      "--prompt",
+      "hello",
+      "--result-json-path",
+      "result.json",
+    ]),
+    0,
+  );
+  assertEquals(codexRequests, 1);
+  assertEquals(gatewayRequests, 0);
+  assertEquals(observed?.promptCacheMode, undefined);
+  assertEquals(observed?.engine?.getRunState().modelProvider, "openai-codex");
+  assertEquals(
+    observed?.engine?.getRunState().modelAuthSource,
+    LOOM_LOCAL_AUTH_SOURCE,
+  );
+  assertEquals(
+    observed?.engine?.getRunState().credentialOwner,
+    LOOM_LOCAL_CREDENTIAL_OWNER,
+  );
+  assertEquals(
+    JSON.stringify(observed?.engine?.getRunState()).includes(home),
+    false,
+  );
+  const batchResult = JSON.parse(batchResultJson);
+  assertEquals(batchResult.model_provider, "openai-codex");
+  assertEquals(batchResult.model_auth_source, LOOM_LOCAL_AUTH_SOURCE);
+  assertEquals(batchResult.credential_owner, LOOM_LOCAL_CREDENTIAL_OWNER);
+  assertEquals(io.stderr, []);
+});
+
+Deno.test("local Loom host rejects explicit gateway cache options for Codex before traffic", async () => {
+  const home = await Deno.makeTempDir();
+  let requests = 0;
+  const io = ioBuffers();
+  const host = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {},
+    credentialStore: new InMemoryHarnessCredentialStore(),
+    providerSettingsStore: configured("openai-codex"),
+    fetchFn: () => {
+      requests += 1;
+      return Promise.reject(new Error("must not request"));
+    },
+    cliDependencies: { cwd: home, io: io.io },
+  });
+
+  assertEquals(
+    await host.runBatch(["--prompt-cache-mode", "explicit", "hello"]),
+    1,
+  );
+  assertEquals(requests, 0);
+  assertEquals(JSON.parse(io.stderr.join("")).error.code, "provider-mismatch");
+});
+
+Deno.test("local Loom host blocks disconnected Codex before all provider traffic", async () => {
+  const home = await Deno.makeTempDir();
+  let requests = 0;
+  const io = ioBuffers();
+  const host = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {},
+    credentialStore: new InMemoryHarnessCredentialStore(),
+    providerSettingsStore: configured("openai-codex"),
+    fetchFn: () => {
+      requests += 1;
+      return Promise.reject(new Error("must not request"));
+    },
+    cliDependencies: { cwd: home, io: io.io },
+  });
+
+  assertEquals(await host.runBatch(["--prompt", "hello"]), 1);
+  assertEquals(requests, 0);
+  const failure = JSON.parse(io.stderr.join(""));
+  assertEquals(failure.error.code, "provider-auth-required");
+  assertEquals(JSON.stringify(failure).includes(home), false);
+});
+
+Deno.test("local Loom host blocks reconnect-required Codex before all provider traffic", async () => {
+  const home = await Deno.makeTempDir();
+  const credentials = new InMemoryHarnessCredentialStore();
+  await credentials.updateRecord("local", "openai-codex", () => ({
+    credential: {
+      type: "oauth",
+      providerId: "openai-codex",
+      accessToken: "expired-secret",
+      refreshToken: "revoked-secret",
+      expiresAt: 0,
+      accountId: "account-secret",
+    },
+    health: { status: "reconnect-required", reason: "revoked" },
+  }));
+  let requests = 0;
+  const io = ioBuffers();
+  const host = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {},
+    credentialStore: credentials,
+    providerSettingsStore: configured("openai-codex"),
+    fetchFn: () => {
+      requests += 1;
+      return Promise.reject(new Error("must not request"));
+    },
+    cliDependencies: { cwd: home, io: io.io },
+  });
+
+  assertEquals(await host.runBatch(["--prompt", "hello"]), 1);
+  assertEquals(requests, 0);
+  assertEquals(
+    JSON.parse(io.stderr.join("")).error.code,
+    "provider-auth-required",
+  );
+});
+
+Deno.test("local Loom host leaves refresh to the resolver immediately before Codex traffic", async () => {
+  const home = await Deno.makeTempDir();
+  const workspace = await Deno.makeTempDir();
+  const credentials = new InMemoryHarnessCredentialStore();
+  await credentials.set("local", "openai-codex", {
+    type: "oauth",
+    providerId: "openai-codex",
+    accessToken: "expired-access",
+    refreshToken: "refresh-old",
+    expiresAt: 0,
+    accountId: "account-1",
+  });
+  let refreshes = 0;
+  let codexRequests = 0;
+  const io = ioBuffers();
+  const host = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {},
+    credentialStore: credentials,
+    providerSettingsStore: configured("openai-codex"),
+    fetchFn: (input) => {
+      if (String(input).includes("/oauth/token")) {
+        refreshes += 1;
+        return Promise.resolve(
+          new Response(JSON.stringify({
+            access_token: jwt("account-1"),
+            refresh_token: "refresh-new",
+            expires_in: 3600,
+          })),
+        );
+      }
+      codexRequests += 1;
+      return Promise.resolve(sseCompletion());
+    },
+    cliDependencies: {
+      cwd: workspace,
+      io: io.io,
+      createPromptLoop: (options) => ({
+        runPrompt: async () => {
+          const response = await options.modelClient!.complete({
+            model: options.model ?? "gpt-5.6-terra",
+            transcript: [{ role: "user", content: "hello" }],
+            tools: [],
+            nativeModelToolIds: [],
+            runId: options.engine!.getRunState().runId,
+          });
+          return completedResult(options, response.assistant.content);
+        },
+        runTranscript: () => Promise.reject(new Error("unexpected resume")),
+      }),
+    },
+  });
+
+  assertEquals(refreshes, 0, "preflight must not refresh");
+  assertEquals(await host.runBatch(["--prompt", "hello"]), 0);
+  assertEquals(refreshes, 1);
+  assertEquals(codexRequests, 1);
+  assertEquals(
+    (await credentials.get("local", "openai-codex"))?.refreshToken,
+    "refresh-new",
+  );
+});
+
+Deno.test("local Loom host requires valid persistent provider configuration", async () => {
+  for (
+    const state of [
+      { state: "missing" } as const,
+      { state: "invalid", detail: "bad JSON" } as const,
+    ]
+  ) {
+    const home = await Deno.makeTempDir();
+    let requests = 0;
+    const io = ioBuffers();
+    const host = await createLoomLocalCfHarnessHost({
+      harnessHome: home,
+      env: {},
+      providerSettingsStore: providerStore(state),
+      fetchFn: () => {
+        requests += 1;
+        return Promise.reject(new Error("must not request"));
+      },
+      cliDependencies: { cwd: home, io: io.io },
+    });
+    assertEquals(await host.runBatch(["--prompt", "hello"]), 1);
+    assertEquals(requests, 0);
+    assertEquals(
+      JSON.parse(io.stderr.join("")).error.code,
+      "provider-configuration-required",
+    );
+  }
+});
+
+Deno.test("local Loom host pins a symlinked home to one real directory", async () => {
+  const root = await Deno.makeTempDir();
+  const first = `${root}/first`;
+  const second = `${root}/second`;
+  const alias = `${root}/current`;
+  await Deno.mkdir(first, { mode: 0o700 });
+  await Deno.mkdir(second, { mode: 0o700 });
+  await Deno.writeTextFile(
+    `${first}/config.json`,
+    JSON.stringify({
+      version: 1,
+      modelProvider: "openai-compatible-gateway",
+    }),
+    { mode: 0o600 },
+  );
+  await Deno.writeTextFile(
+    `${second}/config.json`,
+    JSON.stringify({ version: 1, modelProvider: "openai-codex" }),
+    { mode: 0o600 },
+  );
+  await Deno.symlink(first, alias);
+  const io = ioBuffers();
+  let observedProvider: HarnessModelProviderId | undefined;
+  const aliasedHost = await createLoomLocalCfHarnessHost({
+    harnessHome: alias,
+    env: { CF_HARNESS_GATEWAY_AUTH_MODE: "none" },
+    cliDependencies: {
+      cwd: root,
+      io: io.io,
+      createPromptLoop: (options) => ({
+        runPrompt: () => {
+          observedProvider = options.modelProvider;
+          return Promise.resolve(completedResult(options, "pinned"));
+        },
+        runTranscript: () => Promise.reject(new Error("unexpected resume")),
+      }),
+    },
+  });
+  const directHost = await createLoomLocalCfHarnessHost({
+    harnessHome: first,
+    env: { CF_HARNESS_GATEWAY_AUTH_MODE: "none" },
+  });
+  assertEquals(
+    aliasedHost.harnessHomeIdentity,
+    directHost.harnessHomeIdentity,
+  );
+
+  await Deno.remove(alias);
+  await Deno.symlink(second, alias);
+  assertEquals(await aliasedHost.runBatch(["--prompt", "hello"]), 0);
+  assertEquals(observedProvider, "openai-compatible-gateway");
+  assertEquals(io.stderr, []);
+});
+
+Deno.test("local Loom host sends explicit gateway traffic only for persisted gateway", async () => {
+  const home = await Deno.makeTempDir();
+  let gatewayRequests = 0;
+  let credentialReads = 0;
+  const credentials = new InMemoryHarnessCredentialStore();
+  const originalGetRecord = credentials.getRecord.bind(credentials);
+  credentials.getRecord = (...args) => {
+    credentialReads += 1;
+    return originalGetRecord(...args);
+  };
+  const io = ioBuffers();
+  const host = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {
+      CF_HARNESS_GATEWAY_BASE_URL: "https://gateway.example/",
+      CF_HARNESS_API_KEY: "gateway-secret",
+      CF_HARNESS_PROMPT_CACHE_MODE: "explicit",
+    },
+    credentialStore: credentials,
+    providerSettingsStore: configured("openai-compatible-gateway"),
+    fetchFn: (input) => {
+      assertStringIncludes(String(input), "gateway.example");
+      gatewayRequests += 1;
+      return Promise.resolve(new Response("{}"));
+    },
+    cliDependencies: {
+      cwd: home,
+      io: io.io,
+      createPromptLoop: (options) => ({
+        runPrompt: async () => {
+          assertEquals(options.promptCacheMode, "explicit");
+          assertEquals(options.gatewayAuthMode, "bearer");
+          assertEquals(options.apiKey, "gateway-secret");
+          await options.fetchFn!(options.gatewayBaseUrl!);
+          return completedResult(options, "gateway response");
+        },
+        runTranscript: () => Promise.reject(new Error("unexpected resume")),
+      }),
+    },
+  });
+
+  assertEquals(
+    await host.runBatch([
+      "--model-provider=openai-compatible-gateway",
+      "--prompt",
+      "hello",
+    ]),
+    0,
+  );
+  assertEquals(gatewayRequests, 1);
+  assertEquals(credentialReads, 0);
+  assertEquals(io.stderr, []);
+});
+
+Deno.test("local Loom interactive host uses the same fixed Codex binding", async () => {
+  const home = await Deno.makeTempDir();
+  const credentials = new InMemoryHarnessCredentialStore();
+  await credentials.set("local", "openai-codex", {
+    type: "oauth",
+    providerId: "openai-codex",
+    accessToken: "access-secret",
+    refreshToken: "refresh-secret",
+    expiresAt: Date.now() + 60 * 60_000,
+    accountId: "account-secret",
+  });
+  let observed: RunHarnessInteractiveChatStdioOptions | undefined;
+  const host = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {
+      CF_HARNESS_GATEWAY_BASE_URL: "https://must-not-be-used.invalid/",
+      CF_HARNESS_GATEWAY_AUTH_MODE: "none",
+    },
+    credentialStore: credentials,
+    providerSettingsStore: configured("openai-codex"),
+    interactiveStdioRunner: (options) => {
+      observed = options;
+      return Promise.resolve();
+    },
+  });
+
+  await host.runInteractive([]);
+  assertEquals(observed?.basePromptLoopOptions?.modelProvider, "openai-codex");
+  assertEquals(
+    observed?.basePromptLoopOptions?.modelAuthSource,
+    LOOM_LOCAL_AUTH_SOURCE,
+  );
+  assertEquals(observed?.credentialOwner, LOOM_LOCAL_CREDENTIAL_OWNER);
+  assertEquals(
+    observed?.basePromptLoopOptions?.runManifest?.harnessHomeIdentity,
+    host.harnessHomeIdentity,
+  );
+  assertEquals(
+    "gatewayBaseUrl" in (observed?.basePromptLoopOptions ?? {}),
+    false,
+  );
+});
+
+Deno.test("local Loom host rejects resume binding switches before provider traffic", async () => {
+  const home = await Deno.makeTempDir();
+  let requests = 0;
+  const io = ioBuffers();
+  const identityHost = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {},
+    providerSettingsStore: configured("openai-codex"),
+    credentialStore: new InMemoryHarnessCredentialStore(),
+    cliDependencies: { cwd: home, io: io.io },
+  });
+  const host = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {},
+    providerSettingsStore: configured("openai-compatible-gateway"),
+    readRunArtifacts: () =>
+      Promise.resolve({
+        runRoot: "/runs/one",
+        runStatePath: "/runs/one/run-state.json",
+        runState: {
+          runId: "one",
+          status: "completed",
+          createdAt: "2026-08-13T00:00:00Z",
+          updatedAt: "2026-08-13T00:00:01Z",
+          cfcEnforcementMode: "disabled",
+          currentDir: "/workspace",
+          model: "gpt-5.6-terra",
+          modelProvider: "openai-codex",
+          modelAuthSource: LOOM_LOCAL_AUTH_SOURCE,
+          credentialOwnerKey: "local",
+          credentialOwner: LOOM_LOCAL_CREDENTIAL_OWNER,
+          harnessHomeIdentity: identityHost.harnessHomeIdentity,
+          runManifest: {
+            type: "cf-harness.loom-run-manifest",
+            version: 1,
+            source: "loom",
+            model: "gpt-5.6-terra",
+            modelProvider: "openai-codex",
+            modelAuthSource: LOOM_LOCAL_AUTH_SOURCE,
+            credentialOwner: LOOM_LOCAL_CREDENTIAL_OWNER,
+            harnessHomeIdentity: identityHost.harnessHomeIdentity,
+          },
+          policyEvents: [],
+          toolOutputs: [],
+        },
+      }),
+    fetchFn: () => {
+      requests += 1;
+      return Promise.reject(new Error("must not request"));
+    },
+    cliDependencies: { cwd: home, io: io.io },
+  });
+
+  assertEquals(
+    await host.runBatch([
+      "--resume-run",
+      "run-one",
+      "--model-provider",
+      "openai-compatible-gateway",
+    ]),
+    1,
+  );
+  assertEquals(requests, 0);
+  assertEquals(JSON.parse(io.stderr.join("")).error.code, "provider-mismatch");
+});
+
+Deno.test("local Loom host resumes one exact artifact snapshot with its recorded gateway auth", async () => {
+  const home = await Deno.makeTempDir();
+  const workspace = await Deno.makeTempDir();
+  const identityHost = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {},
+    providerSettingsStore: configured("openai-compatible-gateway"),
+  });
+  const artifacts = localRunArtifacts({
+    harnessHomeIdentity: identityHost.harnessHomeIdentity,
+    authSource: "none",
+  });
+  let artifactReads = 0;
+  let providerRequests = 0;
+  let observed: CreateHarnessPromptLoopOptions | undefined;
+  let observedTranscript: unknown;
+  const io = ioBuffers();
+  const host = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {
+      CF_HARNESS_GATEWAY_BASE_URL: "https://gateway.example/",
+      CF_HARNESS_GATEWAY_AUTH_MODE: "bearer",
+    },
+    providerSettingsStore: configured("openai-codex"),
+    readRunArtifacts: () => {
+      artifactReads += 1;
+      return Promise.resolve(artifacts);
+    },
+    fetchFn: (input) => {
+      assertStringIncludes(String(input), "gateway.example");
+      providerRequests += 1;
+      return Promise.resolve(new Response("{}"));
+    },
+    cliDependencies: {
+      cwd: workspace,
+      io: io.io,
+      createPromptLoop: (options) => {
+        observed = options;
+        return {
+          runPrompt: () => Promise.reject(new Error("unexpected prompt")),
+          runTranscript: async ({ transcript }) => {
+            observedTranscript = transcript;
+            await options.fetchFn!(options.gatewayBaseUrl!);
+            return completedResult(options, "resumed gateway response");
+          },
+        };
+      },
+    },
+  });
+
+  assertEquals(await host.runBatch(["--resume-run", "run-one"]), 0);
+  assertEquals(artifactReads, 1);
+  assertEquals(providerRequests, 1);
+  assertEquals(observedTranscript, artifacts.transcript);
+  assertEquals(observed?.gatewayAuthMode, "none");
+  assertEquals(observed?.engine?.getRunState().modelAuthSource, "none");
+  assertEquals(io.stderr, []);
+});
+
+Deno.test("local Loom host positively resumes an authenticated Codex binding", async () => {
+  const home = await Deno.makeTempDir();
+  const credentials = new InMemoryHarnessCredentialStore();
+  await credentials.set("local", "openai-codex", {
+    type: "oauth",
+    providerId: "openai-codex",
+    accessToken: "access-secret",
+    refreshToken: "refresh-secret",
+    expiresAt: Date.now() + 60 * 60_000,
+    accountId: "account-secret",
+  });
+  const identityHost = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {},
+    credentialStore: credentials,
+    providerSettingsStore: configured("openai-codex"),
+  });
+  let codexRequests = 0;
+  let gatewayRequests = 0;
+  const io = ioBuffers();
+  const host = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {
+      CF_HARNESS_GATEWAY_BASE_URL: "https://must-not-be-used.invalid/",
+      CF_HARNESS_GATEWAY_AUTH_MODE: "none",
+    },
+    credentialStore: credentials,
+    providerSettingsStore: configured("openai-compatible-gateway"),
+    readRunArtifacts: () =>
+      Promise.resolve(localRunArtifacts({
+        harnessHomeIdentity: identityHost.harnessHomeIdentity,
+        provider: "openai-codex",
+        authSource: LOOM_LOCAL_AUTH_SOURCE,
+      })),
+    fetchFn: (input) => {
+      if (String(input).includes("chatgpt.com/backend-api/codex/responses")) {
+        codexRequests += 1;
+        return Promise.resolve(sseCompletion());
+      }
+      gatewayRequests += 1;
+      return Promise.reject(new Error("unexpected gateway request"));
+    },
+    cliDependencies: {
+      cwd: home,
+      io: io.io,
+      createPromptLoop: (options) => ({
+        runPrompt: () => Promise.reject(new Error("unexpected prompt")),
+        runTranscript: async ({ transcript }) => {
+          const response = await options.modelClient!.complete({
+            model: options.model ?? "gpt-5.6-terra",
+            transcript,
+            tools: [],
+            nativeModelToolIds: [],
+            runId: options.engine!.getRunState().runId,
+          });
+          return completedResult(options, response.assistant.content);
+        },
+      }),
+    },
+  });
+
+  assertEquals(await host.runBatch(["--resume-run", "run-one"]), 0);
+  assertEquals(codexRequests, 1);
+  assertEquals(gatewayRequests, 0);
+  assertEquals(io.stderr, []);
+});
+
+Deno.test("local Loom host positively resumes a gateway API-key binding", async () => {
+  const home = await Deno.makeTempDir();
+  const identityHost = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {},
+    providerSettingsStore: configured("openai-compatible-gateway"),
+  });
+  const credentials = new InMemoryHarnessCredentialStore();
+  let credentialReads = 0;
+  const originalGetRecord = credentials.getRecord.bind(credentials);
+  credentials.getRecord = (...args) => {
+    credentialReads += 1;
+    return originalGetRecord(...args);
+  };
+  let gatewayRequests = 0;
+  const io = ioBuffers();
+  const host = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {
+      CF_HARNESS_GATEWAY_BASE_URL: "https://gateway.example/",
+      CF_HARNESS_GATEWAY_AUTH_MODE: "bearer",
+      CF_HARNESS_API_KEY: "gateway-secret",
+    },
+    credentialStore: credentials,
+    providerSettingsStore: configured("openai-codex"),
+    readRunArtifacts: () =>
+      Promise.resolve(localRunArtifacts({
+        harnessHomeIdentity: identityHost.harnessHomeIdentity,
+        authSource: "api-key",
+      })),
+    fetchFn: (input) => {
+      assertStringIncludes(String(input), "gateway.example");
+      gatewayRequests += 1;
+      return Promise.resolve(new Response("{}"));
+    },
+    cliDependencies: {
+      cwd: home,
+      io: io.io,
+      createPromptLoop: (options) => ({
+        runPrompt: () => Promise.reject(new Error("unexpected prompt")),
+        runTranscript: async () => {
+          assertEquals(options.gatewayAuthMode, "bearer");
+          assertEquals(options.apiKey, "gateway-secret");
+          await options.fetchFn!(options.gatewayBaseUrl!);
+          return completedResult(options, "resumed gateway response");
+        },
+      }),
+    },
+  });
+
+  assertEquals(await host.runBatch(["--resume-run", "run-one"]), 0);
+  assertEquals(gatewayRequests, 1);
+  assertEquals(credentialReads, 0);
+  assertEquals(io.stderr, []);
+});
+
+Deno.test("local Loom host rejects resumed gateway auth overrides before provider traffic", async () => {
+  const home = await Deno.makeTempDir();
+  const identityHost = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {},
+    providerSettingsStore: configured("openai-compatible-gateway"),
+  });
+  let providerRequests = 0;
+  const io = ioBuffers();
+  const host = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {
+      CF_HARNESS_GATEWAY_BASE_URL: "https://gateway.example/",
+      CF_HARNESS_GATEWAY_AUTH_MODE: "bearer",
+      CF_HARNESS_API_KEY: "must-not-be-used",
+    },
+    providerSettingsStore: configured("openai-compatible-gateway"),
+    readRunArtifacts: () =>
+      Promise.resolve(localRunArtifacts({
+        harnessHomeIdentity: identityHost.harnessHomeIdentity,
+        authSource: "none",
+      })),
+    fetchFn: () => {
+      providerRequests += 1;
+      return Promise.reject(new Error("must not request"));
+    },
+    cliDependencies: { cwd: home, io: io.io },
+  });
+
+  assertEquals(
+    await host.runBatch([
+      "--resume-run",
+      "run-one",
+      "--gateway-auth-mode",
+      "bearer",
+    ]),
+    1,
+  );
+  assertEquals(providerRequests, 0);
+  assertEquals(JSON.parse(io.stderr.join("")).error.code, "provider-mismatch");
+});
+
+Deno.test("local Loom host ignores literal binding flags after the option terminator", async () => {
+  const home = await Deno.makeTempDir();
+  const credentials = new InMemoryHarnessCredentialStore();
+  await credentials.set("local", "openai-codex", {
+    type: "oauth",
+    providerId: "openai-codex",
+    accessToken: "access-secret",
+    refreshToken: "refresh-secret",
+    expiresAt: Date.now() + 60 * 60_000,
+    accountId: "account-secret",
+  });
+  let providerRequests = 0;
+  let observed: CreateHarnessPromptLoopOptions | undefined;
+  let observedPrompt = "";
+  const io = ioBuffers();
+  const host = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {},
+    credentialStore: credentials,
+    providerSettingsStore: configured("openai-codex"),
+    fetchFn: () => {
+      providerRequests += 1;
+      return Promise.resolve(sseCompletion());
+    },
+    cliDependencies: {
+      cwd: home,
+      io: io.io,
+      createPromptLoop: (options) => {
+        observed = options;
+        return {
+          runPrompt: async ({ prompt }) => {
+            observedPrompt = prompt;
+            const response = await options.modelClient!.complete({
+              model: options.model ?? "gpt-5.6-terra",
+              transcript: [{ role: "user", content: prompt }],
+              tools: [],
+              nativeModelToolIds: [],
+              runId: options.engine!.getRunState().runId,
+            });
+            return completedResult(options, response.assistant.content);
+          },
+          runTranscript: () => Promise.reject(new Error("unexpected resume")),
+        };
+      },
+    },
+  });
+
+  assertEquals(
+    await host.runBatch([
+      "--output-mode",
+      "batch",
+      "--",
+      "--model-provider",
+      "openai-compatible-gateway",
+      "--gateway-auth-mode",
+      "none",
+    ]),
+    0,
+  );
+  assertEquals(observed?.modelProvider, "openai-codex");
+  assertEquals(
+    observedPrompt,
+    "--model-provider openai-compatible-gateway --gateway-auth-mode none",
+  );
+  assertEquals(providerRequests, 1);
+  assertEquals(io.stderr, []);
+});
+
+Deno.test("local Loom host rejects inconsistent recorded bindings before provider traffic", async () => {
+  const home = await Deno.makeTempDir();
+  const identityHost = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {},
+    providerSettingsStore: configured("openai-compatible-gateway"),
+  });
+  const cases: Array<{
+    name: string;
+    mutate?: (artifacts: HarnessRunArtifacts) => void;
+    args?: readonly string[];
+    requestedManifest?: Record<string, unknown>;
+  }> = [
+    {
+      name: "provider",
+      mutate: (artifacts) => {
+        artifacts.runState.modelProvider = "openai-codex";
+      },
+    },
+    {
+      name: "model",
+      mutate: (artifacts) => {
+        artifacts.runState.model = "other-model";
+      },
+    },
+    {
+      name: "owner",
+      mutate: (artifacts) => {
+        artifacts.runState.credentialOwner = {
+          ...LOOM_LOCAL_CREDENTIAL_OWNER,
+          ownerKey: "other",
+        };
+      },
+    },
+    {
+      name: "home",
+      mutate: (artifacts) => {
+        artifacts.runState.harnessHomeIdentity = "sha256:other";
+      },
+    },
+    {
+      name: "source",
+      mutate: (artifacts) => {
+        artifacts.runState.runManifest!.source = "other" as "loom";
+      },
+    },
+    {
+      name: "auth source",
+      mutate: (artifacts) => {
+        artifacts.runState.modelAuthSource = "api-key";
+      },
+    },
+    {
+      name: "manifest provider",
+      mutate: (artifacts) => {
+        artifacts.runState.runManifest!.modelProvider = "openai-codex";
+      },
+    },
+    {
+      name: "manifest model",
+      mutate: (artifacts) => {
+        artifacts.runState.runManifest!.model = "other-model";
+      },
+    },
+    {
+      name: "manifest owner",
+      mutate: (artifacts) => {
+        artifacts.runState.runManifest!.credentialOwner = {
+          ...LOOM_LOCAL_CREDENTIAL_OWNER,
+          ownerKey: "other",
+        };
+      },
+    },
+    {
+      name: "manifest home",
+      mutate: (artifacts) => {
+        artifacts.runState.runManifest!.harnessHomeIdentity = "sha256:other";
+      },
+    },
+    {
+      name: "manifest auth source",
+      mutate: (artifacts) => {
+        artifacts.runState.runManifest!.modelAuthSource = "api-key";
+      },
+    },
+    {
+      name: "CLI model",
+      args: ["--model", "other-model"],
+    },
+    {
+      name: "supplied run-manifest model",
+      args: ["--run-manifest", "requested-run.json"],
+      requestedManifest: {
+        type: "cf-harness.loom-run-manifest",
+        version: 1,
+        source: "loom",
+        model: "other-model",
+      },
+    },
+  ];
+
+  for (const testCase of cases) {
+    const artifacts = localRunArtifacts({
+      harnessHomeIdentity: identityHost.harnessHomeIdentity,
+      authSource: "none",
+    });
+    testCase.mutate?.(artifacts);
+    let providerRequests = 0;
+    let artifactReads = 0;
+    const io = ioBuffers();
+    const host = await createLoomLocalCfHarnessHost({
+      harnessHome: home,
+      env: {
+        CF_HARNESS_GATEWAY_BASE_URL: "https://gateway.example/",
+        CF_HARNESS_GATEWAY_AUTH_MODE: "none",
+      },
+      providerSettingsStore: configured("openai-compatible-gateway"),
+      readRunArtifacts: () => {
+        artifactReads += 1;
+        return Promise.resolve(artifacts);
+      },
+      fetchFn: () => {
+        providerRequests += 1;
+        return Promise.reject(new Error("must not request"));
+      },
+      cliDependencies: {
+        cwd: home,
+        io: io.io,
+        readTextFile: () =>
+          Promise.resolve(JSON.stringify(testCase.requestedManifest)),
+      },
+    });
+
+    assertEquals(
+      await host.runBatch([
+        "--resume-run",
+        "run-one",
+        ...(testCase.args ?? []),
+      ]),
+      1,
+      testCase.name,
+    );
+    assertEquals(artifactReads, 1, testCase.name);
+    assertEquals(providerRequests, 0, testCase.name);
+    assertEquals(
+      JSON.parse(io.stderr.join("")).error.code,
+      "provider-mismatch",
+      testCase.name,
+    );
+  }
+});
+
+Deno.test("local Loom host rejects every incomplete recorded binding before provider traffic", async () => {
+  const home = await Deno.makeTempDir();
+  const identityHost = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {},
+    providerSettingsStore: configured("openai-compatible-gateway"),
+  });
+  const fields = [
+    "modelProvider",
+    "model",
+    "modelAuthSource",
+    "credentialOwner",
+    "harnessHomeIdentity",
+  ] as const;
+  const cases = [
+    ...fields.map((field) => ({ surface: "state" as const, field })),
+    ...fields.map((field) => ({ surface: "manifest" as const, field })),
+    { surface: "manifest" as const, field: "source" as const },
+  ];
+
+  for (const testCase of cases) {
+    const artifacts = localRunArtifacts({
+      harnessHomeIdentity: identityHost.harnessHomeIdentity,
+      authSource: "none",
+    });
+    const surface = testCase.surface === "state"
+      ? artifacts.runState
+      : artifacts.runState.runManifest!;
+    Reflect.deleteProperty(surface, testCase.field);
+    let providerRequests = 0;
+    const io = ioBuffers();
+    const host = await createLoomLocalCfHarnessHost({
+      harnessHome: home,
+      env: {
+        CF_HARNESS_GATEWAY_BASE_URL: "https://gateway.example/",
+        CF_HARNESS_GATEWAY_AUTH_MODE: "none",
+      },
+      providerSettingsStore: configured("openai-compatible-gateway"),
+      readRunArtifacts: () => Promise.resolve(artifacts),
+      fetchFn: () => {
+        providerRequests += 1;
+        return Promise.reject(new Error("must not request"));
+      },
+      cliDependencies: { cwd: home, io: io.io },
+    });
+    const label = `${testCase.surface}.${testCase.field}`;
+
+    assertEquals(
+      await host.runBatch(["--resume-run", "run-one"]),
+      1,
+      label,
+    );
+    assertEquals(providerRequests, 0, label);
+    assertEquals(
+      JSON.parse(io.stderr.join("")).error.code,
+      "provider-mismatch",
+      label,
+    );
+  }
+});
+
+Deno.test("local Loom host fails closed for legacy resume artifacts without a binding", async () => {
+  const home = await Deno.makeTempDir();
+  const identityHost = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {},
+    providerSettingsStore: configured("openai-compatible-gateway"),
+  });
+  const artifacts = localRunArtifacts({
+    harnessHomeIdentity: identityHost.harnessHomeIdentity,
+    authSource: "none",
+  });
+  delete artifacts.runState.runManifest;
+  let providerRequests = 0;
+  const io = ioBuffers();
+  const host = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {
+      CF_HARNESS_GATEWAY_BASE_URL: "https://gateway.example/",
+      CF_HARNESS_GATEWAY_AUTH_MODE: "none",
+    },
+    providerSettingsStore: configured("openai-compatible-gateway"),
+    readRunArtifacts: () => Promise.resolve(artifacts),
+    fetchFn: () => {
+      providerRequests += 1;
+      return Promise.reject(new Error("must not request"));
+    },
+    cliDependencies: { cwd: home, io: io.io },
+  });
+
+  assertEquals(await host.runBatch(["--resume-run", "run-one"]), 1);
+  assertEquals(providerRequests, 0);
+  assertEquals(JSON.parse(io.stderr.join("")).error.code, "provider-mismatch");
+});
+
+Deno.test("local Loom host classifies invalid, internal, and unavailable failures", async () => {
+  const invalidIo = ioBuffers();
+  let invalidRequests = 0;
+  const invalidHome = await Deno.makeTempDir();
+  const invalidHost = await createLoomLocalCfHarnessHost({
+    harnessHome: invalidHome,
+    env: {},
+    providerSettingsStore: configured("openai-compatible-gateway"),
+    fetchFn: () => {
+      invalidRequests += 1;
+      return Promise.reject(new Error("must not request"));
+    },
+    cliDependencies: { cwd: invalidHome, io: invalidIo.io },
+  });
+  assertEquals(await invalidHost.runBatch(["--model-provider"]), 1);
+  assertEquals(invalidRequests, 0);
+  assertEquals(
+    JSON.parse(invalidIo.stderr.join("")).error.code,
+    "invalid-request",
+  );
+
+  const internalIo = ioBuffers();
+  let internalRequests = 0;
+  const internalHome = await Deno.makeTempDir();
+  const internalHost = await createLoomLocalCfHarnessHost({
+    harnessHome: internalHome,
+    env: {
+      CF_HARNESS_GATEWAY_BASE_URL: "https://gateway.example/",
+      CF_HARNESS_GATEWAY_AUTH_MODE: "none",
+    },
+    providerSettingsStore: configured("openai-compatible-gateway"),
+    fetchFn: () => {
+      internalRequests += 1;
+      return Promise.reject(new Error("must not request"));
+    },
+    cliDependencies: {
+      cwd: internalHome,
+      io: internalIo.io,
+      createPromptLoop: () => ({
+        runPrompt: () => Promise.reject(new Error("injected secret failure")),
+        runTranscript: () => Promise.reject(new Error("unexpected resume")),
+      }),
+    },
+  });
+  assertEquals(await internalHost.runBatch(["--prompt", "hello"]), 1);
+  assertEquals(internalRequests, 0);
+  const internalFailure = JSON.parse(internalIo.stderr.join(""));
+  assertEquals(internalFailure.error.code, "internal-error");
+  assertEquals(JSON.stringify(internalFailure).includes("secret"), false);
+
+  const unavailableIo = ioBuffers();
+  let unavailableRequests = 0;
+  const unavailableHome = await Deno.makeTempDir();
+  const unavailableHost = await createLoomLocalCfHarnessHost({
+    harnessHome: unavailableHome,
+    env: {
+      CF_HARNESS_GATEWAY_BASE_URL: "https://gateway.example/",
+      CF_HARNESS_GATEWAY_AUTH_MODE: "none",
+    },
+    providerSettingsStore: configured("openai-compatible-gateway"),
+    fetchFn: (input) => {
+      assertStringIncludes(String(input), "gateway.example");
+      unavailableRequests += 1;
+      return Promise.resolve(
+        new Response("upstream secret failure", { status: 400 }),
+      );
+    },
+    cliDependencies: { cwd: unavailableHome, io: unavailableIo.io },
+  });
+  assertEquals(
+    await unavailableHost.runBatch([
+      "--prompt",
+      "hello",
+      "--cfc-enforcement-mode",
+      "disabled",
+    ]),
+    1,
+  );
+  assertEquals(unavailableRequests, 1, unavailableIo.stderr.join(""));
+  const unavailableFailure = JSON.parse(unavailableIo.stderr.join(""));
+  assertEquals(unavailableFailure.error.code, "provider-unavailable");
+  assertEquals(JSON.stringify(unavailableFailure).includes("secret"), false);
+});
+
+Deno.test("interactive startup blockers use the chat protocol", async () => {
+  const request = JSON.stringify({
+    type: "cf-harness.chat.request",
+    protocolVersion: 1,
+    requestId: "request-1",
+    method: "status",
+    params: {},
+  });
+  let output = "";
+  await runLoomLocalInteractiveFailureStdio(
+    new HarnessControlError(
+      "provider-auth-required",
+      "connect cf-harness Codex",
+    ),
+    {
+      input: new Response(`${request}\n`).body!,
+      output: new WritableStream({
+        write(chunk: Uint8Array) {
+          output += new TextDecoder().decode(chunk);
+        },
+      }),
+    },
+  );
+  const response = JSON.parse(output);
+  assertEquals(response.requestId, "request-1");
+  assertEquals(response.ok, false);
+  assertEquals(response.error.code, "provider-auth-required");
+});
+
+Deno.test("local Loom interactive entrypoint returns missing config on stdout protocol", async () => {
+  const home = await Deno.makeTempDir();
+  const request = JSON.stringify({
+    type: "cf-harness.chat.request",
+    protocolVersion: 1,
+    requestId: "request-entrypoint",
+    method: "status",
+    params: {},
+  });
+  const child = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--quiet",
+      "--no-lock",
+      "-A",
+      fromFileUrl(new URL("../src/loom-local-host-main.ts", import.meta.url)),
+      "interactive",
+    ],
+    env: {
+      CF_HARNESS_HOME: home,
+      CF_HARNESS_MODEL_PROVIDER: "",
+    },
+    stdin: "piped",
+    stdout: "piped",
+    stderr: "piped",
+  }).spawn();
+  const writer = child.stdin.getWriter();
+  await writer.write(new TextEncoder().encode(`${request}\n`));
+  await writer.close();
+  const result = await child.output();
+  const response = JSON.parse(new TextDecoder().decode(result.stdout));
+
+  assertEquals(result.code, 1);
+  assertEquals(response.type, "cf-harness.chat.response");
+  assertEquals(response.protocolVersion, 1);
+  assertEquals(response.requestId, "request-entrypoint");
+  assertEquals(response.ok, false);
+  assertEquals(response.error.code, "provider-configuration-required");
+  assertEquals(new TextDecoder().decode(result.stderr), "");
+});
+
+Deno.test("local Loom host rejects non-canonical credential homes and provider overrides", async () => {
+  const root = await Deno.makeTempDir();
+  const file = `${root}/not-a-directory`;
+  await Deno.writeTextFile(file, "not a directory");
+  const missing = `${root}/missing`;
+  const cases = [
+    { home: "relative/home", message: "absolute canonical path" },
+    { home: `${root}/../${root.split("/").at(-1)}`, message: "normalized" },
+    { home: missing, message: "existing directory" },
+    { home: file, message: "existing directory" },
+  ];
+
+  for (const testCase of cases) {
+    await assertRejects(
+      () => createLoomLocalCfHarnessHost({ harnessHome: testCase.home }),
+      HarnessControlError,
+      testCase.message,
+    );
+  }
+
+  await assertRejects(
+    () =>
+      createLoomLocalCfHarnessHost({
+        harnessHome: root,
+        env: { CF_HARNESS_MODEL_PROVIDER: "openai-codex" },
+      }),
+    HarnessControlError,
+    "do not accept CF_HARNESS_MODEL_PROVIDER overrides",
+  );
+});
+
+Deno.test("local Loom host classifies malformed binding options before configuration or traffic", async () => {
+  const home = await Deno.makeTempDir();
+  const cases: Array<{ args: readonly string[]; message: string }> = [
+    { args: ["--model="], message: "--model requires a value" },
+    {
+      args: ["--gateway-base-url"],
+      message: "--gateway-base-url requires a value",
+    },
+    {
+      args: ["--prompt-cache-mode="],
+      message: "--prompt-cache-mode requires a value",
+    },
+    {
+      args: [
+        "--gateway-auth-mode",
+        "none",
+        "--gateway-auth-mode",
+        "bearer",
+      ],
+      message: "duplicate --gateway-auth-mode",
+    },
+    {
+      args: ["--", "--gateway-auth-mode", "invalid"],
+      message: "--gateway-auth-mode must be bearer or none",
+    },
+    {
+      args: ["--resume-run", "one", "--resume-run", "two"],
+      message: "duplicate --resume-run",
+    },
+    {
+      args: ["--model", "one", "--model", "two"],
+      message: "duplicate --model",
+    },
+    {
+      args: [
+        "--model-provider",
+        "openai-codex",
+        "--model-provider",
+        "openai-codex",
+      ],
+      message: "duplicate --model-provider",
+    },
+    {
+      args: ["--model-provider", "unsupported"],
+      message: "unsupported --model-provider",
+    },
+  ];
+
+  for (const testCase of cases) {
+    let providerReads = 0;
+    let providerRequests = 0;
+    const io = ioBuffers();
+    const host = await createLoomLocalCfHarnessHost({
+      harnessHome: home,
+      env: {},
+      providerSettingsStore: {
+        inspect: () => {
+          providerReads += 1;
+          return Promise.resolve({
+            state: "configured" as const,
+            settings: {
+              version: 1 as const,
+              modelProvider: "openai-compatible-gateway" as const,
+            },
+          });
+        },
+      },
+      fetchFn: () => {
+        providerRequests += 1;
+        return Promise.reject(new Error("must not request"));
+      },
+      cliDependencies: { cwd: home, io: io.io },
+    });
+
+    assertEquals(await host.runBatch(testCase.args), 1, testCase.message);
+    assertEquals(providerReads, 0, testCase.message);
+    assertEquals(providerRequests, 0, testCase.message);
+    const failure = JSON.parse(io.stderr.join(""));
+    assertEquals(failure.error.code, "invalid-request", testCase.message);
+    assertStringIncludes(failure.error.message, testCase.message);
+  }
+});
+
+Deno.test("local Loom host validates gateway environment and credential-store availability", async () => {
+  const home = await Deno.makeTempDir();
+  const invalidGatewayIo = ioBuffers();
+  const invalidGatewayHost = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: { CF_HARNESS_GATEWAY_AUTH_MODE: "invalid" },
+    providerSettingsStore: configured("openai-compatible-gateway"),
+    cliDependencies: { cwd: home, io: invalidGatewayIo.io },
+  });
+  assertEquals(await invalidGatewayHost.runBatch(["--prompt", "hello"]), 1);
+  assertEquals(
+    JSON.parse(invalidGatewayIo.stderr.join("")).error.code,
+    "provider-configuration-required",
+  );
+
+  const unavailableCredentials = new InMemoryHarnessCredentialStore();
+  unavailableCredentials.getRecord = () =>
+    Promise.reject(new Error("secret-bearing storage failure"));
+  const unavailableIo = ioBuffers();
+  const unavailableHost = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {},
+    credentialStore: unavailableCredentials,
+    providerSettingsStore: configured("openai-codex"),
+    cliDependencies: { cwd: home, io: unavailableIo.io },
+  });
+  assertEquals(await unavailableHost.runBatch(["--prompt", "hello"]), 1);
+  const unavailableFailure = JSON.parse(unavailableIo.stderr.join(""));
+  assertEquals(unavailableFailure.error.code, "provider-unavailable");
+  assertEquals(
+    JSON.stringify(unavailableFailure).includes("secret-bearing"),
+    false,
+  );
+
+  const defaultIoHost = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {},
+    providerSettingsStore: configured("openai-compatible-gateway"),
+  });
+  assertEquals(await defaultIoHost.runBatch(["--model-provider"]), 1);
+});
+
+Deno.test("interactive startup failure protocol handles malformed requests and bounded internal errors", async () => {
+  const input = new Response(
+    `\nnot-json\n${JSON.stringify({ requestId: 42 })}\n${
+      JSON.stringify({ requestId: "known" })
+    }\n`,
+  ).body!;
+  let output = "";
+  await runLoomLocalInteractiveFailureStdio(
+    new HarnessControlError("invalid-request", "bounded invalid request"),
+    {
+      input,
+      output: new WritableStream({
+        write(chunk: Uint8Array) {
+          output += new TextDecoder().decode(chunk);
+        },
+      }),
+    },
+  );
+  const responses = output.trim().split("\n").map((line) => JSON.parse(line));
+  assertEquals(responses.map((response) => response.requestId), [
+    "invalid",
+    "invalid",
+    "known",
+  ]);
+  assertEquals(
+    responses.map((response) => response.error.code),
+    ["internal_error", "internal_error", "internal_error"],
+  );
+
+  let unknownOutput = "";
+  await runLoomLocalInteractiveFailureStdio(
+    new Error("secret-bearing unexpected failure"),
+    {
+      input: new Response(`${JSON.stringify({ requestId: "unknown" })}\n`)
+        .body!,
+      output: new WritableStream({
+        write(chunk: Uint8Array) {
+          unknownOutput += new TextDecoder().decode(chunk);
+        },
+      }),
+    },
+  );
+  const unknown = JSON.parse(unknownOutput);
+  assertEquals(unknown.error.code, "internal_error");
+  assertEquals(JSON.stringify(unknown).includes("secret-bearing"), false);
+});

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -554,6 +554,13 @@ Deno.test("Codex parent and child loops share one serialized credential refresh"
       model: "gpt-5.4",
       modelProvider: "openai-codex",
       credentialOwnerKey: "loom:user-1",
+      credentialOwner: {
+        type: "cf-harness.credential-owner-ref",
+        version: 1,
+        ownerKey: "loom:user-1",
+      },
+      modelAuthSource: "cf-harness-local-store",
+      harnessHomeIdentity: "sha256:opaque-home",
       cfcEnforcementMode: "disabled",
     }),
   });
@@ -568,6 +575,22 @@ Deno.test("Codex parent and child loops share one serialized credential refresh"
   assertEquals(
     result.runState.subagentRuns?.[0]?.manifest.modelProvider,
     "openai-codex",
+  );
+  assertEquals(
+    result.runState.subagentRuns?.[0]?.manifest.modelAuthSource,
+    "cf-harness-local-store",
+  );
+  assertEquals(
+    result.runState.subagentRuns?.[0]?.manifest.credentialOwner,
+    {
+      type: "cf-harness.credential-owner-ref",
+      version: 1,
+      ownerKey: "loom:user-1",
+    },
+  );
+  assertEquals(
+    result.runState.subagentRuns?.[0]?.manifest.harnessHomeIdentity,
+    "sha256:opaque-home",
   );
   const serialized = JSON.stringify(result.runState.subagentRuns);
   assertEquals(serialized.includes("initial-refresh-secret"), false);
@@ -1331,6 +1354,51 @@ Deno.test("CfHarnessPromptLoop forwards abort signals to gateway requests", asyn
 
   assertEquals(result.finalAssistantText, "Hi.");
   assertEquals(seenSignal, controller.signal);
+});
+
+Deno.test("CfHarnessPromptLoop preserves custom abort reasons for local gateway runs", async () => {
+  const reason = new Error("custom cancellation reason");
+  const controller = new AbortController();
+  controller.abort(reason);
+  const modelClient: HarnessModelClient = {
+    providerId: "openai-compatible-gateway",
+    complete: () => Promise.reject(reason),
+  };
+  const credentialOwner = {
+    type: "cf-harness.credential-owner-ref" as const,
+    version: 1 as const,
+    ownerKey: "local",
+  };
+  const loop = new CfHarnessPromptLoop({
+    modelClient,
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: "run-local-gateway-custom-abort",
+      model: "gpt-5.4",
+      modelProvider: "openai-compatible-gateway",
+      modelAuthSource: "none",
+      credentialOwner,
+      harnessHomeIdentity: "sha256:opaque-home",
+      runManifest: {
+        type: "cf-harness.loom-run-manifest",
+        version: 1,
+        source: "loom",
+        modelProvider: "openai-compatible-gateway",
+        modelAuthSource: "none",
+        credentialOwner,
+        harnessHomeIdentity: "sha256:opaque-home",
+      },
+      cfcEnforcementMode: "disabled",
+    }),
+  });
+
+  let caught: unknown;
+  try {
+    await loop.runPrompt({ prompt: "Say hi.", signal: controller.signal });
+  } catch (error) {
+    caught = error;
+  }
+  assert(caught === reason, "custom abort reason must be rethrown unchanged");
 });
 
 Deno.test("CfHarnessPromptLoop forwards abort signals to delegate_task child loops", async () => {

--- a/packages/cf-harness/test/run-manifest.test.ts
+++ b/packages/cf-harness/test/run-manifest.test.ts
@@ -1,6 +1,11 @@
 import { assertEquals, assertThrows } from "@std/assert";
 import { CFC_PROMPT_SLOT_BOUND_ATOM_TYPE } from "../src/contracts/prompt-slot.ts";
-import { parseLoomRunManifestJson } from "../src/contracts/run-manifest.ts";
+import {
+  bindLoomLocalRunManifest,
+  type HarnessRunManifest,
+  type LoomLocalHostBinding,
+  parseLoomRunManifestJson,
+} from "../src/contracts/run-manifest.ts";
 
 Deno.test("parseLoomRunManifestJson validates prompt-slot evidence", () => {
   const manifest = parseLoomRunManifestJson(
@@ -58,6 +63,21 @@ Deno.test("parseLoomRunManifestJson rejects malformed prompt-slot evidence", () 
       ),
     Error,
     "unsupported prompt slot binding type",
+  );
+});
+
+Deno.test("parseLoomRunManifestJson rejects a non-Loom source", () => {
+  assertThrows(
+    () =>
+      parseLoomRunManifestJson(
+        JSON.stringify({
+          type: "cf-harness.loom-run-manifest",
+          version: 1,
+          source: "hosted",
+        }),
+      ),
+    Error,
+    "unsupported run manifest source: hosted",
   );
 });
 
@@ -126,6 +146,32 @@ Deno.test("parseLoomRunManifestJson preserves a non-secret credential owner refe
   });
 });
 
+Deno.test("parseLoomRunManifestJson preserves non-secret local host binding metadata", () => {
+  const manifest = parseLoomRunManifestJson(JSON.stringify({
+    type: "cf-harness.loom-run-manifest",
+    version: 1,
+    source: "loom",
+    modelProvider: "openai-codex",
+    modelAuthSource: "cf-harness-local-store",
+    harnessHomeIdentity: "sha256:opaque-home",
+  }));
+
+  assertEquals(manifest.modelAuthSource, "cf-harness-local-store");
+  assertEquals(manifest.harnessHomeIdentity, "sha256:opaque-home");
+  for (const invalid of ["", "  ", "secrets-file"] as const) {
+    assertThrows(
+      () =>
+        parseLoomRunManifestJson(JSON.stringify({
+          type: "cf-harness.loom-run-manifest",
+          version: 1,
+          source: "loom",
+          modelAuthSource: invalid,
+        })),
+      Error,
+    );
+  }
+});
+
 Deno.test("parseLoomRunManifestJson rejects malformed provider ownership", () => {
   for (
     const credentialOwner of [
@@ -167,4 +213,96 @@ Deno.test("parseLoomRunManifestJson rejects malformed provider ownership", () =>
     Error,
     "unsupported run manifest modelProvider",
   );
+});
+
+Deno.test("parseLoomRunManifestJson rejects a path-shaped harness home identity", () => {
+  assertThrows(
+    () =>
+      parseLoomRunManifestJson(JSON.stringify({
+        type: "cf-harness.loom-run-manifest",
+        version: 1,
+        source: "loom",
+        harnessHomeIdentity: "/Users/alice/.cf-harness",
+      })),
+    Error,
+    "invalid run manifest harnessHomeIdentity",
+  );
+});
+
+Deno.test("bindLoomLocalRunManifest rejects every conflicting caller binding", () => {
+  const binding: LoomLocalHostBinding = {
+    source: "loom",
+    modelProvider: "openai-codex",
+    modelAuthSource: "cf-harness-local-store",
+    credentialOwner: {
+      type: "cf-harness.credential-owner-ref",
+      version: 1,
+      ownerKey: "local",
+      tenantKey: "tenant-a",
+    },
+    harnessHomeIdentity: "sha256:home-a",
+  };
+  const baseManifest: HarnessRunManifest = {
+    type: "cf-harness.loom-run-manifest",
+    version: 1,
+    source: "loom",
+  };
+  const cases: Array<{
+    label: string;
+    manifest: HarnessRunManifest;
+    model?: string;
+  }> = [
+    {
+      label: "provider",
+      manifest: {
+        ...baseManifest,
+        modelProvider: "openai-compatible-gateway",
+      },
+    },
+    {
+      label: "auth source",
+      manifest: { ...baseManifest, modelAuthSource: "none" },
+    },
+    {
+      label: "credential owner",
+      manifest: {
+        ...baseManifest,
+        credentialOwner: { ...binding.credentialOwner, tenantKey: "tenant-b" },
+      },
+    },
+    {
+      label: "harness home",
+      manifest: { ...baseManifest, harnessHomeIdentity: "sha256:home-b" },
+    },
+    {
+      label: "model",
+      manifest: { ...baseManifest, model: "gpt-a" },
+      model: "gpt-b",
+    },
+  ];
+
+  for (const testCase of cases) {
+    assertThrows(
+      () =>
+        bindLoomLocalRunManifest(
+          testCase.manifest,
+          binding,
+          testCase.model,
+        ),
+      Error,
+      `Loom-local ${testCase.label} does not match the host binding`,
+    );
+  }
+
+  const owner = structuredClone(binding.credentialOwner);
+  const bound = bindLoomLocalRunManifest(
+    { ...baseManifest, wishId: "W-coverage", credentialOwner: owner },
+    binding,
+    "gpt-a",
+  );
+  assertEquals(bound.wishId, "W-coverage");
+  assertEquals(bound.model, "gpt-a");
+  assertEquals(bound.credentialOwner, binding.credentialOwner);
+  owner.ownerKey = "mutated-after-bind";
+  assertEquals(bound.credentialOwner?.ownerKey, "local");
 });

--- a/packages/cf-harness/test/run-report.test.ts
+++ b/packages/cf-harness/test/run-report.test.ts
@@ -54,6 +54,36 @@ Deno.test("run reports do not invent API-key auth for legacy run state", () => {
   assertEquals(report.modelAuthSource, undefined);
 });
 
+Deno.test("run reports preserve the non-secret local Loom host binding", () => {
+  const report = createHarnessRunReport({
+    runState: {
+      runId: "loom-local",
+      status: "completed",
+      updatedAt: "2026-08-13T00:00:00.000Z",
+      cfcEnforcementMode: "disabled",
+      modelProvider: "openai-codex",
+      modelAuthSource: "cf-harness-local-store",
+      credentialOwner: {
+        type: "cf-harness.credential-owner-ref",
+        version: 1,
+        ownerKey: "local",
+      },
+      harnessHomeIdentity: "sha256:opaque-home",
+      policyEvents: [],
+      policyDecisions: [],
+      toolOutputs: [],
+    },
+    model: "gpt-5.6-terra",
+    modelTurns: 1,
+    toolActivity: [],
+  });
+
+  assertEquals(report.modelProvider, "openai-codex");
+  assertEquals(report.modelAuthSource, "cf-harness-local-store");
+  assertEquals(report.credentialOwner?.ownerKey, "local");
+  assertEquals(report.harnessHomeIdentity, "sha256:opaque-home");
+});
+
 Deno.test("run reports preserve aggregate and per-turn model usage", () => {
   const usage = {
     inputTokens: 300,

--- a/packages/cf-harness/test/sqlite-session-store.test.ts
+++ b/packages/cf-harness/test/sqlite-session-store.test.ts
@@ -12,9 +12,11 @@ import {
   type HarnessInteractivePromptLoopFactory,
 } from "../src/interactive-chat-service.ts";
 import type {
+  CreateHarnessPromptLoopOptions,
   HarnessPromptLoopResult,
   RunHarnessTranscriptOptions,
 } from "../src/prompt-loop.ts";
+import type { LoomLocalHostBinding } from "../src/contracts/run-manifest.ts";
 import { openSqliteHarnessChatSessionStore } from "../src/sqlite-session-store.ts";
 
 const nextIsoNow = () => {
@@ -37,6 +39,24 @@ const makeResult = (
   ],
   modelTurns: 1,
   runState: {} as HarnessPromptLoopResult["runState"],
+});
+
+const localHostPromptLoopOptions = (
+  binding: LoomLocalHostBinding,
+  model?: string,
+): CreateHarnessPromptLoopOptions => ({
+  modelProvider: binding.modelProvider,
+  modelAuthSource: binding.modelAuthSource,
+  credentialOwner: binding.credentialOwner,
+  credentialOwnerKey: binding.credentialOwner.ownerKey,
+  harnessHomeIdentity: binding.harnessHomeIdentity,
+  ...(model !== undefined ? { model } : {}),
+  runManifest: {
+    type: "cf-harness.loom-run-manifest",
+    version: 1,
+    ...binding,
+    ...(model !== undefined ? { model } : {}),
+  },
 });
 
 Deno.test("sqlite session store rejects unsupported URL schemes", async () => {
@@ -175,6 +195,283 @@ Deno.test("sqlite session store persists chat sessions and replayable events", a
       duplicate.ok === false ? duplicate.error.code : "",
       "session_exists",
     );
+  } finally {
+    store.close();
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("sqlite session restart rejects changed or missing local Loom bindings before model traffic", async () => {
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const store = await openSqliteHarnessChatSessionStore({
+    url: toFileUrl(path),
+  });
+  const credentialOwner = {
+    type: "cf-harness.credential-owner-ref",
+    version: 1,
+    ownerKey: "local",
+  } as const;
+  const gatewayBinding: LoomLocalHostBinding = {
+    source: "loom",
+    modelProvider: "openai-compatible-gateway",
+    modelAuthSource: "api-key",
+    credentialOwner,
+    harnessHomeIdentity: "sha256:home-a",
+  };
+  const codexBinding: LoomLocalHostBinding = {
+    ...gatewayBinding,
+    modelProvider: "openai-codex",
+    modelAuthSource: "cf-harness-local-store",
+  };
+  let promptLoopCreations = 0;
+  let modelCalls = 0;
+
+  try {
+    const original = new HarnessInteractiveChatService({
+      basePromptLoopOptions: localHostPromptLoopOptions(gatewayBinding),
+      createPromptLoop: () => {
+        promptLoopCreations += 1;
+        return {
+          runTranscript: (options) =>
+            Promise.resolve(makeResult(options, "Should not run.")),
+        };
+      },
+      sessionStore: store,
+    });
+    const started = await original.startSession("req-start", {
+      sessionId: "session-gateway",
+      workspace: { hostPath: "/workspace" },
+      model: "gpt-session",
+    });
+    assertEquals(started.ok, true);
+    assertEquals(store.getSession("session-gateway")?.session, {
+      ...original.status("session-gateway").sessions[0],
+      model: "gpt-session",
+      loomLocalHostBinding: gatewayBinding,
+    });
+
+    store.saveSession({
+      session: createHarnessChatSessionStatus({
+        sessionId: "session-legacy",
+        workspace: { hostPath: "/workspace" },
+        model: "gpt-session",
+      }),
+      transcript: [],
+    });
+
+    const restored = new HarnessInteractiveChatService({
+      credentialOwner,
+      basePromptLoopOptions: {
+        ...localHostPromptLoopOptions(codexBinding),
+        modelClient: {
+          providerId: "openai-codex",
+          credentialOwner,
+          complete: () => {
+            modelCalls += 1;
+            return Promise.reject(new Error("unexpected model call"));
+          },
+        },
+      },
+      createPromptLoop: () => {
+        promptLoopCreations += 1;
+        return {
+          runTranscript: (options) =>
+            Promise.resolve(makeResult(options, "Should not run.")),
+        };
+      },
+      sessionStore: store,
+    });
+    await restored.initializeFromStore();
+
+    const changedProvider = await restored.startTurn("req-old", {
+      sessionId: "session-gateway",
+      turnId: "turn-old",
+      input: { text: "Do not migrate this transcript" },
+    });
+    assertEquals(changedProvider.ok, false);
+    assertEquals(
+      changedProvider.ok === false ? changedProvider.error.code : undefined,
+      "provider-mismatch",
+    );
+
+    const missingBinding = await restored.startTurn("req-legacy", {
+      sessionId: "session-legacy",
+      turnId: "turn-legacy",
+      input: { text: "Do not use an unbound transcript" },
+    });
+    assertEquals(missingBinding.ok, false);
+    assertEquals(
+      missingBinding.ok === false ? missingBinding.error.code : undefined,
+      "provider-mismatch",
+    );
+
+    const newSession = await restored.startSession("req-new", {
+      sessionId: "session-codex",
+      workspace: { hostPath: "/workspace" },
+      model: "gpt-new-session",
+    });
+    assertEquals(newSession.ok, true);
+    assertEquals(
+      newSession.ok ? newSession.result.loomLocalHostBinding : undefined,
+      codexBinding,
+    );
+    assertEquals(
+      newSession.ok ? newSession.result.model : undefined,
+      "gpt-new-session",
+    );
+    assertEquals(restored.listTurns().turns, []);
+    assertEquals(promptLoopCreations, 0);
+    assertEquals(modelCalls, 0);
+  } finally {
+    store.close();
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("sqlite session restart rejects a changed local Loom model before model traffic", async () => {
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const store = await openSqliteHarnessChatSessionStore({
+    url: toFileUrl(path),
+  });
+  const binding: LoomLocalHostBinding = {
+    source: "loom",
+    modelProvider: "openai-compatible-gateway",
+    modelAuthSource: "none",
+    credentialOwner: {
+      type: "cf-harness.credential-owner-ref",
+      version: 1,
+      ownerKey: "local",
+    },
+    harnessHomeIdentity: "sha256:home-a",
+  };
+  let promptLoopCreations = 0;
+
+  try {
+    const original = new HarnessInteractiveChatService({
+      basePromptLoopOptions: localHostPromptLoopOptions(binding, "gpt-a"),
+      createPromptLoop: () => {
+        promptLoopCreations += 1;
+        return {
+          runTranscript: (options) =>
+            Promise.resolve(makeResult(options, "Should not run.")),
+        };
+      },
+      sessionStore: store,
+    });
+    const started = await original.startSession("req-start", {
+      sessionId: "session-model-a",
+      workspace: { hostPath: "/workspace" },
+    });
+    assertEquals(started.ok ? started.result.model : undefined, "gpt-a");
+
+    const restored = new HarnessInteractiveChatService({
+      basePromptLoopOptions: localHostPromptLoopOptions(binding, "gpt-b"),
+      createPromptLoop: () => {
+        promptLoopCreations += 1;
+        return {
+          runTranscript: (options) =>
+            Promise.resolve(makeResult(options, "Should not run.")),
+        };
+      },
+      sessionStore: store,
+    });
+    await restored.initializeFromStore();
+    const turn = await restored.startTurn("req-turn", {
+      sessionId: "session-model-a",
+      turnId: "turn-model-a",
+      input: { text: "Keep the original model" },
+    });
+
+    assertEquals(turn.ok, false);
+    assertEquals(
+      turn.ok === false ? turn.error.code : undefined,
+      "provider-mismatch",
+    );
+    assertEquals(restored.listTurns().turns, []);
+    assertEquals(promptLoopCreations, 0);
+  } finally {
+    store.close();
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("sqlite session restart validates every durable local Loom binding field", async () => {
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const store = await openSqliteHarnessChatSessionStore({
+    url: toFileUrl(path),
+  });
+  const binding: LoomLocalHostBinding = {
+    source: "loom",
+    modelProvider: "openai-compatible-gateway",
+    modelAuthSource: "none",
+    credentialOwner: {
+      type: "cf-harness.credential-owner-ref",
+      version: 1,
+      ownerKey: "local",
+      tenantKey: "tenant-a",
+    },
+    harnessHomeIdentity: "sha256:home-a",
+  };
+  const cases = [
+    {
+      name: "auth",
+      binding: { ...binding, modelAuthSource: "api-key" as const },
+    },
+    {
+      name: "owner",
+      binding: {
+        ...binding,
+        credentialOwner: { ...binding.credentialOwner, tenantKey: "tenant-b" },
+      },
+    },
+    {
+      name: "home",
+      binding: { ...binding, harnessHomeIdentity: "sha256:home-b" },
+    },
+    { name: "model", binding, model: undefined },
+  ];
+  let promptLoopCreations = 0;
+
+  try {
+    for (const testCase of cases) {
+      store.saveSession({
+        session: createHarnessChatSessionStatus({
+          sessionId: `session-${testCase.name}`,
+          workspace: { hostPath: "/workspace" },
+          ...(testCase.model === undefined && testCase.name === "model"
+            ? {}
+            : { model: "gpt-a" }),
+          loomLocalHostBinding: testCase.binding,
+        }),
+        transcript: [],
+      });
+    }
+
+    const restored = new HarnessInteractiveChatService({
+      basePromptLoopOptions: localHostPromptLoopOptions(binding, "gpt-a"),
+      createPromptLoop: () => {
+        promptLoopCreations += 1;
+        throw new Error("must not create a prompt loop");
+      },
+      sessionStore: store,
+    });
+    await restored.initializeFromStore();
+
+    for (const testCase of cases) {
+      const result = await restored.startTurn(`req-${testCase.name}`, {
+        sessionId: `session-${testCase.name}`,
+        turnId: `turn-${testCase.name}`,
+        input: { text: "Do not cross the durable binding" },
+      });
+      assertEquals(result.ok, false, testCase.name);
+      assertEquals(
+        result.ok === false ? result.error.code : undefined,
+        "provider-mismatch",
+        testCase.name,
+      );
+    }
+    assertEquals(promptLoopCreations, 0);
+    assertEquals(restored.listTurns().turns, []);
   } finally {
     store.close();
     await Deno.remove(path);


### PR DESCRIPTION
## Why

Local single-user Loom needs one authoritative cf-harness execution boundary that can use a separately authenticated personal Codex subscription without silently falling back to the shared gateway. Slice 1 (#5749) added persistent provider and auth controls; this slice makes those controls binding for every local Loom batch and interactive run.

## What Changed

- Add an exported local Loom host factory and one batch/interactive executable entrypoint.
- Require strict persisted provider configuration and a dedicated, real-path-pinned CF_HARNESS_HOME.
- Bind every run to the fixed local credential owner, provider, non-secret auth source, home identity, and model.
- Construct Codex credentials only for Codex, scrub incompatible gateway and prompt-cache settings, and reject explicit gateway-only options before traffic.
- Validate one complete, exact state-and-manifest snapshot on resume; reject missing fields or binding drift before auth/provider traffic.
- Persist binding metadata in run state, manifests, reports, batch results, child runs, and durable chat sessions, including the per-session model selected by interactive Loom.
- Return stable structured host failures on batch stderr and interactive startup blockers through stdout NDJSON.
- Fail closed for legacy runs and chat sessions that predate the complete binding.
- Preserve caller cancellation reasons and expose batch/interactive help plus batch capability discovery without requiring provider configuration or authentication.

## Test plan

- All 717 cf-harness package tests pass locally after rebasing onto current `main`.
- Real interactive gateway and Codex turns persist current-format artifacts and resume through a fresh host on exactly the recorded provider route.
- Dedicated host/interactive counter tests cover authenticated Codex, gateway API-key and auth-free modes, credential loss after preflight, ambient and explicit cache settings, refresh-on-use, exact and incomplete resume snapshots, state/manifest binding mismatches, durable restart mismatches, symlink retargeting, cancellation, failure classification, informational controls, real executable protocol paths, and zero provider traffic on binding conflicts.
- Fresh coverage confirms every line identified by the coverage gate in the host entrypoint and binding parser is exercised, including the closed-stdin interactive startup path.
- Full package formatting, lint, type-check, and diff checks pass.
- Independent implementation, counter-test, full-branch, and follow-up correctness reviews were completed; all reported findings were fixed and the final review is clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
