### PR TITLE
docs: drop "modern" where nothing old is left, and fix a wrong registry entry

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -1205,13 +1205,20 @@ ESM module-record loader is now the only loader. See
 [`docs/history/specs/module-loading-implementation-plan.md`](../history/specs/module-loading-implementation-plan.md),
 whose status header records the removal.
 
-### `EXPERIMENTAL_MODERN_DATA_MODEL` (never implemented)
+### `modernDataModel` / `MODERN_DATA_MODEL` (removed)
 
-Mentioned only in
+The flag that selected the fabric data model during its rollout. It was a
+memory-config flag with a matching environment variable, carried in the memory
+protocol's flag set so that peers agreed on which encoding was in use, and it
+bifurcated cell-storage behavior along with the tests that pinned it — interned
+symbols and the special numbers among them — for as long as the two encodings
+coexisted. It ran from March 2026 until #3821 removed the environment variable
+and the memory-config flag together; the fabric data model is now the only one.
+
 [`docs/history/specs/persistent-scheduler-state/implementation_notes.md`](../history/specs/persistent-scheduler-state/implementation_notes.md)
-as an example of how to plumb a flag through the runtime, shell, toolshed, and
-CLI. It was never built; the persistent-scheduler-state flag was built instead,
-following the same plumbing pattern.
+cites it as the worked example of how to plumb a flag through the runtime,
+shell, toolshed, and CLI, which is the pattern the persistent-scheduler-state
+flag then followed.
 
 ---
 

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -15,10 +15,10 @@ Draft formal spec — extracted from the data model proposal.
 ### 1.1 Overview
 
 The system stores **fabric values** — data that can flow through the runtime
-as modern types and be serialized to wire/storage formats at boundary crossings.
+as typed values and be serialized to wire/storage formats at boundary crossings.
 All persistent data and in-flight messages use this representation.
 
-The key design principle is **late serialization**: modern types flow through the
+The key design principle is **late serialization**: values flow through the
 runtime as themselves; serialization to wire/storage formats happens only at
 boundary crossings (persistence, IPC, network).
 
@@ -2554,7 +2554,7 @@ export interface SerializationContext<SerializedForm = unknown> {
 - `encode(value)` serializes a `FabricValue` into the `/<Type>@<Version>`
   tagged wire format, then stringifies the result.
 - `decode(data, context)` parses a JSON string, then deserializes tagged
-  forms back into modern runtime types.
+  forms back into runtime types.
 
 > **Why the boundary is this narrow.** Tag wrapping and unwrapping are
 > machinery internal to the context class, leaving only the
@@ -2573,7 +2573,7 @@ Internally, `JsonCodecEngine`'s `encode()` method calls a private encode walker
 (`#encodeValue()`) to walk the `FabricValue` tree and produce a
 `JsonCodecValue` tree, then stringifies it. The `decode()` method parses
 the JSON string, then calls a private decode walker (`#decodeValue()`) to
-walk the `JsonCodecValue` tree and reconstruct modern runtime types. The
+walk the `JsonCodecValue` tree and reconstruct runtime types. The
 recursive descent and codec dispatch are entirely internal to `JsonCodecEngine`.
 
 ### 4.5 Codecs, the Registry, and Internal Tree Walking


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) audited the tree for `modern`-something
language with no surviving legacy referent. Two things came out of it: four
orphaned lines in one spec, and a registry entry that turned out to be
factually wrong.

## 1. Four orphans in the fabric-values spec

`docs/specs/space-model-formal-spec/1-fabric-values.md`:

| before | after |
| --- | --- |
| data that can flow through the runtime **as modern types** | **as typed values** |
| late serialization: **modern types** flow through the runtime as themselves | **values** flow through the runtime as themselves |
| deserializes tagged forms back into **modern runtime types** | back into **runtime types** |
| reconstruct **modern runtime types** | reconstruct **runtime types** |

The contrast each of these draws is between a value *in the runtime* and the
same value *serialized* — that is what late serialization means, and what
decode undoes. None of them contrasts with an older type system, because there
isn't one. The file's six uses of `legacy` are all decode-only affordances
(legacy link forms, legacy-data import, legacy `Error` wrapping), none of which
is a superseded type system. So the word points at a referent a reader will
look for and not find.

Two `modern`s stay in that file, both with a live counterpart:

- **line 1184** — "the modern, object-shaped form of a reference to fabric
  data". That is the arm `modernCellRep` selects, against the
  `{ "/": { "link@1": … } }` sigil envelope the flag still **defaults to**.
  Both forms ship.
- **line 2847** — "Old context reads legacy format, new context writes modern
  format", an abstract illustration of why codec contexts are pluggable. Both
  halves are named in the one sentence.

## 2. The flag registry said a shipped flag was never built

`EXPERIMENTAL_OPTIONS.md` filed `EXPERIMENTAL_MODERN_DATA_MODEL` under **"never
implemented"**, on the strength of a single mention in a history document. I
repeated that claim in the first version of this description, and @danfuzz
caught it: the flag shipped and ran for months.

| when | what |
| --- | --- |
| 2026-03-16 → 03-19 | `modernDataModel` / `MODERN_DATA_MODEL` first appear (#3134, and the memory version-override seam) |
| through spring | "Bifurcate cell-storage Symbol tests across `modernDataModel`" (#3511); the same for special numbers (#3499) |
| 2026-06-02 | #3821 removes the environment variable and the memory-config flag together, and drops it from `parseMemoryProtocolFlags()` |

It was a memory-config flag with a matching environment variable, carried in
the memory protocol's flag set so peers agreed on which encoding was in use,
and it bifurcated cell-storage behavior along with the tests that pinned it.

The entry is now `### modernDataModel / MODERN_DATA_MODEL (removed)`, shaped
like the `esmModuleLoader` entry beside it. The history document keeps its role
as the worked example of plumbing a flag through the runtime, shell, toolshed
and CLI — that part was accurate; only "it was never built" was not. Nothing
links to the old anchor.

## The rest of the audit, for the record

315 live occurrences of `modern*` across 71 files, and the four above were the
only orphans. The rest: 144 are the `modernCellRep` flag with its env var and
config accessors; 30 are the Scrabble word list (`MODERNISATION` is a legal
play); 15 are the *Frankenstein* fixture in `content-hash` ("the Modern
Prometheus"); 9 are ordinary English ("modern browsers", "a modern dark
scheme"); and the balance sit against a live legacy arm — `state-inspector`'s
typed `Regime = "modern" | "legacy" | "n/a"` with its written retirement note,
`runner`'s "modern manifest" against a **pre-manifest** form the same test
exercises, and the `modernCellRep` regime throughout `runner`, `data-model`,
`memory`, `api` and `piece`.

`modernCellRep` is the only live flag named that way.

Left alone deliberately, as active work: `runner/src/sigil-types.ts:99`, whose
comment describes a future that has since arrived, and
`docs/specs/memory-v2/04-protocol.md:396`, which calls a `link@1` payload
"modern" where line 459 of the same document calls that shape the legacy
representation.

## Checks

`deno task check-docs`: **All 549 checked code block(s) passed.**
`check-docs-history-index` and `check-skill-facts` clean. `deno fmt --check`
clean over the tree. No line exceeds 80 columns.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


