### PR TITLE
refactor: ask the object-only question where only an object fits

### DIFF
--- a/packages/background-piece-service/src/worker-ipc.ts
+++ b/packages/background-piece-service/src/worker-ipc.ts
@@ -1,5 +1,5 @@
 import { isKeyPairRaw, KeyPairRaw } from "@commonfabric/identity";
-import { isObjectOrArray } from "@commonfabric/utils/types";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 
 export enum WorkerIPCMessageType {
   Initialize = "initialize",
@@ -20,7 +20,7 @@ export type InitializationData = {
 export function isInitializationData(
   value: unknown,
 ): value is InitializationData {
-  return !!(isObjectOrArray(value) &&
+  return !!(isObjectNotArray(value) &&
     typeof value.did === "string" &&
     typeof value.toolshedUrl === "string" &&
     isKeyPairRaw(value.rawIdentity));
@@ -31,7 +31,7 @@ export type RunData = {
 };
 
 export function isRunData(value: unknown): value is RunData {
-  return !!(isObjectOrArray(value) &&
+  return !!(isObjectNotArray(value) &&
     typeof value.pieceId === "string");
 }
 
@@ -49,7 +49,7 @@ export type WorkerIPCRequest = {
 };
 
 export function isWorkerIPCRequest(value: unknown): value is WorkerIPCRequest {
-  if (!isObjectOrArray(value) || typeof value.msgId !== "number") {
+  if (!isObjectNotArray(value) || typeof value.msgId !== "number") {
     return false;
   }
   if (value.type === WorkerIPCMessageType.Cleanup) {
@@ -73,7 +73,7 @@ export type WorkerIPCResponse = {
 export function isWorkerIPCResponse(
   value: unknown,
 ): value is WorkerIPCResponse {
-  return !!(isObjectOrArray(value) &&
+  return !!(isObjectNotArray(value) &&
     typeof value.msgId === "number" &&
     ("error" in value ? typeof value.error === "string" : true) &&
     ("type" in value ? typeof value.type === "string" : true));

--- a/packages/data-model/src/cell-rep.ts
+++ b/packages/data-model/src/cell-rep.ts
@@ -6,6 +6,7 @@
 
 import { backtickQuote } from "@commonfabric/utils/markdown";
 import {
+  isObjectNotArray,
   isObjectOrArray,
   isPlainObject,
   isUnsafeObjectKey,
@@ -82,7 +83,7 @@ export function entityRefFrom(hash: FabricHash): EntityRef {
 export function isEntityRef(value: unknown): value is EntityRef {
   return modernCellRepEnabled
     ? value instanceof FabricHash
-    : isObjectOrArray(value) && typeof value["/"] === "string";
+    : isObjectNotArray(value) && typeof value["/"] === "string";
 }
 
 /**

--- a/packages/identity/src/interface.ts
+++ b/packages/identity/src/interface.ts
@@ -1,4 +1,4 @@
-import { isObjectOrArray } from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 
 export type DID = `did:${string}:${string}`;
 export type DIDKey = `did:key:${string}`;
@@ -128,7 +128,7 @@ export type KeyPairRaw = CryptoKeyPair | InsecureCryptoKeyPair;
 export function isCryptoKeyPair(input: unknown): input is CryptoKeyPair {
   return !!(
     globalThis.CryptoKey &&
-    isObjectOrArray(input) &&
+    isObjectNotArray(input) &&
     input.privateKey instanceof globalThis.CryptoKey &&
     input.publicKey instanceof globalThis.CryptoKey
   );

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -64,7 +64,7 @@ import type {
 } from "@commonfabric/api";
 import { toSchema } from "@commonfabric/api";
 import type { Schema } from "@commonfabric/api/schema";
-import { isObjectOrArray } from "@commonfabric/utils/types";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 
 import type { ImplementationIdentity } from "../cfc/types.ts";
 import type { EntityKind } from "../entity-kind.ts";
@@ -215,7 +215,8 @@ export type StreamValue = {
 };
 
 export function isStreamValue(value: unknown): value is StreamValue {
-  return isObjectOrArray(value) && "$stream" in value && value.$stream === true;
+  return isObjectNotArray(value) && "$stream" in value &&
+    value.$stream === true;
 }
 
 declare module "@commonfabric/api" {

--- a/packages/runner/src/cfc/clause.ts
+++ b/packages/runner/src/cfc/clause.ts
@@ -1,6 +1,6 @@
 import { CFC_ATOM_TYPE, type CfcAtom } from "@commonfabric/api/cfc";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
-import { isObjectOrArray } from "@commonfabric/utils/types";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { atomEntails } from "./atom-pattern.ts";
 import { uniqueCfcAtoms } from "./observation.ts";
@@ -28,7 +28,7 @@ export type CfcOrClause = { readonly anyOf: readonly CfcAtom[] };
 export type CfcConfClause = CfcAtom | CfcOrClause;
 
 export const isOrClause = (value: unknown): value is CfcOrClause =>
-  isObjectOrArray(value) &&
+  isObjectNotArray(value) &&
   Array.isArray((value as { anyOf?: unknown }).anyOf) &&
   Object.keys(value).length === 1;
 

--- a/packages/runner/src/cfc/metadata.ts
+++ b/packages/runner/src/cfc/metadata.ts
@@ -1,4 +1,4 @@
-import { isObjectOrArray } from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import type { URI } from "@commonfabric/memory/interface";
 import type { NormalizedFullLink } from "../link-utils.ts";
 import type {
@@ -22,8 +22,8 @@ const isPrefix = (
   left.every((segment, index) => segment === right[index]);
 
 const isCfcMetadata = (value: unknown): value is CfcMetadata =>
-  isObjectOrArray(value) && value.version === 1 &&
-  isObjectOrArray(value.labelMap) &&
+  isObjectNotArray(value) && value.version === 1 &&
+  isObjectNotArray(value.labelMap) &&
   Array.isArray(value.labelMap.entries);
 
 export const readStoredCfcMetadata = (

--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -2,6 +2,7 @@ import type { CfcAtom } from "@commonfabric/api/cfc";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import {
+  isObjectNotArray,
   isObjectOrArray,
   isReadonlyObjectOrArray,
 } from "@commonfabric/utils/types";
@@ -72,7 +73,7 @@ type WriterIdentityClaim = {
 };
 
 const isWriterIdentityClaim = (value: unknown): value is WriterIdentityClaim =>
-  isObjectOrArray(value) && isObjectOrArray(value.__ctWriterIdentityOf);
+  isObjectNotArray(value) && isObjectNotArray(value.__ctWriterIdentityOf);
 
 // The per-input provenance fields a verified write may have stamped onto a
 // writer-identity claim. New claims carry only the content-addressed

--- a/packages/runner/src/cfc/structured-result.ts
+++ b/packages/runner/src/cfc/structured-result.ts
@@ -293,6 +293,12 @@ const childSchemaForKey = (
     return true;
   }
   const childSchemas: JSONSchema[] = [];
+  // An array counts as a `properties` map here. `validateAgainstSchema()`
+  // enumerates the keyword with `Object.entries()` and asks `Object.hasOwn()`,
+  // both of which read an array's indices as property names, so a stored
+  // `properties` array declares a property per index as far as validation is
+  // concerned. Answering "no declared properties" would route those keys to
+  // `additionalProperties` below, which validation does not do.
   if (isObjectOrArray(resolved.properties)) {
     const child = resolved.properties[key];
     if (isSubschema(child)) {

--- a/packages/runner/src/cfc/structured-result.ts
+++ b/packages/runner/src/cfc/structured-result.ts
@@ -1,5 +1,6 @@
 import type { JSONSchema } from "@commonfabric/api";
 import { isObjectOrArray } from "@commonfabric/utils/types";
+import { isSubschema } from "../schema-walk.ts";
 import { cfcOpaqueLinkForPath } from "./observation.ts";
 import {
   cfcCombinatorObjectSurface,
@@ -124,7 +125,7 @@ const matchingBranches = (
   }
   return branches
     .filter((branch): branch is JSONSchema =>
-      (typeof branch === "boolean" || isObjectOrArray(branch)) &&
+      isSubschema(branch) &&
       validateAgainstSchemaForSanitization(
           branch,
           value,
@@ -196,7 +197,7 @@ const matchingBranch = (
     return undefined;
   }
   const branch = branches.find((branch): branch is JSONSchema =>
-    (typeof branch === "boolean" || isObjectOrArray(branch)) &&
+    isSubschema(branch) &&
     validateAgainstSchemaForSanitization(
         branch,
         value,
@@ -294,14 +295,13 @@ const childSchemaForKey = (
   const childSchemas: JSONSchema[] = [];
   if (isObjectOrArray(resolved.properties)) {
     const child = resolved.properties[key];
-    if (typeof child === "boolean" || isObjectOrArray(child)) {
+    if (isSubschema(child)) {
       childSchemas.push(child);
     }
   }
   if (
     !(isObjectOrArray(resolved.properties) && key in resolved.properties) &&
-    (typeof resolved.additionalProperties === "boolean" ||
-      isObjectOrArray(resolved.additionalProperties))
+    isSubschema(resolved.additionalProperties)
   ) {
     childSchemas.push(resolved.additionalProperties);
   }
@@ -363,11 +363,11 @@ const itemSchemaForIndex = (
       : undefined;
     if (prefixItems !== undefined && index < prefixItems.length) {
       const slot = prefixItems[index];
-      if (typeof slot === "boolean" || isObjectOrArray(slot)) {
+      if (isSubschema(slot)) {
         itemSchemas.push(slot);
       }
     } else if (
-      typeof resolved.items === "boolean" || isObjectOrArray(resolved.items)
+      isSubschema(resolved.items)
     ) {
       itemSchemas.push(resolved.items);
     }

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -1,4 +1,4 @@
-import { isObjectOrArray } from "@commonfabric/utils/types";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 import { isLinkRef, linkRefPayload } from "@commonfabric/data-model/cell-rep";
 import {
   type CellScope,
@@ -148,7 +148,7 @@ export function isPrimitiveCellLink(
 }
 
 export function isNormalizedLink(value: any): value is NormalizedLink {
-  if (!isObjectOrArray(value)) return false;
+  if (!isObjectNotArray(value)) return false;
   const { path, id, space, scope } = value;
   return Array.isArray(path) &&
     (typeof id === "string" || id === undefined) &&
@@ -169,7 +169,7 @@ export function isNormalizedLink(value: any): value is NormalizedLink {
  */
 export function isNormalizedFullLink(value: any): value is NormalizedFullLink {
   return (
-    isObjectOrArray(value) &&
+    isObjectNotArray(value) &&
     typeof value.id === "string" &&
     typeof value.space === "string" &&
     (value.scope === "space" || value.scope === "user" ||
@@ -204,8 +204,8 @@ export function isWriteRedirectLink(
  * to point to an actual cell. In data they are plain values.
  */
 export function isAliasBinding(value: any): value is AliasBinding {
-  return isObjectOrArray(value) && "$alias" in value &&
-    isObjectOrArray(value.$alias) &&
+  return isObjectNotArray(value) && "$alias" in value &&
+    isObjectNotArray(value.$alias) &&
     Array.isArray(value.$alias.path) &&
     (value.$alias.partialCause !== undefined ||
       value.$alias.cell === "result" || value.$alias.cell === "argument");

--- a/packages/runner/test/cfc-schema-merge.test.ts
+++ b/packages/runner/test/cfc-schema-merge.test.ts
@@ -1197,4 +1197,24 @@ describe("cfcSchemaMergeIssue", () => {
     expect(issue?.migration).toBe(false);
     expect(issue?.message).toContain("confidentiality cannot be weakened");
   });
+
+  it("refuses two different claims whose identity is an array", () => {
+    // A claim reconciles with another only when their bindings correspond,
+    // which is read from the identity's `file` and `path`. An array carries
+    // neither. Different bindings conflict.
+    const mergeArrayIdentities = () =>
+      mergeCfcSchemaEnvelopes({
+        ifc: {
+          writeAuthorizedBy: { __ctWriterIdentityOf: ["one"] },
+        } as any,
+      }, {
+        ifc: {
+          writeAuthorizedBy: { __ctWriterIdentityOf: ["two"] },
+        } as any,
+      });
+
+    expect(mergeArrayIdentities).toThrow(
+      "writeAuthorizedBy must remain stable",
+    );
+  });
 });

--- a/packages/runtime-client/protocol/guards.ts
+++ b/packages/runtime-client/protocol/guards.ts
@@ -1,5 +1,5 @@
 import { isDID } from "@commonfabric/identity";
-import { isObjectOrArray } from "@commonfabric/utils/types";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 import {
   CellRef,
   CellUpdateNotification,
@@ -22,7 +22,7 @@ import {
 } from "./types.ts";
 
 export function isCellRef(value: unknown): value is CellRef {
-  if (!isObjectOrArray(value)) return false;
+  if (!isObjectNotArray(value)) return false;
   return Array.isArray(value.path) && typeof value.id === "string" &&
     !!value.id &&
     isDID(value.space);
@@ -32,7 +32,7 @@ export function isInitializationData(
   value: unknown,
 ): value is InitializationData {
   return (
-    isObjectOrArray(value) &&
+    isObjectNotArray(value) &&
     typeof value.apiUrl === "string" && !!value.identity &&
     typeof value.spaceDid === "string"
   );
@@ -40,7 +40,7 @@ export function isInitializationData(
 
 export function isIPCClientRequest(value: unknown): value is IPCClientRequest {
   return (
-    isObjectOrArray(value) &&
+    isObjectNotArray(value) &&
     typeof value.type === "string" &&
     Object.values(RequestType).includes(
       value.type as RequestType,
@@ -50,7 +50,7 @@ export function isIPCClientRequest(value: unknown): value is IPCClientRequest {
 
 export function isIPCClientMessage(value: unknown): value is IPCClientMessage {
   return (
-    isObjectOrArray(value) &&
+    isObjectNotArray(value) &&
     typeof value.msgId === "number" &&
     isIPCClientRequest(value.data)
   );
@@ -60,7 +60,7 @@ export function isIPCClientNotification(
   value: unknown,
 ): value is IPCClientNotification {
   return (
-    isObjectOrArray(value) &&
+    isObjectNotArray(value) &&
     typeof value.type === "string" &&
     Object.values(ClientNotificationType).includes(
       value.type as ClientNotificationType,
@@ -78,7 +78,7 @@ export function isIPCRemoteResponse(
   value: unknown,
 ): value is IPCRemoteResponse {
   return (
-    isObjectOrArray(value) &&
+    isObjectNotArray(value) &&
     typeof value.msgId === "number" &&
     ("error" in value ? typeof value.error === "string" : true)
   );
@@ -97,7 +97,7 @@ export function isCellUpdateNotification(
   value: unknown,
 ): value is CellUpdateNotification {
   return (
-    isObjectOrArray(value) &&
+    isObjectNotArray(value) &&
     value.type === NotificationType.CellUpdate &&
     typeof value.cell === "object" &&
     "value" in value
@@ -108,7 +108,7 @@ export function isConsoleNotification(
   value: unknown,
 ): value is ConsoleNotification {
   return (
-    isObjectOrArray(value) &&
+    isObjectNotArray(value) &&
     value.type === NotificationType.ConsoleMessage &&
     typeof value.method === "string" &&
     Array.isArray(value.args)
@@ -119,9 +119,9 @@ export function isNavigateRequestNotification(
   value: unknown,
 ): value is NavigateRequestNotification {
   return (
-    isObjectOrArray(value) &&
+    isObjectNotArray(value) &&
     value.type === NotificationType.NavigateRequest &&
-    isObjectOrArray(value.targetCellRef)
+    isObjectNotArray(value.targetCellRef)
   );
 }
 
@@ -129,7 +129,7 @@ export function isErrorNotification(
   value: unknown,
 ): value is ErrorNotification {
   return (
-    isObjectOrArray(value) &&
+    isObjectNotArray(value) &&
     value.type === NotificationType.ErrorReport &&
     typeof value.message === "string"
   );
@@ -139,7 +139,7 @@ export function isTelemetryNotification(
   value: unknown,
 ): value is TelemetryNotification {
   return (
-    isObjectOrArray(value) &&
+    isObjectNotArray(value) &&
     value.type === NotificationType.Telemetry &&
     typeof value.marker === "object"
   );
@@ -149,7 +149,7 @@ export function isPendingWritesNotification(
   value: unknown,
 ): value is PendingWritesNotification {
   return (
-    isObjectOrArray(value) &&
+    isObjectNotArray(value) &&
     value.type === NotificationType.PendingWritesChanged &&
     typeof value.pending === "boolean"
   );
@@ -159,7 +159,7 @@ export function isVDomBatchNotification(
   value: unknown,
 ): value is VDomBatchNotification {
   return (
-    isObjectOrArray(value) &&
+    isObjectNotArray(value) &&
     value.type === NotificationType.VDomBatch &&
     typeof value.batchId === "number" &&
     Array.isArray(value.ops)


### PR DESCRIPTION
Nineteen type predicates narrow to a named object type while testing with `isObjectOrArray()`, which an array passes. Each therefore claims a type its own check does not establish, and a caller reading a declared field off the result reads it off an array.

The predicates were found by their shape rather than by inspection: a declaration of the form `value is T`, where `T` is a named object type, whose body asks the array-inclusive question. Three that match the shape are correct and stay as they are. `isProxyForArrayValue()` and `isCellResult()` in `query-result-proxy.ts` accept an array because an array-backed cell result is one. `isVNodeLike()` in `cli/lib/piece.ts` asks whether a key may be read, which array-ness does not bear on.

Two modules are converted whole, every guard in them narrowing to a message shape that is never an array: the IPC protocol guards in `runtime-client`, and the worker IPC guards in
`background-piece-service`.

None of this changes an outcome that a value in contract can reach. An array carrying a named own property is not something JSON produces, nor something the data model admits, so the guards go on answering as they did. What changes is that the check now establishes what the signature claims, which is the property a reader is entitled to rely on.

`structured-result.ts` separately carried six copies of the test for what a schema may be, written out as `typeof x === "boolean" || isObjectOrArray(x)` and each pushing its result into a `JSONSchema[]`. They call `isSubschema()` now -- the same definition the schema walk and the definition validator use -- so the branch selector, the child-schema lookup and the item-schema lookup agree with those by construction rather than by three parallel spellings that have to be kept in step by hand. The remaining `isObjectOrArray()` calls in that file ask a different question, whether a schema is in its object form rather than a boolean, and the schema walk spells that the same way.

A merge of two writer-identity claims whose identity is an array gets a test. It passes either way: the claims fail to correspond on their `file` and `path` regardless, so the guard was never the thing refusing them. The case had no coverage, and now records what the merge does with it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

