### PR TITLE
docs(plans): a required key that survives, and a $comment that is not inert

### DIFF
--- a/docs/plans/projection-key-classification.md
+++ b/docs/plans/projection-key-classification.md
@@ -41,11 +41,13 @@ design:
   boundary**: past it, a schema is the runner's to act on.
   `SchemaObjectTraverser` (`packages/runner/src/traverse.ts`) acts on the
   traversal semantics it supports — the declared `type`, the descent through
-  `properties` and `items`, and `required`, which decides whether an object is
-  read at all. Value constraints are not among them: `minLength`, `minimum`,
-  `minItems` and their neighbours appear nowhere in that traversal. `required`
-  being one of the keywords it does act on is what makes a caller's schema
-  crossing this boundary consequential.
+  `properties` and `items`, `required`, which decides whether an object is read
+  at all, the item schema under `items`, which decides the same for an array,
+  and `$comment`, three values of which the runner reserves as control
+  markers. Value constraints are not among them: `minLength`, `minimum`,
+  `minItems` and their neighbours appear nowhere in that traversal. That
+  `required` and `$comment` are both keywords it acts on is what makes a
+  caller's schema crossing this boundary consequential.
 
 `resolveProjection` builds all three, and it builds them two different ways.
 For the concise spelling it derives the output schema through
@@ -165,8 +167,9 @@ boundary because a caller wrote it — it describes what a caller is allowed to
 write and what the reader puts in the schema it builds because of it.
 
 The reader supplies exactly one key from somewhere other than the classified
-projection, and `selectSourceSchema` already derives that key this way, with a
-comment giving exactly this reason:
+projection, and `selectSourceSchema`
+(`packages/cli/lib/cell-selection.ts:selectSourceSchema`) already derives that
+key this way, with a comment giving exactly this reason:
 
 ```text
 A rejected position holds nothing to require. Keeping it required makes
@@ -181,7 +184,189 @@ rather than the caller's. That derivation runs on the source-read schema and on
 the concise path's output schema, and on no JSON-path output schema. **This item
 extends an existing derivation to a second call site rather than inventing
 one**, and what it extends is *derive the constraint*, not *delete the
-keyword*.
+keyword*. What "survived selection" has to mean is the next section, because it
+is not what the filter currently asks.
+
+### What "survived selection" has to mean
+
+Extended as it stands, that derivation would reproduce [#5734] through the
+document that folds [#5734] in.
+
+`selectSourceSchema` keeps a source-required key where
+`key in properties && properties[key] !== false`. Both clauses ask about the
+caller's **projection membership**: the first whether the caller named the
+position, the second whether the caller rejected it outright. Neither asks
+whether the value at that position survives traversal. A property the caller
+projected under a constraint that value then fails stays required — and the
+runner voids the object around it.
+
+What it collides with is any caller constraint the value fails, and the
+simplest of those is a mismatched scalar. Take a source declaring `id`
+(number, `required`) alongside `title`, read through a projection asking for
+`id` as a string and `title`. Today that returns `{"title":"Visible"}`: the
+caller's schema crosses the boundary verbatim, it carries no `required` of its
+own, and the mismatched `id` is dropped by itself. Hand the same read a
+constructed schema carrying the derived `required: ["id"]` and the answer is
+`undefined` — the whole object, not the one position. `traverseWithSchema`
+fails the child `invalidType`, `traverseObjectWithSchema` leaves it out of the
+object it assembles, and that function's closing required check returns
+`undefined` for the object. A parent reads that as `invalidObject` and voids in
+turn, so the emptying climbs to the root of the read.
+
+That is [#5734]'s failure mode exactly — an unsatisfiable `required` silently
+emptying a whole read, exit 0 — arriving through the design that claims to fix
+it, over a key no caller wrote. **Ceasing to carry the caller's `required` does
+not fix [#5734] by itself; it relocates it.** The two requirements have to be
+settled together or they collide.
+
+So the derivation needs the survival test its own comment already describes and
+its filter does not implement:
+
+> **A source-`required` property stays required in the schema the reader
+> constructs only where nothing the caller wrote inside that property can cause
+> the property itself to be rejected.** A position the caller narrowed may be
+> omitted; the object holding it must not be voided because it was.
+
+Whether a caller's constraint stays where it was written or rejects the
+property holding it is the runner's decision, and the two containers do not
+decide it the same way.
+
+### An object contains a rejection; an array does not
+
+`traverseObjectWithSchema` (`packages/runner/src/traverse.ts`) assembles an
+object property by property and keeps the ones whose traversal returned no
+error; a property that failed is simply never assigned, and assembly carries
+on. `traverseArrayWithSchema` in the same module carries one `valid` flag
+across every element and returns `undefined` if any element failed. Its own
+comment states the consequence:
+
+```text
+This array is invalid; one or more items do not match the
+schema — the ENTIRE array reads as invalid for this caller.
+```
+
+**A rejected object property is omitted. A rejected array element voids the
+array around it.** Measured against a `SchemaObjectTraverser`, with the caller
+narrowing one of two children to `string` in each case and neither container
+required:
+
+| Source value | Constructed child | Result |
+| --- | --- | --- |
+| `{"a":1,"b":"ok"}` | object, `a` and `b` both `string` | `{"b":"ok"}` |
+| `[1,"ok"]` | array, `items` `string` | the property is **gone** |
+
+The object drops the child that failed and hands back the one that passed. The
+array hands back nothing at all — the element that matched is discarded with
+the element that did not. **The two rows are the same shape of narrowing**:
+`{"properties":{"a":{"type":"string"}}}` and `{"items":{"type":"string"}}` are
+both a caller stating a scalar type one level down. Only one of them can take
+the property with it.
+
+Put the array row under a source-`required` key and the derived `required`
+finds a property that is not there:
+
+| Constructed schema over `{"values":[1],"title":"Visible"}` | Result |
+| --- | --- |
+| `values` an array of `string` | `{"title":"Visible"}` |
+| `values` an array of `string`, **`required`** | **`undefined`** |
+
+That is [#5734]'s shape a third time, over a container that any rule treating
+both containers alike keeps. The asymmetry is why the two cannot share one case,
+and it is invisible from the projection: nothing in what the caller wrote says
+which of the two narrowings is survivable.
+
+Against the classified projection the rule resolves into a question about where
+the child's type comes from, with one answer per case:
+
+- **The caller states no type there** — `true`, or `{}`, which normalizes to
+  the same wildcard. `selectSourceSchema` answers a `true` mask with the
+  source's own schema, so the constructed child *is* the unprojected one: it
+  declines exactly the values an unprojected read declines. That is the
+  source's meaning, which is the meaning `required` is being derived to carry.
+  **Stays required.**
+- **The caller states a scalar `type`** — the constraint is the caller's, and
+  declining a value is what a caller writes one for. **Drops out of
+  `required`.** This is the case projection membership misses, and it is also
+  the case the mask cannot see: a scalar position masks to `true`, so a reader
+  consulting the mask here would conclude "no caller type" and keep the key.
+  The reader has the caller's `type` in hand only because it builds from the
+  classification — the same reason half 2 gives for not building from the
+  mask.
+- **The caller states an object** — `properties`, or a keyword
+  `impliedProjectionType` derives an object from. A constraint the caller wrote
+  inside narrows a *descendant*, and a narrowed descendant is omitted from the
+  object rather than rejecting it, so nothing written below this point reaches
+  the property itself. That holds on one condition: each descendant's own
+  derived `required` follows this same rule, which is what stops an inner
+  `required` from voiding the object an outer one is keeping. **Stays
+  required.**
+- **The caller states an array** — `items`, or a keyword
+  `impliedProjectionType` derives an array from. Here what the caller wrote
+  does not stay where it was written: it constrains elements, and one rejected
+  element voids the array itself. So the answer follows the element schema
+  rather than the array. A wildcard `items` rejects no element and the property
+  **stays required**. An `items` naming a **scalar `type`** rejects every
+  element whose value that type excludes, which rejects the array, so the
+  property **drops out**. An array carries no `required` of its own for the
+  recursion to empty, so there is nothing below it to absorb the rejection. An
+  `items` naming an object rejects an element only through that item object's
+  own derived `required`, which this rule has already emptied of everything the
+  caller can fail, so the property **stays required**.
+- **The caller writes `false`** — the case the existing comment was written
+  for. **Drops out**, as it does today.
+
+Where the implied container contradicts the source's declared type, either
+container has narrowed the position to nothing readable, and it **drops out**.
+
+**The recursion descends `items` as well as `properties`.** That is what makes
+both container answers hold at depth, and each half of it is a read that
+changes when the descent is missing:
+
+| Constructed schema | Result |
+| --- | --- |
+| `details` object `required`, its `values` array of `string` `required` | `undefined` |
+| the same, `values` **not** required | `{"details":{},"title":"Visible"}` |
+| `rows` array `required`, item object's `id` `required` and narrowed to `string` | `undefined` |
+| the same, `id` **not** required at the item level | `{"rows":[{"name":"a"}],"title":"Visible"}` |
+
+Rows one and two are the array case reached through an object: dropping the
+inner `required` contains the failure at `details`, and the read survives. Rows
+three and four are the object case reached through an array, and they are the
+sharper of the two — an item object that voids does not merely lose itself, it
+voids the array holding it, and the array's absence then voids whatever
+required the array. **An object's tolerance of an omitted property does not
+survive being an array element**, so the rule has to reach the item's own
+`required` to keep the read.
+
+What bounds it: nothing else in the honored vocabulary escalates. The honored
+keys descend to exactly two kinds of child — an object property, whether named
+in `properties` or admitted by `additionalProperties`, and an array element —
+and only the element descent voids its container on a child's failure.
+`invalidArray` is returned from exactly two places in `traverse.ts`, the array
+branch of `_traverseWithSchemaInner` and the fast path in
+`traversePlainSchemaWithReads`, and both are the same whole-array `valid` flag
+set by a failing element. The tier C keywords that might otherwise reject a
+container — `minItems`, `maxItems`, `uniqueItems`, `minProperties`,
+`maxProperties` — appear nowhere in `traverse.ts`, and tier C stops them at the
+boundary regardless.
+
+One narrower bound, stated so it is not mistaken for a reason to keep a key:
+where the caller's item schema admits `null` or `undefined`,
+`traverseArrayWithSchema` substitutes that in the failing element's place
+instead of voiding, so `{"type":["string","null"]}` over `[1]` reads `[null]`
+and the array survives. The rule does not lean on it. Dropping a key that would
+have survived costs nothing — the rule only ever declines to void a read —
+while keeping one that would not costs the entire read.
+
+Two consequences worth stating. The concise path is undisturbed:
+`conciseSelectionSchema` writes `type: "object"`, `properties`,
+`additionalProperties` and `true` leaves, with no `items` and no scalar types
+at all, so every position it produces falls under the first case or the object
+case and keeps the `required` it derives now — which is what lets `--select`
+stay out of scope. The array case cannot arise there at all, because stating an
+element type needs a spelling the field-path grammar does not have. And the
+rule only ever declines to void a read; it cannot empty one that succeeds
+today.
 
 ## Four tiers
 
@@ -224,12 +409,12 @@ Their treatment is: **the caller's tier C constraint is consumed during
 inference and is not propagated.** That is a claim about the caller's key, not
 about the keyword. The reader may legitimately emit the same keyword from a
 different origin: `selectSourceSchema` reconstructs `required` from the *source*
-schema, filtered to the properties that survived selection, and that `required`
-carries the source's meaning across the read boundary. Discarding what the
-caller wrote must leave that derivation intact — the two are one spelling over
-two origins, and only one of them is the caller's to supply. A key that changed
-the read, was then discarded, and whose spelling the reader may re-emit on its
-own authority is a third thing. A registry that records a class rather than a
+schema, filtered by the survival rule above, and that `required` carries the
+source's meaning across the read boundary. Discarding what the caller wrote must
+leave that derivation intact — the two are one spelling over two origins, and
+only one of them is the caller's to supply. A key that changed the read, was
+then discarded, and whose spelling the reader may re-emit on its own authority
+is a third thing. A registry that records a class rather than a
 spelling has to be able to say so — which is the reason to record a class at
 all: a key admitted without its kind has its treatment decided by whatever the
 reader happens to default to.
@@ -241,9 +426,59 @@ registries from forking when a keyword like `tier` or `deprecated` is added to
 the durable dialect. Because the outgoing schema is constructed key by key, a
 tolerated key is a decision rather than a default: it is accepted from the
 caller, and it reaches the constructed schema only where carrying it is provably
-inert. `$id` and `$schema` are the plain case for dropping — they declare the
-identity and dialect of a *document*, and the reader is not producing the
-caller's document.
+inert.
+
+**The derivation supplies the candidates. It does not supply that proof.**
+`ANNOTATION_KEYS` records which keywords the compatibility checker may ignore
+when it compares two schemas across an update. That says nothing about what the
+*runner* does with a key on a read; they are different questions about
+different code, and only the second one decides whether carrying a key is
+inert. So inertness is a separate obligation, discharged **per key against the
+runner** — `packages/runner/src/traverse.ts` and
+`packages/runner/src/schema-view.ts`, the modules that act on a schema past the
+read boundary — and never against the registry the candidates came from. A key
+that cannot be shown inert there is accepted and dropped rather than carried.
+
+Three of the twelve are accepted without reaching the constructed schema:
+
+- `$id` and `$schema` declare the identity and dialect of a *document*, and the
+  reader is not producing the caller's document.
+- **`$comment` is not inert: the runner acts on it.** Three of its values are
+  reserved as control markers. `schema-view.ts` defines `EXCLUDED_EMPTY`,
+  `EXCLUDED_MISSING` and `EXCLUDED_REJECTED` as `$comment: "emptyProperties"`,
+  `"missingProperty"` and `"rejectedProperty"`, and `isExcluded` in that module
+  tests a schema for exactly those three; `traverse.ts` holds the first two as
+  `EMPTY_PROPERTIES_MARKER` and `MISSING_PROPERTY_MARKER`, and
+  `SchemaObjectTraverser.traverseObjectWithSchema` tests a property's schema
+  for them by value. They are how the runner tells a position the schema did
+  not select from one it selected as anything, so a caller writing one is not
+  annotating a schema — they are writing runner control flow and having the
+  CLI carry it across the read boundary.
+
+Measured on a read: where a property schema of `true` returns that property, a
+property schema of `{"$comment":"emptyProperties"}` returns `{}`, and
+`"missingProperty"` does the same — `traverseObjectWithSchema` routes both to
+`addOptionalProperty`, which the eager read's object creator implements as a
+no-op. Put either on a position the source marks `required` and the read
+returns `undefined` altogether: the property never reaches the object, and the
+required check voids the object around it. That is [#5734]'s shape a fourth
+time, over a key the tier called inert because nobody asked the runner.
+
+**A carried `$comment` is caller-forgeable control flow reaching the read
+boundary** — precisely what this document's general rule exists to prevent.
+
+Dropping the key beats refusing the three reserved values, though refusing is
+the option that would preserve a caller's genuine comments. A refusal has to
+know what is reserved, and that list is not derivable: both marker sets are
+module-private frozen constants, they sit in two different runner modules, and
+they do not agree with each other — `traverse.ts` acts on two of the values,
+`schema-view.ts` on three. Tracking them from `packages/cli` would add a second
+cross-package coupling, this one with no registry to derive from and no
+fallback test available, and a marker added to the runner later would re-open
+the hole in silence. Dropping needs to know nothing and cannot be circumvented
+by a value nobody has reserved yet. What it costs is a caller's genuine
+`$comment`, which has no reader: the schema that reaches the boundary is the
+CLI's, and nothing displays the caller's copy.
 
 **R** is everything else, and it keeps three keys that are *also* annotation
 keys: `default`, `$defs`, and `definitions`. All three are refused today, for
@@ -257,6 +492,10 @@ Tier T couples the projection reader to the compatibility checker. Three
 properties of that coupling are easy to state wrongly, and each one wrong costs
 something concrete: a red test, a derivation that admits keys projection cannot
 honor, and a refusal message that sends a caller somewhere that does not exist.
+
+All three are about which keys the derivation *offers*. Whether carrying an
+offered key is inert is a separate question with a different answer key — the
+runner — and tier T above says how it is discharged.
 
 ### 1. The derivation is not one-to-one
 
@@ -408,13 +647,14 @@ happens to a key, never what a key means.
 - A key in no tier is refused, and the message names the key and its position.
 - A caller-written tier C key is read for container inference and no
   caller-written tier C constraint reaches the read boundary.
-- The reader's own derivation is untouched by the bullet above: a read whose
-  source schema marks a projected property required still carries `required`
-  past the read boundary, filtered to the projected properties, exactly as
-  `selectSourceSchema` builds it.
+- The reader's own derivation survives the bullet above: a read whose source
+  schema marks a projected property required still carries `required` past the
+  read boundary. It is filtered by the survival rule rather than by projection
+  membership, so `selectSourceSchema`'s present filter is the part that
+  changes, not the part that is preserved.
 - A test holds those two apart, **inspecting the output schema specifically**: a
   caller's `required` does not survive into it, and a source-derived `required`
-  does, filtered to the projected properties. The schema it inspects is the one
+  does, filtered by the survival rule. The schema it inspects is the one
   `deriveSelectedValue` re-asserts on `result.key("value")`, read back off that
   output cell. **A selector captured from the storage provider does not satisfy
   this and cannot stand in for it**: that selector is `sourceReadSchema`, built
@@ -423,9 +663,45 @@ happens to a key, never what a key means.
   dropping it from the output schema would pass an assertion over it while
   failing this criterion. The two schemas have to be asserted separately because
   they are two schemas.
-- A tier T key is accepted and changes nothing about what is read.
+- **A tier T key is accepted, and a read through a projection carrying it
+  returns what the same projection returns without it.** Asserted as a read
+  outcome, per key, against a value the key could plausibly disturb — not as
+  membership in `ANNOTATION_KEYS`, and not as a property of the normalized
+  schema. This is the criterion `$comment` fails, and would have failed on the
+  day it was admitted: a membership assertion passes for a key the runner acts
+  on, so membership can never stand in for inertness.
 - A projection naming a `required` field it does not project reads the fields it
   does project, rather than nothing.
+- **One test covers a source-required property and a caller type mismatch
+  together**: a source declaring `id` (number) `required` alongside `title`,
+  read through a projection asking for `id` as a string and `title`, returns
+  the object with `title` and without `id` — not `undefined`. **The two
+  criteria this one combines do not expose the interaction between them**, so a
+  reader who assumes they do will leave it untested. The [#5734] criterion
+  projects a required field the caller *does not name*, which the derivation
+  drops for absence under any survival rule; the nested type-mismatch criterion
+  uses a property the source does not require, so nothing voids around the
+  omission. The failure needs both halves at once and shows up in neither half
+  alone.
+- **One test covers a source-required array and a caller item-type mismatch
+  together**: a source declaring `values` (an array of numbers) `required`
+  alongside `title`, read through a projection asking for `values` with
+  `items` of `{"type":"string"}`, returns the object with `title` and without
+  `values` — not `undefined`. **The combined criterion above does not cover
+  this one**, and neither does any pairing of the criteria it combines. That
+  one narrows a *scalar property*, and the object it sits in survives the
+  narrowing by omitting it; here the caller narrows an *element*, the whole
+  array is rejected because one element was, and the read fails at the array
+  before any `required` under it is consulted. A survival rule that treats the
+  two containers as one case passes the scalar criterion and fails this one.
+- **A source-required array of objects with a mismatched leaf still reads.** A
+  source declaring `rows` (an array of objects, each with a required number
+  `id`) `required`, projected with `id` narrowed to `{"type":"string"}`,
+  returns `rows` with each object's remaining fields rather than `undefined`.
+  This is the criterion that fails when the survival rule recurses through
+  `properties` but not through `items`: the item object's own derived
+  `required` is the only thing standing between a narrowed leaf and a voided
+  array.
 - A misspelled `properties` beside a stated `type` is refused, rather than
   returning the whole object.
 - **A scalar leaf whose declared type does not match the stored value is still

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -150,8 +150,17 @@ about by the CLI beyond container inference, and acted on by the runner, so
 tolerating it forwards it. #5734 is that failure — an unsatisfiable `required`
 empties the whole read, exit 0 — and it belongs to this item. The rule its fix
 needs already exists one call site over: `selectSourceSchema` derives the
-constructed schema's `required` from the *source*, filtered to the properties
-that survived selection, with a comment giving exactly this reason.
+constructed schema's `required` from the *source*, with a comment giving exactly
+this reason. **Its filter needs the survival test that comment describes**,
+though. As written the filter asks only whether the caller projected the
+position, so a property the caller projected under a type its value fails stays
+required, is then dropped by traversal, and empties the read — #5734 again,
+over a key no caller wrote. Ceasing to carry the caller's `required` without
+that does not fix #5734; it relocates it. The design works the rule out, and
+the two containers do not answer it alike: a rejected object property is
+omitted and the object survives, while a rejected array element voids the
+array, so a caller's element type takes down the whole property and everything
+that required it.
 
 *Four tiers, not three.* Honored (`type`, `properties`, `items`,
 `additionalProperties`, `$link`); **consulted** (`required`, `minProperties`,
@@ -182,6 +191,15 @@ the key, its position, and the accepted vocabulary.
 to be missing from a set drafted out of the standard JSON Schema vocabulary.
 They belong in the tolerated set on day one.
 
+**Deriving the tolerated tier gives you candidates, not a proof that carrying
+one is inert.** That proof is owed per key and is discharged against the
+runner, not against the checker's registry. `$comment` fails it: the runner
+reserves three of its values as control markers, so a caller's `$comment` is
+forgeable control flow reaching the read boundary — a projection setting one
+on a property drops that property, and one on a source-required property
+empties the read the way #5734 does. It is accepted and dropped, alongside `$id`
+and `$schema`.
+
 *Measured: nothing in the tree breaks.* Four JSON Schema keywords appear in
 keyword position across every `--schema` argument in the repository — `type`,
 `properties`, `items`, `$link` — all honored.
@@ -195,9 +213,13 @@ the caller's copy goes no further, while the source-derived `required` the
 reader builds still reaches the read boundary — asserted against the output
 schema itself, which the selector handed to the storage provider is not; a
 projection naming a `required` field it does not project reads the fields it
-does; and a caller's scalar `type` still filters the leaf it is written on, at
-depth as well as at an array item. A command that ran only because a key was
-silently dropped now fails loudly, which is the point rather than a regression.
+does; a caller's scalar `type` still filters the leaf it is written on, at
+depth as well as at an array item; and a source-required array narrowed by a
+caller's item type reads its siblings rather than emptying the object, which
+the scalar cases do not cover because the array's failure escalates from an
+element rather than occurring where the caller wrote it. A command that ran
+only because a key was silently dropped now fails loudly, which is the point
+rather than a regression.
 
 **3. A rejection propagates up through what holds it.** *(S)* The projection
 mask reduces either container whose whole selection rejects — an array whose


### PR DESCRIPTION
Closes #5783.

## Why

Two defects landed with #5753 and are on `main` now. Both were found by review reading the code the design names, and both are the same mistake: **a key admitted by a set-membership rule without checking what the runtime does with it.** A third, below, is that same mistake made once more *inside the fix for the first* — a container case reasoned about generally and verified only against objects. Review caught it before it landed.

### 1. Source-derived `required` conflicts with preserved type filtering

The design requires reconstructing `required` from the source, and separately requires a mismatched scalar child to be omitted without invalidating its parent. Those collide when the omitted child is source-required — reproduced directly against a real `Runtime`:

| | result |
| --- | --- |
| today | `{"title":"Visible"}` |
| through the design's constructed schema | **`undefined`** |

The whole read empties. `selectSourceSchema` filters `required` on **projection membership, not survival**, so a property the caller projected but traversal drops stays required.

**That is #5734's failure mode, arriving through the document that folds #5734 in and claims to fix it.** The document now says so.

Mechanism confirmed end to end: `traverseWithSchema` fails `invalidType`, `traverseObjectWithSchema` omits the property, its closing required check returns `undefined`, and the parent reads that as `invalidObject` — so the emptying climbs to the root.

### 2. Caller `$comment` is classified inert; the runner acts on it

Tier T admits `$comment` by deriving from `ANNOTATION_KEYS`. But `$comment` carries traversal control markers. Reproduced: property schema `true` returns `{"title":"Visible"}`; `{"$comment":"emptyProperties"}` returns `{}`; `"missingProperty"` likewise.

So a carried caller `$comment` is **caller-forgeable control flow reaching the read boundary** — the precise thing the design's general rule exists to prevent.

**The two compound.** `$comment` on a source-*required* position empties the whole read — #5734's shape a fourth time.

### 3. A single container case in the survival rule is wrong for arrays

The rule this PR writes has to answer for arrays as well as objects, and one container case cannot. A source-`required` array narrowed by a caller's item type empties the whole read, exactly as the scalar case did — reproduced against a `SchemaObjectTraverser`:

| Constructed schema over `{"values":[1],"title":"Visible"}` | result |
| --- | --- |
| `values` an array of `string` | `{"title":"Visible"}` |
| `values` an array of `string`, **`required`** | **`undefined`** |

**The mechanism is an asymmetry between the containers that nothing documented.** `traverse.ts:traverseObjectWithSchema` assembles an object and never assigns a property whose traversal failed — the object survives. `traverse.ts:traverseArrayWithSchema` carries one `valid` flag across every element and returns `undefined` if any element failed; its own comment says *"the ENTIRE array reads as invalid for this caller."* Measured side by side, with the same shape of narrowing one level down:

| source value | constructed child | result |
| --- | --- | --- |
| `{"a":1,"b":"ok"}` | object, `a` and `b` both `string` | `{"b":"ok"}` |
| `[1,"ok"]` | array, `items` `string` | the property is **gone** |

An object drops the child that failed and keeps the one that passed. An array discards the element that matched along with the one that did not. The previous round verified the container case against *object* containers only, and the asymmetry is why that generalised wrongly.

## What Changed

**A survival rule for `required`**, stated as one question — *can anything the caller wrote inside this property cause the property itself to be rejected?* — and answered per case: caller states no type → stays (the mask answers with the source's own schema); caller states a **scalar** type → **drops**; caller states an **object** → stays, because a narrowed descendant is omitted rather than rejecting the object, provided each descendant's own `required` follows the same rule; caller states an **array** → follows the *element* schema, because a rejected element voids the array itself, so a scalar `items` type **drops** while a wildcard `items` or an object `items` stays; caller writes `false` → drops, as today.

**This is the generalisation, not an array special-case.** The criterion is uniform; only the answer differs, and it differs because of a property of the runner rather than of the rule. An object has an omission escape and an array does not, so "the caller narrowed something inside this child" means *a descendant may be omitted* under an object and *the child itself is rejected* under an array. An array also has no `required` of its own for the recursion to empty, so there is nothing below it to absorb the rejection — which is why the object case's recursion argument does not transfer.

**The recursion descends `items` as well as `properties`**, and both halves were measured. An array nested in a projected object is contained by dropping the inner `required`. An array *of objects* with a narrowed leaf is the sharper one: an item object that voids does not merely lose itself, it voids the array holding it. **An object's tolerance of an omitted property does not survive being an array element.**

Bounded: the honored keys descend to exactly two kinds of child, and only the array element voids its container — `invalidArray` is returned from exactly two places in `traverse.ts`, both the same whole-array `valid` flag. The tier C keywords that might otherwise reject a container appear nowhere in `traverse.ts` and never reach the boundary anyway.

The concise path stays undisturbed and `--select` stays out of scope: `conciseSelectionSchema` writes no `items` and no scalar types, so the array case cannot arise there — stating an element type needs a spelling the field-path grammar does not have.

**Caller `$comment` is dropped, not refused.** Refusing needs to know what is reserved, and that list is not derivable: both marker sets are module-private frozen constants in two different runner modules, and **they disagree** — `traverse.ts` tests two values, `schema-view.ts:isExcluded` tests three. Tracking them from `packages/cli` adds a cross-package coupling with no registry behind it and no fallback test available, and a marker added later re-opens the hole silently. Dropping needs to know nothing, and a caller's genuine `$comment` has no reader.

**Four exit criteria.** A *combined* required-plus-type-mismatch case, stating explicitly why the two criteria it combines do not expose the interaction — the #5734 criterion projects a required field the caller does not name, and the type-mismatch criterion uses a property the source does not require. A *source-required array plus item-type mismatch* case, which that combined criterion does not cover either: it narrows a scalar property and the object survives by omitting it, where this narrows an element and the array is rejected before any `required` under it is consulted. A *source-required array of objects with a mismatched leaf*, which is what fails when the rule recurses through `properties` but not through `items`. And a *behavioural* tier T criterion, asserted as a read outcome per key rather than as `ANNOTATION_KEYS` membership.

**Tier T now says the general thing**: the derivation supplies **candidates**; inertness is a separate per-key obligation discharged against the runner, not the registry.

Four consequential-staleness fixes ride along, all the same phrasing that hid the bug — "filtered to the properties that survived selection" / "exactly as `selectSourceSchema` builds it" — now pointing at the survival rule, including item 2 in `verbs-implementation.md`.

## Test plan

- `deno task check-docs` → **0** (550 blocks)
- `deno task check-skill-facts` → **0** (45 documents)
- `deno task check-conflict-markers` → **0**
- `deno task docs-links --orphan` → **0**

Rebased onto `origin/main` (through #5782) before these ran.

The first two defects were reproduced against a real `Runtime` before the rule was written. The third was reproduced against a `SchemaObjectTraverser` over a backing store — ten cases covering both containers with and without `required`, the two nesting directions, and the `null`-admitting item schema that substitutes instead of voiding. No `deno fmt` evidence claimed — `docs/` is excluded.

## Correction to #5783

That issue lists `"rejectedProperty"` among the values affecting this read path. It does not: `traverse.ts:traverseObjectWithSchema` tests only `"emptyProperties"` and `"missingProperty"`. All three are tested by `schema-view.ts:isExcluded`. The disagreement between the two lists is itself the argument for dropping rather than refusing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


