### PR TITLE
docs: American spelling in `runner`, `dashboard` and the rest of `cli`

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -39,7 +39,7 @@ explicit selectors. JSON-, YAML-, Markdown-, Python-, and other language-shaped
 source is not guessed from its syntax.
 
 A diff shows its whole-diff change totals at the top right corner of its first
-line: the added line count and the removed line count, coloured like additions
+line: the added line count and the removed line count, colored like additions
 and removals.
 
 Markdown files can switch between the source and a rendered terminal view with
@@ -62,7 +62,7 @@ rendered view returns to source first.
 ```bash
 cf check pattern.tsx --show-transformed --no-run | cf view
 cf view .github/workflows/deno.yml
-cf view scripts/analyse.py
+cf view scripts/analyze.py
 git diff upstream/main | cf view
 cf view --rendered README.md
 generate-source | cf view --filename generated.py

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -658,7 +658,7 @@ export function invocationPhaseReporter(
  * wall-clock span per observed phase transition (verb contract WS-D, phase
  * timings). Spans are bounded by the phases the `onPhase` callback already
  * observes — initial sync up to dispatch, the dispatched handler run up to
- * its transaction-local commit acknowledgement, the receipt classification,
+ * its transaction-local commit acknowledgment, the receipt classification,
  * and the receipt readback up to settlement — because those boundaries are
  * what the invocation actually reports; nothing new is instrumented inside
  * the runner. Every line goes to stderr so stdout stays exactly the settled
@@ -666,7 +666,7 @@ export function invocationPhaseReporter(
  * a failure exit keeps every span observed before the failure — `finish`
  * closes the in-flight span with the outcome that ended it: `settled`,
  * `failed`, or `detached` for a `--no-wait` exit that stopped at the commit
- * acknowledgement and skipped the readback.
+ * acknowledgment and skipped the readback.
  */
 export function pieceCallPhaseObserver(
   verbose: boolean,
@@ -835,10 +835,10 @@ export function invocationJson(
 
 /** How long `cf piece call` waits for a handler invocation (verb contract
  * WS-F, F3). `settle` is the default: await this handling's commit
- * acknowledgement plus receipt readback, optionally bounded by the caller's
+ * acknowledgment plus receipt readback, optionally bounded by the caller's
  * patience (`--wait <seconds>`). `commit` (`--no-wait`) awaits the
- * transaction-local commit acknowledgement — the durable point; the handler
- * runs in THIS process, so the acknowledgement is not skippable — and skips
+ * transaction-local commit acknowledgment — the durable point; the handler
+ * runs in THIS process, so the acknowledgment is not skippable — and skips
  * only the receipt readback. */
 export interface PieceCallWaitControl {
   mode: "settle" | "commit";

--- a/packages/cli/commands/space.ts
+++ b/packages/cli/commands/space.ts
@@ -68,7 +68,7 @@ function fromFileUrl(url: string): string {
  * Reject a snapshot URL that would put a whole space on the wire in the clear.
  *
  * A snapshot is the entire contents of a space — the same confidentiality
- * judgement that keeps the dump endpoint hard-off in production — so plaintext
+ * judgment that keeps the dump endpoint hard-off in production — so plaintext
  * transport is refused rather than merely discouraged in the help text.
  * Loopback is the exception: it never leaves the machine, and the tests serve
  * fixtures over it.

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -615,7 +615,7 @@ run_piece_call_retry() {
   assert_message_count "$RETRY_PIECE_ID" 1 \
     "A fresh-id retry after a pre-dispatch failure should record exactly one message"
 
-  # --- 2. Dispatched, then the caller died before acknowledgement. ----------
+  # --- 2. Dispatched, then the caller died before acknowledgment. ----------
   # The riskiest window: the event is on its way and the caller cannot know
   # whether it committed. The kill is triggered by the CLI's own dispatch
   # announcement, so this lands in the window deterministically rather than
@@ -952,7 +952,7 @@ run_three_topic_fixture() {
 
   # --- 6. Exactly three topics; references, reciprocals, attribution. -------
   # One step so the derived views (topicCount, referencedBy) recompute from
-  # the committed writes: acknowledgement is transaction-local (D2), so the
+  # the committed writes: acknowledgment is transaction-local (D2), so the
   # calls above deliberately never waited for derived recomputation.
   cf piece step $SPACE_ARGS --piece "$TOPIC_PIECE_ID"
 
@@ -987,7 +987,7 @@ run_three_topic_fixture() {
      .references == [$u]' > /dev/null ||
     error "Child B's returned reference should open the dropped create's canonical child, got: $CHILD_B_FINAL"
 
-  # The reciprocal derived references (this fixture's crossrefs analogue):
+  # The reciprocal derived references (this fixture's crossrefs analog):
   # children point up at the umbrella, the revised umbrella points down at
   # both children, derived — never persisted.
   RECIPROCAL=$(cf piece get $SPACE_ARGS --piece "$TOPIC_PIECE_ID" referencedBy)

--- a/packages/cli/integration/pattern/topic-graph.tsx
+++ b/packages/cli/integration/pattern/topic-graph.tsx
@@ -66,7 +66,7 @@ interface TopicGraphOutput {
   topics: TopicEntry[];
   topicCount: number;
   /** Reciprocal edges, derived at read time and never persisted — topic id →
-   * ids of the topics whose `references` name it (this fixture's analogue of
+   * ids of the topics whose `references` name it (this fixture's analog of
    * the topics board's crossrefs). */
   referencedBy: Record<string, string[]>;
   createTopic: Stream<CreateTopicEvent, CreateTopicResult>;

--- a/packages/cli/integration/pattern/tracker.tsx
+++ b/packages/cli/integration/pattern/tracker.tsx
@@ -27,7 +27,7 @@ import {
 } from "commonfabric";
 
 /** One work item. Deliberately small: this fixture is about what a verb hands
- * back and how a caller addresses what it made, not about modelling work. */
+ * back and how a caller addresses what it made, not about modeling work. */
 export interface ItemOutput {
   /** File a new item beneath this one. */
   addChild: Stream<AddChildEvent, AddChildResult>;

--- a/packages/cli/integration/pattern/verb-results.tsx
+++ b/packages/cli/integration/pattern/verb-results.tsx
@@ -28,7 +28,7 @@ import {
 } from "commonfabric";
 
 /** One note. Deliberately small: this fixture is about what a verb hands back,
- * not about modelling notes. */
+ * not about modeling notes. */
 export interface NoteOutput {
   [NAME]: string;
   title: string;

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -108,8 +108,8 @@ export interface CallableExecutionDeps {
   /** Phase observer for early-exit reporting. */
   onPhase?: (phase: InvocationPhase) => void;
   /** `--no-wait`: await this handling's transaction-local commit
-   * acknowledgement, then return WITHOUT the receipt readback (sync + read).
-   * The commit acknowledgement cannot be skipped: the handler executes in
+   * acknowledgment, then return WITHOUT the receipt readback (sync + read).
+   * The commit acknowledgment cannot be skipped: the handler executes in
    * THIS process's runtime, so exiting before the commit is acknowledged
    * would abandon the invocation un-executed — nothing durable would have
    * happened — not leave it settling elsewhere. What CAN be skipped is
@@ -139,7 +139,7 @@ export interface CallableExecutionDeps {
    * what it holds — a reactive result's carries none — but either way the
    * fetch has happened first.) The shared step also awaits the runtime's
    * global idle plus storage sync, so a shaped call result can wait on
-   * derived recomputation the plain call's transaction-local acknowledgement
+   * derived recomputation the plain call's transaction-local acknowledgment
    * does not — a documented cost of shaping at the call
    * (`deriveSelectedValue`, cell-selection.ts). A verb that returns nothing
    * keeps returning nothing — there is no value for a selection to be

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -2504,7 +2504,7 @@ export async function deriveSelectedValue(
     // runtime — but a shaped `piece call` readback arrives here right after
     // its handler ran, so the selection waits on whatever derived
     // recomputation that handler triggered elsewhere, a coupling the plain
-    // call's transaction-local acknowledgement deliberately avoids.
+    // call's transaction-local acknowledgment deliberately avoids.
     // Documented as a known cost of shaping at the call (decided
     // 2026-08-14; packages/cli/README.md names the shape-the-collect
     // alternative); scoping this wait to the transform's own computation is

--- a/packages/cli/lib/fuse-mount-flags.ts
+++ b/packages/cli/lib/fuse-mount-flags.ts
@@ -286,11 +286,11 @@ function requireValue(args: string[], index: number, flag: string): string {
 const HELP_DESCRIPTION_COLUMN = 34;
 
 function helpLine(label: string, help: string): string {
-  const labelled = `  ${label}`;
-  if (labelled.length + 1 > HELP_DESCRIPTION_COLUMN) {
-    return `${labelled}\n${" ".repeat(HELP_DESCRIPTION_COLUMN)}${help}`;
+  const labeled = `  ${label}`;
+  if (labeled.length + 1 > HELP_DESCRIPTION_COLUMN) {
+    return `${labeled}\n${" ".repeat(HELP_DESCRIPTION_COLUMN)}${help}`;
   }
-  return `${labelled.padEnd(HELP_DESCRIPTION_COLUMN)}${help}`;
+  return `${labeled.padEnd(HELP_DESCRIPTION_COLUMN)}${help}`;
 }
 
 export function supervisorHelp(): string {

--- a/packages/cli/lib/ingest-channels.ts
+++ b/packages/cli/lib/ingest-channels.ts
@@ -130,7 +130,7 @@ async function call<T>(
  * A fresh idempotency key per invocation. Reuse the SAME id when retrying a
  * failed call and the server answers 409 rather than minting a second live
  * token — within a replay window of about half an hour, which is what the
- * defence is sized for. A retry days later mints a new token and supersedes
+ * defense is sized for. A retry days later mints a new token and supersedes
  * the old one.
  */
 export const newRequestId = (): string => crypto.randomUUID();

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -289,7 +289,7 @@ Deno.test("command: a deno line that is not ours is reported as such", async () 
   assertEquals(out, ":cf:notmine");
 });
 
-Deno.test("shaping: a piece is labelled by name, falling back to its pattern", () => {
+Deno.test("shaping: a piece is labeled by name, falling back to its pattern", () => {
   assertEquals(
     shapePieceCandidates([
       { id: "fid1:a", name: "Todo List" },

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -1143,7 +1143,7 @@ describe("renderPieceCallHelp", () => {
     // caller has no way to reach — and it is the last line of the page.
     expect(help).not.toContain("write JSON to this file");
     expect(help).not.toContain("Alternatively");
-    // The neighbouring note is about this command's own spelling, and stays.
+    // The neighboring note is about this command's own spelling, and stays.
     expect(help).toContain(
       "Invoke alone will call the handler without any inputs.",
     );

--- a/packages/cli/test/inspect-churn.test.ts
+++ b/packages/cli/test/inspect-churn.test.ts
@@ -13,8 +13,8 @@ import { cf, stripAnsi } from "./utils.ts";
 /**
  * `CliResult` streams are line arrays; join before substring assertions.
  *
- * The escapes go too: the CLI colours help and error output whenever the
- * environment asks for colour, so an assertion on raw text passes or fails by
+ * The escapes go too: the CLI colors help and error output whenever the
+ * environment asks for color, so an assertion on raw text passes or fails by
  * where the developer ran it.
  */
 const text = (lines: string[]): string => stripAnsi(lines.join("\n"));

--- a/packages/cli/test/install-cf.test.ts
+++ b/packages/cli/test/install-cf.test.ts
@@ -308,7 +308,7 @@ Deno.test("a dry run predicts a failing real run", async () => {
 
 Deno.test("warns when an explicit --dir is not on PATH", async () => {
   // Auto-detection only picks directories on PATH. An explicit --dir is
-  // honoured, but installing somewhere unreachable is the exact silent failure
+  // honored, but installing somewhere unreachable is the exact silent failure
   // this whole area exists to prevent, so it is said out loud.
   await withTempDir(async (dir) => {
     const checkout = join(dir, "labs");

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -1363,7 +1363,7 @@ function createPieceCallableHarness(options: {
    * original receipt. */
   receiptExists?: boolean;
   /** Hold settlement open: `send` records the dispatch but never invokes the
-   * commit callback, so anything awaiting acknowledgement waits forever.
+   * commit callback, so anything awaiting acknowledgment waits forever.
    * This is how a test proves a path does NOT await the commit — the path
    * completes anyway — or exercises a wait bound against a call that can
    * never beat it. */
@@ -2659,7 +2659,7 @@ describe("piece call wait control", () => {
     });
   });
 
-  it("still awaits the commit acknowledgement under --no-wait", async () => {
+  it("still awaits the commit acknowledgment under --no-wait", async () => {
     const harness = createPieceCallableHarness({
       callableKind: "handler",
       cellKey: "addComment",
@@ -2671,7 +2671,7 @@ describe("piece call wait control", () => {
         required: ["message"],
       },
       // The commit callback never fires. --no-wait must NOT return: exiting
-      // before the acknowledgement would abandon the invocation un-executed
+      // before the acknowledgment would abandon the invocation un-executed
       // (the handler runs in this process), not leave it settling elsewhere.
       neverCommit: true,
     });
@@ -2689,7 +2689,7 @@ describe("piece call wait control", () => {
     ).catch((e) => e);
 
     // Only the deadline got us out — the skip-readback path was still
-    // parked on the commit acknowledgement, exactly where it must wait.
+    // parked on the commit acknowledgment, exactly where it must wait.
     expect(error).toBeInstanceOf(WaitBoundExpired);
     expect(phases).toEqual(["dispatched"]);
     expect(harness.tracker.receiptLinkRequested).toBeUndefined();
@@ -2883,7 +2883,7 @@ describe("piece call wait control", () => {
     observer.finish("detached");
     // "settled" would be a lie here — the readback was skipped, so nobody
     // observed a settlement. The span sequence also documents where
-    // --no-wait stops: after the commit acknowledgement, never before it.
+    // --no-wait stops: after the commit acknowledgment, never before it.
     expect(lines).toEqual([
       "timing: initial_sync → dispatched 20.0ms",
       "timing: dispatched → committed 30.0ms",
@@ -4516,7 +4516,7 @@ describe("reportVerbInputErrorOrRethrow", () => {
     expect(printed[1]).toMatch(/<piece>/);
   });
 
-  // Anything that is not an input rejection has to keep travelling: a network
+  // Anything that is not an input rejection has to keep traveling: a network
   // failure reported as a payload problem would send an agent to fix a payload
   // that was fine.
   it("re-throws an unrelated failure untouched", () => {

--- a/packages/cli/test/piece-render.test.ts
+++ b/packages/cli/test/piece-render.test.ts
@@ -90,7 +90,7 @@ describe("piece-render", () => {
           );
           const vdom = await cellHolding(
             runtime,
-            "static-labelled",
+            "static-labeled",
             vnode("div", {}, [label]),
           );
 

--- a/packages/cli/test/space.test.ts
+++ b/packages/cli/test/space.test.ts
@@ -15,8 +15,8 @@ import { cf, stripAnsi } from "./utils.ts";
 /**
  * `CliResult` streams are line arrays; join before substring assertions.
  *
- * The escapes go too: the CLI colours help and error output whenever the
- * environment asks for colour, so an assertion on raw text passes or fails by
+ * The escapes go too: the CLI colors help and error output whenever the
+ * environment asks for color, so an assertion on raw text passes or fails by
  * where the developer ran it.
  */
 const text = (lines: string[]): string => stripAnsi(lines.join("\n"));
@@ -394,7 +394,7 @@ describe("cf space", () => {
 
   it("refuses to pull a whole-space snapshot over plaintext http", async () => {
     // A snapshot is the entire contents of a space — the same confidentiality
-    // judgement that keeps the dump endpoint off in production. Loopback is
+    // judgment that keeps the dump endpoint off in production. Loopback is
     // exempt (it never leaves the machine) and the tests above rely on that.
     await withFixture(async ({ clone }) => {
       const result = await cf(

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -56,7 +56,7 @@ dashboard/
 collects each tile that is due (respecting its `intervalMs`), renders the
 results uniformly, mounts any drill-down routes a tile declares, and pushes new
 tile markup as each independent collection completes. Every registered tile has
-a gray placeholder labelled with its id in its registered position until its
+a gray placeholder labeled with its id in its registered position until its
 first collection completes, so slow collectors do not leave holes in the board.
 A later ticker pass skips a tile or shared workflow fetch that is still
 updating. It starts every other due collection, so pending work does not pause
@@ -642,7 +642,7 @@ Notes:
   **Only a broad, across-the-board move shifts an index.** A regression in one
   benchmark barely registers, however slow that benchmark is. The drill-down
   covers individual benchmarks. A summed total would instead be dominated by
-  the few slowest benchmarks. Each CPU has its own coloured line. The headline
+  the few slowest benchmarks. Each CPU has its own colored line. The headline
   shows the largest established CPU trend. A second line names how many
   benchmarks the latest run measured and the highlighted window when applicable.
   **Red** marks the **most recent run failing outright, or finishing green on CI
@@ -661,7 +661,7 @@ Notes:
   with nothing readable reads **no benchmark data**. A **running** badge sits in
   the header while a run is under way, wherever in the list it sits — a rerun
   keeps its original place instead of moving to the head. The badge says the
-  colour may be about to move; the runs that have finished still set it. The red
+  color may be about to move; the runs that have finished still set it. The red
   state reads the workflow-run list and the latest run's cached result. It
   therefore fires when the artifacts cannot be read. **Orange** means at least
   one CPU index is **trending up** past 5%. Each CPU trend uses the runs in the
@@ -736,9 +736,9 @@ Notes:
   - The tile drills through to the per-benchmark history behind `/bench`, which the
     tile's collection keeps warm in the background. The collection lists
     benchmark runs on main. It samples one completed run per shortest-view
-    bucket, whatever colour it finished, downloads that artifact, and unzips it
+    bucket, whatever color it finished, downloads that artifact, and unzips it
     in the process. It then reads each benchmark's timings and CPU. A run's
-    colour does not say whether it measured anything: `deno bench` exits
+    color does not say whether it measured anything: `deno bench` exits
     non-zero when one benchmark throws, having already written a complete report
     of the rest, and dropping those runs cost about a seventh of the history in
     blocks a dozen runs long. The artifact decides instead. A report without a
@@ -751,7 +751,7 @@ Notes:
     finished. Only new runs and attempts are fetched after the first fill or a
     server restart. The shortest-view buckets are about 8 minutes wide. The
     first cache fill can therefore download more artifacts.
-  - Its **runtime benchmarks** view at `/bench?view=runtime` shows one coloured
+  - Its **runtime benchmarks** view at `/bench?view=runtime` shows one colored
     line per CPU for **every** benchmark. The lines share a calendar-time axis.
     A late-starting CPU line sits at the right. A single sample appears as a
     point. A stale line visibly ends short of the current date. The dashboard
@@ -759,7 +759,7 @@ Notes:
     Selectors choose which measurement to plot (**p0** = the fastest sample,
     **mean** = the arithmetic mean, **p75**, **p99**, **p99.5**, **p99.9**,
     **p100** = the slowest) and whether to group by source **file** or sort by
-    latest **duration** or **trend**. The mean selector was once labelled
+    latest **duration** or **trend**. The mean selector was once labeled
     `p50`, and `?stat=p50` still opens it so that a saved link does not quietly
     fall back to the default column.
     A "hide green" checkbox drops the steady ones. A slider from 1
@@ -775,9 +775,9 @@ Notes:
     directly. Each row shows one latest value and trend from the CPU with the
     most benchmark samples in the selected window. A tie uses the CPU with the
     newest sample, then its name for a stable result. That representative CPU
-    also sets the row colour and sorting. A numbered CPU key identifies the
+    also sets the row color and sorting. A numbered CPU key identifies the
     representative series and links to its definition. The same key and a
-    colour swatch appear in one CPU legend after all benchmark graphs instead
+    color swatch appear in one CPU legend after all benchmark graphs instead
     of repeating processor names in every row. It includes the full processor
     identity reported by the artifacts, the number of benchmark graphs and runs
     shown for that CPU, and the observed date range. The page reads from the

--- a/packages/dashboard/ci-job-history.ts
+++ b/packages/dashboard/ci-job-history.ts
@@ -3169,7 +3169,7 @@ export function ciJobHistoryPage(
     : "";
   const rangeContent = `<div id="range-content">
     ${progressHtml}${coverageHtml}
-    <p class="legend">Job start-to-finish duration. Overall CI runs from the first job start to the last job completion. A shard group's line is the longest-running shard in each run. Lower is faster; colour follows the selected ${days}-day trend. Duration sort uses the latest sample.</p>
+    <p class="legend">Job start-to-finish duration. Overall CI runs from the first job start to the last job completion. A shard group's line is the longest-running shard in each run. Lower is faster; color follows the selected ${days}-day trend. Duration sort uses the latest sample.</p>
     ${refreshNotice}${body}
     <p class="note">Every successful main run is sampled when the selected window contains at most ${CI_HISTORY_POINT_TARGET}. Larger sets keep exactly ${CI_HISTORY_POINT_TARGET} builds spread evenly through the chronological run sequence from <a href="${
     escapeHtml(workflowUrl)

--- a/packages/dashboard/gcp.ts
+++ b/packages/dashboard/gcp.ts
@@ -12,7 +12,7 @@
  *
  * BigQuery has no API-key authentication: a key does not identify a principal,
  * and every query runs as some service account. So this is the closest
- * analogue to the bearer token the GitHub tiles use — a token obtained without
+ * analog to the bearer token the GitHub tiles use — a token obtained without
  * a command-line tool.
  */
 

--- a/packages/dashboard/lib.test.ts
+++ b/packages/dashboard/lib.test.ts
@@ -23,11 +23,11 @@ Deno.test("landingHref: parses only the first line", () => {
 
 Deno.test("concDot: only genuine failures are red", () => {
   assertEquals(concDot("success", 1), "green");
-  assertEquals(concDot("success", 2), "grey"); // passed only on retry
+  assertEquals(concDot("success", 2), "gray"); // passed only on retry
   assertEquals(concDot("failure", 1), "red");
   assertEquals(concDot("timed_out", 1), "red");
-  assertEquals(concDot("cancelled", 1), "grey"); // non-verdict, not a failure
-  assertEquals(concDot(null, 1), "grey");
+  assertEquals(concDot("cancelled", 1), "gray"); // non-verdict, not a failure
+  assertEquals(concDot(null, 1), "gray");
 });
 
 Deno.test("daysLabel: consistent 'x days' text", () => {

--- a/packages/dashboard/lib.ts
+++ b/packages/dashboard/lib.ts
@@ -153,7 +153,7 @@ export function memo<T>(ttlMs: number, fn: () => Promise<T>): () => Promise<T> {
 }
 
 // good/warn/bad/unknown -> the dot color class the renderer uses.
-export const STATUS_DOT: Record<Status, string> = { good: "green", warn: "amber", bad: "red", unknown: "grey" };
+export const STATUS_DOT: Record<Status, string> = { good: "green", warn: "amber", bad: "red", unknown: "gray" };
 
 export const escapeHtml = (s: string) =>
   s.replace(/[<>&"]/g, (c) => ({ "<": "&lt;", ">": "&gt;", "&": "&amp;", '"': "&quot;" }[c]!));
@@ -231,9 +231,9 @@ export function usd(n: number): string {
 
 // A completed run's dot color: only genuine failures are red.
 export function concDot(conclusion: string | null, attempt: number): string {
-  if (conclusion === "success") return attempt > 1 ? "grey" : "green";
+  if (conclusion === "success") return attempt > 1 ? "gray" : "green";
   if (conclusion === "failure" || conclusion === "timed_out" || conclusion === "startup_failure") return "red";
-  return "grey";
+  return "gray";
 }
 
 // A lighter tint of a "#rrggbb" color, blended toward white. Sparklines mark the

--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -29,7 +29,7 @@ Deno.test("renderTile: status drives the tile class, the dot color and the headl
     good: "green",
     warn: "amber",
     bad: "red",
-    unknown: "grey",
+    unknown: "gray",
   };
   for (const [status, dot] of Object.entries(dots) as [Status, string][]) {
     const html = renderTile(view({ status, value: "passing" }));
@@ -515,7 +515,7 @@ Deno.test("shell: the turned texture layer still covers a tile far wider than it
   assertStringIncludes(layer[0], "aspect-ratio:1");
   assertStringIncludes(layer[0], "top:50%;left:50%");
   assertStringIncludes(layer[0], "translate(-50%,-50%)");
-  // Turning a square about its centre sweeps its corners inward, so the layer
+  // Turning a square about its center sweeps its corners inward, so the layer
   // covers the tile only while half its side still reaches the tile's corner.
   // That reach is the tile's half-diagonal. The layer is measured off the
   // tile's width alone, so the shape that strains it is a tall narrow tile:

--- a/packages/dashboard/render.ts
+++ b/packages/dashboard/render.ts
@@ -56,7 +56,7 @@ const TEXTURE_HEIGHT = 24;
 
 /**
  * A tiling mask of one stroked path, for the texture that sits behind a tile's
- * flat colour wash. The mask lets CSS paint the path with the active theme's
+ * flat color wash. The mask lets CSS paint the path with the active theme's
  * status color. The path is drawn in a `period` by `TEXTURE_HEIGHT` space, and
  * its corners come to a point.
  *
@@ -93,7 +93,7 @@ const ZIGZAG_TEXTURE = strokeTexture(
   48,
 ) + `;background-color:${statusLayer("bad", TEXTURE_ALPHA)}`;
 // Two copies of the same dot grid make a triangular lattice, where each dot has
-// six neighbours at one distance rather than a square lattice's four near ones
+// six neighbors at one distance rather than a square lattice's four near ones
 // and four far ones. The copies are one dot spacing apart across, one spacing
 // times the square root of three apart down, and the second copy is shifted by
 // half of each. That puts its dots above the midpoint of the gap between two
@@ -121,7 +121,7 @@ const MAX_TILE_ASPECT = 1.5;
 
 // The side of the square texture layer, as a percentage of the tile's width.
 // Turning the layer sweeps its corners inward, so half its side has to reach
-// the tile's corner from the tile's centre — the tile's half-diagonal — at
+// the tile's corner from the tile's center — the tile's half-diagonal — at
 // whatever angle the texture is turned to.
 const TEXTURE_LAYER_PCT = Math.ceil(Math.hypot(1, MAX_TILE_ASPECT) * 100);
 
@@ -258,16 +258,16 @@ ${DASHBOARD_THEME_STYLES}
   .tile.wide{margin-bottom:12px}
 ${TILE_RULES}
   .tile.unknown,.tile.wide.unknown{border-color:var(--border-strong)}
-  /* Each status carries a texture as well as a colour, so the wall reads at a
-     glance and without relying on colour alone: dots for gray, waves for
+  /* Each status carries a texture as well as a color, so the wall reads at a
+     glance and without relying on color alone: dots for gray, waves for
      amber, zig-zags for red. The waves run across the zig-zags, a quarter turn
      from the angle the others take. The texture layer covers the tile and sits
-     above the colour wash and below the content. It carries the fade: whole
+     above the color wash and below the content. It carries the fade: whole
      for the top seventh of the tile, thinning from there, and gone seven
      tenths of the way down. Inside it the texture is turned on an angle, on a
-     square layer centred on the tile and measured from the tile's width.
+     square layer centered on the tile and measured from the tile's width.
      Turning a box sweeps its corners inward, so the layer only still covers
-     the tile if half its side reaches the tile's corner from the centre. That
+     the tile if half its side reaches the tile's corner from the center. That
      distance is the tile's half-diagonal, which ${TEXTURE_LAYER_PCT}% of the
      width clears for a tile up to ${MAX_TILE_ASPECT} times as tall as it is
      wide. The fade is measured against the tile and the texture is drawn in

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -116,7 +116,7 @@ function updateFromEvent(event: string): TestUpdate {
 function tileHtml(label: string, html = page()): string {
   const parts = html.split(`<div class="tile `);
   const hit = parts.filter((p) => p.includes(`</span> ${label}<span class="spacer">`));
-  assertEquals(hit.length, 1, `expected exactly one tile labelled "${label}"`);
+  assertEquals(hit.length, 1, `expected exactly one tile labeled "${label}"`);
   return hit[0];
 }
 

--- a/packages/dashboard/test/spend.test.ts
+++ b/packages/dashboard/test/spend.test.ts
@@ -217,7 +217,7 @@ describe("spend", () => {
     expect(quiet[0]).toBeGreaterThan(lines[0][19][1]);
   });
 
-  it("marks a day both its neighbours are missing", () => {
+  it("marks a day both its neighbors are missing", () => {
     // On 3 January a 2-day lag reaches 1 January, so the January side of the
     // hole is a single day with nothing to join it to.
     const github = source(

--- a/packages/dashboard/tiles/benchmark.test.ts
+++ b/packages/dashboard/tiles/benchmark.test.ts
@@ -1349,7 +1349,7 @@ Deno.test("benchmark: a stalled sample does not move the trend", async () => {
 });
 
 Deno.test("benchmark: a run still in flight is not sampled", async () => {
-  // A conclusion of null is not a colour, it is an absence: the run has not
+  // A conclusion of null is not a color, it is an absence: the run has not
   // finished and has no artifact to read. Only completed runs are sampled.
   const id = 11_700;
   const inFlight = {
@@ -1709,7 +1709,7 @@ Deno.test("benchmark: a run under way is a badge, not a verdict", async () => {
   await withApi({ pages: { 1: [inFlight, ...newestFirst] }, artifacts, zips }, async () => {
     const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
     assertStringIncludes(v.aside ?? "", "running");
-    assertEquals(v.status, "good"); // the runs that finished still set the colour
+    assertEquals(v.status, "good"); // the runs that finished still set the color
   });
   await withApi({ pages: { 1: newestFirst }, artifacts, zips }, async () => {
     const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
@@ -2646,7 +2646,7 @@ Deno.test("benchmark: CPU-less cached runs are fetched again", async () => {
   }
 });
 
-Deno.test("/bench: grouped by source file, each benchmark coloured by its own trend", async () => {
+Deno.test("/bench: grouped by source file, each benchmark colored by its own trend", async () => {
   const html = await page("?stat=p99&sort=file");
   assertEquals(
     [...html.matchAll(/<h2>([^<]*)<\/h2>/g)].map((m) => m[1]),
@@ -2915,7 +2915,7 @@ Deno.test("/bench: the measurement selector changes what is plotted", async () =
     await page("?stat=mean"),
     "<title>Benchmarks — mean</title>",
   );
-  // The mean column was once labelled p50, so a link saved under that name still
+  // The mean column was once labeled p50, so a link saved under that name still
   // opens it rather than falling back to the default.
   assertEquals(
     rows(await page("?stat=p50")).find((r) => r.name === "hot/steep")?.value,

--- a/packages/dashboard/tiles/benchmark.ts
+++ b/packages/dashboard/tiles/benchmark.ts
@@ -7,7 +7,7 @@
  * time budget, so a performance change moves the per-operation times without
  * materially changing the run's wall-clock time.
  *
- * Each processor has its own coloured line, and the headline shows the largest
+ * Each processor has its own colored line, and the headline shows the largest
  * established trend. Orange means at least one processor trends up. Green
  * means every established processor stays flat or falls. Red means the most
  * recent run failed, or finished successfully without readable benchmark data.
@@ -32,7 +32,7 @@
  *
  * A red run is read like any other: `deno bench` exits non-zero when one
  * benchmark throws, having written a complete report of the rest, so a run's
- * colour says nothing about whether it measured anything. What decides that is
+ * color says nothing about whether it measured anything. What decides that is
  * the artifact, which has to parse, name a processor, and carry benchmarks the
  * tile trends. The failed state reads the workflow-run list and the latest
  * run's cached result, so it is unaffected by which runs the trend samples, and
@@ -54,7 +54,7 @@
  * shortest-view time bucket. It unzips each artifact in the process and reads
  * every benchmark's timings and processor identity. Results for a run attempt
  * are immutable and persisted, so later collections fetch only new runs and
- * attempts. The drill-down overlays one coloured line per processor for each
+ * attempts. The drill-down overlays one colored line per processor for each
  * benchmark. The CI duration and Gantt views also live behind /bench, and this
  * tile's collection keeps their history warm.
  */
@@ -708,7 +708,7 @@ async function markBenchmarkRefreshed(
 }
 
 // Every completed run in the window, thinned to one per collection bucket. A
-// run's colour does not decide whether it measured anything: `deno bench` exits
+// run's color does not decide whether it measured anything: `deno bench` exits
 // non-zero when any one benchmark throws, having already written a complete
 // report of the rest, and the workflow uploads that report either way. Over one
 // recent 45-day stretch, 26 of the 30 red runs carried an artifact
@@ -785,7 +785,7 @@ const errorMessage = (error: unknown): string =>
 // user-facing timings that tail is what a person actually notices. Reading it
 // from these runs would need the stalls told apart from the tail the code
 // produces, which the current sample counts do not allow: on the busiest
-// processor, `p99` puts 11% of neighbouring run pairs more than a quarter
+// processor, `p99` puts 11% of neighboring run pairs more than a quarter
 // apart with no change behind them, against 2% for the 75th percentile. The
 // drill-down plots the whole ladder from `min` to `max` in the meantime.
 function sharedBenchmarkRatio(
@@ -1095,7 +1095,7 @@ function benchmarkIndexView(
   const latestCompleted = latestCompletedRun(runs);
   const failedCi = latestCompleted !== undefined && runFailed(latestCompleted);
   // A run under way is a header badge, and leaves the verdict to the runs that
-  // have finished. The badge is what says the tile's colour may be about to move.
+  // have finished. The badge is what says the tile's color may be about to move.
   const aside = runInFlight(runs) ? RUNNING_BADGE : undefined;
   // A run that finished green on CI but whose artifact resolved to no readable
   // benchmark data is as good as failed: it ran and produced nothing usable. Only
@@ -1111,7 +1111,7 @@ function benchmarkIndexView(
     ? benchmarkFailureLabel(runs, now)
     : "no benchmark data";
   // The runs with processor identities and readable artifacts in the window,
-  // oldest -> newest. The artifact decides, not the run's colour.
+  // oldest -> newest. The artifact decides, not the run's color.
   const cached = (benchmarkStore.refreshedRuns() ?? benchmarkStore.list(cutoff))
     .filter((run): run is CpuBenchmarkRun =>
       run.at >= cutoff && run.cpu !== undefined && productMetricCount(run) > 0
@@ -2034,7 +2034,7 @@ export function benchPage(
 
   const rangeContent = `<div id="range-content">
     ${progressHtml}${refreshNotice}
-    <p class="legend">Per-op time across a run's samples — p0 = the fastest, p100 = the slowest, mean = the arithmetic mean. Lower is faster. Each CPU has its own coloured line. The value, trend, and row colour use the CPU with the most benchmark samples in the selected ${days}-day window; a tie uses the CPU with the newest sample. Fewer than seven distinct days are marked new. Duration and trend sorting use the displayed value and trend.</p>
+    <p class="legend">Per-op time across a run's samples — p0 = the fastest, p100 = the slowest, mean = the arithmetic mean. Lower is faster. Each CPU has its own colored line. The value, trend, and row color use the CPU with the most benchmark samples in the selected ${days}-day window; a tie uses the CPU with the newest sample. Fewer than seven distinct days are marked new. Duration and trend sorting use the displayed value and trend.</p>
     ${body}
     ${cpuLegend}
     <p class="note">Successful main runs come from the <a href="https://github.com/${REPO}/actions/workflows/${WORKFLOW}" target="_blank" rel="noopener">${WORKFLOW} runs ↗</a> (deno bench artifacts). Collection keeps enough samples for the shortest window, and charts reduce longer windows to about ${CI_HISTORY_POINT_TARGET} evenly spaced points.</p>

--- a/packages/dashboard/tiles/ci-duration.test.ts
+++ b/packages/dashboard/tiles/ci-duration.test.ts
@@ -271,7 +271,7 @@ Deno.test("the Gantt page shares the performance view selector", async () => {
   assert(!html.includes('class="spinner"'));
   assert(!html.includes("min runs per job"));
   assert(!html.includes("minRuns"));
-  // The runs slider offers only what the image route will honour, so dragging it
+  // The runs slider offers only what the image route will honor, so dragging it
   // to either end can't ask for a limit that comes back silently clamped.
   assertStringIncludes(html, `id="limit" min="1" max="150"`);
   assertEquals((await gantt("?limit=150")).args.indexOf("150") >= 0, true);

--- a/packages/dashboard/tiles/ci-trust.ts
+++ b/packages/dashboard/tiles/ci-trust.ts
@@ -15,11 +15,11 @@ import {
 import { strip } from "../lib.ts";
 import { CI_RUNS_MAX, CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, REPO, TRUST_COLS, TRUST_GOOD, TRUST_WARN } from "../config.ts";
 
-type TrustOutcome = "green" | "red" | "run" | "grey";
+type TrustOutcome = "green" | "red" | "run" | "gray";
 
 function trustOutcome(run: Run): TrustOutcome {
   if (run.status === "in_progress") return "run";
-  if (run.status !== "completed" || !run.conclusion) return "grey";
+  if (run.status !== "completed" || !run.conclusion) return "gray";
   return run.conclusion === "success" && run.run_attempt === 1 ? "green" : "red";
 }
 

--- a/packages/dashboard/tiles/discord-online.test.ts
+++ b/packages/dashboard/tiles/discord-online.test.ts
@@ -222,7 +222,7 @@ Deno.test("discord snapshot: an online user with no member record counts as a vi
   assertEquals(snap.teamColor, "#0000ff"); // a decimal Discord color, zero-padded
 });
 
-Deno.test("discord snapshot: a colorless Team role uses the visitor grey", () => {
+Deno.test("discord snapshot: a colorless Team role uses the visitor gray", () => {
   const online = [{ user: { id: "a" }, status: "online" }];
   const members = [{ user: { id: "a" }, roles: ["team"] }];
   // The role exists and is counted, but carries Discord's "no color" sentinel.

--- a/packages/dashboard/tiles/discord-online.ts
+++ b/packages/dashboard/tiles/discord-online.ts
@@ -107,7 +107,7 @@ interface Snapshot {
 }
 
 // A role's swatch color: decimal Discord color -> "#rrggbb"; the 0 sentinel
-// (Discord's "no color") maps to the neutral grey used elsewhere in the shell.
+// (Discord's "no color") maps to the neutral gray used elsewhere in the shell.
 function roleColor(color: number): string {
   if (!Number.isInteger(color) || color <= 0) return VISITOR_COLOR;
   return "#" + (color & 0xffffff).toString(16).padStart(6, "0");

--- a/packages/dashboard/tiles/github-ci-spend.test.ts
+++ b/packages/dashboard/tiles/github-ci-spend.test.ts
@@ -311,7 +311,7 @@ Deno.test("ci spend: no Actions budget in GitHub -> the projection stands, uncom
   assertEquals(none.sub, undefined);
   assertStringIncludes(none.extra ?? "", "Budget $???");
   assertEquals(none.status, "good"); // an absent budget never alarms
-  // The org budgets Actions' neighbours but not Actions.
+  // The org budgets Actions' neighbors but not Actions.
   const other = await view("2026-01-20T09:00:00Z", {
     [usagePath(2026, 1)]: usage,
     [budgetsPath()]: {

--- a/packages/dashboard/tiles/github-ci-spend.ts
+++ b/packages/dashboard/tiles/github-ci-spend.ts
@@ -419,7 +419,7 @@ async function blacksmithSpend(
   // The daily endpoint answers for a range of days, a record per day it has
   // runner cost to report. Past its newest record a quiet day and an unwritten
   // day read the same, so the tile stops there rather than charging the days
-  // after it at $0. The invoice is left out of that judgement: it is a running
+  // after it at $0. The invoice is left out of that judgment: it is a running
   // total with no date on it, so it cannot show that Blacksmith's billing is
   // still moving.
   const { byDay, reportedThrough } = parseBlacksmithDaily(daily);

--- a/packages/dashboard/tiles/model-spend.test.ts
+++ b/packages/dashboard/tiles/model-spend.test.ts
@@ -125,7 +125,7 @@ Deno.test("model spend: all three providers read -> green, combined MTD, a line 
         `<p class="sub">${themedSwatch("#10a37f")} OpenAI • ` +
           `${themedSwatch("#d97757")} Anthropic • OR $5</p>`,
       );
-      // Each line is drawn in its provider's color and labelled with its own MTD.
+      // Each line is drawn in its provider's color and labeled with its own MTD.
       assertStringIncludes(v.extra ?? "", `pointer-events:none">$${DOM}</span>`);
       assertStringIncludes(v.extra ?? "", `pointer-events:none">$${2 * DOM}</span>`);
       assertStringIncludes(v.extra ?? "", "#10a37f");
@@ -211,7 +211,7 @@ Deno.test("model spend: a provider with no bucket at all draws no line of $0", a
     const v = await modelSpend.collect(ctx({ OPENAI_ADMIN_KEY: "oa", ANTHROPIC_ADMIN_KEY: "an" }));
     assertEquals(v.status, "good");
     assertEquals(v.aside, `<span class="hmtd">$${2 * DOM} MTD</span>`); // Anthropic's $2/day alone
-    // OpenAI's colour survives in the key's swatch and nowhere in the chart.
+    // OpenAI's color survives in the key's swatch and nowhere in the chart.
     assertEquals((v.extra ?? "").match(/#10a37f/gi)?.length, 1);
     assertStringIncludes(v.extra ?? "", "#d97757");
   });

--- a/packages/dashboard/tiles/model-spend.ts
+++ b/packages/dashboard/tiles/model-spend.ts
@@ -12,7 +12,7 @@
  * projected full-month spend, extrapolated from the recent daily rate and
  * spilling into last month's tail when this month is under two weeks old,
  * summed across every provider we could read. The subtitle is the key, saying
- * which colour is which provider and carrying OpenRouter's total since it has
+ * which color is which provider and carrying OpenRouter's total since it has
  * no line of its own. The combined month-to-date total sits in the header
  * aside, and the span the chart covers goes to the tile's duration slot.
  *

--- a/packages/dashboard/tiles/prod-uptime.ts
+++ b/packages/dashboard/tiles/prod-uptime.ts
@@ -38,7 +38,7 @@ const STATUS_DOT: Record<Status, string> = {
   good: "green",
   warn: "amber",
   bad: "red",
-  unknown: "grey",
+  unknown: "gray",
 };
 const STATUS_RANK: Record<Status, number> = {
   good: 0,

--- a/packages/dashboard/tiles/recent-runs.ts
+++ b/packages/dashboard/tiles/recent-runs.ts
@@ -150,7 +150,7 @@ export const recentRuns: Tile = {
         escapeHtml(href)
       }" target="_blank" rel="noopener" aria-label="Open landed change on GitHub">↗</a></div>`;
     }).join("") ||
-      `<div class="ev"><span class="dot grey"></span><span>waiting for first poll…</span></div>`;
+      `<div class="ev"><span class="dot gray"></span><span>waiting for first poll…</span></div>`;
 
     return {
       label: `recent main runs · ${runs.length} in window`,

--- a/packages/dashboard/trend.ts
+++ b/packages/dashboard/trend.ts
@@ -20,7 +20,7 @@ const RAPID_PCT = 0.20;
 const LEVEL_SAMPLE_CAP = 64;
 // Samples either side of a change point, so each level rests on three or more.
 const MIN_SEGMENT = 3;
-// How far apart two neighbouring levels must sit, in standard errors of their
+// How far apart two neighboring levels must sit, in standard errors of their
 // difference, for the boundary between them to count as a change point.
 const CHANGE_POINT_SIGMAS = 4;
 // How much smaller the straight line's total deviation must be for it to
@@ -58,7 +58,7 @@ function groupedSamples(values: number[]): number[] {
 }
 
 // The typical size of a sample-to-sample move, read from the differences
-// between neighbours. A level change contributes one difference however large
+// between neighbors. A level change contributes one difference however large
 // it is, so the median of them describes the noise around the levels.
 function noiseScale(logs: number[]): number {
   const steps: number[] = [];
@@ -158,7 +158,7 @@ export function trendPct(times: number[], values: number[]): number {
   if (distinctTrendDays(times, values) < MIN_TREND_DAYS) return 0;
   const logs = groupedSamples(values.filter((value) => value > 0))
     .map((value) => Math.log(value));
-  // A scale of zero means most neighbours agree exactly. The search then treats
+  // A scale of zero means most neighbors agree exactly. The search then treats
   // any daylight between two levels as real, and still asks for `MIN_SEGMENT`
   // samples either side of the boundary, so a single stray sample is not one.
   const scale = noiseScale(logs);

--- a/packages/runner/src/builder/node-utils.ts
+++ b/packages/runner/src/builder/node-utils.ts
@@ -138,7 +138,7 @@ function attachCfcToOutputs(
     //
     // A `FabricInstance` is refused. Its codec contents can hold a `Cell`,
     // unreachable by property name, so passing one through leaves that cell
-    // _unlabelled_ while its plain siblings are labelled -- confidentiality
+    // _unlabelled_ while its plain siblings are labeled -- confidentiality
     // silently not applied, which is the unsafe direction, unlike the
     // policy-input walks in `runner.ts` whose equivalent gap fails closed.
     //

--- a/packages/runner/src/cfc/exchange-eval.ts
+++ b/packages/runner/src/cfc/exchange-eval.ts
@@ -39,7 +39,7 @@ import type { TrustResolver } from "./trust.ts";
 /**
  * The guarded-rewrite evaluator (spec §4.4.5, Epic B4 of
  * docs/history/plans/cfc-future-work-implementation.md §3): runs a policy snapshot's
- * exchange rules over one label to a fuelled fixpoint. The ONLY things a
+ * exchange rules over one label to a fueled fixpoint. The ONLY things a
  * firing may do:
  *
  * - ADD instantiated alternatives to the clause whose alternative the rule's
@@ -70,7 +70,7 @@ import type { TrustResolver } from "./trust.ts";
  * federation soundness (docs/specs/cfc-spec-changes.md SC-28).
  *
  * Termination (spec §4.4.5): add-only rule sets converge by monotonicity;
- * add+drop sets can cycle, so the evaluator is fuelled and FAILS CLOSED on
+ * add+drop sets can cycle, so the evaluator is fueled and FAILS CLOSED on
  * exhaustion — `exhausted: true` with the ORIGINAL label, never a partial
  * rewrite (invariant 6: violating a policy disables exchange, it never
  * silently downgrades).
@@ -759,7 +759,7 @@ const applyRuleMatch = (
 };
 
 /**
- * Runs every snapshot rule over `label` to a fuelled fixpoint and returns
+ * Runs every snapshot rule over `label` to a fueled fixpoint and returns
  * the rewritten label (or the ORIGINAL on fuel exhaustion, flagged).
  *
  * Determinism: records and rules evaluate in canonical (id) order; matches

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -186,7 +186,7 @@ export function areMaybeLinkAndNormalizedLinkSame(
   return areNormalizedLinksSame(normalizedLink, normalizedLink2);
 }
 
-// Link identity (`areNormalizedLinksSame` and neighbours) lives in
+// Link identity (`areNormalizedLinksSame` and neighbors) lives in
 // ./link-types.ts — one canonical implementation — and reaches importers of
 // this module through the `export *` above.
 

--- a/packages/runner/src/pattern-source-scheme.ts
+++ b/packages/runner/src/pattern-source-scheme.ts
@@ -134,7 +134,7 @@ export function systemPatternSourceForModuleName(
  * two things this change does not do. Durable pre-existing provenance has to be
  * migrated, which only happens on a successful check and therefore never on a
  * deployment running with `systemPatternAutoUpdate` off. And
- * `isLegacyPieceRegistryRoot` reads this to recognise a root that tracks the
+ * `isLegacyPieceRegistryRoot` reads this to recognize a root that tracks the
  * official default app, on a path with no flag gate at all.
  */
 export function normalizePatternSource(

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -2045,7 +2045,7 @@ export class Runner {
       });
       // Same condition as the durable stamp, deliberately: an observer that
       // saw instantiations the store does not label would report update
-      // targets that cannot be found again, and one that missed a labelled
+      // targets that cannot be found again, and one that missed a labeled
       // root would under-report. That includes the KEYLESS case —
       // `entryRefForPattern` always yields a ref, minting a `keyless:<hash>`
       // session pointer when there is no content-addressed one, and that

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -2103,7 +2103,7 @@ export class Runtime {
    * NOTE(#1): The derivation is intentionally name-based for now — `createSession`
    * derives the space key from the name alone (the identity is ignored on the
    * `spaceName` path), so equal names map to the same shared space across users.
-   * This is the deliberate "shared profile space" behaviour today; revisit once
+   * This is the deliberate "shared profile space" behavior today; revisit once
    * we can derive unique space DIDs from a string.
    */
   async resolveSpaceName(name: string): Promise<MemorySpace> {
@@ -2232,7 +2232,7 @@ export class Runtime {
   /**
    * The host that serves a space's space-bound work (LLM, fetch, blob).
    * A mapped space resolves to its host; everything else to the
-   * default `apiUrl`. The single compute-side analogue of the storage
+   * default `apiUrl`. The single compute-side analog of the storage
    * layer's per-space address resolver.
    */
   hostForSpace(space: MemorySpace): URL {

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -1210,7 +1210,7 @@ export class Scheduler {
   // Client-facing quiescence: reactive quiescence AND durability of in-flight
   // commits. Commits are issued fire-and-forget (event handlers, direct cell
   // writes over IPC, reactive recomputation write-backs), so plain idle()
-  // reports quiescence while a commit is still travelling to the server; a
+  // reports quiescence while a commit is still traveling to the server; a
   // client that reads idle as a safe point to navigate or reload would then
   // drop that write when the page and its worker are torn down. The pending
   // set is sourced from the storage manager — the single chokepoint every

--- a/packages/runner/src/scheduler/run.ts
+++ b/packages/runner/src/scheduler/run.ts
@@ -140,7 +140,7 @@ export function watchReactiveActionCommit(state: {
     // A CONFLICT is an upstream stale read: the authoritative version is ahead of
     // this replica, and the action's read set is stale until the replica catches
     // up (the conflict's `readyToRetry` gates exactly that catch-up). A
-    // STORAGE-TRANSACTION-INCONSISTENT is the local analogue: a value the
+    // STORAGE-TRANSACTION-INCONSISTENT is the local analog: a value the
     // transaction read changed on this replica between the read and the commit,
     // which re-running against the settled replica resolves. It carries no
     // `readyToRetry`, so the re-queue below runs it afresh once the local write

--- a/packages/runner/src/storage/mergeable-ops.ts
+++ b/packages/runner/src/storage/mergeable-ops.ts
@@ -91,7 +91,7 @@ export interface MergeableBuildContext {
  *
  * In today's reachable cases the reshaping write also leaves an unmarked read at
  * the path, which keeps it in the conflict set anyway — so this is belt and
- * braces rather than a demonstrated behaviour change. It is kept because the
+ * braces rather than a demonstrated behavior change. It is kept because the
  * guarantee should not rest on that coincidence: nothing makes a reshape
  * obliged to read what it overwrites.
  */
@@ -110,7 +110,7 @@ export interface MergeableBuildResult {
 //   target is even resolved (an empty tail op). Absent means "always record".
 // - `fold` — how a delta combines into the path's accumulated intent.
 // - `build` — how an accumulated intent becomes wire ops and diff-suppression,
-//   or is abandoned in favour of the plain diff (see `abandon` above).
+//   or is abandoned in favor of the plain diff (see `abandon` above).
 // - `payloadContains` — whether a path lies inside the live values this op sends
 //   (see {@link mergeableOpPayloadContains}). Absent means "carries no live
 //   subtree", which is the answer for every op but the tail ops.

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -3428,7 +3428,7 @@ class SpaceReplica implements ISpaceReplica {
   /**
    * Mark a commit's outcome as finalized and remove it from the cascade scan
    * set. Idempotent — pushCommit's finally may run after reset() already
-   * signalled a local rejection for the same entry.
+   * signaled a local rejection for the same entry.
    */
   private settleInFlightCommit(localSeq: number): void {
     const entry = this.#inFlightCommits.get(localSeq);

--- a/packages/runner/test/cfc-atom-pattern.test.ts
+++ b/packages/runner/test/cfc-atom-pattern.test.ts
@@ -17,7 +17,7 @@ import { clauseSubsumes } from "../src/cfc/clause.ts";
 // Epic B1 (docs/history/plans/cfc-future-work-implementation.md §3): the atom
 // pattern-matching kernel of the exchange-rule calculus (spec §4.3.3/§4.3.4)
 // plus the per-family entailment hook and the new atom families' registry
-// entries. Pure helpers — B4 wires them into the fuelled evaluator.
+// entries. Pure helpers — B4 wires them into the fueled evaluator.
 
 const userA = cfcAtom.user("did:key:alice");
 const userB = cfcAtom.user("did:key:bob");

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -3343,7 +3343,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     }
   });
 
-  it("persists cfc metadata for nested entity documents created from labelled collection items", async () => {
+  it("persists cfc metadata for nested entity documents created from labeled collection items", async () => {
     const { runtime, storageManager } = createRuntime();
     try {
       const tx = runtime.edit();

--- a/packages/runner/test/cfc-cross-space-integrity.test.ts
+++ b/packages/runner/test/cfc-cross-space-integrity.test.ts
@@ -422,7 +422,7 @@ describe("CFC cross-space integrity", () => {
   // -------------------------------------------------------------------------
   // GAP (remaining): the spec's reference annotation (§8.2 `passThrough`) is
   // unimplemented; a write through a schema declaring it FAILS CLOSED rather
-  // than being silently ignored. Reference behaviours stay reachable via
+  // than being silently ignored. Reference behaviors stay reachable via
   // per-path labels and links (scenarios 1c / 3).
   // -------------------------------------------------------------------------
   it("scenario 3a [GAP] — the passThrough ifc annotation fails closed (unimplemented)", async () => {

--- a/packages/runner/test/cfc-exchange-eval.test.ts
+++ b/packages/runner/test/cfc-exchange-eval.test.ts
@@ -21,7 +21,7 @@ import type { IFCLabel } from "../src/cfc/label-view-core.ts";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 
 // Epic B4 (docs/history/plans/cfc-future-work-implementation.md §3): the guarded
-// rewrite + fuelled fixpoint (spec §4.4.5). Property tests (i)-(vi) from the
+// rewrite + fueled fixpoint (spec §4.4.5). Property tests (i)-(vi) from the
 // plan, plus the worked examples the calculus exists for.
 
 const ALICE = "did:key:alice";

--- a/packages/runner/test/cfc-label-view.test.ts
+++ b/packages/runner/test/cfc-label-view.test.ts
@@ -190,7 +190,7 @@ describe("CFC label view helpers", () => {
   it("does not treat schema constraints as display labels", () => {
     const cell = {
       getAsNormalizedFullLink: () => ({
-        id: "of:labelled-cell",
+        id: "of:labeled-cell",
         space: "did:key:test",
         type: "application/json",
         path: [],
@@ -209,7 +209,7 @@ describe("CFC label view helpers", () => {
   it("does not ask result metadata for label display", () => {
     const cell = {
       getAsNormalizedFullLink: () => ({
-        id: "of:labelled-result-cell",
+        id: "of:labeled-result-cell",
         space: "did:key:test",
         type: "application/json",
         path: [],
@@ -245,7 +245,7 @@ describe("CFC label view helpers", () => {
         type: "application/json",
         path: [],
       }, {
-        value: "labelled content",
+        value: "labeled content",
         cfc: {
           version: 1,
           schemaHash: "test-schema",
@@ -1294,7 +1294,7 @@ describe("CFC label view helpers", () => {
         type: "application/json",
         path: [],
       }, {
-        value: { body: "labelled content" },
+        value: { body: "labeled content" },
         cfc: {
           version: 1,
           schemaHash: "test-schema",
@@ -1337,7 +1337,7 @@ describe("CFC label view helpers", () => {
   it("reads stored metadata directly from the queried cell", () => {
     const cell = {
       getAsNormalizedFullLink: () => ({
-        id: "of:labelled-cell",
+        id: "of:labeled-cell",
         space: "did:key:test",
         type: "application/json",
         path: [],

--- a/packages/runner/test/cfc-llm-observation-failclosed.test.ts
+++ b/packages/runner/test/cfc-llm-observation-failclosed.test.ts
@@ -26,7 +26,7 @@ import {
 
 const cellWhoseMetadataReadErrors = {
   getAsNormalizedFullLink: () => ({
-    id: "of:labelled-cell",
+    id: "of:labeled-cell",
     space: "did:key:test",
     type: "application/json",
     path: [],

--- a/packages/runner/test/cfc-prepare-bypass.test.ts
+++ b/packages/runner/test/cfc-prepare-bypass.test.ts
@@ -17,7 +17,7 @@ const signer = await Identity.fromPassphrase("runner-cfc-prepare-bypass-tests");
 // policy-violating transaction cleanly.
 //
 // The fix removes the input parameter entirely so verification always runs.
-// This test pins the behavioural contract: a relevant, policy-violating
+// This test pins the behavioral contract: a relevant, policy-violating
 // transaction can never reach a committed state through prepareCfc.
 describe("CFC prepareCfc verification bypass", () => {
   it("rejects a writeAuthorizedBy violation even when prepareCfc is driven directly", async () => {

--- a/packages/runner/test/engine-test-support.ts
+++ b/packages/runner/test/engine-test-support.ts
@@ -13,7 +13,7 @@ export type { RuntimeProgram } from "../src/harness/types.ts";
 
 export const signer = await Identity.fromPassphrase("test operator");
 
-// All authored modules' compiled CommonJS bodies, joined — the ESM analogue of
+// All authored modules' compiled CommonJS bodies, joined — the ESM analog of
 // the old single-bundle `jsScript.js` for transformer-output assertions.
 export const joinedBodies = (graph: CompiledModuleGraph): string =>
   [...graph.compiledBodies.values()].join("\n");

--- a/packages/runner/test/memory-v2-acl-mutation.test.ts
+++ b/packages/runner/test/memory-v2-acl-mutation.test.ts
@@ -481,7 +481,7 @@ Deno.test("ACL mutation preserves sibling envelope fields", async () => {
   const ctx = await withGenesisedSpace("runner-acl-mutation-siblings");
   const bob = await Identity.fromPassphrase("runner-acl-mutation-siblings bob");
   try {
-    // Install a sibling out-of-band, as a labelling layer would.
+    // Install a sibling out-of-band, as a labeling layer would.
     const current = await ctx.server.readDocument(
       ctx.space,
       `of:${ctx.space}`,

--- a/packages/runner/test/memory-v2-remote-session.test.ts
+++ b/packages/runner/test/memory-v2-remote-session.test.ts
@@ -448,7 +448,7 @@ describe("StorageManager.registerSpaceHost", () => {
   });
 });
 
-describe("WebSocketTransport failure signalling", () => {
+describe("WebSocketTransport failure signaling", () => {
   // A socket the test opens, closes, and errors by hand. Nothing here waits on
   // a real connection or a timer: the transport reaches its close and error
   // handlers because the test dispatches those events synchronously.

--- a/packages/runner/test/node-utils.test.ts
+++ b/packages/runner/test/node-utils.test.ts
@@ -1,5 +1,5 @@
 /**
- * What the CFC output-labelling walk does with a `FabricSpecialObject`. Such a
+ * What the CFC output-labeling walk does with a `FabricSpecialObject`. Such a
  * value has zero enumerable own properties, so the walk's `Object.entries()`
  * descent ends at it. That costs a `FabricPrimitive` nothing -- a leaf holds no
  * cell to label -- but for a `FabricInstance` it means a cell in its codec
@@ -94,7 +94,7 @@ describe("node-utils", () => {
 
     it("throws for a `FabricError` holding a cell rather than skipping it", () => {
       withinHandler(() => {
-        // The control is the point: the same cell _is_ labelled when it sits in
+        // The control is the point: the same cell _is_ labeled when it sits in
         // a plain record, so what changes the outcome is the wrapper.
         const input = new Cell("classified", {
           type: "string",

--- a/packages/runner/test/pattern-update-argument-validation.test.ts
+++ b/packages/runner/test/pattern-update-argument-validation.test.ts
@@ -192,7 +192,7 @@ describe("pattern update validates the stored argument", () => {
     // The refusal must be CLASSIFIABLE, not just readable. A boot repair keys
     // its recovery on this: re-running the same identity refuses identically,
     // so `PiecesController` escalates to the roll-forward backstop instead of
-    // retrying, and a failure it cannot classify is discarded in favour of the
+    // retrying, and a failure it cannot classify is discarded in favor of the
     // original start error. Assert against the error the runner ACTUALLY threw
     // rather than a hand-written string, so the thrower and the classifier
     // cannot drift apart.
@@ -225,7 +225,7 @@ describe("pattern update validates the stored argument", () => {
     expect(
       getPatternIdentityRef(cell as Cell<unknown>)?.identity,
       "a refused roll-forward rolled the pointer back. That is a deliberate " +
-        "behaviour change, not a cleanup: the repair reaches this path BECAUSE " +
+        "behavior change, not a cleanup: the repair reaches this path BECAUSE " +
         "the previously pinned pattern could not be set up either",
     ).toBe(rejectedIdentity);
     expect(

--- a/packages/runner/test/reactive-stale-basis-strand.test.ts
+++ b/packages/runner/test/reactive-stale-basis-strand.test.ts
@@ -3,12 +3,12 @@
 // (StorageTransactionInconsistent) must converge, not exhaust a bounded retry
 // budget and strand at its stale value.
 //
-// This is the reactive-path analogue of the event-handler residual closed in
+// This is the reactive-path analog of the event-handler residual closed in
 // mergeable-append-multispace-conflict.test.ts. StorageTransactionInconsistent
 // is a stale-basis rejection: a value the transaction read changed on this
 // replica between the read and the commit, which re-running against the settled
 // replica resolves (see packages/runner/src/storage/rejection.ts). A conflict —
-// the upstream stale-read analogue — has always been retried off the reactive
+// the upstream stale-read analog — has always been retried off the reactive
 // budget (a WAIT for catch-up, not a failure). The local same-replica race was
 // not: it fell into the bounded MAX_RETRIES_FOR_REACTIVE path alongside genuinely
 // terminal transport/malformed errors, so a burst longer than the budget left the

--- a/packages/runner/test/replica-eviction-invariants.test.ts
+++ b/packages/runner/test/replica-eviction-invariants.test.ts
@@ -6,7 +6,7 @@
 // These are deliberately small and fast — they are meant to be the loop you run
 // while working on eviction, rather than a 100 KB suite whose failure you then
 // have to localize. Neither test knows anything about how eviction is
-// configured: they assert the behaviour a reader is entitled to, so they answer
+// configured: they assert the behavior a reader is entitled to, so they answer
 // the question whatever the mechanism turns out to be.
 //
 // What each one is a guard against:

--- a/packages/runner/test/scheduler-timing.test.ts
+++ b/packages/runner/test/scheduler-timing.test.ts
@@ -395,7 +395,7 @@ describe("debounce and throttling", () => {
 
       expect(runCount).toBe(0);
     } finally {
-      // The scheduler is disposed above as the behaviour under test, and the
+      // The scheduler is disposed above as the behavior under test, and the
       // real teardown still runs over it — see scheduler-dispose-idle.test.ts
       // for the contract that makes the two compose.
       await disposeSchedulerTestRuntime(local);

--- a/packages/runner/test/space-host-late-hint.test.ts
+++ b/packages/runner/test/space-host-late-hint.test.ts
@@ -1116,15 +1116,15 @@ describe("late space host hints", () => {
     }
   });
 
-  it("keeps the route when a committed write loses its acknowledgement", async () => {
+  it("keeps the route when a committed write loses its acknowledgment", async () => {
     const signer = await Identity.fromPassphrase(
-      "lost-acknowledgement-route-write",
+      "lost-acknowledgment-route-write",
     );
     const targetSpace = (await Identity.fromPassphrase(
-      "lost-acknowledgement-route-write-target",
+      "lost-acknowledgment-route-write-target",
     )).did();
-    const targetId = "of:lost-acknowledgement-route-write-target" as URI;
-    const defaultServer = makeServer("lost-acknowledgement-route-default");
+    const targetId = "of:lost-acknowledgment-route-write-target" as URI;
+    const defaultServer = makeServer("lost-acknowledgment-route-default");
     const factory = new LoopbackSessionFactory(() => defaultServer);
     const manager = TestStorageManager.create(
       signer,
@@ -1140,7 +1140,7 @@ describe("late space host hints", () => {
           );
           connection.session.transact = async (commit, beforeIssue) => {
             await transact(commit, beforeIssue);
-            throw new Error("write acknowledgement lost");
+            throw new Error("write acknowledgment lost");
           };
           return connection;
         },

--- a/packages/runner/test/to-encodable-form.test.ts
+++ b/packages/runner/test/to-encodable-form.test.ts
@@ -267,7 +267,7 @@ describe("to-encodable-form", () => {
     });
 
     it("throws given an array that is not inert, rather than laundering it", () => {
-      // The array analogue of the plain-object case above, and it matters for
+      // The array analog of the plain-object case above, and it matters for
       // the same reason: `.map()` rebuilds by index, so a named property is
       // dropped and an accessor-backed index is EVALUATED into a data
       // property, each yielding an array that satisfies `isFabricValue()`


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) am opening this as the second of three,
from a full-repo audit for remaining Britishisms. Companions: #5819 (`cf view`)
and #5820 (docs and the long tail). The rule is in
`docs/development/DEVELOPMENT.md` (#5805).

67 files, 138 words — comments and test names, plus a few self-contained code
sites.

## `dashboard`'s `grey` is a CSS token, not prose

Worth reading twice, because it is the one place in the whole audit where a
spelling is load-bearing. `"grey"` is a class name: `STATUS_DOT` maps a status
to it, `ci-trust.ts` and `prod-uptime.ts` carry their own copies, and tiles emit
`class="dot grey"`.

What makes it safe is that the stylesheet is not a separate file that could
fall out of step. `render.ts:158` generates the rule from the same constant:

```ts
`.dot.${STATUS_DOT[s]}::before{${DOT_SHAPE[s]};…}`
```

So the class and the rule move together by construction. After the change,
`grep -rn grey packages/dashboard` returns nothing — no orphan on either side.

The positive check: `deno task test` in `packages/dashboard` is **675 passed, 0
failed**, and the run includes `lib.test.ts`, whose `concDot` cases assert the
token value directly (`assertEquals(concDot("success", 2), "gray")`).

## The other code sites

| site | change |
| --- | --- |
| `cli/lib/fuse-mount-flags.ts` | function-local `labelled` → `labeled` (4 uses) |
| `cli/lib/view/diffedit.ts` | local `recoloured` → `recolored` (2 uses) |
| `runner/test/cfc-label-view.test.ts` and friends | test-local fixture ids (`of:labeled-cell`) |
| `runner/test/space-host-late-hint.test.ts` | test-local ids (`lost-acknowledgment-route-write`) |

Each fixture id is self-consistent within its own file, and both halves move in
this change. I checked repo-wide for a string literal carrying a British word
that appears in more than one package: there is exactly one, and it is
`aria-labelledby`.

`packages/cli/README.md` also changes an invented example path,
`cf view scripts/analyse.py` → `analyze.py`. There is no such file; it is
illustrative.

## What stays

`cancelled` throughout — the documented carve-out. `analyses` wherever it is
the noun plural, which is already the American form.

## Checks

`deno task test`: `runner` **ok | 1206 passed (6529 steps) | 0 failed
(4m39s)**; `cli` **ok | 174 passed (206 steps) | 0 failed**; `dashboard` **675
passed, 0 failed**. `deno fmt --check` over the changed files and `deno lint`
over all three packages are clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

