### PR TITLE
feat: server-execution v2 Phase 5 — cross-space: grant-scoped reads, .inSpace journeys, served wishes

### DIFF
--- a/docs/plans/server-execution-v2.md
+++ b/docs/plans/server-execution-v2.md
@@ -652,11 +652,16 @@ Tasks:
       authority; foreign commits wake the home runtime (server-internal
       subscription). LANDED 2026-08-14: foreign SPACE-scope reads flow
       on the serving runtime's ordinary storage plane (per-space
-      loopback sessions), and the host fans a foreign admission to
-      every active SpaceServer whose runtime holds sessions into that
-      space (the §3b server-internal wake — never home input; W stays
-      per home space); activation's basis re-mark judges foreign rows
-      against their own co-hosted engines (serving-loop.md §6 step 2).
+      loopback sessions), and the wake needed NO host machinery — a
+      fan-out built for it was mutation-probed redundant and REMOVED
+      (survival test): the foreign commit's frames arrive on the home
+      runtime's own foreign loopback session, the scheduler re-runs
+      autonomously off storage notifications, and the re-run's seal
+      wakes the loop (the §3b server-internal wake — never home
+      input; W stays per home space); activation's basis re-mark
+      judges foreign rows against their own co-hosted engines
+      (serving-loop.md §6 step 2, pinned at the helper —
+      `selectForeignStaleInstances`).
       Foreign SCOPED reads are FAIL-CLOSED refused at both ends — the
       RULED 2026-08-13 delegated-scoped-read precondition: the
       grant-scoped read design landed in protocol.md §2 (carried actor
@@ -676,17 +681,25 @@ Tasks:
 - [x] `.inSpace()` provisioning server-side: foreign-first split at the
       wave commit step, event-derived deterministic DIDs (CT-1650),
       replay-idempotent (protocol.md §2b). LANDED 2026-08-14: the
-      serving loop runs the wave's accept-with-carriage posture — a
-      foreign write is admitted at accumulation iff the run carries
-      the §2b delegated carriage (acting + capabilityRef; #stampRun
-      supplies the grant for served runs acting as a principal), a
-      carriage-less foreign write keeps the ruled action-scoped
-      refusal — and resolves foreign co-hosted engines ahead of the
-      commit step (stage G's foreign-first sequencing + FP1 rows were
-      already live). The RULED wish line item rides the same crossing:
-      per-demanding-identity wish resolution (builtins.md §5 —
-      `homeSpacePrincipalFor`; the serving wish resolves the
-      demanding user's home space, never the service identity's).
+      serving loop runs the wave's accept posture as an AUTHORIZATION
+      boundary — a foreign write is admitted at accumulation iff the
+      run carries the §2b delegated carriage (acting + capabilityRef)
+      AND the acting identity holds a structural write grant for the
+      TARGET space (the memory server's `foreignWriteAuthorityFor`:
+      owner-by-identity, fresh-store creation with a DID-shape check,
+      or the target's own ACL grant — fail-closed otherwise; the
+      accept posture cannot be configured without the probe). A
+      carriage-less or ungranted foreign write keeps the ruled
+      action-scoped refusal. Foreign co-hosted engines resolve ahead
+      of the commit step with per-space failure ISOLATION (an
+      unresolvable target fails only its own contributions, counted —
+      never a home-space park). The RULED wish line item rides the
+      same crossing: per-demanding-identity wish resolution
+      (builtins.md §5 — `homeSpacePrincipalFor`; the serving wish
+      resolves the demanding user's home space, never the service
+      identity's; sidecar surfaces AND their closure caches key per
+      demanding identity, so two demanders never share a create
+      surface).
 
 Success criteria:
 

--- a/docs/plans/server-execution-v2.md
+++ b/docs/plans/server-execution-v2.md
@@ -648,14 +648,45 @@ Success criteria:
 
 Tasks:
 
-- [ ] Home-space runtime reads foreign spaces with the piece's granted
+- [x] Home-space runtime reads foreign spaces with the piece's granted
       authority; foreign commits wake the home runtime (server-internal
-      subscription).
+      subscription). LANDED 2026-08-14: foreign SPACE-scope reads flow
+      on the serving runtime's ordinary storage plane (per-space
+      loopback sessions), and the host fans a foreign admission to
+      every active SpaceServer whose runtime holds sessions into that
+      space (the §3b server-internal wake — never home input; W stays
+      per home space); activation's basis re-mark judges foreign rows
+      against their own co-hosted engines (serving-loop.md §6 step 2).
+      Foreign SCOPED reads are FAIL-CLOSED refused at both ends — the
+      RULED 2026-08-13 delegated-scoped-read precondition: the
+      grant-scoped read design landed in protocol.md §2 (carried actor
+      + grant; resolution refuses, never envelope fallback), its
+      fail-closed interim is the producer-side provider refusal + the
+      admission-side unnamed-scoped refusal, and the read row gained
+      FP2's cross-engine widening + the per-process full-DR1-holder
+      sharpening (`v2-explicit-read.test.ts`'s Phase-5 arms,
+      red-first).
 - [ ] Per-reader clearance enforced where the read is served (sqlite row
-      admissibility, CFC labels).
-- [ ] `.inSpace()` provisioning server-side: foreign-first split at the
+      admissibility, CFC labels). (The per-reader memo/materialization
+      machinery is builtins.md §2's landed base; cross-space label
+      metadata flows with reads on the existing per-run CFC path.
+      Foreign-batch sqlite attachment stays refused — no producer; its
+      identity design rides the grant-scoped read design. Ticks with
+      the acceptance gate below.)
+- [x] `.inSpace()` provisioning server-side: foreign-first split at the
       wave commit step, event-derived deterministic DIDs (CT-1650),
-      replay-idempotent (protocol.md §2b).
+      replay-idempotent (protocol.md §2b). LANDED 2026-08-14: the
+      serving loop runs the wave's accept-with-carriage posture — a
+      foreign write is admitted at accumulation iff the run carries
+      the §2b delegated carriage (acting + capabilityRef; #stampRun
+      supplies the grant for served runs acting as a principal), a
+      carriage-less foreign write keeps the ruled action-scoped
+      refusal — and resolves foreign co-hosted engines ahead of the
+      commit step (stage G's foreign-first sequencing + FP1 rows were
+      already live). The RULED wish line item rides the same crossing:
+      per-demanding-identity wish resolution (builtins.md §5 —
+      `homeSpacePrincipalFor`; the serving wish resolves the
+      demanding user's home space, never the service identity's).
 
 Success criteria:
 
@@ -665,7 +696,10 @@ Success criteria:
 - [ ] Profile creation (the `.inSpace()` flow: `profile-create`,
       `home-profile`) green in the ON arm, including a kill between the
       foreign and home commits — replay converges on the same DIDs, no
-      orphans, no duplicates.
+      orphans, no duplicates. (The wave-level kill/replay halves are
+      pinned — foreign-failure-withholds-home and
+      requeue-after-foreign-landed in `executor-wave.test.ts`; the
+      browser-flow gates carry the E2E.)
 
 ## Phase 6 — Push priority, budgets, scale
 

--- a/docs/specs/server-side-execution/builtins.md
+++ b/docs/specs/server-side-execution/builtins.md
@@ -149,14 +149,22 @@ stream is passed to other spaces, which then append intents to it.
   resolution backstop). Its home-space bootstrap writes ride
   protocol.md §2b's `.inSpace` sanctioned crossing — authored-class,
   foreign-first, under the demanding principal's acting identity +
-  grant (the wave's accept-with-carriage gate, serving-loop.md §3d).
-  A carriage-less foreign write — the lunch-wall class — still
-  refuses at accumulation, action-scoped and counted
-  (`foreignWriteRefusals`). The serving side's sidecar compile-cache
-  context is the SERVED space, never the service identity's own
-  (the same class of ambient-identity leak, closed with the same
-  lift). Client wishes are byte-identical to before (cardinality 1:
-  the runtime's own user).
+  grant, ADMITTED at the wave's accept gate because the target IS the
+  demander's own home space (the gate's owner-by-identity structural
+  grant, serving-loop.md §3d — carriage alone admits nothing). A
+  carriage-less or UNGRANTED foreign write — the lunch-wall class,
+  and an actor reaching beyond its authority — still refuses at
+  accumulation, action-scoped and counted (`foreignWriteRefusals`).
+  The serving side's sidecar compile-cache context is the SERVED
+  space, never the service identity's own (the same class of
+  ambient-identity leak, closed with the same lift), and the sidecar
+  SURFACES key per demanding identity — the result/ready cells AND
+  the builtin's per-node closure caches alike (one wish node serves
+  every demander; a shared cache slot would hand demander #2
+  demander #1's create surface and clobber the pending input).
+  Client wishes are byte-identical to before (cardinality 1: the
+  runtime's own user; the client suggestion-cell cause carries no
+  user key, exactly as before).
 
 ## 6. Adding a new built-in under v2 (checklist for future work)
 

--- a/docs/specs/server-side-execution/builtins.md
+++ b/docs/specs/server-side-execution/builtins.md
@@ -136,17 +136,27 @@ stream is passed to other spaces, which then append intents to it.
   LOAD-BEARING on main in `filter.ts`/`flatmap.ts` (#4367, #4438), so
   "do not port" is not on the table; decide its end state against
   serving-loop.md §6 when Phase 1 lands the list coordinators.
-- `wish` home-space materialization under serving (RULED 2026-08-14
-  (c)): a serving-runtime wish that materializes home-space state
-  resolves against the SERVICE identity's home space, so its writes
-  are foreign to the served space — REFUSED at wave accumulation
-  (serving-loop.md §3d: action-scoped, loud, counted into §7's
-  `foreignWriteRefusals`; the wave and the loop keep serving; the
-  commit-step foreign-engine guard stays as backstop). No client
-  diversion. Phase 5 lifts it as per-demanding-identity wish
-  resolution riding protocol.md §2b's `.inSpace` sanctioned crossing —
-  both halves already exist (P2-F's per-run identity supply, stage G's
-  foreign-first provisioning sequencing).
+- `wish` home-space materialization under serving — LIFTED by Phase 5
+  as **per-demanding-identity wish resolution** (RULED 2026-08-14;
+  supersedes the (c)-ruled interim refusal): on a serving runtime the
+  wish's home-space targets (`#favorites`/`#journal`/`#profile`
+  family) resolve against the RUN's demanding identity — the
+  demand-supplied instance identity (P2-F's run supply) or the
+  event's stamped actor, read from the stamped run context — NEVER
+  the service identity (`Runtime.homeSpacePrincipalFor`); a
+  home-space wish with NO demanding identity refuses loudly (a
+  WishError at the resolution guards; a hard error at the cell
+  resolution backstop). Its home-space bootstrap writes ride
+  protocol.md §2b's `.inSpace` sanctioned crossing — authored-class,
+  foreign-first, under the demanding principal's acting identity +
+  grant (the wave's accept-with-carriage gate, serving-loop.md §3d).
+  A carriage-less foreign write — the lunch-wall class — still
+  refuses at accumulation, action-scoped and counted
+  (`foreignWriteRefusals`). The serving side's sidecar compile-cache
+  context is the SERVED space, never the service identity's own
+  (the same class of ambient-identity leak, closed with the same
+  lift). Client wishes are byte-identical to before (cardinality 1:
+  the runtime's own user).
 
 ## 6. Adding a new built-in under v2 (checklist for future work)
 

--- a/docs/specs/server-side-execution/protocol.md
+++ b/docs/specs/server-side-execution/protocol.md
@@ -382,16 +382,42 @@ keep resolving from the session. FP2 (RULED 2026-08-03) widens the
 holder condition to ANY live lease holder on the co-hosted memory
 server, so cross-space scoped reads (§2b's free read row) can name
 their foreign instance instead of silently resolving
-`user:<serviceDID>`. Anticipated hardening, OUT OF v2 SCOPE and
-named without design: grant-scoped foreign reads — admissibility
-derived from the piece's granted read authority rather than lease
-identity — alongside remote attestation. (Phase-1 implementation
-bound, stage F: the landed check consults the READ space's own live
-lease — sufficient for every Phase-1 producer, which reads only its
-own space. FP2's widened acceptance — a home holder naming a FOREIGN
-space's instances under its own space's lease — has no producer
-until Phase 5's cross-space serving and lands with it, alongside the
-cross-engine lease lookup it needs.)
+`user:<serviceDID>`. **Phase 5 LANDED both halves the Phase-1 bound
+deferred:** the read space's own lease is checked first, then FP2's
+cross-engine fallback — any live lease on the co-hosted server; and
+the equality is SHARPENED to the FULL DR1 holder minted by the
+co-hosted process (service identity + process-instance component),
+retiring the Phase-1 recorded acceptance under which a second
+process sharing the service DID passed on the first process's lease
+row (verification-coverage.md's stage-F read-row entry).
+
+**The grant-scoped read DESIGN (Phase 5; the RULED 2026-08-13
+precondition — the design, or an explicit fail-closed refusal, lands
+BEFORE any delegated-scoped-read producer ships, and producer and
+refusal land together as one stack).** A DELEGATED scoped read — the
+home SpaceServer reading a FOREIGN scoped instance on behalf of a
+carried actor — resolves against the CARRIED actor's instance under
+an explicit grant, NEVER the delegating envelope, and NEVER silently
+empty (the FP2 silent-empty-instance trap is the failure mode this
+kills). The design, stated for the implementation that follows the
+per-doc grant store (OW13's trigger): the read carries the acting
+identity + `capabilityRef` exactly like the server-produced authored
+row; admission resolves the grant against the target doc and admits
+the NAMED instance (`entity_scope_key` constructed from the CARRIED
+actor); a read whose grant does not resolve REFUSES — it never falls
+back to lease-wide trust or the envelope. Until that store exists,
+the FAIL-CLOSED interim is normative and LANDED with Phase 5's
+producers, at both ends of the stack: (i) the serving runtime's
+storage plane REFUSES scoped (user/session) reads of any non-home
+space outright — a foreign scoped read cannot leave the producer,
+named or unnamed; (ii) admission REFUSES an UNNAMED scoped root from
+a co-hosted serving session (a live-lease principal) reading a space
+whose lease it does not hold — the shape that would silently resolve
+`user:<serviceDID>`. Cross-space serving therefore reads foreign
+SPACE-scope state freely (§2b's free-read row) and foreign SCOPED
+state not at all; lifting that refusal is exactly the grant
+resolution above, never a lease-trust widening. Remote attestation
+stays anticipated future work.
 
 **Run identity for a derivation (S1).** A derivation runs PER
 DEMANDED INSTANCE and the DEMAND supplies the identity — a

--- a/docs/specs/server-side-execution/serving-loop.md
+++ b/docs/specs/server-side-execution/serving-loop.md
@@ -341,12 +341,13 @@ executing:
   for it — survival-tested: the foreign read's loopback session IS
   the registration; a foreign commit's frames arrive on that session,
   the scheduler runs autonomously off storage notifications, and the
-  re-run's SEAL wakes the loop — a wake the loop LATCHES when no
-  input waiter is armed (a seal chained in a cycle's last microtasks
-  is not yet visible to the idle check; the latch keeps the wake
-  deterministic instead of falling back to the idle timeout, which
-  the removed fan-out had covered incidentally). The foreign commit
-  is never home input — W and the input batch stay per home space.
+  re-run's SEAL wakes the loop — with chained-not-yet-applied seals
+  counted as WORK by the idle check (a seal chained in a cycle's
+  last microtasks is otherwise invisible to it; the level keeps the
+  wake deterministic instead of falling back to the idle timeout,
+  which the removed fan-out had covered incidentally). The foreign
+  commit is never home input — W and the input batch stay per home
+  space.
   Foreign SCOPED reads are the exception: fail-closed refused until
   the grant-scoped read design's resolution lands — protocol.md §2.)*
 - **Scope discovery is part of read discovery**: a run's scope is the

--- a/docs/specs/server-side-execution/serving-loop.md
+++ b/docs/specs/server-side-execution/serving-loop.md
@@ -337,7 +337,14 @@ executing:
   granted authority) registers, by being logged, a server-internal wake
   on that doc for the home SpaceServer. Same one-run-late soundness.
   v2 assumes spaces co-hosted on one memory server; sharding is out of
-  scope.
+  scope. *(Phase 5 pinned the wake end to end and added NO machinery
+  for it — survival-tested: the foreign read's loopback session IS
+  the registration; a foreign commit's frames arrive on that session,
+  the scheduler runs autonomously off storage notifications, and the
+  re-run's SEAL wakes the loop. The foreign commit is never home
+  input — W and the input batch stay per home space. Foreign SCOPED
+  reads are the exception: fail-closed refused until the grant-scoped
+  read design's resolution lands — protocol.md §2.)*
 - **Scope discovery is part of read discovery**: a run's scope is the
   narrowest scope of anything it read, so it too is discovered by
   running. A narrowing discovery writes the broad-slot redirect AND
@@ -785,18 +792,25 @@ sequential, stop at first failure). The wave does not close until the
 split completes or fails as a unit (same-host store sequencing, not a
 network await).
 
-Until Phase 5 sanctions the crossing, a serving wave REFUSES
-foreign-space writes at ACCUMULATION (RULED 2026-08-14 (c)):
-home-space wish materialization under serving — a wish resolving
-against the serving RUNTIME's home space, which is the service
-identity's — refuses at the seal sink, action-scoped (that action's
-tx fails loudly and is counted into §7's `foreignWriteRefusals`; its
-already-sealed spaces withdraw per this section's failure isolation)
-while the wave commits everything else; the commit-step
-foreign-engine guard stays as backstop. Phase 5's line item for
-lifting this is per-demanding-identity wish resolution riding §2b's
-`.inSpace` sanctioned crossing (builtins.md §5 carries the register
-row).
+Phase 5 SANCTIONED the crossing, and the accumulation gate (RULED
+2026-08-14 (c)) survives as its shape check: a serving wave ADMITS a
+foreign-space write at ACCUMULATION iff the sealing run's context
+carries the §2b delegated carriage — acting identity AND
+`capabilityRef`, the provisioning shape protocol.md §2's
+server-produced authored row requires on EVERY foreign commit. A
+carriage-less foreign write — the lunch-wall class: a run resolving
+against the SERVICE identity's ambient state — still refuses at the
+seal sink, action-scoped (that action's tx fails loudly and is
+counted into §7's `foreignWriteRefusals`; its already-sealed spaces
+withdraw per this section's failure isolation) while the wave commits
+everything else; the commit-step foreign-engine resolution (the
+serving loop resolves the wave's foreign co-hosted engines ahead of
+the commit step) keeps the sink's delegated validation as backstop.
+The producers this admits: `.inSpace` provisioning handlers (the
+event's acting principal + grant), and per-demanding-identity wish
+resolution — a demanded run acting as its demander (scopes.md §5)
+whose home-space bootstrap writes ride the same crossing (builtins.md
+§5 carries the register row; RULED 2026-08-14).
 
 ## 3e. Pattern updates
 
@@ -963,7 +977,11 @@ On activate after crash or deploy:
    Recovery is index-guided re-marking, NOT commit replay — own derived
    commits are echo-skipped live (§3), so replay could not re-mark the
    frontier anyway. Subscribe from the head the index scan ran against;
-   later commits arrive as ordinary input.
+   later commits arrive as ordinary input. Rows whose `entity_space` is
+   FOREIGN (§3b's cross-space reads) are judged against that space's
+   own co-hosted engine's head (Phase 5); a failed foreign resolution
+   degrades to surfacing, never a wedge — correctness rides
+   recompute-on-demand either way.
 3. The first wave recomputes the dirty frontier; memo hits suppress
    re-firing completed effects; memo misses re-fire effects whose
    results never landed. External effects are therefore at-least-once

--- a/docs/specs/server-side-execution/serving-loop.md
+++ b/docs/specs/server-side-execution/serving-loop.md
@@ -341,10 +341,14 @@ executing:
   for it — survival-tested: the foreign read's loopback session IS
   the registration; a foreign commit's frames arrive on that session,
   the scheduler runs autonomously off storage notifications, and the
-  re-run's SEAL wakes the loop. The foreign commit is never home
-  input — W and the input batch stay per home space. Foreign SCOPED
-  reads are the exception: fail-closed refused until the grant-scoped
-  read design's resolution lands — protocol.md §2.)*
+  re-run's SEAL wakes the loop — a wake the loop LATCHES when no
+  input waiter is armed (a seal chained in a cycle's last microtasks
+  is not yet visible to the idle check; the latch keeps the wake
+  deterministic instead of falling back to the idle timeout, which
+  the removed fan-out had covered incidentally). The foreign commit
+  is never home input — W and the input batch stay per home space.
+  Foreign SCOPED reads are the exception: fail-closed refused until
+  the grant-scoped read design's resolution lands — protocol.md §2.)*
 - **Scope discovery is part of read discovery**: a run's scope is the
   narrowest scope of anything it read, so it too is discovered by
   running. A narrowing discovery writes the broad-slot redirect AND
@@ -793,24 +797,56 @@ split completes or fails as a unit (same-host store sequencing, not a
 network await).
 
 Phase 5 SANCTIONED the crossing, and the accumulation gate (RULED
-2026-08-14 (c)) survives as its shape check: a serving wave ADMITS a
-foreign-space write at ACCUMULATION iff the sealing run's context
-carries the §2b delegated carriage — acting identity AND
-`capabilityRef`, the provisioning shape protocol.md §2's
-server-produced authored row requires on EVERY foreign commit. A
-carriage-less foreign write — the lunch-wall class: a run resolving
-against the SERVICE identity's ambient state — still refuses at the
-seal sink, action-scoped (that action's tx fails loudly and is
-counted into §7's `foreignWriteRefusals`; its already-sealed spaces
-withdraw per this section's failure isolation) while the wave commits
-everything else; the commit-step foreign-engine resolution (the
-serving loop resolves the wave's foreign co-hosted engines ahead of
-the commit step) keeps the sink's delegated validation as backstop.
-The producers this admits: `.inSpace` provisioning handlers (the
-event's acting principal + grant), and per-demanding-identity wish
-resolution — a demanded run acting as its demander (scopes.md §5)
-whose home-space bootstrap writes ride the same crossing (builtins.md
-§5 carries the register row; RULED 2026-08-14).
+2026-08-14 (c)) survives as its AUTHORIZATION seat: a serving wave
+ADMITS a foreign-space write at ACCUMULATION iff BOTH hold —
+
+- the sealing run's context carries the §2b delegated carriage
+  (acting identity AND `capabilityRef`, the provisioning shape
+  protocol.md §2's server-produced authored row requires on EVERY
+  foreign commit); and
+- the ACTING identity holds a **structural write grant for the
+  TARGET space**, probed against the co-hosted memory server
+  (`foreignWriteAuthorityFor`; the wave REFUSES the accept posture
+  at construction without an authority probe, so the gate cannot be
+  configured vacuous — carriage alone is minted for every acting
+  run and authorizes nothing). The structural grants:
+  **owner-by-identity** (the target space IS the actor's own DID —
+  their home space, the wish bootstrap's target),
+  **fresh-store creation** (the target store does not exist — §2b's
+  sanctioned provisioning, where the creating commit makes the
+  space the actor's; the probe checks the space NAME is a
+  well-formed DID and never materializes a store itself, so a
+  carriage-bearing write to a garbage space string cannot silently
+  provision one — the recorded residual is that a well-formed FRESH
+  DID still provisions at commit, §2b's sanctioned minting with
+  quota attribution the standing residual, README §3.8), or an
+  **explicit ACL grant** (the target's own ACL document grants the
+  actor WRITE — checked mode-independently: this is the serving
+  plane's normative fail-closed interim, not the client ACL
+  rollout, so neither the service-DID blanket nor the
+  missing-ACL-populated-legacy compat arm applies). Per-DOC grant
+  RESOLUTION stays the OW13 owed hardening.
+
+A carriage-less foreign write — the lunch-wall class: a run resolving
+against the SERVICE identity's ambient state — and an UNGRANTED one —
+an actor reaching for a space it holds no authority over — both
+refuse at the seal sink, action-scoped (that action's tx fails loudly
+and is counted into §7's `foreignWriteRefusals`; its already-sealed
+spaces withdraw per this section's failure isolation) while the wave
+commits everything else. The commit-step foreign-engine resolution
+(the serving loop resolves the wave's foreign co-hosted engines ahead
+of the commit step) keeps the sink's delegated validation as
+backstop, and is itself failure-ISOLATED per space: a foreign engine
+that cannot resolve fails exactly the contributions targeting it
+(events requeue and replay; derivations drop to recompute-on-demand;
+counted into §7's `foreignEngineFailures`) while the wave commits the
+rest — never a loop failure, so one misdirected crossing can never
+park the HOME space. The producers the gate admits: `.inSpace`
+provisioning handlers (the event's acting principal + grant), and
+per-demanding-identity wish resolution — a demanded run acting as its
+demander (scopes.md §5) whose home-space bootstrap writes ride the
+same crossing (builtins.md §5 carries the register row; RULED
+2026-08-14).
 
 ## 3e. Pattern updates
 
@@ -1012,7 +1048,8 @@ block: `servingLoop: { activeSpaces, waves, wavesBudgetExhausted,
 supersededWrites, authoredSeen, effectAcks, derivedCommits,
 structureLoadFailures, structureLoadDeferred, structureLoadTerminal,
 structureLoadRearmed, watermarkClamped,
-unstampedSealRefusals, watermarkLag, events:
+unstampedSealRefusals, foreignWriteRefusals, foreignEngineFailures,
+watermarkLag, events:
 {appended, processed, coalescedPerWaveMax, skippedIdempotent}, memo:
 {hits, misses, inflight}, outbox: {queued, completed, failed}, lease:
 {held, lost} }` (`structureLoadFailures`/`structureLoadDeferred`
@@ -1037,7 +1074,12 @@ transactions refused at the seal by §3d's unstamped refusal —
 structurally ZERO when every server-side commit path declares its
 run context, so any non-zero count names an undeclared commit path,
 the class that wedged the resumed list builtins' recovery seeds
-until they stamped `bookkeeping`) (`effectAcks` counts
+until they stamped `bookkeeping`; `foreignWriteRefusals` counts §3d's
+accept-gate refusals — carriage-less AND ungranted foreign writes,
+both action-scoped; `foreignEngineFailures` counts commit-step
+foreign-engine resolutions that failed and were isolated per space —
+a growing count names a foreign store that persistently cannot open,
+never a home-space outage) (`effectAcks` counts
 effect-channel ack writes, so the
 §3 amplification metric is computable from counters alone). Every
 Phase gate in the plan reads these counters; tests MUST assert on

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -1832,11 +1832,13 @@ delta):
   the already-landed chain — foreign session frames → the scheduler's
   autonomous storage-notification runs → the seal's loop wake — so
   the spec sentence is satisfied by construction, not by new
-  machinery. The seal wake is LATCHED when no input waiter is armed
-  (the review's F4: a seal chained in a cycle's last microtasks was
-  invisible to the idle check and fell back to the idle timeout —
-  latency-only, closed with the same level-conversion shape as the
-  shadow-flip wake; not a guard, so no mutation probe attaches).
+  machinery. Chained-not-yet-applied wave seals now COUNT as work in
+  the loop's idle check (the review's F4: a seal chained in a cycle's
+  last microtasks was invisible to the contribution count and fell
+  back to the idle timeout — latency-only; the level shape was chosen
+  over an edge latch after the latch double-counted the loop's own
+  mid-cycle watermark seal, caught by the shadow-clamp pin; not a
+  guard, so no mutation probe attaches).
   Activation's foreign basis re-mark (§6 step 2's Phase-5 sentence)
   rides `selectForeignBasisRows` + per-space head resolution,
   fail-degrading to surfacing (accounting parity with the home scan;

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -20,11 +20,11 @@ families), the Phase 1 dry-run, and the doc-review panels
 | doc | rules | instrument-covered | impl-gate | deferral | derivable | owed |
 | --- | --- | --- | --- | --- | --- | --- |
 | README | 31 | 17 | 9 | 1 | 2 | 2* |
-| protocol | 61 | 47 | 6 | 3 | 4 | 1* |
+| protocol | 63 | 47 | 8 | 3 | 4 | 1* |
 | events | 34 | 25 | 4 | 2 | 2 | 1 |
 | scopes | 25 | 17 | 3 | 1 | 2 | 2 |
 | builtins | 15 | 6 | 3 | 1 | 4 | 1 |
-| serving-loop | 78 | 46 | 20 | 1 | 5 | 6 |
+| serving-loop | 79 | 46 | 21 | 1 | 5 | 6 |
 | key-vocabulary | 9 | 5 | 3 | 0 | 0 | 1 |
 | speculation | 16 | 11 | 2 | 0 | 1 | 2 |
 | testing | 14 | 4 | 10 | 0 | 0 | 0 |
@@ -823,7 +823,11 @@ above carries the coverage):**
   fail-closed admission refusal, BEFORE any delegated-scoped-read
   producer ships — a Phase-5 work-order PRECONDITION, and the
   producer and its refusal/design land together as one stack, so no
-  interim exposure window exists.
+  interim exposure window exists. DISCHARGED with Phase 5
+  (2026-08-14): the design landed in protocol §2 and its fail-closed
+  interim landed at both ends of the stack (the 2026-08-14 delta
+  below carries the coverage); the grant-RESOLUTION obligation stays
+  owed on its original trigger.
 
 **Stage G pre-gate — LANDED with stage G (2026-08-06):**
 
@@ -1019,7 +1023,10 @@ nod, 2026-08-07; recorded in the plan's stage list):**
   test that a post-handover session stops receiving other
   instances' rows. Trigger: Phase 5's grant-scoped read hardening
   (FP2's named follow-up), or the first multi-server lease
-  handover work, whichever lands first.
+  handover work, whichever lands first. DISCHARGED with Phase 5
+  (2026-08-14; the delta below carries the evidence — the re-verify
+  and the post-handover tests exist, the half-(ii) mitigation
+  stands).
 - OW23 — unvalidated scope strings reach `resolveScopeKey` with no
   default arm (pre-existing adjacency): the switch covers the three
   `CellScope` members and TypeScript exhaustiveness assumes the
@@ -1781,6 +1788,112 @@ residual postures, and the delegated-scoped-reads deferral; protocol
 - OW13 updated in place with the delegated-scoped-reads deferral
   ruling (no count move — the register row carries the Phase-5
   work-order precondition; see the row).
+
+Delta 2026-08-14 — Phase 5 (cross-space serving; the phase PR;
+protocol 61 → 63, serving-loop 78 → 79 — the map edited with this
+delta):
+
+- protocol §2's grant-scoped read DESIGN (+1 rule) with its
+  FAIL-CLOSED interim (+1 rule) — the RULED 2026-08-13 Phase-5
+  precondition, discharged as one stack with the producers: →
+  COVERED, impl-gate, red-first. `memory/test/v2-explicit-read.test.ts`
+  ("Phase 5" arms, all three red at the pre-change tree): FP2's
+  cross-engine widening (a home holder names a FOREIGN space's
+  instance under its own space's lease; a lease-less client stays
+  refused), the per-process sharpening (a second process's lease row
+  admits nobody — full-DR1-holder equality), and the fail-closed
+  unnamed-scoped-foreign refusal (a co-hosted serving session's
+  unnamed scoped read of a space it does not hold refuses; ordinary
+  clients, space-scope foreign reads, and home scoped reads are
+  untouched). The producer half is
+  `runner/test/executor-cross-space.test.ts`'s provider refusal (a
+  serving manager's FOREIGN provider refuses scoped reads; space-scope
+  and home and non-serving managers unaffected). The unnamed-path
+  check is fully synchronous (the resolved-engine index), preserving
+  the ACL revocation-race invariant; its per-query cost is one
+  prepared-statement lease probe per open co-hosted engine, only for
+  flag-ON scoped reads by principal-bearing sessions.
+- protocol §2's read-row Phase-1 recorded acceptance (the
+  service-identity-only equality): RETIRED — the sharpened check
+  compares the full DR1 holder minted by the co-hosted process
+  (CHANGED sentences on the existing row; coverage above).
+- serving-loop §3b's server-internal foreign wake (+1 rule,
+  impl-gate): → COVERED, with a survival-test finding recorded
+  honestly. `executor-cross-space.test.ts`'s wake test pins the
+  END-TO-END behavior — a home derivation over a foreign doc
+  re-derives on the foreign commit alone (idle window 600 s). A
+  host-side fan-out built for the wake was MUTATION-PROBED REDUNDANT
+  (the test stayed green with it disabled) and REMOVED: the wake is
+  the already-landed chain — foreign session frames → the scheduler's
+  autonomous storage-notification runs → the seal's loop wake — so
+  the spec sentence is satisfied by construction, not by new
+  machinery. Activation's foreign basis re-mark (§6 step 2's Phase-5
+  sentence) rides `selectForeignBasisRows` + per-space head
+  resolution, fail-degrading to surfacing (accounting parity with
+  the home scan; recovery correctness rides recompute-on-demand).
+- serving-loop §3d's accumulation gate (CHANGED sentence — the
+  Phase-5 accept-with-carriage posture): → COVERED.
+  `executor-wave.test.ts`: full carriage admitted with the foreign
+  scoped row keyed from the CARRIED identity (the stage-F delegated
+  test, now under the live gate); partial carriage (no grant) refused
+  at ACCUMULATION action-scoped with the wave surviving vacuous; the
+  sink's scoped-op-without-carriage refusal re-pinned DIRECTLY as the
+  backstop ("Phase 5 backstop" test). The serving loop passes
+  "accept" (space-server.ts) and resolves foreign co-hosted engines
+  ahead of the commit step; a carriage-less foreign write stays
+  counted in §7's `foreignWriteRefusals`.
+- builtins §5's wish row (CHANGED — the RULED 2026-08-14
+  per-demanding-identity lift): → COVERED, impl-gate.
+  `executor-cross-space.test.ts`'s home-space resolution test: a
+  stamped derivation resolves the DEMANDING principal's home space, a
+  stamped handler resolves the ACTOR's, an identity-less serving run
+  refuses (never the service DID), and a client runtime is
+  byte-identical to before. The wish builtin's guards ride
+  `homeSpacePrincipalFor`; the sidecar compile-cache context is the
+  SERVED space on serving runtimes; sidecar result cells key by the
+  home-space user (two demanders never collide on the service DID).
+  The lunch-ON gate's profile leg is the E2E witness (the phase PR's
+  gates table carries its status).
+- OW13 — the delegated-grant RESOLUTION row's Phase-5 PRECONDITION is
+  DISCHARGED (the design + fail-closed refusals above, one stack with
+  the producers). The row's original obligation — grant RESOLUTION
+  against a per-doc grant store, with negative tests — STAYS OWED on
+  its original trigger (the store landing); Phase 5's write-side
+  carriage stays presence+completeness (`capabilityRef` minted
+  structurally at #stampRun: `event-consequence:<eventId>` /
+  `demanded-run:<principal>`, the FP1 `stream-append:<sidecarId>`
+  precedent — a below-spec-granularity surface FLAGGED in the
+  Phase-5 PR).
+- OW22 — DISCHARGED (evidence recorded on this delta; the row's
+  trigger was Phase 5's grant-scoped read hardening): the exemption
+  re-verifies on CURRENT holdership at every push-path use
+  (`#currentLeaseHolderExemption` — Phase 5 widens it to exactly the
+  admission's co-hosted condition, full-holder equality), lease loss
+  clears the persisted bit, and the post-handover test exists
+  red-first ("lease-holder push exemption dies with the lease" +
+  the resume revalidation test, `v2-explicit-read.test.ts`). The
+  half (ii) wire-upsert scope-name mitigation (forced full resync)
+  stands unchanged and keeps its comment.
+- OW17 — RE-TAGGED with the Phase-5 posture (flag-don't-fill upheld):
+  the trigger anticipated foreign scoped instances making the
+  replica's scope-name collapse load-bearing; Phase 5 instead
+  REFUSES foreign scoped reads fail-closed (the grant-design
+  interim), so no foreign instance can enter a serving replica and
+  the collapse's exposure is unchanged from P2-F. The owed leg
+  (replica-level per-instance read keying + per-(action × instance)
+  local precision) now triggers with the grant-scoped read
+  RESOLUTION landing — the same work that first admits a foreign
+  scoped instance producer.
+- LT9 rec (c) — ADOPTED-PENDING-VETO, the COUPLING SEAM half only
+  (the plan defers protocol §5's sessionId persistence beyond
+  Phase 5, so per the rec's fork the durable wiring waits):
+  `InitializationData.eventAppendQueuePersistence` is the typed
+  declarative seam the worker maps onto the manager's
+  `eventAppendQueueStore` option (`resolveEventAppendQueuePersistence`
+  — memory kind honored; any other kind REFUSES initialization
+  loudly rather than silently degrading a durability declaration).
+  OW20 stands unchanged (browser adapter + queue debts, trigger: the
+  sessionId persistence work).
 
 ## 4. Standing rule
 

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -1808,11 +1808,16 @@ delta):
   untouched). The producer half is
   `runner/test/executor-cross-space.test.ts`'s provider refusal (a
   serving manager's FOREIGN provider refuses scoped reads; space-scope
-  and home and non-serving managers unaffected). The unnamed-path
-  check is fully synchronous (the resolved-engine index), preserving
-  the ACL revocation-race invariant; its per-query cost is one
-  prepared-statement lease probe per open co-hosted engine, only for
-  flag-ON scoped reads by principal-bearing sessions.
+  and home and non-serving managers unaffected), refused ENTRY-scoped
+  at `pull()` — per caller, before the coalesced watch-refresh batch —
+  so one scoped offender cannot poison innocent space-scope foreign
+  reads sharing the batch's single pending promise (the review's F3;
+  the concurrent scoped+plain coalescing arm is pinned red-first, and
+  the batch-level check survives as a loud bypass backstop). The
+  unnamed-path check is fully synchronous (the resolved-engine index),
+  preserving the ACL revocation-race invariant; its per-query cost is
+  one prepared-statement lease probe per open co-hosted engine, only
+  for flag-ON scoped reads by principal-bearing sessions.
 - protocol §2's read-row Phase-1 recorded acceptance (the
   service-identity-only equality): RETIRED — the sharpened check
   compares the full DR1 holder minted by the co-hosted process
@@ -1827,43 +1832,92 @@ delta):
   the already-landed chain — foreign session frames → the scheduler's
   autonomous storage-notification runs → the seal's loop wake — so
   the spec sentence is satisfied by construction, not by new
-  machinery. Activation's foreign basis re-mark (§6 step 2's Phase-5
-  sentence) rides `selectForeignBasisRows` + per-space head
-  resolution, fail-degrading to surfacing (accounting parity with
-  the home scan; recovery correctness rides recompute-on-demand).
-- serving-loop §3d's accumulation gate (CHANGED sentence — the
-  Phase-5 accept-with-carriage posture): → COVERED.
-  `executor-wave.test.ts`: full carriage admitted with the foreign
-  scoped row keyed from the CARRIED identity (the stage-F delegated
-  test, now under the live gate); partial carriage (no grant) refused
-  at ACCUMULATION action-scoped with the wave surviving vacuous; the
-  sink's scoped-op-without-carriage refusal re-pinned DIRECTLY as the
+  machinery. The seal wake is LATCHED when no input waiter is armed
+  (the review's F4: a seal chained in a cycle's last microtasks was
+  invisible to the idle check and fell back to the idle timeout —
+  latency-only, closed with the same level-conversion shape as the
+  shadow-flip wake; not a guard, so no mutation probe attaches).
+  Activation's foreign basis re-mark (§6 step 2's Phase-5 sentence)
+  rides `selectForeignBasisRows` + per-space head resolution,
+  fail-degrading to surfacing (accounting parity with the home scan;
+  recovery correctness rides recompute-on-demand) — and because that
+  catch makes breakage invisible by design, the DECISION is
+  unit-pinned (the review's F5): `selectForeignStaleInstances` in
+  `executor-cross-space.test.ts` — foreign rows only, at-head rows
+  never re-mark (the `>=` mutation is red), behind-head rows do, a
+  foreign-head move flips an at-head row stale, home-scan findings
+  are not double-added.
+- serving-loop §3d's accumulation gate (CHANGED — the Phase-5 accept
+  posture as an AUTHORIZATION boundary, per the review's F1: carriage
+  is minted for every acting run, so an admitted-iff-carriage gate
+  authorized nothing): → COVERED. The gate admits iff carriage AND
+  the acting identity holds a structural write grant for the TARGET
+  space (`Server.foreignWriteAuthorityFor`: owner-by-identity /
+  fresh-store creation, DID-shape-checked and probed WITHOUT
+  materializing a store (F1c) / the target's own ACL grant,
+  mode-independent — no service-DID blanket, no populated-legacy
+  compat; fail-closed otherwise), and `foreignWrites: "accept"`
+  REFUSES construction without the probe — the vacuous configuration
+  is unrepresentable. `executor-wave.test.ts`: full carriage admitted
+  with the foreign scoped row keyed from the CARRIED identity (the
+  stage-F delegated test, now under the live gate, allow-all probe);
+  the UNGRANTED crossing (full carriage, existing no-ACL target)
+  refused action-scoped and counted with the actor's OWN home space
+  admitted beside it (red under the grant-check-neutralized
+  mutation — the pre-fix shape); partial carriage refused at
+  ACCUMULATION with the wave surviving vacuous (red under the
+  carriage-arm mutation); the probe's own arms (owner / creation /
+  non-creating second probe / garbage name / no-ACL fail-closed /
+  ACL WRITE grant / no-row refusal) pinned in
+  `executor-cross-space.test.ts`; the sink's
+  scoped-op-without-carriage refusal re-pinned DIRECTLY as the
   backstop ("Phase 5 backstop" test). The serving loop passes
-  "accept" (space-server.ts) and resolves foreign co-hosted engines
-  ahead of the commit step; a carriage-less foreign write stays
-  counted in §7's `foreignWriteRefusals`.
+  "accept" + the memory server's probe (space-server.ts) and resolves
+  foreign co-hosted engines ahead of the commit step with PER-SPACE
+  failure isolation (the review's F1b: pre-fix an unresolvable
+  foreign engine threw out of the cycle — loop-failed → park for the
+  HOME space; now the failing space's contributions withdraw
+  action-scoped — events requeue, derivations drop — the wave commits
+  the rest, counted in §7's `foreignEngineFailures`; the E2E is red
+  under the catch-reverted mutation, reproducing park(loop-failed)
+  verbatim). Carriage-less and ungranted foreign writes stay counted
+  in §7's `foreignWriteRefusals`. Residual recorded (F1c): a
+  well-formed FRESH space DID still provisions a store at commit —
+  §2b's sanctioned minting (deterministic per-user-per-event ids;
+  quota attribution the standing residual, README §3.8).
 - builtins §5's wish row (CHANGED — the RULED 2026-08-14
   per-demanding-identity lift): → COVERED, impl-gate.
   `executor-cross-space.test.ts`'s home-space resolution test: a
   stamped derivation resolves the DEMANDING principal's home space, a
-  stamped handler resolves the ACTOR's, an identity-less serving run
-  refuses (never the service DID), and a client runtime is
-  byte-identical to before. The wish builtin's guards ride
-  `homeSpacePrincipalFor`; the sidecar compile-cache context is the
-  SERVED space on serving runtimes; sidecar result cells key by the
-  home-space user (two demanders never collide on the service DID).
-  The lunch-ON gate's profile leg is the E2E witness (the phase PR's
+  stamped handler resolves the ACTOR's, MIXED carriage (instance
+  owner's scopeKeyIdentity + a different acting pair) resolves the
+  INSTANCE OWNER (the review's F6 — red under the precedence-swap
+  mutation), an identity-less serving run refuses (never the service
+  DID), and a client runtime is byte-identical to before. The wish
+  builtin's guards ride `homeSpacePrincipalFor`; the sidecar
+  compile-cache context is the SERVED space on serving runtimes;
+  sidecar result cells AND the builtin's per-node closure caches key
+  by the home-space user — PINNED by the two-demander test (the
+  review's F2: the closure caches were per-node singles, so demander
+  #2 reused demander #1's create surface and clobbered the shared
+  pending input; the reviewer's M6 mutation — both keyings reverted
+  to the service DID — now fails the test, where pre-fix it survived
+  every suite; the suggestion sidecar gains the same per-user keying
+  on SERVING runtimes only, client cause byte-identical). The
+  lunch-ON gate's profile leg is the E2E witness (the phase PR's
   gates table carries its status).
 - OW13 — the delegated-grant RESOLUTION row's Phase-5 PRECONDITION is
   DISCHARGED (the design + fail-closed refusals above, one stack with
   the producers). The row's original obligation — grant RESOLUTION
   against a per-doc grant store, with negative tests — STAYS OWED on
   its original trigger (the store landing); Phase 5's write-side
-  carriage stays presence+completeness (`capabilityRef` minted
+  carriage is presence+completeness (`capabilityRef` minted
   structurally at #stampRun: `event-consequence:<eventId>` /
   `demanded-run:<principal>`, the FP1 `stream-append:<sidecarId>`
   precedent — a below-spec-granularity surface FLAGGED in the
-  Phase-5 PR).
+  Phase-5 PR) PLUS the accept gate's per-TARGET-SPACE structural
+  grant check above — space-granular authorization now, doc-granular
+  resolution still owed.
 - OW22 — DISCHARGED (evidence recorded on this delta; the row's
   trigger was Phase 5's grant-scoped read hardening): the exemption
   re-verifies on CURRENT holdership at every push-path use

--- a/packages/memory/test/v2-explicit-read.test.ts
+++ b/packages/memory/test/v2-explicit-read.test.ts
@@ -908,3 +908,313 @@ Deno.test("a non-canonical entity_scope_key (raw '/') is refused at admission �
     await server.close();
   }
 });
+
+// ---------------------------------------------------------------------------
+// Phase 5 — the read row's cross-space widening and its fail-closed twin
+// (protocol.md §2; verification-coverage.md's stage-F read-row entry):
+//
+// - FP2 (RULED 2026-08-03): the requester holds A live execution_lease on
+//   the co-hosted memory server — its OWN space's lease, not necessarily
+//   the read space's — so a home SpaceServer's cross-space serving reads
+//   can name a FOREIGN space's instances.
+// - The per-process sharpening: equality is against the FULL DR1 holder
+//   minted by THIS process, so a second process sharing the service DID
+//   no longer passes on this process's lease rows.
+// - The delegated-scoped-read fail-closed refusal (RULED 2026-08-13, the
+//   Phase-5 precondition): a co-hosted serving session's UNNAMED scoped
+//   read of a space it does not hold refuses loudly instead of silently
+//   resolving the delegating envelope's (empty) instance.
+// ---------------------------------------------------------------------------
+
+const HOME_SPACE = "did:key:z6Mk-explicit-read-home";
+
+const openSessionIn = async (
+  harness: Harness,
+  space: string,
+  principal: string,
+): Promise<{ sessionId: string }> => {
+  await harness.connection.receive(encodeMemoryBoundary({
+    type: "session.open",
+    requestId: nextRequestId("open"),
+    space,
+    session: {},
+    invocation: {
+      iss: principal,
+      aud: harness.sessionOpen.audience,
+      challenge: harness.sessionOpen.challenge.value,
+    },
+  }));
+  const response = shiftMessage(harness.messages) as ResponseMessage<
+    { sessionId: string; sessionOpen: SessionOpenAuthMetadata }
+  >;
+  assertExists(response.ok, JSON.stringify(response.error));
+  harness.sessionOpen = response.ok.sessionOpen;
+  return { sessionId: response.ok.sessionId };
+};
+
+Deno.test("Phase 5: a home holder names a FOREIGN space's instance under its own space's lease (FP2's widened read row)", async () => {
+  const server = newServer("memory://explicit-read-fp2");
+  setServerExecutionConfig(true);
+  try {
+    // Alice's instance lives in SPACE; the serving session's lease lives
+    // in HOME_SPACE (the home SpaceServer serving cross-space reads).
+    const alice = await connect(server);
+    const { sessionId: aliceSession } = await openSession(alice, ALICE);
+    await writeAliceProfile(server, aliceSession, 1, { name: "alice" });
+    const aliceKey = resolveScopeKey("user", { principal: ALICE });
+
+    const homeEngine = await server.engineForSpace(HOME_SPACE);
+    const holder = executionLeaseHolder(SERVICE);
+    assertEquals(
+      acquireExecutionLease(homeEngine, {
+        space: HOME_SPACE,
+        holder,
+        ttlMs: 600_000,
+      }),
+      true,
+    );
+
+    const service = await connect(server);
+    const { sessionId: serviceSession } = await openSessionIn(
+      service,
+      SPACE,
+      SERVICE,
+    );
+    const widened = await server.graphQuery({
+      type: "graph.query",
+      requestId: nextRequestId("fp2"),
+      space: SPACE,
+      sessionId: serviceSession,
+      query: {
+        roots: [{
+          id: "of:profile",
+          scope: "user",
+          entityScopeKey: aliceKey,
+          selector: { path: [], schema: false },
+        }],
+      },
+    });
+    assertExists(
+      widened.ok,
+      `FP2's widened acceptance must admit a co-hosted home holder: ${
+        JSON.stringify(widened.error)
+      }`,
+    );
+    assertEquals(widened.ok.entities.length, 1);
+    assertEquals(widened.ok.entities[0].document?.value, { name: "alice" });
+
+    // A plain client with NO lease anywhere stays refused — the widening
+    // admits holders, never everyone.
+    const bob = await connect(server);
+    const { sessionId: bobSession } = await openSession(bob, BOB);
+    const refused = await server.graphQuery({
+      type: "graph.query",
+      requestId: nextRequestId("fp2-nonholder"),
+      space: SPACE,
+      sessionId: bobSession,
+      query: {
+        roots: [{
+          id: "of:profile",
+          scope: "user",
+          entityScopeKey: aliceKey,
+          selector: { path: [], schema: false },
+        }],
+      },
+    });
+    assertEquals(refused.error?.name, "ProtocolError");
+
+    alice.connection.close();
+    service.connection.close();
+    bob.connection.close();
+  } finally {
+    resetServerExecutionConfig();
+    await server.close();
+  }
+});
+
+Deno.test("Phase 5: a second process's lease row admits nobody here (the per-process DR1 sharpening)", async () => {
+  const server = newServer("memory://explicit-read-per-process");
+  setServerExecutionConfig(true);
+  try {
+    const alice = await connect(server);
+    const { sessionId: aliceSession } = await openSession(alice, ALICE);
+    await writeAliceProfile(server, aliceSession, 1, { name: "alice" });
+    const aliceKey = resolveScopeKey("user", { principal: ALICE });
+
+    // The lease row was minted by ANOTHER process sharing the service
+    // DID (a deploy overlap): its holder carries a foreign
+    // process-instance component. The Phase-1 service-identity-only
+    // equality admitted this session on that row; the sharpened check
+    // must refuse — this process's serving session holds nothing.
+    const engine = await server.engineForSpace(SPACE);
+    const foreignProcessHolder = executionLeaseHolder(
+      SERVICE,
+      "00000000-dead-beef-0000-000000000000",
+    );
+    assertEquals(
+      acquireExecutionLease(engine, {
+        space: SPACE,
+        holder: foreignProcessHolder,
+        ttlMs: 600_000,
+      }),
+      true,
+    );
+
+    const service = await connect(server);
+    const { sessionId: serviceSession } = await openSessionIn(
+      service,
+      SPACE,
+      SERVICE,
+    );
+    const refused = await server.graphQuery({
+      type: "graph.query",
+      requestId: nextRequestId("per-process"),
+      space: SPACE,
+      sessionId: serviceSession,
+      query: {
+        roots: [{
+          id: "of:profile",
+          scope: "user",
+          entityScopeKey: aliceKey,
+          selector: { path: [], schema: false },
+        }],
+      },
+    });
+    assertEquals(
+      refused.error?.name,
+      "ProtocolError",
+      "a session must not be admitted on ANOTHER process's lease row " +
+        `(per-process sharpening): ${JSON.stringify(refused.ok)}`,
+    );
+
+    alice.connection.close();
+    service.connection.close();
+  } finally {
+    resetServerExecutionConfig();
+    await server.close();
+  }
+});
+
+Deno.test("Phase 5: a co-hosted serving session's UNNAMED scoped read of a foreign space is refused fail-closed (the grant-scoped read design's interim)", async () => {
+  const server = newServer("memory://explicit-read-fail-closed");
+  setServerExecutionConfig(true);
+  try {
+    const alice = await connect(server);
+    const { sessionId: aliceSession } = await openSession(alice, ALICE);
+    await writeAliceProfile(server, aliceSession, 1, { name: "alice" });
+
+    // The serving session's lease lives in HOME_SPACE; SPACE is foreign
+    // to it.
+    const homeEngine = await server.engineForSpace(HOME_SPACE);
+    const holder = executionLeaseHolder(SERVICE);
+    assertEquals(
+      acquireExecutionLease(homeEngine, {
+        space: HOME_SPACE,
+        holder,
+        ttlMs: 600_000,
+      }),
+      true,
+    );
+    const service = await connect(server);
+    const { sessionId: serviceSession } = await openSessionIn(
+      service,
+      SPACE,
+      SERVICE,
+    );
+
+    // UNNAMED scoped root: pre-Phase-5 this resolved user:<serviceDID> —
+    // a silently EMPTY instance. Now it refuses loudly.
+    const refused = await server.graphQuery({
+      type: "graph.query",
+      requestId: nextRequestId("fail-closed"),
+      space: SPACE,
+      sessionId: serviceSession,
+      query: {
+        roots: [{
+          id: "of:profile",
+          scope: "user",
+          selector: { path: [], schema: false },
+        }],
+      },
+    });
+    assertEquals(
+      refused.error?.name,
+      "ProtocolError",
+      "an unnamed scoped read by a foreign serving session must refuse " +
+        `fail-closed, never silently resolve the service instance: ${
+          JSON.stringify(refused.ok)
+        }`,
+    );
+    assertEquals(
+      refused.error?.message.includes("grant-scoped read design"),
+      true,
+    );
+
+    // The same session's unnamed SPACE-scope read stays free (§2b's
+    // free-read row): only scoped roots are the trap.
+    const spaceRead = await server.graphQuery({
+      type: "graph.query",
+      requestId: nextRequestId("space-scope"),
+      space: SPACE,
+      sessionId: serviceSession,
+      query: {
+        roots: [{
+          id: "of:profile",
+          selector: { path: [], schema: false },
+        }],
+      },
+    });
+    assertExists(spaceRead.ok, JSON.stringify(spaceRead.error));
+
+    // An ordinary client's unnamed scoped read is untouched (resolves
+    // its own instance as today).
+    const bob = await connect(server);
+    const { sessionId: bobSession } = await openSession(bob, BOB);
+    const bobOwn = await server.graphQuery({
+      type: "graph.query",
+      requestId: nextRequestId("bob-own"),
+      space: SPACE,
+      sessionId: bobSession,
+      query: {
+        roots: [{
+          id: "of:profile",
+          scope: "user",
+          selector: { path: [], schema: false },
+        }],
+      },
+    }) as ResponseMessage<GraphQueryResult>;
+    assertExists(bobOwn.ok, JSON.stringify(bobOwn.error));
+
+    // A serving session's unnamed scoped read of ITS OWN space (it holds
+    // the lease there) keeps today's tolerated behavior — the home
+    // collapsed-view path (the OW17 residual), not the cross-space trap.
+    const homeService = await connect(server);
+    const { sessionId: homeSession } = await openSessionIn(
+      homeService,
+      HOME_SPACE,
+      SERVICE,
+    );
+    const homeRead = await server.graphQuery({
+      type: "graph.query",
+      requestId: nextRequestId("home-scoped"),
+      space: HOME_SPACE,
+      sessionId: homeSession,
+      query: {
+        roots: [{
+          id: "of:home-doc",
+          scope: "user",
+          selector: { path: [], schema: false },
+        }],
+      },
+    });
+    assertExists(homeRead.ok, JSON.stringify(homeRead.error));
+
+    alice.connection.close();
+    service.connection.close();
+    bob.connection.close();
+    homeService.connection.close();
+  } finally {
+    resetServerExecutionConfig();
+    await server.close();
+  }
+});

--- a/packages/memory/v2/scheduler-basis.ts
+++ b/packages/memory/v2/scheduler-basis.ts
@@ -154,6 +154,47 @@ ORDER BY b.action, b.action_scope_key
   return { stale: shape(stale), foreignReadInstances: shape(foreign) };
 };
 
+/** One cross-space basis row (Phase 5's foreign re-mark): the recorded
+ * foreign input plus its owning (action, instance), so the activation
+ * scan can compare the recorded seq against the FOREIGN space's head
+ * through that space's own co-hosted engine (serving-loop.md §3b's
+ * foreign-read logging; §6 step 2). */
+export type ForeignBasisRow = SchedulerBasisEntry & StaleBasisInstance;
+
+/**
+ * Every basis row whose recorded input lives in ANOTHER space
+ * (serving-loop.md §3b's cross-space bullet). The caller judges
+ * staleness against each entity_space's own engine — this engine cannot
+ * (its head table holds only its own docs).
+ */
+export const selectForeignBasisRows = (
+  engine: Engine,
+  options: { branch: string; space: string },
+): ForeignBasisRow[] => {
+  const rows = engine.database.prepare(`
+SELECT action, action_scope_key, entity_space, entity, entity_scope_key, seq
+FROM scheduler_basis
+WHERE branch = :branch
+  AND entity_space != :space
+ORDER BY action, action_scope_key, entity_space, entity, entity_scope_key
+`).all({ branch: options.branch, space: options.space }) as Array<{
+    action: string;
+    action_scope_key: string;
+    entity_space: string;
+    entity: string;
+    entity_scope_key: string;
+    seq: number;
+  }>;
+  return rows.map((row) => ({
+    action: row.action,
+    actionScopeKey: row.action_scope_key,
+    entitySpace: row.entity_space,
+    entity: row.entity,
+    entityScopeKey: row.entity_scope_key,
+    seq: row.seq,
+  }));
+};
+
 /** Read one instance's rows back (recovery's re-mark scan, and tests). */
 export const selectSchedulerBasisRows = (
   engine: Engine,

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -4587,6 +4587,116 @@ export class Server {
     return this.openEngine(space);
   }
 
+  /**
+   * The structural write grant for a FOREIGN provisioning write
+   * (server-execution v2 Phase 5; protocol.md §2b; serving-loop.md
+   * §3d's accept gate): whether `principal` — the CARRIED acting
+   * identity of a served run — holds authority to write `space`. The
+   * wave's accumulation gate consults this per crossing, so "admitted
+   * iff carriage" becomes a real authorization predicate instead of a
+   * vacuous shape check (carriage is minted for every acting run).
+   *
+   * The grants, in check order — each a structural fact this process
+   * holds, never a trust widening:
+   *
+   * - **owner-by-identity**: the target space IS the principal's own
+   *   DID (a user's home space — the demanded wish bootstrap's
+   *   sanctioned target, builtins.md §5).
+   * - **creation**: the target store does not exist — §2b's sanctioned
+   *   provisioning ("provision a foreign/NEW space"), where the
+   *   creating commit is what makes it the actor's (CT-1650's
+   *   deterministic per-user-per-event DIDs; quota attribution stays
+   *   the recorded residual, README §3.8). Probed WITHOUT creating:
+   *   the open-engine map first, then the store path — `openEngine`
+   *   materializes a store as a side effect, which is exactly what an
+   *   ungranted probe must not do.
+   * - **acl**: the target's OWN ACL document grants the principal (or
+   *   `ANYONE`) WRITE/OWNER — the same per-space grant structure the
+   *   client session path enforces. Checked mode-independently: this
+   *   gate is the serving plane's normative fail-closed interim
+   *   (protocol.md §2's posture), not the client ACL rollout, so
+   *   `acl.mode: "off"` does not disable it, the service-DID blanket
+   *   (`#isServicePrincipal`) does NOT apply (resolving ambient
+   *   service authority is the lunch-wall class), and the
+   *   missing-ACL-populated-legacy compat arm does not apply either
+   *   (fail closed; the per-DOC grant resolution stays OW13's owed
+   *   hardening).
+   *
+   * Anything else refuses — including a malformed space name, so a
+   * carriage-bearing write to a garbage space string can never
+   * silently provision a store on the co-hosted server.
+   */
+  async foreignWriteAuthorityFor(
+    space: string,
+    principal: string | undefined,
+  ): Promise<
+    | { granted: true; via: "owner" | "creation" | "acl" }
+    | { granted: false; reason: string }
+  > {
+    if (!/^did:[^:]+:[^:]+$/.test(space)) {
+      return {
+        granted: false,
+        reason: `"${space}" is not a space DID — refusing to resolve (or ` +
+          "provision) a store for a malformed space name (protocol.md §2b)",
+      };
+    }
+    if (principal === undefined || principal === "") {
+      return {
+        granted: false,
+        reason: "no acting principal — a foreign provisioning write is " +
+          "admitted only under a carried actor's grant (protocol.md §2b)",
+      };
+    }
+    if (principal === space) {
+      return { granted: true, via: "owner" };
+    }
+    if (!(await this.#spaceStoreExists(space))) {
+      return { granted: true, via: "creation" };
+    }
+    const engine = await this.openEngine(space);
+    const state = this.#aclState(engine, space);
+    if (state.kind === "valid") {
+      const capability = state.acl[principal] ?? state.acl[ANYONE_USER] ??
+        null;
+      if (capability !== null && isCapable(capability, "WRITE")) {
+        return { granted: true, via: "acl" };
+      }
+      return {
+        granted: false,
+        reason: `the ACL of ${space} grants ${principal} ` +
+          `${capability ?? "nothing"} (WRITE required)`,
+      };
+    }
+    return {
+      granted: false,
+      reason: state.kind === "missing"
+        ? `${space} exists with no ACL document — the serving plane fails ` +
+          "closed (protocol.md §2's interim; the client path's legacy " +
+          "compat arm is a rollout accommodation, not a grant)"
+        : `${space} has a malformed, ownerless, or retracted ACL`,
+    };
+  }
+
+  /** Whether a store for `space` already exists, WITHOUT creating one
+   * (the foreignWriteAuthorityFor probe's creation arm — `openEngine`
+   * materializes stores as a side effect). An open (or opening) engine
+   * exists by definition; a file-backed store exists iff its file
+   * does; a memory-backed store exists only while an engine holds it. */
+  async #spaceStoreExists(space: string): Promise<boolean> {
+    if (this.#engines.has(space)) return true;
+    if (this.#store === undefined) return false;
+    const url = resolveSpaceStoreUrl(
+      this.#store,
+      space as `did:${string}:${string}`,
+    );
+    if (url.protocol !== "file:") return false;
+    try {
+      return await FS.exists(Path.fromFileUrl(url));
+    } catch {
+      return false;
+    }
+  }
+
   private openEngine(space: string): Promise<Engine.Engine> {
     const existing = this.#engines.get(space);
     if (existing !== undefined) {

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -102,8 +102,8 @@ import {
   trackGraph,
 } from "./query.ts";
 import {
+  executionLeaseHolder,
   liveExecutionLeaseHolder,
-  serviceIdentityOfExecutionLeaseHolder,
 } from "./execution-lease.ts";
 import { respondToHello } from "./handshake.ts";
 import { compressServerMessageSchemas } from "./sync-schema-table.ts";
@@ -904,6 +904,9 @@ export class Server {
   #sessions: SessionRegistry;
   #connections = new Map<string, Connection>();
   #engines = new Map<string, Promise<Engine.Engine>>();
+  // The resolved-engine index for the SYNC cross-engine lease lookup
+  // (server-execution v2 Phase 5; see openEngine / #liveCoHostedLeaseSpaceFor).
+  #resolvedEngines = new Map<string, Engine.Engine>();
   // Synthesized session state for direct out-of-band document writes, such as blob uploads.
   #directSessionId = `server:${crypto.randomUUID()}`;
   #directLocalSeq = 0;
@@ -1380,6 +1383,7 @@ export class Server {
       Engine.close(await engine);
     }
     this.#engines.clear();
+    this.#resolvedEngines.clear();
     this.#connections.clear();
     this.#readPool.close();
   }
@@ -2741,6 +2745,22 @@ export class Server {
         ),
       );
     }
+    {
+      // Phase 5's fail-closed twin (sync — no added await on the
+      // unnamed path): a foreign serving session's UNNAMED scoped root
+      // refuses rather than silently resolving the service instance.
+      const denyForeign = this.#denyForeignServingScopedRead(
+        message.space,
+        session,
+        message.query.roots,
+      );
+      if (denyForeign) {
+        return respondTypedError<GraphQueryResult>(
+          message.requestId,
+          denyForeign,
+        );
+      }
+    }
     if (this.#namesExplicitInstance(message.query.roots)) {
       // protocol.md §2's read row: explicit entity_scope_key roots are
       // lease-holder-only. Gated on the sync scan so the no-key path
@@ -2953,6 +2973,20 @@ export class Server {
         return respondTypedError<WatchSetResult>(message.requestId, deny);
       }
     }
+    {
+      // Phase 5's fail-closed twin (sync — see graphQuery's site).
+      const denyForeign = this.#denyForeignServingScopedRead(
+        message.space,
+        session,
+        message.watches.flatMap((watch) => watch.query.roots),
+      );
+      if (denyForeign) {
+        return respondTypedError<WatchSetResult>(
+          message.requestId,
+          denyForeign,
+        );
+      }
+    }
     if (
       this.#namesExplicitInstance(
         message.watches.flatMap((watch) => watch.query.roots),
@@ -3045,6 +3079,20 @@ export class Server {
         );
       if (deny) {
         return respondTypedError<WatchAddResult>(message.requestId, deny);
+      }
+    }
+    {
+      // Phase 5's fail-closed twin (sync — see graphQuery's site).
+      const denyForeign = this.#denyForeignServingScopedRead(
+        message.space,
+        session,
+        message.watches.flatMap((watch) => watch.query.roots),
+      );
+      if (denyForeign) {
+        return respondTypedError<WatchAddResult>(
+          message.requestId,
+          denyForeign,
+        );
       }
     }
     if (
@@ -3987,28 +4035,36 @@ export class Server {
   /**
    * The read-side admission row (protocol.md §2, ratified LD5): a read
    * naming an explicit `entity_scope_key` is admissible only for a live
-   * lease holder on this co-hosted memory server. The operand mapping
-   * (stage F design): the session's authenticated principal must equal
-   * the SERVICE-IDENTITY component of the read space's live lease holder
-   * — the identity the ExecutorHost minted its DR1 holder from. A
-   * non-holder naming a key is REJECTED; a read naming none resolves
-   * from the session as today and never reaches this check.
+   * lease holder on this co-hosted memory server. Phase 5 landed both
+   * halves the Phase-1 bounds deferred (verification-coverage.md's
+   * stage-F read-row entry):
    *
-   * Phase-1 bound, deliberate: the check consults the READ space's own
-   * lease row. FP2's widening — a home SpaceServer naming a FOREIGN
-   * space's instances under its own space's lease — has no producer
-   * until cross-space serving (Phase 5) and needs the cross-engine
-   * lease lookup designed with it.
+   * - FP2's WIDENING (RULED 2026-08-03): the requester holds A live
+   *   `execution_lease` on this co-hosted memory server — its OWN
+   *   space's lease, not necessarily the read space's — so a home
+   *   SpaceServer's cross-space serving reads can name a FOREIGN
+   *   space's instances instead of silently resolving
+   *   `user:<serviceDID>`. The read space's own lease is checked
+   *   first; the fallback is the sync cross-engine scan
+   *   (#liveCoHostedLeaseSpaceFor).
+   * - The PER-PROCESS sharpening: equality is against the FULL DR1
+   *   holder minted by THIS process (`executionLeaseHolder`, binding
+   *   the module-level process-instance component), never the
+   *   service-identity component alone — a second process sharing the
+   *   service DID no longer passes on this process's lease rows.
    *
-   * A second Phase-1 bound, also deliberate: the equality below
-   * compares the SERVICE-IDENTITY component of the holder, not the
-   * full DR1 holder — so a second process authenticated as the same
-   * service DID passes on the FIRST process's lease row. Co-hosted
-   * Phase 1 runs one serving process per memory server, so the
-   * distinction has no instances; the per-process sharpening belongs
-   * to Phase 5's cross-engine lease lookup design (the same design
-   * FP2's widening needs), recorded in verification-coverage.md's
-   * stage-F read-row entry.
+   * A non-holder naming a key is REJECTED; an ordinary read naming
+   * none resolves from the session as today. The one NEW unnamed-read
+   * refusal is the delegated-scoped-read fail-closed rule (protocol.md
+   * §2's grant-scoped read design, the RULED 2026-08-13 Phase-5
+   * precondition): a session that IS a co-hosted serving session (its
+   * principal holds a live lease on some space of this server) reading
+   * a SCOPED root of a space whose lease it does NOT hold, WITHOUT an
+   * explicit instance name, would silently resolve the service
+   * identity's (empty) instance — the FP2 silent-empty-instance trap,
+   * cross-space edition. That shape REFUSES loudly instead; the
+   * serving runtime names foreign instances explicitly or does not
+   * read them.
    */
   async #denyExplicitInstanceReads(
     space: string,
@@ -4071,12 +4127,19 @@ export class Server {
       );
     }
     const engine = await this.openEngine(space);
-    const holder = liveExecutionLeaseHolder(engine, space);
-    if (
-      holder === undefined ||
-      session.principal === undefined ||
-      serviceIdentityOfExecutionLeaseHolder(holder) !== session.principal
-    ) {
+    const fullHolder = session.principal === undefined
+      ? undefined
+      : executionLeaseHolder(session.principal);
+    const readSpaceHolder = liveExecutionLeaseHolder(engine, space);
+    const holdsReadSpace = fullHolder !== undefined &&
+      readSpaceHolder === fullHolder;
+    // FP2's widened acceptance: a live lease on ANY space of this
+    // co-hosted server admits (the home SpaceServer naming a foreign
+    // instance for a cross-space serving read).
+    const holdsCoHosted = holdsReadSpace ||
+      (session.principal !== undefined &&
+        this.#liveCoHostedLeaseSpaceFor(session.principal) !== undefined);
+    if (!holdsCoHosted) {
       return toError(
         "ProtocolError",
         "read naming an entity_scope_key rejected: requester does not " +
@@ -4104,12 +4167,23 @@ export class Server {
     session: SessionState,
   ): Promise<boolean> {
     if (session.leaseHolderReads !== true) return false;
+    if (session.principal === undefined) {
+      session.leaseHolderReads = false;
+      return false;
+    }
+    // The same holdership the admission accepts (Phase 5): the read
+    // space's own lease, or — FP2's widening — any live co-hosted
+    // lease held by THIS process's full DR1 holder (a home SpaceServer
+    // keeps receiving the foreign instances its cross-space serving
+    // reads named). Full-holder equality throughout (the per-process
+    // sharpening).
     const engine = await this.openEngine(space);
-    const holder = liveExecutionLeaseHolder(engine, space);
+    const fullHolder = executionLeaseHolder(session.principal);
+    const holdsReadSpace = liveExecutionLeaseHolder(engine, space) ===
+      fullHolder;
     if (
-      holder === undefined ||
-      session.principal === undefined ||
-      serviceIdentityOfExecutionLeaseHolder(holder) !== session.principal
+      !holdsReadSpace &&
+      this.#liveCoHostedLeaseSpaceFor(session.principal) === undefined
     ) {
       session.leaseHolderReads = false;
       return false;
@@ -4126,6 +4200,66 @@ export class Server {
       if (root.entityScopeKey !== undefined) return true;
     }
     return false;
+  }
+
+  /**
+   * The delegated-scoped-read fail-closed refusal (Phase 5; protocol.md
+   * §2's grant-scoped read design — RULED 2026-08-13: the design, or an
+   * explicit fail-closed admission refusal, lands BEFORE any
+   * delegated-scoped-read producer ships). A co-hosted SERVING session
+   * (its principal holds a live lease on some space of this server)
+   * reading a SCOPED root of a space whose lease it does NOT hold,
+   * without naming an `entity_scope_key`, would silently resolve the
+   * delegating service envelope's (empty) instance — the FP2
+   * silent-empty-instance trap, cross-space edition. Refused loudly.
+   *
+   * FULLY SYNCHRONOUS (called without await at the three read sites):
+   * ordinary client reads keep sharing one engine turn with their
+   * authorization (the ACL revocation-race invariant). Ordinary
+   * sessions hold no lease and exit at the scan; a serving session's
+   * HOME reads (it holds the read space's lease) keep today's
+   * tolerated collapsed-view behavior (the OW17 residual).
+   */
+  #denyForeignServingScopedRead(
+    space: string,
+    session: SessionState,
+    roots: Iterable<GraphQuery["roots"][number]>,
+  ): V2Error | undefined {
+    if (!getServerExecutionConfig()) return undefined;
+    if (session.principal === undefined) return undefined;
+    let unnamedScopedRoot: string | undefined;
+    for (const root of roots) {
+      if (
+        root.entityScopeKey === undefined && (root.scope ?? "space") !== "space"
+      ) {
+        unnamedScopedRoot = `${root.id} (scope "${root.scope}")`;
+        break;
+      }
+    }
+    if (unnamedScopedRoot === undefined) return undefined;
+    const fullHolder = executionLeaseHolder(session.principal);
+    // Home holdership short-circuits: only a RESOLVED engine can hold a
+    // lease row (a never-opened engine has none), so the sync map is
+    // authoritative here.
+    const readEngine = this.#resolvedEngines.get(space);
+    if (
+      readEngine !== undefined &&
+      liveExecutionLeaseHolder(readEngine, space) === fullHolder
+    ) {
+      return undefined;
+    }
+    const leaseSpace = this.#liveCoHostedLeaseSpaceFor(session.principal);
+    if (leaseSpace === undefined || leaseSpace === space) return undefined;
+    return toError(
+      "ProtocolError",
+      `scoped read of ${unnamedScopedRoot} refused: the requesting ` +
+        `session is a co-hosted serving session (live lease on ` +
+        `${leaseSpace}) reading foreign space ${space} without naming ` +
+        "an entity_scope_key — resolving it from the delegating " +
+        "envelope would silently read an empty instance (protocol.md " +
+        "§2's grant-scoped read design; delegated scoped reads are " +
+        "fail-closed until grant resolution lands)",
+    );
   }
 
   /** The identity a session's scoped reads and cache keys resolve
@@ -4471,13 +4605,51 @@ export class Server {
       }
       return await Engine.open({ url });
     })();
-    opened.catch(() => {
+    // The SYNC engine view (server-execution v2 Phase 5): the read-row
+    // admission's cross-engine lease lookup (protocol.md §2, FP2) must
+    // stay synchronous on the unnamed read path (the ACL revocation-race
+    // invariant — no added microtask boundary), so resolved engines are
+    // indexed here for the sync scan. A lease can only exist on an OPEN
+    // engine (co-hosted activation opens it before acquiring), so the
+    // resolved map sees every live lease.
+    opened.then((engine) => {
+      if (this.#engines.get(space) === opened) {
+        this.#resolvedEngines.set(space, engine);
+      }
+    }, () => {
       if (this.#engines.get(space) === opened) {
         this.#engines.delete(space);
+        this.#resolvedEngines.delete(space);
       }
     });
     this.#engines.set(space, opened);
     return opened;
+  }
+
+  /**
+   * The live co-hosted execution lease held by `principal`'s serving
+   * process, if any (server-execution v2 Phase 5; protocol.md §2's read
+   * row as widened by FP2, RULED 2026-08-03). Two properties, both
+   * deliberate:
+   *
+   * - PER-PROCESS sharpening (the Phase-1 recorded acceptance's
+   *   follow-up, verification-coverage.md's stage-F read-row entry):
+   *   equality is against the FULL DR1 holder minted by THIS process —
+   *   `executionLeaseHolder(principal)` binds the module-level
+   *   process-instance component the co-hosted ExecutorHost mints
+   *   holders from — so a second process authenticated as the same
+   *   service DID no longer passes on this process's lease rows.
+   * - SYNCHRONOUS: scans the RESOLVED engine map only (see openEngine),
+   *   so callers on the read path add no microtask boundary. Sound
+   *   because a lease row can only be written through an open co-hosted
+   *   engine.
+   */
+  #liveCoHostedLeaseSpaceFor(principal: string): string | undefined {
+    const holder = executionLeaseHolder(principal);
+    for (const [space, engine] of this.#resolvedEngines) {
+      if (liveExecutionLeaseHolder(engine, space) === holder) return space;
+    }
+    return undefined;
   }
 }
 

--- a/packages/patterns/integration/sx2-events.test.ts
+++ b/packages/patterns/integration/sx2-events.test.ts
@@ -194,15 +194,20 @@ describe("sx2 events (Phase 3 gates)", () => {
     const dupWatermark =
       (watermarkCell(cc.runtime, space).get() as { seq?: number } | undefined)
         ?.seq ?? 0;
+    // The caller-supplied eventId travels WITH the session it was
+    // chosen within (main's WS-D invocation-identity contract — an
+    // unscoped id is refused); the same (id, session, stream) pair
+    // scopes to the same durable delivery id, which is exactly what
+    // the dedupe horizon needs to see a duplicate.
     resultCell.key("increment").send(
       undefined as never,
       undefined,
-      { eventId: "sx2-dup-1" } as never,
+      { eventId: "sx2-dup-1", session: "sx2-dup-session" } as never,
     );
     resultCell.key("increment").send(
       undefined as never,
       undefined,
-      { eventId: "sx2-dup-1" } as never,
+      { eventId: "sx2-dup-1", session: "sx2-dup-session" } as never,
     );
     await cc.runtime.idle();
     await settleAfter(space, dupWatermark);

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -1840,44 +1840,66 @@ export function wish(
     cancelRegistered: false,
   };
 
-  // Per-instance suggestion pattern result cell
-  let suggestionPatternInput:
-    | {
+  // Per-instance sidecar state, keyed by the HOME-SPACE user (the F2
+  // fix, builtins.md §5's per-demanding-identity wish resolution): the
+  // scheduler drives ONE singular wish node once per demanded instance
+  // (same Action closure, per-instance stamped txs), so on a serving
+  // runtime two demanders reach these caches through one closure. A
+  // single cached cell/input made demander #2 reuse demander #1's
+  // sidecar result cell and clobber the shared pending input —
+  // cross-user mixing in both directions. Each demanding identity gets
+  // its own slot; the slot key is the SAME expression the sidecar cell
+  // causes key on (`homeSpaceUserDID(ctx) ?? runtime.userIdentityDID`),
+  // so cells and closure state can never disagree. Clients stay
+  // cardinality 1 (one slot: the runtime's own user).
+  interface SuggestionSidecarSlot {
+    input?: {
       situation: string;
       context: Record<string, any>;
       initialResults?: unknown;
-    }
-    | undefined;
-  let suggestionPatternResultCell: Cell<WishState<any>> | undefined;
-  let profileCreatePatternInput:
-    | {
+    };
+    resultCell?: Cell<WishState<any>>;
+  }
+  interface ProfileCreateSidecarSlot {
+    input?: {
       profiles: unknown;
       inputId: string;
       buttonId: string;
-    }
-    | undefined;
-  let profileCreatePatternResultCell: Cell<any> | undefined;
-  let profileCreatePatternReadyCell: Cell<boolean> | undefined;
-  let profilePickerPatternInput:
-    | {
+    };
+    resultCell?: Cell<any>;
+    readyCell?: Cell<boolean>;
+  }
+  interface ProfilePickerSidecarSlot {
+    input?: {
       profiles: unknown;
       defaultProfile: unknown;
       mru: unknown;
+    };
+    resultCell?: Cell<any>;
+  }
+  const suggestionSidecars = new Map<string, SuggestionSidecarSlot>();
+  const profileCreateSidecars = new Map<string, ProfileCreateSidecarSlot>();
+  const profilePickerSidecars = new Map<string, ProfilePickerSidecarSlot>();
+  const slotFor = <T>(map: Map<string, T>, user: string, empty: () => T): T => {
+    let slot = map.get(user);
+    if (slot === undefined) {
+      slot = empty();
+      map.set(user, slot);
     }
-    | undefined;
-  let profilePickerPatternResultCell: Cell<any> | undefined;
+    return slot;
+  };
 
   addCancel(() => {
     cancelled = true;
     releaseCurrentSharedHashtagResolver();
-    if (suggestionPatternResultCell) {
-      runtime.runner.stop(suggestionPatternResultCell);
+    for (const slot of suggestionSidecars.values()) {
+      if (slot.resultCell) runtime.runner.stop(slot.resultCell);
     }
-    if (profileCreatePatternResultCell) {
-      runtime.runner.stop(profileCreatePatternResultCell);
+    for (const slot of profileCreateSidecars.values()) {
+      if (slot.resultCell) runtime.runner.stop(slot.resultCell);
     }
-    if (profilePickerPatternResultCell) {
-      runtime.runner.stop(profilePickerPatternResultCell);
+    for (const slot of profilePickerSidecars.values()) {
+      if (slot.resultCell) runtime.runner.stop(slot.resultCell);
     }
   });
 
@@ -1936,6 +1958,7 @@ export function wish(
   }
 
   function launchSuggestionPattern(
+    ctx: WishContext,
     input: {
       situation: string;
       context: Record<string, any>;
@@ -1943,13 +1966,32 @@ export function wish(
     },
     providedTx?: IExtendedStorageTransaction,
   ) {
-    suggestionPatternInput = input;
+    // Per-demanding-identity slot (the F2 fix; see the slot map above).
+    const sidecarUser = homeSpaceUserDID(ctx) ?? runtime.userIdentityDID;
+    const slot = slotFor(
+      suggestionSidecars,
+      sidecarUser,
+      (): SuggestionSidecarSlot => ({}),
+    );
+    slot.input = input;
     const tx = providedTx || runtime.edit();
 
-    if (!suggestionPatternResultCell) {
-      suggestionPatternResultCell = runtime.getCell(
+    if (!slot.resultCell) {
+      slot.resultCell = runtime.getCell(
         parentCell.space,
-        { wish: { suggestionPattern: cause, situation: input.situation } },
+        {
+          wish: {
+            suggestionPattern: cause,
+            situation: input.situation,
+            // The F2 fix's suggestion half (pre-existing gap: this cause
+            // carried NO user key): on a SERVING runtime the cell keys
+            // by the demanding identity, so two demanders never share a
+            // suggestion cell. Clients keep the pre-existing cause
+            // byte-identical (cardinality 1 — re-keying would orphan
+            // every persisted client suggestion cell for no gain).
+            ...(runtime.servingPosture ? { user: sidecarUser } : {}),
+          },
+        },
         undefined,
         tx,
       );
@@ -1964,23 +2006,23 @@ export function wish(
         runtime.servingPosture ? parentCell.space : undefined,
       ).then(
         (pattern) => {
-          if (!cancelled && pattern && suggestionPatternResultCell) {
+          if (!cancelled && pattern && slot.resultCell) {
             runtime.run(
               undefined,
               pattern,
-              suggestionPatternInput,
-              suggestionPatternResultCell!,
+              slot.input,
+              slot.resultCell,
             );
           }
         },
       );
     } else {
-      if (!cancelled && suggestionPatternResultCell) {
+      if (!cancelled && slot.resultCell) {
         runtime.run(
           tx,
           cachedSuggestionPattern,
-          suggestionPatternInput,
-          suggestionPatternResultCell,
+          slot.input,
+          slot.resultCell,
         );
       }
     }
@@ -1990,7 +2032,7 @@ export function wish(
       tx.commit();
     }
 
-    return suggestionPatternResultCell;
+    return slot.resultCell;
   }
 
   // Renders an error message into a pattern result cell in its own committed
@@ -2047,9 +2089,22 @@ export function wish(
     ctx: WishContext,
     providedTx?: IExtendedStorageTransaction,
   ): Cell<any> {
+    // Phase 5: the sidecar cells key by the HOME-SPACE user — the
+    // demanding identity on a serving runtime (two users' create
+    // surfaces must not collide on the service DID), the runtime's own
+    // user on a client (unchanged). The CLOSURE state keys by the SAME
+    // expression (the F2 fix): the singular wish node runs once per
+    // demanded instance, and a shared cached cell/input made demander
+    // #2 reuse demander #1's surface and clobber the pending input.
+    const sidecarUser = homeSpaceUserDID(ctx) ?? runtime.userIdentityDID;
+    const slot = slotFor(
+      profileCreateSidecars,
+      sidecarUser,
+      (): ProfileCreateSidecarSlot => ({}),
+    );
     const homeDefaultPattern = getHomeSpaceCell(ctx).key("defaultPattern")
       .resolveAsCell();
-    profileCreatePatternInput = {
+    slot.input = {
       profiles: createSigilLinkFromParsedLink(
         homeDefaultPattern.key("profiles").getAsNormalizedFullLink(),
       ),
@@ -2058,13 +2113,8 @@ export function wish(
     };
     const tx = providedTx || runtime.edit();
 
-    // Phase 5: the sidecar cells key by the HOME-SPACE user — the
-    // demanding identity on a serving runtime (two users' create
-    // surfaces must not collide on the service DID), the runtime's own
-    // user on a client (unchanged).
-    const sidecarUser = homeSpaceUserDID(ctx) ?? runtime.userIdentityDID;
-    if (!profileCreatePatternResultCell) {
-      profileCreatePatternResultCell = runtime.getCell(
+    if (!slot.resultCell) {
+      slot.resultCell = runtime.getCell(
         parentCell.space,
         {
           wish: {
@@ -2076,8 +2126,8 @@ export function wish(
         tx,
       );
     }
-    if (!profileCreatePatternReadyCell) {
-      profileCreatePatternReadyCell = runtime.getCell<boolean>(
+    if (!slot.readyCell) {
+      slot.readyCell = runtime.getCell<boolean>(
         parentCell.space,
         {
           wish: {
@@ -2089,52 +2139,62 @@ export function wish(
         tx,
       );
     }
-    profileCreatePatternReadyCell.get();
+    slot.readyCell.get();
 
     const profileCreateInputForTx = (tx: IExtendedStorageTransaction) => {
       const bindInputCell = (cell: unknown) =>
         cell && typeof (cell as { withTx?: unknown }).withTx === "function"
           ? (cell as Cell<unknown>).withTx(tx)
           : cell;
-      return profileCreatePatternInput && {
-        ...profileCreatePatternInput,
-        profiles: bindInputCell(profileCreatePatternInput.profiles),
+      return slot.input && {
+        ...slot.input,
+        profiles: bindInputCell(slot.input.profiles),
       };
     };
 
     const cachedProfileCreatePattern = profileCreatePatternCache.cached();
     if (!cachedProfileCreatePattern) {
       void profileCreatePatternCache.fetch(runtime, () => {
-        if (profileCreatePatternReadyCell) {
+        // The pattern arrived: re-arm EVERY demander's create surface —
+        // the fetch is node-shared (memoized), so the ready signal must
+        // reach every slot registered while it was in flight, not only
+        // the demander whose launch started it (the F2 fix).
+        const readySlots = [...profileCreateSidecars.values()].filter(
+          (readySlot) => readySlot.readyCell !== undefined,
+        );
+        if (readySlots.length > 0) {
           const readyTx = runtime.edit();
           // Cache-fetch onLoaded continuation — no scheduler run stamps
           // it; bookkeeping per serving-loop.md §3d.
           runtime.stampServerRun(readyTx, {
-            actionId:
-              `wish/profile-create-ready/${profileCreatePatternReadyCell.sourceURI}`,
+            actionId: `wish/profile-create-ready/${
+              readySlots[0].readyCell!.sourceURI
+            }`,
             kind: "bookkeeping",
           });
-          profileCreatePatternReadyCell.withTx(readyTx).set(true);
+          for (const readySlot of readySlots) {
+            readySlot.readyCell!.withTx(readyTx).set(true);
+          }
           runtime.prepareTxForCommit(readyTx);
           readyTx.commit();
         }
       }, runtime.servingPosture ? parentCell.space : undefined).then(
         (pattern) => {
-          if (!cancelled && pattern && profileCreatePatternResultCell) {
+          if (!cancelled && pattern && slot.resultCell) {
             runSidecarInOwnTx(
-              profileCreatePatternResultCell,
+              slot.resultCell,
               pattern,
               profileCreateInputForTx,
             );
           }
         },
       );
-    } else if (!cancelled && profileCreatePatternResultCell) {
+    } else if (!cancelled && slot.resultCell) {
       runtime.run(
         tx,
         cachedProfileCreatePattern,
         profileCreateInputForTx(tx),
-        profileCreatePatternResultCell.withTx(tx),
+        slot.resultCell.withTx(tx),
       );
     }
 
@@ -2143,7 +2203,7 @@ export function wish(
       tx.commit();
     }
 
-    return profileCreatePatternResultCell;
+    return slot.resultCell;
   }
 
   function profileCreateUI(ctx: WishContext): VNode {
@@ -2174,9 +2234,18 @@ export function wish(
     ctx: WishContext,
     providedTx?: IExtendedStorageTransaction,
   ): Cell<any> {
+    // Per-demanding-identity slot (the F2 fix) — the slot key is the
+    // same expression the cell cause keys on; see
+    // launchProfileCreatePattern.
+    const sidecarUser = homeSpaceUserDID(ctx) ?? runtime.userIdentityDID;
+    const slot = slotFor(
+      profilePickerSidecars,
+      sidecarUser,
+      (): ProfilePickerSidecarSlot => ({}),
+    );
     const homeDefaultPattern = getHomeSpaceCell(ctx).key("defaultPattern")
       .resolveAsCell();
-    profilePickerPatternInput = {
+    slot.input = {
       profiles: createSigilLinkFromParsedLink(
         homeDefaultPattern.key("profiles").getAsNormalizedFullLink(),
       ),
@@ -2189,15 +2258,15 @@ export function wish(
     };
     const tx = providedTx || runtime.edit();
 
-    if (!profilePickerPatternResultCell) {
-      profilePickerPatternResultCell = runtime.getCell(
+    if (!slot.resultCell) {
+      slot.resultCell = runtime.getCell(
         parentCell.space,
         {
           wish: {
             profilePickerPattern: cause,
             // Phase 5: keyed by the home-space user (the demanding
             // identity on serving) — see launchProfileCreatePattern.
-            user: homeSpaceUserDID(ctx) ?? runtime.userIdentityDID,
+            user: sidecarUser,
           },
         },
         undefined,
@@ -2210,10 +2279,10 @@ export function wish(
         cell && typeof (cell as { withTx?: unknown }).withTx === "function"
           ? (cell as Cell<unknown>).withTx(tx)
           : cell;
-      return profilePickerPatternInput && {
-        profiles: bindInputCell(profilePickerPatternInput.profiles),
-        defaultProfile: bindInputCell(profilePickerPatternInput.defaultProfile),
-        mru: bindInputCell(profilePickerPatternInput.mru),
+      return slot.input && {
+        profiles: bindInputCell(slot.input.profiles),
+        defaultProfile: bindInputCell(slot.input.defaultProfile),
+        mru: bindInputCell(slot.input.mru),
       };
     };
 
@@ -2225,10 +2294,10 @@ export function wish(
         runtime.servingPosture ? parentCell.space : undefined,
       ).then(
         (pattern) => {
-          if (cancelled || !profilePickerPatternResultCell) return;
+          if (cancelled || !slot.resultCell) return;
           if (pattern) {
             runSidecarInOwnTx(
-              profilePickerPatternResultCell,
+              slot.resultCell,
               pattern,
               pickerInputForTx,
             );
@@ -2240,7 +2309,7 @@ export function wish(
             // (ordered[0]), not this sidecar (a superseded fetch also resolves
             // to undefined — a benign extra error UI on a since-replaced cell).
             commitPatternErrorUI(
-              profilePickerPatternResultCell,
+              slot.resultCell,
               `Can't load profile-picker.tsx`,
             );
           }
@@ -2248,19 +2317,19 @@ export function wish(
       ).catch((error) => {
         // Defensive: a throw inside the `.then` body (or a truly-rejecting
         // fetch) would otherwise be an unhandled rejection. Surface it too.
-        if (!cancelled && profilePickerPatternResultCell) {
+        if (!cancelled && slot.resultCell) {
           commitPatternErrorUI(
-            profilePickerPatternResultCell,
+            slot.resultCell,
             errorMessage(error),
           );
         }
       });
-    } else if (!cancelled && profilePickerPatternResultCell) {
+    } else if (!cancelled && slot.resultCell) {
       runtime.run(
         tx,
         cachedProfilePickerPattern,
         pickerInputForTx(tx),
-        profilePickerPatternResultCell.withTx(tx),
+        slot.resultCell.withTx(tx),
       );
     }
 
@@ -2269,7 +2338,7 @@ export function wish(
       tx.commit();
     }
 
-    return profilePickerPatternResultCell;
+    return slot.resultCell;
   }
 
   // Wish action, reactive to changes in inputsCell and any cell we read during
@@ -2548,6 +2617,7 @@ export function wish(
                     sendResult(
                       tx,
                       launchSuggestionPattern(
+                        ctx,
                         {
                           situation: query,
                           context: context ?? {},
@@ -2587,6 +2657,7 @@ export function wish(
                   queryKey,
                   () =>
                     launchSuggestionPattern(
+                      ctx,
                       {
                         situation: query,
                         context: context ?? {},
@@ -2642,6 +2713,14 @@ export function wish(
           );
         } else {
           // Otherwise it's a generic query, instantiate suggestion.tsx
+          const suggestionCtx: WishContext = {
+            runtime,
+            tx,
+            parentCell,
+            scope,
+            nowCell,
+            nowCause: cause,
+          };
           measureWishPhase(
             "send-suggestion",
             queryKey,
@@ -2649,6 +2728,7 @@ export function wish(
               sendResult(
                 tx,
                 launchSuggestionPattern(
+                  suggestionCtx,
                   { situation: query, context: context ?? {} },
                   tx,
                 ),

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -330,6 +330,20 @@ function getHomeSpaceCell(ctx: WishContext): Cell<unknown> {
 }
 
 /**
+ * The user whose HOME SPACE this wish resolution targets (server-execution
+ * v2 Phase 5; builtins.md §5's per-demanding-identity wish resolution,
+ * RULED 2026-08-14): the runtime's own user on a client (cardinality 1,
+ * today's behavior), the RUN's demanding identity on a serving runtime —
+ * NEVER the service identity (the lunch-wall trap: a served wish
+ * materializing against the service home space). Undefined on a serving
+ * runtime whose run carries no demanding principal; callers refuse with
+ * a WishError.
+ */
+function homeSpaceUserDID(ctx: WishContext): string | undefined {
+  return ctx.runtime.homeSpacePrincipalFor(ctx.tx);
+}
+
+/**
  * A profile link is valid when it resolves to a cell in another space (the
  * profile's own `inSpace` space) with an empty path. An unset link, or one that
  * still points into the home space, means the profile does not exist yet.
@@ -516,7 +530,7 @@ function searchFavoritesForHashtag(
   pathPrefix: string[],
 ): BaseResolution[] {
   const queryKey = sanitizeQueryKey(`#${searchTermWithoutHash}`);
-  const userDID = ctx.runtime.userIdentityDID;
+  const userDID = homeSpaceUserDID(ctx);
   if (!userDID) return [];
 
   const favoritesCell = measureWishPhase(
@@ -807,7 +821,7 @@ function resolveHomeSpaceTarget(
 ): BaseResolution[] | null {
   switch (parsed.key) {
     case "#favorites": {
-      const userDID = ctx.runtime.userIdentityDID;
+      const userDID = homeSpaceUserDID(ctx);
       if (!userDID) {
         throw new WishError("User identity DID not available for #favorites");
       }
@@ -851,7 +865,7 @@ function resolveHomeSpaceTarget(
     }
 
     case "#journal": {
-      const userDID = ctx.runtime.userIdentityDID;
+      const userDID = homeSpaceUserDID(ctx);
       if (!userDID) {
         throw new WishError("User identity DID not available for #journal");
       }
@@ -862,7 +876,7 @@ function resolveHomeSpaceTarget(
     }
 
     case "#learned": {
-      const userDID = ctx.runtime.userIdentityDID;
+      const userDID = homeSpaceUserDID(ctx);
       if (!userDID) {
         throw new WishError("User identity DID not available for #learned");
       }
@@ -876,7 +890,7 @@ function resolveHomeSpaceTarget(
       // The free-form learned summary string (home `learned.summary`). This is
       // what `#profile` used to resolve to before it was repurposed for the
       // profile default pattern object; summary consumers wish for this instead.
-      const userDID = ctx.runtime.userIdentityDID;
+      const userDID = homeSpaceUserDID(ctx);
       if (!userDID) {
         throw new WishError(
           "User identity DID not available for #learnedSummary",
@@ -889,7 +903,7 @@ function resolveHomeSpaceTarget(
     }
 
     case "#profile": {
-      const userDID = ctx.runtime.userIdentityDID;
+      const userDID = homeSpaceUserDID(ctx);
       if (!userDID) {
         throw new WishError("User identity DID not available for #profile");
       }
@@ -1276,7 +1290,7 @@ function resolveSpaceTarget(
   }
 
   // "~" → include home space
-  if (ctx.scope?.includes("~") && ctx.runtime.userIdentityDID) {
+  if (ctx.scope?.includes("~") && homeSpaceUserDID(ctx) !== undefined) {
     const homeSpaceCell = getHomeSpaceCell(ctx);
     results.push(resolutionFor(homeSpaceCell));
   }
@@ -1540,6 +1554,7 @@ export function createSidecarPatternCache(options: {
   async function fetchPattern(
     runtime: Runtime,
     url: string,
+    compileSpace?: Cell<unknown>["space"],
   ): Promise<Pattern | undefined> {
     try {
       const program = await runtime.harness.resolve(
@@ -1552,7 +1567,13 @@ export function createSidecarPatternCache(options: {
       const compiled = await runtime.patternManager.compilePattern(
         program,
         options.compileInUserSpace
-          ? { space: runtime.userIdentityDID }
+          // Phase 5: a SERVING runtime's compile-cache context is the
+          // SERVED space (the wave's home — its writebacks are
+          // bookkeeping wave writes, serving-loop.md §3d), never the
+          // service identity's own space (a foreign wave write — the
+          // lunch-wall class). Callers pass it; clients keep the
+          // per-user cache context (CT-1623).
+          ? { space: compileSpace ?? runtime.userIdentityDID }
           : undefined,
       );
 
@@ -1577,6 +1598,7 @@ export function createSidecarPatternCache(options: {
     fetch(
       runtime: Runtime,
       onSuccess?: (pattern: Pattern) => void,
+      compileSpace?: Cell<unknown>["space"],
     ): Promise<Pattern | undefined> {
       const url = patternUrl();
       if (!fetchPromise || fetchUrl !== url) {
@@ -1585,6 +1607,7 @@ export function createSidecarPatternCache(options: {
         const started: Promise<Pattern | undefined> = fetchPattern(
           runtime,
           url,
+          compileSpace,
         ).then((fetched) => {
           // Only the fetch the cache currently points to records and reports
           // its result; launches chained on a superseded fetch get undefined
@@ -1935,7 +1958,11 @@ export function wish(
     const cachedSuggestionPattern = suggestionPatternCache.cached();
     if (!cachedSuggestionPattern) {
       // Once fetch completes, run the pattern without a tx (it creates its own)
-      void suggestionPatternCache.fetch(runtime).then(
+      void suggestionPatternCache.fetch(
+        runtime,
+        undefined,
+        runtime.servingPosture ? parentCell.space : undefined,
+      ).then(
         (pattern) => {
           if (!cancelled && pattern && suggestionPatternResultCell) {
             runtime.run(
@@ -2031,13 +2058,18 @@ export function wish(
     };
     const tx = providedTx || runtime.edit();
 
+    // Phase 5: the sidecar cells key by the HOME-SPACE user — the
+    // demanding identity on a serving runtime (two users' create
+    // surfaces must not collide on the service DID), the runtime's own
+    // user on a client (unchanged).
+    const sidecarUser = homeSpaceUserDID(ctx) ?? runtime.userIdentityDID;
     if (!profileCreatePatternResultCell) {
       profileCreatePatternResultCell = runtime.getCell(
         parentCell.space,
         {
           wish: {
             profileCreatePattern: cause,
-            user: runtime.userIdentityDID,
+            user: sidecarUser,
           },
         },
         undefined,
@@ -2050,7 +2082,7 @@ export function wish(
         {
           wish: {
             profileCreatePatternReady: cause,
-            user: runtime.userIdentityDID,
+            user: sidecarUser,
           },
         },
         undefined,
@@ -2086,15 +2118,17 @@ export function wish(
           runtime.prepareTxForCommit(readyTx);
           readyTx.commit();
         }
-      }).then((pattern) => {
-        if (!cancelled && pattern && profileCreatePatternResultCell) {
-          runSidecarInOwnTx(
-            profileCreatePatternResultCell,
-            pattern,
-            profileCreateInputForTx,
-          );
-        }
-      });
+      }, runtime.servingPosture ? parentCell.space : undefined).then(
+        (pattern) => {
+          if (!cancelled && pattern && profileCreatePatternResultCell) {
+            runSidecarInOwnTx(
+              profileCreatePatternResultCell,
+              pattern,
+              profileCreateInputForTx,
+            );
+          }
+        },
+      );
     } else if (!cancelled && profileCreatePatternResultCell) {
       runtime.run(
         tx,
@@ -2161,7 +2195,9 @@ export function wish(
         {
           wish: {
             profilePickerPattern: cause,
-            user: runtime.userIdentityDID,
+            // Phase 5: keyed by the home-space user (the demanding
+            // identity on serving) — see launchProfileCreatePattern.
+            user: homeSpaceUserDID(ctx) ?? runtime.userIdentityDID,
           },
         },
         undefined,
@@ -2183,7 +2219,11 @@ export function wish(
 
     const cachedProfilePickerPattern = profilePickerPatternCache.cached();
     if (!cachedProfilePickerPattern) {
-      void profilePickerPatternCache.fetch(runtime).then(
+      void profilePickerPatternCache.fetch(
+        runtime,
+        undefined,
+        runtime.servingPosture ? parentCell.space : undefined,
+      ).then(
         (pattern) => {
           if (cancelled || !profilePickerPatternResultCell) return;
           if (pattern) {

--- a/packages/runner/src/executor/engine-wave-sink.ts
+++ b/packages/runner/src/executor/engine-wave-sink.ts
@@ -26,9 +26,10 @@
 //   rule as the transact path, keyed by the accumulator's per-RUN scope
 //   keys), attached before and detached after the synchronous apply. A
 //   sink constructed WITHOUT the hook still refuses such a batch
-//   loudly. Sqlite ops in FOREIGN batches stay refused — no Phase-1
-//   producer folds sqlite into provisioning, and the attachment
-//   identity for a foreign run is Phase 5's cross-space design.
+//   loudly. Sqlite ops in FOREIGN batches stay refused — Phase 5 KEPT
+//   this refusal deliberately: no sanctioned producer folds sqlite into
+//   provisioning, and the foreign attachment identity rides the
+//   grant-scoped read design (protocol.md §2).
 //
 // Stage G also forwards the wave's durable outbound-append rows
 // (serving-loop.md §5, FP1): `batch.outboxAppends` land INSIDE the same
@@ -171,9 +172,11 @@ export class EngineWaveCommitSink implements WaveCommitSink {
             error: {
               name: "WaveCommitRejected",
               message: "sqlite ops in a FOREIGN wave batch are refused: " +
-                "cross-space sqlite attachment lands with Phase 5's " +
-                "cross-space serving (protocol.md §2b; the stage-G " +
-                "discharge covers home batches only)",
+                "no sanctioned producer folds sqlite into provisioning, " +
+                "and the foreign attachment identity rides the " +
+                "grant-scoped read design (protocol.md §2, §2b; the " +
+                "stage-G discharge covers home batches only — Phase 5 " +
+                "kept this refusal deliberately)",
             },
           });
         }

--- a/packages/runner/src/executor/host.ts
+++ b/packages/runner/src/executor/host.ts
@@ -142,6 +142,13 @@ export class ExecutorHost {
 
   #onCommitAdmitted(notice: AdmittedCommitNotice): void {
     if (this.#closed) return;
+    // Phase 5's server-internal foreign wake needs NO host machinery
+    // (survival-tested: a fan-out built here was mutation-probed
+    // redundant and removed): a foreign commit's frames arrive on the
+    // home serving runtime's foreign loopback session, the scheduler
+    // runs autonomously off storage notifications, and the re-run's
+    // SEAL wakes the loop (SpaceServer.seal's feed wake). The
+    // executor-cross-space E2E pins the end-to-end behavior.
     const existing = this.#spaces.get(notice.space);
     if (existing !== undefined) {
       // Active OR still activating: the record must reach the feed

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -325,12 +325,19 @@ export class SpaceServer implements TransactionSealDestination {
    * shape as the shadow-flip wake): set when re-armed roots became
    * retryable mid-cycle, consumed by the next #waitForInput. */
   #pendingStructureRetryWake = false;
-  /** Level-converted SEAL wake (the F4 fix — same latch shape): set
-   * when a wave-bound seal arrived while no input waiter was armed
-   * (the cycle's last microtasks, after wave-detach), so the next
-   * #waitForInput runs a cycle immediately instead of sleeping out the
-   * idle window over a contribution #hasWork() could not yet see. */
-  #pendingSealWake = false;
+  /** Wave-bound seals CHAINED but not yet applied (the F4 fix, as a
+   * LEVEL): seal() returns after arming the seal chain, so a seal
+   * landing in a cycle's last microtasks — after the closing wave
+   * detached — is invisible to #hasWork()'s contribution count until
+   * the chain runs, and the edge-triggered wake fired into no waiter;
+   * the loop then armed and slept out the idle window over real work.
+   * Counting chained-not-yet-applied seals makes #hasWork() see them:
+   * a pre-detach seal drains before its own cycle's commit barrier
+   * (`await #sealChain`), so it adds no spurious cycle, while a
+   * post-detach seal keeps the loop running one more cycle — the
+   * deterministic wake the removed host fan-out had provided
+   * incidentally. */
+  #pendingWaveSeals = 0;
   /** The activation scan's head: records at or below it are covered
    * by the basis re-mark and never drained (activation filters the
    * queued feed the same way). Late-arrival accounting keys off it. */
@@ -806,24 +813,24 @@ export class SpaceServer implements TransactionSealDestination {
       },
     );
     this.#sealChain = sealed.then(() => undefined, () => undefined);
+    // The F4 window: a seal chained during the cycle's last microtasks
+    // (after wave-detach) is not yet APPLIED when #hasWork() evaluates
+    // — count it as pending work until the chain settles, so the loop
+    // runs one more cycle instead of sleeping out the idle window over
+    // a real contribution (correctness was never at stake — the
+    // wait's timeout commits the pending wave — but the wake should
+    // be deterministic, not eventually-timed). A pre-detach seal
+    // drains before its own cycle's `await #sealChain`, adding no
+    // extra cycle.
+    this.#pendingWaveSeals += 1;
+    const sealApplied = () => {
+      this.#pendingWaveSeals -= 1;
+    };
+    sealed.then(sealApplied, sealApplied);
     // The scheduler runs autonomously off storage notifications: a seal
     // can arrive while the loop waits for input, and the wave it opened
-    // must be committed — wake the loop. LATCHED when no waiter is
-    // armed (the F4 residual, same shape as the shadow-flip latch): a
-    // seal chained during the cycle's last microtasks — after the
-    // closing wave detached, before the loop re-arms — is not yet
-    // APPLIED when #hasWork() evaluates (wave.seal runs later on the
-    // seal chain), so the edge-triggered wake alone let the loop arm
-    // and sleep out the idle window before committing the contribution
-    // (the removed host fan-out had closed this window incidentally;
-    // correctness was never at stake — the wait's timeout commits the
-    // pending wave — but the wake should be deterministic, not
-    // eventually-timed).
-    if (this.#feedArrived !== undefined) {
-      this.#feedArrived.resolve();
-    } else {
-      this.#pendingSealWake = true;
-    }
+    // must be committed — wake the loop.
+    this.#feedArrived?.resolve();
     return sealed;
   }
 
@@ -1408,6 +1415,9 @@ export class SpaceServer implements TransactionSealDestination {
   #hasWork(): boolean {
     return this.#feed.length > 0 ||
       (this.#currentWave?.contributionCount ?? 0) > 0 ||
+      // Chained-not-yet-applied wave seals (the F4 fix): real work the
+      // contribution count cannot see yet.
+      this.#pendingWaveSeals > 0 ||
       this.#eventScanOwed ||
       this.#effectsRetirementOwed ||
       // Deferred effect batches of the OPEN wave are work (round-2
@@ -1456,14 +1466,6 @@ export class SpaceServer implements TransactionSealDestination {
       // consume the latch and run a cycle now — the floor has lifted
       // and the catch-up wave must not wait out the idle window.
       this.#pendingShadowFlipWake = false;
-      return;
-    }
-    if (this.#pendingSealWake) {
-      // A wave-bound seal landed while no waiter was armed (the F4
-      // latch): its contribution is on the seal chain — run a cycle
-      // now so the wave commits deterministically instead of after
-      // the idle timeout.
-      this.#pendingSealWake = false;
       return;
     }
     this.#feedArrived = Promise.withResolvers<void>();

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -863,11 +863,34 @@ export class SpaceServer implements TransactionSealDestination {
         // the sealing run carries the §2b delegated carriage (acting
         // identity + capabilityRef — the sanctioned `.inSpace`/
         // provisioning shape, which #stampRun supplies for served runs
-        // acting as a principal). A carriage-less foreign write — the
-        // lunch-wall class: a run resolving against the SERVICE
-        // identity's ambient state — still refuses action-scoped,
-        // loud, and counted into §7's foreignWriteRefusals.
+        // acting as a principal) AND the acting identity holds a
+        // structural write grant for the TARGET space (the probe
+        // below — the F1 fix: carriage alone is minted for every
+        // acting run and authorizes nothing). A carriage-less OR
+        // ungranted foreign write — the lunch-wall class: a run
+        // resolving against the SERVICE identity's ambient state, or
+        // one reaching for a space its actor holds no authority
+        // over — refuses action-scoped, loud, and counted into §7's
+        // foreignWriteRefusals.
         foreignWrites: "accept",
+        // The co-hosted memory server's structural grant supply
+        // (protocol.md §2b): owner-by-identity (the actor's own home
+        // space), fresh-store creation (§2b's sanctioned provisioning,
+        // DID-shape-checked), or the target's own ACL granting the
+        // actor WRITE — fail-closed otherwise. The refusal reason is
+        // logged here; the wave's refusal message stays generic.
+        foreignWriteGrant: async (foreignSpace, acting) => {
+          const verdict = await this.#options.server
+            .foreignWriteAuthorityFor(foreignSpace, acting.user);
+          if (!verdict.granted) {
+            logger.warn("foreign-write-ungranted", () => [
+              `foreign write to ${foreignSpace} by acting identity ` +
+              `${acting.user} holds no structural grant: ` +
+              `${verdict.reason} (protocol.md §2b)`,
+            ]);
+          }
+          return verdict.granted;
+        },
         onForeignWriteRefusal: () => {
           this.#options.stats.foreignWriteRefusals += 1;
         },

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -691,14 +691,37 @@ export class SpaceServer implements TransactionSealDestination {
 
   /** Resolve the co-hosted engines for a closing wave's foreign spaces
    * (Phase 5): same host, same process — store sequencing, not a
-   * network await (protocol.md §2b). */
+   * network await (protocol.md §2b). Failure is isolated PER SPACE
+   * (the F1b fix): a space whose engine cannot resolve fails exactly
+   * the contributions targeting it (wave.failForeignSpace — requeue
+   * for events, drop for derivations; counted) and the wave commits
+   * the rest. Before this isolation the un-caught await threw out of
+   * the cycle — loop-failed → park + backoff for the HOME space, the
+   * exact "space outage from one misdirected materialization" class
+   * the RULED 2026-08-14 (c) accumulation refusal was built to
+   * prevent, re-opened at the commit step. */
   async #resolveForeignEngines(wave: WaveAccumulator): Promise<void> {
     for (const space of wave.foreignSpaces) {
       if (this.#foreignEngines.has(space)) continue;
-      this.#foreignEngines.set(
-        space,
-        await this.#options.server.engineForSpace(space),
-      );
+      try {
+        this.#foreignEngines.set(
+          space,
+          await this.#options.server.engineForSpace(space),
+        );
+      } catch (error) {
+        this.#options.stats.foreignEngineFailures += 1;
+        logger.warn("foreign-engine-resolution-failed", () => [
+          `co-hosted engine for foreign space ${space} failed to ` +
+          "resolve; failing its contributions action-scoped and " +
+          "committing the rest of the wave (protocol.md §2b; " +
+          "serving-loop.md §3d's failure isolation)",
+          error,
+        ]);
+        wave.failForeignSpace(
+          space,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
     }
   }
 

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -186,6 +186,49 @@ const DEFAULT_FLUSH_DEADLINE_MS = 100;
 const DEFAULT_IDLE_PARK_MS = 30_000;
 const DEFAULT_PARK_DISPOSE_TIMEOUT_MS = 5_000;
 
+/**
+ * Phase 5's foreign re-mark decision (serving-loop.md §3b's cross-space
+ * bullet; §6 step 2): the (action, instance) set whose recorded FOREIGN
+ * inputs moved — each basis row whose `entity_space` is not the home
+ * space is judged against THAT space's own co-hosted engine's head,
+ * exactly like the home scan judges home rows. Returns only instances
+ * NOT already in `alreadyStale` (the home scan's findings), in row
+ * order. Extracted from the activation scan so the decision is
+ * unit-pinned (the F5 fix — the catch in `activate` converts any
+ * breakage here into a `basis-foreign-remark-failed` warn, an
+ * invisible-by-design degradation, so the helper itself must hold the
+ * test surface).
+ */
+export async function selectForeignStaleInstances(
+  engine: Engine.Engine,
+  scope: { branch: string; space: string },
+  engineForSpace: (space: MemorySpace) => Promise<Engine.Engine>,
+  alreadyStale: ReadonlyArray<{ action: string; actionScopeKey: string }>,
+): Promise<Array<{ action: string; actionScopeKey: string }>> {
+  const foreignRows = selectForeignBasisRows(engine, scope);
+  const staleKeys = new Set(
+    alreadyStale.map((entry) => `${entry.action}\0${entry.actionScopeKey}`),
+  );
+  const added: Array<{ action: string; actionScopeKey: string }> = [];
+  for (const row of foreignRows) {
+    const key = `${row.action}\0${row.actionScopeKey}`;
+    if (staleKeys.has(key)) continue;
+    const foreignEngine = await engineForSpace(row.entitySpace as MemorySpace);
+    const head = Engine.selectDocHead(foreignEngine, {
+      id: row.entity,
+      scopeKey: row.entityScopeKey,
+    });
+    if (head > row.seq) {
+      staleKeys.add(key);
+      added.push({
+        action: row.action,
+        actionScopeKey: row.actionScopeKey,
+      });
+    }
+  }
+  return added;
+}
+
 /** The well-known never-a-piece id classes excluded from piece demand
  * (RULED 2026-08-07): a `computed:` doc is a derivation result, a
  * `cid:` doc is a content-addressed bundle, and the watermark doc is
@@ -282,6 +325,12 @@ export class SpaceServer implements TransactionSealDestination {
    * shape as the shadow-flip wake): set when re-armed roots became
    * retryable mid-cycle, consumed by the next #waitForInput. */
   #pendingStructureRetryWake = false;
+  /** Level-converted SEAL wake (the F4 fix — same latch shape): set
+   * when a wave-bound seal arrived while no input waiter was armed
+   * (the cycle's last microtasks, after wave-detach), so the next
+   * #waitForInput runs a cycle immediately instead of sleeping out the
+   * idle window over a contribution #hasWork() could not yet see. */
+  #pendingSealWake = false;
   /** The activation scan's head: records at or below it are covered
    * by the basis re-mark and never drained (activation filters the
    * queued feed the same way). Late-arrival accounting keys off it. */
@@ -557,31 +606,12 @@ export class SpaceServer implements TransactionSealDestination {
     // surfacing, never a wedge).
     if (foreignReadInstances.length > 0) {
       try {
-        const foreignRows = selectForeignBasisRows(engine, {
-          branch: "",
-          space,
-        });
-        const staleKeys = new Set(
-          stale.map((entry) => `${entry.action}\0${entry.actionScopeKey}`),
-        );
-        for (const row of foreignRows) {
-          const key = `${row.action}\0${row.actionScopeKey}`;
-          if (staleKeys.has(key)) continue;
-          const foreignEngine = await this.#options.server.engineForSpace(
-            row.entitySpace as MemorySpace,
-          );
-          const head = Engine.selectDocHead(foreignEngine, {
-            id: row.entity,
-            scopeKey: row.entityScopeKey,
-          });
-          if (head > row.seq) {
-            staleKeys.add(key);
-            stale.push({
-              action: row.action,
-              actionScopeKey: row.actionScopeKey,
-            });
-          }
-        }
+        stale.push(...await selectForeignStaleInstances(
+          engine,
+          { branch: "", space },
+          (foreignSpace) => this.#options.server.engineForSpace(foreignSpace),
+          stale,
+        ));
       } catch (error) {
         logger.warn("basis-foreign-remark-failed", () => [
           `${foreignReadInstances.length} basis instance(s) carry ` +
@@ -778,8 +808,22 @@ export class SpaceServer implements TransactionSealDestination {
     this.#sealChain = sealed.then(() => undefined, () => undefined);
     // The scheduler runs autonomously off storage notifications: a seal
     // can arrive while the loop waits for input, and the wave it opened
-    // must be committed — wake the loop.
-    this.#feedArrived?.resolve();
+    // must be committed — wake the loop. LATCHED when no waiter is
+    // armed (the F4 residual, same shape as the shadow-flip latch): a
+    // seal chained during the cycle's last microtasks — after the
+    // closing wave detached, before the loop re-arms — is not yet
+    // APPLIED when #hasWork() evaluates (wave.seal runs later on the
+    // seal chain), so the edge-triggered wake alone let the loop arm
+    // and sleep out the idle window before committing the contribution
+    // (the removed host fan-out had closed this window incidentally;
+    // correctness was never at stake — the wait's timeout commits the
+    // pending wave — but the wake should be deterministic, not
+    // eventually-timed).
+    if (this.#feedArrived !== undefined) {
+      this.#feedArrived.resolve();
+    } else {
+      this.#pendingSealWake = true;
+    }
     return sealed;
   }
 
@@ -1412,6 +1456,14 @@ export class SpaceServer implements TransactionSealDestination {
       // consume the latch and run a cycle now — the floor has lifted
       // and the catch-up wave must not wait out the idle window.
       this.#pendingShadowFlipWake = false;
+      return;
+    }
+    if (this.#pendingSealWake) {
+      // A wave-bound seal landed while no waiter was armed (the F4
+      // latch): its contribution is on the seal chain — run a cycle
+      // now so the wave commits deterministically instead of after
+      // the idle timeout.
+      this.#pendingSealWake = false;
       return;
     }
     this.#feedArrived = Promise.withResolvers<void>();

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -71,7 +71,10 @@ import {
   ExecutionLeaseCycle,
   executionLeaseHolder,
 } from "@commonfabric/memory/v2/execution-lease";
-import { selectStaleBasisInstances } from "@commonfabric/memory/v2/scheduler-basis";
+import {
+  selectForeignBasisRows,
+  selectStaleBasisInstances,
+} from "@commonfabric/memory/v2/scheduler-basis";
 import { getLogger } from "@commonfabric/utils/logger";
 import type { Runtime, ServerRunInfo } from "../runtime.ts";
 import type {
@@ -545,11 +548,48 @@ export class SpaceServer implements TransactionSealDestination {
       engine,
       { branch: "", space },
     );
+    // Phase 5's foreign re-mark (serving-loop.md §3b's cross-space
+    // bullet; §6 step 2): recorded FOREIGN inputs are judged against
+    // their own space's co-hosted engine — same surfacing posture as
+    // the home scan (counted and logged; recovery correctness rides
+    // recompute-on-demand over the fresh runtime either way, so a
+    // failed foreign-head resolution degrades to conservative
+    // surfacing, never a wedge).
     if (foreignReadInstances.length > 0) {
-      logger.warn("basis-foreign-rows", () => [
-        `${foreignReadInstances.length} basis instance(s) carry ` +
-        "cross-space reads; cross-space re-marking lands with Phase 5",
-      ]);
+      try {
+        const foreignRows = selectForeignBasisRows(engine, {
+          branch: "",
+          space,
+        });
+        const staleKeys = new Set(
+          stale.map((entry) => `${entry.action}\0${entry.actionScopeKey}`),
+        );
+        for (const row of foreignRows) {
+          const key = `${row.action}\0${row.actionScopeKey}`;
+          if (staleKeys.has(key)) continue;
+          const foreignEngine = await this.#options.server.engineForSpace(
+            row.entitySpace as MemorySpace,
+          );
+          const head = Engine.selectDocHead(foreignEngine, {
+            id: row.entity,
+            scopeKey: row.entityScopeKey,
+          });
+          if (head > row.seq) {
+            staleKeys.add(key);
+            stale.push({
+              action: row.action,
+              actionScopeKey: row.actionScopeKey,
+            });
+          }
+        }
+      } catch (error) {
+        logger.warn("basis-foreign-remark-failed", () => [
+          `${foreignReadInstances.length} basis instance(s) carry ` +
+          "cross-space reads and the foreign re-mark failed; " +
+          "recompute-on-demand covers them (serving-loop.md §6 step 2)",
+          error,
+        ]);
+      }
     }
     logger.info?.("activate", () => [
       `space ${space} activated: W=${this.#watermark} scanHead=${scanHead} ` +
@@ -625,13 +665,41 @@ export class SpaceServer implements TransactionSealDestination {
     return true;
   }
 
-  #foreignEngineFor(_space: MemorySpace): Engine.Engine {
-    // Cross-space serving is Phase 5; Phase 1 waves write their home
-    // space only (no provisioning producers exist yet).
-    throw new Error(
-      "cross-space wave commits are Phase 5 (protocol.md §2b); no " +
-        "Phase-1 producer writes a foreign space",
-    );
+  /** Resolved co-hosted engines for FOREIGN spaces this loop's waves
+   * provision into (protocol.md §2b — Phase 5). Populated by
+   * #resolveForeignEngines ahead of each commit step; the sink's
+   * engineFor lookup is synchronous, so a miss here is a sequencing
+   * bug, not a recoverable state. Cleared on park (a re-activation
+   * re-resolves — engines may have been closed meanwhile). */
+  readonly #foreignEngines = new Map<MemorySpace, Engine.Engine>();
+
+  #foreignEngineFor(space: MemorySpace): Engine.Engine {
+    const engine = this.#foreignEngines.get(space);
+    if (engine === undefined) {
+      // The commit-step backstop (serving-loop.md §3d): reachable only
+      // if a foreign batch bypassed #resolveForeignEngines — the
+      // accumulation gate admits sanctioned crossings and the cycle
+      // resolves their engines before commitWave, so this names a bug.
+      throw new Error(
+        `no resolved co-hosted engine for foreign space ${space}: the ` +
+          "wave commit step runs after #resolveForeignEngines " +
+          "(protocol.md §2b; serving-loop.md §3d's commit-step backstop)",
+      );
+    }
+    return engine;
+  }
+
+  /** Resolve the co-hosted engines for a closing wave's foreign spaces
+   * (Phase 5): same host, same process — store sequencing, not a
+   * network await (protocol.md §2b). */
+  async #resolveForeignEngines(wave: WaveAccumulator): Promise<void> {
+    for (const space of wave.foreignSpaces) {
+      if (this.#foreignEngines.has(space)) continue;
+      this.#foreignEngines.set(
+        space,
+        await this.#options.server.engineForSpace(space),
+      );
+    }
   }
 
   /** The host's in-process feed (plane (d)): every admitted commit for
@@ -641,6 +709,7 @@ export class SpaceServer implements TransactionSealDestination {
     this.#feed.push(record);
     this.#feedArrived?.resolve();
   }
+
 
   /** A session opened or its demand may have changed: reconsider the
    * demanded roots on the next cycle. */
@@ -789,10 +858,16 @@ export class SpaceServer implements TransactionSealDestination {
         onUnstampedSeal: () => {
           this.#options.stats.unstampedSealRefusals += 1;
         },
-        // Default posture ("refuse", RULED 2026-08-14 (c)): a foreign-
-        // space write refuses at ACCUMULATION, action-scoped — the wave
-        // and the loop survive a misdirected wish materialization
-        // instead of dying at the commit-step guard. Counted into §7.
+        // The Phase-5 serving posture (serving-loop.md §3d; protocol.md
+        // §2b): foreign-space writes are ADMITTED at accumulation IFF
+        // the sealing run carries the §2b delegated carriage (acting
+        // identity + capabilityRef — the sanctioned `.inSpace`/
+        // provisioning shape, which #stampRun supplies for served runs
+        // acting as a principal). A carriage-less foreign write — the
+        // lunch-wall class: a run resolving against the SERVICE
+        // identity's ambient state — still refuses action-scoped,
+        // loud, and counted into §7's foreignWriteRefusals.
+        foreignWrites: "accept",
         onForeignWriteRefusal: () => {
           this.#options.stats.foreignWriteRefusals += 1;
         },
@@ -852,6 +927,28 @@ export class SpaceServer implements TransactionSealDestination {
         ? { acting: info.acting }
         : acting !== undefined
         ? { acting }
+        : {}),
+      // Phase 5 (protocol.md §2b's sanctioned crossing): a served run
+      // acting AS a principal carries the delegated GRANT alongside its
+      // actor, so its provisioning writes (a handler's `.inSpace`
+      // creation, a demanded wish's home-space bootstrap) are
+      // admissible at the wave's accept gate and at the target's
+      // delegated admission. Structural presence, following the FP1
+      // outbox precedent (`stream-append:<sidecarId>`): grant
+      // RESOLUTION against per-doc grants is the OW13 owed hardening —
+      // no per-doc grant store exists yet. Never for bookkeeping (the
+      // loop's own writes carry no acting principal, protocol.md §1),
+      // and never without an actor (a carriage-less foreign write
+      // refuses at accumulation, by design).
+      ...(info.kind !== "bookkeeping" &&
+          (info.acting !== undefined || acting !== undefined)
+        ? {
+          capabilityRef: info.kind === "event-handler"
+            ? `event-consequence:${info.eventId ?? "unidentified"}`
+            : `demanded-run:${
+              (info.acting ?? acting)!.user
+            }`,
+        }
         : {}),
       ...(info.streamEntry !== undefined
         ? { streamEntry: info.streamEntry }
@@ -2388,6 +2485,11 @@ export class SpaceServer implements TransactionSealDestination {
     this.#currentWave = undefined;
     await this.#sealChain;
 
+    // Phase 5 (protocol.md §2b): resolve the co-hosted engines for the
+    // wave's foreign provisioning targets BEFORE the commit step — the
+    // sink's engineFor is synchronous. Same host, same process.
+    await this.#resolveForeignEngines(closing);
+
     const derivedThrough = !exhausted && advanceSealed
       ? advanceTo
       : this.#watermark;
@@ -2634,6 +2736,10 @@ export class SpaceServer implements TransactionSealDestination {
     this.#terminalStructureLoads.clear();
     this.#rearmedAwaitingSettle.clear();
     this.#pendingStructureRetryWake = false;
+    // Phase 5: foreign engine resolutions die with the tenure (a
+    // re-activation re-resolves; the map must not outlive engines the
+    // server may close meanwhile).
+    this.#foreignEngines.clear();
     const wave = this.#currentWave;
     this.#currentWave = undefined;
     await this.#sealChain;

--- a/packages/runner/src/executor/stats.ts
+++ b/packages/runner/src/executor/stats.ts
@@ -105,11 +105,23 @@ export type ServingLoopStats = {
    * not as fast as admissions arrive). */
   reactivationBackoffs: number;
   /** Foreign-space writes refused at wave ACCUMULATION (serving-loop.md
-   * §3d, RULED 2026-08-14 (c)): action-scoped — the writing action
-   * fails, the wave and the loop keep serving. Nonzero names a pattern
-   * materializing home-space state under serving (cross-space serving
-   * is Phase 5). */
+   * §3d, RULED 2026-08-14 (c); Phase 5 keeps the counter for the
+   * accept gate's refusals): action-scoped — the writing action fails,
+   * the wave and the loop keep serving. Nonzero names either a
+   * carriage-less foreign write (a pattern materializing ambient
+   * service-identity state — the lunch-wall class) or an UNGRANTED one
+   * (an acting identity reaching for a space it holds no structural
+   * grant on — protocol.md §2b's authorization predicate). */
   foreignWriteRefusals: number;
+  /** Foreign co-hosted ENGINE resolutions that FAILED at the wave's
+   * commit step (Phase 5, the F1b isolation): the failing space's
+   * contributions withdraw action-scoped (events requeue, derivations
+   * drop) and the wave commits the rest — the home space never parks
+   * for one unresolvable foreign target. Counted per failed space per
+   * wave; a growing count names a foreign store that persistently
+   * cannot open (disk trouble, or a provisioning target with an
+   * unusable path). */
+  foreignEngineFailures: number;
   /** max over active spaces of (store head seq − W). */
   watermarkLag: number;
   events: {
@@ -141,6 +153,7 @@ export const emptyServingLoopStats = (): ServingLoopStats => ({
   parkDisposeTimeouts: 0,
   reactivationBackoffs: 0,
   foreignWriteRefusals: 0,
+  foreignEngineFailures: 0,
   watermarkLag: 0,
   events: {
     appended: 0,

--- a/packages/runner/src/executor/wave.ts
+++ b/packages/runner/src/executor/wave.ts
@@ -508,6 +508,18 @@ export class WaveAccumulator
    * for the re-drain. Store-owned idempotency (the engine's nonce
    * dedupe) absorbs the re-run's re-issue. */
   readonly #sealFailedEventIds = new Set<string>();
+  /** Foreign spaces whose co-hosted ENGINE failed to resolve for this
+   * wave's commit step (Phase 5, the F1b fix): commitWave withdraws
+   * exactly the contributions that sealed into these spaces (requeue
+   * for events, drop for derivations — the standard per-kind
+   * withdrawal semantics) and commits the rest, instead of the
+   * resolution failure throwing out of the cycle and PARKING the home
+   * space — the "space outage from one misdirected materialization"
+   * class the RULED 2026-08-14 (c) accumulation refusal exists to
+   * prevent, re-opened at the commit step for carriage-bearing writes
+   * until this isolation. Marked by the serving loop's
+   * per-space-caught foreign-engine resolution (failForeignSpace). */
+  readonly #failedForeignSpaces = new Map<MemorySpace, string>();
   /** Outbound appends staged per transaction before its seal
    * (enqueueOutboundAppend); folded (by copy) into the contribution at
    * seal so only surviving contributions' appends ride the wave (FP1).
@@ -801,6 +813,31 @@ export class WaveAccumulator
       return;
     }
     this.#sealFailedEventIds.add(context.eventId);
+  }
+
+  /**
+   * Mark a FOREIGN space's co-hosted engine as unresolvable for this
+   * wave (Phase 5, the F1b fix): called by the serving loop when
+   * `engineForSpace` fails during the pre-commit foreign resolution.
+   * commitWave withdraws the contributions that sealed into the space
+   * (requeue for events — the entry stays pending and replays; drop
+   * for derivations — recompute-on-demand covers them), commits the
+   * rest, and never builds a batch the sink would need the missing
+   * engine for. Action-scoped, mirroring the accumulation refusal's
+   * posture — the alternative was the resolution failure throwing out
+   * of the cycle: loop-failed → park + backoff for the HOME space, a
+   * whole-space outage from one misdirected crossing.
+   */
+  failForeignSpace(space: MemorySpace, reason: string): void {
+    if (this.#closed) return;
+    if (space === this.#space) {
+      throw new Error(
+        "failForeignSpace on the wave's OWN home space: the home engine " +
+          "is the loop's engine — its failure is a loop failure, not a " +
+          "foreign-resolution one",
+      );
+    }
+    this.#failedForeignSpaces.set(space, reason);
   }
 
   /**
@@ -1354,6 +1391,36 @@ export class WaveAccumulator
           this.#sealFailedEventIds.has(contribution.context.eventId)
         ) {
           requeued.add(contribution.index);
+        }
+      }
+    }
+
+    // Seed withdrawals for contributions that sealed into a foreign
+    // space whose co-hosted engine failed to resolve (failForeignSpace
+    // — the F1b fix): action-scoped, per the standard kind semantics
+    // (an event requeues and its entry replays; a derivation drops and
+    // recompute-on-demand covers it). resolveConflicts' closures fold
+    // in readers and same-event siblings; #buildForeignBatches only
+    // iterates survivors, so no batch targeting the failed space ever
+    // reaches the sink's engine lookup.
+    if (this.#failedForeignSpaces.size > 0) {
+      for (const contribution of this.#contributions) {
+        if (
+          requeued.has(contribution.index) ||
+          droppedWhole.has(contribution.index)
+        ) {
+          continue;
+        }
+        const failed = contribution.spaces.some((sealed) =>
+          sealed.space !== this.#space &&
+          this.#failedForeignSpaces.has(sealed.space)
+        );
+        if (!failed) continue;
+        if (contribution.context.kind === "event-handler") {
+          requeued.add(contribution.index);
+        } else {
+          droppedWhole.add(contribution.index);
+          outcome.dependencyDroppedWrites += this.#homeOpCount(contribution);
         }
       }
     }

--- a/packages/runner/src/executor/wave.ts
+++ b/packages/runner/src/executor/wave.ts
@@ -478,6 +478,17 @@ export class WaveAccumulator
   readonly #lease: WaveLease | undefined;
   readonly #sealedTenure: number;
   readonly #foreignWrites: "refuse" | "accept";
+  readonly #foreignWriteGrant:
+    | ((
+      space: MemorySpace,
+      acting: { user: string; session?: string },
+    ) => boolean | Promise<boolean>)
+    | undefined;
+  /** Grant verdicts per (space, acting user) for THIS wave — one probe
+   * per crossing pair, not per sealed tx. A new wave re-probes (grants
+   * can change between waves; a transient probe failure must not stick
+   * beyond the wave that observed it). */
+  readonly #foreignGrantVerdicts = new Map<string, Promise<boolean>>();
   readonly #onForeignWriteRefusal:
     | ((info: { space: MemorySpace; actionId?: string }) => void)
     | undefined;
@@ -540,10 +551,29 @@ export class WaveAccumulator
      * Phase-5 SERVING posture (the serving loop passes it since
      * Phase 5): a foreign write is admitted IFF the sealing run's
      * context carries the §2b delegated carriage (acting identity +
-     * capabilityRef — the sanctioned `.inSpace`/provisioning shape);
-     * a carriage-less foreign write keeps refusing action-scoped and
-     * counted. The commit-step guard stays as backstop. */
+     * capabilityRef — the sanctioned `.inSpace`/provisioning shape)
+     * AND the acting identity holds a structural write grant for the
+     * TARGET space (`foreignWriteGrant` below — carriage alone is a
+     * shape, not an authorization: #stampRun mints it for every
+     * acting run). A carriage-less or UNGRANTED foreign write keeps
+     * refusing action-scoped and counted. The commit-step guard stays
+     * as backstop. */
     foreignWrites?: "refuse" | "accept";
+    /** The authorization predicate of the accept gate (Phase 5;
+     * protocol.md §2b): whether `acting` holds a structural write
+     * grant for `space`. REQUIRED with `foreignWrites: "accept"` — an
+     * accept-mode wave without an authority probe would admit any
+     * acting run into any co-hosted space (the F1 vacuous-gate class),
+     * so the constructor refuses the combination. The serving loop
+     * wires the co-hosted memory server's
+     * `foreignWriteAuthorityFor` (owner-by-identity / fresh-store
+     * creation / the target's own ACL grant — fail-closed otherwise);
+     * a probe that THROWS refuses the crossing (fail closed), scoped
+     * to this wave. Probed once per (space, acting user) per wave. */
+    foreignWriteGrant?: (
+      space: MemorySpace,
+      acting: { user: string; session?: string },
+    ) => boolean | Promise<boolean>;
     /** Fired once per refused foreign-space write (above): the serving
      * loop counts it into §7's `foreignWriteRefusals`. */
     onForeignWriteRefusal?: (
@@ -558,6 +588,19 @@ export class WaveAccumulator
     this.#sealedTenure = options.lease?.tenure ?? 0;
     this.#onUnstampedSeal = options.onUnstampedSeal;
     this.#foreignWrites = options.foreignWrites ?? "refuse";
+    this.#foreignWriteGrant = options.foreignWriteGrant;
+    if (
+      this.#foreignWrites === "accept" && this.#foreignWriteGrant === undefined
+    ) {
+      // The gate is an AUTHORIZATION boundary, not a shape check: an
+      // accept posture with no authority probe is exactly the vacuous
+      // gate the F1 review found (carriage is minted for every acting
+      // run). Refuse the configuration instead of admitting it.
+      throw new Error(
+        'foreignWrites: "accept" requires a foreignWriteGrant authority ' +
+          "probe (serving-loop.md §3d's accept gate; protocol.md §2b)",
+      );
+    }
     this.#onForeignWriteRefusal = options.onForeignWriteRefusal;
   }
 
@@ -858,20 +901,20 @@ export class WaveAccumulator
    * layered view later runs read) and holds the verdict open until the
    * wave commit step disposes of it.
    */
-  sealSpaceCommit(
+  async sealSpaceCommit(
     space: MemorySpace,
     native: NativeStorageCommit,
     source: IStorageTransaction,
   ): Promise<Result<Unit, CommitError>> {
     const assembly = this.#assembly;
     if (assembly === undefined) {
-      return Promise.resolve({
+      return {
         error: {
           name: "StorageTransactionAborted",
           message: "sealSpaceCommit outside a seal() call",
           reason: new Error("seal-out-of-order"),
         },
-      });
+      };
     }
     if (space !== this.#space) {
       // Accumulation-time gate (serving-loop.md §3d, RULED 2026-08-14
@@ -888,21 +931,37 @@ export class WaveAccumulator
       //   admitted IFF the sealing run's context carries the §2b
       //   delegated carriage — acting identity AND capabilityRef, the
       //   provisioning shape protocol.md §2's server-produced authored
-      //   row requires on EVERY foreign commit. A carriage-less foreign
-      //   write keeps refusing exactly like "refuse": admitting it
-      //   would commit authored-class under the bare service envelope
-      //   with no acting identity — the silent-empty-instance trap's
-      //   write-side twin. The commit-step sink's delegated validation
-      //   stays as backstop.
+      //   row requires on EVERY foreign commit — AND the acting
+      //   identity holds a structural write grant for the TARGET space
+      //   (the foreignWriteGrant probe; the F1 fix). Carriage alone is
+      //   a shape, not an authorization — #stampRun mints it for every
+      //   acting run, so a carriage-only gate admitted any served
+      //   pattern acting for any user into ANY co-hosted space through
+      //   the engine-direct sink (which bypasses session ACL). A
+      //   carriage-less foreign write keeps refusing exactly like
+      //   "refuse": admitting it would commit authored-class under the
+      //   bare service envelope with no acting identity — the
+      //   silent-empty-instance trap's write-side twin. An UNGRANTED
+      //   one refuses the same way, loud and counted. The commit-step
+      //   sink's delegated validation stays as backstop.
+      const acting = assembly.context?.acting;
       const carriage = assembly.context !== undefined &&
         this.#delegatedFor(assembly.context) !== undefined;
-      if (this.#foreignWrites === "refuse" || !carriage) {
+      let why: string | undefined;
+      if (this.#foreignWrites === "refuse") {
+        why = "cross-space serving is Phase 5";
+      } else if (!carriage || acting === undefined) {
+        why = "the run context carries no §2b delegated carriage (acting " +
+          "identity + capabilityRef; protocol.md §2's server-produced " +
+          "authored row)";
+      } else if (!(await this.#foreignGrantFor(space, acting))) {
+        why = `the acting identity ${acting.user} holds no structural ` +
+          `write grant for ${space} (protocol.md §2b: owner-by-identity, ` +
+          "fresh-store creation, or the target's own ACL grant; " +
+          "fail-closed otherwise)";
+      }
+      if (why !== undefined) {
         const actionId = assembly.context?.actionId;
-        const why = this.#foreignWrites === "refuse"
-          ? "cross-space serving is Phase 5"
-          : "the run context carries no §2b delegated carriage (acting " +
-            "identity + capabilityRef; protocol.md §2's server-produced " +
-            "authored row)";
         logger.warn("foreign-write-refused", () => [
           `foreign-space write refused at wave accumulation: action ` +
           `${actionId ?? "<unstamped>"} attempted to write ${space} from ` +
@@ -913,7 +972,7 @@ export class WaveAccumulator
           space,
           ...(actionId !== undefined ? { actionId } : {}),
         });
-        return Promise.resolve({
+        return {
           error: {
             name: "StorageTransactionAborted",
             message: `foreign-space write refused at wave accumulation ` +
@@ -922,7 +981,7 @@ export class WaveAccumulator
               `the wave serving ${this.#space} — ${why}`,
             reason: new Error("foreign-write-refused"),
           },
-        });
+        };
       }
     }
     const replica = this.#replicaFor(space);
@@ -1912,6 +1971,36 @@ export class WaveAccumulator
       ...(sqliteScopeKeys.length === 0 ? {} : { sqliteScopeKeys }),
       ...(outboxAppends.length === 0 ? {} : { outboxAppends }),
     };
+  }
+
+  /** The accept gate's authority verdict for one (space, acting user)
+   * crossing (the F1 fix): probes `foreignWriteGrant` once per pair
+   * per wave and caches the verdict promise. A probe that THROWS
+   * refuses the crossing — fail closed, never an unhandled crash out
+   * of the seal path — and the refusal is scoped to this wave (the
+   * next wave's fresh accumulator re-probes). */
+  #foreignGrantFor(
+    space: MemorySpace,
+    acting: { user: string; session?: string },
+  ): Promise<boolean> {
+    const key = `${space}\0${acting.user}`;
+    let verdict = this.#foreignGrantVerdicts.get(key);
+    if (verdict === undefined) {
+      verdict = (async () => this.#foreignWriteGrant!(space, acting))().then(
+        (granted) => granted,
+        (error) => {
+          logger.warn("foreign-write-grant-probe-failed", () => [
+            `the foreign-write authority probe for ${space} (acting ` +
+            `${acting.user}) failed; refusing the crossing fail-closed ` +
+            "for this wave (protocol.md §2b)",
+            error,
+          ]);
+          return false;
+        },
+      );
+      this.#foreignGrantVerdicts.set(key, verdict);
+    }
+    return verdict;
   }
 
   /** The delegated-identity carriage a contribution's foreign batch

--- a/packages/runner/src/executor/wave.ts
+++ b/packages/runner/src/executor/wave.ts
@@ -530,18 +530,19 @@ export class WaveAccumulator
     onUnstampedSeal?: () => void;
     /** Foreign-space writes at ACCUMULATION (serving-loop.md §3d, RULED
      * 2026-08-14 (c) — the lunch-wall trigger's ruled seat): on
-     * `"refuse"` (the DEFAULT — the Phase-1..4 truth that no sanctioned
-     * producer writes a foreign space from a serving wave yet), a
-     * sealing tx carrying a foreign-space commit is refused
-     * ACTION-SCOPED — that tx fails loudly (its already-sealed spaces
-     * withdraw per §3d's failure isolation) and the wave keeps serving
-     * everything else, instead of the whole wave dying later at the
-     * commit step's foreign-engine guard (loop-failed → park: a space
-     * outage from one misdirected wish materialization). `"accept"`
-     * is the Phase-5 posture — per-demanding-identity resolution
-     * riding §2b's `.inSpace` sanctioned crossing — kept dark-but-
-     * tested by the §2b accumulator tests until Phase 5 flips the
-     * serving loop over. The commit-step guard stays as backstop. */
+     * `"refuse"` (the pre-Phase-5 default), a sealing tx carrying a
+     * foreign-space commit is refused ACTION-SCOPED — that tx fails
+     * loudly (its already-sealed spaces withdraw per §3d's failure
+     * isolation) and the wave keeps serving everything else, instead
+     * of the whole wave dying later at the commit step's
+     * foreign-engine guard (loop-failed → park: a space outage from
+     * one misdirected wish materialization). `"accept"` is the
+     * Phase-5 SERVING posture (the serving loop passes it since
+     * Phase 5): a foreign write is admitted IFF the sealing run's
+     * context carries the §2b delegated carriage (acting identity +
+     * capabilityRef — the sanctioned `.inSpace`/provisioning shape);
+     * a carriage-less foreign write keeps refusing action-scoped and
+     * counted. The commit-step guard stays as backstop. */
     foreignWrites?: "refuse" | "accept";
     /** Fired once per refused foreign-space write (above): the serving
      * loop counts it into §7's `foreignWriteRefusals`. */
@@ -585,6 +586,20 @@ export class WaveAccumulator
    * appends never actually ride). */
   get hasOutboundAppends(): boolean {
     return this.#contributions.some((c) => c.outboundAppends.length > 0);
+  }
+
+  /** The FOREIGN spaces sealed contributions target (protocol.md §2b's
+   * provisioning commits). The serving loop resolves these spaces'
+   * co-hosted engines BEFORE driving the commit step, so the sink's
+   * synchronous engineFor lookup never misses (Phase 5). */
+  get foreignSpaces(): MemorySpace[] {
+    const spaces = new Set<MemorySpace>();
+    for (const contribution of this.#contributions) {
+      for (const sealed of contribution.spaces) {
+        if (sealed.space !== this.#space) spaces.add(sealed.space);
+      }
+    }
+    return [...spaces];
   }
 
   /**
@@ -858,39 +873,57 @@ export class WaveAccumulator
         },
       });
     }
-    if (space !== this.#space && this.#foreignWrites === "refuse") {
-      // Accumulation-time refusal (serving-loop.md §3d, RULED 2026-08-14
-      // (c)): a foreign-space write from a serving-wave action — the
-      // lunch-wall trigger was a wish materialization resolving against
-      // the SERVICE identity's home space — refuses HERE, action-scoped:
-      // seal() fails this tx (withdrawing its already-sealed spaces) and
-      // the wave keeps every other contribution, where the pre-ruling
-      // behavior let the batch through and the whole wave died at the
-      // commit step's foreign-engine guard, parking the space. Loud and
-      // counted; Phase 5 (per-demanding-identity resolution riding §2b's
-      // `.inSpace` crossing) flips the posture.
-      const actionId = assembly.context?.actionId;
-      logger.warn("foreign-write-refused", () => [
-        `foreign-space write refused at wave accumulation: action ` +
-        `${actionId ?? "<unstamped>"} attempted to write ${space} from ` +
-        `the wave serving ${this.#space} (serving-loop.md §3d, RULED ` +
-        "2026-08-14 (c); cross-space serving is Phase 5)",
-      ]);
-      this.#onForeignWriteRefusal?.({
-        space,
-        ...(actionId !== undefined ? { actionId } : {}),
-      });
-      return Promise.resolve({
-        error: {
-          name: "StorageTransactionAborted",
-          message: `foreign-space write refused at wave accumulation ` +
-            `(serving-loop.md §3d, RULED 2026-08-14 (c)): action ` +
-            `${actionId ?? "<unstamped>"} may not write ${space} from ` +
-            `the wave serving ${this.#space}; cross-space serving is ` +
-            "Phase 5",
-          reason: new Error("foreign-write-refused"),
-        },
-      });
+    if (space !== this.#space) {
+      // Accumulation-time gate (serving-loop.md §3d, RULED 2026-08-14
+      // (c); lifted by Phase 5 for the SANCTIONED shape only):
+      //
+      // - "refuse" (the pre-Phase-5 default): every foreign-space write
+      //   refuses HERE, action-scoped — seal() fails this tx
+      //   (withdrawing its already-sealed spaces) and the wave keeps
+      //   every other contribution, instead of the whole wave dying at
+      //   the commit step's foreign-engine guard (the lunch-wall
+      //   trigger: a wish materialization resolving against the SERVICE
+      //   identity's home space).
+      // - "accept" (the Phase-5 serving posture): a foreign write is
+      //   admitted IFF the sealing run's context carries the §2b
+      //   delegated carriage — acting identity AND capabilityRef, the
+      //   provisioning shape protocol.md §2's server-produced authored
+      //   row requires on EVERY foreign commit. A carriage-less foreign
+      //   write keeps refusing exactly like "refuse": admitting it
+      //   would commit authored-class under the bare service envelope
+      //   with no acting identity — the silent-empty-instance trap's
+      //   write-side twin. The commit-step sink's delegated validation
+      //   stays as backstop.
+      const carriage = assembly.context !== undefined &&
+        this.#delegatedFor(assembly.context) !== undefined;
+      if (this.#foreignWrites === "refuse" || !carriage) {
+        const actionId = assembly.context?.actionId;
+        const why = this.#foreignWrites === "refuse"
+          ? "cross-space serving is Phase 5"
+          : "the run context carries no §2b delegated carriage (acting " +
+            "identity + capabilityRef; protocol.md §2's server-produced " +
+            "authored row)";
+        logger.warn("foreign-write-refused", () => [
+          `foreign-space write refused at wave accumulation: action ` +
+          `${actionId ?? "<unstamped>"} attempted to write ${space} from ` +
+          `the wave serving ${this.#space} (serving-loop.md §3d, RULED ` +
+          `2026-08-14 (c); ${why})`,
+        ]);
+        this.#onForeignWriteRefusal?.({
+          space,
+          ...(actionId !== undefined ? { actionId } : {}),
+        });
+        return Promise.resolve({
+          error: {
+            name: "StorageTransactionAborted",
+            message: `foreign-space write refused at wave accumulation ` +
+              `(serving-loop.md §3d, RULED 2026-08-14 (c)): action ` +
+              `${actionId ?? "<unstamped>"} may not write ${space} from ` +
+              `the wave serving ${this.#space} — ${why}`,
+            reason: new Error("foreign-write-refused"),
+          },
+        });
+      }
     }
     const replica = this.#replicaFor(space);
     if (replica.sealNative === undefined) {

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -60,6 +60,7 @@ import {
   stampSpeculationRunContext,
 } from "./speculation/overlay-destination.ts";
 import { EffectsChannel } from "./speculation/effects-channel.ts";
+import { waveRunContextOf } from "./executor/wave.ts";
 import { Action, Scheduler } from "./scheduler.ts";
 import {
   type CommitBackpressurePolicy,
@@ -2567,12 +2568,52 @@ export class Runtime {
     );
   }
 
+  /**
+   * The principal whose HOME SPACE a home-space resolution targets —
+   * the wish builtin's `#favorites`/`#profile` family (server-execution
+   * v2 Phase 5; builtins.md §5's per-demanding-identity wish
+   * resolution, RULED 2026-08-14):
+   *
+   * - On a CLIENT (and the whole OFF arm): the runtime's own user —
+   *   cardinality 1, today's behavior byte-for-byte.
+   * - On a SERVING runtime: the RUN's identity — the demand-supplied
+   *   instance identity (P2-F's run supply) or the event's stamped
+   *   actor — read from the transaction's stamped wave run context.
+   *   NEVER the runtime's own identity: that is the SERVICE identity,
+   *   and resolving it was the lunch-wall trap (a wish materializing
+   *   against the service home space — a foreign wave write).
+   * - On a serving runtime with NO acting run identity (a space-scope
+   *   run with no demanding principal): undefined — the caller
+   *   refuses loudly rather than falling back to the service DID.
+   */
+  homeSpacePrincipalFor(
+    tx?: IExtendedStorageTransaction,
+  ): DID | undefined {
+    if (!this.servingPosture) return this.userIdentityDID;
+    const context = tx === undefined ? undefined : waveRunContextOf(tx);
+    const principal = context?.scopeKeyIdentity?.principal ??
+      context?.acting?.user;
+    return principal as DID | undefined;
+  }
+
   getHomeSpaceCell(
     tx?: IExtendedStorageTransaction,
   ): Cell<SpaceCellContents> {
+    const principal = this.homeSpacePrincipalFor(tx);
+    if (principal === undefined) {
+      // Serving posture with no demanding identity (see
+      // homeSpacePrincipalFor): fail closed — never the service DID.
+      throw new Error(
+        "home-space resolution on a serving runtime requires the run's " +
+          "demanding identity (builtins.md §5's per-demanding-identity " +
+          "wish resolution; scopes.md §5 — the demand supplies the " +
+          "identity); refusing to resolve the SERVICE identity's home " +
+          "space",
+      );
+    }
     return this.getCell(
-      this.userIdentityDID,
-      this.userIdentityDID,
+      principal,
+      principal,
       spaceCellSchema,
       tx,
     ) as Cell<SpaceCellContents>;

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -547,6 +547,14 @@ export interface Options {
    *  sessionId persistence is itself unbuilt; a host that persists
    *  sessions supplies a durable store through this seam). */
   eventAppendQueueStore?: EventAppendQueueStore;
+  /** Server-execution v2 Phase 5: declares this manager a SERVING
+   *  manager whose home space is `servingHomeSpace`. Providers opened
+   *  for OTHER spaces refuse scoped (user/session) reads fail-closed
+   *  (protocol.md §2's grant-scoped read design, RULED 2026-08-13) —
+   *  a serving runtime's foreign scoped read would otherwise resolve
+   *  against the delegating service envelope and silently read an
+   *  empty instance. Absent on every non-serving manager. */
+  servingHomeSpace?: MemorySpace;
 }
 
 /**
@@ -777,6 +785,8 @@ export class StorageManager implements IStorageManager {
   #pendingCommitsSubscribers = new Set<(pending: boolean) => void>();
   #sessionFactory: SessionFactory;
   #eventAppendQueueStore?: EventAppendQueueStore;
+  /** Phase 5: the serving manager's home space (Options.servingHomeSpace). */
+  #servingHomeSpace?: MemorySpace;
   #spaceIdentities = new Map<MemorySpace, Signer>();
   /** Seed map from Options — fixed for the manager's lifetime. */
   #seedHosts: Record<string, string>;
@@ -838,6 +848,7 @@ export class StorageManager implements IStorageManager {
     // a durable adapter through the same seam (see Options).
     this.#eventAppendQueueStore = options.eventAppendQueueStore ??
       memoryEventAppendQueueStore();
+    this.#servingHomeSpace = options.servingHomeSpace;
     if (options.spaceIdentity) {
       this.registerSpaceIdentity(options.spaceIdentity);
     }
@@ -966,6 +977,11 @@ export class StorageManager implements IStorageManager {
         settings: this.#settings,
         subscription: this.#subscription,
         scopeKeyIdentity: () => this.scopeKeyIdentity(),
+        // Phase 5's producer-side foreign-scoped-read refusal: only a
+        // serving manager sets a home space, and only its FOREIGN
+        // providers refuse (see Options.servingHomeSpace).
+        refuseForeignScopedReads: this.#servingHomeSpace !== undefined &&
+          this.#servingHomeSpace !== space,
         routeState,
         createSession: this.#sessionFactory.supportsAclBootstrap === true
           ? (routeGeneration, routeSignal) =>
@@ -1755,6 +1771,15 @@ type ProviderOptions = {
   getTelemetry?: () => TelemetrySink | undefined;
   /** The LT9 event-intent persistence seam (see Options). */
   eventAppendQueueStore?: EventAppendQueueStore;
+  /** Server-execution v2 Phase 5 (protocol.md §2's grant-scoped read
+   * design, RULED 2026-08-13 — the delegated-scoped-read fail-closed
+   * precondition): set on a SERVING manager's FOREIGN-space providers.
+   * A scoped (user/session) read against such a provider REFUSES
+   * loudly instead of shipping an unnamed scoped root the memory
+   * server would resolve against the delegating service envelope —
+   * the silent-empty-instance trap. Space-scope foreign reads (the
+   * §2b free-read row) are unaffected. */
+  refuseForeignScopedReads?: boolean;
 };
 
 type SpaceReplicaOptions = Omit<ProviderOptions, "createSession"> & {
@@ -2137,6 +2162,9 @@ class SpaceReplica implements ISpaceReplica {
    * offline event queue. */
   #eventAppendQueue?: EventAppendQueue;
   #eventAppendQueueStore?: EventAppendQueueStore;
+  /** Phase 5's producer-side foreign-scoped-read refusal (see
+   * ProviderOptions.refuseForeignScopedReads). */
+  #refuseForeignScopedReads = false;
   #closed = false;
   readonly #closeSignal = Promise.withResolvers<void>();
   #getTelemetry: () => TelemetrySink | undefined;
@@ -2263,6 +2291,7 @@ class SpaceReplica implements ISpaceReplica {
     this.#routeState = options.routeState;
     this.#routeGeneration = options.routeGeneration;
     this.#eventAppendQueueStore = options.eventAppendQueueStore;
+    this.#refuseForeignScopedReads = options.refuseForeignScopedReads === true;
     // Eager queue init (LT9; verdict blocker, 2026-08-12): a persisted
     // backlog — a dead predecessor's intents in the manager-shared
     // store, or a durable adapter's reload survivors — must discharge
@@ -3409,6 +3438,30 @@ class SpaceReplica implements ISpaceReplica {
       );
       if (watchEntries.length === 0) {
         return { ok: {} };
+      }
+      // Phase 5's delegated-scoped-read fail-closed refusal, producer
+      // side (protocol.md §2's grant-scoped read design; see
+      // ProviderOptions.refuseForeignScopedReads): a serving runtime's
+      // scoped read of a FOREIGN space never reaches the wire — the
+      // unnamed scoped root would resolve against the delegating
+      // service envelope (a silently empty instance), and the runner
+      // cannot yet name a per-run foreign instance on a subscription.
+      // The memory server's admission carries the co-hosted belt; this
+      // is the producer half, so the two land as one stack.
+      if (this.#refuseForeignScopedReads) {
+        for (const [address] of watchEntries) {
+          const scope = address.scope ?? "space";
+          if (scope !== "space") {
+            throw new Error(
+              `foreign scoped read refused on the serving path: ` +
+                `${address.id} (scope "${scope}") in ${this.#space} — ` +
+                "a serving runtime reads foreign scoped instances only " +
+                "under the grant-scoped read design (protocol.md §2; " +
+                "delegated scoped reads are fail-closed until grant " +
+                "resolution lands)",
+            );
+          }
+        }
       }
 
       const watches = watchEntries.map(([address, selector]) => ({

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -2916,6 +2916,36 @@ class SpaceReplica implements ISpaceReplica {
     }
 
     const normalizedEntries = normalizeSyncEntries(entries);
+    // Phase 5's delegated-scoped-read fail-closed refusal, ENTRY-scoped
+    // (the F3 fix; protocol.md §2's grant-scoped read design): decided
+    // HERE, per caller, before the entries join the coalesced
+    // watch-refresh batch — the batch shares ONE pending promise across
+    // every concurrent caller, so a refusal thrown inside the batch
+    // (the refreshWatchSet backstop below) poisons innocent SPACE-scope
+    // foreign reads coalesced beside the offender: the load-bearing
+    // §2b free-read row would fail intermittently whenever any pattern
+    // persistently attempted one foreign scoped read. Refusing the
+    // OFFENDING caller's pull keeps the refusal action-scoped, the
+    // arc's standing refusal convention.
+    if (this.#refuseForeignScopedReads) {
+      for (const [address] of normalizedEntries) {
+        const scope = normalizeCellScope(address.scope) ?? "space";
+        if (scope !== "space") {
+          return {
+            error: toPullError(
+              new Error(
+                `foreign scoped read refused on the serving path: ` +
+                  `${address.id} (scope "${scope}") in ${this.#space} — ` +
+                  "a serving runtime reads foreign scoped instances only " +
+                  "under the grant-scoped read design (protocol.md §2; " +
+                  "delegated scoped reads are fail-closed until grant " +
+                  "resolution lands)",
+              ),
+            ),
+          };
+        }
+      }
+    }
     // Compose the dedup key from per-part hashes instead of hashing a fresh
     // wrapper object: hashOf's frozen-object cache is only consulted at entry
     // level, so embedding the (large, already canonical) selector schema in a
@@ -3448,6 +3478,15 @@ class SpaceReplica implements ISpaceReplica {
       // cannot yet name a per-run foreign instance on a subscription.
       // The memory server's admission carries the co-hosted belt; this
       // is the producer half, so the two land as one stack.
+      //
+      // BACKSTOP only (the F3 fix): the live refusal is ENTRY-scoped at
+      // pull() — per caller, before the entry joins the batch — because
+      // a throw HERE fails the whole coalesced batch (one shared
+      // pending promise), poisoning innocent space-scope reads beside
+      // the offender. Every watch entry flows through pull(), so this
+      // arm firing means a new path bypassed the entry refusal — a
+      // bug, kept loud rather than silently filtered (dropping the
+      // entry would resolve its caller OK without the data).
       if (this.#refuseForeignScopedReads) {
         for (const [address] of watchEntries) {
           const scope = address.scope ?? "space";

--- a/packages/runner/test/clock-preload.ts
+++ b/packages/runner/test/clock-preload.ts
@@ -63,5 +63,11 @@ installFakeClock({
     // renew interval and flush deadline; auto-advance turns the renew
     // cadence into a runaway.
     "executor-effect-channel",
+    // The Phase-5 cross-space suite drives a live ExecutorHost (the
+    // foreign-wake journey) under the same wall-clock policies — the
+    // renew interval, flush deadline, and the failure-park backoff;
+    // auto-advance expires the lease TTL instantly and turns the renew
+    // cadence + reactivation backoff into a runaway.
+    "executor-cross-space",
   ],
 });

--- a/packages/runner/test/executor-cross-space.test.ts
+++ b/packages/runner/test/executor-cross-space.test.ts
@@ -29,6 +29,7 @@ import type {
 } from "../src/storage/interface.ts";
 import { ExecutorHost } from "../src/executor/host.ts";
 import { stampWaveRunContext } from "../src/executor/wave.ts";
+import { ACLManager } from "../src/acl-manager.ts";
 import { wish as wishBuiltin } from "../src/builtins/wish.ts";
 import { UI } from "../src/builder/types.ts";
 import {
@@ -312,6 +313,85 @@ describe("Phase 5 cross-space serving", () => {
     } finally {
       await serving.dispose();
       await manager.close();
+    }
+  });
+
+  it("foreignWriteAuthorityFor: the structural grant supply — owner-by-identity, fresh-store creation (non-creating probe), the target's own ACL, fail-closed otherwise (protocol.md §2b; the F1 fix)", async () => {
+    const aliceDid = aliceSigner.did();
+    const bobDid = bobSigner.did();
+
+    // Owner-by-identity: the target space IS the actor's DID (their
+    // home space — the wish bootstrap's sanctioned target).
+    expect(
+      await server.foreignWriteAuthorityFor(aliceDid, aliceDid),
+    ).toEqual({ granted: true, via: "owner" });
+
+    // Creation: a well-formed, never-materialized space is §2b's
+    // sanctioned provisioning...
+    const freshSigner = await Identity.fromPassphrase(
+      "x-space fresh provision target",
+    );
+    const fresh = freshSigner.did();
+    expect(await server.foreignWriteAuthorityFor(fresh, aliceDid)).toEqual({
+      granted: true,
+      via: "creation",
+    });
+    // ...and the probe itself must NOT create the store: a second
+    // probe still sees a fresh space (had the first probe materialized
+    // it, this would now be exists-with-no-ACL → refused).
+    expect(await server.foreignWriteAuthorityFor(fresh, bobDid)).toEqual({
+      granted: true,
+      via: "creation",
+    });
+
+    // A malformed space name never resolves (or provisions) a store —
+    // the F1c arbitrary-store-creation arm.
+    const garbage = await server.foreignWriteAuthorityFor(
+      "junk-not-a-space",
+      aliceDid,
+    );
+    expect(garbage.granted).toBe(false);
+    // No acting principal: refused outright.
+    expect(
+      (await server.foreignWriteAuthorityFor(fresh, undefined)).granted,
+    ).toBe(false);
+
+    // An EXISTING space with no ACL document fails closed on the
+    // serving plane (the client path's populated-legacy compat arm is
+    // a rollout accommodation, not a grant).
+    await server.engineForSpace(foreignSpace);
+    const noAcl = await server.foreignWriteAuthorityFor(
+      foreignSpace,
+      aliceDid,
+    );
+    expect(noAcl.granted).toBe(false);
+
+    // The target's OWN ACL document is a real grant: bob grants alice
+    // WRITE on bob's space; carol (no row, no wildcard) stays refused.
+    const bobManager = SharedServerStorageManager.connectTo(server, {
+      as: bobSigner,
+    });
+    const bobRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: bobManager,
+    });
+    try {
+      const acl = new ACLManager(bobRuntime, bobDid);
+      await acl.set(bobDid, "OWNER");
+      await acl.set(aliceDid, "WRITE");
+      await bobRuntime.storageManager.synced();
+      expect(await server.foreignWriteAuthorityFor(bobDid, aliceDid)).toEqual(
+        { granted: true, via: "acl" },
+      );
+      const carolSigner = await Identity.fromPassphrase("x-space carol");
+      const carol = await server.foreignWriteAuthorityFor(
+        bobDid,
+        carolSigner.did(),
+      );
+      expect(carol.granted).toBe(false);
+    } finally {
+      await bobRuntime.dispose();
+      await bobManager.close();
     }
   });
 

--- a/packages/runner/test/executor-cross-space.test.ts
+++ b/packages/runner/test/executor-cross-space.test.ts
@@ -795,6 +795,31 @@ describe("Phase 5 cross-space serving", () => {
       );
       expect(foreignSpaceScope.error).toBeUndefined();
 
+      // The F3 fix — refusal is ENTRY-scoped, decided at sync() entry
+      // before the batch: a scoped read and an innocent SPACE-scope
+      // read issued concurrently coalesce into ONE watch-refresh batch
+      // with one shared pending promise, and pre-fix the scoped
+      // refusal threw over the whole batch — the load-bearing §2b
+      // free-read row failed alongside the offender (a persistently
+      // retrying scoped reader degraded a space's legitimate foreign
+      // reads into flake).
+      const provider = manager.open(foreignSpace);
+      const [poisoner, innocent] = await Promise.all([
+        provider.sync(
+          "of:x-batch-scoped" as never,
+          { path: [], schema: false },
+          "user",
+        ),
+        provider.sync(
+          "of:x-batch-plain" as never,
+          { path: [], schema: false },
+        ),
+      ]);
+      expect(poisoner.error?.message ?? "").toContain(
+        "foreign scoped read refused on the serving path",
+      );
+      expect(innocent.error).toBeUndefined();
+
       // HOME scoped reads keep today's behavior (the OW17 tolerated
       // collapsed view).
       const homeScoped = await manager.open(homeSpace).sync(

--- a/packages/runner/test/executor-cross-space.test.ts
+++ b/packages/runner/test/executor-cross-space.test.ts
@@ -28,9 +28,15 @@ import type {
   MemorySpace,
 } from "../src/storage/interface.ts";
 import { ExecutorHost } from "../src/executor/host.ts";
+import { selectForeignStaleInstances } from "../src/executor/space-server.ts";
 import { stampWaveRunContext } from "../src/executor/wave.ts";
 import { ACLManager } from "../src/acl-manager.ts";
 import { wish as wishBuiltin } from "../src/builtins/wish.ts";
+import {
+  replaceSchedulerBasisRows,
+  selectForeignBasisRows,
+} from "@commonfabric/memory/v2/scheduler-basis";
+import { selectDocHead } from "@commonfabric/memory/v2/engine";
 import { UI } from "../src/builder/types.ts";
 import {
   getPatternEnvironment,
@@ -313,6 +319,137 @@ describe("Phase 5 cross-space serving", () => {
     } finally {
       await serving.dispose();
       await manager.close();
+    }
+  });
+
+  it("the activation foreign re-mark judges recorded foreign inputs against their OWN space's head (serving-loop.md §6 step 2; the F5 pin)", async () => {
+    // The re-mark's activation arm fail-degrades to a warn by design
+    // (recovery correctness rides recompute-on-demand), so a breakage
+    // is invisible there — the decision helper carries the test
+    // surface: rows behind their foreign head re-mark, rows AT head do
+    // not, home-scan findings are not double-added, and only foreign
+    // rows are selected at all.
+    const homeEngine = await server.engineForSpace(homeSpace);
+
+    // A real foreign doc with a real head: bob writes it twice.
+    const bobManager = SharedServerStorageManager.connectTo(server, {
+      as: bobSigner,
+    });
+    const bobRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: bobManager,
+    });
+    try {
+      const doc = bobRuntime.getCell<{ n: number }>(
+        foreignSpace,
+        "f5-foreign-input",
+        undefined,
+      );
+      {
+        const tx = bobRuntime.edit();
+        doc.withTx(tx).set({ n: 1 });
+        expect((await tx.commit()).error).toBeUndefined();
+      }
+      await bobRuntime.storageManager.synced();
+      const docId = doc.getAsNormalizedFullLink().id;
+      const foreignEngine = await server.engineForSpace(foreignSpace);
+      const headAtRead = selectDocHead(foreignEngine, {
+        id: docId,
+        scopeKey: "space",
+      });
+      expect(headAtRead).toBeGreaterThan(0);
+
+      // Recorded basis rows on the HOME engine: action-current read the
+      // doc at its current head; action-behind at head-1; action-covered
+      // is already in the home scan's stale set; action-home reads only
+      // a home entity (never selected as foreign).
+      const scope = { branch: "", space: homeSpace };
+      replaceSchedulerBasisRows(homeEngine, {
+        ...scope,
+        action: "action-current",
+        actionScopeKey: "space",
+        rows: [{
+          entitySpace: foreignSpace,
+          entity: docId,
+          entityScopeKey: "space",
+          seq: headAtRead,
+        }],
+      });
+      replaceSchedulerBasisRows(homeEngine, {
+        ...scope,
+        action: "action-behind",
+        actionScopeKey: "space",
+        rows: [{
+          entitySpace: foreignSpace,
+          entity: docId,
+          entityScopeKey: "space",
+          seq: headAtRead - 1,
+        }],
+      });
+      replaceSchedulerBasisRows(homeEngine, {
+        ...scope,
+        action: "action-covered",
+        actionScopeKey: "space",
+        rows: [{
+          entitySpace: foreignSpace,
+          entity: docId,
+          entityScopeKey: "space",
+          seq: headAtRead - 1,
+        }],
+      });
+      replaceSchedulerBasisRows(homeEngine, {
+        ...scope,
+        action: "action-home",
+        actionScopeKey: "space",
+        rows: [{
+          entitySpace: homeSpace,
+          entity: "of:f5-home-entity",
+          entityScopeKey: "space",
+          seq: 1,
+        }],
+      });
+
+      // Only foreign rows are selected, all of them.
+      const foreignRows = selectForeignBasisRows(homeEngine, scope);
+      expect(foreignRows.map((row) => row.action).sort()).toEqual([
+        "action-behind",
+        "action-covered",
+        "action-current",
+      ]);
+
+      const engineFor = (s: MemorySpace) => server.engineForSpace(s);
+
+      // At-head rows do NOT re-mark; behind rows DO; home-scan-covered
+      // rows are not double-added.
+      expect(
+        await selectForeignStaleInstances(homeEngine, scope, engineFor, [
+          { action: "action-covered", actionScopeKey: "space" },
+        ]),
+      ).toEqual([{ action: "action-behind", actionScopeKey: "space" }]);
+
+      // The foreign head MOVES (bob writes again): the at-head row is
+      // now behind and re-marks — the park → foreign-move → reactivate
+      // schedule's decision, judged against the foreign engine.
+      {
+        const tx = bobRuntime.edit();
+        doc.withTx(tx).set({ n: 2 });
+        expect((await tx.commit()).error).toBeUndefined();
+      }
+      await bobRuntime.storageManager.synced();
+      expect(
+        selectDocHead(foreignEngine, { id: docId, scopeKey: "space" }),
+      ).toBeGreaterThan(headAtRead);
+      expect(
+        await selectForeignStaleInstances(homeEngine, scope, engineFor, [
+          { action: "action-covered", actionScopeKey: "space" },
+        ]),
+      ).toEqual([
+        { action: "action-behind", actionScopeKey: "space" },
+        { action: "action-current", actionScopeKey: "space" },
+      ]);
+    } finally {
+      await bobRuntime.dispose();
+      await bobManager.close();
     }
   });
 

--- a/packages/runner/test/executor-cross-space.test.ts
+++ b/packages/runner/test/executor-cross-space.test.ts
@@ -21,10 +21,20 @@ import { Identity } from "@commonfabric/identity";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import type { Options } from "../src/storage/v2.ts";
-import { Runtime } from "../src/runtime.ts";
-import type { MemorySpace } from "../src/storage/interface.ts";
+import { Runtime, spaceCellSchema } from "../src/runtime.ts";
+import type { Cell } from "../src/cell.ts";
+import type {
+  IExtendedStorageTransaction,
+  MemorySpace,
+} from "../src/storage/interface.ts";
 import { ExecutorHost } from "../src/executor/host.ts";
 import { stampWaveRunContext } from "../src/executor/wave.ts";
+import { wish as wishBuiltin } from "../src/builtins/wish.ts";
+import { UI } from "../src/builder/types.ts";
+import {
+  getPatternEnvironment,
+  setPatternEnvironment,
+} from "../src/builder/env.ts";
 import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 
 class SharedServerStorageManager extends EmulatedStorageManager {
@@ -300,6 +310,208 @@ describe("Phase 5 cross-space serving", () => {
         await client.dispose();
       }
     } finally {
+      await serving.dispose();
+      await manager.close();
+    }
+  });
+
+  it("two demanders on one wish node get their OWN sidecar surfaces — no cross-user mixing (builtins.md §5; the F2 fix)", async () => {
+    // The mixed-demand schedule the phase exists to serve: the scheduler
+    // runs demanded instances over ONE singular wish node (same Action
+    // closure, per-instance stamped txs — scheduler/run.ts), so the
+    // builtin's per-node sidecar caches MUST key per demanding identity.
+    // Pre-fix, demander #2 reused demander #1's create-surface result
+    // cell and clobbered the shared pending input — cross-user mixing in
+    // both directions.
+    const manager = SharedServerStorageManager.connectTo(server, {
+      as: serviceSigner,
+      servingHomeSpace: homeSpace,
+    });
+    const serving = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: manager,
+      servingPosture: true,
+      experimental: { serverExecution: true },
+    });
+
+    // Seed BOTH users' home spaces: a defaultPattern link with no
+    // profiles, so a #profile wish falls to the create surface.
+    const seedHome = async (signer: Identity) => {
+      const did = signer.did() as MemorySpace;
+      const m = SharedServerStorageManager.connectTo(server, { as: signer });
+      const r = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: m,
+      });
+      const tx = r.edit();
+      const homeCell = r.getCell(did, did, spaceCellSchema, tx);
+      const defaultCell = r.getCell(
+        did,
+        "x-space-home-default",
+        undefined,
+        tx,
+      );
+      (homeCell as Cell<Record<string, unknown>>).key("defaultPattern").set(
+        defaultCell as never,
+      );
+      const committed = await tx.commit();
+      expect(committed.error).toBeUndefined();
+      await r.storageManager.synced();
+      await r.dispose();
+      await m.close();
+      return did;
+    };
+    const aliceDid = await seedHome(aliceSigner);
+    const bobDid = await seedHome(bobSigner);
+
+    // Serve the profile-create sidecar SOURCE through a gated fetch stub:
+    // the test controls when the (memoized, node-shared) pattern fetch
+    // resolves, so both demanders run while the fetch is pending — the
+    // exact schedule that clobbered the shared input holder.
+    const sidecarSource = [
+      "import { pattern } from 'commonfabric';",
+      "export default pattern<{ profiles: unknown }, { echo: unknown }>(",
+      "  ({ profiles }) => ({ echo: profiles }),",
+      ");",
+    ].join("\n");
+    const gate = Promise.withResolvers<void>();
+    const originalFetch = globalThis.fetch;
+    const originalEnvironment = getPatternEnvironment();
+    setPatternEnvironment({
+      apiUrl: new URL("https://x-space-sidecar.test/"),
+    });
+    globalThis.fetch = (async (input: Request | URL | string) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.endsWith("/api/patterns/system/profile-create.tsx")) {
+        await gate.promise;
+        return new Response(sidecarSource, { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+
+    const cancels: (() => void)[] = [];
+    try {
+      // Preload the foreign home docs into the serving runtime (wish
+      // reads are synchronous; the scheduler's re-trigger is not driven
+      // in this direct-drive test).
+      for (const did of [aliceDid, bobDid]) {
+        const home = serving.getCell(did, did, spaceCellSchema);
+        await home.sync();
+        await (home as Cell<Record<string, unknown>>).key("defaultPattern")
+          .resolveAsCell().sync();
+      }
+
+      // The wish node: ONE inputs cell, ONE parent, ONE cause — the
+      // singular node — driven directly with per-demander stamped txs.
+      const seedTx = serving.edit();
+      const inputsCell = serving.getCell<{ query: string }>(
+        homeSpace,
+        "x-space-wish-inputs",
+        undefined,
+        seedTx,
+      );
+      inputsCell.set({ query: "#profile" });
+      const parentCell = serving.getCell<Record<string, unknown>>(
+        homeSpace,
+        "x-space-wish-parent",
+        undefined,
+        seedTx,
+      );
+      const causeCell = serving.getCell<Record<string, unknown>>(
+        homeSpace,
+        "x-space-wish-cause",
+        undefined,
+        seedTx,
+      );
+      const seedCommitted = await seedTx.commit();
+      expect(seedCommitted.error).toBeUndefined();
+
+      const sent: {
+        user: string;
+        tx: IExtendedStorageTransaction;
+        state: Cell<unknown>;
+      }[] = [];
+      const action = wishBuiltin(
+        inputsCell as never,
+        (tx, result) => {
+          sent.push({
+            user: "pending",
+            tx,
+            state: result as Cell<unknown>,
+          });
+        },
+        (cancel) => cancels.push(cancel),
+        [causeCell as never],
+        parentCell as never,
+        serving,
+      );
+
+      const runAs = async (
+        principal: string,
+        sessionId: string,
+        actionId: string,
+      ): Promise<Cell<unknown>> => {
+        const tx = serving.edit();
+        stampWaveRunContext(tx, {
+          actionId,
+          kind: "derivation",
+          scopeKeyIdentity: { principal, sessionId },
+          acting: { user: principal, session: sessionId },
+        });
+        sent.length = 0;
+        action(tx);
+        expect(sent.length).toBe(1);
+        const state = sent[0].state;
+        const sidecar = state.key(UI as never).key("props").key("$cell")
+          .resolveAsCell();
+        const committed = await tx.commit();
+        expect(committed.error).toBeUndefined();
+        return sidecar;
+      };
+
+      // Alice's instance runs first (fetch pending), then bob's.
+      const aliceSidecar = await runAs(aliceDid, "sess-a", "wish/x-a");
+      const bobSidecar = await runAs(bobDid, "sess-b", "wish/x-b");
+
+      // Demander #2 must get their OWN create surface, not demander
+      // #1's cell (pre-fix: the closure cache short-circuited on the
+      // first demander's cell — bob typed into alice's surface).
+      expect(bobSidecar.sourceURI).not.toBe(aliceSidecar.sourceURI);
+
+      // Release the pattern fetch: each pending launch must run ITS OWN
+      // demander's input into ITS OWN cell (pre-fix: the shared input
+      // holder was clobbered with bob's home link, and alice's pending
+      // launch ran bob's input into alice's cell).
+      gate.resolve();
+      // The landed echo resolves through the run's input `profiles`
+      // link into the DEMANDER's home space; before the run lands the
+      // key is unset and resolves within the served space.
+      const echoSpaceOf = (sidecar: Cell<unknown>): string | undefined => {
+        try {
+          const echo = (sidecar as Cell<Record<string, unknown>>)
+            .key("echo").resolveAsCell();
+          const link = echo.getAsNormalizedFullLink();
+          return link.space === homeSpace ? undefined : link.space;
+        } catch {
+          return undefined;
+        }
+      };
+      await waitUntil(
+        () =>
+          echoSpaceOf(aliceSidecar) !== undefined &&
+          echoSpaceOf(bobSidecar) !== undefined,
+        `both sidecar runs to land (alice: ${
+          echoSpaceOf(aliceSidecar)
+        }, bob: ${echoSpaceOf(bobSidecar)})`,
+      );
+      expect(echoSpaceOf(aliceSidecar)).toBe(aliceDid);
+      expect(echoSpaceOf(bobSidecar)).toBe(bobDid);
+    } finally {
+      gate.resolve();
+      globalThis.fetch = originalFetch;
+      setPatternEnvironment(originalEnvironment);
+      for (const cancel of cancels) cancel();
+      await serving.idle();
       await serving.dispose();
       await manager.close();
     }

--- a/packages/runner/test/executor-cross-space.test.ts
+++ b/packages/runner/test/executor-cross-space.test.ts
@@ -290,6 +290,24 @@ describe("Phase 5 cross-space serving", () => {
       expect(serving.homeSpacePrincipalFor(handler)).toBe(bobSigner.did());
       handler.abort(new Error("test-only"));
 
+      // MIXED carriage (the F6 pin): a handler run on user B's
+      // INSTANCE fired by actor A carries both — the instance owner's
+      // scopeKeyIdentity wins over the acting pair (builtins.md §5:
+      // the run resolves the instance it runs AS, scopes.md §5).
+      const mixed = serving.edit();
+      stampWaveRunContext(mixed, {
+        actionId: "handler/mixed",
+        kind: "event-handler",
+        eventId: "e-2",
+        scopeKeyIdentity: {
+          principal: bobSigner.did(),
+          sessionId: "sess-b",
+        },
+        acting: { user: aliceSigner.did(), session: "sess-a" },
+      });
+      expect(serving.homeSpacePrincipalFor(mixed)).toBe(bobSigner.did());
+      mixed.abort(new Error("test-only"));
+
       // NO demanding identity: undefined, and the cell resolution
       // REFUSES — never the service DID (the lunch-wall trap).
       const unstamped = serving.edit();

--- a/packages/runner/test/executor-cross-space.test.ts
+++ b/packages/runner/test/executor-cross-space.test.ts
@@ -1,0 +1,360 @@
+// Server-execution v2 Phase 5 — cross-space serving
+// (docs/specs/server-side-execution/serving-loop.md §3b's cross-space
+// bullet; protocol.md §2, §2b; builtins.md §5's per-demanding-identity
+// wish resolution):
+//
+// - a home derivation reads a FOREIGN doc through the serving runtime's
+//   ordinary storage plane, and a foreign commit WAKES the home loop
+//   (the server-internal wake — never home input: W stays put, the
+//   derived value still updates);
+// - home-space resolution on a serving runtime targets the RUN's
+//   demanding identity, never the service identity (the lunch-wall
+//   trap), and refuses loudly with no identity;
+// - the producer-side fail-closed refusal: a serving manager's FOREIGN
+//   providers refuse scoped reads (protocol.md §2's grant-scoped read
+//   design — delegated scoped reads are fail-closed until grant
+//   resolution lands).
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import type { Options } from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { MemorySpace } from "../src/storage/interface.ts";
+import { ExecutorHost } from "../src/executor/host.ts";
+import { stampWaveRunContext } from "../src/executor/wave.ts";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+
+class SharedServerStorageManager extends EmulatedStorageManager {
+  static override connectTo(
+    server: MemoryV2Server.Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): SharedServerStorageManager {
+    return super.connectTo(server, options) as SharedServerStorageManager;
+  }
+}
+
+const newSharedServer = () =>
+  new MemoryV2Server.Server({
+    subscriptionRefreshDelayMs: 0,
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
+  });
+
+const homeSigner = await Identity.fromPassphrase("cross-space home");
+const homeSpace = homeSigner.did() as MemorySpace;
+const foreignSigner = await Identity.fromPassphrase("cross-space foreign");
+const foreignSpace = foreignSigner.did() as MemorySpace;
+const serviceSigner = await Identity.fromPassphrase("cross-space service");
+const aliceSigner = await Identity.fromPassphrase("cross-space alice");
+const bobSigner = await Identity.fromPassphrase("cross-space bob");
+
+const waitUntil = async (
+  predicate: () => boolean,
+  label: string,
+  timeoutMs = 10_000,
+): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${label}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+};
+
+describe("Phase 5 cross-space serving", () => {
+  let server: MemoryV2Server.Server;
+  let host: ExecutorHost | undefined;
+  let clientManager: SharedServerStorageManager;
+  let clientRuntime: Runtime;
+  let servingRuntime: Runtime | undefined;
+  let onServingRuntime: ((runtime: Runtime) => Promise<void>) | undefined;
+
+  const newHost = (): ExecutorHost =>
+    new ExecutorHost({
+      server,
+      serviceIdentity: serviceSigner.did(),
+      createRuntime: async (space) => {
+        const manager = SharedServerStorageManager.connectTo(server, {
+          as: serviceSigner,
+          // Phase 5: the serving manager declares its home space so
+          // its FOREIGN providers refuse scoped reads (the producer
+          // half of the delegated-scoped-read fail-closed rule).
+          servingHomeSpace: space,
+        });
+        const runtime = new Runtime({
+          apiUrl: new URL(import.meta.url),
+          storageManager: manager,
+          servingPosture: true,
+          experimental: { serverExecution: true },
+        });
+        servingRuntime = runtime;
+        await onServingRuntime?.(runtime);
+        return {
+          runtime,
+          dispose: async () => {
+            await runtime.dispose();
+            await manager.close();
+          },
+        };
+      },
+      policy: { flushDeadlineMs: 5_000, idleParkMs: 600_000 },
+    });
+
+  beforeEach(() => {
+    server = newSharedServer();
+    servingRuntime = undefined;
+    onServingRuntime = undefined;
+  });
+
+  afterEach(async () => {
+    await host?.close();
+    host = undefined;
+    await clientRuntime?.dispose();
+    await clientManager?.close();
+    await server.close();
+  });
+
+  it("a foreign commit WAKES the home loop: the home derivation over a foreign doc re-derives without home input (serving-loop.md §3b's server-internal wake)", async () => {
+    host = newHost();
+
+    // Seed the FOREIGN input doc (bob's space) before the home loop
+    // activates, so the first derivation reads a real value.
+    const bobManager = SharedServerStorageManager.connectTo(server, {
+      as: bobSigner,
+    });
+    const bobRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: bobManager,
+    });
+    const bobInput = bobRuntime.getCell<{ n: number }>(
+      foreignSpace,
+      "x-space-input",
+      undefined,
+    );
+    {
+      const tx = bobRuntime.edit();
+      bobInput.withTx(tx).set({ n: 1 });
+      const committed = await tx.commit();
+      expect(committed.error).toBeUndefined();
+    }
+    await bobRuntime.storageManager.synced();
+
+    // The serving graph: a HOME pattern whose argument is the FOREIGN
+    // doc — the home derivation reads across the space boundary
+    // (serving-loop.md §3b: reads cross freely; the result commits
+    // HOME, protocol.md §2b's derive-from-foreign row).
+    onServingRuntime = async (runtime) => {
+      const compiled = await runtime.patternManager.compilePattern({
+        main: "/main.tsx",
+        files: [{
+          name: "/main.tsx",
+          contents: [
+            "import { computed, pattern } from 'commonfabric';",
+            "export default pattern<{ n: number }, { total: number }>(",
+            "  ({ n }) => ({ total: computed(() => n + 100) }),",
+            ");",
+          ].join("\n"),
+        }],
+      }, { space: homeSpace });
+      const foreignArgument = runtime.getCell<{ n: number }>(
+        foreignSpace,
+        "x-space-input",
+        undefined,
+      );
+      const result = runtime.getCell<{ total: number }>(
+        homeSpace,
+        "x-space-result",
+        compiled.resultSchema,
+      );
+      for (let attempt = 0;; attempt++) {
+        await foreignArgument.sync();
+        await result.sync();
+        const tx = runtime.edit();
+        runtime.run(tx, compiled, foreignArgument, result);
+        const committed = await tx.commit();
+        if (committed.error === undefined) break;
+        if (attempt >= 4) {
+          throw new Error(
+            `serving pattern run failed: ${committed.error.message}`,
+          );
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      await runtime.idle();
+    };
+
+    // The client's DEMAND on the HOME result activates the home space.
+    clientManager = SharedServerStorageManager.connectTo(server, {
+      as: aliceSigner,
+    });
+    clientRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: clientManager,
+    });
+    const clientResult = clientRuntime.getCell<{ total: number }>(
+      homeSpace,
+      "x-space-result",
+      undefined,
+    );
+    let observed: number | undefined;
+    const cancel = clientResult.sink((value) => {
+      observed = value?.total;
+    });
+    try {
+      await waitUntil(
+        () => observed === 101,
+        `first derivation over the foreign input (saw ${observed})`,
+      );
+      expect(host.spaceServer(homeSpace)?.active).toBe(true);
+
+      // The FOREIGN commit: bob updates his own space. No home input
+      // follows — the wake chain (foreign session frames → autonomous
+      // scheduler re-run → seal-wake) must start the re-derivation
+      // well before the idle window (10 minutes here) expires.
+      {
+        const tx = bobRuntime.edit();
+        bobInput.withTx(tx).set({ n: 2 });
+        const committed = await tx.commit();
+        expect(committed.error).toBeUndefined();
+      }
+      await waitUntil(
+        () => observed === 102,
+        `re-derivation after the foreign commit (saw ${observed})`,
+      );
+    } finally {
+      cancel();
+      await bobRuntime.dispose();
+      await bobManager.close();
+    }
+  });
+
+  it("home-space resolution on a serving runtime targets the RUN's demanding identity, never the service identity (builtins.md §5, RULED 2026-08-14)", async () => {
+    const manager = SharedServerStorageManager.connectTo(server, {
+      as: serviceSigner,
+      servingHomeSpace: homeSpace,
+    });
+    const serving = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: manager,
+      servingPosture: true,
+      experimental: { serverExecution: true },
+    });
+    try {
+      // A stamped run acting for alice: home space = ALICE's DID space.
+      const stamped = serving.edit();
+      stampWaveRunContext(stamped, {
+        actionId: "wish/test",
+        kind: "derivation",
+        scopeKeyIdentity: {
+          principal: aliceSigner.did(),
+          sessionId: "sess-1",
+        },
+      });
+      expect(serving.homeSpacePrincipalFor(stamped)).toBe(aliceSigner.did());
+      expect(serving.getHomeSpaceCell(stamped).space).toBe(aliceSigner.did());
+      stamped.abort(new Error("test-only"));
+
+      // A handler run's stamped ACTOR resolves the same way.
+      const handler = serving.edit();
+      stampWaveRunContext(handler, {
+        actionId: "handler/test",
+        kind: "event-handler",
+        eventId: "e-1",
+        acting: { user: bobSigner.did(), session: "sess-2" },
+      });
+      expect(serving.homeSpacePrincipalFor(handler)).toBe(bobSigner.did());
+      handler.abort(new Error("test-only"));
+
+      // NO demanding identity: undefined, and the cell resolution
+      // REFUSES — never the service DID (the lunch-wall trap).
+      const unstamped = serving.edit();
+      expect(serving.homeSpacePrincipalFor(unstamped)).toBeUndefined();
+      expect(() => serving.getHomeSpaceCell(unstamped)).toThrow(
+        "per-demanding-identity",
+      );
+      unstamped.abort(new Error("test-only"));
+
+      // A CLIENT runtime keeps today's behavior: its own user, tx or
+      // not.
+      const client = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: SharedServerStorageManager.connectTo(server, {
+          as: aliceSigner,
+        }),
+      });
+      try {
+        expect(client.homeSpacePrincipalFor(undefined)).toBe(
+          aliceSigner.did(),
+        );
+        expect(client.getHomeSpaceCell().space).toBe(aliceSigner.did());
+      } finally {
+        await client.storageManager.close();
+        await client.dispose();
+      }
+    } finally {
+      await serving.dispose();
+      await manager.close();
+    }
+  });
+
+  it("a serving manager's FOREIGN provider refuses scoped reads fail-closed (protocol.md §2's grant-scoped read design)", async () => {
+    const manager = SharedServerStorageManager.connectTo(server, {
+      as: serviceSigner,
+      servingHomeSpace: homeSpace,
+    });
+    try {
+      // Scoped read of a FOREIGN space: refused at the producer, before
+      // any wire frame — the unnamed scoped root would resolve against
+      // the delegating service envelope (a silently empty instance).
+      const foreignScoped = await manager.open(foreignSpace).sync(
+        "of:x-scoped" as never,
+        { path: [], schema: false },
+        "user",
+      );
+      expect(foreignScoped.error?.message ?? "").toContain(
+        "foreign scoped read refused on the serving path",
+      );
+
+      // Space-scope foreign reads stay free (§2b's free-read row).
+      const foreignSpaceScope = await manager.open(foreignSpace).sync(
+        "of:x-plain" as never,
+        { path: [], schema: false },
+      );
+      expect(foreignSpaceScope.error).toBeUndefined();
+
+      // HOME scoped reads keep today's behavior (the OW17 tolerated
+      // collapsed view).
+      const homeScoped = await manager.open(homeSpace).sync(
+        "of:x-home-scoped" as never,
+        { path: [], schema: false },
+        "user",
+      );
+      expect(homeScoped.error).toBeUndefined();
+
+      // A NON-serving manager (no servingHomeSpace) is untouched.
+      const plain = SharedServerStorageManager.connectTo(server, {
+        as: aliceSigner,
+      });
+      try {
+        const clientScoped = await plain.open(foreignSpace).sync(
+          "of:x-scoped" as never,
+          { path: [], schema: false },
+          "user",
+        );
+        expect(clientScoped.error).toBeUndefined();
+      } finally {
+        await plain.close();
+      }
+    } finally {
+      await manager.close();
+    }
+  });
+});

--- a/packages/runner/test/executor-cross-space.test.ts
+++ b/packages/runner/test/executor-cross-space.test.ts
@@ -316,6 +316,179 @@ describe("Phase 5 cross-space serving", () => {
     }
   });
 
+  it("a foreign space whose engine cannot resolve fails ONLY its contributions — the home space keeps serving instead of parking (protocol.md §2b; the F1b fix)", async () => {
+    // Pre-fix, #resolveForeignEngines was awaited un-caught in the
+    // commit step: ONE unresolvable foreign target threw out of the
+    // cycle — loop-failed → park + backoff for the whole HOME space,
+    // the exact outage class the RULED accumulation refusal exists to
+    // prevent. The failure must be action-scoped: the crossing's own
+    // contribution withdraws (counted), everything else commits.
+    const badSigner = await Identity.fromPassphrase("x-space bad engine");
+    const badSpace = badSigner.did() as MemorySpace;
+    const proxiedServer = new Proxy(server, {
+      get(target, prop, receiver) {
+        if (prop === "engineForSpace") {
+          return (s: string) =>
+            s === badSpace
+              ? Promise.reject(new Error("engine open failed (test)"))
+              : target.engineForSpace(s);
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as MemoryV2Server.Server;
+
+    host = new ExecutorHost({
+      server: proxiedServer,
+      serviceIdentity: serviceSigner.did(),
+      createRuntime: async (space) => {
+        const manager = SharedServerStorageManager.connectTo(server, {
+          as: serviceSigner,
+          servingHomeSpace: space,
+        });
+        const runtime = new Runtime({
+          apiUrl: new URL(import.meta.url),
+          storageManager: manager,
+          servingPosture: true,
+          experimental: { serverExecution: true },
+        });
+        servingRuntime = runtime;
+        await onServingRuntime?.(runtime);
+        return {
+          runtime,
+          dispose: async () => {
+            await runtime.dispose();
+            await manager.close();
+          },
+        };
+      },
+      policy: { flushDeadlineMs: 2_000, idleParkMs: 600_000 },
+    });
+
+    // A served home derivation whose input the client can move — the
+    // "everything else" that must keep committing.
+    onServingRuntime = async (runtime) => {
+      const compiled = await runtime.patternManager.compilePattern({
+        main: "/main.tsx",
+        files: [{
+          name: "/main.tsx",
+          contents: [
+            "import { computed, pattern } from 'commonfabric';",
+            "export default pattern<{ n: number }, { total: number }>(",
+            "  ({ n }) => ({ total: computed(() => n + 500) }),",
+            ");",
+          ].join("\n"),
+        }],
+      }, { space: homeSpace });
+      const argument = runtime.getCell<{ n: number }>(
+        homeSpace,
+        "f1b-arg",
+        undefined,
+      );
+      const result = runtime.getCell<{ total: number }>(
+        homeSpace,
+        "f1b-result",
+        compiled.resultSchema,
+      );
+      for (let attempt = 0;; attempt++) {
+        await argument.sync();
+        await result.sync();
+        const tx = runtime.edit();
+        runtime.run(tx, compiled, argument, result);
+        const committed = await tx.commit();
+        if (committed.error === undefined) break;
+        if (attempt >= 4) {
+          throw new Error(
+            `serving pattern run failed: ${committed.error.message}`,
+          );
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      await runtime.idle();
+    };
+
+    clientManager = SharedServerStorageManager.connectTo(server, {
+      as: aliceSigner,
+    });
+    clientRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: clientManager,
+    });
+    {
+      const tx = clientRuntime.edit();
+      clientRuntime.getCell<{ n: number }>(homeSpace, "f1b-arg", undefined, tx)
+        .set({ n: 1 });
+      const committed = await tx.commit();
+      expect(committed.error).toBeUndefined();
+    }
+    const clientResult = clientRuntime.getCell<{ total: number }>(
+      homeSpace,
+      "f1b-result",
+      undefined,
+    );
+    let observed: number | undefined;
+    const cancel = clientResult.sink((value) => {
+      observed = value?.total;
+    });
+    try {
+      await waitUntil(
+        () => observed === 501,
+        `first derivation (saw ${observed})`,
+      );
+      expect(host.spaceServer(homeSpace)?.active).toBe(true);
+
+      // The misdirected crossing: full §2b carriage, owner-by-identity
+      // grant (acting user IS the target space DID, so the accept gate
+      // admits without touching the engine) — and the target's engine
+      // cannot open.
+      const serving = servingRuntime!;
+      const badTx = serving.edit();
+      stampWaveRunContext(badTx, {
+        actionId: "provision-into-bad-space",
+        kind: "event-handler",
+        eventId: "e-bad-space",
+        acting: { user: badSpace, session: "sess-bad" },
+        capabilityRef: "cap:test-grant",
+      });
+      serving.getCell<{ value: number }>(
+        badSpace,
+        "f1b-bad-doc",
+        undefined,
+        badTx,
+      ).set({ value: 1 });
+      const badCommit = await badTx.commit();
+      // Accepted into the wave (the gate admits it) — the failure is
+      // decided at the commit step's engine resolution.
+      expect(badCommit.error).toBeUndefined();
+
+      // The home space must KEEP SERVING: the client moves the input
+      // and the served derivation lands in a wave that also had to
+      // resolve (and isolate) the bad foreign target.
+      {
+        const tx = clientRuntime.edit();
+        clientRuntime.getCell<{ n: number }>(
+          homeSpace,
+          "f1b-arg",
+          undefined,
+          tx,
+        ).set({ n: 2 });
+        const committed = await tx.commit();
+        expect(committed.error).toBeUndefined();
+      }
+      await waitUntil(
+        () => observed === 502,
+        `re-derivation after the isolated foreign failure (saw ${observed})`,
+      );
+      expect(host.spaceServer(homeSpace)?.active).toBe(true);
+      await waitUntil(
+        () => host!.stats().foreignEngineFailures >= 1,
+        "the isolated failure to be counted",
+      );
+    } finally {
+      cancel();
+    }
+  });
+
   it("foreignWriteAuthorityFor: the structural grant supply — owner-by-identity, fresh-store creation (non-creating probe), the target's own ACL, fail-closed otherwise (protocol.md §2b; the F1 fix)", async () => {
     const aliceDid = aliceSigner.did();
     const bobDid = bobSigner.did();

--- a/packages/runner/test/executor-outbox.test.ts
+++ b/packages/runner/test/executor-outbox.test.ts
@@ -93,6 +93,10 @@ describe("stage G outbox + sqlite discharge", () => {
       // ("refuse", RULED 2026-08-14 (c)) — pinned in
       // executor-serving-loop.test.ts and executor-wave.test.ts.
       foreignWrites: "accept",
+      // Allow-all authority probe: these tests exercise the FP1 fold
+      // mechanics; the gate's grant predicate is pinned in
+      // executor-wave.test.ts and executor-cross-space.test.ts.
+      foreignWriteGrant: () => true,
       ...(options.lease !== undefined ? { lease: options.lease } : {}),
     });
 

--- a/packages/runner/test/executor-outbox.test.ts
+++ b/packages/runner/test/executor-outbox.test.ts
@@ -671,6 +671,10 @@ describe("stage G outbox + sqlite discharge", () => {
       actionId: "handle-foreign-only",
       kind: "event-handler",
       eventId: "evt-foreign-only",
+      // The §2b provisioning carriage (Phase 5's accept gate): a
+      // foreign write is admitted only under acting + grant.
+      acting: { user: "user:alice", session: "sess-1" },
+      capabilityRef: "cap-fo",
     });
     foreignCell.withTx(tx1).set({ value: 5 });
     wave.enqueueOutboundAppend(tx1, {

--- a/packages/runner/test/executor-wave.test.ts
+++ b/packages/runner/test/executor-wave.test.ts
@@ -92,6 +92,9 @@ describe("stage D seal-into-wave", () => {
 
   const newWave = (options: {
     lease?: ConstructorParameters<typeof WaveAccumulator>[0]["lease"];
+    foreignWriteGrant?: ConstructorParameters<
+      typeof WaveAccumulator
+    >[0]["foreignWriteGrant"];
   } = {}): WaveAccumulator =>
     new WaveAccumulator({
       space,
@@ -112,6 +115,13 @@ describe("stage D seal-into-wave", () => {
       // RULED 2026-08-14 (c)) — pinned by its own tests below and in
       // executor-serving-loop.test.ts.
       foreignWrites: "accept",
+      // Allow-all authority probe unless a test binds the grant arm:
+      // these tests exercise the wave MECHANICS (sequencing, carriage
+      // completeness, withdrawal closure) against synthetic spaces.
+      // The gate's real predicate is pinned by its own arms below and
+      // by executor-cross-space.test.ts against the memory server's
+      // foreignWriteAuthorityFor.
+      foreignWriteGrant: options.foreignWriteGrant ?? (() => true),
       ...(options.lease !== undefined ? { lease: options.lease } : {}),
     });
 
@@ -2210,6 +2220,125 @@ describe("stage D seal-into-wave", () => {
     );
   });
 
+  it("Phase 5 accept gate is an AUTHORIZATION boundary: an UNGRANTED crossing refuses action-scoped even with full carriage; the actor's own home space admits (protocol.md §2b; the F1 fix)", async () => {
+    // The F1 finding: carriage (acting + capabilityRef) is minted for
+    // every acting run, so a carriage-only gate authorized nothing —
+    // any served pattern acting for any user could write ANY co-hosted
+    // space. The gate now consults a REAL authorization predicate; here
+    // it is wired to the memory server's structural grant supply
+    // (foreignWriteAuthorityFor), exactly as the serving loop wires it.
+    const actorSigner = await Identity.fromPassphrase("wave grant actor");
+    const actor = actorSigner.did();
+    const victimSigner = await Identity.fromPassphrase(
+      "wave grant victim space",
+    );
+    const victim = victimSigner.did() as MemorySpace;
+    // The victim space EXISTS (engine open) and carries no ACL: the
+    // serving plane fails closed for it (fail-closed interim,
+    // protocol.md §2 — the client path's populated-legacy compat is a
+    // rollout accommodation, not a grant).
+    await server.engineForSpace(victim);
+
+    let refusals = 0;
+    const wave = new WaveAccumulator({
+      space,
+      basisSeq: Engine.serverSeq(engine),
+      scopeKeyIdentity: {
+        principal: signer.did(),
+        sessionId: "wave-grant-session",
+      },
+      replicaFor: (s) => storageManager.open(s).replica,
+      foreignWrites: "accept",
+      foreignWriteGrant: async (s, acting) =>
+        (await server.foreignWriteAuthorityFor(s, acting.user)).granted,
+      onForeignWriteRefusal: () => {
+        refusals += 1;
+      },
+    });
+    runtime.installSealDestination(wave);
+    try {
+      // UNGRANTED: full §2b carriage, existing foreign space, no
+      // authority — the review's concrete attack (a run acting for
+      // alice writing a space alice holds nothing on). Pre-fix this
+      // ADMITTED; it must refuse action-scoped, loud and counted.
+      const ungrantedTarget = runtime.getCell<{ value: number }>(
+        victim,
+        "wave-grant-victim-doc",
+        undefined,
+      );
+      const homeBeside = runtime.getCell<{ value: number }>(
+        space,
+        "wave-grant-home-doc",
+        undefined,
+      );
+      const ungrantedTx = runtime.edit();
+      stampWaveRunContext(ungrantedTx, {
+        actionId: "provision-ungranted",
+        kind: "event-handler",
+        eventId: "e-ungranted",
+        acting: { user: actor, session: "sess-1" },
+        capabilityRef: "cap:test-grant",
+      });
+      ungrantedTx.enableMultiSpaceWrites?.([victim, space]);
+      ungrantedTarget.withTx(ungrantedTx).set({ value: 1 });
+      homeBeside.withTx(ungrantedTx).set({ value: 2 });
+      const ungrantedCommit = await ungrantedTx.commit();
+      expect(ungrantedCommit.error?.message ?? "").toContain(
+        "holds no structural write grant",
+      );
+      expect(refusals).toBe(1);
+
+      // GRANTED (owner-by-identity): the SAME carriage shape targeting
+      // the acting identity's OWN home space (space DID == actor DID)
+      // is admitted at the gate — the demanded wish bootstrap's
+      // sanctioned §2b crossing.
+      const ownTarget = runtime.getCell<{ value: number }>(
+        actor as MemorySpace,
+        "wave-grant-own-home-doc",
+        undefined,
+      );
+      const homeBeside2 = runtime.getCell<{ value: number }>(
+        space,
+        "wave-grant-home-doc-2",
+        undefined,
+      );
+      const grantedTx = runtime.edit();
+      stampWaveRunContext(grantedTx, {
+        actionId: "provision-own-home",
+        kind: "event-handler",
+        eventId: "e-own-home",
+        acting: { user: actor, session: "sess-1" },
+        capabilityRef: "cap:test-grant",
+      });
+      grantedTx.enableMultiSpaceWrites?.([actor as MemorySpace, space]);
+      ownTarget.withTx(grantedTx).set({ value: 3 });
+      homeBeside2.withTx(grantedTx).set({ value: 4 });
+      const grantedCommit = await grantedTx.commit();
+      expect(grantedCommit.error).toBeUndefined();
+      expect(refusals).toBe(1);
+      expect(wave.foreignSpaces).toEqual([actor as MemorySpace]);
+    } finally {
+      runtime.clearSealDestination();
+      wave.abandon("test-only");
+      await wave.settled();
+    }
+  });
+
+  it("Phase 5 accept gate cannot be configured VACUOUS: accept without an authority probe refuses at construction (the F1 fix)", () => {
+    expect(() =>
+      new WaveAccumulator({
+        space,
+        basisSeq: Engine.serverSeq(engine),
+        scopeKeyIdentity: {
+          principal: signer.did(),
+          sessionId: "wave-vacuous-session",
+        },
+        replicaFor: (s) => storageManager.open(s).replica,
+        foreignWrites: "accept",
+      })
+    ).toThrow("foreignWriteGrant");
+  });
+
   it("stage F: a read in a space the run wrote nothing to folds the reader into a withdrawal (the discharged stage-D bound)", async () => {
     const foreignSigner = await Identity.fromPassphrase(
       "wave read-only space",
@@ -2801,8 +2930,10 @@ describe("stage F fix round: foreign-batch settle sequences and shallow reads", 
         principal: signer.did(),
         sessionId: "wave-foreign-seq-session",
       },
-      // §2b Phase-5 machinery under test (see newWave's posture note).
+      // §2b Phase-5 machinery under test (see newWave's posture note,
+      // including the allow-all authority probe).
       foreignWrites: "accept",
+      foreignWriteGrant: () => true,
       replicaFor: (s) => {
         const real = storageManager.open(s).replica;
         return new Proxy(real, {
@@ -2964,8 +3095,10 @@ describe("stage F fix round: foreign-batch settle sequences and shallow reads", 
         principal: signer.did(),
         sessionId: "wave-shallow-session",
       },
-      // §2b Phase-5 machinery under test (see newWave's posture note).
+      // §2b Phase-5 machinery under test (see newWave's posture note,
+      // including the allow-all authority probe).
       foreignWrites: "accept",
+      foreignWriteGrant: () => true,
       replicaFor: (s) => storageManager.open(s).replica,
       lease: cycle,
     });

--- a/packages/runner/test/executor-wave.test.ts
+++ b/packages/runner/test/executor-wave.test.ts
@@ -837,6 +837,9 @@ describe("stage D seal-into-wave", () => {
         kind: "event-handler",
         eventId: "e-prov",
         acting: { user: "did:key:alice", session: "sess-1" },
+        // The §2b provisioning shape (Phase 5's accept-with-carriage
+        // gate): every foreign commit carries acting + grant.
+        capabilityRef: "cap:test-grant",
       });
       tx.enableMultiSpaceWrites?.([foreign, space]);
       foreignCell.withTx(tx).set({ value });
@@ -1107,6 +1110,8 @@ describe("stage D seal-into-wave", () => {
       kind: "event-handler",
       eventId: "e-foreign-writer",
       acting: { user: "did:key:alice", session: "sess-1" },
+      // The §2b provisioning carriage (Phase 5's accept gate).
+      capabilityRef: "cap:test-grant",
     });
     writerTx.enableMultiSpaceWrites?.([foreign, space]);
     foreignSeed.withTx(writerTx).set({ value: 3 });
@@ -1119,6 +1124,13 @@ describe("stage D seal-into-wave", () => {
     stampWaveRunContext(readerTx, {
       actionId: "derive-from-foreign",
       kind: "derivation",
+      // A demanded run acting as its demander (the Phase-5 wish shape:
+      // per-demanding-identity resolution riding §2b's crossing) — the
+      // acting + grant carriage is what admits its foreign write at
+      // the accept gate.
+      acting: { user: "did:key:alice", session: "sess-1" },
+      scopeKeyIdentity: { principal: "did:key:alice", sessionId: "sess-1" },
+      capabilityRef: "cap:test-grant",
     });
     readerTx.enableMultiSpaceWrites?.([foreign, space]);
     const seen = foreignSeed.withTx(readerTx).get();
@@ -2121,20 +2133,81 @@ describe("stage D seal-into-wave", () => {
     expect(meta.acting_session).toBe("sess-1");
     expect(meta.capability_ref).toBe("cap:test-grant");
 
-    // WITHOUT the capabilityRef (partial carriage): the foreign batch has
-    // no delegated identity, so the scoped write is refused — never
-    // silently keyed from the sink's own principal.
-    const partialWave = await provision({
+    // WITHOUT the capabilityRef (partial carriage): refused at
+    // ACCUMULATION (Phase 5's accept-with-carriage gate — a foreign
+    // write is admitted only under the full §2b delegated carriage), so
+    // the tx fails action-scoped and NOTHING reaches the sink, let
+    // alone keys from its principal. The sink's own delegated
+    // validation stays as backstop (its direct test below).
+    const partialWave = newWave({ lease });
+    runtime.installSealDestination(partialWave);
+    const foreignScoped = runtime.getCell<{ value: number }>(
+      foreign,
+      "wave-delegated-scoped",
+      undefined,
+      undefined,
+      "user",
+    );
+    const home = runtime.getCell<{ value: number }>(
+      space,
+      "wave-delegated-home",
+      undefined,
+    );
+    const partialTx = runtime.edit();
+    stampWaveRunContext(partialTx, {
       actionId: "provision-scoped-2",
       kind: "event-handler",
       eventId: "e-partial",
       acting,
       scopeKeyIdentity: { principal: acting.user, sessionId: acting.session },
       // no capabilityRef
-    }, 21);
+    });
+    partialTx.enableMultiSpaceWrites?.([foreign, space]);
+    foreignScoped.withTx(partialTx).set({ value: 21 });
+    home.withTx(partialTx).set({ value: 22 });
+    const partialCommit = await partialTx.commit();
+    expect(partialCommit.error?.message ?? "").toContain(
+      "foreign-space write refused at wave accumulation",
+    );
+    runtime.clearSealDestination();
     const outcome2 = await partialWave.commitWave(sink);
     await partialWave.settled();
-    expect(outcome2.aborted).toBe("foreign-commit-failed");
+    // Nothing sealed: the refused tx withdrew whole, the wave is vacuous.
+    expect(outcome2.aborted).toBeUndefined();
+    expect(outcome2.committedEventIds).toEqual([]);
+  });
+
+  it("Phase 5 backstop: the sink still refuses a foreign batch's scoped op without delegated carriage (protocol.md §2's delegated row)", async () => {
+    const foreignSigner = await Identity.fromPassphrase(
+      "wave sink backstop foreign space",
+    );
+    const foreign = foreignSigner.did() as MemorySpace;
+    const foreignEngine = await server.engineForSpace(foreign);
+    const sink = new EngineWaveCommitSink({
+      engineFor: () => foreignEngine,
+      sessionId: executionLeaseHolder(`service:${space}`),
+    });
+    const refused = await sink.commitWave({
+      space: foreign,
+      home: false,
+      basisSeq: 0,
+      rebasedHeads: [],
+      operations: [{
+        op: "set",
+        id: "of:backstop",
+        scope: "user",
+        value: { value: { v: 1 } },
+      } as never],
+      preconditions: [],
+      annotations: [],
+      consequenceOf: [],
+      basisInstances: [],
+      holder: undefined,
+      // no delegated carriage
+    });
+    expect(refused.error?.message ?? "").toContain(
+      "scoped write in a foreign wave batch refused",
+    );
   });
 
   it("stage F: a read in a space the run wrote nothing to folds the reader into a withdrawal (the discharged stage-D bound)", async () => {

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -14,6 +14,7 @@ import { PieceController, PiecesController } from "@commonfabric/piece/ops";
 import {
   assertServerExecutionPostureAgreement,
   browserWorkerParamsFromInitializationData,
+  resolveEventAppendQueuePersistence,
   renderConfidentialityResolverFor,
   renderMembershipProviderFor,
   RuntimeProcessor,
@@ -2997,6 +2998,27 @@ describe("worker/host server-execution posture agreement (review 2026-08-11 m7)"
         { experimental: { serverExecution: true } },
       )
     ).toThrow(/posture mismatch/);
+  });
+});
+
+describe("resolveEventAppendQueuePersistence", () => {
+  // The LT9 coupling seam (server-execution v2 Phase 5, rec (c) —
+  // adopted pending veto): the host DECLARES an event-append-queue
+  // persistence kind; the worker honors exactly the in-memory default
+  // in this build and refuses anything else LOUDLY — a durability
+  // declaration must never silently degrade to memory (events.md §5;
+  // the durable worker adapter is verification-coverage.md OW20's
+  // follow-up, landing with protocol §5's sessionId persistence).
+  it("honors absent and memory declarations as the in-memory default", () => {
+    expect(resolveEventAppendQueuePersistence(undefined)).toEqual({});
+    expect(resolveEventAppendQueuePersistence({ kind: "memory" })).toEqual({});
+  });
+
+  it("refuses a kind this build cannot honor, loudly (fail closed)", () => {
+    expect(() => resolveEventAppendQueuePersistence({ kind: "web-storage" }))
+      .toThrow(/not available in the worker runtime/);
+    expect(() => resolveEventAppendQueuePersistence({ kind: "indexeddb" }))
+      .toThrow(/OW20/);
   });
 });
 

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -231,6 +231,37 @@ function resolveBlobUrl(url: string, apiUrl: URL, space: DID): string {
  * that declares nothing and a worker that resolves OFF agree, which is
  * every pre-existing deployment. Exported for testing.
  */
+/**
+ * The LT9 worker persistence seam (server-execution v2 Phase 5, rec (c)
+ * — ADOPTED-PENDING-VETO; events.md §5, protocol.md §5). Maps the
+ * host's DECLARED event-append-queue persistence onto the storage
+ * manager's `eventAppendQueueStore` option — the one seam the durable
+ * adapter will also ride when sessionId persistence lands (OW20).
+ *
+ * This build honors: absent, `{ kind: "memory" }` (both the in-memory
+ * default — the same persistence class as `sessionId` today). Any other
+ * kind REFUSES loudly: the worker realm has no Web Storage, the durable
+ * worker adapter is the OW20 follow-up, and silently downgrading a
+ * declared durability to memory would lose queued user intents a host
+ * believed durable (LT9's ruled requirement). Exported for testing.
+ */
+export function resolveEventAppendQueuePersistence(
+  declared: InitializationData["eventAppendQueuePersistence"],
+): Record<never, never> {
+  if (declared === undefined || declared.kind === "memory") {
+    // The manager's own default IS the memory store; declare nothing.
+    return {};
+  }
+  throw new Error(
+    `event-append-queue persistence kind "${declared.kind}" is not ` +
+      "available in the worker runtime: the durable worker adapter " +
+      "lands with protocol §5's sessionId persistence " +
+      "(verification-coverage.md OW20) — refusing initialization " +
+      "rather than silently degrading a durability declaration to " +
+      "memory (events.md §5, LT9)",
+  );
+}
+
 export function assertServerExecutionPostureAgreement(
   declared: InitializationData["experimental"],
   runtime: { experimental: { serverExecution?: boolean | undefined } },
@@ -600,6 +631,16 @@ export class RuntimeProcessor {
         experimentalConcurrentWatchRefresh:
           data.concurrentWatchRefresh === true,
       },
+      // The LT9 coupling seam (server-execution v2 Phase 5, rec (c) —
+      // adopted pending veto): the host's declared event-queue
+      // persistence routes through the SAME manager option the durable
+      // adapter will use when protocol §5's sessionId persistence lands
+      // (OW20). This build honors exactly the in-memory kind; an
+      // undeliverable declaration refuses initialization loudly rather
+      // than silently degrading a durability promise.
+      ...(resolveEventAppendQueuePersistence(
+        data.eventAppendQueuePersistence,
+      )),
     });
 
     // Mirror the durability barrier to the page: `pending` is true while any

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -242,6 +242,24 @@ export interface InitializationData {
   // effect on the next runtime (reload), not live. Off by default; the shell
   // dogfood toggle `commonfabric.concurrentWatchRefresh()` sets it.
   concurrentWatchRefresh?: boolean;
+  // The LT9 offline-event-queue persistence declaration for the
+  // WORKER-hosted runtime (server-execution v2 Phase 5, rec (c) —
+  // ADOPTED-PENDING-VETO: the durable store wiring lands COUPLED to
+  // protocol §5's sessionId persistence, and this field IS the coupling
+  // seam — the same declarative surface will carry the session
+  // persistence config when that work lands). Structured-clone-safe by
+  // construction: the host DECLARES a store kind, the worker CONSTRUCTS
+  // the adapter (no live objects cross the IPC boundary).
+  //
+  // - absent / `{ kind: "memory" }`: the in-memory default — the same
+  //   persistence class as `sessionId` today (events.md §5,
+  //   protocol.md §5).
+  // - any other kind: the worker REFUSES initialization loudly. The
+  //   durable worker adapter (IndexedDB or a main-thread bridge) is the
+  //   OW20 follow-up that lands WITH sessionId persistence; declaring a
+  //   kind this build cannot honor must fail closed, never silently
+  //   degrade a durability promise to memory.
+  eventAppendQueuePersistence?: { kind: string };
 }
 
 export interface InitializeRequest extends BaseRequest {

--- a/packages/toolshed/lib/server-execution.ts
+++ b/packages/toolshed/lib/server-execution.ts
@@ -47,6 +47,11 @@ export function startServerExecutionHost(options: {
     createRuntime: (space) => {
       const storageManager = LoopbackStorageManager.connect(options.server, {
         as: options.identity,
+        // Phase 5 (protocol.md §2's grant-scoped read design): the
+        // serving manager's FOREIGN-space providers refuse scoped
+        // reads fail-closed — the producer half of the
+        // delegated-scoped-read precondition.
+        servingHomeSpace: space,
       });
       const runtime = new Runtime({
         apiUrl: options.apiUrl,


### PR DESCRIPTION
## Why

Phase 5 of the server-execution v2 train (stacked on
`claude/server-exec-v2-phase-4`): the CROSS-SPACE phase. Three
arc-accumulated obligations come due here and this PR discharges them as
one stack:

1. **The RULED delegated-scoped-reads precondition (2026-08-13,
   verification-coverage OW13):** the grant-scoped read design — or an
   explicit fail-closed refusal — MUST land before any
   delegated-scoped-read producer ships, and Phase 5 introduces the
   producers (cross-space serving reads). This PR lands the design
   (protocol §2) AND its fail-closed interim at both ends of the stack, so
   no exposure window exists.
2. **The §2b crossing goes live under serving:** stage G built the
   foreign-first commit sequencing and FP1 durable rows dark; the
   2026-08-14 (c) lunch-wall ruling parked all foreign writes at
   accumulation. Phase 5 sanctions exactly the carriage-bearing shape and
   keeps the ruled refusal for everything else.
3. **The RULED wish line item (2026-08-14, the lunch residual):**
   per-demanding-identity wish resolution — a serving wish resolves the
   DEMANDING user's home space (P2-F's run supply provides the identity),
   never the service identity's (the lunch-wall trap), with its bootstrap
   writes riding the §2b sanctioned crossing.

## What Changed

**Delegated scoped reads — design + fail-closed interim (protocol §2):**
- FP2's widening landed: the read row admits any live lease holder on the
  co-hosted memory server (cross-engine lookup over a resolved-engine
  index), so a home SpaceServer can name a FOREIGN space's instances.
- The per-process sharpening landed: equality is against the FULL DR1
  holder minted by the co-hosted process — a second process sharing the
  service DID no longer passes (retires the Phase-1 recorded acceptance).
- Fail-closed twin, admission side: an UNNAMED scoped root from a
  co-hosted serving session reading a space whose lease it does not hold
  REFUSES (fully synchronous — the ACL revocation-race invariant holds)
  instead of silently resolving `user:<serviceDID>`.
- Fail-closed twin, producer side: a serving manager
  (`Options.servingHomeSpace`, set by the ExecutorHost factory) refuses
  scoped reads on its FOREIGN providers before any wire frame. Foreign
  SPACE-scope reads stay free (§2b's free-read row).

**The §2b crossing under serving (serving-loop §3d):**
- The wave's accept-with-carriage gate: the serving loop now passes
  `foreignWrites: "accept"`, and a foreign write is admitted at
  accumulation IFF the run context carries the §2b delegated carriage
  (acting identity + `capabilityRef`). Carriage-less foreign writes — the
  lunch-wall class — keep the ruled action-scoped refusal, loud and
  counted (`foreignWriteRefusals`). The sink's delegated validation stays
  as backstop (now pinned directly).
- `SpaceServer` resolves foreign co-hosted engines ahead of the commit
  step (`#foreignEngineFor` no longer throws unconditionally); resolutions
  die on park.
- `#stampRun` supplies the structural grant for served runs acting as a
  principal (`event-consequence:<eventId>` / `demanded-run:<principal>` —
  the FP1 `stream-append:` precedent; flagged below).
- Activation's basis re-mark now judges FOREIGN rows against their own
  space's engines (`selectForeignBasisRows`; fail-degrades to surfacing).

**Per-demanding-identity wish resolution (builtins §5, RULED 2026-08-14):**
- `Runtime.homeSpacePrincipalFor(tx)`: client → own user (byte-identical);
  serving → the run's stamped demanding identity or event actor; serving
  with NO identity → refuse loudly (never the service DID).
- The wish's home-space guards ride it; sidecar result cells key by the
  home-space user (two demanders never collide on the service DID); the
  sidecar compile-cache context is the SERVED space on serving runtimes.

**Foreign wake — a survival-test finding, recorded honestly:** a host-side
fan-out built for §3b's server-internal wake was MUTATION-PROBED REDUNDANT
(the E2E stayed green with it disabled) and removed: the wake is the
already-landed chain — foreign session frames → autonomous scheduler runs
→ the seal's loop wake. The new `executor-cross-space.test.ts` pins the
end-to-end behavior (a foreign commit re-derives a home derivation with no
home input, under a 600 s idle window).

**LT9 worker wiring — rec (c), ADOPTED-PENDING-VETO (flagged for the
owner):** the plan defers protocol §5's sessionId persistence beyond
Phase 5, so per the rec's fork this PR lands the COUPLING SEAM ONLY:
`InitializationData.eventAppendQueuePersistence`, mapped by
`resolveEventAppendQueuePersistence` onto the manager's
`eventAppendQueueStore` option. The memory kind is honored; any other kind
refuses initialization loudly (a durability declaration never silently
degrades). OW20 (the durable worker adapter + queue debts) stands
unchanged on its original trigger. **Veto point: if the owner rejects
rec (c), revert the typed field + resolver + tests — nothing else depends
on them.**

**Reconciliation:** `sx2-events` updated to main's WS-D
invocation-identity contract (a caller-supplied eventId now requires its
session — base-inherited drift; the dedupe arm passes the same
(id, session) pair on both fires).

**Specs (with the implementing batch):** protocol §2 (the grant-scoped
read design + landed widening/sharpening), serving-loop §3b/§3d/§6,
builtins §5's wish row, the plan's Phase-5 boxes, and the
verification-coverage Phase-5 delta (OW13 precondition discharged, OW22
discharged, OW17 re-tagged to the grant-resolution trigger, the LT9 row).

## Test plan

- Red-first: the three Phase-5 read-row arms fail 3/3 at the pre-change
  tree; five mutation probes (carriage gate, wish service-DID fallback,
  holder-equality sharpening, provider guard, host fan-out) — four red as
  expected, the fifth SURVIVED and its machinery was removed (see above).
- Full runner suite 1199/1199 (twice on the final tree); full memory 516;
  spec-model 23; runtime-client 62+23; `deno check` on every touched
  file; `deno task check-docs` green.
- Soaks: executor-serving-loop 10× green, executor-effect-channel 10×
  green (wedge + park/renew-blip pins ride these suites).
- Live ON arm (fresh store, from-source servers, flag on both sides):
  sx2-serving-loop 5× green, sx2-speculation, sx2-effect-channel,
  sx2-events green.

## Gates table (honest)

| gate | status | mechanism |
| ---- | ------ | --------- |
| sx2-serving-loop ×5, sx2-speculation, sx2-effect-channel, sx2-events (ON, fresh store) | GREEN | sx2-events green after the WS-D reconciliation |
| full runner / memory / spec-model / runtime-client | GREEN | 1199 / 516 / 23 / 85 |
| serving-loop + effect-channel soaks 10× | GREEN | wedge/park pins included |
| `shared-profile`, `profile-embed`, `home-profile` (ON) | RED — **base-inherited** | `#wish-profile-name-input` (the profile-create surface) never renders under the full-ON posture; profile-embed reproduces IDENTICALLY on the unmodified P4 base with base-built servers — the browser-ON red family the P3 triage tracks (OW25's class). Not caused here; not yet fixed here. |
| `sqlite-read-clearance-multi-runtime` (ON) | RED — **base-inherited** | worker-side event append refused "OFF arm has no event-append admission" (a worker flag-posture gap); identical at the base tree |
| **the lunch-ON gate** (`cfc-group-chat-demo-two-browsers`, ON, 2×) | **RED 2/2** | run 1: SaveProfile click → worker `runtime:idle` timeout (64 s); run 2: 300 s stall. Serving counters CLEAN both runs (`foreignWriteRefusals` 0, `unstampedSealRefusals` 0, `structureLoadFailures` 0, waves committing) — the pre-P5 lunch-wall chain (wish → foreign refusal → park loop) does NOT re-fire; the remaining blocker is the base-inherited client-side browser-ON family above, consistent with the arc record of this gate's local bimodality (CI's compiled-binary harness is its arbiter). **The Phase-5-gated annotation on #5612 is therefore NOT yet retired** — the serving-side wall is gone, the client-side family still gates the leg. |

## Flagged forks (flag-don't-fill)

1. **The wish bootstrap WRITE path's multi-space opt-in:** protocol §2b
   names the `.inSpace()` chain as the ONE explicit opt-in to multi-space
   commits; the ruled wish lift sanctions home-space bootstrap writes
   riding that crossing, but whether the wish should opt in via
   `optIntoInSpaceMultiSpaceCommit` or a new sanctioned opt-in point is
   UNSTATED. The resolution and wave layers are landed and probe-pinned;
   the write path's E2E is blocked behind the base-inherited browser red,
   so the fork could not be forced live. Owner call requested.
2. **The structural `capabilityRef` vocabulary**
   (`event-consequence:<eventId>` / `demanded-run:<principal>`) is a
   below-spec-granularity surface (the FP1 precedent); grant RESOLUTION
   stays OW13's owed hardening.
3. **LT9 rec (c)** — adopted pending veto, see above.
4. **Foreign-batch sqlite** stays refused (no producer; the attachment
   identity rides the grant-scoped read design) — recorded in the sink and
   the plan, not silently deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

