### PR TITLE
docs(plan): the issue tail carries the work that was open and unwritten

### DIFF
--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -638,7 +638,7 @@ from a plan is one nobody schedules, which is the whole reason for this table.
 | Issue | What | Attaches at |
 | --- | --- | --- |
 | #5633 | a projected read fails on the SECOND read of the same source and schema; the handler is a red herring | **fixed** by #5764 — a list coordinator owed the setup writes a lost commit discarded, its result container's links among them, and the fix makes those writes a debt rather than a flag. #5706, which is why it reproduced every time, stands |
-| #5576 | `cf piece verbs` lists data fields as handlers, so discovery reports what cannot be called | **fixed** by #5683, with #5662 |
+| #5576 | `cf piece verbs` lists data fields as handlers, so discovery reports what cannot be called | **fixed** by #5683, with #5662 — and the other direction by #5794 |
 | #5698 | `cf piece verbs` returns nothing for a piece whose declared result type omits its verbs, though they are callable | the other direction of the same surface, and **fixed** by #5794: the listing enumerates candidates from the compiled graph as well as the result cell, and classifies each one on the stored signal that closed the first direction |
 | #5706 | a shaped read permanently writes to the user's space — per-element sub-patterns land at space scope | runner-owned, beside #5633 |
 | #5722 | a verb's help shows its usage twice, and shows no way to copy it | found by driving the surface by hand, which no test does |
@@ -651,6 +651,16 @@ from a plan is one nobody schedules, which is the whole reason for this table.
 | #5589 | a click's `detail` and a `cf-select`'s `target.value` reach a handler as types no pattern declares | carried alongside — it belongs to whoever next touches `packages/html`. The ruling that closed item 9b also removed the only thing that ever compared the renderer's output against an author's declared type, so this has no detector left |
 | #5560 | an address a call returns cannot be passed back as a verb argument | item 11, and **row 14** — it had no ordering row until one was added. Not to be confused with ordering step 11, "one piece, one address", which is #5632 and decided |
 | #5534 | a capability probe passes while covering nothing: a dispatch rejection is not a synchronous throw | carried alongside |
+| #5685 | no CI job runs any verb integration script, and one of them says it does | **unscheduled, and the sharpest of these.** `verbs-over-the-cli.sh` and `verb-session-gaps.sh` are the arc's honesty checks and gate nothing; a claim that one runs is worse than the gap, because it is why nobody looked |
+| #5663 | the compat checker admits a newly required verb event field, breaking every existing caller | **unscheduled.** It sits in `packages/piece/src/schema-compatibility.ts`, the set item 2 derives its tolerated tier from, so a change there meets this |
+| #5689 | `cf piece call` accepts any name into dispatch; a non-verb fails with no diagnostic | unscheduled. The listing now refuses to offer a non-verb (#5683, #5794); the dispatcher still accepts one |
+| #5684 | `cf piece get --select` returns `{}` for a field path that cannot match | unscheduled. Item 2's shape on the concise path, which item 2 puts out of scope — a projection that answers nothing rather than refusing |
+| #5686 | design rule 1 says input schemas are closed-world; after the #5589 ruling the runtime does the opposite | unscheduled and unowned. Not settled by [designing verbs so they can change](verb-evolution.md), which says nothing about closed-world inputs — searched, not assumed |
+| #5756 | `ensureKeylessPatternIdentity`'s doc comment claims a structural-dedup property the code does not have | runner-owned. Measured: two structurally identical patterns get different keyless identities |
+| #5758 | a call's readback traverses the reference graph with no work budget | memory-owned. `maxDepth` and `maxEntities` are in `docs/specs/memory-v2/05-queries.md` and not on the wire |
+| #5759 | `Cell.equals()` is cache-dependent | runner-owned, and **answered**: this is the runtime's eventual consistency, not a defect. Closeable |
+| #5760 | an indirect reference has no contract | runner-owned. Two of its three questions are answered; whether a rendered address should declare itself indirect is deferred and gates nothing |
+| #5761 | the projection derivation cannot express conjunction; `allOf` refuses | filed out of item 2 and **relied on by it**: `sourceProvesContainer` refuses to prove a container through `allOf` for this reason |
 
 **Filed against neighboring subsystems, and not sequenced here.** `{ proxy:
 true }` never reaching `module.writableProxy` for a transformed pattern


### PR DESCRIPTION
## Why

Ten verb-arc issues were open and appeared **nowhere** in the plan of record. The plan says of that tail: *"an issue absent from a plan is one nobody schedules, which is the whole reason for this table."* A driver reading it saw a shorter arc than the arc has.

Found by cross-referencing every open issue on this arc against the document, rather than by noticing any one of them.

## The two worth reading first

**#5685 — no CI job runs any verb integration script, and one of them says it does.** `verbs-over-the-cli.sh` and `verb-session-gaps.sh` are what this arc treats as its honesty check. They gate nothing. The claim that one runs is worse than the gap itself, because it is the reason nobody looked — a false guarantee, which is the shape this arc has turned up four times in documentation and once now in CI.

**#5663 — the compat checker admits a newly required verb event field**, breaking every existing caller. It lives in `packages/piece/src/schema-compatibility.ts`, which is the same file item 2 derives its tolerated tier from, so a change there meets this.

## Four filed out of this arc and never written back

#5756, #5758, #5759, #5761 — all produced by measurements taken during this work, none recorded here.

**#5761 is load-bearing for item 2 and was unlinked.** `sourceProvesContainer` refuses to prove a container through `allOf` *because* the derivation cannot express conjunction. The implementation depends on an issue the plan did not mention.

**#5759 is answered and closeable** — cache-dependent equality is the runtime's eventual consistency, not a defect.

## What Changed

Ten rows appended to the issue tail, each carrying who owns it and why it is not sequenced. One existing row updated: #5576 now records that #5794 closed the other direction of the same surface.

No row is scheduled by this PR. Recording is not scheduling, and which of these earn steps is the arc owner's call.

## Test plan

- `deno task check-docs` → **0**
- `deno task check-skill-facts` → **0**
- `deno task check-conflict-markers` → **0**

Documentation only; `docs/` is excluded from `deno fmt`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

