### PR TITLE
docs(development): a `## Word choice` rule, wider than spelling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,10 +151,12 @@ complete rule is in
 
 Three obligations that are easy to miss:
 
-- `docs/README.md` governs everything this repository writes down. It says how
-  to write documentation, where a new document belongs, which examples belong in
-  one, and which spelling of English both documents and comments use. Read it
-  before you write either.
+- `docs/README.md` governs everything this repository writes down: how to write
+  documentation, where a new document belongs, and which examples belong in one.
+  Read it before you write a document. The words themselves — American spelling,
+  and one word per concept — are standardized under "Word choice" in
+  `docs/development/DEVELOPMENT.md`, and that reaches comments, error and log
+  messages, and test descriptions as much as it reaches documents.
 - `docs/development/EXPERIMENTAL_OPTIONS.md` is the central registry of every
   experimental flag. Read it before adding, changing, or removing a flag, and
   update it in the same change.

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ additionally carry descriptive JSDoc.
 [`development/code-comment-style.md`](development/code-comment-style.md) is the
 guide to both kinds: what earns a comment, what a doc comment carries, the
 markup they share with error and log messages, and the shapes that make a
-comment go stale or mislead. The spelling rule below reaches comments too.
+comment go stale or mislead. The word-choice rule below reaches comments too.
 
 ## Live documentation
 
@@ -96,8 +96,8 @@ flavors do the job, and code lifted from this repository does it worse for two
 reasons that compound. Real code moves, and nothing about moving it brings
 anyone back to the document that quoted it. And while it sits there it answers
 searches for the identifier it names, with a hit that is not a use of it —
-the same reason [the spelling rule](#spelling) exists, pointed at a different
-target.
+the same reason [the word-choice rule](#word-choice) exists, pointed at a
+different target.
 
 An example that documents a specific hazard is the exception, because the
 hazard is the real thing: a guide to what goes wrong with a particular
@@ -106,22 +106,18 @@ knowingly. `deno task check-docs` covers only the first half of the first one,
 catching drift that stops the block compiling and never drift that compiles
 and is no longer true.
 
-## Spelling
+## Word choice
 
 Prose written here — comments, documents, error and log messages, test
-descriptions — uses American spellings: `behavior`, `color`, `center`,
-`serialize`, `analyze`, `gray`.
+descriptions — standardizes on one spelling per word (American: `behavior`,
+`color`, `serialize`) and one word per concept (`returns`, not `answers`). A
+search for a word then finds all of it, and two files stating the same kind of
+fact read as though they do.
 
-This is standardization rather than a claim about which English is better: one
-spelling per word means a search for a word finds all of it, and this is the
-variety already in overwhelming use in these files.
-
-Two carve-outs. Material quoted from outside — a dependency's name, a message
-relayed from another system, a specification's wording, a data file's contents
-— keeps whatever spelling it arrived with. And an identifier vocabulary
-already established in the codebase, `cancelled` among them, is a rename
-rather than a spelling fix: match the surrounding code, and treat a change to
-it as the code change it is.
+The rule, its carve-outs, and the list of settled pairs are in
+[`development/DEVELOPMENT.md`](development/DEVELOPMENT.md#word-choice). It lives
+with the coding standards because code is where it applies most; documents are
+held to the same standard.
 
 ## Map of this tree
 

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -165,6 +165,52 @@ abstract class Fryer {
   and to the Markdown markup that comments, error messages, and log messages
   all use.
 
+### Word choice
+
+Prose written in this repository — comments, documents, error and log messages,
+test descriptions — standardizes on one spelling per word and one word per
+concept. Both halves buy the same thing: a search for a word finds all of it,
+and two files stating the same kind of fact read as though they do.
+
+The rule is forward-looking. New prose follows it, an edit conforms the prose it
+touches, and converting a whole file or package is its own change rather than a
+side effect of another one.
+
+#### Spelling
+
+American spellings: `behavior`, `color`, `center`, `serialize`, `analyze`,
+`gray`. This is standardization rather than a claim about which English is
+better, and it is the variety already in overwhelming use in these files.
+
+Two carve-outs. Material quoted from outside — a dependency's name, a message
+relayed from another system, a specification's wording, a data file's contents —
+keeps whatever spelling it arrived with. And an identifier vocabulary already
+established in the codebase, `cancelled` among them, is a rename rather than a
+spelling fix: match the surrounding code, and treat a change to it as the code
+change it is.
+
+#### One word per concept
+
+Where two words would do, this repository picks one. The list grows as the pairs
+come up.
+
+- **`returns`**, not `answers`, for what a call evaluates to. A call is not a
+  question put to the code, and the metaphor stands in for a word that is
+  already exact and already shorter.
+  [`unit-test-coding-style.md`](unit-test-coding-style.md#writing-the-description-strings)
+  states this for an `it()` description, which is where it comes up most often;
+  it holds everywhere else too.
+- **`represents`**, `denotes`, or `is written as` — not `spells` — for the
+  relation between a construct and what it means. A path fragment denotes a ref
+  that cannot resolve, and a non-positive bound means "don't wait". The verb
+  belongs to orthography, and borrowing it dresses a semantic relation in
+  orthographic clothes. Three uses survive: the noun names a surface form ("the
+  same spelling the root span uses"), the verb is exact when the claim is about
+  the form itself ("the string that spells the number"), and "spell out" is
+  ordinary English for writing something at length. `spell` is additionally an
+  identifier here — the retired name for a pattern, still read by the state
+  inspector — so prose that borrows the word costs a search as well.
+
 ## Code Design & Principles
 
 ### Error Handling

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -11,7 +11,8 @@ mapped in [`../README.md`](../README.md).
 ## Start here
 
 - [`DEVELOPMENT.md`](DEVELOPMENT.md) — coding standards, design principles,
-  and the build and test workflow. Read this first
+  the word choice all prose here standardizes on, and the build and test
+  workflow. Read this first
 - [`code-comment-style.md`](code-comment-style.md) — how a comment is written:
   what earns one, the rule that a comment describes the system as it stands and
   the shapes that break it, the Markdown markup comments and error messages

--- a/docs/development/code-comment-style.md
+++ b/docs/development/code-comment-style.md
@@ -6,9 +6,10 @@ a liability. This covers both kinds — the `//` comment that explains local
 mechanics, and the JSDoc doc comment that states a contract.
 
 Neighboring guidance: [`../README.md`](../README.md) governs the documentation
-tree, including which spelling of English everything written here uses, and
-[`DEVELOPMENT.md`](DEVELOPMENT.md) carries the rest of the coding standards,
-the 80-column line width among them. The `describe()` and `it()` description
+tree, and [`DEVELOPMENT.md`](DEVELOPMENT.md) carries the rest of the coding
+standards — the 80-column line width among them, and the
+[word choice](DEVELOPMENT.md#word-choice) a comment is held to, American
+spelling included. The `describe()` and `it()` description
 strings of a test have their own guide,
 [`unit-test-coding-style.md`](unit-test-coding-style.md), which governs how
 they are worded. What they take from here is the markup below, and the rule

--- a/docs/development/unit-test-coding-style.md
+++ b/docs/development/unit-test-coding-style.md
@@ -159,7 +159,9 @@ Where the fact is a return value, the verb is **"returns"**. Specifically not
 "answers": that casts the call as a question put to the code, which is a
 metaphor standing in for a word that is already exact and already shorter. It
 also splits the vocabulary of the suite, so that two files pinning the same
-kind of fact no longer read as though they do.
+kind of fact no longer read as though they do. This is one instance of the
+[word choice](DEVELOPMENT.md#one-word-per-concept) the repository standardizes
+on, which holds outside tests as well.
 
 Mark up descriptions in Markdown, the same as a comment — backticks around code
 and code-like things. The one exception is a `describe()` whose title would


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) am opening this as the first of a
series. This one writes the rule down; the ones that follow conform the tree to
it, package by package.

## What was there

Word-level standardization lived in two places at mismatched scopes:

- `docs/README.md` `## Spelling` — American spellings, justified by
  searchability: "one spelling per word means a search for a word finds all of
  it."
- `docs/development/unit-test-coding-style.md` — `returns` and specifically not
  `answers`, scoped to an `it()` description. Its rationale is already general:
  the wrong word "splits the vocabulary of the suite, so that two files pinning
  the same kind of fact no longer read as though they do."

Same argument, two scopes, and the narrower one is stated at a scope its own
justification outgrows.

## What this does

`DEVELOPMENT.md` gains `### Word choice` under Style & Conventions, holding:

- `#### Spelling` — the moved text, both carve-outs intact.
- `#### One word per concept` — a list that grows as the pairs come up,
  starting with `returns` over `answers` and `represents`/`denotes` over
  `spells`.

It lives with the coding guidelines rather than the documentation guide because
code is where it applies most: in `packages`, the noun `spelling` alone runs to
271 uses against 123 across all of live `docs/`.

The rule is explicitly forward-looking, in the same terms `code-comment-style.md`
already uses — new prose follows it, an edit conforms the prose it touches, and
converting a whole file or package is its own change.

## Why the `spells` entry is cut narrowly

A census over the tree found the word doing four jobs, only one of which is the
tic:

| job | example | verdict |
| --- | --- | --- |
| noun, naming a surface form | "the same spelling the root span uses" | exact; 271 uses in `packages` |
| verb, claim genuinely about the form | "the string that spells the number" | exact |
| phrasal "spell out" | "spells out 128 levels of nesting" | ordinary English; 15 uses |
| bare transitive verb, semantic relation | "each fragment spells a ref that cannot resolve" | the tic; ~58 uses |

Only the last is ruled out, and the fix is the verb the site actually wants —
_denotes_, _represents_, _means_ — not one substitute applied throughout.

There is also a repo-specific argument, which is the same one the spelling rule
already runs on. `spell` is the retired identifier for a pattern: the pre-#3522
process-cell format, still read by `state-inspector/model.ts` and still declared
in `runner/src/schemas.ts`. Prose that borrows the word answers searches for the
identifier with hits that are not uses of it.

## Pointers

`docs/README.md` keeps a short `## Word choice` section pointing at the new
home. `AGENTS.md`, `code-comment-style.md`, `unit-test-coding-style.md` and
`docs/development/README.md` are repointed. All five anchors resolve.

`deno fmt --check`, `check-skill-facts` and `check-docs-history-index` pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

