### PR TITLE
fix(tasks): fail `deno task check` on an off-pin Deno unless told otherwise

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ can run their own spaces or use hosted versions.
 
 Installing
 [Deno 2 directly](https://docs.deno.com/runtime/getting_started/installation/)
-also works. `deno task check` accepts the supported range in `tasks/check.sh`
-and warns when the installed version differs from the pin in `mise.toml`.
+also works. `deno task check` refuses a version that differs from the pin in
+`mise.toml`; set `DENO_CHECK_VERSION_LENIENT=1` to accept one inside the
+supported range in `tasks/check.sh`.
 
 For Claude Code users, run [`/deps`](.claude/commands/deps.md) to verify
 prerequisites, [`/start-local-dev`](.claude/commands/start-local-dev.md) to

--- a/tasks/check.sh
+++ b/tasks/check.sh
@@ -14,8 +14,12 @@ baseDir="${cmdDir%/*}" # Parent of `cmdDir`, repo root in this case.
 cd "${baseDir}"
 
 # The exact Deno version for this repository is pinned in mise.toml, which mise
-# installs (see README.md). Versions inside the range below are accepted, with
-# a warning when the version differs from the pin.
+# installs (see README.md). A run under any other version stops before
+# checking: different Deno versions carry different TypeScript compilers,
+# which can return different verdicts on one tree, and an off-pin verdict is
+# not the verdict this check exists to report. DENO_CHECK_VERSION_LENIENT=1
+# accepts an off-pin version inside the range below; the mismatch is then
+# reported again after the diagnostics, where it is the last thing on screen.
 # tasks/check-deno-pins.ts verifies that the range contains the pin.
 DENO_VERSION_MIN="2.8.0"
 DENO_VERSION_MAX="2.10.0"
@@ -62,8 +66,23 @@ if (( $(version_num "${DENO_VERSION}") < $(version_num "${DENO_VERSION_MIN}") ||
 fi
 
 if [[ "${DENO_VERSION}" != "${DENO_VERSION_PINNED}" ]]; then
+  if [[ "${DENO_CHECK_VERSION_LENIENT:-}" == '' ]]; then
+    echo "ERROR: Deno version is ${DENO_VERSION}; this repository pins ${DENO_VERSION_PINNED} (mise.toml)."
+    echo "ERROR: An off-pin toolchain can pass code the pin refuses, and refuse code the pin passes."
+    echo "ERROR: Install the pin with mise <https://mise.jdx.dev/> and 'mise install', then run"
+    echo "ERROR: 'mise exec -- deno task check'; or set DENO_CHECK_VERSION_LENIENT=1 to accept"
+    echo "ERROR: an off-pin verdict."
+    exit 1
+  fi
   echo "WARNING: Deno version is ${DENO_VERSION}; this repository pins ${DENO_VERSION_PINNED} (mise.toml)."
-  echo "WARNING: To use the pinned version, install mise <https://mise.jdx.dev/> and run 'mise install'."
+  echo "WARNING: DENO_CHECK_VERSION_LENIENT is set, so the check runs anyway."
+  # Repeated when the run ends, pass or fail: the lines above scroll away
+  # behind one Check line per module, and the verdict's provenance belongs
+  # next to the verdict.
+  version_mismatch_reminder() {
+    echo "WARNING: This check ran under Deno ${DENO_VERSION}, not the pinned ${DENO_VERSION_PINNED}."
+  }
+  trap version_mismatch_reminder EXIT
 fi
 
 # Collect all paths to check. Glob patterns will be expanded by bash.


### PR DESCRIPTION
## Why

#5798's first recommendation. `tasks/check.sh` accepts any Deno in [2.8.0, 2.10.0) and, off the mise.toml pin, warns and proceeds — with the warning printed at line ~12 and ~2,700 `Check` lines then scrolling it away. That range spans a TypeScript major (2.8.1 carries TS 5.9, the 2.9.4 pin carries TS 6.0.3), and the two compilers return different verdicts on the same tree (#5798 has the matrix; #5799 removed the one known divergence). A verdict whose toolchain provenance is a warning nobody sees reads as flaky CI from the inside — that misread is what #5798 documents.

## What changed

A `deno task check` under any Deno but the pin now stops before checking, with an error saying how to get the pin (`mise install`, `mise exec -- deno task check`) and how to proceed deliberately. Setting `DENO_CHECK_VERSION_LENIENT=1` restores the old behavior for an off-pin version inside the supported range — and the mismatch is then repeated when the run ends, pass or fail (EXIT trap), so it sits next to the verdict instead of above 2,700 lines of scroll. The range bounds and `check-deno-pins` alignment gate are untouched; CI resolves its Deno from the same pin (`deno-setup` reads mise.toml, and no workflow overrides its `deno-version` input), so CI never trips the gate.

## Verification

- Pinned 2.9.4: full `deno task check` unchanged and silent — green, no gate output.
- Off-pin 2.8.1, strict: stops before checking with the error text, exit 1.
- Off-pin 2.8.1, `DENO_CHECK_VERSION_LENIENT=1`: warns up top, runs fully, and prints `WARNING: This check ran under Deno 2.8.1, not the pinned 2.9.4.` as the last line **after** the diagnostics on the failure path too (verified on a tree that is red under 2.8.1), preserving the run's exit code.
- `deno task check-deno-pins` aligned; its test suite 33/33; repo-wide `deno fmt --check` and `deno lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

