### PR TITLE
docs(runner): say "returns" where "answers" was doing the work, in `test`

### DIFF
--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -320,7 +320,7 @@ describe("Cell", () => {
     const arrWithToJSON = [1, 2, 3] as unknown[] & { toJSON?: () => unknown };
     arrWithToJSON.toJSON = () => "custom-array-value";
 
-    // An array is answered by the array rule whatever it carries, and `toJSON`
+    // An array is handled by the array rule whatever it carries, and `toJSON`
     // is a named own property, which that rule rejects. Converting by it would
     // mean storing an array by the very property that disqualifies it.
     expect(() => c.set({ arr: arrWithToJSON })).toThrow(

--- a/packages/runner/test/cell-from-url-builtin.test.ts
+++ b/packages/runner/test/cell-from-url-builtin.test.ts
@@ -148,7 +148,7 @@ describe("cellFromUrl builtin", () => {
   });
 
   it("clears a resolved cell once the URL stops naming one", async () => {
-    // Reading through the stored link answers undefined for an empty target,
+    // Reading through the stored link returns `undefined` for an empty target,
     // so a guard on that would leave the previous URL's answer in place.
     const id = anExistingCell();
     const url = runtime.getCell<string>(space, "cell-from-url-input", {

--- a/packages/runner/test/cfc-atom-pattern.test.ts
+++ b/packages/runner/test/cfc-atom-pattern.test.ts
@@ -134,7 +134,7 @@ describe("CFC atom patterns", () => {
     it("fails closed on malformed var-bearing records, both directions", () => {
       // A record with a `var` key that is not the exact placeholder shape is
       // a malformed pattern: it matches nothing — including atom data that
-      // literally spells the same record.
+      // is literally the same record.
       const malformed = { var: "$x", type: "t" };
       expect(matchAtomPattern(malformed, { var: "$x", type: "t" })).toBeNull();
       expect(matchAtomPattern(malformed, roleAliceX)).toBeNull();

--- a/packages/runner/test/cfc-trust.test.ts
+++ b/packages/runner/test/cfc-trust.test.ts
@@ -202,7 +202,7 @@ describe("CFC trust closure (B3)", () => {
           { from: LOCATION_ROUNDING, to: AGE_ROUNDING },
         ],
       }));
-      // Terminates and answers correctly despite the cycle.
+      // Terminates and is correct despite the cycle.
       expect(
         cycleResolver.conceptSatisfied(
           LOCATION_ROUNDING,

--- a/packages/runner/test/cfc-wildcard-link-applicability.test.ts
+++ b/packages/runner/test/cfc-wildcard-link-applicability.test.ts
@@ -119,7 +119,7 @@ describe("CFC wildcard policy value conditions on fabric-primitive types", () =>
   });
 
   it("stays conservative on a type name outside the vocabulary", () => {
-    // The matcher's unknown-type fallthrough answers "applies" so a policy
+    // The matcher's unknown-type fallthrough returns "applies" so a policy
     // with a type this build does not know cannot be dodged.
     const unknownCondition = {
       type: "SomeFutureType",

--- a/packages/runner/test/convert-cells-to-links-sharing.test.ts
+++ b/packages/runner/test/convert-cells-to-links-sharing.test.ts
@@ -1,7 +1,7 @@
 /**
  * A value reachable twice by different paths is SHARED, not circular. The
- * conversion answers an ancestor with a back-link -- that is what makes a cycle
- * representable -- and must not answer a sibling the same way, which would
+ * conversion returns a back-link for an ancestor -- that is what makes a cycle
+ * representable -- and must not do the same for a sibling, which would
  * rewrite one of the two positions into a pointer at the other.
  */
 
@@ -48,7 +48,7 @@ describe("convert-cells-to-links-sharing", () => {
   });
 
   it("converts a twice-reachable value that converts to a primitive", () => {
-    // A `Date` becomes a `FabricEpochNsec`, which the walk answers without
+    // A `Date` becomes a `FabricEpochNsec`, which the walk returns without
     // descending. Every exit has to leave the ancestor set as it found it, or
     // the second position sees an ancestor that is really a sibling.
     const shared = new Date(1234);

--- a/packages/runner/test/create-ref-cell-routes.test.ts
+++ b/packages/runner/test/create-ref-cell-routes.test.ts
@@ -6,7 +6,7 @@
  *
  * Two cells at different paths of one document holding equal contents run
  * through most of it, because anything identifying a cell by its contents
- * rather than by what names it answers the same for both. The one input that
+ * rather than by what names it returns the same for both. The one input that
  * fails closed is a cell method: a reactive proxy makes it and a same-named
  * data key one object with one encodable form, so a derived id cannot say
  * which was meant.
@@ -50,7 +50,7 @@ describe("create-ref-cell-routes", () => {
    * Two cells at different paths of one document, holding equal contents, and
    * the query-result proxy for each. Equal contents is what makes the pair
    * discriminating: anything that identifies these by value rather than by
-   * position answers the same for both.
+   * position returns the same for both.
    */
   function siblings() {
     const root = runtime.getCell<{ a: { v: number }; b: { v: number } }>(
@@ -98,7 +98,7 @@ describe("create-ref-cell-routes", () => {
     // and deriving through the link agree anyway.
     const first = idOf(causable);
 
-    // Idempotent: a second derivation answers what the first did, rather than
+    // Idempotent: a second derivation returns what the first did, rather than
     // one preimage before the link exists and another after.
     expect(idOf(causable)).toBe(first);
 

--- a/packages/runner/test/create-ref-fail-closed.test.ts
+++ b/packages/runner/test/create-ref-fail-closed.test.ts
@@ -29,7 +29,7 @@ describe("createRef fail-closed", () => {
   it('derives distinct ids for the encodable forms `7` and `"7"`', () => {
     // An encodable form reaches the walk in place of the value it came from, so
     // a primitive form arrives past the point where a primitive INPUT is
-    // answered. Stringifying one would make these two name one document.
+    // handled. Stringifying one would make these two name one document.
     const asNumber = createRef({ held: { toEncodableForm: () => 7 } }, "cause");
     const asString = createRef(
       { held: { toEncodableForm: () => "7" } },

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -1766,11 +1766,11 @@ describe("data-updating", () => {
       expect(long.reads).toBeLessThan(50);
     });
 
-    it("stores a value answering `toCell` as the link it names", () => {
+    it("stores a value carrying `toCell` as the link it names", () => {
       // What the walk stops at, the diff replaces with a link -- which is
       // what makes an unchanged element of a read-back list cost nothing to
       // write, and is the property the walk stopping must not disturb. Both
-      // kinds of value answer `toCell` and both land the same way: the live
+      // kinds of value carry `toCell` and both land the same way: the live
       // view a schemaless read hands out, and the frozen result a read
       // through a schema annotates.
       const source = runtime.getCell<{ inner: { deep: number } }>(

--- a/packages/runner/test/derived-copy-identity.test.ts
+++ b/packages/runner/test/derived-copy-identity.test.ts
@@ -82,7 +82,7 @@ describe("noteDerivedCopy trust carry", () => {
   });
 
   it("records nothing for a value derived from itself", () => {
-    // A walk answers an unchanged subtree by identity, so a caller can reach
+    // A walk returns an unchanged subtree by identity, so a caller can reach
     // here with one object for both sides. Recording that would make the
     // value its own ancestor.
     const value = brandTrustedPattern(patternShape());

--- a/packages/runner/test/encodable-form.test.ts
+++ b/packages/runner/test/encodable-form.test.ts
@@ -286,7 +286,7 @@ describe("encodable-form", () => {
 
     describe("values the conversion decides for itself", () => {
       it("leaves an array carrying an own serializer alone", () => {
-        // An array is answered by the array rule whatever it carries.
+        // An array is handled by the array rule whatever it carries.
         const value = Object.assign([1, 2], {
           toEncodableForm: () => "replaced",
         });
@@ -471,7 +471,7 @@ describe("encodable-form", () => {
       });
 
       it("is _not_ told about a value that came back unchanged", () => {
-        // Answered by identity, so there is no copy and nothing to carry.
+        // Returned by identity, so there is no copy and nothing to carry.
         const { seen } = copies({ a: 1, b: { c: [1, 2, 3] } });
         expect(seen).toEqual([]);
       });
@@ -499,7 +499,7 @@ describe("encodable-form", () => {
     it("returns false for a value carrying only `toJSON`", () => {
       // The JSON protocol's name gets no standing here. A cell carries it too,
       // for `JSON.stringify`, and reading storage's answer off it would mean
-      // every value bearing the protocol's member answered as well.
+      // every value bearing the protocol's member counted as well.
       expect(hasEncodableForm({ toJSON: () => ({}) })).toBe(false);
     });
 
@@ -590,7 +590,7 @@ describe("encodable-form", () => {
 
     it("tells an explicit `undefined` `ifNone` from an omitted one", () => {
       // The distinction is what lets a caller stand a computed fallback behind
-      // a `??`: omitting it answers the value, which is never nullish for an
+      // a `??`: omitting it returns the value, which is never nullish for an
       // object, so a `??` would never reach the fallback.
       const value = { a: 1 };
       expect(encodableFormOf(value)).toBe(value);

--- a/packages/runner/test/error-taming.test.ts
+++ b/packages/runner/test/error-taming.test.ts
@@ -92,7 +92,7 @@ describe("Error.isError under SES lockdown", () => {
     it("recognizes an error handed in from the host", () => {
       // The reason to restore the genuine intrinsic rather than polyfill with
       // `instanceof`: the compartment's `Error` is not the host's, so only the
-      // internal-slot test answers this correctly.
+      // internal-slot test is correct here.
       const check = evaluateFunctionSourceInSES(
         `function (value) { return Error.isError(value); }`,
         { lockdown: true },

--- a/packages/runner/test/pattern-auto-update.test.ts
+++ b/packages/runner/test/pattern-auto-update.test.ts
@@ -20,7 +20,7 @@ import {
 
 const signer = await Identity.fromPassphrase("lazy system pattern updates");
 const PARENT_PATH = "/api/patterns/system/lazy-update-parent.tsx";
-// The `system:` ref that route path spells — what a checked piece is stamped
+// The `system:` ref that route path denotes — what a checked piece is stamped
 // with, whichever legacy spelling it started from.
 const PARENT_SOURCE = systemPatternSource("system/lazy-update-parent.tsx");
 const SOURCE_PATH = "/api/patterns/system/lazy-update-test.tsx";

--- a/packages/runner/test/pattern-source-scheme.test.ts
+++ b/packages/runner/test/pattern-source-scheme.test.ts
@@ -100,7 +100,7 @@ describe("normalizePatternSource", () => {
 
   it("drops a query or fragment rather than minting an unusable ref", () => {
     // The patterns route serves a file by path, so neither selects anything;
-    // keeping either would spell a ref the resolver rejects, leaving the piece
+    // keeping either would name a ref the resolver rejects, leaving the piece
     // with provenance nothing would follow again.
     expect(normalizePatternSource("/api/patterns/custom/my-app.tsx?v=2", HOST))
       .toBe("system:custom/my-app.tsx");
@@ -123,7 +123,7 @@ describe("normalizePatternSource", () => {
   });
 
   it("refuses a legacy locator that does not address a file on the route", () => {
-    // Climbing, an empty path, and a doubled separator each spell a ref that
+    // Climbing, an empty path, and a doubled separator each denote a ref that
     // cannot resolve, so the locator is left as authored instead.
     for (
       const source of [

--- a/packages/runner/test/query-result-proxy-enumeration.test.ts
+++ b/packages/runner/test/query-result-proxy-enumeration.test.ts
@@ -355,8 +355,8 @@ describe("CT-1240: query result proxy enumeration", () => {
     }
   });
 
-  // `in` IS the `has` trap's own operator, so inherited names SHOULD answer
-  // true there. Pinned so a future cleanup does not "fix" both traps alike.
+  // `in` IS the `has` trap's own operator, so inherited names SHOULD be true
+  // there. Pinned so a future cleanup does not "fix" both traps alike.
   it("the `in` operator still sees inherited names", () => {
     const cell = runtime.getCell<{ a: number }>(
       space,

--- a/packages/runner/test/query-result-proxy-transaction-lifetime.test.ts
+++ b/packages/runner/test/query-result-proxy-transaction-lifetime.test.ts
@@ -8,7 +8,7 @@
 //
 // A transaction marked for lazy materialization turns the same call into a view
 // over the state that one transaction sees, fixed at creation. Reading after
-// the transaction finishes throws instead of quietly answering from committed
+// the transaction finishes throws instead of quietly reading from committed
 // state, which is what a materialized read wants: the value it describes is the
 // value that was there when it was taken.
 
@@ -149,7 +149,7 @@ describe("query-result-proxy transaction lifetime", () => {
       await readTx.commit();
 
       // The transaction it was made against is gone, and the handle still
-      // answers — from current committed state, not from a refusal.
+      // reads — from current committed state, not from a refusal.
       expect(handle.outer.middle.leaf).toBe(1);
 
       const update = runtime.edit();

--- a/packages/runner/test/scheduler/node-record.test.ts
+++ b/packages/runner/test/scheduler/node-record.test.ts
@@ -16,8 +16,9 @@ describe("NodeRegistry", () => {
 
       it("returns the record from `get()` after removal", () => {
         // The record is deliberately kept so a re-registration recovers the
-        // ordinal and parent. `get()` therefore answers for a node that is no
-        // longer scheduled, and cannot stand in for a registration check.
+        // ordinal and parent. `get()` therefore returns a record for a node
+        // that is no longer scheduled, and cannot stand in for a registration
+        // check.
         const nodes = new NodeRegistry();
         const action: Action = function removed() {};
         nodes.register(action, "computation");

--- a/packages/runner/test/schema-view.test.ts
+++ b/packages/runner/test/schema-view.test.ts
@@ -473,9 +473,9 @@ describe("schema-view", () => {
     // An optional handle — `Cell<T> | undefined` — generates as a union whose
     // one branch carries `asCell` and whose other is the absent case, and the
     // branches arrive as `$ref`s into `$defs`. Both facts hid the marker: a
-    // union answers `hasAsCell` only when EVERY branch declares one, and a bare
-    // `$ref` declares nothing until it is resolved. A reader got a plain value
-    // where the pattern declared a handle.
+    // union satisfies `hasAsCell` only when EVERY branch declares one, and a
+    // bare `$ref` declares nothing until it is resolved. A reader got a plain
+    // value where the pattern declared a handle.
     it("returns a Cell for an optional handle declared through $ref branches", async () => {
       const read = await seeded(
         "optional-handle",
@@ -988,7 +988,7 @@ describe("schema-view", () => {
     });
 
     it("still reads a property whose shape the narrowing cannot see through", async () => {
-      // `schemaAtPath` also answers `false` where it cannot read a child out of
+      // `schemaAtPath` also returns `false` where it cannot read a child out of
       // the shape it was given. That is not a rejection, and the subschema is
       // still reachable below it.
       const read = await seeded(

--- a/packages/runner/test/storage-preflight.test.ts
+++ b/packages/runner/test/storage-preflight.test.ts
@@ -63,7 +63,7 @@ describe("flattenBuilderArtifacts()", () => {
   });
 
   it("leaves a value it did not copy out of the side table", () => {
-    // Nothing was replaced, so the value is answered by identity and is its
+    // Nothing was replaced, so the value is returned by identity and is its
     // own original -- not a derivation of anything.
     const value = { a: 1, b: { c: [1, 2, 3] } };
     expect(flattenBuilderArtifacts(value)).toBe(value);


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) am opening this as the companion to
#5808, which did `packages/runner/src`. Same rule (`## Word choice`, landed in
#5805), same triage, applied to `packages/runner/test`.

19 files, 29 edits, comments and two `it()` descriptions. No assertions or
fixtures touched.

## What changed

| before | after |
| --- | --- |
| `A walk answers an unchanged subtree by identity` | `... returns an unchanged subtree by identity` |
| `the value is answered by identity` | `... is returned by identity` |
| `An array is answered by the array rule` | `... is handled by the array rule` |
| `throws instead of quietly answering from committed state` | `... quietly reading from committed state` |
| `it("stores a value answering `toCell` ...")` | `it("stores a value carrying `toCell` ...")` |

Four `spell` sites travel with them, matching #5808: the `system:` ref a route
path `spells` is now one it `denotes`, a locator no ref can `spell` is one none
can `name`, and atom data that `literally spells the same record` is data that
`is literally the same record`.

## What did not change

The carve-outs, and the LLM domain, which is most of the population here:

- **The noun** — "a wrong answer", "the useful answer", "one wrong answer for
  another".
- **The verb where the paragraph poses the question** — link-resolution probes
  that "answer a different question ('is there a link here?')"; eviction tests
  that "answer the question whatever the mechanism turns out to be"; a
  validator that "asks whether `undefined` is an object, which nothing answers
  yes to".
- **A server, transport, or network answering a request** — the scripted
  transport that "answers the watch.add with a sync", the SPA fallback that
  "answers 200 with HTML", `pull-first-sync-race`'s "network" answering.
- **The LLM sense**, which is a genuine domain noun here: "Hold the model's
  answer", `content: "Second answer"`, `{ answer: 42 }` fixtures, and
  `properties: { answer: { type: "string" } }` schemas. Untouched.
- **Every `spell` about a surface form** — the resolver-dependent file spelling
  in `cfc-writer-claim-correspondence`, `piece-spelled claim`, and how a builder
  artifact `spells` its serializer.

## Checks

`deno task test` in `packages/runner`: **ok | 1203 passed (6528 steps) | 0
failed (4m22s)**. `deno fmt --check` and `deno lint` clean over the package. No
added line exceeds 80 columns.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

