### PR TITLE
docs(cli): American spelling through the `cf view` viewer

### DIFF
--- a/packages/cli/commands/view.ts
+++ b/packages/cli/commands/view.ts
@@ -9,7 +9,7 @@ const description = cliText(
 A less-like viewer for the dense output of '--show-transformed' and saved source
 files. Transformed TypeScript is parsed with the same parser the transformer
 uses, so blocks, closures, schemas, type positions and Common Fabric builders
-(pattern/lift/handler/…) are coloured exactly as the compiler sees them.
+(pattern/lift/handler/…) are colored exactly as the compiler sees them.
 Markdown, JSON, JSONC, YAML and Python files use syntax highlighting selected
 from language metadata. Python interpreter shebangs select Python. Node, Deno
 and Bun shebangs select the TypeScript and JavaScript language family.
@@ -23,13 +23,13 @@ explicitly with '--language' or supply a virtual name with '--filename'. Either
 option suppresses unified-diff auto-detection; use '--diff' instead for a diff.
 The Markdown language also has a rendered view that formats headings, lists,
 quotes, tables, links, emphasis and code while retaining source line positions.
-Source views remain verbatim and add colour only.
+Source views remain verbatim and add color only.
 
 Raw unified diffs are detected automatically when their structural header is
 the first nonblank line. Standard Git commit output is detected from its complete
 header. Binary detection examines bytes; other source content is not used to
 guess a language. Piping 'git diff' in gives added and removed lines their
-tints, full syntax colour, a structure tree of the code each hunk touches, and
+tints, full syntax color, a structure tree of the code each hunk touches, and
 the semantic features (inferred types, go-to-definition) answered against the
 CURRENT state of the workspace files the diff names.
 
@@ -46,7 +46,7 @@ KEYS (press ? in the viewer for the full list):
   Enter info card · in it: ↑/↓ pick a reference · Enter opens it · z reveals it
   v source/rendered · t look up a definition · # line numbers · \\ wrap mode · q quit
 
-When stdout is not a terminal (piped/redirected) it prints the colourised text
+When stdout is not a terminal (piped/redirected) it prints the colorized text
 and exits, like less.`,
 );
 
@@ -59,7 +59,7 @@ export const view = new Command()
   )
   .example(
     cliText(`git diff origin/main | cf view`),
-    "View a diff with syntax colour, structure navigation and types.",
+    "View a diff with syntax color, structure navigation and types.",
   )
   .example(
     cliText(`cf view transformed.ts`),
@@ -67,12 +67,12 @@ export const view = new Command()
   )
   .option(
     "--color <when:string>",
-    "Colourise: always | auto | never (auto = when stdout is a TTY).",
+    "Colorize: always | auto | never (auto = when stdout is a TTY).",
     { default: "auto" },
   )
   .option(
     "--plain",
-    "Do not launch the interactive pager; print colourised text and exit.",
+    "Do not launch the interactive pager; print colorized text and exit.",
   )
   .option(
     "-n, --line-numbers",

--- a/packages/cli/lib/view/actions.ts
+++ b/packages/cli/lib/view/actions.ts
@@ -238,7 +238,7 @@ export function nodeAtLine(
 }
 
 /**
- * Frame a node's source range nicely: if the whole node fits on screen, centre
+ * Frame a node's source range nicely: if the whole node fits on screen, center
  * it vertically; otherwise put its top line about a tenth of the way down so
  * there is a little lead-in but most of the screen shows the node. Used by `z`.
  */

--- a/packages/cli/lib/view/ansi.ts
+++ b/packages/cli/lib/view/ansi.ts
@@ -1,7 +1,7 @@
 /**
  * Minimal ANSI escape-sequence helpers for the `cf view` pager.
  *
- * Self-contained (no dependencies) so the viewer stays lean. Colours use
+ * Self-contained (no dependencies) so the viewer stays lean. Colors use
  * 24-bit truecolor (`\x1b[38;2;r;g;bm`), which every modern macOS/Linux
  * terminal we target supports. When the output stream is not a TTY (or the
  * user passes `--no-color`) styling is suppressed at the call site, never here.
@@ -99,7 +99,7 @@ export const term = {
   moveTo(row: number, col: number): string {
     return `${CSI}${row};${col}H`;
   },
-  /** Set the terminal's default background colour (OSC 11). This is the colour
+  /** Set the terminal's default background color (OSC 11). This is the color
    * the terminal fills the area outside the character grid with — the sub-cell
    * padding below the last row and beside the last column — which no cell can
    * reach. */
@@ -107,6 +107,6 @@ export const term = {
     const h = rgb.map((c) => c.toString(16).padStart(2, "0")).join("");
     return `${OSC}11;#${h}${BEL}`;
   },
-  /** Restore the terminal's own default background colour (OSC 111). */
+  /** Restore the terminal's own default background color (OSC 111). */
   resetDefaultBg: `${OSC}111${BEL}`,
 };

--- a/packages/cli/lib/view/card.ts
+++ b/packages/cli/lib/view/card.ts
@@ -1,11 +1,11 @@
 /**
- * Builds the Enter "info card": a structured, colourised summary of a structure
+ * Builds the Enter "info card": a structured, colorized summary of a structure
  * node assembled from its extracted {@link NodeMeta}, the navigation tree, and
  * cross-references — i.e. information that is NOT obvious from the raw source.
  * The verbatim source is returned alongside so the overlay can toggle to it.
  *
  * Pure: produces model {@link Line}s (the same shape the renderer already draws)
- * with token classes chosen so the existing theme colours everything coherently.
+ * with token classes chosen so the existing theme colors everything coherently.
  */
 import type {
   Document,
@@ -177,7 +177,7 @@ export function buildPeekCard(
 }
 
 /** The card title. A generic AST node leads with its AST kind(s) rather than
- * the internal "node" label; a recognised shape keeps its structure kind. */
+ * the internal "node" label; a recognized shape keeps its structure kind. */
 function cardTitle(node: StructureNode): string {
   if (node.kind === "node" || node.kind === "comment") {
     const k = node.astKinds && node.astKinds.length > 0
@@ -407,7 +407,7 @@ function importDetail(
 /**
  * The meaningful descendants for the outline: declarations, builders, control
  * flow and the like, hoisted up through the generic expression/wrapper nodes
- * that now sit between them in the full-AST tree. So the card summarises a
+ * that now sit between them in the full-AST tree. So the card summarizes a
  * node's real sub-structure rather than listing a lone `VariableDeclarationList`
  * or every sub-expression.
  */
@@ -811,7 +811,7 @@ function enclosingNode(
 
 const INLINE_MAX = 56;
 
-/** A labelled schema: `input  { token: string }` inline, or a heading + block. */
+/** A labeled schema: `input  { token: string }` inline, or a heading + block. */
 function schemaSection(label: string, schema: SchemaMeta): Line[] {
   const inline = inlineSchemaParts(schema);
   const labelPart: Part = [`${label}  `, "comment"];

--- a/packages/cli/lib/view/diffdoc.ts
+++ b/packages/cli/lib/view/diffdoc.ts
@@ -69,7 +69,7 @@ export interface DiffWorkspace {
 export function realWorkspace(cwd: string): DiffWorkspace {
   const repoRoot = findRepoRoot(cwd);
   const bases = repoRoot && repoRoot !== cwd ? [repoRoot, cwd] : [cwd];
-  // The bound is physical, not lexical: paths are canonicalised before the
+  // The bound is physical, not lexical: paths are canonicalized before the
   // containment check, so an in-repo symlink pointing outside the workspace
   // cannot smuggle an outside file in.
   const realBases = bases.map((b) => safeRealPath(b) ?? b);
@@ -113,7 +113,7 @@ export function realWorkspace(cwd: string): DiffWorkspace {
       for (const base of bases) {
         const abs = join(base, path);
         if (!bounded(abs)) continue; // `..` escapes and symlinks out: blocked
-        // bounded() canonicalised abs via realPathSync, so statSync resolves;
+        // bounded() canonicalized abs via realPathSync, so statSync resolves;
         // only the file-vs-directory check remains. read() guards the contents.
         if (Deno.statSync(abs).isFile) return abs;
       }
@@ -831,7 +831,7 @@ export function buildDiffDocument(
 
   for (const [fileIndex, file] of model.files.entries()) {
     // The language is chosen once per file, from its path, and every operation
-    // on the file — parsing the workspace copy, colouring fragments, projecting
+    // on the file — parsing the workspace copy, coloring fragments, projecting
     // structure — dispatches through it. A rename can change the extension, so
     // the old and new sides resolve separately.
     const newLanguage = languageForFile(file.newPath ?? file.oldPath);
@@ -999,7 +999,7 @@ interface FragmentLine {
   code: string;
   /** Whether decoding removed a BOM before parsing this source line. */
   omitsUtf8Bom?: boolean;
-  /** Context can establish old-side state without replacing new-side colours. */
+  /** Context can establish old-side state without replacing new-side colors. */
   render?: boolean;
 }
 
@@ -1021,7 +1021,7 @@ interface HunkCtx {
   definitions: Map<string, Definition[]>;
   hunks: DiffHunkInfo[];
   /** The languages of the new and old sides (they differ across a rename that
-   * changes the extension); each colours its side's fragments and, for the new
+   * changes the extension); each colors its side's fragments and, for the new
    * side, projects the hunk's structure. */
   newLanguage: Language;
   oldLanguage: Language;

--- a/packages/cli/lib/view/diffedit.ts
+++ b/packages/cli/lib/view/diffedit.ts
@@ -126,7 +126,7 @@ export function diffSource(
   }
 
   // Editability is decided against the current diff structure. Re-parsing the
-  // whole buffer on each edit key is wasteful, so memoise the parse and the
+  // whole buffer on each edit key is wasteful, so memoize the parse and the
   // message scan by the text they came from; the several guard calls within one
   // keystroke reuse them.
   let memoText: string | null = null;
@@ -239,9 +239,9 @@ export function diffSource(
     parse: (text, lineEndings) =>
       reparse(ws, text, cache, completeFiles, "source", lineEndings),
     ...renderedView,
-    // Live highlighting recolours the lines an edit changes and reuses the seed
-    // (buildDiffDocument's colours, including the file/hunk headers and the
-    // workspace-file syntax highlighting) for the rest. Languages whose colour
+    // Live highlighting recolors the lines an edit changes and reuses the seed
+    // (buildDiffDocument's colors, including the file/hunk headers and the
+    // workspace-file syntax highlighting) for the rest. Languages whose color
     // can cross lines re-highlight the complete file. The full parse on
     // pause restores workspace-verified spans across the edit.
     createHighlighter: (text, seed, lineEndings) =>
@@ -783,7 +783,7 @@ function hunkFooting(
   // which an inserted line does not extend), not the display `@@` counts (which
   // an insert grows past the file range). Insertion positions and the global
   // index come from the parse. Clamp how far context may grow by the
-  // neighbouring hunks of the SAME file, so an expansion never overlaps another
+  // neighboring hunks of the SAME file, so an expansion never overlaps another
   // hunk's file range — that would splice the two ranges into each
   // other (silently dropping edits or duplicating lines) and malform the diff.
   const range = hunks[index];
@@ -815,7 +815,7 @@ function hunkFooting(
       up: Math.max(0, rangeStart - prevEnd),
       down: Math.max(0, nextStart - downFrom),
       // Nothing left is the file running out only where the range reaches its
-      // edge; otherwise it is the neighbouring hunk in the way.
+      // edge; otherwise it is the neighboring hunk in the way.
       atFileTop: rangeStart <= 0,
       atFileBottom: downFrom >= fileLen,
     },
@@ -981,7 +981,7 @@ function expandContext(
   // last body line (down), both in current-text coordinates.
   const insertedAt = up ? target.headerLine + 1 : target.endLine + 1;
   const insertedRows = ctx.length;
-  // Those lines may have been the last between this hunk and its neighbour, in
+  // Those lines may have been the last between this hunk and its neighbor, in
   // which case the two now touch and the header between them describes nothing.
   // The header that goes is the one at the join: this hunk's own when the lines
   // came from above it, the next hunk's when they came from below.
@@ -1200,12 +1200,12 @@ function applyExpansion(
 }
 
 /**
- * An incremental highlighter for a diff. It recolours only the lines an edit
+ * An incremental highlighter for a diff. It recolors only the lines an edit
  * changes (found by a common prefix/suffix of the line arrays) and keeps `seed`
- * — the colours {@link buildDiffDocument} produced for the unedited text — for
+ * — the colors {@link buildDiffDocument} produced for the unedited text — for
  * every line the edit leaves alone. Edited removed lines use the complete old
  * file's spans. Other edited body lines use a marker-aware single-line parse.
- * A language can ask to re-highlight complete files when its colours depend on
+ * A language can ask to re-highlight complete files when its colors depend on
  * preceding lines. The headers stay in the unchanged prefix or suffix. When no
  * seed is given, the highlighter renders every line itself.
  */
@@ -1272,7 +1272,7 @@ export function createDiffHighlighter(
         s,
       );
       const model = parseDiff(next);
-      const recoloured = newRaw.slice(p, newRaw.length - s).map((l, i) =>
+      const recolored = newRaw.slice(p, newRaw.length - s).map((l, i) =>
         diffLineRender(
           l,
           diffFileNameAt(newRaw, p + i, model),
@@ -1280,7 +1280,7 @@ export function createDiffHighlighter(
         )
       );
       lines = lines.slice(0, p).concat(
-        recoloured,
+        recolored,
         lines.slice(oldRaw.length - s),
       );
       rehighlightTouchedHunks(
@@ -1738,9 +1738,9 @@ function diffLogicalEnd(
 }
 
 /**
- * Render one edited diff line: the marker keeps its diff colour and row tint and
+ * Render one edited diff line: the marker keeps its diff color and row tint and
  * the code after it is highlighted, shifted one column right. Mirrors how the
- * diff document builder paints a line, so a live edit re-colours correctly
+ * diff document builder paints a line, so a live edit re-colors correctly
  * without rebuilding the whole diff.
  */
 function diffLineRender(
@@ -1749,8 +1749,8 @@ function diffLineRender(
   oldSpans?: readonly Span[],
 ): Line {
   if (lineText.length === 0) return { text: "", spans: [] };
-  // A hunk header carries its own colour and its counts change when an edit
-  // grows or shrinks the hunk, so colour it the way the full parse does rather
+  // A hunk header carries its own color and its counts change when an edit
+  // grows or shrinks the hunk, so color it the way the full parse does rather
   // than as a body line.
   if (/^@@ /.test(lineText)) {
     return {

--- a/packages/cli/lib/view/display.ts
+++ b/packages/cli/lib/view/display.ts
@@ -7,8 +7,8 @@
  *     glyph (U+000B → ␋, tab → ␉, ESC → ␛), one column each. Nothing is hidden
  *     and every source code point maps to exactly one display column, so the
  *     column arithmetic the editor relies on is preserved.
- *   - "ansi": runs that parse as ANSI colour (SGR) sequences are consumed and
- *     their colours override the syntax highlighting of the text that follows,
+ *   - "ansi": runs that parse as ANSI color (SGR) sequences are consumed and
+ *     their colors override the syntax highlighting of the text that follows,
  *     until the next sequence or a reset. Every other non-printable is shown as
  *     its Control Pictures glyph.
  *   - "hidden": runs that parse as ANSI control sequences are dropped entirely.
@@ -37,14 +37,14 @@ export function displayModeLabel(mode: DisplayMode): string {
     case "pictures":
       return "control pictures";
     case "ansi":
-      return "ANSI colour";
+      return "ANSI color";
     case "hidden":
       return "hidden";
   }
 }
 
 /** One drawn column: the glyph, the source column it originates from, the token
- * colour of that source column, and an ANSI colour override when one is active
+ * color of that source column, and an ANSI color override when one is active
  * (mode "ansi"). */
 export interface DisplayCell {
   readonly ch: string;
@@ -55,7 +55,7 @@ export interface DisplayCell {
   readonly ansi?: Style;
 }
 
-/** One source code point with its column and token colour. */
+/** One source code point with its column and token color. */
 interface SourcePoint {
   readonly cp: string;
   readonly col: number;
@@ -63,7 +63,7 @@ interface SourcePoint {
 }
 
 /** Expand a line's spans into its code points, each tagged with its column (a
- * code-point index) and the token colour of the span it belongs to. The spans
+ * code-point index) and the token color of the span it belongs to. The spans
  * are gapless and concatenate to the verbatim line, so this reconstructs the
  * whole line. */
 function sourcePoints(line: Line, styler: SpanStyler): SourcePoint[] {
@@ -79,7 +79,7 @@ function sourcePoints(line: Line, styler: SpanStyler): SourcePoint[] {
   return out;
 }
 
-/** Resolves the colour for a span. The default is the editor palette; the
+/** Resolves the color for a span. The default is the editor palette; the
  * overlay passes the dialog palette. */
 export type SpanStyler = (span: Line["spans"][number]) => Style;
 
@@ -185,7 +185,7 @@ export function displayLine(
   }
 }
 
-/** ANSI mode: consume SGR colour sequences and carry their colour forward as an
+/** ANSI mode: consume SGR color sequences and carry their color forward as an
  * override; show every other non-printable as a Control Pictures glyph. */
 function displayAnsi(src: readonly SourcePoint[]): DisplayCell[] {
   const cells: DisplayCell[] = [];
@@ -265,7 +265,7 @@ function isNonPrintableCode(codePoint: number): boolean {
 }
 
 /** Whether `text` holds any non-printable character — the display modes only
- * differ (control pictures vs. ANSI colour vs. hidden) when it does. */
+ * differ (control pictures vs. ANSI color vs. hidden) when it does. */
 export function hasNonPrintable(text: string): boolean {
   for (const cp of text) if (isNonPrintable(cp)) return true;
   return false;
@@ -288,7 +288,7 @@ export function glyphFor(cp: string): string {
 interface CsiMatch {
   /** Number of source code points the whole sequence spans. */
   readonly len: number;
-  /** The final byte, e.g. "m" for a colour (SGR) sequence. */
+  /** The final byte, e.g. "m" for a color (SGR) sequence. */
   readonly final: string;
   /** The parameter bytes between `ESC [` and the final byte. */
   readonly params: string;
@@ -342,7 +342,7 @@ function hasStyle(style: Style): boolean {
     style.underline === true;
 }
 
-/** The 16 standard ANSI colours as RGB (Visual Studio Code's default palette). */
+/** The 16 standard ANSI colors as RGB (Visual Studio Code's default palette). */
 const ANSI_16: readonly Rgb[] = [
   [0, 0, 0],
   [205, 49, 49],
@@ -406,8 +406,8 @@ function applySgr(prev: Style, params: string): Style {
   return st;
 }
 
-/** Read a `38`/`48` extended-colour argument beginning after index `k`: either
- * `5;<n>` (a 256-colour index) or `2;<r>;<g>;<b>` (truecolor). Returns the RGB
+/** Read a `38`/`48` extended-color argument beginning after index `k`: either
+ * `5;<n>` (a 256-color index) or `2;<r>;<g>;<b>` (truecolor). Returns the RGB
  * and how many further parameters it consumed, or null when malformed. */
 function extendedColor(
   codes: readonly number[],
@@ -430,7 +430,7 @@ function byte(n: number): number {
   return Math.max(0, Math.min(255, n | 0));
 }
 
-/** Map a 256-colour palette index to RGB: 0–15 are the standard colours, 16–231
+/** Map a 256-color palette index to RGB: 0–15 are the standard colors, 16–231
  * a 6×6×6 cube, 232–255 a 24-step grayscale ramp. */
 function xterm256(index: number): Rgb {
   const n = byte(index);

--- a/packages/cli/lib/view/editsource.ts
+++ b/packages/cli/lib/view/editsource.ts
@@ -39,7 +39,7 @@ export type RevertScope = "chunk" | "file" | "message" | "all";
  * `removedAt` is the `@@` header a join took out, also a line of the
  * pre-expansion text, or null when nothing joined. Revealing the last file line
  * between two hunks leaves them touching, and a header between lines that are
- * neighbours in the file describes nothing: the two become one hunk.
+ * neighbors in the file describes nothing: the two become one hunk.
  *
  * So a line `n` of the pre-expansion text is afterwards at
  * `n + (n >= insertedAt ? inserted : 0) - (removedAt !== null && n > removedAt ?
@@ -62,7 +62,7 @@ export interface ExpandResult {
 /** How much context a hunk can still reveal each way, and what stops it where it
  * cannot: `atFileTop` / `atFileBottom` say the hunk's range reaches the file's
  * first or last line, so a zero there is the file running out. A zero without
- * one is the neighbouring hunk butting against it, with nothing in between. */
+ * one is the neighboring hunk butting against it, with nothing in between. */
 export interface HunkRoom {
   up: number;
   down: number;
@@ -114,11 +114,11 @@ export interface EditableSource {
   /** Build an incremental highlighter seeded with `text`, for live highlighting
    * whose cost tracks the size of each edit rather than the whole document. The
    * session re-baselines it on the deferred re-parse. When present it is used in
-   * preference to {@link highlight}. `seedLines` is the already-rendered colour
+   * preference to {@link highlight}. `seedLines` is the already-rendered color
    * of `text` (the current document's lines): a source that cannot recompute a
-   * line's colour cheaply on its own — a diff, whose colouring needs the
+   * line's color cheaply on its own — a diff, whose coloring needs the
    * workspace files — reuses it for the unchanged lines so only edited lines are
-   * recoloured. */
+   * recolored. */
   createHighlighter?(
     text: string,
     seedLines?: readonly Line[],

--- a/packages/cli/lib/view/filegateway.ts
+++ b/packages/cli/lib/view/filegateway.ts
@@ -33,7 +33,7 @@ export interface FileGateway {
   list(absDir: string): DirEntry[] | null;
   /** Open a file: its source and decoded buffer, or null on failure. */
   open(absPath: string): { source: EditableSource; text: string } | null;
-  /** Join a directory and a path segment, normalised. */
+  /** Join a directory and a path segment, normalized. */
   join(dir: string, segment: string): string;
   /** The parent directory of a path. */
   parent(path: string): string;

--- a/packages/cli/lib/view/highlight.ts
+++ b/packages/cli/lib/view/highlight.ts
@@ -1,9 +1,9 @@
 /**
- * Turns model {@link Span}s into ANSI-coloured strings. Used both by the
+ * Turns model {@link Span}s into ANSI-colored strings. Used both by the
  * non-interactive print path (`renderLineColored` over every line) and as the
  * per-span styling primitive for the interactive renderer.
  *
- * Colour never changes the active representation's characters:
+ * Color never changes the active representation's characters:
  * `renderLinePlain` and the concatenated span text of `renderLineColored` are
  * byte-for-byte identical to the document line.
  */
@@ -19,8 +19,8 @@ export function spanStyle(span: Span): Style {
   return withRichModifiers(base, span);
 }
 
-/** The style for a span shown inside a dialog (a light-grey panel), where the
- * editor's bright colours would not read. */
+/** The style for a span shown inside a dialog (a light-gray panel), where the
+ * editor's bright colors would not read. */
 export function overlaySpanStyle(span: Span): Style {
   return withRichModifiers(dialogStyleFor(span.cls), span);
 }
@@ -36,7 +36,7 @@ function withRichModifiers(style: Style, span: Span): Style {
   };
 }
 
-/** The active source or rendered line, with no colour. */
+/** The active source or rendered line, with no color. */
 export function renderLinePlain(line: Line): string {
   return line.text;
 }

--- a/packages/cli/lib/view/keys.ts
+++ b/packages/cli/lib/view/keys.ts
@@ -1,5 +1,5 @@
 /**
- * Decodes raw terminal bytes into normalised {@link Key} events.
+ * Decodes raw terminal bytes into normalized {@link Key} events.
  *
  * Pure and incremental: {@link decodeKeys} returns the keys it could fully
  * parse plus any trailing bytes that form an incomplete escape sequence, which
@@ -12,7 +12,7 @@
 
 export interface Key {
   /**
-   * Normalised name: an arrow/nav name ("up", "down", "left", "right",
+   * Normalized name: an arrow/nav name ("up", "down", "left", "right",
    * "pageup", "pagedown", "home", "end"), a function key ("f1".."f12"), an
    * editing name ("enter", "escape", "backspace", "delete", "tab", "space"), a
    * control combo ("ctrl-c", "ctrl-d", …), or the literal character for a

--- a/packages/cli/lib/view/languages/json/json.ts
+++ b/packages/cli/lib/view/languages/json/json.ts
@@ -1,14 +1,14 @@
 /**
  * A small JSON / JSONC highlighter and structure builder for the pager. It is
  * hand-written — it shares nothing with the TypeScript parser — so a `.json` or
- * `.jsonc` file is coloured as data (keys apart from string values, numbers,
+ * `.jsonc` file is colored as data (keys apart from string values, numbers,
  * `true`/`false`/`null`, rainbow brackets) rather than run through a TypeScript
  * parse that would misread a bare top-level `{…}` as a block and shred it.
  *
  * The tokeniser is lenient: it never throws on malformed input (an unterminated
- * string or comment simply runs to end of file) so the pager keeps colouring a
+ * string or comment simply runs to end of file) so the pager keeps coloring a
  * file the user is midway through editing. JSONC line and block comments and
- * trailing commas are coloured, not rejected. Object keys become a navigation
+ * trailing commas are colored, not rejected. Object keys become a navigation
  * tree, so `wasd`/Tab step through a document's structure.
  */
 import type {
@@ -29,7 +29,7 @@ interface Token {
   readonly start: number;
   readonly end: number;
   readonly cls: TokenClass;
-  /** Nesting depth for `bracket` tokens, for rainbow colouring. */
+  /** Nesting depth for `bracket` tokens, for rainbow coloring. */
   readonly depth?: number;
 }
 
@@ -165,7 +165,7 @@ function isWordChar(c: string): boolean {
   return (c >= "a" && c <= "z") || (c >= "A" && c <= "Z");
 }
 
-/** Colour `text` into rendered lines by splitting each token across the line
+/** Color `text` into rendered lines by splitting each token across the line
  * boundaries it spans (a block comment is the only token that crosses one). */
 export function jsonHighlightLines(text: string): Line[] {
   const lineStarts = computeLineStarts(text);
@@ -205,7 +205,7 @@ export function jsonHighlightLines(text: string): Line[] {
   return rawLines.map((t, i) => ({ text: t, spans: spans[i] }));
 }
 
-/** A whole-document JSON highlighter. JSON is cheap enough to recolour whole on
+/** A whole-document JSON highlighter. JSON is cheap enough to recolor whole on
  * every keystroke, so no incremental state is needed. */
 export function createJsonHighlighter(initial: string): Highlighter {
   let lines: Line[] = jsonHighlightLines(initial);
@@ -220,7 +220,7 @@ export function createJsonHighlighter(initial: string): Highlighter {
   };
 }
 
-/** A full JSON {@link Document}: coloured lines, an object-key navigation tree,
+/** A full JSON {@link Document}: colored lines, an object-key navigation tree,
  * and a name → declaration index over the keys. */
 export function jsonDocument(text: string): Document {
   const lines = jsonHighlightLines(text);

--- a/packages/cli/lib/view/languages/json/language.ts
+++ b/packages/cli/lib/view/languages/json/language.ts
@@ -1,5 +1,5 @@
 /**
- * The JSON / JSONC language for the pager. Colouring and structure live in
+ * The JSON / JSONC language for the pager. Coloring and structure live in
  * {@link ./json.ts}; this module adapts them to the {@link Language} contract.
  *
  * JSON has no semantic layer (no types or cross-file definitions to resolve),

--- a/packages/cli/lib/view/languages/language.ts
+++ b/packages/cli/lib/view/languages/language.ts
@@ -1,6 +1,6 @@
 /**
  * The contract every source language plugs into so the `cf view` pager can
- * colour, navigate, edit and (optionally) reason about it, plus selecting the
+ * color, navigate, edit and (optionally) reason about it, plus selecting the
  * right language and byte decoder for a file. A language is a stateless
  * strategy object: one instance describes each supported syntax. Selection
  * combines explicit language choices, filename or shebang metadata, and byte
@@ -80,7 +80,7 @@ export interface Semantics {
    * when nothing resolves.
    */
   definitionOf(offset: number): DefTarget[];
-  /** Read and colour an external file (within the workspace) so the pager can
+  /** Read and color an external file (within the workspace) so the pager can
    * show a definition that lives outside the document. Null when unreadable. */
   fileLines(filePath: string): readonly Line[] | null;
   /** Build the backing program now (off the interactive path), so the first
@@ -195,11 +195,11 @@ export interface Language {
   /** Filename, explicit-name, and shebang selectors for this language. */
   readonly metadata: LanguageMetadata;
 
-  /** Parse `text` into the full document model: coloured lines, a structure
+  /** Parse `text` into the full document model: colored lines, a structure
    * tree, and a name → definition index. `fileName` is advisory. */
   parseDocument(text: string, fileName?: string): Document;
 
-  /** Colour `text` into rendered lines only — the per-keystroke-safe subset of
+  /** Color `text` into rendered lines only — the per-keystroke-safe subset of
    * {@link parseDocument}, with no structure tree or definitions. Used by the
    * non-interactive fast path and the diff fragment renderer. `fileName` is
    * advisory (a language may parse `.ts` and `.tsx` differently). */
@@ -240,10 +240,10 @@ export interface Language {
   readonly renderNeedsCompleteFile?: boolean;
 
   /** Whether live diff edits need complete-file highlighting because an earlier
-   * line can determine how later lines are coloured. */
+   * line can determine how later lines are colored. */
   readonly highlightFullFileOnDiffEdit?: boolean;
 
-  /** Highlight one source-line edit from its previous complete-file colours, or
+  /** Highlight one source-line edit from its previous complete-file colors, or
    * return null when the edit can affect syntax outside one token. */
   highlightDiffLineEditLocally?(before: Line, after: string): Line | null;
 
@@ -358,7 +358,7 @@ export function readOnlyReasonFor(language: Language): string | undefined {
  * singletons: they and this module form an import cycle (a language's semantic
  * layer resolves external files back through {@link languageForFile}), and
  * building the array eagerly would read a singleton that a cycle-first load had
- * not yet initialised. By first use every module has finished evaluating.
+ * not yet initialized. By first use every module has finished evaluating.
  */
 let languages: readonly Language[] | undefined;
 function allLanguages(): readonly Language[] {

--- a/packages/cli/lib/view/languages/markdown/language.ts
+++ b/packages/cli/lib/view/languages/markdown/language.ts
@@ -1,5 +1,5 @@
 /**
- * The Markdown language for the pager. Colouring and structure live in {@link
+ * The Markdown language for the pager. Coloring and structure live in {@link
  * ./markdown.ts}; this module adapts them to the {@link Language} contract.
  *
  * Markdown has no semantic layer (no `createSemantics`/`createDiffSemantics`),

--- a/packages/cli/lib/view/languages/markdown/markdown.ts
+++ b/packages/cli/lib/view/languages/markdown/markdown.ts
@@ -1,8 +1,8 @@
 /**
  * A small Markdown highlighter, used when a diff (or a directly-opened file)
- * names a `.md`/`.markdown` file. The pager otherwise colours everything as
+ * names a `.md`/`.markdown` file. The pager otherwise colors everything as
  * TypeScript, which turns prose into a soup of identifiers and operators and
- * paints inline-code backticks as runaway template literals. This colours the
+ * paints inline-code backticks as runaway template literals. This colors the
  * things Markdown actually has — headings, fenced and inline code, block quotes,
  * list markers, rules and links — and leaves prose plain. Headings also become
  * the navigation tree, so `wasd`/Tab step through a document's sections.
@@ -24,7 +24,7 @@ import { computeLineStarts, lineIndexOf } from "../../lines.ts";
 import { Lexer } from "marked";
 import { decodeHTMLStrict as decodeEntities } from "entities";
 
-/** Colour Markdown text into rendered lines. */
+/** Color Markdown text into rendered lines. */
 export function highlightMarkdownLines(text: string): Line[] {
   const raw = text.split("\n");
   const out: Line[] = [];
@@ -1318,7 +1318,7 @@ function renderTableDivider(widths: readonly number[]): Line {
   return singleStyledLine(text, "punctuation");
 }
 
-/** Colour one non-fenced line by classifying each code point, then run-length
+/** Color one non-fenced line by classifying each code point, then run-length
  * encoding the classes into spans. */
 function renderLine(t: string): Line {
   if (t.length === 0) return { text: "", spans: [] };

--- a/packages/cli/lib/view/languages/python/python.ts
+++ b/packages/cli/lib/view/languages/python/python.ts
@@ -1,11 +1,11 @@
 /**
  * A lossless Python highlighter for the pager. The scanner follows Python's
- * lexical tokens while remaining lenient enough to colour a file during an
- * incomplete edit. It recognises current string prefixes, multiline strings,
+ * lexical tokens while remaining lenient enough to color a file during an
+ * incomplete edit. It recognizes current string prefixes, multiline strings,
  * identifiers, keywords, numeric forms, comments, operators, and delimiters.
  *
  * The scanner consumes the complete document because a triple-quoted string can
- * determine the colour of later lines. It does not execute Python or require a
+ * determine the color of later lines. It does not execute Python or require a
  * Python installation.
  */
 import type { Document, Line, Span, TokenClass } from "../../model.ts";
@@ -314,8 +314,8 @@ function identifierClass(
 }
 
 /**
- * `match`, `case`, and `type` are soft keywords. They retain identifier colour
- * in assignments and calls, while their statement forms receive keyword colour.
+ * `match`, `case`, and `type` are soft keywords. They retain identifier color
+ * in assignments and calls, while their statement forms receive keyword color.
  */
 function softKeywordAt(
   text: string,
@@ -836,7 +836,7 @@ export function pythonHighlightLines(text: string): Line[] {
   }));
 }
 
-/** A full Python document with syntax colouring and no semantic structure. */
+/** A full Python document with syntax coloring and no semantic structure. */
 export function pythonDocument(text: string): Document {
   return {
     text,

--- a/packages/cli/lib/view/languages/typescript/language.ts
+++ b/packages/cli/lib/view/languages/typescript/language.ts
@@ -2,7 +2,7 @@
  * The TypeScript (and TSX/JS) language for the pager. It handles named files in
  * that language family. The selection layer also uses it for filename-free
  * transformed compiler output. Highlighting, structure, incremental editing
- * and the semantic layer all live in the neighbouring {@link ./parse.ts} and
+ * and the semantic layer all live in the neighboring {@link ./parse.ts} and
  * {@link ./semantics.ts}; this module only adapts them to the {@link Language}
  * contract.
  */

--- a/packages/cli/lib/view/languages/typescript/parse.ts
+++ b/packages/cli/lib/view/languages/typescript/parse.ts
@@ -9,7 +9,7 @@
  * plain text so the pager remains usable.
  *
  * Three products come out of one parse:
- *   1. Per-line coloured {@link Span}s (full-fidelity: every character is
+ *   1. Per-line colored {@link Span}s (full-fidelity: every character is
  *      classified, via a deep token walk plus trivia gap-filling).
  *   2. A {@link StructureNode} tree (sections, functions, closures, builders,
  *      schemas, bindings) for navigation and folding.
@@ -197,7 +197,7 @@ function parseTypeScriptDocument(text: string, fileName: string): Document {
 }
 
 /**
- * Just the coloured lines for `text` — the syntax highlighting — without the
+ * Just the colored lines for `text` — the syntax highlighting — without the
  * structure tree, definitions or comment nodes. This is the work that has to
  * stay correct on every keystroke; it is a fraction of a full {@link
  * parseDocument} (the structure build over the whole AST is the expensive part),
@@ -244,7 +244,7 @@ function scriptKindFor(fileName: string): ts.ScriptKind {
 /**
  * A conventional quoted string remains one token when an edit changes only its
  * unescaped contents. Replacing only that span preserves the complete-file
- * colours and bracket depths of every other token on the line.
+ * colors and bracket depths of every other token on the line.
  */
 export function highlightLineEditLocally(
   before: Line,
@@ -691,8 +691,8 @@ function tokenAt(sf: ts.SourceFile, pos: number): ts.Node {
 
 /** Whether `kind` is a JSDoc node. The token walk does not descend into these:
  * a `{@link Name}` tag parses `Name` as an Identifier leaf, which would split
- * the comment and leave the text after it uncoloured — a JSDoc comment stays
- * trivia, coloured whole by {@link classifyTrivia}. */
+ * the comment and leave the text after it uncolored — a JSDoc comment stays
+ * trivia, colored whole by {@link classifyTrivia}. */
 function isJSDocNode(kind: ts.SyntaxKind): boolean {
   return kind >= SK.FirstJSDocNode && kind <= SK.LastJSDocNode;
 }
@@ -1137,7 +1137,7 @@ function inSchema(node: ts.Node, schemaSet: Set<ts.Node>): boolean {
   return false;
 }
 
-/** Object literals that materialise a `… satisfies …JSONSchema`. */
+/** Object literals that materialize a `… satisfies …JSONSchema`. */
 function collectSchemaObjects(sf: ts.SourceFile): Set<ts.Node> {
   const set = new Set<ts.Node>();
   const walk = (node: ts.Node) => {
@@ -1189,7 +1189,7 @@ interface BuildCtx {
 /**
  * One classification result. `recurseInto` lists the *child source nodes*
  * {@link buildNode} descends into for sub-structure — chosen explicitly rather
- * than taken from `forEachChild`. A recognised shape narrows or suppresses its
+ * than taken from `forEachChild`. A recognized shape narrows or suppresses its
  * children: an import, schema, type alias, interface or enum lists none; a
  * builder lists only its arguments; a closure or function its body. A generic
  * (unclassified) node lists all its children, so the whole AST stays navigable.
@@ -1208,7 +1208,7 @@ interface Desc {
  * Build a structure node for `node` and, recursively, every AST node beneath it
  * — the whole tree is navigable. Special shapes (functions, schemas, builders,
  * patterns, …) keep their rich label and card metadata via {@link classify};
- * everything else becomes a generic node labelled by its source. Nodes that
+ * everything else becomes a generic node labeled by its source. Nodes that
  * share `node`'s exact source range are merged into this one (so the user never
  * lands on two nodes that look identical), and every merged AST kind is recorded
  * for the info card.
@@ -1250,7 +1250,7 @@ function buildNode(node: ts.Node, depth: number, ctx: BuildCtx): StructureNode {
   };
   if (desc.name) registerDefinition(ctx, desc, sn);
   // Descend only into the child source nodes the classification chose. A
-  // recognised shape narrows or suppresses its children here — an import,
+  // recognized shape narrows or suppresses its children here — an import,
   // schema, type literal or other fold lists no children, a builder lists only
   // its arguments — so the navigable tree stops at the fold instead of
   // expanding into raw AST. A generic (unclassified) node lists all its
@@ -1277,8 +1277,8 @@ function generatedOriginOf(desc: Desc): string | undefined {
 }
 
 /**
- * The classification for a merged chain: the most specific recognised shape
- * among the layers (outermost first), else a generic node labelled by its first
+ * The classification for a merged chain: the most specific recognized shape
+ * among the layers (outermost first), else a generic node labeled by its first
  * source line.
  */
 function describeMerged(layers: ts.Node[], ctx: BuildCtx): Desc {
@@ -1300,7 +1300,7 @@ function describeMerged(layers: ts.Node[], ctx: BuildCtx): Desc {
 
 /**
  * A short label for a generic AST node. Chained calls and member accesses are
- * labelled by the distinguishing segment (`.version(…)`, `.name`) rather than
+ * labeled by the distinguishing segment (`.version(…)`, `.name`) rather than
  * the shared left-hand prefix, which a raw first-line slice would show for every
  * link in a fluent chain.
  */
@@ -1499,10 +1499,10 @@ function registerDefinition(
  *
  *   - Every statement is a node, its kind refined by its content.
  *   - In expression position, the reactive/structural shapes (closures,
- *     recognised builder/pattern/registered/synthetic calls, JSON-schema object
+ *     recognized builder/pattern/registered/synthetic calls, JSON-schema object
  *     literals) are nodes too.
  *
- * `recurseInto` chooses each shape's child source nodes: a recognised shape
+ * `recurseInto` chooses each shape's child source nodes: a recognized shape
  * narrows or suppresses them (an import or schema lists none, a builder lists
  * its arguments), while a statement wrapping an expression lists that
  * expression so the call or closure inside stays its own node.
@@ -1618,7 +1618,7 @@ function classify(node: ts.Node, ctx: BuildCtx): Desc | null {
   // A single binding is represented by the whole statement (so the `variable`
   // node covers `export const … ;`); a multi-declarator statement stays generic
   // and each declaration becomes its own binding node. The single declaration
-  // itself stays generic to avoid labelling one binding at two nesting levels.
+  // itself stays generic to avoid labeling one binding at two nesting levels.
   if (ts.isVariableStatement(node)) {
     const decls = node.declarationList.declarations;
     if (decls.length === 1) return bindingDesc(decls[0], ctx);
@@ -1809,7 +1809,7 @@ function expressionStatementDesc(expr: ts.Expression, ctx: BuildCtx): Desc {
   };
 }
 
-/** Build a builder/pattern node from a recognised reactive call. */
+/** Build a builder/pattern node from a recognized reactive call. */
 function callDesc(
   call: ts.CallExpression,
   callee: string,
@@ -2285,7 +2285,7 @@ function describeInitializer(
   init: ts.Expression | undefined,
   sf: ts.SourceFile,
 ): string {
-  if (!init) return "(uninitialised)";
+  if (!init) return "(uninitialized)";
   return nodeFirstLine(init, sf, 56);
 }
 
@@ -2391,8 +2391,8 @@ function firstLine(text: string, max: number): string {
 /**
  * The first source line of a node, trimmed and capped at `max`, read straight
  * from the source between the node's offsets. Unlike `node.getText()` it never
- * materialises the whole (possibly multi-line, possibly huge) node text, so
- * labelling every node in the full-AST tree stays linear instead of quadratic.
+ * materializes the whole (possibly multi-line, possibly huge) node text, so
+ * labeling every node in the full-AST tree stays linear instead of quadratic.
  */
 function nodeFirstLine(node: ts.Node, sf: ts.SourceFile, max: number): string {
   const text = sf.text;

--- a/packages/cli/lib/view/languages/typescript/semantics.ts
+++ b/packages/cli/lib/view/languages/typescript/semantics.ts
@@ -77,7 +77,7 @@ export function createSemantics(
     sections.find((s) => offset >= s.start && offset < s.end);
   const sectionByVfile = new Map(sections.map((s) => [s.name, s] as const));
 
-  // Memoise resolutions and real-file reads: the info card resolves the same
+  // Memoize resolutions and real-file reads: the info card resolves the same
   // offsets repeatedly (a symbol appears in both "depends on" and "defined
   // elsewhere"), and many external defs land in the same large file.
   const defCache = new Map<number, DefTarget[]>();
@@ -640,7 +640,7 @@ function lexicallyWithin(child: string, parent: string): boolean {
 }
 
 /**
- * True if `child` sits beneath `parent` PHYSICALLY: the check canonicalises
+ * True if `child` sits beneath `parent` PHYSICALLY: the check canonicalizes
  * both sides, so an in-workspace symlink pointing outside the workspace does
  * not pass. `child` must exist (a nonexistent path cannot be read anyway).
  */

--- a/packages/cli/lib/view/languages/typescript/vocab.ts
+++ b/packages/cli/lib/view/languages/typescript/vocab.ts
@@ -1,10 +1,10 @@
 /**
  * Common Fabric naming vocabulary used to give the transformed output its
- * domain-aware colouring (highlighting `pattern`/`lift`/`handler` builders and
+ * domain-aware coloring (highlighting `pattern`/`lift`/`handler` builders and
  * the synthetic helpers the transformer injects).
  *
  * The builder/call name sets are imported from the transformer's own registry
- * so new builders are recognised automatically and we never drift out of sync.
+ * so new builders are recognized automatically and we never drift out of sync.
  * The synthetic-name prefixes are stable internal strings declared alongside
  * the transformer that emits them; they are mirrored here (with citations) to
  * avoid pulling the heavy `ast/call-kind.ts` graph into the pager. A unit test
@@ -54,7 +54,7 @@ const SYNTHETIC_PREFIXES = [
 /**
  * Names the transformer emits for the module wrapper itself. These are ordinary
  * identifiers (no `__cf` prefix), so they are listed by exact name rather than
- * recognised by prefix.
+ * recognized by prefix.
  */
 const SCAFFOLDING_NAMES: ReadonlySet<string> = new Set([
   "define",

--- a/packages/cli/lib/view/languages/yaml/yaml.ts
+++ b/packages/cli/lib/view/languages/yaml/yaml.ts
@@ -47,7 +47,7 @@ interface HighlightState {
   pendingNodeIndent?: number;
 }
 
-/** Colour YAML text into rendered lines. */
+/** Color YAML text into rendered lines. */
 export function yamlHighlightLines(text: string): Line[] {
   const rawLines = text.split("\n");
   const state: HighlightState = {
@@ -60,7 +60,7 @@ export function yamlHighlightLines(text: string): Line[] {
   );
 }
 
-/** A full YAML document. YAML currently contributes syntax colour only. */
+/** A full YAML document. YAML currently contributes syntax color only. */
 export function yamlDocument(text: string): Document {
   return {
     text,

--- a/packages/cli/lib/view/model.ts
+++ b/packages/cli/lib/view/model.ts
@@ -10,7 +10,7 @@
 
 /**
  * Lexical/semantic classification of a contiguous run of source text. Drives
- * colour selection in {@link ../theme.ts}. Derived from the TypeScript token
+ * color selection in {@link ../theme.ts}. Derived from the TypeScript token
  * kind, refined by the identifier's syntactic role in the AST.
  */
 export type TokenClass =
@@ -21,7 +21,7 @@ export type TokenClass =
   | "storageKeyword" // const/let/var/function/type/interface/class
   | "operator"
   | "punctuation"
-  | "bracket" // (){}[] — coloured by nesting depth, see `bracketDepth`
+  | "bracket" // (){}[] — colored by nesting depth, see `bracketDepth`
   | "string"
   | "template"
   | "number"
@@ -51,13 +51,13 @@ export type TokenClass =
 /** Which representation of the underlying source the pager is displaying. */
 export type ViewMode = "source" | "rendered";
 
-/** A coloured run of text on a single logical (pre-wrap) source line. */
+/** A colored run of text on a single logical (pre-wrap) source line. */
 export interface Span {
   /** 0-based column where this span starts on its line. */
   readonly col: number;
   readonly text: string;
   readonly cls: TokenClass;
-  /** Nesting depth for `bracket` spans, used for rainbow colouring. */
+  /** Nesting depth for `bracket` spans, used for rainbow coloring. */
   readonly bracketDepth?: number;
   /** Symbol name to resolve only at this position, not by matching span text. */
   readonly exactDefinitionName?: string;
@@ -70,7 +70,7 @@ export interface Span {
   readonly strikethrough?: boolean;
 }
 
-/** One logical display line and its coloured spans. */
+/** One logical display line and its colored spans. */
 export interface Line {
   readonly text: string;
   readonly spans: readonly Span[];
@@ -103,7 +103,7 @@ export type StructureKind =
   | "comment" // a `//` or `/* */` comment
   | "hunk"; // a `@@ … @@` hunk in a diff view
 
-/** A field of a JSON schema, summarised for display. */
+/** A field of a JSON schema, summarized for display. */
 export interface SchemaField {
   readonly name: string;
   /** Compact type, e.g. `string`, `string[]`, `object`, `boolean`. */
@@ -113,7 +113,7 @@ export interface SchemaField {
   readonly fields?: readonly SchemaField[];
 }
 
-/** A JSON schema (an object-literal `… satisfies JSONSchema`), summarised. */
+/** A JSON schema (an object-literal `… satisfies JSONSchema`), summarized. */
 export interface SchemaMeta {
   readonly rootType: string;
   readonly required: readonly string[];
@@ -210,7 +210,7 @@ export interface StructureNode {
    * navigable node (e.g. an expression statement and the call it wraps). */
   readonly astKinds?: readonly string[];
   /** A human description of why this node is machine-generated, when a language
-   * can vouch that it is (e.g. the TypeScript view recognising a transformer's
+   * can vouch that it is (e.g. the TypeScript view recognizing a transformer's
    * synthetic helper). Absent means "not known to be generated"; the info card
    * shows an origin line only when it is present. */
   readonly generatedOrigin?: string;

--- a/packages/cli/lib/view/pager.ts
+++ b/packages/cli/lib/view/pager.ts
@@ -107,8 +107,8 @@ export async function runPager(
 
   // The terminal fills the area outside the character grid (the sub-cell padding
   // below the last row) with its default background. Set that to the status
-  // bar's colour so the strip beneath the last line blends in instead of showing
-  // the terminal's own background; restore it on exit. Only with colour on.
+  // bar's color so the strip beneath the last line blends in instead of showing
+  // the terminal's own background; restore it on exit. Only with color on.
   const padBg = options.color ? ui.statusBar.bg : undefined;
 
   const session = new Session(

--- a/packages/cli/lib/view/references.ts
+++ b/packages/cli/lib/view/references.ts
@@ -100,7 +100,7 @@ export function findDependencies(
       const spanOffset = charOffset;
       charOffset += span.text.length;
       // Stay within the node's actual span, not the whole boundary lines, so a
-      // sibling on the same line (e.g. the `const page =` it initialises) is
+      // sibling on the same line (e.g. the `const page =` it initializes) is
       // not mistaken for a dependency.
       if (line === node.startLine && span.col < node.startCol) continue;
       if (line === node.endLine && span.col >= node.endCol) continue;

--- a/packages/cli/lib/view/render.ts
+++ b/packages/cli/lib/view/render.ts
@@ -5,7 +5,7 @@
  *
  * Composition is cell-based: each visible content row is built as an array of
  * (char, style) cells so overlays layer with a clear precedence
- * (search match > node selection > schema/closure region tint > token colour),
+ * (search match > node selection > schema/closure region tint > token color),
  * then run-length encoded into ANSI. Horizontal scrolling, the line-number
  * gutter and the structure guide bar are all column maths over that grid.
  */
@@ -109,8 +109,8 @@ function diffTotalsSegments(totals: DiffTotals): [string, string] {
   return [`+${totals.adds} `, `−${totals.dels}`];
 }
 
-/** The corner label's cells: the added count in the addition colour, the
- * removed count in the removal colour. */
+/** The corner label's cells: the added count in the addition color, the
+ * removed count in the removal color. */
 function diffTotalsCells(totals: DiffTotals): SuffixCell[] {
   const [add, del] = diffTotalsSegments(totals);
   return [
@@ -209,7 +209,7 @@ export interface ViewState {
   /** Command/search input line, e.g. "/token"; null in normal mode. */
   inputLine: string | null;
   overlay: OverlayState | null;
-  /** A modal prompt drawn as a centred Turbo Vision dialog (the save, revert and
+  /** A modal prompt drawn as a centered Turbo Vision dialog (the save, revert and
    * amend confirmations). Covers the content like an overlay; the two never
    * coexist. */
   dialog?: DialogState | null;
@@ -337,7 +337,7 @@ export interface OverlayState {
   /** Index into `lines` of the selected (highlighted) reference, if any. */
   readonly selectedLine?: number;
   /** The overlay shows source code, so it is drawn as a blue editor window
-   * rather than a grey dialog. */
+   * rather than a gray dialog. */
   readonly sourceView?: boolean;
 }
 
@@ -350,7 +350,7 @@ export interface DialogButton {
   readonly kind?: "default" | "cancel" | "normal";
 }
 
-/** A centred modal prompt: a title, one or more body lines, and a button row. */
+/** A centered modal prompt: a title, one or more body lines, and a button row. */
 export interface DialogState {
   readonly title: string;
   readonly body: readonly string[];
@@ -866,7 +866,7 @@ function composeContent(
 ): string {
   const { color } = view;
   // Every content cell sits on the blue editor background; a diff line carries a
-  // full-row add/removed tint instead. Syntax colours paint on top, and the
+  // full-row add/removed tint instead. Syntax colors paint on top, and the
   // selection background still wins inside its range.
   const rowBg: Style = color
     ? { bg: line?.bg ? lineBg(line.bg) : ui.editorBg }
@@ -1163,7 +1163,7 @@ function hintsPlain(hints: readonly KeyHint[]): string {
   return hints.map((h) => `${h.key} ${h.label}`).join("  ");
 }
 
-/** The same, coloured: each key highlighted, the labels plain, on the bar bg. */
+/** The same, colored: each key highlighted, the labels plain, on the bar bg. */
 function hintsAnsi(hints: readonly KeyHint[]): string {
   let out = "";
   hints.forEach((h, i) => {
@@ -1198,7 +1198,7 @@ export interface OverlayBox {
   innerH: number;
 }
 
-/** Geometry of the centred overlay box for the given terminal size. The box is
+/** Geometry of the centered overlay box for the given terminal size. The box is
  * clamped to fit inside the terminal, so on a terminal too small to hold the box
  * the dimensions collapse to the terminal size rather than going negative. Inner
  * dimensions never go below 0, which keeps {@link applyOverlay}'s repeat/slice
@@ -1237,7 +1237,7 @@ function applyOverlay(
   if (boxW < 2 || boxH < 2) return;
 
   // An overlay showing source code is a blue editor window; everything else is
-  // a grey dialog. The border carries the same background as the body, so the
+  // a gray dialog. The border carries the same background as the body, so the
   // panel reads as one solid block rather than a frame over the content behind.
   const source = !!overlay.sourceView;
   const panelBg = source ? ui.editorBg : ui.overlayBg;
@@ -1303,7 +1303,7 @@ function castShadow(
 }
 
 /** Repaint `count` cells at visible column `from` of row `r` in the shadow
- * colour, keeping whatever characters were there. Clamped to the row and the
+ * color, keeping whatever characters were there. Clamped to the row and the
  * terminal width so the fixed row width is preserved. */
 function darkenSpan(
   rows: string[],
@@ -1359,7 +1359,7 @@ export interface DialogBox {
   innerH: number;
 }
 
-/** Geometry of the centred dialog box, sized to its content (title, body and
+/** Geometry of the centered dialog box, sized to its content (title, body and
  * button row) and clamped to leave two cells for the drop shadow. */
 export function dialogBox(view: ViewState, dialog: DialogState): DialogBox {
   const titleW = cpLen(dialog.title) + 4; // the padding spaces and some fill
@@ -1384,7 +1384,7 @@ export function dialogBox(view: ViewState, dialog: DialogState): DialogBox {
   };
 }
 
-/** The top border of a dialog: the title centred in the width and filled with
+/** The top border of a dialog: the title centered in the width and filled with
  * the double rule. */
 function titleBar(title: string, width: number): string {
   if (width <= 0) return "";
@@ -1397,7 +1397,7 @@ interface ButtonPos {
   faceW: number;
 }
 
-/** Left-to-right positions of the buttons, as a block centred in `innerW`. */
+/** Left-to-right positions of the buttons, as a block centered in `innerW`. */
 function layoutButtons(
   buttons: readonly DialogButton[],
   innerW: number,
@@ -1470,7 +1470,7 @@ function applyDialog(
   if (view.color) castShadow(rows, view, x, y, boxW, boxH);
 }
 
-/** Write `text` centred in `cells`, one blank margin column inside each edge. */
+/** Write `text` centered in `cells`, one blank margin column inside each edge. */
 function placeCentered(cells: Cell[], text: string, style: Style): void {
   const innerW = cells.length;
   const chars = [...showControls(text)];

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -283,7 +283,7 @@ export class Session {
   private semantics?: Semantics;
   quit = false;
   /** An edit patched only the changed lines for speed; a full re-parse (for
-   * structure, cross-references, and multi-line token colours) is owed. The
+   * structure, cross-references, and multi-line token colors) is owed. The
    * driver runs it on a short idle, so typing stays responsive. */
   needsReparse = false;
   /** What the last key revealed (Ctrl-L in pager mode), for the driver to walk
@@ -903,7 +903,7 @@ export class Session {
           ? o.targets[o.cardSel]?.cardLine
           : undefined,
         // Source (the toggled-to source view, or a peek that is itself source)
-        // is drawn as a blue editor window; a structured card is a grey dialog.
+        // is drawn as a blue editor window; a structured card is a gray dialog.
         sourceView: o.mode === "source" ||
           (o.mode === "info" && !!o.infoIsSource),
       }
@@ -1362,7 +1362,7 @@ export class Session {
       this.message = `Cannot open ${target.filePath}`;
       return;
     }
-    // Lead the title with the filename and line: the overlay centres and
+    // Lead the title with the filename and line: the overlay centers and
     // left-truncates titles, so a raw absolute path would keep only its shared
     // workspace prefix and drop the identifying part.
     const name = target.filePath!.split(/[\\/]/).pop() ?? target.filePath!;
@@ -1707,7 +1707,7 @@ export class Session {
       case "z":
       case "Z": {
         // Reveal the target: an external file opens in place; an in-blob target
-        // closes the card and centres the main view on it. A "… N more" line has
+        // closes the card and centers the main view on it. A "… N more" line has
         // no destination to reveal.
         const reveal = this.overlayRevealTarget(overlay);
         if (reveal?.expand) break;
@@ -2197,10 +2197,10 @@ export class Session {
   }
 
   /** Create (or re-baseline) the incremental highlighter, seeded with the
-   * current document's colours at the current buffer text. Called when editing
+   * current document's colors at the current buffer text. Called when editing
    * starts and after the deferred re-parse — the two moments the document's
    * lines and the buffer text are known to agree — so a diff's live highlighter
-   * can reuse the workspace-coloured lines for everything an edit doesn't touch. */
+   * can reuse the workspace-colored lines for everything an edit doesn't touch. */
   private seedHighlighter(): void {
     this.highlighter = this.source?.createHighlighter?.(
       this.buffer!.text(),
@@ -3684,7 +3684,7 @@ export class Session {
     // upwards holds the hunk's header and pushes the body down; expanding
     // downwards holds what follows the hunk and lifts the body up. A join takes
     // that very header away, so what is held is the line the other side of it —
-    // the neighbouring hunk's body, which is what is left to hold on to.
+    // the neighboring hunk's body, which is what is left to hold on to.
     const pinDoc = r.removedAt !== null
       ? (r.up ? r.removedAt - 1 : r.removedAt + 1)
       : (r.up ? r.insertedAt - 1 : r.insertedAt);
@@ -4710,7 +4710,7 @@ export function helpOverlay(): {
     ["  W / S", "previous / next sibling (W → parent, S → out, at ends)"],
     ["  A / D", "parent / first child"],
     ["  Tab / ⇧Tab", "next / previous node (depth-first)"],
-    ["  Z", "centre selected node"],
+    ["  Z", "center selected node"],
     ["  ^L", "diff: reveal more context at the marked edge"],
     ["  Esc", "clear selection / search"],
     ["", ""],
@@ -4730,7 +4730,7 @@ export function helpOverlay(): {
     ["Info card (Enter on a node)", ""],
     ["  Enter", "open the reference — or expand a “… N more” line"],
     ["  Esc", "back to the card you came from (or close)"],
-    ["  Z", "close & centre the main view on the target"],
+    ["  Z", "close & center the main view on the target"],
     ["  Tab", "toggle info card ⇄ source"],
     ["  t", "look up a definition by name"],
     ["", ""],
@@ -4738,7 +4738,7 @@ export function helpOverlay(): {
     ["  V", "toggle source / rendered view when the language supports it"],
     ["  #", "line numbers: off / input position / file or message line"],
     ["  \\", "line wrapping: off / hard / word"],
-    ["  C", "cycle non-printables: pictures / ANSI colour / hidden"],
+    ["  C", "cycle non-printables: pictures / ANSI color / hidden"],
     ["  ?", "this help   ·   Q  quit"],
   ];
   const info: Line[] = rows.map(([k, v]) => {

--- a/packages/cli/lib/view/theme.ts
+++ b/packages/cli/lib/view/theme.ts
@@ -1,12 +1,12 @@
 /**
- * Colour theme for the `cf view` pager: a modern dark scheme. Light-grey text on
+ * Color theme for the `cf view` pager: a modern dark scheme. Light-gray text on
  * a near-black editor surface, with a One-Dark-inspired accent palette — purple
  * keywords, green strings, amber types, blue functions, orange numbers, and
  * bright-white comments. A slightly lighter surface holds the status bar and
  * dialogs. Each {@link TokenClass} maps to an ANSI {@link Style}; the chrome
  * styles (status bar, selection, search, overlay) and the rainbow bracket cycle
  * round it out. The general aesthetic (double-line dialog frames, drop shadows,
- * green buttons) is unchanged — only the colours differ.
+ * green buttons) is unchanged — only the colors differ.
  */
 import { hex, type Rgb, type Style } from "./ansi.ts";
 import type { Line, TokenClass } from "./model.ts";
@@ -77,7 +77,7 @@ const TOKEN_STYLES: Record<TokenClass, Style> = {
   diffMeta: { fg: C.fgDim },
 };
 
-/** Full-row background tints for diff lines (syntax colours stay on top). */
+/** Full-row background tints for diff lines (syntax colors stay on top). */
 const LINE_BGS: Record<NonNullable<Line["bg"]>, Rgb> = {
   add: C.addBg,
   del: C.delBg,
@@ -101,7 +101,7 @@ export function styleFor(cls: TokenClass): Style {
   return TOKEN_STYLES[cls];
 }
 
-/** Token colours for content shown inside a dialog. The comment token marks
+/** Token colors for content shown inside a dialog. The comment token marks
  * muted labels there, while builderCall marks shortcut keys. */
 const DIALOG_TOKEN_STYLES: Record<TokenClass, Style> = {
   ...TOKEN_STYLES,
@@ -111,7 +111,7 @@ const DIALOG_TOKEN_STYLES: Record<TokenClass, Style> = {
 };
 
 /** The dialog-palette style for a token class (bracket depth is ignored: a
- * dialog draws every bracket in the default colour rather than rainbow). */
+ * dialog draws every bracket in the default color rather than rainbow). */
 export function dialogStyleFor(cls: TokenClass): Style {
   return DIALOG_TOKEN_STYLES[cls];
 }

--- a/packages/cli/test/view-actions.test.ts
+++ b/packages/cli/test/view-actions.test.ts
@@ -217,17 +217,17 @@ Deno.test("nodeAtLine finds the innermost containing node", () => {
   );
 });
 
-Deno.test("frameTop: centres a node that fits on screen", () => {
+Deno.test("frameTop: centers a node that fits on screen", () => {
   // node lines 20–29 (height 10), height 40 -> contentRows 39 (fits)
-  // centred: top = 20 - floor((39 - 10) / 2) = 20 - 14 = 6
+  // centered: top = 20 - floor((39 - 10) / 2) = 20 - 14 = 6
   const top = frameTop(20, 29, 40, 1000);
   assertEquals(top, 6);
-  // the node is fully visible and roughly centred
+  // the node is fully visible and roughly centered
   const rows = 39;
   assert(20 >= top && 29 <= top + rows - 1, "whole node on screen");
   const above = 20 - top;
   const below = (top + rows - 1) - 29;
-  assert(Math.abs(above - below) <= 1, "node roughly centred");
+  assert(Math.abs(above - below) <= 1, "node roughly centered");
 });
 
 Deno.test("frameTop: puts a too-tall node's top line ~1/10 down", () => {

--- a/packages/cli/test/view-ansi.test.ts
+++ b/packages/cli/test/view-ansi.test.ts
@@ -30,7 +30,7 @@ Deno.test("stripAnsi / visibleWidth ignore escapes", () => {
   const colored = paint("hello", { fg: [10, 20, 30], bold: true });
   assertEquals(stripAnsi(colored), "hello");
   assertEquals(visibleWidth(colored), 5);
-  assert(colored.length > 5, "the coloured form has escapes");
+  assert(colored.length > 5, "the colored form has escapes");
 });
 
 Deno.test("cpLen counts a non-BMP glyph as one display column", () => {

--- a/packages/cli/test/view-card-cov.test.ts
+++ b/packages/cli/test/view-card-cov.test.ts
@@ -16,7 +16,7 @@ function infoText(doc: Document, node: StructureNode, semantics?: Semantics) {
 
 function findByLabel(doc: Document, label: string): StructureNode {
   const node = doc.flatStructure.find((n) => n.label === label);
-  assert(node, `no node labelled "${label}"`);
+  assert(node, `no node labeled "${label}"`);
   return node!;
 }
 
@@ -91,7 +91,7 @@ Deno.test("card: a node with no AST kinds falls back to its structure kind", () 
 
 // --- detail sections by meta kind --------------------------------------------
 
-Deno.test("card: a schema node renders its labelled type", () => {
+Deno.test("card: a schema node renders its labeled type", () => {
   const doc = parseDocument(`// transformed: /app.ts
 const __cfLift_1 = lift({
     type: "object",
@@ -475,7 +475,7 @@ Deno.test("card: a deferred dependency does not use a same-named local jump", ()
   );
   assert(
     collapsedText.includes("1 possible dependency"),
-    `the syntactic match is labelled as unresolved: ${collapsedText}`,
+    `the syntactic match is labeled as unresolved: ${collapsedText}`,
   );
 
   const expanded = buildPeekCard(doc, consumer, semantics, true);
@@ -704,7 +704,7 @@ Deno.test("card: a short scalar-root schema renders inline", () => {
 });
 
 Deno.test("card: a wide scalar-root schema renders on its own indented line", () => {
-  // A root type long enough to exceed the inline budget pushes the labelled
+  // A root type long enough to exceed the inline budget pushes the labeled
   // schema onto a heading plus a multiline body, whose scalar-root branch
   // emits a single indented type line.
   const longType =

--- a/packages/cli/test/view-card.test.ts
+++ b/packages/cli/test/view-card.test.ts
@@ -235,7 +235,7 @@ Deno.test("card: dependencies stay within the node's own span", () => {
   const deps = findDependencies(doc, fd);
   // `url` (a shorthand reference inside the call) is a real dependency...
   assert(deps.some((d) => d.name === "url"), "url is a dependency");
-  // ...but `page`, the binding the call initialises on the same line, is not
+  // ...but `page`, the binding the call initializes on the same line, is not
   assert(!deps.some((d) => d.name === "page"), "page is not a dependency");
 });
 

--- a/packages/cli/test/view-cli.test.ts
+++ b/packages/cli/test/view-cli.test.ts
@@ -1,7 +1,7 @@
 /**
  * End-to-end coverage of the `cf view` command and its non-interactive entry
  * (mod.ts). Each case runs the real CLI as a subprocess: with stdout piped the
- * viewer prints the colourised text and exits, like `less` when redirected, so
+ * viewer prints the colorized text and exits, like `less` when redirected, so
  * these exercise the command wiring, argument handling, input reading and the
  * print path without a terminal.
  */
@@ -46,7 +46,7 @@ function runViewForBytes(args: string[]): Promise<Deno.CommandOutput> {
   });
 }
 
-Deno.test("cf view --plain prints colourised source and exits 0", async () => {
+Deno.test("cf view --plain prints colorized source and exits 0", async () => {
   const { code, stdout } = await cf("view --plain", { stdin: SRC });
   assertEquals(code, 0);
   assert(stdout.join("\n").includes("pattern"), stdout.join("\n"));

--- a/packages/cli/test/view-diff.test.ts
+++ b/packages/cli/test/view-diff.test.ts
@@ -271,7 +271,7 @@ new file mode 100644
 
 // --- document -------------------------------------------------------------------
 
-Deno.test("diff doc: verbatim text, tints, markers and syntax colour", () => {
+Deno.test("diff doc: verbatim text, tints, markers and syntax color", () => {
   const { ws, done } = tempWorkspace();
   try {
     const model = parseDiff(DIFF)!;
@@ -288,7 +288,7 @@ Deno.test("diff doc: verbatim text, tints, markers and syntax colour", () => {
     // Markers classified.
     assertEquals(doc.lines[9].spans[0].cls, "diffAdd");
     assertEquals(doc.lines[8].spans[0].cls, "diffDel");
-    // Syntax colour under the diff: both complete file parses classify the
+    // Syntax color under the diff: both complete file parses classify the
     // `export` keyword as a storage keyword.
     const cls = (line: number, text: string) =>
       doc.lines[line].spans.find((s) => s.text === text)?.cls;
@@ -685,7 +685,7 @@ Deno.test("diff doc: a stale diff shifted against the workspace maps nothing", (
 Deno.test("diff doc: a shifted coincidental match cannot answer about the wrong occurrence", () => {
   // The reviewer's repro: function b was inserted above function a after the
   // diff was taken; the added `log(x)` coincides textually with b's body at
-  // the diff's stated line numbers, but neighbouring lines do not match, so
+  // the diff's stated line numbers, but neighboring lines do not match, so
   // the hunk fails verification and maps nothing (instead of answering with
   // function b's types).
   const root = Deno.makeTempDirSync();
@@ -805,7 +805,7 @@ Deno.test("diff semantics: a definition outside the diff opens as a file", () =>
 
 // --- rendering ------------------------------------------------------------------
 
-Deno.test("diff render: added lines carry the add tint under the syntax colour", () => {
+Deno.test("diff render: added lines carry the add tint under the syntax color", () => {
   const { ws, done } = tempWorkspace();
   try {
     const model = parseDiff(DIFF)!;

--- a/packages/cli/test/view-diffdoc-cov.test.ts
+++ b/packages/cli/test/view-diffdoc-cov.test.ts
@@ -646,7 +646,7 @@ Deno.test("buildDiffDocument: a missing model entry inside the hunk body is skip
   ];
   const model = craftedModel(lines, 0, 2, 4);
   const { doc } = buildDiffDocument(text, model, NO_WS);
-  // The hunk loop skips the entry-less body line (no diff colouring); it keeps
+  // The hunk loop skips the entry-less body line (no diff coloring); it keeps
   // only the default plain span the top-level "other" pass assigned.
   assertEquals(
     doc.lines[4].spans.map((s) => s.cls),

--- a/packages/cli/test/view-diffdoc-gate.test.ts
+++ b/packages/cli/test/view-diffdoc-gate.test.ts
@@ -5,7 +5,7 @@ import { realWorkspace } from "../lib/view/diffdoc.ts";
 // --- realWorkspace.resolve: the file-vs-directory check ----------------------
 //
 // resolve() walks each base and, for a candidate that bounded() accepts, checks
-// Deno.statSync(abs).isFile. bounded() already canonicalised abs through
+// Deno.statSync(abs).isFile. bounded() already canonicalized abs through
 // realPathSync, so the stat resolves; the separate try/catch it once carried was
 // removed (read() guards the file contents). These tests pin resolve()'s data
 // paths — a bounded regular file, a directory, an out-of-bounds path — the ones
@@ -52,7 +52,7 @@ Deno.test("realWorkspace.resolve: a directory is bounded but not a file, so reso
     const ws = realWorkspace(root);
     // statSync succeeds on a directory and isFile is false, so the if-body never
     // returns and the catch never runs; resolve falls through every base to
-    // null. This is the closest reachable neighbour of the catch: statSync
+    // null. This is the closest reachable neighbor of the catch: statSync
     // returns rather than throws.
     assertEquals(ws.resolve("adir"), null, "a directory is not a file");
   } finally {

--- a/packages/cli/test/view-diffdoc.test.ts
+++ b/packages/cli/test/view-diffdoc.test.ts
@@ -44,7 +44,7 @@ Deno.test("buildDiffDocument: a deleted Markdown file (new path /dev/null) highl
       JSON.stringify(doc.lines[headIdx].spans)
     }`,
   );
-  // The marker keeps its removal colour.
+  // The marker keeps its removal color.
   assertEquals(doc.lines[headIdx].spans[0].cls, "diffDel", "marker is diffDel");
 
   // No TypeScript identifier classification leaked onto the removed prose.

--- a/packages/cli/test/view-diffedit-cov.test.ts
+++ b/packages/cli/test/view-diffedit-cov.test.ts
@@ -838,10 +838,10 @@ describe("deferred diff parsing", () => {
   });
 });
 
-Deno.test("diffedit cov: the highlighter recolours a Markdown body line via the +++ header scan", () => {
+Deno.test("diffedit cov: the highlighter recolors a Markdown body line via the +++ header scan", () => {
   // Seed-less so the highlighter renders every line itself, then edit a body
   // line whose nearest preceding header is `+++ b/doc.md` — exercising the
-  // Markdown-aware path in the recolour.
+  // Markdown-aware path in the recolor.
   const diff = `diff --git a/doc.md b/doc.md
 --- a/doc.md
 +++ b/doc.md
@@ -856,7 +856,7 @@ Deno.test("diffedit cov: the highlighter recolours a Markdown body line via the 
   raw[bodyIdx] = "+new body text changed";
   const out = hl.update(raw.join("\n"));
   assertEquals(out[bodyIdx].text, "+new body text changed");
-  // The marker keeps its added-line colour.
+  // The marker keeps its added-line color.
   assertEquals(out[bodyIdx].spans[0].cls, "diffAdd");
 });
 
@@ -941,7 +941,7 @@ Deno.test("diffedit cov: the highlighter scans past a missing +++ to the diff --
   assertEquals(out[idx].spans[0].cls, "diffAdd");
 });
 
-Deno.test("diffedit cov: the highlighter returns plain (non-Markdown) colouring when no header precedes a line", () => {
+Deno.test("diffedit cov: the highlighter returns plain (non-Markdown) coloring when no header precedes a line", () => {
   // A body-only fragment with no preceding header: the backward scan finds
   // nothing and reports not-Markdown.
   const text = [" context", "-old", "+changed"].join("\n");

--- a/packages/cli/test/view-diffedit.test.ts
+++ b/packages/cli/test/view-diffedit.test.ts
@@ -250,7 +250,7 @@ Deno.test("diffedit: a context line is editable and writes its file line", () =>
   }
 });
 
-Deno.test("diffedit: the incremental highlighter recolours only edited lines", () => {
+Deno.test("diffedit: the incremental highlighter recolors only edited lines", () => {
   const { ws, done } = tempWorkspace();
   try {
     const model = parseDiff(DIFF)!;
@@ -262,7 +262,7 @@ Deno.test("diffedit: the incremental highlighter recolours only edited lines", (
     const out = hl.update(raw.join("\n"));
     assertEquals(out[5].text, raw[5], "edited line reflects the new text");
     // Every other line — the file/hunk headers especially — is byte-identical
-    // to the seed, so nothing reflows or flickers colour between keystrokes.
+    // to the seed, so nothing reflows or flickers color between keystrokes.
     for (let i = 0; i < doc.lines.length; i++) {
       if (i === 5) continue;
       assertEquals(
@@ -340,7 +340,7 @@ export const shown = 2;
   }
 });
 
-Deno.test("diffedit: stateful languages keep complete-file colours after edits", () => {
+Deno.test("diffedit: stateful languages keep complete-file colors after edits", () => {
   const root = Deno.makeTempDirSync();
   try {
     const cases = [
@@ -391,7 +391,7 @@ Deno.test("diffedit: stateful languages keep complete-file colours after edits",
       assertEquals(
         editedLine.spans.find((span) => span.text === "after")?.cls,
         testCase.cls,
-        `${testCase.path} live colour`,
+        `${testCase.path} live color`,
       );
 
       const editedAgainText = editedText.replace("+after", "+again");
@@ -402,7 +402,7 @@ Deno.test("diffedit: stateful languages keep complete-file colours after edits",
       assertEquals(
         editedAgainLine.spans.find((span) => span.text === "again")?.cls,
         testCase.cls,
-        `${testCase.path} repeated live colour`,
+        `${testCase.path} repeated live color`,
       );
 
       const reparsed = source.parse(editedAgainText);
@@ -412,7 +412,7 @@ Deno.test("diffedit: stateful languages keep complete-file colours after edits",
       assertEquals(
         parsedLine.spans.find((span) => span.text === "again")?.cls,
         testCase.cls,
-        `${testCase.path} deferred colour`,
+        `${testCase.path} deferred color`,
       );
     }
   } finally {
@@ -468,7 +468,7 @@ Deno.test("diffedit: a local string edit leaves surrounding template state intac
   }
 });
 
-Deno.test("diffedit: a local string edit retains same-line contextual colours", () => {
+Deno.test("diffedit: a local string edit retains same-line contextual colors", () => {
   const root = Deno.makeTempDirSync();
   try {
     const file = [

--- a/packages/cli/test/view-display.test.ts
+++ b/packages/cli/test/view-display.test.ts
@@ -52,7 +52,7 @@ Deno.test("DISPLAY_MODES: pictures is first, and every mode has a label", () => 
   assertEquals(DISPLAY_MODES[0], "pictures");
   assertEquals(DISPLAY_MODES.length, 3);
   assertEquals(displayModeLabel("pictures"), "control pictures");
-  assertEquals(displayModeLabel("ansi"), "ANSI colour");
+  assertEquals(displayModeLabel("ansi"), "ANSI color");
   assertEquals(displayModeLabel("hidden"), "hidden");
 });
 
@@ -74,20 +74,20 @@ Deno.test("pictures: printable text is untouched and maps 1:1 to columns", () =>
 });
 
 Deno.test("pictures: does not interpret ANSI — the escape shows as ␛", () => {
-  // A colour sequence is shown literally: ␛ then its printable bytes.
+  // A color sequence is shown literally: ␛ then its printable bytes.
   assertEquals(glyphs("\x1b[31mx", "pictures"), "␛[31mx");
 });
 
 // --- ansi mode ---------------------------------------------------------------
 
-Deno.test("ansi: an SGR colour sequence is hidden and colours the text after it", () => {
+Deno.test("ansi: an SGR color sequence is hidden and colors the text after it", () => {
   const cells = displayLine(ln("a\x1b[31mb"), "ansi");
   // The 5-code-point sequence (ESC [ 3 1 m) is consumed; two cells remain.
   assertEquals(cells.map((c) => c.ch).join(""), "ab");
   assertEquals(
     cells[0].ansi,
     undefined,
-    "text before the sequence is uncoloured",
+    "text before the sequence is uncolored",
   );
   assertEquals(cells[1].ansi?.fg, [205, 49, 49], "text after is ANSI red");
   // The surviving cells keep their original source columns.
@@ -95,12 +95,12 @@ Deno.test("ansi: an SGR colour sequence is hidden and colours the text after it"
   assertEquals(cells[1].col, 6);
 });
 
-Deno.test("ansi: a reset (and a bare ESC[m) clears the colour override", () => {
+Deno.test("ansi: a reset (and a bare ESC[m) clears the color override", () => {
   for (const reset of ["\x1b[0m", "\x1b[m"]) {
     const cells = displayLine(ln(`\x1b[31ma${reset}b`), "ansi");
     assertEquals(cells.map((c) => c.ch).join(""), "ab");
     assertEquals(cells[0].ansi?.fg, [205, 49, 49], "a is red");
-    assertEquals(cells[1].ansi, undefined, `b is uncoloured after ${reset}`);
+    assertEquals(cells[1].ansi, undefined, `b is uncolored after ${reset}`);
   }
 });
 
@@ -111,12 +111,12 @@ Deno.test("ansi: attributes and background codes accumulate", () => {
   assertEquals(cells[0].ansi?.bg, [13, 188, 121], "green background");
 });
 
-Deno.test("ansi: a non-colour CSI sequence is not hidden", () => {
+Deno.test("ansi: a non-color CSI sequence is not hidden", () => {
   // ESC [ 2 J (clear screen) does not end in `m`, so it is shown, not consumed.
   assertEquals(glyphs("\x1b[2Jx", "ansi"), "␛[2Jx");
 });
 
-Deno.test("ansi: 256-colour and truecolor foregrounds", () => {
+Deno.test("ansi: 256-color and truecolor foregrounds", () => {
   const c256 = displayLine(ln("\x1b[38;5;196mx"), "ansi")[0];
   assertEquals(c256.ansi?.fg, [255, 0, 0], "palette index 196 is red");
   const truecolor = displayLine(ln("\x1b[38;2;10;20;30mx"), "ansi")[0];
@@ -186,7 +186,7 @@ Deno.test("displayColumnOf: hidden maps a source column to the compacted column"
   );
 });
 
-Deno.test("displayColumnOf: ansi skips a hidden colour sequence", () => {
+Deno.test("displayColumnOf: ansi skips a hidden color sequence", () => {
   const line = ln("a\x1b[31mb"); // display cells stand at source cols 0 and 6
   assertEquals(displayColumnOf(line, "ansi", 0), 0);
   assertEquals(
@@ -228,16 +228,16 @@ Deno.test("internal applySgr: the full code range folds into a style", () => {
   assertEquals(applySgr({ bg: [1, 2, 3] }, "49").bg, undefined, "default bg");
   assertEquals(applySgr({}, "92").fg, [35, 209, 139], "bright green fg");
   assertEquals(applySgr({}, "105").bg, [214, 112, 214], "bright magenta bg");
-  // A malformed extended-colour code (missing its arguments) is ignored.
+  // A malformed extended-color code (missing its arguments) is ignored.
   assertEquals(applySgr({}, "38").fg, undefined);
-  // A `48` extended-colour code sets the background.
+  // A `48` extended-color code sets the background.
   assertEquals(applySgr({}, "48;5;21").bg, [0, 0, 255], "256-index background");
   assertEquals(
     applySgr({}, "48;2;9;8;7").bg,
     [9, 8, 7],
     "truecolor background",
   );
-  // Anything unrecognised leaves the style unchanged.
+  // Anything unrecognized leaves the style unchanged.
   assertEquals(applySgr({ bold: true }, "73").bold, true);
 });
 

--- a/packages/cli/test/view-editor.test.ts
+++ b/packages/cli/test/view-editor.test.ts
@@ -1,8 +1,8 @@
 /**
- * Editor behaviour at the session level: revealing/moving/hiding the text
+ * Editor behavior at the session level: revealing/moving/hiding the text
  * cursor, live re-highlighting on edit, the Emacs kill/yank bindings reached
  * through the session, saving to disk, and the dirty-quit save prompt. The
- * cursor-free pager behaviour lives in view-session.test.ts; the pure edit
+ * cursor-free pager behavior lives in view-session.test.ts; the pure edit
  * engine is covered in view-editbuffer.test.ts.
  */
 import { assert, assertEquals } from "@std/assert";
@@ -502,13 +502,13 @@ Deno.test("editor: typing re-highlights live and defers only the structure repar
   assert(!s.needsReparse, "reparse clears the deferred flag");
 });
 
-Deno.test("editor: opening a block comment re-colours the following lines live", () => {
+Deno.test("editor: opening a block comment re-colors the following lines live", () => {
   const { src } = memSource();
   const s = editSession("const a = 1;\nconst b = 2;\n", src);
   press(s, "e"); // reveal at (0,0)
   type(s, "/* "); // open an (unterminated) block comment at the top
-  // Line 1 is now inside the comment — re-coloured immediately, no reparse. A
-  // per-line patch would leave `const` on line 1 still keyword-coloured.
+  // Line 1 is now inside the comment — re-colored immediately, no reparse. A
+  // per-line patch would leave `const` on line 1 still keyword-colored.
   const line1 = s.doc.lines[1];
   assert(
     !line1.spans.some((sp) => sp.cls === "storageKeyword"),
@@ -516,7 +516,7 @@ Deno.test("editor: opening a block comment re-colours the following lines live",
   );
   assert(
     line1.spans.some((sp) => sp.cls === "comment"),
-    `line 1 should be comment-coloured: ${line1.spans.map((x) => x.cls)}`,
+    `line 1 should be comment-colored: ${line1.spans.map((x) => x.cls)}`,
   );
 });
 

--- a/packages/cli/test/view-filegateway-cov.test.ts
+++ b/packages/cli/test/view-filegateway-cov.test.ts
@@ -432,7 +432,7 @@ Deno.test("realFileGateway.open: returns null when the file cannot be read", () 
   assertEquals(gw.open(missing), null);
 });
 
-Deno.test("realFileGateway.join: joins and normalises a directory and segment", () => {
+Deno.test("realFileGateway.join: joins and normalizes a directory and segment", () => {
   const gw = realFileGateway();
   assertEquals(gw.join("/work", "a.ts"), join("/work", "a.ts"));
   assertEquals(gw.join("/work/sub", ".."), join("/work/sub", ".."));

--- a/packages/cli/test/view-helpers.ts
+++ b/packages/cli/test/view-helpers.ts
@@ -8,13 +8,13 @@ import type { Rgb } from "../lib/view/ansi.ts";
 
 export { parseDocument };
 
-/** The `48;2;r;g;b` background run for a colour, as it appears in an SGR escape;
- * lets a test assert on a theme colour without hard-coding its hex. */
+/** The `48;2;r;g;b` background run for a color, as it appears in an SGR escape;
+ * lets a test assert on a theme color without hard-coding its hex. */
 export function bgCode(rgb: Rgb): string {
   return `48;2;${rgb[0]};${rgb[1]};${rgb[2]}`;
 }
 
-/** The `38;2;r;g;b` foreground run for a colour. */
+/** The `38;2;r;g;b` foreground run for a color. */
 export function fgCode(rgb: Rgb): string {
   return `38;2;${rgb[0]};${rgb[1]};${rgb[2]}`;
 }

--- a/packages/cli/test/view-highlight-cov.test.ts
+++ b/packages/cli/test/view-highlight-cov.test.ts
@@ -8,7 +8,7 @@ import type { Line } from "../lib/view/model.ts";
 import { stripAnsi } from "../lib/view/ansi.ts";
 import { parseDocument, SAMPLE } from "./view-helpers.ts";
 
-Deno.test("renderLinePlain returns the verbatim line text, no colour", () => {
+Deno.test("renderLinePlain returns the verbatim line text, no color", () => {
   const line: Line = {
     text: "const x = 1;",
     spans: [
@@ -59,7 +59,7 @@ Deno.test("renderLinePlain matches every parsed line of the sample blob", () => 
   }
 });
 
-Deno.test("renderLinePlain equals stripAnsi of the coloured render", () => {
+Deno.test("renderLinePlain equals stripAnsi of the colored render", () => {
   const doc = parseDocument(SAMPLE);
   for (const line of doc.lines) {
     const plain = renderLinePlain(line);

--- a/packages/cli/test/view-highlighter.test.ts
+++ b/packages/cli/test/view-highlighter.test.ts
@@ -1,11 +1,11 @@
 /**
  * The incremental highlighter ({@link createHighlighter}) must produce exactly
- * the same coloured lines as a full {@link highlightDocument} parse — it keeps
+ * the same colored lines as a full {@link highlightDocument} parse — it keeps
  * the TypeScript source file warm and re-highlights only the region an edit
  * touches, so its result has to match a from-scratch parse at every step of a
  * realistic edit. These tests drive it through the edits a person makes: typing
  * a file out and deleting it one character at a time, and opening then closing
- * the multi-line constructs (block comment, template, string) whose colour
+ * the multi-line constructs (block comment, template, string) whose color
  * spills onto later lines.
  */
 import { assert, assertEquals } from "@std/assert";
@@ -81,7 +81,7 @@ Deno.test("highlighter: opening and closing multi-line constructs matches a full
   const tail = SAMPLE.slice(mid);
   const at = (s: string) => head + s + tail;
   // A block comment, a template literal, and a string, each grown one keystroke
-  // at a time from unterminated to closed — the states that recolour the lines
+  // at a time from unterminated to closed — the states that recolor the lines
   // below the cursor.
   checkSequence("open-close-constructs", [
     SAMPLE,
@@ -124,7 +124,7 @@ Deno.test("highlighter: inserting and deleting at every position matches a full 
 });
 
 Deno.test("highlighter: an edit re-baselines correctly across a multi-line comment", () => {
-  // Opening a block comment recolours the lines it now swallows; closing it
+  // Opening a block comment recolors the lines it now swallows; closing it
   // restores them. The incremental result must track a full parse through both.
   const hl = createHighlighter(
     "const a = 1;\nconst b = 2;\nconst c = 3;\n",
@@ -134,7 +134,7 @@ Deno.test("highlighter: an edit re-baselines correctly across a multi-line comme
   const inc = hl.update(opened);
   assert(
     inc[1].spans.every((s) => s.cls === "comment" || s.cls === "whitespace"),
-    "line inside the open comment is comment-coloured",
+    "line inside the open comment is comment-colored",
   );
   assertEquals(firstDiff(inc, highlightDocument(opened, "m.ts")), -1);
   const closed = "/* const a = 1;\nconst b = 2; */\nconst c = 3;\n";

--- a/packages/cli/test/view-json.test.ts
+++ b/packages/cli/test/view-json.test.ts
@@ -1,10 +1,10 @@
 /**
  * The JSON / JSONC language: a `.json` or `.jsonc` file (opened directly or seen
- * in a diff) is coloured as data — object keys apart from string values,
+ * in a diff) is colored as data — object keys apart from string values,
  * numbers, `true`/`false`/`null`, rainbow brackets, JSONC comments — with its
  * object keys forming the navigation tree, and is never run through the
  * TypeScript parser. The highlighter is hand-written and lenient: malformed
- * input colours without throwing.
+ * input colors without throwing.
  */
 import { assert, assertEquals } from "@std/assert";
 import { join } from "@std/path";
@@ -19,7 +19,7 @@ import { parseDiff } from "../lib/view/diff.ts";
 import { buildDiffDocument, type DiffWorkspace } from "../lib/view/diffdoc.ts";
 import { createDiffHighlighter } from "../lib/view/diffedit.ts";
 
-/** The verbatim text of a set of lines — colouring must never change it. */
+/** The verbatim text of a set of lines — coloring must never change it. */
 function verbatim(lines: readonly Line[]): string {
   return lines.map((l) => l.spans.map((s) => s.text).join("")).join("\n");
 }
@@ -59,7 +59,7 @@ Deno.test("json: keys, values, and literals get distinct classes", () => {
   assert(classesOf(lines, ",").has("punctuation"));
 });
 
-Deno.test("json: brackets carry a nesting depth for rainbow colouring", () => {
+Deno.test("json: brackets carry a nesting depth for rainbow coloring", () => {
   const lines = jsonHighlightLines(`{ "a": [ 1 ] }`);
   const brackets = lines[0].spans.filter((s) => s.cls === "bracket");
   const byText = new Map(brackets.map((s) => [s.text, s.bracketDepth]));
@@ -71,7 +71,7 @@ Deno.test("json: brackets carry a nesting depth for rainbow colouring", () => {
   assertEquals(byText.get("]"), 1);
 });
 
-Deno.test("json: JSONC line and block comments are coloured, not rejected", () => {
+Deno.test("json: JSONC line and block comments are colored, not rejected", () => {
   const src = [
     "{",
     "  // a line comment",
@@ -83,10 +83,10 @@ Deno.test("json: JSONC line and block comments are coloured, not rejected", () =
   ].join("\n");
   const lines = jsonHighlightLines(src);
   assertEquals(lines[1].spans.map((s) => s.cls), ["whitespace", "comment"]);
-  // The block comment spans two lines; both are coloured as comment.
+  // The block comment spans two lines; both are colored as comment.
   assert(lines[3].spans.some((s) => s.cls === "comment"));
   assert(lines[4].spans.some((s) => s.cls === "comment"));
-  // The trailing comma after `2` is punctuation, and colouring is lossless.
+  // The trailing comma after `2` is punctuation, and coloring is lossless.
   assert(classesOf(lines, ",").has("punctuation"));
   assertEquals(verbatim(lines), src);
 });
@@ -99,7 +99,7 @@ Deno.test("json: a bare non-BMP character stays one span", () => {
   assertEquals(spans[0].text, "😀");
 });
 
-Deno.test("json: colouring is byte-for-byte lossless", () => {
+Deno.test("json: coloring is byte-for-byte lossless", () => {
   const src = `{
   "emoji": "🎉 é ✓",
   "nums": [1, -2.5, 3e10],
@@ -138,7 +138,7 @@ Deno.test("json: a non-string object key is skipped, not treated as a member", (
 
 Deno.test("json: pathologically deep nesting degrades to no structure", () => {
   // Deep enough to overflow the structure walk's recursion; `jsonDocument`
-  // catches it and returns colouring with an empty tree rather than throwing.
+  // catches it and returns coloring with an empty tree rather than throwing.
   const deep = "[".repeat(100000);
   const doc = jsonDocument(deep);
   assertEquals(doc.structure, []);
@@ -196,7 +196,7 @@ Deno.test("json: the incremental highlighter matches a whole re-highlight", () =
   );
 });
 
-Deno.test("json: malformed input colours without throwing", () => {
+Deno.test("json: malformed input colors without throwing", () => {
   for (
     const bad of [
       '{ "unterminated: 1',
@@ -214,7 +214,7 @@ Deno.test("json: malformed input colours without throwing", () => {
   }
 });
 
-Deno.test("json: a .json file in a diff is coloured and navigated as JSON", () => {
+Deno.test("json: a .json file in a diff is colored and navigated as JSON", () => {
   const root = Deno.makeTempDirSync();
   try {
     const file = `{\n  "name": "widget",\n  "count": 2\n}\n`;
@@ -241,7 +241,7 @@ Deno.test("json: a .json file in a diff is coloured and navigated as JSON", () =
 `;
     const model = parseDiff(diff)!;
     const { doc } = buildDiffDocument(diff, model, ws);
-    // The context line for the key is coloured as JSON: the key is a
+    // The context line for the key is colored as JSON: the key is a
     // propertyName, proving the JSON language (not TypeScript) ran.
     const keyLine = doc.lines.find((l) =>
       l.spans.some((s) => s.text === '"count"')
@@ -274,7 +274,7 @@ Deno.test("json: a .json file in a diff is coloured and navigated as JSON", () =
   }
 });
 
-Deno.test("json: editing a line in a json diff recolours it as json", () => {
+Deno.test("json: editing a line in a json diff recolors it as json", () => {
   const diff = [
     "diff --git a/c.json b/c.json",
     "--- a/c.json",

--- a/packages/cli/test/view-jumplist.test.ts
+++ b/packages/cli/test/view-jumplist.test.ts
@@ -88,7 +88,7 @@ const SHOW = [
   "",
 ].join("\n");
 
-Deno.test("jumplist: i lists the diff's files, dirs summarised", () => {
+Deno.test("jumplist: i lists the diff's files, dirs summarized", () => {
   const s = diffSession(TWO_FILES);
   press(s, "i");
   assertEquals(entryText(s), [

--- a/packages/cli/test/view-keys-cov.test.ts
+++ b/packages/cli/test/view-keys-cov.test.ts
@@ -113,7 +113,7 @@ Deno.test("decode: CSI function keys P/Q/R/S map to f1-f4", () => {
 });
 
 Deno.test("decode: CSI unknown final is 'unknown'", () => {
-  // ESC [ X (0x58) — not a modelled final.
+  // ESC [ X (0x58) — not a modeled final.
   assertEquals(only(raw(0x1b, 0x5b, 0x58)).name, "unknown");
 });
 
@@ -161,7 +161,7 @@ Deno.test("decode: tilde function keys f1-f12", () => {
 });
 
 Deno.test("decode: tilde unknown code is 'unknown'", () => {
-  // ESC [ 9 9 ~ — code 99 is not modelled.
+  // ESC [ 9 9 ~ — code 99 is not modeled.
   const k = only(raw(0x1b, 0x5b, 0x39, 0x39, 0x7e));
   assertEquals(k.name, "unknown");
 });
@@ -186,7 +186,7 @@ Deno.test("decode: SS3 function keys P/Q/R/S map to f1-f4", () => {
 });
 
 Deno.test("decode: SS3 unknown final is 'unknown'", () => {
-  // ESC O X (0x58) — not a modelled SS3 final.
+  // ESC O X (0x58) — not a modeled SS3 final.
   assertEquals(only(raw(0x1b, 0x4f, 0x58)).name, "unknown");
 });
 

--- a/packages/cli/test/view-markdown-cov.test.ts
+++ b/packages/cli/test/view-markdown-cov.test.ts
@@ -1,5 +1,5 @@
 /**
- * Coverage-focused behavioural tests for the Markdown highlighter
+ * Coverage-focused behavioral tests for the Markdown highlighter
  * (`lib/view/languages/markdown/markdown.ts`). Each test drives a specific code path —
  * the whole-document `Highlighter` wrapper, the empty/non-empty single-span
  * helper, the horizontal-rule branch, mismatched and unclosed inline-code
@@ -59,7 +59,7 @@ Deno.test("markdown: a horizontal rule line is a single punctuation span", () =>
     assertEquals(line.text, rule);
   }
   // A line that merely starts with a dash is a list, not a rule, so it keeps
-  // its marker-plus-prose colouring rather than collapsing to one span.
+  // its marker-plus-prose coloring rather than collapsing to one span.
   const [list] = highlightMarkdownLines("- a real list item");
   assert(
     list.spans.length > 1,
@@ -83,7 +83,7 @@ Deno.test("markdown: inline code with an interior backtick run of a different le
   );
 });
 
-Deno.test("markdown: an unclosed inline backtick run does not colour the rest of the line", () => {
+Deno.test("markdown: an unclosed inline backtick run does not color the rest of the line", () => {
   // A lone opening backtick with no matching close: the scan finds no close,
   // advances past the run (`i += n`), and the rest of the line stays plain.
   const [line] = highlightMarkdownLines("an `unclosed run of prose");

--- a/packages/cli/test/view-markdown-render.test.ts
+++ b/packages/cli/test/view-markdown-render.test.ts
@@ -85,7 +85,7 @@ Deno.test("markdown rendered view formats blocks and inline content", () => {
   );
   assert(
     lines[2].spans.some((span) => span.cls === "string"),
-    "inline code has code colour",
+    "inline code has code color",
   );
   assert(
     lines[6].spans.some((span) => span.bold),

--- a/packages/cli/test/view-markdown.test.ts
+++ b/packages/cli/test/view-markdown.test.ts
@@ -1,6 +1,6 @@
 /**
  * The Markdown highlighter: a `.md` file (opened directly or seen in a diff) is
- * coloured as Markdown — headings, fenced/inline code, lists, quotes, links —
+ * colored as Markdown — headings, fenced/inline code, lists, quotes, links —
  * not parsed as TypeScript, and its headings form the navigation tree.
  */
 import { assert, assertEquals } from "@std/assert";
@@ -17,7 +17,7 @@ import { buildDiffDocument, type DiffWorkspace } from "../lib/view/diffdoc.ts";
 import { createDiffHighlighter } from "../lib/view/diffedit.ts";
 import { spanStyle } from "../lib/view/highlight.ts";
 
-Deno.test("markdown: language metadata recognises markdown extensions", () => {
+Deno.test("markdown: language metadata recognizes markdown extensions", () => {
   assertEquals(languageForFile("README.md").id, "markdown");
   assertEquals(languageForFile("/a/b/AGENTS.markdown").id, "markdown");
   assertEquals(languageForFile("notes.MD").id, "markdown");
@@ -26,7 +26,7 @@ Deno.test("markdown: language metadata recognises markdown extensions", () => {
   assertEquals(languageForFile(undefined).id, "plain-text");
 });
 
-Deno.test("markdown: headings, code, lists, quotes and prose get distinct, non-TS colours", () => {
+Deno.test("markdown: headings, code, lists, quotes and prose get distinct, non-TS colors", () => {
   const lines = highlightMarkdownLines(
     `# Title
 
@@ -53,7 +53,7 @@ deno task cf
   );
   assert(
     !list.some((s) => s.cls === "identifier" || s.cls === "operator"),
-    "no TypeScript identifier/operator colours",
+    "no TypeScript identifier/operator colors",
   );
   // The fenced code block: fences are punctuation, content is a string.
   assertEquals(lines[3].spans.map((s) => s.cls), ["punctuation"]); // ```bash
@@ -128,7 +128,7 @@ Deno.test("markdown: languageForFile dispatches on a .md filename", () => {
   );
 });
 
-Deno.test("markdown: editing a line in a markdown diff recolours it as markdown", () => {
+Deno.test("markdown: editing a line in a markdown diff recolors it as markdown", () => {
   const diff = [
     "diff --git a/r.md b/r.md",
     "--- a/r.md",
@@ -140,7 +140,7 @@ Deno.test("markdown: editing a line in a markdown diff recolours it as markdown"
   ].join("\n");
   const hl = createDiffHighlighter(diff);
   const out = hl.update(diff.replace("`code`", "`codex`"));
-  // The edited markdown line colours its inline code as a string (markdown),
+  // The edited markdown line colors its inline code as a string (markdown),
   // not as a TypeScript template that swallows the rest.
   const edited = out[5];
   assert(
@@ -387,9 +387,9 @@ index 0000000..1111111 100644
     // The heading line, past its diff marker, is a section header.
     assert(
       doc.lines[5].spans.some((s) => s.cls === "sectionHeader"),
-      "the heading is markdown-coloured in the diff",
+      "the heading is markdown-colored in the diff",
     );
-    // The added line keeps its diff marker and colours the inline code green.
+    // The added line keeps its diff marker and colors the inline code green.
     const added = doc.lines[8];
     assertEquals(added.spans[0].cls, "diffAdd", "the + marker");
     assert(

--- a/packages/cli/test/view-meta.test.ts
+++ b/packages/cli/test/view-meta.test.ts
@@ -4,7 +4,7 @@ import type { Document, StructureNode } from "../lib/view/model.ts";
 
 function byLabel(doc: Document, label: string): StructureNode {
   const node = doc.flatStructure.find((n) => n.label === label);
-  if (!node) throw new Error(`no node labelled "${label}"`);
+  if (!node) throw new Error(`no node labeled "${label}"`);
   return node;
 }
 

--- a/packages/cli/test/view-model-cov.test.ts
+++ b/packages/cli/test/view-model-cov.test.ts
@@ -1,7 +1,7 @@
 /**
  * The shared model's one runtime helper: flattenStructure turns a structure
  * tree into the pre-order sequence that `flatStructure` holds. It is exercised
- * by every parse/markdown/diff document build; this pins its behaviour directly.
+ * by every parse/markdown/diff document build; this pins its behavior directly.
  */
 import { assertEquals } from "@std/assert";
 import { flattenStructure, type StructureNode } from "../lib/view/model.ts";

--- a/packages/cli/test/view-pager-cov.test.ts
+++ b/packages/cli/test/view-pager-cov.test.ts
@@ -152,7 +152,7 @@ Deno.test("pager: unknown named files schedule no semantic work", async () => {
   assertEquals(timers.size, 0);
 });
 
-Deno.test("pager: with colour, matches the terminal background to the status bar and restores it", async () => {
+Deno.test("pager: with color, matches the terminal background to the status bar and restores it", async () => {
   // A redraw (the 'j' scroll) in its own read precedes the quit, so the frame is
   // drawn again inside the loop.
   const { deps, writes } = makeFake({
@@ -167,9 +167,9 @@ Deno.test("pager: with colour, matches the terminal background to the status bar
   );
   const all = writes.join("");
   const set = term.setDefaultBg(ui.statusBar.bg!);
-  // OSC 11 sets the terminal default background to the status bar colour, and it
+  // OSC 11 sets the terminal default background to the status bar color, and it
   // is re-asserted on every frame so a terminal that drops it cannot leave a
-  // strip in its own colour; OSC 111 restores it on exit.
+  // strip in its own color; OSC 111 restores it on exit.
   assert(all.includes(set), "set the default background");
   assert(all.split(set).length - 1 >= 2, "re-asserted on redraw");
   assert(all.includes("\x1b]111\x07"), "restored the default background");

--- a/packages/cli/test/view-parse-cov.test.ts
+++ b/packages/cli/test/view-parse-cov.test.ts
@@ -1,6 +1,6 @@
 /**
  * Coverage-driving tests for `lib/view/languages/typescript/parse.ts`. These exercise the parser's
- * less-travelled branches: the incremental highlighter's no-op and walk-back
+ * less-traveled branches: the incremental highlighter's no-op and walk-back
  * paths, the full set of identifier classifications, every structure-tree
  * classification (methods, enums, namespaces, control flow, labels), the schema
  * and type metadata extractors, and the syntactic type-inference branches.
@@ -218,7 +218,7 @@ Deno.test("createHighlighter: an edit near a JSDoc comment stays one whole comme
 
 // --- classifyToken: null is a boolean-class literal (line 803) ---------------
 
-Deno.test("parse: null, true and false are coloured as boolean literals", () => {
+Deno.test("parse: null, true and false are colored as boolean literals", () => {
   const doc = parseDocument(
     "const a = null;\nconst b = true;\nconst c = false;\n",
   );
@@ -239,7 +239,7 @@ Deno.test("parse: function, method and interface declaration names are classifie
     "class C { method() {} field = 1; }",
     "const ce = class Named {};",
     "type Ali = number;",
-    "enum Colour { Red, Green }",
+    "enum Color { Red, Green }",
   ].join("\n");
   const doc = parseDocument(src, "m.ts");
   assert(classesOf(doc, "topFn").has("functionName"), "function name");
@@ -249,7 +249,7 @@ Deno.test("parse: function, method and interface declaration names are classifie
   assert(classesOf(doc, "C").has("typeName"), "class declaration name");
   assert(classesOf(doc, "Named").has("typeName"), "class expression name");
   assert(classesOf(doc, "Ali").has("typeName"), "type alias name");
-  assert(classesOf(doc, "Colour").has("typeName"), "enum name");
+  assert(classesOf(doc, "Color").has("typeName"), "enum name");
   assert(classesOf(doc, "field").has("propertyName"), "class property");
   assert(classesOf(doc, "p").has("propertyName"), "property signature");
   assert(classesOf(doc, "Red").has("propertyName"), "enum member");
@@ -363,7 +363,7 @@ Deno.test("parse: comments are merged into the structure tree in source order", 
 
 Deno.test("parse: an element-access expression gets a […] generic label", () => {
   const doc = parseDocument("const e = arr[index];\n", "m.ts");
-  // The element-access node is labelled `arr[…]`.
+  // The element-access node is labeled `arr[…]`.
   assert(
     findNode(doc, (n) => n.label === "arr[…]"),
     `expected an element-access node, got ${labels(doc).join(" | ")}`,
@@ -502,16 +502,16 @@ Deno.test("parse: an unusual statement still becomes a reachable statement node"
 
 // --- bindingDesc: no initializer (lines 1496-1505) ---------------------------
 
-Deno.test("parse: an uninitialised binding becomes a variable node with no init meta", () => {
+Deno.test("parse: an uninitialized binding becomes a variable node with no init meta", () => {
   const doc = parseDocument("let pending: number;\n", "m.ts");
   const node = findNode(doc, (n) => n.name === "pending");
-  assert(node, "the uninitialised binding is a node");
+  assert(node, "the uninitialized binding is a node");
   assertEquals(node!.kind, "variable");
   assertEquals(node!.label, "pending");
-  // Its variable meta reports an uninitialised binding and the annotated type.
+  // Its variable meta reports an uninitialized binding and the annotated type.
   assert(node!.meta && node!.meta.kind === "variable");
   if (node!.meta && node!.meta.kind === "variable") {
-    assertEquals(node!.meta.bindsTo, "(uninitialised)");
+    assertEquals(node!.meta.bindsTo, "(uninitialized)");
     assertEquals(node!.meta.typeText, "number");
   }
 });
@@ -616,7 +616,7 @@ Deno.test("parse: every control-flow shape gets its distinct label", () => {
 
 // --- calleeName: a non-identifier non-property callee (line 1708) ------------
 
-Deno.test("parse: a computed-callee call is labelled by its first source line", () => {
+Deno.test("parse: a computed-callee call is labeled by its first source line", () => {
   // `(obj["m"])(…)` — the callee is neither a plain identifier nor a property
   // access, so calleeName falls back to nodeFirstLine.
   const doc = parseDocument(`const r = (table["run"])(1);\n`, "m.ts");

--- a/packages/cli/test/view-parse-cov2.test.ts
+++ b/packages/cli/test/view-parse-cov2.test.ts
@@ -2,7 +2,7 @@
  * Second-round coverage tests for `lib/view/languages/typescript/parse.ts`, extending
  * `view-parse.test.ts` and `view-parse-cov.test.ts`. The dead and duplicate
  * branches these originally documented were removed or folded away at the
- * source; the tests here exercise the reachable behaviour around them:
+ * source; the tests here exercise the reachable behavior around them:
  * identifier classification, type-position resolution (qualified names,
  * `typeof`, heritage types), comment merging, definition registration, control
  * labels, and metadata extraction on malformed input, plus `safe`'s
@@ -40,7 +40,7 @@ function labelsOf(doc: Document): string[] {
   return doc.flatStructure.map((n) => n.label);
 }
 
-// --- isTypePosition: qualified names in type position (neighbour of 913) ---
+// --- isTypePosition: qualified names in type position (neighbor of 913) ---
 
 Deno.test("qualified name in a type annotation resolves as a type name", () => {
   // `a.b.c.D` in type position climbs the qualified-name chain in
@@ -54,7 +54,7 @@ Deno.test("qualified name in a type annotation resolves as a type name", () => {
   );
 });
 
-// --- isTypePosition: typeof type (neighbour of 916) ---
+// --- isTypePosition: typeof type (neighbor of 916) ---
 
 Deno.test("typeof in a type annotation resolves the operand as a type name", () => {
   // `typeof foo` as a type produces a TypeQueryNode parent for `foo`. Because a
@@ -70,7 +70,7 @@ Deno.test("typeof in a type annotation resolves the operand as a type name", () 
   );
 });
 
-// --- isTypePosition: heritage clause (neighbour of 917, 919, 920) ---
+// --- isTypePosition: heritage clause (neighbor of 917, 919, 920) ---
 
 Deno.test("class heritage type resolves as a type name", () => {
   // `extends Base<number>` produces an ExpressionWithTypeArguments whose
@@ -93,7 +93,7 @@ Deno.test("interface heritage type resolves as a type name", () => {
   );
 });
 
-// --- classifyIdentifier neighbours of 836: the full reachable classification ---
+// --- classifyIdentifier neighbors of 836: the full reachable classification ---
 
 Deno.test("identifier classifications across declaration and use sites", () => {
   const src = [
@@ -120,7 +120,7 @@ Deno.test("identifier classifications across declaration and use sites", () => {
   assert(sideClasses.has("propertyName") || sideClasses.has("binding"));
 });
 
-// --- mergeByStart neighbour of 1215: non-empty comment batches merge in ---
+// --- mergeByStart neighbor of 1215: non-empty comment batches merge in ---
 
 Deno.test("comments are threaded into the structure tree", () => {
   const src = [
@@ -145,7 +145,7 @@ Deno.test("comments are threaded into the structure tree", () => {
   );
 });
 
-// --- registerDefinition neighbour of 1260: named declarations register ---
+// --- registerDefinition neighbor of 1260: named declarations register ---
 
 Deno.test("named declarations are registered as definitions", () => {
   const src = [
@@ -167,7 +167,7 @@ Deno.test("named declarations are registered as definitions", () => {
   assertEquals(alpha[0].name, "alpha");
 });
 
-// --- controlLabel neighbours of 1674: all eight control-statement labels ---
+// --- controlLabel neighbors of 1674: all eight control-statement labels ---
 
 Deno.test("every control statement gets its dedicated label", () => {
   const src = [
@@ -193,7 +193,7 @@ Deno.test("every control statement gets its dedicated label", () => {
   assert(has(/^try$/), "missing try label");
 });
 
-// --- safe() neighbours of 1725-1727: extractors never throw on parseable input ---
+// --- safe() neighbors of 1725-1727: extractors never throw on parseable input ---
 
 Deno.test("metadata extraction survives malformed but parseable input", () => {
   // These all parse (via TypeScript error recovery) into nodes with valid
@@ -224,7 +224,7 @@ Deno.test("import metadata is extracted without error", () => {
   assertEquals(imp!.meta!.kind, "import");
 });
 
-// --- describeInitializer neighbours of 2051-2053 ---
+// --- describeInitializer neighbors of 2051-2053 ---
 
 Deno.test("a raw arrow initializer becomes a closure node, not a variable", () => {
   // bindingDesc routes the arrow to a closure before variableMeta /
@@ -245,7 +245,7 @@ Deno.test("a parenthesised arrow initializer also becomes a closure node", () =>
 });
 
 Deno.test("describeInitializer reports non-closure initializers", () => {
-  // The reachable describeInitializer outputs: the no-initialiser case and the
+  // The reachable describeInitializer outputs: the no-initializer case and the
   // nodeFirstLine fall-through. These run for the variable-kind nodes below.
   const doc = parseDocument(
     "let pending;\nconst result = computeValue();\nconst total = a + b;",
@@ -253,10 +253,10 @@ Deno.test("describeInitializer reports non-closure initializers", () => {
   const pending = findNode(doc, (n) => n.name === "pending");
   assert(pending, "expected a node bound to `pending`");
   assertEquals(pending!.meta?.kind, "variable");
-  // An uninitialised binding reports the sentinel from describeInitializer.
+  // An uninitialized binding reports the sentinel from describeInitializer.
   assertEquals(
     (pending!.meta as { bindsTo?: string }).bindsTo,
-    "(uninitialised)",
+    "(uninitialized)",
   );
 
   const result = findNode(doc, (n) => n.name === "result");

--- a/packages/cli/test/view-parse-gate.test.ts
+++ b/packages/cli/test/view-parse-gate.test.ts
@@ -1,8 +1,8 @@
 /**
- * Behavioural tests for the parse paths the coverage gate flagged in
+ * Behavioral tests for the parse paths the coverage gate flagged in
  * `lib/view/languages/typescript/parse.ts`. The dead and duplicate branches at those lines were
  * removed or folded away at the source; these tests exercise the reachable
- * behaviour that remains, through the public API:
+ * behavior that remains, through the public API:
  *
  *   - classifyIdentifier: a leaf identifier is classified by its parent.
  *   - isTypePosition: a qualified name, a `typeof` operand, and a class or
@@ -117,7 +117,7 @@ Deno.test("gate 913: a qualified name in a type annotation resolves as a type", 
 
 // --- 916: typeof type resolves via ts.isTypeNode before the TypeQuery branch -
 
-Deno.test("gate 916: a `typeof` type colours its operand as a type name", () => {
+Deno.test("gate 916: a `typeof` type colors its operand as a type name", () => {
   // `typeof base` as a type makes `base`'s parent a TypeQueryNode. Because a
   // TypeQueryNode is itself a TypeNode, isTypePosition returns at the
   // ts.isTypeNode check above; the dedicated isTypeQueryNode branch never runs.
@@ -130,7 +130,7 @@ Deno.test("gate 916: a `typeof` type colours its operand as a type name", () => 
 
 // --- 917, 919, 920: heritage types resolve via ts.isTypeNode first ----------
 
-Deno.test("gate 917-920: a class heritage type colours as a type name", () => {
+Deno.test("gate 917-920: a class heritage type colors as a type name", () => {
   // `extends Parent<number>` produces an ExpressionWithTypeArguments whose
   // expression is `Parent`. That node is also a TypeNode, so `Parent` resolves
   // as a typeName at the ts.isTypeNode check, never reaching the
@@ -142,7 +142,7 @@ Deno.test("gate 917-920: a class heritage type colours as a type name", () => {
   );
 });
 
-Deno.test("gate 917-920: an interface heritage type colours as a type name", () => {
+Deno.test("gate 917-920: an interface heritage type colors as a type name", () => {
   const doc = parseDocument("interface Sub extends Sup { z: number }");
   assert(
     classesOf(doc, "Sup").has("typeName"),
@@ -303,7 +303,7 @@ Deno.test("gate 2045-2047: an arrow initializer becomes a closure node", () => {
 });
 
 Deno.test("gate 2045-2047: describeInitializer reports the reachable non-closure cases", () => {
-  // The reachable describeInitializer outputs: the uninitialised sentinel and
+  // The reachable describeInitializer outputs: the uninitialized sentinel and
   // the nodeFirstLine fall-through for a non-arrow initializer. Neither is the
   // "closure" string, confirming that branch stays dead for variable nodes.
   const doc = parseDocument(
@@ -318,7 +318,7 @@ Deno.test("gate 2045-2047: describeInitializer reports the reachable non-closure
   assertEquals(pending.meta?.kind, "variable");
   assertEquals(
     (pending.meta as { bindsTo?: string }).bindsTo,
-    "(uninitialised)",
+    "(uninitialized)",
   );
 
   const total = byName(doc, "total")!;
@@ -332,7 +332,7 @@ Deno.test("gate 2045-2047: describeInitializer reports the reachable non-closure
 });
 
 Deno.test("gate 2045-2047: incremental highlighter re-highlights an edited closure line", () => {
-  // Editing a line into an arrow keeps the byte-for-byte text and re-colours the
+  // Editing a line into an arrow keeps the byte-for-byte text and re-colors the
   // arrow token, exercising the incremental path that feeds the same classifier
   // and binding routing as a full parse.
   const h = createHighlighter("const a = 1;\nconst b = 2;\n");

--- a/packages/cli/test/view-parse.test.ts
+++ b/packages/cli/test/view-parse.test.ts
@@ -79,7 +79,7 @@ Deno.test("parse: schema keys differ from ordinary identifiers", () => {
   );
 });
 
-Deno.test("parse: type positions are coloured as types", () => {
+Deno.test("parse: type positions are colored as types", () => {
   const doc = parseDocument(SAMPLE);
   assert(classesOf(doc, "Foo").has("typeName"), "Foo type alias name");
   assert(classesOf(doc, "Bar").has("interfaceName"), "Bar interface name");
@@ -375,8 +375,8 @@ Deno.test("parse: the whole AST is navigable — RHS expression, chained calls, 
     n.kind === "node" && (n.astKinds?.includes("CallExpression") ?? false) &&
     n.label === ".run(…)"
   );
-  assert(rhs, "the call chain is a node, labelled by its outermost method");
-  // Chained calls are distinct nodes, each labelled by its own method.
+  assert(rhs, "the call chain is a node, labeled by its outermost method");
+  // Chained calls are distinct nodes, each labeled by its own method.
   assert(flat.some((n) => n.label === ".name(…)"), "chained .name() is a node");
   assert(flat.some((n) => n.label === "make(…)"), "the base call is a node");
   // Their arguments are nodes too.
@@ -400,7 +400,7 @@ const x = 1;
   const lines = highlightDocument(text, "m.ts");
   // Lines 0–3 are the whole comment. Every span is a doc comment: the
   // {@link Document} reference is not torn out as an identifier, and the text
-  // after it (and the following lines) is not left uncoloured.
+  // after it (and the following lines) is not left uncolored.
   for (let i = 0; i <= 3; i++) {
     for (const s of lines[i].spans) {
       assertEquals(
@@ -448,8 +448,8 @@ Deno.test("parse: nodes sharing an exact range merge into one", () => {
   );
 });
 
-Deno.test("parse: recognised folds do not expand into raw AST children", () => {
-  // A node classified as a recognised shape (import, schema, type alias,
+Deno.test("parse: recognized folds do not expand into raw AST children", () => {
+  // A node classified as a recognized shape (import, schema, type alias,
   // interface) suppresses its children: the build descends only into the child
   // source nodes the classification chose (`recurseInto`), never into raw
   // `forEachChild` output. Each of these is a leaf in the structure tree.

--- a/packages/cli/test/view-python.test.ts
+++ b/packages/cli/test/view-python.test.ts
@@ -78,7 +78,7 @@ Deno.test("python: the language registry selects Python extensions", () => {
   );
 });
 
-Deno.test("python: declarations, keywords, calls, properties, and comments colour", () => {
+Deno.test("python: declarations, keywords, calls, properties, and comments color", () => {
   const source = [
     "#!/usr/bin/env python3",
     "@decorator",

--- a/packages/cli/test/view-render-cov.test.ts
+++ b/packages/cli/test/view-render-cov.test.ts
@@ -291,15 +291,15 @@ Deno.test("renderStatus: an edit hint shows when there is no message", () => {
   assert(status.includes("Esc Done"), `edit hint shown: "${status}"`);
 });
 
-Deno.test("renderStatus: key hints are highlighted in colour", () => {
+Deno.test("renderStatus: key hints are highlighted in color", () => {
   const doc = parseDocument(SAMPLE);
   const rows = renderFrame(
     doc,
     baseView({ editHint: [{ key: "Esc", label: "Done" }], color: true }),
   );
   const status = rows[rows.length - 1];
-  // The key is painted in the status-key colour on the status-bar background.
-  assert(status.includes(fgCode(ui.statusKey.fg!)), "the key colour");
+  // The key is painted in the status-key color on the status-bar background.
+  assert(status.includes(fgCode(ui.statusKey.fg!)), "the key color");
   assert(status.includes(bgCode(ui.statusBar.bg!)), "on the status bar");
 });
 
@@ -569,7 +569,7 @@ const SAVE_DIALOG: DialogState = {
   ],
 };
 
-Deno.test("dialog: frames a centred title, body and button row", () => {
+Deno.test("dialog: frames a centered title, body and button row", () => {
   const rows = renderFrame(
     parseDocument(SAMPLE),
     baseView({ width: 60, height: 18, color: false, dialog: SAVE_DIALOG }),
@@ -594,14 +594,14 @@ Deno.test("dialog: the default button is brighter and the shortcuts are yellow",
   );
   const raw = rows.join("");
   const face = bgCode(ui.button.bg!);
-  assert(raw.includes(face), "button face colour");
+  assert(raw.includes(face), "button face color");
   assert(
     raw.includes(fgCode(ui.buttonDefault.fg!) + ";" + face),
-    "default-button label colour on the face",
+    "default-button label color on the face",
   );
   assert(
     raw.includes(fgCode(ui.buttonKey.fg!) + ";" + face),
-    "shortcut-letter colour on the face",
+    "shortcut-letter color on the face",
   );
   // The button shadows are half-block glyphs, not solid cells.
   const plain = stripAnsi(raw);
@@ -694,7 +694,7 @@ Deno.test("dialog: the focused button — not just the default — is highlighte
         dialog: { ...dlg, focus },
       }),
     );
-  // The bright face is the default-button colour on the button-face background;
+  // The bright face is the default-button color on the button-face background;
   // it only appears where a button is highlighted.
   const brightFace = fgCode(ui.buttonDefault.fg!) + ";" + bgCode(ui.button.bg!);
 
@@ -898,7 +898,7 @@ Deno.test("dialog: control characters in the body are shown as glyphs", () => {
       },
     }),
   );
-  // The frame carries its own resets even without colour, so the check is that
+  // The frame carries its own resets even without color, so the check is that
   // the body's own escape and bell are not among what reaches the terminal.
   const joined = rows.join("\n");
   assert(!joined.includes("\x1b[31m"), "the body's escape is not passed on");

--- a/packages/cli/test/view-render.test.ts
+++ b/packages/cli/test/view-render.test.ts
@@ -36,7 +36,7 @@ function diffView(over: Partial<ViewState> = {}): ViewState {
 }
 
 /** The editor background sits behind every cell, so a "highlighted" cell is one
- * whose background is some OTHER colour (a selection tint, a search match, a
+ * whose background is some OTHER color (a selection tint, a search match, a
  * diff row). */
 const EDITOR_BG = bgCode(ui.editorBg);
 
@@ -65,7 +65,7 @@ function bgColumns(row: string): boolean[] {
   return out;
 }
 
-/** Background colour active at one visible column, as an RGB tuple string. */
+/** Background color active at one visible column, as an RGB tuple string. */
 function bgAtColumn(row: string, target: number): string | null {
   let bg: string | null = null;
   let col = 0;
@@ -89,7 +89,7 @@ function bgAtColumn(row: string, target: number): string | null {
   return null;
 }
 
-/** Foreground colour active at one visible column, as an RGB tuple string. */
+/** Foreground color active at one visible column, as an RGB tuple string. */
 function fgAtColumn(row: string, target: number): string | null {
   let fg: string | null = null;
   let col = 0;
@@ -281,7 +281,7 @@ Deno.test("renderFrame: edit mode leaves rows after the document blank", () => {
   assertEquals(rows[1], " ".repeat(15));
 });
 
-Deno.test("renderFrame: content rows are verbatim under the colour", () => {
+Deno.test("renderFrame: content rows are verbatim under the color", () => {
   const doc = parseDocument(SAMPLE);
   const rows = renderFrame(doc, baseView());
   // line 0 is the section header, line 1 is `const define = undefined;`
@@ -574,7 +574,7 @@ Deno.test("renderFrame: draws the whole-diff totals in the first line's corner",
   assert(!scrolled.some((row) => row.includes("+456")));
 });
 
-Deno.test("renderFrame: colours the totals as removals and additions", () => {
+Deno.test("renderFrame: colors the totals as removals and additions", () => {
   const doc = parseDocument("meta");
   const rows = renderFrame(
     doc,
@@ -1168,7 +1168,7 @@ Deno.test("renderFrame: hidden mode collapses a control run and shifts text left
   );
 });
 
-Deno.test("renderFrame: ansi mode paints the sequence's colour onto later text", () => {
+Deno.test("renderFrame: ansi mode paints the sequence's color onto later text", () => {
   const doc = docOf("a\x1b[31mb");
   const rows = renderFrame(doc, baseView({ displayMode: "ansi" }));
   // The escape is consumed; "b" is painted ANSI red (205;49;49) while "a" is not.
@@ -1464,7 +1464,7 @@ Deno.test("overlayBox: inner dimensions never go negative", () => {
       assert(box.innerH >= 0, `innerH >= 0 at ${width}x${height}`);
       assert(box.x >= 0, `x >= 0 at ${width}x${height}`);
       assert(box.y >= 0, `y >= 0 at ${width}x${height}`);
-      // The box never extends past the terminal it is centred in.
+      // The box never extends past the terminal it is centered in.
       assert(box.boxW <= Math.max(0, width), `boxW fits at ${width}x${height}`);
       assert(
         box.boxH <= Math.max(0, height),
@@ -1512,7 +1512,7 @@ Deno.test("renderFrame: the overlay uses a double-line (Turbo Pascal) frame", ()
   }
 });
 
-Deno.test("renderFrame: the info panel uses the dialog panel and text colours", () => {
+Deno.test("renderFrame: the info panel uses the dialog panel and text colors", () => {
   const doc = parseDocument(SAMPLE);
   const rows = renderFrame(
     doc,
@@ -1531,11 +1531,11 @@ Deno.test("renderFrame: the info panel uses the dialog panel and text colours", 
     }),
   );
   const body = rows.find((r) => stripAnsi(r).includes("hello"))!;
-  assert(body.includes(bgCode(ui.overlayBg)), "the dialog panel colour");
-  assert(body.includes(fgCode(ui.dialogText.fg!)), "the dialog text colour");
+  assert(body.includes(bgCode(ui.overlayBg)), "the dialog panel color");
+  assert(body.includes(fgCode(ui.dialogText.fg!)), "the dialog text color");
 });
 
-Deno.test("renderFrame: a source overlay uses the editor colours, not the dialog panel", () => {
+Deno.test("renderFrame: a source overlay uses the editor colors, not the dialog panel", () => {
   const doc = parseDocument(SAMPLE);
   const overlay = (sourceView: boolean) => ({
     title: "SRC",
@@ -1557,9 +1557,9 @@ Deno.test("renderFrame: a source overlay uses the editor colours, not the dialog
   );
   const dialogBody = rowsDialog.find((r) => stripAnsi(r).includes("code"))!;
   const sourceBody = rowsSource.find((r) => stripAnsi(r).includes("code"))!;
-  assert(dialogBody.includes(bgCode(ui.overlayBg)), "the dialog panel colour");
+  assert(dialogBody.includes(bgCode(ui.overlayBg)), "the dialog panel color");
   assert(
     sourceBody.includes(bgCode(ui.editorBg)),
-    "the source panel is the editor colour",
+    "the source panel is the editor color",
   );
 });

--- a/packages/cli/test/view-semantics-cov.test.ts
+++ b/packages/cli/test/view-semantics-cov.test.ts
@@ -620,7 +620,7 @@ Deno.test("diff semantics: a definition outside the diff opens as a file", () =>
     const lines = sem.fileLines(ext!.filePath!);
     assert(
       lines && lines.some((l) => l.text.includes("export function ext")),
-      "fileLines colours the external file",
+      "fileLines colors the external file",
     );
     assertEquals(sem.fileLines(join(root, "..", "outside.ts")), null);
   } finally {

--- a/packages/cli/test/view-semantics-cov2.test.ts
+++ b/packages/cli/test/view-semantics-cov2.test.ts
@@ -8,7 +8,7 @@
  *
  * The public surface only takes `text`, `cwd`, an `offset` and a `filePath`,
  * so the throwing inputs here are values whose declared type matches the API
- * (a `string`, a `number`) but whose runtime behaviour throws when the code
+ * (a `string`, a `number`) but whose runtime behavior throws when the code
  * touches them. That is exactly the input the module documents itself as being
  * robust against: "every query is wrapped so a failure degrades to `null`".
  */
@@ -123,7 +123,7 @@ Deno.test("semantics: typeAt swallows a throw raised while locating the section"
 
 Deno.test("semantics: definitionOf swallows a throw and caches the empty result", () => {
   // Same hostile offset, but through definitionOf: the throw lands in its try,
-  // the catch resets `out` to [], and the empty array is memoised.
+  // the catch resets `out` to [], and the empty array is memoized.
   const blob = `// transformed: /m.ts\nconst x: number = 1;\nconst y = x;`;
   const sem = createSemantics(blob, { cwd: CWD })!;
   sem.prewarm();

--- a/packages/cli/test/view-semantics-gate.test.ts
+++ b/packages/cli/test/view-semantics-gate.test.ts
@@ -6,7 +6,7 @@
  * and no-program paths directly through the test-only `_internal` handle. The
  * redundant `prewarm` and `realDir` try/catch wrappers and the always-true
  * `splitSections` guard were removed at the source. The remaining tests drive
- * the surrounding, reachable behaviour: the observable degrade-to-null and
+ * the surrounding, reachable behavior: the observable degrade-to-null and
  * degrade-to-empty results the failure isolation protects.
  */
 import { assert, assertEquals } from "@std/assert";
@@ -243,7 +243,7 @@ Deno.test("lazyProgram: caches a success and latches a failed build", () => {
   assertEquals(nullCalls, 1, "a program-less build latches and is not retried");
 });
 
-// makeHost's readReal memoises real-file reads. Under the pager's module
+// makeHost's readReal memoizes real-file reads. Under the pager's module
 // resolution TypeScript reads each file once, so the cache hit never fires
 // there; reading the same path twice through the host exercises it directly.
 Deno.test("makeHost: a repeated read of the same file is served from the cache", () => {

--- a/packages/cli/test/view-semantics.test.ts
+++ b/packages/cli/test/view-semantics.test.ts
@@ -464,7 +464,7 @@ const useIt = beta;`;
   );
 });
 
-Deno.test("card: surfaces an external definition; fileLines colours it (bounded)", () => {
+Deno.test("card: surfaces an external definition; fileLines colors it (bounded)", () => {
   const root = Deno.makeTempDirSync();
   try {
     Deno.writeTextFileSync(
@@ -490,7 +490,7 @@ const flag = ext();`;
       ext!.filePath!.endsWith("ext.ts"),
       `points at ext.ts: ${ext!.filePath}`,
     );
-    // fileLines reads and colours the external file...
+    // fileLines reads and colors the external file...
     const lines = sem.fileLines(ext!.filePath!);
     assert(lines && lines.length >= 3, "reads the file lines");
     assert(

--- a/packages/cli/test/view-session-cov.test.ts
+++ b/packages/cli/test/view-session-cov.test.ts
@@ -1,5 +1,5 @@
 /**
- * Coverage-driving behavioural tests for the pager state machine in
+ * Coverage-driving behavioral tests for the pager state machine in
  * `lib/view/session.ts`. Each test reaches a specific code path by feeding keys
  * and inspecting `view()` / `doc` / `quit`, mirroring the style of
  * `view-session.test.ts`, `view-filepicker.test.ts` and `view-diffedit.test.ts`.
@@ -1038,7 +1038,7 @@ Deno.test("session: an unmodelled Alt combo while editing is a no-op", () => {
   const { s } = fileSession("text\n");
   press(s, "e"); // enter edit mode
   const before = s.doc.text;
-  s.handleKey(alt("q")); // not a modelled Alt binding
+  s.handleKey(alt("q")); // not a modeled Alt binding
   assertEquals(s.doc.text, before, "unmodelled Alt combo changed nothing");
 });
 

--- a/packages/cli/test/view-session-cov2.test.ts
+++ b/packages/cli/test/view-session-cov2.test.ts
@@ -101,12 +101,12 @@ const useB = base;`;
 });
 
 // ===========================================================================
-// Behavioural anchor near revealMatch (580).
+// Behavioral anchor near revealMatch (580).
 // ===========================================================================
 // revealMatch reads matches[currentMatch] and guards `!m`. Every public caller
 // (runSearch, refreshSearchMatches, stepMatch) checks for an empty match set
 // before reaching it, so the no-match return is unreachable from the public
-// API; this test asserts the surrounding reveal behaviour stays correct.
+// API; this test asserts the surrounding reveal behavior stays correct.
 Deno.test("session: a committed search reveals its single match", () => {
   const doc = parseDocument("// transformed: /m.ts\nconst tokenz = 1;");
   const s = new Session(
@@ -341,10 +341,10 @@ Deno.test("filepickercov2: paging the picker up to the top keeps the scroll non-
 });
 
 // ===========================================================================
-// Behavioural anchors for the reachable structure-tree edges near 288/377/380.
+// Behavioral anchors for the reachable structure-tree edges near 288/377/380.
 // ===========================================================================
 // These do not force the unreachable defensive returns, but assert the
-// surrounding navigation/card behaviour stays correct from a real session.
+// surrounding navigation/card behavior stays correct from a real session.
 
 Deno.test("session: card down then up across a multi-target card stays consistent", () => {
   const doc = parseDocument(SAMPLE);

--- a/packages/cli/test/view-session.test.ts
+++ b/packages/cli/test/view-session.test.ts
@@ -837,7 +837,7 @@ Deno.test("session: c cycles the non-printable display mode and reports it", () 
   assertEquals(s.view().displayMode, "pictures", "starts on the first mode");
   press(s, "c");
   assertEquals(s.view().displayMode, "ansi");
-  assert(s.view().message.includes("ANSI colour"), "reports the new mode");
+  assert(s.view().message.includes("ANSI color"), "reports the new mode");
   press(s, "c");
   assertEquals(s.view().displayMode, "hidden");
   press(s, "c");
@@ -990,7 +990,7 @@ Deno.test("session: Enter in the card opens the selected reference's card", () =
   assertEquals(ov.selectedLine, undefined, "selection reset after navigating");
 });
 
-Deno.test("session: z closes the card and centres the main view on the target", () => {
+Deno.test("session: z closes the card and centers the main view on the target", () => {
   const doc = parseDocument(SAMPLE);
   const s = new Session(
     doc,
@@ -1006,7 +1006,7 @@ Deno.test("session: z closes the card and centres the main view on the target", 
   assert(s.view().selected, "a node is selected at the destination");
 });
 
-Deno.test("session: z frames the revealed node (centred when it fits)", () => {
+Deno.test("session: z frames the revealed node (centered when it fits)", () => {
   const doc = parseDocument(SAMPLE);
   const height = 14;
   const s = new Session(

--- a/packages/cli/test/view-vocab.test.ts
+++ b/packages/cli/test/view-vocab.test.ts
@@ -21,13 +21,13 @@ Deno.test("vocab: builders and calls come straight from the transformer registry
   // Drift guard: the pager's name sets ARE the transformer's registry sets.
   assertEquals(BUILDER_NAMES, COMMONFABRIC_BUILDER_EXPORT_NAMES);
   assertEquals(CALL_NAMES, COMMONFABRIC_CALL_EXPORT_NAMES);
-  // Stable vocabulary the colouring depends on.
+  // Stable vocabulary the coloring depends on.
   for (const name of ["pattern", "lift", "handler", "computed"]) {
     assert(isBuilderName(name), `${name} should be a builder`);
   }
 });
 
-Deno.test("vocab: reactive call helpers are recognised", () => {
+Deno.test("vocab: reactive call helpers are recognized", () => {
   // ifElse is a canonical reactive call in the registry.
   assert(isCallName("ifElse") || CALL_NAMES.size === 0);
   assert(!isBuilderName("totallyNotABuilder"));
@@ -43,7 +43,7 @@ Deno.test("vocab: synthetic identifiers are detected by prefix", () => {
   assert(!isSyntheticName("pattern"));
 });
 
-Deno.test("vocab: hoisted pattern helpers are recognised and described", () => {
+Deno.test("vocab: hoisted pattern helpers are recognized and described", () => {
   // The transformer hoists the bare pattern call in `mapWithPattern(pattern(...))`
   // to `const __cfPattern_N = __cfHelpers.pattern(...)`. Without the prefix the
   // pager would treat that synthetic helper as an authored identifier.
@@ -58,7 +58,7 @@ Deno.test("vocab: hoisted pattern helpers are recognised and described", () => {
 });
 
 Deno.test("vocab: synthetic prefix literals match the documented transformer names", () => {
-  // Pins the mirrored literals so a typo cannot silently break colouring.
+  // Pins the mirrored literals so a typo cannot silently break coloring.
   assertEquals(CF_HELPERS_IDENTIFIER, "__cfHelpers");
   assertEquals(SYNTHETIC_LIFT_HOIST_PREFIX, "__cfLift");
   assertEquals(FUNCTION_HARDENING_HELPER_PREFIX, "__cfHardenFn");


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) am opening this as the first of three,
from a full-repo audit for remaining Britishisms. The word-choice rule is in
`docs/development/DEVELOPMENT.md` (#5805).

69 files, 339 words. Almost all comments and test names.

## Why this is its own PR

`cf view` had a self-consistent `colour` / `colourise` / `recolour` /
`uncoloured` vocabulary running through its source comments, `Deno.test` names
and assertion messages — 208 of the repo's ~690 remaining hits, in one
subsystem.

The flag was already `--color`. Its own help text read:

> `"Colourise: always | auto | never (auto = when stdout is a TTY)."`

So conforming the prose is not an interface change; it removes a contradiction
between a flag and the sentence describing it.

## The one user-visible move

`displayModeLabel("ansi")` returned `"ANSI colour"` and now returns `"ANSI
color"`. Both of its assertions travel in this change:

- `test/view-display.test.ts:55` — `assertEquals(displayModeLabel("ansi"), "ANSI color")`
- `test/view-session.test.ts:840` — `assert(s.view().message.includes("ANSI color"))`

The viewer's `"(uninitialized)"` placeholder and three key-hint strings
(`"center selected node"`, `"cycle non-printables: … / ANSI color / hidden"`)
move with it.

## What the sweep would not touch

It is a vetted word table over a vetted path scope, not a blanket
search-and-replace:

- `cancelled` — the documented carve-out; the British form is the repo majority
  and almost entirely identifiers.
- `aria-labelledby` — a web standard. Word boundaries keep the sweep out of
  camelCase compounds, so `updateAriaLabelledBy` is untouched by construction.
- `analyses` — also the American noun plural, so `rawAnalyses` and friends are
  already correct.
- `AnalyserNode` / `createAnalyser` — the Web Audio API's own spelling
  (`packages/ui`, out of this PR's scope and excluded from the sweep entirely).

## Checks

`deno task test` in `packages/cli`: **ok | 174 passed (206 steps) | 0 failed
(2m38s)**. I checked that the renamed files actually ran rather than trusting
the count — the run log contains the new names, e.g. `displayColumnOf: ansi
skips a hidden color sequence` and `the highlighter recolors a Markdown body
line`. `deno fmt --check` and `deno lint` clean over the package. A repo-wide
grep finds no British half left paired with an American one.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

