### PR TITLE
fix(cli): a bare no-input verb call no longer waits on stdin

### DIFF
--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -571,6 +571,14 @@ async function resolveImplicitPipedHandlerInput(
     return null;
   }
 
+  // A schema-less input declares no payload, so no piped input exists to
+  // infer: return before consulting stdin at all. Reading it would hold the
+  // advertised bare spelling open until a non-terminal stdin reaches EOF —
+  // a hang whenever the pipe outlives the call.
+  if (isSchemaLessHandlerInput(spec.inputSchema)) {
+    return null;
+  }
+
   const isTerminal = deps.isStdinTerminal?.() ?? Deno.stdin.isTerminal();
   if (isTerminal) {
     return null;

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -585,6 +585,31 @@ describe("resolveParsedExecInput edge cases", () => {
     ).toEqual({});
   });
 
+  it("resolves a bare schema-less handler call without reading piped stdin", async () => {
+    // A rejecting reader proves stdin stays untouched: a schema-less input
+    // declares no payload, so the bare call must not wait on EOF even when
+    // stdin is a pipe.
+    const deps = {
+      isStdinTerminal: () => false,
+      readTextInput: () => Promise.reject(new Error("stdin was read")),
+    };
+
+    const stream = await resolveExecInvocation(
+      makeSpec("handler", { asCell: ["stream"] } as JSONSchema),
+      [],
+      deps,
+    );
+    expect(stream.parsed.verb).toBe("invoke");
+    expect(stream.input).toBeUndefined();
+
+    const unschematized = await resolveExecInvocation(
+      makeSpec("handler", true),
+      [],
+      deps,
+    );
+    expect(unschematized.input).toBeUndefined();
+  });
+
   it("normalizes only object inputs for tools with a string help field", () => {
     const spec = makeSpec("tool", {
       type: "object",

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -344,6 +344,54 @@ describe("executePieceCallable", () => {
     expect(harness.tracker.sendOptions).toEqual([]);
   });
 
+  // The $ref-carrying stream shape is schema-less to the arg parser, so a
+  // bare call skips the implicit-pipe read and the absence gate above
+  // decides — with stdin untouched. A rejecting reader pins the "untouched"
+  // half: piped bytes cannot reach a verb through this shape, they can only
+  // be spelled explicitly (`--json`, `--json-file -`).
+  it("refuses a bare $ref-stream verb call without reading piped stdin", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "recordMessage",
+      inputSchema: {
+        $ref: "#/$defs/RecordMessageEvent",
+        asCell: ["stream"],
+        $defs: {
+          RecordMessageEvent: {
+            type: "object",
+            properties: {
+              message: { type: "string" },
+            },
+            required: ["message"],
+          },
+        },
+      } as JSONSchema,
+    });
+
+    await expect(
+      executePieceCallable(
+        {
+          apiUrl: "http://localhost:8000",
+          identity: "/tmp/test-identity.pem",
+          piece: "fid1:piece-123",
+          space: "home",
+        },
+        "recordMessage",
+        [],
+        {
+          loadPieces: () => Promise.resolve(harness.pieces),
+          loadPiece: () => Promise.resolve(harness.piece),
+          isStdinTerminal: () => false,
+          readTextInput: () => Promise.reject(new Error("stdin was read")),
+        },
+      ),
+    ).rejects.toThrow(
+      /Invalid input for "recordMessage": no payload was supplied/,
+    );
+
+    expect(harness.tracker.handlerWrites).toEqual([]);
+  });
+
   it("normalizes an absent payload to {} so an all-defaulted verb receives its defaults", async () => {
     const harness = createPieceCallableHarness({
       callableKind: "handler",
@@ -761,6 +809,42 @@ describe("executePieceCallable", () => {
         value: {
           detail: { value: "Use `cat` to read files" },
         },
+      },
+    ]);
+  });
+
+  it("invokes a schema-less verb bare without reading piped stdin", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "archive",
+      inputSchema: { asCell: ["stream"] } as JSONSchema,
+    });
+
+    // A rejecting reader proves stdin stays untouched: the verb declares no
+    // input, so the bare spelling dispatches immediately instead of waiting
+    // for a pipe to reach EOF.
+    await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-123",
+        space: "home",
+      },
+      "archive",
+      [],
+      {
+        loadPieces: () => Promise.resolve(harness.pieces),
+        loadPiece: () => Promise.resolve(harness.piece),
+        isStdinTerminal: () => false,
+        readTextInput: () => Promise.reject(new Error("stdin was read")),
+      },
+    );
+
+    expect(harness.tracker.handlerWrites).toEqual([
+      {
+        cellProp: "result",
+        path: ["archive"],
+        value: undefined,
       },
     ]);
   });


### PR DESCRIPTION
## Why

`cf piece call --piece <piece> <verb>` with no payload hangs until stdin reaches EOF when the verb declares no input and stdin is not a tty — which is every pipe-fed shell, agent harness, and supervised script. It killed `verb-session-demo.sh`'s `archive` act twice (exit 143, exit 137) before it was understood, and it makes the exact spelling the help page advertises for no-input verbs unusable in scripts. (The issue's "hangs at a terminal until Ctrl-D" observation is this same mechanism: something reading a pipe fed by the terminal. A true tty stdin never reached the read — the resolver's terminal check already skipped it.) Fixes #5838.

The cause is neither of the documented stdin paths (`--json` / `--json-file -` / `--value-file -`). It is the implicit piped-input resolver: any handler invoked with zero raw args and a non-terminal stdin gets stdin read to EOF, on the theory that the payload was piped in. For a schema-less input (`Stream<void>`'s `{ asCell: ["stream"] }`, or a handler with no schema at all) there is no payload that read could produce — the CLI already renders these inputs as `void` and prints "Invoke alone will call the handler without any inputs."

## What Changed

`resolveImplicitPipedHandlerInput` returns before consulting stdin when `isSchemaLessHandlerInput` holds, so `cf piece call … <verb>` now dispatches immediately, exactly as `… <verb> -- invoke` does. That predicate is the schema-less branch of `handlerAllowsInvokeWithoutInputs`, the gate the help page advertises the bare spelling with — deliberately the narrower of the two:

- Handlers that declare input (object schemas, typed primitives) keep the implicit pipe unchanged.
- **Consciously accepted residual:** an all-optional object verb also gets the bare spelling advertised, and its bare call still waits on a piped stdin. That wait is inherent to keeping implicit piped JSON meaningful for such verbs — no code can tell a silent pipe from a slow one without waiting. Script authors who want no-wait there have `-- invoke`.
- The `$ref`-carrying stream shape also stops consulting stdin. The implicit read there could only deliver a raw string for the dispatch validator to refuse; a bare call now gets the clearer "no payload was supplied" refusal, with stdin untouched.

## Test plan

- New test at the resolver level: a bare schema-less handler call resolves without reading a non-terminal stdin (a rejecting reader proves stdin stays untouched), for both `{ asCell: ["stream"] }` and the schema-`true` fallback.
- New test through `executePieceCallable`: a schema-less verb invoked bare with piped stdin dispatches without reading it.
- New test pinning the `$ref`-stream shape: a bare call refuses with "no payload was supplied" without reading piped stdin, so a later narrowing of `isSchemaLessHandlerInput` cannot silently revert it.
- All three fail on unmodified code, and pass with the fix.
- Full `packages/cli` suite green. Repo-wide `deno fmt --check` and `deno lint` clean; `deno check` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)