### PR TITLE
docs: say "returns" and "denotes" where the runtime prose already does

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -38,7 +38,7 @@ Add a line for each new document to the index below.
   typed error instead of a silent absent read or an endless wait
 - [`lazy-cell-materialization.md`](lazy-cell-materialization.md) — the
   schema-observing view a marked transaction hands back from a read, what it
-  checks and when, and the rules that keep it answering as an eager read does
+  checks and when, and the rules that keep it agreeing with an eager read
 - [`data-uri-identifiers.md`](data-uri-identifiers.md) — the cell identifiers
   that carry their own frozen value rather than naming a document in a space,
   why the runtime keeps both a broad and a narrow test for one, and what

--- a/docs/features/lazy-cell-materialization.md
+++ b/docs/features/lazy-cell-materialization.md
@@ -55,18 +55,18 @@ which is where an eager read decides the same question:
 
 Either way the read that failed is registered first.
 
-## Answering "nothing is there" still owes a read
+## Returning "nothing is there" still owes a read
 
 The entry point takes the container's value without telling the scheduler, and
 lets whatever materializes it register reads as it walks. So every way a view
-answers without a value has to register the read it stands in for: a refusal, a
+returns without a value has to register the read it stands in for: a refusal, a
 key the container does not hold, and a value replaced by the schema's `default`.
 Miss one and the reader holds no dependency on the path it just found empty — it
 goes on reading its default however late the value arrives.
 
 ## Agreeing with an eager read
 
-A view and an eager read must answer alike; where they do not, the view is
+A view and an eager read must agree; where they do not, the view is
 wrong. Six rules exist only to hold that:
 
 - **The last link hop's schema is combined in.** Eager traversal walks *through*
@@ -88,7 +88,7 @@ wrong. Six rules exist only to hold that:
   [`data:` identifier](data-uri-identifiers.md), and the view does the same. The
   read stays on the slot, and recursively: the identity is derived from the whole
   element value.
-- **A property the schema turns down is answered off the schema, not by reading
+- **A property the schema turns down is settled off the schema, not by reading
   it.** Declaring it `false` turns it down, and so does leaving it unnamed by a
   schema that refuses the properties it does not name. Either way it is absent
   to a reader — from `in`, from enumeration and from a plain access alike — and
@@ -98,7 +98,7 @@ wrong. Six rules exist only to hold that:
   and a marked collection would otherwise load one document per element.
   Requiring such a property instead voids the object, since nothing reaches the
   filtered result at that key. This is narrower than it sounds — schema
-  narrowing also answers `false` where it cannot read a child out of the shape
+  narrowing also returns `false` where it cannot read a child out of the shape
   it was given, an `allOf` among them, and there the subschema is still
   reachable below.
 - **A read-only array method visits every element, even past one that does not
@@ -144,7 +144,7 @@ Assignment, deletion, `defineProperty` and freezing all throw. Snapshot it with
 `snapshotQueryResult` if you need a value you own. A view also keeps the
 transaction it was created with, so what it describes stays what was there when
 it was taken; reading after that transaction finishes throws rather than quietly
-answering from committed state.
+reading from committed state.
 
 That last point is what separates a view from the schema-less proxy in
 [`query-result-proxy.ts`](../../packages/runner/src/query-result-proxy.ts),

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -108,7 +108,7 @@ carrier: explicit source provenance travels with it. For an unstamped non-root
 piece, its verified source-doc closure supplies the authored entry path — but
 only a path under the patterns route is admitted, since a module's name equals
 its route only for a program compiled over HTTP. The runtime persists the
-`system:` ref that path spells, and only after the matching `?identity` route
+`system:` ref that path denotes, and only after the matching `?identity` route
 succeeds.
 
 ## The implemented specialized model

--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -180,7 +180,7 @@ Whether a type gets a name is decided by `getNamedTypeKey`
 sets — not the short name list in the README. A type is *excluded* when any of
 these holds:
 
-- the type **node** spells a wrapper: `Default`, `Cell`, `Writable`,
+- the type **node** names a wrapper: `Default`, `Cell`, `Writable`,
   `ReadonlyCell`, `WriteonlyCell`, `ComparableCell`, `OpaqueCell`, `Stream`,
   `SqliteDb` (name sets `CELL_LIKE_WRAPPER_NAMES` / `OPAQUE_WRAPPER_NAMES`;
   `Reactive` is *not* excluded on the node axis);

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -1277,7 +1277,7 @@ Section 4.5.
   because an array's prototype has no representation as array content, so
   accepting one could only mean dropping it silently. A subclass prototype is
   live code besides — an overridden `Symbol.iterator`, say, makes iteration
-  answer differently than the indices do, and freezing the array does not
+  yield different content than the indices do, and freezing the array does not
   change that. Plain objects are governed by the same principle; see the
   object rule below.
 - May be dense or sparse
@@ -1390,7 +1390,7 @@ expanded, or a shared subtree quietly copied in two, is a value that decodes
 to a different graph than the one encoded, with nothing at either end saying
 so.
 
-**Conversion answers separately from serialization, and refuses a cycle.**
+**Conversion is decided separately from serialization, and refuses a cycle.**
 `fabricFromNativeValue()` builds a fabric value out of native data, and will not
 build one containing a cycle; it preserves shared references, so the converted
 form for a given original is reused and structural sharing survives. That is a
@@ -3555,9 +3555,9 @@ export function fabricFromNativeValue(
 > `"Date"`, `"RegExp"`, `"Array"`, `"Object"`, `"Primitive"`,
 > `"FabricInstance"`). The conversion function then switches on the tag to
 > route to the appropriate wrapping logic. An array is the exception to the
-> constructor lookup: `Array.isArray()` is consulted first and answers
+> constructor lookup: `Array.isArray()` is consulted first and returns
 > `"Array"` unconditionally, so a subclass instance, a severed-prototype array,
-> and a cross-realm array all reach array handling and are answered by the
+> and a cross-realm array all reach array handling and are handled by the
 > array rule of Section 1.5, rather than being rejected as some unrecognized
 > class or routed elsewhere by something the array carries. Fallback paths
 > handle exotic Error subclasses (via `Error.isError()`) and null-prototype


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) am opening this as part of the
conformance work behind the `## Word choice` rule (#5805). Earlier passes:
#5807 (`data-model`), #5808 and #5810 (`runner`), #5811 (`cli`).

5 files, 13 edits. These are the live documents that describe behavior whose
comments changed in the runtime passes, so a document and the code it describes
read alike again.

## What changed

`features/lazy-cell-materialization.md` carries most of it, and each edit has a
counterpart already in the runtime:

| document | matching code |
| --- | --- |
| a view that `answers without a value` → `returns without a value` | — |
| schema narrowing that `answers `false`` → `returns `false`` | `schema-view.ts` |
| `throws rather than quietly answering from committed state` → `... reading from` | `storage/interface.ts`, `storage/reactivity-log.ts` |
| a view and an eager read must `answer alike` → must `agree` | the section is titled "Agreeing with an eager read" |

Two `spell` sites go the way the runner's did: the `system:` ref a route path
`spells` is one it `denotes` (`pattern-updates.md`), and a type node that
`spells a wrapper` `names` one (`ts_to_json_schema_mapping.md`).

The formal spec's array rules take the `data-model` wording from #5807:
iteration now `yields different content than the indices do`, and
`Array.isArray()` `returns` `"Array"` unconditionally.

One heading changes — `## Answering "nothing is there" still owes a read` →
`## Returning ...`. Nothing links to its anchor; I checked.

## What did not change

Everything else in `docs/`. The specs use `answer` for a ruled question, a
reference answer, and a deferral (`Deferrals are answers`), which is exactly
the word for those. `docs/common/verbs-over-the-cli.md` stays with
`packages/cli` for the reason set out in #5811 — a `--select` is a query the
caller writes.

Also untouched: every `spell` about a surface form — `stays spelled
`Stream<Event>``, ``required` is spelled correctly`, `regardless of how it is
spelled`, `stored/spelled "of:fid1:<hash>"`.

`docs/history/` is untouched by construction.

## Checks

`deno task check-docs`: **All 549 checked code block(s) passed.**
`check-docs-history-index` and `check-skill-facts` clean. No line exceeds 80
columns.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

