### PR TITLE
docs(data-model): say "represent" where "spell" was doing the work

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -1810,7 +1810,7 @@ export type TerminalCodec<Encoded> = FabricCodec<Encoded>;
  * kind serves. A terminal codec serves that format alone, a nonterminal one
  * serves every format, and both are "for" this one.
  *
- * Spelling the union out is unavoidable. `FabricCodec` is invariant in
+ * Writing the union out is unavoidable. `FabricCodec` is invariant in
  * `Encoded` -- the parameter sits in both an argument and a return position
  * -- so a `NonterminalCodec` is assignable to no format's instantiation, and
  * the two arms have to be named separately.

--- a/packages/data-model/src/codec-common/BaseCodecEngine.ts
+++ b/packages/data-model/src/codec-common/BaseCodecEngine.ts
@@ -332,7 +332,7 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
       // and returning one of these -- are the codec author's choice and say
       // nothing about what a caller wants. `lenient` is what says that, so
       // this instance settles both into the same answer: a strict decode
-      // fails, whichever way the codec spelled it.
+      // fails, whichever way the codec reported it.
       //
       // `ProblematicValue`'s own codec is exempt, because for that one a
       // `ProblematicValue` is the successful product rather than a refusal.

--- a/packages/data-model/src/codec-interface/interface.ts
+++ b/packages/data-model/src/codec-interface/interface.ts
@@ -180,7 +180,7 @@ export type TerminalCodec<Encoded> = FabricCodec<Encoded>;
  * serves every format, and both are "for" this one. This is what a mixed
  * roster holds, what {@link CodecRegistry} stores, and what it hands back.
  *
- * Spelling the union out is unavoidable. {@link FabricCodec} is invariant in
+ * Writing the union out is unavoidable. {@link FabricCodec} is invariant in
  * `Encoded` -- the parameter sits in both an argument and a return position --
  * so a `NonterminalCodec` is assignable to no format's instantiation, and the
  * two arms have to be named separately.

--- a/packages/data-model/src/codec-json/JsonCodecEngine.ts
+++ b/packages/data-model/src/codec-json/JsonCodecEngine.ts
@@ -102,8 +102,8 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
   /**
    * @inheritDoc
    *
-   * A run of holes is spelled as a `/hole` count, JSON having no way to write
-   * an absent index.
+   * A run of holes is represented as a `/hole` count, JSON having no way
+   * to write an absent index.
    */
   protected override encodeArray(
     value: readonly FabricValue[],

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -462,9 +462,9 @@ function fabricFromNativeValueInternal(
   }
 
   // Primitives, `null`, and `undefined` don't need recursion or freezing.
-  // Spelled as a `typeof` test rather than `!isObjectOrArray()` so the non-object
-  // arms of `FabricValueLayer` narrow: every non-object layer value is
-  // already a `FabricValue`.
+  // Written as a `typeof` test rather than `!isObjectOrArray()` so the
+  // non-object arms of `FabricValueLayer` narrow: every non-object layer
+  // value is already a `FabricValue`.
   //
   // Nothing is recorded in `converted` here. Reaching this means `original`
   // was not a record: every record the shallow conversion accepts returns an

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -194,7 +194,7 @@ export function isFabricValue(value: unknown): value is FabricValue {
 /**
  * Indicates whether a fabric value is a plain object, an array, or a
  * `FabricSpecialObject` -- everything a `typeof value === "object"` test
- * accepts, minus `null`. The name spells out the array case because "object"
+ * accepts, minus `null`. The name states the array case because "object"
  * alone reads as excluding it.
  *
  * The runtime behavior matches a bare `isObjectOrArray()` exactly. The

--- a/packages/data-model/test/codec-common/BaseCodecEngine.test.ts
+++ b/packages/data-model/test/codec-common/BaseCodecEngine.test.ts
@@ -248,7 +248,7 @@ describe("BaseCodecEngine", () => {
         expect(engine.decode(UNCLAIMED, CONTEXT)).toBeInstanceOf(UnknownValue);
       });
 
-      it("carries tag and state however the codec spelled the rejection", () => {
+      it("carries tag and state however the codec reported it", () => {
         // Throwing and returning a `ProblematicValue` are the codec author's
         // choice and say nothing about what a caller wants, so a strict
         // failure must look the same either way. It did not: the returned

--- a/packages/data-model/test/data-uri-codec.test.ts
+++ b/packages/data-model/test/data-uri-codec.test.ts
@@ -80,7 +80,7 @@ describe("data-uri-codec", () => {
 
     // The payload is base64url of the UTF-8 form of the encoded text. The id
     // is that payload, so however the bytes are arrived at, the answer has to
-    // be the one this spells out. The cases cover text that is entirely
+    // be the one stated here. The cases cover text that is entirely
     // ASCII, text that is not, and text too long to take any short cut.
     it("mints a payload that is base64url of the encoded text", () => {
       const textEncoder = new TextEncoder();

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -4,7 +4,7 @@
  *
  * `type` and `name` are stored separately, and the encoding leans on their
  * usual agreement: `name` is written as `null` when it matches `type`, and
- * spelled out only when it does not. Decoding has to invert that, rebuild the
+ * written out only when it does not. Decoding has to invert that, rebuild the
  * right `Error` subclass from `type`, and still accept older state in which
  * only `name` was present.
  *


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) am acting on an observation of his:
agent-written comments here reach for "spell" where "represent" is meant, and
that is a quirk of how the text was produced rather than usage this register
supports.

## What changed

Nine sites across `data-model` and the spec section that mirrors it. The verb
each site actually wants differs, so this is not one word substituted
throughout:

| Was | Now | Why |
|---|---|---|
| a run of holes is **spelled** as a `/hole` count | **represented as** | it is a wire form |
| whichever way the codec **spelled** it | **reported** it | the domain verb these codecs already use |
| **Spelled** as a `typeof` test | **Written** as | about how a line of source is put |
| the name **spells out** the array case | the name **states** | about what a name says |
| **Spelling** the union out is unavoidable | **Writing** | about source text |
| `name` … **spelled out** only when it does not | **written out** | keeps the parallel with "written as `null`" a line above |
| the answer has to be the one this **spells out** | the one **stated here** | about what the test asserts |

## What deliberately did not change

The noun **"spelling"** in the sense of *which surface form is used* —
`3-identity-and-references.md`'s "the two spellings name the same entity",
about `of:fid1:…` versus a tagged hash. That sense is precise, and it is what
the rest of the repository means by the word: `--await` versus an alias,
enum versus node-path, canonical claim paths, wrapper names. A census outside
`data-model` found the noun dominant and the verb-as-represent rare, which is
the evidence for treating them as two different words rather than one to sweep.

## Scope

`data-model` and its spec, per @danfuzz. The same tic exists in a handful of
sites elsewhere (`utils/src/markdown.ts`, `runner/src/pattern-updater.ts`,
`cli`, `dashboard`, and two spec documents); those are left for whoever is
next in those files, rather than opening a repository-wide prose diff.

## Verification

Comments and one test name; no message string, no behavior. `data-model`
`54 passed (2431 steps)`. Repo-wide `deno fmt --check` and `deno lint` clean,
plus `check`, `check-docs`, `check-no-waitfor`, `check-conflict-markers`,
`check-skill-facts` and `check-docs-history-index`. Every reworded line
re-wrapped inside 80 columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PVVZAPbXomq2hMqmF7szXd


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

