### PR TITLE
docs: the fabric-primitive vocabulary's net state, recorded where it shows

### DIFF
--- a/docs/specs/json_schema.md
+++ b/docs/specs/json_schema.md
@@ -215,8 +215,9 @@ Deliberate extensions beyond the 2020-12 vocabulary:
   TypeScript structural rule that a `FabricBytes` is assignable to
   `{length: number}`. The nominal brand key
   (`FABRIC_SPECIAL_OBJECT_BRAND` in `packages/api/index.ts`), which
-  generated schemas name in `required`, has no runtime existence and counts
-  as present on any fabric value. Property sub-schemas are still not walked
+  schemas from pre-vocabulary compilations name in `required` (current
+  generator emissions omit it everywhere), has no runtime existence and
+  counts as present on any fabric value. Property sub-schemas are still not walked
   against a primitive: presence is checked, shapes are not, so
   `{ "type": "object", "properties": { "source": { "type": "number" } } }`
   matches a `FabricRegExp` even though its `source` is a string. Schemas

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -37,7 +37,7 @@ into the same active-origin and revision model.
 
 ## Last Updated
 
-2026-07-22
+2026-08-13
 
 ## Motivation
 
@@ -377,6 +377,17 @@ the two paths cannot drift apart on what "compatible" means.
 - **Every** baseline is checked, never just the newest: a piece rolls forward
   from whatever version it last opened at, and the evolution-policy allowances
   are not guaranteed to compose across steps.
+- One refusal is policy, not shape drift: a baseline that describes a fabric
+  special object structurally — an object schema whose `required` carries the
+  `FabricSpecialObject` brand key, the emission of pre-vocabulary
+  compilations — is not accepted against the fabric-primitive type name
+  (`{ type: "FabricBytes" }` and friends) the same authored field compiles to
+  today, even with the source unchanged. Stored values re-stage verbatim
+  across an update, so a structural inhabitant of the wrong kind would
+  survive it only to fail every prototype-matched read; updating such a piece
+  takes redeployment or `dangerouslyAllowIncompatibleSchema`. The full
+  argument lives with the check (`schemaSubsetIssue`,
+  `packages/piece/src/schema-compatibility.ts`).
 - Baselines are **never pruned**, and `deno task pattern-compat --update` can
   only add one. An author-run command that could remove a baseline could remove
   the one that would have caught the break.

--- a/packages/runner/src/cfc/schema-sanitization.ts
+++ b/packages/runner/src/cfc/schema-sanitization.ts
@@ -1666,10 +1666,12 @@ const validateAgainstSchemaInternal = (
       if (typeAllowsObject && Array.isArray(schema.required)) {
         for (const key of schema.required) {
           // The nominal brand key has no runtime existence; a fabric value
-          // satisfies it by construction. Removable with the other brand
-          // exemptions (see opaqueLeafMissesRequired in traverse.ts) once
-          // the schema-generator skips the brand and stored schemas that
-          // carry it have cycled out.
+          // satisfies it by construction. Only schemas from pre-vocabulary
+          // compilations carry it (current emissions skip it everywhere).
+          // Removable with the other brand exemptions (see
+          // opaqueLeafMissesRequired in traverse.ts) once those stored
+          // schemas have cycled out — a redeploy-gated horizon, since
+          // pattern update refuses the structural-to-vocabulary transition.
           if (key === FABRIC_SPECIAL_OBJECT_BRAND) continue;
           if (!(key in value)) {
             return mismatch(`missing required property ${key}`);

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -4755,13 +4755,16 @@ function schemaTypeIncludesObject(type: JSONSchemaObj["type"]): boolean {
  * — prototype chain included, the same check the anyOf prefilters apply —
  * so a class accessor such as `FabricBytes.length` satisfies
  * `required: ["length"]` while a key the primitive lacks rejects it. The
- * nominal brand key generated schemas require has no runtime existence and
- * is satisfied by the instance itself; that exemption (here and at the
- * other brand-aware check sites) exists because the schema-generator's
- * object formatter currently emits the brand into `required`, and it can
- * be removed once the generator skips the brand and stored schemas that
- * carry it have cycled out. A fabric-primitive-typed schema is not gated
- * here (its type never includes "object").
+ * nominal brand key that schemas from pre-vocabulary compilations require
+ * has no runtime existence and is satisfied by the instance itself; that
+ * exemption (here and at the other brand-aware check sites) exists for
+ * those stored schemas — current generator emissions carry the brand
+ * nowhere — and it can be removed once they have cycled out. That horizon
+ * is redeploy-gated: pattern update refuses the structural-to-vocabulary
+ * transition (`packages/piece/src/schema-compatibility.ts`), so such a
+ * schema persists until its piece is redeployed. A
+ * fabric-primitive-typed schema is not gated here (its type never
+ * includes "object").
  *
  * Presence is the whole check: property sub-schemas are NOT enforced
  * against a primitive's accessor values, so


### PR DESCRIPTION
## What

The fabric-primitive schema-vocabulary arc landed in two steps — #5483 (the generator emits the vocabulary and skips the `FabricSpecialObject` brand) and #5591 (the pattern-evolution allowance for the structural→vocabulary transition is removed; the refusal is deliberate). This PR records the net state in the four places that still described an intermediate one:

1. **`docs/specs/json_schema.md`** — the brand key was described as one "which generated schemas name in `required`". That is true of pre-vocabulary compilations only; current emissions omit the brand everywhere. One clause.
2. **`docs/specs/pattern-imports/pattern-updates.md`** — the CI-gate section (`deno task pattern-compat`) gains a bullet naming the one refusal that is policy rather than shape drift: a brand-marked structural baseline refuses against the fabric-primitive type name the same authored field compiles to today, even with the source unchanged. The bullet names the consequence (recompiling an unchanged pattern with such a field trips the gate), the escape hatches (redeployment, `dangerouslyAllowIncompatibleSchema`), and points at `schemaSubsetIssue` for the full argument.
3. **`packages/runner/src/traverse.ts` + `packages/runner/src/cfc/schema-sanitization.ts`** (comments only) — both brand-exemption comments conditioned their removal on "once the schema-generator skips the brand and stored schemas that carry it have cycled out". The first condition is met; the second is redeploy-gated by the #5591 refusal, so the comments now say what actually gates the horizon.

No behavior changes; the two runner edits are comment-only.

## Verification

- `deno fmt --check` on touched files, `deno lint` on the two runner files, `check-docs` (549 blocks), `check-conflict-markers` — all green under the pinned deno 2.9.4
- Repo-wide `deno task check` fails identically with and without these changes (verified by stash test on the base commit `c936e01ac`): three pre-existing `TS2339 'headers'` errors in `packages/toolshed/lib/gateway-provenance.{ts,test.ts}` (from #5678) that reproduce locally under the pinned toolchain and a fresh `DENO_DIR`, while CI reports the same commit green — the same warm-check-cache masking pattern as the recent `cell-selection.ts` episode. Flagged separately; not introduced or touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

