### PR TITLE
docs(plan): row 2 landed, and item 11 gets the ordering row it never had

### DIFF
--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -426,7 +426,7 @@ its own track.
 | # | Step | Delivers | After | Why here |
 | --- | --- | --- | --- | --- |
 | 1 | The doubly-linked tracker fixture and its walkthrough | **on main** (#5639, #5631) — repro for #5577, #5632, #5633, #5637; item 11's subject | — | Five things verify against a piece that holds a back-reference, and none could be demonstrated until one existed. `verb-session-gaps.sh` is where they are asserted, and several of its assertions expect a gap and fail loudly the day it closes — so a capability arriving announces itself instead of quietly turning a check green. The script states its own count; repeating it here only creates a second place to be wrong |
-| 2 | A projected read survives a handler | #5633 — **in review** (#5764) | 1 | Breaks call-then-read-shaped, which is the loop items 4, 5, 10 and #5577 all demonstrate against. Diagnose before estimating: if it sits in runner materialization rather than the read path, it moves after step 7 rather than holding the line |
+| 2 | A projected read survives a handler | **on main** (#5764) — #5633 | 1 | Breaks call-then-read-shaped, which is the loop items 4, 5, 10 and #5577 all demonstrate against. Diagnose before estimating: if it sits in runner materialization rather than the read path, it moves after step 7 rather than holding the line |
 | 3 | Listing rows carry a handler's declared result | **on main** (#5629) — item 10, #5619 | — | The consumer half of item 1 |
 | 4 | The forced-stream fallback stops inventing verbs | **on main** (#5683) — #5576, #5662 | 3 | Same file as step 3, which has landed, so this is the front of the queue. It narrows the listing, so sweep the open branches for writers first |
 | 5 | The help page stops claiming a verb returns nothing | **on main** (#5680) — #5558, first half | — | `Output: No output on success.` is wrong for a declared verb. Asserting there is no output is worse than saying nothing, and stopping it needs no schema and no decision, which is why it precedes the half that does |
@@ -440,6 +440,7 @@ its own track.
 | 12 | An unrecognized projection key is refused | item 2 | 9 | The largest remaining step, and the one carrying design surface, since it couples the projection reader to the compatibility checker's annotation keys. Its design is [projection keys, and the schema a read is handed](projection-key-classification.md) |
 | 12a | `cf` refuses an undeclared field on a call | item 12 | — | Same refusal shape as the step above and independent of it, so it can go either side; building them together is what keeps one vocabulary for what a refusal says |
 | 13 | `cf wish` and `cf exec` take the read options | item 5 | 11, 12 | Last by construction: it spreads the vocabulary to two more starting points, so the vocabulary should have stopped moving — and it now has. No resolving marker is planned, so the grammar step 13 spreads is the grammar that exists |
+| 14 | A caller may name a reference | item 11, #5560 | — | Item 11 has carried this since the State table was written and the ordering never gave it a step, so nothing scheduled it. Sequenced last only because it is unstarted, not because anything gates it — and it is the most consequential thing open: the shape-matching payload the CLI does accept **stores a detached copy and reports success**, so a caller relating two pieces is told it worked |
 
 **`--show-links` is not redundant, and nothing should schedule its removal
 yet.** [Verb result selection](verb-result-selection.md) prices it as a stopgap
@@ -648,7 +649,7 @@ from a plan is one nobody schedules, which is the whole reason for this table.
 | #5632 | `--show-links` and a `$link` read return different entity ids for the same piece | step 11 — **working as designed**; closes once #5754 lands the documentation |
 | #5498 | `getEntityId()` strips the entity URI scheme, collapsing two kinds to one identity | unscheduled. It rode ordering step 11 while that step was a question about identity; the answer there was that the two routes are aliases by design, which says nothing about a scheme the id itself drops. Independent, and still open |
 | #5589 | a click's `detail` and a `cf-select`'s `target.value` reach a handler as types no pattern declares | carried alongside — it belongs to whoever next touches `packages/html`. The ruling that closed item 9b also removed the only thing that ever compared the renderer's output against an author's declared type, so this has no detector left |
-| #5560 | an address a call returns cannot be passed back as a verb argument | item 11 |
+| #5560 | an address a call returns cannot be passed back as a verb argument | item 11, and **row 14** — it had no ordering row until one was added. Not to be confused with ordering step 11, "one piece, one address", which is #5632 and decided |
 | #5534 | a capability probe passes while covering nothing: a dispatch rejection is not a synchronous throw | carried alongside |
 
 **Filed against neighbouring subsystems, and not sequenced here.** `{ proxy:

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -637,7 +637,7 @@ from a plan is one nobody schedules, which is the whole reason for this table.
 
 | Issue | What | Attaches at |
 | --- | --- | --- |
-| #5633 | a projected read fails on the SECOND read of the same source and schema; the handler is a red herring | **in review** (#5764) — a list coordinator owes the setup writes a lost commit discarded, its result container's links among them. #5706, which is why it reproduces every time, stands |
+| #5633 | a projected read fails on the SECOND read of the same source and schema; the handler is a red herring | **fixed** by #5764 — a list coordinator owed the setup writes a lost commit discarded, its result container's links among them, and the fix makes those writes a debt rather than a flag. #5706, which is why it reproduced every time, stands |
 | #5576 | `cf piece verbs` lists data fields as handlers, so discovery reports what cannot be called | **fixed** by #5683, with #5662 |
 | #5698 | `cf piece verbs` returns nothing for a piece whose declared result type omits its verbs, though they are callable | the other direction of the same surface: 8 verbs invisible to the listing AND to tab-completion |
 | #5706 | a shaped read permanently writes to the user's space — per-element sub-patterns land at space scope | runner-owned, beside #5633 |


### PR DESCRIPTION
## Why

Two places where the plan of record disagrees with what happened.

**Row 2 still reads "in review (#5764)".** That PR merged as `2ebe54275` and closed #5633. It was not inferred from the merge — the gap harness reported `GAP CLOSED` against that build, which is what the harness exists to do.

**Item 11 has never had an ordering row, so nothing sequenced it.** It has sat in the State table since that table was written, and the ordering table — the thing a driver reads to decide what to pick up — does not mention it. The plan says of that table: *"a driver needs to know what is already moving before scheduling anything new."* An item with no row is one nobody schedules.

That matters more than bookkeeping here. Item 11 is #5560, and the shape-matching payload the CLI *does* accept **stores a detached copy and reports success** — a caller relating two pieces is told it worked. It is the most consequential thing still open on this arc, and it was the least visible.

## What Changed

- **Row 2** → `**on main** (#5764) — #5633`.
- **Row 14 added**: *A caller may name a reference*, `item 11, #5560`, with no dependency. Sequenced last because it is unstarted, not because anything gates it.
- **The issue tail entry for #5560** now says which 11 is which.

## The confusion worth naming

There are two elevens, and they are different work:

| | | |
| --- | --- | --- |
| **Item 11** (State table) | a caller may name a reference | #5560 — open, unstarted |
| **Ordering step 11** | one piece, one address | #5632 — decided, closed |

Reading one for the other is not hypothetical: earlier today the aliasing decision for ordering step 11 was written into item 11's row, which marked an open data-loss defect complete. That was caught and reverted in #5754. The tail entry now states the distinction where the next reader meets it.

An independent review of this arc also reached the opposite conclusion — that #5560 is *not* item 11 — which is the same confusion from the other side. It is item 11; what it lacked was an ordering row.

## Test plan

- `deno task check-docs` → **0**
- `deno task check-skill-facts` → **0**
- `deno task check-conflict-markers` → **0**

Documentation only; `docs/` is excluded from `deno fmt`, so no fmt evidence is claimed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

