### PR TITLE
feat: server-execution v2 Phase 6 — push priority, budgets, scale

### DIFF
--- a/docs/plans/server-execution-v2.md
+++ b/docs/plans/server-execution-v2.md
@@ -721,19 +721,48 @@ only push priority and the budget/backpressure hardening.
 
 Tasks:
 
-- [ ] Push priority on the subscription channel: subscribed-doc
-      `derived` commits flush first (protocol.md §3).
-- [ ] Per-space budgets in the executor (CPU per wave, outstanding LLM
-      calls, egress rate); a runaway pattern degrades only its own space.
-- [ ] Event/binding backpressure shaping ahead of the commit stream.
+- [x] Push priority on the subscription channel: subscribed-doc
+      `derived` commits flush first (protocol.md §3) — LANDED
+      2026-08-14: two-phase fan-out (derived-subscribed sessions
+      before bulk-only, across every connection), `servingLoop.push`
+      counters; ordering pinned in
+      `packages/memory/test/v2-push-priority.test.ts`
+      (verification-coverage OW8).
+- [x] Per-space budgets in the executor (CPU per wave, outstanding LLM
+      calls, egress rate); a runaway pattern degrades only its own
+      space — LANDED 2026-08-14: T_flush already bounds per-wave CPU
+      (stage D) and is now env-tunable
+      (`SERVER_EXECUTION_FLUSH_DEADLINE_MS`); the outbox gained the
+      outstanding-network-effect cap (toolshed default 16,
+      `SERVER_EXECUTION_MAX_OUTSTANDING_EFFECTS`) and the egress-rate
+      token bucket (`SERVER_EXECUTION_EGRESS_RATE_PER_S`, default
+      unpaced) — serving-loop.md §5, `executor-outbox-budget.test.ts`.
+- [ ] Event/binding backpressure shaping ahead of the commit stream —
+      FLAGGED, not filled (verification-coverage OW27): the §3.8
+      binding-layer shaping's semantics (pace vs batch vs drop, the
+      hold-latency bound, per-stream keying, UI-default visibility)
+      are an unstated fork needing the owner's ruling; the register
+      row carries the candidate resolutions and their costs. The ON
+      arm ships without an event-flood bound until it lands (W4's
+      collapse is flag-disabled by design).
 
 Success criteria:
 
 - [ ] No integration test needs a poll-loop for "is the server done."
+      (Gate landed: `sx2-scale` audits the sx2 family — watermark
+      settles, no `waitForCondition`; ticks on CI green.)
 - [ ] `cf-checkbox` in-suite ≈ isolated (v1 measured 4 s vs 138 s; flat
       accumulation is the requirement, whatever the v1 mechanism was).
+      (Gate landed: `sx2-scale`'s accumulation test measures the
+      requirement's substance headlessly — a late fresh space's settle
+      latency stays in the first space's ballpark; ticks on CI green.)
 - [ ] A deliberate LLM fan-out loop in one space leaves a second space's
-      propagation latency inside budget.
+      propagation latency inside budget. (Gate landed: `sx2-scale`'s
+      isolation test — a 20-wide fetch fan-out against a slow local
+      endpoint, the same egress class as an LLM loop, CI-runnable
+      keyless; space B's settle stays inside the calibrated envelope
+      and space A's `outbox.budgetDeferrals` proves the budget
+      engaged; ticks on CI green.)
 
 ## Phase 7 — Flip and retire
 

--- a/docs/plans/server-execution-v2.md
+++ b/docs/plans/server-execution-v2.md
@@ -730,13 +730,18 @@ Tasks:
       (verification-coverage OW8).
 - [x] Per-space budgets in the executor (CPU per wave, outstanding LLM
       calls, egress rate); a runaway pattern degrades only its own
-      space — LANDED 2026-08-14: T_flush already bounds per-wave CPU
-      (stage D) and is now env-tunable
+      space — LANDED 2026-08-14: T_flush (stage D) is the per-wave
+      compute bound — it bounds a wave's wall-clock accumulation
+      between seals, not a single non-yielding action, which escapes
+      any budget in both arms (pre-existing) — and is now env-tunable
       (`SERVER_EXECUTION_FLUSH_DEADLINE_MS`); the outbox gained the
       outstanding-network-effect cap (toolshed default 16,
-      `SERVER_EXECUTION_MAX_OUTSTANDING_EFFECTS`) and the egress-rate
-      token bucket (`SERVER_EXECUTION_EGRESS_RATE_PER_S`, default
-      unpaced) — serving-loop.md §5, `executor-outbox-budget.test.ts`.
+      `SERVER_EXECUTION_MAX_OUTSTANDING_EFFECTS` — literal `0` opts
+      out; unparseable values fall back to the default, loudly) and
+      the egress-rate token bucket (`SERVER_EXECUTION_EGRESS_RATE_PER_S`,
+      default unpaced) — serving-loop.md §5,
+      `executor-outbox-budget.test.ts`,
+      `toolshed/lib/server-execution.test.ts`.
 - [ ] Event/binding backpressure shaping ahead of the commit stream —
       FLAGGED, not filled (verification-coverage OW27): the §3.8
       binding-layer shaping's semantics (pace vs batch vs drop, the

--- a/docs/specs/server-side-execution/protocol.md
+++ b/docs/specs/server-side-execution/protocol.md
@@ -558,6 +558,18 @@ the target's `eventWatermark` makes processing exactly-once.
   Bookkeeping MUST NOT ride the commit stream at all (lease renewals are
   table updates; watermarks piggyback on derived commits), so in practice
   priority is about big authored blobs vs small derived values.
+  *(LANDED Phase 6 — the implementation shape, stated so no one infers a
+  stronger one: each session gets ONE frame per flush cycle, so priority
+  orders the serialized per-session evaluation/send chain — a two-phase
+  fan-out runs every connection's derived-subscribed sessions before any
+  bulk-only session — never the content of a frame; a session whose one
+  frame mixes derived and bulk carries the whole frame at derived
+  priority, because frames apply atomically and splitting one would put
+  the catch-up marker ahead of undelivered covered docs — an INV-5
+  hazard. Counters: `servingLoop.push.{prioritizedSessions,
+  followerSessions, mixedFlushes}`, all-zero in the OFF arm by
+  construction; the deterministic order pin is
+  `packages/memory/test/v2-push-priority.test.ts`.)*
 - Self-echo: SpaceServer skips its own `derived` commits on receipt
   (serving-loop.md §3).
 

--- a/docs/specs/server-side-execution/serving-loop.md
+++ b/docs/specs/server-side-execution/serving-loop.md
@@ -1006,7 +1006,10 @@ the durable rows of §5 carry APPENDS, never effect state).
   README §3.8's "outstanding LLM calls") and an egress-rate token
   bucket (`egressRatePerSecond`, burst = one second's tokens), both
   `SpaceServerPolicy` knobs threaded from the toolshed bootstrap's env
-  (`SERVER_EXECUTION_MAX_OUTSTANDING_EFFECTS`, default 16;
+  (`SERVER_EXECUTION_MAX_OUTSTANDING_EFFECTS`, default 16 — the
+  LITERAL `0` is the only opt-out to unbounded; an unparseable or
+  negative value falls back to the default with a warning, so a typo
+  can never disable the production bound — FAIL-CLOSED;
   `SERVER_EXECUTION_EGRESS_RATE_PER_S`, default unpaced;
   `SERVER_EXECUTION_FLUSH_DEADLINE_MS` tunes §3's T_flush the same
   way). The gate holds DISPATCH only: the in-flight dedupe entry exists
@@ -1102,7 +1105,10 @@ effect-channel ack writes, so the
 `outbox.budgetDeferrals` counts Phase-6 budget dispatch holds — §5;
 the `push` block is the memory server's Phase-6 push-priority
 counters (protocol.md §3), nested under `servingLoop` in the health
-route so the OFF-arm response never changes shape). Every
+route so the OFF-arm response never changes shape —
+`push.prioritizedSessions`/`push.followerSessions` count sessions
+EVALUATED per group in mixed batches, frame or no frame: an ordering
+witness, not a delivered-frame metric). Every
 Phase gate in the plan reads these counters; tests MUST assert on
 counters, not logs.
 

--- a/docs/specs/server-side-execution/serving-loop.md
+++ b/docs/specs/server-side-execution/serving-loop.md
@@ -1001,8 +1001,22 @@ the durable rows of §5 carry APPENDS, never effect state).
 - Authority: the capability handle bound at wiring time (README §3.8);
   the outbox holds provider credentials via the existing broker; the
   SpaceServer's runtime never sees raw secrets.
-- Per-space budget hooks live here (Phase 6): outstanding-effect caps,
-  egress rate.
+- Per-space budget hooks live here (Phase 6 — LANDED): a cap on
+  DISPATCHED-but-unsettled network effects (`maxOutstandingEffects` —
+  README §3.8's "outstanding LLM calls") and an egress-rate token
+  bucket (`egressRatePerSecond`, burst = one second's tokens), both
+  `SpaceServerPolicy` knobs threaded from the toolshed bootstrap's env
+  (`SERVER_EXECUTION_MAX_OUTSTANDING_EFFECTS`, default 16;
+  `SERVER_EXECUTION_EGRESS_RATE_PER_S`, default unpaced;
+  `SERVER_EXECUTION_FLUSH_DEADLINE_MS` tunes §3's T_flush the same
+  way). The gate holds DISPATCH only: the in-flight dedupe entry exists
+  from admission, so a re-admit during a hold attaches instead of
+  double-firing. LOCAL kinds (sqlite-query — no egress) bypass the
+  gate. On park/close, held dispatches DROP — the crash-equivalent
+  posture (memo re-miss re-fires on re-activation); firing them would
+  egress work for a dead runtime. Holds are counted
+  (`outbox.budgetDeferrals`, §7) — growth under load is the budget
+  working, not a failure.
 
 ## 6. Recovery, precisely
 
@@ -1052,8 +1066,10 @@ structureLoadRearmed, watermarkClamped,
 unstampedSealRefusals, foreignWriteRefusals, foreignEngineFailures,
 watermarkLag, events:
 {appended, processed, coalescedPerWaveMax, skippedIdempotent}, memo:
-{hits, misses, inflight}, outbox: {queued, completed, failed}, lease:
-{held, lost} }` (`structureLoadFailures`/`structureLoadDeferred`
+{hits, misses, inflight}, outbox: {queued, completed, failed,
+budgetDeferrals}, lease:
+{held, lost}, push: {prioritizedSessions, followerSessions,
+mixedFlushes} }` (`structureLoadFailures`/`structureLoadDeferred`
 count demanded-structure loads that threw / could not land yet —
 never-a-piece id classes are EXCLUDED from piece demand and count
 nothing, RULED 2026-08-07; `structureLoadFailures` also counts a
@@ -1082,7 +1098,11 @@ foreign-engine resolutions that failed and were isolated per space —
 a growing count names a foreign store that persistently cannot open,
 never a home-space outage) (`effectAcks` counts
 effect-channel ack writes, so the
-§3 amplification metric is computable from counters alone). Every
+§3 amplification metric is computable from counters alone;
+`outbox.budgetDeferrals` counts Phase-6 budget dispatch holds — §5;
+the `push` block is the memory server's Phase-6 push-priority
+counters (protocol.md §3), nested under `servingLoop` in the health
+route so the OFF-arm response never changes shape). Every
 Phase gate in the plan reads these counters; tests MUST assert on
 counters, not logs.
 

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -1088,22 +1088,92 @@ nod, 2026-08-07; recorded in the plan's stage list):**
   ≥500ms between the failure and the next input the wedge does not
   arm. Reachable only downstream of a §4 runtime error today, but
   one erroring pattern then degrades the whole space's serving
-  (waitForSettled stalls for every session). Owed: a scheduler fix
-  aligning the erroring-demanded-effect posture with the
-  erroring-derivation posture (charge, bounded retry, settle), plus
-  a regression test racing an input into the failure window; the
-  three refusal tests' absence asserts then move from fixed drains
-  to the kick-and-await-W barrier this batch had to revert.
-  Trigger: before the Phase-7 flip (a flip with a user-authorable
-  space-wide W freeze is not shippable), or the first additional
-  throwing effect builtin, whichever lands first.
+  (waitForSettled stalls for every session). Original owed: a
+  scheduler fix aligning the erroring-demanded-effect posture with
+  the erroring-derivation posture (charge, bounded retry, settle),
+  plus a regression test racing an input into the failure window;
+  the three refusal tests' absence asserts then move from fixed
+  drains to the kick-and-await-W barrier that batch had to revert.
+  DISCHARGED with Phase 6 (2026-08-14) — the repro was re-run to
+  root cause, and the recorded symptoms all traced to the OBSERVER,
+  not a scheduler posture gap:
+  (i) the reverted kick-and-await-W barriers derived their targets
+  from `Engine.serverSeq`, which counts the serving loop's own
+  derived wave echoes — and coverage NEVER claims a trailing echo on
+  a quiet space (the advance is input-driven; `#drainFeed` skips
+  self-echoes for `#coverageHead`), so the BARRIER hung, not W's
+  contract (deterministic for the fast-settling statically-demanded
+  thrower, ~1-in-4 when the echo raced the target read, disarmed by
+  a ≥500 ms gap — every recorded arm);
+  (ii) "no further charge ever appears" came from the recorded racing
+  input writing an UNRELATED doc — the thrower's registered reads
+  are path-granular, so it legitimately never re-ran (an input that
+  re-points the target re-runs and re-charges it);
+  (iii) offset sweeps 0–250 ms (overlapping commits included, 30+
+  runs) found NO genuine settled-contract stall: the
+  erroring-demanded-effect posture already matches the
+  erroring-derivation posture — charged, settled, W covers every
+  authored seq. No scheduler change was needed or made.
+  The obligation's substance landed as: the OW26 pin test racing
+  authored inputs into the failure window and asserting
+  charged/settled/W-advances directly; the three refusal tests'
+  bounded 300 ms drains RETIRED for deterministic kick-and-await-W
+  barriers with authored-seq targets (`settleAnotherWaveFamily` +
+  `authoredSeqOf` in `executor-effect-channel.test.ts` — the
+  reverted barriers' safety, restored by correct arithmetic, is the
+  discharge's acceptance evidence). Standing lesson, binding on test
+  authors: a settled-contract barrier targets the AUTHORED seq of
+  its own kick — never a server seq, which derived echoes inflate
+  (protocol §4's client-use sentence was always the contract; the
+  helper enforces it).
+
+- OW27 — binding-layer event/binding backpressure shaping (the
+  Phase-6 plan bullet's third item, FLAGGED as a design fork rather
+  than filled — 2026-08-14): README §3.8 promises "event floods
+  (key-repeat driving `stream.send()`) are rate-shaped at the binding
+  layer before they become commits", and under the flag the W4
+  last-wins collapse is DISABLED (events.ts gates it off — collapse
+  would destroy durable intent ids), so the ON arm currently has NO
+  event-flood bound at all; the two shapers that exist do not satisfy
+  §3.8 (the scheduler's WakeShaper shapes when patterns OBSERVE a
+  commit — after it exists; the UI InputTimingController reduces
+  commit volume but is per-component, defaults `immediate` for
+  boolean bindings, and is OFF-arm-visible to change). The unstated
+  semantics are exactly the escalate-don't-fill fork class: pace vs
+  batch vs drop (events are intent — dropping loses it), the hold-
+  latency bound a paced send imposes on the flooding user's own
+  legitimate rapid interactions, per-stream vs per-space keying, and
+  whether UI timing defaults may change (user-visible in BOTH arms).
+  Candidate resolutions, costs recorded: (a) client-side send pacing
+  in the flag-gated append path (token bucket per stream, pace-never-
+  drop — OFF-arm untouched by construction; chooses a latency bound);
+  (b) batch coalescing — N held sends commit as ONE authored commit
+  carrying N event appends (intent preserved, commit RATE bounded;
+  touches fresh Phase-3 admission machinery and the offline-queue
+  discharge path); (c) UI-layer defaults (flag-reach into packages/ui
+  — rejected shape unless gated). Owed: the owner's semantics ruling,
+  then the implementation with its tests. Trigger: before the
+  Phase-7 flip (the ON arm ships with no event-flood bound until
+  then; W4's cheap guard still bounds the OFF arm).
 
 **Phase 6 (the contract is fixed now, the check lands with
 hardening):**
 
-- OW8 — push priority: subscribed derived rows flush before
-  bookkeeping/bulk (README §3.3, protocol §3). Counter/ordering
-  assertion in `sx2-scale`.
+- OW8 — LANDED with Phase 6 (2026-08-14): `noteExecutorCommit`
+  classifies derived commits' dirty keys, and the fan-out runs two
+  phases per flush batch — every connection's derived-subscribed
+  sessions evaluate and send before any bulk-only session (protocol
+  §3's implementation-shape note carries the frame/marker rationale).
+  The ORDERING half pins deterministically at the unit level
+  (`packages/memory/test/v2-push-priority.test.ts` —
+  registration-order-adversarial, mutation-probed against the
+  reverted split, with vacuous-arm negatives); the COUNTER half rides
+  `sx2-scale` (`servingLoop.push.*` present and sane in the ON arm) —
+  split deliberately: a live mixed batch needs derived and bulk
+  novelty in one flush window, which wall-clock integration timing
+  cannot force reliably. Original obligation: push priority —
+  subscribed derived rows flush before bookkeeping/bulk (README §3.3,
+  protocol §3), counter/ordering assertion in `sx2-scale`.
 
 Delta 2026-08-10 — Phase 3 (events-down, D-v2-1; the phase PR):
 
@@ -1950,6 +2020,47 @@ delta):
   loudly rather than silently degrading a durability declaration).
   OW20 stands unchanged (browser adapter + queue debts, trigger: the
   sessionId persistence work).
+
+Delta 2026-08-14 — Phase 6 (push priority, budgets, scale; the phase
+PR):
+
+- protocol §3's push-priority row: IMPL-GATE → COVERED. The
+  implementation-shape note added to §3 (session-chain ordering,
+  two-phase fan-out, whole-frame-at-derived-priority for mixed
+  frames, the INV-5 rationale against frame splitting) is +1 binding
+  sentence; its pins are the memory unit suite's
+  registration-order-adversarial ordering test (mutation-probed
+  against the reverted split) and `sx2-scale`'s counter half
+  (OW8's row above carries the split rationale).
+- serving-loop §5's budget-hooks row: IMPL-GATE → COVERED. The §5
+  rewrite (+1 binding sentence set) names the mechanism: outstanding
+  cap + egress token bucket as `SpaceServerPolicy` knobs, env-wired
+  in the toolshed bootstrap (`SERVER_EXECUTION_MAX_OUTSTANDING_EFFECTS`
+  default 16, `SERVER_EXECUTION_EGRESS_RATE_PER_S` default unpaced,
+  `SERVER_EXECUTION_FLUSH_DEADLINE_MS` for T_flush — the §3 "tuned in
+  Phase 6" knob's landing), eager in-flight registration with
+  dispatch-only deferral, the sqlite-query LOCAL exemption, and
+  drop-on-park. Pins: `executor-outbox-budget.test.ts` (cap + FIFO
+  drain, local exemption, token pacing, close-drops — real-clock,
+  listed in the preload). NEW implementation surfaces below spec
+  granularity, FLAGGED in the Phase-6 PR rather than silently
+  normative: (i) the LOCAL_EFFECT_KINDS exemption set (sqlite-query
+  is the one shipped non-egress effect kind); (ii) the 16-outstanding
+  toolshed default (an operator-tunable production posture, not a
+  spec constant); (iii) `outbox.budgetDeferrals` + the
+  `servingLoop.push` counter block (§7's list updated).
+- The Phase-6 gate calibration (impl-gate, lands with `sx2-scale`):
+  the budget-isolation and flat-accumulation gates bind
+  noise-tolerant envelopes (absolute ceiling + same-box baseline
+  multiple, constants at the head of `sx2-scale.test.ts`) rather
+  than the §3.3 300 ms LAN p50, which is a quiet-box number the
+  plan's Phase-7 criterion re-measures under the §1 method; the
+  cf-checkbox in-suite≈isolated criterion is held as its SUBSTANCE
+  (server latency flat as spaces accumulate) measured headlessly —
+  the v1 mechanism was never pinned and the browser-context timing
+  rides the ordinary suite.
+- OW26's discharge and the OW27 flag are recorded in their register
+  rows above (§3).
 
 ## 4. Standing rule
 

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -1095,8 +1095,9 @@ nod, 2026-08-07; recorded in the plan's stage list):**
   the three refusal tests' absence asserts then move from fixed
   drains to the kick-and-await-W barrier that batch had to revert.
   DISCHARGED with Phase 6 (2026-08-14) — the repro was re-run to
-  root cause, and the recorded symptoms all traced to the OBSERVER,
-  not a scheduler posture gap:
+  root cause, and every symptom that REPRODUCED traced to the
+  OBSERVER, not a scheduler posture gap (one recorded symptom did
+  not reproduce at all — the residual below):
   (i) the reverted kick-and-await-W barriers derived their targets
   from `Engine.serverSeq`, which counts the serving loop's own
   derived wave echoes — and coverage NEVER claims a trailing echo on
@@ -1114,6 +1115,40 @@ nod, 2026-08-07; recorded in the plan's stage list):**
   erroring-demanded-effect posture already matches the
   erroring-derivation posture — charged, settled, W covers every
   authored seq. No scheduler change was needed or made.
+  (iv — recorded 2026-08-15, from the Phase-6 independent review)
+  The original record's computed-control contrast ("a throwing
+  computed under the IDENTICAL schedule does not wedge", above) was
+  ALSO observer read-timing, not a product asymmetry: the review's
+  directed computed-control probe — a throwing `computed` under the
+  identical schedule and the same flawed `serverSeq` arithmetic, run
+  at both the Phase-6 base and head — froze IDENTICALLY (same
+  watermark-only echoes, same frozen wrong-class target, same
+  instant coverage of the input's own authored seq). The original
+  control's barrier simply read its target BEFORE the trailing echo
+  landed. So the two postures are symmetric from BOTH directions —
+  erroring demanded-effect and erroring derivation are each charged,
+  settled, and W covers every authored seq — which is the
+  discharge's central claim; the review's main probe added the
+  product-liveness discriminator the original observation lacked
+  (during the recorded "wedge" state the product accepts and settles
+  a fresh authored input in ~50 ms, at base and head alike).
+  RESIDUAL (keep watching): the original record's "every subsequent
+  flush exhausts its deadline" was NOT reproduced — it is
+  unexplained, not explained: `wavesBudgetExhausted` stayed 0 in
+  every armed wedge-schedule state across the root-cause re-runs and
+  the independent review's probes (base and head). By mechanism the
+  recorded ingredients cannot produce it (an erroring action writes
+  nothing, so it cannot re-dirty itself, and budget backoff defers
+  invalid actions out of the dirty pull set), and real-load
+  exhaustion — normal and benign, observed under the sx2-scale
+  flood — is a plausible mundane source of the original observation.
+  This row REOPENS if a schedule surfaces where W genuinely stalls
+  below an authored seq; the OW26 pin suite in
+  `executor-effect-channel.test.ts` is the resurface point.
+  (Correction 2026-08-15: this residual previously lived only in the
+  Phase-6 PR body — the self-review's claim that the discharge text
+  carried it was wrong; the register is the canon and now carries
+  it.)
   The obligation's substance landed as: the OW26 pin test racing
   authored inputs into the failure window and asserting
   charged/settled/W-advances directly; the three refusal tests'
@@ -1125,7 +1160,13 @@ nod, 2026-08-07; recorded in the plan's stage list):**
   authors: a settled-contract barrier targets the AUTHORED seq of
   its own kick — never a server seq, which derived echoes inflate
   (protocol §4's client-use sentence was always the contract; the
-  helper enforces it).
+  helper enforces it). The lesson is also PINNED in-suite
+  (2026-08-15, from the Phase-6 independent review): every barrier
+  waits for the trailing derived echo to land BEFORE reading its
+  target, because pre-echo a `serverSeq`-degraded target is correct
+  by accident and the whole suite stayed green under that
+  degradation; post-echo the degraded arithmetic times out at every
+  barrier (mutation-verified red at all four sites, green restored).
 
 - OW27 — binding-layer event/binding backpressure shaping (the
   Phase-6 plan bullet's third item, FLAGGED as a design fork rather
@@ -1791,7 +1832,9 @@ Delta 2026-08-11 — Phase 4 (the client-effect channel; the phase PR):
   after a restart surfaces the same loud error (nothing further is
   lost — its navigation already happened), and the throw is the
   first deterministic thrower on a DEMANDED effect node, exposing
-  the pre-existing OW26 scheduler wedge above;
+  the pre-existing OW26 scheduler wedge above (as recorded at the
+  time; DISCHARGED with Phase 6 as an observer artifact, not a
+  scheduler wedge — see the OW26 row);
   (P1-4) the ack WIRE SHAPE (`acks[nonce]` map vs protocol.md §5's
   scalar `{ ackedNonce }`) was PENDING OWNER RATIFICATION — neither
   the spec nor the implementation was touched; the plan doc's
@@ -2061,6 +2104,26 @@ PR):
   rides the ordinary suite.
 - OW26's discharge and the OW27 flag are recorded in their register
   rows above (§3).
+
+Delta 2026-08-15 — Phase 6 independent-review fixes (same PR):
+
+- OW26's row: the computed-control arm reconciled (observer
+  read-timing, probed at base and head) and the flush-deadline
+  residual moved INTO the register (it had lived only in the PR
+  body); the standing lesson is now pinned in-suite — every
+  kick-and-await-W barrier in `executor-effect-channel.test.ts` reads
+  its target after the trailing echo, so the `serverSeq` regression
+  class is deterministically red (mutation-verified at all four
+  barrier sites).
+- serving-loop §5's env-knob sentence gained +1 binding clause: the
+  outstanding-effect cap's env parse is FAIL-CLOSED (literal `0` is
+  the only opt-out; garbage/negative → default 16, warned). Pin:
+  `packages/toolshed/lib/server-execution.test.ts`
+  (`serverExecutionPolicyFromEnv`; the pre-fix parser mapped garbage
+  to unbounded — mutation-verified red).
+- §7's `push.*` counters are DEFINED as sessions EVALUATED per group
+  (an ordering witness, not delivered frames) — the exported type's
+  doc said "sends"; corrected, no counter change.
 
 ## 4. Standing rule
 

--- a/packages/memory/test/v2-push-priority.test.ts
+++ b/packages/memory/test/v2-push-priority.test.ts
@@ -250,7 +250,7 @@ describe("v2 push priority (Phase 6, protocol.md §3)", () => {
     }
   });
 
-  it("keeps a derived-only batch on the single pass (no split without followers)", async () => {
+  it("counts nothing for a derived-only batch (the two-phase path runs with an EMPTY follower group — a vacuous split)", async () => {
     const server = new Server({
       ...testSessionOpenServerOptions,
       store: new URL("memory://push-priority-pure"),

--- a/packages/memory/test/v2-push-priority.test.ts
+++ b/packages/memory/test/v2-push-priority.test.ts
@@ -1,0 +1,292 @@
+// Server-execution v2 Phase 6: push priority on the subscription
+// channel (protocol.md §3 — "when flushing a batch to a client socket,
+// `derived` commits touching docs that client subscribes to go first;
+// everything else follows"; verification-coverage.md OW8).
+//
+// The mechanism under test: `noteExecutorCommit` classifies a derived
+// commit's dirty keys; the fan-out then runs TWO PHASES over every
+// connection — derived-subscribed sessions evaluate and send first,
+// bulk-only sessions follow — so a big authored blob's evaluation never
+// heads-of-line a derived frame anywhere in the serialized chain. Each
+// session still gets its ONE frame per cycle — priority reorders the
+// chain, never frame content or catch-up-marker semantics.
+//
+// The ordering pin is registration-order-adversarial: the BULK
+// connection opens first, so pre-feature fan-out order (connection
+// registration order) would send bulk first — the assertion fails on
+// exactly the reverted two-phase split (the mutation probe).
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { FakeTime } from "@std/testing/time";
+import {
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  MEMORY_PROTOCOL,
+  type ResponseMessage,
+  type ServerMessage,
+  type SessionEffectMessage,
+  type SessionOpenAuthMetadata,
+  type SessionSync,
+} from "../v2.ts";
+import { Server } from "../v2/server.ts";
+import { testSessionOpenServerOptions } from "./v2-auth-test-helpers.ts";
+
+const HELLO = {
+  type: "hello",
+  protocol: MEMORY_PROTOCOL,
+  flags: getMemoryProtocolFlags(),
+} as const;
+
+type TaggedMessage = { tag: string; message: ServerMessage };
+
+/** Take the response for `requestId` out of a sink, leaving any
+ * session/effect frames (initial watch syncs) in place. */
+const takeResponse = <T>(
+  messages: ServerMessage[],
+  requestId: string,
+): ResponseMessage<T> => {
+  const index = messages.findIndex((message) =>
+    message.type === "response" &&
+    (message as ResponseMessage<T>).requestId === requestId
+  );
+  expect(index).toBeGreaterThanOrEqual(0);
+  return messages.splice(index, 1)[0] as ResponseMessage<T>;
+};
+
+/** Open one connection + one watching session, recording sends into the
+ * SHARED ordered sink (tagged) so cross-connection send order is
+ * observable. */
+const openTaggedWatchingSession = async (
+  server: Server,
+  shared: TaggedMessage[],
+  tag: string,
+  space: string,
+  docId: string,
+): Promise<string> => {
+  const own: ServerMessage[] = [];
+  const connection = server.connect((message) => {
+    own.push(message);
+    shared.push({ tag, message });
+  });
+  await connection.receive(encodeMemoryBoundary(HELLO));
+  const hello = own.shift() as { sessionOpen?: SessionOpenAuthMetadata };
+  const sessionOpen = hello.sessionOpen!;
+  await connection.receive(encodeMemoryBoundary({
+    type: "session.open",
+    requestId: `open-${tag}`,
+    space,
+    session: {},
+    invocation: {
+      aud: sessionOpen.audience,
+      challenge: sessionOpen.challenge.value,
+    },
+  }));
+  const opened = takeResponse<{ sessionId: string }>(own, `open-${tag}`);
+  expect(opened.error).toBeUndefined();
+  const sessionId = opened.ok!.sessionId;
+  await connection.receive(encodeMemoryBoundary({
+    type: "session.watch.set",
+    requestId: `watch-${tag}`,
+    space,
+    sessionId,
+    watches: [{
+      id: "root",
+      kind: "graph",
+      query: {
+        roots: [{ id: docId, selector: { path: [], schema: false } }],
+      },
+    }],
+  }));
+  takeResponse(own, `watch-${tag}`);
+  return sessionId;
+};
+
+/** The (tag, docIds) of each non-empty session/effect frame in the
+ * shared sink, in send order. */
+const effectFrames = (
+  shared: TaggedMessage[],
+): Array<{ tag: string; docIds: string[] }> =>
+  shared
+    .filter(({ message }) => message.type === "session/effect")
+    .map(({ tag, message }) => ({
+      tag,
+      docIds:
+        (((message as SessionEffectMessage).effect as SessionSync).upserts ??
+          []).map((upsert) => upsert.id),
+    }))
+    .filter((frame) => frame.docIds.length > 0);
+
+describe("v2 push priority (Phase 6, protocol.md §3)", () => {
+  let time: FakeTime;
+
+  beforeEach(() => {
+    time = new FakeTime();
+  });
+
+  afterEach(() => {
+    time.restore();
+  });
+
+  it("flushes the session subscribed to derived novelty before the bulk session, and counts the reorder", async () => {
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://push-priority-order"),
+      subscriptionRefreshDelayMs: "manual",
+    });
+    try {
+      const space = "did:key:z6Mk-push-priority-order";
+      const shared: TaggedMessage[] = [];
+      // ADVERSARIAL registration order: the bulk connection first — the
+      // pre-feature fan-out order (connection registration order) is
+      // bulk-first.
+      await openTaggedWatchingSession(
+        server,
+        shared,
+        "bulk",
+        space,
+        "of:doc:bulk",
+      );
+      await openTaggedWatchingSession(
+        server,
+        shared,
+        "derived",
+        space,
+        "of:doc:derived",
+      );
+
+      // Seed both docs and deliver the initial state, so the measured
+      // flush is the incremental one.
+      await server.writeDocument(space, "of:doc:bulk", { seeded: true });
+      await server.writeDocument(space, "of:doc:derived", { seeded: true });
+      await server.flushSessions([space]);
+      shared.length = 0;
+
+      const statsBefore = server.pushPriorityStats();
+
+      // One mixed batch: bulk novelty (a direct write — "everything
+      // else") and derived novelty (the wave-commit report path used by
+      // the serving loop's own commits).
+      await server.writeDocument(space, "of:doc:bulk", { round: 2 });
+      await server.writeDocument(space, "of:doc:derived", { round: 2 });
+      server.noteExecutorCommit({
+        space,
+        seq: 999,
+        class: "derived",
+        sessionId: "loopback:test",
+        writes: [{ id: "of:doc:derived", scopeKey: "space" }],
+      });
+      await server.flushSessions([space]);
+
+      const frames = effectFrames(shared);
+      expect(frames.length).toBe(2);
+      // The derived-subscribed session's frame is SENT first (protocol.md
+      // §3's push priority), despite the bulk connection registering
+      // first.
+      expect(frames[0].tag).toBe("derived");
+      expect(frames[0].docIds).toEqual(["of:doc:derived"]);
+      expect(frames[1].tag).toBe("bulk");
+      expect(frames[1].docIds).toEqual(["of:doc:bulk"]);
+
+      // The reorder is counted (testing.md §4: gates assert counters).
+      const statsAfter = server.pushPriorityStats();
+      expect(statsAfter.mixedFlushes).toBe(statsBefore.mixedFlushes + 1);
+      expect(statsAfter.prioritizedSessions).toBe(
+        statsBefore.prioritizedSessions + 1,
+      );
+      expect(statsAfter.followerSessions).toBe(
+        statsBefore.followerSessions + 1,
+      );
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("stays vacuous — single pass, no counter movement — when a batch carries no derived novelty", async () => {
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://push-priority-vacuous"),
+      subscriptionRefreshDelayMs: "manual",
+    });
+    try {
+      const space = "did:key:z6Mk-push-priority-vacuous";
+      const shared: TaggedMessage[] = [];
+      await openTaggedWatchingSession(
+        server,
+        shared,
+        "bulk",
+        space,
+        "of:doc:bulk",
+      );
+      await openTaggedWatchingSession(
+        server,
+        shared,
+        "other",
+        space,
+        "of:doc:other",
+      );
+      await server.writeDocument(space, "of:doc:bulk", { seeded: true });
+      await server.writeDocument(space, "of:doc:other", { seeded: true });
+      await server.flushSessions([space]);
+      shared.length = 0;
+
+      const statsBefore = server.pushPriorityStats();
+      await server.writeDocument(space, "of:doc:bulk", { round: 2 });
+      await server.writeDocument(space, "of:doc:other", { round: 2 });
+      await server.flushSessions([space]);
+
+      // Both sessions still get their frames, in registration order
+      // (delivery is priority-agnostic; no derived novelty = today's
+      // single pass)…
+      const frames = effectFrames(shared);
+      expect(frames.length).toBe(2);
+      expect(frames[0].tag).toBe("bulk");
+      expect(frames[1].tag).toBe("other");
+      // …and nothing counted (all-zero OFF by construction — only
+      // derived-classed batches reorder).
+      expect(server.pushPriorityStats()).toEqual(statsBefore);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("keeps a derived-only batch on the single pass (no split without followers)", async () => {
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://push-priority-pure"),
+      subscriptionRefreshDelayMs: "manual",
+    });
+    try {
+      const space = "did:key:z6Mk-push-priority-pure";
+      const shared: TaggedMessage[] = [];
+      await openTaggedWatchingSession(
+        server,
+        shared,
+        "derived",
+        space,
+        "of:doc:derived",
+      );
+      await server.writeDocument(space, "of:doc:derived", { seeded: true });
+      await server.flushSessions([space]);
+      shared.length = 0;
+
+      const statsBefore = server.pushPriorityStats();
+      await server.writeDocument(space, "of:doc:derived", { round: 2 });
+      server.noteExecutorCommit({
+        space,
+        seq: 1000,
+        class: "derived",
+        sessionId: "loopback:test",
+        writes: [{ id: "of:doc:derived", scopeKey: "space" }],
+      });
+      await server.flushSessions([space]);
+
+      // Delivered — and the split stayed vacuous (prioritized sessions
+      // existed, followers did not), so no counter movement.
+      expect(effectFrames(shared).length).toBe(1);
+      expect(server.pushPriorityStats()).toEqual(statsBefore);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -191,6 +191,33 @@ const recordSlowQueryDuration = (
 /** Returns the last N slow query/watch operations (>100ms). */
 export const getSlowQueries = (): readonly SlowQuery[] => slowQueries;
 
+/**
+ * Push-priority counters (server-execution v2 Phase 6 — protocol.md §3's
+ * "push priority" contract): when one flush batch carries BOTH derived
+ * novelty and other content, sessions subscribed to the derived docs are
+ * evaluated and sent first; everything else follows. The counters make
+ * the reorder observable (testing.md §4: gates assert counters, not
+ * logs):
+ * - `mixedFlushes` — flush batches where the split was non-vacuous
+ *   (both a prioritized and a follower group existed);
+ * - `prioritizedSessions` / `followerSessions` — session sends in each
+ *   group across those mixed batches.
+ * All-zero in the OFF arm by construction: only the serving loop's wave
+ * commits classify dirty keys as derived. Registered by the Server
+ * instance (last registration wins — one co-hosted server per process);
+ * surfaced under the health route's `servingLoop.push` block.
+ */
+export type PushPriorityStats = {
+  prioritizedSessions: number;
+  followerSessions: number;
+  mixedFlushes: number;
+};
+
+let pushPriorityStatsProvider: (() => PushPriorityStats) | undefined;
+
+export const getPushPriorityStats = (): PushPriorityStats | undefined =>
+  pushPriorityStatsProvider?.();
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
 
@@ -830,14 +857,28 @@ class Connection {
     space: string,
     dirtyIds?: ReadonlySet<string>,
     dirtyOrigins?: ReadonlyMap<string, DirtyOrigin>,
-  ): Promise<void> {
+    // Push priority (Phase 6, protocol.md §3): when the flush batch
+    // carries derived novelty, the fan-out runs this connection TWICE —
+    // a "prioritized" phase over sessions subscribed to the derived
+    // keys, then a "followers" phase over the rest — so derived frames
+    // clear the whole serialized send chain ahead of bulk evaluation.
+    // A session's single frame still carries its whole covered batch:
+    // priority orders the chain, never frame content or catch-up-marker
+    // semantics. Absent phase = today's single pass. Returns the number
+    // of sessions this call evaluated (the split-vacuity witness).
+    phase?: {
+      derivedDirty: ReadonlySet<string>;
+      group: "prioritized" | "followers";
+    },
+  ): Promise<number> {
     if (this.#closed) {
-      return;
+      return 0;
     }
 
+    let processed = 0;
     for (const { space: sessionSpace, sessionId } of this.#sessions.values()) {
       if (this.#closed) {
-        return;
+        return processed;
       }
       // A construction intentionally reuses one authenticated session id in
       // every space. Dirty refresh is still space-specific: syncing that id
@@ -846,6 +887,20 @@ class Connection {
       if (sessionSpace !== space) {
         continue;
       }
+      if (phase !== undefined) {
+        // Membership is re-read per phase; a prioritized session keeps
+        // tracking its delivered derived docs (trackedIds persist), so
+        // the phases stay disjoint across the back-to-back calls.
+        const prioritized = this.server.sessionTracksAny(
+          space,
+          sessionId,
+          phase.derivedDirty,
+        );
+        if (prioritized !== (phase.group === "prioritized")) {
+          continue;
+        }
+      }
+      processed += 1;
       const effect = await this.server.syncSessionForConnection(
         space,
         sessionId,
@@ -859,7 +914,7 @@ class Connection {
         if (effect !== null) {
           this.server.rollbackUndeliveredSync(space, sessionId, effect);
         }
-        return;
+        return processed;
       }
       // ACL revocation can remove the session while watch evaluation awaits
       // its engine. Never emit the already-computed effect after that removal
@@ -886,6 +941,7 @@ class Connection {
         }
       }
     }
+    return processed;
   }
 
   close(): void {
@@ -913,6 +969,23 @@ export class Server {
   #dirtySpaces = new Set<string>();
   #dirtyDocsBySpace = new Map<string, Set<string>>();
   #dirtyOriginsBySpace = new Map<string, Map<string, DirtyOrigin>>();
+  // Push priority (Phase 6, protocol.md §3): the subset of each space's
+  // dirty keys whose LATEST novelty came from a `derived` commit — a
+  // PARALLEL annotation, deliberately not a `DirtyOrigin` field: the
+  // origin record is load-bearing for own-echo suppression and is
+  // DELETED on mixed provenance (CT-1927), which must not erase the
+  // priority class. Populated only by `noteExecutorCommit` (the wave
+  // commits), consumed and cleared with the dirty batch, re-merged by
+  // the requeue arm on fan-out failure. A key later re-dirtied by an
+  // authored commit stays in the set — the doc still carries derived
+  // novelty the subscriber has not seen, and priority is best-effort
+  // ordering, never a correctness gate.
+  #derivedDirtyBySpace = new Map<string, Set<string>>();
+  #pushPriorityStats: PushPriorityStats = {
+    prioritizedSessions: 0,
+    followerSessions: 0,
+    mixedFlushes: 0,
+  };
   #refreshTurn: ArmedTurn | null = null;
   #refreshing: Promise<void> | null = null;
   // Transactions and fan-out share one publication turn per space. A verdict
@@ -1027,6 +1100,40 @@ export class Server {
   ) {
     this.#sessions = options.sessions ?? new SessionRegistry();
     this.#store = options.store;
+    // Push-priority counters (Phase 6): module-level provider for the
+    // health route, same last-registration-wins posture as the runner's
+    // serving-loop stats registry (one co-hosted server per process).
+    pushPriorityStatsProvider = () => this.pushPriorityStats();
+  }
+
+  /** A copy of the push-priority counters (Phase 6, protocol.md §3). */
+  pushPriorityStats(): PushPriorityStats {
+    return { ...this.#pushPriorityStats };
+  }
+
+  /** Whether the session currently tracks (has been delivered / watches)
+   * ANY of `keys` — the flush loop's cheap admission gate, reused by the
+   * push-priority partition (Phase 6). */
+  sessionTracksAny(
+    space: string,
+    sessionId: string,
+    keys: ReadonlySet<string>,
+  ): boolean {
+    const session = this.#sessions.get(space, sessionId);
+    if (session === null) return false;
+    for (const key of keys) {
+      if (session.trackedIds.has(key)) return true;
+    }
+    return false;
+  }
+
+  /** Count one non-vacuous push-priority reorder (Phase 6). Called by the
+   * connection's flush loop when a batch produced BOTH a prioritized and
+   * a follower group. */
+  notePushPrioritySplit(prioritized: number, followers: number): void {
+    this.#pushPriorityStats.mixedFlushes += 1;
+    this.#pushPriorityStats.prioritizedSessions += prioritized;
+    this.#pushPriorityStats.followerSessions += followers;
   }
 
   nowSeconds(): number {
@@ -4025,10 +4132,21 @@ export class Server {
    * skips its own by class + holder — serving-loop.md §3's self-echo).
    */
   noteExecutorCommit(notice: AdmittedCommitNotice): void {
-    this.markSpaceDirty(
-      notice.space,
-      notice.writes.map((write) => toDirtyKey(write.id, write.scopeKey)),
+    const keys = notice.writes.map((write) =>
+      toDirtyKey(write.id, write.scopeKey)
     );
+    // Push priority (Phase 6, protocol.md §3): the wave's derived rows
+    // are the content subscribers wait on — classify their dirty keys so
+    // the flush loop can order sessions carrying them ahead of bulk.
+    if (notice.class === "derived" && keys.length > 0) {
+      let derived = this.#derivedDirtyBySpace.get(notice.space);
+      if (derived === undefined) {
+        derived = new Set();
+        this.#derivedDirtyBySpace.set(notice.space, derived);
+      }
+      for (const key of keys) derived.add(key);
+    }
+    this.markSpaceDirty(notice.space, keys);
     this.#notifyCommitAdmitted(notice);
   }
 
@@ -4403,6 +4521,7 @@ export class Server {
       this.#dirtySpaces.clear();
       this.#dirtyDocsBySpace.clear();
       this.#dirtyOriginsBySpace.clear();
+      this.#derivedDirtyBySpace.clear();
     }
   }
 
@@ -4458,6 +4577,20 @@ export class Server {
 
       pending = undefined;
 
+      // Push priority (Phase 6, protocol.md §3): spaces carrying derived
+      // novelty flush ahead of spaces with only bulk/authored content —
+      // the cross-space half of "derived commits flush first" (the
+      // per-session half is refreshDirty's two-pass). Stable partition:
+      // insertion order is preserved within each group.
+      spaces.sort((left, right) => {
+        const leftDerived = (this.#derivedDirtyBySpace.get(left)?.size ?? 0) > 0
+          ? 0
+          : 1;
+        const rightDerived =
+          (this.#derivedDirtyBySpace.get(right)?.size ?? 0) > 0 ? 0 : 1;
+        return leftDerived - rightDerived;
+      });
+
       for (const space of spaces) {
         await this.withSpacePublicationLock(space, async () => {
           // Removed at its own processing turn (CT-1927): pre-deleting the
@@ -4473,6 +4606,12 @@ export class Server {
           if (dirtyOrigins !== undefined) {
             this.#dirtyOriginsBySpace.delete(space);
           }
+          // Push priority (Phase 6): consume the batch's derived-key
+          // classification with the batch.
+          const derivedDirty = this.#derivedDirtyBySpace.get(space);
+          if (derivedDirty !== undefined) {
+            this.#derivedDirtyBySpace.delete(space);
+          }
           // Fan-out is a scheduled/batched timer decoupled from transact, so it
           // must be its own root span. `root: true` makes that explicit — the
           // context manager propagates the active context into timer callbacks,
@@ -4487,12 +4626,42 @@ export class Server {
                 span.setAttribute("subscriber.count", this.#connections.size);
                 span.setAttribute("dirty.count", dirtyIds?.size ?? 0);
                 try {
-                  for (const connection of this.#connections.values()) {
-                    await connection.refreshDirty(
-                      space,
-                      dirtyIds,
-                      dirtyOrigins,
-                    );
+                  if (derivedDirty !== undefined && derivedDirty.size > 0) {
+                    // Push priority (Phase 6, protocol.md §3): two-phase
+                    // fan-out — every connection's derived-subscribed
+                    // sessions evaluate and send BEFORE any connection's
+                    // bulk-only sessions, so a big authored blob's
+                    // evaluation never heads-of-line a derived frame
+                    // anywhere in the serialized chain.
+                    let prioritized = 0;
+                    for (const connection of this.#connections.values()) {
+                      prioritized += await connection.refreshDirty(
+                        space,
+                        dirtyIds,
+                        dirtyOrigins,
+                        { derivedDirty, group: "prioritized" },
+                      );
+                    }
+                    let followers = 0;
+                    for (const connection of this.#connections.values()) {
+                      followers += await connection.refreshDirty(
+                        space,
+                        dirtyIds,
+                        dirtyOrigins,
+                        { derivedDirty, group: "followers" },
+                      );
+                    }
+                    if (prioritized > 0 && followers > 0) {
+                      this.notePushPrioritySplit(prioritized, followers);
+                    }
+                  } else {
+                    for (const connection of this.#connections.values()) {
+                      await connection.refreshDirty(
+                        space,
+                        dirtyIds,
+                        dirtyOrigins,
+                      );
+                    }
                   }
                 } finally {
                   span.end();
@@ -4543,6 +4712,18 @@ export class Server {
                   currentOrigins.set(id, origin);
                 }
               }
+            }
+            // Push priority (Phase 6): re-merge the consumed batch's
+            // derived classification alongside the requeued ids (union —
+            // a key derived in EITHER batch still carries undelivered
+            // derived novelty).
+            if (derivedDirty !== undefined && derivedDirty.size > 0) {
+              let currentDerived = this.#derivedDirtyBySpace.get(space);
+              if (currentDerived === undefined) {
+                currentDerived = new Set();
+                this.#derivedDirtyBySpace.set(space, currentDerived);
+              }
+              for (const id of derivedDirty) currentDerived.add(id);
             }
             this.scheduleRefresh();
             throw error;

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -200,8 +200,11 @@ export const getSlowQueries = (): readonly SlowQuery[] => slowQueries;
  * logs):
  * - `mixedFlushes` — flush batches where the split was non-vacuous
  *   (both a prioritized and a follower group existed);
- * - `prioritizedSessions` / `followerSessions` — session sends in each
- *   group across those mixed batches.
+ * - `prioritizedSessions` / `followerSessions` — sessions EVALUATED in
+ *   each group across those mixed batches (`refreshDirty`'s per-phase
+ *   count — a session is counted whether or not its evaluation produced
+ *   a frame, so a quiet co-space session counts as a follower). These
+ *   are an ORDERING witness, not a delivered-frame metric.
  * All-zero in the OFF arm by construction: only the serving loop's wave
  * commits classify dirty keys as derived. Registered by the Server
  * instance (last registration wins — one co-hosted server per process);

--- a/packages/patterns/integration/sx2-scale.test.ts
+++ b/packages/patterns/integration/sx2-scale.test.ts
@@ -24,8 +24,9 @@
 //   ON-arm stats carry the `servingLoop.push` counter block (the
 //   deterministic frame-ORDER pin lives in
 //   packages/memory/test/v2-push-priority.test.ts — a live mixed batch
-//   is timing-shaped, so the gate here asserts the counters exist and
-//   never regress, not a forced reorder);
+//   is timing-shaped, so the gate here asserts only that the counter
+//   block is WIRED in the ON arm — present and non-negative — not a
+//   forced reorder);
 // - NO POLL-LOOPS (the plan's "no integration test needs a poll-loop
 //   for 'is the server done'"): the sx2 gate family itself is audited —
 //   server-done waits ride `waitForSettled`, never text-polling.

--- a/packages/patterns/integration/sx2-scale.test.ts
+++ b/packages/patterns/integration/sx2-scale.test.ts
@@ -1,0 +1,412 @@
+// Server-execution v2 Phase 6 gate: budgets and scale, live
+// (testing.md §5's `sx2-scale`; docs/plans/server-execution-v2.md
+// Phase 6). Headless: PiecesController clients drive real patterns
+// against toolshed; in the ON arm the toolshed's ExecutorHost serves
+// the spaces and this suite asserts the Phase-6 gates from
+// `/api/health/stats` COUNTERS and watermark settles — never logs,
+// never text-polling (testing.md §3–§4):
+//
+// - BUDGET ISOLATION (the plan's "a deliberate LLM fan-out loop in one
+//   space leaves a second space's propagation latency inside budget"):
+//   space A floods NETWORK effects (a fetch fan-out against a
+//   deliberately slow local endpoint — the same egress class as an LLM
+//   fan-out, CI-runnable without provider keys), space B runs the
+//   plain counter workload; B's settle latency mid-flood stays inside
+//   budget, and A's per-space budget ENGAGES
+//   (`outbox.budgetDeferrals` counts — the fan-out exceeds the
+//   default 16-outstanding cap);
+// - FLAT ACCUMULATION (the plan's "cf-checkbox in-suite ≈ isolated",
+//   held as its substance: server latency must stay flat as spaces
+//   accumulate — v1 measured 4 s isolated vs 138 s in-suite): a fresh
+//   space's settle latency after N accumulated served spaces stays in
+//   the ballpark of the first space's;
+// - PUSH PRIORITY (protocol.md §3; verification-coverage.md OW8): the
+//   ON-arm stats carry the `servingLoop.push` counter block (the
+//   deterministic frame-ORDER pin lives in
+//   packages/memory/test/v2-push-priority.test.ts — a live mixed batch
+//   is timing-shaped, so the gate here asserts the counters exist and
+//   never regress, not a forced reorder);
+// - NO POLL-LOOPS (the plan's "no integration test needs a poll-loop
+//   for 'is the server done'"): the sx2 gate family itself is audited —
+//   server-done waits ride `waitForSettled`, never text-polling.
+//
+// OFF arm: the same workloads run client-derived (byte-identical
+// writes); the servingLoop stats block is absent, settles ride
+// `synced()`, and the ON-arm assertions are skipped explicitly.
+
+import { env } from "@commonfabric/integration";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import { assert, assertEquals } from "@std/assert";
+import { Identity } from "@commonfabric/identity";
+import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import {
+  waitForSettled,
+  watermarkCell,
+} from "@commonfabric/runner/executor/watermark";
+import type { MemorySpace } from "@commonfabric/runner";
+import {
+  initializePiecesController,
+  type PieceController,
+  type PiecesController,
+} from "./pieces-controller.ts";
+
+const { API_URL, SPACE_NAME } = env;
+
+const FLAG_ON = Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION") === "true";
+
+/** The Phase-6 budget-isolation calibration. The spec budget for the
+ * push hot path is 300 ms p50 LAN on a quiet box (README §3.3);
+ * CI boxes are neither quiet nor calibrated, so the gate binds a
+ * decisive-but-noise-tolerant envelope: absolute ceiling + a multiple
+ * of the same box's own baseline. A coupled flood (v1's failure mode)
+ * blows both by an order of magnitude. */
+const SETTLE_BUDGET_ABSOLUTE_MS = 5_000;
+const SETTLE_BUDGET_BASELINE_MULTIPLE = 5;
+const ACCUMULATION_ABSOLUTE_MS = 2_500;
+const ACCUMULATION_BASELINE_MULTIPLE = 4;
+
+/** How hard space A's fan-out floods (> the default 16-outstanding
+ * per-space cap, so the budget visibly engages in the ON arm). */
+const FLOOD_PIECES = 20;
+const SLOW_ENDPOINT_DELAY_MS = 2_500;
+
+type ServingLoopStats = {
+  waves: number;
+  authoredSeen: number;
+  effectAcks: number;
+  derivedCommits: number;
+  outbox: {
+    queued: number;
+    completed: number;
+    failed: number;
+    budgetDeferrals: number;
+  };
+  push?: {
+    prioritizedSessions: number;
+    followerSessions: number;
+    mixedFlushes: number;
+  };
+};
+
+const fetchServingLoopStats = async (): Promise<
+  ServingLoopStats | undefined
+> => {
+  const response = await fetch(new URL("/api/health/stats", API_URL));
+  const body = await response.json() as { servingLoop?: ServingLoopStats };
+  return body.servingLoop;
+};
+
+/** Bounded counter read (the two-producer notice hop — see
+ * sx2-serving-loop): the CONDITION is a counter predicate, the wait
+ * gives the in-process notice its beat to drain. */
+const waitForStats = async (
+  predicate: (stats: ServingLoopStats) => boolean,
+  label: string,
+  timeoutMs = 20_000,
+): Promise<ServingLoopStats> => {
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    const stats = await fetchServingLoopStats();
+    if (stats !== undefined && predicate(stats)) return stats;
+    if (Date.now() > deadline) {
+      throw new Error(
+        `timed out waiting for ${label} — last stats: ${JSON.stringify(stats)}`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+};
+
+/** A fetch fan-out piece: one network effect per piece, distinct URL →
+ * distinct memo key → a real per-piece egress. */
+const FLOOD_PATTERN = [
+  "import { fetchJson, pattern } from 'commonfabric';",
+  "export default pattern<{ url: string }, { status: string }>(",
+  "  ({ url }) => {",
+  "    const data = fetchJson<{ ok?: boolean }>({ url });",
+  "    return { status: data.result ? 'done' : 'pending' };",
+  "  },",
+  ");",
+].join("\n");
+
+describe("sx2 scale (Phase 6 gates)", () => {
+  let slowServer: Deno.HttpServer | undefined;
+  let slowPort = 0;
+  const controllers: PiecesController[] = [];
+
+  const newController = async (suffix: string): Promise<PiecesController> => {
+    const identity = await Identity.generate({ implementation: "noble" });
+    const controller = await initializePiecesController({
+      spaceName: `${SPACE_NAME}-sx2-scale-${suffix}`,
+      apiUrl: new URL(API_URL),
+      identity,
+    });
+    controllers.push(controller);
+    return controller;
+  };
+
+  /** Stand up the counter pattern with a live reader (the demand the
+   * serving loop maps server-side), returning a measured settle:
+   * one authored write to `value`, then the arm-appropriate settle —
+   * watermark (ON) or synced (OFF) — timed. */
+  const standUpCounter = async (
+    cc: PiecesController,
+  ): Promise<{
+    piece: PieceController;
+    cancel: () => void;
+    settleWrite: (value: number) => Promise<number>;
+  }> => {
+    const sourcePath = join(
+      import.meta.dirname!,
+      "..",
+      "counter",
+      "counter.tsx",
+    );
+    const program = await cc.runtime.harness.resolve(
+      new FileSystemProgramResolver(sourcePath),
+    );
+    const piece = await cc.create(program, { start: true });
+    const resultCell = cc.getResult(piece.getCell());
+    const cancel = resultCell.sink(() => {});
+    const runtime = cc.runtime;
+    const space = piece.getCell().getAsNormalizedFullLink()
+      .space as MemorySpace;
+    if (FLAG_ON) {
+      await runtime.storageManager.synced();
+      await waitForSettled(runtime, space, 1, { timeoutMs: 30_000 });
+    } else {
+      await runtime.storageManager.synced();
+    }
+    const settleWrite = async (value: number): Promise<number> => {
+      const startedAt = Date.now();
+      // The settled target derives from the OBSERVED pre-write
+      // watermark (the sx2-serving-loop shape): the write advances the
+      // space head by ≥1, so W must pass watermarkBefore. Never a
+      // server-seq-derived target — those count the loop's own derived
+      // echoes, which coverage never claims on a quiet space (the OW26
+      // lesson).
+      const watermarkBefore = FLAG_ON
+        ? ((watermarkCell(runtime, space).get() as
+          | { seq?: number }
+          | undefined)?.seq ?? 0)
+        : 0;
+      const tx = runtime.edit();
+      resultCell.withTx(tx).key("value").set(value);
+      const committed = await tx.commit();
+      if (committed.error !== undefined) {
+        throw new Error(`authored write failed: ${committed.error.message}`);
+      }
+      await runtime.storageManager.synced();
+      if (FLAG_ON) {
+        await waitForSettled(runtime, space, watermarkBefore + 1, {
+          timeoutMs: 30_000,
+        });
+      }
+      return Date.now() - startedAt;
+    };
+    return { piece, cancel, settleWrite };
+  };
+
+  beforeAll(() => {
+    // The deliberately slow local endpoint the fan-out floods — the
+    // stand-in for a slow LLM provider, CI-runnable with no keys.
+    slowServer = Deno.serve(
+      { port: 0, onListen: () => {} },
+      async () => {
+        await new Promise((resolve) =>
+          setTimeout(resolve, SLOW_ENDPOINT_DELAY_MS)
+        );
+        return new Response(JSON.stringify({ ok: true }), {
+          headers: { "content-type": "application/json" },
+        });
+      },
+    );
+    slowPort = (slowServer.addr as Deno.NetAddr).port;
+  });
+
+  afterAll(async () => {
+    for (const controller of controllers) {
+      await controller.dispose();
+    }
+    await slowServer?.shutdown();
+  });
+
+  it("a hostile effect fan-out in space A leaves space B's propagation inside budget, and A's per-space budget engages (Phase 6)", async () => {
+    const ccB = await newController("quiet");
+    const counterB = await standUpCounter(ccB);
+
+    // Baseline: B's settle latency on a quiet server (3 reps, take the
+    // max — counters and set relations over single-shot latencies).
+    let baseline = 0;
+    for (const value of [1, 2, 3]) {
+      baseline = Math.max(baseline, await counterB.settleWrite(value));
+    }
+
+    const statsBefore = FLAG_ON ? await fetchServingLoopStats() : undefined;
+    if (FLAG_ON) {
+      assert(
+        statsBefore !== undefined,
+        "the ON arm must expose the servingLoop stats block",
+      );
+    }
+
+    // The flood: FLOOD_PIECES fetch fan-out pieces in space A, each a
+    // distinct slow URL (distinct memo keys — real per-piece egress),
+    // each with a live reader (the demand that makes the ON arm serve
+    // its effect).
+    const ccA = await newController("flood");
+    // The first create compiles (and caches) the pattern; the rest run
+    // CONCURRENTLY so the fan-out's effect admissions BUNCH — a serial
+    // create chain spreads them past the slow endpoint's window and >16
+    // are never outstanding at once, making the budget witness flaky.
+    const compiledOnce = await ccA.create(FLOOD_PATTERN, {
+      start: true,
+      input: { url: `http://127.0.0.1:${slowPort}/slow/seed` },
+    });
+    const floodCancels: Array<() => void> = [];
+    floodCancels.push(ccA.getResult(compiledOnce.getCell()).sink(() => {}));
+    const rest = await Promise.all(
+      Array.from(
+        { length: FLOOD_PIECES - 1 },
+        (_, index) =>
+          ccA.create(FLOOD_PATTERN, {
+            start: true,
+            input: { url: `http://127.0.0.1:${slowPort}/slow/${index + 1}` },
+          }),
+      ),
+    );
+    for (const piece of rest) {
+      floodCancels.push(ccA.getResult(piece.getCell()).sink(() => {}));
+    }
+    await ccA.runtime.storageManager.synced();
+
+    // Space B's propagation DURING the flood: the isolation gate.
+    let midFlood = 0;
+    for (const value of [10, 20, 30]) {
+      midFlood = Math.max(midFlood, await counterB.settleWrite(value));
+    }
+    assert(
+      midFlood <= SETTLE_BUDGET_ABSOLUTE_MS,
+      `space B settle ${midFlood}ms mid-flood exceeds the absolute ` +
+        `${SETTLE_BUDGET_ABSOLUTE_MS}ms budget — the fan-out coupled ` +
+        "across spaces (Phase 6's isolation gate)",
+    );
+    assert(
+      midFlood <=
+        Math.max(
+          baseline * SETTLE_BUDGET_BASELINE_MULTIPLE,
+          SETTLE_BUDGET_ABSOLUTE_MS / 2,
+        ),
+      `space B settle ${midFlood}ms mid-flood vs baseline ${baseline}ms ` +
+        "exceeds the relative budget — the fan-out coupled across spaces",
+    );
+
+    if (FLAG_ON) {
+      // The per-space budget ENGAGED: the fan-out exceeds the default
+      // 16-outstanding cap, so dispatch holds were counted. This is
+      // the counter witness that the flood really rode the budget
+      // gate (a vacuously-quiet flood would prove nothing).
+      await waitForStats(
+        (stats) =>
+          stats.outbox.budgetDeferrals >
+            (statsBefore?.outbox.budgetDeferrals ?? 0),
+        "space A's fan-out to engage the per-space budget " +
+          "(outbox.budgetDeferrals)",
+        60_000,
+      );
+    }
+
+    for (const cancel of floodCancels) cancel();
+    counterB.cancel();
+  });
+
+  it("propagation latency stays flat as served spaces accumulate (the suite-context degradation gate)", async () => {
+    // Baseline: the first fresh space.
+    const first = await standUpCounter(await newController("acc-first"));
+    let baseline = 0;
+    for (const value of [1, 2]) {
+      baseline = Math.max(baseline, await first.settleWrite(value));
+    }
+    first.cancel();
+
+    // Accumulate: N more served spaces, each with real work.
+    for (let index = 0; index < 8; index++) {
+      const accumulated = await standUpCounter(
+        await newController(`acc-${index}`),
+      );
+      await accumulated.settleWrite(1);
+      accumulated.cancel();
+    }
+
+    // The late fresh space: latency must stay in the first one's
+    // ballpark (v1's suite-context degradation was 34×).
+    const late = await standUpCounter(await newController("acc-late"));
+    let lateLatency = 0;
+    for (const value of [1, 2]) {
+      lateLatency = Math.max(lateLatency, await late.settleWrite(value));
+    }
+    late.cancel();
+    assert(
+      lateLatency <=
+        Math.max(
+          baseline * ACCUMULATION_BASELINE_MULTIPLE,
+          ACCUMULATION_ABSOLUTE_MS,
+        ),
+      `late-space settle ${lateLatency}ms vs first-space ${baseline}ms — ` +
+        "server latency accumulated with space count (the v1 " +
+        "suite-context degradation class)",
+    );
+  });
+
+  it("carries the push-priority counters in the ON arm (protocol.md §3; OW8's counter half)", async () => {
+    if (!FLAG_ON) {
+      assertEquals(await fetchServingLoopStats(), undefined);
+      return;
+    }
+    const stats = await fetchServingLoopStats();
+    assert(stats !== undefined);
+    // The counter block exists and is sane; the deterministic ORDER pin
+    // is unit-level (packages/memory/test/v2-push-priority.test.ts) —
+    // a live mixed batch needs derived and bulk novelty in ONE flush
+    // window, which wall-clock timing cannot force reliably here.
+    assert(
+      stats.push !== undefined,
+      "the ON-arm servingLoop stats must carry the push-priority block",
+    );
+    assert(stats.push.prioritizedSessions >= 0);
+    assert(stats.push.followerSessions >= 0);
+    assert(stats.push.mixedFlushes >= 0);
+  });
+
+  it("keeps the sx2 gate family free of server-done poll-loops (testing.md §3)", async () => {
+    // The Phase-6 criterion "no integration test needs a poll-loop for
+    // 'is the server done'", enforced where this train owns the tests:
+    // the sx2 gate family settles via the watermark. Bounded
+    // counter-condition waits (waitForStats) and value-arrival reads
+    // after a settle are NOT server-done polls; `waitForCondition` and
+    // raw settle-by-sleep are.
+    const dir = import.meta.dirname!;
+    // Built indirectly so this file's own audit does not self-flag on
+    // its assertion message.
+    const pollNeedle = ["waitForCondition", "("].join("");
+    for await (const entry of Deno.readDir(dir)) {
+      if (!entry.name.startsWith("sx2-") || !entry.name.endsWith(".test.ts")) {
+        continue;
+      }
+      const source = await Deno.readTextFile(join(dir, entry.name));
+      assert(
+        !source.includes(pollNeedle),
+        `${entry.name} polls with ${pollNeedle}) — use waitForSettled ` +
+          "(testing.md §3)",
+      );
+      if (entry.name !== "sx2-scale.test.ts") {
+        assert(
+          source.includes("waitForSettled"),
+          `${entry.name} must settle via the watermark helper ` +
+            "(testing.md §3)",
+        );
+      }
+    }
+  });
+});

--- a/packages/runner/src/executor/outbox.ts
+++ b/packages/runner/src/executor/outbox.ts
@@ -69,7 +69,11 @@ export type OutboxBudgetPolicy = {
   /** Cap on DISPATCHED-but-unsettled network effects. Admitted effects
    * over the cap hold their dispatch (FIFO wake order) until a slot
    * frees; the in-flight dedupe entry exists from ADMISSION either way,
-   * so re-admits attach instead of double-firing. */
+   * so re-admits attach instead of double-firing. Undefined = unbounded.
+   * CAUTION for direct callers: `0` is NOT "unbounded" here — it holds
+   * every network dispatch forever (no slot can ever free). The env
+   * path never produces it (the toolshed bootstrap maps a literal env
+   * `0` to ABSENT — `serverExecutionPolicyFromEnv`). */
   maxOutstandingEffects?: number;
   /** Egress pacing: network-effect dispatches per second (token bucket
    * with burst = one second's tokens, minimum 1). */
@@ -261,7 +265,12 @@ export class SpaceOutbox {
   /** Park/teardown (Phase 6): admitted-but-held dispatches are dropped
    * — every waiter wakes into the closed check — and nothing new
    * dispatches. In-flight work is not awaited (park never awaits the
-   * network), exactly the pre-budget posture. */
+   * network), exactly the pre-budget posture. Accounting note: a
+   * dropped hold was counted `queued` at admission but is neither
+   * `completed` nor `failed` (it never dispatched), so after a park
+   * `outbox.queued` may exceed `completed + failed` by the drop count.
+   * No gate binds that identity; the drop is the sanctioned
+   * crash-equivalent posture (memo re-miss re-fires on re-activation). */
   close(): void {
     if (this.#closed) return;
     this.#closed = true;

--- a/packages/runner/src/executor/outbox.ts
+++ b/packages/runner/src/executor/outbox.ts
@@ -58,6 +58,33 @@ export interface SealedEffectBatch {
   context: WaveRunContext | undefined;
 }
 
+/** Per-space egress budgets (Phase 6 — serving-loop.md §5's
+ * "outstanding-effect caps, egress rate"; README §3.8's multi-tenancy
+ * contract: a runaway pattern degrades only its own space). Applied to
+ * NETWORK effect kinds only — a local kind (sqlite-query) egresses
+ * nothing and throttling it would only starve local DB work. Both
+ * knobs default UNBOUNDED (today's behavior); the toolshed bootstrap
+ * sets production values from env. */
+export type OutboxBudgetPolicy = {
+  /** Cap on DISPATCHED-but-unsettled network effects. Admitted effects
+   * over the cap hold their dispatch (FIFO wake order) until a slot
+   * frees; the in-flight dedupe entry exists from ADMISSION either way,
+   * so re-admits attach instead of double-firing. */
+  maxOutstandingEffects?: number;
+  /** Egress pacing: network-effect dispatches per second (token bucket
+   * with burst = one second's tokens, minimum 1). */
+  egressRatePerSecond?: number;
+  /** Test clock (defaults to Date.now). */
+  now?: () => number;
+};
+
+/** Local (non-egress) effect kinds exempt from the budget gate — an
+ * implementation choice FLAGGED in the Phase-6 PR: the spec names the
+ * budget's targets by example ("outstanding LLM calls, egress rate"),
+ * and sqlite-query is the one shipped effect kind with no network
+ * egress. */
+const LOCAL_EFFECT_KINDS = new Set(["sqlite-query"]);
+
 export class SpaceOutbox {
   readonly #stats: ServingLoopStats;
   readonly #server: MemoryServer;
@@ -102,6 +129,19 @@ export class SpaceOutbox {
    * effect (fetch/llm callbacks return synchronously after starting
    * it), and outbox.completed counts only when it settles. */
   #capturing: Array<Promise<unknown>> | undefined;
+  // Per-space egress budgets (Phase 6, serving-loop.md §5).
+  readonly #budget: OutboxBudgetPolicy | undefined;
+  readonly #now: () => number;
+  /** DISPATCHED-but-unsettled network effects (the outstanding cap's
+   * subject; local kinds bypass the gate and are never counted). */
+  #outstanding = 0;
+  /** FIFO of admitted-but-held dispatch starters, woken one per freed
+   * slot (and drained wholesale on close — the park path). */
+  readonly #dispatchWaiters: Array<() => void> = [];
+  /** Token bucket for the egress rate (burst = one second's tokens). */
+  #egressTokens = 0;
+  #egressRefilledAt = 0;
+  #closed = false;
 
   constructor(options: {
     stats: ServingLoopStats;
@@ -117,6 +157,8 @@ export class SpaceOutbox {
     /** The host's process-lifetime localSeq counter, shared with the
      * wave sink (the replay-keying discipline — engine-wave-sink.ts). */
     localSeqRef: { value: number };
+    /** Per-space egress budgets (Phase 6); absent = unbounded. */
+    budget?: OutboxBudgetPolicy;
   }) {
     this.#stats = options.stats;
     this.#server = options.server;
@@ -124,6 +166,108 @@ export class SpaceOutbox {
     this.#space = options.space;
     this.#sessionId = options.sessionId;
     this.#localSeqRef = options.localSeqRef;
+    this.#budget = options.budget;
+    this.#now = options.budget?.now ?? Date.now;
+    this.#egressRefilledAt = this.#now();
+    this.#egressTokens = this.#burstCapacity();
+  }
+
+  #burstCapacity(): number {
+    const rate = this.#budget?.egressRatePerSecond;
+    if (rate === undefined || rate <= 0) return Number.POSITIVE_INFINITY;
+    return Math.max(1, Math.floor(rate));
+  }
+
+  /** Continuous refill up to the burst capacity. */
+  #refillEgressTokens(): void {
+    const rate = this.#budget?.egressRatePerSecond;
+    if (rate === undefined || rate <= 0) return;
+    const now = this.#now();
+    const elapsed = Math.max(0, now - this.#egressRefilledAt);
+    if (elapsed <= 0) return;
+    this.#egressTokens = Math.min(
+      this.#burstCapacity(),
+      this.#egressTokens + (elapsed / 1000) * rate,
+    );
+    this.#egressRefilledAt = now;
+  }
+
+  /** Ms until one egress token is available (0 when unpaced). */
+  #msUntilEgressToken(): number {
+    const rate = this.#budget?.egressRatePerSecond;
+    if (rate === undefined || rate <= 0) return 0;
+    this.#refillEgressTokens();
+    if (this.#egressTokens >= 1) return 0;
+    return Math.ceil(((1 - this.#egressTokens) / rate) * 1000);
+  }
+
+  /** Whether the budget gate applies to this effect (network kinds
+   * only). */
+  #budgeted(effect: PostCommitSideEffect): boolean {
+    if (this.#budget === undefined) return false;
+    if (
+      this.#budget.maxOutstandingEffects === undefined &&
+      (this.#budget.egressRatePerSecond === undefined ||
+        this.#budget.egressRatePerSecond <= 0)
+    ) {
+      return false;
+    }
+    return !LOCAL_EFFECT_KINDS.has(effect.kind);
+  }
+
+  /**
+   * Hold until a dispatch slot AND an egress token are available (FIFO
+   * wake for the cap; timer wake for the rate). Returns false when the
+   * outbox closed while holding — the park path: the deferred dispatch
+   * is DROPPED, the sanctioned crash-equivalent posture (the effect
+   * re-misses from its memo key on re-activation; firing against a
+   * dying runtime would egress work for a dead space).
+   */
+  async #acquireDispatchSlot(): Promise<boolean> {
+    while (true) {
+      if (this.#closed) return false;
+      const cap = this.#budget?.maxOutstandingEffects;
+      if (cap !== undefined && this.#outstanding >= cap) {
+        this.#stats.outbox.budgetDeferrals += 1;
+        await new Promise<void>((resolve) =>
+          this.#dispatchWaiters.push(resolve)
+        );
+        continue;
+      }
+      const waitMs = this.#msUntilEgressToken();
+      if (waitMs > 0) {
+        this.#stats.outbox.budgetDeferrals += 1;
+        await new Promise((resolve) => setTimeout(resolve, waitMs));
+        continue;
+      }
+      if (this.#egressTokens !== Number.POSITIVE_INFINITY) {
+        this.#egressTokens = Math.max(0, this.#egressTokens - 1);
+      }
+      this.#outstanding += 1;
+      return true;
+    }
+  }
+
+  #releaseDispatchSlot(): void {
+    this.#outstanding = Math.max(0, this.#outstanding - 1);
+    this.#dispatchWaiters.shift()?.();
+  }
+
+  /** DIAGNOSTIC (tests): dispatched-but-unsettled network effects. */
+  get outstandingCount(): number {
+    return this.#outstanding;
+  }
+
+  /** Park/teardown (Phase 6): admitted-but-held dispatches are dropped
+   * — every waiter wakes into the closed check — and nothing new
+   * dispatches. In-flight work is not awaited (park never awaits the
+   * network), exactly the pre-budget posture. */
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    while (this.#dispatchWaiters.length > 0) {
+      this.#dispatchWaiters.shift()?.();
+    }
   }
 
   /** The runtime's async-work observer hook (installed by the
@@ -197,7 +341,18 @@ export class SpaceOutbox {
         if (batch.context !== undefined) {
           this.#carriage.set(key, batch.context);
         }
-        const work = this.#runEffect(key, effect, batch.tx);
+        // The in-flight entry (dedupe/carriage/retirement) exists from
+        // ADMISSION; only the DISPATCH defers behind the Phase-6 budget
+        // gate — a re-admit during the hold attaches to this entry
+        // instead of double-firing (the eager-registration contract).
+        const work = this.#budgeted(effect)
+          ? this.#acquireDispatchSlot().then((acquired) =>
+            acquired
+              ? this.#runEffect(key, effect, batch.tx)
+                .finally(() => this.#releaseDispatchSlot())
+              : undefined
+          )
+          : this.#runEffect(key, effect, batch.tx);
         const retirement = work.catch(() => undefined)
           .then(() => this.#awaitRetireBarriers(key))
           .finally(() => {

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -91,8 +91,8 @@ import type {
 } from "../storage/interface.ts";
 import type { CommitError } from "../storage/interface.ts";
 import {
-  type EnsurePieceVerdict,
   ensurePieceRunningVerdict,
+  type EnsurePieceVerdict,
 } from "../ensure-piece-running.ts";
 import {
   stampWaveRunContext,
@@ -131,8 +131,16 @@ const EFFECTS_RETIREMENT_ACTION_ID = "server-execution/effects-retirement";
 
 export type SpaceServerPolicy = {
   /** serving-loop.md §3's consequence-flush deadline T_flush (order
-   * 50–100 ms; a policy knob tuned in Phase 6). */
+   * 50–100 ms; a policy knob tuned in Phase 6 — the toolshed bootstrap
+   * reads SERVER_EXECUTION_FLUSH_DEADLINE_MS). */
   flushDeadlineMs?: number;
+  /** Phase 6 (serving-loop.md §5's per-space budgets; README §3.8):
+   * cap on dispatched-but-unsettled NETWORK effects per space —
+   * "outstanding LLM calls". Undefined = unbounded. */
+  maxOutstandingEffects?: number;
+  /** Phase 6: per-space network-effect egress pacing (dispatches per
+   * second, token bucket). Undefined = unpaced. */
+  egressRatePerSecond?: number;
   /** serving-loop.md §1's IDLE_PARK_MS. */
   idleParkMs?: number;
   renewIntervalMs?: number;
@@ -524,7 +532,9 @@ export class SpaceServer implements TransactionSealDestination {
           scopeKeyByOpIndex,
         ),
     });
-    // The effect channel (stage G, serving-loop.md §4–§5).
+    // The effect channel (stage G, serving-loop.md §4–§5). Phase 6
+    // threads the per-space egress budgets (§5's outstanding-effect cap
+    // + egress rate) from the policy.
     const outbox = new SpaceOutbox({
       stats: this.#options.stats,
       space: this.#options.space,
@@ -532,6 +542,24 @@ export class SpaceServer implements TransactionSealDestination {
       engine,
       sessionId: this.#holder,
       localSeqRef: this.#options.localSeqRef,
+      ...(this.#options.policy?.maxOutstandingEffects !== undefined ||
+          this.#options.policy?.egressRatePerSecond !== undefined
+        ? {
+          budget: {
+            ...(this.#options.policy?.maxOutstandingEffects !== undefined
+              ? {
+                maxOutstandingEffects: this.#options.policy
+                  .maxOutstandingEffects,
+              }
+              : {}),
+            ...(this.#options.policy?.egressRatePerSecond !== undefined
+              ? {
+                egressRatePerSecond: this.#options.policy.egressRatePerSecond,
+              }
+              : {}),
+          },
+        }
+        : {}),
     });
     this.#outbox = outbox;
     runtime.asyncWorkObserver = (work) => outbox.observeAsyncWork(work);
@@ -613,12 +641,14 @@ export class SpaceServer implements TransactionSealDestination {
     // surfacing, never a wedge).
     if (foreignReadInstances.length > 0) {
       try {
-        stale.push(...await selectForeignStaleInstances(
-          engine,
-          { branch: "", space },
-          (foreignSpace) => this.#options.server.engineForSpace(foreignSpace),
-          stale,
-        ));
+        stale.push(
+          ...await selectForeignStaleInstances(
+            engine,
+            { branch: "", space },
+            (foreignSpace) => this.#options.server.engineForSpace(foreignSpace),
+            stale,
+          ),
+        );
       } catch (error) {
         logger.warn("basis-foreign-remark-failed", () => [
           `${foreignReadInstances.length} basis instance(s) carry ` +
@@ -687,8 +717,7 @@ export class SpaceServer implements TransactionSealDestination {
     // registry through the seam above.
     runtime.installSealDestination(this, {
       runStamper: (tx, info) => this.#stampRun(tx, info),
-      runInstanceResolver: (pieceRootId) =>
-        this.#runInstancesFor(pieceRootId),
+      runInstanceResolver: (pieceRootId) => this.#runInstancesFor(pieceRootId),
     });
 
     // Stage B's renew cadence, finally driven (serving-loop.md §2).
@@ -769,7 +798,6 @@ export class SpaceServer implements TransactionSealDestination {
     this.#feed.push(record);
     this.#feedArrived?.resolve();
   }
-
 
   /** A session opened or its demand may have changed: reconsider the
    * demanded roots on the next cycle. */
@@ -1042,9 +1070,7 @@ export class SpaceServer implements TransactionSealDestination {
         ? {
           capabilityRef: info.kind === "event-handler"
             ? `event-consequence:${info.eventId ?? "unidentified"}`
-            : `demanded-run:${
-              (info.acting ?? acting)!.user
-            }`,
+            : `demanded-run:${(info.acting ?? acting)!.user}`,
         }
         : {}),
       ...(info.streamEntry !== undefined
@@ -1112,7 +1138,9 @@ export class SpaceServer implements TransactionSealDestination {
       const instanceKey = key.slice(0, key.indexOf("\0"));
       if (!instances.has(instanceKey)) instances.set(instanceKey, identity);
     }
-    return [...instances.entries()].map(([actionScopeKey, scopeKeyIdentity]) => ({
+    return [...instances.entries()].map((
+      [actionScopeKey, scopeKeyIdentity],
+    ) => ({
       scopeKeyIdentity,
       actionScopeKey: actionScopeKey as ScopeKey,
     }));
@@ -2851,6 +2879,10 @@ export class SpaceServer implements TransactionSealDestination {
     // awaited (park never awaits the network); its writebacks fail
     // against the disposed runtime and are caught by the builtins.
     this.#pendingEffectsByWave.clear();
+    // Phase 6: wake budget-held dispatches into the closed check so
+    // they DROP (the crash-equivalent path) instead of firing network
+    // work for a dead runtime after re-activation rebuilt the outbox.
+    this.#outbox?.close();
     this.#outbox = undefined;
     try {
       if (this.#runtime !== undefined) {

--- a/packages/runner/src/executor/stats.ts
+++ b/packages/runner/src/executor/stats.ts
@@ -131,7 +131,16 @@ export type ServingLoopStats = {
     skippedIdempotent: number;
   };
   memo: { hits: number; misses: number; inflight: number };
-  outbox: { queued: number; completed: number; failed: number };
+  outbox: {
+    queued: number;
+    completed: number;
+    failed: number;
+    /** Phase 6 (serving-loop.md §5's per-space budgets): dispatch
+     * holds — an admitted network effect waiting on the outstanding
+     * cap or an egress-rate token. Growth under load is the budget
+     * WORKING (the runaway degrades its own space), not a failure. */
+    budgetDeferrals: number;
+  };
   lease: { held: number; lost: number };
 };
 
@@ -162,7 +171,7 @@ export const emptyServingLoopStats = (): ServingLoopStats => ({
     skippedIdempotent: 0,
   },
   memo: { hits: 0, misses: 0, inflight: 0 },
-  outbox: { queued: 0, completed: 0, failed: 0 },
+  outbox: { queued: 0, completed: 0, failed: 0, budgetDeferrals: 0 },
   lease: { held: 0, lost: 0 },
 });
 

--- a/packages/runner/test/clock-preload.ts
+++ b/packages/runner/test/clock-preload.ts
@@ -69,5 +69,10 @@ installFakeClock({
     // auto-advance expires the lease TTL instantly and turns the renew
     // cadence + reactivation backoff into a runaway.
     "executor-cross-space",
+    // The Phase-6 outbox-budget suite: the egress-rate token bucket's
+    // pacing sleeps are wall-clock policy, and the auto-advance clock's
+    // virtual timers diverge from the bucket's time source (Date.now) —
+    // the rate gate would regenerate its refill sleep unboundedly.
+    "executor-outbox-budget",
   ],
 });

--- a/packages/runner/test/executor-effect-channel.test.ts
+++ b/packages/runner/test/executor-effect-channel.test.ts
@@ -368,10 +368,27 @@ describe("Phase 4 client-effect channel", () => {
     const tx = clientRuntime.edit();
     kick.withTx(tx).set({ n: Date.now() });
     expect((await tx.commit()).error).toBeUndefined();
-    const kickSeq = authoredSeqOf(engine, kick.getAsNormalizedFullLink().id);
+    const kickDocId = kick.getAsNormalizedFullLink().id;
+    const kickSeq = authoredSeqOf(engine, kickDocId);
+    // Regression armor for the OW26 trap arithmetic: wait for the
+    // serving loop's trailing derived echo to land BEFORE computing
+    // the barrier target. Pre-echo, `serverSeq`-degraded arithmetic
+    // is correct BY ACCIDENT (serverSeq still equals the kick's own
+    // authored seq at that instant), which left the degradation green
+    // across the whole suite; with the echo landed, wrong-class
+    // arithmetic targets the echo seq — which coverage never claims
+    // on a quiet space — and the wait below times out red.
     await waitUntil(
-      () => (host!.spaceServer(space)?.watermark ?? 0) >= kickSeq,
-      `the watermark to cover the ${kickName} barrier kick (seq ${kickSeq})`,
+      () => Engine.serverSeq(engine) > kickSeq,
+      `the trailing derived echo after the ${kickName} kick (seq ${kickSeq})`,
+    );
+    // Recomputed AFTER the echo: a no-op for correct (authored-class)
+    // arithmetic — the authored seq is stable — and the read that
+    // turns a serverSeq regression deterministically red.
+    const target = authoredSeqOf(engine, kickDocId);
+    await waitUntil(
+      () => (host!.spaceServer(space)?.watermark ?? 0) >= target,
+      `the watermark to cover the ${kickName} barrier kick (seq ${target})`,
     );
   };
 
@@ -1623,8 +1640,20 @@ describe("Phase 4 client-effect channel", () => {
     // the racing input's own AUTHORED seq (never `Engine.serverSeq`,
     // which the loop's derived echoes inflate — the recorded freeze).
     const racedSeq = authoredSeqOf(engine, kick.getAsNormalizedFullLink().id);
+    // Wait for the trailing echo BEFORE the barrier read (the same
+    // regression armor as `settleAnotherWaveFamily`): pre-echo, a
+    // serverSeq degradation reads correct-by-accident and the pin
+    // would stay green against the exact arithmetic it exists to pin.
     await waitUntil(
-      () => (host!.spaceServer(space)?.watermark ?? 0) >= racedSeq,
+      () => Engine.serverSeq(engine) > racedSeq,
+      "the trailing derived echo after the racing input",
+    );
+    const racedTarget = authoredSeqOf(
+      engine,
+      kick.getAsNormalizedFullLink().id,
+    );
+    await waitUntil(
+      () => (host!.spaceServer(space)?.watermark ?? 0) >= racedTarget,
       "the watermark to cover the input racing the failure window",
       15_000,
     );

--- a/packages/runner/test/executor-effect-channel.test.ts
+++ b/packages/runner/test/executor-effect-channel.test.ts
@@ -31,8 +31,13 @@
 //   consequences, a chain with NO acting session, and an acting
 //   session NOT connected to the computing space (LT3) all raise the
 //   runtime error, write no intent anywhere, and the charging wave
-//   settles (a racing input CAN wedge the demanded-effect retry — the
-//   flagged OW26 scheduler adjacency, see the no-context test);
+//   settles; the refusal asserts sit behind deterministic
+//   kick-and-await-W barriers (OW26 root-caused and discharged in
+//   Phase 6: the recorded "wedge" was the reverted barriers' target
+//   arithmetic racing the loop's own derived echoes, plus an
+//   unrelated-doc input that never re-dirtied the thrower — the OW26
+//   pin test races inputs into the failure window and asserts the
+//   charged/settled/W-advances posture directly);
 // - enactment failure leaves the intent UN-ACKED (protocol.md §5's
 //   enact-then-ack ordering): the ack follows enactment SUCCESS, a
 //   failed enactment retracts the enacted-nonce record, and the entry
@@ -106,6 +111,33 @@ const waitUntil = async (
     }
     await new Promise((resolve) => setTimeout(resolve, 20));
   }
+};
+
+/** The highest AUTHORED seq that wrote `docId` — the only seq class a
+ * kick-and-await-W barrier may target (protocol.md §4: settled for a
+ * client = W ≥ seq of its own AUTHORED commit). Deriving the target
+ * from `Engine.serverSeq` instead is the OW26 trap: the loop's own
+ * derived wave echoes ride the same counter, coverage never claims a
+ * trailing echo on a quiet space (the advance is input-driven and
+ * `#drainFeed` skips self-echoes), so a barrier that raced one froze
+ * "deterministically" — the recorded wedge, root-caused Phase 6. */
+const authoredSeqOf = (engine: Engine.Engine, docId: string): number => {
+  const commits = Engine.selectCommitsSince(engine, {
+    fromSeq: 0,
+    limit: 1000,
+  });
+  let seq = 0;
+  for (const commit of commits) {
+    const commitClass = (commit as { commitClass?: string }).commitClass ??
+      (commit as { class?: string }).class;
+    if (commitClass !== "authored") continue;
+    if (
+      (commit.writes as Array<{ id: string }>).some((w) => w.id === docId)
+    ) {
+      seq = Math.max(seq, commit.seq);
+    }
+  }
+  return seq;
 };
 
 /** The stored effects instance of one (principal, sessionId) — read
@@ -312,6 +344,35 @@ describe("Phase 4 client-effect channel", () => {
       expect((await tx.commit()).error).toBeUndefined();
     }
     return { compiled, argument, result };
+  };
+
+  /** The deterministic kick-and-await-W barrier (Phase 6, OW26's owed
+   * replacement for the bounded refusal-test drains): commit a fresh
+   * authored write and wait until the space's watermark covers ITS OWN
+   * authored seq — the settled contract exactly as a client uses it.
+   * The Phase-4 fixer built and reverted this barrier with
+   * `Engine.serverSeq`-derived targets; that arithmetic races the
+   * loop's own derived echo (see `authoredSeqOf`) and was the recorded
+   * OW26 "wedge". With authored-seq targets the barrier is safe — the
+   * probe sweep found no genuine contract stall at any input offset. */
+  const settleAnotherWaveFamily = async (
+    engine: Engine.Engine,
+    kickName: string,
+  ): Promise<void> => {
+    const kick = clientRuntime.getCell<{ n: number }>(
+      space,
+      kickName,
+      undefined,
+    );
+    await kick.sync();
+    const tx = clientRuntime.edit();
+    kick.withTx(tx).set({ n: Date.now() });
+    expect((await tx.commit()).error).toBeUndefined();
+    const kickSeq = authoredSeqOf(engine, kick.getAsNormalizedFullLink().id);
+    await waitUntil(
+      () => (host!.spaceServer(space)?.watermark ?? 0) >= kickSeq,
+      `the watermark to cover the ${kickName} barrier kick (seq ${kickSeq})`,
+    );
   };
 
   it("the served intent (T2 hops 1–4): fire → wave computes navigateTo → the §5 entry lands in the FIRING session's instance, issuedIn stamped, annotations addressing + acting", async () => {
@@ -1409,19 +1470,174 @@ describe("Phase 4 client-effect channel", () => {
       () => (host!.spaceServer(space)?.watermark ?? 0) > 0,
       "the serving loop to settle the kick",
     );
-    // Deliberately NOT the settleAnotherWaveFamily barrier here: an
-    // authored input landing in the tight window after a DEMANDED
-    // effect builtin's failure arms a scheduler liveness wedge — the
-    // failed action's retry parks idle-blocking and STARVES (no second
-    // charge ever appears), every subsequent flush exhausts its
-    // deadline, and W freezes below the new input (observed ≥30s with
-    // no recovery; a throwing `computed` under the IDENTICAL schedule
-    // does not wedge, so the class is the demanded-EFFECT retry park,
-    // not the throw itself). FLAGGED as verification-coverage.md OW26
-    // and in the Phase-4 fixer report — until that scheduler adjacency
-    // is fixed, this test bounds the drain with a fixed settle window
-    // instead of racing an input into the wedge.
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    // The deterministic kick-and-await-W barrier (OW26 RETIRED the
+    // bounded 300 ms drain, Phase 6): a fresh authored wave family
+    // settles — W covers its own authored seq — before the absence
+    // assert, so a late intent write could not hide behind a fixed
+    // window. Safe now that the barrier targets AUTHORED seqs; the
+    // reverted Phase-4 barriers froze on `serverSeq`-derived targets
+    // that included the loop's own derived echoes (the recorded
+    // "wedge", root-caused Phase 6 — see authoredSeqOf).
+    await settleAnotherWaveFamily(engine, "noctx-barrier");
+    const instances = engine.database.prepare(
+      `SELECT scope_key FROM head WHERE id = :id AND op != 'delete'`,
+    ).all({ id: SERVER_EXECUTION_EFFECTS_DOC_ID }) as Array<
+      { scope_key: string }
+    >;
+    for (const row of instances) {
+      const value = Engine.readState(engine, {
+        id: SERVER_EXECUTION_EFFECTS_DOC_ID,
+        scopeKey: row.scope_key,
+      })?.document?.value as SessionEffectsDocValue | undefined;
+      expect(value?.entries ?? []).toEqual([]);
+    }
+    cancelDemand();
+  });
+
+  it("the OW26 pin (Phase 6): authored inputs racing a DEMANDED effect's failure window — the erroring effect is charged, the space settles, W covers every authored seq", async () => {
+    // The verification-coverage.md OW26 recorded repro, re-run to root
+    // cause and pinned. A statically-demanded navigateTo throws
+    // builtins.md §4's no-context error; authored inputs race the
+    // failure window (one re-arming the thrower itself, one landing
+    // within milliseconds of the re-throw). The recorded symptoms all
+    // traced to the OBSERVER, not the scheduler:
+    // - "W freezes below the new input": the reverted barriers
+    //   targeted `Engine.serverSeq`, which counts the loop's own
+    //   derived wave echoes; coverage never claims a trailing echo on
+    //   a quiet space (input-driven advance; #drainFeed's self-echo
+    //   skip), so the barrier — not W's contract — hung. Deterministic
+    //   for this fast-settling thrower, intermittent (~1-in-4) when
+    //   the echo raced the target read, disarmed by a ≥500 ms gap.
+    // - "no further charge ever appears": the recorded racing input
+    //   wrote an UNRELATED doc; the thrower's registered reads are
+    //   path-granular, so it legitimately never re-ran.
+    // The erroring-demanded-effect posture already matches the
+    // erroring-derivation posture — charged, settled, W advances —
+    // which this pin asserts under the exact racing schedule (offset
+    // sweeps 0–250 ms, overlapping commits included, found no genuine
+    // contract stall).
+    ({ manager: clientManager, runtime: clientRuntime } = openClient(
+      aliceSigner,
+    ));
+    const engine = await server.engineForSpace(space);
+    const STATIC_NAVIGATE_PATTERN = [
+      "import { navigateTo, pattern } from 'commonfabric';",
+      "export default pattern<",
+      "  { target: unknown },",
+      "  { nav: boolean }",
+      ">(({ target }) => ({ nav: navigateTo(target) }));",
+    ].join("\n");
+    const compiled = await clientRuntime.patternManager.compilePattern({
+      main: "/main.tsx",
+      files: [{ name: "/main.tsx", contents: STATIC_NAVIGATE_PATTERN }],
+    }, { space });
+    const argument = clientRuntime.getCell<{ target: unknown }>(
+      space,
+      "ow26-arg",
+      undefined,
+    );
+    const destination = clientRuntime.getCell<{ label: string }>(
+      space,
+      "ow26-destination",
+      undefined,
+    );
+    const result = clientRuntime.getCell<Record<string, unknown>>(
+      space,
+      "ow26-result",
+      compiled.resultSchema,
+    );
+    await argument.sync();
+    await destination.sync();
+    await result.sync();
+    {
+      const seed = clientRuntime.edit();
+      destination.withTx(seed).set({ label: "somewhere" });
+      argument.withTx(seed).set({ target: destination as never });
+      expect((await seed.commit()).error).toBeUndefined();
+    }
+    {
+      const tx = clientRuntime.edit();
+      clientRuntime.run(tx, compiled, argument, result);
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    const cancelDemand = result.sink(() => {});
+    await clientRuntime.idle();
+    await clientRuntime.storageManager.synced();
+
+    const servedErrors: unknown[] = [];
+    host = newHost(undefined, (runtime) => {
+      runtime.scheduler.onError((error) => {
+        servedErrors.push(error);
+      });
+    });
+    // Kick the serving side (activation + demand): an authored write.
+    const kick = clientRuntime.getCell<{ n: number }>(
+      space,
+      "ow26-kick",
+      undefined,
+    );
+    await kick.sync();
+    {
+      const tx = clientRuntime.edit();
+      kick.withTx(tx).set({ n: 1 });
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    // The §4 error is raised and charged to the served run…
+    await waitUntil(
+      () =>
+        servedErrors.some((error) =>
+          /no firing-event context/.test(String(error))
+        ),
+      "the builtins.md §4 no-context error to be charged to the run",
+    );
+    // …the charging wave settles (the baseline: the charging wave
+    // itself never wedged)…
+    await waitUntil(
+      () => (host!.spaceServer(space)?.watermark ?? 0) > 0,
+      "the serving loop to settle the kick",
+    );
+    // …then an input DIRTIES the demanded effect itself (a new target
+    // link), forcing the erroring re-run whose failure window the next
+    // input races…
+    const destination2 = clientRuntime.getCell<{ label: string }>(
+      space,
+      "ow26-destination-2",
+      undefined,
+    );
+    await destination2.sync();
+    {
+      const tx = clientRuntime.edit();
+      destination2.withTx(tx).set({ label: "elsewhere" });
+      argument.withTx(tx).set({ target: destination2 as never });
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    // …and the RACING authored input lands in the tight window after
+    // that failure (back-to-back commits land it well inside the
+    // recorded <500 ms arming window).
+    {
+      const tx = clientRuntime.edit();
+      kick.withTx(tx).set({ n: 2 });
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    // The settled contract, with the CORRECT arithmetic: W must cover
+    // the racing input's own AUTHORED seq (never `Engine.serverSeq`,
+    // which the loop's derived echoes inflate — the recorded freeze).
+    const racedSeq = authoredSeqOf(engine, kick.getAsNormalizedFullLink().id);
+    await waitUntil(
+      () => (host!.spaceServer(space)?.watermark ?? 0) >= racedSeq,
+      "the watermark to cover the input racing the failure window",
+      15_000,
+    );
+    // The erroring-derivation posture, not silence: the re-armed
+    // demanded effect's re-run is CHARGED again (the recorded "no
+    // further charge" came from an unrelated-doc input that never
+    // re-dirtied the thrower — a re-pointed target does).
+    expect(
+      servedErrors.filter((error) =>
+        /no firing-event context/.test(String(error))
+      ).length,
+    ).toBeGreaterThanOrEqual(2);
+    // And no intent leaked from any of the erroring runs.
     const instances = engine.database.prepare(
       `SELECT scope_key FROM head WHERE id = :id AND op != 'delete'`,
     ).all({ id: SERVER_EXECUTION_EFFECTS_DOC_ID }) as Array<
@@ -1501,14 +1717,13 @@ describe("Phase 4 client-effect channel", () => {
       },
       "the sessionless event's handler consequence to land",
     );
-    // Bounded settle, then assert: no NEW intent anywhere — not in
-    // alice's instance, not in a service-keyed one. NOT a
-    // kick-and-await-W barrier: an authored input racing the window
-    // right after the §4 throw intermittently arms the OW26
-    // demanded-effect retry wedge (see the no-context test) and
-    // freezes W — the fixed drain stays until that scheduler
-    // adjacency is fixed.
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    // The deterministic kick-and-await-W barrier (OW26 RETIRED the
+    // bounded 300 ms drain, Phase 6), then assert: no NEW intent
+    // anywhere — not in alice's instance, not in a service-keyed one.
+    // The Phase-4 attempt froze ~1-in-4 on `serverSeq`-derived targets
+    // racing the wave echo; authored-seq targets are safe (see the
+    // no-context test).
+    await settleAnotherWaveFamily(engine, "sessionless-barrier");
     expect(
       intentsOf(engine, aliceSigner.did(), clientManager.id).length,
     ).toBe(intentsBefore);
@@ -1583,9 +1798,9 @@ describe("Phase 4 client-effect channel", () => {
       },
       "the LT3 event's handler consequence to land",
     );
-    // Bounded settle (not a kick-and-await-W barrier — the OW26 wedge;
-    // see the sessionless test above).
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    // The deterministic kick-and-await-W barrier (OW26 RETIRED the
+    // bounded 300 ms drain, Phase 6; see the sessionless test above).
+    await settleAnotherWaveFamily(engine, "lt3-barrier");
     expect(
       intentsOf(
         engine,

--- a/packages/runner/test/executor-outbox-budget.test.ts
+++ b/packages/runner/test/executor-outbox-budget.test.ts
@@ -1,0 +1,225 @@
+// Server-execution v2 Phase 6: the per-space egress budgets
+// (serving-loop.md §5's "outstanding-effect caps, egress rate";
+// README §3.8's multi-tenancy contract — a runaway pattern degrades
+// only its own space). The SpaceOutbox's budget gate:
+//
+// - the OUTSTANDING CAP bounds dispatched-but-unsettled NETWORK
+//   effects; admitted effects over the cap hold (FIFO wake), and the
+//   in-flight dedupe entry exists from ADMISSION either way, so a
+//   re-admit during the hold attaches instead of double-firing;
+// - the EGRESS RATE paces dispatches through a token bucket (burst =
+//   one second's tokens);
+// - LOCAL kinds (sqlite-query) bypass the gate — no egress, nothing
+//   to budget;
+// - CLOSE (the park path) drops held dispatches — the crash-equivalent
+//   posture: the effect re-misses from its memo key on re-activation,
+//   and firing against a dying runtime would egress work for a dead
+//   space.
+//
+// REAL CLOCK (listed in clock-preload.ts): the rate gate's pacing
+// sleeps are wall-clock policy, and the auto-advance clock's virtual
+// timers diverge from the bucket's time source — same class as the
+// serving-loop suites.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import * as Engine from "@commonfabric/memory/v2/engine";
+import { executionLeaseHolder } from "@commonfabric/memory/v2/execution-lease";
+import type {
+  IExtendedStorageTransaction,
+  MemorySpace,
+} from "../src/storage/interface.ts";
+import type { PostCommitSideEffect } from "../src/cfc/types.ts";
+import { SpaceOutbox } from "../src/executor/outbox.ts";
+import { emptyServingLoopStats } from "../src/executor/stats.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
+
+const signer = await Identity.fromPassphrase("executor outbox budget test");
+const space = signer.did() as MemorySpace;
+
+describe("Phase 6 outbox budgets (serving-loop.md §5)", () => {
+  let server: MemoryV2Server.Server;
+  let engine: Engine.Engine;
+  let localSeqRef: { value: number };
+
+  const holder = executionLeaseHolder(`service:${space}`);
+
+  beforeEach(async () => {
+    localSeqRef = { value: 0 };
+    server = newSharedServer();
+    engine = await server.engineForSpace(space);
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  const waitUntil = async (
+    predicate: () => boolean,
+    label: string,
+    timeoutMs = 10_000,
+  ): Promise<void> => {
+    const deadline = Date.now() + timeoutMs;
+    while (!predicate()) {
+      if (Date.now() > deadline) {
+        throw new Error(`timed out waiting for ${label}`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+  };
+
+  const heldEffect = (
+    id: string,
+    kind: string,
+    started: string[],
+  ): { effect: PostCommitSideEffect; release: () => void } => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    return {
+      effect: {
+        id,
+        kind,
+        flush: () => {
+          started.push(id);
+          return gate;
+        },
+      },
+      release,
+    };
+  };
+
+  const newBudgetOutbox = (
+    budget: NonNullable<
+      ConstructorParameters<typeof SpaceOutbox>[0]["budget"]
+    >,
+  ): {
+    outbox: SpaceOutbox;
+    stats: ReturnType<typeof emptyServingLoopStats>;
+  } => {
+    const stats = emptyServingLoopStats();
+    return {
+      outbox: new SpaceOutbox({
+        stats,
+        server,
+        engine,
+        space,
+        sessionId: holder,
+        localSeqRef,
+        budget,
+      }),
+      stats,
+    };
+  };
+
+  it("caps dispatched-but-unsettled network effects per space, draining held dispatches FIFO as slots free", async () => {
+    const { outbox, stats } = newBudgetOutbox({ maxOutstandingEffects: 2 });
+    const started: string[] = [];
+    const held = ["a", "b", "c", "d", "e"].map((name) =>
+      heldEffect(`llmTest:${name}`, "llmTest-start", started)
+    );
+    outbox.admitSealedEffects([{
+      tx: {} as IExtendedStorageTransaction,
+      effects: held.map((entry) => entry.effect),
+      context: undefined,
+    }]);
+    // All five are ADMITTED (in-flight dedupe live from admission)…
+    expect(outbox.inflightCount).toBe(5);
+    // …but only the cap's worth DISPATCH.
+    await waitUntil(() => started.length === 2, "the first two starts");
+    // Hold a beat: nothing beyond the cap may start.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(started.length).toBe(2);
+    expect(outbox.outstandingCount).toBe(2);
+    expect(started).toEqual(["llmTest:a", "llmTest:b"]);
+    expect(stats.outbox.budgetDeferrals).toBeGreaterThanOrEqual(1);
+    // Settling one frees one slot — FIFO wake.
+    held[0].release();
+    await waitUntil(() => started.length === 3, "the third start");
+    expect(started[2]).toBe("llmTest:c");
+    expect(outbox.outstandingCount).toBe(2);
+    // Drain the rest.
+    for (const entry of held) entry.release();
+    await outbox.settle();
+    expect(started.length).toBe(5);
+    expect(outbox.outstandingCount).toBe(0);
+    expect(stats.outbox.completed).toBe(5);
+  });
+
+  it("exempts local kinds (sqlite-query) from the budget gate — no egress, no throttle", async () => {
+    const { outbox, stats } = newBudgetOutbox({
+      maxOutstandingEffects: 1,
+      egressRatePerSecond: 1,
+    });
+    const started: string[] = [];
+    const held = ["x", "y", "z"].map((name) =>
+      heldEffect(`sqlite:${name}`, "sqlite-query", started)
+    );
+    outbox.admitSealedEffects([{
+      tx: {} as IExtendedStorageTransaction,
+      effects: held.map((entry) => entry.effect),
+      context: undefined,
+    }]);
+    // Local kinds dispatch immediately (synchronously), uncounted and
+    // unpaced.
+    expect(started.length).toBe(3);
+    expect(outbox.outstandingCount).toBe(0);
+    expect(stats.outbox.budgetDeferrals).toBe(0);
+    for (const entry of held) entry.release();
+    await outbox.settle();
+  });
+
+  it("paces network dispatches by the egress token bucket", async () => {
+    // 20/s → the 2-effect tail beyond the burst drains in ~100 ms of
+    // real time; the assertions ride edges, never sleeps.
+    const { outbox, stats } = newBudgetOutbox({ egressRatePerSecond: 20 });
+    const started: string[] = [];
+    const held = Array.from(
+      { length: 22 },
+      (_, index) =>
+        heldEffect(`fetchTest:${index}`, "fetchTest-start", started),
+    );
+    // Release every gate up front: pacing (dispatch), not settlement,
+    // is what the bucket bounds.
+    for (const entry of held) entry.release();
+    outbox.admitSealedEffects([{
+      tx: {} as IExtendedStorageTransaction,
+      effects: held.map((entry) => entry.effect),
+      context: undefined,
+    }]);
+    // The burst (one second's tokens = 20) dispatches promptly; the
+    // remaining 2 hold for refill.
+    await waitUntil(() => started.length >= 20, "the burst dispatch");
+    expect(stats.outbox.budgetDeferrals).toBeGreaterThanOrEqual(1);
+    // The refill drains the paced tail.
+    await outbox.settle();
+    expect(started.length).toBe(22);
+    expect(stats.outbox.completed).toBe(22);
+  });
+
+  it("drops budget-held dispatches on close — the park path never egresses for a dead runtime", async () => {
+    const { outbox } = newBudgetOutbox({ maxOutstandingEffects: 1 });
+    const started: string[] = [];
+    const first = heldEffect("llmTest:first", "llmTest-start", started);
+    const second = heldEffect("llmTest:second", "llmTest-start", started);
+    outbox.admitSealedEffects([{
+      tx: {} as IExtendedStorageTransaction,
+      effects: [first.effect, second.effect],
+      context: undefined,
+    }]);
+    await waitUntil(() => started.length === 1, "the first dispatch");
+    // Park: the held dispatch must DROP (crash-equivalent; memo re-miss
+    // covers it on re-activation), and retirement must not wedge.
+    outbox.close();
+    first.release();
+    await outbox.settle();
+    // A beat of real time: a buggy late dispatch would land here.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(started).toEqual(["llmTest:first"]);
+    expect(outbox.inflightCount).toBe(0);
+    expect(outbox.outstandingCount).toBe(0);
+  });
+});

--- a/packages/runner/test/executor-outbox.test.ts
+++ b/packages/runner/test/executor-outbox.test.ts
@@ -885,7 +885,10 @@ describe("stage G outbox + sqlite discharge", () => {
   it("OW15: a DECLARED userless row delivers — the target stamps firedAt = { session: 'server' } with NO user; undeclared userless stays refused (the floor negatives)", async () => {
     const ow15Stream = { id: "of:ow15-stream", path: ["events"] };
     const ow15Sidecar = streamEntriesDocId(ow15Stream);
-    const ow15UndeclaredStream = { id: "of:ow15-undeclared", path: [] as string[] };
+    const ow15UndeclaredStream = {
+      id: "of:ow15-undeclared",
+      path: [] as string[],
+    };
     const ow15UndeclaredSidecar = streamEntriesDocId(ow15UndeclaredStream);
     insertExecutionOutboxRows(engine, {
       branch: "",

--- a/packages/toolshed/lib/server-execution.test.ts
+++ b/packages/toolshed/lib/server-execution.test.ts
@@ -1,0 +1,95 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  DEFAULT_MAX_OUTSTANDING_EFFECTS,
+  serverExecutionPolicyFromEnv,
+} from "@/lib/server-execution.ts";
+
+// The Phase-6 env knobs (serving-loop.md §5) are the production
+// multi-tenancy bound: a runaway fan-out must degrade only its own space,
+// so the outstanding-effect cap is ON by default and only the LITERAL `0`
+// opts out. The property worth pinning is that a typo cannot disable it:
+// garbage must fall back to the default (loudly), never read as the
+// opt-out (the Phase-6 independent review's F4 — the pre-fix parser
+// mapped "abc"/"-1" to `undefined` = unbounded, indistinguishable from
+// the explicit `0`).
+
+const envOf = (values: Record<string, string | undefined>) => (name: string) =>
+  values[name];
+
+describe("serverExecutionPolicyFromEnv", () => {
+  it("defaults the outstanding cap ON when the knob is unset or empty", () => {
+    const warnings: string[] = [];
+    expect(serverExecutionPolicyFromEnv(envOf({}), (m) => warnings.push(m)))
+      .toEqual({ maxOutstandingEffects: DEFAULT_MAX_OUTSTANDING_EFFECTS });
+    expect(
+      serverExecutionPolicyFromEnv(
+        envOf({ SERVER_EXECUTION_MAX_OUTSTANDING_EFFECTS: "" }),
+        (m) => warnings.push(m),
+      ),
+    ).toEqual({ maxOutstandingEffects: DEFAULT_MAX_OUTSTANDING_EFFECTS });
+    expect(warnings).toEqual([]);
+  });
+
+  it("honors an explicit positive cap and the literal 0 opt-out (unbounded)", () => {
+    const warnings: string[] = [];
+    expect(
+      serverExecutionPolicyFromEnv(
+        envOf({ SERVER_EXECUTION_MAX_OUTSTANDING_EFFECTS: "8" }),
+        (m) => warnings.push(m),
+      ),
+    ).toEqual({ maxOutstandingEffects: 8 });
+    // The operator's deliberate opt-out: the key is ABSENT from the
+    // policy (the outbox reads absent as unbounded).
+    expect(
+      serverExecutionPolicyFromEnv(
+        envOf({ SERVER_EXECUTION_MAX_OUTSTANDING_EFFECTS: "0" }),
+        (m) => warnings.push(m),
+      ),
+    ).toEqual({});
+    expect(warnings).toEqual([]);
+  });
+
+  it("FAILS CLOSED on garbage/negative/fractional cap values: default cap, loud warning — never the unbounded opt-out", () => {
+    for (const raw of ["abc", "-1", "1.5", "16abc", "0x10", " 4"]) {
+      const warnings: string[] = [];
+      const policy = serverExecutionPolicyFromEnv(
+        envOf({ SERVER_EXECUTION_MAX_OUTSTANDING_EFFECTS: raw }),
+        (m) => warnings.push(m),
+      );
+      expect(policy).toEqual({
+        maxOutstandingEffects: DEFAULT_MAX_OUTSTANDING_EFFECTS,
+      });
+      expect(warnings.length).toBe(1);
+      expect(warnings[0]).toContain("SERVER_EXECUTION_MAX_OUTSTANDING_EFFECTS");
+      expect(warnings[0]).toContain(JSON.stringify(raw));
+    }
+  });
+
+  it("threads the T_flush and egress-rate knobs; garbage there reads as unset (built-in default) with a warning", () => {
+    const warnings: string[] = [];
+    expect(
+      serverExecutionPolicyFromEnv(
+        envOf({
+          SERVER_EXECUTION_FLUSH_DEADLINE_MS: "250",
+          SERVER_EXECUTION_EGRESS_RATE_PER_S: "5",
+          SERVER_EXECUTION_MAX_OUTSTANDING_EFFECTS: "0",
+        }),
+        (m) => warnings.push(m),
+      ),
+    ).toEqual({ flushDeadlineMs: 250, egressRatePerSecond: 5 });
+    expect(warnings).toEqual([]);
+    expect(
+      serverExecutionPolicyFromEnv(
+        envOf({
+          SERVER_EXECUTION_FLUSH_DEADLINE_MS: "fast",
+          SERVER_EXECUTION_EGRESS_RATE_PER_S: "0",
+        }),
+        (m) => warnings.push(m),
+      ),
+    ).toEqual({ maxOutstandingEffects: DEFAULT_MAX_OUTSTANDING_EFFECTS });
+    expect(warnings.length).toBe(2);
+    expect(warnings[0]).toContain("SERVER_EXECUTION_FLUSH_DEADLINE_MS");
+    expect(warnings[1]).toContain("SERVER_EXECUTION_EGRESS_RATE_PER_S");
+  });
+});

--- a/packages/toolshed/lib/server-execution.ts
+++ b/packages/toolshed/lib/server-execution.ts
@@ -32,16 +32,45 @@ export function startServerExecutionHost(options: {
   apiUrl: URL;
   envGet?: EnvReader;
 }): ExecutorHost | undefined {
-  const experimental = experimentalOptionsFromEnv(
-    options.envGet ?? Deno.env.get,
-  );
+  const envGet = options.envGet ?? Deno.env.get;
+  const experimental = experimentalOptionsFromEnv(envGet);
   if (experimental.serverExecution !== true) {
     return undefined;
   }
   console.log(
     `Server-execution v2: serving loop ON (service ${options.identity.did()})`,
   );
+  // Phase 6 policy knobs (serving-loop.md §3's T_flush "tuned in
+  // Phase 6 with the other budgets"; §5's per-space budgets). Each is
+  // env-overridable; the defaults are the production posture:
+  // - T_flush stays the SpaceServer's built-in default (100 ms, the
+  //   ruled 50–100 ms order) unless overridden;
+  // - the outstanding-network-effect cap defaults to 16 per space (the
+  //   §3.8 multi-tenancy contract needs a bound ON by default — a
+  //   runaway LLM fan-out must degrade only its own space);
+  // - egress pacing defaults OFF (the cap alone bounds concurrency;
+  //   a rate value is a deliberate operator choice).
+  const envInt = (name: string): number | undefined => {
+    const raw = envGet(name);
+    if (raw === undefined || raw === "") return undefined;
+    const value = Number.parseInt(raw, 10);
+    return Number.isFinite(value) && value > 0 ? value : undefined;
+  };
+  const flushDeadlineMs = envInt("SERVER_EXECUTION_FLUSH_DEADLINE_MS");
+  // `0` (or any non-positive value) means UNBOUNDED — the operator's
+  // explicit opt-out of the default cap; unset means the default.
+  const maxOutstandingEffects =
+    envGet("SERVER_EXECUTION_MAX_OUTSTANDING_EFFECTS") === undefined ||
+      envGet("SERVER_EXECUTION_MAX_OUTSTANDING_EFFECTS") === ""
+      ? 16
+      : envInt("SERVER_EXECUTION_MAX_OUTSTANDING_EFFECTS");
+  const egressRatePerSecond = envInt("SERVER_EXECUTION_EGRESS_RATE_PER_S");
   host = new ExecutorHost({
+    policy: {
+      ...(flushDeadlineMs !== undefined ? { flushDeadlineMs } : {}),
+      ...(maxOutstandingEffects !== undefined ? { maxOutstandingEffects } : {}),
+      ...(egressRatePerSecond !== undefined ? { egressRatePerSecond } : {}),
+    },
     server: options.server,
     serviceIdentity: options.identity.did(),
     createRuntime: (space) => {

--- a/packages/toolshed/lib/server-execution.ts
+++ b/packages/toolshed/lib/server-execution.ts
@@ -20,6 +20,101 @@ import type { Identity } from "@commonfabric/identity";
 
 let host: ExecutorHost | undefined;
 
+/** The production default for the per-space outstanding-network-effect
+ * cap (serving-loop.md §5; README §3.8's multi-tenancy contract needs a
+ * bound ON by default — a runaway LLM fan-out must degrade only its own
+ * space). An operator-tunable posture, not a spec constant. */
+export const DEFAULT_MAX_OUTSTANDING_EFFECTS = 16;
+
+/** The Phase-6 policy knobs the toolshed bootstrap threads into the
+ * ExecutorHost (`SpaceServerPolicy`'s env-overridable subset). */
+export type ServerExecutionEnvPolicy = {
+  flushDeadlineMs?: number;
+  maxOutstandingEffects?: number;
+  egressRatePerSecond?: number;
+};
+
+/**
+ * Resolve the Phase-6 policy knobs from env (serving-loop.md §3's
+ * T_flush "tuned in Phase 6 with the other budgets"; §5's per-space
+ * budgets). Each is env-overridable; the defaults are the production
+ * posture:
+ * - T_flush stays the SpaceServer's built-in default (100 ms, the ruled
+ *   50–100 ms order) unless overridden;
+ * - the outstanding-network-effect cap defaults to
+ *   `DEFAULT_MAX_OUTSTANDING_EFFECTS` per space; the LITERAL `0` is the
+ *   operator's explicit opt-out (unbounded);
+ * - egress pacing defaults OFF (the cap alone bounds concurrency; a rate
+ *   value is a deliberate operator choice).
+ *
+ * Parsing is FAIL-CLOSED for the cap: an unparseable or negative value
+ * ("abc", "-1", "1.5") falls back to the default and warns, instead of
+ * being silently indistinguishable from the explicit `0` opt-out (a
+ * typo must never disable the production bound). The other two knobs
+ * have no dangerous "absent" meaning — absent = the built-in default —
+ * so garbage there simply reads as unset (also warned).
+ */
+export function serverExecutionPolicyFromEnv(
+  envGet: EnvReader,
+  warn: (message: string) => void = (message) => console.warn(message),
+): ServerExecutionEnvPolicy {
+  /** A strictly non-negative decimal integer, or undefined for anything
+   * else (garbage, sign, fraction, exponent — `parseInt` would accept
+   * prefixes of those). */
+  const strictNonNegativeInt = (raw: string): number | undefined =>
+    /^\d+$/.test(raw) ? Number.parseInt(raw, 10) : undefined;
+  const readRaw = (name: string): string | undefined => {
+    const raw = envGet(name);
+    return raw === undefined || raw === "" ? undefined : raw;
+  };
+  /** Positive-int knobs whose absence means the built-in default. */
+  const positiveOrDefault = (name: string): number | undefined => {
+    const raw = readRaw(name);
+    if (raw === undefined) return undefined;
+    const value = strictNonNegativeInt(raw);
+    if (value === undefined || value <= 0) {
+      warn(
+        `Server-execution v2: ignoring ${name}=${JSON.stringify(raw)} ` +
+          "(expected a positive integer); using the built-in default",
+      );
+      return undefined;
+    }
+    return value;
+  };
+  const flushDeadlineMs = positiveOrDefault(
+    "SERVER_EXECUTION_FLUSH_DEADLINE_MS",
+  );
+  const egressRatePerSecond = positiveOrDefault(
+    "SERVER_EXECUTION_EGRESS_RATE_PER_S",
+  );
+  const capRaw = readRaw("SERVER_EXECUTION_MAX_OUTSTANDING_EFFECTS");
+  let maxOutstandingEffects: number | undefined;
+  if (capRaw === undefined) {
+    maxOutstandingEffects = DEFAULT_MAX_OUTSTANDING_EFFECTS;
+  } else {
+    const value = strictNonNegativeInt(capRaw);
+    if (value === undefined) {
+      warn(
+        "Server-execution v2: ignoring SERVER_EXECUTION_MAX_OUTSTANDING_EFFECTS=" +
+          `${JSON.stringify(capRaw)} (expected a non-negative integer; ` +
+          "the literal 0 means unbounded); using the default " +
+          `${DEFAULT_MAX_OUTSTANDING_EFFECTS}`,
+      );
+      maxOutstandingEffects = DEFAULT_MAX_OUTSTANDING_EFFECTS;
+    } else if (value === 0) {
+      // The explicit opt-out: unbounded (absent from the policy).
+      maxOutstandingEffects = undefined;
+    } else {
+      maxOutstandingEffects = value;
+    }
+  }
+  return {
+    ...(flushDeadlineMs !== undefined ? { flushDeadlineMs } : {}),
+    ...(maxOutstandingEffects !== undefined ? { maxOutstandingEffects } : {}),
+    ...(egressRatePerSecond !== undefined ? { egressRatePerSecond } : {}),
+  };
+}
+
 /**
  * Start the serving loop's host when the flag is on. Called once from
  * toolshed startup, after the memory server exists. Returns the host (or
@@ -40,37 +135,9 @@ export function startServerExecutionHost(options: {
   console.log(
     `Server-execution v2: serving loop ON (service ${options.identity.did()})`,
   );
-  // Phase 6 policy knobs (serving-loop.md §3's T_flush "tuned in
-  // Phase 6 with the other budgets"; §5's per-space budgets). Each is
-  // env-overridable; the defaults are the production posture:
-  // - T_flush stays the SpaceServer's built-in default (100 ms, the
-  //   ruled 50–100 ms order) unless overridden;
-  // - the outstanding-network-effect cap defaults to 16 per space (the
-  //   §3.8 multi-tenancy contract needs a bound ON by default — a
-  //   runaway LLM fan-out must degrade only its own space);
-  // - egress pacing defaults OFF (the cap alone bounds concurrency;
-  //   a rate value is a deliberate operator choice).
-  const envInt = (name: string): number | undefined => {
-    const raw = envGet(name);
-    if (raw === undefined || raw === "") return undefined;
-    const value = Number.parseInt(raw, 10);
-    return Number.isFinite(value) && value > 0 ? value : undefined;
-  };
-  const flushDeadlineMs = envInt("SERVER_EXECUTION_FLUSH_DEADLINE_MS");
-  // `0` (or any non-positive value) means UNBOUNDED — the operator's
-  // explicit opt-out of the default cap; unset means the default.
-  const maxOutstandingEffects =
-    envGet("SERVER_EXECUTION_MAX_OUTSTANDING_EFFECTS") === undefined ||
-      envGet("SERVER_EXECUTION_MAX_OUTSTANDING_EFFECTS") === ""
-      ? 16
-      : envInt("SERVER_EXECUTION_MAX_OUTSTANDING_EFFECTS");
-  const egressRatePerSecond = envInt("SERVER_EXECUTION_EGRESS_RATE_PER_S");
+  // Phase 6 policy knobs — see `serverExecutionPolicyFromEnv`.
   host = new ExecutorHost({
-    policy: {
-      ...(flushDeadlineMs !== undefined ? { flushDeadlineMs } : {}),
-      ...(maxOutstandingEffects !== undefined ? { maxOutstandingEffects } : {}),
-      ...(egressRatePerSecond !== undefined ? { egressRatePerSecond } : {}),
-    },
+    policy: serverExecutionPolicyFromEnv(envGet),
     server: options.server,
     serviceIdentity: options.identity.did(),
     createRuntime: (space) => {

--- a/packages/toolshed/routes/health/health.handlers.ts
+++ b/packages/toolshed/routes/health/health.handlers.ts
@@ -4,7 +4,10 @@ import { z } from "zod";
 import { resolveGitSha } from "@/lib/build-info.ts";
 import type { AppRouteHandler } from "@/lib/types.ts";
 import type { DashRoute, IndexRoute, StatsRoute } from "./health.routes.ts";
-import { getSlowQueries } from "@commonfabric/memory/v2/server";
+import {
+  getPushPriorityStats,
+  getSlowQueries,
+} from "@commonfabric/memory/v2/server";
 import { getServingLoopStats } from "@commonfabric/runner/executor/stats";
 import {
   getLoggerCountsBreakdown,
@@ -45,15 +48,21 @@ export const stats: AppRouteHandler<StatsRoute> = (c) => {
   // The serving loop's §7 counters
   // (docs/specs/server-side-execution/serving-loop.md §7): present only
   // when an ExecutorHost runs in this process (the ON arm); the OFF-arm
-  // response is byte-identical to today.
+  // response is byte-identical to today. Phase 6 nests the memory
+  // server's push-priority counters (protocol.md §3) under the same
+  // ON-arm-only block — all-zero OFF by construction, but the block's
+  // very presence stays flag-gated so the OFF response never changes.
   const servingLoop = getServingLoopStats();
+  const push = getPushPriorityStats();
   return c.json({
     timestamp: Date.now(),
     serverStart: serverStartTimestamp,
     logCounts: getLoggerCountsBreakdown(),
     timingStats: getTimingStatsBreakdown(),
     slowQueries: [...getSlowQueries()],
-    ...(servingLoop === undefined ? {} : { servingLoop }),
+    ...(servingLoop === undefined ? {} : {
+      servingLoop: { ...servingLoop, ...(push === undefined ? {} : { push }) },
+    }),
   }, HttpStatusCodes.OK);
 };
 


### PR DESCRIPTION
## Why

Phase 6 of the server-execution v2 train (base: `claude/server-exec-v2-phase-5`): the budgets/priority phase. Three problems this closes ahead of the Phase-7 flip: (1) a big authored blob's flush evaluation could head-of-line a derived frame anywhere in the serialized push chain — the hot path README §3.3 says to design deliberately; (2) nothing bounded a runaway pattern's egress (an LLM fan-out loop would saturate the host, not just its space — §3.8's multi-tenancy contract was unimplemented); (3) the owed OW26 "demanded-effect wedge" blocked the flip and kept three refusal tests on bounded-sleep drains. It also lands the `sx2-scale` gate suite the plan's Phase-6 criteria bind to, and flags (not fills) the one genuinely unstated design fork.

## What Changed

**Push priority (protocol.md §3; verification-coverage OW8 — LANDED).** `noteExecutorCommit` classifies derived commits' dirty keys (a parallel annotation — deliberately not a `DirtyOrigin` field, whose mixed-provenance delete would erase it); the flush fan-out runs two phases per batch: every connection's derived-subscribed sessions evaluate and send before any bulk-only session. No frame is split — a mixed frame rides whole at derived priority (splitting would put the catch-up marker ahead of undelivered covered docs, an INV-5 hazard; the rejected design is recorded in the §3 note). Counters: `servingLoop.push.{prioritizedSessions,followerSessions,mixedFlushes}`, all-zero OFF by construction. Deterministic, registration-order-adversarial ordering pin: `packages/memory/test/v2-push-priority.test.ts`.

**Per-space budgets (serving-loop.md §5; README §3.8).** `SpaceOutbox` gains a budget gate at the admit→dispatch seam: an outstanding-network-effect cap (FIFO wake) and an egress-rate token bucket (burst = one second's tokens). The in-flight dedupe entry registers eagerly at admission — only DISPATCH defers — so re-admits attach instead of double-firing, and the B-1 retirement barriers are unchanged. `sqlite-query` (local, no egress) bypasses the gate. On park, held dispatches DROP (crash-equivalent posture; memo re-miss re-fires on re-activation) — `outbox.close()` added to the park path. Policy knobs thread `SpaceServerPolicy` → toolshed env: `SERVER_EXECUTION_MAX_OUTSTANDING_EFFECTS` (default **16**), `SERVER_EXECUTION_EGRESS_RATE_PER_S` (default unpaced), `SERVER_EXECUTION_FLUSH_DEADLINE_MS` (T_flush — the §3 "tuned in Phase 6" knob). New counter `outbox.budgetDeferrals`.

**OW26 — discharged with a root cause, not a scheduler fix.** The recorded repro was re-run and swept (offsets 0–250 ms, overlapping commits, 30+ executor-level runs): the erroring-demanded-effect posture is ALREADY aligned — charged, settled, W covers every authored seq. Every recorded symptom traced to the observer: the reverted kick-and-await-W barriers targeted `Engine.serverSeq`, which counts the serving loop's own derived wave echoes — and coverage structurally never claims a trailing echo on a quiet space (input-driven advance; `#drainFeed`'s self-echo skip), so the barrier hung, not W's contract (this reproduces deterministically in the probe schedule: W frozen below an echo-inflated target for 12s+, scheduler idle, fresh input recovers instantly); and "no further charge" came from the recorded racing input writing an unrelated doc — path-granular triggers mean it legitimately never re-ran the thrower. Landed: the OW26 pin test (races inputs into the failure window, asserts charged/settled/W-advances), the three refusal tests' 300 ms drains RETIRED for deterministic barriers with authored-seq targets (`settleAnotherWaveFamily` + `authoredSeqOf`), and the register's standing lesson (barriers target AUTHORED seqs — protocol §4 was always the contract).

**Backpressure shaping — FLAGGED as OW27, not filled.** README §3.8's binding-layer shaping ("rate-shaped … before they become commits") has genuinely unstated semantics — pace vs batch vs drop (events are intent), the hold-latency bound, per-stream keying, UI-default visibility (the boolean binding controller defaults `immediate`, and changing it is user-visible in BOTH arms). Under the flag the W4 collapse is disabled by design, so the ON arm currently has NO event-flood bound — stated loudly in the register row with candidate resolutions and costs. This is the plan bullet left unticked.

**Gates:** `sx2-scale` (budget isolation via a 20-wide fetch fan-out against a slow local endpoint — the same egress class as an LLM loop, CI-runnable keyless; flat accumulation measured headlessly as the cf-checkbox criterion's substance; push-counter presence; a poll-loop audit over the sx2 family). Spec/register/plan edits land with the batch: protocol §3 note, serving-loop §5 rewrite + §7 counters, verification-coverage OW8/OW26/OW27 + the Phase-6 delta, plan Phase-6 section.

## Test plan

New: `v2-push-priority.test.ts` (3), `executor-outbox-budget.test.ts` (4, real-clock), the OW26 pin + 3 barrier retirements in `executor-effect-channel.test.ts`, `sx2-scale.test.ts` (4). All suites below run FOREGROUND on this branch.

| gate | result |
|---|---|
| full runner suite (`deno task test`, packages/runner) | 1200 passed / 6649 steps, 0 failed |
| full memory suite | 517 passed / 228 steps |
| spec-model | 23 passed |
| runtime-client | 62 passed / 214 steps |
| piece | 37 passed / 451 steps |
| `executor-effect-channel` (OW26 pin + retired barriers) | **10/10 consecutive greens** |
| `executor-serving-loop` (wedge/park/backoff/renew-blip/B-1 pins in-suite) | **10/10 consecutive greens** |
| sx2-serving-loop, fresh-store ON | 5/5 greens |
| sx2-speculation ON | green |
| sx2-scale ON (fresh store) | 4/5 greens — the 1 red was a test-side flake (serial piece creation spread admissions past the effect window; fixed by concurrent creation), 3/3 green after the fix |
| sx2-scale OFF (fresh store) | green |
| `deno check` (touched files), `deno fmt`, `deno lint`, `deno task check-docs` | green (548 doc blocks) |
| mutation probes | split-reverted → RED; cap-disabled → RED; exemption-removed → RED; close-drop-removed → RED; barrier-arithmetic-degraded → NOT red in-suite (0/5; artifact reproduces only in the probe schedule — recorded honestly in the review report) |

## Flagged forks (owner attention)

1. **OW27** — binding-layer event/binding shaping: semantics ruling owed (options + costs in the register row). The ON arm ships without an event-flood bound until it lands.
2. **OW26 residual** — the discharge concludes observer-side root cause; if a schedule exists where the fixer's "every flush exhausts its deadline" was a genuine W stall (my wedged states showed `wavesBudgetExhausted: 0`), the row must reopen. The pin suite is where it would resurface.
3. **The 16-outstanding toolshed default** — a production ON-arm posture chosen here (env-overridable; `0` = unbounded). Confirm or retune.
4. **`LOCAL_EFFECT_KINDS = {sqlite-query}`** — the budget gate's network/local taxonomy is an implementation choice (flagged in the register delta).
5. **cf-checkbox criterion mapping** — measured headlessly as flat accumulation (the criterion's stated substance); confirm the reading.
6. **runtime-mapping N9's "revisit budgets in Phase 6"** — revisited: the park criterion already honors armed gate wakes (stage F); auto-debounce kept as-is. No spec edit made; noted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

