### PR TITLE
fix(ts-transformers): carry an optional access through an inline callback to its owning call's site

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -497,13 +497,22 @@ Diagnostics emitted in all modes:
     `computed(() => ...)` or module-scope `lift()`
 - **Error** `pattern-context:optional-chaining`
   - optional property / element access that appears outside a supported
-    lowerable expression site
+    lowerable expression site — including inside a lowered array-method
+    callback (`map`/`filter`/`flatMap`) and inside a callback whose owning
+    call has no lowerable site
+  - an optional access inside an inline callback argument is carried by the
+    callback's owning call when that call is outside the lowered array-method
+    families and itself sits at a lowerable expression site: the site's lift
+    absorbs the callback, so the access runs on resolved values
+    (`rows.get().toSorted((a, b) => (a?.sentAt ?? 0) - (b?.sentAt ?? 0))`)
   - optional calls do not receive this diagnostic merely because they are
     optional: their underlying call root is classified by the same policy as a
     non-optional call
   - at supported expression sites, receiver optionality (`value?.method()`),
     invocation optionality (`value.method?.()`), and combined chains lower as
     whole calls with JavaScript short-circuit and receiver semantics intact
+  - message instructs the author to wrap the computation in
+    `computed(() => ...)` or move it to a site that lowers
 - **Error** `pattern-context:computation`
   - binary/unary/conditional computations using opaque dependencies outside
     wrappers

--- a/packages/ts-transformers/src/transformers/expression-site-policy.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-policy.ts
@@ -1373,6 +1373,54 @@ export function findLowerableExpressionSite(
   return deferredArrayMethodReceiverSite;
 }
 
+/**
+ * A carrier site for an expression whose own site walk stops at a callback
+ * boundary: the expression sits inside an inline callback argument, and the
+ * callback's owning call lowers at an expression site of its own. The lift
+ * wrapping that site absorbs the callback, so the expression runs on resolved
+ * values — `rows.get().toSorted((a, b) => (a?.sentAt ?? 0) - (b?.sentAt ?? 0))`
+ * carries the comparator's `?.` inside the lift body.
+ *
+ * Callbacks of the array-method families (`map`/`filter`/`flatMap`) are
+ * excluded: those lower through their `*WithPattern` counterparts, whose
+ * callback-pattern machinery models elements on its own terms.
+ */
+export function findInlineCallbackCarrierSite(
+  expression: ts.Expression,
+  context: TransformationContext,
+  analyze: AnalyzeFn,
+): LowerableExpressionSite | undefined {
+  let current: ts.Node | undefined = expression.parent;
+
+  while (current) {
+    if (ts.isFunctionLike(current)) {
+      const parent: ts.Node | undefined = current.parent;
+      if (
+        !parent || !ts.isCallExpression(parent) ||
+        !ts.isExpression(current) || !parent.arguments.includes(current)
+      ) {
+        return undefined;
+      }
+
+      if (classifyArrayMethodCall(parent)) {
+        return undefined;
+      }
+
+      const site = findLowerableExpressionSite(parent, context, analyze);
+      if (site) {
+        return site;
+      }
+
+      current = parent.parent;
+      continue;
+    }
+
+    current = current.parent;
+  }
+
+  return undefined;
+}
+
 export function findPreferredNestedLowerableExpressionSite(
   expression: ts.Expression,
   context: TransformationContext,

--- a/packages/ts-transformers/src/transformers/expression-site-policy.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-policy.ts
@@ -1394,10 +1394,18 @@ export function findInlineCallbackCarrierSite(
 
   while (current) {
     if (ts.isFunctionLike(current)) {
-      const parent: ts.Node | undefined = current.parent;
+      // Parentheses around the callback are transparent, here as everywhere
+      // in the site rules: `toSorted(((a, b) => ...))` carries like
+      // `toSorted((a, b) => ...)`.
+      let argument: ts.Node = current;
+      let parent: ts.Node | undefined = current.parent;
+      while (parent && ts.isParenthesizedExpression(parent)) {
+        argument = parent;
+        parent = parent.parent;
+      }
       if (
         !parent || !ts.isCallExpression(parent) ||
-        !ts.isExpression(current) || !parent.arguments.includes(current)
+        !ts.isExpression(argument) || !parent.arguments.includes(argument)
       ) {
         return undefined;
       }

--- a/packages/ts-transformers/src/transformers/pattern-context-validation.ts
+++ b/packages/ts-transformers/src/transformers/pattern-context-validation.ts
@@ -26,8 +26,10 @@
  * - Property access used in computation: ERROR (must wrap in computed())
  * - Optional chaining:
  *   - optional property/element access is allowed in supported lowerable
- *     expression sites
- *   - non-lowerable optional access still errors
+ *     expression sites, and inside an inline callback whose owning call
+ *     lowers at one (the lift absorbs the callback)
+ *   - non-lowerable optional access still errors, including inside a
+ *     lowered array-method callback
  * - Calling .get() on a cell with no lowerable expression site to carry the
  *   read: ERROR (must wrap in computed()); a read at a lowerable site is
  *   auto-wrapped into a lift instead
@@ -59,6 +61,7 @@ import {
 import {
   classifyRestrictedReactiveComputation,
   classifyUnsupportedExpressionSiteCallRoot,
+  findInlineCallbackCarrierSite,
   findLowerableExpressionSite,
 } from "./expression-site-policy.ts";
 import {
@@ -218,9 +221,11 @@ export class PatternContextValidationTransformer
 
       // Check for optional navigation in reactive context. Optional property /
       // element access remains valid at lowerable expression sites (including
-      // JSX). When the chain is a call callee, the call-root policy decides
-      // whether the underlying call kind is lowerable; optionality itself does
-      // not change that decision.
+      // JSX), and inside an inline callback whose owning call lowers at one —
+      // the lift wrapping that site absorbs the callback, so the access runs
+      // on resolved values. When the chain is a call callee, the call-root
+      // policy decides whether the underlying call kind is lowerable;
+      // optionality itself does not change that decision.
       if (
         (
           ts.isPropertyAccessExpression(node) ||
@@ -233,14 +238,18 @@ export class PatternContextValidationTransformer
         if (
           !optionalCallTargetHandledByCallRootPolicy &&
           isInRestrictedReactiveContext(node, checker, context) &&
-          !findLowerableExpressionSite(node, context, analyze)
+          !findLowerableExpressionSite(node, context, analyze) &&
+          !findInlineCallbackCarrierSite(node, context, analyze)
         ) {
           context.reportDiagnostic({
             severity: "error",
             type: "pattern-context:optional-chaining",
             message:
-              `Optional chaining '?.' is not allowed in reactive context. ` +
-              `Use ifElse() or wrap in computed() for conditional access.`,
+              `This optional access has no expression site that can carry ` +
+              `it, so it cannot be lowered against resolved values. Wrap ` +
+              `it in computed(() => ...) for conditional access, or use it ` +
+              `at a site that lowers — a binding, a return, an object ` +
+              `property, or a JSX expression.`,
             node,
           });
         }

--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -3311,6 +3311,77 @@ Deno.test("Reactive .get() Validation", async (t) => {
   );
 
   await t.step(
+    "allows optional access inside an inline comparator on a .get() chain",
+    async () => {
+      const source = `      import { pattern, Writable } from "commonfabric";
+
+      interface Row {
+        sentAt: number;
+      }
+
+      export default pattern<{ rows: Writable<Row[]> }>(({ rows }) => {
+        const sorted = rows.get().toSorted((a, b) =>
+          (a?.sentAt ?? 0) - (b?.sentAt ?? 0)
+        );
+        return { sorted };
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertEquals(
+        errors.length,
+        0,
+        "the binding site's lift absorbs the comparator, so its '?.' runs " +
+          "on resolved values",
+      );
+    },
+  );
+
+  await t.step(
+    "still errors on optional access inside a lowered array-method callback",
+    async () => {
+      const source = `      import { pattern, Writable } from "commonfabric";
+
+      interface Row {
+        flag?: boolean;
+      }
+
+      export default pattern<{ rows: Writable<Row[]> }>(({ rows }) => {
+        const flagged = rows.get().filter((r) => r?.flag);
+        return { flagged };
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertGreater(errors.length, 0, "Expected at least one error");
+      assertHasErrorType(errors, "pattern-context:optional-chaining");
+    },
+  );
+
+  await t.step(
+    "still errors on optional access inside a plain array-method callback",
+    async () => {
+      const source = `      import { pattern, Writable } from "commonfabric";
+
+      export default pattern<{ label: Writable<string> }>(({ label }) => {
+        const lens = ["a", "bb"].map((s) => s?.length ?? 0);
+        return { lens, label };
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertGreater(errors.length, 0, "Expected at least one error");
+      assertHasErrorType(errors, "pattern-context:optional-chaining");
+    },
+  );
+
+  await t.step(
     "errors on a .get() inside a reactive array-method callback",
     async () => {
       const source = `      import { pattern, Writable } from "commonfabric";

--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -3340,6 +3340,41 @@ Deno.test("Reactive .get() Validation", async (t) => {
   );
 
   await t.step(
+    "allows optional access inside a parenthesized inline comparator",
+    async () => {
+      const source = `      import { pattern, Writable } from "commonfabric";
+
+      interface Row {
+        sentAt: number;
+      }
+
+      export default pattern<{ rows: Writable<Row[]> }>(({ rows }) => {
+        const sorted = rows.get().toSorted(((a, b) =>
+          (a?.sentAt ?? 0) - (b?.sentAt ?? 0)
+        ));
+        return { sorted };
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      // The parenthesized spelling still draws the (pre-existing)
+      // function-creation rejection — parentheses hide the callback from
+      // that validation's inline-argument allowance, a separate gap. This
+      // step pins the carrier decision alone: optionality is carried
+      // through the parentheses, so no optional-chaining error joins it.
+      assertEquals(
+        errors.some((error) =>
+          error.type === "pattern-context:optional-chaining"
+        ),
+        false,
+        "parentheses around the callback do not change the carrier decision",
+      );
+    },
+  );
+
+  await t.step(
     "still errors on optional access inside a lowered array-method callback",
     async () => {
       const source = `      import { pattern, Writable } from "commonfabric";


### PR DESCRIPTION
## Problem

`pattern-context:optional-chaining` rejected `?.` inside an inline callback even when the callback's owning call lowers at an expression site and absorbs the callback into the lift body as plain JS. The site walk (`findLowerableExpressionSite`) hard-stops at function boundaries, so an optional access inside a comparator can never see the initializer site that carries the whole chain:

```tsx
const sorted = rows.get().toSorted((a, b) => (a?.sentAt ?? 0) - (b?.sentAt ?? 0));
// rejected — while the identical comparator without `?.` compiles, and emits
// the comparator VERBATIM as plain JS inside the lift body:
//   ({ rows }) => rows.get().toSorted((a, b) => (a.sentAt ?? 0) - (b.sentAt ?? 0))
```

This is the residual blocker #5454's description named for `topic.tsx`'s `commentsView` (`a?.sentAt` / `b?.sentAt` in the `.toSorted` comparator). It also breaks the ratified optionality-orthogonality principle: the non-optional twin is supported language, and the matrix says optionality does not change the classification — so no normative text moves here, and no design-deltas entry is needed. The current-behavior spec §6 entry is updated.

## Fix

`findInlineCallbackCarrierSite()` (expression-site-policy.ts): climb from the access to the nearest enclosing inline callback argument; if the callback's owning call has a lowerable site of its own, that site carries the access. Two deliberate exclusions bound the blast radius:

- **Lowered array-method families** (`map`/`filter`/`flatMap`, per `classifyArrayMethodCall`) stay rejected — those lower through their `*WithPattern` counterparts, whose callback-pattern machinery models elements on its own terms. Revisiting that arm is its own follow-up.
- **A callback whose owning call has no lowerable site** (a plain array method over plain values) stays rejected, matching the plain-array conservatism settled in #5454.

`toSorted` is not in the array-method registry, so the motivating comparator is carried. The diagnostic message now names the actual rule (no expression site to carry the access), mirroring #5454's get-call reword; no test pinned the old text.

## Verification

- Full package suite green (1139, includes spec-sync); three new validation pins: comparator-accept, lowered-array-method-callback-reject, plain-array-callback-reject
- Probe battery both sides of the boundary: the full commentsView shape and the minimal comparator flip to accepted; optional access in a reactive `map` callback stays accepted (unchanged path); `?.` in a lowered `.filter` callback on a get chain and in a plain-plain callback stay rejected; the #5454 get-call battery is unchanged
- The real `commentsView` unwrap in `topic.tsx` compiles clean under this fix (scratch-verified, not included — it stays wrapped pending the JSX-map-over-lift-result lowering gap, tracked separately)
- Emitted output inspected: the comparator rides inside the lift body verbatim with `?.` preserved, schema unchanged from the non-optional twin
- `deno fmt --check`, `deno lint`, `check-docs` green under the pinned toolchain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

