### PR TITLE
test(memory): pin the ack a session closed mid-flight must not schedule

### DIFF
--- a/packages/memory/test/v2-client-watch.test.ts
+++ b/packages/memory/test/v2-client-watch.test.ts
@@ -1,6 +1,12 @@
 import { assertEquals } from "@std/assert";
 import { Server } from "../v2/server.ts";
-import { connect, loopback, WatchView } from "../v2/client.ts";
+import {
+  connect,
+  loopback,
+  type SpaceSession,
+  type Transport,
+  WatchView,
+} from "../v2/client.ts";
 import type { EntitySnapshot } from "../v2.ts";
 import {
   testSessionOpenAuthFactory,
@@ -162,6 +168,86 @@ Deno.test("memory v2 client installs a watch set and receives live updates", asy
   } finally {
     await writerClient.close();
     await watcherClient.close();
+    await server.close();
+  }
+});
+
+/**
+ * `runWatchMutation()` checks that the session is open when the call is made
+ * and then awaits the response, so the `apply` step that acks that response
+ * can run after the session has closed. A closed session must arm no new
+ * work: `close()` drains the background tasks it knows about and returns, so
+ * anything queued afterwards is work that nothing awaits.
+ *
+ * The armed timer is the observation, because the wire cannot tell the two
+ * cases apart. `flushScheduledAcks()` independently declines to speak for a
+ * closed session, so no `session.ack` frame is sent either way, and a test
+ * that watched the wire would pass whether or not the session still schedules
+ * the ack.
+ */
+Deno.test("memory v2 session closed mid-watch-set arms no ack timer", async () => {
+  const server = new Server({
+    ...testSessionOpenServerOptions,
+    store: new URL("memory://watch-set-close-before-apply"),
+    subscriptionRefreshDelayMs: 0,
+  });
+  const inner = loopback(server);
+
+  let setRequestId: string | null = null;
+  let closing: Promise<void> | null = null;
+  let session: SpaceSession | null = null;
+  let countTimers = false;
+  let timersArmed = 0;
+
+  const transport: Transport = {
+    send(payload: string) {
+      // Frames carry the `fvj1:` fabric-value encoding, not bare JSON, so this
+      // reads the payload as text.
+      if (payload.includes('"session.watch.set"')) {
+        setRequestId = /"requestId":"([^"]+)"/.exec(payload)?.[1] ?? null;
+      }
+      return inner.send(payload);
+    },
+    close: () => inner.close(),
+    setReceiver(receiver: (payload: string) => void) {
+      inner.setReceiver((payload: string) => {
+        if ((setRequestId !== null) && payload.includes(setRequestId)) {
+          setRequestId = null;
+          // The close lands between the response frame and the `apply` that
+          // frame resolves, so the session is already closed when `apply`
+          // reaches its ack.
+          closing = session?.close() ?? null;
+          countTimers = true;
+        }
+        receiver(payload);
+      });
+    },
+    setCloseReceiver: (r) => inner.setCloseReceiver?.(r),
+  };
+
+  const client = await connect({ transport });
+  const space = "did:key:z6Mk-watch-set-close-before-apply";
+  session = await client.mount(space, {}, testSessionOpenAuthFactory);
+
+  // Counted rather than faked: the timer is armed for real, and only the
+  // count is observed. Saved and restored rather than assumed native, since a
+  // package preload may already own this property.
+  const realSetTimeout = globalThis.setTimeout;
+  globalThis.setTimeout = ((...args: Parameters<typeof setTimeout>) => {
+    if (countTimers) timersArmed++;
+    return realSetTimeout(...args);
+  }) as typeof setTimeout;
+
+  try {
+    await session.watchSetSync([]);
+    // `apply` has run by now: the mutation resolves on its return value.
+    countTimers = false;
+    assertEquals(closing !== null, true, "the close raced the apply");
+    await closing;
+    assertEquals(timersArmed, 0, "a closed session arms no ack timer");
+  } finally {
+    globalThis.setTimeout = realSetTimeout;
+    await client.close();
     await server.close();
   }
 });


### PR DESCRIPTION
`packages/memory/v2/client.ts` lines 1101-1102 — the closed-session guard in
`scheduleAck()` — are covered on some CI runs and not others with no change to
their source, so the coverage-debt gate charges the movement to whatever pull
request happens to be measured against a run that covered them. #5776, a pure
rename that does not touch `client.ts`, spent an `ACCEPT_COVERAGE_DEBT` marker
on it. This is the follow-on that gate's comment asks for.

I (agent working on behalf of @danfuzz) drove the condition rather than
re-running until it looked settled.

## Why the line moves

`runWatchMutation()` calls `#assertOpen()` when the call is made and then
awaits the response, so the `apply` step that acks that response can run after
the session closed — the in-flight request is not one of the outstanding
commits `close()` rejects. Whether the close lands before or after the response
is an ordering race, which is why the line flaps.

The test makes the order deliberate: a loopback transport closes the session
from inside its receiver, immediately before forwarding the `watch.set`
response, which puts the close between the response frame and the `apply` it
resolves.

## What it observes, and why not the wire

The obvious assertion — a closed session puts no `session.ack` on the wire —
**cannot fail**. `flushScheduledAcks()` independently checks the closed flag,
so the wire is silent whether or not the guard exists. I wrote that test first,
deleted the guard, and watched it pass anyway.

So the test observes the timer the ack would arm. That is the guard's own
effect: a closed session arms no further work. `close()` drains the background
tasks it knows about and returns, so anything queued afterwards is awaited by
nothing. The timer is armed for real and only counted; `setTimeout` is saved
and restored rather than assumed native, since a package preload may already
own that property.

## Verification

- **Ablation.** With the guard deleted the test fails on the armed timer
  (expected `0`, got `1`). `client.ts` was restored byte-exact afterwards —
  this PR changes one test file and no source.
- **The measurement `docs/development/COVERAGE.md` prescribes.** Clean profile
  directory, this test alone: `DA:1101,1` and `DA:1102,1`, with `DA:1104,0`
  confirming the guard fired rather than fell through.
- Full `memory` suite green (499 passed). Repo-wide `deno fmt --check`,
  `deno lint`, `deno task check` and `deno task check-no-waitfor` all pass.

No assertions were deleted, nothing is marked ignored, and the gate is
unchanged.

## The other way to fix this, if a reviewer prefers it

The reason the honest assertion took finding is that the guard is very nearly
redundant. `flushScheduledAcks()` already refuses to speak for a closed
session, and every other caller is already gated: `handleEffect()` checks the
closed flag first, the post-flush re-arm at line 1123 checks it in its own
condition, and `restore()`'s two calls sit after the check at line 963 with no
`await` between, so the flag cannot change under them. That leaves the `apply`
callbacks of `watchSetSync()` and `watchAddSync()` as the only sites that can
reach `scheduleAck()` on a closed session — and everything they would go on to
do is declined downstream anyway.

So the alternative is to delete lines 1101-1102 rather than cover them. A line
that does not exist cannot flap, and the gate stops charging anyone for it.
That is a smaller diff than this one and it removes a branch instead of adding
a test.

What it gives up:

- **Post-close work still gets queued.** `#pendingAckSeq` advances and a
  background task is armed after `close()` has already snapshotted and drained
  `#background`, so that task is awaited by nothing. It is harmless today
  because the flush declines, but "harmless because something downstream
  catches it" is a property that holds until someone edits the downstream
  check.
- **It is a behavior change in a foundation package**, where this PR is a test
  and no source change at all.
- **The redundancy stops being enforced.** Nothing would then fail if a later
  change made `scheduleAck()` reachable-and-consequential on a closed session.

If you would rather go that way, the test in this PR is what makes the choice
visible: delete the guard and it fails on the armed timer, so the decision
surfaces as a red test rather than as drift. Either outcome fixes the flake —
this is a judgment call about which invariant is worth keeping, not about
whether the gate goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vyoNfY94Mn4biMaEz3gni


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


