### PR TITLE
docs: say "returns" in the last few places it was "answers"

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -714,7 +714,7 @@ Notes:
   their difference apart, with at least 3 samples supporting each — so noise
   produces no levels, and one stray sample is not a level. The second fit is a
   **straight line** through the median of the pairwise log-slopes, which is the
-  shape a series takes when it drifts, and it answers when its total deviation
+  shape a series takes when it drifts, and it wins when its total deviation
   is at least a tenth smaller. Reporting the difference across the fit rather
   than a slope extended over the window means a shift reads at its true size
   wherever in the window it sits: a shift in the newest samples is the one worth

--- a/packages/dashboard/tiles/benchmark.test.ts
+++ b/packages/dashboard/tiles/benchmark.test.ts
@@ -48,7 +48,7 @@ import { PERFORMANCE_VIEW_STYLES } from "../performance-views.ts";
 // The history store falls back to the system temporary directory when no cache
 // directory is named. The package's test runner names a fresh one for each run.
 // Running this file directly gets whatever the last run left behind, which then
-// answers these tests in place of their own fixtures. Name a directory here when
+// feeds these tests in place of their own fixtures. Name a directory here when
 // nothing else has.
 if (Deno.env.get("DASHBOARD_CACHE_DIR") === undefined) {
   Deno.env.set(
@@ -3349,7 +3349,7 @@ Deno.test("benchmark: more samples than the fit reads are grouped, and the rise 
 });
 
 Deno.test("benchmark: a steady climb reads as the whole of its rise", () => {
-  // No step to find, so the straight line describes the series and answers with
+  // No step to find, so the straight line describes the series and reports
   // its rise from the first sample to the last.
   const times: number[] = [], values: number[] = [];
   for (let i = 0; i < 21; i++) {

--- a/packages/dashboard/trend.ts
+++ b/packages/dashboard/trend.ts
@@ -142,7 +142,7 @@ function medianSlope(logs: number[]): number {
 // Overall change as the fractional difference between the start and the end of
 // a robust fit (+0.2 means the fit ends 20% higher than it starts).
 //
-// Two fits describe the series and the closer one answers. The first is a set
+// Two fits describe the series and the closer one wins. The first is a set
 // of flat levels meeting at change points, which is the shape a series takes
 // when something lands and shifts it. The second is a straight line through the
 // median pairwise slope, which is the shape a series takes when it drifts. Each

--- a/packages/integration/astral-adapter.ts
+++ b/packages/integration/astral-adapter.ts
@@ -36,7 +36,7 @@ export type ElementHandle = AstralElementHandle & {
 export interface InteractionObserver {
   // `element` is absent when the click was aimed at a point rather than
   // resolved to a handle, which is how the CFC helpers dispatch: the wait that
-  // settles the control answers with coordinates, and no handle is taken.
+  // settles the control returns coordinates, and no handle is taken.
   beforeClick?(
     element: ElementHandle | undefined,
     point: { x: number; y: number },

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -283,7 +283,7 @@ const fillAndVerify = async (
 /**
  * Which elements a marked click is about to be aimed at.
  *
- * A finder answers with the elements to mark, in the order their tokens were
+ * A finder returns the elements to mark, in the order their tokens were
  * supplied, or `undefined` when the page does not yet present all of them. It
  * decides only which elements qualify — being rendered, surviving a settle, and
  * carrying the mark are {@link settleAndMarkTargets}'s business, and every

--- a/packages/patterns/notes/note.tsx
+++ b/packages/patterns/notes/note.tsx
@@ -425,7 +425,7 @@ const Note = pattern<NoteInput, NoteOutput>(
       return splitDefinitions(body).definitions.map((d) => d.address);
     });
 
-    // One resolution per address. `cellFromUrl` answers with no cell for an
+    // One resolution per address. `cellFromUrl` returns no cell for an
     // address that names no piece, which is how an ordinary reference link
     // stays an ordinary reference link.
     const pendingResolutions = pendingAddresses.map((address) =>

--- a/packages/piece/test/state-continuity-harness.ts
+++ b/packages/piece/test/state-continuity-harness.ts
@@ -699,7 +699,7 @@ export function comparableState(value: unknown): unknown {
  * rest of the object.
  *
  * A schema-driven read resolves nothing at a `{"type": "unknown"}` position —
- * `schemaTypeValidity` in `traverse.ts` answers `Unknown` there, and the value
+ * `schemaTypeValidity` in `traverse.ts` returns `Unknown` there, and the value
  * comes back `undefined` WHATEVER the document holds. That is the right answer
  * for a reader; it is the wrong one for this comparison, because "the schema
  * did not resolve it" then reads exactly like "the document does not hold it",
@@ -714,7 +714,7 @@ export function comparableState(value: unknown): unknown {
  * that stranded any of them would have replayed clean.
  *
  * `required` goes for a different reason, measured on the committed topics
- * fixture. A schema-driven read answers `undefined` for the WHOLE object when a
+ * fixture. A schema-driven read returns `undefined` for the WHOLE object when a
  * required property does not resolve — and a pattern's own result schema marks
  * its session-local drafts required: `topic.tsx` requires `bodyDraft`,
  * `commentDraft`, `editingBody`, `linkUrlDraft` and `linkLabelDraft`, each a

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -202,9 +202,9 @@ export function isInertArray(array: unknown): boolean {
   }
 
   // Every index (each key before `length`, given the check above) must also
-  // hold a data property; an accessor answers `get` / `set` in its descriptor
+  // hold a data property; an accessor carries `get` / `set` in its descriptor
   // and has no `value`. (`length` itself is always a data property.) The
-  // non-null assertion trusts the object to answer a descriptor for a key it
+  // non-null assertion trusts the object to return a descriptor for a key it
   // itself reported; a proxy that disavows one is buggy (this is a
   // best-effort system with regards to proxies), and the resulting
   // `TypeError` is its to own.

--- a/packages/utils/test/objects.test.ts
+++ b/packages/utils/test/objects.test.ts
@@ -217,7 +217,7 @@ describe("objects", () => {
 
     it("returns `false` for a `Proxy` that disowns a key it reported", () => {
       // A proxy whose `ownKeys()` names a key its `getOwnPropertyDescriptor()`
-      // then answers `undefined` for. Inertness cannot be established, so the
+      // then returns `undefined` for. Inertness cannot be established, so the
       // answer is `false`; only a trap that throws on its own account takes
       // this check off its "answers rather than throws" contract.
       const ghosted = new Proxy({ a: 1 }, {


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) am opening this as the last of the
conformance work behind the `## Word choice` rule (#5805). Earlier passes:
#5807 (`data-model`), #5808 and #5810 (`runner`), #5811 (`cli`), #5812
(`docs/`).

9 files, 11 edits, comments only, across `dashboard`, `integration`,
`patterns`, `piece` and `utils`.

## What changed

| before | after |
| --- | --- |
| ``schemaTypeValidity` answers `Unknown` there` | `... returns `Unknown` there` |
| `A finder answers with the elements to mark` | `A finder returns the elements to mark` |
| ``cellFromUrl` answers with no cell` | `... returns no cell` |
| `an accessor answers `get` / `set` in its descriptor` | `... carries `get` / `set` ...` |
| `Two fits describe the series and the closer one answers` | `... the closer one wins` |

## `toolshed` needed nothing, and that is the result rather than an omission

`packages/toolshed` carries 60 lines with `answer` in them and not one is the
tic. Every single one is an HTTP response — `answers 409`, `answers 502`,
`stoker's defaultHook answering a zod failure`, `the service never answered, or
answered in a way that carried no status` — or the LLM sense, where an answer
is what a model produced. A server answering a request is the word doing its
own job, and the rule carves it out.

Nearly all of `packages/dashboard` is the same: a host that answers, a proxy
answering every reconnect with an error page, SigNoz answering a query, GitHub
answering a workflow-run query, and DNS with `either an A or AAAA answer`. Only
the trend-fit sentences, where two fits compete and one is chosen, were the
metaphor.

Every `spell` in these packages is a surface form and stays: `keys a number
apart from the string that spells it`, `a path component spelled this way`,
`Markdown has no way to spell an empty code span`, `how a sparkline caption
spells a day span`, `the costs endpoint spells amounts`. So do the `spellcheck`
attributes, the `spellId` field, `state-inspector`'s legacy `spell` key, and
`cfc-browser-helpers.test.ts`'s two uses of `for a spell` meaning a short while.

## Checks

`deno task test` in each touched package: `dashboard` **10 passed, 0 failed**;
`utils` **99 passed (664 steps), 0 failed**; `piece` **37 passed (449 steps), 0
failed**; `integration` **47 passed, 0 failed**; `patterns` **62 passed (47
steps) + 1 passed, 0 failed**. `deno fmt --check` over the changed files and
`deno lint` over each package are clean. No added line exceeds 80 columns.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

