### PR TITLE
fix(llm): validate the fields a request actually carries

### DIFF
--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -1,4 +1,4 @@
-import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 import type { JSONValue } from "@commonfabric/api";
 import { isPureJson } from "@commonfabric/pure-json";
 import type {
@@ -144,17 +144,19 @@ export function isLLMRequestMetadata(
 export function isLLMContent(input: unknown): input is LLMContent {
   return typeof input === "string" || (Array.isArray(input) && input.every(
     (item) =>
-      isObjectOrArray(item) &&
+      isObjectNotArray(item) &&
       (item.type === "text" || item.type === "image" ||
         item.type === "tool-call" || item.type === "tool-result"),
   ));
 }
 
-export function isLLMToolCall(input: unknown): input is LLMToolCall {
-  return isObjectNotArray(input) &&
-    typeof input.id === "string" &&
-    typeof input.name === "string" &&
-    isObjectOrArray(input.arguments);
+// The parameter is `value` rather than `input` because `LLMToolCall` carries a
+// field of that name, and the guard has to read it.
+export function isLLMToolCall(value: unknown): value is LLMToolCall {
+  return isObjectNotArray(value) &&
+    typeof value.id === "string" &&
+    typeof value.name === "string" &&
+    isObjectNotArray(value.input);
 }
 
 export function isLLMToolResult(input: unknown): input is LLMToolResult {
@@ -166,7 +168,7 @@ export function isLLMToolResult(input: unknown): input is LLMToolResult {
 export function isLLMTool(input: unknown): input is LLMTool {
   return isObjectNotArray(input) &&
     typeof input.description === "string" &&
-    isObjectOrArray(input.inputSchema) &&
+    isObjectNotArray(input.inputSchema) &&
     (!("handler" in input) || typeof input.handler === "function");
 }
 
@@ -214,7 +216,7 @@ export function isLLMRequest(input: unknown): input is LLMRequest {
     (!("stop" in input) || typeof input.stop === "string") &&
     (!("mode" in input) || input.mode === "json") &&
     (!("metadata" in input) || isLLMRequestMetadata(input.metadata)) &&
-    (!("tools" in input) || (isObjectOrArray(input.tools) &&
+    (!("tools" in input) || (isObjectNotArray(input.tools) &&
       Object.values(input.tools).every((tool: unknown) => isLLMTool(tool)))) &&
     (!("nativeModelToolIds" in input) ||
       (Array.isArray(input.nativeModelToolIds) &&

--- a/packages/llm/test/types.test.ts
+++ b/packages/llm/test/types.test.ts
@@ -1,10 +1,32 @@
 import { describe, it } from "@std/testing/bdd";
 import { assert } from "@std/assert";
+import { expect } from "@std/expect";
 import {
   DEFAULT_MODEL_NAME,
   GOOGLE_SEARCH_NATIVE_MODEL_TOOL,
   isLLMRequest,
+  isLLMTool,
+  isLLMToolCall,
+  type LLMTool,
+  type LLMToolCall,
 } from "../src/types.ts";
+
+// These carry their declared types so that renaming a field stops this file
+// compiling. A guard reads fields by name, which no type check reaches, so an
+// untyped fixture would go on agreeing with a guard that the type had left
+// behind.
+
+/** The shape `client.ts` builds from a `tool-call` stream event. */
+const TOOL_CALL: LLMToolCall = {
+  id: "call_1",
+  name: "lookup",
+  input: { term: "fabric" },
+};
+
+const TOOL: LLMTool = {
+  description: "Look a term up",
+  inputSchema: { type: "object" },
+};
 
 describe("types", () => {
   describe("isLLMRequest", () => {
@@ -105,6 +127,60 @@ describe("types", () => {
       failRequest({ metadata: { nope: Number.NaN } });
       failRequest({ nativeModelToolIds: ["unknown_search"] });
       failRequest({ nativeModelToolIds: [GOOGLE_SEARCH_NATIVE_MODEL_TOOL, 1] });
+    });
+
+    it("returns `false` for a `tools` map given as an array", () => {
+      expect(
+        isLLMRequest({
+          messages: [],
+          model: DEFAULT_MODEL_NAME,
+          cache: true,
+          tools: [],
+        }),
+      ).toBe(false);
+    });
+
+    it("returns `true` for a request whose message carries tool calls", () => {
+      expect(
+        isLLMRequest({
+          messages: [{
+            role: "assistant",
+            content: "Looking that up",
+            toolCalls: [TOOL_CALL],
+          }],
+          model: DEFAULT_MODEL_NAME,
+          cache: true,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("isLLMToolCall()", () => {
+    it("returns `true` for the shape the client builds", () => {
+      expect(isLLMToolCall(TOOL_CALL)).toBe(true);
+    });
+
+    it("returns `false` when the `input` map is missing", () => {
+      expect(isLLMToolCall({ id: "call_1", name: "lookup" })).toBe(false);
+    });
+
+    it("returns `false` for an `input` map given as an array", () => {
+      expect(isLLMToolCall({ ...TOOL_CALL, input: [] })).toBe(false);
+    });
+
+    it("returns `false` when the id or name is not a string", () => {
+      expect(isLLMToolCall({ ...TOOL_CALL, id: 1 })).toBe(false);
+      expect(isLLMToolCall({ ...TOOL_CALL, name: undefined })).toBe(false);
+    });
+  });
+
+  describe("isLLMTool()", () => {
+    it("returns `true` for a description and an object schema", () => {
+      expect(isLLMTool(TOOL)).toBe(true);
+    });
+
+    it("returns `false` for an `inputSchema` given as an array", () => {
+      expect(isLLMTool({ ...TOOL, inputSchema: [] })).toBe(false);
     });
   });
 });


### PR DESCRIPTION
`isLLMToolCall()` requires an `arguments` map. No tool call has one. The type declares `input`, the client builds `{ id, name, input }` from a `tool-call` stream event, and `BuiltInLLMToolCallPart` in the api package declares `input` too. The guard was reading a property nothing sets and never reading the one every tool call carries, so it returned `false` for every well-formed tool call.

That answer propagates. `isLLMMessage()` walks `toolCalls` with this guard, `isLLMRequest()` walks the messages, and the toolshed LLM route refuses a payload the guard rejects. A conversation carrying tool calls was turned away at the server boundary.

The guard was correct when written and was orphaned by the next change: it arrived checking `arguments`, and the field was later renamed to `input` on the type and in the client, leaving the validator behind. Its parameter is renamed from `input` to `value` here, because a parameter sharing a name with the field being read is what made `input.arguments` look plausible.

Two more guards accepted an array where the type declares a map. `isLLMTool()` took an `inputSchema` of `[]`, which no `JSONSchema` can be. `isLLMRequest()` took a `tools` of `[]`, because `Object.values([])` is empty and `every()` on it is vacuously true. Both are the shape that admits an empty array as a valid empty access-control list elsewhere: the checks that would reject a bad entry never run, there being no entry. Both now ask `isObjectNotArray()`, as does the content-part check beside them.

No test carried a tool call at all, which is how a guard that rejected every one of them survived. Coverage over the previous test file reports `isLLMToolCall()` as never executed: its only call site sits behind `"toolCalls" in input`, and no case supplied the key. There are cases now for the shape the client builds, for a message carrying tool calls, and for both array forms, each of which fails against the previous guards.

The fixtures carry their declared types, so that renaming a field stops the test file compiling. Without that, a fixture written as a bare object literal keeps whatever field name it was born with and goes on agreeing with a guard the type has left behind -- which is exactly how this bug survived, and a test reproducing it would not have caught it coming back. A guard reads fields by name, through `unknown`, where no type check can follow; the annotation on the fixture is what ties the two together. Renaming `LLMToolCall`'s field now fails `deno task check` here as well as at the call sites in `llm-dialog.ts`.

`BuiltInLLMMessage` still declares no `toolCalls`, though `isLLMMessage()` validates one, so the request-level case cannot be bound the same way. Declaring that field reaches `ui`, `cf-harness`, and `runner`, and is its own change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

