### PR TITLE
docs(common): name the walkthrough's two companion scripts outright

### DIFF
--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -12,7 +12,10 @@ The subject is a work-item tracker — items in a tree, plus typed cross-links.
 It is a real pattern: `packages/cli/integration/pattern/tracker.tsx`, which
 belongs to this document and the two scripts beside it, so a change to a
 pattern the product ships can never break a demonstration of the verb surface.
-Every measurement below was taken against it on a local toolshed.
+The scripts are `packages/cli/integration/verb-session-demo.sh`, the session as
+it is meant to read, and `packages/cli/integration/verb-session-gaps.sh`, the
+gap harness CI runs to keep the **[today]**/**[blocked]** marks below honest.
+Every measurement below was taken against that pattern on a local toolshed.
 
 **Every step is marked for what is real.** The point of the document is the
 line between them.


### PR DESCRIPTION
The fixture paragraph in `docs/common/verb-session-walkthrough.md` said tracker.tsx belongs to "this document and the two scripts beside it" without naming them — a citation a reader cannot follow, the same complaint cubic raised against integration.sh's gap-harness note in #5784. That comment was fixed to point at the script; this is the other half: the walkthrough now names both scripts, so its readers get the pointer to the scripts that measure it.

- `packages/cli/integration/verb-session-demo.sh` — the session as it is meant to read
- `packages/cli/integration/verb-session-gaps.sh` — the gap harness CI runs (integration.sh's `piece-call` section) to keep the **[today]**/**[blocked]** marks honest

Also repoints the measurement sentence's pronoun ("against it" → "against that pattern"), since the script names now sit between the pronoun and its antecedent.

Docs-only prose change: no code blocks touched, so `check-docs` is unaffected; `docs/` is fmt-excluded by the root `deno.jsonc`, so the new lines are hand-wrapped to the file's 80-column style. Repo-wide `deno fmt --check` and `deno lint` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

