### PR TITLE
fix(cli): the verb listing stops losing verbs the result type omits

### DIFF
--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -100,6 +100,14 @@ do I get" are answerable before the first call rather than by making one:
 A value-less verb carries no `outputSchema` at all, which is how a caller tells
 the two apart without calling.
 
+The listing names every verb the piece exposes, including one the pattern's
+declared result type does not mention: a pattern whose result type is its
+argument schema reused still returns the streams it wired, and those are as
+callable as any other. What it does *not* name is a data field — a property
+with no stream stored behind it is never offered as callable. Absence from the
+listing therefore means there is nothing to call, not that the listing could
+not see it.
+
 One verb at a time, `--help` answers the same question from the callable
 itself:
 

--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -100,13 +100,32 @@ do I get" are answerable before the first call rather than by making one:
 A value-less verb carries no `outputSchema` at all, which is how a caller tells
 the two apart without calling.
 
-The listing names every verb the piece exposes, including one the pattern's
-declared result type does not mention: a pattern whose result type is its
-argument schema reused still returns the streams it wired, and those are as
-callable as any other. What it does *not* name is a data field — a property
-with no stream stored behind it is never offered as callable. Absence from the
-listing therefore means there is nothing to call, not that the listing could
-not see it.
+The listing names verbs the pattern's declared result type does not mention: a
+pattern whose result type is its argument schema reused still returns the
+streams and tools it wired, and those are as callable as any other. Candidate
+names are drawn from the piece's stored surface and from its compiled pattern,
+and each one is listed only when the piece stores a callable behind it — so a
+data field is never offered as callable, whatever the pattern hangs at that
+name.
+
+Every row is real: a name in the listing is a name `cf piece call` resolves.
+The converse is weaker, and worth knowing before treating an empty listing as
+an answer:
+
+- A handler whose stored schema carries no stream marker is **callable but not
+  listed**. Nothing stored distinguishes it from a data field, and the one
+  probe that finds it accepts every name it is given, so listing on that probe
+  would offer the whole piece as callable. Given such a verb's name,
+  `cf piece call` still reaches it.
+- When the compiled pattern cannot be read, a verb the declared result type
+  omits has no other source of its name and is missing. The listing says so
+  rather than passing the short list off as the surface: `incomplete` carries
+  `"pattern-unavailable"` in `--json`, and the human listing prints the same
+  note. The verbs it does name are still callable.
+
+So absence from a listing that reports no `incomplete` means no *listable*
+verb of that name — strong enough to enumerate against, not strong enough to
+prove a named verb does not exist.
 
 One verb at a time, `--help` answers the same question from the callable
 itself:

--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -108,7 +108,13 @@ and each one is listed only when the piece stores a callable behind it — so a
 data field is never offered as callable, whatever the pattern hangs at that
 name.
 
-Every row is real: a name in the listing is a name `cf piece call` resolves.
+Every row is real, and says where it lives: a name in the listing is a name
+`cf piece call` resolves, and the row's `on` names the cell the dispatcher
+will reach it on. Result shadows input there exactly as it does in
+`cf piece call`, so a verb stored on both cells is listed — and called — on
+the result cell, carrying that cell's schema. Build a payload from the row and
+it is the payload the verb you reach expects.
+
 The converse is weaker, and worth knowing before treating an empty listing as
 an answer:
 

--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -376,6 +376,31 @@ script separately checks the expected artifact names
 coverage files. A manual run without the environment variable uses the GitHub API
 download path instead.
 
+### Measuring a before/after locally
+
+The gate reports a group total rather than a per-line diff, so localizing a rise
+means measuring the same group twice: once with the branch's tree, once with the
+tree it will merge onto. Set `DENO_COVERAGE_DIR` for each run and convert with
+`tasks/write-coverage-lcov.ts`, exactly as the CI jobs do, then compare the two
+LCOV reports' zero-hit lines across the files the branch changed.
+
+Take both measurements from the same base. Rebasing between them straddles two
+trees and the delta stops meaning anything, so rebase first and measure after.
+
+A local total will not match CI's. CI sums a group over every job that loads its
+files and one local suite loads a subset, so the absolute numbers differ. The
+offset is constant between two runs of the same suite, which is what leaves the
+delta comparable when the totals are not.
+
+The baseline half checks the merge base out over the packages being measured, so
+for the length of that run the worktree holds the base's code rather than the
+branch's. A tree sampled during it reads as though the branch had been reverted.
+It has not been: the branch's work is in its commits, and anything uncommitted is
+in the stash the measurement pushed. `git stash list` and
+`git grep <symbol> <branch-sha> -- <paths>` settle that from outside the run,
+without waiting for it to finish. Restore with `git checkout HEAD -- <paths>`
+followed by `git stash pop`.
+
 ## Compile cache state and cold runs
 
 The pattern test jobs restore a compile byte cache keyed on a fingerprint hash

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -373,7 +373,11 @@ never proposes is indistinguishable to that caller from one that was
 deprecated or retired. `cf piece verbs` therefore draws its candidates from
 the piece's stored surface and its compiled graph rather than from the
 pattern's declared result type, and a verb the type omits is listed on the
-same terms as one it names.
+same terms as one it names. Two residual gaps are the probing caller's to
+know about, and [the CLI verb guide](../common/verbs-over-the-cli.md) states
+both: a listing reporting `incomplete` is a lower bound, and a handler whose
+stored schema carries no stream marker is callable without ever being listed.
+Absence is evidence of retirement only on a listing that reports neither.
 
 | Provider evolution | Full Output | Fields only | Req. verb | Opt. verb | Versioned |
 | --- | --- | --- | --- | --- | --- |
@@ -634,10 +638,11 @@ channel exists — the shape already lifts deprecation out of JSDoc into
 listings — and it carries a standing precondition, because that channel is
 the listing surface: instructions served over a surface that drops their
 subject arrive incomplete, so whatever carries them must ride an enumeration
-that names every verb the piece has, not the subset its declared result type
-mentions. Scoped acknowledgment is the natural place to ask for the
-instructions themselves: a deliberate break proceeds when it says what those
-it breaks should do instead.
+no narrower than the piece's stored surface and its compiled graph, and must
+propagate that enumeration's own report of when it fell short rather than
+serving a quietly shortened set. Scoped acknowledgment is the natural place
+to ask for the instructions themselves: a deliberate break proceeds when it
+says what those it breaks should do instead.
 
 The anchors are the systems that permit breakage and manage it rather than
 forbid it. Kubernetes deprecates an API, keeps serving it for a published

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -367,12 +367,13 @@ provider's whole **Output** type (today's default), a narrow demand naming
 **fields only**, one naming a **required verb**, one naming an **optional
 verb**, and a **versioned** interface demand. Probing callers are omitted —
 they bind late and survive every *evolution* row, which is what the table
-scores. What late binding does not survive is an enumeration defect: [#5698]
-measures 8 callable verbs across 4 files that `cf piece verbs` and
-tab-completion both miss, because candidate names are built from the declared
-result type rather than from what the piece stores. A probing caller is
-therefore only as good as the listing it probes, and absence from one today
-is ambiguous between deprecated, retired, and never enumerated.
+scores. What late binding does not survive is an enumeration defect, so a
+probing caller is only as good as the listing it probes: a name the listing
+never proposes is indistinguishable to that caller from one that was
+deprecated or retired. `cf piece verbs` therefore draws its candidates from
+the piece's stored surface and its compiled graph rather than from the
+pattern's declared result type, and a verb the type omits is listed on the
+same terms as one it names.
 
 | Provider evolution | Full Output | Fields only | Req. verb | Opt. verb | Versioned |
 | --- | --- | --- | --- | --- | --- |
@@ -630,13 +631,11 @@ person, a recipe for a tool. Where it lives matters most: askable of the
 piece itself, so an agent watching a holding piece's errors can ask the
 held piece for upgrade instructions and decide whether to apply them. The
 channel exists — the shape already lifts deprecation out of JSDoc into
-listings — and it carries a named precondition, because that channel is the
-listing surface: while [#5698] holds, the listing omits verbs the piece
-really has, and instructions served over a surface that drops their subject
-arrive incomplete. Closing that enumeration gap is on this direction's
-critical path; where it sits in the order is the owner of
-[the verbs implementation plan](verbs-implementation.md) to decide, not this
-document. Scoped acknowledgment is the natural place to ask for the
+listings — and it carries a standing precondition, because that channel is
+the listing surface: instructions served over a surface that drops their
+subject arrive incomplete, so whatever carries them must ride an enumeration
+that names every verb the piece has, not the subset its declared result type
+mentions. Scoped acknowledgment is the natural place to ask for the
 instructions themselves: a deliberate break proceeds when it says what those
 it breaks should do instead.
 
@@ -689,5 +688,4 @@ Five smaller calls belong to whoever does the work:
   rather than one list is for.
 
 [#5663]: https://github.com/commontoolsinc/labs/issues/5663
-[#5698]: https://github.com/commontoolsinc/labs/issues/5698
 [#5746]: https://github.com/commontoolsinc/labs/pull/5746

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -638,7 +638,7 @@ from a plan is one nobody schedules, which is the whole reason for this table.
 | --- | --- | --- |
 | #5633 | a projected read fails on the SECOND read of the same source and schema; the handler is a red herring | **in review** (#5764) — a list coordinator owes the setup writes a lost commit discarded, its result container's links among them. #5706, which is why it reproduces every time, stands |
 | #5576 | `cf piece verbs` lists data fields as handlers, so discovery reports what cannot be called | **fixed** by #5683, with #5662 |
-| #5698 | `cf piece verbs` returns nothing for a piece whose declared result type omits its verbs, though they are callable | the other direction of the same surface: 8 verbs invisible to the listing AND to tab-completion |
+| #5698 | `cf piece verbs` returns nothing for a piece whose declared result type omits its verbs, though they are callable | the other direction of the same surface, and **fixed** by #5793: the listing enumerates candidates from the compiled graph as well as the result cell, and classifies each one on the stored signal that closed the first direction |
 | #5706 | a shaped read permanently writes to the user's space — per-element sub-patterns land at space scope | runner-owned, beside #5633 |
 | #5722 | a verb's help shows its usage twice, and shows no way to copy it | found by driving the surface by hand, which no test does |
 | #5558 | `piece call --help` claims every handler returns nothing, including one that declares a result | **fixed** by #5680 (the false claim) and #5717 (the enumerated fields) |

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -638,7 +638,7 @@ from a plan is one nobody schedules, which is the whole reason for this table.
 | --- | --- | --- |
 | #5633 | a projected read fails on the SECOND read of the same source and schema; the handler is a red herring | **in review** (#5764) — a list coordinator owes the setup writes a lost commit discarded, its result container's links among them. #5706, which is why it reproduces every time, stands |
 | #5576 | `cf piece verbs` lists data fields as handlers, so discovery reports what cannot be called | **fixed** by #5683, with #5662 |
-| #5698 | `cf piece verbs` returns nothing for a piece whose declared result type omits its verbs, though they are callable | the other direction of the same surface, and **fixed** by #5793: the listing enumerates candidates from the compiled graph as well as the result cell, and classifies each one on the stored signal that closed the first direction |
+| #5698 | `cf piece verbs` returns nothing for a piece whose declared result type omits its verbs, though they are callable | the other direction of the same surface, and **fixed** by #5794: the listing enumerates candidates from the compiled graph as well as the result cell, and classifies each one on the stored signal that closed the first direction |
 | #5706 | a shaped read permanently writes to the user's space — per-element sub-patterns land at space scope | runner-owned, beside #5633 |
 | #5722 | a verb's help shows its usage twice, and shows no way to copy it | found by driving the surface by hand, which no test does |
 | #5558 | `piece call --help` claims every handler returns nothing, including one that declares a result | **fixed** by #5680 (the false claim) and #5717 (the enumerated fields) |

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -2063,6 +2063,14 @@ after --. Handlers interpret piped input when no input argument is present.`,
     const omission = hiddenCount > 0 && !options.all
       ? `${partition.wrapper} wrapper, ${partition.deprecated} deprecated hidden; --all lists them`
       : undefined;
+    // The same rule the hidden counts follow, applied to the other way this
+    // listing can be short: a verb the declared result type omits is named
+    // only by the compiled pattern, so when that could not be read the list is
+    // a lower bound and must say so instead of reading as the whole surface.
+    // `--all` does not recover these — nothing here can.
+    const incomplete = listing.incomplete === "pattern-unavailable"
+      ? "the pattern could not be read, so verbs its result type omits are missing; the verbs listed are still callable"
+      : undefined;
     if (options.json) {
       render({
         ...listing,
@@ -2084,6 +2092,7 @@ after --. Handlers interpret piped input when no input argument is present.`,
           ? `<no callable verbs shown> (${omission})`
           : "<no callable verbs>",
       );
+      if (incomplete !== undefined) render(`(${incomplete})`);
       return;
     }
     if (listing.pattern) {
@@ -2104,6 +2113,7 @@ after --. Handlers interpret piped input when no input argument is present.`,
       ]).toString(),
     );
     if (omission !== undefined) render(`(${omission})`);
+    if (incomplete !== undefined) render(`(${incomplete})`);
     hint(
       cliText(
         `TIP: --json includes each verb's input schema; 'cf piece call --piece ${pieceConfig.piece} <verb> --help --json' has the full command spec.`,

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -36,7 +36,10 @@ import {
   SpaceConfig,
   stepPiece,
 } from "../lib/piece.ts";
-import type { ExecutedPieceCallable } from "../lib/piece.ts";
+import type {
+  ExecutedPieceCallable,
+  PieceCallablesListing,
+} from "../lib/piece.ts";
 import type { PatternCompatibilityReport } from "@commonfabric/piece/ops";
 import type {
   InvocationIdentity,
@@ -124,6 +127,105 @@ export function formatPatternIdentity(
   return patternRef === undefined
     ? "<unknown>"
     : `cf:module/${patternRef.identity}#${patternRef.symbol}`;
+}
+
+/** The parenthesised notes under a `cf piece verbs` listing, in print order.
+ *
+ * A listing can be short in two ways, and neither may be silent — the hidden
+ * counts always print, and so does the report that the compiled pattern could
+ * not be read. The second is not recoverable with `--all`: nothing in this
+ * command can name a verb the pattern would have named.
+ *
+ * Held apart from the command action so the exact text a caller sees is
+ * assertable without driving cliffy. */
+export function verbListingNotes(
+  listing: PieceCallablesListing,
+  partition: { wrapper: number; deprecated: number },
+  all: boolean,
+): string[] {
+  const notes: string[] = [];
+  if (partition.wrapper + partition.deprecated > 0 && !all) {
+    notes.push(
+      `${partition.wrapper} wrapper, ${partition.deprecated} deprecated hidden; --all lists them`,
+    );
+  }
+  if (listing.incomplete === "pattern-unavailable") {
+    notes.push(
+      "the pattern could not be read, so verbs its result type omits are missing; the verbs listed are still callable",
+    );
+  }
+  return notes;
+}
+
+/** Every line `cf piece verbs` prints for the human-readable view, in order.
+ *
+ * The whole view, not a fragment of it: a caller reads the omission notes
+ * against the rows above them, so a test that cannot see both together cannot
+ * tell a listing that admits it is short from one that does not. */
+export function verbListingLines(
+  listing: PieceCallablesListing,
+  all: boolean,
+): string[] {
+  const partition = partitionVerbListing(listing.verbs);
+  const shown = all ? listing.verbs : partition.shown;
+  const notes = verbListingNotes(listing, partition, all);
+  // The hidden-count note rides the placeholder when there is no table to
+  // hang it under; anything else would print a bare "(...)" with nothing
+  // above it to qualify.
+  if (shown.length === 0) {
+    const hiddenNote = partition.wrapper + partition.deprecated > 0 && !all
+      ? notes[0]
+      : undefined;
+    return [
+      hiddenNote !== undefined
+        ? `<no callable verbs shown> (${hiddenNote})`
+        : "<no callable verbs>",
+      ...notes.filter((note) => note !== hiddenNote).map((note) => `(${note})`),
+    ];
+  }
+  return [
+    ...(listing.pattern
+      ? [`PATTERN ${formatPatternIdentity(listing.pattern)}`]
+      : []),
+    Table.from([
+      ["NAME", "KIND", "ON", "MARKS"],
+      ...shown.map((v) => [
+        v.name,
+        v.kind,
+        v.on,
+        [
+          ...(v.tier === "wrapper" ? ["wrapper"] : []),
+          ...(v.deprecated ? ["deprecated"] : []),
+        ].join(","),
+      ]),
+    ]).toString(),
+    ...notes.map((note) => `(${note})`),
+  ];
+}
+
+/** The `--json` payload for `cf piece verbs`: the listing as
+ * `listPieceCallables` returned it, narrowed to the rows actually shown, plus
+ * the hidden counts when any row was withheld. `incomplete` rides through
+ * untouched — a machine reader needs the lower-bound flag more than a human
+ * does, because it has no listing text to read it off. */
+export function verbListingJson(
+  listing: PieceCallablesListing,
+  all: boolean,
+): Record<string, unknown> {
+  const partition = partitionVerbListing(listing.verbs);
+  const hiddenCount = partition.wrapper + partition.deprecated;
+  return {
+    ...listing,
+    verbs: all ? listing.verbs : partition.shown,
+    ...(hiddenCount > 0 && !all
+      ? {
+        hidden: {
+          wrapper: partition.wrapper,
+          deprecated: partition.deprecated,
+        },
+      }
+      : {}),
+  };
 }
 
 export function renderPieceSummaries(
@@ -2056,64 +2158,18 @@ after --. Handlers interpret piped input when no input argument is present.`,
     // Default view: wrapper-tier (session-UI affordances) and deprecated
     // verbs are omitted, LOUDLY — the hidden counts always print, so nothing
     // is silently invisible. Rows carry their marks in both views, and
-    // `cf piece call` never consults them.
-    const partition = partitionVerbListing(listing.verbs);
-    const hiddenCount = partition.wrapper + partition.deprecated;
-    const shown = options.all ? listing.verbs : partition.shown;
-    const omission = hiddenCount > 0 && !options.all
-      ? `${partition.wrapper} wrapper, ${partition.deprecated} deprecated hidden; --all lists them`
-      : undefined;
-    // The same rule the hidden counts follow, applied to the other way this
-    // listing can be short: a verb the declared result type omits is named
-    // only by the compiled pattern, so when that could not be read the list is
-    // a lower bound and must say so instead of reading as the whole surface.
-    // `--all` does not recover these — nothing here can.
-    const incomplete = listing.incomplete === "pattern-unavailable"
-      ? "the pattern could not be read, so verbs its result type omits are missing; the verbs listed are still callable"
-      : undefined;
+    // `cf piece call` never consults them. The same rule covers the other way
+    // this listing can be short, which `verbListingNotes` prints beside them.
     if (options.json) {
-      render({
-        ...listing,
-        verbs: shown,
-        ...(omission !== undefined
-          ? {
-            hidden: {
-              wrapper: partition.wrapper,
-              deprecated: partition.deprecated,
-            },
-          }
-          : {}),
-      }, { json: true });
+      render(verbListingJson(listing, !!options.all), { json: true });
       return;
     }
-    if (shown.length === 0) {
-      render(
-        omission !== undefined
-          ? `<no callable verbs shown> (${omission})`
-          : "<no callable verbs>",
-      );
-      if (incomplete !== undefined) render(`(${incomplete})`);
-      return;
-    }
-    if (listing.pattern) {
-      render(`PATTERN ${formatPatternIdentity(listing.pattern)}`);
-    }
-    render(
-      Table.from([
-        ["NAME", "KIND", "ON", "MARKS"],
-        ...shown.map((v) => [
-          v.name,
-          v.kind,
-          v.on,
-          [
-            ...(v.tier === "wrapper" ? ["wrapper"] : []),
-            ...(v.deprecated ? ["deprecated"] : []),
-          ].join(","),
-        ]),
-      ]).toString(),
-    );
-    if (omission !== undefined) render(`(${omission})`);
-    if (incomplete !== undefined) render(`(${incomplete})`);
+    for (const line of verbListingLines(listing, !!options.all)) render(line);
+    const shown = options.all
+      ? listing.verbs
+      : partitionVerbListing(listing.verbs).shown;
+    // No rows means no per-verb help to point at.
+    if (shown.length === 0) return;
     hint(
       cliText(
         `TIP: --json includes each verb's input schema; 'cf piece call --piece ${pieceConfig.piece} <verb> --help --json' has the full command spec.`,

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1883,8 +1883,9 @@ function samePatternLink(left: unknown, right: unknown): boolean {
     leftAlias.scope === rightAlias.scope;
 }
 
-/** A compiled pattern's declared verb results, keyed by the result property
- * each verb is exposed under.
+/** Every verb a compiled pattern drives from a result property, keyed by that
+ * property and mapped to the verb's declared result — or to `undefined` where
+ * nothing names one.
  *
  * A handler node's `$event` input and the result property exposing that
  * handler's stream are one cell written twice in the pattern's own terms, so
@@ -1894,14 +1895,23 @@ function samePatternLink(left: unknown, right: unknown): boolean {
  * `Stream<E, R>`'s `R` is lowered (verb contract WS-C). A stream two handler
  * nodes share names no single result and so contributes none.
  *
+ * The KEYS are the graph's own account of which result properties are verbs,
+ * and that account is independent of the pattern's declared result TYPE: a
+ * pattern may wire a handler to a property its result type never mentions, and
+ * then no durable schema and no schema-filtered read ever offers the name. The
+ * listing enumerates candidates from these keys as well as from the result
+ * cell for exactly that case — but a key here says the pattern wires a handler
+ * to the property, never that the piece stores a stream at it, so every
+ * candidate is still classified against the stored signal before it is listed.
+ *
  * A compiled pattern is CALLABLE, so it is not a record and must not be tested
  * as one; only its `result` and `nodes` are read here. */
-function declaredVerbResults(
+function patternVerbResults(
   pattern: { result?: unknown; nodes?: unknown } | null | undefined,
-): Map<string, JSONSchema> {
-  const declared = new Map<string, JSONSchema>();
+): Map<string, JSONSchema | undefined> {
+  const verbs = new Map<string, JSONSchema | undefined>();
   const result = pattern?.result;
-  if (!isObjectOrArray(result)) return declared;
+  if (!isObjectOrArray(result)) return verbs;
   const nodes = Array.isArray(pattern?.nodes) ? pattern.nodes : [];
   for (const [name, link] of Object.entries(result)) {
     let resultSchema: JSONSchema | undefined;
@@ -1915,11 +1925,10 @@ function declaredVerbResults(
         resultSchema = module.resultSchema as JSONSchema;
       }
     }
-    if (matched === 1 && resultSchema !== undefined) {
-      declared.set(name, resultSchema);
-    }
+    if (matched === 0) continue;
+    verbs.set(name, matched === 1 ? resultSchema : undefined);
   }
-  return declared;
+  return verbs;
 }
 
 /** One verb's declared result, matched through the piece's compiled pattern.
@@ -1940,7 +1949,7 @@ async function declaredVerbResult(
   callableName: string,
 ): Promise<JSONSchema | undefined> {
   try {
-    return declaredVerbResults(await piece.getPattern()).get(callableName);
+    return patternVerbResults(await piece.getPattern()).get(callableName);
   } catch {
     return undefined;
   }
@@ -1948,13 +1957,19 @@ async function declaredVerbResult(
 
 /**
  * Enumerate every callable a piece exposes (verb contract: Verb discovery,
- * docs/plans/pattern-verb-contract.md). Everything in the durable schema is
- * listed — hiding is a display default driven by the listing marks
+ * docs/plans/pattern-verb-contract.md). Nothing listed is hidden from a
+ * caller — hiding is a display default driven by the listing marks
  * (`tier: "wrapper"`, `deprecated: true`), never a capability boundary: the
  * rows carry the marks, `partitionVerbListing` decides the default view, and
- * `--all` shows the full surface. Walks result then input with the same classification
- * `cf piece call` resolves through, so the listing and the dispatcher can
- * never disagree about what is callable.
+ * `--all` shows the full surface.
+ *
+ * Candidate names come from the result cell, then the input cell, then the
+ * piece root and the compiled pattern's verb properties; every one of them is
+ * put to the same classification `cf piece call` resolves through, so the
+ * listing and the dispatcher can never disagree about what is callable. The
+ * two halves are deliberately asymmetric — enumeration is generous because a
+ * name it never proposes can never be listed, and classification is strict
+ * because a name it wrongly accepts is a verb a caller cannot call.
  */
 export async function listPieceCallables(
   config: PieceConfig,
@@ -1974,13 +1989,15 @@ export async function listPieceCallables(
   // result lives on its node in the compiled graph — so the listing resolves
   // the pattern once and matches nodes to result properties. Resolution is
   // cached by identity, so this costs one load per listing, not one per row.
-  let declaredResults = new Map<string, JSONSchema>();
+  // The same match also names every verb the graph drives, which is what the
+  // candidate sweep below enumerates from.
+  let patternVerbs = new Map<string, JSONSchema | undefined>();
   if (typeof piece.getPattern === "function") {
     try {
-      declaredResults = declaredVerbResults(await piece.getPattern());
+      patternVerbs = patternVerbResults(await piece.getPattern());
     } catch {
       // Advisory in the same way the identity above is: a piece with no
-      // reachable pattern still lists every verb it exposes.
+      // reachable pattern still lists every verb its stored surface offers.
     }
   }
 
@@ -2017,7 +2034,7 @@ export async function listPieceCallables(
       // only a result-cell row can claim one: a same-named verb reached on the
       // input cell is a different stream that merely shares its name.
       const outputSchema = spec.outputSchemaSummary ??
-        (cellProp === "result" ? declaredResults.get(name) : undefined);
+        (cellProp === "result" ? patternVerbs.get(name) : undefined);
       listings.set(name, {
         name,
         kind,
@@ -2029,12 +2046,23 @@ export async function listPieceCallables(
     }
   }
 
-  // Third resolution path, mirrored from resolvePieceCallable: a name the
-  // ordinary walk rejected can still be dispatched by name, so it is
-  // considered here too.
+  // Candidates the walk above could not offer, each still put to the same
+  // classification. Two sources, and they fail in opposite directions.
   //
-  // It is classified on the two DEFINITE stored signals the read-path guard
-  // uses — a link-derived schema that answers as a stream, or the stored
+  // The piece root's own keys mirror resolvePieceCallable's third resolution
+  // path: a name the ordinary walk REJECTED can still be dispatched by name.
+  //
+  // The graph's verb properties cover the walk never SEEING a name: the
+  // result cell reads through the pattern's declared result type, so a verb
+  // that type omits is absent from the schema-filtered value and from the
+  // durable schema alike, and no amount of classification reaches a name
+  // nothing proposed. `cf piece call` never had this problem — a dispatcher is
+  // handed the name — which is how a piece answers "no verbs" and then accepts
+  // one.
+  //
+  // Both are candidate sources and neither is a verdict. Classification stays
+  // on the two DEFINITE stored signals the read-path guard uses — a
+  // link-derived schema that answers as a stream, or the stored
   // `{$stream: true}` sentinel — and never on the dispatcher's forced-stream
   // cast. That cast asserts what it then asks: its stream schema survives link
   // resolution for an inline value, so `Cell.isStream` answers from the
@@ -2043,18 +2071,23 @@ export async function listPieceCallables(
   // in a listing, which is a statement about what exists. A listing that names
   // every data field costs more than one that misses a marker-less handler,
   // because it makes the whole surface untrustworthy — and such a handler
-  // stays dispatchable regardless.
+  // stays dispatchable regardless. Widening the enumeration is safe for the
+  // same reason narrowing the classification was necessary: a candidate that
+  // stores no stream is dropped here exactly as a data field is.
   const pieceCell = typeof piece.getCell === "function"
     ? piece.getCell()
     : undefined;
-  if (pieceCell) {
-    const pieceValue = pieceCell.get?.();
-    if (isObjectOrArray(pieceValue)) {
-      for (const name of Object.keys(pieceValue)) {
-        if (!listings.has(name)) rejected.add(name);
-      }
+  const pieceValue = pieceCell?.get?.();
+  if (isObjectOrArray(pieceValue)) {
+    for (const name of Object.keys(pieceValue)) {
+      if (!listings.has(name)) rejected.add(name);
     }
-    const resultRootValue = resultRoot?.get?.();
+  }
+  for (const name of patternVerbs.keys()) {
+    if (!listings.has(name)) rejected.add(name);
+  }
+  const resultRootValue = resultRoot?.get?.();
+  if (resultRoot) {
     for (const name of rejected) {
       if (listings.has(name)) continue;
       const callableCell = resultRoot.key(name).asSchemaFromLinks();
@@ -2067,7 +2100,12 @@ export async function listPieceCallables(
         continue;
       }
       const spec = callableCommandSpec(callableCell, "handler");
-      const outputSchema = declaredResults.get(name);
+      const outputSchema = patternVerbs.get(name);
+      // `result`, because that is where the row was reached and where
+      // `cf piece call` reaches it: a graph candidate is a property of the
+      // PATTERN's result, and a piece-root candidate is dispatched on the
+      // result cell too. Neither is on the input cell, whose same-named verb
+      // would be a different stream.
       listings.set(name, {
         name,
         kind: "handler",

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1806,6 +1806,19 @@ export interface PieceCallablesListing {
   /** The deployed pattern's source identity; null when the piece exposes
    * none (e.g. harness doubles). */
   pattern: PiecePatternRef | null;
+  /** Present when the listing is a LOWER BOUND rather than the surface,
+   * naming what it could not read. `verbs` is still every callable the
+   * listing found, and every row in it is still real.
+   *
+   * `"pattern-unavailable"` means the compiled pattern could not be
+   * consulted, so a callable the declared result type omits had no other
+   * source of its name and is missing. Absent means the listing enumerated
+   * from every source it has — which is not the same as a guarantee that
+   * nothing else is callable, because a handler whose stored schema carries
+   * no stream marker is reachable by name and, by design, unlistable: see
+   * `probeForcedStreamCell`, whose cast is the only thing that finds one and
+   * finds every data field with it. */
+  incomplete?: "pattern-unavailable";
   verbs: PieceCallableListing[];
 }
 
@@ -1883,9 +1896,40 @@ function samePatternLink(left: unknown, right: unknown): boolean {
     leftAlias.scope === rightAlias.scope;
 }
 
-/** Every verb a compiled pattern drives from a result property, keyed by that
- * property and mapped to the verb's declared result — or to `undefined` where
- * nothing names one.
+/** Every property a compiled pattern hangs off its result — the graph's own
+ * account of what the piece exposes there.
+ *
+ * That account is independent of the pattern's declared result TYPE: a pattern
+ * may return a callable at a property its result type never mentions, and then
+ * no durable schema and no schema-filtered read ever offers the name. The
+ * listing enumerates candidates from here as well as from the result cell for
+ * exactly that case.
+ *
+ * These are CANDIDATE names and nothing more. A key here says the pattern
+ * wires something to the property — a handler's stream, a tool, or ordinary
+ * data — so every name is put to the same classification the result-cell walk
+ * uses, against the same stored signals, before any of it is listed. That is
+ * why the enumeration is deliberately not filtered to the handler-driven
+ * subset `handlerVerbResults` matches: a tool compiles to no node and stores
+ * no stream, so a handler-keyed enumeration cannot propose one however
+ * carefully it is written, and a filter that guesses a candidate's kind is a
+ * classification wearing an enumeration's clothes.
+ *
+ * A compiled pattern is CALLABLE, so it is not a record and must not be tested
+ * as one; only its `result` is read here. */
+function patternResultNames(
+  pattern: { result?: unknown } | null | undefined,
+): string[] {
+  const result = pattern?.result;
+  return isObjectOrArray(result) ? Object.keys(result) : [];
+}
+
+/** The declared result of each verb a compiled pattern drives from a result
+ * property, keyed by that property — or `undefined` where nothing names one.
+ *
+ * Metadata about candidates, never the list of them: a name absent here is a
+ * name with no declared result to report, which is the common case and says
+ * nothing about whether the property is callable.
  *
  * A handler node's `$event` input and the result property exposing that
  * handler's stream are one cell written twice in the pattern's own terms, so
@@ -1896,18 +1940,9 @@ function samePatternLink(left: unknown, right: unknown): boolean {
  * nodes share is still a verb and still keyed here, but it names no single
  * result, so it maps to `undefined` rather than to one node's arbitrarily.
  *
- * The KEYS are the graph's own account of which result properties are verbs,
- * and that account is independent of the pattern's declared result TYPE: a
- * pattern may wire a handler to a property its result type never mentions, and
- * then no durable schema and no schema-filtered read ever offers the name. The
- * listing enumerates candidates from these keys as well as from the result
- * cell for exactly that case — but a key here says the pattern wires a handler
- * to the property, never that the piece stores a stream at it, so every
- * candidate is still classified against the stored signal before it is listed.
- *
- * A compiled pattern is CALLABLE, so it is not a record and must not be tested
- * as one; only its `result` and `nodes` are read here. */
-function patternVerbResults(
+ * A tool is absent by construction: it is not driven by a node, and its result
+ * schema rides its own callable cell, where `callableCommandSpec` reads it. */
+function handlerVerbResults(
   pattern: { result?: unknown; nodes?: unknown } | null | undefined,
 ): Map<string, JSONSchema | undefined> {
   const verbs = new Map<string, JSONSchema | undefined>();
@@ -1950,7 +1985,7 @@ async function declaredVerbResult(
   callableName: string,
 ): Promise<JSONSchema | undefined> {
   try {
-    return patternVerbResults(await piece.getPattern()).get(callableName);
+    return handlerVerbResults(await piece.getPattern()).get(callableName);
   } catch {
     return undefined;
   }
@@ -1965,12 +2000,18 @@ async function declaredVerbResult(
  * `--all` shows the full surface.
  *
  * Candidate names come from the result cell, then the input cell, then the
- * piece root and the compiled pattern's verb properties; every one of them is
- * put to the same classification `cf piece call` resolves through, so the
+ * piece root and the compiled pattern's result properties; every one of them
+ * is put to the same classification `cf piece call` resolves through, so the
  * listing and the dispatcher can never disagree about what is callable. The
  * two halves are deliberately asymmetric — enumeration is generous because a
  * name it never proposes can never be listed, and classification is strict
  * because a name it wrongly accepts is a verb a caller cannot call.
+ *
+ * The listing degrades rather than fails, and reports the degradation on
+ * `incomplete` rather than absorbing it: the compiled pattern is the only
+ * source for a callable the declared result type omits, so losing it loses
+ * rows, and a shortened list presented as the whole surface is the failure
+ * this command exists to avoid.
  */
 export async function listPieceCallables(
   config: PieceConfig,
@@ -1986,19 +2027,33 @@ export async function listPieceCallables(
     }
   }
 
-  // A tool's result schema rides its callable cell, but a handler's declared
-  // result lives on its node in the compiled graph — so the listing resolves
-  // the pattern once and matches nodes to result properties. Resolution is
+  // The compiled pattern, read once for two independent jobs. Its result
+  // properties are candidate NAMES for the sweep below — the only source for a
+  // callable the declared result type omits. Its handler nodes carry declared
+  // RESULTS, which are metadata on rows enumerated from anywhere. Resolution is
   // cached by identity, so this costs one load per listing, not one per row.
-  // The same match also names every verb the graph drives, which is what the
-  // candidate sweep below enumerates from.
-  let patternVerbs = new Map<string, JSONSchema | undefined>();
+  //
+  // Unlike the identity above, this one is not advisory, and the listing says
+  // so when it is missing. `getPattern` throws on a piece carrying no pattern
+  // identity and on one whose pattern source will not load in this space
+  // (PieceController.#loadCurrentPattern) — both states in which every stored
+  // verb still DISPATCHES, because resolution never consults the graph. So the
+  // listing must not fail: it would refuse to describe a piece it can still
+  // drive, to tab-completion and to an agent that could have acted on the
+  // partial answer. What it must not do either is present a shortened list as
+  // the whole surface, which is the difference between losing a row's
+  // `outputSchema` and losing the row.
+  let graphNames: string[] = [];
+  let handlerResults = new Map<string, JSONSchema | undefined>();
+  let graphConsulted = false;
   if (typeof piece.getPattern === "function") {
     try {
-      patternVerbs = patternVerbResults(await piece.getPattern());
+      const compiled = await piece.getPattern();
+      graphNames = patternResultNames(compiled);
+      handlerResults = handlerVerbResults(compiled);
+      graphConsulted = true;
     } catch {
-      // Advisory in the same way the identity above is: a piece with no
-      // reachable pattern still lists every verb its stored surface offers.
+      // Reported as `incomplete` below rather than swallowed.
     }
   }
 
@@ -2035,7 +2090,7 @@ export async function listPieceCallables(
       // only a result-cell row can claim one: a same-named verb reached on the
       // input cell is a different stream that merely shares its name.
       const outputSchema = spec.outputSchemaSummary ??
-        (cellProp === "result" ? patternVerbs.get(name) : undefined);
+        (cellProp === "result" ? handlerResults.get(name) : undefined);
       listings.set(name, {
         name,
         kind,
@@ -2053,7 +2108,7 @@ export async function listPieceCallables(
   // The piece root's own keys mirror resolvePieceCallable's third resolution
   // path: a name the ordinary walk REJECTED can still be dispatched by name.
   //
-  // The graph's verb properties cover the walk never SEEING a name: the
+  // The graph's result properties cover the walk never SEEING a name: the
   // result cell reads through the pattern's declared result type, so a verb
   // that type omits is absent from the schema-filtered value and from the
   // durable schema alike, and no amount of classification reaches a name
@@ -2084,7 +2139,7 @@ export async function listPieceCallables(
       if (!listings.has(name)) rejected.add(name);
     }
   }
-  for (const name of patternVerbs.keys()) {
+  for (const name of graphNames) {
     if (!listings.has(name)) rejected.add(name);
   }
   const resultRootValue = resultRoot?.get?.();
@@ -2092,16 +2147,28 @@ export async function listPieceCallables(
     for (const name of rejected) {
       if (listings.has(name)) continue;
       const callableCell = resultRoot.key(name).asSchemaFromLinks();
-      // `rejected` collects names from the result/input walk AND from the
-      // piece root's own value, so the sentinel is looked for on both — one
-      // cell in a live piece, two objects wherever they are supplied apart.
-      const storedValue = getCallableValue(resultRootValue, name) ??
-        getCallableValue(pieceValue, name);
-      if (!isStreamValue(storedValue) && !isHandlerCell(callableCell)) {
-        continue;
-      }
-      const spec = callableCommandSpec(callableCell, "handler");
-      const outputSchema = patternVerbs.get(name);
+      // `detectCallableKind`, not an assumed "handler": the walk above uses it,
+      // `cf piece call` resolves through it, and a candidate proposed by the
+      // graph arrives with no evidence of its kind at all — a tool sits in the
+      // pattern's result exactly as a handler's stream does. Assuming here
+      // would list a tool as a handler and hand a caller `invoke` and the
+      // wrong input schema for it.
+      //
+      // `rejected` collects names from the result/input walk AND from the piece
+      // root's own value — one cell in a live piece, two objects wherever they
+      // are supplied apart — so the two stored values are two independent
+      // pieces of evidence and each is asked on its own. Coalescing them with
+      // `??` would let any non-null value on the result view, ordinary data
+      // included, hide a stream sentinel stored at the same name on the piece
+      // root.
+      const kind = detectCallableKind(
+        getCallableValue(resultRootValue, name),
+        callableCell,
+      ) ??
+        detectCallableKind(getCallableValue(pieceValue, name), callableCell);
+      if (!kind) continue;
+      const spec = callableCommandSpec(callableCell, kind);
+      const outputSchema = spec.outputSchemaSummary ?? handlerResults.get(name);
       // `result`, because that is where the row was reached and where
       // `cf piece call` reaches it: a graph candidate is a property of the
       // PATTERN's result, and a piece-root candidate is dispatched on the
@@ -2109,7 +2176,7 @@ export async function listPieceCallables(
       // would be a different stream.
       listings.set(name, {
         name,
-        kind: "handler",
+        kind,
         on: "result",
         inputSchema: spec.inputSchema,
         ...(outputSchema !== undefined ? { outputSchema } : {}),
@@ -2121,6 +2188,7 @@ export async function listPieceCallables(
   // must sort identically on every host (utf8Compare is the repo comparator).
   return {
     pattern,
+    ...(graphConsulted ? {} : { incomplete: "pattern-unavailable" as const }),
     verbs: [...listings.values()].sort((a, b) => utf8Compare(a.name, b.name)),
   };
 }

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1893,7 +1893,8 @@ function samePatternLink(left: unknown, right: unknown): boolean {
  * — a structural comparison inside one compiled object, with no live cell to
  * resolve. The declared result rides on that node's module, which is where
  * `Stream<E, R>`'s `R` is lowered (verb contract WS-C). A stream two handler
- * nodes share names no single result and so contributes none.
+ * nodes share is still a verb and still keyed here, but it names no single
+ * result, so it maps to `undefined` rather than to one node's arbitrarily.
  *
  * The KEYS are the graph's own account of which result properties are verbs,
  * and that account is independent of the pattern's declared result TYPE: a

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -2130,22 +2130,56 @@ export async function listPieceCallables(
   // stays dispatchable regardless. Widening the enumeration is safe for the
   // same reason narrowing the classification was necessary: a candidate that
   // stores no stream is dropped here exactly as a data field is.
+  //
+  // PRECEDENCE, mirrored from resolvePieceCallable rather than invented here.
+  // The dispatcher tries three places in a fixed order:
+  //
+  //   resolved = onResultCell ?? onInputCell ?? tryResolvePieceHandler(...)
+  //
+  // and this sweep's two stored signals are the first and third of them.
+  // `tryResolvePieceCallableAt(piece, ..., "result")` classifies
+  // `resultRoot.key(name).asSchemaFromLinks()` against `resultRoot.get()[name]`
+  // — the sweep's FIRST call, argument for argument — so a name that call
+  // accepts is a name the dispatcher resolves on the result cell, ahead of any
+  // input row. The second call is the piece root's sentinel, which stands in
+  // for `tryResolvePieceHandler`, and the dispatcher reaches that only once the
+  // input cell has declined. Hence: a result-cell signal REPLACES a row the
+  // walk placed on the input cell; a piece-root signal does not; neither
+  // disturbs a row already on the result cell. Which source proposed the name
+  // does not enter into it — rank follows the signal that classified it.
+  //
+  // These guards are the SECOND thing in this change to have been written for
+  // a sweep that only supplied fallbacks for names already seen, and left
+  // alone when the sweep became a source of names. `!listings.has(name)` used
+  // to mean "nothing more to learn about this name"; once the graph proposes
+  // names the result walk cannot see, it means "nothing more to learn unless
+  // the graph proposes it, which outranks an input row". The first was the
+  // `catch {}` around `getPattern` above — honest while the pattern supplied
+  // metadata, silent loss once it supplied names. Both are the same mistake:
+  // the sweep's role changed and its guards did not. If a third candidate
+  // source is ever added here, settle its rank against the list above before
+  // adding it, not after.
   const pieceCell = typeof piece.getCell === "function"
     ? piece.getCell()
     : undefined;
   const pieceValue = pieceCell?.get?.();
+  // A row already on the result cell has won rank 1 and has nothing to learn
+  // here; anything else is still open to a result-side classification.
+  const openToResultSide = (name: string) =>
+    listings.get(name)?.on !== "result";
   if (isObjectOrArray(pieceValue)) {
     for (const name of Object.keys(pieceValue)) {
-      if (!listings.has(name)) rejected.add(name);
+      if (openToResultSide(name)) rejected.add(name);
     }
   }
   for (const name of graphNames) {
-    if (!listings.has(name)) rejected.add(name);
+    if (openToResultSide(name)) rejected.add(name);
   }
   const resultRootValue = resultRoot?.get?.();
   if (resultRoot) {
     for (const name of rejected) {
-      if (listings.has(name)) continue;
+      const existing = listings.get(name);
+      if (existing?.on === "result") continue;
       const callableCell = resultRoot.key(name).asSchemaFromLinks();
       // `detectCallableKind`, not an assumed "handler": the walk above uses it,
       // `cf piece call` resolves through it, and a candidate proposed by the
@@ -2161,12 +2195,16 @@ export async function listPieceCallables(
       // `??` would let any non-null value on the result view, ordinary data
       // included, hide a stream sentinel stored at the same name on the piece
       // root.
-      const kind = detectCallableKind(
+      const resultSideKind = detectCallableKind(
         getCallableValue(resultRootValue, name),
         callableCell,
-      ) ??
+      );
+      const kind = resultSideKind ??
         detectCallableKind(getCallableValue(pieceValue, name), callableCell);
       if (!kind) continue;
+      // Rank 3 does not displace rank 2: an input row stands unless the RESULT
+      // cell itself classified the name, whatever the piece root stores at it.
+      if (existing !== undefined && resultSideKind === null) continue;
       const spec = callableCommandSpec(callableCell, kind);
       const outputSchema = spec.outputSchemaSummary ?? handlerResults.get(name);
       // `result`, because that is where the row was reached and where

--- a/packages/cli/test/piece-verbs-live.test.ts
+++ b/packages/cli/test/piece-verbs-live.test.ts
@@ -58,13 +58,20 @@ const DECLARED_PROGRAM = {
  * Nothing about these two verbs is hidden or unusual; they are simply absent
  * from the type the result cell reads through, so a walk of that cell never
  * proposes their names and never gets as far as classifying them.
+ *
+ * `hiddenTool` is the same omission for the OTHER kind of callable. A tool is
+ * not a stream and is wired to no handler node, so an enumeration keyed on
+ * handler nodes cannot propose it however wide it is — and a candidate the
+ * declared result type omits arrives with no evidence of its kind except its
+ * own stored value, which is what makes classifying it, rather than assuming
+ * it, load-bearing.
  */
 const UNDECLARED_PROGRAM = {
   main: "/main.tsx",
   files: [{
     name: "/main.tsx",
     contents: [
-      'import { handler, pattern, schema } from "commonfabric";',
+      'import { handler, pattern, patternTool, schema } from "commonfabric";',
       'import "commonfabric/schema";',
       "",
       "const model = schema({",
@@ -85,10 +92,15 @@ const UNDECLARED_PROGRAM = {
       "  state.value.set(state.value.get() - 1);",
       "});",
       "",
+      "const echo = pattern<{ query: string }, { echoed: string }>(",
+      "  ({ query }) => ({ echoed: query }),",
+      ");",
+      "",
       "export default pattern((cell) => {",
       "  return {",
       "    increment: increment(cell),",
       "    decrement: decrement(cell),",
+      "    hiddenTool: patternTool(echo),",
       "    value: cell.value,",
       "    stringField: cell.stringField,",
       "    arrayField: cell.arrayField,",
@@ -190,19 +202,35 @@ describe("listPieceCallables against a live piece", () => {
       "listing-live-undeclared",
     );
 
-    // Both verbs, and none of the three data fields. The two halves of this
-    // equality fail against opposite implementations, which is why they are
-    // asserted together: enumerating candidates from the result cell alone
-    // loses `decrement` and `increment` and leaves the listing EMPTY — what a
-    // caller sees today on a piece that accepts both — while classifying a
+    // Both handlers, the tool, and none of the three data fields. The halves
+    // of this equality fail against opposite implementations, which is why
+    // they are asserted together: enumerating candidates from the result cell
+    // alone loses all three and leaves the listing EMPTY — what a caller sees
+    // today on a piece that accepts every one of them — while classifying a
     // candidate on the forced-stream cast rather than on a stored stream adds
-    // `arrayField`, `stringField` and `value` back.
+    // `arrayField`, `stringField` and `value` back. `hiddenTool` fails a third
+    // way: an enumeration that proposes only the properties matching a handler
+    // node's `$event` never reaches a tool at all, since a tool compiles to no
+    // node and stores no stream.
     expect(listing.verbs.map((verb) => verb.name)).toEqual([
       "decrement",
+      "hiddenTool",
       "increment",
     ]);
+    const byName = new Map(listing.verbs.map((verb) => [verb.name, verb]));
+    expect(byName.get("decrement")?.kind).toBe("handler");
+    expect(byName.get("increment")?.kind).toBe("handler");
+    // Classified, not assumed: a fallback that hard-codes `"handler"` lists
+    // this row with the wrong kind and with a handler's `invoke` command spec,
+    // so `cf piece verbs` and `cf piece call` disagree about what it is.
+    expect(byName.get("hiddenTool")?.kind).toBe("tool");
+    // A tool's input schema rides its own callable cell, so a correctly
+    // classified row carries the sub-pattern's arguments; the handler branch
+    // of `callableCommandSpec` would offer the cell's own schema instead.
+    expect(byName.get("hiddenTool")?.inputSchema).toMatchObject({
+      properties: { query: { type: "string" } },
+    });
     for (const verb of listing.verbs) {
-      expect(verb.kind).toBe("handler");
       // The result cell is where the graph exposes them and where
       // `cf piece call` resolves them, whatever the result TYPE says.
       expect(verb.on).toBe("result");

--- a/packages/cli/test/piece-verbs-live.test.ts
+++ b/packages/cli/test/piece-verbs-live.test.ts
@@ -3,11 +3,13 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { getResultCellWithSourceSchema } from "../../runner/src/piece-helpers.ts";
 import { listPieceCallables } from "../lib/piece.ts";
 
 /**
  * One pattern with one verb and three data fields of different shapes — a
- * scalar with a default, a computed number, and an array.
+ * scalar with a default, a computed number, and an array. Its result type
+ * DECLARES the verb, so the verb reaches the listing through the result cell.
  *
  * The listing's classification is exercised against CELLS THE RUNTIME BUILT,
  * because the defect this pins cannot be reproduced against a double: the
@@ -16,7 +18,7 @@ import { listPieceCallables } from "../lib/piece.ts";
  * from the cast. Every data field below was reported as a callable handler,
  * with the field's own schema offered as its input schema.
  */
-const PROGRAM = {
+const DECLARED_PROGRAM = {
   main: "/main.tsx",
   files: [{
     name: "/main.tsx",
@@ -47,61 +49,163 @@ const PROGRAM = {
   }],
 };
 
+/**
+ * The same shape as `packages/cli/integration/pattern/main.tsx`: the result
+ * type is the argument schema reused, so it describes the piece's DATA and
+ * mentions neither verb — while the pattern returns both, and
+ * `integration.sh` calls `increment` and asserts the counter moves.
+ *
+ * Nothing about these two verbs is hidden or unusual; they are simply absent
+ * from the type the result cell reads through, so a walk of that cell never
+ * proposes their names and never gets as far as classifying them.
+ */
+const UNDECLARED_PROGRAM = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      'import { handler, pattern, schema } from "commonfabric";',
+      'import "commonfabric/schema";',
+      "",
+      "const model = schema({",
+      "  type: 'object',",
+      "  properties: {",
+      "    value: { type: 'number', default: 0, asCell: ['cell'] },",
+      "    stringField: { type: 'string' },",
+      "    arrayField: { type: 'array', items: { type: 'number' } },",
+      "  },",
+      "  default: { value: 0 },",
+      "});",
+      "",
+      "const increment = handler({}, model, (_, state) => {",
+      "  state.value.set(state.value.get() + 1);",
+      "});",
+      "",
+      "const decrement = handler({}, model, (_, state) => {",
+      "  state.value.set(state.value.get() - 1);",
+      "});",
+      "",
+      "export default pattern((cell) => {",
+      "  return {",
+      "    increment: increment(cell),",
+      "    decrement: decrement(cell),",
+      "    value: cell.value,",
+      "    stringField: cell.stringField,",
+      "    arrayField: cell.arrayField,",
+      "  };",
+      "}, model, model);",
+    ].join("\n"),
+  }],
+};
+
+/**
+ * Compile and run `program`, then list the callables of the piece it produces.
+ *
+ * The result cell is narrowed by `getResultCellWithSourceSchema`, which is the
+ * one step `PiecesController.getPieceCell` applies before any `cf` command
+ * sees a piece: it recovers the pattern's result schema from the cell's own
+ * `schema` metadata and reads through it. Handing the lister the unnarrowed
+ * cell instead would hide the whole defect, because an unnarrowed `get()`
+ * offers every stored key including the ones the result type omits.
+ */
+async function listLivePiece(
+  program: unknown,
+  passphrase: string,
+  id: string,
+): Promise<Awaited<ReturnType<typeof listPieceCallables>>> {
+  const signer = await Identity.fromPassphrase(passphrase);
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL("https://example.com"),
+    storageManager,
+  });
+  const space = signer.did();
+
+  try {
+    const compiled = await runtime.patternManager.compilePattern(
+      program as never,
+      { space },
+    );
+    const tx = runtime.edit();
+    const rootCell = runtime.getCell(space, id, undefined, tx);
+    const root = runtime.run(tx, compiled, {}, rootCell);
+    runtime.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    await root.pull();
+
+    // The piece surface `listPieceCallables` walks: a result cell read through
+    // the pattern's result schema, an empty input cell, the piece root it
+    // sweeps for names the walk rejected, and the compiled pattern.
+    const result = getResultCellWithSourceSchema(root);
+    const emptyInput = runtime.getCell(space, `${id}-input`);
+    const piece = {
+      result: { getCell: () => Promise.resolve(result) },
+      input: { getCell: () => Promise.resolve(emptyInput) },
+      getCell: () => result,
+      getPattern: () => Promise.resolve(compiled),
+    };
+
+    return await listPieceCallables(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:live",
+        space,
+      },
+      {
+        loadPieces: () => Promise.resolve({ getSpace: () => space } as never),
+        loadPiece: () => Promise.resolve(piece as never),
+      },
+    );
+  } finally {
+    await runtime.dispose?.();
+    await storageManager.close?.();
+  }
+}
+
 describe("listPieceCallables against a live piece", () => {
   it("lists the verb and none of the data fields", async () => {
-    const signer = await Identity.fromPassphrase("piece-verbs-live");
-    const storageManager = StorageManager.emulate({ as: signer });
-    const runtime = new Runtime({
-      apiUrl: new URL("https://example.com"),
-      storageManager,
+    const listing = await listLivePiece(
+      DECLARED_PROGRAM,
+      "piece-verbs-live",
+      "listing-live",
+    );
+
+    // The pattern declares exactly one verb; every other name is data. The
+    // listing must never offer data as callable, and this equality is what
+    // fails against a listing that classifies on the forced-stream cast: that
+    // cast passes `count`, `items` and `label` too.
+    expect(listing.verbs.map((verb) => verb.name)).toEqual(["add"]);
+    expect(listing.verbs[0].kind).toBe("handler");
+    // The verb's input schema is the event's, not the property's own.
+    expect(listing.verbs[0].inputSchema).toMatchObject({
+      properties: { title: { type: "string" } },
     });
-    const space = signer.did();
+  });
 
-    try {
-      const compiled = await runtime.patternManager.compilePattern(
-        PROGRAM as never,
-        { space },
-      );
-      const tx = runtime.edit();
-      const rootCell = runtime.getCell(space, "listing-live", undefined, tx);
-      const root = runtime.run(tx, compiled, {}, rootCell);
-      runtime.prepareTxForCommit(tx);
-      expect((await tx.commit()).error).toBeUndefined();
-      await root.pull();
+  it("lists a verb the pattern's declared result type omits", async () => {
+    const listing = await listLivePiece(
+      UNDECLARED_PROGRAM,
+      "piece-verbs-live-undeclared",
+      "listing-live-undeclared",
+    );
 
-      // The piece surface `listPieceCallables` walks: a result cell, an empty
-      // input cell, and the piece root it sweeps for names the walk rejected.
-      const emptyInput = runtime.getCell(space, "listing-live-input");
-      const piece = {
-        result: { getCell: () => Promise.resolve(root) },
-        input: { getCell: () => Promise.resolve(emptyInput) },
-        getCell: () => root,
-      };
-
-      const listing = await listPieceCallables(
-        {
-          apiUrl: "http://localhost:8000",
-          identity: "/tmp/test-identity.pem",
-          piece: "fid1:live",
-          space,
-        },
-        {
-          loadPieces: () => Promise.resolve({ getSpace: () => space } as never),
-          loadPiece: () => Promise.resolve(piece as never),
-        },
-      );
-
-      // The pattern declares exactly one verb; every other name is data.
-      // The listing must never offer data as callable.
-      expect(listing.verbs.map((verb) => verb.name)).toEqual(["add"]);
-      expect(listing.verbs[0].kind).toBe("handler");
-      // The verb's input schema is the event's, not the property's own.
-      expect(listing.verbs[0].inputSchema).toMatchObject({
-        properties: { title: { type: "string" } },
-      });
-    } finally {
-      await runtime.dispose?.();
-      await storageManager.close?.();
+    // Both verbs, and none of the three data fields. The two halves of this
+    // equality fail against opposite implementations, which is why they are
+    // asserted together: enumerating candidates from the result cell alone
+    // loses `decrement` and `increment` and leaves the listing EMPTY — what a
+    // caller sees today on a piece that accepts both — while classifying a
+    // candidate on the forced-stream cast rather than on a stored stream adds
+    // `arrayField`, `stringField` and `value` back.
+    expect(listing.verbs.map((verb) => verb.name)).toEqual([
+      "decrement",
+      "increment",
+    ]);
+    for (const verb of listing.verbs) {
+      expect(verb.kind).toBe("handler");
+      // The result cell is where the graph exposes them and where
+      // `cf piece call` resolves them, whatever the result TYPE says.
+      expect(verb.on).toBe("result");
     }
   });
 });

--- a/packages/cli/test/piece-verbs.test.ts
+++ b/packages/cli/test/piece-verbs.test.ts
@@ -1,7 +1,9 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { JSONSchema } from "@commonfabric/api";
+import type { PieceCallablesListing } from "../lib/piece.ts";
 import { listPieceCallables, partitionVerbListing } from "../lib/piece.ts";
+import { verbListingJson, verbListingLines } from "../commands/piece.ts";
 
 const TEST_PATTERN_REF = {
   source: {
@@ -79,6 +81,45 @@ function schemaFilteredCell(
   };
 }
 
+/** The same schema-filtered result cell, with an event schema on each hidden
+ * stream's callable cell. That schema is what `callableCommandSpec` publishes
+ * as a handler row's `inputSchema`, so it is what tells a result-side row
+ * apart from a same-named input-side one — a test that only counted rows
+ * could not see the two swap. `noteCount` is the declared result type's whole
+ * content, and answers no to `isStream` like any data field. */
+function resultCellWithHiddenStreams(hidden: Record<string, JSONSchema>): {
+  schema: JSONSchema;
+  get: () => unknown;
+  getRaw: () => unknown;
+  asSchemaFromLinks: () => unknown;
+  key: (name: string) => unknown;
+} {
+  const child = (name: string) => {
+    const self = {
+      schema: hidden[name],
+      get: () => undefined,
+      getRaw: () => undefined,
+      isStream: () => Object.hasOwn(hidden, name),
+      asSchemaFromLinks: () => self,
+      key: () => self,
+    };
+    return self;
+  };
+  const value = { noteCount: 3 };
+  return {
+    schema: {
+      type: "object",
+      properties: { noteCount: { type: "number" } },
+    },
+    get: () => value,
+    getRaw: () => value,
+    asSchemaFromLinks: function () {
+      return this;
+    },
+    key: child,
+  };
+}
+
 const ADD_TOPIC_EVENT: JSONSchema = {
   type: "object",
   properties: {
@@ -87,6 +128,19 @@ const ADD_TOPIC_EVENT: JSONSchema = {
     agentName: { type: "string" },
   },
   required: ["title"],
+};
+
+/** Two event schemas that cannot be mistaken for one another: a row carrying
+ * one names which cell the listing reached the verb on. */
+const RESULT_SIDE_EVENT: JSONSchema = {
+  type: "object",
+  properties: { note: { type: "string" } },
+  required: ["note"],
+};
+
+const INPUT_SIDE_EVENT: JSONSchema = {
+  type: "object",
+  properties: { seed: { type: "number" } },
 };
 
 const SEARCH_ARGUMENTS: JSONSchema = {
@@ -479,6 +533,139 @@ describe("listPieceCallables", () => {
     expect(listing.incomplete).toBe("pattern-unavailable");
   });
 
+  it("gives a result-side callable the row when an input callable shares its name", async () => {
+    // `resolvePieceCallable` tries the result cell first and only reaches the
+    // input cell `if (!onResultCell)`. The listing must draw the same line,
+    // and the case where it is hardest to draw is exactly the one this change
+    // created: the result walk cannot SEE a verb the declared result type
+    // omits, so the input walk gets there first and the graph candidate then
+    // finds the name already listed.
+    //
+    // `notify` is stored on both cells with different event schemas. The
+    // dispatcher sends a payload shaped by RESULT_SIDE_EVENT, so a listing
+    // publishing INPUT_SIDE_EVENT hands a caller the wrong shape for the verb
+    // it will actually reach — a disagreement, not merely a mislabel.
+    const resultRoot = resultCellWithHiddenStreams({
+      notify: RESULT_SIDE_EVENT,
+    });
+    const inputRoot = cell(
+      { notify: { $stream: true } },
+      { type: "object", properties: { notify: INPUT_SIDE_EVENT } },
+    );
+    const pattern = compiledPattern({
+      result: {
+        notify: streamAlias({ stream: "notify" }),
+        noteCount: streamAlias("noteCount", { type: "number" }),
+      },
+      nodes: [
+        {
+          module: { wrapper: "handler", resultSchema: CREATE_NOTE_RESULT },
+          inputs: { $event: streamAlias({ stream: "notify" }) },
+          outputs: {},
+        },
+      ],
+    });
+    const piece = {
+      result: { getCell: () => Promise.resolve(resultRoot) },
+      input: { getCell: () => Promise.resolve(inputRoot) },
+      getCell: () => resultRoot,
+      getPattern: () => Promise.resolve(pattern),
+    };
+    const listing = await listPieceCallables(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-794",
+        space: "home",
+      },
+      {
+        loadPieces: () => Promise.resolve({} as never),
+        loadPiece: () => Promise.resolve(piece as never),
+      },
+    );
+
+    // One row, not two: a name resolves to one callable.
+    expect(listing.verbs.map((verb) => verb.name)).toEqual(["notify"]);
+    // Fails against a sweep whose guards skip a name already listed — the
+    // input row survives and reports `on: "input"`.
+    expect(listing.verbs[0].on).toBe("result");
+    // And the assertion that makes the row's identity load-bearing rather
+    // than its label: a listing left reporting the input row publishes
+    // INPUT_SIDE_EVENT for a verb the dispatcher reaches with
+    // RESULT_SIDE_EVENT.
+    expect(listing.verbs[0].inputSchema).toEqual(RESULT_SIDE_EVENT);
+    // The declared result rides the replacement, as on any result-side row.
+    expect(listing.verbs[0].outputSchema).toEqual(CREATE_NOTE_RESULT);
+  });
+
+  it("keeps an input row when nothing on the result cell classifies the name", async () => {
+    // The other side of the precedence, and what stops "the graph wins" from
+    // passing for a fix. `resolvePieceCallable` reaches the piece root's
+    // forced-stream probe only after the INPUT cell declines, so an input row
+    // outranks a piece-root sentinel and yields only to the result cell.
+    //
+    // `graphOnly` is a graph result property and an input verb, with nothing
+    // stored at it on the result cell. `rootOnly` is a piece-root sentinel and
+    // an input verb, likewise. The dispatcher resolves both on the input cell,
+    // so both must keep reporting `on: "input"` with the input event schema.
+    const resultRoot = resultCellWithHiddenStreams({});
+    const inputRoot = cell(
+      { graphOnly: { $stream: true }, rootOnly: { $stream: true } },
+      {
+        type: "object",
+        properties: {
+          graphOnly: INPUT_SIDE_EVENT,
+          rootOnly: INPUT_SIDE_EVENT,
+        },
+      },
+    );
+    const pattern = compiledPattern({
+      result: {
+        graphOnly: streamAlias({ stream: "graphOnly" }),
+        noteCount: streamAlias("noteCount", { type: "number" }),
+      },
+      nodes: [
+        {
+          module: { wrapper: "handler" },
+          inputs: { $event: streamAlias({ stream: "graphOnly" }) },
+          outputs: {},
+        },
+      ],
+    });
+    const piece = {
+      result: { getCell: () => Promise.resolve(resultRoot) },
+      input: { getCell: () => Promise.resolve(inputRoot) },
+      getCell: () => ({ get: () => ({ rootOnly: { $stream: true } }) }),
+      getPattern: () => Promise.resolve(pattern),
+    };
+    const listing = await listPieceCallables(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-795",
+        space: "home",
+      },
+      {
+        loadPieces: () => Promise.resolve({} as never),
+        loadPiece: () => Promise.resolve(piece as never),
+      },
+    );
+
+    const byName = new Map(listing.verbs.map((verb) => [verb.name, verb]));
+    expect([...byName.keys()].sort()).toEqual(["graphOnly", "rootOnly"]);
+    // `graphOnly` fails against a fix that lets any graph candidate replace an
+    // input row: the graph names it, but the result cell stores nothing there,
+    // so the dispatcher never leaves the input cell.
+    expect(byName.get("graphOnly")?.on).toBe("input");
+    expect(byName.get("graphOnly")?.inputSchema).toEqual(INPUT_SIDE_EVENT);
+    // `rootOnly` fails against a fix that replaces an input row on ANY stored
+    // signal rather than on the result cell's: the piece-root sentinel does
+    // classify, and ranking it above the input row inverts
+    // `onInputCell ?? tryResolvePieceHandler(...)`.
+    expect(byName.get("rootOnly")?.on).toBe("input");
+    expect(byName.get("rootOnly")?.inputSchema).toEqual(INPUT_SIDE_EVENT);
+  });
+
   it("checks the result view and the piece root for a stored signal independently", async () => {
     // Two sources of stored evidence, and neither is allowed to mask the
     // other. `notify` reads as an ordinary number through the declared result
@@ -625,5 +812,133 @@ describe("listPieceCallables", () => {
     expect(partition.shown.map((verb) => verb.name)).toEqual(["addTopic"]);
     expect(partition.wrapper).toBe(1);
     expect(partition.deprecated).toBe(1);
+  });
+});
+
+/** A listing as `listPieceCallables` returns one, built by hand so the
+ * rendering is exercised over shapes the lister reaches only against a live
+ * piece. */
+function listingOf(
+  verbs: PieceCallablesListing["verbs"],
+  extra: Partial<PieceCallablesListing> = {},
+): PieceCallablesListing {
+  return { pattern: null, verbs, ...extra };
+}
+
+/** A pattern ref carrying the two fields `formatPatternIdentity` reads, so
+ * the rendered PATTERN line is a real identity rather than `undefined`. */
+const IDENTIFIED_PATTERN_REF = {
+  identity: "sha256:feed",
+  symbol: "default",
+  source: { ref: "sha256:feed" },
+} as never;
+
+const ADD_TOPIC_ROW: PieceCallablesListing["verbs"][number] = {
+  name: "addTopic",
+  kind: "handler",
+  on: "result",
+  inputSchema: ADD_TOPIC_EVENT,
+};
+
+describe("cf piece verbs rendering", () => {
+  it("prints no incomplete note for a listing that read its pattern", () => {
+    const lines = verbListingLines(listingOf([ADD_TOPIC_ROW]), false);
+
+    // The negative, asserted on the whole output rather than on a flag: this
+    // is what fails against a renderer that prints the note unconditionally,
+    // which an assertion that only looked for the note when it IS expected
+    // would pass.
+    expect(lines.join("\n")).not.toContain("the pattern could not be read");
+    expect(lines.some((line) => line.startsWith("("))).toBe(false);
+    // And the rows really did render, so the absence above is not the absence
+    // of all output.
+    expect(lines.join("\n")).toContain("addTopic");
+  });
+
+  it("prints the incomplete note under the rows when the pattern was unreadable", () => {
+    const lines = verbListingLines(
+      listingOf([ADD_TOPIC_ROW], { incomplete: "pattern-unavailable" }),
+      false,
+    );
+
+    // Order is the assertion: a caller reads the note against the rows above
+    // it, so a note printed before the table would describe nothing.
+    expect(lines[lines.length - 1]).toBe(
+      "(the pattern could not be read, so verbs its result type omits are missing; the verbs listed are still callable)",
+    );
+    expect(lines.slice(0, -1).join("\n")).toContain("addTopic");
+  });
+
+  it("prints the incomplete note when no verbs are listed at all", () => {
+    // The case the note exists for. Without it `<no callable verbs>` is
+    // indistinguishable from a piece that genuinely has none — the failure
+    // this whole change is about, at the surface a person actually reads.
+    const lines = verbListingLines(
+      listingOf([], { incomplete: "pattern-unavailable" }),
+      false,
+    );
+
+    expect(lines).toEqual([
+      "<no callable verbs>",
+      "(the pattern could not be read, so verbs its result type omits are missing; the verbs listed are still callable)",
+    ]);
+  });
+
+  it("keeps the hidden-verb note and the incomplete note apart", () => {
+    // Both ways a listing can be short, at once. The hidden count rides the
+    // placeholder because it explains why the placeholder says "shown"; the
+    // incomplete note is its own line because `--all` cannot recover what it
+    // reports. Fails against a renderer that concatenates them, or that drops
+    // either when the other is present.
+    const lines = verbListingLines(
+      listingOf([{ ...ADD_TOPIC_ROW, tier: "wrapper" }], {
+        incomplete: "pattern-unavailable",
+      }),
+      false,
+    );
+
+    expect(lines).toEqual([
+      "<no callable verbs shown> (1 wrapper, 0 deprecated hidden; --all lists them)",
+      "(the pattern could not be read, so verbs its result type omits are missing; the verbs listed are still callable)",
+    ]);
+  });
+
+  it("shows a wrapper row under --all, with no hidden note and the pattern line", () => {
+    const lines = verbListingLines(
+      listingOf([{ ...ADD_TOPIC_ROW, tier: "wrapper" }], {
+        pattern: IDENTIFIED_PATTERN_REF,
+      }),
+      true,
+    );
+
+    // `--all` recovers the hidden row, so its note must go; the pattern
+    // identity heads the view whenever the listing carries one.
+    expect(lines[0]).toBe("PATTERN cf:module/sha256:feed#default");
+    expect(lines.join("\n")).toContain("addTopic");
+    expect(lines.join("\n")).toContain("wrapper");
+    expect(lines.some((line) => line.startsWith("(1 wrapper"))).toBe(false);
+  });
+
+  it("carries incomplete into the --json payload and omits it otherwise", () => {
+    // A machine reader has no listing text to read the bound off, so the flag
+    // must survive into JSON — and must be absent, not false, when the
+    // listing is whole.
+    const degraded = verbListingJson(
+      listingOf([ADD_TOPIC_ROW], { incomplete: "pattern-unavailable" }),
+      false,
+    );
+    expect(degraded.incomplete).toBe("pattern-unavailable");
+    expect(degraded.verbs).toEqual([ADD_TOPIC_ROW]);
+
+    const whole = verbListingJson(listingOf([ADD_TOPIC_ROW]), false);
+    expect(Object.hasOwn(whole, "incomplete")).toBe(false);
+
+    // The hidden counts keep their own shape beside it.
+    const hidden = verbListingJson(
+      listingOf([{ ...ADD_TOPIC_ROW, deprecated: true }]),
+      false,
+    );
+    expect(hidden.hidden).toEqual({ wrapper: 0, deprecated: 1 });
+    expect(hidden.verbs).toEqual([]);
   });
 });

--- a/packages/cli/test/piece-verbs.test.ts
+++ b/packages/cli/test/piece-verbs.test.ts
@@ -40,6 +40,45 @@ function cell(value: unknown, schema?: JSONSchema): {
   return self;
 }
 
+/** A result cell as a `cf` command is actually handed one: `get()` and
+ * `schema` offer only what the pattern's declared result TYPE carries, while
+ * `key()` still reaches every stored property. `streams` names the properties
+ * whose stored cell answers as a stream; every other child answers no, which
+ * is what makes this double able to refuse — the forced-stream cast the
+ * listing must not use would get "yes" from all of them. */
+function schemaFilteredCell(
+  value: Record<string, unknown>,
+  schema: JSONSchema,
+  streams: ReadonlySet<string>,
+): {
+  schema: JSONSchema;
+  get: () => unknown;
+  getRaw: () => unknown;
+  asSchemaFromLinks: () => unknown;
+  key: (name: string) => unknown;
+} {
+  const child = (name: string) => {
+    const self = {
+      schema: undefined,
+      get: () => undefined,
+      getRaw: () => undefined,
+      isStream: () => streams.has(name),
+      asSchemaFromLinks: () => self,
+      key: () => self,
+    };
+    return self;
+  };
+  return {
+    schema,
+    get: () => value,
+    getRaw: () => value,
+    asSchemaFromLinks: function () {
+      return this;
+    },
+    key: child,
+  };
+}
+
 const ADD_TOPIC_EVENT: JSONSchema = {
   type: "object",
   properties: {
@@ -309,6 +348,84 @@ describe("listPieceCallables", () => {
     expect(Object.hasOwn(byName.get("touch")!, "outputSchema")).toBe(false);
     // Data stays out of the listing whatever its node declares.
     expect(byName.has("noteCount")).toBe(false);
+  });
+
+  it("lists a graph verb the result cell omits, and only if it is stored", async () => {
+    // The result cell reads through the pattern's DECLARED result type, so a
+    // verb that type omits appears in neither the value nor the durable
+    // schema — the walk is never offered the name at all, which is a different
+    // failure from classifying it wrongly. The graph names it, so the graph is
+    // a candidate source.
+    //
+    // It is a candidate source and not a verdict, which `ghostVerb` is here to
+    // hold: the graph wires a handler to it exactly as it does `hiddenVerb`,
+    // but the piece stores no stream there, so it must not be listed. Without
+    // that second gate the graph becomes a way to name rows nobody can call —
+    // the direction #5683 closed, reopened from the other end.
+    const streams = new Set(["hiddenVerb"]);
+    const resultRoot = schemaFilteredCell(
+      { noteCount: 3 },
+      { type: "object", properties: { noteCount: { type: "number" } } },
+      streams,
+    );
+    const pattern = compiledPattern({
+      result: {
+        hiddenVerb: streamAlias({ stream: "hiddenVerb" }),
+        ghostVerb: streamAlias({ stream: "ghostVerb" }),
+        noteCount: streamAlias("noteCount", { type: "number" }),
+      },
+      nodes: [
+        {
+          module: { wrapper: "handler", resultSchema: CREATE_NOTE_RESULT },
+          inputs: { $event: streamAlias({ stream: "hiddenVerb" }) },
+          outputs: {},
+        },
+        {
+          module: { wrapper: "handler" },
+          inputs: { $event: streamAlias({ stream: "ghostVerb" }) },
+          outputs: {},
+        },
+        // Ordinary data: no `$event`, so never a candidate in the first place.
+        {
+          module: { type: "javascript", resultSchema: { type: "number" } },
+          inputs: { list: streamAlias("notes") },
+          outputs: streamAlias("noteCount"),
+        },
+      ],
+    });
+    const piece = {
+      result: { getCell: () => Promise.resolve(resultRoot) },
+      input: { getCell: () => Promise.resolve(cell(undefined, undefined)) },
+      getCell: () => resultRoot,
+      getPattern: () => Promise.resolve(pattern),
+    };
+    const listing = await listPieceCallables(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-791",
+        space: "home",
+      },
+      {
+        loadPieces: () => Promise.resolve({} as never),
+        loadPiece: () => Promise.resolve(piece as never),
+      },
+    );
+
+    // One row for three graph properties. Enumerating from the result cell
+    // alone drops `hiddenVerb` and the list is empty; listing on the graph's
+    // say-so adds `ghostVerb`; classifying on the forced-stream cast adds
+    // `noteCount` as well.
+    expect(listing.verbs.map((verb) => verb.name)).toEqual(["hiddenVerb"]);
+    // The row is complete, not a stub: a graph candidate claims its declared
+    // result on the same terms a result-cell row does.
+    expect(listing.verbs[0]).toEqual({
+      name: "hiddenVerb",
+      kind: "handler",
+      on: "result",
+      inputSchema: true,
+      outputSchema: CREATE_NOTE_RESULT,
+    });
   });
 
   it("lists a piece whose pattern cannot be resolved", async () => {

--- a/packages/cli/test/piece-verbs.test.ts
+++ b/packages/cli/test/piece-verbs.test.ts
@@ -426,6 +426,94 @@ describe("listPieceCallables", () => {
       inputSchema: true,
       outputSchema: CREATE_NOTE_RESULT,
     });
+    // The graph WAS read, so the listing claims to be the whole surface. An
+    // implementation that reports `incomplete` unconditionally, or that reads
+    // the flag off anything other than whether the pattern resolved, fails
+    // here rather than only in the paired case below.
+    expect(listing.incomplete).toBeUndefined();
+  });
+
+  it("reports the listing as incomplete when the pattern cannot be read", async () => {
+    // The paired failure of the case above, and the reason the pattern is not
+    // advisory here the way the source identity is. `getPattern` rejects on a
+    // real piece that carries no pattern identity and on one whose source will
+    // not load in this space, and in both the piece still DISPATCHES every
+    // verb — resolution never consults the graph. So the listing keeps
+    // answering. What it must not do is answer as though it had looked
+    // everywhere: `hiddenVerb` is named by the graph alone, so it is gone, and
+    // a caller reading this listing would otherwise conclude the piece has
+    // nothing to call.
+    const streams = new Set(["hiddenVerb"]);
+    const resultRoot = schemaFilteredCell(
+      { noteCount: 3 },
+      { type: "object", properties: { noteCount: { type: "number" } } },
+      streams,
+    );
+    const piece = {
+      result: { getCell: () => Promise.resolve(resultRoot) },
+      input: { getCell: () => Promise.resolve(cell(undefined, undefined)) },
+      getCell: () => resultRoot,
+      getPattern: () =>
+        Promise.reject(new Error("could not load pattern sha256:x#default")),
+    };
+    const listing = await listPieceCallables(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-792",
+        space: "home",
+      },
+      {
+        loadPieces: () => Promise.resolve({} as never),
+        loadPiece: () => Promise.resolve(piece as never),
+      },
+    );
+
+    // The loss is real and is not recoverable — no second source names a verb
+    // the declared result type omits.
+    expect(listing.verbs).toEqual([]);
+    // ...so the listing says it is a lower bound. This is what fails against a
+    // `catch {}` that leaves the candidate names empty and returns the short
+    // list as though it were the surface: `incomplete` is undefined there, and
+    // an empty listing is indistinguishable from a piece with no verbs.
+    expect(listing.incomplete).toBe("pattern-unavailable");
+  });
+
+  it("checks the result view and the piece root for a stored signal independently", async () => {
+    // Two sources of stored evidence, and neither is allowed to mask the
+    // other. `notify` reads as an ordinary number through the declared result
+    // type while the piece root stores the stream sentinel at the same name —
+    // one cell in a live piece, two objects wherever a surface supplies them
+    // apart, which is the case this pins.
+    const resultRoot = cell(
+      { notify: 3 },
+      { type: "object", properties: { notify: { type: "number" } } },
+    );
+    const piece = {
+      result: { getCell: () => Promise.resolve(resultRoot) },
+      input: { getCell: () => Promise.resolve(cell(undefined, undefined)) },
+      getCell: () => ({ get: () => ({ notify: { $stream: true } }) }),
+    };
+    const listing = await listPieceCallables(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-793",
+        space: "home",
+      },
+      {
+        loadPieces: () => Promise.resolve({} as never),
+        loadPiece: () => Promise.resolve(piece as never),
+      },
+    );
+
+    // Fails against coalescing the two values before classifying either —
+    // `resultValue ?? pieceValue` and `resultValue || pieceValue` both yield
+    // `3` here, and `3` carries no stream signal, so the sentinel is never
+    // looked at and the listing is empty. It passes only when each stored
+    // value is put to classification on its own.
+    expect(listing.verbs.map((verb) => verb.name)).toEqual(["notify"]);
+    expect(listing.verbs[0].kind).toBe("handler");
   });
 
   it("lists a piece whose pattern cannot be resolved", async () => {


### PR DESCRIPTION
## Why

`cf piece verbs` returned `{"verbs":[]}` for a piece whose pattern declares a
result type that omits its verbs — while `cf piece call` reached those same
verbs and worked (#5698). Verb discovery is the surface an agent uses to find
out what a piece can do, and a piece that answers "nothing" while accepting
`increment` teaches a caller it is inert. That is a quieter failure than listing
something uncallable, because there is nothing to be suspicious of.

The cause was enumeration, not classification. `listPieceCallables` built its
candidate names from the result cell, which `PiecesController.getPieceCell`
narrows to the pattern's declared result schema. A verb that type never mentions
is absent from the schema-filtered value and from the durable schema alike, so
the name was never proposed — and no classification runs on a name nothing
proposed. `cf piece call` never had the problem: a dispatcher is handed a name
rather than enumerating one.

This is the second direction of the same surface. #5683 fixed the first — the
listing inventing verbs, by classifying on definite stored signals rather than a
forced-stream cast — and the constraint here was to recover the lost verbs
without re-introducing the phantoms that fix removed. Every candidate, from
wherever it is proposed, must still pass a definite stored signal, so a data
field stays out of the listing exactly as before.

## What Changed

**Enumeration is separated from classification, and neither guesses the other.**

- `packages/cli/lib/piece.ts`: the compiled pattern is read once for two
  independent jobs. `patternResultNames` enumerates **every** `pattern.result`
  property as a candidate name; `handlerVerbResults` (was `patternVerbResults`)
  matches handler nodes to result properties and supplies a row's declared
  result as **metadata**. Fusing the two hid every `patternTool()` the declared
  result type omits, because a tool compiles to no node and stores no stream, so
  no handler-keyed enumeration can propose one however carefully it is written.
- The candidate sweep classifies with `detectCallableKind` — the same call the
  result-cell walk and `cf piece call` resolve through — instead of hard-coding
  `"handler"`. A graph candidate arrives with no evidence of its kind; assuming
  one listed a tool as a handler, with `invoke` and the wrong input schema.
- The sweep's two stored signals are checked **independently**.
  `getCallableValue(resultRootValue, name) ?? getCallableValue(pieceValue, name)`
  let any non-null value on the result view — ordinary data included — hide a
  stream sentinel stored at the same name on the piece root.

**A result-side verb now outranks a same-named input verb, structurally.**
`resolvePieceCallable` tries the result cell, then the input cell, then the
forced-stream probe on the piece root. The listing inverted that for the one
case this change created: the result walk cannot *see* a verb the declared
result type omits, so the input walk reached the name first and the sweep's
`!listings.has(name)` guard skipped the graph candidate that would have
corrected it. A caller built a payload from the input cell's schema and sent it
to the result-side callable.

Rank now follows **which stored signal classified the name**, not which source
proposed it, because the two line up exactly:
`tryResolvePieceCallableAt(piece, ..., "result")` classifies
`resultRoot.key(name).asSchemaFromLinks()` against `resultRoot.get()[name]` —
the sweep's first `detectCallableKind` call, argument for argument. So a
result-cell signal replaces a row the walk put on the input cell, a piece-root
signal does not, and neither disturbs a row already on the result cell. The
listing's `on` and the dispatcher's choice of cell cannot drift apart by
construction rather than by matching two code paths by hand.

**The listing degrades visibly instead of silently.** `getPattern()` throws on a
piece carrying no pattern identity and on one whose source will not load in this
space (`PieceController.#loadCurrentPattern`). In both, every stored verb still
**dispatches** — resolution never consults the graph — so the listing must keep
answering rather than fail. But the `catch {}` was honest only while the pattern
supplied metadata: once it supplies **names**, swallowing it turns "lost an
`outputSchema`" into "lost the row", with the short list still presenting itself
as the surface. `listPieceCallables` now returns
`incomplete: "pattern-unavailable"`, which `cf piece verbs` prints (including on
the empty-listing path) and rides on `--json` — the rule the hidden-verb counts
already follow, applied to the other way this listing can be short.

**Two guards, one mechanism.** The `catch {}` and the `!listings.has(name)`
guard were both written for a sweep that supplied *fallbacks* for names already
seen, and both were left alone when the sweep became a source of *names*. That
is noted in the code at the sweep, so the next reader meets the shape before
adding a third candidate source.

**Presentation extracted so it can be tested.** `verbListingNotes`,
`verbListingLines` and `verbListingJson` are pure and exported; the command
action calls them. The printed text is **byte-identical** — worth stating
plainly, since a presentation refactor is exactly where an unintended wording
change would hide, and the tests pin the strings.

**No new pattern load.** The listing already resolved `getPattern()` for declared
results, and this reuses that one call. The dispatch path is untouched, so
`piece-call-help-live.test.ts`'s pin that an ordinary `cf piece call` loads
**zero** patterns still holds.

**Docs.** `docs/common/verbs-over-the-cli.md` states what the listing covers,
how strong absence from it is, and that a row's `on` names the cell the
dispatcher will reach. `docs/plans/verb-evolution.md` no longer carries #5698 as
a live precondition and names the two residual gaps a probing caller must know
about. `docs/plans/verbs-implementation.md`'s issue tail marks it fixed.
`docs/development/COVERAGE.md` gains the local before/after procedure.

## Test plan

**Red first.** Each new assertion was run against the code it accuses.

| Assertion | Actual before | Expected |
| --- | --- | --- |
| `lists a verb the pattern's declared result type omits` (handlers only, vs main) | `[]` | `["decrement","increment"]` |
| same case, with the omitted `patternTool` | `["decrement","increment"]` | `["decrement","hiddenTool","increment"]` |
| `lists a graph verb the result cell omits, and only if it is stored` | `[]` | `["hiddenVerb"]` |
| `reports the listing as incomplete when the pattern cannot be read` | `undefined` | `"pattern-unavailable"` |
| `checks the result view and the piece root ... independently` | `[]` | `["notify"]` |
| `gives a result-side callable the row when an input callable shares its name` | `on: "input"` | `on: "result"` |

`[]` in the first row is #5698 verbatim. In the fourth the listing was *also*
empty before the change and said nothing about it — the silent degradation the
flag exists to end.

**Mutation, for the assertions whose failure mode is subtler than absence.**

- Hard-coding `kind: "handler"` in the sweep (its state before this change):
  `hiddenTool` lists as a handler — `expected tool, actual handler`.
- Never setting `graphConsulted = true`: `lists a graph verb the result cell
  omits` fails on `expect(listing.incomplete).toBeUndefined()`, so the flag
  cannot be satisfied by reporting it unconditionally.
- Dropping the stored-signal gate (`kind ?? "handler"`): 6 of 8 unit steps and
  both live steps fail, `ghostVerb` among them. The guard #5683 installed still
  bites through `detectCallableKind`.
- Reverting the precedence guards to `!listings.has(name)`: the shadowing case
  reproduces the disagreement exactly.
- Letting a piece-root signal displace an input row: `keeps an input row when
  nothing on the result cell classifies the name` fails on `rootOnly`, which is
  what pins rank 3 below rank 2 rather than merely "the graph wins".
- Printing the incomplete note unconditionally: `prints no incomplete note for a
  listing that read its pattern` fails. The negative is asserted over the whole
  rendered output, not over a flag.
- `??` and `||` both yield `3` in the two-signals case, so neither coalescing
  fix passes it; only asking each stored value on its own does.

**Corpus.** Every `*.tsx` under `packages/patterns` and
`packages/cli/integration/pattern` (398 files, `.test.tsx` excluded) compiled and
run as a real piece against emulated storage, result cell narrowed as
`getPieceCell` narrows it. 248 ran, 150 skipped identically across revisions.

| | listing rows |
| --- | --- |
| `origin/main` | 219 |
| this PR | 225 |

**+6, all additions**; no row removed, no row's kind changed. Five are the
issue's own table: `setGender` (`gender.tsx`) and `recordNow`, `getStats`,
`getOccurrences`, `deleteOccurrence` (`occurrence-tracker.tsx`). The sixth is a
live instance rather than a constructed one: `packages/patterns/shopping-list.tsx`
returns `searchItems`, a `patternTool(searchItemsPattern, { items })`, and its
`Output` interface names `addItem`, `addItemForOmnibot` and `addItems` but not
`searchItems` — invisible to `cf piece verbs` on main, now listed as
`kind: "tool"`.

The precedence change moved **nothing** in the corpus: the listing is
byte-identical before and after it, with no row changing name, kind, or `on`.
All 225 rows are `on: "result"`, so the corpus contains no input-side verb at
all and could never have caught that defect — which is why it is pinned by a
targeted double instead. Zero pieces reported `incomplete`.

**Coverage.** `packages/cli` measured twice from the same base, after rebasing,
per the procedure added to `COVERAGE.md`:

| | `packages/cli` uncovered lines |
| --- | --- |
| merge base (`2ebe54275`) | 3336 |
| this PR | 3300 |

**−36**, entirely in `commands/piece.ts` (593 → 557). `lib/piece.ts` is
unchanged at 544 — every line this PR adds there is covered by the new tests.
The six lines an earlier revision added (`commands/piece.ts` 2070–2073, 2095,
2116; 2070 is a comment line credited by V8 block projection) sat inside a
cliffy action no test could reach, which is a reason to move the logic somewhere
testable rather than to spend an `ACCEPT_COVERAGE_DEBT` marker. All three
extracted helpers now report zero uncovered lines.

A local total does not match CI's — CI sums the group over every job that loads
its files and one local suite loads a subset — so read the delta, not the
absolute. The offset against CI's last reported baseline was +60.

**Gates** (real exit codes, no pipes): `cd packages/cli && deno task test` **0**
(1677 passed / 1034 steps, and 174 / 206; the log names every new step by name,
including `piece-call-help-live.test.ts`'s `loads the pattern for a help page
and not for a dispatch`); `deno fmt --check` **0**; `deno lint` **0**;
`deno task check` **0** (log names `packages/cli/lib/piece.ts`,
`packages/cli/commands/piece.ts` and both changed test files);
`deno task check-no-waitfor` **0**; `deno task check-docs` **0** (549 blocks);
`deno task check-skill-facts` **0**; `deno task check-conflict-markers` **0**.

Not run: `packages/cli/integration/*.sh`, which need a live toolshed. They read
`.verbs[]` and named verbs, never a verb count and never the listing's top-level
key set, so the added `incomplete` key cannot disturb them.

Closes #5698.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Also in this change, and not part of the fix

**The candidate sweep's guard moved from `pieceCell` to `resultRoot`.** The loop
calls `resultRoot.key(name)`, so `resultRoot` is what it needs; `resultRoot` is
declared `let resultRoot: any` and assigned only where the walk reaches a result
cell, so both directions were reachable: with `resultRoot` undefined and
`pieceCell` defined the old guard entered the loop and threw a `TypeError`; with
the reverse it skipped the sweep entirely. Neither is exercised by a test here.

**The verbs command action shrank.** Extracting the presentation removed the
duplicated `omission`/`incomplete` string building from the action. The printed
text is byte-identical, and the extracted functions are covered.

**The earlier wording of the doc claim was wrong and is replaced, not
softened.** `docs/common/verbs-over-the-cli.md` said "Absence from the listing
therefore means there is nothing to call". Two things made that false: the
swallowed `getPattern()` failure above, and markerless handlers, which are
excluded **on purpose** — nothing stored distinguishes one from a data field,
and `probeForcedStreamCell`, the only probe that finds one, accepts every name
it is given, so listing on it would offer the whole piece as callable. That
second gap is unachievable rather than unimplemented, which is why the fix is to
state the bound rather than to chase it: absence from a listing reporting no
`incomplete` means no *listable* verb of that name — strong enough to enumerate
against, not strong enough to prove a named verb does not exist.
