### PR TITLE
feat(cli): the demo shows the two refusals, in one shape

### DIFF
--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -58,11 +58,13 @@ SPACE="${SPACE:-$(mktemp -u demoXXXXXXXX)}"
 
 B=$'\033[1m'; D=$'\033[2m'; C=$'\033[36m'; Y=$'\033[33m'; N=$'\033[0m'
 R=$'\033[31m'
-# Every act makes a claim: one not marked BROKEN says the command works, one
-# marked BROKEN says a named defect is still there. Both are counted, so a
-# transcript that got either wrong cannot exit 0 and read as a clean session.
+# Every act makes a claim: an unmarked one says the command works, a BROKEN one
+# says a named defect is still there, a REFUSED one says the surface turns this
+# down. All three are counted, so a transcript that got any of them wrong cannot
+# exit 0 and read as a clean session.
 UNEXPECTED=0
 CLOSED=0
+UNREFUSED=0
 # stderr is read back rather than shown as it arrives, so a failure can be
 # printed under the act it belongs to. mktemp rather than a name built from the
 # pid: this runs in a shared directory, and a predictable path is one an
@@ -134,6 +136,29 @@ broken() {
       "$R" "$N"
     printf '%s     its own signature%s\n' "$R" "$N"
     CLOSED=$((CLOSED + 1))
+  fi
+}
+
+# Same, for a command that is SUPPOSED to fail: a refusal is a capability, so
+# the error is the act's payoff and a nonzero exit is the success condition.
+# The inverse of `run`, and checked the same way — an act claiming a refusal
+# that the surface no longer makes is as wrong as an act claiming a success it
+# does not get, and reports itself rather than printing a result under a line
+# that says it was turned down.
+refused() {
+  local why=$1
+  shift
+  printf '\n%s   $ %s%s\n' "$C" "$(shown "$@")" "$N"
+  printf '%s     REFUSED — %s%s\n' "$D" "$why" "$N"
+  "$@" >/dev/null 2>"$ERR"
+  local rc=$?
+  grep -v '^invocation:\|^session:\|^TIP:\|^(Use --quiet\|^NEXT STEPS:\|^  *→' \
+    "$ERR" | grep -v '^$' | sed 's/^/       /'
+  if [ "$rc" = "0" ]; then
+    printf '%s     NOT REFUSED — this act says the surface turns this down,%s\n' \
+      "$R" "$N"
+    printf '%s     and it was accepted%s\n' "$R" "$N"
+    UNREFUSED=$((UNREFUSED + 1))
   fi
 }
 
@@ -215,7 +240,25 @@ run cf piece call -s "$SPACE" --piece "$KID" archive -- invoke
 say "What it changed is a read away, on the one field the caller never sets."
 run cf piece get -s "$SPACE" --piece "$KID" status
 
-act "10 · Relate two items — PENDING"
+act "10 · Ask for something that is not there"
+say "Every act so far named something the pattern declares. Getting it wrong is"
+say "the other half of a surface knowing its own vocabulary."
+# The payload carries `title` as well as the typo, so what is being refused is
+# the undeclared field and nothing else. A payload of the typo alone is refused
+# for missing a required property instead — the same exit code for a different
+# reason, and an act that cannot tell those apart would read the same before and
+# after this capability arrived.
+refused "a field the verb does not declare" \
+  cf piece call -s "$SPACE" --piece board addItem \
+  '{"title":"Ship it","titel":"typo"}'
+refused "a keyword the projection reader does not recognize" \
+  cf piece get -s "$SPACE" --piece "$EPIC" children \
+  --schema '{"type":"array","items":{"type":"object","propertes":{"title":true}}}'
+say "One shape of answer from both ends: what was wrong, the position it sat at,"
+say "what that position accepts, and the nearest thing you probably meant. The"
+say "call was turned down before an invocation was spent."
+
+act "11 · Relate two items — PENDING"
 say "The tracker is a graph, not just a tree: an item can wait on any other."
 pending "cf piece call -s $SPACE --piece <cookies> blockOn -- --on <csrf-address>" \
   "an address cannot yet be a verb argument (references-as-arguments.md)" \
@@ -228,11 +271,11 @@ pending "cf piece call -s $SPACE --piece <cookies> blockOn -- --on <csrf-address
   }
 }'
 
-act "11 · One item, two paths, one address — PENDING"
+act "12 · One item, two paths, one address — PENDING"
 say "This is what addresses are for: the same item under a parent AND as a blocker,"
 say "and a caller can tell it is one item rather than two copies."
 pending "cf piece get -s $SPACE --piece board items --select title,children@,blockedOn@" \
-  "needs the edge from act 10" \
+  "needs the edge from act 11" \
   'the same of:fid1:… appears under one item'"'"'s children and another'"'"'s blockedOn'
 
 printf '\n%s━━ %s %s\n' "$B" "What just happened" "$N"
@@ -243,7 +286,7 @@ say "One name was typed: 'board'. Everything under it was addressed by the id a"
 say "call handed back — which is the composition the verb surface exists for,"
 say "and the reason those lines are as long as they are."
 say ""
-say "Acts 10 and 11 are the graph half, sequenced as references-as-arguments."
+say "Acts 11 and 12 are the graph half, sequenced as references-as-arguments."
 say "verb-session-gaps.sh asserts both, and fails the day either one starts"
 say "working — so this demo cannot quietly go stale."
 
@@ -254,6 +297,13 @@ if [ "$UNEXPECTED" != "0" ]; then
   say "One of them did not hold, so this transcript does not describe cf."
 fi
 
+if [ "$UNREFUSED" != "0" ]; then
+  printf '\n%s━━ %d act(s) marked REFUSED were accepted%s\n' \
+    "$R" "$UNREFUSED" "$N"
+  say "A refusal this demo shows as a capability is no longer being made. Either"
+  say "it was withdrawn, or the payload it was written against became valid."
+fi
+
 if [ "$CLOSED" != "0" ]; then
   printf '\n%s━━ %d act(s) marked BROKEN no longer match their signature%s\n' \
     "$R" "$CLOSED" "$N"
@@ -262,4 +312,4 @@ if [ "$CLOSED" != "0" ]; then
   say "the same evidence so that neither can go stale alone."
 fi
 
-[ "$UNEXPECTED" = "0" ] && [ "$CLOSED" = "0" ]
+[ "$UNEXPECTED" = "0" ] && [ "$CLOSED" = "0" ] && [ "$UNREFUSED" = "0" ]


### PR DESCRIPTION
## Why

#5817 and #5835 each added a refusal, and the demo could show neither before
they landed: both cases previously succeeded, one silently.

Shown together they make a claim neither makes alone. A field the verb does not
declare and a keyword the projection reader does not recognize answer in the
**same shape** — what was wrong, the position it sat at, what that position
accepts, and the nearest thing you probably meant:

```
Invalid input for "addItem": "titel" at <event> is not a field this verb
declares. Did you mean "title"? <event> takes "title"

Invalid --schema at <root>[]: "propertes" is not a projection schema keyword.
Did you mean "properties"? Projection reads "type", "properties", "items",
"additionalProperties", "$link"
```

That is one vocabulary across the call end and the read end of the surface,
which is worth a person seeing side by side.

## What Changed

- Act 10 runs both refusals. The two PENDING acts renumber to 11 and 12.
- A fourth helper, `refused`. It is the inverse of `run`: a nonzero exit is the
  success condition, and an act claiming a refusal the surface no longer makes
  reports itself and fails the run — the way `broken` reports a defect that has
  been fixed. Every act now carries a claim that can fail: a success, a defect,
  or a refusal.

## The payload is the part worth reviewing

`{"title":"Ship it","titel":"typo"}` carries the required field **beside** the
typo, and that is deliberate. A payload of the typo alone is refused for
*missing a required property* — same exit code, different reason — so an act
written that way would have read identically before and after #5835 and told
nobody anything. It was written that way first; running it against main before
the PRs landed is what caught it.

## Test plan

Verified in both directions.

- **Against main with #5817 and #5835 in** (`bbddcb129`): demo exits 0, act 10
  prints both refusals, deterministic across runs. Harness untouched at 22
  passed, 0 failed, 2 gaps open.
- **Against main before they landed**: exit 1, `2 act(s) marked REFUSED were
  accepted` — the helper detecting its own act's claim going stale, which is the
  property it exists for.

`deno fmt --check` clean.

## Note for the reviewer

Overlaps #5839 in `verb-session-demo.sh`, in the footer and the act numbering
rather than in act 4. Whichever lands second rebases; both were verified after
their own rebases rather than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

