### PR TITLE
refactor(data-model): share the codec benchmark subjects, and fix the decode walk's missing cycle state

### DIFF
--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -210,16 +210,18 @@ come up.
   ordinary English for writing something at length. `spell` is additionally an
   identifier here — the retired name for a pattern, still read by the state
   inspector — so prose that borrows the word costs a search as well.
-- **`visits`**, `finds`, or naming the place a thing arrived — not `meets` — for
-  coming across something during a walk or on a channel. A walk visits every node
-  it descends through; a format carrying no marker finds data it never emits; and
-  a cycle *here* arrived from a channel, which is usually better with no verb of
-  encountering in it at all. This is the sense the word can least afford, because
-  two others are already at work in these files and both stay: `meet` a
-  requirement — `meets the schema`, `must meet the threshold` — is ordinary and
-  exact, and `meet` is the lattice operation the Contextual Flow Control code is
-  built on, a technical term with test files named after it, where a stray prose
-  use costs a search.
+- **`visits`**, `reads`, `encounters`, `finds` — the list is open — not `meets`,
+  for coming across something during a walk or on a channel. It is the word that
+  is wrong here and not the sense, so pick what the site wants rather than one
+  substitute throughout: a walk visits every node it descends through, a decoder
+  reads what arrives, a format carrying no marker encounters data it never emits.
+  Often the cleanest sentence names where the thing arrived and wants no such
+  verb at all — "a cycle *here* arrived from a channel". What rules `meets` out
+  is that two other senses are already at work in these files, and both stay:
+  `meet` a requirement — `meets the schema`, `must meet the threshold` — is
+  ordinary and exact, and `meet` is the lattice operation the Contextual Flow
+  Control code is built on, a technical term with test files named after it,
+  where a stray prose use costs a search.
 
 ## Code Design & Principles
 

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -210,6 +210,16 @@ come up.
   ordinary English for writing something at length. `spell` is additionally an
   identifier here — the retired name for a pattern, still read by the state
   inspector — so prose that borrows the word costs a search as well.
+- **`visits`**, `finds`, or naming the place a thing arrived — not `meets` — for
+  coming across something during a walk or on a channel. A walk visits every node
+  it descends through; a format carrying no marker finds data it never emits; and
+  a cycle *here* arrived from a channel, which is usually better with no verb of
+  encountering in it at all. This is the sense the word can least afford, because
+  two others are already at work in these files and both stay: `meet` a
+  requirement — `meets the schema`, `must meet the threshold` — is ordinary and
+  exact, and `meet` is the lattice operation the Contextual Flow Control code is
+  built on, a technical term with test files named after it, where a stray prose
+  use costs a search.
 
 ## Code Design & Principles
 

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -217,10 +217,13 @@ come up.
   reads what arrives, a format carrying no marker encounters data it never emits.
   Often the cleanest sentence names where the thing arrived and wants no such
   verb at all — "a cycle *here* arrived from a channel". What rules `meets` out
-  is that two other senses are already at work in these files, and both stay:
-  `meet` a requirement — `meets the schema`, `must meet the threshold` — is
-  ordinary and exact, and `meet` is the lattice operation the Contextual Flow
-  Control code is built on, a technical term with test files named after it,
+  is that two other senses are already at work in these files, and both stay.
+  `meet` a requirement — `meet the condition`, `must meet the threshold` — is
+  ordinary and exact, with the caveat that the verb takes the requirement itself
+  as its object and not the artifact stating one: a value **satisfies** a schema,
+  or meets the schema's *requirements*, where "meets the schema" reaches past
+  what the verb selects for. And `meet` is the lattice operation the Contextual
+  Flow Control code is built on, a technical term with test files named after it,
   where a stray prose use costs a search.
 
 ## Code Design & Principles

--- a/packages/data-model/bench/codec-fixtures.ts
+++ b/packages/data-model/bench/codec-fixtures.ts
@@ -1,0 +1,305 @@
+/**
+ * Subjects shared by the codec benchmarks, built once so that every format
+ * measures the same values.
+ *
+ * A format's benchmark supplies its own encoded forms and its own
+ * `Deno.bench()` cases; what it takes from here is the values going in. That is
+ * what lets two formats' numbers be read side by side: a difference between
+ * them is a difference between the formats rather than between two sets of
+ * subjects that happen to have been written separately.
+ *
+ * The containers hold nothing but the number `0`. That is deliberate: it makes
+ * the per-element cost as close to nil as a format allows, so what the size
+ * series measures is the walker and the container handling rather than any one
+ * codec. The single-value group covers the codecs themselves, one subject each,
+ * and the omnibus groups cover what a mixed tree costs when escaping, holes,
+ * and several codecs all appear at once.
+ */
+
+import type { FabricValue } from "../src/interface.ts";
+import { FabricBytes } from "../src/fabric-primitives/FabricBytes.ts";
+import { FabricEpochNsec } from "../src/fabric-primitives/FabricEpochNsec.ts";
+import { FabricRegExp } from "../src/fabric-primitives/FabricRegExp.ts";
+import { FabricError } from "../src/fabric-instances/FabricError.ts";
+
+/** Container sizes: the empty case, then five orders of magnitude. */
+export const SIZES = [0, 1, 10, 100, 1000, 10000, 100000] as const;
+
+/**
+ * Sizes for the sparse series. Below ten there is nothing for a gap pattern to
+ * do: the generator always fills index zero, so a one-element array comes out
+ * dense, and an empty one has nothing to be sparse about.
+ */
+export const SPARSE_SIZES = SIZES.filter((size) => size >= 10);
+
+/**
+ * One subject per interesting path through the codec system: the
+ * self-representing cases, the four JavaScript types JSON cannot carry, a
+ * terminal and a nonterminal fabric codec, and both structural escapes.
+ *
+ * The two escapes are here rather than only inside the omnibus because that is
+ * where a path's own cost is legible. A `/`-prefixed key alone does not settle
+ * which applies: an object whose values are all plain data is quote-safe and
+ * gets `/quote`, where one carrying anything that itself encodes to a tagged
+ * form gets `/object` and has its entries decoded one by one.
+ */
+export const SINGLES: readonly (readonly [string, FabricValue])[] = [
+  ["null", null],
+  ["number", 914],
+  ["string", "a modest string"],
+  ["bigint", 9_007_199_254_740_993n],
+  ["special-number", Number.NaN],
+  ["symbol", Symbol.for("bench.symbol")],
+  ["undefined", undefined],
+  ["bytes", new FabricBytes(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]))],
+  ["epoch-nsec", new FabricEpochNsec(1_700_000_000_000_000_000n)],
+  ["regexp", new FabricRegExp(/wildcard.*match/gi)],
+  ["error", FabricError.fromNativeError(new Error("bench"))],
+  [
+    "quote-escape",
+    Object.freeze({
+      id: 914,
+      label: "plain throughout, so quote-safe",
+      enabled: true,
+      "/looks-tagged": "escaped by `/quote`",
+    }),
+  ],
+  [
+    "object-escape",
+    Object.freeze({
+      id: 914,
+      label: "carries a tagged value, so not quote-safe",
+      when: new FabricEpochNsec(1_700_000_000_000_000_000n),
+      "/looks-tagged": "escaped by `/object`",
+    }),
+  ],
+];
+
+/** Builds an array of `size` zeroes. */
+export function makeArray(size: number): FabricValue {
+  return Object.freeze(new Array(size).fill(0));
+}
+
+/**
+ * Builds a sparse array of `size` logical elements, with gaps that widen as
+ * the array goes on.
+ *
+ * Runs of a single hole would be the easy shape to generate and the least
+ * informative one: a run of any length costs exactly one wire entry, so
+ * alternating present and absent would measure one run length over and over
+ * and never exercise a large count. Widening the gaps covers the range
+ * instead, from ten missing indices up to runs of thousands. (Not from one:
+ * the first gap is already ten wide, `Math.max((1 * 3) - 10, 10)` having
+ * floored it there. A run of a single hole is exercised by the omnibus.)
+ *
+ * A consequence worth expecting rather than being surprised by: gaps that
+ * widen geometrically leave a count of present elements that grows with the
+ * logarithm of `size`. Under JSON, that makes the decode side of this series
+ * nearly flat across the magnitudes while the encode side still scales with
+ * the index range it walks. The flat column is the result to expect there.
+ * Large sparse arrays ceasing to decode quickly would mean a `/hole` run had
+ * stopped costing one entry, which is the property this series exists to hold.
+ * A format that carries a hole as a hole has no such run to hold, and reads
+ * differently.
+ */
+export function makeSparseArray(size: number): FabricValue {
+  const result = new Array(size);
+  let holeCount = 1;
+
+  for (let at = 0; at < size; at += holeCount + 1) {
+    result[at] = 0;
+    holeCount = Math.max((holeCount * 3) - 10, 10);
+  }
+
+  return Object.freeze(result);
+}
+
+/** Builds a plain object of `size` distinct keys, every value zero. */
+export function makeObject(size: number): FabricValue {
+  const result: Record<string, FabricValue> = {};
+  for (let i = 0; i < size; i++) {
+    result[`k${i}`] = 0;
+  }
+  return Object.freeze(result);
+}
+
+/**
+ * Builds a mixed tree of roughly `leaves` leaf values: nested containers, a
+ * sample of each codec, a rare array hole, and a rare `/`-prefixed key. This
+ * is the shape a real payload has, where the size series above deliberately
+ * has none of it.
+ *
+ * About one item in a hundred carries a `/`-prefixed key, which in a real
+ * payload rounds to none at all; giving one to every item would measure the
+ * escaping path rather than a tree that happens to contain it.
+ *
+ * Those rare items come in both flavors, because a `/`-prefixed key alone does
+ * not settle which escaping applies. An object whose values are all plain data
+ * is quote-safe and gets `/quote`; one carrying anything that itself encodes
+ * to a tagged form is not, and gets `/object` with its entries decoded
+ * individually. Two different paths through the walker, so both appear here --
+ * and at these frequencies both appear even in the smallest tree below.
+ */
+export function makeOmnibus(leaves: number): FabricValue {
+  const items: FabricValue[] = [];
+  for (let i = 0; i < leaves; i++) {
+    const flavor = i % 200;
+
+    if (flavor === 0) {
+      // Plain data throughout, so this one escapes as `/quote`.
+      items.push(Object.freeze({
+        id: i,
+        label: `item_${i}`,
+        enabled: (i % 2) === 0,
+        ratio: i / 7,
+        nested: Object.freeze({ depth: 1, tags: Object.freeze(["a", "b"]) }),
+        "/looks-tagged": "escaped by `/quote`",
+      }));
+      continue;
+    }
+
+    const item: Record<string, FabricValue> = {
+      id: i,
+      label: `item_${i}`,
+      enabled: (i % 2) === 0,
+      ratio: i / 7,
+      missing: undefined,
+      big: BigInt(i) * 1_000_000_007n,
+      when: new FabricEpochNsec(BigInt(i) * 1_000_000n),
+      pattern: new FabricRegExp(/x/g),
+      blob: new FabricBytes(new Uint8Array([i & 0xff, (i >> 8) & 0xff])),
+      nested: Object.freeze({
+        depth: 1,
+        // Sparse for about one item in a hundred. A hole is at least as rare
+        // in a real payload as a reserved key is, so making every item carry
+        // one would weight this toward a shape that does not occur.
+        items: Object.freeze(
+          (i % 100) === 2 ? [i, , i + 2] : [i, i + 1, i + 2],
+        ),
+      }),
+    };
+
+    if (flavor === 1) {
+      // Carries tagged values, so this one escapes as `/object`.
+      item["/looks-tagged"] = "escaped by `/object`";
+    }
+
+    items.push(Object.freeze(item));
+  }
+
+  return Object.freeze({
+    kind: "omnibus",
+    generated: new FabricEpochNsec(1_700_000_000_000_000_000n),
+    items: Object.freeze(items),
+  });
+}
+
+/**
+ * Builds a mixed tree of roughly `leaves` leaf values, every one of them a
+ * type JSON carries directly: no `/`-prefixed key, no array hole, no special
+ * number, and no `FabricSpecialObject`. The shape otherwise matches
+ * {@link makeOmnibus}, so the two are comparable size for size.
+ *
+ * Pass-through under JSON, and therefore under any format: nothing here draws
+ * a tag or an escape, so what a walk costs over this tree is the walk itself.
+ * A format that hands an unchanged subtree back by identity returns the whole
+ * of this one, the outermost value included.
+ */
+export function makeJsonPassThroughOmnibus(leaves: number): FabricValue {
+  const items: FabricValue[] = [];
+
+  for (let i = 0; i < leaves; i++) {
+    items.push(Object.freeze({
+      id: i,
+      label: `item_${i}`,
+      enabled: (i % 2) === 0,
+      ratio: i / 7,
+      nested: Object.freeze({
+        depth: 1,
+        tags: Object.freeze(["a", "b"]),
+        items: Object.freeze([i, i + 1, i + 2]),
+      }),
+    }));
+  }
+
+  return Object.freeze({
+    kind: "omnibus",
+    generated: "2026-01-01T00:00:00Z",
+    items: Object.freeze(items),
+  });
+}
+
+/**
+ * Builds a mixed tree of roughly `leaves` leaf values, every one of them a
+ * type structured cloning carries directly. That is everything
+ * {@link makeJsonPassThroughOmnibus} holds plus the five things JSON has to
+ * write out as tagged text or escape around: `bigint`, `undefined`, the
+ * special numbers, a `/`-prefixed key, and an array hole. No symbol and no
+ * `FabricSpecialObject`, cloning refusing the first and having no reading of
+ * the second.
+ *
+ * This is the difference between the two formats stated as a value. Pass-
+ * through for a realm-crossing format, which returns the whole tree by
+ * identity; under JSON nearly every item here is tagged or escaped, so the
+ * gap between this series and {@link makeJsonPassThroughOmnibus} is what the
+ * tagging machinery costs.
+ */
+export function makeRealmPassThroughOmnibus(leaves: number): FabricValue {
+  const items: FabricValue[] = [];
+
+  for (let i = 0; i < leaves; i++) {
+    items.push(Object.freeze({
+      id: i,
+      label: `item_${i}`,
+      enabled: (i % 2) === 0,
+      ratio: i / 7,
+      missing: undefined,
+      big: BigInt(i) * 1_000_000_007n,
+      odd: [Number.NaN, -0, Number.POSITIVE_INFINITY][i % 3],
+      "/looks-tagged": "an ordinary key where nothing reserves one",
+      nested: Object.freeze({
+        depth: 1,
+        // A hole in every item rather than one in a hundred: this series
+        // exists to hold the whole of what cloning carries and JSON does not,
+        // so every item carries every one of them.
+        items: Object.freeze([i, , i + 2]),
+      }),
+    }));
+  }
+
+  return Object.freeze({
+    kind: "omnibus",
+    generated: 1_700_000_000_000_000_000n,
+    items: Object.freeze(items),
+  });
+}
+
+//
+// Pre-built subjects, so that a benchmark measures only the call under test.
+//
+
+export const ARRAYS = SIZES.map((size) => [size, makeArray(size)] as const);
+export const SPARSE = SPARSE_SIZES.map(
+  (size) => [size, makeSparseArray(size)] as const,
+);
+export const OBJECTS = SIZES.map((size) => [size, makeObject(size)] as const);
+/** Leaf counts for every omnibus series, so the three are read against each other. */
+const OMNIBUS_SIZES = [10, 100, 1000] as const;
+
+export const OMNIBUSES = OMNIBUS_SIZES.map(
+  (n) => [n, makeOmnibus(n)] as const,
+);
+export const JSON_PASS_THROUGH_OMNIBUSES = OMNIBUS_SIZES.map(
+  (n) => [n, makeJsonPassThroughOmnibus(n)] as const,
+);
+export const REALM_PASS_THROUGH_OMNIBUSES = OMNIBUS_SIZES.map(
+  (n) => [n, makeRealmPassThroughOmnibus(n)] as const,
+);
+
+/**
+ * Zero-pads a size, so that group keys sort by magnitude: the largest container
+ * sorts after the smallest rather than between `1` and `10`.
+ */
+export function groupKey(prefix: string, size: number): string {
+  return `${prefix}-${String(size).padStart(6, "0")}`;
+}

--- a/packages/data-model/bench/codec-json.bench.ts
+++ b/packages/data-model/bench/codec-json.bench.ts
@@ -5,19 +5,13 @@
  *
  *     deno bench --no-check bench/codec-json.bench.ts
  *
- * Each group pairs the two directions over one subject, so the encode/decode
- * ratio for that subject reads off a single block. Group keys are zero-padded
- * to six digits, so that the largest container sorts after the smallest rather
- * than between `1` and `10`. A name repeats its group because `--filter`
- * matches names and not groups, and a subject one cannot select is a subject
- * one cannot iterate on.
+ * The subjects come from `codec-fixtures.ts`, shared with the other formats'
+ * benchmarks so that their numbers can be read side by side.
  *
- * The containers hold nothing but the number `0`. That is deliberate: it makes
- * the per-element cost as close to nil as the format allows, so what the size
- * series measures is the walker and the container handling rather than any
- * one codec. The single-value group covers the codecs themselves, one subject
- * each, and the omnibus groups cover what a mixed tree costs when escaping,
- * holes, and several codecs all appear at once.
+ * Each group pairs the two directions over one subject, so the encode/decode
+ * ratio for that subject reads off a single block. A name repeats its group
+ * because `--filter` matches names and not groups, and a subject one cannot
+ * select is a subject one cannot iterate on.
  *
  * Every subject is built before any measurement, and no case has setup to
  * exclude, so these take the plain `fn()` form rather than bracketing with
@@ -26,196 +20,16 @@
  */
 
 import { fabricFromJsonValue, jsonFromFabricValue } from "../src/codecs.ts";
-import type { FabricValue } from "../src/interface.ts";
-import { FabricBytes } from "../src/fabric-primitives/FabricBytes.ts";
-import { FabricEpochNsec } from "../src/fabric-primitives/FabricEpochNsec.ts";
-import { FabricRegExp } from "../src/fabric-primitives/FabricRegExp.ts";
-import { FabricError } from "../src/fabric-instances/FabricError.ts";
-
-//
-// Subjects
-//
-
-/** Container sizes: the empty case, then five orders of magnitude. */
-const SIZES = [0, 1, 10, 100, 1000, 10000, 100000] as const;
-
-/**
- * Sizes for the sparse series. Below ten there is nothing for a gap pattern to
- * do: the generator always fills index zero, so a one-element array comes out
- * dense, and an empty one has nothing to be sparse about.
- */
-const SPARSE_SIZES = SIZES.filter((size) => size >= 10);
-
-/**
- * One subject per interesting path through the codec system: the
- * self-representing cases, the four JavaScript types JSON cannot carry, a
- * terminal and a nonterminal fabric codec, and both structural escapes.
- *
- * The two escapes are here rather than only inside the omnibus because that is
- * where a path's own cost is legible. A `/`-prefixed key alone does not settle
- * which applies: an object whose values are all plain data is quote-safe and
- * gets `/quote`, where one carrying anything that itself encodes to a tagged
- * form gets `/object` and has its entries decoded one by one.
- */
-const SINGLES: readonly (readonly [string, FabricValue])[] = [
-  ["null", null],
-  ["number", 914],
-  ["string", "a modest string"],
-  ["bigint", 9_007_199_254_740_993n],
-  ["special-number", Number.NaN],
-  ["symbol", Symbol.for("bench.symbol")],
-  ["undefined", undefined],
-  ["bytes", new FabricBytes(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]))],
-  ["epoch-nsec", new FabricEpochNsec(1_700_000_000_000_000_000n)],
-  ["regexp", new FabricRegExp(/wildcard.*match/gi)],
-  ["error", FabricError.fromNativeError(new Error("bench"))],
-  [
-    "quote-escape",
-    Object.freeze({
-      id: 914,
-      label: "plain throughout, so quote-safe",
-      enabled: true,
-      "/looks-tagged": "escaped by `/quote`",
-    }),
-  ],
-  [
-    "object-escape",
-    Object.freeze({
-      id: 914,
-      label: "carries a tagged value, so not quote-safe",
-      when: new FabricEpochNsec(1_700_000_000_000_000_000n),
-      "/looks-tagged": "escaped by `/object`",
-    }),
-  ],
-];
-
-/** Builds an array of `size` zeroes. */
-function makeArray(size: number): FabricValue {
-  return Object.freeze(new Array(size).fill(0));
-}
-
-/**
- * Builds a sparse array of `size` logical elements, with gaps that widen as
- * the array goes on.
- *
- * Runs of a single hole would be the easy shape to generate and the least
- * informative one: a run of any length costs exactly one wire entry, so
- * alternating present and absent would measure one run length over and over
- * and never exercise a large count. Widening the gaps covers the range
- * instead, from ten missing indices up to runs of thousands. (Not from one:
- * the first gap is already ten wide, `Math.max((1 * 3) - 10, 10)` having
- * floored it there. A run of a single hole is exercised by the omnibus.)
- *
- * A consequence worth expecting rather than being surprised by: gaps that
- * widen geometrically leave a count of present elements that grows with the
- * logarithm of `size`, so the decode side of this series is nearly flat across
- * the magnitudes while the encode side still scales with the index range it
- * walks. The flat column is the result to expect. Large sparse arrays ceasing
- * to decode quickly would mean a `/hole` run had stopped costing one entry,
- * which is the property this series exists to hold.
- */
-function makeSparseArray(size: number): FabricValue {
-  const result = new Array(size);
-  let holeCount = 1;
-
-  for (let at = 0; at < size; at += holeCount + 1) {
-    result[at] = 0;
-    holeCount = Math.max((holeCount * 3) - 10, 10);
-  }
-
-  return Object.freeze(result);
-}
-
-/** Builds a plain object of `size` distinct keys, every value zero. */
-function makeObject(size: number): FabricValue {
-  const result: Record<string, FabricValue> = {};
-  for (let i = 0; i < size; i++) {
-    result[`k${i}`] = 0;
-  }
-  return Object.freeze(result);
-}
-
-/**
- * Builds a mixed tree of roughly `leaves` leaf values: nested containers, a
- * sample of each codec, a rare array hole, and a rare `/`-prefixed key. This
- * is the shape a real payload has, where the size series above deliberately
- * has none of it.
- *
- * About one item in a hundred carries a `/`-prefixed key, which in a real
- * payload rounds to none at all; giving one to every item would measure the
- * escaping path rather than a tree that happens to contain it.
- *
- * Those rare items come in both flavors, because a `/`-prefixed key alone does
- * not settle which escaping applies. An object whose values are all plain data
- * is quote-safe and gets `/quote`; one carrying anything that itself encodes
- * to a tagged form is not, and gets `/object` with its entries decoded
- * individually. Two different paths through the walker, so both appear here --
- * and at these frequencies both appear even in the smallest tree below.
- */
-function makeOmnibus(leaves: number): FabricValue {
-  const items: FabricValue[] = [];
-  for (let i = 0; i < leaves; i++) {
-    const flavor = i % 200;
-
-    if (flavor === 0) {
-      // Plain data throughout, so this one escapes as `/quote`.
-      items.push(Object.freeze({
-        id: i,
-        label: `item_${i}`,
-        enabled: (i % 2) === 0,
-        ratio: i / 7,
-        nested: Object.freeze({ depth: 1, tags: Object.freeze(["a", "b"]) }),
-        "/looks-tagged": "escaped by `/quote`",
-      }));
-      continue;
-    }
-
-    const item: Record<string, FabricValue> = {
-      id: i,
-      label: `item_${i}`,
-      enabled: (i % 2) === 0,
-      ratio: i / 7,
-      missing: undefined,
-      big: BigInt(i) * 1_000_000_007n,
-      when: new FabricEpochNsec(BigInt(i) * 1_000_000n),
-      pattern: new FabricRegExp(/x/g),
-      blob: new FabricBytes(new Uint8Array([i & 0xff, (i >> 8) & 0xff])),
-      nested: Object.freeze({
-        depth: 1,
-        // Sparse for about one item in a hundred. A hole is at least as rare
-        // in a real payload as a reserved key is, so making every item carry
-        // one would weight this toward a shape that does not occur.
-        items: Object.freeze(
-          (i % 100) === 2 ? [i, , i + 2] : [i, i + 1, i + 2],
-        ),
-      }),
-    };
-
-    if (flavor === 1) {
-      // Carries tagged values, so this one escapes as `/object`.
-      item["/looks-tagged"] = "escaped by `/object`";
-    }
-
-    items.push(Object.freeze(item));
-  }
-
-  return Object.freeze({
-    kind: "omnibus",
-    generated: new FabricEpochNsec(1_700_000_000_000_000_000n),
-    items: Object.freeze(items),
-  });
-}
-
-//
-// Pre-built subjects, so that a benchmark measures only the call under test.
-//
-
-const ARRAYS = SIZES.map((size) => [size, makeArray(size)] as const);
-const SPARSE = SPARSE_SIZES.map(
-  (size) => [size, makeSparseArray(size)] as const,
-);
-const OBJECTS = SIZES.map((size) => [size, makeObject(size)] as const);
-const OMNIBUSES = [10, 100, 1000].map((n) => [n, makeOmnibus(n)] as const);
+import {
+  ARRAYS,
+  groupKey,
+  JSON_PASS_THROUGH_OMNIBUSES,
+  OBJECTS,
+  OMNIBUSES,
+  REALM_PASS_THROUGH_OMNIBUSES,
+  SINGLES,
+  SPARSE,
+} from "./codec-fixtures.ts";
 
 /** Encoded forms, for the decode direction. */
 const SINGLES_JSON = SINGLES.map(([n, v]) =>
@@ -233,11 +47,12 @@ const OBJECTS_JSON = OBJECTS.map(([n, v]) =>
 const OMNIBUSES_JSON = OMNIBUSES.map(([n, v]) =>
   [n, jsonFromFabricValue(v)] as const
 );
-
-/** Zero-pads a size, so that group keys sort by magnitude. */
-function groupKey(prefix: string, size: number): string {
-  return `${prefix}-${String(size).padStart(6, "0")}`;
-}
+const JSON_PASS_THROUGH_JSON = JSON_PASS_THROUGH_OMNIBUSES.map(([n, v]) =>
+  [n, jsonFromFabricValue(v)] as const
+);
+const REALM_PASS_THROUGH_JSON = REALM_PASS_THROUGH_OMNIBUSES.map(([n, v]) =>
+  [n, jsonFromFabricValue(v)] as const
+);
 
 // Warm up. Deno warms each benchmark on its own, so this is belt-and-braces
 // -- but it covers the codec paths rather than only the container walks,
@@ -369,6 +184,55 @@ for (const [leaves, json] of OMNIBUSES_JSON) {
   Deno.bench({
     name: `decode ${groupKey("omnibus", leaves)}`,
     group: groupKey("omnibus", leaves),
+    fn() {
+      fabricFromJsonValue(json);
+    },
+  });
+}
+
+//
+// Omnibus trees whose contents need no encoding, and those whose contents need
+// none only under a realm-crossing format. The gap between the two is what
+// this format's tagging and escaping cost over a tree that another format
+// carries directly.
+//
+
+for (const [leaves, value] of JSON_PASS_THROUGH_OMNIBUSES) {
+  Deno.bench({
+    name: `encode ${groupKey("json-pass-through", leaves)}`,
+    group: groupKey("json-pass-through", leaves),
+    baseline: true,
+    fn() {
+      jsonFromFabricValue(value);
+    },
+  });
+}
+
+for (const [leaves, json] of JSON_PASS_THROUGH_JSON) {
+  Deno.bench({
+    name: `decode ${groupKey("json-pass-through", leaves)}`,
+    group: groupKey("json-pass-through", leaves),
+    fn() {
+      fabricFromJsonValue(json);
+    },
+  });
+}
+
+for (const [leaves, value] of REALM_PASS_THROUGH_OMNIBUSES) {
+  Deno.bench({
+    name: `encode ${groupKey("realm-pass-through", leaves)}`,
+    group: groupKey("realm-pass-through", leaves),
+    baseline: true,
+    fn() {
+      jsonFromFabricValue(value);
+    },
+  });
+}
+
+for (const [leaves, json] of REALM_PASS_THROUGH_JSON) {
+  Deno.bench({
+    name: `decode ${groupKey("realm-pass-through", leaves)}`,
+    group: groupKey("realm-pass-through", leaves),
     fn() {
       fabricFromJsonValue(json);
     },

--- a/packages/data-model/bench/codec-json.bench.ts
+++ b/packages/data-model/bench/codec-json.bench.ts
@@ -29,7 +29,7 @@ import {
   REALM_PASS_THROUGH_OMNIBUSES,
   SINGLES,
   SPARSE,
-} from "./codec-fixtures.ts";
+} from "./fixtures/codec-fixtures.ts";
 
 /** Encoded forms, for the decode direction. */
 const SINGLES_JSON = SINGLES.map(([n, v]) =>

--- a/packages/data-model/bench/fixtures/codec-fixtures.ts
+++ b/packages/data-model/bench/fixtures/codec-fixtures.ts
@@ -16,11 +16,11 @@
  * and several codecs all appear at once.
  */
 
-import type { FabricValue } from "../src/interface.ts";
-import { FabricBytes } from "../src/fabric-primitives/FabricBytes.ts";
-import { FabricEpochNsec } from "../src/fabric-primitives/FabricEpochNsec.ts";
-import { FabricRegExp } from "../src/fabric-primitives/FabricRegExp.ts";
-import { FabricError } from "../src/fabric-instances/FabricError.ts";
+import type { FabricValue } from "../../src/interface.ts";
+import { FabricBytes } from "../../src/fabric-primitives/FabricBytes.ts";
+import { FabricEpochNsec } from "../../src/fabric-primitives/FabricEpochNsec.ts";
+import { FabricRegExp } from "../../src/fabric-primitives/FabricRegExp.ts";
+import { FabricError } from "../../src/fabric-instances/FabricError.ts";
 
 /** Container sizes: the empty case, then five orders of magnitude. */
 export const SIZES = [0, 1, 10, 100, 1000, 10000, 100000] as const;

--- a/packages/data-model/src/codec-common/BaseCodecEngine.ts
+++ b/packages/data-model/src/codec-common/BaseCodecEngine.ts
@@ -139,10 +139,29 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
   /** Wraps a tag and state into this format's tagged wire form. */
   protected abstract wrapTag(tag: string, state: Encoded): Encoded;
 
-  /** Decodes a transport tree back into fabric values. */
+  /**
+   * Decodes a transport tree back into fabric values.
+   *
+   * `seen` carries the nodes whose decoding is in progress, the decode side's
+   * counterpart to what {@link #encodeValue} threads, so that a cycle arriving
+   * on a channel is caught rather than followed. Whether there is one at all
+   * is the format's decision, taken at its public entry points: a format whose
+   * input it parses for itself cannot be handed a cycle and pays nothing here,
+   * where one handed a tree it did not build starts a set.
+   *
+   * An implementation that is given a set owes it one thing: every object it
+   * is about to descend through goes through {@link #enterOrReport} first, and
+   * comes back out however the descent ends. That means the tagged form as
+   * much as a container -- a format whose transport can carry a graph can
+   * close a cycle through tagged nodes alone. Here rather than in
+   * {@link #decodeTagged}, because this method is the one that meets every
+   * node, and entering in both places would enter a state twice and report a
+   * cycle that is not there.
+   */
   protected abstract decodeValue(
     data: Encoded,
     context: ReconstructionContext,
+    seen?: Set<object>,
   ): FabricValue;
 
   //
@@ -285,11 +304,19 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
    * Frozen-ness contract: a value returned through the codec arm here is
    * deep-frozen, so callers do not each have to freeze. The unknown-tag
    * fallback is a separate arm and is intentionally NOT covered by it.
+   *
+   * Three of the arms below walk the state again -- a nonterminal codec's, an
+   * unknown tag's, and a malformed tag's -- and each carries `seen` into that
+   * walk. Entering the state is not this method's business: it is
+   * {@link #decodeValue} that meets every node of the tree, the tagged form
+   * included, and entering there is what keeps one node from being entered
+   * twice.
    */
   protected decodeTagged(
     tag: any,
     rawState: Encoded,
     context: ReconstructionContext,
+    seen?: Set<object>,
   ): FabricValue {
     if (!isCodecTypeTag(tag)) {
       // Anything that is not a tag syntactically is an encoding error whatever
@@ -299,7 +326,7 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
       // decoded state, so that a lenient result carries what arrived.
       return this.reportMalformed(
         tag,
-        this.decodeValue(rawState, context),
+        this.decodeValue(rawState, context, seen),
         `tagged value has a malformed tag: ${
           backtickQuote(toCompactDebugString(tag, 30))
         }`,
@@ -312,14 +339,16 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
       // A tag this registry does not carry, kept in the unknown form so that
       // it round-trips. Not covered by the deep-frozen contract the codec arm
       // below states.
-      return new UnknownValue(tag, this.decodeValue(rawState, context));
+      return new UnknownValue(tag, this.decodeValue(rawState, context, seen));
     }
 
     // A terminal codec takes the state exactly as it arrived; a nonterminal
     // one takes it expanded. The casts restate what `instanceof` just
     // established, which TypeScript drops on a generic class.
     const terminal = matched instanceof BaseTerminalCodec;
-    const state = terminal ? rawState : this.decodeValue(rawState, context);
+    const state = terminal
+      ? rawState
+      : this.decodeValue(rawState, context, seen);
 
     let decoded: FabricValue;
 
@@ -376,6 +405,40 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
     // `FabricPrimitive` is already frozen, making it an O(1) cache hit -- and
     // the lenient fallback above alike.
     return deepFreeze(decoded);
+  }
+
+  /**
+   * Enters a container into the in-progress set, reporting rather than
+   * entering if it is already there.
+   *
+   * Reported rather than raised, unlike the encode side's refusal: a cycle met
+   * here arrived from a channel, and every malformation off a channel settles
+   * against {@link #lenient}. Raising unconditionally would also be the one
+   * refusal a lenient decode could not contain.
+   *
+   * The report carries a rendering of the container rather than the container
+   * itself, a cyclic graph being the one thing a `ProblematicValue` cannot
+   * hold onto.
+   *
+   * @param seen The containers whose decoding is in progress.
+   * @param value The container about to be walked.
+   * @returns The report, or `null` if `value` was entered.
+   * @throws If this engine is not lenient.
+   */
+  protected enterOrReport(
+    seen: Set<object>,
+    value: object,
+  ): FabricValue | null {
+    if (seen.has(value)) {
+      return this.reportMalformed(
+        "",
+        toCompactDebugString(value, 50),
+        "circular reference in decoded data",
+      );
+    }
+
+    seen.add(value);
+    return null;
   }
 
   /** Encodes one value through the codec the registry matched to it. */

--- a/packages/data-model/src/codec-common/BaseCodecEngine.ts
+++ b/packages/data-model/src/codec-common/BaseCodecEngine.ts
@@ -116,7 +116,7 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
    *
    * @throws If `data` is not this format's serialized form -- which a format
    *   carrying a marker can tell from the marker alone, and one without can
-   *   only tell from meeting something it never emits -- or if a codec rejects
+   *   only tell from finding something it never emits -- or if a codec rejects
    *   a state and this instance is not lenient.
    */
   abstract decode(
@@ -154,7 +154,7 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
    * comes back out however the descent ends. That means the tagged form as
    * much as a container -- a format whose transport can carry a graph can
    * close a cycle through tagged nodes alone. Here rather than in
-   * {@link #decodeTagged}, because this method is the one that meets every
+   * {@link #decodeTagged}, because this method is the one that visits every
    * node, and entering in both places would enter a state twice and report a
    * cycle that is not there.
    */
@@ -308,7 +308,7 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
    * Three of the arms below walk the state again -- a nonterminal codec's, an
    * unknown tag's, and a malformed tag's -- and each carries `seen` into that
    * walk. Entering the state is not this method's business: it is
-   * {@link #decodeValue} that meets every node of the tree, the tagged form
+   * {@link #decodeValue} that visits every node of the tree, the tagged form
    * included, and entering there is what keeps one node from being entered
    * twice.
    */
@@ -411,7 +411,7 @@ export abstract class BaseCodecEngine<Encoded, SerializedForm = Encoded>
    * Enters a container into the in-progress set, reporting rather than
    * entering if it is already there.
    *
-   * Reported rather than raised, unlike the encode side's refusal: a cycle met
+   * Reported rather than raised, unlike the encode side's refusal: a cycle
    * here arrived from a channel, and every malformation off a channel settles
    * against {@link #lenient}. Raising unconditionally would also be the one
    * refusal a lenient decode could not contain.

--- a/packages/data-model/src/codec-common/UnknownValue.ts
+++ b/packages/data-model/src/codec-common/UnknownValue.ts
@@ -18,8 +18,8 @@ import { ProblematicStateError } from "./ProblematicStateError.ts";
 
 /**
  * Container for an unrecognized type's data, used for round-tripping. When the
- * serialization system meets a tag no codec claims during deserialization, it
- * wraps the tag and state here; on re-serialization, the preserved pair
+ * serialization system encounters a tag no codec claims during deserialization,
+ * it wraps the tag and state here; on re-serialization, the preserved pair
  * reproduces the original wire form. See Section 3.3 of the formal spec.
  *
  * The tag is a real tag, checked at construction. That is what makes the

--- a/packages/data-model/src/codec-json/JsonCodecEngine.ts
+++ b/packages/data-model/src/codec-json/JsonCodecEngine.ts
@@ -58,6 +58,11 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
    *
    * Checks the format tag, parses what follows it, and walks the resulting
    * tree back into fabric values.
+   *
+   * The walk carries no cycle guard, and needs none: what it walks is the
+   * product of `JSON.parse()`, and a parse of text yields a tree. This format
+   * never receives a tree it did not build itself, which is the condition
+   * under which a decode can be handed a cycle at all.
    */
   override decode(data: string, context: ReconstructionContext): FabricValue {
     if (!JsonCodecEngine.seemsLikeEncoded(data)) {
@@ -77,7 +82,11 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
     return JsonCodecEngine.#toBytes(this.encodeValue(value));
   }
 
-  /** Deserializes UTF-8 JSON bytes back into a fabric value. */
+  /**
+   * Deserializes UTF-8 JSON bytes back into a fabric value. Carries no cycle
+   * guard, for the reason {@link #decode} gives: this walk too gets its tree
+   * from a parse.
+   */
   decodeFromBytes(
     bytes: Uint8Array,
     context: ReconstructionContext,
@@ -199,6 +208,7 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
   protected override decodeValue(
     data: JsonCodecValue,
     context: ReconstructionContext,
+    seen?: Set<object>,
   ): FabricValue {
     const decoded = JsonCodecEngine.#unwrapTag(data);
     if (decoded !== null) {
@@ -219,14 +229,14 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
           if (isUnsafeObjectKey(key)) {
             return this.reportReservedKey(key, inner);
           }
-          result[key] = this.decodeValue(val, context);
+          result[key] = this.decodeValue(val, context, seen);
         }
         return Object.freeze(result);
       }
 
       // `/quote` and `/object` returned above, so no codec ever sees their
       // state, and `/quote` contents alone go undecoded.
-      return this.decodeTagged(tag, rawState, context);
+      return this.decodeTagged(tag, rawState, context, seen);
     }
 
     // Primitives pass through.
@@ -238,7 +248,7 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
     }
 
     if (Array.isArray(data)) {
-      return this.#decodeArray(data, context);
+      return this.#decodeArray(data, context, seen);
     }
 
     // `Array.isArray()` above removed the array arm, but TypeScript keeps it
@@ -246,6 +256,7 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
     return this.#decodePlainObject(
       data as Record<string, JsonCodecValue>,
       context,
+      seen,
     );
   }
 
@@ -272,6 +283,7 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
   #decodeArray(
     data: readonly JsonCodecValue[],
     context: ReconstructionContext,
+    seen: Set<object> | undefined,
   ): FabricValue {
     const result: FabricValue[] = new Array(data.length);
     let targetIndex = 0;
@@ -292,7 +304,7 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
         }
         targetIndex += count;
       } else {
-        result[targetIndex] = this.decodeValue(entry, context);
+        result[targetIndex] = this.decodeValue(entry, context, seen);
         targetIndex++;
       }
     }
@@ -324,6 +336,7 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
   #decodePlainObject(
     data: Record<string, JsonCodecValue>,
     context: ReconstructionContext,
+    seen: Set<object> | undefined,
   ): FabricValue {
     const result: Record<string, FabricValue> = {};
     for (const [key, val] of Object.entries(data)) {
@@ -342,7 +355,7 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
       if (isUnsafeObjectKey(key)) {
         return this.reportReservedKey(key, data);
       }
-      result[key] = this.decodeValue(val, context);
+      result[key] = this.decodeValue(val, context, seen);
     }
     return Object.freeze(result);
   }

--- a/packages/data-model/test/codec-common/BaseCodecEngine.test.ts
+++ b/packages/data-model/test/codec-common/BaseCodecEngine.test.ts
@@ -141,6 +141,76 @@ describe("BaseCodecEngine", () => {
     });
   });
 
+  describe("decodeValue()", () => {
+    // The guard these exercise is the base's, reached through `enterOrReport()`
+    // and the `seen` threaded from `decode()`. A format whose transport is a
+    // tree can be handed a cycle by a peer, where one that parses its own
+    // input cannot, so this is wire data like any other malformation and
+    // settles against `lenient` rather than raising unconditionally.
+
+    it("reports a circular reference through a container", () => {
+      const { engine } = newProbeEngine({ lenient: true });
+      const data: Record<string, ProbeValue> = { a: 1 };
+      data.self = data;
+
+      const result = engine.decode(data, CONTEXT) as Record<
+        string,
+        FabricValue
+      >;
+
+      expect(result.a).toBe(1);
+      expect(result.self).toBeInstanceOf(ProblematicValue);
+      expect((result.self as ProblematicValue).error)
+        .toMatch(/circular reference/);
+    });
+
+    it("reports a circular reference that closes through a tagged node", () => {
+      // A cycle need not run through a container at all: the state under a tag
+      // is walked for an unknown tag, as it is for a nonterminal codec, so
+      // guarding only the container arms would follow this one forever.
+      const { engine } = newProbeEngine({ lenient: true });
+      const state: Record<string, ProbeValue> = {};
+      const tagged = new Tagged("Zz@1", state);
+      state.back = tagged;
+
+      const result = engine.decode(tagged, CONTEXT);
+
+      expect(result).toBeInstanceOf(UnknownValue);
+      const inner = (result as UnknownValue).state as Record<
+        string,
+        FabricValue
+      >;
+      expect(inner.back).toBeInstanceOf(ProblematicValue);
+      expect((inner.back as ProblematicValue).error)
+        .toMatch(/circular reference/);
+    });
+
+    it("throws given a circular reference when not lenient", () => {
+      const { engine } = newProbeEngine();
+      const data: Record<string, ProbeValue> = { a: 1 };
+      data.self = data;
+
+      expect(() => engine.decode(data, CONTEXT))
+        .toThrow(ProblematicStateError);
+    });
+
+    it("does not mistake a repeated node for a circular one", () => {
+      // The same node twice over is not a cycle, so `seen` has to be unwound as
+      // the walk leaves each node rather than only grown. Both a container and
+      // a tagged node, those being entered by the same call site.
+      const { engine } = newProbeEngine();
+      const shared: Record<string, ProbeValue> = { v: 1 };
+      const tagged = new Tagged("Zz@1", 2);
+
+      expect(() =>
+        engine.decode(
+          { a: shared, b: shared, c: tagged, d: tagged },
+          CONTEXT,
+        )
+      ).not.toThrow();
+    });
+  });
+
   describe("decodeTagged()", () => {
     it("wraps an unrecognized tag in an `UnknownValue`, decoded state kept", () => {
       const { engine } = newProbeEngine();

--- a/packages/data-model/test/codec-common/probe-engine.ts
+++ b/packages/data-model/test/codec-common/probe-engine.ts
@@ -293,11 +293,14 @@ export class ProbeEngine extends BaseCodecEngine<ProbeValue> {
     return this.encodeValue(value);
   }
 
+  // A set is started here, unlike `JsonCodecEngine`'s entry points: this
+  // format's transport is the tree itself, so a caller can hand `decode()` a
+  // graph with a cycle in it, and the base's guard is what refuses one.
   override decode(
     data: ProbeValue,
     context: ReconstructionContext,
   ): FabricValue {
-    return this.decodeValue(data, context);
+    return this.decodeValue(data, context, new Set());
   }
 
   protected override wrapTag(tag: string, state: ProbeValue): ProbeValue {
@@ -330,20 +333,37 @@ export class ProbeEngine extends BaseCodecEngine<ProbeValue> {
   protected override decodeValue(
     data: ProbeValue,
     context: ReconstructionContext,
+    seen?: Set<object>,
   ): FabricValue {
-    if (data instanceof Tagged) {
-      return this.decodeTagged(data.tag, data.state, context);
-    } else if (Array.isArray(data)) {
-      return data.map((d) => this.decodeValue(d, context));
-    } else if ((data !== null) && (typeof data === "object")) {
-      const result: Record<string, FabricValue> = {};
-      for (const [k, v] of Object.entries(data)) {
-        result[k] = this.decodeValue(v as ProbeValue, context);
-      }
-      return result;
+    if ((data === null) || (typeof data !== "object")) {
+      return data as FabricValue;
     }
 
-    return data as FabricValue;
+    // Every object node goes through the guard, the tagged form included: this
+    // format's transport is the tree itself, so a `Tagged` can hold a
+    // reference back to a node above it with no container in between.
+    if (seen !== undefined) {
+      const cycle = this.enterOrReport(seen, data);
+      if (cycle !== null) {
+        return cycle;
+      }
+    }
+
+    try {
+      if (data instanceof Tagged) {
+        return this.decodeTagged(data.tag, data.state, context, seen);
+      } else if (Array.isArray(data)) {
+        return data.map((d) => this.decodeValue(d, context, seen));
+      }
+
+      const result: Record<string, FabricValue> = {};
+      for (const [k, v] of Object.entries(data)) {
+        result[k] = this.decodeValue(v as ProbeValue, context, seen);
+      }
+      return result;
+    } finally {
+      seen?.delete(data);
+    }
   }
 }
 

--- a/packages/runner/test/favorites-row-stored-shape.test.ts
+++ b/packages/runner/test/favorites-row-stored-shape.test.ts
@@ -33,7 +33,7 @@ import type { RuntimeProgram } from "../src/harness/types.ts";
 // fresh-data test stays green against the bug — which is precisely how the
 // mismatch survived every existing test. The swap is what production does when
 // the auto-update moves a piece to new source, and it is the moment the stored
-// row meets the schema.
+// row is checked against the schema.
 
 const signer = await Identity.fromPassphrase("favorites-row-stored-shape");
 const space = signer.did();


### PR DESCRIPTION
Two pieces of groundwork that a second wire format needs, both general and
neither specific to it. I (agent working on behalf of @danfuzz) am opening this
ahead of the realm-format work so that the shared machinery lands and is
reviewed on its own.

## The benchmark subjects become shared

`codec-json.bench.ts` held the only set of codec benchmark subjects. They move
to `codec-fixtures.ts`, so that a second format's benchmark measures the same
values rather than a set written separately beside it — which is what makes a
difference between two formats' numbers a difference between the formats.

The move is faithful. Every code line is identical bar the new import and one
`deno fmt` rewrap; the one paragraph that made a JSON-specific claim (about what
the sparse series holds) now says which format it is claiming it of, rather than
asserting it of every reader of a shared file.

Two omnibus series join the existing one, each defined by what a format has to
*do* with it rather than by its size:

- **`json-pass-through`** holds only types JSON carries directly. It draws no
  tag and no escape under any format, so what a walk costs over it is the walk
  itself.
- **`realm-pass-through`** adds exactly the five things JSON must write out as
  tagged text or escape around — `bigint`, `undefined`, the special numbers, a
  `/`-prefixed key, and an array hole — and nothing else.

The gap between the two is the tagging and escaping machinery stated as a
measurement. Both guarantees are verified rather than asserted: the first emits
no tag at all, and the second emits exactly `/BigInt@1`, `/SpecialNumber@1`,
`/Undefined@1`, `/hole` and `/object`.

## The decode walk gets the cycle state the encode walk has

This is the substantive half, and it is a defect in `BaseCodecEngine` rather
than in any one format.

The encode side owns its cycle state here: `encodeValue()` threads a `seen` set
through every arm, `#encodeTagged()` enters and leaves around the codec
recursion, and `enterOrThrow()` is a static on this class. Every format inherits
a guard covering its tagged form as well as its containers.

The decode side owned nothing. `decodeValue()` took no walk state, and
`decodeTagged()` recursed back into it at three sites — the malformed-tag arm,
the unknown-tag arm, and a nonterminal codec's state — carrying nothing. A
format whose transport can hold a cycle had to invent per-instance state of its
own and guard its own tagged arm, and those three recursion edges inside this
class were invisible to whatever it built.

Now `decodeValue()` and `decodeTagged()` take `seen`, and `enterOrReport()`
joins `enterOrThrow()` as shared machinery. It reports rather than raises,
settled against `lenient`: a cycle on decode arrived from a channel, where one
on encode is a local caller's bug.

**Entering is `decodeValue()`'s job, not `decodeTagged()`'s.** This is the part
that is easy to get backwards, and getting it backwards is not subtle in its
effects: `decodeTagged()` hands the state straight to `decodeValue()`, so
entering in both places enters one node twice and reports a cycle that is not
there. `decodeValue()` is the one method that visits every node of the tree, the
tagged form included, which is what makes it the single correct choke point.

Whether there is a set at all is each format's decision, taken at its public
entry points. `JsonCodecEngine` starts none, and says why: both of its entry
points walk the product of a parse, and a parse of text yields a tree. It is a
format handed a tree it did not build that can be given a cycle — so this is a
no-op for JSON by construction, not by luck.

### Evidence

The probe engine starts a set, so the base's guard is exercised as itself rather
than through a format. Four tests cover it, and three ablations each turn
exactly their own red and leave the others green:

| Ablation | Effect |
|---|---|
| remove the `enterOrReport()` call | both cycle cases red |
| drop `seen` from the unknown-tag recursion | only the cycle closing through a tagged node red |
| never unwind `seen` | only the repeated-node control red |

`packages/data-model` is at 54 passed / 2439 steps. `fmt --check`, `lint`,
`check`, `check-docs`, `check-no-waitfor`, `check-conflict-markers`,
`check-skill-facts` and `check-docs-history-index` are all green.

### Performance

Neutral for `codec-json`, measured rather than reasoned. Same bench file and
fixtures throughout, toggling only the two engine source files between this
branch and `main`, two interleaved A/B rounds over all 41 `decode` benchmarks:

| | this branch / `main` |
|---|---|
| geometric mean | 0.9908 |
| median | 0.9891 |
| min / max | 0.9680 / 1.0386 |
| benchmarks over 1.05 | 0 of 41 |

The aggregate leans very slightly faster, and that is not a claim of a win: the
same-state round-to-round spread — the same binary against itself — has a
median of 1.020 and a max of 1.094, larger than the biggest A/B deviation
measured. The effect is below the noise floor, bounded under ±4% on any single
benchmark and ~1% in aggregate.

That is what the diff predicts. On JSON's path the change adds exactly one
always-`undefined` argument to each decode call: no branch, no allocation and
no set operation, `enterOrReport()` being unreachable without a `seen`. The
encode side has no code change at all, so only decode was measured; encode
follows from the diff rather than from a run.

The two extremes are noise rather than signal. `decode single-undefined` at
1.039 is a 274 ns benchmark where scheduling jitter dominates, and
`decode object-100000` at 0.977 is a 41 ms one where a ~1 ms drift does the
same.



## A word-choice rule, and the sites it governs

`DEVELOPMENT.md` § "Word choice" → "One word per concept" gains a third entry:
**not `meets`**, for coming across something during a walk or on a channel. It
is the word that is wrong rather than the sense, so the entry names `visits`,
`reads`, `encounters` and `finds` and says outright that the list is open — a
reader picks what the site wants rather than treating four words as the
permitted set. What rules `meets` out is that two other senses are already at
work here and both stay: satisfying a requirement (`meet the condition`), and the
lattice operation the Contextual Flow Control code is built on, which has test
files named after it.

Five sites are conformed to it. In `BaseCodecEngine.ts`, two "meets every node"
become "visits" and "can only tell from meeting something it never emits"
becomes "finds"; the last of those came in with #5834 rather than with this
branch. `UnknownValue.ts` now says the serialization system *encounters* a tag
no codec claims. And `runner`'s `favorites-row-stored-shape.test.ts` says the
swap is the moment a stored row *is checked against* the schema — that file is
outside what this change is otherwise about, and is here because leaving the
last site of a rule unconformed is how a rule starts reading as advisory. The
`runner` suite is green at 1206 passed / 6529 steps.

Three uses in the touched packages stay, each checked in its sentence: `a
symbol meets the first condition` is the requirement sense with a condition as
its object, and `the two only meet when a stored row is re-staged` and `where a
byte count meets an empty or exhausted range` are the mutual sense, two things
coming together with neither as the verb's object. Conforming the rest of the
tree is a separate pass; the repository-wide census found ~121 uses of the
family and the great majority are one of the two senses that stay.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->









