### PR TITLE
docs(cli): say "returns" in the test names, and drop two metaphors

### DIFF
--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -771,7 +771,7 @@ const READBACK_FLAGS: ReadonlyArray<
  * of the default (flag parity, so a script can state its intent), which makes
  * `--await --no-wait` a contradiction rather than a precedence puzzle — it is
  * refused. `--await --wait <s>` is fine: both mean "wait", the bound just
- * names the patience. A non-positive bound is refused: it would spell
+ * names the patience. A non-positive bound is refused: it would mean
  * "don't wait" while claiming to be a wait.
  *
  * `--no-wait` also refuses every flag that shapes or annotates the outcome —

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -229,7 +229,7 @@ RC=$?
 check "0" "$RC" "addChild readback on a doubly-linked tree"
 BACKREF=$(printf '%s' "$CALLED" | jq -r '.result.item.parent["$link"].id // ""')
 check "of:" "${BACKREF:0:3}" \
-  "the position that closes the circle answers an address"
+  "the position that closes the circle returns an address"
 AFTER=$($CF piece get --quiet --piece "$EPIC" children $ARGS --step 2>/dev/null |
   jq -r 'length')
 check "$((BEFORE + 1))" "$AFTER" "the write the result describes landed"

--- a/packages/cli/lib/completion/static.ts
+++ b/packages/cli/lib/completion/static.ts
@@ -2,7 +2,7 @@
  * Candidates derivable from the Cliffy command tree alone — subcommands,
  * option names, and the enumerable value sets the tree cannot express.
  *
- * No I/O: every function here answers from the `Command` object graph, so it
+ * No I/O: every function here works from the `Command` object graph, so it
  * stays correct offline and costs nothing beyond process start.
  */
 

--- a/packages/cli/test/main-command.test.ts
+++ b/packages/cli/test/main-command.test.ts
@@ -276,7 +276,7 @@ describe("main command", () => {
 
   it("shows the supervisor's own help for the direct supervisor entry point", async () => {
     // The subcommand forwards its raw argv to the supervisor's parser, so the
-    // compiled binary and a direct `deno run` of the supervisor answer with the
+    // compiled binary and a direct `deno run` of the supervisor produce the
     // same flags and the same help.
     const { code, stdout } = await cf("fuse-supervisor --help");
 

--- a/packages/cli/test/piece-call-cyclic-result-live.test.ts
+++ b/packages/cli/test/piece-call-cyclic-result-live.test.ts
@@ -268,7 +268,7 @@ describe("cf piece call on a piece that points back at its container", () => {
     });
   });
 
-  it("answers a collection that re-enters with one address per element", async () => {
+  it("returns one address per element for a collection that re-enters", async () => {
     await withTracker("cyclic-returns-container", async ({ call }) => {
       await call("addChildSelf", ["--title", "First"]);
       const result = await call("addChildSelf", ["--title", "Second"]) as any;
@@ -331,7 +331,7 @@ describe("cf piece call on a piece that points back at its container", () => {
     });
   });
 
-  it("answers a `--select` that names the closing position with that position alone", async () => {
+  it("returns that position alone for a `--select` naming the closing position", async () => {
     await withTracker("cyclic-selection-names-cut", async ({ call }) => {
       const result = await call("addChild", ["--title", "Pointed"], {
         selection: { projection: parseSelectProjection("item.parent") },

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -74,7 +74,7 @@ const callerSession = "ses:piece-call-test";
 describe("executePieceCallable", () => {
   it("reports not-found when the piece cell has no schema-cast surface", async () => {
     // The forced-stream probe's type guard: a piece cell without asSchema
-    // cannot take the cast, so the third resolution path answers null and
+    // cannot take the cast, so the third resolution path returns null and
     // the resolver reports not-found instead of crashing on the probe.
     const emptyChild: Record<string, unknown> = {
       schema: undefined,
@@ -2474,7 +2474,7 @@ describe("piece call wait control", () => {
     });
   });
 
-  it('refuses a bound that spells "don\'t wait"', () => {
+  it('refuses a bound that means "don\'t wait"', () => {
     expect(() => resolveWaitControl({ wait: 0 })).toThrow(/positive/);
     expect(() => resolveWaitControl({ wait: -1 })).toThrow(/positive/);
     expect(() => resolveWaitControl({ wait: Number.NaN })).toThrow(/positive/);
@@ -4803,7 +4803,7 @@ describe("renderPieceCallOutcome", () => {
       .toBeLessThan(hinted[0].indexOf("CF_INVOCATION_SESSION"));
   });
 
-  it("spells a non-space receipt scope into the collect address", () => {
+  it("writes a non-space receipt scope into the collect address", () => {
     // The scope is part of the address: reopening a session-scoped cell
     // without it resolves the space-scoped instance — a different cell — so
     // the hint carries the id@scope form parseScopedId accepts. The bare

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -1950,7 +1950,7 @@ describe("cf piece get transforms", () => {
     );
   });
 
-  it("answers an unset declared array with no addresses rather than a refusal", async () => {
+  it("returns no addresses for an unset declared array rather than refusing", async () => {
     // An unset declared array is the empty array under the runner's map
     // semantics, and the unmarked spelling already answers `[]`. A marked one
     // must agree: refusing here would tell a caller its piece is malformed
@@ -3222,7 +3222,7 @@ describe("cf piece get transforms", () => {
       return { value, cell: outputCell!.getAsNormalizedFullLink().id };
     }
 
-    it("answers the repeat from the cell the first read set up", async () => {
+    it("returns the repeat from the cell the first read set up", async () => {
       const source = await seededSource(runtime, "repeat-identical-source", [
         { id: 1, title: "First" },
         { id: 2, title: "Second" },
@@ -3239,7 +3239,7 @@ describe("cf piece get transforms", () => {
       expect(second.cell).toBe(first.cell);
     });
 
-    it("answers the repeat with a source change made between the reads", async () => {
+    it("returns the repeat with a source change made between the reads", async () => {
       const source = await seededSource(runtime, "repeat-restated-source", [
         { id: 1, title: "First" },
       ]);
@@ -3262,7 +3262,7 @@ describe("cf piece get transforms", () => {
       expect(second.cell).toBe(first.cell);
     });
 
-    it("answers each differing selection from its own cell", async () => {
+    it("returns each differing selection from its own cell", async () => {
       const source = await seededSource(runtime, "repeat-distinct-source", [
         { id: 1, title: "First" },
         { id: 2, title: "Second" },
@@ -3300,7 +3300,7 @@ describe("cf piece get transforms", () => {
       expect(repeat.cell).toBe(ids.cell);
     });
 
-    it("answers a repeat whose source changed root kind between the reads", async () => {
+    it("returns a repeat whose source changed root kind between the reads", async () => {
       // A source whose schema names no root kind has its array-ness read off
       // the value, and the projection's shape follows it. So the two reads
       // below ask the same thing of two different shapes, and answering the
@@ -3327,7 +3327,7 @@ describe("cf piece get transforms", () => {
         .toEqual({ id: 9 });
     });
 
-    it("answers a second runtime's identical read over the same session", async () => {
+    it("returns a second runtime's identical read over the same session", async () => {
       const source = await seededSource(runtime, "repeat-two-hosts-source", [
         { id: 1, title: "First" },
       ]);


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) am opening this as part of the
conformance work behind the `## Word choice` rule (#5805). Earlier passes:
#5807 (`data-model`), #5808 and #5810 (`runner`).

7 files, 15 edits. This one is small on purpose, and the reason is the
interesting part.

## What changed

**Eight `it()` descriptions.** The unit-test style guide names `returns` as the
verb for a return value and `answers` as specifically the wrong one, with no
carve-out.

| before | after |
| --- | --- |
| `answers the repeat from the cell the first read set up` | `returns the repeat ...` |
| `answers a collection that re-enters with one address per element` | `returns one address per element for a collection that re-enters` |
| `answers an unset declared array with no addresses rather than a refusal` | `returns no addresses for an unset declared array rather than refusing` |

**Four prose sites**, where nothing in view was asked: a resolution path that
`answers null`, two entry points that `answer with the same flags`, a
completion module that `answers from the Command object graph`. One
integration-check label follows the same rule.

**Two `spell` sites**: a bound that would `spell "don't wait"` now *means* it,
and a receipt scope a test `spells into the collect address` is now one it
*writes*.

## What did not change, and why

`packages/cli` carries 283 lines with `answer` in them. Almost all of them
stay, because `cf piece get` is a question-answering surface: a `--select` is a
query the caller writes, and the command answers it. That is the carve-out the
rule names — the verb where the paragraph poses the question it answers — and
here the prose poses it out loud.

The measurement, since it is checkable rather than a matter of taste:

| file | `ask` forms | `answer` forms |
| --- | --- | --- |
| `lib/cell-selection.ts` | 27 | 27 |
| `lib/piece.ts` | 5 | 9 |
| `README.md` | 3 | 9 |

And the ask is usually in the same sentence as the answer:

> `topic` asks for what is stored there, `topic@` asks for its address, and a
> list naming both asks for both.

> dropping it answers with contents where an address was asked

> assert `name` on `cell` is a stream, then ask the runtime whether it answers
> as one

Also untouched: HTTP and NFS request/response (`the server answers 409`, `the
NFS client answers a negative name lookup from its cache`); the editor's
type/definition **queries**; and every `spell` about a surface form — a field
list that `spells the same marker with a trailing @`, a literal that `spells
items: false`, the `spellId` identifier.

If you would rather the selection domain conform too, that is a bigger and
separate change, and I would want to make it in one pass over the grammar's
whole vocabulary rather than piecemeal.

## Checks

`deno task test` in `packages/cli`: **ok | 174 passed (206 steps) | 0 failed
(2m17s)**. `deno fmt --check` and `deno lint` clean over the package. The only
added lines past 80 columns are `it()` descriptions, which the style guide
exempts.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

