### PR TITLE
A verb's documentation reaches the caller who asks

### DIFF
--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -287,14 +287,21 @@ page renders flags from, at the positions that schema already has.
 
 **Which means walking two documents that agree about almost nothing
 structurally.** The same field can be a `$ref` in one and an inline object in
-the other, and which it is depends on what the handler body happens to read — so
-a walk that steps through `properties` key-for-key finds a bare `$ref` on one
-side, no `properties` under it, and stops one level short of the prose. Both
-sides' references are followed for that reason. A served reference is followed
-without being inlined: it names a definition several positions can share, and a
-caller's tooling reads that shape. A field's own prose is therefore written
-where the field is, never into the definition it points at, which would
-attribute one position's sentence to every other holder of the same type.
+the other, and a union the declared side spells as `anyOf` can arrive as one
+merged object — which of these happens depends on what the handler body reads.
+So a walk that steps through `properties` key-for-key finds a bare `$ref` on one
+side with no `properties` under it, or a field whose prose is inside an arm that
+no longer exists on the other side, and stops short of the words in both cases.
+
+Both sides' references are followed for that reason, and a declared combinator
+is read through to its members. A served reference is followed *without* being
+inlined, and a served combinator is never flattened: a caller's tooling reads
+that shape, and a definition several positions share is not one position's to
+rewrite. A field's own prose is therefore written where the field is, never into
+the definition it points at — which would attribute one position's sentence to
+every other holder of the same type. The precise list of positions the fold
+walks is on `withDeclaredFieldProse` (`packages/cli/lib/piece.ts`), enumerated
+rather than summarized, along with the keywords it leaves alone.
 
 **Folded in, never substituted.** The two documents disagree about shape, by
 construction: the declared type is what a caller may send, the read schema is

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -174,10 +174,10 @@ verb's result, because
 [a result is a read on a different cell](../plans/fabric-read-model.md) — 1743
 bytes unshaped, 140 with `--select 'item.title'`.
 
-**The prose above does not reach a caller.** Each verb carries a doc comment
-saying what it is for, which is where that documentation belongs — and it is
-emitted correctly and then lost, so `cf piece verbs` can list a verb and never
-say what it does. Step 2 has the measurement.
+**The prose above reaches a caller.** Each verb carries a doc comment saying
+what it is for, which is where that documentation belongs, and `cf` serves it:
+as a row's `description` under `cf piece verbs --json`, and as the summary line
+of the verb's own help page. Step 2 has the measurement.
 
 
 ## 1. Arrive with a slug **[today]**
@@ -206,6 +206,13 @@ Slug resolution sits on the shared path (`resolvePieceConfigWithPieces`,
 The listing carries the deployed pattern's source identity, which is how a
 client tells it is talking to a newer pattern than it was written against.
 
+**The table is names; `--json` is the description.** The columns are a grid to
+scan, so each row stays one line and a verb's prose — which runs to a sentence
+or several — travels on the machine-readable spelling instead, as the row's
+`description`, alongside the input and output schemas the table has no room for
+either. A person asking what one verb is for reads its help page, where the
+same words are the summary line.
+
 ## 2. Ask what a verb wants **[today]**
 
 ```bash
@@ -218,27 +225,28 @@ Usage:
   cf piece call --piece board addItem <json>
   cf piece call --piece board addItem -- --title <string>
 
+File a new root item on the board.
+
 JSON input:
   Pass inline JSON as one positional argument or after `--json`.
   { title: string }
 
 Flags after `--`:
-  --title <string>    Required.
+  --title <string>    Required. One line naming the work.
 
 Output:
   The invocation's `result`:
     item <json>
 ```
 
-**Structure is published; prose is not.** The flags and the result fields are
-the whole of what `cf` can currently say about a verb. The split is worth
-holding onto:
+**Structure and prose are both published, and they come from different
+documents.** The split is worth holding onto, because only one half is free:
 
-| | Where it comes from | Survives? |
+| | Where it comes from | Reaches `cf`? |
 | --- | --- | --- |
 | flag name, placeholder, required-ness | the event's **type** — `{ title: string }` | **yes** |
 | result field name and placeholder | the result's **type** — `AddItemResult` | **yes** |
-| what `title` means, what the verb is for | the author's **doc comments** | **no** |
+| what `title` means, what the verb is for | the author's **doc comments** | **yes**, read from the pattern |
 
 The `Output:` section names the position a caller collects the value from —
 the settled Invocation JSON's `result` — because that is where a handler's
@@ -251,96 +259,79 @@ The structural half needs nothing authored per pattern:
 `--title <string> Required.`
 falls out of the type. That is why the page exists at all.
 
-The prose half is **emitted and then lost**, which is worth stating precisely
-because the obvious guess sends the fix to the wrong place:
+**The prose half is not on the wire with it**, and knowing why is what keeps a
+reader from looking for it in the wrong place. A verb dispatches through a
+callable cell, and that cell takes its schema from the link chain it resolves
+through (`cell.ts:asSchemaFromLinks`). For a verb that link is the handler
+node's `$event` input, and that schema is not the author's event type at all —
+it is the handler's **read** of the event, narrowed to the fields its
+implementation touches. A declared field the body never mentions is absent from
+it whether or not the type marks it optional. So the served schema is not the
+declared one with the prose taken out; it is a query, generated from usage,
+which never carried an author's words in the first place.
 
-| An author writes… | In the compiled pattern | Served to `cf` |
-| --- | --- | --- |
-| a comment on an **event field** (what `title` means) | **yes** — `$defs.<Event>.properties.title.description` | no |
-| a comment on the **verb itself**, as in the model above | **yes** — beside the `$ref` | no |
-| a comment on the **event interface** (what the verb is for) | no | no |
+So the prose is read from the **pattern**, which is the only place it survives
+compilation:
 
-So the generator handles two of the three correctly — one pattern here carries
-descriptions on 36 `Stream` properties. What the CLI is served is the
-*resolved* form of the event schema, with no `$defs` and no `$ref`, and the
-descriptions are not in it. The loss is in that resolution, not in emission
-([#5637](https://github.com/commontoolsinc/labs/issues/5637)).
+| An author writes… | Where the compiled pattern keeps it |
+| --- | --- |
+| a comment on the **verb itself**, as in the model above | `resultSchema.properties.<verb>.description`, a sibling of the `$ref` naming its event |
+| a comment on an **event field** (what `title` means) | `$defs.<Event>.properties.<field>.description` |
+| a comment on the **event interface** | nowhere — this one does not compile ([#5559](https://github.com/commontoolsinc/labs/issues/5559)) |
 
-The renderer is ready for two of the three: `specificFlagLines` reads a
-`description` through `schemaDescription` and would print one the moment it
-were given one, and a listing row would carry one as soon as it were supplied.
-The verb's *purpose* needs a second change on top, because
-`renderPieceCallHelp` has nowhere to put it — the page runs Usage, JSON input,
-Flags, Output, with no summary line.
+`cf piece verbs` and `cf piece call <verb> --help` already load that pattern to
+report what a verb hands back, so both read the prose from the same load. The
+verb's own comment becomes the listing row's `description` and the help page's
+summary line. The event fields' comments are folded into the input schema the
+page renders flags from, at the positions that schema already has.
 
-So the help page names `--title <string>  Required.` and `item <json>`, and
-says nothing about what either means.
+**Folded in, never substituted.** The two documents disagree about shape, by
+construction: the declared type is what a caller may send, the read schema is
+what the implementation looks at. Only `description` annotations cross between
+them, so the served schema stays the authority on shape and takes only the
+words. Substituting the declared type instead would offer a caller flags for
+fields the running handler does not read — a page describing the source rather
+than the piece being talked to.
 
-### What the page becomes **[blocked]**
+Which leaves a real question this does not settle: a field an author declares
+and the body never reads is a field a caller cannot discover. Whether the two
+schemas should be reconciled, and in which direction, is open.
 
-Every line below already exists as a doc comment in `tracker.tsx`. Nothing here
-is invented for the illustration — this is that file's own prose, reaching a
-caller. The structure around it is what the page renders today; the prose is
-what it does not:
+### What the page still owes **[blocked]**
+
+Every line of prose on the page above already exists as a doc comment in
+`tracker.tsx`. Nothing is invented for the illustration — it is that file's own
+words, reaching a caller. One line is still missing, and it is the last one:
 
 ```text
-Usage:
-  cf piece call --piece board addItem -- --title <string>
-
-File a new root item on the board.
-
-JSON input:
-  { title: string }
-
-Flags after `--`:
-  --title <string>    Required. One line naming the work.
-
 Output:
   The invocation's `result`:
     item <json>       The root item this call created.
 ```
 
-**Three levels of documentation, three different fates.** An author writes each
-one where the thing it describes is declared — the verb says what it does, and
+**Three levels of documentation, and one of them stops short.** An author writes
+each where the thing it describes is declared — the verb says what it does, and
 each parameter describes itself:
 
 | Level | Written on | Compiled? | Reaches `cf`? |
 | --- | --- | --- | --- |
-| the verb — *what it does* | the `Stream` property | **yes**, beside the `$ref` | no |
-| an **input** parameter | a field of the event interface | **yes**, in `$defs.<Event>.properties` | no |
-| an **output** parameter | a field of the result interface | **yes**, on the declared result | **yes**, under `--help --json` |
+| the verb — *what it does* | the `Stream` property | **yes**, beside the `$ref` | **yes**, as the summary line |
+| an **input** parameter | a field of the event interface | **yes**, in `$defs.<Event>.properties` | **yes**, beside its flag |
+| an **output** parameter | a field of the result interface | **yes**, on the declared result | **yes**, under `--help --json` — but not on the text page |
 
-The first two are the same loss: emitted, then absent from the resolved schema
-the CLI is served, so they come back together
-([#5637](https://github.com/commontoolsinc/labs/issues/5637)).
+The output parameter's is the one still short of the page, and it is short by a
+single step. A verb's declared result reaches `cf` **unresolved** — `--help
+--json` on `addItem` serves `properties.item` as a `$ref` into `$defs.ItemOutput`
+carrying `"description": "The root item this call created."`, the author's own
+comment, verbatim. What drops it is the rendering: the text page writes each
+result property as `name <placeholder>` and never reads the `description` beside
+it. So the prose is on the wire and one line of rendering away.
 
-The third travels furthest, and it is the one worth understanding. A verb's
-declared result reaches `cf` **unresolved** — `--help --json` on `addItem`
-serves `properties.item` as a `$ref` into `$defs.ItemOutput` carrying
-`"description": "The root item this call created."`, the author's own comment,
-verbatim. Nothing strips it, because nothing resolves it. Where the input side
-loses its prose to `$ref` resolution, the output side keeps it.
-
-What drops it is the last step: the text page renders each result property as
-`name <placeholder>` and never reads the `description` beside it. So the prose
-is on the wire and one line of rendering away, which is a different problem
-from the two above and a much smaller one.
-
-The summary is worth one more note. An event *interface's* comment would be the
-other candidate for that line, and it is the one thing here that genuinely
-never compiles — so sourcing the summary from the verb's own comment, which is
-already emitted, is both the smaller change and the better place for an author
-to write it.
-
-Two things are missing from that page, and they are the same thing twice.
-
-**A flag's prose never arrives**, per the measurement above — the renderer is
-ready for it and the resolution does not carry it.
-
-**The verb's purpose is absent** for the same reason, not a different one: its
-comment is emitted and lost in the same step, and the page has no summary line
-to print it on even once it survives. `cf` can say what `addItem` takes and
-hands back, and not what either is for.
+The summary line is worth one more note, because an event *interface's* comment
+would be the other candidate for it. That is the one level here that does not
+compile at all ([#5559](https://github.com/commontoolsinc/labs/issues/5559)) —
+so the verb's own comment is both the shorter road and the better place for an
+author to write it, since it sits beside the type it describes.
 
 ## 3. Complete against the live piece **[today]**
 
@@ -489,15 +480,14 @@ Declared results make an **output** self-describing; this is about what an
 
 | Gap | Needs |
 | --- | --- |
-| A flag's prose absent from its help page | Same loss as the row below — emitted into the `$def`, absent from the resolved schema the CLI is served |
-| A verb's purpose absent from its help page | A genuine emission gap, then a renderer one — an event interface's comment never compiles, and the page has no summary line |
-| A verb's own doc comment absent everywhere | Not emission — it is emitted and lost when the event `$ref` is resolved for the CLI |
 | A result field's prose absent from the text page | Only the renderer — the description is already served under `--help --json`, beside the field it documents |
+| An event interface's own comment absent everywhere | The one prose level that does not compile ([#5559](https://github.com/commontoolsinc/labs/issues/5559)). Nothing downstream can serve what was never emitted |
+| A declared event field the handler body never reads is absent from the served input schema | A decision, not a patch: the served schema is the handler's read and the declared type is the contract, and which one a caller is owed is open |
 | `--select` completion, and refusal before the call | A provider reading the declared result the help page already resolves |
 | An address accepted as an argument | The round-trip property above |
 
-Six rows, five distinct gaps: the three prose rows above the fourth are one
-problem seen from three sides — an author writes about a verb on its event
-interface, on an event field, or on the verb itself, and none of it reaches a
-caller. The fourth is not that problem: an output field's prose does reach the
-CLI, and only the text renderer drops it.
+Five rows and five distinct gaps, and the first three are worth reading
+together because they look like one. They are not: the first is a renderer that
+does not print what it is handed, the second is a comment nothing emits, and the
+third is a *field* — not prose at all — and an open question rather than a
+defect. Only the second is an author's words going missing.

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -144,9 +144,9 @@ interface ItemOutput {
 **A verb says what it does; its parameters describe themselves.** The comment
 on `addItem` does not restate what it takes or returns, because
 `AddItemEvent.title` and `AddItemResult.item` already say so where they are
-declared — which is where `--help` sources its `Output:` line today, and where
-it would source a flag's prose. Restating it in the verb comment would be the
-same content twice, and the copy that goes stale when a parameter changes.
+declared — which is where `--help` sources both its `Output:` line and a flag's
+prose. Restating it in the verb comment would be the same content twice, and
+the copy that goes stale when a parameter changes.
 
 **One interface, holding both.** An item's fields and its verbs sit together
 because that is what an item *is*: a child in `children` is a full item, and
@@ -284,6 +284,17 @@ report what a verb hands back, so both read the prose from the same load. The
 verb's own comment becomes the listing row's `description` and the help page's
 summary line. The event fields' comments are folded into the input schema the
 page renders flags from, at the positions that schema already has.
+
+**Which means walking two documents that agree about almost nothing
+structurally.** The same field can be a `$ref` in one and an inline object in
+the other, and which it is depends on what the handler body happens to read — so
+a walk that steps through `properties` key-for-key finds a bare `$ref` on one
+side, no `properties` under it, and stops one level short of the prose. Both
+sides' references are followed for that reason. A served reference is followed
+without being inlined: it names a definition several positions can share, and a
+caller's tooling reads that shape. A field's own prose is therefore written
+where the field is, never into the definition it points at, which would
+attribute one position's sentence to every other holder of the same type.
 
 **Folded in, never substituted.** The two documents disagree about shape, by
 construction: the declared type is what a caller may send, the read schema is

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -91,19 +91,46 @@ HELP=$($CF piece call --piece board $ARGS addItem -- --help 2>/dev/null)
 echo "$HELP" | grep -q -- "--title" &&
   ok "the flag is derived from the event schema" ||
   bad "no --title flag in the generated help"
-# The author's JSDoc reaches the COMPILED pattern but not the schema this help
-# page reads, so the prose is stripped before a caller can see it. Asserted as
-# a gap so the day it flows, this fails and tells us. The needle is read out
-# of the fixture rather than hard-coded, so rewording the doc comment moves
-# the probe with it instead of silently "re-opening" the gap.
-NEEDLE=$(sed -n '/interface AddItemEvent {/,/^}/p' "$FIXTURE" |
+# The author's prose, at both levels it is written on. Each needle is read out
+# of the FIXTURE rather than hard-coded, so rewording a doc comment moves the
+# probe with it — a hard-coded string would turn a reworded comment into a
+# failure and an unchanged one into a check that passes without reading
+# anything.
+FIELD_DOC=$(sed -n '/interface AddItemEvent {/,/^}/p' "$FIXTURE" |
   sed -n 's/.*\/\*\* *\(.*[^ ]\) *\*\/.*/\1/p' | head -1)
-if [ -z "$NEEDLE" ]; then
+if [ -z "$FIELD_DOC" ]; then
   bad "no JSDoc on AddItemEvent's field in the fixture — the probe has no needle"
 else
-  echo "$HELP" | grep -qiF "$NEEDLE"
-  gap "$?" "JSDoc on an event field reaching its flag description"
+  echo "$HELP" | grep -qiF "$FIELD_DOC" &&
+    ok "an event field's JSDoc reaches its flag description" ||
+    bad "the flag carries no description: [$FIELD_DOC]"
 fi
+# The verb's own comment, on the line above its `Stream` property. Its needle
+# comes from BoardOutput rather than from the event interface, because the two
+# travel by different routes — this one is a sibling of the property's `$ref`,
+# the one above lives inside the `$defs` target it names — and a probe that
+# could not tell them apart would report one arriving as both.
+VERB_DOC=$(sed -n '/interface BoardOutput {/,/^}/p' "$FIXTURE" |
+  grep -B 1 'addItem:' | sed -n 's/.*\/\*\* *\(.*[^ ]\) *\*\/.*/\1/p' | head -1)
+if [ -z "$VERB_DOC" ]; then
+  bad "no JSDoc on BoardOutput.addItem in the fixture — the probe has no needle"
+else
+  echo "$HELP" | grep -qiF "$VERB_DOC" &&
+    ok "the verb's own JSDoc reaches its help page" ||
+    bad "the help page has no summary line: [$VERB_DOC]"
+  # And the same words on the discovery surface, where a client reads them.
+  echo "$VERBS" | jq -e --arg d "$VERB_DOC" \
+    '[.verbs[]? | select(.name=="addItem") | .description] | index($d)' \
+    >/dev/null 2>&1 &&
+    ok "the verb's own JSDoc reaches its listing row" ||
+    bad "the listing row carries no description: [$VERB_DOC]"
+fi
+# The third prose level — an event INTERFACE's own comment — is not probed
+# here, and deliberately. It never compiles, so the honest assertion is that it
+# is absent from the page; but `AddItemEvent`'s comment and `addItem`'s are the
+# same sentence in this fixture, and the verb's does arrive. A containment probe
+# would read one level's success as the other's and report a gap closed that is
+# wide open. It is recorded in the walkthrough's table instead, against #5559.
 
 step "4. A create hands back the piece, and the address chains"
 R=$($CF piece call --quiet --show-links --piece board $ARGS \

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -8,7 +8,8 @@ export interface ExecCommandSpec {
   defaultVerb: "invoke" | "run";
   inputSchema: JSONSchema;
   outputSchemaSummary?: JSONSchema;
-  /** What this callable is FOR, in the author's own words: the doc comment on
+  /**
+   * What this callable is FOR, in the author's own words: the doc comment on
    * the pattern property that declares it.
    *
    * Absent where the author wrote none, which is why it is optional rather
@@ -16,7 +17,8 @@ export interface ExecCommandSpec {
    * carrying a restated property name says something false about where it came
    * from. It describes the callable and not its input, so it does not ride
    * `inputSchema`, whose own `description` would be a claim about the event
-   * object a caller sends. */
+   * object a caller sends.
+   */
   description?: string;
 }
 

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -8,6 +8,16 @@ export interface ExecCommandSpec {
   defaultVerb: "invoke" | "run";
   inputSchema: JSONSchema;
   outputSchemaSummary?: JSONSchema;
+  /** What this callable is FOR, in the author's own words: the doc comment on
+   * the pattern property that declares it.
+   *
+   * Absent where the author wrote none, which is why it is optional rather
+   * than defaulted — a page with no summary line says nothing, while one
+   * carrying a restated property name says something false about where it came
+   * from. It describes the callable and not its input, so it does not ride
+   * `inputSchema`, whose own `description` would be a claim about the event
+   * object a caller sends. */
+  description?: string;
 }
 
 export interface ParsedExecArgs {
@@ -1027,6 +1037,7 @@ export function parseExecArgs(
 export function renderExecHelpJson(spec: ExecCommandSpec): string {
   const value: Record<string, unknown> = {
     callableKind: spec.callableKind,
+    ...(spec.description !== undefined && { description: spec.description }),
     inputSchema: spec.inputSchema,
   };
   if (spec.outputSchemaSummary !== undefined) {
@@ -1137,6 +1148,11 @@ export function renderPieceCallHelp(
   const lines = [
     "Usage:",
     ...pieceUsageLines(commandPrefix, spec),
+    // The verb's own prose, as a paragraph of its own between Usage and the
+    // sections describing the payload. Nothing stands here when the author
+    // wrote no comment: an empty paragraph would read as a summary the page
+    // failed to fill in, rather than as a verb nobody documented.
+    ...(spec.description !== undefined ? ["", spec.description] : []),
     "",
     "JSON input:",
     ...pieceJsonInputLines(spec.inputSchema),

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -5,6 +5,7 @@ import { loadIdentity } from "./identity.ts";
 import {
   Cell,
   deepEqual,
+  encodeJsonPointer,
   entityIdFrom,
   experimentalOptionsFromEnv,
   formatFabricRef,
@@ -316,12 +317,14 @@ async function resultProjectionFailedAtPath(
  */
 export interface ResolvedPieceCallable extends CallableResolution {
   commandSpec: ExecCommandSpec;
-  /** This verb's documentation, resolved on demand — a thunk for the same
+  /**
+   * This verb's documentation, resolved on demand — a thunk for the same
    * reason `declaredResult` is one, and attached under the same condition:
    * the pattern declaring the verb is the only document that carries it, and
    * reaching it costs a load no dispatch should pay.
    *
-   * Only the help page pulls it. A dispatch needs nothing an author wrote. */
+   * Only the help page pulls it. A dispatch needs nothing an author wrote.
+   */
   declaredProse?: () => Promise<DeclaredVerbProse | undefined>;
 }
 
@@ -1852,14 +1855,16 @@ export interface PieceCallableListing {
    * declared result. Absent when the verb declares none — the value-less
    * shape, which is the common one. */
   outputSchema?: JSONSchema;
-  /** What the verb is FOR, in the author's own words: the doc comment on the
+  /**
+   * What the verb is FOR, in the author's own words: the doc comment on the
    * pattern property declaring it, the same prose `call <verb> --help` prints
    * as its summary line.
    *
    * Absent where the author documented nothing, and absent where the pattern
    * could not be read (`incomplete`). Never derived from the name — a listing
    * that restates `addItem` as "add item" reports the schema back to the
-   * caller who wrote it and calls it documentation. */
+   * caller who wrote it and calls it documentation.
+   */
   description?: string;
   /** Listing mark: a UI affordance outside the headless contract (inferred
    * from session-scoped handler bindings at compile time). Hidden from the
@@ -1992,22 +1997,29 @@ function handlerVerbResults(
   return verbs;
 }
 
-/** What a pattern's own result schema says a verb is for, and what its event
- * fields mean — the author's doc comments, as the compiler lowered them. */
+/**
+ * What a pattern's own result schema says a verb is for, and what its event
+ * fields mean — the author's doc comments, as the compiler lowered them.
+ */
 interface DeclaredVerbProse {
-  /** The doc comment on the property declaring the verb: what the verb DOES.
+  /**
+   * The doc comment on the property declaring the verb: what the verb DOES.
    * A sibling of the property's `$ref`, and never a statement about the event
    * object, which is why it is held apart from `eventSchema` below rather than
-   * merged into it. */
+   * merged into it.
+   */
   description?: string;
-  /** The verb's declared event schema with its `$ref` followed against the
+  /**
+   * The verb's declared event schema with its `$ref` followed against the
    * result schema's own root, so the field descriptions inside the `$defs`
    * target are reachable. Read for annotations ONLY — never to decide a shape;
-   * see `withDeclaredFieldProse`. */
+   * see `withDeclaredFieldProse`.
+   */
   eventSchema?: JSONSchema;
 }
 
-/** Every verb's prose, keyed by the result property declaring it.
+/**
+ * Every verb's prose, keyed by the result property declaring it.
  *
  * A pattern's `resultSchema` is the only place both descriptions survive
  * compilation. Neither reaches the callable cell a verb dispatches through:
@@ -2024,7 +2036,8 @@ interface DeclaredVerbProse {
  *
  * The `$defs` live at the result schema's ROOT while the `$ref` sits on the
  * property, so the root is passed explicitly. Resolving the property alone
- * would consult a document that carries no definitions at all. */
+ * would consult a document that carries no definitions at all.
+ */
 function declaredVerbProse(
   pattern: { resultSchema?: unknown } | null | undefined,
 ): Map<string, DeclaredVerbProse> {
@@ -2052,8 +2065,26 @@ function declaredVerbProse(
   return prose;
 }
 
-/** `served` with `description` annotations filled in from `declared` wherever
- * it has none, at every position the two schemas share.
+/**
+ * One `description` to write into the served schema, addressed by its path
+ * within that document.
+ *
+ * Addressed rather than applied in place because a served position may live
+ * inside a shared `$defs` entry, which several positions reach and no
+ * single-pass rebuild of the tree can reach twice. Collecting first and
+ * applying second lets one definition receive edits found from anywhere in the
+ * walk without the walk having to know where it sits.
+ */
+interface DescriptionEdit {
+  /** Keys from the served document's root down to the `description` slot. */
+  readonly path: readonly string[];
+  readonly description: string;
+}
+
+/**
+ * `served` with `description` annotations filled in from `declared` wherever it
+ * has none, at every position the two documents share — following a `$ref` on
+ * either side to find one.
  *
  * ANNOTATIONS ONLY, and that bound is the point rather than a simplification.
  * The two schemas disagree about shape by construction, not by accident:
@@ -2063,78 +2094,243 @@ function declaredVerbProse(
  * `description` cannot change which payloads pass, so this can never make the
  * served schema disagree with the dispatch it governs. Copying anything else
  * could, which is why nothing else is copied and no position is ADDED: a key
- * absent from `served` stays absent, and a page never offers a flag the
- * handler does not read.
+ * absent from `served` stays absent, a `$ref` is never inlined, and a page
+ * never offers a flag the handler does not read.
  *
  * The root description is never taken. It belongs to the verb, not to the
- * event object, and it travels as the spec's own `description`. */
+ * event object, and it travels as the spec's own `description`.
+ *
+ * The bound on what this reaches: a position is filled only where the walk can
+ * put the two documents side by side. A served `$ref` naming a definition the
+ * served root does not carry stops the descent there, as does a declared `$ref`
+ * that does not resolve — those subtrees keep whatever prose they already had.
+ */
 function withDeclaredFieldProse(
   served: JSONSchema | true,
   declared: JSONSchema | undefined,
 ): JSONSchema | true {
-  return served === true
-    ? served
-    : fillDescriptions(served, declared, false) as JSONSchema;
-}
-
-function fillDescriptions(
-  served: JSONSchema,
-  declared: JSONSchema | undefined,
-  fillRoot: boolean,
-): JSONSchema {
-  if (
-    declared === undefined || !isObjectOrArray(served) ||
-    !isObjectOrArray(declared)
-  ) {
+  if (served === true || declared === undefined || !isObjectOrArray(served)) {
     return served;
   }
-  let next: Record<string, unknown> | undefined;
-  const patched = () => (next ??= { ...served });
+  const edits: DescriptionEdit[] = [];
+  collectDescriptionEdits(
+    { served, declared, servedRoot: served, declaredRoot: declared },
+    [],
+    false,
+    edits,
+    new Set<string>(),
+  );
+  return applyDescriptionEdits(served, edits);
+}
+
+/**
+ * The two documents at one position, plus the roots their `$ref`s resolve
+ * against. Held together because every step of the walk needs all four.
+ */
+interface ProsePair {
+  readonly served: JSONSchema;
+  readonly declared: JSONSchema;
+  readonly servedRoot: JSONSchema;
+  readonly declaredRoot: JSONSchema;
+}
+
+/**
+ * The `$defs` name a served node references, or `undefined` when it references
+ * nothing the served root defines.
+ *
+ * Matched by ENCODING each definition name with the runner's own encoder and
+ * comparing, rather than by decoding the `$ref`. The encoder is the function
+ * that wrote these strings, so round-tripping through it cannot disagree with
+ * them, and no pointer-decoding helper has to be re-exported to get here.
+ */
+function servedDefinitionName(
+  node: JSONSchema,
+  servedRoot: JSONSchema,
+): string | undefined {
+  if (!isObjectOrArray(node) || typeof node.$ref !== "string") return undefined;
+  if (!isObjectOrArray(servedRoot) || !isObjectOrArray(servedRoot.$defs)) {
+    return undefined;
+  }
+  for (const name of Object.keys(servedRoot.$defs)) {
+    if (encodeJsonPointer(["#", "$defs", name]) === node.$ref) return name;
+  }
+  return undefined;
+}
+
+/**
+ * Walk both documents in lockstep, recording every `description` the served
+ * side lacks and the declared side supplies.
+ *
+ * `path` addresses `served` within the served document. `fillOwnDescription` is
+ * false only at the root, whose description belongs to the verb rather than to
+ * the event object.
+ *
+ * TERMINATION, which `$ref`-following makes a real question. Descent is over
+ * the SERVED structure, whose inline part is a finite tree, so the only way to
+ * recur forever is through a served `$ref` — and every one of those resolves to
+ * a `$defs` entry, so refusing a definition already in `visitedDefinitions`
+ * bounds the walk at the number of definitions plus the inline depth. A
+ * self-referential type is the case that needs it: an item whose `children` are
+ * items reaches its own definition on the second hop. The declared side cannot
+ * extend the walk, because following its refs never descends the served side,
+ * and `resolveCfcSchemaRefs` carries a cycle guard of its own.
+ *
+ * `schemaAtPath` would look like the shorter road here and is not: it resolves
+ * refs eagerly and without a cycle guard, so it overflows the stack on exactly
+ * the self-referential type above, before any guard written here could run.
+ *
+ * Visiting a definition once is also what decides a collision: two positions
+ * referencing one definition write the prose found from the first, in the
+ * stable order `Object.entries` gives. Both are the author's words for that
+ * same definition, so the choice is between equals — and the position-specific
+ * half never goes there, because a node's own description is recorded at the
+ * node's own path, never at the shared target's.
+ */
+function collectDescriptionEdits(
+  pair: ProsePair,
+  path: readonly string[],
+  fillOwnDescription: boolean,
+  edits: DescriptionEdit[],
+  visitedDefinitions: Set<string>,
+): void {
+  const { served, servedRoot, declaredRoot } = pair;
+  if (!isObjectOrArray(served)) return;
+  // Only the declared side is resolved through: it is read, never emitted, so
+  // inlining it costs the served shape nothing.
+  const declared = isObjectOrArray(pair.declared) &&
+      typeof pair.declared.$ref === "string"
+    ? resolveCfcSchemaRefs(pair.declared, declaredRoot)
+    : pair.declared;
+  if (!isObjectOrArray(declared)) return;
 
   if (
-    fillRoot && served.description === undefined &&
+    fillOwnDescription && served.description === undefined &&
     typeof declared.description === "string"
   ) {
-    patched().description = declared.description;
+    edits.push({
+      path: [...path, "description"],
+      description: declared.description,
+    });
   }
 
+  // Where the served node's CHILDREN live. For a `$ref` that is the definition
+  // it names, which is left in place: a caller's tooling reads the served
+  // shape, and inlining the target to annotate it would rewrite what it reads.
+  // Definitions are observed to arrive with their own prose intact, so this
+  // descent commonly finds nothing to fill and exists to keep the walk honest
+  // where it does.
+  let target = served;
+  let targetPath = path;
+  const definitionName = servedDefinitionName(served, servedRoot);
+  if (definitionName !== undefined) {
+    if (visitedDefinitions.has(definitionName)) return;
+    visitedDefinitions.add(definitionName);
+    const definitions = isObjectOrArray(servedRoot)
+      ? servedRoot.$defs as Record<string, JSONSchema>
+      : {};
+    const definition = definitions[definitionName];
+    if (!isObjectOrArray(definition)) return;
+    target = definition;
+    targetPath = ["$defs", definitionName];
+  } else if (typeof served.$ref === "string") {
+    // A reference the served root does not define. Nothing here can annotate
+    // what it cannot address, so the subtree is left exactly as served.
+    return;
+  }
+
+  const childPair = (
+    servedChild: JSONSchema,
+    declaredChild: JSONSchema | undefined,
+  ): ProsePair | undefined =>
+    declaredChild === undefined ? undefined : {
+      served: servedChild,
+      declared: declaredChild,
+      servedRoot,
+      declaredRoot,
+    };
+
   if (
-    isObjectOrArray(served.properties) && isObjectOrArray(declared.properties)
+    isObjectOrArray(target.properties) && isObjectOrArray(declared.properties)
   ) {
     const declaredProperties = declared.properties as Record<
       string,
       JSONSchema
     >;
-    let properties: Record<string, JSONSchema> | undefined;
     for (
       const [key, child] of Object.entries(
-        served.properties as Record<string, JSONSchema>,
+        target.properties as Record<string, JSONSchema>,
       )
     ) {
-      const filled = fillDescriptions(child, declaredProperties[key], true);
-      if (filled !== child) {
-        (properties ??= { ...served.properties as Record<string, JSONSchema> })[
-          key
-        ] = filled;
-      }
+      const next = childPair(child, declaredProperties[key]);
+      if (next === undefined) continue;
+      collectDescriptionEdits(
+        next,
+        [...targetPath, "properties", key],
+        true,
+        edits,
+        visitedDefinitions,
+      );
     }
-    if (properties !== undefined) patched().properties = properties;
   }
 
   // An array's element schema, so a documented field inside a list of objects
   // keeps its prose. Tuple `items` (an array of schemas) needs no case of its
   // own: `isObjectOrArray` admits it, and the recursion then finds no
-  // `properties` on either side and hands the input straight back.
-  if (served.items !== undefined && declared.items !== undefined) {
-    const filled = fillDescriptions(
-      served.items as JSONSchema,
+  // `properties` on either side and records nothing.
+  if (target.items !== undefined && declared.items !== undefined) {
+    const next = childPair(
+      target.items as JSONSchema,
       declared.items as JSONSchema,
-      true,
     );
-    if (filled !== served.items) patched().items = filled;
+    if (next !== undefined) {
+      collectDescriptionEdits(
+        next,
+        [...targetPath, "items"],
+        true,
+        edits,
+        visitedDefinitions,
+      );
+    }
   }
+}
 
-  return (next ?? served) as JSONSchema;
+/**
+ * `root` with every collected description written in, sharing every subtree no
+ * edit touches. Returns `root` itself when there is nothing to write.
+ */
+function applyDescriptionEdits(
+  root: JSONSchema,
+  edits: readonly DescriptionEdit[],
+): JSONSchema {
+  let next = root;
+  for (const edit of edits) {
+    next = writeDescriptionAt(next, edit.path, edit.description);
+  }
+  return next;
+}
+
+/**
+ * `node` with `description` set at `path`, copying only the nodes along it.
+ *
+ * Every path ends at a `description` slot the walk found empty, so this only
+ * ever fills a hole — it cannot overwrite an author's own words, and a path
+ * whose interior has since been rewritten by an earlier edit still lands, since
+ * each edit reads the document the previous one produced.
+ */
+function writeDescriptionAt(
+  node: JSONSchema,
+  path: readonly string[],
+  description: string,
+): JSONSchema {
+  if (!isObjectOrArray(node) || path.length === 0) return node;
+  const [head, ...rest] = path;
+  if (rest.length === 0) {
+    return { ...node, [head]: description } as JSONSchema;
+  }
+  const child = (node as Record<string, JSONSchema>)[head];
+  const updated = writeDescriptionAt(child, rest, description);
+  if (updated === child) return node;
+  return { ...node, [head]: updated } as JSONSchema;
 }
 
 /** One verb's declared result, matched through the piece's compiled pattern.
@@ -2161,12 +2357,14 @@ async function declaredVerbResult(
   }
 }
 
-/** One verb's prose, read through the piece's compiled pattern.
+/**
+ * One verb's prose, read through the piece's compiled pattern.
  *
  * The listing's `declaredVerbProse` narrowed to a single name, on the same
  * terms `declaredVerbResult` above states: one reader, so a help page and
  * `cf piece verbs` cannot describe the same verb differently, and a pattern
- * that will not load costs the page its prose rather than the whole page. */
+ * that will not load costs the page its prose rather than the whole page.
+ */
 async function declaredVerbProseFor(
   loadPattern: () => Promise<any>,
   callableName: string,
@@ -2249,11 +2447,13 @@ export async function listPieceCallables(
     }
   }
 
-  /** The prose row for a callable, on the same terms `handlerResults` is
+  /**
+   * The prose row for a callable, on the same terms `handlerResults` is
    * claimed: the pattern's result properties key it, so only a row reached on
    * the RESULT cell may claim one. A same-named verb on the input cell is a
    * different stream that merely shares its name, and handing it another
-   * verb's documentation would be worse than handing it none. */
+   * verb's documentation would be worse than handing it none.
+   */
   const proseFor = (
     on: "result" | "input",
     name: string,
@@ -2455,7 +2655,8 @@ export async function listPieceCallables(
   };
 }
 
-/** The command spec a help page is rendered from: the resolved one, plus what
+/**
+ * The command spec a help page is rendered from: the resolved one, plus what
  * only the declaring pattern can say — the verb's declared result, its own
  * prose, and the prose on the event fields the page renders as flags.
  *
@@ -2467,7 +2668,8 @@ export async function listPieceCallables(
  * The served `inputSchema` stays the authority on shape. It is the document a
  * payload is validated against, and only its `description` annotations are
  * filled in here, so a page can never describe a flag the dispatch would
- * refuse. */
+ * refuse.
+ */
 async function withDeclaredPatternDocs(
   spec: ExecCommandSpec,
   resolved: ResolvedPieceCallable,

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -31,6 +31,7 @@ import {
   type IFCLabel,
   mergeCfcLabelViews,
   redactCaveatSourcesForDisplay,
+  resolveCfcSchemaRefs,
   validateSchemaValue,
 } from "@commonfabric/runner/cfc";
 import type { CellScope, JSONSchema } from "@commonfabric/api";
@@ -315,6 +316,13 @@ async function resultProjectionFailedAtPath(
  */
 export interface ResolvedPieceCallable extends CallableResolution {
   commandSpec: ExecCommandSpec;
+  /** This verb's documentation, resolved on demand — a thunk for the same
+   * reason `declaredResult` is one, and attached under the same condition:
+   * the pattern declaring the verb is the only document that carries it, and
+   * reaching it costs a load no dispatch should pay.
+   *
+   * Only the help page pulls it. A dispatch needs nothing an author wrote. */
+  declaredProse?: () => Promise<DeclaredVerbProse | undefined>;
 }
 
 export interface PieceCallableDependencies extends CallableExecutionDeps {
@@ -1771,9 +1779,17 @@ async function resolvePieceCallable(
     // does. A piece surface with no pattern to consult carries no thunk at all,
     // which is the honest statement — the absence says this resolution cannot
     // describe a result, rather than promising an answer that is always none.
+    //
+    // Both thunks read ONE load. They answer from the same compiled pattern
+    // and a help page pulls both, so a loader per thunk would double what a
+    // page costs — and the reason the result is a thunk at all is that the
+    // load is the expensive part.
+    let patternOnce: Promise<any> | undefined;
+    const loadPattern = () => (patternOnce ??= piece.getPattern());
     return {
       ...resolved,
-      declaredResult: () => declaredVerbResult(piece, callableName),
+      declaredResult: () => declaredVerbResult(loadPattern, callableName),
+      declaredProse: () => declaredVerbProseFor(loadPattern, callableName),
     };
   }
 
@@ -1836,6 +1852,15 @@ export interface PieceCallableListing {
    * declared result. Absent when the verb declares none — the value-less
    * shape, which is the common one. */
   outputSchema?: JSONSchema;
+  /** What the verb is FOR, in the author's own words: the doc comment on the
+   * pattern property declaring it, the same prose `call <verb> --help` prints
+   * as its summary line.
+   *
+   * Absent where the author documented nothing, and absent where the pattern
+   * could not be read (`incomplete`). Never derived from the name — a listing
+   * that restates `addItem` as "add item" reports the schema back to the
+   * caller who wrote it and calls it documentation. */
+  description?: string;
   /** Listing mark: a UI affordance outside the headless contract (inferred
    * from session-scoped handler bindings at compile time). Hidden from the
    * default listing; always callable. */
@@ -1967,6 +1992,151 @@ function handlerVerbResults(
   return verbs;
 }
 
+/** What a pattern's own result schema says a verb is for, and what its event
+ * fields mean — the author's doc comments, as the compiler lowered them. */
+interface DeclaredVerbProse {
+  /** The doc comment on the property declaring the verb: what the verb DOES.
+   * A sibling of the property's `$ref`, and never a statement about the event
+   * object, which is why it is held apart from `eventSchema` below rather than
+   * merged into it. */
+  description?: string;
+  /** The verb's declared event schema with its `$ref` followed against the
+   * result schema's own root, so the field descriptions inside the `$defs`
+   * target are reachable. Read for annotations ONLY — never to decide a shape;
+   * see `withDeclaredFieldProse`. */
+  eventSchema?: JSONSchema;
+}
+
+/** Every verb's prose, keyed by the result property declaring it.
+ *
+ * A pattern's `resultSchema` is the only place both descriptions survive
+ * compilation. Neither reaches the callable cell a verb dispatches through:
+ * that cell adopts the schema embedded in its resolved link chain
+ * (`Cell.asSchemaFromLinks`), which for a verb is the handler node's `$event`
+ * input — the handler's READ of the event, narrowed to the fields its
+ * implementation touches, rather than a rendering of the declared event type.
+ * A query carries no author's words, so a caller's schema is not the declared
+ * one stripped of prose; reading the declared one here is what recovers it.
+ *
+ * A name absent here is a name the pattern's declared result type does not
+ * mention — the same condition that hides a verb from the result-cell walk —
+ * and says nothing about whether the verb is callable.
+ *
+ * The `$defs` live at the result schema's ROOT while the `$ref` sits on the
+ * property, so the root is passed explicitly. Resolving the property alone
+ * would consult a document that carries no definitions at all. */
+function declaredVerbProse(
+  pattern: { resultSchema?: unknown } | null | undefined,
+): Map<string, DeclaredVerbProse> {
+  const prose = new Map<string, DeclaredVerbProse>();
+  const resultSchema = pattern?.resultSchema;
+  if (
+    !isObjectOrArray(resultSchema) || !isObjectOrArray(resultSchema.properties)
+  ) {
+    return prose;
+  }
+  for (const [name, property] of Object.entries(resultSchema.properties)) {
+    if (!isObjectOrArray(property)) continue;
+    const description = typeof property.description === "string"
+      ? property.description
+      : undefined;
+    const eventSchema = typeof property.$ref === "string"
+      ? resolveCfcSchemaRefs(property, resultSchema as JSONSchema)
+      : property as JSONSchema;
+    if (description === undefined && eventSchema === undefined) continue;
+    prose.set(name, {
+      ...(description !== undefined && { description }),
+      ...(eventSchema !== undefined && { eventSchema }),
+    });
+  }
+  return prose;
+}
+
+/** `served` with `description` annotations filled in from `declared` wherever
+ * it has none, at every position the two schemas share.
+ *
+ * ANNOTATIONS ONLY, and that bound is the point rather than a simplification.
+ * The two schemas disagree about shape by construction, not by accident:
+ * `served` is the handler's read of the event, narrowed to what its body
+ * touches, while `declared` is the event TYPE the pattern's result publishes.
+ * A field declared and never read appears in one and not the other. Copying a
+ * `description` cannot change which payloads pass, so this can never make the
+ * served schema disagree with the dispatch it governs. Copying anything else
+ * could, which is why nothing else is copied and no position is ADDED: a key
+ * absent from `served` stays absent, and a page never offers a flag the
+ * handler does not read.
+ *
+ * The root description is never taken. It belongs to the verb, not to the
+ * event object, and it travels as the spec's own `description`. */
+function withDeclaredFieldProse(
+  served: JSONSchema | true,
+  declared: JSONSchema | undefined,
+): JSONSchema | true {
+  return served === true
+    ? served
+    : fillDescriptions(served, declared, false) as JSONSchema;
+}
+
+function fillDescriptions(
+  served: JSONSchema,
+  declared: JSONSchema | undefined,
+  fillRoot: boolean,
+): JSONSchema {
+  if (
+    declared === undefined || !isObjectOrArray(served) ||
+    !isObjectOrArray(declared)
+  ) {
+    return served;
+  }
+  let next: Record<string, unknown> | undefined;
+  const patched = () => (next ??= { ...served });
+
+  if (
+    fillRoot && served.description === undefined &&
+    typeof declared.description === "string"
+  ) {
+    patched().description = declared.description;
+  }
+
+  if (
+    isObjectOrArray(served.properties) && isObjectOrArray(declared.properties)
+  ) {
+    const declaredProperties = declared.properties as Record<
+      string,
+      JSONSchema
+    >;
+    let properties: Record<string, JSONSchema> | undefined;
+    for (
+      const [key, child] of Object.entries(
+        served.properties as Record<string, JSONSchema>,
+      )
+    ) {
+      const filled = fillDescriptions(child, declaredProperties[key], true);
+      if (filled !== child) {
+        (properties ??= { ...served.properties as Record<string, JSONSchema> })[
+          key
+        ] = filled;
+      }
+    }
+    if (properties !== undefined) patched().properties = properties;
+  }
+
+  // An array's element schema, so a documented field inside a list of objects
+  // keeps its prose. Tuple `items` (an array of schemas) needs no case of its
+  // own: `isObjectOrArray` admits it, and the recursion then finds no
+  // `properties` on either side and hands the input straight back.
+  if (served.items !== undefined && declared.items !== undefined) {
+    const filled = fillDescriptions(
+      served.items as JSONSchema,
+      declared.items as JSONSchema,
+      true,
+    );
+    if (filled !== served.items) patched().items = filled;
+  }
+
+  return (next ?? served) as JSONSchema;
+}
+
 /** One verb's declared result, matched through the piece's compiled pattern.
  *
  * The same lookup a listing makes for every row, made for a single name — one
@@ -1981,11 +2151,28 @@ function handlerVerbResults(
  * whether a piece HAS one is settled before the thunk is attached.
  */
 async function declaredVerbResult(
-  piece: any,
+  loadPattern: () => Promise<any>,
   callableName: string,
 ): Promise<JSONSchema | undefined> {
   try {
-    return handlerVerbResults(await piece.getPattern()).get(callableName);
+    return handlerVerbResults(await loadPattern()).get(callableName);
+  } catch {
+    return undefined;
+  }
+}
+
+/** One verb's prose, read through the piece's compiled pattern.
+ *
+ * The listing's `declaredVerbProse` narrowed to a single name, on the same
+ * terms `declaredVerbResult` above states: one reader, so a help page and
+ * `cf piece verbs` cannot describe the same verb differently, and a pattern
+ * that will not load costs the page its prose rather than the whole page. */
+async function declaredVerbProseFor(
+  loadPattern: () => Promise<any>,
+  callableName: string,
+): Promise<DeclaredVerbProse | undefined> {
+  try {
+    return declaredVerbProse(await loadPattern()).get(callableName);
   } catch {
     return undefined;
   }
@@ -2027,11 +2214,14 @@ export async function listPieceCallables(
     }
   }
 
-  // The compiled pattern, read once for two independent jobs. Its result
+  // The compiled pattern, read once for three independent jobs. Its result
   // properties are candidate NAMES for the sweep below — the only source for a
   // callable the declared result type omits. Its handler nodes carry declared
-  // RESULTS, which are metadata on rows enumerated from anywhere. Resolution is
-  // cached by identity, so this costs one load per listing, not one per row.
+  // RESULTS, which are metadata on rows enumerated from anywhere. And its
+  // result SCHEMA carries the author's prose, which no other document does —
+  // a verb's callable cell adopts the handler node's `$event` schema, an
+  // emission with no annotations in it at all. Resolution is cached by
+  // identity, so this costs one load per listing, not one per row.
   //
   // Unlike the identity above, this one is not advisory, and the listing says
   // so when it is missing. `getPattern` throws on a piece carrying no pattern
@@ -2045,17 +2235,30 @@ export async function listPieceCallables(
   // `outputSchema` and losing the row.
   let graphNames: string[] = [];
   let handlerResults = new Map<string, JSONSchema | undefined>();
+  let verbProse = new Map<string, DeclaredVerbProse>();
   let graphConsulted = false;
   if (typeof piece.getPattern === "function") {
     try {
       const compiled = await piece.getPattern();
       graphNames = patternResultNames(compiled);
       handlerResults = handlerVerbResults(compiled);
+      verbProse = declaredVerbProse(compiled);
       graphConsulted = true;
     } catch {
       // Reported as `incomplete` below rather than swallowed.
     }
   }
+
+  /** The prose row for a callable, on the same terms `handlerResults` is
+   * claimed: the pattern's result properties key it, so only a row reached on
+   * the RESULT cell may claim one. A same-named verb on the input cell is a
+   * different stream that merely shares its name, and handing it another
+   * verb's documentation would be worse than handing it none. */
+  const proseFor = (
+    on: "result" | "input",
+    name: string,
+  ): DeclaredVerbProse | undefined =>
+    on === "result" ? verbProse.get(name) : undefined;
 
   const listings = new Map<string, PieceCallableListing>();
   // Names ordinary detection rejected: candidates for the forced-stream
@@ -2091,12 +2294,21 @@ export async function listPieceCallables(
       // input cell is a different stream that merely shares its name.
       const outputSchema = spec.outputSchemaSummary ??
         (cellProp === "result" ? handlerResults.get(name) : undefined);
+      const prose = proseFor(cellProp, name);
       listings.set(name, {
         name,
         kind,
         on: cellProp,
-        inputSchema: spec.inputSchema,
+        // The prose is folded into the schema a caller is ALREADY served, not
+        // served in place of it: `--help --json` publishes this same schema,
+        // and the two surfaces must not describe one verb's payload two ways.
+        inputSchema: kind === "handler"
+          ? withDeclaredFieldProse(spec.inputSchema, prose?.eventSchema)
+          : spec.inputSchema,
         ...(outputSchema !== undefined ? { outputSchema } : {}),
+        ...(prose?.description !== undefined
+          ? { description: prose.description }
+          : {}),
         ...marks,
       });
     }
@@ -2212,12 +2424,24 @@ export async function listPieceCallables(
       // PATTERN's result, and a piece-root candidate is dispatched on the
       // result cell too. Neither is on the input cell, whose same-named verb
       // would be a different stream.
+      //
+      // Which is also why the prose is claimed on the same terms as above: a
+      // row placed here is a result-cell row. The common case is that the
+      // declared result type omits the name entirely — that is what sent it
+      // through this sweep — so there is no prose to claim, and the lookup
+      // simply misses.
+      const prose = proseFor("result", name);
       listings.set(name, {
         name,
         kind,
         on: "result",
-        inputSchema: spec.inputSchema,
+        inputSchema: kind === "handler"
+          ? withDeclaredFieldProse(spec.inputSchema, prose?.eventSchema)
+          : spec.inputSchema,
         ...(outputSchema !== undefined ? { outputSchema } : {}),
+        ...(prose?.description !== undefined
+          ? { description: prose.description }
+          : {}),
       });
     }
   }
@@ -2231,21 +2455,37 @@ export async function listPieceCallables(
   };
 }
 
-/** The command spec a help page is rendered from: the resolved one, plus the
- * verb's declared result where the resolution can supply one.
+/** The command spec a help page is rendered from: the resolved one, plus what
+ * only the declaring pattern can say — the verb's declared result, its own
+ * prose, and the prose on the event fields the page renders as flags.
  *
- * Only a handler's resolution carries the thunk, so a tool's spec passes
+ * Only a handler's resolution carries the thunks, so a tool's spec passes
  * through untouched and `callableCommandSpec` keeps deciding what a tool
  * publishes — its result schema rides its callable cell and is already on the
- * spec. */
-async function withDeclaredResult(
+ * spec.
+ *
+ * The served `inputSchema` stays the authority on shape. It is the document a
+ * payload is validated against, and only its `description` annotations are
+ * filled in here, so a page can never describe a flag the dispatch would
+ * refuse. */
+async function withDeclaredPatternDocs(
   spec: ExecCommandSpec,
   resolved: ResolvedPieceCallable,
 ): Promise<ExecCommandSpec> {
-  const declared = await resolved.declaredResult?.();
-  return declared === undefined ? spec : {
+  const [declared, prose] = await Promise.all([
+    resolved.declaredResult?.(),
+    resolved.declaredProse?.(),
+  ]);
+  const inputSchema = withDeclaredFieldProse(
+    spec.inputSchema,
+    prose?.eventSchema,
+  );
+  return {
     ...spec,
-    outputSchemaSummary: declared,
+    ...(declared !== undefined && { outputSchemaSummary: declared }),
+    ...(prose?.description !== undefined && { description: prose.description }),
+    ...(inputSchema !== spec.inputSchema &&
+      { inputSchema: inputSchema as JSONSchema }),
   };
 }
 
@@ -2267,12 +2507,14 @@ export async function executePieceCallable(
     rawArgs,
     deps,
     renderHelp: async (commandSpec, parsed) => {
-      // The declared result is fetched HERE and nowhere earlier: the parse has
-      // established that a page is being rendered, so the pattern load it
-      // costs is spent on a caller who asked what the verb hands back. Both
-      // spellings of the page take it — `--help --json` serves the schema
-      // itself as `outputSchema`, the text page enumerates its fields.
-      const spec = await withDeclaredResult(commandSpec, resolved);
+      // The pattern is consulted HERE and nowhere earlier: the parse has
+      // established that a page is being rendered, so the load it costs is
+      // spent on a caller who asked what the verb hands back and what it is
+      // for. Both spellings of the page take it — `--help --json` serves the
+      // declared result as `outputSchema` and the prose as `description`, the
+      // text page enumerates the result's fields and prints the prose as its
+      // summary line.
+      const spec = await withDeclaredPatternDocs(commandSpec, resolved);
       return parsed.showHelpJson
         ? renderExecHelpJson(spec)
         : renderPieceCallHelp(

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -2001,7 +2001,7 @@ function handlerVerbResults(
  * What a pattern's own result schema says a verb is for, and what its event
  * fields mean — the author's doc comments, as the compiler lowered them.
  */
-interface DeclaredVerbProse {
+export interface DeclaredVerbProse {
   /**
    * The doc comment on the property declaring the verb: what the verb DOES.
    * A sibling of the property's `$ref`, and never a statement about the event
@@ -2037,8 +2037,13 @@ interface DeclaredVerbProse {
  * The `$defs` live at the result schema's ROOT while the `$ref` sits on the
  * property, so the root is passed explicitly. Resolving the property alone
  * would consult a document that carries no definitions at all.
+ *
+ * Exported for the direct tests in `test/verb-prose-overlay.test.ts`, alongside
+ * `withDeclaredFieldProse`: the two are the pure halves of this feature, and a
+ * result schema holding a boolean property or an unresolvable reference is
+ * reachable by construction and not by compiling a pattern.
  */
-function declaredVerbProse(
+export function declaredVerbProse(
   pattern: { resultSchema?: unknown } | null | undefined,
 ): Map<string, DeclaredVerbProse> {
   const prose = new Map<string, DeclaredVerbProse>();
@@ -2083,29 +2088,47 @@ interface DescriptionEdit {
 
 /**
  * `served` with `description` annotations filled in from `declared` wherever it
- * has none, at every position the two documents share — following a `$ref` on
- * either side to find one.
+ * has none.
+ *
+ * THE POSITIONS IT WALKS, enumerated rather than summarized, because the
+ * summary is the part a reader would otherwise have to take on trust:
+ *
+ * - `properties`, by key.
+ * - `items` in its single-schema form, and in its positional array form.
+ * - `prefixItems`, by index.
+ * - the members of `allOf`, `anyOf` and `oneOf`.
+ *
+ * It follows a `$ref` on either side to reach any of those. Everything else a
+ * JSON Schema can hold is NOT walked and keeps whatever prose it arrived with:
+ * `additionalProperties`, `patternProperties`, `propertyNames`, `contains`,
+ * `not`, `if`/`then`/`else`, `dependentSchemas`, and `unevaluated*`.
  *
  * ANNOTATIONS ONLY, and that bound is the point rather than a simplification.
  * The two schemas disagree about shape by construction, not by accident:
  * `served` is the handler's read of the event, narrowed to what its body
  * touches, while `declared` is the event TYPE the pattern's result publishes.
- * A field declared and never read appears in one and not the other. Copying a
- * `description` cannot change which payloads pass, so this can never make the
+ * A field declared and never read appears in one and not the other; a union the
+ * declared side spells as `anyOf` can arrive flattened into one object. Copying
+ * a `description` cannot change which payloads pass, so this can never make the
  * served schema disagree with the dispatch it governs. Copying anything else
  * could, which is why nothing else is copied and no position is ADDED: a key
- * absent from `served` stays absent, a `$ref` is never inlined, and a page
- * never offers a flag the handler does not read.
+ * absent from `served` stays absent, a `$ref` is never inlined, a combinator is
+ * never flattened, and a page never offers a flag the handler does not read.
  *
  * The root description is never taken. It belongs to the verb, not to the
  * event object, and it travels as the spec's own `description`.
  *
- * The bound on what this reaches: a position is filled only where the walk can
- * put the two documents side by side. A served `$ref` naming a definition the
- * served root does not carry stops the descent there, as does a declared `$ref`
- * that does not resolve — those subtrees keep whatever prose they already had.
+ * Two more bounds worth stating. A served `$ref` naming a definition the served
+ * root does not carry stops the descent there, as does a declared `$ref` that
+ * does not resolve. And where the served side spells a combinator the declared
+ * side does not, the branches are offered the declared node as a whole and no
+ * branch takes its description — a disjunction's arms are alternatives, and one
+ * sentence written across all of them would describe each of them wrongly.
+ *
+ * Exported for the direct tests in `test/verb-prose-overlay.test.ts`, which
+ * reach the degenerate schema shapes a compiled pattern does not produce.
  */
-function withDeclaredFieldProse(
+export function withDeclaredFieldProse(
   served: JSONSchema | true,
   declared: JSONSchema | undefined,
 ): JSONSchema | true {
@@ -2195,18 +2218,22 @@ function collectDescriptionEdits(
 ): void {
   const { served, servedRoot, declaredRoot } = pair;
   if (!isObjectOrArray(served)) return;
-  // Only the declared side is resolved through: it is read, never emitted, so
-  // inlining it costs the served shape nothing.
-  const declared = isObjectOrArray(pair.declared) &&
-      typeof pair.declared.$ref === "string"
-    ? resolveCfcSchemaRefs(pair.declared, declaredRoot)
-    : pair.declared;
-  if (!isObjectOrArray(declared)) return;
+  // Every declared node that can describe this position: the node itself and,
+  // transitively, the members of any combinator it carries. A union the
+  // declared side spells as `anyOf` can arrive on the served side flattened
+  // into one object, and then a field's prose is inside whichever arm declares
+  // it — reachable only by asking the arms.
+  const candidates = declaredCandidates(pair.declared, declaredRoot);
+  if (candidates.length === 0) return;
+  const declared = candidates[0];
 
   if (
     fillOwnDescription && served.description === undefined &&
     typeof declared.description === "string"
   ) {
+    // From the position's own node, never from an arm of a combinator on it: an
+    // arm describes one alternative, and promoting that to describe the whole
+    // position would state something the author did not.
     edits.push({
       path: [...path, "description"],
       description: declared.description,
@@ -2238,60 +2265,172 @@ function collectDescriptionEdits(
     return;
   }
 
-  const childPair = (
+  const descend = (
     servedChild: JSONSchema,
     declaredChild: JSONSchema | undefined,
-  ): ProsePair | undefined =>
-    declaredChild === undefined ? undefined : {
-      served: servedChild,
-      declared: declaredChild,
-      servedRoot,
-      declaredRoot,
-    };
+    childPath: readonly string[],
+    fillChildDescription: boolean,
+  ): void => {
+    if (declaredChild === undefined) return;
+    collectDescriptionEdits(
+      {
+        served: servedChild,
+        declared: declaredChild,
+        servedRoot,
+        declaredRoot,
+      },
+      childPath,
+      fillChildDescription,
+      edits,
+      visitedDefinitions,
+    );
+  };
 
-  if (
-    isObjectOrArray(target.properties) && isObjectOrArray(declared.properties)
-  ) {
-    const declaredProperties = declared.properties as Record<
-      string,
-      JSONSchema
-    >;
+  /** The first candidate that offers something at this position. */
+  const fromCandidates = <T>(
+    pick: (candidate: Record<string, unknown>) => T | undefined,
+  ): T | undefined => {
+    for (const candidate of candidates) {
+      const found = pick(candidate);
+      if (found !== undefined) return found;
+    }
+    return undefined;
+  };
+
+  if (isObjectOrArray(target.properties)) {
     for (
       const [key, child] of Object.entries(
         target.properties as Record<string, JSONSchema>,
       )
     ) {
-      const next = childPair(child, declaredProperties[key]);
-      if (next === undefined) continue;
-      collectDescriptionEdits(
-        next,
+      descend(
+        child,
+        fromCandidates((candidate) =>
+          isObjectOrArray(candidate.properties)
+            ? (candidate.properties as Record<string, JSONSchema>)[key]
+            : undefined
+        ),
         [...targetPath, "properties", key],
         true,
-        edits,
-        visitedDefinitions,
       );
     }
   }
 
-  // An array's element schema, so a documented field inside a list of objects
-  // keeps its prose. Tuple `items` (an array of schemas) needs no case of its
-  // own: `isObjectOrArray` admits it, and the recursion then finds no
-  // `properties` on either side and records nothing.
-  if (target.items !== undefined && declared.items !== undefined) {
-    const next = childPair(
+  // `items` in its single-schema form: one element schema for the whole array,
+  // so a documented field inside a list of objects keeps its prose.
+  if (target.items !== undefined && !Array.isArray(target.items)) {
+    descend(
       target.items as JSONSchema,
-      declared.items as JSONSchema,
+      fromCandidates((candidate) =>
+        candidate.items !== undefined && !Array.isArray(candidate.items)
+          ? candidate.items as JSONSchema
+          : undefined
+      ),
+      [...targetPath, "items"],
+      true,
     );
-    if (next !== undefined) {
-      collectDescriptionEdits(
-        next,
-        [...targetPath, "items"],
+  }
+
+  // Positional element schemas: `prefixItems`, and the array form of `items`
+  // that predates it. Paired by index against the same keyword, which is the
+  // only correspondence a tuple has — position IS its identity.
+  for (const keyword of ["prefixItems", "items"] as const) {
+    const servedList = target[keyword];
+    if (!Array.isArray(servedList)) continue;
+    const declaredList = fromCandidates((candidate) =>
+      Array.isArray(candidate[keyword])
+        ? candidate[keyword] as JSONSchema[]
+        : undefined
+    );
+    if (declaredList === undefined) continue;
+    const shared = Math.min(servedList.length, declaredList.length);
+    for (let index = 0; index < shared; index++) {
+      descend(
+        servedList[index] as JSONSchema,
+        declaredList[index],
+        [...targetPath, keyword, String(index)],
         true,
-        edits,
-        visitedDefinitions,
       );
     }
   }
+
+  // Combinator members. `allOf` is included deliberately, and the refusal to
+  // prove a container through a conjunction elsewhere in the tree does not
+  // carry here: that refusal is about PROOF, which needs the members combined
+  // the way the specification says, and this is annotation. A value satisfies
+  // every conjunct, so a description on any conjunct describes the value.
+  //
+  // Members pair by index when both sides spell the same keyword with the same
+  // arity. Otherwise each served member is offered the declared node whole, and
+  // takes no description of its own from it — a disjunction's arms are
+  // alternatives, and one sentence copied onto all of them describes each
+  // wrongly, while a field nested inside an arm is still worth reaching.
+  for (const keyword of COMBINATOR_KEYWORDS) {
+    const servedMembers = target[keyword];
+    if (!Array.isArray(servedMembers)) continue;
+    const declaredMembers = fromCandidates((candidate) =>
+      Array.isArray(candidate[keyword]) &&
+        (candidate[keyword] as unknown[]).length === servedMembers.length
+        ? candidate[keyword] as JSONSchema[]
+        : undefined
+    );
+    for (let index = 0; index < servedMembers.length; index++) {
+      descend(
+        servedMembers[index] as JSONSchema,
+        declaredMembers === undefined ? declared : declaredMembers[index],
+        [...targetPath, keyword, String(index)],
+        declaredMembers !== undefined,
+      );
+    }
+  }
+}
+
+/** The combinator keywords the walk descends, in a fixed order. */
+const COMBINATOR_KEYWORDS = ["allOf", "anyOf", "oneOf"] as const;
+
+/**
+ * Every declared node that can describe one position: the node itself, plus —
+ * transitively — the members of any combinator it carries, each with its
+ * references followed. The node itself is always first, so a caller wanting
+ * only the position's own account can take `[0]`.
+ *
+ * Flattening the combinator is what lets a served side that spells a union as
+ * one merged object still find each field's prose, which lives in whichever arm
+ * declares it. Nothing here is written back: these are read to look a position
+ * up, and the served document keeps its own shape.
+ *
+ * Terminates on a cycle two ways over, because either alone can be defeated: a
+ * followed reference is recorded by its pointer string, and a resolved node by
+ * its identity. Identity alone is not enough, since `resolveCfcSchemaRefs` only
+ * interns when its input is deep-frozen and hands back a fresh object
+ * otherwise.
+ */
+function declaredCandidates(
+  declared: JSONSchema | undefined,
+  declaredRoot: JSONSchema,
+): Record<string, unknown>[] {
+  const candidates: Record<string, unknown>[] = [];
+  const seenNodes = new Set<unknown>();
+  const seenRefs = new Set<string>();
+  const visit = (node: JSONSchema | undefined): void => {
+    if (node === undefined || !isObjectOrArray(node)) return;
+    let resolved: JSONSchema | undefined = node;
+    if (typeof node.$ref === "string") {
+      if (seenRefs.has(node.$ref)) return;
+      seenRefs.add(node.$ref);
+      resolved = resolveCfcSchemaRefs(node, declaredRoot);
+    }
+    if (!isObjectOrArray(resolved) || seenNodes.has(resolved)) return;
+    seenNodes.add(resolved);
+    candidates.push(resolved);
+    for (const keyword of COMBINATOR_KEYWORDS) {
+      const members = resolved[keyword];
+      if (!Array.isArray(members)) continue;
+      for (const member of members) visit(member as JSONSchema);
+    }
+  };
+  visit(declared);
+  return candidates;
 }
 
 /**
@@ -2316,21 +2455,36 @@ function applyDescriptionEdits(
  * ever fills a hole — it cannot overwrite an author's own words, and a path
  * whose interior has since been rewritten by an earlier edit still lands, since
  * each edit reads the document the previous one produced.
+ *
+ * An array along the way is copied as an array. A combinator member and a tuple
+ * position are addressed by index, and object-spreading a list to replace one
+ * would hand back `{"0": …, "1": …}` — a served `anyOf` silently turned into
+ * something no reader of it expects.
+ *
+ * It carries no guard against a path that addresses nothing, because there is
+ * no such path to guard against: `collectDescriptionEdits` builds every one by
+ * walking this document, and an edit only ever ADDS a `description` key, which
+ * leaves every other path it recorded still addressing what it addressed. That
+ * invariant is the precondition — a caller assembling a path any other way owes
+ * its own check.
  */
 function writeDescriptionAt(
   node: JSONSchema,
   path: readonly string[],
   description: string,
 ): JSONSchema {
-  if (!isObjectOrArray(node) || path.length === 0) return node;
   const [head, ...rest] = path;
-  if (rest.length === 0) {
-    return { ...node, [head]: description } as JSONSchema;
+  const value: unknown = rest.length === 0 ? description : writeDescriptionAt(
+    (node as Record<string, JSONSchema>)[head],
+    rest,
+    description,
+  );
+  if (Array.isArray(node)) {
+    const copy = [...node] as unknown[];
+    copy[Number(head)] = value;
+    return copy as unknown as JSONSchema;
   }
-  const child = (node as Record<string, JSONSchema>)[head];
-  const updated = writeDescriptionAt(child, rest, description);
-  if (updated === child) return node;
-  return { ...node, [head]: updated } as JSONSchema;
+  return { ...(node as object), [head]: value } as JSONSchema;
 }
 
 /** One verb's declared result, matched through the piece's compiled pattern.

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -28,10 +28,12 @@ import {
   type CfcLabelView,
   cfcLabelViewForCellWithStatus,
   cfcLabelViewFromSchema,
+  cfcSchemaChildRoot,
   getCarriedCfcLabelView,
   type IFCLabel,
   mergeCfcLabelViews,
   redactCaveatSourcesForDisplay,
+  resolveCfcSchemaRefRoot,
   resolveCfcSchemaRefs,
   validateSchemaValue,
 } from "@commonfabric/runner/cfc";
@@ -2103,6 +2105,21 @@ interface DescriptionEdit {
  * `additionalProperties`, `patternProperties`, `propertyNames`, `contains`,
  * `not`, `if`/`then`/`else`, `dependentSchemas`, and `unevaluated*`.
  *
+ * Three rules govern which declared account answers for a position, and each is
+ * a place a shorter implementation silently loses prose:
+ *
+ * - **Every** account is consulted, not the first one that mentions the
+ *   position. An arm declaring a field without documenting it must not shadow a
+ *   later arm that documents it.
+ * - The first account that actually SAYS something wins, in declaration order.
+ *   Two arms documenting one field differently describe two different values,
+ *   so their sentences are not merged — merging would produce prose no author
+ *   wrote.
+ * - A reference resolves in the scope that declares it. A definition may carry
+ *   `$defs` of its own, and its nested references name those; resolving them at
+ *   the event root finds nothing, or a same-named definition belonging to
+ *   someone else.
+ *
  * ANNOTATIONS ONLY, and that bound is the point rather than a simplification.
  * The two schemas disagree about shape by construction, not by accident:
  * `served` is the handler's read of the event, narrowed to what its body
@@ -2137,24 +2154,69 @@ export function withDeclaredFieldProse(
   }
   const edits: DescriptionEdit[] = [];
   collectDescriptionEdits(
-    { served, declared, servedRoot: served, declaredRoot: declared },
+    {
+      served,
+      servedRoot: served,
+      declared: [{ schema: declared, root: declared, direct: true }],
+    },
     [],
     false,
-    edits,
-    new Set<string>(),
+    { edits, written: new Set<string>(), openDefinitions: [], openRefs: [] },
   );
   return applyDescriptionEdits(served, edits);
 }
 
 /**
- * The two documents at one position, plus the roots their `$ref`s resolve
- * against. Held together because every step of the walk needs all four.
+ * One declared node that may describe a position, with the scope its own
+ * references resolve against.
+ *
+ * The scope travels WITH the node because a `$defs` closure is local: a
+ * definition may carry definitions of its own, and its nested references name
+ * those rather than the ones at the event root. Carrying one root for the whole
+ * walk resolves such a reference in the wrong document, which finds either
+ * nothing or — worse — a same-named definition belonging to someone else.
+ *
+ * `direct` separates an account OF the position from an account of one
+ * ALTERNATIVE at it. Both are read when looking a child up; only a direct one
+ * may give the position its own description.
  */
-interface ProsePair {
+interface DeclaredCandidate {
+  readonly schema: JSONSchema;
+  readonly root: JSONSchema;
+  readonly direct: boolean;
+}
+
+/** The served node at one position, with the declared accounts of it. */
+interface ProseWalk {
   readonly served: JSONSchema;
-  readonly declared: JSONSchema;
   readonly servedRoot: JSONSchema;
-  readonly declaredRoot: JSONSchema;
+  readonly declared: readonly DeclaredCandidate[];
+}
+
+/**
+ * State threaded through the whole walk: what has been recorded, and what is
+ * currently open on the path.
+ *
+ * Both open lists are STACKS rather than sets of everything ever seen. A set
+ * answers "have I been here before", and a legitimate second visit — two arms
+ * of a union naming one definition, two fields of the same type — is
+ * indistinguishable from a cycle under that question, so the second visit is
+ * dropped along with the prose it would have found. A stack answers "am I
+ * inside this right now", which is the question termination actually asks.
+ */
+interface ProseWalkState {
+  readonly edits: DescriptionEdit[];
+  /** Paths already recorded, so the first account of a position wins. Two
+   * positions sharing one `$defs` target can each reach it now that the guard
+   * is path-scoped, and without this the later one would silently overwrite
+   * the earlier. */
+  readonly written: Set<string>;
+  /** Served `$defs` names open on the current descent. */
+  readonly openDefinitions: string[];
+  /** Declared references open on the current expansion, each with the scope it
+   * was followed in — the same reference in two different scopes is two
+   * different targets. */
+  readonly openRefs: { ref: string; root: JSONSchema }[];
 }
 
 /**
@@ -2181,6 +2243,73 @@ function servedDefinitionName(
 }
 
 /**
+ * Every declared node that can describe one position: each entry with its
+ * references followed, plus — transitively — the members of any combinator it
+ * carries. Entries and their ref-chains are `direct`; combinator members are
+ * not.
+ *
+ * Flattening the combinator is what lets a served side that spells a union as
+ * one merged object still find each field's prose, which lives in whichever arm
+ * declares it. Nothing here is written back: these are read to look a position
+ * up, and the served document keeps its own shape.
+ *
+ * Scope is threaded rather than assumed. `cfcSchemaChildRoot` opens a new one
+ * wherever a subtree carries its own `$defs`, and `resolveCfcSchemaRefRoot`
+ * reports the scope a ref chain ends in, so a definition's nested references
+ * resolve in the document that declares them.
+ *
+ * Termination is by the open-reference stack, keyed on the pair of reference
+ * and scope, pushed on the way in and popped on the way out. Object identity
+ * is deliberately not used as a backstop: `resolveCfcSchemaRefs` hands back a
+ * fresh object whenever it merges ref-site siblings over a target, so identity
+ * is not stable across resolution and a guard built on it would never fire.
+ */
+function expandDeclared(
+  entries: readonly DeclaredCandidate[],
+  openRefs: { ref: string; root: JSONSchema }[],
+): DeclaredCandidate[] {
+  const candidates: DeclaredCandidate[] = [];
+  const visit = (
+    node: JSONSchema | undefined,
+    root: JSONSchema,
+    direct: boolean,
+  ): void => {
+    if (!isObjectOrArray(node)) return;
+    // A node carrying its own definitions opens a scope before its own `$ref`
+    // is read, because that reference may name one of them.
+    const scope = cfcSchemaChildRoot(node, root);
+    const ref = node.$ref;
+    let resolved: JSONSchema | undefined = node;
+    let childRoot = scope;
+    if (typeof ref === "string") {
+      if (openRefs.some((open) => open.ref === ref && open.root === scope)) {
+        return;
+      }
+      openRefs.push({ ref, root: scope });
+      resolved = resolveCfcSchemaRefs(node, scope);
+      childRoot = isObjectOrArray(resolved)
+        ? cfcSchemaChildRoot(resolved, resolveCfcSchemaRefRoot(node, scope))
+        : scope;
+    }
+    try {
+      if (!isObjectOrArray(resolved)) return;
+      candidates.push({ schema: resolved, root: childRoot, direct });
+      for (const keyword of COMBINATOR_KEYWORDS) {
+        const members = resolved[keyword];
+        if (!Array.isArray(members)) continue;
+        for (const member of members) {
+          visit(member as JSONSchema, childRoot, false);
+        }
+      }
+    } finally {
+      if (typeof ref === "string") openRefs.pop();
+    }
+  };
+  for (const entry of entries) visit(entry.schema, entry.root, entry.direct);
+  return candidates;
+}
+
+/**
  * Walk both documents in lockstep, recording every `description` the served
  * side lacks and the declared side supplies.
  *
@@ -2188,56 +2317,52 @@ function servedDefinitionName(
  * false only at the root, whose description belongs to the verb rather than to
  * the event object.
  *
+ * WHICH ACCOUNT WINS, where several describe one position: the first direct
+ * candidate that actually carries a description, in the order the declared
+ * document lists them. Not the first candidate that merely mentions the
+ * position — an arm declaring a field without documenting it must not shadow a
+ * later arm that documents it. Not a merge of every arm's sentence either: two
+ * arms documenting one field differently are describing two different values,
+ * and concatenating them would produce prose no author wrote. First that says
+ * something, deterministically.
+ *
  * TERMINATION, which `$ref`-following makes a real question. Descent is over
  * the SERVED structure, whose inline part is a finite tree, so the only way to
  * recur forever is through a served `$ref` — and every one of those resolves to
- * a `$defs` entry, so refusing a definition already in `visitedDefinitions`
- * bounds the walk at the number of definitions plus the inline depth. A
- * self-referential type is the case that needs it: an item whose `children` are
- * items reaches its own definition on the second hop. The declared side cannot
- * extend the walk, because following its refs never descends the served side,
- * and `resolveCfcSchemaRefs` carries a cycle guard of its own.
+ * a `$defs` entry. `openDefinitions` holds the ones open on the current path,
+ * pushed on descent and popped after, so a definition that reaches itself stops
+ * while two siblings naming one definition are each still walked. A
+ * self-referential type is the case that needs the first half: an item whose
+ * `children` are items reaches its own definition on the second hop. Two fields
+ * of one type are the case that needs the second.
  *
  * `schemaAtPath` would look like the shorter road here and is not: it resolves
  * refs eagerly and without a cycle guard, so it overflows the stack on exactly
  * the self-referential type above, before any guard written here could run.
- *
- * Visiting a definition once is also what decides a collision: two positions
- * referencing one definition write the prose found from the first, in the
- * stable order `Object.entries` gives. Both are the author's words for that
- * same definition, so the choice is between equals — and the position-specific
- * half never goes there, because a node's own description is recorded at the
- * node's own path, never at the shared target's.
  */
 function collectDescriptionEdits(
-  pair: ProsePair,
+  walk: ProseWalk,
   path: readonly string[],
   fillOwnDescription: boolean,
-  edits: DescriptionEdit[],
-  visitedDefinitions: Set<string>,
+  state: ProseWalkState,
 ): void {
-  const { served, servedRoot, declaredRoot } = pair;
+  const { served, servedRoot } = walk;
   if (!isObjectOrArray(served)) return;
-  // Every declared node that can describe this position: the node itself and,
-  // transitively, the members of any combinator it carries. A union the
-  // declared side spells as `anyOf` can arrive on the served side flattened
-  // into one object, and then a field's prose is inside whichever arm declares
-  // it — reachable only by asking the arms.
-  const candidates = declaredCandidates(pair.declared, declaredRoot);
+  const candidates = expandDeclared(walk.declared, state.openRefs);
   if (candidates.length === 0) return;
-  const declared = candidates[0];
 
-  if (
-    fillOwnDescription && served.description === undefined &&
-    typeof declared.description === "string"
-  ) {
-    // From the position's own node, never from an arm of a combinator on it: an
-    // arm describes one alternative, and promoting that to describe the whole
-    // position would state something the author did not.
-    edits.push({
-      path: [...path, "description"],
-      description: declared.description,
-    });
+  if (fillOwnDescription && served.description === undefined) {
+    const described = candidates.find((candidate) =>
+      candidate.direct && isObjectOrArray(candidate.schema) &&
+      typeof candidate.schema.description === "string"
+    );
+    if (described !== undefined) {
+      recordDescription(
+        state,
+        [...path, "description"],
+        (described.schema as Record<string, unknown>).description as string,
+      );
+    }
   }
 
   // Where the served node's CHILDREN live. For a `$ref` that is the definition
@@ -2248,15 +2373,17 @@ function collectDescriptionEdits(
   // where it does.
   let target = served;
   let targetPath = path;
+  let openedDefinition: string | undefined;
   const definitionName = servedDefinitionName(served, servedRoot);
   if (definitionName !== undefined) {
-    if (visitedDefinitions.has(definitionName)) return;
-    visitedDefinitions.add(definitionName);
+    if (state.openDefinitions.includes(definitionName)) return;
     const definitions = isObjectOrArray(servedRoot)
       ? servedRoot.$defs as Record<string, JSONSchema>
       : {};
     const definition = definitions[definitionName];
     if (!isObjectOrArray(definition)) return;
+    state.openDefinitions.push(definitionName);
+    openedDefinition = definitionName;
     target = definition;
     targetPath = ["$defs", definitionName];
   } else if (typeof served.$ref === "string") {
@@ -2265,37 +2392,67 @@ function collectDescriptionEdits(
     return;
   }
 
+  try {
+    descendInto(target, targetPath, candidates, walk, state);
+  } finally {
+    if (openedDefinition !== undefined) state.openDefinitions.pop();
+  }
+}
+
+/** Record one description unless this position already has an account. */
+function recordDescription(
+  state: ProseWalkState,
+  path: readonly string[],
+  description: string,
+): void {
+  // Keyed as JSON rather than by joining on a separator: a path segment is a
+  // property name and may contain any character, so no separator is safe.
+  const key = JSON.stringify(path);
+  if (state.written.has(key)) return;
+  state.written.add(key);
+  state.edits.push({ path, description });
+}
+
+/** The child positions of one served node, each paired with every declared
+ * account of it. Split out so the definition bookkeeping above reads as the one
+ * thing it is. */
+function descendInto(
+  target: Record<string, unknown>,
+  targetPath: readonly string[],
+  candidates: readonly DeclaredCandidate[],
+  walk: ProseWalk,
+  state: ProseWalkState,
+): void {
+  // `target` is either the served node this was reached with or a `$defs`
+  // entry, and the caller has already established that each is a record.
+  const { servedRoot } = walk;
   const descend = (
     servedChild: JSONSchema,
-    declaredChild: JSONSchema | undefined,
+    declared: DeclaredCandidate[],
     childPath: readonly string[],
     fillChildDescription: boolean,
   ): void => {
-    if (declaredChild === undefined) return;
+    if (declared.length === 0) return;
     collectDescriptionEdits(
-      {
-        served: servedChild,
-        declared: declaredChild,
-        servedRoot,
-        declaredRoot,
-      },
+      { served: servedChild, servedRoot, declared },
       childPath,
       fillChildDescription,
-      edits,
-      visitedDefinitions,
+      state,
     );
   };
 
-  /** The first candidate that offers something at this position. */
-  const fromCandidates = <T>(
-    pick: (candidate: Record<string, unknown>) => T | undefined,
-  ): T | undefined => {
-    for (const candidate of candidates) {
-      const found = pick(candidate);
-      if (found !== undefined) return found;
-    }
-    return undefined;
-  };
+  /** Every candidate's account of one child position, in declaration order. */
+  const accounts = (
+    pick: (candidate: Record<string, unknown>) => JSONSchema | undefined,
+  ): DeclaredCandidate[] =>
+    candidates.flatMap((candidate) => {
+      const found = isObjectOrArray(candidate.schema)
+        ? pick(candidate.schema)
+        : undefined;
+      return found === undefined
+        ? []
+        : [{ schema: found, root: candidate.root, direct: true }];
+    });
 
   if (isObjectOrArray(target.properties)) {
     for (
@@ -2305,7 +2462,7 @@ function collectDescriptionEdits(
     ) {
       descend(
         child,
-        fromCandidates((candidate) =>
+        accounts((candidate) =>
           isObjectOrArray(candidate.properties)
             ? (candidate.properties as Record<string, JSONSchema>)[key]
             : undefined
@@ -2321,7 +2478,7 @@ function collectDescriptionEdits(
   if (target.items !== undefined && !Array.isArray(target.items)) {
     descend(
       target.items as JSONSchema,
-      fromCandidates((candidate) =>
+      accounts((candidate) =>
         candidate.items !== undefined && !Array.isArray(candidate.items)
           ? candidate.items as JSONSchema
           : undefined
@@ -2337,17 +2494,15 @@ function collectDescriptionEdits(
   for (const keyword of ["prefixItems", "items"] as const) {
     const servedList = target[keyword];
     if (!Array.isArray(servedList)) continue;
-    const declaredList = fromCandidates((candidate) =>
-      Array.isArray(candidate[keyword])
-        ? candidate[keyword] as JSONSchema[]
-        : undefined
-    );
-    if (declaredList === undefined) continue;
-    const shared = Math.min(servedList.length, declaredList.length);
-    for (let index = 0; index < shared; index++) {
+    for (let index = 0; index < servedList.length; index++) {
       descend(
         servedList[index] as JSONSchema,
-        declaredList[index],
+        accounts((candidate) => {
+          const list = candidate[keyword];
+          return Array.isArray(list) && index < list.length
+            ? list[index] as JSONSchema
+            : undefined;
+        }),
         [...targetPath, keyword, String(index)],
         true,
       );
@@ -2360,26 +2515,39 @@ function collectDescriptionEdits(
   // the way the specification says, and this is annotation. A value satisfies
   // every conjunct, so a description on any conjunct describes the value.
   //
-  // Members pair by index when both sides spell the same keyword with the same
-  // arity. Otherwise each served member is offered the declared node whole, and
-  // takes no description of its own from it — a disjunction's arms are
-  // alternatives, and one sentence copied onto all of them describes each
+  // Members pair by index against a candidate spelling the same keyword with
+  // the same arity. Otherwise each served member is offered every candidate
+  // whole, and takes no description of its own from them — a disjunction's arms
+  // are alternatives, and one sentence copied onto all of them describes each
   // wrongly, while a field nested inside an arm is still worth reaching.
   for (const keyword of COMBINATOR_KEYWORDS) {
     const servedMembers = target[keyword];
     if (!Array.isArray(servedMembers)) continue;
-    const declaredMembers = fromCandidates((candidate) =>
-      Array.isArray(candidate[keyword]) &&
-        (candidate[keyword] as unknown[]).length === servedMembers.length
-        ? candidate[keyword] as JSONSchema[]
-        : undefined
+    const paired = candidates.filter((candidate) =>
+      isObjectOrArray(candidate.schema) &&
+      Array.isArray((candidate.schema as Record<string, unknown>)[keyword]) &&
+      ((candidate.schema as Record<string, unknown>)[keyword] as unknown[])
+          .length === servedMembers.length
     );
     for (let index = 0; index < servedMembers.length; index++) {
+      const declared = paired.length > 0
+        ? paired.map((candidate) => ({
+          schema: (candidate.schema as Record<string, unknown>)[
+            keyword
+          ] as JSONSchema[],
+          root: candidate.root,
+          direct: true,
+        })).map((entry) => ({
+          schema: (entry.schema as unknown as JSONSchema[])[index],
+          root: entry.root,
+          direct: true,
+        }))
+        : candidates.map((candidate) => ({ ...candidate, direct: false }));
       descend(
         servedMembers[index] as JSONSchema,
-        declaredMembers === undefined ? declared : declaredMembers[index],
+        declared,
         [...targetPath, keyword, String(index)],
-        declaredMembers !== undefined,
+        paired.length > 0,
       );
     }
   }
@@ -2387,51 +2555,6 @@ function collectDescriptionEdits(
 
 /** The combinator keywords the walk descends, in a fixed order. */
 const COMBINATOR_KEYWORDS = ["allOf", "anyOf", "oneOf"] as const;
-
-/**
- * Every declared node that can describe one position: the node itself, plus —
- * transitively — the members of any combinator it carries, each with its
- * references followed. The node itself is always first, so a caller wanting
- * only the position's own account can take `[0]`.
- *
- * Flattening the combinator is what lets a served side that spells a union as
- * one merged object still find each field's prose, which lives in whichever arm
- * declares it. Nothing here is written back: these are read to look a position
- * up, and the served document keeps its own shape.
- *
- * Terminates on a cycle two ways over, because either alone can be defeated: a
- * followed reference is recorded by its pointer string, and a resolved node by
- * its identity. Identity alone is not enough, since `resolveCfcSchemaRefs` only
- * interns when its input is deep-frozen and hands back a fresh object
- * otherwise.
- */
-function declaredCandidates(
-  declared: JSONSchema | undefined,
-  declaredRoot: JSONSchema,
-): Record<string, unknown>[] {
-  const candidates: Record<string, unknown>[] = [];
-  const seenNodes = new Set<unknown>();
-  const seenRefs = new Set<string>();
-  const visit = (node: JSONSchema | undefined): void => {
-    if (node === undefined || !isObjectOrArray(node)) return;
-    let resolved: JSONSchema | undefined = node;
-    if (typeof node.$ref === "string") {
-      if (seenRefs.has(node.$ref)) return;
-      seenRefs.add(node.$ref);
-      resolved = resolveCfcSchemaRefs(node, declaredRoot);
-    }
-    if (!isObjectOrArray(resolved) || seenNodes.has(resolved)) return;
-    seenNodes.add(resolved);
-    candidates.push(resolved);
-    for (const keyword of COMBINATOR_KEYWORDS) {
-      const members = resolved[keyword];
-      if (!Array.isArray(members)) continue;
-      for (const member of members) visit(member as JSONSchema);
-    }
-  };
-  visit(declared);
-  return candidates;
-}
 
 /**
  * `root` with every collected description written in, sharing every subtree no

--- a/packages/cli/test/verb-prose-live.test.ts
+++ b/packages/cli/test/verb-prose-live.test.ts
@@ -1,0 +1,320 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { getResultCellWithSourceSchema } from "../../runner/src/piece-helpers.ts";
+import { executePieceCallable, listPieceCallables } from "../lib/piece.ts";
+import { verbListingJson } from "../commands/piece.ts";
+
+/**
+ * One pattern documented the way an author is told to document one: the verb
+ * says what it does where its `Stream` is declared, and each event field says
+ * what it means where it is declared.
+ *
+ * Driven against a COMPILED, RUN pattern rather than a hand-built schema,
+ * because the whole subject is what survives the compile pipeline and what
+ * does not. A fixture asserting the shape by hand would agree with any
+ * implementation, including the one that loses the prose: the two descriptions
+ * below reach the pattern by two different routes — one as a sibling of the
+ * verb property's `$ref`, one inside the `$defs` target that `$ref` names —
+ * and only a real compile puts them where they actually land.
+ *
+ * `rename` carries no prose at all. It is the control: a verb an author has
+ * not documented must gain no description, so an implementation that invents
+ * one (the property's name, the event type's name, an empty string) fails
+ * against it rather than passing everything.
+ *
+ * `AddEvent.urgent` is the other control, and it is the more interesting one.
+ * It is declared, documented, and ABSENT from the schema the verb dispatches
+ * through, because the handler's body never reads it and that schema is the
+ * handler's read rather than the declared type. So the two documents this file
+ * is about disagree on shape as well as on prose, and the assertion below pins
+ * which one wins: the prose is folded into what a caller is served, never
+ * served in its place.
+ */
+const PROGRAM = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      'import { action, cell, pattern, Stream } from "commonfabric";',
+      "",
+      "interface AddEvent {",
+      "  /** One line naming the work. */",
+      "  title: string;",
+      "  /** Whether to file it at the top of the board. */",
+      "  urgent?: boolean;",
+      "}",
+      "",
+      "interface RenameEvent { title: string; }",
+      "",
+      "interface Out {",
+      "  /** Root items only. */",
+      "  items: string[];",
+      "  /** File a new root item on the board. */",
+      "  add: Stream<AddEvent>;",
+      "  rename: Stream<RenameEvent>;",
+      "}",
+      "",
+      "export default pattern<Record<string, never>, Out>(() => {",
+      "  const items = cell<string[]>([]);",
+      "  const add = action((event: AddEvent) => { items.push(event.title); });",
+      "  const rename = action((event: RenameEvent) => {",
+      "    items.set([event.title]);",
+      "  });",
+      "  return { items, add, rename };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+const VERB_PROSE = "File a new root item on the board.";
+const FIELD_PROSE = "One line naming the work.";
+
+interface LivePiece {
+  piece: unknown;
+  space: string;
+  dispose: () => Promise<void>;
+}
+
+/** Compile and run the program above, and hand back the piece surface both
+ * caller-facing commands walk. */
+async function runLivePiece(passphrase: string): Promise<LivePiece> {
+  const signer = await Identity.fromPassphrase(passphrase);
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL("https://example.com"),
+    storageManager,
+  });
+  const space = signer.did();
+  const compiled = await runtime.patternManager.compilePattern(
+    PROGRAM as never,
+    { space },
+  );
+  const tx = runtime.edit();
+  const rootCell = runtime.getCell(space, "verb-prose-live", undefined, tx);
+  const root = runtime.run(tx, compiled, {}, rootCell);
+  runtime.prepareTxForCommit(tx);
+  expect((await tx.commit()).error).toBeUndefined();
+  await root.pull();
+
+  // `getResultCellWithSourceSchema` is the one narrowing `PiecesController`
+  // applies before any `cf` command sees a piece; skipping it would hand the
+  // lister a cell no caller is ever served.
+  const result = getResultCellWithSourceSchema(root);
+  return {
+    space,
+    piece: {
+      result: { getCell: () => Promise.resolve(result) },
+      input: {
+        getCell: () =>
+          Promise.resolve(runtime.getCell(space, "verb-prose-live-input")),
+      },
+      getCell: () => result,
+      getPattern: () => Promise.resolve(compiled),
+    },
+    dispose: async () => {
+      await runtime.dispose?.();
+      await storageManager.close?.();
+    },
+  };
+}
+
+function configFor(space: string) {
+  return {
+    apiUrl: "http://localhost:8000",
+    identity: "/tmp/test-identity.pem",
+    piece: "fid1:live",
+    space,
+  };
+}
+
+function depsFor(live: LivePiece) {
+  return {
+    loadPieces: () => Promise.resolve({ getSpace: () => live.space } as never),
+    loadPiece: () => Promise.resolve(live.piece as never),
+  };
+}
+
+/** The `cf piece verbs --json` payload, exactly as the command emits it. */
+async function verbsJson(live: LivePiece): Promise<Record<string, unknown>> {
+  const listing = await listPieceCallables(
+    configFor(live.space),
+    depsFor(live),
+  );
+  return verbListingJson(listing, false);
+}
+
+/** The `cf piece call <verb> --help --json` payload, as the command emits it. */
+async function callHelpJson(
+  live: LivePiece,
+  verb: string,
+): Promise<Record<string, unknown>> {
+  const executed = await executePieceCallable(
+    configFor(live.space),
+    verb,
+    ["--help", "--json"],
+    depsFor(live),
+  );
+  return JSON.parse(executed.helpText ?? "{}");
+}
+
+/** The `cf piece call <verb> --help` text page. */
+async function callHelpText(live: LivePiece, verb: string): Promise<string> {
+  const executed = await executePieceCallable(
+    configFor(live.space),
+    verb,
+    ["--help"],
+    depsFor(live),
+  );
+  return executed.helpText ?? "";
+}
+
+function verbRow(
+  payload: Record<string, unknown>,
+  name: string,
+): Record<string, unknown> {
+  const verbs = payload.verbs as Record<string, unknown>[];
+  const row = verbs.find((verb) => verb.name === name);
+  expect(row).toBeDefined();
+  return row!;
+}
+
+describe("an author's verb prose reaching a caller", () => {
+  describe("cf piece verbs --json", () => {
+    it("carries the verb's own doc comment as its description", async () => {
+      const live = await runLivePiece("verb-prose-listing");
+      try {
+        expect(verbRow(await verbsJson(live), "add").description)
+          .toBe(VERB_PROSE);
+      } finally {
+        await live.dispose();
+      }
+    });
+
+    it("carries an event field's doc comment in the row's input schema", async () => {
+      const live = await runLivePiece("verb-prose-listing-field");
+      try {
+        const row = verbRow(await verbsJson(live), "add");
+        expect(row.inputSchema).toMatchObject({
+          properties: { title: { type: "string", description: FIELD_PROSE } },
+        });
+      } finally {
+        await live.dispose();
+      }
+    });
+
+    it("adds no property the dispatch schema does not carry", async () => {
+      const live = await runLivePiece("verb-prose-listing-shape");
+      try {
+        const inputSchema = verbRow(await verbsJson(live), "add")
+          .inputSchema as Record<string, unknown>;
+        // `AddEvent.urgent` is declared and documented, and the schema the verb
+        // dispatches through does not carry it: that schema is the handler's
+        // read of the event, and this handler's body reads only `title`. The
+        // pattern's prose must not paper over that — a caller offered
+        // `--urgent` would be offered a flag the running handler ignores.
+        //
+        // This is what fails against the obvious implementation — merging the
+        // declared event schema over the served one, or serving the declared
+        // one in its place. Both would list `urgent`, and both would make this
+        // listing a claim about the pattern's source rather than about the
+        // piece a caller is talking to.
+        expect(Object.keys(inputSchema.properties as object)).toEqual([
+          "title",
+        ]);
+      } finally {
+        await live.dispose();
+      }
+    });
+
+    it("carries a description on the documented verb and not on its neighbor", async () => {
+      const live = await runLivePiece("verb-prose-listing-undocumented");
+      try {
+        const payload = await verbsJson(live);
+        // An implementation that supplies a description from anywhere but the
+        // author's comment — the property name, the event type's name, an
+        // empty string — fails on the first of these while passing every other
+        // assertion in this file.
+        expect("description" in verbRow(payload, "rename")).toBe(false);
+        // And one that keys the prose by anything looser than the property
+        // name — the first documented verb, say — fails on the second.
+        expect(verbRow(payload, "add").description).toBe(VERB_PROSE);
+      } finally {
+        await live.dispose();
+      }
+    });
+  });
+
+  describe("cf piece call --help --json", () => {
+    it("carries the verb's own doc comment as its description", async () => {
+      const live = await runLivePiece("verb-prose-help-json");
+      try {
+        expect((await callHelpJson(live, "add")).description).toBe(VERB_PROSE);
+      } finally {
+        await live.dispose();
+      }
+    });
+
+    it("carries an event field's doc comment in the served input schema", async () => {
+      const live = await runLivePiece("verb-prose-help-json-field");
+      try {
+        expect((await callHelpJson(live, "add")).inputSchema).toMatchObject({
+          properties: { title: { type: "string", description: FIELD_PROSE } },
+        });
+      } finally {
+        await live.dispose();
+      }
+    });
+
+    it("leaves an undocumented verb with no description", async () => {
+      const live = await runLivePiece("verb-prose-help-json-undocumented");
+      try {
+        expect("description" in await callHelpJson(live, "rename")).toBe(false);
+      } finally {
+        await live.dispose();
+      }
+    });
+  });
+
+  describe("cf piece call --help", () => {
+    it("prints the verb's own doc comment as the page's summary line", async () => {
+      const live = await runLivePiece("verb-prose-help-text");
+      try {
+        const page = await callHelpText(live, "add");
+        // Between Usage and JSON input, as a paragraph of its own: asserted as
+        // a whole block rather than by containment, because the prose also
+        // reaches the page through nothing else and a bare `toContain` would
+        // pass against a page that printed it in the wrong place or twice.
+        expect(page).toContain(`\n\n${VERB_PROSE}\n\nJSON input:\n`);
+      } finally {
+        await live.dispose();
+      }
+    });
+
+    it("prints an event field's doc comment beside its flag", async () => {
+      const live = await runLivePiece("verb-prose-help-text-field");
+      try {
+        expect(await callHelpText(live, "add"))
+          .toContain(`--title <string>  Required. ${FIELD_PROSE}`);
+      } finally {
+        await live.dispose();
+      }
+    });
+
+    it("prints no summary line for an undocumented verb", async () => {
+      const live = await runLivePiece("verb-prose-help-text-undocumented");
+      try {
+        // Usage runs straight into JSON input, with no blank paragraph
+        // standing where prose would be.
+        expect(await callHelpText(live, "rename")).toContain(
+          "\n\nJSON input:\n",
+        );
+        expect(await callHelpText(live, "rename")).not.toContain(VERB_PROSE);
+      } finally {
+        await live.dispose();
+      }
+    });
+  });
+});

--- a/packages/cli/test/verb-prose-live.test.ts
+++ b/packages/cli/test/verb-prose-live.test.ts
@@ -92,6 +92,23 @@ const PROGRAM = {
       "  node: Node;",
       "}",
       "",
+      "interface Cat {",
+      "  /** How loud it is. */",
+      "  meow: string;",
+      "  kind: 'cat';",
+      "}",
+      "",
+      "interface Dog {",
+      "  /** How deep it is. */",
+      "  woof: string;",
+      "  kind: 'dog';",
+      "}",
+      "",
+      "interface ClassifyEvent {",
+      "  /** The animal to file. */",
+      "  pet: Cat | Dog;",
+      "}",
+      "",
       "interface RenameEvent { title: string; }",
       "",
       "interface Out {",
@@ -103,6 +120,8 @@ const PROGRAM = {
       "  annotate: Stream<AddEvent>;",
       "  /** Graft a subtree onto the board. */",
       "  graft: Stream<GraftEvent>;",
+      "  /** File an animal by its kind. */",
+      "  classify: Stream<ClassifyEvent>;",
       "  rename: Stream<RenameEvent>;",
       "}",
       "",
@@ -123,10 +142,15 @@ const PROGRAM = {
       "        event.node.children.map((child) => child.label).join(','),",
       "    );",
       "  });",
+      "  const classify = action((event: ClassifyEvent) => {",
+      "    items.push(",
+      "      event.pet.kind === 'cat' ? event.pet.meow : event.pet.woof,",
+      "    );",
+      "  });",
       "  const rename = action((event: RenameEvent) => {",
       "    items.set([event.title]);",
       "  });",
-      "  return { items, add, annotate, graft, rename };",
+      "  return { items, add, annotate, graft, classify, rename };",
       "});",
     ].join("\n"),
   }],
@@ -377,6 +401,35 @@ describe("an author's verb prose reaching a caller", () => {
       }
     });
 
+    it("carries prose out of the arms of a union the served side flattened", async () => {
+      const live = await runLivePiece("verb-prose-listing-union");
+      try {
+        // `pet: Cat | Dog` is `anyOf` on the declared side and a single merged
+        // object on the served one — the handler reads both arms' fields, so
+        // the read carries `meow` and `woof` side by side with no combinator
+        // at all. Neither field's prose is reachable from the position: it
+        // lives inside whichever arm declares it, one reference further in.
+        //
+        // This is the case a walk that only pairs `properties` key-for-key
+        // cannot reach even with reference following, because there is no
+        // matching key to follow from.
+        const row = verbRow(await verbsJson(live), "classify");
+        expect(row.inputSchema).toMatchObject({
+          properties: {
+            pet: {
+              description: "The animal to file.",
+              properties: {
+                meow: { description: "How loud it is." },
+                woof: { description: "How deep it is." },
+              },
+            },
+          },
+        });
+      } finally {
+        await live.dispose();
+      }
+    });
+
     it("leaves a served reference as a reference and its definition untouched", async () => {
       const live = await runLivePiece("verb-prose-listing-ref-shape");
       try {
@@ -477,6 +530,25 @@ describe("an author's verb prose reaching a caller", () => {
           .toMatchObject({
             properties: {
               details: { properties: { note: { description: NESTED_PROSE } } },
+            },
+          });
+      } finally {
+        await live.dispose();
+      }
+    });
+
+    it("carries prose out of the arms of a union the served side flattened", async () => {
+      const live = await runLivePiece("verb-prose-help-json-union");
+      try {
+        expect((await callHelpJson(live, "classify")).inputSchema)
+          .toMatchObject({
+            properties: {
+              pet: {
+                properties: {
+                  meow: { description: "How loud it is." },
+                  woof: { description: "How deep it is." },
+                },
+              },
             },
           });
       } finally {

--- a/packages/cli/test/verb-prose-live.test.ts
+++ b/packages/cli/test/verb-prose-live.test.ts
@@ -1,3 +1,16 @@
+/**
+ * An author's documentation reaching the caller who asks for it, across the
+ * three surfaces that answer: `cf piece verbs --json`, and both spellings of a
+ * verb's own help page.
+ *
+ * Every case runs against a COMPILED, RUN pattern rather than a hand-built
+ * schema, because the subject is precisely what the compile pipeline does with
+ * an author's words. The prose reaches the pattern by several different routes
+ * — a sibling of a `$ref`, a field inside the `$defs` target that `$ref` names,
+ * a field two definitions deep — and only a real compile puts each where it
+ * actually lands. A fixture asserting those positions by hand would agree with
+ * any implementation, the one that loses the prose included.
+ */
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
@@ -12,13 +25,18 @@ import { verbListingJson } from "../commands/piece.ts";
  * says what it does where its `Stream` is declared, and each event field says
  * what it means where it is declared.
  *
- * Driven against a COMPILED, RUN pattern rather than a hand-built schema,
- * because the whole subject is what survives the compile pipeline and what
- * does not. A fixture asserting the shape by hand would agree with any
- * implementation, including the one that loses the prose: the two descriptions
- * below reach the pattern by two different routes — one as a sibling of the
- * verb property's `$ref`, one inside the `$defs` target that `$ref` names —
- * and only a real compile puts them where they actually land.
+ * The shapes here are chosen because the two documents the fix reconciles make
+ * DIFFERENT inlining choices, measured on this fixture:
+ *
+ * - `details` is a `$ref` on the declared side and inlined on the served one,
+ *   so reaching `details.note` and `details.tags` means following a declared
+ *   reference the served document does not have.
+ * - `details.tags.items` is a `$ref` on BOTH sides, so its element prose is
+ *   already in place — and the served `$ref` must survive, since a caller's
+ *   tooling reads that shape.
+ * - `primary` is the same `Tag` reached a second way, inlined. It proves the
+ *   walk annotates a position without disturbing the shared definition, and
+ *   that reaching one definition twice is handled.
  *
  * `rename` carries no prose at all. It is the control: a verb an author has
  * not documented must gain no description, so an implementation that invents
@@ -28,10 +46,9 @@ import { verbListingJson } from "../commands/piece.ts";
  * `AddEvent.urgent` is the other control, and it is the more interesting one.
  * It is declared, documented, and ABSENT from the schema the verb dispatches
  * through, because the handler's body never reads it and that schema is the
- * handler's read rather than the declared type. So the two documents this file
- * is about disagree on shape as well as on prose, and the assertion below pins
- * which one wins: the prose is folded into what a caller is served, never
- * served in its place.
+ * handler's read rather than the declared type. So the two documents disagree
+ * on shape as well as on prose, and the assertions below pin which one wins:
+ * the prose is folded into what a caller is served, never served in its place.
  */
 const PROGRAM = {
   main: "/main.tsx",
@@ -40,11 +57,39 @@ const PROGRAM = {
     contents: [
       'import { action, cell, pattern, Stream } from "commonfabric";',
       "",
+      "interface Tag {",
+      "  /** The tag's visible text. */",
+      "  label: string;",
+      "}",
+      "",
+      "interface Details {",
+      "  /** Free text the caller may attach. */",
+      "  note: string;",
+      "  /** Labels to file it under. */",
+      "  tags: Tag[];",
+      "}",
+      "",
       "interface AddEvent {",
       "  /** One line naming the work. */",
       "  title: string;",
       "  /** Whether to file it at the top of the board. */",
       "  urgent?: boolean;",
+      "  /** Anything else worth recording. */",
+      "  details: Details;",
+      "  /** The tag that leads. */",
+      "  primary: Tag;",
+      "}",
+      "",
+      "interface Node {",
+      "  /** What this node is called. */",
+      "  label: string;",
+      "  /** Nodes filed under this one. */",
+      "  children: Node[];",
+      "}",
+      "",
+      "interface GraftEvent {",
+      "  /** The subtree to graft. */",
+      "  node: Node;",
       "}",
       "",
       "interface RenameEvent { title: string; }",
@@ -54,16 +99,34 @@ const PROGRAM = {
       "  items: string[];",
       "  /** File a new root item on the board. */",
       "  add: Stream<AddEvent>;",
+      "  /** Attach a note to the board. */",
+      "  annotate: Stream<AddEvent>;",
+      "  /** Graft a subtree onto the board. */",
+      "  graft: Stream<GraftEvent>;",
       "  rename: Stream<RenameEvent>;",
       "}",
       "",
       "export default pattern<Record<string, never>, Out>(() => {",
       "  const items = cell<string[]>([]);",
-      "  const add = action((event: AddEvent) => { items.push(event.title); });",
+      "  const add = action((event: AddEvent) => {",
+      "    items.push(",
+      "      event.title + event.primary.label +",
+      "        event.details.tags.map((tag) => tag.label).join(','),",
+      "    );",
+      "  });",
+      "  const annotate = action((event: AddEvent) => {",
+      "    items.push(event.details.note);",
+      "  });",
+      "  const graft = action((event: GraftEvent) => {",
+      "    items.push(",
+      "      event.node.label +",
+      "        event.node.children.map((child) => child.label).join(','),",
+      "    );",
+      "  });",
       "  const rename = action((event: RenameEvent) => {",
       "    items.set([event.title]);",
       "  });",
-      "  return { items, add, rename };",
+      "  return { items, add, annotate, graft, rename };",
       "});",
     ].join("\n"),
   }],
@@ -71,6 +134,12 @@ const PROGRAM = {
 
 const VERB_PROSE = "File a new root item on the board.";
 const FIELD_PROSE = "One line naming the work.";
+/** `Details.note` — one declared reference deep. */
+const NESTED_PROSE = "Free text the caller may attach.";
+/** `Details.tags` — the array property, one declared reference deep. */
+const NESTED_ARRAY_PROSE = "Labels to file it under.";
+/** `Tag.label` — reached through the inlined `primary`, two deep. */
+const ELEMENT_PROSE = "The tag's visible text.";
 
 interface LivePiece {
   piece: unknown;
@@ -78,8 +147,10 @@ interface LivePiece {
   dispose: () => Promise<void>;
 }
 
-/** Compile and run the program above, and hand back the piece surface both
- * caller-facing commands walk. */
+/**
+ * Compile and run the program above, and hand back the piece surface both
+ * caller-facing commands walk.
+ */
 async function runLivePiece(passphrase: string): Promise<LivePiece> {
   const signer = await Identity.fromPassphrase(passphrase);
   const storageManager = StorageManager.emulate({ as: signer });
@@ -223,7 +294,120 @@ describe("an author's verb prose reaching a caller", () => {
         // piece a caller is talking to.
         expect(Object.keys(inputSchema.properties as object)).toEqual([
           "title",
+          "details",
+          "primary",
         ]);
+      } finally {
+        await live.dispose();
+      }
+    });
+
+    it("carries an array field's prose from behind a declared reference", async () => {
+      const live = await runLivePiece("verb-prose-listing-nested-array");
+      try {
+        const row = verbRow(await verbsJson(live), "add");
+        // `details` is a `$ref` to `Details` on the declared side and an inline
+        // object on the served one, so `tags` sits at a position the two
+        // documents do not share key-for-key. An overlay that recurses through
+        // `properties` without following a `$ref` finds the declared `details`
+        // has no `properties` of its own and stops, leaving this bare — which
+        // is the defect this case exists for.
+        expect(row.inputSchema).toMatchObject({
+          properties: {
+            details: {
+              description: "Anything else worth recording.",
+              properties: {
+                tags: { type: "array", description: NESTED_ARRAY_PROSE },
+              },
+            },
+          },
+        });
+      } finally {
+        await live.dispose();
+      }
+    });
+
+    it("carries an object field's prose from behind a declared reference", async () => {
+      const live = await runLivePiece("verb-prose-listing-nested-object");
+      try {
+        // `annotate` reads `details.note` and nothing else, so its served
+        // `details` is an inline object holding one undocumented scalar. The
+        // same declared reference has to be followed to reach it, at a
+        // different position and on a different verb.
+        const row = verbRow(await verbsJson(live), "annotate");
+        expect(row.inputSchema).toMatchObject({
+          properties: {
+            details: {
+              properties: {
+                note: { type: "string", description: NESTED_PROSE },
+              },
+            },
+          },
+        });
+      } finally {
+        await live.dispose();
+      }
+    });
+
+    it("terminates on a self-referential event type and annotates it", async () => {
+      const live = await runLivePiece("verb-prose-listing-cycle");
+      try {
+        // `Node.children` is `Node[]`, which compiles to a genuine cycle in the
+        // SERVED document: `$defs.AnonymousType_1.items` references
+        // `$defs.Node`, whose `children` references `AnonymousType_1` again.
+        // Following references without refusing a definition already visited
+        // does not fail this assertion — it never reaches it, exhausting the
+        // stack first. Reaching the assertion at all is half of what this pins.
+        const row = verbRow(await verbsJson(live), "graft");
+        // The other half: the cycle is walked far enough to be useful. The
+        // served `children` is a bare reference with no prose of its own, and
+        // its description comes from the declared `Node`, one reference in.
+        expect(row.inputSchema).toMatchObject({
+          properties: {
+            node: {
+              description: "The subtree to graft.",
+              properties: {
+                children: { description: "Nodes filed under this one." },
+              },
+            },
+          },
+        });
+      } finally {
+        await live.dispose();
+      }
+    });
+
+    it("leaves a served reference as a reference and its definition untouched", async () => {
+      const live = await runLivePiece("verb-prose-listing-ref-shape");
+      try {
+        const inputSchema = verbRow(await verbsJson(live), "add")
+          .inputSchema as Record<string, unknown>;
+        const properties = inputSchema.properties as Record<string, any>;
+        // `Tag` is reached twice — through `details.tags.items` and through
+        // `primary` — and both are served as references that must stay
+        // references, byte for byte. An implementation that inlined a target to
+        // annotate it would satisfy every description assertion in this file
+        // and silently change the shape a caller's tooling reads, so these are
+        // equalities rather than subsets.
+        expect(properties.details.properties.tags.items).toEqual({
+          $ref: "#/$defs/Tag",
+        });
+        expect(properties.primary).toEqual({
+          $ref: "#/$defs/Tag",
+          description: "The tag that leads.",
+        });
+        // And the shared definition is untouched. This is the assertion that
+        // fails against writing a position's own prose into the target it
+        // names: `primary` is "The tag that leads.", and a `Tag` carrying that
+        // sentence would tell every OTHER holder of a tag the same thing —
+        // including `details.tags`, which leads nothing.
+        expect((inputSchema.$defs as Record<string, any>).Tag).toEqual({
+          type: "object",
+          properties: {
+            label: { type: "string", description: ELEMENT_PROSE },
+          },
+          required: ["label"],
+        });
       } finally {
         await live.dispose();
       }
@@ -268,6 +452,58 @@ describe("an author's verb prose reaching a caller", () => {
       }
     });
 
+    it("carries an array field's prose from behind a declared reference", async () => {
+      const live = await runLivePiece("verb-prose-help-json-nested-array");
+      try {
+        // The help path assembles its spec separately from the listing, so a
+        // fix applied to one and not the other passes half this file. Both
+        // nested shapes are asserted on both surfaces for that reason.
+        expect((await callHelpJson(live, "add")).inputSchema).toMatchObject({
+          properties: {
+            details: {
+              properties: { tags: { description: NESTED_ARRAY_PROSE } },
+            },
+          },
+        });
+      } finally {
+        await live.dispose();
+      }
+    });
+
+    it("carries an object field's prose from behind a declared reference", async () => {
+      const live = await runLivePiece("verb-prose-help-json-nested-object");
+      try {
+        expect((await callHelpJson(live, "annotate")).inputSchema)
+          .toMatchObject({
+            properties: {
+              details: { properties: { note: { description: NESTED_PROSE } } },
+            },
+          });
+      } finally {
+        await live.dispose();
+      }
+    });
+
+    it("leaves a served reference as a reference and its definition untouched", async () => {
+      const live = await runLivePiece("verb-prose-help-json-ref-shape");
+      try {
+        const inputSchema = (await callHelpJson(live, "add"))
+          .inputSchema as Record<string, any>;
+        expect(inputSchema.properties.details.properties.tags.items).toEqual({
+          $ref: "#/$defs/Tag",
+        });
+        expect(inputSchema.$defs.Tag).toEqual({
+          type: "object",
+          properties: {
+            label: { type: "string", description: ELEMENT_PROSE },
+          },
+          required: ["label"],
+        });
+      } finally {
+        await live.dispose();
+      }
+    });
+
     it("leaves an undocumented verb with no description", async () => {
       const live = await runLivePiece("verb-prose-help-json-undocumented");
       try {
@@ -296,8 +532,14 @@ describe("an author's verb prose reaching a caller", () => {
     it("prints an event field's doc comment beside its flag", async () => {
       const live = await runLivePiece("verb-prose-help-text-field");
       try {
-        expect(await callHelpText(live, "add"))
-          .toContain(`--title <string>  Required. ${FIELD_PROSE}`);
+        // On the flag's own line, after its required-ness. The column width is
+        // whatever the widest flag on the page needs, so the gap is matched as
+        // whitespace rather than counted — but it must be a gap and not a line
+        // break, which is what makes this an assertion about the flag line
+        // rather than about the page containing the sentence anywhere.
+        expect(await callHelpText(live, "add")).toMatch(
+          new RegExp(`--title <string> +Required\\. ${FIELD_PROSE}`),
+        );
       } finally {
         await live.dispose();
       }

--- a/packages/cli/test/verb-prose-overlay.test.ts
+++ b/packages/cli/test/verb-prose-overlay.test.ts
@@ -1,0 +1,420 @@
+/**
+ * The two pure halves of verb documentation, tested directly against
+ * constructed schemas: reading an author's prose out of a compiled pattern's
+ * result schema, and folding it into the schema a caller is served.
+ *
+ * Its companion `verb-prose-live.test.ts` drives the same code through
+ * `cf piece verbs` and `cf piece call --help` against compiled, run patterns,
+ * and that is where the behavior a caller sees is pinned. This file exists for
+ * the shapes a compiled pattern does not produce and a served schema may still
+ * hold: a reference naming a definition that is not there, a definition that is
+ * a boolean, a tuple, an `allOf`. Those are the branches nothing would exercise
+ * otherwise, and an unexercised branch is the one that inverts unnoticed.
+ *
+ * The division is deliberate. A constructed schema is a claim about the world,
+ * and this file is careful to make only claims the live file does not need to
+ * carry — every position class here that a pattern CAN produce is asserted
+ * there as well, against output the compiler actually emitted.
+ */
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { JSONSchema } from "@commonfabric/api";
+import { declaredVerbProse, withDeclaredFieldProse } from "../lib/piece.ts";
+
+/** `withDeclaredFieldProse` with both sides as plain objects. */
+function fold(
+  served: JSONSchema | true,
+  declared: JSONSchema | undefined,
+): any {
+  return withDeclaredFieldProse(served, declared);
+}
+
+/** An object schema with the given properties, as both documents spell one. */
+function object(properties: Record<string, unknown>, rest: object = {}) {
+  return { type: "object", properties, ...rest } as unknown as JSONSchema;
+}
+
+describe("verb prose", () => {
+  describe("withDeclaredFieldProse()", () => {
+    describe("positions it walks", () => {
+      it("fills a property's description", () => {
+        const result = fold(
+          object({ title: { type: "string" } }),
+          object({ title: { type: "string", description: "The title." } }),
+        );
+        expect(result.properties.title.description).toBe("The title.");
+      });
+
+      it("fills a description inside a single-schema `items`", () => {
+        const result = fold(
+          {
+            type: "array",
+            items: object({ x: { type: "string" } }),
+          } as unknown as JSONSchema,
+          {
+            type: "array",
+            items: object({ x: { type: "string", description: "An x." } }),
+          } as unknown as JSONSchema,
+        );
+        expect(result.items.properties.x.description).toBe("An x.");
+      });
+
+      it("fills a description at a `prefixItems` position, by index", () => {
+        const result = fold(
+          {
+            type: "array",
+            prefixItems: [{ type: "string" }, { type: "number" }],
+          } as unknown as JSONSchema,
+          {
+            type: "array",
+            prefixItems: [
+              { type: "string", description: "First." },
+              { type: "number", description: "Second." },
+            ],
+          } as unknown as JSONSchema,
+        );
+        // Index is a tuple position's whole identity, so the two descriptions
+        // must not be swapped — asserted as a pair for that reason.
+        expect(result.prefixItems.map((p: any) => p.description)).toEqual([
+          "First.",
+          "Second.",
+        ]);
+        // And the list is still a list. Addressing an index and then
+        // object-spreading the container would hand back `{"0": …, "1": …}`.
+        expect(Array.isArray(result.prefixItems)).toBe(true);
+      });
+
+      it("fills a description at a positional `items` entry, by index", () => {
+        const result = fold(
+          {
+            type: "array",
+            items: [{ type: "string" }],
+          } as unknown as JSONSchema,
+          {
+            type: "array",
+            items: [{ type: "string", description: "The only one." }],
+          } as unknown as JSONSchema,
+        );
+        expect(Array.isArray(result.items)).toBe(true);
+        expect(result.items[0].description).toBe("The only one.");
+      });
+
+      for (const keyword of ["allOf", "anyOf", "oneOf"] as const) {
+        it(`fills a description inside a \`${keyword}\` member, by index`, () => {
+          const result = fold(
+            {
+              [keyword]: [object({ x: { type: "string" } })],
+            } as unknown as JSONSchema,
+            {
+              [keyword]: [
+                object({ x: { type: "string", description: "An x." } }),
+              ],
+            } as unknown as JSONSchema,
+          );
+          expect(result[keyword][0].properties.x.description).toBe("An x.");
+          expect(Array.isArray(result[keyword])).toBe(true);
+          expect(result[keyword]).toHaveLength(1);
+        });
+      }
+
+      it("finds a property's prose in whichever declared arm declares it", () => {
+        // The served side spells a union as one merged object, which is what
+        // the compiler emits when a handler reads fields from both arms. The
+        // prose for each field is inside a different arm.
+        const result = fold(
+          object({ meow: { type: "string" }, woof: { type: "string" } }),
+          {
+            anyOf: [
+              object({ meow: { type: "string", description: "How loud." } }),
+              object({ woof: { type: "string", description: "How deep." } }),
+            ],
+          } as unknown as JSONSchema,
+        );
+        expect(result.properties.meow.description).toBe("How loud.");
+        expect(result.properties.woof.description).toBe("How deep.");
+      });
+
+      it("follows a reference on either side to reach a position", () => {
+        const result = fold(
+          object({ pet: { $ref: "#/$defs/Cat" } }, {
+            $defs: { Cat: object({ meow: { type: "string" } }) },
+          }),
+          object({ pet: { $ref: "#/$defs/Cat" } }, {
+            $defs: {
+              Cat: object({ meow: { type: "string", description: "Loud." } }),
+            },
+          }),
+        );
+        // Written into the served definition, and the reference to it left
+        // exactly as it was.
+        expect(result.$defs.Cat.properties.meow.description).toBe("Loud.");
+        expect(result.properties.pet).toEqual({ $ref: "#/$defs/Cat" });
+      });
+    });
+
+    describe("what it refuses to do", () => {
+      it("gives no arm the description of the position holding it", () => {
+        // The served side spells a disjunction the declared side does not, so
+        // the arms cannot be paired. The declared node's own sentence describes
+        // the position, not any one alternative, and copying it onto every arm
+        // would describe each of them wrongly.
+        const result = fold(
+          {
+            anyOf: [
+              object({ x: { type: "string" } }),
+              object({ y: { type: "string" } }),
+            ],
+          } as unknown as JSONSchema,
+          object({ x: { type: "string", description: "An x." } }, {
+            description: "The whole thing.",
+          }),
+        );
+        expect(result.anyOf[0].description).toBeUndefined();
+        expect(result.anyOf[1].description).toBeUndefined();
+        // Nested positions are still reached, which is the whole reason the
+        // unpaired case descends at all.
+        expect(result.anyOf[0].properties.x.description).toBe("An x.");
+      });
+
+      it("never overwrites a description the served schema already carries", () => {
+        const result = fold(
+          object({ title: { type: "string", description: "Served says." } }),
+          object({ title: { type: "string", description: "Declared says." } }),
+        );
+        expect(result.properties.title.description).toBe("Served says.");
+      });
+
+      it("adds no property the served schema does not carry", () => {
+        const result = fold(
+          object({ title: { type: "string" } }),
+          object({
+            title: { type: "string" },
+            extra: { type: "string", description: "Not served." },
+          }),
+        );
+        expect(Object.keys(result.properties)).toEqual(["title"]);
+      });
+
+      it("takes no description for the root position", () => {
+        // The root's prose belongs to the VERB and rides the spec's own
+        // `description`; putting it here would make it a claim about the event
+        // object a caller sends.
+        const result = fold(
+          object({ title: { type: "string" } }),
+          object({ title: { type: "string" } }, { description: "The verb." }),
+        );
+        expect(result.description).toBeUndefined();
+      });
+
+      it("returns the same object when there is nothing to fill", () => {
+        const served = object({ title: { type: "string" } });
+        // Identity, not equality: every subtree no edit touches is shared, so a
+        // rebuild that copied the document wholesale would fail here even
+        // though its output looked right.
+        expect(fold(served, object({ title: { type: "string" } })))
+          .toBe(served);
+      });
+
+      it("returns an unconstrained served schema untouched", () => {
+        expect(fold(true, object({ x: { type: "string" } }))).toBe(true);
+      });
+    });
+
+    describe("shapes it cannot read", () => {
+      it("leaves a served reference naming no definition alone", () => {
+        const served = object({ pet: { $ref: "#/$defs/Missing" } }, {
+          $defs: { Cat: object({ meow: { type: "string" } }) },
+        });
+        const result = fold(
+          served,
+          object({
+            pet: object({ meow: { type: "string", description: "L." } }),
+          }),
+        );
+        expect(result).toBe(served);
+      });
+
+      it("leaves a served reference alone when the root defines nothing", () => {
+        const served = object({ pet: { $ref: "#/$defs/Cat" } });
+        const result = fold(
+          served,
+          object({
+            pet: object({ meow: { type: "string", description: "L." } }),
+          }),
+        );
+        expect(result).toBe(served);
+      });
+
+      it("leaves a served reference to a non-schema definition alone", () => {
+        const served = object({ pet: { $ref: "#/$defs/Cat" } }, {
+          $defs: { Cat: true },
+        });
+        const result = fold(
+          served,
+          object({
+            pet: object({ meow: { type: "string", description: "L." } }),
+          }),
+        );
+        expect(result).toBe(served);
+      });
+
+      it("leaves a position alone when the declared reference does not resolve", () => {
+        const served = object({ pet: object({ meow: { type: "string" } }) });
+        const result = fold(
+          served,
+          object({ pet: { $ref: "#/$defs/Gone" } }),
+        );
+        expect(result).toBe(served);
+      });
+
+      it("leaves a served position with no declared counterpart alone", () => {
+        const served = object({ title: { type: "string" } });
+        expect(fold(served, object({ other: { type: "string" } })))
+          .toBe(served);
+      });
+
+      it("leaves served tuple positions alone when the declared side has none", () => {
+        // A tuple pairs by index and by nothing else, so a declared side that
+        // spells the same position as a single element schema offers no index
+        // to pair with. Filling from it would put the element type's prose on
+        // whichever tuple slot happened to come first.
+        const served = {
+          type: "array",
+          prefixItems: [{ type: "string" }, { type: "number" }],
+        } as unknown as JSONSchema;
+        const declared = {
+          type: "array",
+          items: { type: "string", description: "Every element." },
+        } as unknown as JSONSchema;
+        expect(fold(served, declared)).toBe(served);
+      });
+
+      it("skips a combinator member that is not a schema object", () => {
+        // `anyOf: [true, …]` is legal and carries no positions. Asking it for
+        // one must skip it rather than treat `true` as a node with properties.
+        const result = fold(
+          object({ x: { type: "string" } }),
+          {
+            anyOf: [
+              true,
+              object({ x: { type: "string", description: "An x." } }),
+            ],
+          } as unknown as JSONSchema,
+        );
+        expect(result.properties.x.description).toBe("An x.");
+      });
+
+      it("leaves a non-object served position alone", () => {
+        const served = object({ anything: true });
+        expect(
+          fold(
+            served,
+            object({ anything: { type: "string", description: "A." } }),
+          ),
+        ).toBe(served);
+      });
+
+      it("walks none of the keywords outside its enumerated list", () => {
+        // The contract names what it walks; this is the other half of that
+        // claim, and it fails the day one of these is added without the
+        // documentation catching up.
+        const served = object({}, {
+          additionalProperties: object({ x: { type: "string" } }),
+          not: object({ y: { type: "string" } }),
+          if: object({ z: { type: "string" } }),
+        });
+        const declared = object({}, {
+          additionalProperties: object({
+            x: { type: "string", description: "An x." },
+          }),
+          not: object({ y: { type: "string", description: "A y." } }),
+          if: object({ z: { type: "string", description: "A z." } }),
+        });
+        expect(fold(served, declared)).toBe(served);
+      });
+    });
+
+    describe("termination", () => {
+      it("returns for a schema whose definitions reference each other", () => {
+        // Reaching this assertion at all is what it pins: a walk that follows
+        // references without refusing a definition it has already visited
+        // exhausts the stack before returning.
+        const cyclic = (described: boolean) =>
+          object({ root: { $ref: "#/$defs/Node" } }, {
+            $defs: {
+              Node: object({
+                label: described
+                  ? { type: "string", description: "Its name." }
+                  : { type: "string" },
+                kids: { type: "array", items: { $ref: "#/$defs/Node" } },
+              }),
+            },
+          });
+        const result = fold(cyclic(false), cyclic(true));
+        expect(result.$defs.Node.properties.label.description)
+          .toBe("Its name.");
+      });
+
+      it("returns for a combinator whose members reference each other", () => {
+        const cyclic = (described: boolean) =>
+          object({ root: { $ref: "#/$defs/Loop" } }, {
+            $defs: {
+              Loop: {
+                anyOf: [
+                  { $ref: "#/$defs/Loop" },
+                  object({
+                    end: described
+                      ? { type: "string", description: "The end." }
+                      : { type: "string" },
+                  }),
+                ],
+              },
+            },
+          });
+        const result = fold(cyclic(false), cyclic(true));
+        expect(result.$defs.Loop.anyOf[1].properties.end.description)
+          .toBe("The end.");
+      });
+    });
+  });
+
+  describe("declaredVerbProse()", () => {
+    it("returns a verb's own description and its resolved event schema", () => {
+      const prose = declaredVerbProse({
+        resultSchema: object({
+          add: { $ref: "#/$defs/AddEvent", description: "Add one." },
+        }, {
+          $defs: { AddEvent: object({ title: { type: "string" } }) },
+        }),
+      });
+      expect(prose.get("add")?.description).toBe("Add one.");
+      expect(prose.get("add")?.eventSchema).toMatchObject({
+        properties: { title: { type: "string" } },
+      });
+    });
+
+    it("skips a result property that is not a schema object", () => {
+      const prose = declaredVerbProse({
+        resultSchema: object({ anything: true, add: { description: "Add." } }),
+      });
+      expect(prose.has("anything")).toBe(false);
+      expect(prose.get("add")?.description).toBe("Add.");
+    });
+
+    it("skips a property whose reference resolves to nothing and says nothing", () => {
+      // No description of its own and no reachable event schema: there is
+      // nothing to report, and an entry here would be an empty promise a caller
+      // of the map has to re-check.
+      const prose = declaredVerbProse({
+        resultSchema: object({ add: { $ref: "#/$defs/Gone" } }),
+      });
+      expect(prose.has("add")).toBe(false);
+    });
+
+    it("returns nothing for a pattern with no result schema", () => {
+      expect(declaredVerbProse(undefined).size).toBe(0);
+      expect(declaredVerbProse({}).size).toBe(0);
+      expect(declaredVerbProse({ resultSchema: true }).size).toBe(0);
+    });
+  });
+});

--- a/packages/cli/test/verb-prose-overlay.test.ts
+++ b/packages/cli/test/verb-prose-overlay.test.ts
@@ -117,6 +117,77 @@ describe("verb prose", () => {
         });
       }
 
+      it("visits one definition once per arm that names it", () => {
+        // Both arms reference `Cat`, each adding its own sentence at the ref
+        // site. A guard recording "this reference has been seen" rather than
+        // "this reference is open on the path" drops the second arm whole, and
+        // with it the only account of `loud`.
+        const result = fold(
+          object({ quiet: { type: "string" }, loud: { type: "string" } }),
+          {
+            anyOf: [
+              {
+                $ref: "#/$defs/Cat",
+                properties: { quiet: { description: "Barely heard." } },
+              },
+              {
+                $ref: "#/$defs/Cat",
+                properties: { loud: { description: "Heard next door." } },
+              },
+            ],
+            $defs: {
+              Cat: object({
+                quiet: { type: "string" },
+                loud: { type: "string" },
+              }),
+            },
+          } as unknown as JSONSchema,
+        );
+        expect(result.properties.quiet.description).toBe("Barely heard.");
+        expect(result.properties.loud.description).toBe("Heard next door.");
+      });
+
+      it("prefers the arm that documents a field over one that merely declares it", () => {
+        // The first arm mentions `meow` without saying anything about it.
+        // Taking the first arm that HAS the key, rather than the first that
+        // SAYS something, loses the only sentence written about this field.
+        const result = fold(
+          object({ meow: { type: "string" } }),
+          {
+            anyOf: [
+              object({ meow: { type: "string" } }),
+              object({ meow: { type: "string", description: "How loud." } }),
+            ],
+          } as unknown as JSONSchema,
+        );
+        expect(result.properties.meow.description).toBe("How loud.");
+      });
+
+      it("resolves a nested reference in the scope that declares it", () => {
+        // `Outer` carries `$defs` of its own, and its `pet` names a `Cat`
+        // declared there — a different `Cat` from the one at the event root.
+        // Resolving in the root scope finds the root's, whose `meow` says
+        // nothing: the prose is lost, and a WRONG document answered.
+        const result = fold(
+          object({ pet: object({ meow: { type: "string" } }) }),
+          {
+            $ref: "#/$defs/Outer",
+            $defs: {
+              Outer: object({ pet: { $ref: "#/$defs/Cat" } }, {
+                $defs: {
+                  Cat: object({
+                    meow: { type: "string", description: "The inner cat." },
+                  }),
+                },
+              }),
+              Cat: object({ meow: { type: "string" } }),
+            },
+          } as unknown as JSONSchema,
+        );
+        expect(result.properties.pet.properties.meow.description)
+          .toBe("The inner cat.");
+      });
+
       it("finds a property's prose in whichever declared arm declares it", () => {
         // The served side spells a union as one merged object, which is what
         // the compiler emits when a handler reads fields from both arms. The
@@ -132,6 +203,53 @@ describe("verb prose", () => {
         );
         expect(result.properties.meow.description).toBe("How loud.");
         expect(result.properties.woof.description).toBe("How deep.");
+      });
+
+      it("reaches one served definition from every position that names it", () => {
+        // Two served positions share `$defs/Cat`. The first position's declared
+        // account says nothing; the second's documents the field. A guard that
+        // retires a served definition after one visit stops at the first and
+        // the prose is never found — the same "seen once" mistake as on the
+        // declared side, on the other document.
+        const served = object({
+          stray: { $ref: "#/$defs/Cat" },
+          housecat: { $ref: "#/$defs/Cat" },
+        }, { $defs: { Cat: object({ meow: { type: "string" } }) } });
+        const result = fold(
+          served,
+          object({
+            stray: object({ meow: { type: "string" } }),
+            housecat: object({
+              meow: { type: "string", description: "How loud." },
+            }),
+          }),
+        );
+        expect(result.$defs.Cat.properties.meow.description).toBe("How loud.");
+      });
+
+      it("gives a shared served definition the first account of it", () => {
+        // Both positions reach `$defs/Cat` and both are documented, so both
+        // want to write the same slot. A definition is shared, so one of them
+        // has to lose: the first in document order wins, deterministically.
+        // Letting the later one through would make the words a caller reads
+        // depend on property ordering.
+        const served = object({
+          alpha: { $ref: "#/$defs/Cat" },
+          beta: { $ref: "#/$defs/Cat" },
+        }, { $defs: { Cat: object({ meow: { type: "string" } }) } });
+        const result = fold(
+          served,
+          object({
+            alpha: object({
+              meow: { type: "string", description: "Alpha's account." },
+            }),
+            beta: object({
+              meow: { type: "string", description: "Beta's account." },
+            }),
+          }),
+        );
+        expect(result.$defs.Cat.properties.meow.description)
+          .toBe("Alpha's account.");
       });
 
       it("follows a reference on either side to reach a position", () => {


### PR DESCRIPTION
## Why

Closes #5637 (verbs arc, step 5a).

An author documents a verb where its `Stream` is declared, and documents each
event field where the field is declared. Both survive compilation. Neither
reached `cf`, so `cf piece verbs` could list a verb and never say what it does —
and that is the surface a person, a script, or an agent uses to *discover* what
a piece can do.

It is load-bearing rather than cosmetic. `docs/history/plans/pattern-verb-contract-implementation.md`
records verb result shapes as having no update-gate protection, with the
accepted interim being "prose in the verb's `description`" — exactly what was
being lost.

**The diagnosis is not what the issue's three prior hypotheses said**, and the
difference decides where the fix goes.

- The `$ref`-sibling story is dead: `schema-refs.ts:resolveCfcSchemaRefsUncached`
  merges ref-site siblings *over* the resolved target on purpose.
- The `resolveSchema`-has-no-root lead is dead **on the served path**, measured:
  `cell.ts:key` carries the reachable `$defs` closure onto the child schema, so
  `resolveSchema(result.key("add").schema)` returns the fully merged form with
  *both* descriptions. Nothing on the served path resolves a `$ref` at all.
- It is **one mechanism**. `cell.ts:asSchemaFromLinks` discards the property
  schema `key()` built — sibling `description`, `$defs` closure and all — and
  adopts the schema embedded in the resolved link chain. For a verb that link is
  the handler node's `$event` input, which is the handler's **read** of the
  event, narrowed to the fields its body touches. It never carried an author's
  words, so nothing stripped them.

That also settles the fact the issue could not reconcile — "something resolved,
because the caller receives a populated inlined event shape". Nothing resolved.
The populated shape is the `$event` read schema, which was never a `$ref`.

## What Changed

The prose is read from the compiled pattern's `resultSchema`, the only document
that keeps it. Both commands already load that pattern to report what a verb
hands back, so neither pays a new load — `declaredResult` and the new
`declaredProse` share one.

- `piece.ts:declaredVerbProse` reads `resultSchema.properties.<verb>` and
  follows its `$ref` against the result-schema **root**, where the `$defs` live.
- The verb's own comment becomes `PieceCallableListing.description`
  (`cf piece verbs --json`) and `ExecCommandSpec.description`, which
  `renderExecHelpJson` emits and `renderPieceCallHelp` prints as a summary line.
- Event-field comments are folded into the input schema the page renders flags
  from, by `piece.ts:withDeclaredFieldProse` — **annotations only**. The served
  schema stays the authority on shape, so a page can never offer a flag the
  running handler does not read.
- `docs/common/verb-session-walkthrough.md` described the old, wrong mechanism
  and marked these steps blocked; it now describes what the page renders.
- `verb-session-gaps.sh` asserted this as a gap that "fails loudly the day it
  closes". It closed, so those became capability checks.

### The overlay's contract, and why it is an enumeration

`withDeclaredFieldProse` walks: `properties` by key; `items` in its
single-schema and positional forms; `prefixItems` by index; and the members of
`allOf`, `anyOf`, `oneOf`. It names the keywords it does **not** walk. Three
rounds of review each found the walk missing a position class while a universal
claim ("every position the schemas share") said otherwise, so the comment is now
a list a reader can check against the code in seconds — and a test asserts the
unwalked keywords stay unwalked.

Three rules decide which declared account answers a position, each a place a
shorter implementation loses prose: every account is consulted, not the first
that mentions the position; the first that actually *says* something wins, in
declaration order, rather than a merge that would fabricate prose; and a
reference resolves in the scope that declares it, threaded with
`cfcSchemaChildRoot` / `resolveCfcSchemaRefRoot` — the shape #5817 established
for the same problem in the projection reader.

Termination is by two path stacks, not seen-sets. "Ever seen" cannot tell a
cycle from a legitimate second visit, and drops the second along with its prose.

**Not taken, and why.** The third symptom — an event *interface's* own comment —
is a genuine emission gap in `schema-generator`, a different package and lane;
it stays with #5559.

## Test plan

`test/verb-prose-live.test.ts` drives `cf piece verbs --json`,
`cf piece call --help` and `--help --json` against compiled, run patterns.
`test/verb-prose-overlay.test.ts` tests the two pure halves directly, for the
degenerate shapes a compiled pattern cannot produce.

Red first at every round: 10/13 steps failed before the original change; the
nested-reference cases failed before round two; the union case before round
three; the four context cases before round four.

### Mutation evidence

Guards that pass in both states by construction are proved to fail:

| mutation | reds |
| --- | --- |
| write a position's prose into the `$defs` target it names | both shape guards |
| deep-inline every served `$ref` before annotating | both shape guards |
| remove the cycle guard | `RangeError: Maximum call stack size exceeded` |
| remove combinator + positional descent | 5 position-class cases |
| remove the array-aware copy | same 5 (`{"0": …}` instead of a list) |
| let unpaired arms take the position's description | the no-arm-takes-it case |
| stop flattening declared combinators | unit *and* live union cases |
| restore the global declared-ref set | the sibling-reuse case, and nothing else |
| take the first account that mentions a position | the documents-vs-declares case |
| resolve every reference at the event root | the nested-scope case |
| restore the global served-definition set | the shared-definition case |
| drop the first-wins edit guard | the shared-definition ordering case |

### Coverage

`packages/cli` debt against the merge-base, the repo's own metric:

```
coverage-debt: packages/cli uncovered lines:  base=3228  head=3228  delta=+0
```

Added-and-uncovered lines in the two changed source files: **0**. The thirteen
reported earlier are gone — eight were real branches, now covered by direct
tests; five were dead defensive guards whose invariant is now stated instead.

### Gates

`packages/cli` `deno task test` **0** (1680 + 174 passed, 0 failed) ·
`deno fmt --check` **0** · `deno lint` **0** · `deno task check` **0** ·
`check-no-waitfor` **0** · `check-docs` **0** · `check-conflict-markers` **0** ·
`check-skill-facts` **0** · `bash -n verb-session-gaps.sh` **0**

Not run: `verb-session-gaps.sh` needs a live toolshed. Its needle extraction was
verified against the fixture and the strings match the page this branch renders.

## Two findings for the arc, neither fixed here

**A declared event field the handler body never reads is invisible to a
caller.** Measured three ways: optional-and-unread absent, optional-and-read
present, required-and-unread absent — read-narrowing, not optionality. Whether a
caller is owed the declared type or the read schema is a design question,
recorded in the walkthrough's gap table rather than decided.

**A result field's prose still misses the text page** — already served under
`--help --json`, one line of rendering away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
