### PR TITLE
fix(ts-transformers): analyze an array-method callback behind a `??`

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -1214,12 +1214,17 @@ adjustments:
 - reads inside an inline array-method callback count as reads of the enclosing
   builder's parameter: the element parameter is bound to the receiver's item
   path, so `table.find((row) => equals(self, row.topic))` records
-  `table[].topic` and, through the capture, `self`. This holds wherever the
-  call sits in the body, the left operand of a `??` / `||` fallback included —
-  resolving that operand to a single read stands in for walking it, so an
-  operand whose member/call spine passes through a call is walked as well
-  (`memberSpineContainsCall` in `policy/capability-analysis.ts`;
-  `test/policy/capability-analysis-array-callbacks.test.ts`)
+  `table[].topic` and, through the capture, `self`. The left operand of a `??`
+  / `||` fallback resolves to a single source ref, which reaches a root through
+  a member/call spine and consumes nothing else; an operand whose spine passes
+  through a call is therefore walked as well, covering that call's callback and
+  arguments and any call nested in them (`memberSpineContainsCall` in
+  `policy/capability-analysis.ts`;
+  `test/policy/capability-analysis-array-callbacks.test.ts`). An operand whose
+  ref resolves dynamically instead — a computed element-access key, as in
+  `table[indexes.findIndex(...)]?.mentionedBy ?? []` — marks the root wildcard,
+  which disables shrinking for the whole parameter: its declared shape is
+  emitted intact, without the capability wrappers a walked operand would derive
 - node-driven shrinking can still shrink the inner type of cell-like wrappers
   when `.get()` contributes an empty path but coexists with more specific
   non-empty paths

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -1211,6 +1211,15 @@ adjustments:
 - array-like roots whose observed paths only touch non-item properties
   (`length`, `get`, `set`, `key`, `update`) keep array shape but shrink their
   item type to `unknown`
+- reads inside an inline array-method callback count as reads of the enclosing
+  builder's parameter: the element parameter is bound to the receiver's item
+  path, so `table.find((row) => equals(self, row.topic))` records
+  `table[].topic` and, through the capture, `self`. This holds wherever the
+  call sits in the body, the left operand of a `??` / `||` fallback included —
+  resolving that operand to a single read stands in for walking it, so an
+  operand whose member/call spine passes through a call is walked as well
+  (`memberSpineContainsCall` in `policy/capability-analysis.ts`;
+  `test/policy/capability-analysis-array-callbacks.test.ts`)
 - node-driven shrinking can still shrink the inner type of cell-like wrappers
   when `.get()` contributes an empty path but coexists with more specific
   non-empty paths

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -648,6 +648,26 @@ function isTopmostMemberNode(node: ts.Node): boolean {
   );
 }
 
+/**
+ * True when the member/call spine `resolveSourceRef` walks to reach a root
+ * passes through a call — `table.find(matches)?.mentionedBy`, say, but not
+ * `table.rows.first`.
+ *
+ * Ref resolution consumes that spine without descending into it, so a caller
+ * that resolves a ref in place of visiting the expression leaves whatever
+ * hangs off a call on it — an array method's callback above all — unanalyzed.
+ */
+function memberSpineContainsCall(expression: ts.Expression): boolean {
+  let current = unwrapExpression(expression);
+  while (
+    ts.isPropertyAccessExpression(current) ||
+    ts.isElementAccessExpression(current)
+  ) {
+    current = unwrapExpression(current.expression);
+  }
+  return ts.isCallExpression(current);
+}
+
 function isDeclarationIdentifier(node: ts.Identifier): boolean {
   const parent = node.parent;
   if (!parent) return false;
@@ -2664,6 +2684,17 @@ export function analyzeFunctionCapabilities(
               markPassthrough(leftRef.root);
             } else {
               trackReadRef(leftRef);
+            }
+            // Resolving the ref stood in for walking the operand, so a call on
+            // its spine has gone unvisited and the reads inside that call's
+            // arguments are still unrecorded — the ref for
+            // `table.find((row) => equals(self, row.topic))?.mentionedBy ?? []`
+            // records `mentionedBy` and drops both `self` and each row's
+            // `topic`, shrinking them out of the schema. Walk it, as the for..of
+            // iterable below does for the same reason; the read tracked above is
+            // a set entry, so recording it twice costs nothing.
+            if (memberSpineContainsCall(node.left)) {
+              visit(node.left);
             }
           } else {
             visit(node.left);

--- a/packages/ts-transformers/test/policy/capability-analysis-array-callbacks.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis-array-callbacks.test.ts
@@ -55,6 +55,35 @@ export default { backlinksOf };
   return schema;
 }
 
+/**
+ * As {@link liftInputSchema}, for a body that reaches a second array through a
+ * nested call — `indexes` here is read only from inside the arguments of a
+ * call on the operand's spine, one level deeper again than the callback cases
+ * above.
+ */
+async function liftInputSchemaWithIndexes(
+  body: string,
+): Promise<Record<string, unknown>> {
+  const output = await transformSource(
+    `import { equals, lift } from "commonfabric";
+
+const backlinksOf = lift((
+  { table, indexes, self }: {
+    table: { topic: unknown; mentionedBy: unknown }[];
+    indexes: { topic: unknown }[];
+    self: unknown;
+  },
+): unknown => ${body});
+
+export default { backlinksOf };
+`,
+    { types: COMMONFABRIC_TYPES },
+  );
+  const schema = callSchemas(parseModule(output), "lift")[0];
+  if (!schema) throw new Error("No emitted `lift(cb, input, result)` schema");
+  return schema;
+}
+
 describe("capability-analysis-array-callbacks", () => {
   describe("a property read only inside an array-method callback", () => {
     it("reaches the input schema from a `find` callback behind a `??`", async () => {
@@ -87,6 +116,29 @@ describe("capability-analysis-array-callbacks", () => {
       );
 
       expect(elementProperties(schema)).toEqual({ topic: { type: "unknown" } });
+    });
+  });
+
+  describe("a callback nested in the arguments of a call on the spine", () => {
+    it("reaches the input schema along with the array it iterates", async () => {
+      const schema = await liftInputSchemaWithIndexes(
+        `table.at(indexes.findIndex((row) => equals(self, row.topic)))?.mentionedBy ?? []`,
+      );
+      const properties = schema.properties as Record<
+        string,
+        { items?: { properties?: unknown } }
+      >;
+
+      // Ref resolution walks the spine as far as `at`, so both the callback
+      // and the `indexes.findIndex(...)` argument holding it are skipped —
+      // `indexes` reaches the schema only if the operand is walked.
+      expect(properties.indexes?.items?.properties).toEqual({
+        topic: { type: "unknown" },
+      });
+      expect(properties.self).toEqual({
+        type: "unknown",
+        asCell: ["comparable"],
+      });
     });
   });
 

--- a/packages/ts-transformers/test/policy/capability-analysis-array-callbacks.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis-array-callbacks.test.ts
@@ -1,0 +1,112 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { COMMONFABRIC_TYPES } from "../commonfabric-test-types.ts";
+import { callSchemas, parseModule } from "../transformed-ast.ts";
+import { transformSource } from "../utils.ts";
+
+// A builder's input schema is shrunk to the paths the capability analysis
+// observes the callback reading, so a property the analysis fails to see is
+// not a type-mapping question — it is simply absent from the schema, and the
+// runtime delivers `undefined` for it with nothing to say so. These tests pin
+// the reads that happen one function deeper than the body: inside the arrow
+// passed to `find` / `filter` / `some`.
+//
+// The whole pipeline is the harness rather than `analyzeFunctionCapabilities`
+// alone, because the array-callback descent is keyed off the checker's
+// classification of the receiver and the result only becomes observable once
+// schema injection has written it into the emitted `lift(...)` call.
+
+/** Every property of `table`'s element schema in `schema`, by name. */
+function elementProperties(
+  schema: Record<string, unknown>,
+): Record<string, unknown> {
+  const properties = schema.properties as Record<string, unknown>;
+  const table = properties?.table as { items?: Record<string, unknown> };
+  return (table?.items?.properties ?? {}) as Record<string, unknown>;
+}
+
+/**
+ * The input schema emitted for a `lift` reading `{ table, self }`, where
+ * `body` is its whole body expression.
+ *
+ * Both `self` and the element's properties are declared `unknown`, which is
+ * the shape that makes the omission silent: `unknown` maps to a schema
+ * whatever the analysis concludes, so a dropped property is invisible to the
+ * type system and to every other gate the pipeline runs.
+ */
+async function liftInputSchema(body: string): Promise<Record<string, unknown>> {
+  const output = await transformSource(
+    `import { equals, lift } from "commonfabric";
+
+const backlinksOf = lift((
+  { table, self }: {
+    table: { topic: unknown; mentionedBy: unknown }[];
+    self: unknown;
+  },
+): unknown => ${body});
+
+export default { backlinksOf };
+`,
+    { types: COMMONFABRIC_TYPES },
+  );
+  const schema = callSchemas(parseModule(output), "lift")[0];
+  if (!schema) throw new Error("No emitted `lift(cb, input, result)` schema");
+  return schema;
+}
+
+describe("capability-analysis-array-callbacks", () => {
+  describe("a property read only inside an array-method callback", () => {
+    it("reaches the input schema from a `find` callback behind a `??`", async () => {
+      const schema = await liftInputSchema(
+        `table.find((row) => equals(self, row.topic))?.mentionedBy ?? []`,
+      );
+
+      // `mentionedBy` is read by the outer expression and was never at risk;
+      // `topic` is read only by the callback, and is the regression.
+      expect(elementProperties(schema)).toEqual({
+        topic: { type: "unknown" },
+        mentionedBy: { type: "unknown" },
+      });
+    });
+
+    it("reaches the input schema from a `filter` callback behind a `??`", async () => {
+      const schema = await liftInputSchema(
+        `table.filter((row) => equals(self, row.topic))[0]?.mentionedBy ?? []`,
+      );
+
+      expect(elementProperties(schema)).toEqual({
+        topic: { type: "unknown" },
+        mentionedBy: { type: "unknown" },
+      });
+    });
+
+    it("reaches the input schema from a `some` callback", async () => {
+      const schema = await liftInputSchema(
+        `table.some((row) => equals(self, row.topic))`,
+      );
+
+      expect(elementProperties(schema)).toEqual({ topic: { type: "unknown" } });
+    });
+  });
+
+  describe("a captured parameter read only inside an array-method callback", () => {
+    it("carries the `comparable` cell annotation `equals` needs", async () => {
+      const schema = await liftInputSchema(
+        `table.find((row) => equals(self, row.topic))?.mentionedBy ?? []`,
+      );
+
+      // Without this the comparison receives a plain value rather than a cell
+      // and `equals` compares two `undefined`s, which is the shape the topics
+      // board hit: every row reported zero inbound references.
+      expect((schema.properties as Record<string, unknown>).self).toEqual({
+        type: "unknown",
+        asCell: ["comparable"],
+      });
+      expect([...(schema.required as string[])].sort()).toEqual([
+        "self",
+        "table",
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Why

A property read only inside an array-method callback was silently dropped from
the enclosing builder's input schema, and arrived `undefined` at runtime with
nothing — not the type system, not lint, not a test — to say so. On the topics
board this made every topic report zero inbound references: `equals` was
comparing `undefined` against `undefined`. It took a debugger session to find.

The narrowing itself is the design, and the descent into inline callbacks
already works. `visitInlineEagerCallbackArguments` binds the element parameter
to the receiver's item path, so a callback's reads are charged to the array it
iterates and to whatever it captures. Sweeping the expression contexts a call
can sit in — `return`, `===`, ternary, template literal, object and array
literals, call argument, `if`, `const` initializer, `for..of` — every one of
them records those reads.

Every one except the left operand of `??` / `||`. That branch resolves the
operand to a single source ref *instead of* walking it, and ref resolution
consumes the member/call spine without descending into it. So

```ts
table.find((row) => equals(self, row.topic))?.mentionedBy ?? []
```

resolves through the `find` chain to `table[].mentionedBy`, records that one
read, and never looks at the callback: `self` and each row's `topic` are gone.
Its sibling `mentionedBy` survives, in the same inline type literal and equally
`unknown`, because the outer expression reads it — which is what makes this a
usage-analysis defect rather than a type-mapping one. Rewriting the same
comparison as a loop, one character of the type declaration unchanged, restores
both, because the `for..of` branch forty lines below already guards against
this exact hazard.

## What changed

- `capability-analysis.ts` walks a resolved fallback operand as well when its
  spine passes through a call. Reads are set entries, so re-recording the
  resolved read costs nothing. `memberSpineContainsCall` is the new helper.
- `§10.7` of the current-behavior spec states that an inline array-method
  callback's reads count as reads of the enclosing builder's parameter,
  wherever the call sits.
- A test covering `find` / `filter` / `some`, including the `comparable` cell
  annotation `equals` needs on the captured parameter.

No diagnostic accompanies this. The analysis was not failing to express
something it could see — it believed it had seen every read, and a warning
would have to fire on every narrowed property, which is the whole point of
shrinking. Where the analysis genuinely cannot follow a read it already fails
safe: an unresolvable helper marks the root wildcard and disables shrinking,
and a wildcard `unknown` parameter reports `schema:unknown-type-access`.

## Test plan

- `deno task test` in `ts-transformers`: 1138 passed, and no golden moved —
  the change reaches nothing but the operand it names.
- `deno task integration pattern-tests`: all 120 pattern tests pass.
- `deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs`,
  and the `schema-generator` suite: green.
- The `backlinksOf` declaration this came from, its body restored to the
  `.find()` form, now emits a schema byte-identical to the loop it was
  rewritten as, `asCell: ["comparable"]` on `self` included.
- Each new test was checked against the unpatched analyzer. The `find` and
  `filter` cases and the annotation case fail there; the `some` case cannot,
  since `some` returns a boolean and leaves no spine to resolve through, and
  stands as a contract test rather than a regression guard.

## Follow-up

The two workarounds on `claude/topics-crossrefs-by-reference` —
`topics/topic.tsx` `backlinksOf` and `topics/main.tsx` `crossrefTable`, both
written as plain loops with a comment explaining why — can go back to
`find` / `filter` / `some` once this lands. That branch is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

