### PR TITLE
docs(runner): say "returns" where "answers" was doing the work, in `src`

### DIFF
--- a/packages/runner/src/builder/json-member.ts
+++ b/packages/runner/src/builder/json-member.ts
@@ -5,7 +5,7 @@ import type { FabricExecValue, toEncodableForm } from "./types.ts";
  * `toEncodableForm`. `JSON.stringify` consults this name and no other.
  *
  * Both a module and its factory carry it. A factory because pattern source
- * holds one, so `JSON.stringify(someFactory)` has to keep answering. A module
+ * holds one, so `JSON.stringify(someFactory)` has to keep working. A module
  * because `JSON.stringify` reaches one THROUGH A GRAPH: the internal graph
  * (`serializePatternGraph`) is the in-memory instantiation representation and
  * so holds live modules, whose `implementation` is a function. Absent this,

--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -583,7 +583,7 @@ function factoryFromPattern<T, R>(
     // Important that this refers to patternFactory, as .program will be set on
     // pattern afterwards (see factory.ts:exportsCallback)
     toEncodableForm: () => patternToEncodableForm(patternFactory),
-    // What `JSON.stringify(SomePattern)` answers, which pattern source uses.
+    // What `JSON.stringify(SomePattern)` returns, which pattern source uses.
     toJSON: () => patternToEncodableForm(patternFactory),
   };
 

--- a/packages/runner/src/builtins/cell-from-url.ts
+++ b/packages/runner/src/builtins/cell-from-url.ts
@@ -65,7 +65,7 @@ export function cellFromUrl(
     const cellWithTx = cell.withTx(tx);
     if (id === undefined) {
       // The SLOT, not what it points at: reading through a stored link to an
-      // empty cell answers undefined, and a guard on that would leave the
+      // empty cell returns `undefined`, and a guard on that would leave the
       // previous URL's link in place after the input stopped naming anything.
       if (cellWithTx.getRaw() !== undefined) cellWithTx.set(undefined);
     } else {

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1752,7 +1752,7 @@ export class CellImpl<T extends FabricValue>
         cause,
       );
       const resolvedSchema = resolveSchema(this.schema);
-      // Annotated rather than inferred: `processDefaultValue()` answers `any`,
+      // Annotated rather than inferred: `processDefaultValue()` returns `any`,
       // and assigning that back to `currentValue` would discard the narrowing
       // this block exists to establish.
       const created: FabricValue[] =
@@ -1835,7 +1835,7 @@ export class CellImpl<T extends FabricValue>
       diffAndUpdate(this.runtime, this.tx, resolvedLink, [], cause);
       const resolvedSchema = resolveSchema(this.schema);
       // Annotated for the same reason as in `push()`: `processDefaultValue()`
-      // answers `any`, which would discard the narrowing on assignment.
+      // returns `any`, which would discard the narrowing on assignment.
       const created: FabricValue[] =
         isObjectOrArray(resolvedSchema) && Array.isArray(resolvedSchema.default)
           ? processDefaultValue(
@@ -2074,7 +2074,7 @@ export class CellImpl<T extends FabricValue>
     const array = got as ElemT[];
     // TODO(danfuzz): `typeof ref === "object"` routes a `FabricPrimitive`
     // (or `FabricInstance`) ref to `areLinksSame`, which parses both
-    // operands as links and answers `false` when either is not one — so a
+    // operands as links and returns `false` when either is not one — so a
     // fabric-valued ref matches only by reference identity, never by value,
     // and the call otherwise silently no-ops. The sibling `removeByValue`
     // has the right shape: link comparison for cells, `valueEqual` (which
@@ -3476,8 +3476,9 @@ function linkToCell(cell: Cell<any>, options: CellLinkOptions): SigilLink {
  *
  * `ancestors` holds the ancestors of the value being converted, so what it
  * recognizes is a cycle. A value reachable twice by different paths is not one:
- * it is shared, and each position gets its own conversion. Answering a shared
- * reference with a back-link would rewrite one of its positions into a pointer
+ * it is shared, and each position gets its own conversion. Returning a
+ * back-link for a shared reference would rewrite one of its positions into a
+ * pointer
  * at the other -- and a graph holds plenty of shared structure that is nobody's
  * cycle, an empty `path: []` array reachable from every alias in it being the
  * common case.
@@ -3513,10 +3514,10 @@ export function convertCellsToLinks(
   ancestors.set(original, path); // ...which needs to be tracked for circularity.
 
   // Everything past the line above runs inside this `try`, so that EVERY way
-  // out clears the ancestor just recorded -- the exits that answer a value
+  // out clears the ancestor just recorded -- the exits that return a value
   // without descending into it as much as the ones that recur. An exit that
   // skipped the clearing would leave the value an ancestor of all the rest of
-  // the walk, and the next position holding it would be answered as a cycle.
+  // the walk, and the next position holding it would be taken for a cycle.
   try {
     // A schema-bearing read hangs a non-enumerable `toCell` symbol on the
     // arrays it returns. That symbol is machinery, not content, and an array

--- a/packages/runner/src/cfc/atom-pattern.ts
+++ b/packages/runner/src/cfc/atom-pattern.ts
@@ -34,8 +34,8 @@ import {
  * containing a `var` own key in any other arrangement (extra keys, non-string
  * value, empty string) matches nothing — never silently degrading to literal
  * matching, in either direction (a pattern cannot literally match atom data
- * that happens to spell `{var: …}`, and a malformed placeholder cannot match
- * anything at all).
+ * that happens to look like `{var: …}`, and a malformed placeholder cannot
+ * match anything at all).
  *
  * Bindings are unification-style: the same variable name recurring anywhere
  * across one match (or across patterns in a conjunction) must bind

--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -137,7 +137,7 @@ export function createRef(
     // A _nullish_ form leaves the value in place, which is what the `??` is
     // for -- a value carrying no form at all needs no fallback, since that
     // answer is the value already. `CellImpl` is the one implementation that
-    // answers nullish, doing so for a cell whose link is not built yet, and the
+    // returns nullish, doing so for a cell whose link is not built yet, and the
     // branches below need that cell rather than the `null`: one of them builds
     // the link.
     obj = encodableFormOf(obj) ?? obj;
@@ -186,7 +186,7 @@ export function createRef(
       );
     } else if (typeof obj === "function") return obj.toString();
     // A primitive reaches here only as an encodable FORM, the reassignment above
-    // having replaced the value it came from -- a primitive INPUT is answered at
+    // having replaced the value it came from -- a primitive INPUT is handled at
     // the top of the walk. A form is its own preimage, and stringifying one
     // would make the form `7` and the form `"7"` name a single document.
     else return obj;

--- a/packages/runner/src/encodable-form.ts
+++ b/packages/runner/src/encodable-form.ts
@@ -415,7 +415,7 @@ function ownEncodableFormMethod(
   const method = (value as { toEncodableForm: unknown }).toEncodableForm;
 
   // The `typeof` gate is what settles a value carrying a user-data key of the
-  // name -- a query-result proxy answers `Object.hasOwn()` for any key its
+  // name -- a query-result proxy satisfies `Object.hasOwn()` for any key its
   // record holds -- since a fabric record has no function-valued member to
   // find.
   return typeof method === "function" ? method as () => unknown : undefined;

--- a/packages/runner/src/fabric-url.ts
+++ b/packages/runner/src/fabric-url.ts
@@ -25,7 +25,7 @@ export interface FabricUrlOptions {
 }
 
 /**
- * Percent-decoding that answers rather than throws. A malformed escape is a
+ * Percent-decoding that returns rather than throws. A malformed escape is a
  * URL this cannot read, and the contract is that such a URL names no cell —
  * not that asking about it fails.
  */

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -82,7 +82,7 @@ const recordDereferenceHop = (
 // caps *which* link scopes may be followed; it must never be copied onto the
 // followed link itself.
 //
-// `link.schema` describes the LEAF, so it only answers for a hop found at the
+// `link.schema` describes the LEAF, so it only applies to a hop found at the
 // full path. A hop found at an ancestor is governed by whatever that ancestor's
 // schema declared, which `key()` recorded in `scopeCaps` on its way down —
 // narrowing had already replaced the declaring schema by the time we get here

--- a/packages/runner/src/path-utils.ts
+++ b/packages/runner/src/path-utils.ts
@@ -5,7 +5,7 @@ import { isObjectOrArray } from "@commonfabric/utils/types";
  * Read one path segment out of a data container WITHOUT falling through to the
  * container's prototype.
  *
- * A path segment names data. Plain indexing answers with `Object.prototype`'s
+ * A path segment names data. Plain indexing returns `Object.prototype`'s
  * member when the segment is absent and happens to be named after one —
  * `toString`, `valueOf`, `hasOwnProperty` and the rest are ordinary, legal
  * keys. That turned "absent" into a function: `getValueAtPath({}, ["toString"])`
@@ -17,7 +17,7 @@ import { isObjectOrArray } from "@commonfabric/utils/types";
  * draws between record presence and sparse slots.
  *
  * Primitives need none either, and must not be excluded. `Object.hasOwn()`
- * coerces with `ToObject`, so it answers `true` for a string's `length` and its
+ * coerces with `ToObject`, so it returns `true` for a string's `length` and its
  * indices — genuinely own — and `false` for `toUpperCase`/`toString`, which
  * live on `String.prototype`. Bailing out on everything non-`isObjectOrArray` would
  * lose `getValueAtPath("abc", ["length"])`, which callers rely on to
@@ -52,7 +52,7 @@ export function setValueAtPath(
     // its empty own surface, and the assignment writes the intermediate
     // onto the special object itself: a `TypeError` on a frozen value, a
     // codec-invisible graft on an unfrozen instance. (`getValueAtPath` and
-    // `hasValueAtPath` below answer `undefined`/`false` for any path into
+    // `hasValueAtPath` below return `undefined`/`false` for any path into
     // a `FabricInstance`'s codec contents.)
     if (typeof ownSegment(parent, key) !== "object") {
       parent[key] = typeof path[i + 1] === "number" ? [] : {};

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -591,8 +591,8 @@ export function unwrapOneLevelAndBindToDoc<T extends FabricExecValue>(
       if (converted === undefined) {
         // Nothing under here rebound, so hand back the original.
         // `noteDerivedCopy()` is skipped deliberately: it no-ops when copy and
-        // original are the same value, and `resolveOriginal()` already answers
-        // with the original.
+        // original are the same value, and `resolveOriginal()` already returns
+        // the original.
         return binding;
       }
       // Carry the derivation link (trust + content-addressed entry ref) onto

--- a/packages/runner/src/pattern-source-scheme.ts
+++ b/packages/runner/src/pattern-source-scheme.ts
@@ -91,8 +91,8 @@ function staysInPatternsRoute(pathname: string): boolean {
 }
 
 /**
- * The `system:` ref a compiled module name spells, or `undefined` when the name
- * says nothing about a route.
+ * The `system:` ref a compiled module name denotes, or `undefined` when the
+ * name says nothing about a route.
  *
  * A module's name is a URL pathname only for a program the worker compiled over
  * HTTP, where `HttpProgramResolver` names every module by its pathname. A
@@ -125,7 +125,7 @@ export function systemPatternSourceForModuleName(
  * A query or fragment on a legacy locator is dropped: it selects nothing on the
  * patterns route, which serves a file by path, and revalidation is the
  * `?identity` ETag's job. Keeping it would leave the piece with a locator no
- * ref can spell, and therefore one nothing would ever follow again.
+ * ref can name, and therefore one nothing would ever follow again.
  *
  * The result either resolves as a ref or is the input unchanged; nothing here
  * can mint a ref the resolver rejects.
@@ -154,7 +154,7 @@ function legacyPatternsRoutePath(
   // Both spellings are read as URLs so they get one set of checks: a rooted
   // path against a syntactic base, an absolute locator against the space's own
   // host. Reading only the rooted form as a string let `..`, a query, and a
-  // fragment through, each of which spells a ref that cannot resolve.
+  // fragment through, each of which denotes a ref that cannot resolve.
   let url: URL;
   if (source.startsWith("/")) {
     url = new URL(source, RESOLUTION_BASE);

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -362,9 +362,9 @@ function createViewProxy<T>(
     get: (target, prop, receiver) => {
       // Promise adoption probes `then` on every value it receives, so a view
       // that refuses the probe cannot cross a promise boundary at all — and a
-      // lift's result crosses one by construction. A finished view answers it
-      // with `undefined`, which is what a live one answers for a value with no
-      // `then`; every other property still refuses.
+      // lift's result crosses one by construction. A finished view returns
+      // `undefined` for it, which is what a live one returns for a value
+      // with no `then`; every other property still refuses.
       if (prop === "then" && pinned && !isReadable(viewTx)) return undefined;
       if (Array.isArray(value) && prop === "length") {
         const current = readTx().readValueOrThrow(link) as typeof value;
@@ -755,7 +755,7 @@ function createViewProxy<T>(
         link,
         SHAPE_READ,
       ) as typeof value;
-      // `Object.hasOwn`, not `in`: this trap answers about OWN properties, and
+      // `Object.hasOwn`, not `in`: this trap reports on OWN properties, and
       // `in` walks the prototype chain. Because the underlying value is an
       // ordinary `Object.prototype`-rooted record, `in` reported every member of
       // `Object.prototype` -- `toString`, `valueOf`, `constructor`, `__proto__`

--- a/packages/runner/src/sandbox/error-taming.ts
+++ b/packages/runner/src/sandbox/error-taming.ts
@@ -21,7 +21,7 @@
  * We restore the genuine intrinsic rather than polyfill it. Captured at module
  * evaluation (before any lockdown), it is a pure predicate over the
  * `[[ErrorData]]` internal slot: no powers to withhold, no realm affinity, and
- * it answers correctly for the tamed constructors' instances because those are
+ * it is correct for the tamed constructors' instances because those are
  * still constructed from the original `Error`.
  *
  * Two consequences to be aware of:

--- a/packages/runner/src/sandbox/result-normalization.ts
+++ b/packages/runner/src/sandbox/result-normalization.ts
@@ -181,7 +181,7 @@ function adaptSandboxResult(
   const existing = adapted.get(value);
   if (existing !== undefined) return existing;
 
-  // This boundary answers in canonical shapes: a fresh `Array` for anything
+  // This boundary returns canonical shapes: a fresh `Array` for anything
   // array-shaped, and an `Object.prototype`-rooted record for anything else.
   // A prototype is not part of what a value says as data, and a fabric value
   // has exactly one shape for a record, so a pattern that builds a result with

--- a/packages/runner/src/schema-view.ts
+++ b/packages/runner/src/schema-view.ts
@@ -117,7 +117,7 @@ const EXCLUDED_MISSING: JSONSchema = Object.freeze({
  * document behind it, and reading first would resolve the link and fetch the
  * document the `false` was there to avoid.
  *
- * This is its own marker because `schemaAtPath` also answers `false` for a
+ * This is its own marker because `schemaAtPath` also returns `false` for a
  * shape it cannot read a child out of — an `allOf`, or an object schema that
  * omits `type` — where the schema has turned nothing down and the subschema is
  * still reachable below.
@@ -135,7 +135,7 @@ const isExcluded = (schema: JSONSchema): boolean =>
 /**
  * The type name a schema's `type` keyword would use for this value.
  *
- * A `FabricPrimitive` answers with its own concrete name (`FabricBytes` and the
+ * A `FabricPrimitive` returns its own concrete name (`FabricBytes` and the
  * rest), which is what a schema selecting one declares; `schemaTypeMatchesValueType`
  * still lets an `object` schema accept it through its subtype rule.
  */
@@ -212,7 +212,7 @@ const branchWithOuter = (
  *
  * An optional handle — `Cell<T> | undefined` — generates as a union whose one
  * branch carries the marker and whose other is the absent case. `hasAsCell`
- * answers for a union only when EVERY branch declares one, so that shape reads
+ * holds for a union only when EVERY branch declares one, so that shape reads
  * as "not a cell" and the reader gets a plain value where the pattern declared
  * a handle. An eager read survives it by evaluating every branch and picking
  * the cell among the results (`mergeMatches`); collapsing to the branch is the
@@ -387,8 +387,8 @@ const declaredDefault = (schema: JSONSchema): FabricValue | undefined => {
  * Only one the schema declares at its own top level, which is the rule an eager
  * read applies: a default sitting inside a branch of a union is reached by
  * evaluating that branch against a value, and an absent value gets no branch
- * evaluated. Reading one out anyway would answer where an eager read leaves the
- * value absent.
+ * evaluated. Reading one out anyway would return a value where an eager read
+ * leaves it absent.
  */
 const defaultForAbsentValue = (
   schema: JSONSchema | undefined,
@@ -490,7 +490,7 @@ export function materializeSchemaView(
   }
 
   // An opaque leaf still owes the schema's `required` keys. A `FabricPrimitive`
-  // answers them through class accessors — `FabricBytes.length` satisfies
+  // supplies them through class accessors — `FabricBytes.length` satisfies
   // `required: ["length"]` — so the check is prototype-chain membership with
   // the brand exemption, which is what an eager read applies before letting one
   // through.
@@ -626,7 +626,7 @@ const readChildAt = (
  *
  * An eager read leaves such a property out of the object it filters, and
  * `undefined` is a value a property can legitimately hold, so the two cannot
- * share a return. A view answers `undefined` to a plain property access either
+ * share a return. A view returns `undefined` for a plain property access either
  * way — that is what reading an absent property gives — and uses this to keep
  * enumeration and `in` agreeing with an eager read about which keys exist.
  */

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -1061,11 +1061,11 @@ function deriveDereferenceLabelView(
  * The value a resolved link points at, including the one address that is
  * computed rather than stored.
  *
- * A string's `length` is not a path the store holds. Traversal answers it from
+ * A string's `length` is not a path the store holds. Traversal reads it off
  * the string it sits on (`getAtPath` in `traverse.ts`), so a link ending there
  * — `subject.key("label", "length")` where `label` is a string — resolves to
  * an address the store cannot serve, and a bare read of it yields `undefined`.
- * Answering it from the string applies traversal's rule where a link is
+ * Reading it off the string applies traversal's rule where a link is
  * followed rather than where a value is walked, so both routes agree on what
  * `<string>/length` is worth. An array's `length` needs none of this; the store
  * reads that segment itself.
@@ -1128,7 +1128,7 @@ export function validateAndTransform(
   //
   // A transaction marked for lazy materialization is kept whatever its state:
   // a view reads the state ITS transaction saw, and swapping a finished one for
-  // a fresh read would answer from newer state where the view's contract is to
+  // a fresh read would read newer state where the view's contract is to
   // refuse. The refusal comes from the marked transaction's own guard below.
   if (tx?.isLazyMaterialize() !== true) tx = runtime.readTx(tx);
 

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -1212,7 +1212,7 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
    * any of it. A view also keeps the transaction it was created with, so the
    * value it describes stays the value that was there when it was taken, and
    * reading after the transaction finishes throws rather than quietly
-   * answering from committed state.
+   * reading from committed state.
    *
    * Unmarked, every read behaves exactly as it did before lazy materialization
    * existed — including the standing-handle semantics that long-lived

--- a/packages/runner/src/storage/mergeable-ops.ts
+++ b/packages/runner/src/storage/mergeable-ops.ts
@@ -411,7 +411,7 @@ export const foldMergeableIntent = (
  * payload is `array.slice(tailStart)`, so it holds whatever those elements
  * contain, however deep. An `increment` sends a number and a `remove-by-value`
  * sends the element it removes, neither of which contains another intent's
- * target, so both answer `false`.
+ * target, so both return `false`.
  *
  * This is what makes two intents on one document mutually exclusive. An intent
  * inside another op's payload has ALREADY had its change applied by that op — the

--- a/packages/runner/src/storage/reactivity-log.ts
+++ b/packages/runner/src/storage/reactivity-log.ts
@@ -211,12 +211,12 @@ export function isUiInputBlindWriteTx(tx: object): boolean {
 // tool call dispatched later and a SQLite result flushed post-commit among
 // them. Marked, a view keeps the transaction it was created with, so the value
 // it describes stays the value that was there when it was taken, and reading
-// after that transaction finishes throws rather than quietly answering from
+// after that transaction finishes throws rather than quietly reading from
 // committed state.
 //
 // Nothing outside the mark changes, so an unmarked transaction reads exactly as
 // it did before lazy materialization existed. Marked on the same wrapper chain
-// as the marks above, so a wrapper and the transaction it wraps answer alike.
+// as the marks above, so a wrapper and the transaction it wraps read alike.
 const lazyMaterializationTxs = new WeakSet<object>();
 
 export function markLazyMaterializationTx(tx: object): void {
@@ -260,7 +260,7 @@ export function clearSchemaRefusalTx(tx: object, refusal: unknown): void {
 export function isLazyMaterializationTx(tx: object): boolean {
   // Walk the chain rather than testing the object: a wrapper built over a
   // transaction that was marked earlier has never been marked itself, and must
-  // still answer for what it wraps.
+  // still report the mark of what it wraps.
   for (const layer of blindWriteTxChain(tx)) {
     if (lazyMaterializationTxs.has(layer)) return true;
   }


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) am opening this as part of the
conformance work behind the `## Word choice` rule in #5805. `data-model` went
first in #5807; this is `packages/runner/src`. Its `test` tree follows
separately.

20 files, 40 edits, comments and doc comments only. No code touched.

## What changed

The verb `answers`, and only where what it hands back is a return value.

| before | after |
| --- | --- |
| ``processDefaultValue()` answers `any`` | `... returns `any`` |
| `Plain indexing answers with `Object.prototype`'s member` | `... returns `Object.prototype`'s member` |
| `throws rather than quietly answering from committed state` | `... quietly reading from committed state` |
| `This boundary answers in canonical shapes` | `... returns canonical shapes` |
| `a query-result proxy answers `Object.hasOwn()`` | `... satisfies `Object.hasOwn()`` |

Four `spell` sites travel with them, where the word named a semantic relation
rather than a surface form:

| before | after |
| --- | --- |
| `The `system:` ref a compiled module name spells` | `... denotes` |
| `a locator no ref can spell` | `... no ref can name` |
| `each of which spells a ref that cannot resolve` | `... denotes a ref ...` |
| `atom data that happens to spell `{var: …}`` | `... happens to look like `{var: …}`` |

## What did not change

94 lines in `src` carry `answer`; 36 of them were the tic. The rest are the
carve-outs the rule names:

- **The noun** — "the answer traversal already gives", "the honest answer
  rather than the convenient one", "the one answer to 'is there outstanding
  pull work'".
- **The verb where the paragraph poses the question.** `runner.ts` sets out
  three predicates and quotes what each asks: `sameStoredSetup` answers "is
  this the same run of the same pattern". `fetch-program.ts` has `inFlight`
  answer "am I already resolving this?". `encodable-form.ts` says a hook is
  "Asked about each container ... and answers whether". Removing the verb
  there would break the sentence that sets it up.
- **`answers to`**, the idiom for a name something is known by — a module's
  serializer "under BOTH the names it answers to".
- **A server answering a request** — the shell's SPA fallback "answers 200
  with HTML", a rejected frame that "may well be answered".
- **Every `spell` that is about a surface form** — a data key `spelled the same
  way` in `cell.ts`, the resolver-dependent file spelling in `cfc/prepare.ts`
  and `writer-claim-correspondence.ts`, the way TS `spells` a literal type in
  `schema-format.ts`, and the `spell` / `spellId` identifiers, which are the
  retired name for a pattern and not prose at all.

## Checks

`deno task test` in `packages/runner`: **ok | 1203 passed (6528 steps) | 0
failed (4m20s)**. `deno fmt --check` and `deno lint` clean over the package. No
added line exceeds 80 columns.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

