### PR TITLE
fix(memory): staleness scan excludes the declared layer set, not a predecessor mask

### DIFF
--- a/docs/specs/memory-v2/03-commit-model.md
+++ b/docs/specs/memory-v2/03-commit-model.md
@@ -163,9 +163,9 @@ interface PendingRead {
   // space: the seq of the last accepted write to the document that the
   // client's confirmed view reflected at build time (0 for a document its
   // subscriptions never covered). When present, the staleness check scans
-  // the FULL interval from this basis, excluding only the session's TRUE
-  // PREDECESSOR commits — localSeq below the reader's — per §3.6.3 (the
-  // CT-1910 repair). When absent (a legacy client),
+  // the FULL interval from this basis, excluding only the own-session
+  // layers the `localSeq` array names, per §3.6.3 (the CT-1910 repair
+  // with declared-set validation). When absent (a legacy client),
   // staleness is based at the resolution of the HIGHEST localSeq element —
   // the document's top-of-stack layer below the reader, which the array
   // MUST include (§3.5). Servers ignore unknown fields, so clients attach
@@ -372,6 +372,11 @@ by the read's shape:
   basis never scanned. A `basisSeq` greater than the server's current head
   is a protocol error; values at or below head are trusted, like a
   confirmed read's `seq` (lying corrupts only the session's own data).
+  The declared-set restriction is server-side VALIDATION of the array's
+  completeness attestation, not an extension of what a client may omit:
+  the sanctioned omission remains a processed rejection (§3.5), and a
+  client has nothing to gain from omitting a live layer — the scan
+  converts exactly that bug into a retryable conflict.
 - **Legacy basis (`basisSeq` absent).** The scan is based at the HIGHEST
   element's resolution seq. Writes landing between the reader's confirmed
   basis and that seq are not scanned — the pending-read basis over-advance

--- a/docs/specs/memory-v2/03-commit-model.md
+++ b/docs/specs/memory-v2/03-commit-model.md
@@ -218,12 +218,18 @@ to the observed value and is legitimately absent from the array, and the
 server imposes no resolution requirement on a layer that is not named. This
 is what lets a client process a rejection eagerly and still commit later
 work built over the surviving layers, rather than dooming every dependent
-minted after the verdict. The soundness burden sits with the client:
-omitting a layer whose optimistic value DID contribute to the observed view
+minted after the verdict. The server verifies the DURABLE half of the
+completeness claim: the staleness scan's declared-set exclusion (§3.6.3)
+rejects a read whose omitted own layer left an overlapping durable write in
+the scan interval, so an omission is only ever accepted when the omitted
+layer contributed nothing durable — which a processed rejection never does.
+What remains on the client's honor is only the never-durable half: omitting
+a REJECTED layer whose optimistic value DID contribute to the observed view
 fabricates an observation (the CT-1872 1c phantom shape — an INV-1
 violation, `09-invariants.md`), exactly as a fabricated confirmed read
-would. Omission means "my view did not include this layer", never "I would
-rather not mention it".
+would, and is unverifiable server-side because the rejected value never
+crossed the wire. Omission means "my view did not include this layer",
+never "I would rather not mention it".
 
 The dependency array MUST include the view's top-of-stack pending layer
 below the reader — the highest layer surviving in the overlay when the view
@@ -346,13 +352,21 @@ staleness scan (§3.6.1/§3.6.2) then runs once per read, from a basis chosen
 by the read's shape:
 
 - **True basis (`basisSeq` present).** The scan covers the full interval
-  `(basisSeq, head]` and excludes only the reader's own session's TRUE
-  PREDECESSOR commits — those with `localSeq` below the reader's, the
-  accepted layers its materialized view included. The exclusion is what
-  makes the true basis sound, and its predecessor restriction is what keeps
-  it sound without trusting wire order: an own write with a higher
-  `localSeq` that was admitted first (an out-of-order submission) was not
-  in the reader's view and conflicts exactly like a foreign write. Foreign
+  `(basisSeq, head]` and excludes only the own-session layers the read's
+  dependency array NAMES — the accepted layers whose inclusion in the
+  reader's materialized view the array attests. The exclusion is what
+  makes the true basis sound, and its declared-set restriction is what
+  keeps it sound without trusting either wire order or client discipline:
+  any own write the array does not name conflicts exactly like a foreign
+  write, whether it is a higher `localSeq` admitted first (an out-of-order
+  submission) or an omitted layer whose write is durably integrated — a
+  view missing durable state it never declared away. The server thereby
+  verifies that `basisSeq` plus the named layers fully account for the
+  document's durable history at the read path; §3.5's view-relative
+  omission allowance stays sound because a processed REJECTION left no
+  durable write for the scan to find. (The converse — an omitted rejected
+  layer whose optimistic value DID reach the view — is unverifiable from
+  durable history and remains in the fabricated-read trust class.) Foreign
   writes in the interval conflict — including those between the reader's
   confirmed basis and the top layer's resolution seq, which the legacy
   basis never scanned. A `basisSeq` greater than the server's current head

--- a/docs/specs/memory-v2/09-invariants.md
+++ b/docs/specs/memory-v2/09-invariants.md
@@ -81,9 +81,10 @@ not: a pending read without `basisSeq` is scanned from the highest
 dependency's resolution seq, so overlapping foreign writes landing between
 the reader's confirmed basis and that seq are not scanned. A read declaring
 `basisSeq` is scanned over the full interval from that basis, excluding
-only the session's TRUE PREDECESSOR commits — those with a localSeq below
-the reader's, the accepted layers its view included; an own write admitted
-out of submission order conflicts like a foreign one
+only the own-session layers its dependency array NAMES — the accepted
+layers whose inclusion in the reader's view the array attests; an own
+write the array does not name conflicts like a foreign one, whether
+admitted out of submission order or omitted while durably integrated
 (03-commit-model.md §3.6.3) — the shape current clients always emit. The TLA+ config
 `PendingStacks_Current.cfg` reproduces the legacy-shape violation (kept as a
 regression witness, alongside the legacy-shape engine test in
@@ -124,7 +125,7 @@ generator test asserting the runner's array-op discipline
 > set that (a) includes every pending layer whose acceptance or rejection can
 > change the observed value, and (b) includes the top-of-stack layer of the
 > reader's materialized view. For a read declaring its true confirmed basis
-> (`basisSeq`), the staleness scan runs from that basis with predecessor-only
+> (`basisSeq`), the staleness scan runs from that basis with declared-set
 > own-session exclusion; for a legacy read, the top-of-stack layer's
 > resolution is the staleness basis. Narrowing may drop only non-top layers
 > that provably cannot influence the observed value: a layer whose write
@@ -154,10 +155,14 @@ history (`03-commit-model.md` §3.5): a layer the overlay removed before the
 view was built — a rejection verdict honored, the view rebuilt without it —
 is not a contributor under clause (a), so its absence is a sound narrowing
 and the recorded array may be non-contiguous in the session's `localSeq`
-space. The server cannot check completeness (it does not know the client's
-view); it imposes per-element resolution on what is named and nothing on
-what is not, so the soundness burden for an omission sits entirely with the
-client, in the same trust class as a fabricated read. The interleaving this
+space. The server verifies the durable half of the completeness claim: the
+declared-set exclusion (§3.6.3) makes an omitted own layer's durable
+overlapping write conflict like a foreign one, so an accepted omission is
+one whose omitted layers contributed nothing durable — which a processed
+rejection never does. Only the never-durable half stays on the client's
+honor: an omitted REJECTED contributor's optimistic value never crossed the
+wire, so that omission is unverifiable and sits in the same trust class as
+a fabricated read. The interleaving this
 permits — rejections honored eagerly while an accept's promotion is still
 parked — is reachable in the TLA+ model's `fullstack` recording mode:
 rejection removes the doomed layers from the pending stack, an accepted
@@ -178,9 +183,12 @@ rejection is no longer a contributor); MUST NOT omit a layer of the view
 that overlaps the read path, and MUST NOT omit the view's top-of-stack
 layer. A legacy read MUST NOT base its staleness scan below
 the top of stack; a `basisSeq` read scans from its declared basis and MUST
-exclude only true predecessor own-session commits (localSeq below the
-reader's — an own write accepted out of submission order conflicts like a
-foreign write).
+exclude only the own-session layers its array names — an own write it does
+not name conflicts like a foreign write, whether accepted out of
+submission order or omitted while durably integrated. The declared-set
+exclusion is what lets the server VERIFY the completeness claim against
+durable history instead of trusting it; the phantom direction (an omitted
+rejected contributor) remains unverifiable, as recorded in §3.5.
 
 Checked by: the TLA+ model (both recording modes, under atomic and
 delayed-delivery configs); stacked-commit unit

--- a/docs/specs/memory-v2/09-invariants.md
+++ b/docs/specs/memory-v2/09-invariants.md
@@ -191,8 +191,15 @@ durable history instead of trusting it; the phantom direction (an omitted
 rejected contributor) remains unverifiable, as recorded in §3.5.
 
 Checked by: the TLA+ model (both recording modes, under atomic and
-delayed-delivery configs); stacked-commit unit
-tests (`packages/runner/test/memory-v2-stacked-commit.test.ts`).
+delayed-delivery configs) for recording completeness and sparse-omission
+reachability — its `Build` always names the view's full layer set, so the
+declared-set scan's VALIDATION half (a buggy omission of a durably
+integrated layer) is outside its reach and is checked instead by the
+engine unit tests (`packages/memory/test/v2-sparse-pending-dependencies.test.ts`),
+the differential harness's sparse mutation, and stacked-commit unit
+tests (`packages/runner/test/memory-v2-stacked-commit.test.ts`); see the
+TLA README's "Canonical dependency arrays" note for the coincidence
+argument and the `SkipLayers` refinement that would bring it in scope.
 
 ### INV-4 — Cascade totality
 

--- a/docs/specs/memory-v2/tla/PendingStacks_Repaired.cfg
+++ b/docs/specs/memory-v2/tla/PendingStacks_Repaired.cfg
@@ -1,10 +1,10 @@
 \* Full-stack dependency recording plus the CT-1910 repair (shipped): the
 \* pending-read staleness scan runs from the reader's declared confirmed
 \* basis. The model excludes the reader's whole session from the scan; the
-\* shipped SQL exclusion is predecessor-restricted (own-session commits with
-\* local_seq below the reader's), and the two coincide on every
-\* FIFO-reachable state of this model (see tla/README.md, "Scope of the
-\* certification"). EXPECTED: all invariants HOLD.
+\* shipped SQL exclusion is the DECLARED SET (own-session commits the read's
+\* array names), and the two coincide on every reachable state of this
+\* model because Build always records the full stack (see tla/README.md,
+\* "Scope of the certification"). EXPECTED: all invariants HOLD.
 SPECIFICATION Spec
 CHECK_DEADLOCK FALSE
 CONSTANTS

--- a/docs/specs/memory-v2/tla/README.md
+++ b/docs/specs/memory-v2/tla/README.md
@@ -45,13 +45,27 @@ Repaired result certifies the rule, not the whole pipeline:
 - **FIFO by construction.** `Process` admits `Min(Unresolved(s))`, so a
   later same-session commit can never overtake an earlier one in any
   reachable state. The runner's hold-mode admission CAN reorder sends,
-  which is why the shipped exclusion is predecessor-restricted (own commits
-  with `local_seq` below the reader's) rather than session-wide — a rule
-  that coincides with the model's same-session exclusion in every
-  model-reachable state and stays sound under overtaking. Modeling issued
+  which is one reason the shipped exclusion is the DECLARED SET (own
+  commits the read's array names) rather than session-wide — an own write
+  the array does not name conflicts like a foreign one, whether admitted
+  out of order or omitted while durably integrated. Modeling issued
   versus admitted commits separately, with FIFO as a checked invariant
   rather than a structural given, is the natural refinement if this area
   churns.
+- **Canonical dependency arrays.** `Build` records the layers of the
+  CURRENT stack — under channel delivery that set can be sparse relative
+  to session history (processed rejections are gone from `pend`), but it
+  always names every layer the view sat on, so the model's session-wide
+  scan exclusion coincides with the shipped declared-set exclusion on
+  every reachable state. What the model therefore does NOT exercise is
+  the declared-set scan's VALIDATION role (§3.6.3): a buggy client
+  omitting a live layer whose write is durably integrated. That
+  enforcement is checked by the engine unit tests
+  (`packages/memory/test/v2-sparse-pending-dependencies.test.ts`) and the
+  differential harness's sparse mutation; a `SkipLayers` build choice
+  paired with a named-set `InvalidatedBy` — a violation witness under
+  session-wide exclusion, a pass under named-set — is the natural
+  refinement if omission ever becomes more than a hardening concern.
 
 ## Running
 

--- a/packages/memory/test/naive-admission.ts
+++ b/packages/memory/test/naive-admission.ts
@@ -17,10 +17,12 @@
 //     coarser than this, never finer.
 //   - Pending-read staleness: a read declaring its true confirmed basis
 //     (`basisSeq`, the CT-1910 repair) is scanned over the FULL interval
-//     from that basis, excluding only the reader's own session's TRUE
-//     PREDECESSOR commits (localSeq below the reader's — the layers its
-//     view included; an own write accepted out of submission order
-//     conflicts like a foreign one). A legacy read (no `basisSeq`) is
+//     from that basis, excluding only the own-session layers the read's
+//     dependency array NAMES — the layers whose inclusion in the reader's
+//     view the array attests. An own write the array does not name
+//     conflicts like a foreign one, whether accepted out of submission
+//     order or omitted while durably integrated (the declared-set
+//     validation of §3.6.3). A legacy read (no `basisSeq`) is
 //     based at the HIGHEST dependency's resolution seq — the pre-repair
 //     semantics whose over-advance is recorded against INV-1 in
 //     09-invariants.md and kept here as the reference for legacy traffic.

--- a/packages/memory/test/naive-admission.ts
+++ b/packages/memory/test/naive-admission.ts
@@ -98,17 +98,19 @@ const conflictSeq = (
   id: string,
   readPath: readonly string[],
   afterSeq: number,
-  // CT-1910 true-basis scans exclude the reader's own session's TRUE
-  // PREDECESSOR commits (localSeq below the reader's): those were part of
-  // its materialized view. An own write with a higher localSeq accepted
-  // first (out-of-order submission) conflicts like a foreign write.
-  exclude?: { sessionId: string; beforeLocalSeq: number },
+  // CT-1910 true-basis scans exclude the own-session layers the read
+  // NAMES in its dependency array: those are the layers whose inclusion in
+  // the reader's materialized view the array attests. Any own write the
+  // array does not name — a higher localSeq accepted first (out-of-order
+  // submission) or an omitted predecessor whose write is durable —
+  // conflicts like a foreign write.
+  exclude?: { sessionId: string; namedLocalSeqs: readonly number[] },
 ): number | null => {
   for (const commit of history.accepted) {
     if (commit.seq <= afterSeq) continue;
     if (
       exclude !== undefined && commit.sessionId === exclude.sessionId &&
-      commit.localSeq < exclude.beforeLocalSeq
+      exclude.namedLocalSeqs.includes(commit.localSeq)
     ) {
       continue;
     }
@@ -156,7 +158,7 @@ export const naiveAdmit = (
     const cs = read.basisSeq !== undefined
       ? conflictSeq(history, read.id, read.path, read.basisSeq, {
         sessionId,
-        beforeLocalSeq: commit.localSeq,
+        namedLocalSeqs: layers,
       })
       : conflictSeq(history, read.id, read.path, basis!);
     if (cs !== null) {

--- a/packages/memory/test/v2-differential-consistency.test.ts
+++ b/packages/memory/test/v2-differential-consistency.test.ts
@@ -111,6 +111,11 @@ interface ScheduleStats {
   accepted: number;
   rejected: number;
   pendingReadAccepts: number;
+  /** Commits whose pending read was sparsely mutated, split by verdict —
+   * both sides must stay exercised for the declared-set exclusion to keep
+   * differential coverage (see the vacuity guard). */
+  sparseAccepts: number;
+  sparseRejects: number;
 }
 
 const runSchedule = async (seed: number): Promise<ScheduleStats> => {
@@ -125,6 +130,8 @@ const runSchedule = async (seed: number): Promise<ScheduleStats> => {
     accepted: 0,
     rejected: 0,
     pendingReadAccepts: 0,
+    sparseAccepts: 0,
+    sparseRejects: 0,
   };
 
   const ctx = (step: number, extra: Record<string, unknown> = {}) =>
@@ -185,6 +192,7 @@ const runSchedule = async (seed: number): Promise<ScheduleStats> => {
     for (let step = 0; step < STEPS; step++) {
       const session = pick(rng, sessions);
       const id = pick(rng, ENTITIES);
+      let sparseThisStep = false;
 
       // Writes: whole-doc set, key replace, or array append.
       const operations: ClientCommit["operations"] = [];
@@ -228,15 +236,30 @@ const runSchedule = async (seed: number): Promise<ScheduleStats> => {
           ? pick(rng, KEY_LEAVES)
           : (["value", "items"] as const);
         if (stack.length > 0 && chance(rng, 0.5)) {
+          const declaresBasis = chance(rng, 0.5);
+          let declared = [...stack];
+          // Sparse mutation (declared-set exclusion): a basisSeq read
+          // sometimes omits one non-top layer, modeling a client that
+          // dropped a layer from its overlay — or omitted one by bug. The
+          // engine and the naive validator must agree on the verdict either
+          // way: both reject when the omitted layer's durable write sits in
+          // the scan interval, both accept when it left nothing durable
+          // there. Legacy reads keep the full stack — their basis
+          // semantics lean on the highest element, not on exclusion.
+          if (declaresBasis && declared.length >= 2 && chance(rng, 0.3)) {
+            const victim = pick(rng, declared.slice(0, declared.length - 1));
+            declared = declared.filter((layer) => layer !== victim);
+            sparseThisStep = true;
+          }
           reads.pending.push({
             id,
             path: toDocumentPath([...readLeaf]),
-            localSeq: [...stack],
+            localSeq: declared,
             // Half the pending reads declare the reader's true confirmed
-            // basis (the CT-1910 repaired shape, scanned with own-session
-            // exclusion); the rest stay legacy max-dependency so both
-            // admission paths keep differential coverage.
-            ...(chance(rng, 0.5) ? { basisSeq: session.integratedSeq } : {}),
+            // basis (the CT-1910 repaired shape, scanned with declared-set
+            // own-session exclusion); the rest stay legacy max-dependency
+            // so both admission paths keep differential coverage.
+            ...(declaresBasis ? { basisSeq: session.integratedSeq } : {}),
           });
         } else {
           reads.confirmed.push({
@@ -257,10 +280,12 @@ const runSchedule = async (seed: number): Promise<ScheduleStats> => {
       if (engineSeq !== null) {
         stats.accepted++;
         if (reads.pending.length > 0) stats.pendingReadAccepts++;
+        if (sparseThisStep) stats.sparseAccepts++;
         stack.push(commit.localSeq);
         session.stacks.set(id, stack);
       } else {
         stats.rejected++;
+        if (sparseThisStep) stats.sparseRejects++;
         // Client retry discipline (§3.12): drop the rejected commit and its
         // dependents, refresh, rebuild. Here: reset this entity's stack and
         // catch the watermark up.
@@ -305,18 +330,20 @@ const runSchedule = async (seed: number): Promise<ScheduleStats> => {
       // INV-1 (pending reads, CT-1910 repaired shape): a declared basis makes
       // pending reads post-hoc checkable for the first time — no foreign
       // accepted write overlapping the path may land in (basisSeq, seq).
-      // Own-session writes are skipped only when they are true predecessors
-      // (lower localSeq — the layers the reader's view included); an
-      // out-of-order own write counts like a foreign one. Legacy reads (no
-      // basisSeq) stay uncheckable here; their deviation is recorded against
-      // INV-1 in 09-invariants.md.
+      // Own-session writes are skipped only when the read's array NAMES
+      // them (the layers whose inclusion in the reader's view the array
+      // attests); an own write the array does not name — out-of-order or
+      // omitted — counts like a foreign one. Legacy reads (no basisSeq)
+      // stay uncheckable here; their deviation is recorded against INV-1
+      // in 09-invariants.md.
       for (const rd of record.commit.reads.pending) {
         if (rd.basisSeq === undefined) continue;
+        const named = Array.isArray(rd.localSeq) ? rd.localSeq : [rd.localSeq];
         for (const other of accepted) {
           if (other.seq <= rd.basisSeq || other.seq >= record.seq) continue;
           if (
             other.sessionId === record.sessionId &&
-            other.commit.localSeq < record.commit.localSeq
+            named.includes(other.commit.localSeq)
           ) continue;
           const hit = toNaiveOps(other.commit.operations).some((op) =>
             op.id === rd.id &&
@@ -346,17 +373,28 @@ Deno.test("memory v2 differential: engine admission refines the naive model acro
     accepted: 0,
     rejected: 0,
     pendingReadAccepts: 0,
+    sparseAccepts: 0,
+    sparseRejects: 0,
   };
   for (let seed = 1; seed <= 100; seed++) {
     const stats = await runSchedule(seed);
     totals.accepted += stats.accepted;
     totals.rejected += stats.rejected;
     totals.pendingReadAccepts += stats.pendingReadAccepts;
+    totals.sparseAccepts += stats.sparseAccepts;
+    totals.sparseRejects += stats.sparseRejects;
   }
   // Schedule-shape sanity (deterministic, seeds are fixed): the generator
-  // must keep exercising rejections and accepted pending-stack reads, or
-  // the differential assertions above become vacuous.
-  if (totals.rejected < 50 || totals.pendingReadAccepts < 50) {
+  // must keep exercising rejections, accepted pending-stack reads, and both
+  // verdicts of the sparse mutation (declared-set exclusion), or the
+  // differential assertions above become vacuous. The sparse rate is tuned
+  // LOW on purpose — no current client emits sparse arrays, so the mutation
+  // is a hardening probe, not a workload model; these floors are what keep
+  // "low" from quietly becoming "never".
+  if (
+    totals.rejected < 50 || totals.pendingReadAccepts < 50 ||
+    totals.sparseAccepts < 5 || totals.sparseRejects < 5
+  ) {
     throw new Error(
       `degenerate schedule mix: ${JSON.stringify(totals)} — retune generator`,
     );

--- a/packages/memory/test/v2-pending-read-basis-overadvance.test.ts
+++ b/packages/memory/test/v2-pending-read-basis-overadvance.test.ts
@@ -377,8 +377,9 @@ Deno.test("memory v2 engine: CT-1910 repair — an own-session write accepted ou
     // session:1 localSeq 5 reads x through its layer [1] at basisSeq 0 and
     // claims it observed x = 1. The overtaking own write (localSeq 10, seq
     // 2) was NOT in its view: a session-wide exclusion would excuse it and
-    // accept the incoherent observation — predecessor-only exclusion
-    // (local_seq below the reader's) must conflict, like a foreign write.
+    // accept the incoherent observation — the declared-set exclusion
+    // (only the named layer 1 is excluded) must conflict, like a foreign
+    // write.
     assertThrows(
       () =>
         applyCommit(engine, {

--- a/packages/memory/test/v2-scheduler-state.test.ts
+++ b/packages/memory/test/v2-scheduler-state.test.ts
@@ -802,8 +802,9 @@ Deno.test("memory v2 accepts batched no-op scheduler observations", async () => 
 // basisSeq) is based at the HIGHEST element, so a foreign write before the
 // top layer's resolution does not drop it — the CT-1910 over-advance,
 // retained for that shape. A read declaring `basisSeq` scans the full
-// interval with predecessor-only own-session exclusion: the same foreign
-// write now drops the observation, while own predecessor layers do not.
+// interval with declared-set own-session exclusion: the same foreign
+// write now drops the observation, own layers the array names do not,
+// and an own layer the array OMITS drops it like a foreign write.
 Deno.test("memory v2 scheduler observations resolve array pending reads at the highest layer", async () => {
   const { engine, path } = await createEngine();
   const sessionId = "session:scheduler-array-reads";
@@ -911,8 +912,8 @@ Deno.test("memory v2 scheduler observations resolve array pending reads at the h
           },
           {
             // Repaired shape, coherent: basis 2 reflects the foreign write;
-            // the only writes above it are the session's own predecessor
-            // layers (localSeq 1 and 2, both below 104), excluded — kept.
+            // the only writes above it are the session's own layers
+            // (localSeq 1 and 2), both NAMED by the array, excluded — kept.
             localSeq: 104,
             reads: {
               confirmed: [],
@@ -925,6 +926,25 @@ Deno.test("memory v2 scheduler observations resolve array pending reads at the h
             },
             schedulerObservation: observationForAction(
               "pattern.tsx:array-read:true-basis-kept",
+            ),
+          },
+          {
+            // The same basis, but the array omits layer 2 — whose durable
+            // patch sits in (2, head]. The declared-set exclusion leaves it
+            // unexcluded, so the observation drops; a predecessor mask
+            // (localSeq 2 below 105) would have wrongly kept it.
+            localSeq: 105,
+            reads: {
+              confirmed: [],
+              pending: [{
+                id: "entity:sched-doc",
+                path: toDocumentPath([]),
+                localSeq: [1],
+                basisSeq: 2,
+              }],
+            },
+            schedulerObservation: observationForAction(
+              "pattern.tsx:array-read:omitted-durable",
             ),
           },
         ],
@@ -950,6 +970,11 @@ Deno.test("memory v2 scheduler observations resolve array pending reads at the h
           reason: "stale-pending-read",
         },
         { localSeq: 104, status: "kept", reason: undefined },
+        {
+          localSeq: 105,
+          status: "dropped",
+          reason: "stale-pending-read",
+        },
       ],
     );
   } finally {

--- a/packages/memory/test/v2-sparse-pending-dependencies.test.ts
+++ b/packages/memory/test/v2-sparse-pending-dependencies.test.ts
@@ -4,10 +4,14 @@
  * NON-CONTIGUOUS in the session's sequence space. A rejected layer the
  * client honored — dropped from its overlay before the read view was built —
  * is legitimately unnamed and imposes no resolution requirement, while a
- * NAMED layer without a commit row still dooms the commit. The server never
- * checks completeness (it cannot know the client's view); these tests pin
- * the acceptance side of that contract so a future "help the client" check
- * does not quietly forbid the sparse shape.
+ * NAMED layer without a commit row still dooms the commit, and an omission
+ * is verified against durable history: the staleness scan excludes only
+ * the own-session layers the array NAMES (§3.6.3's declared-set
+ * exclusion), so omitting a layer whose write is durably integrated
+ * conflicts like a foreign write. These tests pin all three sides —
+ * sparse acceptance, named-rejected doom, and omitted-durable doom — so a
+ * future change cannot quietly forbid the sparse shape or quietly re-trust
+ * client discipline.
  */
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
@@ -158,6 +162,103 @@ describe("sparse pending dependencies", () => {
           },
         })
       ).toThrow("pending dependency not resolved: 2");
+    });
+  });
+
+  it("rejects an array that omits an accepted layer whose write is durable", async () => {
+    await withEngine((engine) => {
+      seedHonoredRejection(engine);
+      // A second surviving layer on A: localSeq 4, accepted at seq 3. The
+      // stack a complete view sits on is now [3, 4].
+      applyCommit(engine, {
+        sessionId: SESSION,
+        commit: {
+          localSeq: 4,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "set",
+            id: "entity:A",
+            value: toEntityDocument({ revision: "v4" }),
+          }],
+        },
+      });
+
+      // The buggy omission the declared-set exclusion exists to catch: the
+      // array names only layer 4, silently dropping layer 3 — whose write
+      // is durably integrated at seq 2, inside the scan interval, and NOT
+      // declared away by a processed rejection. Under a predecessor-mask
+      // exclusion this commit would be wrongly accepted (layer 3 is an own
+      // predecessor); the declared set makes it conflict like a foreign
+      // write.
+      expect(() =>
+        applyCommit(engine, {
+          sessionId: SESSION,
+          commit: {
+            localSeq: 5,
+            reads: {
+              confirmed: [],
+              pending: [{
+                id: "entity:A",
+                path: toDocumentPath([]),
+                localSeq: [4],
+                basisSeq: 1,
+              }],
+            },
+            operations: [{
+              op: "set",
+              id: "entity:B",
+              value: toEntityDocument({ derivedFrom: "v4-missing-v3" }),
+            }],
+          },
+        })
+      ).toThrow("stale pending read");
+    });
+  });
+
+  it("accepts the same read when the array names every surviving layer", async () => {
+    await withEngine((engine) => {
+      seedHonoredRejection(engine);
+      applyCommit(engine, {
+        sessionId: SESSION,
+        commit: {
+          localSeq: 4,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "set",
+            id: "entity:A",
+            value: toEntityDocument({ revision: "v4" }),
+          }],
+        },
+      });
+
+      // The no-self-conflict guarantee the exclusion preserves: naming both
+      // surviving layers ([3, 4], sparse only past the rejected 2) excludes
+      // exactly the reader's own attested view, and the commit lands.
+      const applied = applyCommit(engine, {
+        sessionId: SESSION,
+        commit: {
+          localSeq: 5,
+          reads: {
+            confirmed: [],
+            pending: [{
+              id: "entity:A",
+              path: toDocumentPath([]),
+              localSeq: [3, 4],
+              basisSeq: 1,
+            }],
+          },
+          operations: [{
+            op: "set",
+            id: "entity:B",
+            value: toEntityDocument({ derivedFrom: "v4" }),
+          }],
+        },
+      });
+
+      expect(applied.seq).toBe(4);
+      expect(read(engine, { id: "entity:B" })).toEqual({
+        value: { derivedFrom: "v4" },
+      });
     });
   });
 });

--- a/packages/memory/test/v2-sparse-pending-dependencies.test.ts
+++ b/packages/memory/test/v2-sparse-pending-dependencies.test.ts
@@ -261,4 +261,157 @@ describe("sparse pending dependencies", () => {
       });
     });
   });
+
+  it("rejects a scalar localSeq that omits an accepted layer", async () => {
+    await withEngine((engine) => {
+      seedHonoredRejection(engine);
+      applyCommit(engine, {
+        sessionId: SESSION,
+        commit: {
+          localSeq: 4,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "set",
+            id: "entity:A",
+            value: toEntityDocument({ revision: "v4" }),
+          }],
+        },
+      });
+
+      // The scalar shape is the degenerate single-element array and flows
+      // through the same declared-set exclusion: naming 4 alone leaves
+      // layer 3's durable write unexcluded in the interval.
+      expect(() =>
+        applyCommit(engine, {
+          sessionId: SESSION,
+          commit: {
+            localSeq: 5,
+            reads: {
+              confirmed: [],
+              pending: [{
+                id: "entity:A",
+                path: toDocumentPath([]),
+                localSeq: 4,
+                basisSeq: 1,
+              }],
+            },
+            operations: [{
+              op: "set",
+              id: "entity:B",
+              value: toEntityDocument({ derivedFrom: "scalar" }),
+            }],
+          },
+        })
+      ).toThrow("stale pending read");
+    });
+  });
+
+  describe("patch-writing layers", () => {
+    /** Seeds A = { items: {} } at seq 1 (the confirmed basis), then an own
+     * PATCH layer at localSeq 1 adding items.first (accepted, seq 2) — the
+     * layer whose exclusion or omission the tests below exercise through
+     * the patch-scan statement rather than the set/delete one. */
+    const seedPatchLayer = (engine: Engine): void => {
+      applyCommit(engine, {
+        sessionId: "session:seed",
+        commit: {
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "set",
+            id: "entity:P",
+            value: toEntityDocument({ items: {} }),
+          }],
+        },
+      });
+      applyCommit(engine, {
+        sessionId: SESSION,
+        commit: {
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "patch",
+            id: "entity:P",
+            patches: [{ op: "add", path: "/value/items/first", value: 1 }],
+          }],
+        },
+      });
+    };
+
+    it("excludes a named layer whose write is a patch", async () => {
+      await withEngine((engine) => {
+        seedPatchLayer(engine);
+
+        // The patch-scan twin of the no-self-conflict control: layer 1's
+        // patch overlaps the read path and sits in (1, head], but the
+        // array names it, so the reader lands.
+        const applied = applyCommit(engine, {
+          sessionId: SESSION,
+          commit: {
+            localSeq: 2,
+            reads: {
+              confirmed: [],
+              pending: [{
+                id: "entity:P",
+                path: toDocumentPath(["value", "items"]),
+                localSeq: [1],
+                basisSeq: 1,
+              }],
+            },
+            operations: [{
+              op: "set",
+              id: "entity:B",
+              value: toEntityDocument({ observedItems: ["first"] }),
+            }],
+          },
+        });
+
+        expect(applied.seq).toBe(3);
+      });
+    });
+
+    it("rejects an array that omits a patch-writing layer", async () => {
+      await withEngine((engine) => {
+        seedPatchLayer(engine);
+        // A second own layer so the array has something else to name.
+        applyCommit(engine, {
+          sessionId: SESSION,
+          commit: {
+            localSeq: 2,
+            reads: { confirmed: [], pending: [] },
+            operations: [{
+              op: "patch",
+              id: "entity:P",
+              patches: [{ op: "add", path: "/value/items/second", value: 2 }],
+            }],
+          },
+        });
+
+        // Omitting layer 1 leaves its durable patch at seq 2 unexcluded —
+        // the patch-scan statement's own omitted-durable doom.
+        expect(() =>
+          applyCommit(engine, {
+            sessionId: SESSION,
+            commit: {
+              localSeq: 3,
+              reads: {
+                confirmed: [],
+                pending: [{
+                  id: "entity:P",
+                  path: toDocumentPath(["value", "items"]),
+                  localSeq: [2],
+                  basisSeq: 1,
+                }],
+              },
+              operations: [{
+                op: "set",
+                id: "entity:B",
+                value: toEntityDocument({ observedItems: ["second"] }),
+              }],
+            },
+          })
+        ).toThrow("stale pending read");
+      });
+    });
+  });
 });

--- a/packages/memory/test/v2-sparse-pending-dependencies.test.ts
+++ b/packages/memory/test/v2-sparse-pending-dependencies.test.ts
@@ -102,9 +102,10 @@ describe("sparse pending dependencies", () => {
 
       // The reader's rebuilt view: confirmed A@1 plus the surviving layer 3.
       // The array names [3] only — non-contiguous past the rejected 2 — and
-      // basisSeq 1 is the confirmed basis that view reflected. Layer 3's own
-      // accepted write inside the scan interval is a true predecessor
-      // (localSeq below the reader's), so the read is not stale.
+      // basisSeq 1 is the confirmed basis that view reflected. Layer 3's
+      // accepted write inside the scan interval is excluded because the
+      // array NAMES it (the declared-set exclusion), so the read is not
+      // stale.
       const applied = applyCommit(engine, {
         sessionId: SESSION,
         commit: {

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -190,11 +190,17 @@ export type PendingRead = {
    * document its subscriptions never covered.
    *
    * When present, the staleness scan covers the FULL interval
-   * `(basisSeq, head]`, excluding only the session's own TRUE PREDECESSOR
-   * commits — those with a localSeq below the reader's, the accepted layers
-   * its materialized view included. An own write with a higher localSeq
-   * accepted first (out-of-order submission) conflicts like a foreign
-   * write, so soundness does not depend on wire-order discipline. This is
+   * `(basisSeq, head]`, excluding only the own-session layers this read's
+   * `localSeq` array NAMES — the accepted layers whose inclusion in the
+   * reader's materialized view the array attests. Any own write the array
+   * does not name conflicts like a foreign write: a higher localSeq
+   * accepted first (out-of-order submission), or an omitted layer whose
+   * write is durably integrated — so the server verifies that `basisSeq`
+   * plus the named layers fully account for the document's durable history
+   * at the read path, rather than trusting client discipline. (What it
+   * cannot verify is the phantom direction: an omitted REJECTED
+   * contributor left nothing durable to compare against — that stays in
+   * the fabricated-read trust class.) This is
    * the CT-1910 repair
    * (`PendingStacks_Repaired.cfg` certifies it); when absent (a legacy
    * client), staleness is based at the HIGHEST dependency's resolution seq,

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -694,17 +694,24 @@ WHERE session_id = :session_id
 `;
 
 // True-basis (CT-1910) variants of the conflict scans: identical intervals,
-// but writes produced by the reader's own session's TRUE PREDECESSORS
-// (`local_seq` below the reader's) are excluded — the accepted own layers
-// the reader's materialized view included; conflicting with them would be
-// the self-conflict that forced pending reads to over-advance their basis
-// in the first place. The exclusion is deliberately NOT session-wide: an
-// own write with a HIGHER localSeq that was accepted first (out-of-order
-// submission — e.g. the runner's hold-mode admission can release a later
-// blind commit while an earlier read-bearing commit waits) was NOT in the
-// reader's view and must conflict exactly like a foreign write. Checking
-// `local_seq` here, rather than assuming the §3.6.3 same-session ordering
-// holds on the wire, keeps the scan sound without trusting the transport.
+// but writes produced by the layers the read NAMES (`local_seq` in the
+// read's declared dependency array, same session) are excluded — the
+// accepted own layers the reader's materialized view included; conflicting
+// with them would be the self-conflict that forced pending reads to
+// over-advance their basis in the first place. The exclusion is the
+// DECLARED SET, not a predecessor mask (`local_seq <` the reader's): the
+// declared array is the reader's claim of exactly which own layers its
+// view sat on, so an own write the array does NOT name conflicts like a
+// foreign write whatever its localSeq. That covers both an own write with
+// a HIGHER localSeq accepted first (out-of-order submission — e.g. the
+// runner's hold-mode admission can release a later blind commit while an
+// earlier read-bearing commit waits) and an own PREDECESSOR the client
+// omitted while its write is durable — a buggy or selectively-excluding
+// client whose view is missing integrated state (the missed-write
+// direction of INV-1). The declared shape thus validates itself:
+// basisSeq plus the named layers must fully account for the doc's durable
+// history at the read path, and the server checks that rather than
+// trusting client discipline.
 const SELECT_SET_DELETE_CONFLICT_EXCLUDING_SESSION = `
 SELECT r.seq AS seq
 FROM revision r
@@ -714,7 +721,8 @@ WHERE r.branch = :branch
   AND r.scope_key = :scope_key
   AND r.seq > :after_seq
   AND r.op IN ('set', 'delete')
-  AND (c.session_id <> :exclude_session OR c.local_seq >= :before_local_seq)
+  AND (c.session_id <> :exclude_session
+       OR c.local_seq NOT IN (SELECT value FROM json_each(:named_local_seqs)))
 ORDER BY r.seq DESC, r.op_index DESC
 LIMIT 1
 `;
@@ -728,7 +736,8 @@ WHERE r.branch = :branch
   AND r.scope_key = :scope_key
   AND r.seq > :after_seq
   AND r.op = 'patch'
-  AND (c.session_id <> :exclude_session OR c.local_seq >= :before_local_seq)
+  AND (c.session_id <> :exclude_session
+       OR c.local_seq NOT IN (SELECT value FROM json_each(:named_local_seqs)))
 ORDER BY r.seq DESC, r.op_index DESC
 `;
 
@@ -5692,10 +5701,13 @@ const resolvePendingReads = (
     }
 
     // CT-1910 repair: a reader that names its true confirmed basis is
-    // scanned over the FULL interval (basisSeq, head], excluding only its
-    // own session's predecessor commits (local_seq below the reader's) —
-    // the accepted layers its materialized view included. A legacy reader
-    // (no basisSeq) keeps the max-dependency basis, so the over-advance
+    // scanned over the FULL interval (basisSeq, head], excluding only the
+    // own-session layers its dependency array NAMES — the accepted layers
+    // its materialized view included, per its own attestation. An own
+    // write the array omits conflicts like a foreign one, so the scan
+    // verifies that basisSeq plus the named layers fully account for the
+    // doc's durable history at the read path. A legacy reader (no
+    // basisSeq) keeps the max-dependency basis, so the over-advance
     // deviation persists for it alone
     // (docs/specs/memory-v2/09-invariants.md, INV-1).
     const trueBasis = pendingReadBasisSeq(engine, read);
@@ -5708,7 +5720,7 @@ const resolvePendingReads = (
         trueBasis,
         read.path,
         read.nonRecursive ?? false,
-        { sessionKey, beforeLocalSeq: commit.localSeq },
+        { sessionKey, namedLocalSeqs: layers },
       )
       : findConflictSeq(
         engine,
@@ -5744,12 +5756,14 @@ const findConflictSeq = (
   // replace/delete changes the container the shape read observed, so it must
   // still conflict. Only Tier-2 (patch) granularity is refined.
   nonRecursive: boolean = false,
-  // True-basis reads (CT-1910): skip writes produced by this commit session
-  // key's TRUE PREDECESSOR commits (`local_seq < beforeLocalSeq`) — the
-  // reader's own accepted layers, which its view included. Own writes with
-  // a higher localSeq (accepted out of submission order) conflict like
-  // foreign writes; see the comment on the *_EXCLUDING_SESSION statements.
-  exclude?: { sessionKey: string; beforeLocalSeq: number },
+  // True-basis reads (CT-1910): skip writes produced by the own-session
+  // layers the read NAMES — the accepted layers whose inclusion in the
+  // reader's view the declared array attests. Any own write the array does
+  // not name conflicts like a foreign write, whether it is a higher
+  // localSeq accepted out of submission order or an omitted predecessor
+  // whose write is durable; see the comment on the *_EXCLUDING_SESSION
+  // statements.
+  exclude?: { sessionKey: string; namedLocalSeqs: readonly number[] },
 ): number | null => {
   const setDeleteStatement = exclude === undefined
     ? engine.statements.selectSetDeleteConflict
@@ -5759,7 +5773,7 @@ const findConflictSeq = (
     : engine.statements.selectPatchConflictsExcludingSession;
   const exclusionParams = exclude === undefined ? {} : {
     exclude_session: exclude.sessionKey,
-    before_local_seq: exclude.beforeLocalSeq,
+    named_local_seqs: JSON.stringify(exclude.namedLocalSeqs),
   };
   const setOrDeleteConflict = setDeleteStatement.get({
     branch,
@@ -5808,16 +5822,12 @@ const schedulerObservationReadDropReason = (
     principal,
     branch,
     reads,
-    localSeq,
   }: {
     sessionKey: string;
     sessionId: SessionId;
     principal: string | undefined;
     branch: BranchName;
     reads: ClientCommit["reads"];
-    /** The observation commit's localSeq — the predecessor bound for the
-     * true-basis own-session exclusion (CT-1910). */
-    localSeq: number;
   },
 ): SchedulerObservationDropReason | undefined => {
   for (const read of reads.confirmed) {
@@ -5865,7 +5875,7 @@ const schedulerObservationReadDropReason = (
     }
 
     // Same CT-1910 basis selection as resolvePendingReads: true basis with
-    // predecessor-only own-session exclusion when declared, legacy
+    // declared-set own-session exclusion when declared, legacy
     // max-dependency basis otherwise.
     const trueBasis = pendingReadBasisSeq(engine, read);
     const conflictSeq = trueBasis !== undefined
@@ -5877,7 +5887,7 @@ const schedulerObservationReadDropReason = (
         trueBasis,
         read.path,
         read.nonRecursive ?? false,
-        { sessionKey, beforeLocalSeq: localSeq },
+        { sessionKey, namedLocalSeqs: layers },
       )
       : findConflictSeq(
         engine,
@@ -6002,7 +6012,6 @@ const applySchedulerObservationOnlyCommit = (
     principal,
     branch,
     reads,
-    localSeq,
   });
   if (dropReason) {
     recordSchedulerObservationReplay(engine, {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -357,7 +357,8 @@ type PendingCommitRead = {
    * space — the same value the confirmed branch emits as `seq`, which the
    * pre-CT-1910 pending shape discarded. A server that understands it scans
    * staleness over the FULL interval (basisSeq, head], excluding only the
-   * session's own predecessor commits (localSeq below the reader's),
+   * own-session layers the read's dependency array names — for this
+   * runner, which names its full surviving stack, exactly its own view —
    * repairing the pending-read basis over-advance; older servers ignore the
    * field and keep the max-dependency basis. See
    * {@link PendingRead.basisSeq} (memory/v2.ts).
@@ -3882,7 +3883,9 @@ class SpaceReplica implements ISpaceReplica {
       // the doc's top-of-stack below this commit) so a dropped deeper layer
       // still dooms this commit (server: pending-dependency resolution;
       // client: cascade). Servers that honor `basisSeq` scan staleness from
-      // it with predecessor-only own-session exclusion (CT-1910); legacy
+      // it, excluding only the own-session layers the array names
+      // (CT-1910) — naming the full stack is thus also what keeps the
+      // scan from conflicting with this commit's own view. Legacy
       // servers base staleness at the highest element only — a lower-layer
       // basis WITHOUT that exclusion would false-conflict with the
       // session's own later stacked writes (CT-1872 1c).


### PR DESCRIPTION
Consistency hardening for the sparse dependency arrays of #5611: the true-basis staleness scan's own-session exclusion becomes the **declared set** instead of a predecessor mask.

The predecessor mask (`local_seq <` the reader's) assumed the reader's view included every own predecessor — a premise full-stack recording used to supply and the server never checked. Under view-relative completeness that premise is client discipline, and a buggy client that omits a layer whose write is **durably integrated** would previously have been silently accepted with a view missing durable state (INV-1's missed-write direction, self-inflicted). With the declared-set exclusion, any own write the array does not name conflicts like a foreign write, so the server now verifies that `basisSeq` plus the named layers fully account for the document's durable history at the read path.

What this deliberately does NOT do: enable or suggest selective exclusion of live layers as a client behavior. The spec's omission allowance stays scoped to processed rejections; this change just converts one class of client bugs from silent corruption into a loud, retryable `ConflictError` — over-rejection, the sound direction — at identical query cost (same join, different predicate; for a well-behaved client the named set *is* the predecessor set).

The residual trust surface is stated in §3.5/§3.6.3: an omitted **rejected** contributor (the phantom direction) is information-theoretically unverifiable server-side — the rejected value never crossed the wire and left nothing durable to compare against. Naming a rejected layer remains the loudly-caught case (`pending dependency not resolved`).

Changes:

- both `*_EXCLUDING_SESSION` conflict scans take the read's named `localSeq` array (bound as JSON, `json_each`) instead of a `before_local_seq` bound; `resolvePendingReads` and `schedulerObservationReadDropReason` pass their per-read declared layers
- the naive reference validator (`naive-admission.ts`) mirrors the rule, keeping the differential harness a true reference
- `v2-sparse-pending-dependencies.test.ts` gains the omitted-durable doom (verified to FAIL against the predecessor mask) and the full-naming no-self-conflict control
- §3.6.3, §3.5, INV-1 known deviations, INV-3, and the `PendingRead.basisSeq` doc comment now describe the declared-set exclusion and the exact trust boundary

Verified: memory suite 498/498 (differential harness included), runner engine-adjacent suites 89/89, `deno check` / fmt / lint / `check-docs` clean.

Note: overlaps `09-invariants.md` edits with #5788 (TLA delayed-delivery); whichever lands second has a small merge. The TLA `SkipLayers` witness pair for this rule belongs on top of #5788's model as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

