### PR TITLE
docs(data-model): say "returns" where "answers" was doing the work

### DIFF
--- a/packages/data-model/src/codec-common/BaseFabricPrimitive.ts
+++ b/packages/data-model/src/codec-common/BaseFabricPrimitive.ts
@@ -86,7 +86,7 @@ export abstract class BaseFabricPrimitive extends FabricPrimitive {
    * `BaseFabricInstance.isInstance()`.
    *
    * Like its counterpart, this uses "death before confusion" on the mismatch:
-   * it throws rather than quietly answering `false`, so a broken subclass is
+   * it throws rather than quietly returning `false`, so a broken subclass is
    * surfaced at the point of use. The throw is intentional despite the
    * predicate-style name.
    *

--- a/packages/data-model/src/codec-common/toReportableState.ts
+++ b/packages/data-model/src/codec-common/toReportableState.ts
@@ -30,7 +30,7 @@ const MAX_RENDERED_LENGTH = 200;
  * runs on the failure path, where throwing does not surface a second problem
  * so much as replace the first one, the original error being lost in favor of
  * whatever the predicate did. `toCompactDebugString()` needs no such wrapping,
- * already answering `"<unrenderable debug string>"` for anything it cannot
+ * already returning `"<unrenderable debug string>"` for anything it cannot
  * render, and is the floor this rests on.
  *
  * @param state - The state at fault, of any type whatsoever.

--- a/packages/data-model/src/codec-common/toReportableTag.ts
+++ b/packages/data-model/src/codec-common/toReportableTag.ts
@@ -16,7 +16,7 @@ const MAX_RENDERED_LENGTH = 60;
  * What is not a string cannot be kept: a tag is read out of wire data, where a
  * format's tag position can hold anything its transport carries -- a
  * realm-crossing `Map` is keyed by any value at all. `toCompactDebugString()`
- * answers `"<unrenderable debug string>"` for anything it cannot render, so
+ * returns `"<unrenderable debug string>"` for anything it cannot render, so
  * this cannot fail while reporting a failure.
  *
  * The counterpart to {@link toReportableState}, which does the same for the

--- a/packages/data-model/src/codec-interface/BaseFabricCodec.ts
+++ b/packages/data-model/src/codec-interface/BaseFabricCodec.ts
@@ -4,7 +4,7 @@ import type { FabricCodec, ReconstructionContext } from "./interface.ts";
 
 /**
  * Base class for `FabricCodec` which provides commonly-needed functionality:
- * the matching members, and a `tagForValue()` that answers with the codec's one
+ * the matching members, and a `tagForValue()` that returns the codec's one
  * recognized tag.
  *
  * It is abstract in `encode()` and `decode()` and, deliberately, in identity:

--- a/packages/data-model/src/deep-freeze.ts
+++ b/packages/data-model/src/deep-freeze.ts
@@ -2,9 +2,9 @@
  * Freezing a value all the way down, and asking whether it already is.
  *
  * Both walks are memoized in a `WeakSet`, which is what makes the ordinary
- * case cheap: a value frozen once answers in constant time ever after, and a
- * primitive never needs asking at all. Those answers are given before any
- * per-walk state is allocated, so the cheap path costs nothing.
+ * case cheap: a value frozen once takes constant time ever after, and a
+ * primitive never needs asking at all. Both fast paths run before any per-walk
+ * state is allocated, so the cheap path costs nothing.
  *
  * A fabric instance keeps its contents private, so neither walk can descend
  * into one directly. Each calls the instance's own protocol member and passes
@@ -95,7 +95,7 @@ function isNecessarilyOrKnownDeepFrozen(value: unknown): boolean {
  * Handles circular references and sparse arrays.
  */
 export function isDeepFrozen(value: unknown): boolean {
-  // Fast leaf paths first, so a primitive or already-cached value answers
+  // Fast leaf paths first, so a primitive or already-cached value returns
   // without allocating the cycle-tracking set or the recursion closure below.
   if (isNecessarilyOrKnownDeepFrozen(value)) {
     return true;
@@ -278,7 +278,7 @@ export function isDeepFrozenFabricValue(value: unknown): value is FabricValue {
   }
 
   // The frozen-ness question goes first because it is the cheap one, and a
-  // `false` from it settles the conjunction. `isDeepFrozen()` answers in
+  // `false` from it settles the conjunction. `isDeepFrozen()` returns in
   // constant time for anything not frozen at its root, and memoizes every
   // subtree it does walk; `isFabricValue()` walks the whole tree afresh on
   // every call. With the walk second, a mutable tree -- what the write path

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -117,7 +117,7 @@ export function isFabricValueLayer(
  * *convertible* to fabric form).
  */
 export function isFabricValue(value: unknown): value is FabricValue {
-  // Fast leaf paths first, so a function or a primitive answers without
+  // Fast leaf paths first, so a function or a primitive returns without
   // allocating the cycle-tracking set or the recursion closure below.
   if (typeof value === "function") {
     return false;

--- a/packages/data-model/test/SchemaAndHash.test.ts
+++ b/packages/data-model/test/SchemaAndHash.test.ts
@@ -7,7 +7,7 @@
  *
  * A schema may legitimately be absent, or be one of the boolean schemas, and
  * absence is where the two readers differ on purpose: one throws and the other
- * answers `undefined`, so a caller states up front which it is prepared for
+ * returns `undefined`, so a caller states up front which it is prepared for
  * rather than discovering it.
  */
 

--- a/packages/data-model/test/cloneIfNecessary.test.ts
+++ b/packages/data-model/test/cloneIfNecessary.test.ts
@@ -416,9 +416,9 @@ describe("cloneIfNecessary()", () => {
 
   describe(`indirect \`Array\` instances`, () => {
     // An `Array` subclass is not a `FabricValue`, so the deep-frozen identity
-    // optimization must not answer for one: returning it as-is would carry a
+    // optimization must not apply to one: returning it as-is would carry a
     // live prototype into stored state, where an overridden `Symbol.iterator`
-    // answers content that the indices never show.
+    // yields content that the indices never show.
     class Smuggler extends Array<unknown> {
       override *[Symbol.iterator](): Generator<unknown> {
         yield "smuggled";

--- a/packages/data-model/test/codec-common/BaseFabricInstance.test.ts
+++ b/packages/data-model/test/codec-common/BaseFabricInstance.test.ts
@@ -1,6 +1,6 @@
 /**
- * The clone template methods, and exactly when one may answer with the
- * instance it was given rather than a new one.
+ * The clone template methods, and exactly when one may return the instance it
+ * was given rather than a new one.
  *
  * Identity comes back only where it is indistinguishable from a fresh copy,
  * which is a narrower condition than it first looks. A shallow clone may

--- a/packages/data-model/test/codec-common/BaseFabricPrimitive.test.ts
+++ b/packages/data-model/test/codec-common/BaseFabricPrimitive.test.ts
@@ -5,7 +5,7 @@
  * contract above it, and the type guard enforces that rather than merely
  * reporting on it: a value that is a `FabricPrimitive` but not a
  * `BaseFabricPrimitive` is a broken subclass, so the guard throws instead of
- * quietly answering `false` and letting the mistake travel.
+ * quietly returning `false` and letting the mistake travel.
  *
  * The placeholder member is here in order to be a member at all -- an instance
  * type with nothing in it would make an ordinary `value is` guard collapse --

--- a/packages/data-model/test/codec-common/CodecRegistry.test.ts
+++ b/packages/data-model/test/codec-common/CodecRegistry.test.ts
@@ -1,5 +1,5 @@
 /**
- * The registry's two jobs -- accepting codecs and answering lookups -- and the
+ * The registry's two jobs -- accepting codecs and serving lookups -- and the
  * line that freezing draws between them.
  *
  * Acceptance is where the refusals live. A codec has to be classifiable, the
@@ -8,14 +8,14 @@
  * than on one of them, since a registration that arrived by a side door is
  * still one the walker will trust.
  *
- * Lookup answers from a value, from a tag, or with the sentinel meaning that
+ * Lookup works from a value, from a tag, or returns the sentinel meaning that
  * no codec is needed. Which symbol a class's codec is read from is settled
  * here too: the format-agnostic binding wins over the format's own when a
  * class has both, and a binding belonging to some other format is not
  * consulted at all.
  *
  * Freezing then separates the two jobs. Every mutator refuses afterward while
- * every lookup still answers, and extending yields a new registry carrying the
+ * every lookup still works, and extending yields a new registry carrying the
  * base's registrations without the base itself gaining anything.
  */
 
@@ -548,7 +548,7 @@ describe("CodecRegistry", () => {
         .toThrow("Cannot modify frozen `CodecRegistry`");
     });
 
-    it("still answers lookups", () => {
+    it("still returns a codec for a registered tag", () => {
       const base = new CodecRegistry(TEST_FORMAT);
       const codec = new TestCodec("readable@1", undefined);
       base.register(codec);

--- a/packages/data-model/test/codec-interface/BaseFabricCodec.test.ts
+++ b/packages/data-model/test/codec-interface/BaseFabricCodec.test.ts
@@ -2,11 +2,11 @@
  * What the codec base class does on its own, before a concrete codec overrides
  * anything.
  *
- * Two of its answers come straight from what it was constructed with, and both
+ * Two of its results come straight from what it was constructed with, and both
  * are optional: a codec naming no handled class cannot recognize a value by
  * class, and one naming no tag cannot produce a tag. Each is covered in both
  * the supplied and the omitted form, because the omitted form is where the
- * base either answers `undefined` or insists on being overridden, and those
+ * base either returns `undefined` or insists on being overridden, and those
  * are different promises.
  */
 

--- a/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
@@ -1320,7 +1320,7 @@ describe("JsonCodecEngine", () => {
           expect(Object.getPrototypeOf(nested)).toBe(Object.prototype);
 
           // The payload reached nobody: not the decoded records, and not the
-          // shared prototype every object in the process answers through.
+          // shared prototype every object in the process inherits from.
           expect(
             (Object.prototype as Record<string, unknown>).hostile,
           ).toBe(undefined);

--- a/packages/data-model/test/deep-freeze.test.ts
+++ b/packages/data-model/test/deep-freeze.test.ts
@@ -2,14 +2,14 @@
  * Asking whether a value is deep-frozen, and making it so, across the shapes
  * that complicate both.
  *
- * Caching is the part with teeth. An answer is remembered by identity, so a
+ * Caching is the part with teeth. A result is remembered by identity, so a
  * wrong `true` is not one mistake but a permanent one, and several cases exist
  * to pin when a result may be cached and when it may not. One is kept as a
- * regression pin against a cycle that was once answered wrongly.
+ * regression pin against a cycle that was once judged wrongly.
  *
  * The stricter of the two checks also asks whether the value is a
  * `FabricValue` at all, so an accessor-backed property, a symbol key, or an
- * array whose structure is inadmissible makes it answer `false` where a plain
+ * array whose structure is inadmissible makes it return `false` where a plain
  * frozen-ness test would have said `true`.
  *
  * A fabric instance is reached through its own protocol member rather than by
@@ -250,7 +250,7 @@ describe("deep-freeze", () => {
     // Coverage for `isDeepFrozen` on `FabricInstance` and `FabricPrimitive`
     // inputs, including a `FabricInstance` participating in a circular
     // reference. `isDeepFrozen`'s recursion threads an
-    // `inProgress: Set<object>` for cycle-safety and answers a
+    // `inProgress: Set<object>` for cycle-safety and resolves a
     // `FabricInstance` via its `[IS_DEEP_FROZEN]` protocol member --
     // inspecting its logical contents, not its enumerable own-props -- so
     // values held in non-enumerable slots (such as
@@ -291,11 +291,12 @@ describe("deep-freeze", () => {
       it("returns `false` when an unfrozen value lives in a non-enumerable slot (extras bag)", () => {
         // A `FabricInstance`'s logical contents are not all enumerable
         // own-props: `FabricError` keeps its custom properties in a private
-        // extras `Map`. A generic `Object.values` walk can't see them, so the
-        // frozen-status must be answered via the instance's `[IS_DEEP_FROZEN]`
-        // protocol member, which inspects the extras bag. Here the wrapper is
-        // frozen and every enumerable slot is a frozen primitive, but the
-        // extras bag holds a mutable array -> not deep-frozen.
+        // extras `Map`. A generic `Object.values` walk can't see them, so
+        // frozen-status must be determined via the instance's
+        // `[IS_DEEP_FROZEN]` protocol member, which inspects the extras bag.
+        // Here the wrapper is frozen and every enumerable slot is a frozen
+        // primitive, but the extras bag holds a mutable array -> not
+        // deep-frozen.
         const fe = FabricError.fromNativeError(new Error("has-extras"));
         fe.setExtra("payload", [1, 2, 3]);
         Object.freeze(fe);
@@ -424,8 +425,8 @@ describe("deep-freeze", () => {
   describe("`isDeepFrozenFabricValue()` accessor properties", () => {
     it("returns `false` for a frozen object with a getter", () => {
       // Freezing an object does not make an accessor inert: a read still
-      // executes it and can answer differently every time. Such an object
-      // must not be granted the deep-frozen-fabric-value trust level.
+      // executes it and can return a different value every time. Such an
+      // object must not be granted the deep-frozen-fabric-value trust level.
       const obj = { a: 1 };
       Object.defineProperty(obj, "g", { get: () => 2, enumerable: true });
       Object.freeze(obj);

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -786,7 +786,7 @@ describe("native-conversion", () => {
       });
 
       it("throws for an array carrying `toJSON()`", () => {
-        // An array is answered by the array rule whatever it carries, and that
+        // An array is handled by the array rule whatever it carries, and that
         // rule rejects the named own property `toJSON` is.
         const arr = [1, 2, 3] as unknown[] & { toJSON?: () => unknown };
         arr.toJSON = () => "custom array";
@@ -1656,7 +1656,7 @@ describe("native-conversion", () => {
 
       it("throws even for an already-frozen subclass instance", () => {
         // The case the deep-frozen identity short-circuit would otherwise wave
-        // through unconverted, prototype and all: iteration answers content
+        // through unconverted, prototype and all: iteration yields content
         // that the indices never show, and freezing the instance does nothing
         // about the prototype that does it.
         class Smuggler extends Array {

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -140,8 +140,8 @@ describe("type-check", () => {
       });
 
       it("returns `false` for an accessor-backed property", () => {
-        // An accessor is live code, not inert data: a read executes it and
-        // can answer differently every time. Freezing does not change that.
+        // An accessor is live code, not inert data: a read executes it and can
+        // return a different value every time. Freezing does not change that.
         const obj = { a: 1 };
         Object.defineProperty(obj, "g", { get: () => 2, enumerable: true });
         expect(isFabricValueLayer(obj)).toBe(false);
@@ -194,8 +194,8 @@ describe("type-check", () => {
       });
 
       it("returns `false` for an array with an accessor-backed index", () => {
-        // An accessor is live code, not inert data: a read executes it and
-        // can answer differently every time. Freezing does not change that.
+        // An accessor is live code, not inert data: a read executes it and can
+        // return a different value every time. Freezing does not change that.
         const arr = [1, 2, 3];
         Object.defineProperty(arr, 1, {
           get: () => 22,
@@ -421,8 +421,8 @@ describe("type-check", () => {
       });
 
       it("returns `false` for an accessor-backed property, at any depth", () => {
-        // An accessor is live code, not inert data: a read executes it and
-        // can answer differently every time. Freezing does not change that.
+        // An accessor is live code, not inert data: a read executes it and can
+        // return a different value every time. Freezing does not change that.
         const top = { a: 1 };
         Object.defineProperty(top, "g", { get: () => 2, enumerable: true });
         expect(isFabricValue(top)).toBe(false);
@@ -484,7 +484,7 @@ describe("type-check", () => {
 
       it("returns `false` for an indirect `Array` instance, at any depth", () => {
         // A subclass prototype is live code no matter the container: an
-        // overridden `Symbol.iterator` makes iteration answer content the
+        // overridden `Symbol.iterator` makes iteration yield content the
         // indices never show, and freezing does not reach the prototype.
         class Sub extends Array {}
         const top = new Sub();

--- a/packages/data-model/test/valueEquals.test.ts
+++ b/packages/data-model/test/valueEquals.test.ts
@@ -7,14 +7,14 @@
  * at all, as are two fabric values of different concrete classes. The cases
  * walk that branch deliberately rather than sampling it.
  *
- * Frozen state must not change an answer, which is what the matrix over it is
+ * Frozen state must not change a result, which is what the matrix over it is
  * for: equality is about what a value holds, not about whether it can still be
  * written to.
  *
  * Signed zeros and `NaN` get their own group, being where a comparison written
- * with `===` answers differently: `-0` and `+0` are distinct here though `===`
- * merges them, and `NaN` equals itself though `===` denies it. The infinities
- * sit in that group as the counterweight -- `===` already answers correctly
+ * with `===` gives a different result: `-0` and `+0` are distinct here though
+ * `===` merges them, and `NaN` equals itself though `===` denies it. The
+ * infinities sit in that group as the counterweight -- `===` is already correct
  * for those, and so must this, so they pin the absence of an over-correction.
  */
 
@@ -52,9 +52,9 @@ describe("valueEqual()", () => {
 
   it("throws when given a function (not a `FabricValue`)", () => {
     // A function is reachable only via an unsound cast; the comparison
-    // rejects it rather than silently mis-answering, and does so regardless
-    // of which argument is the function. (Distinct values are used so the
-    // `Object.is()` fast path doesn't short-circuit before the check.)
+    // rejects it rather than quietly returning a wrong result, and does so
+    // regardless of which argument is the function. (Distinct values are used
+    // so the `Object.is()` fast path doesn't short-circuit before the check.)
     const fn = (() => {}) as unknown as FabricValue;
     const fn2 = (() => {}) as unknown as FabricValue;
     expect(() => valueEqual(fn, fn2)).toThrow();
@@ -263,7 +263,7 @@ describe("valueEqual()", () => {
   //                                  nested value fails `isDeepFrozen()`, so it
   //                                  takes the general subtype + hash path.
   //   U  (unfrozen)                -> likewise the general subtype + hash path.
-  // Every pairing must agree on the value answer regardless of state.
+  // Every pairing must agree on the result regardless of state.
   describe("frozen-state matrix", () => {
     // The nested array keeps the shallow-frozen `F` build genuinely
     // not-deep-frozen (an all-primitive shallow freeze reads as deep-frozen).


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) am opening this as the first
conformance pass behind the `## Word choice` rule in #5805, which writes down
that the word for what a call evaluates to is `returns`.

`data-model` had its `spell` pass in #5802. This is the `answers` half of the
same cleanup: 17 files, comments and one `it()` description, no code touched.

## What changed

The verb, and only where its object is a return value.

| before | after |
| --- | --- |
| `throws rather than quietly answering `false`` | `... quietly returning `false`` |
| `a `tagForValue()` that answers with the codec's one tag` | `... that returns the codec's one tag` |
| `iteration answers content that the indices never show` | `iteration yields content ...` |
| `the frozen-status must be answered via `[IS_DEEP_FROZEN]`` | `... must be determined via ...` |
| `it("still answers lookups")` | `it("still returns a codec for a registered tag")` |

## What did not change, and why

A census of the package turned up 68 lines carrying the word; 33 edits came out
of it. The rest are three other jobs the word does here, none of them the tic:

- **The noun.** "the honest answer", "the walker's final answer", "the standard
  answer rather than a configured one", "no coherent answer to". Each names a
  result or a resolution rather than what a call hands back, and the rule is
  about the verb.
- **The verb where a question really was asked.** `BaseCodecEngine` lists three
  things a format decides and then says a format that answers those differently
  is a different format. `type-check.ts` poses "may I read this by property
  name?" and has a null-prototype object answer yes. In both, the antecedent
  question is in the same paragraph.
- **Two files built on an asking frame.** `deep-freeze.ts` opens "Freezing a
  value all the way down, and asking whether it already is";
  `native-type-tags.ts` opens on what a value already is and calls it a
  question two lines later. Those framings stay; only the sentences about what
  a call hands back changed.

## Checks

`deno task test` in `packages/data-model`: **ok | 54 passed (2431 steps) | 0
failed**. `deno fmt --check` and `deno lint` clean over the package. No added
line exceeds 80 columns.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

