### PR TITLE
A projection key the reader does not recognize is refused

### DIFF
--- a/docs/history/INDEX.md
+++ b/docs/history/INDEX.md
@@ -62,6 +62,7 @@ One line per archived document; [`README.md`](README.md) has the rules for this 
 ## Shipped or superseded designs and decision records
 
 - [action-id-per-instance-decision.md](specs/action-id-per-instance-decision.md) — per-instance action identity.
+- [projection-key-classification.md](plans/projection-key-classification.md) — the four-tier classification of `--schema` projection keywords, the rule that the projection reader never hands the read boundary a schema it did not construct, and the survival rule for a source-derived `required`, August 2026.
 - [declared-verb-results-case.md](plans/declared-verb-results-case.md) — the case for carrying a verb's declared result on `module.resultSchema` in the interim rather than waiting for the Fabric-types stream; decided yes, conditionally, August 2026.
 - [cfc-render-membership-lookup.md](specs/cfc-render-membership-lookup.md) — render-time space-membership lookup.
 - [cfc-s16-default-transition-design.md](specs/cfc-s16-default-transition-design.md) — S16 default-label transition.

--- a/docs/history/plans/projection-key-classification.md
+++ b/docs/history/plans/projection-key-classification.md
@@ -1,14 +1,21 @@
+---
+status: historical
+created: 2026-08-13
+archived: 2026-08-14
+reason: "Shipped design; the projection reader now classifies keywords and constructs the schema it hands the read boundary."
+---
+
 # Projection keys, and the schema a read is handed
 
 This document designs
-[item 2 of the verbs implementation plan](verbs-implementation.md) — refusing a
+[item 2 of the verbs implementation plan](../../plans/verbs-implementation.md) — refusing a
 projection key the reader does not recognize — and the larger rule that refusal
 is only half of. It is written to be checkable: every claim about current
 behavior below was read out of the named code or measured against it, and the
 symbol it was read from is named beside it.
 
 The command surface it governs is `--schema` on the read commands. The design
-in [shaped reads and verb results](shaped-reads-and-verb-results.md) says what a
+in [shaped reads and verb results](../../plans/shaped-reads-and-verb-results.md) says what a
 projection is for; this says what a projection may contain and what leaves the
 CLI because of it.
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -95,14 +95,6 @@ a record: archive it to `docs/history/plans/` following the procedure in
   work on verbs across both arcs that produced it: what a verb declares, what a
   caller may ask for, and what comes back. Read it for order; read the designs
   it points at for reasoning.
-- [Projection keys, and the schema a read is handed](projection-key-classification.md)
-  designs the refusal of an unrecognized `--schema` key and the rule it is half
-  of — the projection reader never hands the read boundary a schema it did not
-  construct. Four tiers rather than three, because the keys that decide an
-  untyped position's container change behavior, so a caller's copy of one is
-  consumed rather than carried onward. Carries the measured blast radius, and
-  separates a constraint a caller supplies from the same keyword the reader
-  derives from the source schema.
 - [The CLI surface — implementation plan](cli-surface-implementation.md) builds
   the rest of the command surface: positional addresses, the honest top-level
   names, deprecating the spellings they replace, and merging the commands that

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -132,7 +132,7 @@ should declare itself indirect — is deferred in #5760 and gates nothing.
 **2. An unrecognized projection key is refused.** *(M)* **In review as #5817**,
 which is the thing to read before picking any of this up. Two denylists are
 consulted and every key in neither is accepted and carried onward. The design is
-[projection keys, and the schema a read is handed](projection-key-classification.md),
+[projection keys, and the schema a read is handed](../history/plans/projection-key-classification.md),
 which carries the tiers, the measured blast radius, and the reasoning; read it
 before picking this up. What follows is what a driver needs to sequence the
 item.
@@ -438,7 +438,7 @@ its own track.
 | 9 | A rejection propagates up through what holds it | **on main** (#5701) — item 3 | — | First of the projection work; the mask's asymmetry is what makes a marked field below a link load every element |
 | 10 | Two identical projections stop colliding | **on main** (#5757) — #5523 | 9 | Same file. Reachable the moment anything long-lived reads twice, which the command surface invites |
 | 11 | One piece, one address | **decided — they are aliases**; the documentation half is #5754 | — | Measured: the two routes differ because one resolves the link chain and the other renders the link as stored. That is the read model working, not a defect, so the outcome is the statement rather than the fix. What remains is a doc correction and closing #5632 — no code changes, and step 13 is not gated on it |
-| 12 | An unrecognized projection key is refused | **in review** (#5817) — item 2 | 9 | The largest remaining step, and the one carrying design surface, since it couples the projection reader to the compatibility checker's annotation keys. Its design is [projection keys, and the schema a read is handed](projection-key-classification.md) |
+| 12 | An unrecognized projection key is refused | **in review** (#5817) — item 2 | 9 | The largest remaining step, and the one carrying design surface, since it couples the projection reader to the compatibility checker's annotation keys. Its design is [projection keys, and the schema a read is handed](../history/plans/projection-key-classification.md) |
 | 12a | `cf` refuses an undeclared field on a call | item 12 | — | Same refusal shape as the step above and independent of it, so it can go either side; building them together is what keeps one vocabulary for what a refusal says |
 | 13 | `cf wish` and `cf exec` take the read options | item 5 | 11, 12 | Last by construction: it spreads the vocabulary to two more starting points, so the vocabulary should have stopped moving — and it now has. No resolving marker is planned, so the grammar step 13 spreads is the grammar that exists |
 | 14 | A caller may name a reference | item 11, #5560 | — | Item 11 has carried this since the State table was written and the ordering never gave it a step, so nothing scheduled it. Sequenced last only because it is unstarted, not because anything gates it — and it is the most consequential thing open: the shape-matching payload the CLI does accept **stores a detached copy and reports success**, so a caller relating two pieces is told it worked |

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -50,7 +50,7 @@ without reconstructing it.
 | 9b. closed-world event emission | **ruled against** (#5589); does not land |
 | 12. `cf` refuses an undeclared field on a call | not started — where the ruling puts this capability |
 | 4. `receipt` as a top-level envelope field | on main (#5694) |
-| 2. an unrecognized projection key is refused | not started; design landed (#5753) |
+| 2. an unrecognized projection key is refused | **in review** (#5817); design landed (#5753) |
 | 3. a rejection propagates up through what holds it | on main (#5701) |
 | 5. `cf wish` and `cf exec` take the read options | not started |
 | 11. a caller may name a reference | not started; sequenced, gated on one measurement |
@@ -129,7 +129,8 @@ listed here as its equal and is no longer: its CLI half reduces to a
 documentation correction. What remains of it — whether a rendered address
 should declare itself indirect — is deferred in #5760 and gates nothing.
 
-**2. An unrecognized projection key is refused.** *(M)* Two denylists are
+**2. An unrecognized projection key is refused.** *(M)* **In review as #5817**,
+which is the thing to read before picking any of this up. Two denylists are
 consulted and every key in neither is accepted and carried onward. The design is
 [projection keys, and the schema a read is handed](projection-key-classification.md),
 which carries the tiers, the measured blast radius, and the reasoning; read it
@@ -437,7 +438,7 @@ its own track.
 | 9 | A rejection propagates up through what holds it | **on main** (#5701) — item 3 | — | First of the projection work; the mask's asymmetry is what makes a marked field below a link load every element |
 | 10 | Two identical projections stop colliding | **on main** (#5757) — #5523 | 9 | Same file. Reachable the moment anything long-lived reads twice, which the command surface invites |
 | 11 | One piece, one address | **decided — they are aliases**; the documentation half is #5754 | — | Measured: the two routes differ because one resolves the link chain and the other renders the link as stored. That is the read model working, not a defect, so the outcome is the statement rather than the fix. What remains is a doc correction and closing #5632 — no code changes, and step 13 is not gated on it |
-| 12 | An unrecognized projection key is refused | item 2 | 9 | The largest remaining step, and the one carrying design surface, since it couples the projection reader to the compatibility checker's annotation keys. Its design is [projection keys, and the schema a read is handed](projection-key-classification.md) |
+| 12 | An unrecognized projection key is refused | **in review** (#5817) — item 2 | 9 | The largest remaining step, and the one carrying design surface, since it couples the projection reader to the compatibility checker's annotation keys. Its design is [projection keys, and the schema a read is handed](projection-key-classification.md) |
 | 12a | `cf` refuses an undeclared field on a call | item 12 | — | Same refusal shape as the step above and independent of it, so it can go either side; building them together is what keeps one vocabulary for what a refusal says |
 | 13 | `cf wish` and `cf exec` take the read options | item 5 | 11, 12 | Last by construction: it spreads the vocabulary to two more starting points, so the vocabulary should have stopped moving — and it now has. No resolving marker is planned, so the grammar step 13 spreads is the grammar that exists |
 | 14 | A caller may name a reference | item 11, #5560 | — | Item 11 has carried this since the State table was written and the ordering never gave it a step, so nothing scheduled it. Sequenced last only because it is unstarted, not because anything gates it — and it is the most consequential thing open: the shape-matching payload the CLI does accept **stores a detached copy and reports success**, so a caller relating two pieces is told it worked |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -305,6 +305,14 @@ caller narrows the same way, because one rejected element rejects the array
 holding it. A narrowed position is then simply omitted from what comes back
 instead of emptying the read around it.
 
+A property the caller projects as a container keeps its derived `required` only
+where the source declares that container and nothing else. `{"type":"array"}`
+qualifies; `{"type":["array","string"]}` does not, nor does an `anyOf` whose
+branches disagree, nor an undeclared position, nor an `allOf` — each of those
+can hold something a container projection rejects, and the whole point of
+deriving the key this way is that a rejected position is omitted rather than
+emptying the object holding it.
+
 #### Asking for an address instead of contents
 
 A projection marks a position to get that position's address rather than what is

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -241,21 +241,21 @@ schemas. A position that names an object keyword (`properties`,
 `items` projects an array, at every level of nesting and whether or not it also
 states `type` — `{"properties":{"topic":{"properties":{"title":true}}}}` returns
 `topic.title`. Neither `true` nor `{}` names a container, and both keep
-everything at the position they sit at. In an array-item projection, a scalar
-leaf whose declared type does not match the stored value is omitted by the
-runtime rather than reported as an error; prefer `true` leaves unless that type
-filtering is intentional. Schema combinators and references are rejected in
-caller-supplied projection schemas. Concise dotted paths follow the declared
-source schema through nested arrays, so `comments.body` selects `body` from
-every comment without retaining comment siblings. The projection preserves
-source-declared nullable items and properties, including `type` arrays and
-`anyOf` unions. When the source schema does not identify a nested container, the
-concise form applies the same field mask across arrays encountered in the value
-so siblings still cannot leak; use an explicit JSON Schema when the output
-schema itself must be fixed. If a present source value cannot materialize the
-transform, the command exits nonzero and states that the failure is not JSON
-`null`. An absent optional source remains the ordinary successful `null` CLI
-response, as does a valid projected null.
+everything at the position they sit at. A scalar leaf whose declared type does
+not match the stored value is omitted by the runtime rather than reported as an
+error, at any position; prefer `true` leaves unless that type filtering is
+intentional. Schema combinators and references are rejected in caller-supplied
+projection schemas. Concise dotted paths follow the declared source schema
+through nested arrays, so `comments.body` selects `body` from every comment
+without retaining comment siblings. The projection preserves source-declared
+nullable items and properties, including `type` arrays and `anyOf` unions. When
+the source schema does not identify a nested container, the concise form applies
+the same field mask across arrays encountered in the value so siblings still
+cannot leak; use an explicit JSON Schema when the output schema itself must be
+fixed. If a present source value cannot materialize the transform, the command
+exits nonzero and states that the failure is not JSON `null`. An absent optional
+source remains the ordinary successful `null` CLI response, as does a valid
+projected null.
 
 Both transforms run as a short-lived computed pattern in the caller's session.
 When the declared source schema fixes the root container shape, the pattern
@@ -275,6 +275,35 @@ Nested non-stream Cell handles are materialized before the predicate/projection
 JavaScript runs; stream handles remain capabilities. The source cell's schema
 remains authoritative for Common Fabric metadata. A caller cannot introduce or
 override `ifc`, `asCell`, `scope`, or `default` through `--schema`.
+
+#### Which keywords a `--schema` projection may contain
+
+**The reader constructs the schema it applies rather than forwarding the one a
+caller typed**, keyword by keyword. Four things can happen to a keyword.
+
+- **Honored** — `type`, `properties`, `items`, `additionalProperties`, `$link`.
+  These drive the projection and are what the constructed schema is built from.
+- **Consulted** — `required`, `minProperties`, `maxProperties`, `minItems`,
+  `maxItems`, `uniqueItems`. Each names a container, so writing one at an
+  untyped position says which container that position describes. The constraint
+  itself goes no further: nothing a caller writes in one reaches the read.
+  `{"required":["id"]}` therefore projects an object without requiring `id` of
+  it, and `{"minItems":2}` projects an array without imposing a length.
+- **Tolerated** — the annotation keywords, `title`, `description`, `examples`,
+  `deprecated`, `tags`, `tier`, `$id`, `$schema`, `$comment`. Accepted, and a
+  read through a projection carrying one returns what the same projection
+  returns without it.
+- **Refused** — everything else, by name and with the position it sat at, plus
+  the keyword it is nearest to. A misspelled `properties` is refused rather than
+  silently returning the whole object or nothing at all.
+
+The `required` a projected read applies comes from the **source** schema rather
+than from the caller, restricted to the projected properties whose narrowing
+cannot reject the property itself: a property the caller narrows to a scalar
+type the value does not match drops out, and so does an array whose `items` the
+caller narrows the same way, because one rejected element rejects the array
+holding it. A narrowed position is then simply omitted from what comes back
+instead of emptying the read around it.
 
 #### Asking for an address instead of contents
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -313,6 +313,13 @@ can hold something a container projection rejects, and the whole point of
 deriving the key this way is that a rejected position is omitted rather than
 emptying the object holding it.
 
+A source that spells its shape as `{"$ref": "#/$defs/Thing"}` is followed to
+what it names, at the document root and at any depth below it, so a named
+interface carries the same `required` an inline one does. A reference that does
+not resolve, or one that closes a circle, proves nothing and derives nothing —
+the conservative direction, since the cost of declining is a key that would have
+survived and the cost of guessing is the whole read.
+
 #### Asking for an address instead of contents
 
 A projection marks a position to get that position's address rather than what is

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -664,8 +664,14 @@ export const PROJECTION_ANNOTATION_EXCEPTIONS: ReadonlySet<string> = new Set([
  * restated, so that admitting a keyword to the durable dialect's annotations
  * admits it here too — unless it is one of the three
  * {@link PROJECTION_ANNOTATION_EXCEPTIONS} names.
+ *
+ * @internal Exported so the inertness test derives the keys it probes from
+ * this set rather than from a list someone typed. Membership here makes a key
+ * a candidate; that it changes nothing on a read is a separate obligation, and
+ * a test iterating its own copy would never notice a key that arrived without
+ * discharging it.
  */
-const TOLERATED_PROJECTION_KEYS: ReadonlySet<string> = new Set(
+export const TOLERATED_PROJECTION_KEYS: ReadonlySet<string> = new Set(
   [...ANNOTATION_KEYS].filter((key) =>
     !PROJECTION_ANNOTATION_EXCEPTIONS.has(key)
   ),
@@ -2006,6 +2012,74 @@ export function selectSourceSchema(
 }
 
 /**
+ * `source` with its `$ref` chain followed, paired with the local-ref scope the
+ * result sits in — or `undefined` where the chain does not resolve or closes
+ * on itself.
+ *
+ * A named interface is ordinarily spelled as a reference, so a reader that
+ * declined to follow one would prove a container only for sources written
+ * inline. The scope travels beside the schema because a subtree carrying its
+ * own `$defs` opens a new `#/...` scope while everything else keeps resolving
+ * against the document root — which is exactly what a walk that re-roots on
+ * each descent would otherwise lose.
+ *
+ * Resolution is the canonical resolver's, one hop per iteration, never a
+ * private pointer parser. A reference repeated in its own scope closes a
+ * circle and resolves to nothing, which fails closed: `undefined` here proves
+ * no container and so requires nothing.
+ */
+function resolvedSourceNode(
+  source: JSONSchema | undefined,
+  root: JSONSchema,
+): { schema: Exclude<JSONSchema, boolean>; root: JSONSchema } | undefined {
+  const followed: Array<{ root: JSONSchema; ref: string }> = [];
+  let node = source;
+  let scope = root;
+  while (isObjectOrArray(node)) {
+    scope = cfcSchemaChildRoot(node, scope);
+    const ref = node.$ref;
+    if (typeof ref !== "string") return { schema: node, root: scope };
+    if (followed.some((step) => step.ref === ref && step.root === scope)) {
+      return undefined;
+    }
+    const target = resolveCfcSchemaRef(scope, ref);
+    if (target === undefined) return undefined;
+    followed.push({ root: scope, ref });
+    if (isEmbeddedCfcSchemaRef(ref)) scope = target;
+    node = target;
+  }
+  return undefined;
+}
+
+/**
+ * The child schema a resolved source node declares at `key`, **as written**.
+ *
+ * Deliberately not `ContextualFlowControl.schemaAtPath`, which resolves
+ * references eagerly and with no guard against one that closes a circle — a
+ * self-referential definition overflows the stack inside it, before any
+ * caller's own guard can run. {@link resolvedSourceNode} follows the reference
+ * instead, one hop at a time, so what this hands back is the child exactly as
+ * the document spells it.
+ */
+function sourcePropertySchema(
+  node: Exclude<JSONSchema, boolean> | undefined,
+  key: string,
+): JSONSchema | undefined {
+  const properties = node?.properties;
+  if (!isObjectNotArray(properties)) return undefined;
+  const child = properties[key] as JSONSchema | undefined;
+  return child === false ? undefined : child;
+}
+
+/** The element schema a resolved source node declares, as written. */
+function sourceItemSchema(
+  node: Exclude<JSONSchema, boolean> | undefined,
+): JSONSchema | undefined {
+  const items = node?.items as JSONSchema | undefined;
+  return items === false ? undefined : items;
+}
+
+/**
  * Whether `source` **proves** the position holds the container `named`.
  *
  * "Can this be a container" is the wrong question here and "must it be" is the
@@ -2025,32 +2099,43 @@ export function selectSourceSchema(
  * conjunction constrains one value from several members at once, which is not
  * a shape this derivation can state (#5761), and declining to require costs a
  * key that would have survived while requiring wrongly costs the whole read.
+ *
+ * A `$ref` is followed first, so a named interface proves what it names. The
+ * `visiting` set holds the resolved node as well as the one written at the
+ * position, which is what stops a branch that refers back to the union
+ * containing it from recurring.
  */
 function sourceProvesContainer(
   named: "object" | "array",
   source: JSONSchema | undefined,
+  root: JSONSchema,
   visiting = new Set<object>(),
 ): boolean {
-  if (!isObjectOrArray(source)) return false;
-  if (visiting.has(source)) return false;
-  const declared = schemaTypes(source);
+  if (!isObjectOrArray(source) || visiting.has(source)) return false;
+  const resolved = resolvedSourceNode(source, root);
+  if (resolved === undefined) return false;
+  const { schema: node, root: scope } = resolved;
+  if (visiting.has(node)) return false;
+  const declared = schemaTypes(node);
   if (declared.length > 0) {
     return declared.every((type) => type === named);
   }
-  if (source.allOf !== undefined) return false;
+  if (node.allOf !== undefined) return false;
   visiting.add(source);
+  visiting.add(node);
   try {
-    for (const branches of [source.anyOf, source.oneOf]) {
+    for (const branches of [node.anyOf, node.oneOf]) {
       if (
         Array.isArray(branches) && branches.length > 0 &&
         branches.every((branch) =>
-          sourceProvesContainer(named, branch, visiting)
+          sourceProvesContainer(named, branch, scope, visiting)
         )
       ) {
         return true;
       }
     }
   } finally {
+    visiting.delete(node);
     visiting.delete(source);
   }
   return false;
@@ -2104,6 +2189,7 @@ function sourceProvesContainer(
 function requiredSurvivesProjection(
   projection: JSONSchema | undefined,
   source: JSONSchema | undefined,
+  sourceRoot: JSONSchema,
 ): boolean {
   if (projection === false) return false;
   if (projection === undefined || projection === true) return true;
@@ -2112,14 +2198,21 @@ function requiredSurvivesProjection(
   // {@link projectionMask}, so a position naming both vocabularies is read as
   // the array the selector built from it reads.
   if (types.includes("array") || projection.items !== undefined) {
-    return sourceProvesContainer("array", source) &&
-      requiredSurvivesProjection(projection.items, schemaAtArrayItem(source));
+    if (!sourceProvesContainer("array", source, sourceRoot)) return false;
+    // The element sits inside whatever the reference resolved to, so it is
+    // read off the resolved node and carries that node's scope.
+    const resolved = resolvedSourceNode(source, sourceRoot);
+    return requiredSurvivesProjection(
+      projection.items,
+      sourceItemSchema(resolved?.schema),
+      resolved?.root ?? sourceRoot,
+    );
   }
   if (
     types.includes("object") || projection.properties !== undefined ||
     projection.additionalProperties !== undefined
   ) {
-    return sourceProvesContainer("object", source);
+    return sourceProvesContainer("object", source, sourceRoot);
   }
   return types.length === 0;
 }
@@ -2141,12 +2234,27 @@ function requiredSurvivesProjection(
  * A key is derived only for a property the constructed schema names. An open
  * position keeps whatever the source holds there without the reader vouching
  * for it, which declines to require rather than risking an unsatisfiable one.
+ *
+ * `sourceRoot` is the document `source` sits in, threaded down because this
+ * walk re-roots on every descent: a child three levels in still spells its
+ * shape as `#/$defs/Thing` against the root, and the subtree it was read out
+ * of cannot resolve that. It travels beside `source` rather than being
+ * recovered from it, since only the caller of the outermost call knows which
+ * document a position came from.
+ *
+ * @internal Exported for focused reference-resolution tests, which reach the
+ * cases a read cannot: the runner resolves a source schema's references
+ * eagerly, so an unresolvable one fails the read before this is consulted.
  */
-function outputSchemaWithSourceRequired(
+export function outputSchemaWithSourceRequired(
   projection: JSONSchema,
   source: JSONSchema | undefined,
+  sourceRoot: JSONSchema = source ?? true,
 ): JSONSchema {
   if (typeof projection === "boolean") return projection;
+  const resolved = resolvedSourceNode(source, sourceRoot);
+  const node = resolved?.schema;
+  const scope = resolved?.root ?? sourceRoot;
   const types = schemaTypes(projection);
   if (types.includes("array") || projection.items !== undefined) {
     if (projection.items === undefined) return projection;
@@ -2154,30 +2262,28 @@ function outputSchemaWithSourceRequired(
       ...projection,
       items: outputSchemaWithSourceRequired(
         projection.items,
-        schemaAtArrayItem(source),
+        sourceItemSchema(node),
+        scope,
       ),
     };
   }
   const declared = projection.properties;
   if (!isObjectNotArray(declared)) return projection;
-  const sourceRequired =
-    isObjectOrArray(source) && Array.isArray(source.required)
-      ? source.required
-      : [];
+  const sourceRequired = node !== undefined && Array.isArray(node.required)
+    ? node.required
+    : [];
   const properties: Record<string, JSONSchema> = {};
   const required: string[] = [];
   for (const [key, child] of Object.entries(declared)) {
-    const sourceChild = isObjectOrArray(source)
-      ? ContextualFlowControl.schemaAtPath(source, [key])
-      : undefined;
-    const childSource = sourceChild === false ? undefined : sourceChild;
+    const childSource = sourcePropertySchema(node, key);
     properties[key] = outputSchemaWithSourceRequired(
       child as JSONSchema,
       childSource,
+      scope,
     );
     if (
       sourceRequired.includes(key) &&
-      requiredSurvivesProjection(child as JSONSchema, childSource)
+      requiredSurvivesProjection(child as JSONSchema, childSource, scope)
     ) {
       required.push(key);
     }
@@ -2279,9 +2385,13 @@ function resolveProjection(
   // reads only `properties`, `items` and `additionalProperties` off it, so the
   // constructed projection is what it wants. The OUTPUT schema is the one the
   // runner acts on, and it carries the source's `required` besides.
+  // The source cell's own schema is the document every `#/...` in it resolves
+  // against, so it is both the position the walk starts at and the root it
+  // threads down.
   const outputSchema = outputSchemaWithSourceRequired(
     projection.schema,
     sourceSchema,
+    sourceSchema ?? true,
   );
   return {
     outputSchema,

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -646,12 +646,17 @@ const CONSULTED_PROJECTION_KEYS = new Set([
 /**
  * The annotation keywords projection refuses anyway. `default` is the source
  * schema's to state, and the two definition keys have no meaning without the
- * `$ref` projection also refuses. Every member is refused by one of the two
- * denylists above, which is what the coupling test asserts in both directions:
- * a key dropped from `ANNOTATION_KEYS` and left stranded here is drift a
+ * `$ref` projection also refuses.
+ *
+ * Every member is refused **by one of the two denylists above** rather than by
+ * the fall-through, which is asserted over the message each one produces:
+ * dropping a key from its denylist leaves it refused either way, since this set
+ * is what keeps it out of tier T, and only the answer changes. Separately, the
+ * coupling test asserts the two set relations in both directions — a key
+ * dropped from `ANNOTATION_KEYS` and left stranded here is drift a
  * one-directional assertion misses.
  *
- * @internal Exported for the `ANNOTATION_KEYS` coupling test.
+ * @internal Exported for the `ANNOTATION_KEYS` coupling and refusal tests.
  */
 export const PROJECTION_ANNOTATION_EXCEPTIONS: ReadonlySet<string> = new Set([
   "default",
@@ -2100,10 +2105,15 @@ function sourceItemSchema(
  * a shape this derivation can state (#5761), and declining to require costs a
  * key that would have survived while requiring wrongly costs the whole read.
  *
- * A `$ref` is followed first, so a named interface proves what it names. The
- * `visiting` set holds the resolved node as well as the one written at the
- * position, which is what stops a branch that refers back to the union
- * containing it from recurring.
+ * A `$ref` is followed first, so a named interface proves what it names.
+ *
+ * `visiting` holds the schema **as the document writes it**, which is what
+ * bounds the recursion: a branch is drawn from a `node.anyOf` array, resolution
+ * spreads shallowly and so leaves that array's members the document's own
+ * objects, and a document holds finitely many of them. Guarding the RESOLVED
+ * node instead would not bound anything — `resolveCfcSchemaRef` returns a fresh
+ * view whenever the target carries a reference, which is exactly the case a
+ * circle is made of, so no two visits to one definition share an identity.
  */
 function sourceProvesContainer(
   named: "object" | "array",
@@ -2115,14 +2125,12 @@ function sourceProvesContainer(
   const resolved = resolvedSourceNode(source, root);
   if (resolved === undefined) return false;
   const { schema: node, root: scope } = resolved;
-  if (visiting.has(node)) return false;
   const declared = schemaTypes(node);
   if (declared.length > 0) {
     return declared.every((type) => type === named);
   }
   if (node.allOf !== undefined) return false;
   visiting.add(source);
-  visiting.add(node);
   try {
     for (const branches of [node.anyOf, node.oneOf]) {
       if (
@@ -2135,7 +2143,6 @@ function sourceProvesContainer(
       }
     }
   } finally {
-    visiting.delete(node);
     visiting.delete(source);
   }
   return false;

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -2006,17 +2006,54 @@ export function selectSourceSchema(
 }
 
 /**
- * Whether the container `named` can be read at a position the source declares
- * as `source`. A source that declares no type at all admits either container;
- * one that names a different type has narrowed the position to nothing
- * readable, whichever container the caller stated.
+ * Whether `source` **proves** the position holds the container `named`.
+ *
+ * "Can this be a container" is the wrong question here and "must it be" is the
+ * right one. A position the source declares as `["array","string"]` admits an
+ * array and holds whichever branch was stored; where it holds the string, a
+ * caller's array projection rejects it and the property is omitted. A
+ * `required` retained on the strength of the array branch then voids the
+ * object around a position that simply declined to be read — which is the one
+ * failure this whole survival rule exists to prevent.
+ *
+ * A source declaring no type proves nothing either, so it is not a container
+ * for this purpose: an untyped position can hold a scalar just as a union can.
+ *
+ * The same union has a second spelling that never reaches `schemaTypes`, so
+ * `anyOf` and `oneOf` are proven only where **every** branch proves the same
+ * container. `allOf` is refused outright rather than reasoned through: a
+ * conjunction constrains one value from several members at once, which is not
+ * a shape this derivation can state (#5761), and declining to require costs a
+ * key that would have survived while requiring wrongly costs the whole read.
  */
-function containerReadableInSource(
+function sourceProvesContainer(
   named: "object" | "array",
   source: JSONSchema | undefined,
+  visiting = new Set<object>(),
 ): boolean {
+  if (!isObjectOrArray(source)) return false;
+  if (visiting.has(source)) return false;
   const declared = schemaTypes(source);
-  return declared.length === 0 || declared.includes(named);
+  if (declared.length > 0) {
+    return declared.every((type) => type === named);
+  }
+  if (source.allOf !== undefined) return false;
+  visiting.add(source);
+  try {
+    for (const branches of [source.anyOf, source.oneOf]) {
+      if (
+        Array.isArray(branches) && branches.length > 0 &&
+        branches.every((branch) =>
+          sourceProvesContainer(named, branch, visiting)
+        )
+      ) {
+        return true;
+      }
+    }
+  } finally {
+    visiting.delete(source);
+  }
+  return false;
 }
 
 /**
@@ -2054,6 +2091,13 @@ function containerReadableInSource(
  * - `false`. Drops, as it did before any of this: a rejected position holds
  *   nothing to require.
  *
+ * Both container answers stand on the source proving that container at that
+ * position — {@link sourceProvesContainer}, not "the source admits one". A
+ * position the source declares as either an array or a scalar is a position
+ * the caller may have narrowed away from, and requiring it on the strength of
+ * the branch that matches the projection voids the read the same way every
+ * other case here does.
+ *
  * The rule only ever declines to require. Dropping a key that would have
  * survived costs nothing; keeping one that would not costs the entire read.
  */
@@ -2068,14 +2112,14 @@ function requiredSurvivesProjection(
   // {@link projectionMask}, so a position naming both vocabularies is read as
   // the array the selector built from it reads.
   if (types.includes("array") || projection.items !== undefined) {
-    return containerReadableInSource("array", source) &&
+    return sourceProvesContainer("array", source) &&
       requiredSurvivesProjection(projection.items, schemaAtArrayItem(source));
   }
   if (
     types.includes("object") || projection.properties !== undefined ||
     projection.additionalProperties !== undefined
   ) {
-    return containerReadableInSource("object", source);
+    return sourceProvesContainer("object", source);
   }
   return types.length === 0;
 }

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -24,6 +24,7 @@ import {
   isEmbeddedCfcSchemaRef,
   resolveCfcSchemaRef,
 } from "@commonfabric/runner/cfc/schema-refs";
+import { ANNOTATION_KEYS } from "@commonfabric/piece/schema-compatibility";
 import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import { runtimeErrorLog } from "./callable.ts";
 
@@ -597,6 +598,179 @@ const ARRAY_PROJECTION_KEYS = [
 ];
 
 /**
+ * What the reader does with a projection keyword. A registry that recorded a
+ * spelling rather than a class could not tell `consulted` from `tolerated`:
+ * both are accepted and neither reaches the schema the reader hands on, but
+ * only one of them changed the read on the way. A key admitted without its
+ * kind has its treatment decided by whatever the reader happens to default to.
+ */
+export type ProjectionKeyTier =
+  | "honored"
+  | "consulted"
+  | "tolerated"
+  | "refused";
+
+/**
+ * The keywords the projection drives itself from. These are the only ones the
+ * reader carries into the schema it constructs, and `type` is why that
+ * construction reads the classified projection rather than the mask: a scalar
+ * leaf's declared `type` is the whole of what filters that leaf, and a mask
+ * reduces every scalar position to `true`.
+ */
+const HONORED_PROJECTION_KEYS = new Set([
+  "type",
+  "properties",
+  "items",
+  "additionalProperties",
+  LINK_MARKER_KEY,
+]);
+
+/**
+ * The keywords {@link impliedProjectionType} reads to decide which container an
+ * untyped position describes, less the three tier H already claims. They
+ * change the read — a position naming only `minItems` reads as an array — and
+ * are then consumed: nothing the caller wrote in one reaches the read
+ * boundary. The reader may still emit `required` there on its own authority
+ * and with the source's meaning, which is a different key of the same
+ * spelling; {@link outputSchemaWithSourceRequired} is where that happens.
+ */
+const CONSULTED_PROJECTION_KEYS = new Set([
+  "required",
+  "minProperties",
+  "maxProperties",
+  "minItems",
+  "maxItems",
+  "uniqueItems",
+]);
+
+/**
+ * The annotation keywords projection refuses anyway. `default` is the source
+ * schema's to state, and the two definition keys have no meaning without the
+ * `$ref` projection also refuses. Every member is refused by one of the two
+ * denylists above, which is what the coupling test asserts in both directions:
+ * a key dropped from `ANNOTATION_KEYS` and left stranded here is drift a
+ * one-directional assertion misses.
+ *
+ * @internal Exported for the `ANNOTATION_KEYS` coupling test.
+ */
+export const PROJECTION_ANNOTATION_EXCEPTIONS: ReadonlySet<string> = new Set([
+  "default",
+  "$defs",
+  "definitions",
+]);
+
+/**
+ * The keywords a caller may write that change nothing. Derived rather than
+ * restated, so that admitting a keyword to the durable dialect's annotations
+ * admits it here too — unless it is one of the three
+ * {@link PROJECTION_ANNOTATION_EXCEPTIONS} names.
+ */
+const TOLERATED_PROJECTION_KEYS: ReadonlySet<string> = new Set(
+  [...ANNOTATION_KEYS].filter((key) =>
+    !PROJECTION_ANNOTATION_EXCEPTIONS.has(key)
+  ),
+);
+
+/**
+ * The tolerated keywords the reader accepts and drops rather than carries.
+ * Membership in `ANNOTATION_KEYS` makes a key a candidate; that the checker
+ * may ignore it when comparing two schemas says nothing about what the
+ * **runner** does with it on a read, and only the second question decides
+ * whether carrying it is inert.
+ *
+ * `$id` and `$schema` declare the identity and dialect of a document, and the
+ * reader is not producing the caller's document. `$comment` is not inert at
+ * all: `packages/runner/src/schema-view.ts` reserves `"emptyProperties"`,
+ * `"missingProperty"` and `"rejectedProperty"` as control markers and
+ * `packages/runner/src/traverse.ts` acts on the first two, so a carried
+ * `$comment` is caller-forgeable control flow at the read boundary. Dropping
+ * needs to know nothing about which values are reserved, and a marker the
+ * runner reserves later cannot re-open the hole behind it.
+ */
+const DROPPED_TOLERATED_KEYS: ReadonlySet<string> = new Set([
+  "$comment",
+  "$id",
+  "$schema",
+]);
+
+/** The tolerated keywords that do reach the schema the reader constructs. */
+const CARRIED_TOLERATED_KEYS: readonly string[] = [
+  ...TOLERATED_PROJECTION_KEYS,
+].filter((key) => !DROPPED_TOLERATED_KEYS.has(key));
+
+/**
+ * What the projection reader does with `key`.
+ *
+ * @internal Exported for the classification and coupling tests.
+ */
+export function projectionKeyTier(key: string): ProjectionKeyTier {
+  if (HONORED_PROJECTION_KEYS.has(key)) return "honored";
+  if (CONSULTED_PROJECTION_KEYS.has(key)) return "consulted";
+  if (
+    FORBIDDEN_PROJECTION_KEYS.has(key) || UNSUPPORTED_PROJECTION_KEYS.has(key)
+  ) {
+    return "refused";
+  }
+  return TOLERATED_PROJECTION_KEYS.has(key) ? "tolerated" : "refused";
+}
+
+/** The honored vocabulary, as a refusal names it. */
+const HONORED_PROJECTION_VOCABULARY = [...HONORED_PROJECTION_KEYS]
+  .map((key) => `"${key}"`)
+  .join(", ");
+
+/**
+ * The edit distance between `left` and `right`, for the near-miss below.
+ * Adjacent transposition counts as one edit rather than two, because it is the
+ * typo the refusal exists for: `itmes` is one slip from `items` however many
+ * substitutions it takes to spell as substitutions.
+ */
+function keyEditDistance(left: string, right: string): number {
+  const rows: number[][] = [
+    Array.from({ length: right.length + 1 }, (_, j) => j),
+  ];
+  for (let i = 1; i <= left.length; i++) {
+    const current = [i];
+    for (let j = 1; j <= right.length; j++) {
+      const previous = rows[i - 1];
+      current[j] = left[i - 1] === right[j - 1]
+        ? previous[j - 1]
+        : 1 + Math.min(previous[j - 1], previous[j], current[j - 1]);
+      if (
+        i > 1 && j > 1 && left[i - 1] === right[j - 2] &&
+        left[i - 2] === right[j - 1]
+      ) {
+        current[j] = Math.min(current[j], rows[i - 2][j - 2] + 1);
+      }
+    }
+    rows.push(current);
+  }
+  return rows[left.length][right.length];
+}
+
+/**
+ * The keyword `key` was most likely meant to be, or `undefined` where nothing
+ * is close enough to name. No read-side surface prints the source schema, so
+ * for a misspelled key the accepted vocabulary is the entire remediation, and
+ * the one keyword a caller transposed two letters of is the useful half of it.
+ */
+function nearestProjectionKey(key: string): string | undefined {
+  const lowered = key.toLowerCase();
+  let best: string | undefined;
+  let bestDistance = Infinity;
+  for (const candidate of HONORED_PROJECTION_KEYS) {
+    const distance = keyEditDistance(lowered, candidate.toLowerCase());
+    if (distance < bestDistance) {
+      best = candidate;
+      bestDistance = distance;
+    }
+  }
+  return bestDistance <= Math.max(1, Math.floor(key.length / 4))
+    ? best
+    : undefined;
+}
+
+/**
  * The container a projection position describes but did not state. Schema
  * traversal descends `properties` only under `type: "object"` and `items` only
  * under `type: "array"`, so an omitted `type` silently empties the position —
@@ -654,6 +828,19 @@ function normalizeProjectionSchema(
         `Invalid --schema at ${path}: "${key}" is not supported by projection schemas`,
       );
     }
+    if (projectionKeyTier(key) === "refused") {
+      // No read-side surface prints the schema a read runs against, so a
+      // refusal cannot send a caller off to lift one and prune it. What it
+      // says is what the reader knows without any source at all: the key, the
+      // position, and the vocabulary that position accepts.
+      const nearest = nearestProjectionKey(key);
+      throw new CellSelectionError(
+        `Invalid --schema at ${path}: "${key}" is not a projection schema ` +
+          "keyword. " +
+          (nearest === undefined ? "" : `Did you mean "${nearest}"? `) +
+          `Projection reads ${HONORED_PROJECTION_VOCABULARY}`,
+      );
+    }
   }
   const marker = schema[LINK_MARKER_KEY];
   if (marker !== undefined && marker !== true) {
@@ -665,13 +852,27 @@ function normalizeProjectionSchema(
   const { [LINK_MARKER_KEY]: _marker, ...declared } = schema;
   const markers: LinkMarkers = marker === true ? { marked: true } : {};
   const implied = impliedProjectionType(declared);
+  // The reader constructs what it hands on rather than forwarding what a
+  // caller typed. An honored key is written out below; a consulted key was
+  // read by `impliedProjectionType()` just above and goes no further, so no
+  // constraint of the caller's reaches a schema the runner acts on; a
+  // tolerated key is carried only where carrying it is inert past the read
+  // boundary; a refused key never reaches here, the projection naming it
+  // having been rejected.
+  //
   // An implied `type` leads the result, so a normalized schema reads the way a
   // caller would have written it out in full. A position that declared nothing
   // gains nothing: `{}` stays the wildcard it already is, and a bare marker
   // still reduces to `false` below.
-  const result: Record<string, unknown> = implied === undefined
-    ? { ...declared }
-    : { type: implied, ...declared };
+  const result: Record<string, unknown> = {};
+  if (implied !== undefined) result.type = implied;
+  else if (declared.type !== undefined) result.type = declared.type;
+  for (const key of CARRIED_TOLERATED_KEYS) {
+    if (declared[key] !== undefined) result[key] = declared[key];
+  }
+  if (typeof declared.additionalProperties === "boolean") {
+    result.additionalProperties = declared.additionalProperties;
+  }
   if (declared.properties !== undefined) {
     if (!isObjectNotArray(declared.properties)) {
       throw new CellSelectionError(
@@ -1785,6 +1986,14 @@ export function selectSourceSchema(
   // A rejected position holds nothing to require. Keeping it required makes
   // the object unsatisfiable, which reads as an absent value for the whole
   // selection rather than for the one position that declined to be read.
+  //
+  // That test is {@link requiredSurvivesProjection} over the only part of
+  // itself a MASK can state. A mask records `false`, the two containers and
+  // `true`, so a caller's own scalar type is already gone by the time it
+  // reaches here, and "the caller rejected the position outright" is the whole
+  // of what is left to ask. A schema built from the classified projection has
+  // those types in hand and applies the rule entire, in
+  // {@link outputSchemaWithSourceRequired}.
   const selectedRequired = required?.filter((key) =>
     key in properties && properties[key] !== false
   );
@@ -1793,6 +2002,146 @@ export function selectSourceSchema(
     properties,
     ...(selectedRequired?.length ? { required: selectedRequired } : {}),
     additionalProperties: false,
+  };
+}
+
+/**
+ * Whether the container `named` can be read at a position the source declares
+ * as `source`. A source that declares no type at all admits either container;
+ * one that names a different type has narrowed the position to nothing
+ * readable, whichever container the caller stated.
+ */
+function containerReadableInSource(
+  named: "object" | "array",
+  source: JSONSchema | undefined,
+): boolean {
+  const declared = schemaTypes(source);
+  return declared.length === 0 || declared.includes(named);
+}
+
+/**
+ * Whether a source-`required` property stays required in the schema the reader
+ * constructs. It stays only where nothing the caller wrote inside that
+ * property can cause the property **itself** to be rejected: a position the
+ * caller narrowed may be omitted, but the object holding it must not be voided
+ * because it was.
+ *
+ * The two containers do not decide that the same way, and that is why this is
+ * not one case. `traverseObjectWithSchema`
+ * (`packages/runner/src/traverse.ts`) assembles an object out of the
+ * properties whose traversal returned no error and carries on past one that
+ * failed; `traverseArrayWithSchema` carries a single `valid` flag across every
+ * element and returns `undefined` when any element fails. **A rejected object
+ * property is omitted; a rejected array element voids the array around it.**
+ *
+ * So, against the classified projection at that property:
+ *
+ * - No stated type — `true`, or `{}`. The constructed child is the unprojected
+ *   one, declining exactly the values an unprojected read declines, which is
+ *   the source's meaning `required` is being derived to carry. Stays.
+ * - A scalar `type`. The constraint is the caller's, and declining a value is
+ *   what a caller writes one for. Drops. This is the case a mask cannot see,
+ *   every scalar position reducing to `true` in one.
+ * - An object. What the caller wrote inside narrows a descendant, which is
+ *   omitted rather than rejecting the object — on the condition that each
+ *   descendant's own derived `required` follows this same rule, which
+ *   {@link outputSchemaWithSourceRequired} discharges by recursing.
+ * - An array. What the caller wrote does not stay where it was written: it
+ *   constrains elements, and one rejected element voids the array. So the
+ *   answer follows the ELEMENT schema, by the same rule one level down. An
+ *   array carries no `required` of its own for that recursion to empty, so
+ *   there is nothing below it to absorb a rejection.
+ * - `false`. Drops, as it did before any of this: a rejected position holds
+ *   nothing to require.
+ *
+ * The rule only ever declines to require. Dropping a key that would have
+ * survived costs nothing; keeping one that would not costs the entire read.
+ */
+function requiredSurvivesProjection(
+  projection: JSONSchema | undefined,
+  source: JSONSchema | undefined,
+): boolean {
+  if (projection === false) return false;
+  if (projection === undefined || projection === true) return true;
+  const types = schemaTypes(projection);
+  // Arrays are tested first, matching {@link impliedProjectionType} and
+  // {@link projectionMask}, so a position naming both vocabularies is read as
+  // the array the selector built from it reads.
+  if (types.includes("array") || projection.items !== undefined) {
+    return containerReadableInSource("array", source) &&
+      requiredSurvivesProjection(projection.items, schemaAtArrayItem(source));
+  }
+  if (
+    types.includes("object") || projection.properties !== undefined ||
+    projection.additionalProperties !== undefined
+  ) {
+    return containerReadableInSource("object", source);
+  }
+  return types.length === 0;
+}
+
+/**
+ * The schema a JSON projection hands the read boundary: the classified
+ * projection the reader constructed, plus the one key it supplies from
+ * somewhere other than the caller — `required`, taken from the SOURCE schema
+ * and filtered by {@link requiredSurvivesProjection}.
+ *
+ * {@link selectSourceSchema} already derives `required` this way for the
+ * schemas it builds out of the mask, and for the same reason. This extends
+ * that derivation to the position a JSON projection reaches, which is the
+ * position where the caller's own scalar types are in play — so the filter
+ * here is the survival rule rather than the projection membership a mask is
+ * the whole of. Both spell `required`, over two origins, and only one of them
+ * is the caller's to supply.
+ *
+ * A key is derived only for a property the constructed schema names. An open
+ * position keeps whatever the source holds there without the reader vouching
+ * for it, which declines to require rather than risking an unsatisfiable one.
+ */
+function outputSchemaWithSourceRequired(
+  projection: JSONSchema,
+  source: JSONSchema | undefined,
+): JSONSchema {
+  if (typeof projection === "boolean") return projection;
+  const types = schemaTypes(projection);
+  if (types.includes("array") || projection.items !== undefined) {
+    if (projection.items === undefined) return projection;
+    return {
+      ...projection,
+      items: outputSchemaWithSourceRequired(
+        projection.items,
+        schemaAtArrayItem(source),
+      ),
+    };
+  }
+  const declared = projection.properties;
+  if (!isObjectNotArray(declared)) return projection;
+  const sourceRequired =
+    isObjectOrArray(source) && Array.isArray(source.required)
+      ? source.required
+      : [];
+  const properties: Record<string, JSONSchema> = {};
+  const required: string[] = [];
+  for (const [key, child] of Object.entries(declared)) {
+    const sourceChild = isObjectOrArray(source)
+      ? ContextualFlowControl.schemaAtPath(source, [key])
+      : undefined;
+    const childSource = sourceChild === false ? undefined : sourceChild;
+    properties[key] = outputSchemaWithSourceRequired(
+      child as JSONSchema,
+      childSource,
+    );
+    if (
+      sourceRequired.includes(key) &&
+      requiredSurvivesProjection(child as JSONSchema, childSource)
+    ) {
+      required.push(key);
+    }
+  }
+  return {
+    ...projection,
+    properties,
+    ...(required.length > 0 ? { required } : {}),
   };
 }
 
@@ -1882,8 +2231,16 @@ function resolveProjection(
   const itemSchema = projectsArrayItems
     ? (projection.schema as Exclude<JSONSchema, boolean>).items ?? true
     : undefined;
+  // The projector applies the caller's shape to a value already in hand and
+  // reads only `properties`, `items` and `additionalProperties` off it, so the
+  // constructed projection is what it wants. The OUTPUT schema is the one the
+  // runner acts on, and it carries the source's `required` besides.
+  const outputSchema = outputSchemaWithSourceRequired(
+    projection.schema,
+    sourceSchema,
+  );
   return {
-    outputSchema: projection.schema,
+    outputSchema,
     projectionSchema: projection.schema,
     mask,
     projectsArrayItems,
@@ -1892,7 +2249,8 @@ function resolveProjection(
     markers: projection.markers,
     ...(projectsArrayItems
       ? {
-        itemOutputSchema: itemSchema,
+        itemOutputSchema:
+          (outputSchema as Exclude<JSONSchema, boolean>).items ?? true,
         itemProjectionSchema: itemSchema,
         itemMask: projectionMask(itemSchema!),
       }

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -480,9 +480,13 @@ describe("cf piece get transforms", () => {
         '{"additionalProperties":{"type":"string"}}',
       )).schema,
     ).toEqual({ type: "object", additionalProperties: { type: "string" } });
+    // `required` names the container and is then consumed: the caller's
+    // constraint goes no further, because the runner acts on a `required` it
+    // is handed and a caller's would void the read around a position it
+    // narrowed.
     expect(
       (await parseSelectionProjection('{"required":["id"]}')).schema,
-    ).toEqual({ type: "object", required: ["id"], additionalProperties: true });
+    ).toEqual({ type: "object", additionalProperties: true });
     expect(
       (await parseSelectionProjection('{"items":{"properties":{"id":true}}}'))
         .schema,

--- a/packages/cli/test/projection-key-classification.test.ts
+++ b/packages/cli/test/projection-key-classification.test.ts
@@ -1,0 +1,474 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { type Cell, type JSONSchema, Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { ANNOTATION_KEYS } from "@commonfabric/piece/schema-compatibility";
+import {
+  deriveSelectedValue,
+  parseSelectionProjection,
+  PROJECTION_ANNOTATION_EXCEPTIONS,
+  projectionKeyTier,
+} from "../lib/cell-selection.ts";
+
+const signer = await Identity.fromPassphrase(
+  "cf-projection-key-classification",
+);
+const space = signer.did();
+
+/** The keywords the reader drives the projection from. */
+const HONORED = [
+  "type",
+  "properties",
+  "items",
+  "additionalProperties",
+  "$link",
+];
+
+/**
+ * The keywords the reader consults for container inference and then consumes.
+ * Every one of them changes which container an untyped position describes.
+ */
+const CONSULTED = [
+  "required",
+  "minProperties",
+  "maxProperties",
+  "minItems",
+  "maxItems",
+  "uniqueItems",
+];
+
+/** A tolerated keyword, beside a value of the right JSON type for it. */
+const TOLERATED_VALUES: ReadonlyArray<[string, unknown]> = [
+  // `$comment` carries the value the runner reserves as a control marker,
+  // which is the only value of it that could disturb a read.
+  ["$comment", "emptyProperties"],
+  ["$id", "https://example.com/caller.json"],
+  ["$schema", "https://json-schema.org/draft/2020-12/schema"],
+  ["deprecated", true],
+  ["description", "what the caller thinks this is"],
+  ["examples", ["an example"]],
+  ["tags", ["a tag"]],
+  ["tier", "wrapper"],
+  ["title", "A title"],
+];
+
+/** Every key in keyword position anywhere in `schema`. */
+function keywordsIn(schema: unknown, into = new Set<string>()): Set<string> {
+  if (schema === null || typeof schema !== "object" || Array.isArray(schema)) {
+    return into;
+  }
+  for (
+    const [key, child] of Object.entries(schema as Record<string, unknown>)
+  ) {
+    into.add(key);
+    if (key === "properties") {
+      if (child !== null && typeof child === "object") {
+        for (const value of Object.values(child as Record<string, unknown>)) {
+          keywordsIn(value, into);
+        }
+      }
+    } else if (key === "items" || key === "additionalProperties") {
+      keywordsIn(child, into);
+    }
+  }
+  return into;
+}
+
+describe("projection-key-classification", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+      errorHandlers: [() => {}],
+    });
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  /** A cell holding `value` under `schema`, committed and read back fresh. */
+  async function seed(
+    cause: string,
+    schema: JSONSchema,
+    value: unknown,
+  ): Promise<Cell<unknown>> {
+    const tx = runtime.edit();
+    const cell = runtime.getCell(space, cause, schema, tx);
+    cell.set(value as never);
+    expect((await tx.commit()).ok).toBeDefined();
+    return runtime.getCell(space, cause, schema);
+  }
+
+  /** `source` read through the JSON `--schema` spelled by `projection`. */
+  async function read(
+    source: Cell<unknown>,
+    projection: unknown,
+  ): Promise<unknown> {
+    return await deriveSelectedValue(runtime, space, source, {
+      projection: await parseSelectionProjection(JSON.stringify(projection)),
+    });
+  }
+
+  /** The schema `deriveSelectedValue` re-asserts on its output cell. */
+  async function outputSchemaOf(
+    source: Cell<unknown>,
+    projection: unknown,
+  ): Promise<JSONSchema | undefined> {
+    let outputCell: Cell<unknown> | undefined;
+    await deriveSelectedValue(runtime, space, source, {
+      projection: await parseSelectionProjection(JSON.stringify(projection)),
+    }, { onOutputCell: (cell) => outputCell = cell });
+    return outputCell?.schema;
+  }
+
+  describe("a key in no tier", () => {
+    it("refuses the projection, naming the key and the position it sat at", async () => {
+      await expect(
+        parseSelectionProjection(
+          '{"type":"object","propertes":{"title":true}}',
+        ),
+      ).rejects.toThrow(
+        'Invalid --schema at <root>: "propertes" is not a projection schema keyword',
+      );
+    });
+
+    it("names the nested position a refused key sat at", async () => {
+      await expect(parseSelectionProjection(JSON.stringify({
+        properties: { notes: { minLenght: 3 } },
+      }))).rejects.toThrow('Invalid --schema at <root>.notes: "minLenght"');
+    });
+
+    it("names the honored vocabulary a caller can write instead", async () => {
+      await expect(parseSelectionProjection('{"pattern":"^a"}')).rejects
+        .toThrow(
+          'Projection reads "type", "properties", "items", ' +
+            '"additionalProperties", "$link"',
+        );
+    });
+
+    it("suggests the honored keyword a misspelling is one edit from", async () => {
+      await expect(parseSelectionProjection('{"propertes":{"a":true}}')).rejects
+        .toThrow('Did you mean "properties"?');
+      await expect(parseSelectionProjection('{"type":"array","itmes":true}'))
+        .rejects.toThrow('Did you mean "items"?');
+    });
+
+    it("refuses a misspelled `properties` beside a stated `type` rather than returning the whole object", async () => {
+      const source = await seed("classification-widening-source", {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          secret: { type: "string" },
+        },
+      }, { title: "Visible", secret: "not asked for" });
+
+      await expect(
+        read(source, { type: "object", propertes: { title: true } }),
+      ).rejects.toThrow('"propertes" is not a projection schema keyword');
+    });
+
+    it("refuses a misspelled `properties` with no stated `type` rather than reading nothing", async () => {
+      const source = await seed("classification-narrowing-source", {
+        type: "object",
+        properties: { title: { type: "string" } },
+      }, { title: "Visible" });
+
+      await expect(read(source, { propertes: { title: true } })).rejects
+        .toThrow('"propertes" is not a projection schema keyword');
+    });
+
+    it("returns a tier for every keyword the reader accepts", () => {
+      for (const key of HONORED) {
+        expect(projectionKeyTier(key)).toBe("honored");
+      }
+      for (const key of CONSULTED) {
+        expect(projectionKeyTier(key)).toBe("consulted");
+      }
+      for (const [key] of TOLERATED_VALUES) {
+        expect(projectionKeyTier(key)).toBe("tolerated");
+      }
+      for (const key of ["propertes", "pattern", "minLength", "format"]) {
+        expect(projectionKeyTier(key)).toBe("refused");
+      }
+    });
+  });
+
+  describe("a tier C key the caller wrote", () => {
+    it("names the array container an untyped position describes", async () => {
+      expect((await parseSelectionProjection('{"minItems":1}')).schema).toEqual(
+        {
+          type: "array",
+        },
+      );
+      expect((await parseSelectionProjection('{"uniqueItems":true}')).schema)
+        .toEqual({ type: "array" });
+    });
+
+    it("names the object container an untyped position describes", async () => {
+      expect((await parseSelectionProjection('{"required":["id"]}')).schema)
+        .toEqual({ type: "object", additionalProperties: true });
+      expect((await parseSelectionProjection('{"minProperties":1}')).schema)
+        .toEqual({ type: "object", additionalProperties: true });
+    });
+
+    it("leaves no caller-written tier C constraint in the output schema", async () => {
+      const source = await seed("classification-tier-c-source", {
+        type: "object",
+        properties: {
+          id: { type: "number" },
+          title: { type: "string" },
+          notes: { type: "array", items: { type: "string" } },
+        },
+      }, { id: 1, title: "Visible", notes: ["one"] });
+
+      const schema = await outputSchemaOf(source, {
+        type: "object",
+        minProperties: 1,
+        maxProperties: 9,
+        required: ["id"],
+        properties: {
+          title: true,
+          notes: {
+            type: "array",
+            minItems: 1,
+            maxItems: 9,
+            uniqueItems: true,
+            items: true,
+          },
+        },
+      });
+
+      const carried = keywordsIn(schema);
+      for (const key of CONSULTED) {
+        // `required` may appear from the reader's own derivation; here the
+        // source requires nothing, so no origin can put one there.
+        expect([...carried]).not.toContain(key);
+      }
+    });
+
+    it("returns the projected fields for a projection naming a `required` field it does not project", async () => {
+      const source = await seed("classification-5734-source", {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          secret: { type: "string" },
+        },
+      }, { title: "Visible", secret: "not asked for" });
+
+      expect(
+        await read(source, {
+          type: "object",
+          required: ["secret"],
+          properties: { title: true },
+        }),
+      ).toEqual({ title: "Visible" });
+    });
+  });
+
+  describe("a tier T key the caller wrote", () => {
+    it("returns what the same projection returns without it", async () => {
+      const source = await seed("classification-tier-t-source", {
+        type: "object",
+        properties: { title: { type: "string" } },
+      }, { title: "Visible" });
+
+      const baseline = await read(source, {
+        type: "object",
+        properties: { title: {} },
+      });
+      expect(baseline).toEqual({ title: "Visible" });
+
+      for (const [key, value] of TOLERATED_VALUES) {
+        expect(
+          await read(source, {
+            type: "object",
+            properties: { title: { [key]: value } },
+          }),
+        ).toEqual(baseline);
+      }
+    });
+
+    it("is `ANNOTATION_KEYS` less projection's stated exceptions, in both directions", () => {
+      for (const key of ANNOTATION_KEYS) {
+        expect(
+          projectionKeyTier(key) === "tolerated" ||
+            PROJECTION_ANNOTATION_EXCEPTIONS.has(key),
+        ).toBe(true);
+      }
+      for (const key of PROJECTION_ANNOTATION_EXCEPTIONS) {
+        expect(ANNOTATION_KEYS.has(key)).toBe(true);
+      }
+    });
+  });
+
+  describe("the `required` the reader derives from the source", () => {
+    const requiredSourceSchema = {
+      type: "object",
+      properties: {
+        id: { type: "number" },
+        title: { type: "string" },
+      },
+      required: ["id", "title"],
+    } as const satisfies JSONSchema;
+
+    it("carries a source-required projected property into the output schema", async () => {
+      const source = await seed(
+        "classification-derived-required-source",
+        requiredSourceSchema,
+        { id: 1, title: "Visible" },
+      );
+
+      const schema = await outputSchemaOf(source, {
+        type: "object",
+        properties: { title: true },
+      });
+
+      expect((schema as Record<string, unknown>).required).toEqual(["title"]);
+    });
+
+    it("leaves the caller's own `required` out of the schema it carries a derived one into", async () => {
+      const source = await seed(
+        "classification-two-origins-source",
+        requiredSourceSchema,
+        { id: 1, title: "Visible" },
+      );
+
+      const schema = await outputSchemaOf(source, {
+        type: "object",
+        required: ["id"],
+        properties: { title: true },
+      });
+
+      // The caller named `id`; the source requires `title` as well. Only the
+      // reader's own derivation reaches the boundary, so `id` — which the
+      // projection does not name at all — is not there.
+      expect((schema as Record<string, unknown>).required).toEqual(["title"]);
+    });
+
+    it("returns the object without a source-required property the caller narrowed to a mismatched scalar", async () => {
+      const source = await seed("classification-scalar-mismatch-source", {
+        type: "object",
+        properties: {
+          id: { type: "number" },
+          title: { type: "string" },
+        },
+        required: ["id"],
+      }, { id: 1, title: "Visible" });
+
+      expect(
+        await read(source, {
+          type: "object",
+          properties: { id: { type: "string" }, title: true },
+        }),
+      ).toEqual({ title: "Visible" });
+    });
+
+    it("returns the object without a source-required array whose items the caller narrowed to a mismatched scalar", async () => {
+      const source = await seed("classification-item-mismatch-source", {
+        type: "object",
+        properties: {
+          values: { type: "array", items: { type: "number" } },
+          title: { type: "string" },
+        },
+        required: ["values"],
+      }, { values: [1], title: "Visible" });
+
+      expect(
+        await read(source, {
+          type: "object",
+          properties: {
+            values: { type: "array", items: { type: "string" } },
+            title: true,
+          },
+        }),
+      ).toEqual({ title: "Visible" });
+    });
+
+    it("returns a source-required array of objects whose leaf the caller narrowed to a mismatched scalar", async () => {
+      const source = await seed("classification-item-object-source", {
+        type: "object",
+        properties: {
+          rows: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                id: { type: "number" },
+                name: { type: "string" },
+              },
+              required: ["id"],
+            },
+          },
+          title: { type: "string" },
+        },
+        required: ["rows"],
+      }, { rows: [{ id: 1, name: "a" }], title: "Visible" });
+
+      expect(
+        await read(source, {
+          type: "object",
+          properties: {
+            rows: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: { id: { type: "string" }, name: true },
+              },
+            },
+            title: true,
+          },
+        }),
+      ).toEqual({ rows: [{ name: "a" }], title: "Visible" });
+    });
+  });
+
+  describe("the output schema the reader constructs", () => {
+    it("omits a nested scalar leaf whose declared type does not match the stored value", async () => {
+      const source = await seed("classification-nested-scalar-source", {
+        type: "object",
+        properties: {
+          topic: {
+            type: "object",
+            properties: {
+              id: { type: "number" },
+              title: { type: "string" },
+            },
+          },
+        },
+      }, { topic: { id: 1, title: "Visible" } });
+
+      expect(
+        await read(source, {
+          type: "object",
+          properties: {
+            topic: {
+              type: "object",
+              properties: { id: { type: "string" }, title: true },
+            },
+          },
+        }),
+      ).toEqual({ topic: { title: "Visible" } });
+    });
+
+    it("returns none of an object source's fields for a scalar projection over it", async () => {
+      const source = await seed("classification-scalar-over-object-source", {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          secret: { type: "string" },
+        },
+      }, { title: "Visible", secret: "not asked for" });
+
+      expect(await read(source, { type: "string" })).toBeUndefined();
+    });
+  });
+});

--- a/packages/cli/test/projection-key-classification.test.ts
+++ b/packages/cli/test/projection-key-classification.test.ts
@@ -335,6 +335,35 @@ describe("projection-key-classification", () => {
       }
     });
 
+    it("refuses every stated exception through the denylist that claims it", async () => {
+      const byFallThrough: string[] = [];
+      for (const key of PROJECTION_ANNOTATION_EXCEPTIONS) {
+        expect(projectionKeyTier(key)).toBe("refused");
+
+        let message = "<accepted, and should not have been>";
+        try {
+          await parseSelectionProjection(JSON.stringify({ [key]: {} }));
+        } catch (error) {
+          message = (error as Error).message;
+        }
+        // Refused is not enough on its own: an exception dropped from its
+        // denylist is still refused, by fall-through, because the exception
+        // set is what keeps it out of tier T. What changes is the answer. The
+        // denylists say WHY — `default` is the source schema's to state, the
+        // definition keys have no meaning without the `$ref` projection also
+        // refuses — while the fall-through says only that the reader does not
+        // know the key, which is a poor answer for one it knows perfectly well
+        // and refuses on purpose.
+        if (
+          !message.includes(`"${key}"`) ||
+          message.includes("is not a projection schema keyword")
+        ) {
+          byFallThrough.push(`${key}: ${message}`);
+        }
+      }
+      expect(byFallThrough).toEqual([]);
+    });
+
     it("is `ANNOTATION_KEYS` less projection's stated exceptions, in both directions", () => {
       for (const key of ANNOTATION_KEYS) {
         expect(
@@ -460,6 +489,32 @@ describe("projection-key-classification", () => {
         type: "object",
         properties: {
           values: { type: "array", items: { type: "number" } },
+          title: { type: "string" },
+        },
+        required: ["values"],
+      }, { values: [1], title: "Visible" });
+
+      const schema = await outputSchemaOf(source, {
+        type: "object",
+        properties: { values: { type: "array", items: true }, title: true },
+      });
+
+      expect((schema as Record<string, unknown>).required).toEqual(["values"]);
+    });
+
+    it("carries a source-required array into the output schema where every `anyOf` branch is an array", async () => {
+      // The positive of the union rule. Every branch names the container the
+      // caller projected, so whichever one the value took, the projection does
+      // not reject it — nothing the union admits can void the object.
+      const source = await seed("classification-anyof-all-arrays-source", {
+        type: "object",
+        properties: {
+          values: {
+            anyOf: [
+              { type: "array", items: { type: "number" } },
+              { type: "array", items: { type: "string" } },
+            ],
+          },
           title: { type: "string" },
         },
         required: ["values"],
@@ -688,6 +743,30 @@ describe("projection-key-classification", () => {
           },
         }, arrayProjection),
       ).toEqual(["values", "title"]);
+    });
+
+    it("derives `required` where a `$ref` names one of the runner's embedded documents", async () => {
+      // An embedded reference names a whole other document, so a reference
+      // INSIDE it resolves against itself. The vnode document's own root is
+      // `{"$ref": "#/$defs/VNode"}`, and that name exists only there — a
+      // reader that kept the referring document as the scope resolves nothing
+      // and proves no container.
+      expect(
+        await derivedRequired({
+          type: "object",
+          properties: {
+            ui: { $ref: "https://commonfabric.org/schemas/vnode.json" },
+            title: { type: "string" },
+          },
+          required: ["ui"],
+        }, {
+          type: "object",
+          properties: {
+            ui: { type: "object", properties: { type: true } },
+            title: true,
+          },
+        }),
+      ).toEqual(["ui"]);
     });
 
     it("derives no `required` for a position whose `$ref` names nothing in the document", async () => {

--- a/packages/cli/test/projection-key-classification.test.ts
+++ b/packages/cli/test/projection-key-classification.test.ts
@@ -372,6 +372,119 @@ describe("projection-key-classification", () => {
       ).toEqual({ title: "Visible" });
     });
 
+    it("returns the object without a source-required position the source declares as an array or a string", async () => {
+      const source = await seed("classification-union-type-source", {
+        type: "object",
+        properties: {
+          values: { type: ["array", "string"] },
+          title: { type: "string" },
+        },
+        required: ["values"],
+      }, { values: "not a list", title: "Visible" });
+
+      // The source admits an array here but does not require one, and what is
+      // stored is the other branch. The caller's array projection rejects it,
+      // so a `required` derived from "the source could be an array" voids the
+      // object around a position that simply declined to be read.
+      expect(
+        await read(source, {
+          type: "object",
+          properties: { values: { type: "array", items: true }, title: true },
+        }),
+      ).toEqual({ title: "Visible" });
+    });
+
+    it("returns the object without a source-required position an `anyOf` declares as an array or a string", async () => {
+      const source = await seed("classification-union-anyof-source", {
+        type: "object",
+        properties: {
+          values: {
+            anyOf: [
+              { type: "array", items: { type: "number" } },
+              { type: "string" },
+            ],
+          },
+          title: { type: "string" },
+        },
+        required: ["values"],
+      }, { values: "not a list", title: "Visible" });
+
+      expect(
+        await read(source, {
+          type: "object",
+          properties: { values: { type: "array", items: true }, title: true },
+        }),
+      ).toEqual({ title: "Visible" });
+    });
+
+    it("carries a source-required array into the output schema where the source declares only an array", async () => {
+      const source = await seed("classification-only-array-source", {
+        type: "object",
+        properties: {
+          values: { type: "array", items: { type: "number" } },
+          title: { type: "string" },
+        },
+        required: ["values"],
+      }, { values: [1], title: "Visible" });
+
+      const schema = await outputSchemaOf(source, {
+        type: "object",
+        properties: { values: { type: "array", items: true }, title: true },
+      });
+
+      expect((schema as Record<string, unknown>).required).toEqual(["values"]);
+    });
+
+    it("carries a source-required object into the output schema where the source declares only an object", async () => {
+      const source = await seed("classification-only-object-source", {
+        type: "object",
+        properties: {
+          topic: {
+            type: "object",
+            properties: { title: { type: "string" } },
+          },
+          title: { type: "string" },
+        },
+        required: ["topic"],
+      }, { topic: { title: "Inner" }, title: "Visible" });
+
+      const schema = await outputSchemaOf(source, {
+        type: "object",
+        properties: {
+          topic: { type: "object", properties: { title: true } },
+          title: true,
+        },
+      });
+
+      expect((schema as Record<string, unknown>).required).toEqual(["topic"]);
+    });
+
+    it("derives no `required` for a position whose container the source spells under `allOf`", async () => {
+      const source = await seed("classification-allof-source", {
+        type: "object",
+        properties: {
+          values: {
+            allOf: [
+              { type: "array", items: { type: "number" } },
+              { minItems: 1 },
+            ],
+          },
+          title: { type: "string" },
+        },
+        required: ["values"],
+      }, { values: [1], title: "Visible" });
+
+      const schema = await outputSchemaOf(source, {
+        type: "object",
+        properties: { values: { type: "array", items: true }, title: true },
+      });
+
+      // A conjunction constrains one value from several members at once, which
+      // is not a shape this derivation can state. Declining to require costs a
+      // key that would have survived; requiring wrongly costs the whole read.
+      expect((schema as Record<string, unknown>).required).toBeUndefined();
+    });
+
     it("returns the object without a source-required array whose items the caller narrowed to a mismatched scalar", async () => {
       const source = await seed("classification-item-mismatch-source", {
         type: "object",

--- a/packages/cli/test/projection-key-classification.test.ts
+++ b/packages/cli/test/projection-key-classification.test.ts
@@ -722,12 +722,11 @@ describe("projection-key-classification", () => {
     };
 
     it("derives `required` for every projected property where the source's own root is a `$ref`", async () => {
-      // A root spelled as a reference fails differently from a referenced
-      // child: nothing below it resolves at all, so every projected property
-      // loses its guarantee at once. The value still reads in simple cases,
-      // which is what makes this invisible at the call site — the output
-      // schema is weakened, and a consumer downstream of it sees required
-      // data as optional.
+      // A root spelled as a reference is followed like any other, so the
+      // target's own `required` reaches every projected property beneath it
+      // rather than none of them. Distinct from a referenced child because
+      // one unresolved hop here would strand the whole schema, not one
+      // position — which is why the case is pinned separately.
       expect(
         await derivedRequired({
           $ref: "#/$defs/Board",

--- a/packages/cli/test/projection-key-classification.test.ts
+++ b/packages/cli/test/projection-key-classification.test.ts
@@ -6,9 +6,11 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { ANNOTATION_KEYS } from "@commonfabric/piece/schema-compatibility";
 import {
   deriveSelectedValue,
+  outputSchemaWithSourceRequired,
   parseSelectionProjection,
   PROJECTION_ANNOTATION_EXCEPTIONS,
   projectionKeyTier,
+  TOLERATED_PROJECTION_KEYS,
 } from "../lib/cell-selection.ts";
 
 const signer = await Identity.fromPassphrase(
@@ -38,8 +40,20 @@ const CONSULTED = [
   "uniqueItems",
 ];
 
-/** A tolerated keyword, beside a value of the right JSON type for it. */
-const TOLERATED_VALUES: ReadonlyArray<[string, unknown]> = [
+/**
+ * A value each tolerated keyword is probed with — one the key could plausibly
+ * disturb a read by carrying, since a probe the runner would ignore whatever
+ * the tier said proves nothing.
+ *
+ * This is a fixture, not a registry. The keys the inertness loop walks are
+ * derived from {@link TOLERATED_PROJECTION_KEYS}, and a tier T key missing
+ * from here fails rather than being skipped: membership in `ANNOTATION_KEYS`
+ * makes a keyword a *candidate*, and that carrying it changes nothing is a
+ * separate obligation discharged against the runner, per key. A loop over its
+ * own hard-coded list would carry a newly-admitted keyword across the read
+ * boundary and never test it — which is how `$comment` got in.
+ */
+const TOLERATED_PROBE_VALUES = new Map<string, unknown>([
   // `$comment` carries the value the runner reserves as a control marker,
   // which is the only value of it that could disturb a read.
   ["$comment", "emptyProperties"],
@@ -51,7 +65,7 @@ const TOLERATED_VALUES: ReadonlyArray<[string, unknown]> = [
   ["tags", ["a tag"]],
   ["tier", "wrapper"],
   ["title", "A title"],
-];
+]);
 
 /** Every key in keyword position anywhere in `schema`. */
 function keywordsIn(schema: unknown, into = new Set<string>()): Set<string> {
@@ -193,7 +207,7 @@ describe("projection-key-classification", () => {
       for (const key of CONSULTED) {
         expect(projectionKeyTier(key)).toBe("consulted");
       }
-      for (const [key] of TOLERATED_VALUES) {
+      for (const key of TOLERATED_PROJECTION_KEYS) {
         expect(projectionKeyTier(key)).toBe("tolerated");
       }
       for (const key of ["propertes", "pattern", "minLength", "format"]) {
@@ -275,6 +289,28 @@ describe("projection-key-classification", () => {
   });
 
   describe("a tier T key the caller wrote", () => {
+    it("has a probe value for every keyword the tier admits", () => {
+      const undischarged = [...TOLERATED_PROJECTION_KEYS]
+        .filter((key) => !TOLERATED_PROBE_VALUES.has(key))
+        .map((key) =>
+          `${key}: tier T admits this keyword, and nothing has shown that ` +
+          "carrying it changes no read. Add a value it could plausibly " +
+          "disturb to TOLERATED_PROBE_VALUES and watch the read below come " +
+          "back unchanged. Membership in ANNOTATION_KEYS makes a keyword a " +
+          "candidate; inertness is a separate obligation, discharged per key " +
+          "against the runner, and `$comment` is in the tree because nobody " +
+          "discharged it."
+        );
+      expect(undischarged).toEqual([]);
+
+      // The other direction: a probe value for a keyword the tier no longer
+      // admits is a fixture nothing walks, and it would quietly stop covering
+      // the key it was written for.
+      const stranded = [...TOLERATED_PROBE_VALUES.keys()]
+        .filter((key) => !TOLERATED_PROJECTION_KEYS.has(key));
+      expect(stranded).toEqual([]);
+    });
+
     it("returns what the same projection returns without it", async () => {
       const source = await seed("classification-tier-t-source", {
         type: "object",
@@ -287,11 +323,13 @@ describe("projection-key-classification", () => {
       });
       expect(baseline).toEqual({ title: "Visible" });
 
-      for (const [key, value] of TOLERATED_VALUES) {
+      // Derived from the tier, so a keyword admitted to `ANNOTATION_KEYS`
+      // tomorrow is read through here without anyone remembering to add it.
+      for (const key of TOLERATED_PROJECTION_KEYS) {
         expect(
           await read(source, {
             type: "object",
-            properties: { title: { [key]: value } },
+            properties: { title: { [key]: TOLERATED_PROBE_VALUES.get(key) } },
           }),
         ).toEqual(baseline);
       }
@@ -459,6 +497,61 @@ describe("projection-key-classification", () => {
       expect((schema as Record<string, unknown>).required).toEqual(["topic"]);
     });
 
+    it("carries a source-required array into the output schema where a `$ref` names it", async () => {
+      const source = await seed("classification-ref-source", {
+        type: "object",
+        properties: {
+          values: { $ref: "#/$defs/Values" },
+          title: { type: "string" },
+        },
+        required: ["values"],
+        $defs: { Values: { type: "array", items: { type: "number" } } },
+      }, { values: [1], title: "Visible" });
+
+      const schema = await outputSchemaOf(source, {
+        type: "object",
+        properties: { values: { type: "array", items: true }, title: true },
+      });
+
+      expect((schema as Record<string, unknown>).required).toEqual(["values"]);
+    });
+
+    it("carries a source-required array into the output schema where a `$ref` below the root names it", async () => {
+      const source = await seed("classification-ref-depth-source", {
+        type: "object",
+        properties: {
+          topic: {
+            type: "object",
+            properties: {
+              values: { $ref: "#/$defs/Values" },
+              name: { type: "string" },
+            },
+            required: ["values"],
+          },
+          title: { type: "string" },
+        },
+        $defs: { Values: { type: "array", items: { type: "number" } } },
+      }, { topic: { values: [1], name: "a" }, title: "Visible" });
+
+      const schema = await outputSchemaOf(source, {
+        type: "object",
+        properties: {
+          topic: {
+            type: "object",
+            properties: { values: { type: "array", items: true }, name: true },
+          },
+          title: true,
+        },
+      });
+
+      // The reference names the ROOT document's `$defs` from two levels down,
+      // so the walk has to carry the document rather than the subtree it is
+      // standing in.
+      const topic = (schema as { properties: Record<string, unknown> })
+        .properties.topic as Record<string, unknown>;
+      expect(topic.required).toEqual(["values"]);
+    });
+
     it("derives no `required` for a position whose container the source spells under `allOf`", async () => {
       const source = await seed("classification-allof-source", {
         type: "object",
@@ -541,6 +634,132 @@ describe("projection-key-classification", () => {
           },
         }),
       ).toEqual({ rows: [{ name: "a" }], title: "Visible" });
+    });
+  });
+
+  describe("a `$ref` the derivation cannot follow", () => {
+    /**
+     * These reach {@link outputSchemaWithSourceRequired} directly rather than
+     * through a read. The runner resolves a source schema's references eagerly
+     * — `resolveCfcSchemaRefsOrThrow` — so a source carrying an unresolvable
+     * reference or a circle with no base case fails the read outright, before
+     * any derivation is consulted. That is behavior this change neither
+     * introduces nor alters, and asserting through a read would pin it instead
+     * of the question here: what the derivation does when a reference gives it
+     * nothing.
+     */
+    async function derivedRequired(
+      source: JSONSchema,
+      projection: unknown,
+    ): Promise<unknown> {
+      const parsed = await parseSelectionProjection(JSON.stringify(projection));
+      const derived = outputSchemaWithSourceRequired(
+        parsed.schema,
+        source,
+        source,
+      );
+      return (derived as Record<string, unknown>).required;
+    }
+
+    const arrayProjection = {
+      type: "object",
+      properties: { values: { type: "array", items: true }, title: true },
+    };
+
+    it("derives `required` for every projected property where the source's own root is a `$ref`", async () => {
+      // A root spelled as a reference fails differently from a referenced
+      // child: nothing below it resolves at all, so every projected property
+      // loses its guarantee at once. The value still reads in simple cases,
+      // which is what makes this invisible at the call site — the output
+      // schema is weakened, and a consumer downstream of it sees required
+      // data as optional.
+      expect(
+        await derivedRequired({
+          $ref: "#/$defs/Board",
+          $defs: {
+            Board: {
+              type: "object",
+              properties: {
+                values: { type: "array", items: { type: "number" } },
+                title: { type: "string" },
+              },
+              required: ["values", "title"],
+            },
+          },
+        }, arrayProjection),
+      ).toEqual(["values", "title"]);
+    });
+
+    it("derives no `required` for a position whose `$ref` names nothing in the document", async () => {
+      // A reference that does not resolve proves nothing, and proving nothing
+      // declines to require. Resolving optimistically would require a position
+      // whose shape the reader never established.
+      expect(
+        await derivedRequired({
+          type: "object",
+          properties: {
+            values: { $ref: "#/$defs/Missing" },
+            title: { type: "string" },
+          },
+          required: ["values"],
+          $defs: { Values: { type: "array", items: { type: "number" } } },
+        }, arrayProjection),
+      ).toBeUndefined();
+    });
+
+    it("derives no `required` for a position whose `$ref` chain closes a circle", async () => {
+      // Returning at all is half of what this pins; the other half is that a
+      // circle proves no container.
+      expect(
+        await derivedRequired({
+          type: "object",
+          properties: {
+            values: { $ref: "#/$defs/Left" },
+            title: { type: "string" },
+          },
+          required: ["values"],
+          $defs: {
+            Left: { $ref: "#/$defs/Right" },
+            Right: { $ref: "#/$defs/Left" },
+          },
+        }, arrayProjection),
+      ).toBeUndefined();
+    });
+
+    it("derives no `required` for a position whose union refers back to itself", async () => {
+      expect(
+        await derivedRequired({
+          type: "object",
+          properties: {
+            values: { $ref: "#/$defs/Loop" },
+            title: { type: "string" },
+          },
+          required: ["values"],
+          $defs: {
+            Loop: { anyOf: [{ $ref: "#/$defs/Loop" }, { type: "string" }] },
+          },
+        }, arrayProjection),
+      ).toBeUndefined();
+    });
+
+    it("derives `required` for a `$ref` chain that resolves through two hops", async () => {
+      // The negative beside the three above: a chain the resolver can follow
+      // still proves what it names, so "never follow a reference" does not
+      // pass this block.
+      expect(
+        await derivedRequired({
+          type: "object",
+          properties: {
+            values: { $ref: "#/$defs/Alias" },
+            title: { type: "string" },
+          },
+          required: ["values"],
+          $defs: {
+            Alias: { $ref: "#/$defs/Values" },
+            Values: { type: "array", items: { type: "number" } },
+          },
+        }, arrayProjection),
+      ).toEqual(["values"]);
     });
   });
 

--- a/packages/piece/deno.jsonc
+++ b/packages/piece/deno.jsonc
@@ -12,6 +12,7 @@
   },
   "exports": {
     ".": "./src/index.ts",
-    "./ops": "./src/ops/mod.ts"
+    "./ops": "./src/ops/mod.ts",
+    "./schema-compatibility": "./src/schema-compatibility.ts"
   }
 }

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -66,7 +66,19 @@ type ActivePairsByRoot = WeakMap<
   WeakMap<object, WeakMap<object, WeakSet<object>>>
 >;
 
-const ANNOTATION_KEYS = new Set([
+/**
+ * The keywords a schema comparison may ignore: they annotate a schema without
+ * constraining the values it admits, so adding or removing one across a piece
+ * update proves nothing about compatibility either way.
+ *
+ * Exported because a second reader classifies keywords and would otherwise
+ * keep its own copy of this list. What it says is which keywords are
+ * validation-neutral **to this checker**; it is not a statement about what any
+ * other consumer of a schema does with a key, and a reader that acts on one —
+ * the runner reserves three `$comment` values as traversal control markers —
+ * has to settle that against that consumer rather than against this set.
+ */
+export const ANNOTATION_KEYS: ReadonlySet<string> = new Set([
   "$comment",
   "$defs",
   "$id",


### PR DESCRIPTION
## Why

`--schema`'s JSON spelling handed the read boundary the schema a caller
typed. `normalizeProjectionSchema` consulted two denylists and spread every
key in neither into the result, and `resolveProjection` then assigned that
object to `outputSchema` — the schema `deriveSelectedValue` re-asserts on
`result.key("value")` and the runner acts on.

Three failures came out of that, and they are not variations of one:

| A caller writes | What came back | Exit |
| --- | --- | --- |
| `{"propertes":{"title":true}}` | nothing | 0 |
| `{"type":"object","propertes":{"title":true}}` | **the whole object**, every field | 0 |
| `{"type":"object","required":["secret"],"properties":{"title":true}}` | a refusal naming neither the key nor the position | 1 |

Measured on this branch's parent, against a source holding `title` and
`secret`:

```
{"type":"object","propertes":{"title":true}}
  -> {"secret":"not asked for","title":"Visible"}
{"propertes":{"title":true}}
  -> {}
```

The widening one is disclosure-shaped: the caller's schema is the only thing
standing between a value and its reader, and a single transposed letter
removes it while reporting success. The third is [#5734], where a `required`
the caller spelled correctly reaches a boundary whose traverser voids an
object missing a required property, emptying the whole selection.

This is step 12 / item 2 of the verbs arc. Its design —
[projection keys, and the schema a read is handed](https://github.com/commontoolsinc/labs/blob/feat/b4-step12-projection-keys/docs/history/plans/projection-key-classification.md)
(#5753) — ships here and is archived in this change. Step 9 (#5701) is the
prior step that also changed how a mask reduces; step 12a is #5835.

## What Changed

**The reader constructs the outgoing schema rather than forwarding one.**
Four tiers, applied in `normalizeProjectionSchema`:

- **Honored** — `type`, `properties`, `items`, `additionalProperties`,
  `$link`. Reconstructed into the schema the reader hands on.
- **Consulted** — `required`, `minProperties`, `maxProperties`, `minItems`,
  `maxItems`, `uniqueItems`. Read by `impliedProjectionType` to decide which
  container an untyped position names, then dropped. They change the read, so
  "tolerated" would be a lie about what they do.
- **Tolerated** — derived from `ANNOTATION_KEYS`
  (`packages/piece/src/schema-compatibility.ts`, now exported behind a
  `./schema-compatibility` subpath) less `default`, `$defs` and `definitions`,
  which projection refuses on purpose. Membership there is a *candidate* list;
  inertness is discharged per key against the runner, and `$comment`, `$id`
  and `$schema` fail it — `schema-view.ts` reserves three `$comment` values as
  control markers and `traverse.ts` acts on two of them, so a carried
  `$comment` is caller-forgeable control flow at the read boundary. Those
  three are accepted and dropped.
- **Refused** — everything else, by name, with the position it sat at, the
  honored vocabulary, and the keyword it is one edit from.

**The `required` that crosses the boundary is the reader's own**, derived
from the source rather than carried from the caller, and filtered by whether
anything the caller wrote inside a property can reject the property itself:

- no stated type → stays (the constructed child is the unprojected one)
- a scalar `type` → drops
- an object → stays; each descendant's own derived `required` recurses
- an array → follows the **element**: wildcard `items` stays, object `items`
  stays, scalar `items` type drops, because one rejected element voids the
  array around it
- `false` → drops

**Both container answers stand on the source proving that container**, not on
its admitting one. `{"type":["array","string"]}` holds whichever branch was
stored; where it holds the string, a caller's array projection rejects it and
the property is omitted, so a `required` retained on the strength of the array
branch voids the object — [#5734]'s failure mode arriving through the rule
meant to prevent it. `sourceProvesContainer` therefore requires the source to
declare that container and nothing else. The same union has a second spelling
that never reaches `schemaTypes`, so `anyOf`/`oneOf` prove a container only
where every branch does, an undeclared position proves nothing, and `allOf` is
refused outright rather than reasoned through — a conjunction constrains one
value from several members at once, which this derivation cannot state
(#5761).

**A `$ref` is followed before the container is proved.** A source spelling its
shape as `{"$ref": "#/$defs/Thing"}` — the ordinary spelling for a named
interface — otherwise proves nothing, and every projected `required` it should
carry is dropped. The value still reads in simple cases, which is what makes
that invisible at the call site: the output schema is weakened, and a consumer
downstream of it sees required data as optional. A root spelled as a reference
fails harder, since nothing below it resolves at all. `resolvedSourceNode`
follows the chain with the **canonical CFC resolver** — `resolveCfcSchemaRef`,
`cfcSchemaChildRoot`, `isEmbeddedCfcSchemaRef`, the same three `derivePosition`
uses — one hop at a time, threading the local-ref scope beside the schema
because the walk re-roots on every descent and a child three levels in still
spells `#/$defs/Thing` against a document its own subtree cannot see. It fails
closed: a reference that does not resolve, and one repeated in its own scope,
resolve to nothing and prove nothing.

Source children are read as the document writes them rather than through
`ContextualFlowControl.schemaAtPath`, which resolves references eagerly and
with no guard against a circle — a self-referential definition overflows the
stack inside it, before any caller's own guard can run. What bounds the
recursion is the guard on the schema as the document writes it: a branch is
drawn from a `node.anyOf` array, resolution spreads shallowly, and a document
holds finitely many such objects.

Declining to require is always safe; requiring wrongly costs the whole read.
Every conservative branch above takes that trade deliberately.

Ceasing to carry the caller's `required` does not fix [#5734] by itself; it
relocates it onto a key no caller wrote. The two are settled together.

`--select` is untouched: its projection is built by
`conciseProjectionSchema` from paths the CLI parsed itself, which writes
containers and `true` leaves and no scalar types, so every position it
produces already falls under the rules above.

## Accepted risk, recorded

**Keys this surface previously accepted and ignored — `format`, `pattern`,
`minLength` and their neighbours — are now refused.** The repository scan below
finds no caller of any of them, but it cannot see callers outside this
repository, and those break loudly rather than silently. That is the accepted
trade and not an oversight: a constraint the reader never enforced was already
not doing what the caller who wrote it believed, and a loud failure is the only
version of that a caller can act on. A command that ran only because a key was
silently dropped now fails.

## Test plan

`packages/cli/test/projection-key-classification.test.ts`, 42 steps, one per
criterion in the design's "What done looks like" plus the union, composition
and reference regression cases. Each was demonstrated red against a named
implementation before being made green:

| Mutant | Red steps | What it reds |
| --- | --- | --- |
| M0 — this branch's parent | 17 | the refusal, the position, the vocabulary, the near miss, both misspelling reads, tier C inference (×2), tier C non-propagation, [#5734], `$comment`, and every output-schema `required` assertion — including both container-only negatives and both `$ref` positives, which is what stops "never derive" from passing |
| M1 — the derivation extended with its projection-membership filter intact | 9 | every source-`required` read, `undefined` where an object was asked for |
| M2 — the two containers treated as one case | 6 | the source-required array of scalars and every fail-closed case |
| M3 — the output schema built from the mask | 8 | the two mask criteria plus every source-`required` read |
| M4 — tier T carried wholesale, membership taken for inertness | 1 | `$comment`, alone |
| M5 — the derivation not descending `items` | 0 | nothing — recorded because it is the shape the design warned about and it is **not** what the item-object criterion catches |
| M6 — the survival rule recursing through `properties` but not `items` | 1 | the source-required array of objects, alone |
| M7 — the container check asking whether the source *admits* the container | 6 | the mixed-`type` union, the `anyOf` union, the `allOf` refusal, and the three fail-closed reference cases |
| M8 — the union handled in its `type` spelling only | 3 | the `anyOf` union, the `allOf` refusal and the self-referential union, while passing the mixed-`type` one — which is why the second spelling is its own test |
| M9 — reference resolution failing **open** | 2 | the unresolvable reference and the reference chain that closes a circle — both the fail-closed direction, and nothing else |
| M10 — a keyword added to `ANNOTATION_KEYS`, the way #5746 proposes to add `demand` | 1 | the tier T probe-value derivation, alone |
| M11 — the derivation not following a reference at all | 4 | all four reference positives, including the root-is-a-`$ref` case |
| M12 — `default` dropped from `FORBIDDEN_PROJECTION_KEYS` | 1 | the exception-refusal assertion, alone |

M1 and M7 fail the way the design predicts: `undefined` where
`{"title":"Visible"}` was asked for. M11's root case reports
`expected ["values","title"], got undefined`. M6, M8, M9, M10, M11 and M12
each red a criterion the others do not.

M10 is the one worth reading twice. Before review caught it, simulating a new
annotation keyword left all steps passing — the inertness loop walked a
hard-coded list, so membership was derived and inertness was checked only for
keys someone had typed. The loop now derives its keys from the tolerated set
and fails when one has no probe value, with a message that is an instruction:

```
demand: tier T admits this keyword, and nothing has shown that carrying it
changes no read. Add a value it could plausibly disturb to
TOLERATED_PROBE_VALUES and watch the read below come back unchanged.
Membership in ANNOTATION_KEYS makes a keyword a candidate; inertness is a
separate obligation, discharged per key against the runner, and `$comment` is
in the tree because nobody discharged it.
```

M12 is the second of that shape. `PROJECTION_ANNOTATION_EXCEPTIONS`'s comment
claimed every member is refused *by one of the two denylists*, and nothing
asserted it. Asserting the tier alone would not have closed it: with `default`
removed from `FORBIDDEN_PROJECTION_KEYS`, `projectionKeyTier("default")` still
returns `"refused"`, because the exception set is what keeps it out of tier T.
Only the answer changes, so the message is what the test pins — and M12 now
reds with the evidence, `default: … "default" is not a projection schema
keyword`, the fall-through's answer standing in for the denylist's.

Two cases are asserted against the derivation directly rather than through a
read: the runner resolves a source schema's references eagerly, so a source
carrying an unresolvable reference or a circle with no base case fails the read
outright — behaviour this change neither introduces nor alters. Asserting
through a read would pin that instead of the question at hand.

The output-schema assertions read `outputCell.schema` off the cell
`deriveSelectedValue` re-asserts the shape on, not a selector captured from
the storage provider — those are two schemas and an implementation that kept
the caller's `required` on the source read while dropping it from the output
schema would pass an assertion over the wrong one.

### Coverage

Measured locally the way the gate measures it — `DENO_COVERAGE_DIR` over
`packages/cli`'s suite, through `tasks/write-coverage-lcov.ts` — the four lines
were `cell-selection.ts:2048`, `:2118`, `:2134` and `:2135`. Three are now
covered and one is gone:

- **2048**, the embedded-reference re-rooting, by a source referencing the
  runner's vnode document, whose own root is `{"$ref": "#/$defs/VNode"}` — a
  name that exists only there, so the line is the difference between deriving
  `required` and deriving none.
- **2134-2135**, a union proving its container, by the positive of the union
  rule: an `anyOf` every branch of which is an array. Every union in the suite
  until now failed to prove.
- **2118** is **removed rather than covered**, because it could not fire. It
  guarded the *resolved* node, and `resolveCfcSchemaRef` returns a fresh view
  whenever the target carries a reference — which is exactly the case a circle
  is made of — so no two visits to one definition share an identity. The guard
  that bounds the recursion is the one on the schema as written, and the
  comment now says so.

Re-measured after: `packages/cli/lib/cell-selection.ts` has **0 uncovered
lines**, and a whole-package diff of the two reports shows `delta=-4` with the
only moved lines being those four. No `ACCEPT_COVERAGE_DEBT` marker.

## Blast radius

Corpus, re-measured on this branch's parent and again at head, unchanged:
**four** keywords in keyword position across every `--schema` argument in the
tree — `type`, `properties`, `items`, `$link` — all tier H, no tier C, T or R
key used by any command. That corpus measures caller-written arguments; the
reference work changed the derivation's reach over **source** schemas, which it
does not cover. Measured separately, 75 files in the tree declare a local
`#/$defs` reference, 500 in total, and every one of those shapes went from
proving no container to proving what it names.

## Documentation

`packages/cli/README.md` gains the keyword classification, the `required`
derivation, its container-proof qualification and its reference behaviour.

The design is **archived** in this change, per `docs/README.md`'s rule that a
design becomes historical when it ships and the document describes the change
rather than the system. It does: its problem table states behaviour measured at
`5ca4c1296` that no longer exists, and both questions its "not settled" section
left open are answered by the code that landed. The one part still written
forward — section 3, on what a refusal says and where item 12's could point a
caller — has no remaining reader: item 12 is built (#5835), and it worked from
the item's own section in the verbs plan and matched this arc's refusal
vocabulary by reading this PR, citing the design nowhere. Moved to
`docs/history/plans/`, metadata header added, `INDEX.md` entry added, and the
three inbound links repointed (`docs/plans/README.md`'s entry removed, since
that file indexes live plans; two in `verbs-implementation.md` repointed).

`docs/plans/verbs-implementation.md` is touched by #5835 as well, in different
rows.

Gates, all exit 0: `cd packages/cli && deno task test` (1677 + 1 + 174
passed), `cd packages/piece && deno task test` (37 passed), root
`deno fmt --check`, `deno lint`, `deno task check`, `check-no-waitfor`,
`check-docs`, `check-skill-facts`, `check-conflict-markers`,
`check-docs-history-index`, `docs-links --orphan`,
`check-single-copy-deps`, `check-unused-deps`, `check-deno-pins`.

[#5734]: https://github.com/commontoolsinc/labs/issues/5734

🤖 Generated with [Claude Code](https://claude.com/claude-code)