### PR TITLE
A call naming a field the verb does not declare is refused

### DIFF
--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -348,6 +348,50 @@ cf piece call --piece <board> --invocation add-1 \
 That is the difference worth holding onto: a **settled** id replays its original
 result, while a **refused** id was never consumed and is still yours to use.
 
+### A field the verb does not declare
+
+A payload is judged against the verb's declared event schema before anything is
+sent, and a field that schema does not name is refused there. The runtime hands
+a handler the fields its event schema names and drops the rest, so a field
+nobody declared would otherwise reach nothing while the call reported itself
+settled. The refusal names the field, the position it sat at, the vocabulary
+that position takes, and the declared name it is one edit from:
+
+```bash
+cf piece call --piece <board> addTopic '{"titel":"Ship it","agentName":"Sol"}'
+```
+
+```
+Invalid input for "addTopic": "titel" at <event> is not a field this verb
+declares. Did you mean "title"? <event> takes "title", "body", "agentName"
+```
+
+Positions below the root are spelled the way a `--schema` position is —
+`<event>.item`, `<event>.tags[1]` — so one vocabulary covers this refusal and
+the one an unrecognized projection key gets.
+
+Every position that names its fields is judged, however it names them: with a
+stated `type: "object"`, with a `properties` map and no type beside it, with a
+type union admitting an object, or through a conjunction — whose fields are the
+**union** across its members, since a payload satisfying an `allOf` satisfies
+every one of them.
+
+Two kinds of position are passed over, and a call reaching one goes out rather
+than being refused on a guess. Under a **disjunction** (`anyOf`, `oneOf`) a
+payload need satisfy only one branch, so a field missing from one branch may be
+named by another. And a position marked as a cell or a stream may hold a link
+rather than a value, whose `"/"` is nothing anybody declared.
+
+The declared vocabulary is what `cf piece call --piece <id> <verb> --help`
+prints, and it names the fields the verb's handler **reads**. That can be fewer
+than the TypeScript event type declares: a field the body never touches is one
+the runtime would have dropped, so the call is refused rather than accepted and
+quietly emptied. A verb that publishes no event schema at all takes any payload
+— with nothing declared, nothing is dropped either.
+
+Like every other refusal here, this one costs nothing: the invocation id was
+never spent, and the corrected retry can reuse it.
+
 ### Reading is not calling
 
 `cf piece get` reads data. A path that lands on a verb is refused and redirected

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -48,7 +48,7 @@ without reconstructing it.
 | 9a. listing marks | on main (#5309) |
 | 10. listing rows carry a handler's declared result | on main (#5629) |
 | 9b. closed-world event emission | **ruled against** (#5589); does not land |
-| 12. `cf` refuses an undeclared field on a call | not started — where the ruling puts this capability |
+| 12. `cf` refuses an undeclared field on a call | **in review** (#5835) — where the ruling puts this capability |
 | 4. `receipt` as a top-level envelope field | on main (#5694) |
 | 2. an unrecognized projection key is refused | **in review** (#5817); design landed (#5753) |
 | 3. a rejection propagates up through what holds it | on main (#5701) |
@@ -333,11 +333,11 @@ the piece — the root pattern's own verb, reachable today by `pieces.add` from
 inside the runtime and by a model through the dialog builtin, and by no other
 caller.
 
-**12. `cf` refuses an undeclared field on a call.** *(S)* A payload carrying a
-field the verb does not declare is accepted, the field is dropped on the way in,
-and the caller is told the call settled — the silent-strip failure, which is
-what a caller writing JSON by hand or by model hits and a TypeScript author
-never does.
+**12. `cf` refuses an undeclared field on a call.** *(S)* **In review as
+#5835.** A payload carrying a field the verb does not declare is accepted,
+the field is dropped on the way in, and the caller is told the call settled —
+the silent-strip failure, which is what a caller writing JSON by hand or by
+model hits and a TypeScript author never does.
 
 *This is item 2's shape, one surface over.* There a projection key in neither
 denylist is accepted and ignored; here an event field the schema does not
@@ -352,6 +352,27 @@ through the same command.
 event schema before dispatch. What it does not do is treat an undeclared field
 as a reason to refuse — and the schema it validates against names exactly the
 fields the verb declares, so the comparison needs no new source of truth.
+
+*The refusal is derived from where a field actually goes missing*, not from a
+rule about schemas. A position drops what it does not name exactly when it
+reaches a `properties` map with no `additionalProperties` beside it — measured
+against the read a handler's event goes through, and true of every spelling of
+an object-shaped position: a stated `type: "object"`, a bare map, a type union
+admitting an object, and a conjunction, whose declared fields are the union
+across its members. A position reaching no map at all delivers the whole
+payload, so a verb that declares nothing THAT way takes anything; a position
+spelling `properties: {}` delivers nothing, so every field written there is
+refused. Which spellings describe an object is `schemaIsObjectShaped`'s
+question, asked rather than answered a second time. Everywhere else the check
+fails open — a disjunction, an `asCell` position below the root, a container the
+payload does not match — because a refusal can be retried and a call wrongly
+refused cannot be made at all.
+
+*What a caller reads names fewer fields than the TypeScript does.* The emitted
+event schema names the fields the handler body READS, so a field declared in
+the event interface and never touched is one the runtime would have dropped and
+this now refuses. That is the same failure surfacing, and `--help` prints the
+same vocabulary the refusal does.
 
 *Exit:* a call naming a field the verb does not declare is refused, the message
 names the field, and the invocation id is not spent.
@@ -438,8 +459,8 @@ its own track.
 | 9 | A rejection propagates up through what holds it | **on main** (#5701) — item 3 | — | First of the projection work; the mask's asymmetry is what makes a marked field below a link load every element |
 | 10 | Two identical projections stop colliding | **on main** (#5757) — #5523 | 9 | Same file. Reachable the moment anything long-lived reads twice, which the command surface invites |
 | 11 | One piece, one address | **decided — they are aliases**; the documentation half is #5754 | — | Measured: the two routes differ because one resolves the link chain and the other renders the link as stored. That is the read model working, not a defect, so the outcome is the statement rather than the fix. What remains is a doc correction and closing #5632 — no code changes, and step 13 is not gated on it |
-| 12 | An unrecognized projection key is refused | **in review** (#5817) — item 2 | 9 | The largest remaining step, and the one carrying design surface, since it couples the projection reader to the compatibility checker's annotation keys. Its design is [projection keys, and the schema a read is handed](../history/plans/projection-key-classification.md) |
-| 12a | `cf` refuses an undeclared field on a call | item 12 | — | Same refusal shape as the step above and independent of it, so it can go either side; building them together is what keeps one vocabulary for what a refusal says |
+| 12 | An unrecognized projection key is refused | **on main** (#5817) — item 2 | 9 | The largest remaining step, and the one carrying design surface, since it couples the projection reader to the compatibility checker's annotation keys. Its design is [projection keys, and the schema a read is handed](../history/plans/projection-key-classification.md) |
+| 12a | `cf` refuses an undeclared field on a call | **in review** (#5835) — item 12 | — | Same refusal shape as the step above and independent of it, so it can go either side; building them together is what keeps one vocabulary for what a refusal says. Built against #5817's wording rather than its code, since that branch is unmerged |
 | 13 | `cf wish` and `cf exec` take the read options | item 5 | 11, 12 | Last by construction: it spreads the vocabulary to two more starting points, so the vocabulary should have stopped moving — and it now has. No resolving marker is planned, so the grammar step 13 spreads is the grammar that exists |
 | 14 | A caller may name a reference | item 11, #5560 | — | Item 11 has carried this since the State table was written and the ordering never gave it a step, so nothing scheduled it. Sequenced last only because it is unstarted, not because anything gates it — and it is the most consequential thing open: the shape-matching payload the CLI does accept **stores a detached copy and reports success**, so a caller relating two pieces is told it worked |
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -187,6 +187,45 @@ from a later update preserves an existing unambiguous class.
 - The launcher spawns the child CLI with `deno run --quiet` so Deno's own
   warnings (npm "Ignored build scripts" banner) never reach users.
 
+### What a call refuses before it dispatches
+
+`piece call` judges the payload against the verb's declared event schema before
+anything is sent, so a refusal costs nothing: the invocation id was never spent
+and the corrected retry can reuse it.
+
+A field the verb does not declare is one of the things it refuses. The runtime
+hands a handler the fields its event schema names and drops the rest, so a
+payload carrying a field nobody declared would otherwise run the handler without
+it and report the call settled. The refusal names the field, the position it sat
+at, the vocabulary that position takes, and the declared name it is one edit
+from:
+
+```console
+$ cf piece call --piece ID addItem '{"titel":"Milk","done":false}'
+Invalid input for "addItem": "titel" at <event> is not a field this verb
+declares. Did you mean "title"? <event> takes "title", "done"
+```
+
+Positions below the root are spelled the way a `--schema` position is —
+`<event>.item`, `<event>.tags[1]` — so one vocabulary covers both refusals.
+
+Every position that names its fields is judged, whether it states
+`type: "object"`, carries a `properties` map with no type beside it, states a
+type union admitting an object, or reaches its map through a conjunction, whose
+fields are the union across its members. A **disjunction** (`anyOf`, `oneOf`) is
+passed over — a payload need satisfy only one branch — and so is a position
+marked as a cell or a stream, which may hold a link rather than a value. A call
+reaching either goes out rather than being refused on a guess.
+
+The declared vocabulary is what `cf piece call --piece ID <verb> --help` prints,
+which is the list to check when a field comes back refused. It names the fields
+the verb's handler READS, which can be fewer than its TypeScript event type
+declares: a field the body never touches is one the runtime would have dropped,
+and the refusal says so rather than accepting it and losing it.
+
+A verb that publishes no event schema at all — one whose event type names no
+fields — takes any payload. With nothing declared, nothing is dropped either.
+
 ### Transforming `piece get` and `piece call` output
 
 `piece get` can filter an array before it reaches stdout and project the result

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -223,8 +223,11 @@ the verb's handler READS, which can be fewer than its TypeScript event type
 declares: a field the body never touches is one the runtime would have dropped,
 and the refusal says so rather than accepting it and losing it.
 
-A verb that publishes no event schema at all — one whose event type names no
-fields — takes any payload. With nothing declared, nothing is dropped either.
+A verb that publishes **no event schema at all**, or one whose schema carries no
+`properties` key, takes any payload: with nothing declared, nothing is dropped
+either. That is not the same as a schema whose `properties` is empty — that one
+declares that there are no fields, so the runtime delivers none and every field
+a caller sends is refused.
 
 ### Transforming `piece get` and `piece call` output
 

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -13,6 +13,7 @@ import {
   relaxDefaultedRequired,
   validateSchemaValue,
 } from "@commonfabric/runner/cfc/schema-sanitization";
+import { cfcSchemaChildRoot } from "@commonfabric/runner/cfc/schema-refs";
 import {
   type CallableKind,
   classifyCallableEntry,
@@ -362,6 +363,365 @@ export function schemaIsObjectShaped(
 }
 
 /**
+ * The root of a payload, as a refusal names it. Positions below it are spelled
+ * the way the read boundary spells its own (`normalizeProjectionSchema`,
+ * cell-selection.ts): a property is `.name`, an array element is `[index]`. A
+ * caller meets both refusals through the same command, so they name a position
+ * the same way.
+ */
+const EVENT_ROOT_POSITION = "<event>";
+
+/** A field a payload carries at a position whose schema does not declare it,
+ * with what that position does declare. */
+interface UndeclaredEventField {
+  key: string;
+  position: string;
+  declared: string[];
+}
+
+/**
+ * The edit distance between `left` and `right`, for the near-miss below.
+ * Adjacent transposition counts as one edit rather than two, because it is the
+ * typo the refusal exists for: `titel` is one slip from `title` however many
+ * substitutions it takes to spell as substitutions.
+ */
+function fieldEditDistance(left: string, right: string): number {
+  const rows: number[][] = [
+    Array.from({ length: right.length + 1 }, (_, j) => j),
+  ];
+  for (let i = 1; i <= left.length; i++) {
+    const current = [i];
+    for (let j = 1; j <= right.length; j++) {
+      const previous = rows[i - 1];
+      current[j] = left[i - 1] === right[j - 1]
+        ? previous[j - 1]
+        : 1 + Math.min(previous[j - 1], previous[j], current[j - 1]);
+      if (
+        i > 1 && j > 1 && left[i - 1] === right[j - 2] &&
+        left[i - 2] === right[j - 1]
+      ) {
+        current[j] = Math.min(current[j], rows[i - 2][j - 2] + 1);
+      }
+    }
+    rows.push(current);
+  }
+  return rows[left.length][right.length];
+}
+
+/**
+ * The declared field `key` was most likely meant to be, or `undefined` where
+ * nothing is close enough to name. A call site prints no schema, so for a
+ * misspelled field the declared vocabulary is the whole remediation, and the
+ * one name a caller transposed two letters of is the useful half of it.
+ */
+function nearestDeclaredField(
+  key: string,
+  declared: readonly string[],
+): string | undefined {
+  const lowered = key.toLowerCase();
+  let best: string | undefined;
+  let bestDistance = Infinity;
+  for (const candidate of declared) {
+    const distance = fieldEditDistance(lowered, candidate.toLowerCase());
+    if (distance < bestDistance) {
+      best = candidate;
+      bestDistance = distance;
+    }
+  }
+  return bestDistance <= Math.max(1, Math.floor(key.length / 4))
+    ? best
+    : undefined;
+}
+
+/** One property map an object-shaped position reaches, with the local-ref
+ * scope the schemas inside it resolve against. */
+interface DeclaredFieldSource {
+  properties: Record<string, JSONSchema>;
+  root: JSONSchema;
+}
+
+/** What a position declares, and whether anything there honors a field none of
+ * its maps name. */
+interface DeclaredFields {
+  sources: DeclaredFieldSource[];
+  honorsUndeclared: boolean;
+}
+
+/**
+ * Every property map an object-shaped position reaches, and whether it honors a
+ * field none of them name.
+ *
+ * A conjunction constrains one value from several members at once, so the
+ * fields it declares are the UNION across its members: a payload satisfying an
+ * `allOf` satisfies every member, and a field one member names is a field the
+ * position names. Taking the union is also the safe direction — the cost of
+ * missing a member is refusing a field that was declared, and the cost of an
+ * extra member is accepting one that would have been dropped.
+ *
+ * A disjunction anywhere inside makes the whole position honor everything: a
+ * branch a payload was meant for may name a field the others do not, and
+ * choosing among branches is the caller's, not this gate's.
+ *
+ * `followed` breaks reference cycles, and it records the REFERENCE rather than
+ * the schema it resolved to — the same key `localRefTarget` cycles on, and the
+ * only one that works here: resolution hands back a fresh view of a definition
+ * each time, so a recursive `$ref` reaches an object this walk has never seen
+ * and descends forever. A member is skipped once its reference has been
+ * followed in the scope it was written in; a definition contributes its fields
+ * once, and a schema naming itself terminates.
+ */
+function declaredFieldsAt(
+  node: Record<string, unknown>,
+  root: JSONSchema,
+  into: DeclaredFields = { sources: [], honorsUndeclared: false },
+  followed: Map<JSONSchema, Set<string>> = new Map(),
+): DeclaredFields {
+  if (isSchemaObject(node.properties as JSONSchema)) {
+    into.sources.push({
+      properties: node.properties as Record<string, JSONSchema>,
+      root,
+    });
+  }
+  if (node.additionalProperties !== undefined) into.honorsUndeclared = true;
+  if (!Array.isArray(node.allOf)) return into;
+  for (const member of node.allOf as JSONSchema[]) {
+    const memberRoot = cfcSchemaChildRoot(member, root);
+    if (isSchemaObject(member) && typeof member.$ref === "string") {
+      let inScope = followed.get(memberRoot);
+      if (inScope?.has(member.$ref)) continue;
+      if (inScope === undefined) {
+        inScope = new Set();
+        followed.set(memberRoot, inScope);
+      }
+      inScope.add(member.$ref);
+    }
+    const resolved = localRefTarget(member, memberRoot);
+    if (!isSchemaObject(resolved)) continue;
+    if (resolved.anyOf !== undefined || resolved.oneOf !== undefined) {
+      into.honorsUndeclared = true;
+      continue;
+    }
+    declaredFieldsAt(
+      resolved,
+      cfcSchemaChildRoot(resolved, memberRoot),
+      into,
+      followed,
+    );
+  }
+  return into;
+}
+
+/** The vocabulary a refusal names: every field the position's maps declare, in
+ * the order they were reached, each named once. */
+function declaredFieldNames(sources: DeclaredFieldSource[]): string[] {
+  const names: string[] = [];
+  for (const source of sources) {
+    for (const key of Object.keys(source.properties)) {
+      if (!names.includes(key)) names.push(key);
+    }
+  }
+  return names;
+}
+
+/**
+ * Whether a position describes the array a payload holds there.
+ *
+ * The array counterpart of {@link schemaIsObjectShaped}, and it answers the
+ * question the same way: a stated `type` says so, and otherwise the container
+ * keyword being present does. An untyped position naming `items` is an array
+ * to everything except schema traversal's own descent, which requires the
+ * stated type and empties the position without it — the same asymmetry the
+ * object side has, one container over.
+ */
+function schemaIsArrayShaped(node: Record<string, unknown>): boolean {
+  const declaredType = node.type;
+  if (declaredType === "array") return true;
+  if (Array.isArray(declaredType)) return declaredType.includes("array");
+  if (declaredType !== undefined) return false;
+  return node.items !== undefined || node.prefixItems !== undefined;
+}
+
+/** Whether a schema node marks its position as a cell or a stream, which is
+ * where a caller may write a link in place of a value. */
+function carriesCellMarker(node: Record<string, unknown>): boolean {
+  return node.asCell !== undefined || node.asStream !== undefined;
+}
+
+/**
+ * The first field the payload carries that the schema at its position does not
+ * declare, walking the PAYLOAD (finite JSON the caller supplied, so the walk
+ * terminates on its own) and consulting the schema beside it.
+ *
+ * Whether a position describes the object a payload holds there is
+ * {@link schemaIsObjectShaped}'s question, asked here rather than answered
+ * again: a stated `type: "object"`, a `properties` map with no type beside it,
+ * a type union admitting an object, and a conjunction with an object-shaped
+ * member all describe one. Every one of them drops what it does not name, so
+ * every one of them is judged.
+ *
+ * Three positions are passed over, each because the schema stops proving what
+ * the runtime will do with what sits under it:
+ *
+ * - a disjunction (`anyOf`/`oneOf`), here or inside a conjunction, where a
+ *   payload need satisfy only one branch and a field missing from the branch
+ *   this walk inspected may be named by another. Choosing among branches is
+ *   the caller's, not this gate's;
+ * - a position marked `asCell`/`asStream` below the root, where the value may
+ *   be a link (whose `"/"` is not a field anybody declared) and an inline value
+ *   is carried across the boundary rather than filtered at dispatch. The ROOT's
+ *   own marker is ignored, because the stream marker is what makes the schema a
+ *   verb's in the first place and the payload under it is the event;
+ * - a position describing neither the object nor the array the payload holds
+ *   there.
+ *
+ * A key several members of a conjunction constrain is passed over too, one
+ * level down: the walk cannot say which member's schema governs beneath it.
+ *
+ * Every one of them fails open. A refusal spends nothing and can be retried,
+ * but a call this gate wrongly refuses cannot be made at all, so the direction
+ * to be wrong in is the permissive one.
+ */
+function firstUndeclaredEventField(
+  value: unknown,
+  schema: JSONSchema | undefined,
+  root: JSONSchema,
+  position: string,
+  atRoot: boolean,
+): UndeclaredEventField | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  if (!isSchemaObject(schema)) return undefined;
+  if (!atRoot && carriesCellMarker(schema)) return undefined;
+  const scopeRoot = cfcSchemaChildRoot(schema, root);
+  const node = localRefTarget(schema, scopeRoot);
+  if (!isSchemaObject(node)) return undefined;
+  if (!atRoot && carriesCellMarker(node)) return undefined;
+  if (node.anyOf !== undefined || node.oneOf !== undefined) return undefined;
+  const nodeRoot = cfcSchemaChildRoot(node, scopeRoot);
+
+  if (Array.isArray(value)) {
+    if (!schemaIsArrayShaped(node)) return undefined;
+    const prefixItems = Array.isArray(node.prefixItems)
+      ? node.prefixItems as JSONSchema[]
+      : undefined;
+    for (let index = 0; index < value.length; index++) {
+      const child = prefixItems !== undefined && index < prefixItems.length
+        ? prefixItems[index]
+        : node.items as JSONSchema | undefined;
+      const found = firstUndeclaredEventField(
+        value[index],
+        child,
+        nodeRoot,
+        `${position}[${index}]`,
+        false,
+      );
+      if (found !== undefined) return found;
+    }
+    return undefined;
+  }
+
+  if (!schemaIsObjectShaped(node, nodeRoot)) return undefined;
+  const declared = declaredFieldsAt(node, nodeRoot);
+  if (declared.sources.length === 0) return undefined;
+  const entries = Object.entries(value as Record<string, unknown>);
+  const declaringSources = (key: string) =>
+    declared.sources.filter((source) => Object.hasOwn(source.properties, key));
+  if (!declared.honorsUndeclared) {
+    for (const [key] of entries) {
+      if (declaringSources(key).length === 0) {
+        return {
+          key,
+          position,
+          declared: declaredFieldNames(declared.sources),
+        };
+      }
+    }
+  }
+  for (const [key, child] of entries) {
+    const matches = declaringSources(key);
+    const childSchema = matches.length === 1
+      ? matches[0].properties[key]
+      : matches.length === 0
+      ? node.additionalProperties as JSONSchema | undefined
+      : undefined;
+    const found = firstUndeclaredEventField(
+      child,
+      childSchema,
+      matches.length === 1 ? matches[0].root : nodeRoot,
+      `${position}.${key}`,
+      false,
+    );
+    if (found !== undefined) return found;
+  }
+  return undefined;
+}
+
+/**
+ * Refuse a payload carrying a field the verb does not declare, naming the
+ * field, the position it sat at, the vocabulary that position takes, and the
+ * declared name it is one edit from.
+ *
+ * The comparison needs no source of truth beyond the schema already in hand:
+ * the verb's event schema names exactly the fields the verb declares. What it
+ * adds is treating an undeclared one as a reason to refuse, which nothing else
+ * on this path does — the runtime's own read drops the field and delivers the
+ * rest, so the handler runs, the receipt is written, and the caller is told the
+ * call settled with a field it wrote never having arrived. A TypeScript author
+ * never meets that; a caller writing JSON by hand or by model meets it first.
+ *
+ * Which positions drop, measured against the read a handler's event goes
+ * through (`SchemaObjectTraverser.traverseObjectWithSchema`, runner
+ * traverse.ts, whose `addOptionalProperty` is a no-op on the
+ * `validateAndTransform` path), for an object holding one declared and one
+ * undeclared field:
+ *
+ * | The schema at a position | What the handler receives |
+ * | --- | --- |
+ * | `{type: "object"}` | both fields |
+ * | `{type: "object", properties: {declared}}` | the declared field |
+ * | `{type: ["object", "null"], properties: {declared}}` | the declared field |
+ * | `{allOf: [{type: "object", properties: {declared}}]}` | the declared field |
+ * | `{properties: {declared}}` | nothing |
+ * | `{type: "object", properties: {}}` | nothing |
+ * | `{anyOf: [...]}` | both fields |
+ * | any of those plus `additionalProperties` | both fields |
+ *
+ * So a position with no property map is open by construction and refuses
+ * nothing — a verb declaring no fields THAT way takes anything. Every position
+ * that has one drops what none of its maps name, whether or not it also states
+ * a type and whether it reaches the map directly or through a conjunction.
+ *
+ * The two rows delivering NOTHING are two readings of "declares no fields", and
+ * both refuse every field written there. A bare `properties` map drops the
+ * fields it declares as well, which is a defect of its own and not one a gate
+ * over undeclared fields can speak to.
+ *
+ * @internal Exported for the tests that pin the refusal's wording.
+ */
+export function undeclaredVerbFieldError(
+  input: unknown,
+  schema: JSONSchema | undefined,
+): string | undefined {
+  if (schema === undefined || schema === true) return undefined;
+  const found = firstUndeclaredEventField(
+    input,
+    schema,
+    schema,
+    EVENT_ROOT_POSITION,
+    true,
+  );
+  if (found === undefined) return undefined;
+  const nearest = nearestDeclaredField(found.key, found.declared);
+  return `"${found.key}" at ${found.position} is not a field this verb ` +
+    "declares. " +
+    (nearest === undefined ? "" : `Did you mean "${nearest}"? `) +
+    (found.declared.length === 0
+      ? `${found.position} declares no fields at all`
+      : `${found.position} takes ${
+        found.declared.map((key) => `"${key}"`).join(", ")
+      }`);
+}
+
+/**
  * Reject a payload that cannot satisfy the verb's event schema, before it is
  * sent.
  *
@@ -379,6 +739,13 @@ export function schemaIsObjectShaped(
  * and is judged like any supplied payload; against everything else it stays
  * `undefined` and passes — `$event` is genuinely optional in the generated
  * handler schema, and value-less verbs are a supported shape.
+ *
+ * A field the verb does not declare is judged FIRST, ahead of the schema
+ * validation. Both can hold at once — a misspelled required field is missing
+ * and undeclared in one stroke — and of the two answers only one names
+ * something the caller actually wrote. "`titel` is not a field, did you mean
+ * `title`" sends them to the character they typed; "`title` is missing" sends
+ * them looking for a field that is already there.
  */
 export function verbInputSchemaError(
   input: unknown,
@@ -386,6 +753,8 @@ export function verbInputSchemaError(
 ): string | undefined {
   if (input === undefined) return undefined;
   if (schema === undefined || schema === true) return undefined;
+  const undeclared = undeclaredVerbFieldError(input, schema);
+  if (undeclared !== undefined) return undeclared;
   return validateSchemaValue(
     relaxDefaultedRequired(schema, schema, new Map()),
     input,

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -4282,9 +4282,12 @@ describe("verbInputSchemaError", () => {
       .toBeUndefined();
   });
 
+  // `{}` rather than a misspelling, so this reaches the schema validation
+  // rather than the undeclared-field refusal that now precedes it — a
+  // misspelled required property is BOTH, and it is refused as the undeclared
+  // field it is (verb-undeclared-field.test.ts).
   it("rejects a missing required property", () => {
-    expect(verbInputSchemaError({ mesage: "milk" }, objectSchema))
-      .toMatch(/message/);
+    expect(verbInputSchemaError({}, objectSchema)).toMatch(/message/);
   });
 
   it("rejects a payload of the wrong type", () => {

--- a/packages/cli/test/verb-undeclared-field.test.ts
+++ b/packages/cli/test/verb-undeclared-field.test.ts
@@ -1,0 +1,882 @@
+/**
+ * Pins the refusal `cf piece call` gives a payload carrying a field the verb's
+ * event schema does not declare: which positions it fires at, the wording a
+ * caller reads, and — in equal measure — the positions it passes over, each
+ * asserted as the call still dispatching.
+ *
+ * The gate itself is `verbInputSchemaError` (../lib/callable.ts). What is
+ * driven here is the whole path a caller takes to it, so the refusal is pinned
+ * against schemas the transformer emits rather than against hand-built ones
+ * that could only assert back what this file assumed.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { type Cell, type JSONSchema, Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import {
+  executeResolvedCallable,
+  undeclaredVerbFieldError,
+  verbInputSchemaError,
+  VerbInputValidationError,
+} from "../lib/callable.ts";
+import { executePieceCallable } from "../lib/piece.ts";
+
+/**
+ * Dispatch `payload` at a verb publishing `schema`, through the same
+ * pre-dispatch gate `cf piece call` runs, and hand back what reached the
+ * stream.
+ *
+ * A position the walk passes over has to be asserted as the call DISPATCHING,
+ * not as the refusal being absent. Those are different facts, and only the
+ * first one fails when a branch that fails open starts failing closed — which
+ * on this feature means refusing a call that should have gone out. Reading the
+ * dispatched value back states it: the payload reached the stream, and reached
+ * it whole.
+ */
+async function dispatchedPayload(
+  schema: JSONSchema,
+  payload: unknown,
+): Promise<unknown> {
+  let sent: unknown;
+  const callableCell = {
+    schema,
+    get: () => ({ $stream: true }),
+    getRaw: () => ({ $stream: true }),
+    getAsNormalizedFullLink: () => ({ scope: "space" }),
+    send: (value: unknown, onCommit?: (tx: unknown) => void) => {
+      sent = value;
+      onCommit?.({ status: () => ({ status: "ok" }) });
+    },
+  };
+  await executeResolvedCallable({
+    callableCell: callableCell as never,
+    callableKind: "handler",
+    cellKey: "probe",
+    pieces: { runtime: {} } as never,
+    space: "did:key:undeclared-field-probe" as never,
+    inputSchema: schema,
+  }, payload);
+  return sent;
+}
+
+/**
+ * A list whose verbs cover the positions a payload can put a field in: the
+ * event root, an object below it, and an element of an array below that.
+ *
+ * Driven against a COMPILED, RUN pattern rather than a hand-built schema,
+ * because the shape the refusal keys on is one the TRANSFORMER emits. It emits
+ * an event schema naming the fields the handler body READS — `done` and `id`
+ * are in the interfaces below and reach the schema only because the bodies
+ * touch them — so a hand-written schema would assert back whatever this test
+ * assumed rather than what a real verb declares.
+ *
+ * `ping` is the verb that declares nothing: its event type names no field, and
+ * what the transformer emits for it is no schema at all.
+ */
+const PROGRAM = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      'import { action, NAME, pattern, type PatternFactory, type Stream, Writable } from "commonfabric";',
+      "",
+      "interface AddItemEvent { title: string; done: boolean; }",
+      "interface Recorded { entry: string; }",
+      "interface RenameEvent { item: { id: string; label: string }; }",
+      "interface TagEvent { tags: { name: string }[]; }",
+      "type PingEvent = Record<string, never>;",
+      "",
+      "export interface ListOutput {",
+      "  addItem: Stream<AddItemEvent, Recorded>;",
+      "  rename: Stream<RenameEvent, Recorded>;",
+      "  tag: Stream<TagEvent, Recorded>;",
+      "  ping: Stream<PingEvent, Recorded>;",
+      "  entries: string[];",
+      "  [NAME]: string;",
+      "}",
+      "",
+      "interface ListInput { label?: string; }",
+      "",
+      "export const List: PatternFactory<ListInput, ListOutput> = pattern<ListInput, ListOutput>(",
+      "  () => {",
+      "    const entries = new Writable<string[]>([]);",
+      "    const addItem = action<AddItemEvent, Recorded>((event) => {",
+      "      const entry = JSON.stringify({ title: event.title, done: event.done });",
+      "      entries.push(entry);",
+      "      return { entry };",
+      "    });",
+      "    const rename = action<RenameEvent, Recorded>((event) => {",
+      "      const entry = JSON.stringify({ id: event.item?.id, label: event.item?.label });",
+      "      entries.push(entry);",
+      "      return { entry };",
+      "    });",
+      "    const tag = action<TagEvent, Recorded>((event) => {",
+      "      const entry = JSON.stringify((event.tags ?? []).map((tag) => tag.name));",
+      "      entries.push(entry);",
+      "      return { entry };",
+      "    });",
+      "    const ping = action<PingEvent, Recorded>(() => {",
+      "      entries.push('ping');",
+      "      return { entry: 'ping' };",
+      "    });",
+      "    return { [NAME]: 'List', entries, addItem, rename, tag, ping };",
+      "  },",
+      ");",
+      "",
+      "export default List;",
+    ].join("\n"),
+  }],
+};
+
+/**
+ * Two verbs whose event schemas are written out rather than derived from a
+ * TypeScript event type, which is how a pattern reaches the object shapes the
+ * transformer never emits: a `properties` map with no `type` beside it, and a
+ * conjunction holding one.
+ */
+const EXPLICIT_SCHEMA_PROGRAM = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      'import { handler, NAME, pattern, schema, type Stream } from "commonfabric";',
+      'import "commonfabric/schema";',
+      "",
+      "interface Output {",
+      "  [NAME]: string;",
+      "  count: number;",
+      "  bare: Stream<{ title: string }>;",
+      "  conjunct: Stream<{ title: string }>;",
+      "}",
+      "",
+      "interface Input { count: number; }",
+      "",
+      "const model = schema({",
+      "  type: 'object',",
+      "  properties: { count: { type: 'number', default: 0, asCell: ['cell'] } },",
+      "  default: { count: 0 },",
+      "});",
+      "",
+      "const bare = handler(",
+      "  { properties: { title: { type: 'string' } } } as const,",
+      "  model,",
+      "  (_event, state) => { state.count.set(state.count.get() + 1); },",
+      ");",
+      "",
+      "const conjunct = handler(",
+      "  { allOf: [{ type: 'object', properties: { title: { type: 'string' } } }] } as const,",
+      "  model,",
+      "  (_event, state) => { state.count.set(state.count.get() + 1); },",
+      ");",
+      "",
+      "export default pattern<Input, Output>((state) => ({",
+      "  [NAME]: 'Explicit',",
+      "  count: state.count,",
+      "  bare: bare(state),",
+      "  conjunct: conjunct(state),",
+      "}), model);",
+    ].join("\n"),
+  }],
+};
+
+const CONFIG = {
+  apiUrl: "http://localhost:8000",
+  identity: "/tmp/test-identity.pem",
+  piece: "fid1:live",
+  space: "" as string,
+};
+
+interface Tracker {
+  /** Dispatch `verb` the way `cf piece call` does, with `payload` spelled as
+   * the one positional JSON argument a caller writes by hand. */
+  call: (
+    verb: string,
+    payload: unknown,
+    invocationId?: string,
+  ) => Promise<{ id: string; status: string; deduplicated?: boolean }>;
+  /** What the handlers recorded, read off the cell rather than through any
+   * rendering, so it says what the handler actually received. */
+  entries: () => string[];
+  root: Cell<any>;
+}
+
+/** Run `program` and hand a driver to `body`. */
+async function withProgram<T>(
+  passphrase: string,
+  program: typeof PROGRAM,
+  body: (tracker: Tracker) => Promise<T>,
+): Promise<T> {
+  const signer = await Identity.fromPassphrase(passphrase);
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL("https://example.com"),
+    storageManager,
+  });
+  const space = signer.did();
+
+  try {
+    const compiled = await runtime.patternManager.compilePattern(
+      program as never,
+      { space },
+    );
+    const tx = runtime.edit();
+    const rootCell = runtime.getCell(space, "undeclared-field", undefined, tx);
+    const root = runtime.run(tx, compiled, {}, rootCell);
+    runtime.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    await root.pull();
+
+    const piece = {
+      result: { getCell: () => Promise.resolve(root) },
+      input: { getCell: () => Promise.resolve(root) },
+      getCell: () => root,
+      getPattern: () => Promise.resolve(compiled),
+    };
+    const deps = {
+      loadPieces: () =>
+        Promise.resolve({ getSpace: () => space, runtime } as never),
+      loadPiece: () => Promise.resolve(piece as never),
+    };
+
+    let dispatched = 0;
+    return await body({
+      root,
+      entries: () => (root.key("entries").get() ?? []) as unknown as string[],
+      call: async (verb, payload, invocationId) => {
+        dispatched++;
+        const executed = await executePieceCallable(
+          { ...CONFIG, space },
+          verb,
+          ["--json", JSON.stringify(payload)],
+          {
+            ...deps,
+            invocation: {
+              id: invocationId ?? `inv-${dispatched}`,
+              session: "sess",
+            },
+          } as never,
+        );
+        return executed.invocation as never;
+      },
+    });
+  } finally {
+    await runtime.dispose?.();
+    await storageManager.close?.();
+  }
+}
+
+/** Run the list program above and hand a driver to `body`. */
+function withList<T>(
+  passphrase: string,
+  body: (tracker: Tracker) => Promise<T>,
+): Promise<T> {
+  return withProgram(passphrase, PROGRAM, body);
+}
+
+describe("verb-undeclared-field", () => {
+  describe("undeclaredVerbFieldError()", () => {
+    const addItem: JSONSchema = {
+      type: "object",
+      properties: { title: { type: "string" }, done: { type: "boolean" } },
+      required: ["title"],
+    };
+
+    it("names the field, the position it sat at, and the vocabulary that position takes", () => {
+      expect(
+        undeclaredVerbFieldError({ title: "Milk", colour: "red" }, addItem),
+      )
+        .toBe(
+          '"colour" at <event> is not a field this verb declares. ' +
+            '<event> takes "title", "done"',
+        );
+    });
+
+    it("suggests the declared field a misspelling is one edit from", () => {
+      expect(undeclaredVerbFieldError({ titel: "Milk" }, addItem)).toBe(
+        '"titel" at <event> is not a field this verb declares. ' +
+          'Did you mean "title"? <event> takes "title", "done"',
+      );
+    });
+
+    // A transposition is one slip to the caller who made it, whatever it costs
+    // to spell as substitutions, and the threshold for a four-character key is
+    // one edit.
+    it("counts an adjacent transposition as one edit", () => {
+      expect(undeclaredVerbFieldError({ doen: true }, addItem)).toMatch(
+        /Did you mean "done"\?/,
+      );
+    });
+
+    it("returns `undefined` for a payload carrying exactly the declared fields", () => {
+      expect(undeclaredVerbFieldError({ title: "Milk", done: true }, addItem))
+        .toBeUndefined();
+      expect(undeclaredVerbFieldError({ title: "Milk" }, addItem))
+        .toBeUndefined();
+      expect(undeclaredVerbFieldError({}, addItem)).toBeUndefined();
+    });
+
+    it("returns `undefined` where the verb declares no schema", () => {
+      expect(undeclaredVerbFieldError({ anything: 1 }, undefined))
+        .toBeUndefined();
+      expect(undeclaredVerbFieldError({ anything: 1 }, true)).toBeUndefined();
+    });
+
+    // A position with no property map is open by construction: the runtime
+    // delivers the whole payload there, so nothing is dropped and nothing is
+    // refused.
+    it("returns `undefined` for an object schema stating no `properties`", () => {
+      expect(undeclaredVerbFieldError({ anything: 1 }, { type: "object" }))
+        .toBeUndefined();
+    });
+
+    // The other reading of "declares no fields": an explicit empty map, which
+    // the runtime answers by delivering nothing at all. Every field a caller
+    // writes there is refused, and there is no vocabulary to offer instead.
+    it("refuses every field against an explicitly empty `properties` map", () => {
+      expect(
+        undeclaredVerbFieldError({ title: "Milk" }, {
+          type: "object",
+          properties: {},
+        }),
+      ).toBe(
+        '"title" at <event> is not a field this verb declares. ' +
+          "<event> declares no fields at all",
+      );
+    });
+
+    // `additionalProperties` is what makes the runtime deliver a field no map
+    // names, so a position carrying one honors what it is sent.
+    it("returns `undefined` where the position declares `additionalProperties`", () => {
+      for (const additionalProperties of [true, {}, { type: "string" }]) {
+        expect(
+          undeclaredVerbFieldError({ title: "Milk", colour: "red" }, {
+            ...addItem,
+            additionalProperties,
+          } as JSONSchema),
+        ).toBeUndefined();
+      }
+    });
+
+    // The position half of the message is load-bearing: a field goes missing
+    // wherever its enclosing position drops what it does not name, not only at
+    // the root.
+    it("names a nested object position", () => {
+      expect(
+        undeclaredVerbFieldError({ item: { id: "1", lable: "Milk" } }, {
+          type: "object",
+          properties: {
+            item: {
+              type: "object",
+              properties: { id: { type: "string" }, label: { type: "string" } },
+            },
+          },
+        }),
+      ).toBe(
+        '"lable" at <event>.item is not a field this verb declares. ' +
+          'Did you mean "label"? <event>.item takes "id", "label"',
+      );
+    });
+
+    it("names an array element by its index", () => {
+      expect(
+        undeclaredVerbFieldError({
+          tags: [{ name: "a" }, { name: "b", colour: "red" }],
+        }, {
+          type: "object",
+          properties: {
+            tags: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: { name: { type: "string" } },
+              },
+            },
+          },
+        }),
+      ).toBe(
+        '"colour" at <event>.tags[1] is not a field this verb declares. ' +
+          '<event>.tags[1] takes "name"',
+      );
+    });
+
+    it("resolves the top-level `$ref` a stream schema wraps its event in", () => {
+      expect(
+        undeclaredVerbFieldError({ titel: "Milk" }, {
+          $ref: "#/$defs/AddItem",
+          asCell: ["stream"],
+          $defs: {
+            AddItem: {
+              type: "object",
+              properties: { title: { type: "string" } },
+            },
+          },
+        } as JSONSchema),
+      ).toMatch(/"titel" at <event> .* Did you mean "title"\?/);
+    });
+
+    // Below the root a marked position is where a caller may write a link
+    // instead of a value, and `"/"` is not a field anybody declared.
+    it("returns `undefined` inside a position marked `asCell`", () => {
+      const schema: JSONSchema = {
+        type: "object",
+        properties: {
+          target: {
+            type: "object",
+            properties: { n: { type: "number" } },
+            asCell: ["cell"],
+          },
+        },
+      };
+      expect(undeclaredVerbFieldError({ target: { n: 1, extra: 2 } }, schema))
+        .toBeUndefined();
+      expect(
+        undeclaredVerbFieldError(
+          { target: { "/": { id: "of:abc", path: [], space: "did:x:y" } } },
+          schema,
+        ),
+      ).toBeUndefined();
+    });
+
+    // A payload need satisfy only one branch of a disjunction, and schema
+    // traversal unions the branches before deciding which children exist, so a
+    // field only one branch names is one the runtime still delivers.
+    it("returns `undefined` at a position carrying a combinator", () => {
+      expect(
+        undeclaredVerbFieldError({ title: "Milk", colour: "red" }, {
+          type: "object",
+          properties: { title: { type: "string" } },
+          anyOf: [
+            { required: ["title"] },
+            {
+              type: "object",
+              properties: { colour: { type: "string" } },
+            },
+          ],
+        } as JSONSchema),
+      ).toBeUndefined();
+    });
+  });
+
+  // Every shape `schemaIsObjectShaped` recognizes drops what its maps do not
+  // name, so every one of them is judged. An explicit `type: "object"` is only
+  // the most common of the four.
+  describe('an object-shaped position with no explicit `type: "object"`', () => {
+    const bareProperties: JSONSchema = {
+      properties: { title: { type: "string" } },
+    } as JSONSchema;
+    const conjunction: JSONSchema = {
+      allOf: [{ type: "object", properties: { title: { type: "string" } } }],
+    } as JSONSchema;
+    const typeUnion: JSONSchema = {
+      type: ["object", "null"],
+      properties: { title: { type: "string" } },
+    } as JSONSchema;
+
+    it("refuses an undeclared field against a bare `properties` map", () => {
+      expect(
+        undeclaredVerbFieldError(
+          { title: "Milk", colour: "red" },
+          bareProperties,
+        ),
+      )
+        .toBe(
+          '"colour" at <event> is not a field this verb declares. ' +
+            '<event> takes "title"',
+        );
+    });
+
+    it("refuses an undeclared field against a conjunction", () => {
+      expect(
+        undeclaredVerbFieldError({ title: "Milk", colour: "red" }, conjunction),
+      )
+        .toBe(
+          '"colour" at <event> is not a field this verb declares. ' +
+            '<event> takes "title"',
+        );
+    });
+
+    it("refuses an undeclared field against a type union admitting an object", () => {
+      expect(
+        undeclaredVerbFieldError({ title: "Milk", colour: "red" }, typeUnion),
+      )
+        .toBe(
+          '"colour" at <event> is not a field this verb declares. ' +
+            '<event> takes "title"',
+        );
+    });
+
+    // A payload satisfying a conjunction satisfies every member, so the fields
+    // it declares are the union across them.
+    it("takes the fields a conjunction declares as the union across its members", () => {
+      const schema = {
+        type: "object",
+        properties: { title: { type: "string" } },
+        allOf: [
+          { properties: { body: { type: "string" } } },
+          { $ref: "#/$defs/Signed" },
+        ],
+        $defs: {
+          Signed: {
+            type: "object",
+            properties: { agentName: { type: "string" } },
+          },
+        },
+      } as JSONSchema;
+      expect(
+        undeclaredVerbFieldError(
+          { title: "Milk", body: "b", agentName: "Sol" },
+          schema,
+        ),
+      ).toBeUndefined();
+      expect(undeclaredVerbFieldError({ colour: "red" }, schema)).toBe(
+        '"colour" at <event> is not a field this verb declares. ' +
+          '<event> takes "title", "body", "agentName"',
+      );
+    });
+
+    // A member spelled `true` constrains nothing and declares nothing, so the
+    // rest of the conjunction is the whole vocabulary.
+    it("takes nothing from a conjunction member that is a boolean schema", () => {
+      const schema = {
+        type: "object",
+        properties: { title: { type: "string" } },
+        allOf: [true, { properties: { body: { type: "string" } } }],
+      } as JSONSchema;
+      expect(undeclaredVerbFieldError({ title: "Milk", body: "b" }, schema))
+        .toBeUndefined();
+      expect(undeclaredVerbFieldError({ colour: "red" }, schema)).toBe(
+        '"colour" at <event> is not a field this verb declares. ' +
+          '<event> takes "title", "body"',
+      );
+    });
+
+    // A definition whose conjunction names itself contributes its fields once
+    // and terminates, which is what lets a recursive event schema be judged at
+    // all.
+    it("takes the fields of a conjunction that names itself, once", () => {
+      const schema = {
+        type: "object",
+        properties: { title: { type: "string" } },
+        allOf: [{ $ref: "#/$defs/Loop" }],
+        $defs: {
+          Loop: {
+            type: "object",
+            properties: { body: { type: "string" } },
+            allOf: [{ $ref: "#/$defs/Loop" }],
+          },
+        },
+      } as JSONSchema;
+      expect(undeclaredVerbFieldError({ title: "Milk", body: "b" }, schema))
+        .toBeUndefined();
+      expect(undeclaredVerbFieldError({ colour: "red" }, schema)).toBe(
+        '"colour" at <event> is not a field this verb declares. ' +
+          '<event> takes "title", "body"',
+      );
+    });
+
+    // The array counterpart of the object type union: schema traversal descends
+    // the array branch, so the element's undeclared field goes missing there.
+    it("refuses an undeclared field inside a type union admitting an array", () => {
+      expect(
+        undeclaredVerbFieldError({ tags: [{ name: "a", colour: "red" }] }, {
+          type: "object",
+          properties: {
+            tags: {
+              type: ["array", "null"],
+              items: {
+                type: "object",
+                properties: { name: { type: "string" } },
+              },
+            },
+          },
+        } as JSONSchema),
+      ).toBe(
+        '"colour" at <event>.tags[0] is not a field this verb declares. ' +
+          '<event>.tags[0] takes "name"',
+      );
+    });
+
+    it("dispatches a declared payload against a bare `properties` map", async () => {
+      const payload = { title: "Milk" };
+      expect(await dispatchedPayload(bareProperties, payload)).toEqual(payload);
+    });
+
+    it("dispatches a declared payload against a conjunction", async () => {
+      const payload = { title: "Milk" };
+      expect(await dispatchedPayload(conjunction, payload)).toEqual(payload);
+    });
+
+    // A disjunction inside a conjunction makes the whole position honor
+    // everything: the branch a payload was meant for may name a field the
+    // others do not.
+    it("dispatches an undeclared field where a conjunction holds a disjunction", async () => {
+      const schema = {
+        allOf: [
+          { type: "object", properties: { title: { type: "string" } } },
+          {
+            anyOf: [
+              { type: "object", properties: { colour: { type: "string" } } },
+              { type: "object", properties: { size: { type: "string" } } },
+            ],
+          },
+        ],
+      } as JSONSchema;
+      const payload = { title: "Milk", colour: "red" };
+      expect(await dispatchedPayload(schema, payload)).toEqual(payload);
+    });
+
+    // An untyped position naming `items` describes an array the same way an
+    // untyped position naming `properties` describes an object.
+    it("refuses an undeclared field inside an untyped `items` position", () => {
+      expect(
+        undeclaredVerbFieldError({ tags: [{ name: "a", colour: "red" }] }, {
+          type: "object",
+          properties: {
+            tags: {
+              items: {
+                type: "object",
+                properties: { name: { type: "string" } },
+              },
+            },
+          },
+        } as JSONSchema),
+      ).toBe(
+        '"colour" at <event>.tags[0] is not a field this verb declares. ' +
+          '<event>.tags[0] takes "name"',
+      );
+    });
+  });
+
+  // Positions the walk cannot judge, each asserted as the call GOING OUT
+  // rather than as no refusal coming back. The two are different facts, and
+  // only the first one states that a caller can still make the call.
+  describe("a position the walk cannot judge", () => {
+    it("dispatches an array whose elements all carry declared fields", async () => {
+      const schema: JSONSchema = {
+        type: "object",
+        properties: {
+          tags: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: { name: { type: "string" } },
+            },
+          },
+        },
+      };
+      const payload = { tags: [{ name: "urgent" }, { name: "kitchen" }] };
+      expect(await dispatchedPayload(schema, payload)).toEqual(payload);
+    });
+
+    // No `items` beside the `type: "array"`, so the element has no schema and
+    // nothing there declares anything. The runtime delivers the element whole.
+    it("dispatches an array element whose position declares no schema", async () => {
+      const schema: JSONSchema = {
+        type: "object",
+        properties: { tags: { type: "array" } },
+      };
+      const payload = { tags: [{ name: "urgent", colour: "red" }] };
+      expect(await dispatchedPayload(schema, payload)).toEqual(payload);
+    });
+
+    // A `$ref` naming a definition spelled `true` resolves to the wildcard
+    // schema, which declares nothing and refuses nothing.
+    it("dispatches a position whose `$ref` resolves to a boolean schema", async () => {
+      const schema = {
+        type: "object",
+        properties: { detail: { $ref: "#/$defs/Anything" } },
+        $defs: { Anything: true },
+      } as JSONSchema;
+      const payload = { detail: { shape: "unconstrained", n: 1 } };
+      expect(await dispatchedPayload(schema, payload)).toEqual(payload);
+    });
+
+    // The marker rides the DEFINITION rather than the reference site, so it is
+    // reached only after the reference resolves.
+    it("dispatches a position whose `asCell` marker rides the `$ref` target", async () => {
+      const schema = {
+        type: "object",
+        properties: { target: { $ref: "#/$defs/Target" } },
+        $defs: {
+          Target: {
+            type: "object",
+            properties: { n: { type: "number" } },
+            asCell: ["cell"],
+          },
+        },
+      } as JSONSchema;
+      const payload = { target: { n: 1, extra: 2 } };
+      expect(await dispatchedPayload(schema, payload)).toEqual(payload);
+    });
+  });
+
+  describe("verbInputSchemaError()", () => {
+    const addItem: JSONSchema = {
+      type: "object",
+      properties: { title: { type: "string" } },
+      required: ["title"],
+    };
+
+    // Both refusals hold for this payload: `title` is missing and `titel` is
+    // undeclared. Only one of the two answers names something the caller
+    // wrote, and that is the one they get.
+    it("reports the undeclared field ahead of the required one it displaced", () => {
+      expect(verbInputSchemaError({ titel: "Milk" }, addItem)).toBe(
+        '"titel" at <event> is not a field this verb declares. ' +
+          'Did you mean "title"? <event> takes "title"',
+      );
+    });
+
+    it("returns `undefined` for a payload carrying exactly the declared fields", () => {
+      expect(verbInputSchemaError({ title: "Milk" }, addItem)).toBeUndefined();
+    });
+
+    it("still reports a declared field of the wrong type", () => {
+      expect(verbInputSchemaError({ title: 7 }, addItem)).toMatch(/title/);
+    });
+  });
+
+  describe("cf piece call against a live verb", () => {
+    it("declares an event schema naming `properties` with no `additionalProperties`", async () => {
+      // The coupling every refusal below rests on: the shape the transformer
+      // emits is one that drops what it does not name.
+      await withList("undeclared-shape", ({ root }) => {
+        expect(root.key("addItem").schema).toEqual({
+          type: "object",
+          properties: { title: { type: "string" }, done: { type: "boolean" } },
+          required: ["title", "done"],
+        });
+        expect(root.key("ping").schema).toBeUndefined();
+        return Promise.resolve();
+      });
+    });
+
+    it("refuses a payload carrying a field the verb does not declare", async () => {
+      await withList("undeclared-refused", async ({ call, entries }) => {
+        await expect(call("addItem", {
+          title: "Milk",
+          done: false,
+          colour: "red",
+        })).rejects.toThrow(VerbInputValidationError);
+        // Nothing dispatched, so nothing was recorded: the field was refused
+        // rather than dropped on the way in.
+        expect(entries()).toEqual([]);
+      });
+    });
+
+    it("names the verb, the field, the position and the near miss in what the caller reads", async () => {
+      await withList("undeclared-message", async ({ call }) => {
+        await expect(call("addItem", { titel: "Milk", done: false })).rejects
+          .toThrow(
+            'Invalid input for "addItem": "titel" at <event> is not a field ' +
+              'this verb declares. Did you mean "title"? <event> takes ' +
+              '"title", "done"',
+          );
+      });
+    });
+
+    it("names a nested position on a live verb", async () => {
+      await withList("undeclared-nested", async ({ call }) => {
+        await expect(call("rename", { item: { id: "1", lable: "Milk" } }))
+          .rejects.toThrow(
+            '"lable" at <event>.item is not a field this verb declares. ' +
+              'Did you mean "label"? <event>.item takes "id", "label"',
+          );
+      });
+    });
+
+    it("names an array element position on a live verb", async () => {
+      await withList("undeclared-element", async ({ call }) => {
+        await expect(
+          call("tag", { tags: [{ name: "a" }, { name: "b", colour: "red" }] }),
+        ).rejects.toThrow('"colour" at <event>.tags[1] is not a field');
+      });
+    });
+
+    it("dispatches a payload carrying exactly the declared fields", async () => {
+      await withList("undeclared-negative", async ({ call, entries }) => {
+        const outcome = await call("addItem", { title: "Milk", done: false });
+        expect(outcome.status).toBe("settled");
+        expect(entries()).toEqual(['{"title":"Milk","done":false}']);
+      });
+    });
+
+    it("dispatches every payload at a verb that declares no schema", async () => {
+      await withList("undeclared-open", async ({ call, entries }) => {
+        const outcome = await call("ping", { anything: 1 });
+        expect(outcome.status).toBe("settled");
+        expect(entries()).toEqual(["ping"]);
+      });
+    });
+
+    it("leaves the invocation id spendable by the corrected retry", async () => {
+      await withList("undeclared-id", async ({ call, entries }) => {
+        await expect(
+          call("addItem", { title: "Milk", colour: "red" }, "inv-once"),
+        ).rejects.toThrow(VerbInputValidationError);
+        const outcome = await call(
+          "addItem",
+          { title: "Milk", done: false },
+          "inv-once",
+        );
+        expect(outcome.status).toBe("settled");
+        expect(outcome.deduplicated).toBeUndefined();
+        expect(entries()).toEqual(['{"title":"Milk","done":false}']);
+      });
+    });
+  });
+
+  // The same two shapes on a running piece, reached through a verb whose event
+  // schema the pattern writes out. `count` reads what committed, so a dispatch
+  // is stated as the handling landing rather than as the command returning.
+  describe("cf piece call on a verb whose event schema states no `type`", () => {
+    const withExplicit = <T>(
+      passphrase: string,
+      body: (tracker: Tracker) => Promise<T>,
+    ) => withProgram(passphrase, EXPLICIT_SCHEMA_PROGRAM, body);
+
+    it("refuses an undeclared field against a bare `properties` map", async () => {
+      await withExplicit("explicit-bare-refused", async ({ call, root }) => {
+        await expect(call("bare", { title: "Milk", colour: "red" })).rejects
+          .toThrow(
+            '"colour" at <event> is not a field this verb declares. ' +
+              '<event> takes "title"',
+          );
+        // Nothing counted: unwritten, the cell has not materialized its
+        // default, so an absent count and a zero one are the same fact here.
+        expect(root.key("count").get() ?? 0).toBe(0);
+      });
+    });
+
+    it("refuses an undeclared field against a conjunction", async () => {
+      await withExplicit("explicit-allof-refused", async ({ call, root }) => {
+        await expect(call("conjunct", { title: "Milk", colour: "red" }))
+          .rejects.toThrow(
+            '"colour" at <event> is not a field this verb declares. ' +
+              '<event> takes "title"',
+          );
+        // Nothing counted: unwritten, the cell has not materialized its
+        // default, so an absent count and a zero one are the same fact here.
+        expect(root.key("count").get() ?? 0).toBe(0);
+      });
+    });
+
+    it("dispatches a declared payload against a bare `properties` map", async () => {
+      await withExplicit("explicit-bare-dispatch", async ({ call, root }) => {
+        const outcome = await call("bare", { title: "Milk" });
+        expect(outcome.status).toBe("settled");
+        expect(root.key("count").get()).toBe(1);
+      });
+    });
+
+    it("dispatches a declared payload against a conjunction", async () => {
+      await withExplicit("explicit-allof-dispatch", async ({ call, root }) => {
+        const outcome = await call("conjunct", { title: "Milk" });
+        expect(outcome.status).toBe("settled");
+        expect(root.key("count").get()).toBe(1);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Why

A payload carrying a field the verb's event schema does not declare was
accepted, the field was dropped on the way in, and the caller was told the call
settled. Measured on this branch's parent, against a verb declaring `title` and
`done`:

```
addItem declares: {"type":"object","properties":{"title":{"type":"string"},"done":{"type":"boolean"}},"required":["title","done"]}
caller sends:     {"title":"Milk","done":false,"colour":"red"}
cf reports:       "settled" {"entry":"{\"done\":false,\"title\":\"Milk\"}"}
handler saw:      ["{\"done\":false,\"title\":\"Milk\"}"]
```

`colour` never reached the handler, nothing said so, and the exit was 0. That is
the silent-strip failure: what a caller writing JSON by hand or by model hits,
and a TypeScript author never does.

This is step 12a / item 12 of the verbs arc
([verbs-implementation.md](https://github.com/commontoolsinc/labs/blob/main/docs/plans/verbs-implementation.md)).
It is deliberately **not** a schema forbidding the field: closed-world event
emission is ruled against (#5589), and #5686 records that the runtime does the
opposite of the closed-world rule. The refusal lives in the CLI, which is where
that ruling put this capability. Item 2 — the same refusal one surface over — is
in review as #5817; this branch matches its wording without importing its code.

## What Changed

**`verbInputSchemaError` (`packages/cli/lib/callable.ts`) treats an undeclared
field as a reason to refuse.** The schema it already validates against names
exactly the fields the verb declares, so no new source of truth is involved.

**The rule is derived from where a field actually goes missing.** Measured
against the read a handler's event goes through
(`SchemaObjectTraverser.traverseObjectWithSchema`, whose `addOptionalProperty`
is a no-op on the `validateAndTransform` path), for an object holding one
declared and one undeclared field:

| The schema at a position | What the handler receives |
| --- | --- |
| `{type: "object"}` | both fields |
| `{type: "object", properties: {declared}}` | the declared field |
| `{type: ["object","null"], properties: {declared}}` | the declared field |
| `{allOf: [{type: "object", properties: {declared}}]}` | the declared field |
| `{properties: {declared}}` | **nothing** |
| `{type: "object", properties: {}}` | **nothing** |
| `{anyOf: [...]}` | both fields |
| any of those plus `additionalProperties` | both fields |

So the condition is *reaching a `properties` map with no `additionalProperties`
beside it* — not *stating `type: "object"`*. Every spelling of an object-shaped
position drops what its maps do not name.

**Which spellings those are is `schemaIsObjectShaped`'s question (same file),
asked rather than answered a second time.** It already accepts
`type === "object" || isSchemaObject(target.properties)` and walks `allOf`
members through `localRefTarget`, which covers all four shapes: a stated type, a
bare `properties` map, a type union admitting an object (via the `properties`
clause), and a conjunction. Two predicates disagreeing about what an object is
would be worse than either.

**A conjunction's declared fields are the union across its members**, which
`schemaIsObjectShaped` does not give — it answers *is this object-shaped* with
`.some()`, and the gate also needs *which fields*. `declaredFieldsAt` collects
every property map reached, each with the local-ref scope its children resolve
in, recursing through `allOf` members. A payload satisfying an `allOf` satisfies
every member, so a field one member names is a field the position names; the
union is also the safe direction, since the cost of missing a member is refusing
a declared field.

That derivation cycles on the **reference**, not on the schema it resolved to.
The object-identity guard written first did not hold: resolution hands back a
fresh view of a definition on every hop, so a self-referential `$ref` reached an
object the walk had never seen and descended until the stack gave out. Keying on
`(scope, $ref)` — what `localRefTarget` itself cycles on — terminates, and the
test that caught it is in the suite.

**Disjunctions still fail open.** `anyOf`/`oneOf` are a branch choice and a
payload need satisfy only one, so a field absent from the branch inspected may
be named by another — and the measurement confirms the runtime delivers both
fields there. A disjunction *inside* a conjunction makes the whole position
honor everything, for the same reason. The fail-open principle is unchanged; it
was `allOf` that was miscategorised.

**Beyond the review's letter, and flagged for that reason:** the same defect
sits one container over. `{properties: {list: {items: {...}}}}` — an `items`
position with no `type: "array"` — delivers **nothing**, measured alongside the
rows above, so an undeclared element field was silently stripped there too.
`schemaIsArrayShaped` answers the array question the way `schemaIsObjectShaped`
answers the object one: a stated type says so, and otherwise the container
keyword being present does. Say the word if you would rather this were split
out; it is three lines with two tests and two mutants (M15, M18).

**Everywhere else the walk still fails open**, because a refusal spends nothing
and can be retried while a call wrongly refused cannot be made at all: a
position marked `asCell`/`asStream` below the root (where a caller may write a
link, whose `"/"` is not a field anybody declared), a container the payload does
not match, an unresolvable `$ref`, and a key several conjunction members
constrain — the walk cannot say which member's schema governs beneath it. Each
is asserted as **the call dispatching**, not as the refusal being absent; the
two differ, and only the first fails when a fail-open branch starts failing
closed.

**The walk descends the payload, not the schema**, so it terminates on the
caller's own finite JSON: nested objects by property, arrays by `items` /
`prefixItems`, local `$ref`s through `localRefTarget` with `cfcSchemaChildRoot`
threaded beside it.

**The undeclared field is judged ahead of the schema validation.** Both hold at
once for a misspelled required field, and only one of the two answers names
something the caller actually wrote.

### The refusal, matched to #5817's

#5817 refuses a projection key with `Invalid --schema at <root>.notes:
"minLenght" is not a projection schema keyword. Did you mean "minLength"?
Projection reads "type", "properties", …`. Five elements: the surface, the
position, the quoted offending name, the near miss, the accepted vocabulary.
This branch carries all five:

```
Invalid input for "addItem": "titel" at <event> is not a field this verb
declares. Did you mean "title"? <event> takes "title", "done"
```

Positions use the read boundary's own spelling — `<event>`, `<event>.item`,
`<event>.tags[1]`, against `<root>`, `<root>.notes`, `<root>[]` — and the near
miss uses the same Damerau edit distance and the same `max(1, floor(len/4))`
threshold, so a transposition counts as one slip.

One deviation, deliberate: the position follows the key rather than preceding
it. `VerbInputValidationError` fixes the prefix as `Invalid input for "<verb>":
`, and leading the detail with the position yields a double colon. Reordering
would mean changing the error class for every other detail string it carries.

**No code is imported from #5817** — that branch is unmerged and its internals
may still move — so `fieldEditDistance` is a second copy of an eleven-line
helper. Once both land the two should become one.

### What an empty event schema means, decided by measurement

- **No property map at all** — including the schema the transformer emits for a
  verb whose event type names no fields, which is *no schema*
  (`Record<string, never>` and `Record<string, unknown>` both produce
  `undefined`). The runtime delivers the whole payload; nothing is refused.
- **`properties: {}`** — reachable from a hand-written or `asSchema` schema. The
  runtime delivers nothing, so every field written there is refused, and the
  message says `<event> declares no fields at all`.

A bare `properties` map also delivers nothing — it drops the fields it
*declares* as well. That is a defect of its own, out of reach of a gate over
undeclared fields, and it is named where the derivation is written down rather
than left for the next reader to rediscover.

### One sharp edge, recorded rather than smoothed

The emitted event schema names the fields the handler body **reads**, not the
fields its TypeScript event type declares. Measured: `AddItemEvent {title,
done}` emits only `title` until the body touches `done`. So a caller sending a
field the interface declares and the body never reads is now refused — the same
silent-strip surfacing, and the vocabulary the refusal prints is exactly what
`cf piece call <verb> --help` prints.

### Documentation

- `packages/cli/README.md` and `docs/common/verbs-over-the-cli.md` — the
  refusal, and which positions are judged versus passed over, so the
  caller-facing pages describe the behaviour rather than neither.
- `docs/plans/verbs-implementation.md` — item 12's status rows and section.
  Touches lines #5817 does not.

## Blast radius, measured

**Zero call sites in this repository would start failing.** Every payload that
could be resolved against its target handler's declared schema uses only
declared fields. Swept: `.github/`, `tasks/`, `scripts/`, `skills/`, `docs/`,
`.claude/`, every `integration/*.sh`, and `packages/cli/test/`.

- **CI-executed integration scripts** (`integration.sh`, `acl.sh`,
  `fuse-exec.sh`) — every payload is declared. The deliberate-typo probes assert
  only on `Invalid input for "<verb>"` or the error class, so the new wording
  still satisfies them; the absent-payload probe is unchanged, since absence
  normalizes to `{}` and falls through to the missing-required path.
- **`skills/topics/SKILL.md`** — the highest-traffic agent-driven surface — every
  field declared and read by its handler.
- **Fixtures on the cliff**: `legacyWrite` (`integration/pattern/fuse-exec.tsx`)
  and five `piece-call.test.ts` cases declare `{type:"object", properties:{}}`.
  All six send no payload, so they pass; any future edit adding one turns them
  red.
- **`packages/cli/test/piece-call.test.ts`'s "rejects a missing required
  property"** passed `{mesage: "milk"}` and still passes, but now reaches the
  undeclared-field branch, so its name would describe a path it no longer takes.
  Changed to `{}`, which reaches the schema validation it names.
- **Not affected**: tools never reach this gate (handler branch only), nor does
  llm-dialog's `result` injection, FUSE `.handler` writes, or `cf test`'s
  `trusted-test-event.ts`, which merges an undeclared `provenance` key into 42
  pattern-test steps via `actionStream.send` — the largest latent exposure if
  this gate ever moves down to `Cell.send`.
- **Accepted risk**: a caller outside this repository sending a field the handler
  body never reads now fails loudly. A field the runtime was already discarding
  was not doing what its author believed, and a loud failure is the only version
  of that a caller can act on.

## Test plan

`packages/cli/test/verb-undeclared-field.test.ts`, 43 tests across 49 steps: 31
against `undeclaredVerbFieldError` / `verbInputSchemaError` and the pre-dispatch
gate directly, 12 against compiled, run patterns driven through
`executePieceCallable` the way `cf piece call` drives it. Two programs: one
whose event schemas the transformer derives, and one whose two verbs write their
event schemas out, which is how a pattern reaches the object shapes the
transformer never emits.

Every fail-open position is asserted as the call **dispatching** — the payload
read back off the stream, or the handling's own counter — never as a refusal
merely being absent.

Every step was demonstrated red against a named implementation:

| Mutant | Red steps | What it reds |
| --- | --- | --- |
| M0 — this branch's parent (the check absent) | 25 | every refusal, direct and live |
| M1 — `additionalProperties` not consulted | 2 | the `additionalProperties` positive, alone |
| M2 — a position reaching no property map read as declaring nothing | 2 | the open-schema positive, alone |
| M3 — the root checked and nothing below it | 9 | every nested and element position, direct and live |
| M4 — the near miss measured with plain Levenshtein | 10 | every suggestion |
| M5 — the check run after the schema validation | 5 | the misspelled-required case |
| M6 — the `asCell` marker not consulted | 4 | both marked positions, at the reference site and on its target |
| M7 — the check refusing whatever a payload names, consulting no declaration | 38 | **every positive**, including all four live dispatches. This is what stops "refuse everything" from passing |
| M8 — disjunctions judged rather than passed over | 4 | the `anyOf` position and the disjunction inside a conjunction |
| M9 — the undeclared check replacing the schema validation | 2 | the wrong-typed declared field, alone |
| M10 — a missing schema read as declaring nothing | 4 | both no-schema positives, direct and live |
| M11 — a position the walk cannot judge refused rather than passed over | 5 | all four dispatch assertions for the unjudgeable positions |
| M12 — the `asCell` marker consulted at the reference site alone | 2 | the marker riding the `$ref` target |
| M13 — object-shaped decided by a stated `type: "object"` alone | 5 | the bare map, the conjunction and the type union, direct and live |
| M14 — a conjunction's fields taken from the first member that has any | 4 | all three conjunction-vocabulary cases |
| M15 — an untyped `items` position not recognized as an array | 2 | the untyped array element |
| M16 — the reference cycle guard removed | 2 | the self-naming conjunction, which overflows the stack |
| M17 — a boolean conjunction member read as honoring everything | 2 | the `true` member, alone |
| M18 — a type union admitting an array not recognized as one | 2 | the array type union, alone |

42 of the 43 `it()`s are killed by at least one mutant. The one that is not is
"declares an event schema naming `properties` with no `additionalProperties`",
by design: it pins the transformer's emitted shape against measured output, so
no mutant of `callable.ts` can red it. A transformer that started emitting
`additionalProperties` would make every refusal unreachable while leaving the
direct assertions green, and that step is what would catch it.

No `waitFor`, no `setTimeout`, no sleeps, no retries.

### Coverage

The +5 was five lines in `firstUndeclaredEventField`, found by running
`packages/cli` under `DENO_COVERAGE_DIR` and converting with
`tasks/write-coverage-lcov.ts` exactly as CI does — four fail-open branches and
the array branch's own exit, every one reachable from a constructed schema and
none environment-dependent, so no `ACCEPT_COVERAGE_DEBT`:

| Line | What it does |
| --- | --- |
| 505 | the schema at a child position is not an object — nothing there declares anything |
| 509 | a `$ref` resolving to a boolean schema |
| 510 | an `asCell`/`asStream` marker riding the `$ref` target rather than the reference site |
| 537–538 | the array branch completing with every element clean |

The object-shape work then added three more of its own — the boolean conjunction
member, the array type union, and the cycle guard — which the tests above cover
in the course of pinning the behaviour. `packages/cli/lib/callable.ts` now has
**no uncovered line** in anything this branch added.

Local `packages/cli` uncovered lines, the same suite measured three times on
the same base: **3246** at the pushed head, 3244 after the object-shape work,
**3241** with the last three covered — exactly −5. CI reported 3232 → 3237 for
the pushed head, a constant **+9** offset against local, because CI sums the
group over every job that loads its files while one local suite loads a subset.
The delta is what compares, not the absolute, so −5 puts CI back at its 3232
baseline. `packages/cli/lib/callable.ts` is left with the 16 uncovered lines it
had before this branch and no others.

Gates, each exit code captured on its own line rather than after a pipe:
`cd packages/cli && deno task test` **0** (1679 + 1 + 174 passed, 0 failed),
root `deno fmt --check` **0**, `deno lint` **0**, `deno task check` **0**,
`check-no-waitfor` **0**, `check-docs` **0** (549 blocks),
`check-conflict-markers` **0**, `check-skill-facts` **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
