### PR TITLE
fix(data-model): validate a `RegExp@1` state's fields before building one

### DIFF
--- a/packages/data-model/src/codec-common/BaseCodecEngine.ts
+++ b/packages/data-model/src/codec-common/BaseCodecEngine.ts
@@ -83,9 +83,13 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
    * Encodes a fabric value into this format's serialized form, ready to cross
    * whatever boundary the format exists for.
    *
-   * The result carries a marker identifying the format, so that a receiver can
-   * tell one of these from an arbitrary value arriving on the same channel.
-   * What that marker is belongs to the format.
+   * Whether the result identifies itself is the format's to decide, and the
+   * decision follows from its boundary. A form that is persisted, or that
+   * shares a channel with values this system did not write, needs a marker so
+   * a receiver can tell one of these from anything else arriving; a form
+   * constructed, handed straight to a transport and decoded on the far side
+   * has nothing for a marker to distinguish it from. A format that carries one
+   * says what it is, and one that does not says why not.
    *
    * @throws If `value` holds something the format cannot carry: a
    *   `FabricSpecialObject` whose class no codec in the registry claims, a
@@ -110,8 +114,10 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
    * a value survives a round trip through a reader that does not know the
    * type.
    *
-   * @throws If `data` does not carry this format's marker, or if a codec
-   *   rejects a state and this instance is not lenient.
+   * @throws If `data` is not this format's serialized form -- which a format
+   *   carrying a marker can tell from the marker alone, and one without can
+   *   only tell from meeting something it never emits -- or if a codec rejects
+   *   a state and this instance is not lenient.
    */
   abstract decode(
     data: SerializedForm,

--- a/packages/data-model/src/fabric-primitives/FabricRegExp.ts
+++ b/packages/data-model/src/fabric-primitives/FabricRegExp.ts
@@ -138,23 +138,28 @@ export class FabricRegExp extends BaseFabricPrimitive
    * Reads the three fields a wire state carries, or `null` if any of them is
    * present with a type it cannot have.
    *
-   * A missing field takes its default, which is what lets a narrower encoder
-   * omit one. A field that is present and not a string is a different thing
-   * entirely: the constructor stores a non-`es2025` flavor's `source` and
-   * `flags` without touching them, so an unchecked object here reaches the
-   * public getters, which are typed `string`, and takes an unfrozen reference
-   * into a frozen instance with it.
+   * An absent field takes its default, which is what lets a narrower encoder
+   * omit one. A field that is *present* and not a string is a different thing
+   * entirely, and that includes one present as `undefined`: nothing here emits
+   * such a state, and defaulting it would silently answer a question the wire
+   * did actually ask -- a `flavor` sent that way would come back `es2025`,
+   * naming a dialect the sender did not.
+   *
+   * The rest matters more than it looks. The constructor stores a non-`es2025`
+   * flavor's `source` and `flags` without touching them, so an unchecked
+   * object here reaches the public getters, which are typed `string`, and
+   * takes an unfrozen reference into a frozen instance with it.
    */
   static #stateFields(
     state: Record<string, unknown>,
   ): { flavor: string; source: string; flags: string } | null {
-    const { flavor, source, flags } = state;
-
-    for (const one of [flavor, source, flags]) {
-      if ((one !== undefined) && (typeof one !== "string")) {
+    for (const key of ["flavor", "source", "flags"] as const) {
+      if (Object.hasOwn(state, key) && (typeof state[key] !== "string")) {
         return null;
       }
     }
+
+    const { flavor, source, flags } = state;
 
     return {
       flavor: (flavor as string | undefined) ?? DEFAULT_FLAVOR,

--- a/packages/data-model/src/fabric-primitives/FabricRegExp.ts
+++ b/packages/data-model/src/fabric-primitives/FabricRegExp.ts
@@ -134,6 +134,35 @@ export class FabricRegExp extends BaseFabricPrimitive
   // Static members
   //
 
+  /**
+   * Reads the three fields a wire state carries, or `null` if any of them is
+   * present with a type it cannot have.
+   *
+   * A missing field takes its default, which is what lets a narrower encoder
+   * omit one. A field that is present and not a string is a different thing
+   * entirely: the constructor stores a non-`es2025` flavor's `source` and
+   * `flags` without touching them, so an unchecked object here reaches the
+   * public getters, which are typed `string`, and takes an unfrozen reference
+   * into a frozen instance with it.
+   */
+  static #stateFields(
+    state: Record<string, unknown>,
+  ): { flavor: string; source: string; flags: string } | null {
+    const { flavor, source, flags } = state;
+
+    for (const one of [flavor, source, flags]) {
+      if ((one !== undefined) && (typeof one !== "string")) {
+        return null;
+      }
+    }
+
+    return {
+      flavor: (flavor as string | undefined) ?? DEFAULT_FLAVOR,
+      source: (source as string | undefined) ?? "",
+      flags: (flags as string | undefined) ?? "",
+    };
+  }
+
   static #jsonCodec = Object.freeze(
     new (class RegExpCodec extends BaseNonterminalCodec {
       /** Constructs an instance. */
@@ -163,15 +192,22 @@ export class FabricRegExp extends BaseFabricPrimitive
             `RegExp: expected object state, got ${typeof state}`,
           );
         }
-        // Beyond requiring an object, this class does not enforce regex
-        // syntax as part of its wire participation: only the `es2025` flavor
-        // is validated (eagerly, by the constructor building a native
-        // `RegExp`); other flavors are stored faithfully and may carry
-        // arbitrary `source`/`flags`. So a malformed non-`es2025` wire object
-        // is accepted as-is rather than becoming a `ProblematicValue`.
-        const flavor = (state.flavor as string) ?? DEFAULT_FLAVOR;
-        const source = (state.source as string) ?? "";
-        const flags = (state.flags as string) ?? "";
+        // Beyond the three fields being strings, this class does not enforce
+        // regex syntax as part of its wire participation: only the `es2025`
+        // flavor is validated, eagerly, by the constructor building a native
+        // `RegExp`. Another flavor's `source` and `flags` are stored
+        // faithfully and may be any strings at all, that dialect being one
+        // this runtime cannot check.
+        const fields = FabricRegExp.#stateFields(state);
+        if (fields === null) {
+          return new ProblematicValue(
+            typeTag,
+            state,
+            "RegExp: expected string `flavor`, `source` and `flags`",
+          );
+        }
+
+        const { flavor, source, flags } = fields;
         try {
           return new FabricRegExp(flavor, source, flags);
         } catch (e) {

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -187,6 +187,12 @@ describe("FabricRegExp", () => {
               { flavor: "future", source: { mutable: true }, flags: "g" },
               { flavor: "future", source: "a", flags: ["g"] },
               { flavor: ["future"], source: "a", flags: "g" },
+              // Present as `undefined` is present, not absent. A peer can
+              // reach this through the nonterminal walk by encoding the field
+              // as `{"/Undefined@1": null}`, and defaulting it would answer a
+              // question the wire did ask -- with `flavor`, by naming a
+              // dialect the sender did not.
+              { flavor: undefined, source: "a", flags: "g" },
             ]
           ) {
             expect(codec.decode(expectedTag, state as never, context))

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -176,6 +176,38 @@ describe("FabricRegExp", () => {
           expect(decoded).toBeInstanceOf(ProblematicValue);
         });
 
+        it("decodes a non-string field to `ProblematicValue`", () => {
+          // Only the `es2025` flavor is validated for syntax, so under any
+          // other one these values reach the constructor untouched -- and
+          // `source` and `flags` are exposed by getters typed `string`. An
+          // unchecked object here would put one behind such a getter, and take
+          // an unfrozen reference into a frozen instance with it.
+          for (
+            const state of [
+              { flavor: "future", source: { mutable: true }, flags: "g" },
+              { flavor: "future", source: "a", flags: ["g"] },
+              { flavor: ["future"], source: "a", flags: "g" },
+            ]
+          ) {
+            expect(codec.decode(expectedTag, state as never, context))
+              .toBeInstanceOf(ProblematicValue);
+          }
+        });
+
+        it("decodes a state omitting a field, taking that field's default", () => {
+          // Absent is not the same as present-and-wrong: a narrower encoder
+          // may leave a field out, and the default stands in for it.
+          const decoded = codec.decode(
+            expectedTag,
+            {},
+            context,
+          ) as FabricRegExp;
+
+          expect(decoded).toBeInstanceOf(FabricRegExp);
+          expect(decoded.source).toBe("");
+          expect(decoded.flags).toBe("");
+        });
+
         it("decodes an unparseable `es2025` pattern to `ProblematicValue`", () => {
           const decoded = codec.decode(
             expectedTag,


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) am pulling this out of the `codec-realm`
review. Both findings are about `codec-json` or about the shared base, so they
belong ahead of that branch rather than in it.

## A `RegExp@1` state could build an invalid instance

`FabricRegExp`'s JSON codec checked that the state was an object, then cast
`flavor`, `source` and `flags` to `string` without looking at them. Only the
`es2025` flavor is validated for syntax — under any other flavor those values
reach the constructor untouched, and `source` and `flags` are exposed by getters
**typed `string`**.

Verified through the strict public decoder. This state decodes successfully:

```ts
{ flavor: "future", source: { mutable: true }, flags: ["g"] }
```

producing a `FabricRegExp` with `typeof value.source === "object"` and
`Object.isFrozen(value.source) === false` — an unfrozen reference reachable
through a frozen instance, from untrusted wire data.

One `#stateFields()` now reads the three fields, rejecting any that is present
and not a string, and taking the default for any that is absent. Absent and
present-but-wrong are deliberately different: a narrower encoder may omit a
field, which is not a malformation.

The comment claiming another flavor "may carry arbitrary `source`/`flags`" now
says arbitrary **strings**, which is what it meant and not what it licensed.

## The base stated a contract one of its formats does not keep

`BaseCodecEngine.encode()`'s doc said the result "carries a marker identifying
the format", and `decode()` promised to throw when `data` "does not carry this
format's marker". That is true of JSON's `fvj1:` prefix and false in general:
whether a form identifies itself follows from its boundary. A form that is
persisted, or that shares a channel with values this system did not write, needs
a marker; a form constructed, handed straight to a transport and decoded on the
far side has nothing for a marker to distinguish it from.

The base now says that, and asks a format to state which it is and why — rather
than asserting one answer on every format's behalf.

## Verification

`data-model` `54 passed (2434 steps)`. Repo-wide `deno fmt --check` and
`deno lint` clean, plus `check`, `check-docs`, `check-no-waitfor`,
`check-conflict-markers`, `check-skill-facts`.

Two tests come with the validator, and the guard is ablation-verified: making
the type check unconditionally false turns the non-string case red. The second
test pins the distinction the fix depends on — a state omitting a field still
decodes, taking that field's default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PVVZAPbXomq2hMqmF7szXd


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

