### PR TITLE
feat(cli): the demo steps back to read the board, and calls archive bare

### DIFF
--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -57,7 +57,7 @@ verbs, and they differ in nothing but what the new item is filed under:
 | `recordNote` | returns what only the pattern could compute: the clock is a handler capability, so the stamp cannot come from the caller | act 7 |
 | `finish` | returns a derived fact — `openBelow` takes a walk of the whole subtree, which a caller would pay N reads for | act 8 |
 | `archive` | declares no result: the invocation settles carrying no `result` at all, and what it changed is a separate read | act 9 |
-| `blockOn` | takes an address as an **argument** rather than as the receiver | act 10, **[blocked]** |
+| `blockOn` | takes an address as an **argument** rather than as the receiver | act 12, **[blocked]** |
 
 Those act numbers are `packages/cli/integration/verb-session-demo.sh`, which
 drives the session and prints each command before running it — the transcript is
@@ -448,6 +448,9 @@ containers holding it rather than being read past.
 
 The same options work on a call's result, on a wish, and on a direct read: one
 read layer, several arrivals.
+
+The demo's act 10 is this step run against the session's own tree: the whole
+board first, then only what is open, then the refusal.
 
 ## 6. Relate two items **[blocked]**
 

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -234,9 +234,10 @@ run cf piece call -s "$SPACE" --piece "$KID" --select item.title addChild -- --t
 run cf piece call -s "$SPACE" --piece "$EPIC" finish -- --body "shipping behind a flag"
 
 act "9 · A verb that declares no result"
-say "archive is Stream<void>: there is nothing for it to hand back, and the"
-say "invocation says so by settling with no result at all."
-run cf piece call -s "$SPACE" --piece "$KID" archive -- invoke
+say "archive is Stream<void>: nothing to supply, nothing handed back. The call"
+say "is the verb's name alone, and the invocation settles carrying no result"
+say "at all."
+run cf piece call -s "$SPACE" --piece "$KID" archive
 say "What it changed is a read away, on the one field the caller never sets."
 run cf piece get -s "$SPACE" --piece "$KID" status
 

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -240,7 +240,21 @@ run cf piece call -s "$SPACE" --piece "$KID" archive -- invoke
 say "What it changed is a read away, on the one field the caller never sets."
 run cf piece get -s "$SPACE" --piece "$KID" status
 
-act "10 · Ask for something that is not there"
+act "10 · Step back and read the board"
+say "Every change so far was seen one call at a time. One read from the name"
+say "the session started with shows the tree they add up to."
+run cf piece get -s "$SPACE" --piece board items --select title,status,children@
+say "Act 8 paid one verb call for depth — openBelow walked the subtree. Breadth"
+say "is a read: a filter decides membership before projection, so status picks"
+say "the elements and only title comes back."
+run cf piece get -s "$SPACE" --piece "$EPIC" children --select title --filter '.status == "open"'
+# The two halves of that question do not combine, and the refusal's own message
+# carries the reason, so nothing restates it here.
+refused "an address suffix under a filter" \
+  cf piece get -s "$SPACE" --piece "$EPIC" children \
+  --select @,title --filter '.status == "open"'
+
+act "11 · Ask for something that is not there"
 say "Every act so far named something the pattern declares. Getting it wrong is"
 say "the other half of a surface knowing its own vocabulary."
 # The payload carries `title` as well as the typo, so what is being refused is
@@ -258,7 +272,7 @@ say "One shape of answer from both ends: what was wrong, the position it sat at,
 say "what that position accepts, and the nearest thing you probably meant. The"
 say "call was turned down before an invocation was spent."
 
-act "11 · Relate two items — PENDING"
+act "12 · Relate two items — PENDING"
 say "The tracker is a graph, not just a tree: an item can wait on any other."
 pending "cf piece call -s $SPACE --piece <cookies> blockOn -- --on <csrf-address>" \
   "an address cannot yet be a verb argument (references-as-arguments.md)" \
@@ -271,11 +285,11 @@ pending "cf piece call -s $SPACE --piece <cookies> blockOn -- --on <csrf-address
   }
 }'
 
-act "12 · One item, two paths, one address — PENDING"
+act "13 · One item, two paths, one address — PENDING"
 say "This is what addresses are for: the same item under a parent AND as a blocker,"
 say "and a caller can tell it is one item rather than two copies."
 pending "cf piece get -s $SPACE --piece board items --select title,children@,blockedOn@" \
-  "needs the edge from act 11" \
+  "needs the edge from act 12" \
   'the same of:fid1:… appears under one item'"'"'s children and another'"'"'s blockedOn'
 
 printf '\n%s━━ %s %s\n' "$B" "What just happened" "$N"
@@ -286,7 +300,7 @@ say "One name was typed: 'board'. Everything under it was addressed by the id a"
 say "call handed back — which is the composition the verb surface exists for,"
 say "and the reason those lines are as long as they are."
 say ""
-say "Acts 11 and 12 are the graph half, sequenced as references-as-arguments."
+say "Acts 12 and 13 are the graph half, sequenced as references-as-arguments."
 say "verb-session-gaps.sh asserts both, and fails the day either one starts"
 say "working — so this demo cannot quietly go stale."
 


### PR DESCRIPTION
## Why

Stacked on #5843 (base branch `demo/refusals`); held on #5842 for the archive
act.

Two gaps in the demo's story, one act each.

**The session never looked at what it built.** Acts 4–9 change state seven
times, each change shown through its own call, and the transcript went straight
from the last write to the refusals with no step back. The one question a
tracker exists to answer — what is still open — was never asked, and
`--filter`, a read-layer capability the walkthrough's step 5 demonstrates and
the surface-shape plan puts in the shared read tail, appeared nowhere in the
session. The new act 10 reads the tree from the slug the session started with
(`--select title,status,children@`), then asks what is open
(`--select title --filter '.status == "open"'` — status decides membership and
does not come back), and closes with the surface refusing to combine an `@`
suffix with `--filter`, in the CLI's own words. A third refusal in a third
shape, shown where a caller meets it rather than beside act 11's vocabulary
refusals.

**Act 9 taught a workaround as if it were the spelling.** `-- invoke` was
#5840's workaround for the stdin hang (#5838); #5842 removes the hang, which
makes the bare call — the verb's name alone, nothing to supply — the spelling a
no-input verb's act should teach. The act now calls `archive` bare, which is
why this PR is held on #5842.

## What Changed

- New act 10, "Step back and read the board": a tree read from the board, a
  filtered read for open items, and the `@`+`--filter` refusal via `refused`.
  Later acts renumber — refusals to 11, the pendings to 12 and 13 — and the
  epilogue's act references move with them.
- Act 9 calls `archive` bare, and its narration says why the command is that
  short.
- Walkthrough: the blockOn row's act number (already stale at 10) is now 12,
  and step 5 names act 10 as its demo half.

## Test plan

Measured against a local toolshed with #5842's branch merged locally (this PR
ships nothing from it): the demo exits 0 with stdin held open by a silent pipe
for the whole run — the condition that killed the archive act twice before —
and all three claim counters (unexpected, unrefused, closed) at zero. The new
act's transcript: the tree read renders `status` beside `children` addresses,
the filter returns exactly the one open item with no `status` field on it, and
the combination exits 1 with "a filtered array's elements no longer say which
positions they came from, and an address names a position". Repo-wide
`deno fmt --check` clean; `deno task check-docs` passes all 549 blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

