### PR TITLE
fix(toolshed): write out the gateway fetch wrapper's parameter types

### DIFF
--- a/packages/toolshed/lib/gateway-provenance.test.ts
+++ b/packages/toolshed/lib/gateway-provenance.test.ts
@@ -13,7 +13,9 @@ function recordingFetch(): {
 } {
   let seen: Headers | undefined;
   return {
-    fetch: (_input, init) => {
+    // Parameters written out for the reason withGatewayProvenance gives:
+    // `typeof fetch` yields an `init` whose `headers` cannot be read.
+    fetch: (_input: RequestInfo | URL, init?: RequestInit) => {
       seen = new Headers(init?.headers);
       return Promise.resolve(new Response(null, { status: 204 }));
     },

--- a/packages/toolshed/lib/gateway-provenance.ts
+++ b/packages/toolshed/lib/gateway-provenance.ts
@@ -96,9 +96,14 @@ export function gatewayProvenanceHeaders(
  * left `init` silent about them. Silent means absent: an `init` naming
  * something that is no header list, `null` among them, reaches `Headers` and
  * is refused there, which is what `fetch` does with it too.
+ *
+ * The parameter types are written out because `typeof fetch` is not stable
+ * here: with `@types/node`'s globals in the type graph, its `init` becomes a
+ * union of two `RequestInit` declarations, and `headers` cannot be read from
+ * that union.
  */
 export function withGatewayProvenance(inner: typeof fetch): typeof fetch {
-  return (input, init) => {
+  return (input: RequestInfo | URL, init?: RequestInit) => {
     const headers = new Headers(
       init?.headers !== undefined
         ? init.headers


### PR DESCRIPTION
## Why

`tasks/check.sh` accepts any Deno in [2.8.0, 2.10.0) and warns-but-continues off the 2.9.4 pin, so 2.8.x is a supported check environment — and under Deno 2.8.1 (TypeScript 5.9) the tree fails `deno task check` with three TS2339s here:

```
TS2339 [ERROR]: Property 'headers' does not exist on type 'RequestInit | global.RequestInit'.
    at packages/toolshed/lib/gateway-provenance.ts:103, :104, and the test's recorder
```

The wrapper's `(input, init)` parameters are contextually typed from `typeof fetch`. With `@types/node`'s globals in the check program, that type carries two `RequestInit` declarations; under TS 5.9 `init` becomes their union, one member declares no `headers`, and the reads are refused. TS 6.0.3 (Deno 2.9.4) resolves the same program without the union, which is why CI and pinned runs are green. Two aggravations make it worth fixing rather than shrugging at: `gateway-provenance.ts` is the only module under `packages/toolshed` importing a node builtin (`@node/async_hooks`), so the file's own import is what brings those globals into toolshed's check program; and the union only forms in the combined multi-root program `check.sh` builds — `deno check packages/toolshed` alone is green even on 2.8.1, so a package-scoped check never shows it.

Investigation of how this read as "CI's warm cache masks cold checks", and the version-gate condition that actually produced it: #5798.

## What changed

The wrapper's and the test recorder's parameters are written out as `(input: RequestInfo | URL, init?: RequestInit)` instead of being left to contextual typing — the way `cf-harness`'s `HarnessFetch` (`packages/cf-harness/src/contracts/http-fetch.ts`) already writes them out for the same instability — with a comment carrying the rationale. No behavior change.

## Verification

Full `deno task check`, cold caches (fresh `DENO_DIR`, pre-seeded download stores), explicit binaries:

| Deno | before (9a14519ab) | after (this PR) |
|---|---|---|
| 2.9.4 (pin) | green | green |
| 2.8.1 (range floor) | 3× TS2339, exit 1 | green |

Repo-wide `deno fmt --check` and `deno lint`: clean. `packages/toolshed` `deno task test`: 137 passed (415 steps), 0 failed, gateway-provenance file included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

