### PR TITLE
feat(cli): the demo asks the item what it can do before calling it

### DIFF
--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -151,7 +151,9 @@ same content twice, and the copy that goes stale when a parameter changes.
 **One interface, holding both.** An item's fields and its verbs sit together
 because that is what an item *is*: a child in `children` is a full item, and
 declaring it any narrower would be a claim the runtime contradicts — ask that
-child what it can do and it lists all five.
+child what it can do and it lists all five. Act 4 asks it: an address is enough
+to discover a surface, with no schema shipped alongside and nothing looked up
+by type.
 
 **Every field is a reference, not a copy.** `children` holds links to item
 pieces, and so does `blockedOn`. That is the whole reason addresses matter

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -173,7 +173,12 @@ run cf piece call -s "$SPACE" --piece board --select item@ addItem -- --title "L
 # bare hash is a different spelling that resolves by defaulting to `of:`, not
 # the same address — the scheme is part of the identity.
 EPIC=$(printf '%s' "$OUT" | jq -r '.result.item."$link".id')
-say "That id is what --piece takes from here on."
+say "That id is what --piece takes from here on. Ask it the same question act 2"
+say "asked the board, before assuming anything about what it can do."
+run cf piece verbs -s "$SPACE" --piece "$EPIC"
+say "Every verb an item has, and not the board's one: the listing is derived"
+say "from the piece in front of you, so an address is enough to discover a"
+say "surface you were never told about."
 run cf piece call -s "$SPACE" --piece "$EPIC" addChild -- --title "Session cookies"
 say "The item it hands back can be reached from inside itself: its parent holds"
 say "it, and it holds its parent. The position where the author's own type"

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -129,6 +129,14 @@ KIDS=$($CF piece get --quiet --piece "$EPIC" children $ARGS \
   2>/dev/null)
 check "2" "$(echo "$KIDS" | jq -r 'length')" \
   "both children landed under the address the create returned"
+# Step 2's assertion one level down: an address alone discovers a surface, and
+# the surface it discovers is the item's own rather than the board's. Three
+# places say so in prose — the demo narrates it, and the walkthrough claims it
+# twice — and none of them could go stale without this failing first.
+ITEM_VERBS=$($CF piece verbs --piece "$EPIC" $ARGS --json 2>/dev/null)
+check "addChild,archive,blockOn,finish,recordNote" \
+  "$(echo "$ITEM_VERBS" | jq -r '[.verbs[]?.name] | sort | join(",")')" \
+  "an item lists its own verbs, and not the board's"
 
 step "5. Read addresses instead of contents"
 ADDR=$($CF piece get --quiet --piece "$EPIC" children $ARGS \


### PR DESCRIPTION
## Why

Act 4 handed back an address and then called a verb on it, which asks the reader
to take on faith that the address carries a surface. It now asks — the same
`cf piece verbs` act 2 asked the board, against the piece the create just
returned — and the answer is five verbs, none of them the board's one.

That is the claim the whole receiver axis rests on: an address alone is enough
to discover what a piece can do, with no schema shipped beside it and nothing
looked up by type. The walkthrough already asserted it in prose — "ask that
child what it can do and it lists all five" — with nothing in the session
demonstrating it.

## What Changed

- Act 4 runs `cf piece verbs` against the address the create returned, between
  the create and the first call on it.
- The walkthrough paragraph making that claim now names the act that shows it.

## Test plan

Measured against a local toolshed on the rebased branch: the demo exits 0 with
no unexpected failures and repeats identically across three runs. Harness
untouched — 22 passed, 0 failed, 2 gaps open. `deno fmt --check`, `deno lint`,
`check-docs`, `check-conflict-markers`, `check-skill-facts` and
`check-no-waitfor` all pass.

## Note for the reviewer

This **conflicts** with #5840 — both edit the region around act 4's address
extraction in `verb-session-demo.sh`. Verified by merging them rather than
assumed: an earlier draft of this description claimed they touched different
lines, which was wrong.

The resolution is mechanical, and either order works: keep #5840's comment and
its unstripped `EPIC=` line, and keep this PR's narration and `run` lines that
follow it.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


