### PR TITLE
fix(cli): the demo carries the address whole, and stops hanging on archive

### DIFF
--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -166,9 +166,13 @@ run cf piece call -s "$SPACE" --piece board addItem -- --help
 act "4 · Create, and act on what you were handed"
 say "The create returns the piece it made. Its address is the next command's target."
 run cf piece call -s "$SPACE" --piece board --select item@ addItem -- --title "Login rewrite"
-# The address the reader can see in the output above. Taken from that run, not
-# from a second one: `run` leaves the output it displayed in $OUT.
-EPIC=$(printf '%s' "$OUT" | jq -r '.result.item."$link".id' | sed 's/^of://')
+# The address the reader can see in the output above, carried whole. `--piece`
+# takes the `of:` form a read prints, on `get`, `call` and `verbs` alike, so
+# nothing here strips the scheme: the string passed below is the string act 4
+# displayed, which is the round-trip property this session exists to show. The
+# bare hash is a different spelling that resolves by defaulting to `of:`, not
+# the same address — the scheme is part of the identity.
+EPIC=$(printf '%s' "$OUT" | jq -r '.result.item."$link".id')
 say "That id is what --piece takes from here on."
 run cf piece call -s "$SPACE" --piece "$EPIC" addChild -- --title "Session cookies"
 say "The item it hands back can be reached from inside itself: its parent holds"
@@ -195,14 +199,14 @@ act "8 · Finishing reports what the caller could not know"
 say "openBelow walks the whole subtree — a caller would need N reads to learn it."
 say "A grandchild is filed first, so there is a subtree to walk."
 KID=$(cf piece get -s "$SPACE" --piece "$EPIC" children --select @ 2>/dev/null |
-  jq -r '.[0]."$link".id' | sed 's/^of://')
+  jq -r '.[0]."$link".id')
 run cf piece call -s "$SPACE" --piece "$KID" --select item.title addChild -- --title "Rotate signing key"
 run cf piece call -s "$SPACE" --piece "$EPIC" finish -- --body "shipping behind a flag"
 
 act "9 · A verb that declares no result"
 say "archive is Stream<void>: there is nothing for it to hand back, and the"
 say "invocation says so by settling with no result at all."
-run cf piece call -s "$SPACE" --piece "$KID" archive
+run cf piece call -s "$SPACE" --piece "$KID" archive -- invoke
 say "What it changed is a read away, on the one field the caller never sets."
 run cf piece get -s "$SPACE" --piece "$KID" status
 


### PR DESCRIPTION
## Why

Two independent defects in the demo, neither waiting on anything else.

**The address was stripped.** Act 4 read `.["$link"].id` and ran it through
`sed 's/^of://'`, so every later act printed a `--piece` that did not match the
address the reader had just been shown. `--piece` takes the `of:` form on `get`,
`call` and `verbs` alike — measured — so the strip bought nothing and cost the
round-trip property the session exists to demonstrate: an address printed by one
command is the string the next one takes. It is also two of the hand-rolled
prefix conversions `docs/plans/verb-result-selection.md` lists as cleanup.

The bare hash is not the same address. It resolves by defaulting to `of:`, which
is why `--piece computed:…` is refused rather than stripped, and why `toURI` and
`fromURI` both warn at their definitions that the scheme is part of the
identity.

**`archive` hung.** The bare no-payload form does not return until stdin reaches
EOF (#5838), so act 9 waited at a terminal until Ctrl-D, and under a script
whose stdin outlived it, waited until something killed the call. That is the
cause of two previously unexplained failures in this demo — exit 143 and exit
137 on that act — with the piece's `status` left `"open"` both times, so the
write never landed. `-- invoke` is the spelling the help page already advertises
for a verb that takes no input, and it returns immediately.

## What Changed

- Both address extractions drop `sed 's/^of://'`; nine printed command lines now
  carry the address exactly as the act above them displayed it.
- Act 9 calls `archive -- invoke`.
- The comment above the extraction says why the scheme is kept, so the strip is
  not reintroduced as a tidy-up.

## Test plan

Measured on a local toolshed: demo exits 0, nothing unexpected, `archive`
settles and `status` reads `"archived"`. Harness untouched — 22 passed, 0
failed, 2 gaps open. `deno fmt --check` clean.

The `archive` timing behind #5838, measured with the redirect applied
identically to every case so the shell is not the variable:

| Command | Wall time |
| --- | --- |
| `archive < <(sleep 6)` | **6s** |
| `archive -- invoke < <(sleep 6)` | 1s |
| `archive '{}' < <(sleep 6)` | 1s |
| `recordNote -- --body x < <(sleep 6)` | 1s |

## Note for the reviewer

This **conflicts** with #5839 — both edit the region around act 4's address
extraction in `verb-session-demo.sh`. Verified by merging them rather than
assumed: an earlier draft of this description claimed they touched different
lines, which was wrong.

The resolution is mechanical, and either order works: keep this PR's comment and
its unstripped `EPIC=` line, and keep #5839's narration and `run` lines that
follow it.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


