### PR TITLE
feat: server-execution v2 Phase 7 — flip-ready: default ON, flood pacing, served wishes, LT9 simplification

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -647,7 +647,7 @@ jobs:
       # probe here pins that this lane really is OFF (server not serving,
       # shell define unset), so a silent flip of the default cannot move the
       # REQUIRED lanes onto the ON posture unnoticed.
-      - name: ✅ Verify the server-execution posture (default: server OFF, shell define unset)
+      - name: ✅ Verify the server-execution posture (default posture — server OFF, shell define unset)
         timeout-minutes: *posture-probe-timeout
         env:
           TOOLSHED_PORT: 8000
@@ -1107,7 +1107,7 @@ jobs:
       # probe pins that this lane really is OFF (server not serving, shell
       # define unset), so a silent flip of the default cannot move the
       # REQUIRED lanes onto the ON posture unnoticed.
-      - name: ✅ Verify the server-execution posture (default: server OFF, shell define unset)
+      - name: ✅ Verify the server-execution posture (default posture — server OFF, shell define unset)
         timeout-minutes: *posture-probe-timeout
         run: |
           META=$(curl -fsS "http://localhost:8000/api/meta")

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -24,6 +24,9 @@ env:
   CLI_WORK_TIMEOUT_MINUTES: &cli-work-timeout 10
   CLI_FUSE_WORK_TIMEOUT_MINUTES: &cli-fuse-work-timeout 15
   CLI_JOB_TIMEOUT_MINUTES: &cli-job-timeout 25
+  # The server-execution posture probes (two curls against a server that is
+  # already up) take this one; sized for a probe, not a suite.
+  POSTURE_PROBE_TIMEOUT_MINUTES: &posture-probe-timeout 5
 
 # Every step name must begin with a phase-marker emoji (setup / work / shutdown).
 # scripts/ci-gantt.ts reads that emoji to split each job bar by phase. See the
@@ -398,16 +401,22 @@ jobs:
           path: ./dist/toolshed
           if-no-files-found: error
 
-  # The OFF-arm toolshed binary (server-execution v2, Phase 7's flip —
-  # docs/specs/server-side-execution/testing.md §2): since the flip the
-  # default binary above bakes the browser shell's flag ON (the shell's flag
-  # is an esbuild define burned in at build time; unset = the first-party
-  # default), so the OFF regression-guard lanes need a binary whose shell was
-  # built with EXPERIMENTAL_SERVER_EXECUTION=false — otherwise they would run
-  # an ON shell against an OFF server (a mixed posture that asserts nothing).
-  # Same source, same commit; only the shell define differs.
-  build-toolshed-off:
-    name: "Build Binary (toolshed, server-execution OFF shell)"
+  # The ON-arm toolshed binary (server-execution v2, Phase 7 landed
+  # flip-READY with the first-party default OFF — docs/specs/
+  # server-side-execution/testing.md §2): the browser shell's flag is an
+  # esbuild define burned in at build time (unset = the first-party default,
+  # OFF today), so the explicit-`true` ON lanes need a binary whose shell was
+  # built with EXPERIMENTAL_SERVER_EXECUTION=true — an ON lane on the default
+  # binary above would run an OFF shell against an ON server, the MIXED
+  # posture Phases 4–6's ON lanes actually ran (which is why two two-browser
+  # gates were "green ON" before Phase 7). Same source, same commit; only
+  # the shell define differs, and the ON lanes VERIFY the posture the binary
+  # carries (/api/meta's `shellServerExecutionDefine`, written by
+  # tasks/build-binaries.ts from this same environment) before they test.
+  # When the flip PR lands the roles invert: this job bakes `false` for the
+  # explicit-false OFF regression-guard lanes and the default binary is ON.
+  build-toolshed-on:
+    name: "Build Binary (toolshed, server-execution ON shell)"
     runs-on: ubuntu-latest
     timeout-minutes: *job-timeout
     steps:
@@ -420,17 +429,17 @@ jobs:
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
 
-      - name: 🏗️ Build toolshed binary (OFF-arm shell)
+      - name: 🏗️ Build toolshed binary (ON-arm shell)
         timeout-minutes: *work-timeout
         run: deno task build-binaries toolshed
         env:
           COMMIT_SHA: ${{ github.sha }}
-          EXPERIMENTAL_SERVER_EXECUTION: "false"
+          EXPERIMENTAL_SERVER_EXECUTION: "true"
 
-      - name: 📤 Upload toolshed binary (OFF-arm shell)
+      - name: 📤 Upload toolshed binary (ON-arm shell)
         uses: actions/upload-artifact@v7
         with:
-          name: binary-toolshed-off
+          name: binary-toolshed-on
           path: ./dist/toolshed
           if-no-files-found: error
 
@@ -631,13 +640,30 @@ jobs:
             echo "AppArmor unprivileged-userns sysctl is unavailable; no change required."
           fi
 
-      # Since the server-execution v2 Phase 7 flip this lane IS the ON arm
-      # (unset flag = the first-party default; testing.md §2): the toolshed
-      # binary serves, its baked shell is flag-ON, and the test processes
-      # resolve ON. Skips happen only through the explicit list in
-      # tasks/server-execution-on-skips.ts, printed by the run step — never by
-      # silent filtering. The OFF arm is the explicit-`false` regression-guard
-      # lane below.
+      # This is the DEFAULT-posture lane (server-execution v2: flag unset =
+      # the first-party default, OFF while Phase 7 is landed dark;
+      # testing.md §2) — the regression guard for today's behavior. The
+      # explicit-`true` ON arm is the `-server-execution-on` lane below; the
+      # probe here pins that this lane really is OFF (server not serving,
+      # shell define unset), so a silent flip of the default cannot move the
+      # REQUIRED lanes onto the ON posture unnoticed.
+      - name: ✅ Verify the server-execution posture (default: server OFF, shell define unset)
+        timeout-minutes: *posture-probe-timeout
+        env:
+          TOOLSHED_PORT: 8000
+        run: |
+          META=$(curl -fsS "http://localhost:${TOOLSHED_PORT}/api/meta")
+          STATS=$(curl -fsS "http://localhost:${TOOLSHED_PORT}/api/health/stats")
+          echo "$META"
+          echo "$META" | jq -e '.shellServerExecutionDefine == null' > /dev/null || {
+            echo "::error::binary-toolshed carries a shell built with an explicit EXPERIMENTAL_SERVER_EXECUTION define; the default lane must run the default-built shell"
+            exit 1
+          }
+          echo "$STATS" | jq -e '.servingLoop == null' > /dev/null || {
+            echo "::error::the toolshed started the serving loop in the DEFAULT lane; the first-party default is OFF (Phase 7 landed dark) — flip the CI lane roles with the flip PR, never silently"
+            exit 1
+          }
+
       - name: 🧪 Run ${{ matrix.step_name }}
         timeout-minutes: *work-timeout
         working-directory: ${{ matrix.package_dir }}
@@ -651,11 +677,8 @@ jobs:
           if [ "$HEADLESS_ENABLED" = "true" ]; then
             export HEADLESS=1
           fi
-          # The explicit ON-arm skip list; the script prints every skip (or
-          # that there are none) and emits the matching --ignore flag.
-          SX_ON_IGNORE=$(deno run --allow-read ../../tasks/server-execution-on-skips.ts ${{ matrix.suite_name }})
           API_URL="http://localhost:${TOOLSHED_PORT}/" \
-          INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/${JUNIT_NAME}.xml ${SX_ON_IGNORE}" \
+          INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/${JUNIT_NAME}.xml" \
           deno task integration
 
       - name: 🧾 Write coverage report
@@ -680,36 +703,41 @@ jobs:
           retention-days: 90
           if-no-files-found: ignore
 
-  # The server-execution v2 OFF arm — the regression guard (docs/specs/
-  # server-side-execution/testing.md §2; Phase 7's flip made the unset
-  # default ON, so this lane pins EXPERIMENTAL_SERVER_EXECUTION=false on the
-  # toolshed server, on the test processes, AND in the binary's baked
-  # browser shell (build-toolshed-off): the pre-flip posture, byte-identical
-  # up to the recorded acceptances, running the FULL suites — no skip list.
-  # No coverage collection: the default (ON) lane owns coverage. It stays
-  # until the OFF path is removed (the post-soak PR).
-  package-integration-test-server-execution-off:
-    name: "Package Integration Tests / server-execution OFF (${{ matrix.suite_name }})"
+  # The server-execution v2 ON arm (docs/specs/server-side-execution/testing.md
+  # §2): the same package integration suites, byte-identical workloads, with
+  # EXPERIMENTAL_SERVER_EXECUTION=true on the toolshed server, on the test
+  # processes (the runner integration harness and the runtime-client worker
+  # declare the posture from the env — the ON lane is UNIFORM, not the mixed
+  # posture the P7 independent review found), AND in the binary's baked
+  # browser shell (build-toolshed-on) — the FULL ON posture, verified by the
+  # probe below before the suite runs. Skips happen only through the explicit
+  # per-phase lists in tasks/server-execution-on-skips.ts, printed by the run
+  # step — never by silent filtering. No coverage collection: the default lane
+  # owns coverage, and this arm exists to prove behavior under the flag. When
+  # the flip PR lands the roles invert (default = ON with the skip list;
+  # explicit-`false` = the OFF regression guard on an OFF-built binary).
+  package-integration-test-server-execution-on:
+    name: "Package Integration Tests / server-execution ON (${{ matrix.suite_name }})"
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: *job-timeout
-    needs: ["build-toolshed-off"]
+    needs: ["build-toolshed-on"]
     strategy:
       fail-fast: false
       matrix:
         include:
           - suite_name: runner
             package_dir: packages/runner
-            junit_name: runner-server-execution-off
+            junit_name: runner-server-execution-on
             step_name: runner integration tests
             headless: false
           - suite_name: runtime-client
             package_dir: packages/runtime-client
-            junit_name: runtime-client-server-execution-off
+            junit_name: runtime-client-server-execution-on
             step_name: runtime-client integration tests
             headless: false
           - suite_name: shell
             package_dir: packages/shell
-            junit_name: shell-server-execution-off
+            junit_name: shell-server-execution-on
             step_name: shell integration tests
             headless: true
     steps:
@@ -722,13 +750,13 @@ jobs:
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
 
-      - name: 📥 Download toolshed binary (OFF-arm shell)
+      - name: 📥 Download toolshed binary (ON-arm shell)
         uses: actions/download-artifact@v8
         with:
-          name: binary-toolshed-off
+          name: binary-toolshed-on
           path: common-binaries
 
-      - name: 🔌 Start Toolshed server for testing (flag OFF)
+      - name: 🔌 Start Toolshed server for testing (flag ON)
         env:
           TOOLSHED_PORT: 8000
         run: |
@@ -739,9 +767,29 @@ jobs:
           # success and dumps if the server exits before binding.
           CFTS_AI_GATEWAY_URL="" \
           CFTS_AI_LLM_ANTHROPIC_API_KEY=fake \
-          EXPERIMENTAL_SERVER_EXECUTION=false \
+          EXPERIMENTAL_SERVER_EXECUTION=true \
           ./common-binaries/toolshed --port="$TOOLSHED_PORT" \
             --background --log-file="$RUNNER_TEMP/toolshed.log"
+
+      # The posture the binary ACTUALLY carries: the shell define is baked at
+      # build time, so an ON lane on a default-built binary would silently be
+      # the mixed posture; and the server must really be serving.
+      - name: ✅ Verify the server-execution posture (server ON, shell ON-built)
+        timeout-minutes: *posture-probe-timeout
+        env:
+          TOOLSHED_PORT: 8000
+        run: |
+          META=$(curl -fsS "http://localhost:${TOOLSHED_PORT}/api/meta")
+          STATS=$(curl -fsS "http://localhost:${TOOLSHED_PORT}/api/health/stats")
+          echo "$META"
+          echo "$META" | jq -e '.shellServerExecutionDefine == "true"' > /dev/null || {
+            echo "::error::binary-toolshed-on does not carry an ON-built shell (EXPERIMENTAL_SERVER_EXECUTION=true must reach tasks/build-binaries.ts and the shell build); the ON lane would run a MIXED posture"
+            exit 1
+          }
+          echo "$STATS" | jq -e '.servingLoop != null' > /dev/null || {
+            echo "::error::the toolshed did not start the serving loop under EXPERIMENTAL_SERVER_EXECUTION=true; the ON lane's server posture is OFF"
+            exit 1
+          }
 
       # For Astral
       # https://github.com/lino-levan/astral/blob/f5ef833b2c5bde3783564a6b925073d5d46bb4b8/README.md#no-usable-sandbox-with-user-namespace-cloning-enabled
@@ -755,7 +803,7 @@ jobs:
             echo "AppArmor unprivileged-userns sysctl is unavailable; no change required."
           fi
 
-      - name: 🧪 Run ${{ matrix.step_name }} (flag OFF)
+      - name: 🧪 Run ${{ matrix.step_name }} (flag ON)
         timeout-minutes: *work-timeout
         working-directory: ${{ matrix.package_dir }}
         env:
@@ -767,9 +815,16 @@ jobs:
           if [ "$HEADLESS_ENABLED" = "true" ]; then
             export HEADLESS=1
           fi
+          # The explicit ON-arm skip list; the script prints every skip (or
+          # that there are none) and emits the matching --ignore flag. The
+          # flag binds because the package `integration` tasks hand deno a
+          # QUOTED glob it expands itself — `deno test --ignore` filters only
+          # files deno discovers and silently ignores nothing when the same
+          # files arrive as explicit arguments (a shell-expanded glob).
+          SX_ON_IGNORE=$(deno run --allow-read ../../tasks/server-execution-on-skips.ts ${{ matrix.suite_name }})
           API_URL="http://localhost:${TOOLSHED_PORT}/" \
-          EXPERIMENTAL_SERVER_EXECUTION=false \
-          INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/${JUNIT_NAME}.xml" \
+          EXPERIMENTAL_SERVER_EXECUTION=true \
+          INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/${JUNIT_NAME}.xml ${SX_ON_IGNORE}" \
           deno task integration
 
       - name: 📤 Upload test timing data
@@ -1045,13 +1100,28 @@ jobs:
       # to place the LCOV it pulls back at teardown. Absolute, because the
       # harness resolves it against a working directory that differs between the
       # two integration jobs. See docs/development/COVERAGE.md.
-      # Since the server-execution v2 Phase 7 flip this lane IS the ON arm
-      # (unset flag = the first-party default; testing.md §2): the toolshed
-      # binary serves, its baked shell is flag-ON, and the test processes
-      # resolve ON. Skips happen only through the explicit list in
-      # tasks/server-execution-on-skips.ts, printed by the run step — never
-      # by silent filtering. The OFF arm is the explicit-`false`
-      # regression-guard lane below.
+      # This is the DEFAULT-posture lane (server-execution v2: flag unset =
+      # the first-party default, OFF while Phase 7 is landed dark;
+      # testing.md §2) — the regression guard for today's behavior; the
+      # explicit-`true` ON arm is the `-server-execution-on` lane below. The
+      # probe pins that this lane really is OFF (server not serving, shell
+      # define unset), so a silent flip of the default cannot move the
+      # REQUIRED lanes onto the ON posture unnoticed.
+      - name: ✅ Verify the server-execution posture (default: server OFF, shell define unset)
+        timeout-minutes: *posture-probe-timeout
+        run: |
+          META=$(curl -fsS "http://localhost:8000/api/meta")
+          STATS=$(curl -fsS "http://localhost:8000/api/health/stats")
+          echo "$META"
+          echo "$META" | jq -e '.shellServerExecutionDefine == null' > /dev/null || {
+            echo "::error::binary-toolshed carries a shell built with an explicit EXPERIMENTAL_SERVER_EXECUTION define; the default lane must run the default-built shell"
+            exit 1
+          }
+          echo "$STATS" | jq -e '.servingLoop == null' > /dev/null || {
+            echo "::error::the toolshed started the serving loop in the DEFAULT lane; the first-party default is OFF (Phase 7 landed dark) — flip the CI lane roles with the flip PR, never silently"
+            exit 1
+          }
+
       - name: 🧩 Run end-to-end patterns integration tests
         timeout-minutes: *work-timeout
         working-directory: packages/patterns
@@ -1059,9 +1129,6 @@ jobs:
           mapfile -t TEST_FILES < <(deno run --allow-read ../../tasks/select-pattern-integration-files.ts ${{ matrix.shard }}/${{ matrix.total }})
           printf 'Pattern integration shard ${{ matrix.shard }}/${{ matrix.total }} files:\n'
           printf '  %s\n' "${TEST_FILES[@]}"
-          # The explicit ON-arm skip list; the script prints every skip (or
-          # that there are none) and emits the matching --ignore flag.
-          SX_ON_IGNORE=$(deno run --allow-read ../../tasks/server-execution-on-skips.ts patterns)
           mkdir -p ../../test-results
           # --no-check: the Check job type-checks packages/patterns/integration
           # (tasks/check.sh).
@@ -1073,7 +1140,6 @@ jobs:
           DENO_COVERAGE_DIR=../../coverage/raw/pattern-integration-${{ matrix.shard }} \
           deno test --no-check --v8-flags=--max-old-space-size=4096 --trace-leaks -A \
             --junit-path=../../test-results/patterns-${{ matrix.shard }}.xml \
-            ${SX_ON_IGNORE} \
             "${TEST_FILES[@]}"
 
       - name: 🧾 Write coverage report
@@ -1101,21 +1167,23 @@ jobs:
           retention-days: 90
           if-no-files-found: ignore
 
-  # The server-execution v2 OFF arm of the end-to-end pattern suite — the
-  # regression guard (docs/specs/server-side-execution/testing.md §2; Phase
-  # 7's flip made the unset default ON): the same shards, byte-identical
-  # workloads, with EXPERIMENTAL_SERVER_EXECUTION=false on the toolshed
-  # server, on the test processes, AND baked into the binary's browser shell
-  # (build-toolshed-off) — the pre-flip full posture, running the FULL suite
-  # (no skip list). No coverage collection and no cache save-back: the
-  # default (ON) lane owns both; the compile byte cache is restored
-  # read-only (compiled bytes do not depend on the flag). Stays until the OFF
-  # path is removed (the post-soak PR).
-  pattern-integration-test-server-execution-off:
-    name: "Pattern Integration Tests / server-execution OFF (${{ matrix.shard }}/${{ matrix.total }})"
+  # The server-execution v2 ON arm of the end-to-end pattern suite
+  # (docs/specs/server-side-execution/testing.md §2): the same shards,
+  # byte-identical workloads, with EXPERIMENTAL_SERVER_EXECUTION=true on the
+  # toolshed server, on the test processes, AND baked into the binary's
+  # browser shell (build-toolshed-on) — the FULL ON posture, verified by the
+  # probe below before the shard runs. Skips happen only through the explicit
+  # per-phase lists in tasks/server-execution-on-skips.ts, printed by the run
+  # step — never by silent filtering (three `patterns` entries today, all
+  # `phase-7`, each with its loud reason; the flip PR needs the list EMPTY).
+  # No coverage collection and no cache save-back: the default lane owns
+  # both; the compile byte cache is restored read-only (compiled bytes do not
+  # depend on the flag).
+  pattern-integration-test-server-execution-on:
+    name: "Pattern Integration Tests / server-execution ON (${{ matrix.shard }}/${{ matrix.total }})"
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: *job-timeout
-    needs: ["build-toolshed-off"]
+    needs: ["build-toolshed-on"]
     strategy:
       fail-fast: false
       matrix:
@@ -1144,22 +1212,38 @@ jobs:
           restore-keys: |
             cc-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.total }}-${{ matrix.shard }}-
 
-      - name: 📥 Download toolshed binary (OFF-arm shell)
+      - name: 📥 Download toolshed binary (ON-arm shell)
         uses: actions/download-artifact@v8
         with:
-          name: binary-toolshed-off
+          name: binary-toolshed-on
           path: common-binaries
 
-      - name: 🔌 Start Toolshed server for testing (flag OFF)
+      - name: 🔌 Start Toolshed server for testing (flag ON)
         run: |
           chmod +x ./common-binaries/toolshed
           # --background waits until the server has bound its port before it
           # returns, so the test steps never race a not-yet-listening server.
           CFTS_AI_GATEWAY_URL="" \
           CFTS_AI_LLM_ANTHROPIC_API_KEY=fake \
-          EXPERIMENTAL_SERVER_EXECUTION=false \
+          EXPERIMENTAL_SERVER_EXECUTION=true \
           ./common-binaries/toolshed \
             --background --log-file="$RUNNER_TEMP/toolshed.log"
+
+      # The posture the binary ACTUALLY carries (see the package ON lane).
+      - name: ✅ Verify the server-execution posture (server ON, shell ON-built)
+        timeout-minutes: *posture-probe-timeout
+        run: |
+          META=$(curl -fsS "http://localhost:8000/api/meta")
+          STATS=$(curl -fsS "http://localhost:8000/api/health/stats")
+          echo "$META"
+          echo "$META" | jq -e '.shellServerExecutionDefine == "true"' > /dev/null || {
+            echo "::error::binary-toolshed-on does not carry an ON-built shell (EXPERIMENTAL_SERVER_EXECUTION=true must reach tasks/build-binaries.ts and the shell build); the ON lane would run a MIXED posture"
+            exit 1
+          }
+          echo "$STATS" | jq -e '.servingLoop != null' > /dev/null || {
+            echo "::error::the toolshed did not start the serving loop under EXPERIMENTAL_SERVER_EXECUTION=true; the ON lane's server posture is OFF"
+            exit 1
+          }
 
       # For Astral
       # https://github.com/lino-levan/astral/blob/f5ef833b2c5bde3783564a6b925073d5d46bb4b8/README.md#no-usable-sandbox-with-user-namespace-cloning-enabled
@@ -1173,30 +1257,40 @@ jobs:
             echo "AppArmor unprivileged-userns sysctl is unavailable; no change required."
           fi
 
-      - name: 🧩 Run end-to-end patterns integration tests (flag OFF)
+      - name: 🧩 Run end-to-end patterns integration tests (flag ON)
         timeout-minutes: *work-timeout
         working-directory: packages/patterns
         run: |
-          mapfile -t TEST_FILES < <(deno run --allow-read ../../tasks/select-pattern-integration-files.ts ${{ matrix.shard }}/${{ matrix.total }})
+          mapfile -t SHARD_FILES < <(deno run --allow-read ../../tasks/select-pattern-integration-files.ts ${{ matrix.shard }}/${{ matrix.total }})
           printf 'Pattern integration shard ${{ matrix.shard }}/${{ matrix.total }} files:\n'
-          printf '  %s\n' "${TEST_FILES[@]}"
+          printf '  %s\n' "${SHARD_FILES[@]}"
+          # The explicit ON-arm skip list, applied by FILTERING this shard's
+          # file list (the script prints every skip, and which of them it
+          # dropped from THIS list, on stderr): `deno test --ignore` binds
+          # only to files deno discovers itself and silently ignores nothing
+          # when the files arrive as explicit arguments, as they do here.
+          mapfile -t TEST_FILES < <(deno run --allow-read ../../tasks/server-execution-on-skips.ts patterns --filter "${SHARD_FILES[@]}")
+          if [ "${#TEST_FILES[@]}" -eq 0 ]; then
+            echo "Every file of this shard is skip-listed for the ON arm; nothing to run."
+            exit 0
+          fi
           mkdir -p ../../test-results
           # --no-check: the Check job type-checks packages/patterns/integration
           # (tasks/check.sh).
           HEADLESS=1 \
           API_URL=http://localhost:8000/ \
-          EXPERIMENTAL_SERVER_EXECUTION=false \
+          EXPERIMENTAL_SERVER_EXECUTION=true \
           PATTERN_INTEGRATION_SHARD="${{ matrix.shard }}/${{ matrix.total }}" \
           CF_COMPILE_CACHE_FILE="${{ github.workspace }}/.compile-cache/pattern-integration-${{ matrix.shard }}.json" \
           deno test --no-check --v8-flags=--max-old-space-size=4096 --trace-leaks -A \
-            --junit-path=../../test-results/patterns-server-execution-off-${{ matrix.shard }}.xml \
+            --junit-path=../../test-results/patterns-server-execution-on-${{ matrix.shard }}.xml \
             "${TEST_FILES[@]}"
 
       - name: 📤 Upload test timing data
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: test-timing-pattern-integration-server-execution-off-${{ matrix.shard }}
+          name: test-timing-pattern-integration-server-execution-on-${{ matrix.shard }}
           path: test-results/
           retention-days: 90
           if-no-files-found: ignore
@@ -1426,15 +1520,15 @@ jobs:
       - test
       - runner-test
       - build-toolshed
-      - build-toolshed-off
+      - build-toolshed-on
       - build-bg-piece-service
       - build-cf
       - generated-patterns-integration-test
       - package-integration-test
-      - package-integration-test-server-execution-off
+      - package-integration-test-server-execution-on
       - cli-integration-test
       - pattern-integration-test
-      - pattern-integration-test-server-execution-off
+      - pattern-integration-test-server-execution-on
       - pattern-reload-integration-test
       - pattern-unit-test
       - coverage-check

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -398,6 +398,42 @@ jobs:
           path: ./dist/toolshed
           if-no-files-found: error
 
+  # The OFF-arm toolshed binary (server-execution v2, Phase 7's flip —
+  # docs/specs/server-side-execution/testing.md §2): since the flip the
+  # default binary above bakes the browser shell's flag ON (the shell's flag
+  # is an esbuild define burned in at build time; unset = the first-party
+  # default), so the OFF regression-guard lanes need a binary whose shell was
+  # built with EXPERIMENTAL_SERVER_EXECUTION=false — otherwise they would run
+  # an ON shell against an OFF server (a mixed posture that asserts nothing).
+  # Same source, same commit; only the shell define differs.
+  build-toolshed-off:
+    name: "Build Binary (toolshed, server-execution OFF shell)"
+    runs-on: ubuntu-latest
+    timeout-minutes: *job-timeout
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v7
+
+      - name: 🦕 Setup Deno
+        uses: ./.github/actions/deno-setup
+
+      - name: 🔍 Verify lock file & install dependencies
+        uses: ./.github/actions/deno-install
+
+      - name: 🏗️ Build toolshed binary (OFF-arm shell)
+        timeout-minutes: *work-timeout
+        run: deno task build-binaries toolshed
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          EXPERIMENTAL_SERVER_EXECUTION: "false"
+
+      - name: 📤 Upload toolshed binary (OFF-arm shell)
+        uses: actions/upload-artifact@v7
+        with:
+          name: binary-toolshed-off
+          path: ./dist/toolshed
+          if-no-files-found: error
+
   build-bg-piece-service:
     name: "Build Binary (bg-piece-service)"
     runs-on: ubuntu-latest
@@ -595,6 +631,13 @@ jobs:
             echo "AppArmor unprivileged-userns sysctl is unavailable; no change required."
           fi
 
+      # Since the server-execution v2 Phase 7 flip this lane IS the ON arm
+      # (unset flag = the first-party default; testing.md §2): the toolshed
+      # binary serves, its baked shell is flag-ON, and the test processes
+      # resolve ON. Skips happen only through the explicit list in
+      # tasks/server-execution-on-skips.ts, printed by the run step — never by
+      # silent filtering. The OFF arm is the explicit-`false` regression-guard
+      # lane below.
       - name: 🧪 Run ${{ matrix.step_name }}
         timeout-minutes: *work-timeout
         working-directory: ${{ matrix.package_dir }}
@@ -608,8 +651,11 @@ jobs:
           if [ "$HEADLESS_ENABLED" = "true" ]; then
             export HEADLESS=1
           fi
+          # The explicit ON-arm skip list; the script prints every skip (or
+          # that there are none) and emits the matching --ignore flag.
+          SX_ON_IGNORE=$(deno run --allow-read ../../tasks/server-execution-on-skips.ts ${{ matrix.suite_name }})
           API_URL="http://localhost:${TOOLSHED_PORT}/" \
-          INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/${JUNIT_NAME}.xml" \
+          INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/${JUNIT_NAME}.xml ${SX_ON_IGNORE}" \
           deno task integration
 
       - name: 🧾 Write coverage report
@@ -634,45 +680,36 @@ jobs:
           retention-days: 90
           if-no-files-found: ignore
 
-  # The server-execution v2 ON arm (docs/specs/server-side-execution/testing.md
-  # §2): the same package integration suites, byte-identical workloads, with
-  # EXPERIMENTAL_SERVER_EXECUTION=true on both the toolshed server and the test
-  # processes. Skips happen only through the explicit per-phase lists in
-  # tasks/server-execution-on-skips.ts, printed by the run step — never by
-  # silent filtering. No coverage collection: the OFF arm owns coverage, and
-  # this arm exists to prove behavior under the flag. Browser-side runtimes
-  # still run the binary's baked-in shell build (flag OFF): the shell's flag
-  # rides an esbuild define (packages/shell/felt.config.ts) burned in at
-  # `build-binaries`, embedded via --include — there is no serve-time
-  # override. Phase 4 added the first browser-side ON behavior and
-  # discharged this contract's OTHER clause: the affected test is listed in
-  # tasks/server-execution-on-skips.ts (topics-navigation, with the
-  # mixed-posture reason), and the ON shell build itself is the owed row
-  # verification-coverage.md OW25 — until it lands, nothing in this lane
-  # exercises a flag-ON browser shell, and no browser-posture criterion may
-  # tick on this lane's green.
-  package-integration-test-server-execution-on:
-    name: "Package Integration Tests / server-execution ON (${{ matrix.suite_name }})"
+  # The server-execution v2 OFF arm — the regression guard (docs/specs/
+  # server-side-execution/testing.md §2; Phase 7's flip made the unset
+  # default ON, so this lane pins EXPERIMENTAL_SERVER_EXECUTION=false on the
+  # toolshed server, on the test processes, AND in the binary's baked
+  # browser shell (build-toolshed-off): the pre-flip posture, byte-identical
+  # up to the recorded acceptances, running the FULL suites — no skip list.
+  # No coverage collection: the default (ON) lane owns coverage. It stays
+  # until the OFF path is removed (the post-soak PR).
+  package-integration-test-server-execution-off:
+    name: "Package Integration Tests / server-execution OFF (${{ matrix.suite_name }})"
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: *job-timeout
-    needs: ["build-toolshed"]
+    needs: ["build-toolshed-off"]
     strategy:
       fail-fast: false
       matrix:
         include:
           - suite_name: runner
             package_dir: packages/runner
-            junit_name: runner-server-execution-on
+            junit_name: runner-server-execution-off
             step_name: runner integration tests
             headless: false
           - suite_name: runtime-client
             package_dir: packages/runtime-client
-            junit_name: runtime-client-server-execution-on
+            junit_name: runtime-client-server-execution-off
             step_name: runtime-client integration tests
             headless: false
           - suite_name: shell
             package_dir: packages/shell
-            junit_name: shell-server-execution-on
+            junit_name: shell-server-execution-off
             step_name: shell integration tests
             headless: true
     steps:
@@ -685,13 +722,13 @@ jobs:
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
 
-      - name: 📥 Download toolshed binary
+      - name: 📥 Download toolshed binary (OFF-arm shell)
         uses: actions/download-artifact@v8
         with:
-          name: binary-toolshed
+          name: binary-toolshed-off
           path: common-binaries
 
-      - name: 🔌 Start Toolshed server for testing (flag ON)
+      - name: 🔌 Start Toolshed server for testing (flag OFF)
         env:
           TOOLSHED_PORT: 8000
         run: |
@@ -702,7 +739,7 @@ jobs:
           # success and dumps if the server exits before binding.
           CFTS_AI_GATEWAY_URL="" \
           CFTS_AI_LLM_ANTHROPIC_API_KEY=fake \
-          EXPERIMENTAL_SERVER_EXECUTION=true \
+          EXPERIMENTAL_SERVER_EXECUTION=false \
           ./common-binaries/toolshed --port="$TOOLSHED_PORT" \
             --background --log-file="$RUNNER_TEMP/toolshed.log"
 
@@ -718,7 +755,7 @@ jobs:
             echo "AppArmor unprivileged-userns sysctl is unavailable; no change required."
           fi
 
-      - name: 🧪 Run ${{ matrix.step_name }} (flag ON)
+      - name: 🧪 Run ${{ matrix.step_name }} (flag OFF)
         timeout-minutes: *work-timeout
         working-directory: ${{ matrix.package_dir }}
         env:
@@ -730,12 +767,9 @@ jobs:
           if [ "$HEADLESS_ENABLED" = "true" ]; then
             export HEADLESS=1
           fi
-          # The explicit ON-arm skip list; the script prints every skip (or
-          # that there are none) and emits the matching --ignore flag.
-          SX_ON_IGNORE=$(deno run --allow-read ../../tasks/server-execution-on-skips.ts ${{ matrix.suite_name }})
           API_URL="http://localhost:${TOOLSHED_PORT}/" \
-          EXPERIMENTAL_SERVER_EXECUTION=true \
-          INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/${JUNIT_NAME}.xml ${SX_ON_IGNORE}" \
+          EXPERIMENTAL_SERVER_EXECUTION=false \
+          INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/${JUNIT_NAME}.xml" \
           deno task integration
 
       - name: 📤 Upload test timing data
@@ -1011,6 +1045,13 @@ jobs:
       # to place the LCOV it pulls back at teardown. Absolute, because the
       # harness resolves it against a working directory that differs between the
       # two integration jobs. See docs/development/COVERAGE.md.
+      # Since the server-execution v2 Phase 7 flip this lane IS the ON arm
+      # (unset flag = the first-party default; testing.md §2): the toolshed
+      # binary serves, its baked shell is flag-ON, and the test processes
+      # resolve ON. Skips happen only through the explicit list in
+      # tasks/server-execution-on-skips.ts, printed by the run step — never
+      # by silent filtering. The OFF arm is the explicit-`false`
+      # regression-guard lane below.
       - name: 🧩 Run end-to-end patterns integration tests
         timeout-minutes: *work-timeout
         working-directory: packages/patterns
@@ -1018,6 +1059,9 @@ jobs:
           mapfile -t TEST_FILES < <(deno run --allow-read ../../tasks/select-pattern-integration-files.ts ${{ matrix.shard }}/${{ matrix.total }})
           printf 'Pattern integration shard ${{ matrix.shard }}/${{ matrix.total }} files:\n'
           printf '  %s\n' "${TEST_FILES[@]}"
+          # The explicit ON-arm skip list; the script prints every skip (or
+          # that there are none) and emits the matching --ignore flag.
+          SX_ON_IGNORE=$(deno run --allow-read ../../tasks/server-execution-on-skips.ts patterns)
           mkdir -p ../../test-results
           # --no-check: the Check job type-checks packages/patterns/integration
           # (tasks/check.sh).
@@ -1029,6 +1073,7 @@ jobs:
           DENO_COVERAGE_DIR=../../coverage/raw/pattern-integration-${{ matrix.shard }} \
           deno test --no-check --v8-flags=--max-old-space-size=4096 --trace-leaks -A \
             --junit-path=../../test-results/patterns-${{ matrix.shard }}.xml \
+            ${SX_ON_IGNORE} \
             "${TEST_FILES[@]}"
 
       - name: 🧾 Write coverage report
@@ -1056,25 +1101,21 @@ jobs:
           retention-days: 90
           if-no-files-found: ignore
 
-  # The server-execution v2 ON arm of the end-to-end pattern suite
-  # (docs/specs/server-side-execution/testing.md §2): the same shards,
-  # byte-identical workloads, with EXPERIMENTAL_SERVER_EXECUTION=true on both
-  # the toolshed server and the test processes. Skips happen only through the
-  # explicit per-phase lists in tasks/server-execution-on-skips.ts, printed by
-  # the run step — never by silent filtering. No coverage collection and no
-  # cache save-back: the OFF arm owns both; the compile byte cache is
-  # restored read-only (compiled bytes do not depend on the flag).
-  # Browser-side runtimes still run the binary's baked-in shell build (flag
-  # OFF): Phase 4 added the first browser-side ON behavior and discharged
-  # this contract via the list-the-affected-tests clause — see the package
-  # ON job's comment above (topics-navigation skip entry; the ON shell
-  # build is owed as verification-coverage.md OW25). No browser-posture
-  # criterion may tick on this lane's green.
-  pattern-integration-test-server-execution-on:
-    name: "Pattern Integration Tests / server-execution ON (${{ matrix.shard }}/${{ matrix.total }})"
+  # The server-execution v2 OFF arm of the end-to-end pattern suite — the
+  # regression guard (docs/specs/server-side-execution/testing.md §2; Phase
+  # 7's flip made the unset default ON): the same shards, byte-identical
+  # workloads, with EXPERIMENTAL_SERVER_EXECUTION=false on the toolshed
+  # server, on the test processes, AND baked into the binary's browser shell
+  # (build-toolshed-off) — the pre-flip full posture, running the FULL suite
+  # (no skip list). No coverage collection and no cache save-back: the
+  # default (ON) lane owns both; the compile byte cache is restored
+  # read-only (compiled bytes do not depend on the flag). Stays until the OFF
+  # path is removed (the post-soak PR).
+  pattern-integration-test-server-execution-off:
+    name: "Pattern Integration Tests / server-execution OFF (${{ matrix.shard }}/${{ matrix.total }})"
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: *job-timeout
-    needs: ["build-toolshed"]
+    needs: ["build-toolshed-off"]
     strategy:
       fail-fast: false
       matrix:
@@ -1090,11 +1131,11 @@ jobs:
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
 
-      # Read-only seed from the OFF arm's compile byte cache (same key
+      # Read-only seed from the default lane's compile byte cache (same key
       # family): compiled module bytes are a function of sources, not of the
-      # runtime flag, so reuse is sound; only the OFF arm saves. The key
-      # mirrors the OFF arm's, including the total shard count and selector
-      # source, so the seed follows the OFF arm's shard topology.
+      # runtime flag, so reuse is sound; only the default lane saves. The key
+      # mirrors the default lane's, including the total shard count and
+      # selector source, so the seed follows its shard topology.
       - name: ♻️ Restore compile byte cache (read-only)
         uses: actions/cache/restore@v4
         with:
@@ -1103,20 +1144,20 @@ jobs:
           restore-keys: |
             cc-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.total }}-${{ matrix.shard }}-
 
-      - name: 📥 Download toolshed binary
+      - name: 📥 Download toolshed binary (OFF-arm shell)
         uses: actions/download-artifact@v8
         with:
-          name: binary-toolshed
+          name: binary-toolshed-off
           path: common-binaries
 
-      - name: 🔌 Start Toolshed server for testing (flag ON)
+      - name: 🔌 Start Toolshed server for testing (flag OFF)
         run: |
           chmod +x ./common-binaries/toolshed
           # --background waits until the server has bound its port before it
           # returns, so the test steps never race a not-yet-listening server.
           CFTS_AI_GATEWAY_URL="" \
           CFTS_AI_LLM_ANTHROPIC_API_KEY=fake \
-          EXPERIMENTAL_SERVER_EXECUTION=true \
+          EXPERIMENTAL_SERVER_EXECUTION=false \
           ./common-binaries/toolshed \
             --background --log-file="$RUNNER_TEMP/toolshed.log"
 
@@ -1132,34 +1173,30 @@ jobs:
             echo "AppArmor unprivileged-userns sysctl is unavailable; no change required."
           fi
 
-      - name: 🧩 Run end-to-end patterns integration tests (flag ON)
+      - name: 🧩 Run end-to-end patterns integration tests (flag OFF)
         timeout-minutes: *work-timeout
         working-directory: packages/patterns
         run: |
           mapfile -t TEST_FILES < <(deno run --allow-read ../../tasks/select-pattern-integration-files.ts ${{ matrix.shard }}/${{ matrix.total }})
           printf 'Pattern integration shard ${{ matrix.shard }}/${{ matrix.total }} files:\n'
           printf '  %s\n' "${TEST_FILES[@]}"
-          # The explicit ON-arm skip list; the script prints every skip (or
-          # that there are none) and emits the matching --ignore flag.
-          SX_ON_IGNORE=$(deno run --allow-read ../../tasks/server-execution-on-skips.ts patterns)
           mkdir -p ../../test-results
           # --no-check: the Check job type-checks packages/patterns/integration
           # (tasks/check.sh).
           HEADLESS=1 \
           API_URL=http://localhost:8000/ \
-          EXPERIMENTAL_SERVER_EXECUTION=true \
+          EXPERIMENTAL_SERVER_EXECUTION=false \
           PATTERN_INTEGRATION_SHARD="${{ matrix.shard }}/${{ matrix.total }}" \
           CF_COMPILE_CACHE_FILE="${{ github.workspace }}/.compile-cache/pattern-integration-${{ matrix.shard }}.json" \
           deno test --no-check --v8-flags=--max-old-space-size=4096 --trace-leaks -A \
-            --junit-path=../../test-results/patterns-server-execution-on-${{ matrix.shard }}.xml \
-            ${SX_ON_IGNORE} \
+            --junit-path=../../test-results/patterns-server-execution-off-${{ matrix.shard }}.xml \
             "${TEST_FILES[@]}"
 
       - name: 📤 Upload test timing data
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: test-timing-pattern-integration-server-execution-on-${{ matrix.shard }}
+          name: test-timing-pattern-integration-server-execution-off-${{ matrix.shard }}
           path: test-results/
           retention-days: 90
           if-no-files-found: ignore
@@ -1389,14 +1426,15 @@ jobs:
       - test
       - runner-test
       - build-toolshed
+      - build-toolshed-off
       - build-bg-piece-service
       - build-cf
       - generated-patterns-integration-test
       - package-integration-test
-      - package-integration-test-server-execution-on
+      - package-integration-test-server-execution-off
       - cli-integration-test
       - pattern-integration-test
-      - pattern-integration-test-server-execution-on
+      - pattern-integration-test-server-execution-off
       - pattern-reload-integration-test
       - pattern-unit-test
       - coverage-check

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1269,11 +1269,15 @@ jobs:
           # dropped from THIS list, on stderr): `deno test --ignore` binds
           # only to files deno discovers itself and silently ignores nothing
           # when the files arrive as explicit arguments, as they do here.
-          mapfile -t TEST_FILES < <(deno run --allow-read ../../tasks/server-execution-on-skips.ts patterns --filter "${SHARD_FILES[@]}")
-          if [ "${#TEST_FILES[@]}" -eq 0 ]; then
+          # Command substitution (not a process substitution) so a validation
+          # failure in the script fails this step under `bash -e` instead of
+          # reading as an empty list.
+          FILTERED_FILES=$(deno run --allow-read ../../tasks/server-execution-on-skips.ts patterns --filter "${SHARD_FILES[@]}")
+          if [ -z "$FILTERED_FILES" ]; then
             echo "Every file of this shard is skip-listed for the ON arm; nothing to run."
             exit 0
           fi
+          mapfile -t TEST_FILES <<< "$FILTERED_FILES"
           mkdir -p ../../test-results
           # --no-check: the Check job type-checks packages/patterns/integration
           # (tasks/check.sh).

--- a/deno.lock
+++ b/deno.lock
@@ -61,6 +61,7 @@
     "jsr:@std/testing@^1.0.19": "1.0.19",
     "jsr:@std/text@~1.0.7": "1.0.19",
     "jsr:@std/yaml@*": "1.0.12",
+    "jsr:@std/yaml@^1.0.12": "1.0.12",
     "jsr:@zip-js/zip-js@^2.7.52": "2.8.33",
     "npm:@ai-sdk/anthropic@^4.0.16": "4.0.16_zod@4.4.3",
     "npm:@ai-sdk/google-vertex@^5.0.22": "5.0.22_zod@4.4.3",
@@ -2187,6 +2188,7 @@
       },
       "tasks": {
         "dependencies": [
+          "jsr:@std/yaml@^1.0.12",
           "npm:typescript@6.0.3"
         ]
       }

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -35,7 +35,7 @@ was last checked against the code.
 | [`systemPatternAutoUpdate`](#systempatternautoupdate)                       | `EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE` env / shell build define, or `RuntimeOptions.experimental`                                             | on in the shell (same-toolshed system sources, including all roots); off server-side | Bernhard Seefeld (#4611; shell default-on #4619)      | graduate to always-on, then delete flag                                                                                                                                                                                           | implemented, on in the shell                                                    |
 | [`computedCellIds`](#computedcellids)                                       | `EXPERIMENTAL_COMPUTED_CELL_IDS` env, or `RuntimeOptions.experimental`                                                                          | on                                                                                   | Robin McCollum (#4659)                                | graduate to unconditional behavior, then delete flag                                                                                                                                                                              | implemented, on by default                                                      |
 | [`lazyMaterialization`](#lazymaterialization)                               | `EXPERIMENTAL_LAZY_MATERIALIZATION` env, or `RuntimeOptions.experimental`                                                                       | on                                                                                   | Bernhard Seefeld                                      | fold into base read semantics, then delete flag                                                             | implemented, on by default                                         |
-| [`serverExecution`](#serverexecution) | `EXPERIMENTAL_SERVER_EXECUTION` env, or `RuntimeOptions.experimental` | **on** (first-party default since Phase 7's flip; explicit `false` = the OFF arm) | Bernhard Seefeld (#5339, server-execution v2 plan Phase 1 stage A; Phase 7 flip) | soak on main, then delete the flag and the OFF path (the split-out post-soak PR) | Phases 1–7 landed; ON by default in every deployed-topology process; the OFF arm stays selectable as the rollback lever through the soak |
+| [`serverExecution`](#serverexecution) | `EXPERIMENTAL_SERVER_EXECUTION` env, or `RuntimeOptions.experimental` | off (`SERVER_EXECUTION_DEFAULT_ENABLED = false` — the ONE first-party default; Phase 7 landed flip-READY, DARK; explicit `true` = the ON arm) | Bernhard Seefeld (#5339, server-execution v2 plan Phase 1 stage A; Phase 7 flip-ready #5849) | the flip is its OWN one-line PR after the plan's Phase-7 ordered gates; then soak on main, then delete the flag and the OFF path (the split-out post-soak PR) | Phases 1–6 landed; Phase 7 flip-READY landed dark (owner ruling 2026-08-16): OFF by default everywhere, the ON arm fully selectable and CI-tested on an ON-built binary |
 | [`cfcEnforcementMode`](#cfcenforcementmode)                                 | `RuntimeOptions.cfcEnforcementMode` (`CF_CFC_MODE` in the cf-harness / fuse)                                                                    | `enforce-explicit`                                                                   | Bernhard Seefeld (#3263)                              | tighten default toward `enforce-strict`                                                                                                                                                                                           | active; ladder is permanent                                                     |
 | [`cfcFlowLabels`](#cfcflowlabels)                                           | `RuntimeOptions.cfcFlowLabels`                                                                                                                  | `off`                                                                                | Bernhard Seefeld (#4011)                              | move toward `persist`                                                                                                                                                                                                             | implemented, staged rollout                                                     |
 | [`cfcWriteFloor`](#cfcwritefloor)                                           | `RuntimeOptions.cfcWriteFloor`                                                                                                                  | `off`                                                                                | Bernhard Seefeld (#4479)                              | move toward `enforce`                                                                                                                                                                                                             | implemented, staged rollout                                                     |
@@ -67,9 +67,10 @@ These flags make up the `ExperimentalOptions` interface in
 are passed as `new Runtime({ experimental: { ... } })`. Each flag defaults to
 `undefined`, which means "take the built-in default". `commitPreconditions`,
 `plainResultReceipts`, `computedCellIds` and `lazyMaterialization` default on;
-`serverExecution` defaults on in the deployed-topology presets (its section);
-the other flags in this category default off unless their section says
-otherwise.
+`serverExecution` resolves an unset flag to the ONE first-party default
+`SERVER_EXECUTION_DEFAULT_ENABLED` in the deployed-topology presets — `false`
+today, Phase 7 having landed flip-ready DARK (its section); the other flags in
+this category default off unless their section says otherwise.
 
 The mapping from environment variable to flag is defined once, canonically, as
 `EXPERIMENTAL_ENV_VARS` in
@@ -357,8 +358,9 @@ rather than coerced. See [How flags propagate](#how-flags-propagate).
   states, no shippable intermediates (spec README §3.4); deliberately named
   unlike v1's `SERVER_PRIMARY_EXECUTION` so the archived v1 documents never
   alias it. Both states, defined:
-  - **OFF (explicit `false` — the rollback lever; the pre-flip default): the
-    pre-flip behavior, byte-for-byte.** Every client
+  - **OFF (the default today — the first-party default constant is `false`;
+    explicit `false` selects it regardless of the constant): today's
+    behavior, byte-for-byte.** Every client
     runtime runs and commits derivations exactly as it does today, and every
     client commit is `authored`-class — `derived` is never claimed off the
     flag. The commit `class` metadata is still *written* in this arm (it is
@@ -366,8 +368,8 @@ rather than coerced. See [How flags propagate](#how-flags-propagate).
     is enforced from it, and `stream-data` behaves as today. Any OFF-arm
     behavioral diff from a v2 stage is a phase-gate failure by itself
     (testing.md §2).
-  - **ON (the first-party DEFAULT since the Phase 7 flip, 2026-08-15): the
-    v2 posture.** With stages A–F landed
+  - **ON (explicit `true` — or the first-party default once the flip PR
+    sets the constant `true`): the v2 posture.** With stages A–F landed
     this means: the per-class admission rows of protocol.md §2 are enforced
     — the `derived` row is the stage-B lease equality check PLUS stage F's
     derived-envelope defense-in-depth (the producing session must BE the
@@ -400,42 +402,61 @@ rather than coerced. See [How flags propagate](#how-flags-propagate).
     F10 interim — is DELETED). Later stages add their surfaces under
     this same flag; both halves of any coupled behavior move together
     on it.
-- **Current default and planned end state.** **ON by default** since the
-  plan's Phase 7 flip (2026-08-15): the ONE first-party default is
-  `SERVER_EXECUTION_DEFAULT_ENABLED` in
+- **Current default and planned end state.** **OFF by default** — the ONE
+  first-party default is `SERVER_EXECUTION_DEFAULT_ENABLED` in
   [`packages/memory/v2/server-execution-default.ts`](../../packages/memory/v2/server-execution-default.ts),
-  read by every deployed-topology entry point — the `productionServer` /
-  `remoteClient` construction presets (toolshed's operator runtime, the
-  background piece service, the CLI, every pieces controller and
-  integration harness against a toolshed), toolshed's serving-host gate
-  and its memory service-principal grant, and the browser shell's build
-  define fallback. An UNSET flag resolves to it; an explicit
-  `EXPERIMENTAL_SERVER_EXECUTION=false` (or
-  `experimental.serverExecution: false`, or the shell define `false`)
-  selects the OFF arm — the rollback lever until the OFF path is removed.
-  Single-process harnesses are the deliberate exception: a bare `new
-  Runtime` and the `patternTest` / `localDev` / `unitTest` presets have no
-  serving host, so they resolve the ambient baseline (OFF) by construction —
-  the unit suites and `cf test` run the derive-and-commit model; the ON
-  posture's unit coverage sets the flag explicitly (the `executor-*` suites)
-  and its integration coverage is the default CI lanes. In CI (testing.md
-  §2) the DEFAULT lanes are the ON arm (skips only through
-  `tasks/server-execution-on-skips.ts`, printed loudly) and the
-  explicit-`false` lanes on an OFF-built binary are the regression guard.
-  End state: after a soak on main the flag retires and the OFF code path is
-  removed — a separate post-soak PR (the plan's Phase 7 task 2, split from
-  the flip because stacked PRs cannot soak).
-- **Status on 2026-08-15 (Phase 7 flip-ready).** Phases 1–6 landed; Phase 7
-  landed the flip preconditions — OW27 per-stream send pacing in the
-  event-append queue (pace-never-drop, README §3.8), the LT9 simplification
-  (process-lifetime queue), served-wish read authority (the process identity
-  is a memory service principal under the flag) and the nested-piece
-  demand-root chain in the run supply — and the flip itself. Known ON-arm
-  gaps carried honestly on the plan's Phase 7 section (browser-ON multi-user
-  scenarios at scoped cardinality ≥ 2 oscillate on the serving replica's
-  scope-name collapse — verification-coverage.md OW17; fresh
-  `compile-and-run` is inert until its serving port; the topics-navigation
-  skip stands).
+  value `false` (Phase 7 landed flip-READY, DARK, by owner ruling
+  2026-08-16), read by every deployed-topology entry point — the
+  `productionServer` / `remoteClient` construction presets (toolshed's
+  operator runtime, the background piece service, the CLI, every pieces
+  controller and integration harness against a toolshed), toolshed's
+  serving-host gate and its memory service-principal grant, and the browser
+  shell's build define fallback. An UNSET flag resolves to it; an explicit
+  `EXPERIMENTAL_SERVER_EXECUTION=true` (or `experimental.serverExecution:
+  true`, or the shell define `true`) selects the ON arm, an explicit `false`
+  the OFF arm regardless of the constant. Single-process harnesses do not
+  read the constant: a bare `new Runtime` and the `patternTest` /
+  `localDev` / `unitTest` presets have no serving host, so they resolve the
+  ambient baseline (OFF) by construction — the unit suites and `cf test`
+  run the derive-and-commit model; the ON posture's unit coverage sets the
+  flag explicitly (the `executor-*` suites) and its integration coverage is
+  the explicit-`true` CI lanes. In CI (testing.md §2) the DEFAULT lanes are
+  the OFF posture (probed), and the explicit-`true` lanes on an ON-BUILT
+  binary (`build-toolshed-on`; the shell define is baked at build) are the
+  ON arm — the full posture, verified by a probe before each suite, its
+  Deno-side clients declaring the posture from the env — with skips only
+  through `tasks/server-execution-on-skips.ts`, printed loudly (six
+  `phase-7` entries today, all red under the full ON posture, none
+  vacuous). **THE FLIP IS ITS OWN ONE-LINE PR** (the constant → `true`, plus
+  the absolute pin, the CI lane roles + probes, and this entry; repo
+  convention: a flip is reverted by reverting the PR that only flips),
+  landing after the plan's Phase-7 ordered gates: OW32 (the client-side
+  non-settling loop in the two-browser journeys) triaged → OW17 (the
+  serving replica's per-instance re-keying, with OW29) → OW28
+  (`compile-and-run` as an outbox effect kind) → the honest propagation
+  benchmark → the skip list EMPTY and the deployed-topology binaries the
+  presets flip exercised ON by a gate → the flip PR. End state: after a soak
+  on main (which starts at the flip PR's merge) the flag retires and the
+  OFF code path is removed — a separate post-soak PR (the plan's Phase 7
+  task 2, split from the flip because stacked PRs cannot soak).
+- **Status on 2026-08-16 (Phase 7 flip-READY, landed DARK).** Phases 1–6
+  landed; Phase 7 landed the flip's mechanism — the one constant and its
+  readers, OW27 per-stream send pacing in the event-append queue
+  (pace-never-drop, per-stream independence — README §3.8), the LT9
+  simplification (process-lifetime queue), served-wish read authority (the
+  process identity is a memory service principal under the flag —
+  honestly, implicit OWNER for its ordinary session traffic:
+  verification-coverage.md OW31, a ruled item), the demand-root chain in
+  the run supply (nested pieces, result-as-pattern children, and the list
+  builtins' element pieces) — with the constant `false`. Known ON-arm gaps,
+  carried on the plan's Phase 7 section and the register: the two-browser
+  journeys stall on an UNATTRIBUTED client-side scheduler-non-settling
+  loop (OW32, first gate); the serving replica's scope-name collapse at
+  scoped cardinality ≥ 2 (OW17, a bounded architectural leg with a known
+  fix shape); fresh `compile-and-run` inert until its serving port (OW28);
+  the ON-posture Deno-client family surfaced by the uniform ON lanes
+  (OW33); the topics-navigation / two-browser / lunch gates and three
+  package-suite items are ON-skip-listed with loud reasons.
 - **Status on 2026-08-05.** Phase 1 stages A–F landed (E re-keyed the
   vocabulary per instance; F landed the serving loop itself): the
   ExecutorHost + SpaceServer host one committing runtime per active space
@@ -447,9 +468,11 @@ rather than coerced. See [How flags propagate](#how-flags-propagate).
   still dark: OFF by default and byte-identical to today; the ON arm now
   actually serves (with the documented two-deriver interim). Stage G
   (effects + outbox) remains.
-- **Path to removal.** Soak the default on main; then the post-soak PR
+- **Path to removal.** The flip PR (the constant → `true`) after the
+  ordered gates above; soak the default on main; then the post-soak PR
   retires the flag, removes the OFF path (and the OFF regression-guard CI
-  lanes + the OFF-built binary), and closes out this entry.
+  lanes + the OFF-built binary the flip PR introduces by inverting
+  `build-toolshed-on`), and closes out this entry.
 
 ---
 

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -35,7 +35,7 @@ was last checked against the code.
 | [`systemPatternAutoUpdate`](#systempatternautoupdate)                       | `EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE` env / shell build define, or `RuntimeOptions.experimental`                                             | on in the shell (same-toolshed system sources, including all roots); off server-side | Bernhard Seefeld (#4611; shell default-on #4619)      | graduate to always-on, then delete flag                                                                                                                                                                                           | implemented, on in the shell                                                    |
 | [`computedCellIds`](#computedcellids)                                       | `EXPERIMENTAL_COMPUTED_CELL_IDS` env, or `RuntimeOptions.experimental`                                                                          | on                                                                                   | Robin McCollum (#4659)                                | graduate to unconditional behavior, then delete flag                                                                                                                                                                              | implemented, on by default                                                      |
 | [`lazyMaterialization`](#lazymaterialization)                               | `EXPERIMENTAL_LAZY_MATERIALIZATION` env, or `RuntimeOptions.experimental`                                                                       | on                                                                                   | Bernhard Seefeld                                      | fold into base read semantics, then delete flag                                                             | implemented, on by default                                         |
-| [`serverExecution`](#serverexecution) | `EXPERIMENTAL_SERVER_EXECUTION` env, or `RuntimeOptions.experimental` | off | Bernhard Seefeld (#5339, server-execution v2 plan Phase 1 stage A) | default ON at the plan's Phase 7 flip, then delete the flag and the OFF path | Phases 1–3 landed (stages A–G, the Phase 2 client speculation overlay, and Phase 3 events-down — clients no longer derive or commit handler writes under the flag), off by default |
+| [`serverExecution`](#serverexecution) | `EXPERIMENTAL_SERVER_EXECUTION` env, or `RuntimeOptions.experimental` | **on** (first-party default since Phase 7's flip; explicit `false` = the OFF arm) | Bernhard Seefeld (#5339, server-execution v2 plan Phase 1 stage A; Phase 7 flip) | soak on main, then delete the flag and the OFF path (the split-out post-soak PR) | Phases 1–7 landed; ON by default in every deployed-topology process; the OFF arm stays selectable as the rollback lever through the soak |
 | [`cfcEnforcementMode`](#cfcenforcementmode)                                 | `RuntimeOptions.cfcEnforcementMode` (`CF_CFC_MODE` in the cf-harness / fuse)                                                                    | `enforce-explicit`                                                                   | Bernhard Seefeld (#3263)                              | tighten default toward `enforce-strict`                                                                                                                                                                                           | active; ladder is permanent                                                     |
 | [`cfcFlowLabels`](#cfcflowlabels)                                           | `RuntimeOptions.cfcFlowLabels`                                                                                                                  | `off`                                                                                | Bernhard Seefeld (#4011)                              | move toward `persist`                                                                                                                                                                                                             | implemented, staged rollout                                                     |
 | [`cfcWriteFloor`](#cfcwritefloor)                                           | `RuntimeOptions.cfcWriteFloor`                                                                                                                  | `off`                                                                                | Bernhard Seefeld (#4479)                              | move toward `enforce`                                                                                                                                                                                                             | implemented, staged rollout                                                     |
@@ -66,8 +66,10 @@ These flags make up the `ExperimentalOptions` interface in
 [`packages/runner/src/runtime.ts`](../../packages/runner/src/runtime.ts). They
 are passed as `new Runtime({ experimental: { ... } })`. Each flag defaults to
 `undefined`, which means "take the built-in default". `commitPreconditions`,
-`plainResultReceipts`, and `computedCellIds` default on; the other flags in this
-category default off unless their section says otherwise.
+`plainResultReceipts`, `computedCellIds` and `lazyMaterialization` default on;
+`serverExecution` defaults on in the deployed-topology presets (its section);
+the other flags in this category default off unless their section says
+otherwise.
 
 The mapping from environment variable to flag is defined once, canonically, as
 `EXPERIMENTAL_ENV_VARS` in
@@ -355,7 +357,8 @@ rather than coerced. See [How flags propagate](#how-flags-propagate).
   states, no shippable intermediates (spec README §3.4); deliberately named
   unlike v1's `SERVER_PRIMARY_EXECUTION` so the archived v1 documents never
   alias it. Both states, defined:
-  - **OFF (the default): today's behavior, byte-for-byte.** Every client
+  - **OFF (explicit `false` — the rollback lever; the pre-flip default): the
+    pre-flip behavior, byte-for-byte.** Every client
     runtime runs and commits derivations exactly as it does today, and every
     client commit is `authored`-class — `derived` is never claimed off the
     flag. The commit `class` metadata is still *written* in this arm (it is
@@ -363,7 +366,8 @@ rather than coerced. See [How flags propagate](#how-flags-propagate).
     is enforced from it, and `stream-data` behaves as today. Any OFF-arm
     behavioral diff from a v2 stage is a phase-gate failure by itself
     (testing.md §2).
-  - **ON: the v2 posture, growing stage by stage.** With stages A–F landed
+  - **ON (the first-party DEFAULT since the Phase 7 flip, 2026-08-15): the
+    v2 posture.** With stages A–F landed
     this means: the per-class admission rows of protocol.md §2 are enforced
     — the `derived` row is the stage-B lease equality check PLUS stage F's
     derived-envelope defense-in-depth (the producing session must BE the
@@ -396,11 +400,42 @@ rather than coerced. See [How flags propagate](#how-flags-propagate).
     F10 interim — is DELETED). Later stages add their surfaces under
     this same flag; both halves of any coupled behavior move together
     on it.
-- **Current default and planned end state.** Off by default in every process.
-  The integration suites run an ON arm in CI from stage A on, with explicit
-  per-phase skip lists (testing.md §2). End state: the plan's Phase 7 flips
-  the default ON after Phases 1–6 gate green and a soak period, then the flag
-  retires and the OFF code path is removed.
+- **Current default and planned end state.** **ON by default** since the
+  plan's Phase 7 flip (2026-08-15): the ONE first-party default is
+  `SERVER_EXECUTION_DEFAULT_ENABLED` in
+  [`packages/memory/v2/server-execution-default.ts`](../../packages/memory/v2/server-execution-default.ts),
+  read by every deployed-topology entry point — the `productionServer` /
+  `remoteClient` construction presets (toolshed's operator runtime, the
+  background piece service, the CLI, every pieces controller and
+  integration harness against a toolshed), toolshed's serving-host gate
+  and its memory service-principal grant, and the browser shell's build
+  define fallback. An UNSET flag resolves to it; an explicit
+  `EXPERIMENTAL_SERVER_EXECUTION=false` (or
+  `experimental.serverExecution: false`, or the shell define `false`)
+  selects the OFF arm — the rollback lever until the OFF path is removed.
+  Single-process harnesses are the deliberate exception: a bare `new
+  Runtime` and the `patternTest` / `localDev` / `unitTest` presets have no
+  serving host, so they resolve the ambient baseline (OFF) by construction —
+  the unit suites and `cf test` run the derive-and-commit model; the ON
+  posture's unit coverage sets the flag explicitly (the `executor-*` suites)
+  and its integration coverage is the default CI lanes. In CI (testing.md
+  §2) the DEFAULT lanes are the ON arm (skips only through
+  `tasks/server-execution-on-skips.ts`, printed loudly) and the
+  explicit-`false` lanes on an OFF-built binary are the regression guard.
+  End state: after a soak on main the flag retires and the OFF code path is
+  removed — a separate post-soak PR (the plan's Phase 7 task 2, split from
+  the flip because stacked PRs cannot soak).
+- **Status on 2026-08-15 (Phase 7 flip-ready).** Phases 1–6 landed; Phase 7
+  landed the flip preconditions — OW27 per-stream send pacing in the
+  event-append queue (pace-never-drop, README §3.8), the LT9 simplification
+  (process-lifetime queue), served-wish read authority (the process identity
+  is a memory service principal under the flag) and the nested-piece
+  demand-root chain in the run supply — and the flip itself. Known ON-arm
+  gaps carried honestly on the plan's Phase 7 section (browser-ON multi-user
+  scenarios at scoped cardinality ≥ 2 oscillate on the serving replica's
+  scope-name collapse — verification-coverage.md OW17; fresh
+  `compile-and-run` is inert until its serving port; the topics-navigation
+  skip stands).
 - **Status on 2026-08-05.** Phase 1 stages A–F landed (E re-keyed the
   vocabulary per instance; F landed the serving loop itself): the
   ExecutorHost + SpaceServer host one committing runtime per active space
@@ -412,9 +447,9 @@ rather than coerced. See [How flags propagate](#how-flags-propagate).
   still dark: OFF by default and byte-identical to today; the ON arm now
   actually serves (with the documented two-deriver interim). Stage G
   (effects + outbox) remains.
-- **Path to removal.** Execute the plan through its phase gates; at the
-  Phase 7 flip, retire the flag, remove the OFF path, and close out this
-  entry.
+- **Path to removal.** Soak the default on main; then the post-soak PR
+  retires the flag, removes the OFF path (and the OFF regression-guard CI
+  lanes + the OFF-built binary), and closes out this entry.
 
 ---
 

--- a/docs/plans/server-execution-v2.md
+++ b/docs/plans/server-execution-v2.md
@@ -151,7 +151,7 @@ client's only computational commit (spec §3.6).
 | Phase 3 ON — events down (D-v2-1) | unchanged | SpaceServer, reacting to the event commit / ONLY the event append; the local run is speculative echo, and the client handler-write commit path DELETES (events.md §7 — F10's interim ends) | unchanged | handler consequences land in the ACTING principal's instances, resolved from the server-stamped `firedAt` (scopes.md §5, protocol.md §2) | commits nothing but intent: event appends + UI-binding writes; echo via overlay |
 | Phase 4 ON — effect channel | unchanged | unchanged | external effects: server only; session effects (navigate): the server COMPUTES the intent, the client ENACTS and acks by nonce (protocol.md §5) | the effects doc is itself a session-scoped instance; the ack is written into the session's own instance (protocol.md §5) | adds the effects-doc subscription and the enact/ack duty (the ack is an authored write) |
 | Phase 5 ON — cross-space | home SpaceServer over foreign reads, under the piece's granted authority / commits HOME only — never derived into a foreign space (protocol.md §2b) | unchanged; cross-space mutation leaves ONLY as outbox event appends; `.inSpace` provisioning lands authored-class, foreign-first, under the event's acting principal | unchanged; the outbox also carries the cross-space appends | foreign reads name their instance explicitly, lease-holder-only (protocol.md §2's read row) | unchanged |
-| Phase 7 flip (FLIP-READY landed 2026-08-15: default ON, OFF path KEPT as the rollback lever through the soak; removal is the split-out post-soak PR) | SpaceServer only (default); the OFF arm still selectable by explicit `false` | SpaceServer / events only | server, plus the client-enacted channel | unchanged from Phase 5; session-data GC is the remaining owed design (scopes.md §8 item 2); OW17's replica per-instance keying is the flip's blocker at scoped cardinality ≥ 2 | final: speculate freely, commit only intent; flag retires after the soak |
+| Phase 7 flip (FLIP-READY landed DARK 2026-08-16 by owner ruling: the mechanism is in, `SERVER_EXECUTION_DEFAULT_ENABLED = false`, the ON posture selectable by explicit `true`; the flip itself is a separate one-line PR after the ordered gates below; OFF path KEPT as the rollback lever through the soak; removal is the split-out post-soak PR) | SpaceServer only once flipped; today the OFF baseline by default, the ON arm selectable by explicit `true` | SpaceServer / events only | server, plus the client-enacted channel | unchanged from Phase 5; session-data GC is the remaining owed design (scopes.md §8 item 2); OW17's replica per-instance keying is the flip's blocker at scoped cardinality ≥ 2 | final: speculate freely, commit only intent; flag retires after the soak |
 
 A surface a milestone has not yet landed (navigateTo before
 Phase 4, cross-space before Phase 5) has no defined interim
@@ -771,12 +771,24 @@ Success criteria:
 
 ## Phase 7 — Flip and retire
 
-**Scoping (coordinator, 2026-08-15; owner ruling pending — built to
-it): this phase delivers FLIP-READY, and task 2's OFF-path REMOVAL is
-SPLIT OUT into a separate post-merge, post-soak PR** — stacked PRs get
-no CI matrix, so the soak can only start once the stack merges to
-main, and the flag must remain the rollback lever through the soak.
-The plan is NOT archived here (task 3 is close-out after the soak).
+**Scoping (coordinator, 2026-08-15; OWNER RULED 2026-08-16): this
+phase delivers FLIP-READY, LANDED DARK — the mechanism merges with the
+first-party default `false`; THE FLIP IS ITS OWN SEPARATE ONE-LINE PR
+(repo convention: a flip is reverted by reverting the PR that only
+flips), owed AFTER the ON posture works and is performant. Task 2's
+OFF-path REMOVAL stays SPLIT OUT into a separate post-flip, post-soak
+PR** — stacked PRs get no CI matrix, so the soak can only start once the
+flip merges to main, and the flag must remain the rollback lever through
+the soak. The plan is NOT archived here (task 3 is close-out after the
+soak). Ruling rationale (the independent review's verdict, adopted): with
+the constant `true` the REQUIRED default CI lanes went red on merge
+(two two-browser gates stall 300 s under the full ON posture, neither
+skip-listed), the ON posture today breaks every two-user browser
+journey (OW32's client-side non-settling loop, unattributed) and the
+piece-creation/compiler surfaces (OW28), and "flip-ready (true) and hold
+the merge" parks the train behind several stages of work; landing dark
+keeps the mechanism reviewable and revertable in small pieces and gives
+CI an honest meaning on main.
 
 Preconditions (all RULED 2026-08-15, all landed with this phase):
 
@@ -804,8 +816,13 @@ Preconditions (all RULED 2026-08-15, all landed with this phase):
       (`SchedulerObservationIdentity.demandRootIds`) — the lunch
       pattern's `#profile` wish lives in a sub-pattern whose runs had no
       demanded instances and fell to the SERVICE identity's instances
-      (`user:<serviceDID>` rows in the store). Gate state: see the table
-      — RED at cardinality ≥ 2 (OW17), the #5612 gate row NOT edited.
+      (`user:<serviceDID>` rows in the store) — the chain also carries
+      through the LIST builtins' child instantiation since the fixer pass
+      (review finding 4; the wish-sidecar sites are FLAGGED, not chained
+      — verification-coverage OW29). Gate state: see the table — RED;
+      the build's "(1)+(2)+(3) reaches the join UI" claim did NOT
+      reproduce at head (the served wish throws identity-less at step 1;
+      OW17's correction); the #5612 gate row NOT edited.
 - [x] **LT9 simplification — RE-RULED (owner)**: reload survival is a
       non-goal this round; the queue is process-lifetime. Retired: the
       Web-Storage adapter and Phase 5's coupling seam; kept: the
@@ -816,37 +833,63 @@ Preconditions (all RULED 2026-08-15, all landed with this phase):
 
 Tasks:
 
-- [x] **Default ON** — LANDED 2026-08-15 as FLIP-READY: the ONE
-      first-party default `SERVER_EXECUTION_DEFAULT_ENABLED = true`
-      (`packages/memory/v2/server-execution-default.ts`), resolved by
-      the `productionServer` / `remoteClient` presets, the shell define
-      fallback, and toolshed's serving-host gate + service-principal
-      grant; explicit `false` = the OFF arm (rollback lever); the
-      single-process presets keep the OFF baseline by construction
-      (EXPERIMENTAL_OPTIONS.md). CI: the default lanes ARE the ON arm in
-      the FULL posture (the ON shell build lands with the flip — OW25's
-      first condition), the explicit-`false` lanes on an OFF-built
-      binary are the regression guard; the skip list holds ONE entry
-      (topics-navigation, re-justified — see verification-coverage
-      OW25/OW30). **Soak-period caveat: the soak starts at MERGE** —
-      stacked PRs cannot soak; "Phases 1–6 gate green in CI" holds for
-      the sx2 family and the non-browser package suites (table below)
-      and does NOT hold for the browser-ON multi-user family (OW17 —
-      the flip's top blocker), so the flip is landed as READY, not as
-      soaked-and-judged.
+- [ ] **Default ON — FLIP-READY LANDED DARK (2026-08-16, owner ruling);
+      the flip itself is a separate one-line PR, NOT yet landed.** What
+      is in: the ONE first-party default `SERVER_EXECUTION_DEFAULT_
+      ENABLED` (`packages/memory/v2/server-execution-default.ts`) — value
+      `false` today — resolved by the `productionServer` / `remoteClient`
+      presets, the shell define fallback, and toolshed's serving-host
+      gate + service-principal grant; explicit `true` = the ON arm,
+      explicit `false` = the OFF arm; the single-process presets keep the
+      OFF baseline by construction (EXPERIMENTAL_OPTIONS.md); the ONE
+      absolute pin (`packages/toolshed/lib/server-execution-flag.test.
+      ts`) states the current default so a silent flip either way cannot
+      hide behind the relative pins. CI (testing.md §2): the DEFAULT
+      lanes are the OFF posture (a probe pins server-not-serving + shell
+      define unset), the explicit-`true` ON lanes run on `build-toolshed-
+      on` (shell define baked `true`) with the FULL ON posture verified
+      before each suite (`/api/meta.shellServerExecutionDefine === "true"`,
+      `/api/health/stats.servingLoop` present) and the Deno-side test
+      clients declaring the posture from the env (uniform, not mixed);
+      the ON skip list — made EFFECTIVE by the fixer (it had been inert
+      since Phase 4: `deno test --ignore` never applied to explicitly
+      listed files) — holds `phase-7` entries: patterns ×3
+      (`topics-navigation`, `cfc-group-chat-demo-two-browsers`,
+      `lunch-poll-vote`), runner ×1 (`pattern-and-data-persistence`),
+      runtime-client ×2 STEP entries (`tasks/server-execution-on-skips.
+      ts`, each with its loud reason; verification-coverage OW30/OW32/
+      OW33). **THE FLIP PR (one line: the constant → `true`, plus the
+      absolute pin, the lane roles + probes, EXPERIMENTAL_OPTIONS.md)
+      lands only after these ORDERED GATES, in this order:** (1) OW32 —
+      the client-side scheduler-non-settling loop TRIAGED and fixed (the
+      two two-browser gates green 5/5 fresh-store under the full ON
+      posture); (2) OW17 — the SpaceReplica per-instance re-keying (with
+      OW29's space-root demanders + arrival re-runs; P2-F-sized); (3)
+      OW28 — compile-and-run as an outbox effect kind + completion-class
+      writeback; (4) the HONEST propagation benchmark (criterion below)
+      once the two-user family works; (5) the ON skip list EMPTY and the
+      deployed-topology binaries the presets flip
+      (`background-piece-service`, the CLI, cf-harness, every
+      `PiecesController`) exercised ON by a gate — the flip PR's own
+      obligation (review finding 8: today nothing exercises them ON);
+      then (6) the flip PR, and the soak starts at ITS merge. OW31 (the
+      service-principal write-authority posture) is a ruled item for the
+      owner before the flip.
 - [ ] Retire the flag; OFF path removed; `EXPERIMENTAL_OPTIONS.md` entry
       closed out — **SPLIT OUT: the post-soak removal PR** (named here as
       the flip's follow-up; it also removes the OFF regression-guard CI
-      lanes and `build-toolshed-off`).
+      lanes and the OFF-built binary job that the flip PR will introduce
+      by inverting today's `build-toolshed-on`).
 - [ ] Archive this plan to `docs/history/plans/` per the lifecycle
       (close-out, after the soak and the removal PR).
 
 Success criteria:
 
-- [ ] The integration suites run ON-only and green. (NOT ticked: the
-      OFF lanes stay as the regression guard through the soak by design;
-      and the ON lanes are expected-red on the browser-ON multi-user
-      family — table below.)
+- [ ] The integration suites run ON-only and green. (NOT ticked — untrue
+      today: the default lanes are the OFF posture by ruling; the
+      explicit-ON lanes are green only WITH the skip list's six
+      `phase-7` entries, which are RED under the full ON posture, not
+      vacuous — table below.)
 - [ ] Cross-user propagation beats the client-computed baseline on the
       byte-identical workloads (the §1 "faster, not tolerably slower"
       requirement). (NOT ticked — UNMEASURED: the measurement leg is
@@ -856,23 +899,35 @@ Success criteria:
       median/quartiles/max + load; protocol: fresh store per arm,
       adjacent ON/OFF pairs, n ≥ 20 per arm, load recorded — but its
       HARNESS is red under the full ON posture at the unmodified Phase-6
-      base (the two-browsers gate stalls at the first per-user write with
-      60–70k client action runs: OW17's cardinality-2 collapse), so no
-      honest ON number exists yet. The harness must not be tuned to
-      pass; the criterion waits for OW17.)
+      base AND at head — the two-browsers gate stalls at the first
+      per-user write with 40–56 k client action runs on the CLIENT-side
+      scheduler-non-settling loop (OW32; NOT evidenced as OW17 — the
+      serving loop is quiet), so no honest ON browser number exists yet.
+      The harness must not be tuned to pass; the criterion waits for the
+      two-user family (OW32 → OW17+OW29). An HONEST PARTIAL number has a
+      shape, not built (review finding 12): `sx2-scale.test.ts` already
+      builds N `PiecesController` clients with a timed `settleWrite`; two
+      controllers (distinct identities) on ONE space — A appends an event,
+      B's replica sinks the served consequence — timed under explicit ON
+      vs explicit OFF, fresh store per arm, n ≥ 20, gives a byte-identical
+      cross-user propagation number for the Deno client posture today.)
 
-**Phase-7 gates table (2026-08-15, this tree; fresh store per run,
-private port offset, load 1-min 4–6 unless noted):**
+**Phase-7 gates table (re-tensed 2026-08-16 by the fixer pass; the
+independent review's re-runs at head `97cb7aa47` and the unmodified
+Phase-6 base `c75f04f37`, plus the fixer's local runs on the fixed tree;
+fresh store per run, private port offset, loaded box):**
 
 | gate | posture | result |
 | --- | --- | --- |
-| `sx2-serving-loop`, `sx2-speculation`, `sx2-events`, `sx2-effect-channel`, `sx2-scale` | DEFAULT (unset = ON), toolshed serving by default, shell ON | 5/5 GREEN (one run; the sx2 arm detection now reads env-else-default) |
-| same five | explicit `EXPERIMENTAL_SERVER_EXECUTION=false` everywhere (the OFF regression guard) | 5/5 GREEN; toolshed logs no serving loop |
-| runner package integration (14) | DEFAULT | 14/14 GREEN |
-| runtime-client package integration | DEFAULT | 1/1 (45 steps) GREEN |
-| `counter` | DEFAULT | 1 red / 2 green (OW30's controller write-destination race — intermittent) |
-| `cf-checkbox` | DEFAULT | GREEN |
-| `topics-navigation` | DEFAULT (full posture) | RED fast (`missing required property myName`, OW30 class) — SKIP-LISTED with the Phase-7 reason |
-| `cfc-group-chat-demo-two-browsers` (the Phase-2 gate + the benchmark harness) | full ON — HEAD and the unmodified Phase-6 BASE (`c75f04f37`, env=true) | RED both: stalls at the first per-user write, client action runs 67k/56k (base) — the OW17 cardinality-2 collapse; NOT a Phase-7 regression |
-| lunch (`lunch-poll-vote`) | full ON, ≥2 runs at each step | base: 300 s wall at "both runtimes idle" (`lacks READ`; served wish never materialized). After (1)+(2)+(3): idle in 0.3–0.8 s, join UI renders, "host name filled" — then the join click's consequence never settles (cardinality-2 collapse; with the reverted extensions (4)+(5) both users' instances materialize and the loop storms — 4,427 waves / 5 min). RED; #5612 not edited |
-| OFF-arm neutrality | full runner suite (OFF ambient) + memory + toolshed unit suites | see the PR's bar |
+| `sx2-serving-loop`, `sx2-speculation`, `sx2-events`, `sx2-effect-channel`, `sx2-scale` | explicit `EXPERIMENTAL_SERVER_EXECUTION=true` everywhere (the ON arm — the sx2 arm detection reads env-else-default) | see the PR's bar (fixer re-run, fresh store) |
+| same five | DEFAULT (unset = OFF by ruling) | see the PR's bar (fixer re-run) |
+| runner package integration (14) | DEFAULT (OFF) | 14/14 GREEN |
+| runner package integration | explicit ON, UNIFORM (the 4 tests that talk to the lane's toolshed declare ON; the 8 in-process-app harness tests are OFF by construction) | 13/14 GREEN + `pattern-and-data-persistence` RED → ON-skip-listed (OW33); the pre-fix "14/14 under ON" was a MIXED posture (OFF clients) |
+| runtime-client package integration | DEFAULT (OFF) | 45 steps GREEN |
+| runtime-client package integration | explicit ON, UNIFORM (the worker declares ON) | 43 steps GREEN + 2 STEP entries ignored loudly (CT-1606 PerUser header render 3/3 red; single-navigateTo dispatch 1/3 red — OW33) |
+| `counter` | full ON | 1 red / 3 green in the build's runs (OW30's controller write-destination race — intermittent); green in the review's run; server exhausts 2/5 waves with no client loop |
+| `topics-navigation` | full ON | RED fast (`missing required property myName`, OW30 class) — ON-skip-listed (and, since the fixer, actually skipped) |
+| `cfc-group-chat-demo-two-browsers` (the Phase-2 gate + the benchmark harness) | full ON — HEAD 2/2 and the unmodified Phase-6 BASE 1/1 (review) | RED: 300 s stall; serving loop QUIET (waves 20–26, derivedCommits 19–25, events 2/2, watermarkLag 1–2, wavesBudgetExhausted 12–16), BOTH browsers in a client-side `scheduler-non-settling` loop (40–56 k action runs / 5 min) — OW32, UNATTRIBUTED, NOT evidenced as OW17; NOT a Phase-7 regression; ON-skip-listed |
+| lunch (`lunch-poll-vote`) | full ON — HEAD 2/2 (review) | RED: 300 s stall — the served `#profile` wish throws identity-less at STEP 1 (the OW29 space-root-demander gap at first demand) while the reference-only client waits forever (`wish/phase/send-error` ~13.6/s), plus the OW32 client loop; the build's "(1)+(2)+(3) → join UI renders" did NOT reproduce (0/2). ON-skip-listed; #5612 not edited |
+| the deployed-topology binaries the presets flip (`background-piece-service`, CLI, cf-harness, `PiecesController` hosts) | ON | NO gate exercises them ON (review finding 8) — recorded as the flip PR's own obligation; with the constant `false` none flips today |
+| OFF-arm neutrality | full runner suite (OFF ambient) + memory + toolshed unit suites + explicit-OFF sx2 | see the PR's bar |

--- a/docs/plans/server-execution-v2.md
+++ b/docs/plans/server-execution-v2.md
@@ -151,7 +151,7 @@ client's only computational commit (spec §3.6).
 | Phase 3 ON — events down (D-v2-1) | unchanged | SpaceServer, reacting to the event commit / ONLY the event append; the local run is speculative echo, and the client handler-write commit path DELETES (events.md §7 — F10's interim ends) | unchanged | handler consequences land in the ACTING principal's instances, resolved from the server-stamped `firedAt` (scopes.md §5, protocol.md §2) | commits nothing but intent: event appends + UI-binding writes; echo via overlay |
 | Phase 4 ON — effect channel | unchanged | unchanged | external effects: server only; session effects (navigate): the server COMPUTES the intent, the client ENACTS and acks by nonce (protocol.md §5) | the effects doc is itself a session-scoped instance; the ack is written into the session's own instance (protocol.md §5) | adds the effects-doc subscription and the enact/ack duty (the ack is an authored write) |
 | Phase 5 ON — cross-space | home SpaceServer over foreign reads, under the piece's granted authority / commits HOME only — never derived into a foreign space (protocol.md §2b) | unchanged; cross-space mutation leaves ONLY as outbox event appends; `.inSpace` provisioning lands authored-class, foreign-first, under the event's acting principal | unchanged; the outbox also carries the cross-space appends | foreign reads name their instance explicitly, lease-holder-only (protocol.md §2's read row) | unchanged |
-| Phase 7 flip | SpaceServer only — the OFF path is removed | SpaceServer / events only | server, plus the client-enacted channel | unchanged from Phase 5; session-data GC is the remaining owed design (scopes.md §8 item 2) | final: speculate freely, commit only intent; flag retired |
+| Phase 7 flip (FLIP-READY landed 2026-08-15: default ON, OFF path KEPT as the rollback lever through the soak; removal is the split-out post-soak PR) | SpaceServer only (default); the OFF arm still selectable by explicit `false` | SpaceServer / events only | server, plus the client-enacted channel | unchanged from Phase 5; session-data GC is the remaining owed design (scopes.md §8 item 2); OW17's replica per-instance keying is the flip's blocker at scoped cardinality ≥ 2 | final: speculate freely, commit only intent; flag retires after the soak |
 
 A surface a milestone has not yet landed (navigateTo before
 Phase 4, cross-space before Phase 5) has no defined interim
@@ -529,11 +529,11 @@ Tasks:
 - [x] Handler fire commits the event only (payload + target stream);
       admission = append authority + CAS. LANDED 2026-08-10: the fire
       fork (cell.ts) commits a stamped append to the stream's sidecar
-      doc via the fired-order event queue. LT9's durability rides an
-      injectable STORE SEAM whose default is in-memory — the same
-      persistence class as `sessionId` today (protocol §5's sessionId
-      persistence is pre-existing spec debt; the browser adapter lands
-      with it, and until then a reload loses queued intents). The
+      doc via the fired-order event queue. LT9's persistence rides an
+      injectable STORE SEAM whose default is in-memory (Phase 7,
+      2026-08-15: LT9 RE-RULED process-lifetime — reload loss accepted
+      this round; the durable adapter is retired, the manager-shared
+      in-memory store stays). The
       scheduler tell is the discriminator — a send from a
       scheduler-stamped run commits nothing.
 - [x] Server processes events — client-committed and server-originated
@@ -742,14 +742,14 @@ Tasks:
       default unpaced) — serving-loop.md §5,
       `executor-outbox-budget.test.ts`,
       `toolshed/lib/server-execution.test.ts`.
-- [ ] Event/binding backpressure shaping ahead of the commit stream —
-      FLAGGED, not filled (verification-coverage OW27): the §3.8
-      binding-layer shaping's semantics (pace vs batch vs drop, the
-      hold-latency bound, per-stream keying, UI-default visibility)
-      are an unstated fork needing the owner's ruling; the register
-      row carries the candidate resolutions and their costs. The ON
-      arm ships without an event-flood bound until it lands (W4's
-      collapse is flag-disabled by design).
+- [x] Event/binding backpressure shaping ahead of the commit stream —
+      RULED (a) and LANDED with Phase 7 (2026-08-15; verification-
+      coverage OW27): per-stream token-bucket pacing in the client's
+      event-append queue, pace-never-drop; the default posture (20/s,
+      burst 20) is a flagged dial. (Original Phase-6 flag: the §3.8
+      shaping's semantics were an unstated fork — pace vs batch vs
+      drop, the hold-latency bound, per-stream keying, UI-default
+      visibility.)
 
 Success criteria:
 
@@ -771,16 +771,108 @@ Success criteria:
 
 ## Phase 7 — Flip and retire
 
+**Scoping (coordinator, 2026-08-15; owner ruling pending — built to
+it): this phase delivers FLIP-READY, and task 2's OFF-path REMOVAL is
+SPLIT OUT into a separate post-merge, post-soak PR** — stacked PRs get
+no CI matrix, so the soak can only start once the stack merges to
+main, and the flag must remain the rollback lever through the soak.
+The plan is NOT archived here (task 3 is close-out after the soak).
+
+Preconditions (all RULED 2026-08-15, all landed with this phase):
+
+- [x] **OW27 — event-flood shaping, RULED (a)**: per-stream token-bucket
+      pacing in the client's event-append queue, PACE-NEVER-DROP
+      (README §3.8's implementation sentence; verification-coverage
+      OW27 → LANDED). Default posture 20/s sustained, 20 burst — a dial,
+      flagged. Red-first flood test (bounded rate, zero loss, fired
+      order) + the disabled-pacing mutation witness. OFF arm untouched
+      by construction (it never enqueues).
+- [x] **The wish bootstrap write path — RULED `.inSpace()` chain**: the
+      served create surface's `.inSpace()` provisioning stays on the
+      existing chain (`optIntoInSpaceMultiSpaceCommit` →
+      `enableCrossSpaceChildCommit` → the wave's grant-gated §2b accept
+      posture; crossing count stays at two). What the lunch gate ACTUALLY
+      needed, peeled in order and landed: (1) served-wish READ
+      authority — under the flag the toolshed process identity is a
+      memory service principal, so the loopback plane reads the
+      demanding user's home space (`memoryServiceDidsFor`; OFF the
+      configured list verbatim); (2) a flag-ON client's wish REFERENCES
+      the served sidecar cell instead of fetching/instantiating it
+      itself (the bookkeeping-authored instantiation raced the server's
+      derived one — the ~13/s stale-basis loop); (3) the nested-piece
+      DEMAND-ROOT CHAIN in the run supply
+      (`SchedulerObservationIdentity.demandRootIds`) — the lunch
+      pattern's `#profile` wish lives in a sub-pattern whose runs had no
+      demanded instances and fell to the SERVICE identity's instances
+      (`user:<serviceDID>` rows in the store). Gate state: see the table
+      — RED at cardinality ≥ 2 (OW17), the #5612 gate row NOT edited.
+- [x] **LT9 simplification — RE-RULED (owner)**: reload survival is a
+      non-goal this round; the queue is process-lifetime. Retired: the
+      Web-Storage adapter and Phase 5's coupling seam; kept: the
+      manager-shared in-memory store (in-process replacement survival)
+      and its pins. events.md §5 / scenario-traces LT9 re-tensed with
+      the owner's rationale; OW20 CLOSED as out-of-scope-this-round with
+      the recorded future shape (per-tab persistence + orphan adoption).
+
 Tasks:
 
-- [ ] Default ON after Phases 1–6 gate green in CI for a soak period.
+- [x] **Default ON** — LANDED 2026-08-15 as FLIP-READY: the ONE
+      first-party default `SERVER_EXECUTION_DEFAULT_ENABLED = true`
+      (`packages/memory/v2/server-execution-default.ts`), resolved by
+      the `productionServer` / `remoteClient` presets, the shell define
+      fallback, and toolshed's serving-host gate + service-principal
+      grant; explicit `false` = the OFF arm (rollback lever); the
+      single-process presets keep the OFF baseline by construction
+      (EXPERIMENTAL_OPTIONS.md). CI: the default lanes ARE the ON arm in
+      the FULL posture (the ON shell build lands with the flip — OW25's
+      first condition), the explicit-`false` lanes on an OFF-built
+      binary are the regression guard; the skip list holds ONE entry
+      (topics-navigation, re-justified — see verification-coverage
+      OW25/OW30). **Soak-period caveat: the soak starts at MERGE** —
+      stacked PRs cannot soak; "Phases 1–6 gate green in CI" holds for
+      the sx2 family and the non-browser package suites (table below)
+      and does NOT hold for the browser-ON multi-user family (OW17 —
+      the flip's top blocker), so the flip is landed as READY, not as
+      soaked-and-judged.
 - [ ] Retire the flag; OFF path removed; `EXPERIMENTAL_OPTIONS.md` entry
-      closed out.
-- [ ] Archive this plan to `docs/history/plans/` per the lifecycle.
+      closed out — **SPLIT OUT: the post-soak removal PR** (named here as
+      the flip's follow-up; it also removes the OFF regression-guard CI
+      lanes and `build-toolshed-off`).
+- [ ] Archive this plan to `docs/history/plans/` per the lifecycle
+      (close-out, after the soak and the removal PR).
 
 Success criteria:
 
-- [ ] The integration suites run ON-only and green.
+- [ ] The integration suites run ON-only and green. (NOT ticked: the
+      OFF lanes stay as the regression guard through the soak by design;
+      and the ON lanes are expected-red on the browser-ON multi-user
+      family — table below.)
 - [ ] Cross-user propagation beats the client-computed baseline on the
       byte-identical workloads (the §1 "faster, not tolerably slower"
-      requirement).
+      requirement). (NOT ticked — UNMEASURED: the measurement leg is
+      BUILT — `CF_CHAT_MESSAGE_SERIES=N CF_CHAT_MESSAGE_DELAY_MS=ms` on
+      `cfc-group-chat-demo-two-browsers` posts N messages from the first
+      browser and times each send→other-browser-renders, printing
+      median/quartiles/max + load; protocol: fresh store per arm,
+      adjacent ON/OFF pairs, n ≥ 20 per arm, load recorded — but its
+      HARNESS is red under the full ON posture at the unmodified Phase-6
+      base (the two-browsers gate stalls at the first per-user write with
+      60–70k client action runs: OW17's cardinality-2 collapse), so no
+      honest ON number exists yet. The harness must not be tuned to
+      pass; the criterion waits for OW17.)
+
+**Phase-7 gates table (2026-08-15, this tree; fresh store per run,
+private port offset, load 1-min 4–6 unless noted):**
+
+| gate | posture | result |
+| --- | --- | --- |
+| `sx2-serving-loop`, `sx2-speculation`, `sx2-events`, `sx2-effect-channel`, `sx2-scale` | DEFAULT (unset = ON), toolshed serving by default, shell ON | 5/5 GREEN (one run; the sx2 arm detection now reads env-else-default) |
+| same five | explicit `EXPERIMENTAL_SERVER_EXECUTION=false` everywhere (the OFF regression guard) | 5/5 GREEN; toolshed logs no serving loop |
+| runner package integration (14) | DEFAULT | 14/14 GREEN |
+| runtime-client package integration | DEFAULT | 1/1 (45 steps) GREEN |
+| `counter` | DEFAULT | 1 red / 2 green (OW30's controller write-destination race — intermittent) |
+| `cf-checkbox` | DEFAULT | GREEN |
+| `topics-navigation` | DEFAULT (full posture) | RED fast (`missing required property myName`, OW30 class) — SKIP-LISTED with the Phase-7 reason |
+| `cfc-group-chat-demo-two-browsers` (the Phase-2 gate + the benchmark harness) | full ON — HEAD and the unmodified Phase-6 BASE (`c75f04f37`, env=true) | RED both: stalls at the first per-user write, client action runs 67k/56k (base) — the OW17 cardinality-2 collapse; NOT a Phase-7 regression |
+| lunch (`lunch-poll-vote`) | full ON, ≥2 runs at each step | base: 300 s wall at "both runtimes idle" (`lacks READ`; served wish never materialized). After (1)+(2)+(3): idle in 0.3–0.8 s, join UI renders, "host name filled" — then the join click's consequence never settles (cardinality-2 collapse; with the reverted extensions (4)+(5) both users' instances materialize and the loop storms — 4,427 waves / 5 min). RED; #5612 not edited |
+| OFF-arm neutrality | full runner suite (OFF ambient) + memory + toolshed unit suites | see the PR's bar |

--- a/docs/specs/server-side-execution/README.md
+++ b/docs/specs/server-side-execution/README.md
@@ -392,13 +392,18 @@ session-scoped client act. The wiring:
 - **Backpressure**: event floods (key-repeat driving `stream.send()`)
   are rate-shaped at the binding layer before they become commits.
   *Implementation (OW27, RULED (a) by the owner 2026-08-15; Phase 7):
-  the client's event-append queue PACES per stream — a token bucket
-  between the queue head and the wire, `burst` sends immediate,
-  sustained sends at `ratePerSecond`, a flood HELD in fired order and
-  never dropped (events are intent; the default posture 20/s sustained,
-  20 burst, is a dial —* `DEFAULT_EVENT_APPEND_PACING` *in
+  the client's event-append queue PACES per stream — a token bucket per
+  stream between the queue and the wire, `burst` sends immediate,
+  sustained sends at `ratePerSecond`, a flood HELD in that stream's
+  fired order and never dropped (events are intent). Streams are
+  INDEPENDENT (ruled 2026-08-16 with the P7 review): a paced stream
+  holds only its own later sends — the queue sends the earliest-fired
+  entry whose stream has a token, so a flood on one stream never delays
+  another stream's sends (no cross-stream head-of-line hold), while
+  each stream's own fired order stays exact. The default posture 20/s
+  sustained, 20 burst, is a dial —* `DEFAULT_EVENT_APPEND_PACING` *in
   `packages/runner/src/storage/event-append-queue.ts` — flagged for the
-  owner). The OFF arm never constructs the queue.*
+  owner. The OFF arm never constructs the queue.*
 
 ## 4. Measured constraints (what the learning run bought)
 

--- a/docs/specs/server-side-execution/README.md
+++ b/docs/specs/server-side-execution/README.md
@@ -391,6 +391,14 @@ session-scoped client act. The wiring:
   already isolates workers; v2 adds the budgets.
 - **Backpressure**: event floods (key-repeat driving `stream.send()`)
   are rate-shaped at the binding layer before they become commits.
+  *Implementation (OW27, RULED (a) by the owner 2026-08-15; Phase 7):
+  the client's event-append queue PACES per stream — a token bucket
+  between the queue head and the wire, `burst` sends immediate,
+  sustained sends at `ratePerSecond`, a flood HELD in fired order and
+  never dropped (events are intent; the default posture 20/s sustained,
+  20 burst, is a dial —* `DEFAULT_EVENT_APPEND_PACING` *in
+  `packages/runner/src/storage/event-append-queue.ts` — flagged for the
+  owner). The OFF arm never constructs the queue.*
 
 ## 4. Measured constraints (what the learning run bought)
 

--- a/docs/specs/server-side-execution/builtins.md
+++ b/docs/specs/server-side-execution/builtins.md
@@ -164,7 +164,22 @@ stream is passed to other spaces, which then append intents to it.
   demander #1's create surface and clobber the pending input).
   Client wishes are byte-identical to before (cardinality 1: the
   runtime's own user; the client suggestion-cell cause carries no
-  user key, exactly as before).
+  user key, exactly as before). *Phase 7: on a flag-ON NON-serving
+  runtime the sidecar surfaces (create/picker/suggestion) are the
+  SpaceServer's compile-instantiate steps (§3) — the client's
+  speculative wish run REFERENCES the served sidecar cell
+  (cause-derived, so both sides name one doc) and never fetches,
+  instantiates or writes it (pre-Phase-7 a flag-ON client's
+  bookkeeping-stamped instantiation raced the server's on the same
+  docs). The OFF arm and the serving runtime are unchanged.*
+  *Read authority for the demanding user's home space (Phase 7):
+  the served wish's foreign reads ride the serving runtime's loopback
+  plane, whose sessions are admitted by the memory ACL as the process
+  identity — under the flag the toolshed process's identity is a
+  memory service principal (protocol.md §2b's free-read row;
+  `memoryServiceDidsFor`), the posture every deployment checklist
+  already requires of the operator DID; foreign WRITES are not widened
+  by it (the §2b accept gate checks the ACTING identity's grant).*
 
 ## 6. Adding a new built-in under v2 (checklist for future work)
 

--- a/docs/specs/server-side-execution/builtins.md
+++ b/docs/specs/server-side-execution/builtins.md
@@ -178,8 +178,12 @@ stream is passed to other spaces, which then append intents to it.
   identity — under the flag the toolshed process's identity is a
   memory service principal (protocol.md §2b's free-read row;
   `memoryServiceDidsFor`), the posture every deployment checklist
-  already requires of the operator DID; foreign WRITES are not widened
-  by it (the §2b accept gate checks the ACTING identity's grant).*
+  already requires of the operator DID. Honestly (P7 independent review
+  finding 6): a service principal is implicit OWNER for its sessions on
+  every space, so this WIDENS the process identity's ORDINARY session
+  traffic to OWNER everywhere; it is not widened at the wave's §2b
+  accept gate (which checks the ACTING identity's grant). The narrower
+  read-only shape is a ruled item — verification-coverage.md OW31.*
 
 ## 6. Adding a new built-in under v2 (checklist for future work)
 

--- a/docs/specs/server-side-execution/events.md
+++ b/docs/specs/server-side-execution/events.md
@@ -228,10 +228,18 @@ handler-run provenance records.
   the consequence — else a poison event wedges the stream), push.
 - Client offline at fire time (RULED 2026-08-02): events accumulate
   client-side as unacked authored commits and discharge on reconnect
-  in fired order. The queue is DURABLE client-side, in the same
-  persistence class as `sessionId` (protocol.md §5) — a reload
-  while offline preserves it; losing queued user actions to a
-  reload is not permitted (LT9, RULED 2026-08-03). A discharged
+  in fired order. The queue is PROCESS-LIFETIME (LT9, RE-RULED
+  2026-08-15 by the owner, superseding the 2026-08-03 "durable"
+  ruling): queued-but-undischarged intents surviving a client RELOAD
+  is a NON-GOAL this round — in the owner's words, *"the status quo
+  doesn't survive client + server reload either"* — so reload loss is
+  accepted; what the queue DOES survive is an in-process replica
+  replacement (the manager-shared in-memory store hands a dead
+  predecessor's intents to its successor — machinery loss, not reload
+  loss). Sessions are per tab: one writer per session by construction,
+  no leader election, no shared persisted session, no orphan adoption;
+  the recorded future shape, if reload survival is ever wanted, is
+  per-tab persistence + orphan adoption. A discharged
   event whose PRECONDITIONS are gone is
   DROPPED — no consequences commit — and the client MUST be signaled
   so the UI can react.

--- a/docs/specs/server-side-execution/events.md
+++ b/docs/specs/server-side-execution/events.md
@@ -228,7 +228,14 @@ handler-run provenance records.
   the consequence — else a poison event wedges the stream), push.
 - Client offline at fire time (RULED 2026-08-02): events accumulate
   client-side as unacked authored commits and discharge on reconnect
-  in fired order. The queue is PROCESS-LIFETIME (LT9, RE-RULED
+  in fired order — PER STREAM: a stream's sidecar carries only that
+  stream's entries and nothing on the wire orders one stream against
+  another, so the guarantee is each stream's own fired order (unpaced,
+  the queue sends the fired-order head, which serializes the space in
+  fired order as a consequence; under README §3.8's OW27 pacing streams
+  are independent — a paced stream holds only its own later sends,
+  never another stream's; ruled 2026-08-16 with the P7 review's
+  finding 5). The queue is PROCESS-LIFETIME (LT9, RE-RULED
   2026-08-15 by the owner, superseding the 2026-08-03 "durable"
   ruling): queued-but-undischarged intents surviving a client RELOAD
   is a NON-GOAL this round — in the owner's words, *"the status quo

--- a/docs/specs/server-side-execution/field-provenance.md
+++ b/docs/specs/server-side-execution/field-provenance.md
@@ -231,8 +231,10 @@ FP1 and FP2 are the heavyweights.
 - **FP9 — `sessionId` minting (F).** Who generates it (client or
   server), with what uniqueness guarantee — now that LT2 makes the
   same value a trusted identity component in EVERY space?
-- **FP10 — session TTL × durable offline queue (F).** The queue
-  survives a reload (LT9); the session retires by TTL. A client
+- **FP10 — session TTL × offline queue (F).** *(Re-tensed 2026-08-15:
+  the queue is process-lifetime — LT9 re-ruled — so the reload half of
+  this question is moot; the TTL half stands for a live client that
+  reconnects after TTL with queued actions.)* A client
   reconnecting after TTL with queued actions: discharge fails?
   re-authenticate under a fresh session first (whose keys then
   differ)? TTL suspended while actions are queued?

--- a/docs/specs/server-side-execution/protocol.md
+++ b/docs/specs/server-side-execution/protocol.md
@@ -448,7 +448,7 @@ them). v2 keeps that invariant and adds the class discipline:
 
 | crossing | mechanism |
 | --- | --- |
-| read a foreign doc | free — logged read + server-internal wake (§3b) |
+| read a foreign doc | free — logged read + server-internal wake (§3b). *Mechanism (Phase 7): the serving runtime's loopback session is admitted by the memory ACL as the process identity, which is a memory service principal under the flag (`memoryServiceDidsFor`, toolshed) — the deployment checklist's operator-DID posture, automatic where the loop runs; OFF the flag the configured list is used verbatim.* |
 | derive FROM foreign state | home derivation reading foreign inputs; result commits HOME |
 | mutate a foreign space | **an event append to a foreign stream — the ONLY cross-space mutation** |
 | `derived` commit into a foreign space | FORBIDDEN — SpaceServer(B) is B's only deriver; A never derives into B |

--- a/docs/specs/server-side-execution/protocol.md
+++ b/docs/specs/server-side-execution/protocol.md
@@ -281,6 +281,21 @@ validation, no certificates: no commit ever asserts that an execution
 happened elsewhere. If an admission question cannot be answered by
 (target, principal, lease, CAS), the design is drifting — stop.
 
+**`capabilityRef` — the vocabulary, stated (adjudicated by the Phase-7
+independent review, 2026-08-15; spec-sentence, no rename).** The value
+is a provenance TAG naming the authorizing CONTEXT of a server-produced
+authored write, from a closed vocabulary: `stream-append:<sidecarId>`
+(an outbox event append), `event-consequence:<eventId>` (a consequence
+of a processed event), `demanded-run:<user>` (a demanded instance run's
+provisioning). Admission checks its PRESENCE (the completeness floor
+above; wave.ts's staging refusal), never RESOLVES it — resolution
+against a per-doc grant is the owed hardening OW13/FP7 — and the name
+does NOT denote a capability object: nothing is looked up, delegated,
+or transferred through it today. Renaming it would churn the outbox
+column `capability_ref`, the executable model and their pins for no
+semantic gain; when OW13 lands, the value becomes the key of the
+resolved grant and this sentence retires.
+
 **The Phase-3 floor carve-out for sessionless space-scope emissions
 (SHAPE RULED 2026-08-05; implementation lands with Phase 3).** The
 server-produced row's completeness floor admits an ABSENT acting
@@ -448,7 +463,7 @@ them). v2 keeps that invariant and adds the class discipline:
 
 | crossing | mechanism |
 | --- | --- |
-| read a foreign doc | free — logged read + server-internal wake (§3b). *Mechanism (Phase 7): the serving runtime's loopback session is admitted by the memory ACL as the process identity, which is a memory service principal under the flag (`memoryServiceDidsFor`, toolshed) — the deployment checklist's operator-DID posture, automatic where the loop runs; OFF the flag the configured list is used verbatim.* |
+| read a foreign doc | free — logged read + server-internal wake (§3b). *Mechanism (Phase 7): the serving runtime's loopback session is admitted by the memory ACL as the process identity, which is a memory service principal under the flag (`memoryServiceDidsFor`, toolshed) — the deployment checklist's operator-DID posture, automatic where the loop runs; OFF the flag the configured list is used verbatim. Posture, honestly: a service principal is implicit OWNER everywhere for its sessions, so the process identity's ordinary session traffic is widened to OWNER (not this table's accept gate, which checks the acting identity's grant) — verification-coverage.md OW31, a ruled item.* |
 | derive FROM foreign state | home derivation reading foreign inputs; result commits HOME |
 | mutate a foreign space | **an event append to a foreign stream — the ONLY cross-space mutation** |
 | `derived` commit into a foreign space | FORBIDDEN — SpaceServer(B) is B's only deriver; A never derives into B |

--- a/docs/specs/server-side-execution/scenario-traces.md
+++ b/docs/specs/server-side-execution/scenario-traces.md
@@ -641,9 +641,9 @@ these.
 
 ### T8 (GAPS(1))
 - Q1: client-side unacked `authored` event appends, in fired order.
-  [events §5; speculation §5] (LT9 RULED 2026-08-03: the queue is
-  DURABLE client-side, same persistence class as `sessionId` — a
-  reload while offline preserves it.)
+  [events §5; speculation §5] (LT9 RE-RULED 2026-08-15: the queue is
+  PROCESS-LIFETIME — reload loss accepted this round; an in-process
+  replica replacement is survived.)
 - Q2: discharge in fired order (RULED). [events §5; speculation §5]
 - Q3: DROP — "a doc the handler must write was deleted meanwhile"
   meets the unrunnable predicate verbatim; a raced consequence
@@ -933,6 +933,10 @@ answers.
 - **LT8 (T2.Q6) — RULED: accepted.** The reload ×
   optimistic-enactment window may re-enact a nonce; acceptable for
   reversible effects, which every shipped kind is (protocol.md §5).
-- **LT9 (T8.Q1) — RULED:** the offline event queue is DURABLE
-  client-side, same persistence class as `sessionId` (events.md
-  §5).
+- **LT9 (T8.Q1) — RULED 2026-08-03, RE-RULED 2026-08-15 (owner):**
+  the offline event queue is PROCESS-LIFETIME — reload survival is a
+  non-goal this round ("the status quo doesn't survive client + server
+  reload either"); in-process replica replacement is survived via the
+  manager-shared store; per-tab sessions, no leader election, no
+  shared persisted session (events.md §5). The 2026-08-03 "durable"
+  ruling and Phase 3's Web-Storage adapter are retired.

--- a/docs/specs/server-side-execution/serving-loop.md
+++ b/docs/specs/server-side-execution/serving-loop.md
@@ -334,8 +334,10 @@ executing:
   seq (mid-wave commits are next wave's input), so a mid-run discovered
   read cannot tear.
 - **Cross-space**: the first foreign read (executed under the piece's
-  granted authority) registers, by being logged, a server-internal wake
-  on that doc for the home SpaceServer. Same one-run-late soundness.
+  granted authority — concretely, on the loopback plane as the process
+  identity, a memory service principal under the flag since Phase 7;
+  protocol.md §2b's free-read row) registers, by being logged, a
+  server-internal wake on that doc for the home SpaceServer. Same one-run-late soundness.
   v2 assumes spaces co-hosted on one memory server; sharding is out of
   scope. *(Phase 5 pinned the wake end to end and added NO machinery
   for it — survival-tested: the foreign read's loopback session IS

--- a/docs/specs/server-side-execution/testing.md
+++ b/docs/specs/server-side-execution/testing.md
@@ -41,17 +41,34 @@ not-yet-implemented phases via explicit skip lists per phase, never via
 silent filtering. (v1's terminal failure mode: the flags-on branch never
 went through CI at all.)
 
-*Since the Phase 7 flip (2026-08-15) the arms swap roles by env: the
-DEFAULT lanes (flag unset = the first-party default,
-`SERVER_EXECUTION_DEFAULT_ENABLED` — ON) ARE the ON arm, in the FULL
-posture (the toolshed binary serves and its baked browser shell is ON),
-with the skip list printed there; the explicit
-`EXPERIMENTAL_SERVER_EXECUTION=false` lanes are the OFF regression
-guard, on a binary whose shell was built with the define `false`
-(`build-toolshed-off`) so the OFF arm is the pre-flip FULL posture too —
-never a mixed one. Both lanes stay until the OFF path is removed (the
-post-soak PR). Single-process suites (the unit suites, `cf test`) are
-not arms of this contract: they have no serving host and run the
+*Phase 7 landed FLIP-READY, DARK (owner ruling 2026-08-16;
+`SERVER_EXECUTION_DEFAULT_ENABLED = false`; the flip is its own later
+one-line PR). The arms today: the DEFAULT lanes (flag unset = the
+first-party default, OFF) are the regression guard — a posture PROBE
+before each suite pins server-not-serving (`/api/health/stats` carries no
+`servingLoop`) and shell define unset (`/api/meta`'s
+`shellServerExecutionDefine` null), so a silent flip of the default
+cannot move the REQUIRED lanes onto ON; the explicit
+`EXPERIMENTAL_SERVER_EXECUTION=true` lanes are the ON arm in the FULL
+posture — the toolshed serves, the test processes DECLARE the posture
+from the env (the runner integration tests that talk to the lane's
+toolshed; the runtime-client worker — never a bare/undeclared client, the
+mixed posture the Phase-7 review found), and the binary's baked browser
+shell is ON-built (`build-toolshed-on`, the define `true`) — VERIFIED
+by the same probe (`shellServerExecutionDefine === "true"`,
+`servingLoop` present) before the suite runs. Skips only via
+`tasks/server-execution-on-skips.ts` (file entries; STEP entries for a
+one-file suite, guarded in-file and bound to the register), printed
+loudly — and, since 2026-08-16, actually EFFECTIVE: `deno test --ignore`
+binds only to files deno discovers itself, so the package `integration`
+tasks hand deno a quoted glob and the pattern shards filter their file
+list through the script (`--filter`); until then every listed skip ran.
+When the flip PR lands the roles invert (default = ON with the skip list,
+which must be EMPTY by then; explicit `false` = the OFF guard on an
+OFF-built binary), and both lanes stay until the OFF path is removed
+(the post-soak PR). Single-process suites (the unit suites, `cf test`,
+the runner integration files that serve toolshed's `app.ts` in-process)
+are not arms of this contract: they have no serving host and run the
 derive-and-commit model by construction (EXPERIMENTAL_OPTIONS.md).*
 
 ## 3. The watermark replaces polling
@@ -113,10 +130,10 @@ exists, then the properties become the implementation's oracle.
 | 1 | stages A–G land dark: OFF arm byte-identical per stage (§2), stage E's instance re-keying included (OFF-arm neutral by construction); ON arm runs in CI with explicit skip lists (no ON gates — the first ON milestone is Phase 2's) |
 | 2 | `sx2-serving-loop` (counters, amplification, restart-memo) and `sx2-speculation` (echo latency, overlay retirement; the client-side overlay diagnostic witnesses "commits nothing for derivations" — the zero-client-derived STORE-ATTRIBUTION query needs engine access and is pinned, both halves, in `packages/runner/test/speculation-overlay.test.ts`, not duplicated into the browser gate); existing `counter`, `cfc-group-chat-demo-multi-runtime` in ON arm; byte-identical suite both arms |
 | 3 | `sx2-events` (two-user lunch poll via server handlers; kill-between-event-and-consequence restart; duplicate-submit rejection; rapid-fire coalescing: N events fired faster than wave time yield ≪N derived commits and final-only values); propagation ≤300 ms p50 measured on `lunch-poll-vote` UNMODIFIED |
-| 4 | `sx2-effect-channel` (navigate intent/ack; reload between intent and ack; optimistic-enact reconcile); existing `topics-navigation` ON |
+| 4 | `sx2-effect-channel` (navigate intent/ack; reload between intent and ack; optimistic-enact reconcile); existing `topics-navigation` ON — ON-SKIP-LISTED since Phase 4 (red under the full ON posture: OW30's controller write-destination class; not ON coverage until it lifts) |
 | 5 | existing `shared-profile`, `profile-embed`, `sqlite-read-clearance-multi-runtime` green ON — the v1 stragglers are the acceptance tests |
 | 6 | `sx2-scale` (cf-checkbox in-suite ≈ isolated; budget: hostile LLM fan-out in space A leaves space B's propagation in budget); no poll-loops left in the suite |
-| 7 | full suites ON-only; propagation beats OFF-arm baseline on byte-identical workloads |
+| 7 | full suites ON-only; propagation beats OFF-arm baseline on byte-identical workloads — NEITHER met at the flip-ready landing (2026-08-16): the ON lanes are green only with six `phase-7` skip entries (verification-coverage OW30/OW32/OW33) and the benchmark is unmeasured (its harness is the two-browsers gate, red on OW32) |
 
 ## 6. The two standing baselines
 

--- a/docs/specs/server-side-execution/testing.md
+++ b/docs/specs/server-side-execution/testing.md
@@ -41,6 +41,19 @@ not-yet-implemented phases via explicit skip lists per phase, never via
 silent filtering. (v1's terminal failure mode: the flags-on branch never
 went through CI at all.)
 
+*Since the Phase 7 flip (2026-08-15) the arms swap roles by env: the
+DEFAULT lanes (flag unset = the first-party default,
+`SERVER_EXECUTION_DEFAULT_ENABLED` — ON) ARE the ON arm, in the FULL
+posture (the toolshed binary serves and its baked browser shell is ON),
+with the skip list printed there; the explicit
+`EXPERIMENTAL_SERVER_EXECUTION=false` lanes are the OFF regression
+guard, on a binary whose shell was built with the define `false`
+(`build-toolshed-off`) so the OFF arm is the pre-flip FULL posture too —
+never a mixed one. Both lanes stay until the OFF path is removed (the
+post-soak PR). Single-process suites (the unit suites, `cf test`) are
+not arms of this contract: they have no serving host and run the
+derive-and-commit model by construction (EXPERIMENTAL_OPTIONS.md).*
+
 ## 3. The watermark replaces polling
 
 `waitForSettled(space, seq)` — new test helper: resolves when the

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -937,6 +937,55 @@ nod, 2026-08-07; recorded in the plan's stage list):**
   no later than Phase 5's cross-space serving (foreign scoped
   instances make the local collapse load-bearing); flag-don't-fill
   until then.
+  **Phase 7 evidence (2026-08-15) — the collapse is LOAD-BEARING NOW,
+  and it is the flip's honest blocker for multi-user browser
+  scenarios.** Three mechanisms peeled on the lunch gate under the full
+  ON posture, in order: (1) the served `#profile` wish could not READ
+  the demanding user's home space (memory ACL — the process identity
+  was not a service principal; fixed: `memoryServiceDidsFor`);
+  (2) a flag-ON client's wish also fetched + instantiated the create
+  sidecar through bookkeeping-stamped AUTHORED commits, racing the
+  server's derived ones on the same docs (fixed: the client references
+  the served sidecar cell only — builtins.md §5); (3) the lunch
+  pattern's `#profile` wish lives in a NESTED sub-pattern whose actions
+  carried the CHILD root as `pieceRootId`, so the run supply found no
+  demanded instances and the runs fell to the wave-level identity —
+  the served scoped writes landed under `user:<serviceDID>` /
+  `session:<serviceDID>:…` (store dump: 34 user rows + 7 session rows
+  keyed by the SERVICE identity in the lunch space) — the
+  silent-empty-instance trap for WRITES, protocol §2's S1 ("there is
+  no third source of run identity") violated in practice (fixed: the
+  demand-root CHAIN, `SchedulerObservationIdentity.demandRootIds` —
+  nested pieces resolve through the outer root; `executor-run-supply.
+  test.ts`, red-first). With (1)–(3) the gate reaches the join UI
+  ("host name filled") and stalls at the join click's consequence. Two
+  further extensions were BUILT AND REVERTED because they make
+  cardinality ≥ 2 real on the collapsed replica: (4) SPACE-ROOT
+  DEMANDERS — a client watching only the space-scoped piece root
+  registers NO identity (`watchedRootsForSpace` records identity for
+  scoped roots only), so the second browser was never demanded; a
+  registry of (principal, session) demanders per space root + a
+  demand-ARRIVAL re-run (`Scheduler.invalidateActionsForDemandRoots`,
+  needed because a clean action never re-runs for an instance that did
+  not exist when it last ran); (5) the OW17 WRITE-half mitigation — a
+  per-instance run's scoped patch ops sealed as whole-doc SETS (the
+  patch was diffed against a SIBLING instance's collapsed local value,
+  so the engine rejected the whole wave: "wave commit rejected …
+  missing path /value/$UI/props/$cell"). With (4)+(5) both users'
+  instances materialize (store: `user:alice` 37, `session:alice:*` 2,
+  `user:bob` …) and the serving replica OSCILLATES: two instances of
+  one node write the same collapsed local doc alternately, each
+  re-dirtying the other — a wave STORM (4,427 waves / 4,426 derived
+  commits in 5 min, watermarkLag 1,685) — the OW17 VALUE half in its
+  purest form. (4)+(5) are recorded here as the designed shape and are
+  GATED on this row's owed leg (replica-level per-instance keying);
+  they must land WITH it, not before. The same signature (client
+  actionRuns 60–75k / 5 min, no settle) reproduces on the two-browsers
+  gate under the full ON posture at the UNMODIFIED Phase-6 base — the
+  "browser-ON red family" (OW25) IS this collapse at cardinality ≥ 2.
+  Trigger, sharpened: BEFORE the flip's soak can be judged on
+  multi-user browser scenarios; the flip's Phase-7 gates table carries
+  it as the top blocker.
 - OW19 — the demand-cycle terminal state: CLOSED by stage P2-F
   (2026-08-13; the RULED 2026-08-07 direction, built whole). A
   demanded root CONFIRMED synced with no pattern meta parks TERMINAL
@@ -980,19 +1029,26 @@ nod, 2026-08-07; recorded in the plan's stage list):**
 **Phase 3 follow-ups (the independent review's owed rows,
 2026-08-11):**
 
-- OW20 — the LT9 BROWSER ADAPTER (the durable
-  `EventAppendQueueStore`, landing with protocol §5's sessionId
-  persistence it depends on) carries two queue debts alongside the
-  store itself: (i) queue SELF-START on reconnect — discharge today
-  begins only when the next fire calls `#kick`, so a persisted
-  backlog waits for fresh user intent instead of draining on
-  reconnect/construction with a live transport; (ii) the
-  save-ordering contract — `#persist` serializes saves behind the
-  previous save (review m6, pinned in `event-append-client.test.ts`),
-  and an async adapter MUST keep resolving `save()` per call (never
-  coalescing behind a debounce that drops intermediate snapshots)
-  or re-derive its own ordering guarantee. Trigger: the sessionId
-  persistence work.
+- OW20 — CLOSED with Phase 7 (2026-08-15) as OUT-OF-SCOPE-THIS-ROUND
+  (not deferred-owed): the owner RE-RULED LT9 — queued events surviving
+  a client reload is a NON-GOAL this round ("the status quo doesn't
+  survive client + server reload either"), the queue is
+  PROCESS-LIFETIME (events.md §5), and the durable adapter that carried
+  this row (Phase 3's Web-Storage store, Phase 5's
+  `InitializationData.eventAppendQueuePersistence` coupling seam) is
+  RETIRED. Kept: the manager-shared in-memory store and its in-process
+  replacement-survival pins (`event-append-client.test.ts`,
+  `space-host-late-hint.test.ts`) — machinery loss, not reload loss.
+  The recorded FUTURE shape, if reload survival is ever wanted:
+  per-tab persistence + orphan adoption (per-tab sessions, one writer
+  per session by construction, no leader election, no shared persisted
+  session). Original obligation, for the record: the LT9 BROWSER
+  ADAPTER (the durable `EventAppendQueueStore`, landing with protocol
+  §5's sessionId persistence it depends on) carried two queue debts —
+  (i) queue SELF-START on reconnect; (ii) the save-ordering contract
+  (`#persist` serializes saves behind the previous save — review m6,
+  still pinned; an async adapter MUST keep resolving `save()` per
+  call).
 - OW21 — updateArgument's FULL EVENT-ROUTING (per OW16's
   classification): the tool mutation stamps HANDLER-class with NO
   eventId, so on a flag-ON client the overlay REFUSES the seal
@@ -1069,6 +1125,22 @@ nod, 2026-08-07; recorded in the plan's stage list):**
   (the inherited red's fix), and no later than the Phase-7 flip
   (a flip criterion measured on a mixed-posture lane would be
   vacuous).
+  Phase 7 (2026-08-15): the ON shell build LANDS BY THE FLIP — the
+  default binary bakes the shell ON (unset define = the first-party
+  default), so the default CI lanes are the FULL ON posture, and the
+  OFF regression guard gets its own OFF-built binary
+  (`build-toolshed-off`). The inherited red did NOT lift; it is now
+  ATTRIBUTED (OW17's Phase-7 evidence): under the full posture, at the
+  unmodified Phase-6 base, `cfc-group-chat-demo-two-browsers` stalls at
+  the first per-user write with 60–70k client action runs (the
+  cardinality-2 collapse), the lunch gate as recorded, and
+  `topics-navigation` fails fast at the controller's write-destination
+  validation (`missing required property myName` — the same class as
+  the intermittent `counter` failure below, OW30). The topics-navigation
+  skip entry stands with the Phase-7 reason; no browser-posture
+  criterion ticks on the default lanes' green until this family is
+  triaged — the flip's gates table records the lanes as expected-red
+  on the browser-ON family.
 - OW26 — the DEMANDED-EFFECT retry wedge (scheduler adjacency,
   surfaced by the owner-review P1 batch, 2026-08-12): when an
   `isEffect` builtin's action THROWS (the arms are builtins.md §4's
@@ -1168,9 +1240,29 @@ nod, 2026-08-07; recorded in the plan's stage list):**
   degradation; post-echo the degraded arithmetic times out at every
   barrier (mutation-verified red at all four sites, green restored).
 
-- OW27 — binding-layer event/binding backpressure shaping (the
-  Phase-6 plan bullet's third item, FLAGGED as a design fork rather
-  than filled — 2026-08-14): README §3.8 promises "event floods
+- OW27 — LANDED with Phase 7 (2026-08-15; RULED (a) by the owner
+  2026-08-15 — "client-side send pacing in the flag-gated append path,
+  per-stream token bucket, pace-never-drop"): the client event-append
+  queue paces per stream (`EventAppendQueue` — `pacing`, keyed by the
+  stream's sidecar doc; burst passes, sustained sends drain at the
+  rate, a flood is HELD in fired order, never coalesced, never dropped;
+  the head holds everything behind it — cross-stream head-of-line
+  hold is the accepted cost of exact fired order). Default posture
+  `DEFAULT_EVENT_APPEND_PACING` = 20/s sustained, 20 burst — a DIAL,
+  FLAGGED for the owner (the bound on the flooding user's own rapid
+  interactions ≈ (queued − burst)/rate seconds; a held key at ~30 Hz
+  is paced to 20 commits/s and clears within half a second of
+  release). Pinned red-first in `event-append-client.test.ts`: a 40-send
+  key-repeat flood — bounded rate (no 100 ms window above burst +
+  rate·window), ZERO loss, fired order — plus the DISABLED-PACING
+  mutation witness (`pacing: false` → the flood sends in one tick) and
+  close-during-hold (held outcomes settle; the intent stays queued for
+  a successor). OFF-arm untouched by construction: the OFF arm never
+  enqueues (the fire fork is flag-gated), so pacing has nothing to act
+  on there. README §3.8 carries the implementation sentence. Original
+  obligation, for the record — the Phase-6 plan bullet's third item,
+  FLAGGED as a design fork rather than filled (2026-08-14): README
+  §3.8 promises "event floods
   (key-repeat driving `stream.send()`) are rate-shaped at the binding
   layer before they become commits", and under the flag the W4
   last-wins collapse is DISABLED (events.ts gates it off — collapse
@@ -2053,16 +2145,13 @@ delta):
   local precision) now triggers with the grant-scoped read
   RESOLUTION landing — the same work that first admits a foreign
   scoped instance producer.
-- LT9 rec (c) — ADOPTED-PENDING-VETO, the COUPLING SEAM half only
-  (the plan defers protocol §5's sessionId persistence beyond
-  Phase 5, so per the rec's fork the durable wiring waits):
-  `InitializationData.eventAppendQueuePersistence` is the typed
-  declarative seam the worker maps onto the manager's
-  `eventAppendQueueStore` option (`resolveEventAppendQueuePersistence`
-  — memory kind honored; any other kind REFUSES initialization
-  loudly rather than silently degrading a durability declaration).
-  OW20 stands unchanged (browser adapter + queue debts, trigger: the
-  sessionId persistence work).
+- LT9 rec (c) — was ADOPTED-PENDING-VETO (the COUPLING SEAM half only:
+  `InitializationData.eventAppendQueuePersistence` →
+  `resolveEventAppendQueuePersistence` → the manager's
+  `eventAppendQueueStore` option); VETOED BY SIMPLIFICATION with the
+  LT9 re-ruling (owner, 2026-08-15) and RETIRED in Phase 7 — the seam
+  and its tests are deleted (dead weight for a non-goal); OW20 CLOSED
+  (see its row).
 
 Delta 2026-08-14 — Phase 6 (push priority, budgets, scale; the phase
 PR):
@@ -2124,6 +2213,86 @@ Delta 2026-08-15 — Phase 6 independent-review fixes (same PR):
 - §7's `push.*` counters are DEFINED as sessions EVALUATED per group
   (an ordering witness, not delivered frames) — the exported type's
   doc said "sends"; corrected, no counter change.
+
+**Phase 7 (the flip): rows opened by the flip's own gates, 2026-08-15:**
+
+- OW28 — the `compile-and-run` SERVING PORT (stage G's out-of-scope
+  note; builtins.md §3): under the flag fresh `compile-and-run` is
+  INERT everywhere — the client gate suppresses fresh compiles for
+  every non-wave run and the serving side's async writebacks are
+  unstamped, so they refuse at the wave seal — and the flip ships that
+  inertness by default (`common-fabric.tsx`'s piece-creation flow among
+  the consumers). Owed: the port — compilation on the outbox as an
+  effect kind (request-hash memo on the program), the instantiation
+  joining the graph as a completion-class writeback. Trigger: BEFORE
+  the flip's soak is judged (a flip blocker in product terms; nothing
+  in CI exercises fresh compile-and-run in the ON arm — the pins in
+  `compile-and-run.test.ts` assert the gate, not the port).
+- OW29 — space-root demanders + demand-arrival re-runs (the reverted
+  Phase-7 extension recorded under OW17): a client whose only watch is
+  the space-scoped piece root supplies NO identity to the run supply,
+  and a clean action never re-runs for a newly arrived instance. Both
+  are needed for a second user of a shared space to be served at all;
+  both are GATED on OW17's replica per-instance keying (without it they
+  turn silent under-serving into a wave storm). Land the three
+  together. Trigger: OW17.
+- OW30 — the controller-side write-destination validation RACE under
+  the flag (`piece-controller.ts` `validateWriteDestination`, the
+  #4717 guard as narrowed 2026-08-07): under the full ON posture
+  `counter` failed once in three runs on the Phase-7 tree ("current
+  producer value is not accepted as an array container" — the
+  controller read a served-late/speculative producer value of the wrong
+  shape) and `topics-navigation` fails fast on the same class ("missing
+  required property myName"); green on re-run and at the base. Owed:
+  the convergence step the 2026-08-07 narrowing anticipated (validate
+  against a settled view — `waitForSettled` on the piece's space —
+  before judging the written subtree), and its pin. Trigger: the flip
+  soak (an intermittent red in the default lanes).
+
+Delta 2026-08-15 — Phase 7 (the flip; the phase PR):
+
+- README §3.8's backpressure sentence: IMPL-GATE → COVERED (OW27 LANDED
+  above; +1 binding implementation sentence — pace-never-drop, per
+  stream, fired order held; the default posture is a flagged dial).
+- events.md §5's offline-queue persistence sentence RE-TENSED (LT9
+  re-ruled — process-lifetime; the reload half is a non-goal this
+  round, the in-process replacement survival stays pinned); OW20
+  CLOSED, the LT9 rec (c) seam RETIRED (rows above).
+- protocol §2b's free-read row and serving-loop §3b's cross-space read
+  gained the read-authority mechanism sentence (the process identity is
+  a memory service principal under the flag —
+  `packages/toolshed/lib/server-execution-flag.ts`, pinned in
+  `server-execution-flag.test.ts`: OFF the configured list verbatim,
+  ON the identity joins it exactly once). NOT a write widening: the
+  wave's §2b accept gate ignores the service-DID blanket by design.
+- builtins.md §5's wish row: +1 binding sentence (a flag-ON non-serving
+  runtime references the served sidecar cell, never instantiates it)
+  — impl-gate; witnessed live on the lunch gate (the ~13/s stale-basis
+  loop stopped), unit pin owed with OW17's landing (the two-demander
+  sidecar test in `executor-cross-space.test.ts` covers the serving
+  side).
+- scheduler/types.ts `SchedulerObservationIdentity.demandRootIds` (the
+  nested-piece demand-root chain) — an implementation surface below
+  spec granularity, FLAGGED: scopes.md §5's "the demand supplies the
+  identity" now resolves a nested piece through its ancestors; pinned
+  red-first (`executor-run-supply.test.ts`).
+- testing.md §2: the CI arms' role swap by env (default = ON full
+  posture; explicit false = OFF full posture on the OFF-built binary);
+  `tasks/server-execution-on-skips.ts` prints on the default lanes.
+- The flip's own default: `SERVER_EXECUTION_DEFAULT_ENABLED = true`
+  (`packages/memory/v2/server-execution-default.ts`), resolved by the
+  `productionServer` / `remoteClient` presets, the shell define
+  fallback, and toolshed's flag helper; the single-process presets keep
+  the OFF baseline by construction (EXPERIMENTAL_OPTIONS.md). Pins:
+  `runtime-presets.test.ts` (deployed-topology presets carry the
+  default), `shell/test/env.test.ts` (define unset → default; `false`
+  → OFF), `toolshed/lib/server-execution-flag.test.ts`.
+- The plan's Phase-7 section carries the honest gates table: sx2 family
+  green ON (default) and OFF (explicit) fresh-store; runner and
+  runtime-client package integration suites green under the default;
+  the browser-ON multi-user family red at base and head (OW17); the
+  propagation benchmark leg BUILT (opt-in on the two-browsers gate) but
+  UNMEASURED — its harness is red under the full posture at the base.
 
 ## 4. Standing rule
 

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -625,8 +625,12 @@ client does not; this PR):
   demand-cycle starvation fork's reproducer. Stage P2-F
   (2026-08-13) RETIRED that entry too: the terminal state closed
   the fork (the OW19 row below records the closure), and the ON-arm
-  skip list is EMPTY again — the full patterns suite runs both
-  arms.
+  skip list was EMPTY again — the full patterns suite runs both
+  arms. (Dated history: Phase 4 re-added `topics-navigation`, Phase 7's
+  fixer added five more `phase-7` entries — and found the mechanism
+  had been INERT since Phase 4, so "runs and passes ON" for the
+  two-browsers gate was true only of the MIXED-posture lane; see OW25
+  and the 2026-08-16 delta.)
 - testing §4's single-deriver envelope gate: impl-covered — the
   store-attribution query pinned in `speculation-overlay.test.ts`
   (every derived commit's holder is the service identity; none from a
@@ -957,9 +961,21 @@ nod, 2026-08-07; recorded in the plan's stage list):**
   no third source of run identity") violated in practice (fixed: the
   demand-root CHAIN, `SchedulerObservationIdentity.demandRootIds` —
   nested pieces resolve through the outer root; `executor-run-supply.
-  test.ts`, red-first). With (1)–(3) the gate reaches the join UI
-  ("host name filled") and stalls at the join click's consequence. Two
-  further extensions were BUILT AND REVERTED because they make
+  test.ts`, red-first). The build report's "with (1)–(3) the gate
+  reaches the join UI ('host name filled') and stalls at the join
+  click" DID NOT REPRODUCE at head (P7 independent review, 0/2 runs;
+  `review-p7-logs/lunch-head-default-run{1,2}`): at head the served
+  `#profile` wish ran once identity-less and threw at STEP 1
+  (`home-space resolution on a serving runtime requires the run's
+  demanding identity`) — the client's demand supplies NO identity for
+  the wish's piece root (the OW29 space-root-demander gap is live at
+  FIRST demand, not at the join click) — and because fix (2) makes the
+  flag-ON client REFERENCE-ONLY, the client wish churns (~13.6/s,
+  `wish/phase/send-error` n=4078 / 300 s) waiting for a sidecar the
+  server cannot produce: fix (2) without OW29 converts a racy-but-
+  rendering client into a wait-forever client. The builder's join-UI
+  observation was on his tree WITH the reverted extensions applied.
+  Two further extensions were BUILT AND REVERTED because they make
   cardinality ≥ 2 real on the collapsed replica: (4) SPACE-ROOT
   DEMANDERS — a client watching only the space-scoped piece root
   registers NO identity (`watchedRootsForSpace` records identity for
@@ -979,13 +995,58 @@ nod, 2026-08-07; recorded in the plan's stage list):**
   commits in 5 min, watermarkLag 1,685) — the OW17 VALUE half in its
   purest form. (4)+(5) are recorded here as the designed shape and are
   GATED on this row's owed leg (replica-level per-instance keying);
-  they must land WITH it, not before. The same signature (client
-  actionRuns 60–75k / 5 min, no settle) reproduces on the two-browsers
-  gate under the full ON posture at the UNMODIFIED Phase-6 base — the
-  "browser-ON red family" (OW25) IS this collapse at cardinality ≥ 2.
-  Trigger, sharpened: BEFORE the flip's soak can be judged on
-  multi-user browser scenarios; the flip's Phase-7 gates table carries
-  it as the top blocker.
+  they must land WITH it, not before. CORRECTION (P7 independent
+  review, 2026-08-15; fixer 2026-08-16): the two-browsers gate's stall
+  under the full ON posture — at the unmodified Phase-6 base AND at the
+  Phase-7 head — is NOT evidenced as this collapse. Its server stats are
+  QUIET (waves 20–26, derivedCommits 19–25, events 2/2 appended/
+  processed, watermarkLag 1–2; `wavesBudgetExhausted` 12–16 of those
+  waves — but the single-browser `counter` gate exhausts 2/5 with no
+  client loop, so exhaustion alone is not the discriminator) while BOTH
+  browsers run a CLIENT-side `scheduler-non-settling` loop (every
+  ~6.6 s; 40–56 k client action runs / 5 min at head and base;
+  `runner/start/resumeCellSync` n=458–644 piece re-starts). The
+  4,427-wave storm signature above exists ONLY with (4)+(5) applied.
+  The client loop is its own UNATTRIBUTED row (OW32) whose triage comes
+  FIRST in the flip's ordered gates; "the browser-ON red family IS this
+  collapse" is withdrawn.
+  **CLASS VERDICT (P7 independent review, 2026-08-15): a bounded
+  architectural LEG — not a bug, not a redesign.** ONE layer was never
+  re-keyed: the runner-side local view. `SpaceReplica` keys every local
+  doc by scope NAME (`docKey(id, scope)` = `${normalizeCellScope(scope)}
+  \0${id}`, `packages/runner/src/storage/v2.ts` — used by `#docs`,
+  `#sinks`, `#staleFloor`, `#watchedIds`, `#shadowedForeignSeqs`,
+  `#syncTasks`: ~20 sites in one class); the wire upsert cannot name an
+  instance (`SessionSyncUpsert.scope?: CellScope`, `packages/memory/
+  v2.ts` — no scope key); `IMemoryAddress` carries no instance; and the
+  scheduler dependency graph resolves reads/writes against the
+  runtime's OWN identity (`scheduling-writes.ts`; C11b's singular node).
+  Everything else already speaks per instance (engine rows and dirty
+  keys `toDirtyKey(id, scopeKey)`, the lease-holder explicit-instance
+  reads, `DerivedWriteAnnotation.scopeKey`, the P2-F run supply's N
+  stamped runs). Fix SHAPE, with precedent (stage F/M2 re-keyed the
+  scheduler's `entityKey` from name to scope key with the cardinality-1
+  partition unchanged): (1) `SessionSyncUpsert`/`Remove` gain
+  `scopeKey`, populated by the memory server for lease-holder-exempt
+  sessions (the value is already `entry.scopeKey` at the push site);
+  (2) `docKey` takes the scope KEY, resolved from the replica's own
+  identity when no explicit key rides (OFF-arm neutral by
+  construction); (3) the tx→replica read/write seam passes the run's
+  stamped identity (`waveRunContextOf(tx).scopeKeyIdentity`) so an
+  instance run reads/writes ITS doc; (4) scoped-doc change notification
+  fans in to the singular node (any instance's change dirties the node;
+  the N-run loop re-runs; equality cutoffs absorb siblings — the "local
+  dirtiness precision" half stays an optimization). Nothing in C11b
+  forbids this ("instances live in keys" — the local doc map is a key
+  space); no serving-loop, demand, or wave redesign is implied. Size:
+  P2-F-shaped (a stage), cross-cutting but mechanical; not a one-site
+  fix. OW29's two extensions are prerequisites for user #2 to be served
+  at all, and the whole-doc-set write-half hack becomes unnecessary once
+  the diff base is the right instance's doc. Landing OW17+OW29 alone is
+  NOT shown to green the two-user journeys (OW32 first).
+  Trigger, re-stated: the flip's ordered gates (plan Phase 7 task 1):
+  OW32 triage → THIS leg (with OW29) → OW28 → the honest benchmark →
+  the flip PR.
 - OW19 — the demand-cycle terminal state: CLOSED by stage P2-F
   (2026-08-13; the RULED 2026-08-07 direction, built whole). A
   demanded root CONFIRMED synced with no pattern meta parks TERMINAL
@@ -1125,22 +1186,28 @@ nod, 2026-08-07; recorded in the plan's stage list):**
   (the inherited red's fix), and no later than the Phase-7 flip
   (a flip criterion measured on a mixed-posture lane would be
   vacuous).
-  Phase 7 (2026-08-15): the ON shell build LANDS BY THE FLIP — the
-  default binary bakes the shell ON (unset define = the first-party
-  default), so the default CI lanes are the FULL ON posture, and the
-  OFF regression guard gets its own OFF-built binary
-  (`build-toolshed-off`). The inherited red did NOT lift; it is now
-  ATTRIBUTED (OW17's Phase-7 evidence): under the full posture, at the
-  unmodified Phase-6 base, `cfc-group-chat-demo-two-browsers` stalls at
-  the first per-user write with 60–70k client action runs (the
-  cardinality-2 collapse), the lunch gate as recorded, and
-  `topics-navigation` fails fast at the controller's write-destination
-  validation (`missing required property myName` — the same class as
-  the intermittent `counter` failure below, OW30). The topics-navigation
-  skip entry stands with the Phase-7 reason; no browser-posture
-  criterion ticks on the default lanes' green until this family is
-  triaged — the flip's gates table records the lanes as expected-red
-  on the browser-ON family.
+  Phase 7 (2026-08-15, re-tensed 2026-08-16 by the P7 fixer on the
+  independent review — the flip landed DARK, constant `false`): the ON
+  shell build LANDS as its own CI job, `build-toolshed-on` (the shell
+  define baked `true`), feeding the explicit-`EXPERIMENTAL_SERVER_
+  EXECUTION=true` ON lanes — the FULL ON posture (server ON, test
+  processes declaring ON, shell ON-built), VERIFIED by a posture probe
+  before every ON suite (`/api/meta`'s `shellServerExecutionDefine ===
+  "true"` from the COMPILED marker + `/api/health/stats`.servingLoop
+  present). The default lanes stay the OFF posture (their probe pins
+  server OFF + define unset). This row's owed leg is DISCHARGED: no
+  ON-lane green rides a mixed posture anymore. The inherited red did NOT
+  lift and its attribution is CORRECTED: `cfc-group-chat-demo-two-
+  browsers` and `lunch-poll-vote` stall on the UNATTRIBUTED client-side
+  scheduler-non-settling loop (OW32; NOT evidenced as OW17 — see the
+  correction in OW17), `topics-navigation` fails fast at the
+  controller's write-destination validation (`missing required property
+  myName`, OW30's class). All three are ON-skip-listed with loud reasons
+  (`tasks/server-execution-on-skips.ts`), and the fixer found the skip
+  mechanism itself had been INERT since Phase 4 (`deno test --ignore`
+  does not apply to explicitly listed files; fixed and pinned — the
+  quoted-glob tasks + the pattern shard's `--filter`); no browser-
+  posture criterion ticks until OW32/OW30 are triaged.
 - OW26 — the DEMANDED-EFFECT retry wedge (scheduler adjacency,
   surfaced by the owner-review P1 batch, 2026-08-12): when an
   `isEffect` builtin's action THROWS (the arms are builtins.md §4's
@@ -1245,9 +1312,21 @@ nod, 2026-08-07; recorded in the plan's stage list):**
   per-stream token bucket, pace-never-drop"): the client event-append
   queue paces per stream (`EventAppendQueue` — `pacing`, keyed by the
   stream's sidecar doc; burst passes, sustained sends drain at the
-  rate, a flood is HELD in fired order, never coalesced, never dropped;
-  the head holds everything behind it — cross-stream head-of-line
-  hold is the accepted cost of exact fired order). Default posture
+  rate, a flood is HELD in that stream's fired order, never coalesced,
+  never dropped). Streams are INDEPENDENT — RULED 2026-08-16 (P7 fixer,
+  on the P7 independent review's finding 5): the queue sends the
+  earliest-fired entry whose stream has a token, so a paced stream
+  holds only its own later sends and never an unrelated stream's (NO
+  cross-stream head-of-line hold; the P7 build's "accepted cost" wording
+  described a defect — the shipped drain sent strictly the fired-order
+  head, so b1 waited behind a2's hold, reproduced by the review's probe
+  and unpinned by the shipped suite). Fixed red-first: the adopted
+  cross-stream test in `event-append-client.test.ts` (b1 sends
+  immediately, a2/b2 wait only on their own buckets, a3 on A's second
+  refill; every stream's own fired order exact; every intent delivered)
+  went red at head and green with the per-stream selection; events.md
+  §5 and README §3.8 now state per-stream fired order + independence.
+  Default posture
   `DEFAULT_EVENT_APPEND_PACING` = 20/s sustained, 20 burst — a DIAL,
   FLAGGED for the owner (the bound on the flooding user's own rapid
   interactions ≈ (queued − burst)/rate seconds; a held key at ~30 Hz
@@ -2222,12 +2301,31 @@ Delta 2026-08-15 — Phase 6 independent-review fixes (same PR):
   every non-wave run and the serving side's async writebacks are
   unstamped, so they refuse at the wave seal — and the flip ships that
   inertness by default (`common-fabric.tsx`'s piece-creation flow among
-  the consumers). Owed: the port — compilation on the outbox as an
-  effect kind (request-hash memo on the program), the instantiation
-  joining the graph as a completion-class writeback. Trigger: BEFORE
-  the flip's soak is judged (a flip blocker in product terms; nothing
-  in CI exercises fresh compile-and-run in the ON arm — the pins in
-  `compile-and-run.test.ts` assert the gate, not the port).
+  the consumers). CHARACTERIZED by the P7 independent review
+  (2026-08-15) as a product regression relative to OFF: on a flag-ON
+  runtime whose tx carries no wave run context (every CLIENT run —
+  derivation, handler, imperative) `builtins/compile-and-run.ts` sets
+  `pending = true` and RETURNS before launching the compile — no
+  compile, no result, no error, `pending` never clears; on the SERVER
+  (wave-stamped run) the compile launches but its writebacks
+  (`runtime.editWithRetry`, `runSynced`) are UNSTAMPED floating
+  transactions on a serving runtime → refused at the wave seal
+  (`unstampedSealRefusals`), so `pending=false`/`result`/`error` never
+  land either. User-visible under ON: every `compileAndRun` consumer
+  shows "compiling…" forever — `fetchAndRunPattern` in
+  `packages/patterns/system/common-fabric.tsx` (the LLM/tool piece-
+  instantiation flow: `ifElse(pending || …)` never resolves),
+  `packages/patterns/compiler.tsx`, `write-and-run.tsx`,
+  `email-pattern-launcher.tsx`. The pins in `compile-and-run.test.ts`
+  assert exactly the gate (0 launches non-wave, 1 launch wave-stamped),
+  not a working port. FIX SHAPE (owning layer: runner
+  `builtins/compile-and-run.ts` + `executor/outbox.ts` /
+  `effect-completion.ts`, following the request-hash builtins):
+  compilation as an OUTBOX EFFECT KIND memoized on the program hash,
+  the instantiation landing as a COMPLETION-CLASS stamped writeback;
+  the client keeps reading through (speculation.md §2). Trigger: a
+  named flip blocker — third in the flip's ordered gates (plan Phase 7
+  task 1); nothing in CI exercises fresh compile-and-run in the ON arm.
 - OW29 — space-root demanders + demand-arrival re-runs (the reverted
   Phase-7 extension recorded under OW17): a client whose only watch is
   the space-scoped piece root supplies NO identity to the run supply,
@@ -2235,7 +2333,28 @@ Delta 2026-08-15 — Phase 6 independent-review fixes (same PR):
   are needed for a second user of a shared space to be served at all;
   both are GATED on OW17's replica per-instance keying (without it they
   turn silent under-serving into a wave storm). Land the three
-  together. Trigger: OW17.
+  together. Trigger: OW17. The demand-root CHAIN'S coverage folds in
+  here (P7 independent review finding 4, 2026-08-15): the chain
+  (`demandRootIds`) covered nested pattern nodes and result-as-pattern
+  children but MISSED the list builtins' child instantiation
+  (`builtins/map.ts`, `filter.ts`, `flatmap.ts` call `runtime.runner.
+  run` directly) — a mapped child's derivations ran with the service
+  fallback while the parent's `raw:map` ran per instance (probe:
+  alice=0 bob=0 fallback=2), so any per-user state inside a list item's
+  sub-piece was mis-keyed under `user:<serviceDID>` at cardinality 1
+  too. FIXED by the P7 fixer (2026-08-16): the six list-builtin sites
+  pass `parentPieceRootId`; red-first via the adopted probe,
+  parametrized over map/filter/flatMap in `executor-run-supply.test.ts`
+  (mutation-verified per site); the grandchild-composes probe pinned.
+  STILL OPEN, FLAGGED (not filled): wish.ts's four `runtime.run`
+  sidecar launches (profile create / picker / suggestion) also carry no
+  parent — the served sidecar's own actions run under the wave-level
+  identity — but chaining them to the wish's parent root would run each
+  per-demander sidecar for EVERY demanded instance of the outer root
+  (bob's run over alice's sidecar; spurious per-user writes under bob's
+  key), and whether a per-demander sidecar wants the chain's instances
+  or exactly its own demander is an UNSTATED semantic — owner ruling
+  needed before it is wired.
 - OW30 — the controller-side write-destination validation RACE under
   the flag (`piece-controller.ts` `validateWriteDestination`, the
   #4717 guard as narrowed 2026-08-07): under the full ON posture
@@ -2247,7 +2366,100 @@ Delta 2026-08-15 — Phase 6 independent-review fixes (same PR):
   the convergence step the 2026-08-07 narrowing anticipated (validate
   against a settled view — `waitForSettled` on the piece's space —
   before judging the written subtree), and its pin. Trigger: the flip
-  soak (an intermittent red in the default lanes).
+  soak (an intermittent red in the ON lanes; `topics-navigation` is
+  ON-skip-listed on it).
+
+**Rows opened by the Phase 7 independent review and the fixer pass
+(2026-08-15/16; the flip landed DARK — constant `false`):**
+
+- OW31 — the service-principal READ-AUTHORITY grant is a WRITE-AUTHORITY
+  WIDENING for the process identity's ordinary session traffic (P7
+  independent review finding 6; the P7 build's "NOT a write widening"
+  was overstated). Under the flag `memoryServiceDidsFor` makes the
+  toolshed process identity a memory service principal, and a service
+  principal is implicit OWNER for its sessions on EVERY space
+  (`packages/memory/v2/server.ts` — transact, queries, watches, ACL-doc
+  writes, fresh-space genesis; the ACL policy has no read-only service
+  class). So the process identity's ORDINARY session traffic — its own
+  `productionServer` runtime (ingest / webhooks) and the loopback
+  plane's authored/bookkeeping commits — gains OWNER everywhere,
+  wherever `MEMORY_SERVICE_DIDS` did not already list it. Bounded by
+  process trust (the same process already derives every space through
+  the engine-direct sink) and NOT widened at the wave's foreign-write
+  accept gate (`foreignWriteAuthorityFor` ignores the blanket). What the
+  wish's bootstrap NEEDS is READ on the demanding user's home space; the
+  narrower shape — a read-only service-principal class in the memory
+  ACL — is a memory-ACL POLICY addition, and whether it suffices depends
+  on what the served create handler's `.inSpace()` provisioning needs at
+  fresh-space GENESIS (a service DID may initialize a genesis ACL; a
+  read-only principal could not). RULED-POSTURE ITEM FOR THE OWNER:
+  accept the OWNER-everywhere posture under the flag (the deployment
+  checklist's operator-DID posture made automatic where the loop runs),
+  or add the read-only class and route the wish's read through it. Not
+  narrowed by the fixer (flag-don't-fill). Inert while the constant is
+  `false` (the grant is flag-gated; OFF the configured list is used
+  verbatim). Trigger: before the flip PR.
+- OW32 — the CLIENT-side `scheduler-non-settling` loop under the full
+  ON posture in the two-browser journeys — the EVIDENCED mechanism of
+  the two two-browser gates' red, UNATTRIBUTED (P7 independent review
+  findings 1/2; the P7 build had attributed the red to OW17 by
+  inference). Evidence (`review-p7-logs/`, two-browsers 2/2 at head +
+  1 at base, lunch 2/2 at head, 300 s stalls each): the SERVING LOOP is
+  QUIET (waves 20–26, derivedCommits 19–25, events 2/2 appended/
+  processed, watermarkLag 1–2 — no storm) while BOTH browsers run
+  `scheduler-non-settling` every ~6.6 s (40–56 k client action runs /
+  5 min at head AND base; `runner/start/resumeCellSync` n=458–644 piece
+  re-starts); 50–70 % of the server's waves exhaust the flush deadline
+  (`wavesBudgetExhausted` 12–16 of 20–26 — reported here because it was
+  reported nowhere; the single-browser `counter` gate also exhausts 2/5
+  with NO client loop, so exhaustion alone is not the discriminator).
+  Base stall ≈ head stall (head run 1 got one step further; run 2
+  stalled identically at the first per-user write) — P7 is not a
+  regression, but neither is it evidenced progress. The 4,427-wave storm
+  signature exists ONLY on the builder's tree with OW29's reverted
+  extensions applied. NOT evidenced as OW17. The lunch gate ADDITIONALLY
+  hits the served `#profile` wish throwing identity-less at step 1 (see
+  OW17's correction; the OW29 gap at first demand). Owed FIRST in the
+  flip's ordered gates: the discriminating experiment — a
+  `commonfabric.detectNonIdempotent()` capture in one browser of the
+  two-browsers gate plus a debug-level `wave-budget-exhausted` trace
+  naming the non-quiescing server actions — then the fix. Until then
+  both gates are ON-skip-listed with this reason (`tasks/server-
+  execution-on-skips.ts`), red under the full ON posture, NOT green-by-
+  vacuity. Trigger: first of the flip's ordered gates (plan Phase 7 task
+  1); the flip PR needs the skip list EMPTY.
+- OW33 — the ON-posture DENO-CLIENT family, surfaced by making the ON
+  lanes UNIFORM (P7 independent review finding 7; fixer 2026-08-16):
+  once the runner integration tests that talk to the lane's toolshed
+  and the runtime-client worker DECLARE the posture from the env
+  (before: bare `new Runtime` / undeclared worker → OFF client against
+  an ON server, so "runner 14/14" and "runtime-client 45 steps" under
+  the ON lane were mixed-posture evidence), the uniform ON posture is
+  RED on: (a) `packages/runner/integration/pattern-and-data-
+  persistence.test.ts` — Phase 3 starts a NEW piece, `pull()`s its
+  result and reads `getAsQueryResult().sum` (15 under OFF, `undefined`
+  under ON; no sink → no demand — the sink is the demand — and the ON
+  client's own speculative run did not surface the value through this
+  read path either; 13/14 green otherwise); (b) `runtime-client/
+  integration/client.test.ts` step "renders PerUser-derived computed
+  JSX inside cf-screen header slot (CT-1606)" — never reaches its FIRST
+  render in 15 s (3/3 red; a `computed` over `PerUser<myName>` — the
+  same PerUser shape `topics-navigation` fails on under full ON); (c)
+  the same file's "dispatches one navigateTo when a rendered handler
+  changes local state" — FLAKY (1/3 red: two dispatches observed for
+  one handler fire — the double-dispatch class the F10 handler-fork
+  contract exists to prevent); (d) `derive_array_leak.test.ts` counts 0
+  of 50 increments under ON (its own warning fires; green only because
+  it asserts memory). UNTRIAGED — whether the Deno-client speculation
+  overlay should have shown (a)/(b) or the demand should have been
+  registered, and what double-fires (c). Recorded as ON-skip entries
+  (a file entry for (a); STEP-level entries for (b)/(c) so the one-file
+  runtime-client suite keeps its other 43 steps ON — the step guard is
+  in-file, bound to the register and validated). The 8 runner
+  integration files that serve toolshed's `app.ts` in-process (no
+  ExecutorHost) are single-process harnesses, OFF by construction in
+  either lane. Trigger: with OW32's triage (the same "client under ON
+  never settles/renders" family); the flip PR needs the skip list EMPTY.
 
 Delta 2026-08-15 — Phase 7 (the flip; the phase PR):
 
@@ -2263,8 +2475,11 @@ Delta 2026-08-15 — Phase 7 (the flip; the phase PR):
   a memory service principal under the flag —
   `packages/toolshed/lib/server-execution-flag.ts`, pinned in
   `server-execution-flag.test.ts`: OFF the configured list verbatim,
-  ON the identity joins it exactly once). NOT a write widening: the
-  wave's §2b accept gate ignores the service-DID blanket by design.
+  ON the identity joins it exactly once). CORRECTED 2026-08-16: this IS
+  a write widening for the process identity's ordinary session traffic
+  (implicit OWNER everywhere) — not widened at the wave's §2b accept
+  gate, which ignores the service-DID blanket by design; OW31 carries
+  the ruled-posture question.
 - builtins.md §5's wish row: +1 binding sentence (a flag-ON non-serving
   runtime references the served sidecar cell, never instantiates it)
   — impl-gate; witnessed live on the lunch gate (the ~13/s stale-basis
@@ -2276,10 +2491,11 @@ Delta 2026-08-15 — Phase 7 (the flip; the phase PR):
   spec granularity, FLAGGED: scopes.md §5's "the demand supplies the
   identity" now resolves a nested piece through its ancestors; pinned
   red-first (`executor-run-supply.test.ts`).
-- testing.md §2: the CI arms' role swap by env (default = ON full
-  posture; explicit false = OFF full posture on the OFF-built binary);
-  `tasks/server-execution-on-skips.ts` prints on the default lanes.
-- The flip's own default: `SERVER_EXECUTION_DEFAULT_ENABLED = true`
+- testing.md §2: the CI arms (SUPERSEDED the next day — see the fixer
+  delta below): the phase PR swapped the lanes by env (default = ON;
+  explicit false = OFF on an OFF-built binary).
+- The flip's own default (SUPERSEDED — see the fixer delta below): the
+  phase PR set `SERVER_EXECUTION_DEFAULT_ENABLED = true`
   (`packages/memory/v2/server-execution-default.ts`), resolved by the
   `productionServer` / `remoteClient` presets, the shell define
   fallback, and toolshed's flag helper; the single-process presets keep
@@ -2287,12 +2503,82 @@ Delta 2026-08-15 — Phase 7 (the flip; the phase PR):
   `runtime-presets.test.ts` (deployed-topology presets carry the
   default), `shell/test/env.test.ts` (define unset → default; `false`
   → OFF), `toolshed/lib/server-execution-flag.test.ts`.
-- The plan's Phase-7 section carries the honest gates table: sx2 family
-  green ON (default) and OFF (explicit) fresh-store; runner and
-  runtime-client package integration suites green under the default;
-  the browser-ON multi-user family red at base and head (OW17); the
-  propagation benchmark leg BUILT (opt-in on the two-browsers gate) but
-  UNMEASURED — its harness is red under the full posture at the base.
+- The plan's Phase-7 section carries the honest gates table (re-tensed
+  by the fixer delta below).
+
+Delta 2026-08-16 — Phase 7 fixer pass (the independent review's 12
+findings; the OWNER RULING — the flip lands DARK):
+
+- The landing posture: `SERVER_EXECUTION_DEFAULT_ENABLED = false`
+  (owner ruling 2026-08-16 on the review's verdict LANDABLE-WITH-FIXES
+  as flip-READY / NOT-LANDABLE as the flip). The OFF posture is the
+  default again everywhere the constant reaches; the ON posture stays
+  fully selectable; the ONE absolute pin (`server-execution-flag.test.
+  ts`) now states the default IS OFF. THE FLIP IS ITS OWN SEPARATE
+  ONE-LINE PR (repo convention: a flip is reverted by reverting the PR
+  that only flips) — owed after the ON posture works and is performant,
+  in the plan's ordered gates: OW32 triage → OW17 re-keying (+OW29) →
+  OW28 → the honest benchmark → the flip PR (which also flips the
+  absolute pin, the CI lane roles and their posture probes, and
+  EXPERIMENTAL_OPTIONS.md; and MUST land with the ON skip list EMPTY).
+- CI lanes (testing.md §2 re-tensed): default lanes = the OFF posture
+  (probe: server not serving, shell define unset); explicit-`true` ON
+  lanes on `build-toolshed-on` (shell define baked `true`), FULL ON
+  posture VERIFIED before each suite (`/api/meta.shellServerExecution
+  Define === "true"` — a new field read from the COMPILED marker
+  `tasks/build-binaries.ts` writes from the same env the shell bakes;
+  `/api/health/stats.servingLoop` present); the ON lanes' Deno-side
+  clients DECLARE the posture from the env (runner integration tests
+  that talk to the lane's toolshed; the runtime-client worker) — the
+  ON lane is UNIFORM, no longer the mixed posture the review found. The
+  future flip PR's gate obligation for the deployed-topology binaries
+  the review named (finding 8: `background-piece-service`, the CLI,
+  cf-harness, every `PiecesController` resolve ON by the presets — no
+  gate exercises them ON) is RECORDED in the plan's Phase-7 task 1;
+  with the constant `false` none of them flips today.
+- The ON skip mechanism was INERT since Phase 4 (found while adding
+  entries; pinned by spawning deno on both shapes in
+  `tasks/server-execution-on-skips.test.ts`): `deno test --ignore`
+  filters only discovered modules and ignores nothing for explicitly
+  listed files — a shell-expanded glob or the pattern shards' list. The
+  runner/runtime-client/shell `integration` tasks now hand deno a
+  QUOTED glob; the pattern ON shard filters its list through the
+  script's `--filter` mode; STEP-level entries exist (in-file guard
+  bound to the register, validated). Entries today (ALL `phase-7`, none
+  of the lists EMPTY — the P7 phase PR's "one entry" and every earlier
+  "EMPTY" wording were about a mechanism that never bit): patterns ×3
+  (`topics-navigation`, `cfc-group-chat-demo-two-browsers`,
+  `lunch-poll-vote` — the last two on OW32's characterized, unattributed
+  loop), runner ×1 (`pattern-and-data-persistence` — OW33),
+  runtime-client ×2 STEP entries in `client.test.ts` (OW33). Verified
+  locally: runner integration 14/14 default posture, 13/14 + 1 skipped
+  under ON; runtime-client 45 steps default, 43 + 2 ignored under ON.
+- Rows: OW17 gains the review's CLASS VERDICT and the correction (the
+  two-browser red is NOT evidenced as OW17; the lunch "(1)+(2)+(3) →
+  join UI" narrative did not reproduce); OW25 DISCHARGED (the ON shell
+  build runs and is verified); OW27 corrected (cross-stream head-of-line
+  hold was a defect, fixed and pinned — streams independent); OW28
+  carries the characterization and fix shape (compile as an outbox
+  effect kind + completion-class writeback); OW29 folds in the
+  demand-root chain's list-builtin gap (fixed) and the wish-sidecar
+  question (flagged); NEW OW31 (write-authority posture — ruled item),
+  OW32 (the client non-settling loop — first gate), OW33 (the ON-posture
+  Deno-client family).
+- protocol.md §2 gains the `capabilityRef` vocabulary sentence (review
+  finding 11 — adjudicated spec-sentence, no rename): the values are
+  provenance TAGS naming the authorizing context, admitted by PRESENCE,
+  never resolved (OW13/FP7); the name does not denote a capability
+  object.
+- Benchmark (review finding 12): the two-browsers harness red is the
+  OW32 client loop, not a harness bug and not evidenced as OW17. An
+  HONEST partial number has a shape (not built): `sx2-scale.test.ts`
+  already builds N `PiecesController` clients with a timed
+  `settleWrite`; two controllers (distinct identities) on ONE space — A
+  appends an event, B's replica sinks the served consequence — timed
+  under explicit ON vs explicit OFF, fresh store per arm, n ≥ 20, gives
+  a byte-identical cross-user propagation number for the Deno client
+  posture today. Recorded in the plan; the browser number waits for the
+  two-user family.
 
 ## 4. Standing rule
 

--- a/packages/memory/deno.jsonc
+++ b/packages/memory/deno.jsonc
@@ -35,6 +35,7 @@
     "./v2/execution-outbox": "./v2/execution-outbox.ts",
     "./v2/scheduler-basis": "./v2/scheduler-basis.ts",
     "./v2/server": "./v2/server.ts",
+    "./v2/server-execution-default": "./v2/server-execution-default.ts",
     "./v2/standalone": "./v2/standalone.ts",
     "./v2/session-open-auth": "./v2/session-open-auth.ts",
     "./v2/storage-path": "./v2/storage-path.ts",

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -1290,10 +1290,29 @@ const memoryReconstructionContext = new EmptyReconstructionContext(
 // These ambient flags and the memory protocol flags below are catalogued, with
 // their defaults and removal paths, in docs/development/EXPERIMENTAL_OPTIONS.md.
 // Update that registry when adding or removing one.
-let serverExecutionEnabled = false;
 let commitPreconditionsEnabled = true;
 let syncSchemaTableEnabled = true;
 let ownWriteEchoEnabled = true;
+
+export {
+  SERVER_EXECUTION_DEFAULT_ENABLED,
+} from "./v2/server-execution-default.ts";
+
+// The ambient flag's inputs, resolved by getServerExecutionConfig():
+// - the live ENABLER count (below), which forces the flag on — every
+//   explicitly-enabled Runtime and the ExecutorHost claim one;
+// - else an explicit OVERRIDE (`setServerExecutionConfig`: the direct test
+//   seam, and the Runtime constructor's sanctioned explicit-false arm);
+// - else the AMBIENT BASELINE, which is OFF: a BARE construction — no
+//   preset, no explicit flag, nothing else in the process enabling it —
+//   resolves the OFF arm, because a bare construction has no serving host
+//   (the unit-test shape: single-process, the derive-and-commit model by
+//   construction). The FIRST-PARTY default is a different thing: every
+//   deployed-topology entry point resolves an unset flag to
+//   `SERVER_EXECUTION_DEFAULT_ENABLED` (v2/server-execution-default.ts) and
+//   constructs its runtimes explicitly, so in a deployed process the
+//   ambient state follows that default through the enabler count.
+let serverExecutionOverride: boolean | undefined = undefined;
 
 /**
  * Ambient runtime flag for server-execution v2
@@ -1304,17 +1323,25 @@ let ownWriteEchoEnabled = true;
  * Not a handshake capability: admission
  * enforcement is server-local, so nothing about it is negotiated per
  * connection.
+ *
+ * `enabled` undefined clears the explicit override (back to the ambient
+ * baseline); a boolean sets it. A live enabler (below) wins over an
+ * override either way.
  */
 export function setServerExecutionConfig(enabled?: boolean): void {
-  serverExecutionEnabled = enabled ?? false;
+  serverExecutionOverride = enabled;
 }
 
 export function getServerExecutionConfig(): boolean {
-  return serverExecutionEnabled;
+  if (serverExecutionEnablers > 0) return true;
+  return serverExecutionOverride ?? false;
 }
 
+/** HARD reset of the test seam: override cleared, enabler count zero — the
+ * flag reads the ambient baseline (OFF) again. Never called by product
+ * code. */
 export function resetServerExecutionConfig(): void {
-  serverExecutionEnabled = false;
+  serverExecutionOverride = undefined;
   serverExecutionEnablers = 0;
 }
 
@@ -1325,7 +1352,7 @@ export function resetServerExecutionConfig(): void {
 // count cannot see the others, and an unconditional reset from one owner
 // un-claims `derived` for every other owner's in-flight commit. The
 // direct set/reset functions above remain the test seam (reset is a HARD
-// reset: flag off, count zero).
+// reset: override cleared, count zero).
 let serverExecutionEnablers = 0;
 
 /** Live enabler count — consulted by the one sanctioned explicit-disable
@@ -1337,21 +1364,18 @@ export function serverExecutionEnablerCount(): number {
 
 /**
  * Claim the ambient server-execution flag, reference-counted. Returns
- * the matching release; the flag resets only when the LAST live enabler
- * releases. The release is idempotent per handle, so exception-safe
- * callers can release from both a rollback and a finally.
+ * the matching release; the flag falls back to the override/baseline
+ * resolution only when the LAST live enabler releases. The release is
+ * idempotent per handle, so exception-safe callers can release from both
+ * a rollback and a finally.
  */
 export function acquireServerExecutionEnabler(): () => void {
   serverExecutionEnablers += 1;
-  serverExecutionEnabled = true;
   let released = false;
   return () => {
     if (released) return;
     released = true;
     serverExecutionEnablers = Math.max(0, serverExecutionEnablers - 1);
-    if (serverExecutionEnablers === 0) {
-      serverExecutionEnabled = false;
-    }
   };
 }
 

--- a/packages/memory/v2/server-execution-default.ts
+++ b/packages/memory/v2/server-execution-default.ts
@@ -1,0 +1,24 @@
+/**
+ * The ONE first-party default of the server-execution v2 flag
+ * (`EXPERIMENTAL_SERVER_EXECUTION`; docs/specs/server-side-execution/,
+ * docs/plans/server-execution-v2.md Phase 7 — the flip). Every
+ * deployed-topology entry point resolves an UNSET flag to this value: the
+ * `productionServer` / `remoteClient` construction presets
+ * (`packages/runner/src/runtime-presets.ts`), toolshed's serving-host gate
+ * and service-principal grant (`packages/toolshed/lib/server-execution.ts`),
+ * and the browser shell's build-define fallback
+ * (`packages/shell/src/lib/env.ts`), so flipping the default is this one
+ * value. `false` is today's behavior byte-for-byte; `true` is the v2
+ * posture. An explicit `EXPERIMENTAL_SERVER_EXECUTION=false` (or
+ * `experimental.serverExecution: false`) selects the OFF arm regardless of
+ * this value — the rollback lever until the OFF path is removed.
+ *
+ * Deliberately a leaf module: the shell's main thread imports it without
+ * pulling the wire-shape module (`../v2.ts`, which re-exports it).
+ *
+ * Single-process harnesses — a bare `new Runtime`, the `unitTest` /
+ * `patternTest` / `localDev` presets — do NOT read this value: they have no
+ * serving host, so they resolve the ambient baseline (OFF) by construction
+ * (see the ambient flag in `../v2.ts`).
+ */
+export const SERVER_EXECUTION_DEFAULT_ENABLED = false;

--- a/packages/memory/v2/server-execution-default.ts
+++ b/packages/memory/v2/server-execution-default.ts
@@ -9,10 +9,22 @@
  * and the browser shell's build-define fallback
  * (`packages/shell/src/lib/env.ts`), so flipping the default is this one
  * value. `false` is the pre-flip behavior byte-for-byte; `true` is the v2
- * posture — the Phase 7 flip (2026-08-15). An explicit
- * `EXPERIMENTAL_SERVER_EXECUTION=false` (or `experimental.serverExecution:
- * false`) selects the OFF arm regardless of this value — the rollback lever
- * until the OFF path is removed.
+ * posture. An explicit `EXPERIMENTAL_SERVER_EXECUTION=true|false` (or
+ * `experimental.serverExecution`) selects an arm regardless of this value.
+ *
+ * LANDED DARK (owner ruling 2026-08-16, on the Phase 7 independent
+ * review): the flip-ready mechanism landed with this constant `false` —
+ * the OFF posture stays the default everywhere it reaches, the ON posture
+ * stays fully selectable (CI's explicit-`true` lanes run it on an ON-built
+ * binary). The flip to `true` is its OWN separate one-line PR (repo
+ * convention: a flip is reverted by reverting the PR that only flips),
+ * owed AFTER the ON posture works and is performant — the plan's Phase 7
+ * task 1 records the ordered gates (client non-settling triage → OW17
+ * re-keying → OW28 → the honest benchmark → then the flip). The flip PR
+ * changes this value AND the absolute pin in
+ * `packages/toolshed/lib/server-execution-flag.test.ts` (which states the
+ * current default so a silent flip either way cannot hide behind
+ * relative pins), the CI lane roles, and EXPERIMENTAL_OPTIONS.md together.
  *
  * Deliberately a leaf module: the shell's main thread imports it without
  * pulling the wire-shape module (`../v2.ts`, which re-exports it).
@@ -22,4 +34,4 @@
  * serving host, so they resolve the ambient baseline (OFF) by construction
  * (see the ambient flag in `../v2.ts`).
  */
-export const SERVER_EXECUTION_DEFAULT_ENABLED = true;
+export const SERVER_EXECUTION_DEFAULT_ENABLED = false;

--- a/packages/memory/v2/server-execution-default.ts
+++ b/packages/memory/v2/server-execution-default.ts
@@ -8,10 +8,11 @@
  * and service-principal grant (`packages/toolshed/lib/server-execution.ts`),
  * and the browser shell's build-define fallback
  * (`packages/shell/src/lib/env.ts`), so flipping the default is this one
- * value. `false` is today's behavior byte-for-byte; `true` is the v2
- * posture. An explicit `EXPERIMENTAL_SERVER_EXECUTION=false` (or
- * `experimental.serverExecution: false`) selects the OFF arm regardless of
- * this value — the rollback lever until the OFF path is removed.
+ * value. `false` is the pre-flip behavior byte-for-byte; `true` is the v2
+ * posture — the Phase 7 flip (2026-08-15). An explicit
+ * `EXPERIMENTAL_SERVER_EXECUTION=false` (or `experimental.serverExecution:
+ * false`) selects the OFF arm regardless of this value — the rollback lever
+ * until the OFF path is removed.
  *
  * Deliberately a leaf module: the shell's main thread imports it without
  * pulling the wire-shape module (`../v2.ts`, which re-exports it).
@@ -21,4 +22,4 @@
  * serving host, so they resolve the ambient baseline (OFF) by construction
  * (see the ambient flag in `../v2.ts`).
  */
-export const SERVER_EXECUTION_DEFAULT_ENABLED = false;
+export const SERVER_EXECUTION_DEFAULT_ENABLED = true;

--- a/packages/patterns/integration/cfc-group-chat-demo-two-browsers.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo-two-browsers.test.ts
@@ -25,6 +25,7 @@
  */
 
 import { env } from "@commonfabric/integration";
+import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
 import { Identity } from "@commonfabric/identity";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { UI } from "@commonfabric/runner";
@@ -52,6 +53,23 @@ import {
 } from "./cfc-browser-helpers.ts";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME, CFC_BROWSER_PROFILE_COUNT } = env;
+// The opt-in propagation-benchmark leg (see the series step below).
+const CHAT_SERIES = Math.max(
+  0,
+  Number.parseInt(Deno.env.get("CF_CHAT_MESSAGE_SERIES") ?? "0", 10) || 0,
+);
+const CHAT_SERIES_DELAY_MS = Math.max(
+  0,
+  Number.parseInt(Deno.env.get("CF_CHAT_MESSAGE_DELAY_MS") ?? "2000", 10) ||
+    0,
+);
+const CHAT_SERIES_ARM = (() => {
+  const raw = Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION");
+  const on = raw === undefined
+    ? SERVER_EXECUTION_DEFAULT_ENABLED
+    : raw === "true";
+  return on ? "ON" : "OFF";
+})();
 const SAVE_PROFILE_ACTION = "TrustedGroupChatSaveProfile";
 const PROFILE_COUNT = Math.max(2, CFC_BROWSER_PROFILE_COUNT);
 
@@ -339,6 +357,55 @@ describe(
               lockdownMessage,
             ),
         );
+
+        // The Phase-7 cross-user PROPAGATION BENCHMARK leg (opt-in;
+        // docs/plans/server-execution-v2.md Phase 7's criterion — the
+        // README §1 "faster, not tolerably slower" bar): with
+        // CF_CHAT_MESSAGE_SERIES=N set, the first browser posts N further
+        // messages, DELAY apart, and each post is timed from the send
+        // click until the SECOND browser renders it — the byte-identical
+        // workload run in adjacent ON/OFF pairs by the measurement
+        // protocol (fresh store, load recorded, medians + quartiles). Off
+        // by default: the ordinary gate run is unchanged.
+        if (CHAT_SERIES > 0) {
+          const perPost: number[] = [];
+          for (let i = 0; i < CHAT_SERIES; i++) {
+            const text = `series ${i} ${userNames[0]}`;
+            await fillCfInput(pages[0], "#trusted-message-draft", text);
+            await waitForDisabled(pages[0], "#trusted-send-button", false);
+            const t0 = performance.now();
+            await clickCfButton(pages[0], "#trusted-send-button");
+            await waitForText(pages[1], "#trusted-conversation-preview", text);
+            perPost.push(performance.now() - t0);
+            if (CHAT_SERIES_DELAY_MS > 0) {
+              await new Promise((resolve) =>
+                setTimeout(resolve, CHAT_SERIES_DELAY_MS)
+              );
+            }
+          }
+          const sorted = [...perPost].sort((a, b) => a - b);
+          const q = (f: number) =>
+            sorted[Math.min(sorted.length - 1, Math.floor(f * sorted.length))];
+          const load = (() => {
+            try {
+              return Deno.loadavg().map((v) => v.toFixed(2)).join("/");
+            } catch {
+              return "n/a";
+            }
+          })();
+          console.log(
+            `[chat-series] arm=${CHAT_SERIES_ARM} n=${perPost.length} ` +
+              `median=${q(0.5).toFixed(0)}ms q1=${q(0.25).toFixed(0)}ms ` +
+              `q3=${q(0.75).toFixed(0)}ms min=${sorted[0].toFixed(0)}ms ` +
+              `max=${sorted[sorted.length - 1].toFixed(0)}ms ` +
+              `delay=${CHAT_SERIES_DELAY_MS}ms load1/5/15=${load}`,
+          );
+          console.log(
+            `[chat-series] per-post ms: ${
+              perPost.map((v) => v.toFixed(0)).join(" ")
+            }`,
+          );
+        }
 
         // Admin can still add rooms, and every other user sees the shared room.
         await fillCfInput(pages[0], "#trusted-room-name", "Ops");

--- a/packages/patterns/integration/sx2-effect-channel.test.ts
+++ b/packages/patterns/integration/sx2-effect-channel.test.ts
@@ -26,6 +26,7 @@
 // controller (a fresh controller is a fresh session until protocol
 // §5's client-side session persistence lands — OW20's trigger).
 
+import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
 import { env } from "@commonfabric/integration";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
@@ -48,7 +49,13 @@ import {
 
 const { API_URL, SPACE_NAME } = env;
 
-const FLAG_ON = Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION") === "true";
+// The arm this process runs in: the explicit env value, else the
+// first-party default (ON since the server-execution v2 Phase 7 flip —
+// the deployed-topology presets resolve an unset flag to it, and so does
+// the toolshed the harness started).
+const FLAG_ON = Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION") === undefined
+  ? SERVER_EXECUTION_DEFAULT_ENABLED
+  : Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION") === "true";
 
 type EffectStats = { effectAcks: number };
 

--- a/packages/patterns/integration/sx2-events.test.ts
+++ b/packages/patterns/integration/sx2-events.test.ts
@@ -23,6 +23,7 @@
 // actually be killed; this browser-facing surface cannot restart
 // toolshed.
 
+import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
 import { env } from "@commonfabric/integration";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
@@ -42,7 +43,13 @@ import {
 
 const { API_URL, SPACE_NAME } = env;
 
-const FLAG_ON = Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION") === "true";
+// The arm this process runs in: the explicit env value, else the
+// first-party default (ON since the server-execution v2 Phase 7 flip —
+// the deployed-topology presets resolve an unset flag to it, and so does
+// the toolshed the harness started).
+const FLAG_ON = Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION") === undefined
+  ? SERVER_EXECUTION_DEFAULT_ENABLED
+  : Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION") === "true";
 
 type EventStats = {
   derivedCommits: number;

--- a/packages/patterns/integration/sx2-scale.test.ts
+++ b/packages/patterns/integration/sx2-scale.test.ts
@@ -35,6 +35,7 @@
 // writes); the servingLoop stats block is absent, settles ride
 // `synced()`, and the ON-arm assertions are skipped explicitly.
 
+import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
 import { env } from "@commonfabric/integration";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
@@ -54,7 +55,13 @@ import {
 
 const { API_URL, SPACE_NAME } = env;
 
-const FLAG_ON = Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION") === "true";
+// The arm this process runs in: the explicit env value, else the
+// first-party default (ON since the server-execution v2 Phase 7 flip —
+// the deployed-topology presets resolve an unset flag to it, and so does
+// the toolshed the harness started).
+const FLAG_ON = Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION") === undefined
+  ? SERVER_EXECUTION_DEFAULT_ENABLED
+  : Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION") === "true";
 
 /** The Phase-6 budget-isolation calibration. The spec budget for the
  * push hot path is 300 ms p50 LAN on a quiet box (README §3.3);

--- a/packages/patterns/integration/sx2-serving-loop.test.ts
+++ b/packages/patterns/integration/sx2-serving-loop.test.ts
@@ -26,6 +26,7 @@
 // byte-identical); the servingLoop stats block is absent and the
 // ON-arm assertions are skipped explicitly.
 
+import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
 import { env } from "@commonfabric/integration";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
@@ -45,7 +46,13 @@ import {
 
 const { API_URL, SPACE_NAME } = env;
 
-const FLAG_ON = Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION") === "true";
+// The arm this process runs in: the explicit env value, else the
+// first-party default (ON since the server-execution v2 Phase 7 flip —
+// the deployed-topology presets resolve an unset flag to it, and so does
+// the toolshed the harness started).
+const FLAG_ON = Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION") === undefined
+  ? SERVER_EXECUTION_DEFAULT_ENABLED
+  : Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION") === "true";
 
 type ServingLoopStats = {
   waves: number;
@@ -81,9 +88,7 @@ const waitForStats = async (
     if (stats !== undefined && predicate(stats)) return stats;
     if (Date.now() > deadline) {
       throw new Error(
-        `timed out waiting for ${label} — last stats: ${
-          JSON.stringify(stats)
-        }`,
+        `timed out waiting for ${label} — last stats: ${JSON.stringify(stats)}`,
       );
     }
     await new Promise((resolve) => setTimeout(resolve, 50));

--- a/packages/patterns/integration/sx2-speculation.test.ts
+++ b/packages/patterns/integration/sx2-speculation.test.ts
@@ -19,6 +19,7 @@
 // OFF arm: the client derives and commits as today — the overlay never
 // exists (byte-identical posture), asserted explicitly.
 
+import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
 import { env } from "@commonfabric/integration";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
@@ -35,7 +36,13 @@ import {
 
 const { API_URL, SPACE_NAME } = env;
 
-const FLAG_ON = Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION") === "true";
+// The arm this process runs in: the explicit env value, else the
+// first-party default (ON since the server-execution v2 Phase 7 flip —
+// the deployed-topology presets resolve an unset flag to it, and so does
+// the toolshed the harness started).
+const FLAG_ON = Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION") === undefined
+  ? SERVER_EXECUTION_DEFAULT_ENABLED
+  : Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION") === "true";
 
 describe("sx2 speculation (Phase 2 gates)", () => {
   let identity: Identity;

--- a/packages/runner/deno.jsonc
+++ b/packages/runner/deno.jsonc
@@ -13,7 +13,7 @@
       "description": "Run Cell benchmarks for performance analysis",
       "command": "deno bench --allow-read --allow-write --allow-net --allow-ffi --allow-env --no-check test/*.bench.ts"
     },
-    "integration": "LOG_LEVEL=warn deno test -A $INTEGRATION_TEST_FLAGS ./integration/*.test.ts"
+    "integration": "LOG_LEVEL=warn deno test -A $INTEGRATION_TEST_FLAGS \"./integration/*.test.ts\""
   },
   "imports": {
     // Dependency guide: ../../docs/development/DEPENDENCIES.md

--- a/packages/runner/integration/array_push.test.ts
+++ b/packages/runner/integration/array_push.test.ts
@@ -65,6 +65,11 @@ function createRuntime(identity: Identity, base: URL): Runtime {
       memoryHost: new URL(base),
     }),
     experimental: {
+      // Server-execution v2 posture (testing.md §2): this test serves
+      // toolshed's `app.ts` IN-PROCESS with NO ExecutorHost — a
+      // single-process harness whose client is OFF BY CONSTRUCTION,
+      // whatever EXPERIMENTAL_SERVER_EXECUTION says (P7 review finding 7:
+      // only the tests that talk to the lane's toolshed declare it).
       modernCellRep: readExperimentalFlag("EXPERIMENTAL_MODERN_CELL_REP"),
     },
   });

--- a/packages/runner/integration/basic-persistence.test.ts
+++ b/packages/runner/integration/basic-persistence.test.ts
@@ -1,6 +1,10 @@
 #!/usr/bin/env -S deno run -A
 
-import { deepEqual, Runtime } from "@commonfabric/runner";
+import {
+  deepEqual,
+  experimentalOptionsFromEnv,
+  Runtime,
+} from "@commonfabric/runner";
 import { Identity, IdentityCreateConfig } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { type JSONSchema } from "@commonfabric/runner";
@@ -19,6 +23,11 @@ async function test() {
   // First runtime - save data
   const runtime1 = new Runtime({
     apiUrl: new URL(API_URL),
+    // The posture this client runs (server-execution v2, testing.md §2):
+    // declared from the environment so the CI ON lane's test process
+    // really runs the ON client arm (a bare construction resolved OFF and
+    // made the ON lane a MIXED posture — P7 review finding 7); unset = OFF.
+    experimental: experimentalOptionsFromEnv(Deno.env.get),
     storageManager: StorageManager.open({
       as: identity,
       memoryHost: new URL(API_URL),
@@ -50,6 +59,11 @@ async function test() {
   // Second runtime - fetch data
   const runtime2 = new Runtime({
     apiUrl: new URL(API_URL),
+    // The posture this client runs (server-execution v2, testing.md §2):
+    // declared from the environment so the CI ON lane's test process
+    // really runs the ON client arm (a bare construction resolved OFF and
+    // made the ON lane a MIXED posture — P7 review finding 7); unset = OFF.
+    experimental: experimentalOptionsFromEnv(Deno.env.get),
     storageManager: StorageManager.open({
       as: identity,
       memoryHost: new URL(API_URL),

--- a/packages/runner/integration/derive_array_leak.test.ts
+++ b/packages/runner/integration/derive_array_leak.test.ts
@@ -10,6 +10,7 @@
  * Actual behavior: Memory grows by gigabytes (1GB+ per 100 increments)
  */
 import { Identity, Session } from "@commonfabric/identity";
+import { experimentalOptionsFromEnv } from "@commonfabric/runner";
 import { env } from "@commonfabric/integration";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { compileAndSavePattern, Runtime } from "../src/index.ts";
@@ -100,6 +101,11 @@ async function runTest() {
   // Create runtime
   const runtime = new Runtime({
     apiUrl: new URL(API_URL),
+    // The posture this client runs (server-execution v2, testing.md §2):
+    // declared from the environment so the CI ON lane's test process
+    // really runs the ON client arm (a bare construction resolved OFF and
+    // made the ON lane a MIXED posture — P7 review finding 7); unset = OFF.
+    experimental: experimentalOptionsFromEnv(Deno.env.get),
     storageManager,
   });
 

--- a/packages/runner/integration/memory-v2-reactivity.test.ts
+++ b/packages/runner/integration/memory-v2-reactivity.test.ts
@@ -10,6 +10,15 @@ import { defer } from "@commonfabric/utils/defer";
 const createRuntime = (identity: Identity, base: URL) =>
   new Runtime({
     apiUrl: base,
+    // Server-execution v2 posture (testing.md §2): this test serves
+    // toolshed's `app.ts` IN-PROCESS (`Deno.serve` below) with NO
+    // ExecutorHost, so it is a single-process harness — client and memory
+    // server in one process, nothing serving — and its client is OFF BY
+    // CONSTRUCTION, whatever EXPERIMENTAL_SERVER_EXECUTION says (a flag-ON
+    // client here would divert its derivations to a server that does not
+    // exist and wedge). The CI ON lane's env does not reach this file;
+    // only the tests that talk to the lane's toolshed (API_URL) declare
+    // the posture from the env (P7 review finding 7).
     storageManager: StorageManager.open({
       as: identity,
       memoryHost: new URL(base),

--- a/packages/runner/integration/pattern-and-data-persistence.test.ts
+++ b/packages/runner/integration/pattern-and-data-persistence.test.ts
@@ -15,7 +15,11 @@
  */
 
 import { assert, assertEquals } from "@std/assert";
-import { Runtime, type RuntimeProgram } from "@commonfabric/runner";
+import {
+  experimentalOptionsFromEnv,
+  Runtime,
+  type RuntimeProgram,
+} from "@commonfabric/runner";
 import { Identity, type IdentityCreateConfig } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import type { Cell, JSONSchema, MemorySpace } from "@commonfabric/runner";
@@ -100,6 +104,11 @@ function createTestContext(identity: Identity): TestContext {
   });
   const runtime = new Runtime({
     apiUrl: API_URL,
+    // The posture this client runs (server-execution v2, testing.md §2):
+    // declared from the environment so the CI ON lane's test process
+    // really runs the ON client arm (a bare construction resolved OFF and
+    // made the ON lane a MIXED posture — P7 review finding 7); unset = OFF.
+    experimental: experimentalOptionsFromEnv(Deno.env.get),
     storageManager,
   });
   return { runtime, storageManager };

--- a/packages/runner/integration/reconnection.test.ts
+++ b/packages/runner/integration/reconnection.test.ts
@@ -10,6 +10,15 @@ import { defer } from "@commonfabric/utils/defer";
 const createRuntime = (identity: Identity, base: URL) =>
   new Runtime({
     apiUrl: base,
+    // Server-execution v2 posture (testing.md §2): this test serves
+    // toolshed's `app.ts` IN-PROCESS (`Deno.serve` below) with NO
+    // ExecutorHost, so it is a single-process harness — client and memory
+    // server in one process, nothing serving — and its client is OFF BY
+    // CONSTRUCTION, whatever EXPERIMENTAL_SERVER_EXECUTION says (a flag-ON
+    // client here would divert its derivations to a server that does not
+    // exist and wedge). The CI ON lane's env does not reach this file;
+    // only the tests that talk to the lane's toolshed (API_URL) declare
+    // the posture from the env (P7 review finding 7).
     storageManager: StorageManager.open({
       as: identity,
       memoryHost: new URL(base),

--- a/packages/runner/integration/sqlite-cfc-commit-eval.test.ts
+++ b/packages/runner/integration/sqlite-cfc-commit-eval.test.ts
@@ -26,6 +26,15 @@ async function runTest(base: URL) {
   );
   const runtime = new Runtime({
     apiUrl: base,
+    // Server-execution v2 posture (testing.md §2): this test serves
+    // toolshed's `app.ts` IN-PROCESS (`Deno.serve` below) with NO
+    // ExecutorHost, so it is a single-process harness — client and memory
+    // server in one process, nothing serving — and its client is OFF BY
+    // CONSTRUCTION, whatever EXPERIMENTAL_SERVER_EXECUTION says (a flag-ON
+    // client here would divert its derivations to a server that does not
+    // exist and wedge). The CI ON lane's env does not reach this file;
+    // only the tests that talk to the lane's toolshed (API_URL) declare
+    // the posture from the env (P7 review finding 7).
     storageManager: StorageManager.open({
       as: account,
       memoryHost: new URL(base),

--- a/packages/runner/integration/sqlite-cfc-label-link.test.ts
+++ b/packages/runner/integration/sqlite-cfc-label-link.test.ts
@@ -20,6 +20,15 @@ async function runTest(base: URL) {
   );
   const runtime = new Runtime({
     apiUrl: base,
+    // Server-execution v2 posture (testing.md §2): this test serves
+    // toolshed's `app.ts` IN-PROCESS (`Deno.serve` below) with NO
+    // ExecutorHost, so it is a single-process harness — client and memory
+    // server in one process, nothing serving — and its client is OFF BY
+    // CONSTRUCTION, whatever EXPERIMENTAL_SERVER_EXECUTION says (a flag-ON
+    // client here would divert its derivations to a server that does not
+    // exist and wedge). The CI ON lane's env does not reach this file;
+    // only the tests that talk to the lane's toolshed (API_URL) declare
+    // the posture from the env (P7 review finding 7).
     storageManager: StorageManager.open({
       as: account,
       memoryHost: new URL(base),

--- a/packages/runner/integration/sqlite-cfc-label.test.ts
+++ b/packages/runner/integration/sqlite-cfc-label.test.ts
@@ -22,6 +22,15 @@ async function runTest(base: URL) {
   );
   const runtime = new Runtime({
     apiUrl: base,
+    // Server-execution v2 posture (testing.md §2): this test serves
+    // toolshed's `app.ts` IN-PROCESS (`Deno.serve` below) with NO
+    // ExecutorHost, so it is a single-process harness — client and memory
+    // server in one process, nothing serving — and its client is OFF BY
+    // CONSTRUCTION, whatever EXPERIMENTAL_SERVER_EXECUTION says (a flag-ON
+    // client here would divert its derivations to a server that does not
+    // exist and wedge). The CI ON lane's env does not reach this file;
+    // only the tests that talk to the lane's toolshed (API_URL) declare
+    // the posture from the env (P7 review finding 7).
     storageManager: StorageManager.open({
       as: account,
       memoryHost: new URL(base),

--- a/packages/runner/integration/sqlite-cfc-row-label.test.ts
+++ b/packages/runner/integration/sqlite-cfc-row-label.test.ts
@@ -22,6 +22,15 @@ async function runTest(base: URL) {
   );
   const runtime = new Runtime({
     apiUrl: base,
+    // Server-execution v2 posture (testing.md §2): this test serves
+    // toolshed's `app.ts` IN-PROCESS (`Deno.serve` below) with NO
+    // ExecutorHost, so it is a single-process harness — client and memory
+    // server in one process, nothing serving — and its client is OFF BY
+    // CONSTRUCTION, whatever EXPERIMENTAL_SERVER_EXECUTION says (a flag-ON
+    // client here would divert its derivations to a server that does not
+    // exist and wedge). The CI ON lane's env does not reach this file;
+    // only the tests that talk to the lane's toolshed (API_URL) declare
+    // the posture from the env (P7 review finding 7).
     storageManager: StorageManager.open({
       as: account,
       memoryHost: new URL(base),

--- a/packages/runner/integration/sqlite-db-query-decode.test.ts
+++ b/packages/runner/integration/sqlite-db-query-decode.test.ts
@@ -19,6 +19,15 @@ async function runTest(base: URL) {
   );
   const runtime = new Runtime({
     apiUrl: base,
+    // Server-execution v2 posture (testing.md §2): this test serves
+    // toolshed's `app.ts` IN-PROCESS (`Deno.serve` below) with NO
+    // ExecutorHost, so it is a single-process harness — client and memory
+    // server in one process, nothing serving — and its client is OFF BY
+    // CONSTRUCTION, whatever EXPERIMENTAL_SERVER_EXECUTION says (a flag-ON
+    // client here would divert its derivations to a server that does not
+    // exist and wedge). The CI ON lane's env does not reach this file;
+    // only the tests that talk to the lane's toolshed (API_URL) declare
+    // the posture from the env (P7 review finding 7).
     storageManager: StorageManager.open({
       as: account,
       memoryHost: new URL(base),

--- a/packages/runner/integration/sync-schema-path.test.ts
+++ b/packages/runner/integration/sync-schema-path.test.ts
@@ -1,7 +1,11 @@
 #!/usr/bin/env -S deno run -A
 
 import { assertEquals } from "@std/assert/equals";
-import { type NormalizedLink, Runtime } from "@commonfabric/runner";
+import {
+  experimentalOptionsFromEnv,
+  type NormalizedLink,
+  Runtime,
+} from "@commonfabric/runner";
 import { Identity, type IdentityCreateConfig } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import type { JSONSchema, MemorySpace, URI } from "@commonfabric/runner";
@@ -38,6 +42,11 @@ async function test() {
   // First runtime - save data
   const runtime1 = new Runtime({
     apiUrl: new URL(API_URL),
+    // The posture this client runs (server-execution v2, testing.md §2):
+    // declared from the environment so the CI ON lane's test process
+    // really runs the ON client arm (a bare construction resolved OFF and
+    // made the ON lane a MIXED posture — P7 review finding 7); unset = OFF.
+    experimental: experimentalOptionsFromEnv(Deno.env.get),
     storageManager: StorageManager.open({
       as: identity,
       memoryHost: new URL(API_URL),
@@ -110,6 +119,11 @@ async function test() {
   // Attempt to load on runtime2
   const runtime2 = new Runtime({
     apiUrl: new URL(API_URL),
+    // The posture this client runs (server-execution v2, testing.md §2):
+    // declared from the environment so the CI ON lane's test process
+    // really runs the ON client arm (a bare construction resolved OFF and
+    // made the ON lane a MIXED posture — P7 review finding 7); unset = OFF.
+    experimental: experimentalOptionsFromEnv(Deno.env.get),
     storageManager: StorageManager.open({
       as: identity,
       memoryHost: new URL(API_URL),

--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -92,6 +92,13 @@ export function filter(
   awaitSync?: boolean,
 ): RawBuiltinReturnType {
   let result: Cell<any[]> | undefined;
+  // The containing piece's root: every element sub-piece this coordinator
+  // starts is that piece's structure, so its actions' demand roots carry
+  // the parent's chain (server-execution v2 Phase 7's demand-root chain;
+  // RunnerRunOptions.parentPieceRootId) — a serving runtime resolves the
+  // element's demanded instances through the OUTER root a client watches
+  // instead of falling to the service identity (P7 review finding 4).
+  const parentPieceRootId = parentCell.getAsNormalizedFullLink().id;
 
   // Identity-based tracking: maps element address key → element run.
   // resultCell holds the predicate boolean for this element.
@@ -447,6 +454,7 @@ export function filter(
               {
                 doNotUpdateOnPatternChange: true,
                 awaitSyncBeforeInitialRun: elementAwaitSync,
+                parentPieceRootId,
               },
             );
             rollback.setupIssued(existing);
@@ -474,6 +482,7 @@ export function filter(
           {
             doNotUpdateOnPatternChange: true,
             awaitSyncBeforeInitialRun: elementAwaitSync,
+            parentPieceRootId,
           },
         );
         // Link these individual cells to the top cell

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -110,6 +110,13 @@ export function flatMap(
   awaitSync?: boolean,
 ): RawBuiltinReturnType {
   let result: Cell<any[]> | undefined;
+  // The containing piece's root: every element sub-piece this coordinator
+  // starts is that piece's structure, so its actions' demand roots carry
+  // the parent's chain (server-execution v2 Phase 7's demand-root chain;
+  // RunnerRunOptions.parentPieceRootId) — a serving runtime resolves the
+  // element's demanded instances through the OUTER root a client watches
+  // instead of falling to the service identity (P7 review finding 4).
+  const parentPieceRootId = parentCell.getAsNormalizedFullLink().id;
 
   // Identity-based tracking: maps element address key → element run.
   // resultCell holds the per-element result array.
@@ -452,6 +459,7 @@ export function flatMap(
               {
                 doNotUpdateOnPatternChange: true,
                 awaitSyncBeforeInitialRun: elementAwaitSync,
+                parentPieceRootId,
               },
             );
             rollback.setupIssued(existing);
@@ -479,6 +487,7 @@ export function flatMap(
           {
             doNotUpdateOnPatternChange: true,
             awaitSyncBeforeInitialRun: elementAwaitSync,
+            parentPieceRootId,
           },
         );
         // Link the new result cells to the pattern cell too

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -95,6 +95,13 @@ export function map(
   awaitSync?: boolean,
 ): RawBuiltinReturnType {
   let result: Cell<any[]> | undefined;
+  // The containing piece's root: every element sub-piece this coordinator
+  // starts is that piece's structure, so its actions' demand roots carry
+  // the parent's chain (server-execution v2 Phase 7's demand-root chain;
+  // RunnerRunOptions.parentPieceRootId) — a serving runtime resolves the
+  // element's demanded instances through the OUTER root a client watches
+  // instead of falling to the service identity (P7 review finding 4).
+  const parentPieceRootId = parentCell.getAsNormalizedFullLink().id;
 
   // Identity-based tracking: maps element address key → { resultCell, lastIndex }
   // for reuse across position changes. We pass list[i] directly each time, so
@@ -414,6 +421,7 @@ export function map(
             {
               doNotUpdateOnPatternChange: true,
               awaitSyncBeforeInitialRun: elementAwaitSync,
+              parentPieceRootId,
             },
           );
           rollback.setupIssued(existing);
@@ -441,6 +449,7 @@ export function map(
           {
             doNotUpdateOnPatternChange: true,
             awaitSyncBeforeInitialRun: elementAwaitSync,
+            parentPieceRootId,
           },
         );
         // Link these individual cells to the top cell

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -1888,6 +1888,24 @@ export function wish(
     }
     return slot;
   };
+  // Server-execution v2 (Phase 7; builtins.md §3, §5): a wish's sidecar
+  // surfaces — the profile create/picker patterns and the suggestion
+  // pattern — are compile-INSTANTIATE steps (fetch a system pattern, run
+  // it into a deterministic result cell). Under the flag those belong to
+  // the SpaceServer: the served wish run for the demanding identity
+  // fetches, instantiates and commits the sidecar (bookkeeping stamps,
+  // serving-loop.md §3d), and the client's SPECULATIVE wish run only
+  // REFERENCES the same cell — cause-derived, so both sides name one
+  // doc — and renders whatever the server materialized (speculation.md
+  // §2: compile-instantiate children stay unspeculated; the client reads
+  // through). Pre-fix a flag-ON client also fetched + instantiated the
+  // sidecar through its own bookkeeping-stamped (authored) commits,
+  // racing the server's derived commits on the SAME docs — the
+  // lunch-gate churn (a stale-basis rejection loop on the readers of
+  // those cells, ~13 wish re-runs/s, no settle). OFF arm and the serving
+  // runtime: unchanged.
+  const sidecarIsServed = runtime.experimental.serverExecution === true &&
+    !runtime.servingPosture;
 
   addCancel(() => {
     cancelled = true;
@@ -1998,7 +2016,10 @@ export function wish(
     }
 
     const cachedSuggestionPattern = suggestionPatternCache.cached();
-    if (!cachedSuggestionPattern) {
+    if (sidecarIsServed) {
+      // The SpaceServer instantiates the suggestion sidecar for this
+      // demander; this speculative run references its cell only.
+    } else if (!cachedSuggestionPattern) {
       // Once fetch completes, run the pattern without a tx (it creates its own)
       void suggestionPatternCache.fetch(
         runtime,
@@ -2153,7 +2174,11 @@ export function wish(
     };
 
     const cachedProfileCreatePattern = profileCreatePatternCache.cached();
-    if (!cachedProfileCreatePattern) {
+    if (sidecarIsServed) {
+      // The SpaceServer fetches/instantiates the create surface for this
+      // demander and flips its ready cell; this speculative run only
+      // references the served cells (read above for the re-run trigger).
+    } else if (!cachedProfileCreatePattern) {
       void profileCreatePatternCache.fetch(runtime, () => {
         // The pattern arrived: re-arm EVERY demander's create surface —
         // the fetch is node-shared (memoized), so the ready signal must
@@ -2287,7 +2312,10 @@ export function wish(
     };
 
     const cachedProfilePickerPattern = profilePickerPatternCache.cached();
-    if (!cachedProfilePickerPattern) {
+    if (sidecarIsServed) {
+      // The SpaceServer instantiates the picker for this demander; this
+      // speculative run references its cell only.
+    } else if (!cachedProfilePickerPattern) {
       void profilePickerPatternCache.fetch(
         runtime,
         undefined,

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -717,7 +717,8 @@ export class SpaceServer implements TransactionSealDestination {
     // registry through the seam above.
     runtime.installSealDestination(this, {
       runStamper: (tx, info) => this.#stampRun(tx, info),
-      runInstanceResolver: (pieceRootId) => this.#runInstancesFor(pieceRootId),
+      runInstanceResolver: (pieceRootIds) =>
+        this.#runInstancesFor(pieceRootIds),
     });
 
     // Stage B's renew cadence, finally driven (serving-loop.md §2).
@@ -1121,19 +1122,27 @@ export class SpaceServer implements TransactionSealDestination {
   }
 
   /** The per-(action × instance) run supply's resolver (stage P2-F),
-   * installed beside the stamper: the demanded instances of a piece
-   * root, from the demand registry — entries whose demand key names the
-   * root directly plus entries whose structure load RESOLVED to it
+   * installed beside the stamper: the demanded instances of an action's
+   * DEMAND ROOTS — its piece root plus the ancestor piece roots that
+   * instantiated it (Phase 7; `SchedulerObservationIdentity.
+   * demandRootIds`: a nested pattern node or result-as-pattern child is
+   * demanded through the OUTER piece a client watches, and pre-Phase-7
+   * its scoped derivations fell to the service identity's instances) —
+   * from the demand registry: entries whose demand key names one of the
+   * roots directly plus entries whose structure load RESOLVED to one
    * (`#pieceRootByDemandKey`), deduped per instance key. Space-scope
    * demands carry no identity and contribute nothing (the wave-level
    * fallback run). */
   #runInstancesFor(
-    pieceRootId: string,
+    pieceRootIds: readonly string[],
   ): Array<{ scopeKeyIdentity: ScopeKeyIdentity; actionScopeKey: ScopeKey }> {
     const instances = new Map<string, ScopeKeyIdentity>();
+    const roots = new Set(pieceRootIds);
     for (const [key, identity] of this.#demandedIdentities) {
-      const matches = key.endsWith(`\0${pieceRootId}`) ||
-        this.#pieceRootByDemandKey.get(key) === pieceRootId;
+      const keyRoot = key.slice(key.indexOf("\0") + 1);
+      const resolvedRoot = this.#pieceRootByDemandKey.get(key);
+      const matches = roots.has(keyRoot) ||
+        (resolvedRoot !== undefined && roots.has(resolvedRoot));
       if (!matches) continue;
       const instanceKey = key.slice(0, key.indexOf("\0"));
       if (!instances.has(instanceKey)) instances.set(instanceKey, identity);
@@ -2070,10 +2079,6 @@ export class SpaceServer implements TransactionSealDestination {
         return `${scope}\0${root.id}`;
       }
     };
-    // Retire demand for roots no client watches anymore: the sink is
-    // the demand, so cancelling it returns the value to pull-based
-    // laziness (the materialized structure stays registered — structure
-    // is not a start/stop policy, serving-loop.md §1).
     const currentKeys = new Set(roots.map(keyOf));
     for (const [key, cancel] of this.#demandSinks) {
       if (currentKeys.has(key)) continue;

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -890,6 +890,13 @@ type RunnerRunOptions = {
   // Resumed-from-synced-state: hold each action's initial rehydration/run until
   // the space has finished syncing, so consumers don't race the data.
   awaitSyncBeforeInitialRun?: boolean;
+  // The piece root that INSTANTIATED this piece (a nested pattern node's
+  // parent, a result-as-pattern child's producing piece). Its actions'
+  // demand roots (`SchedulerObservationIdentity.demandRootIds`) become the
+  // parent's chain plus this root, so the serving loop's per-(action ×
+  // instance) run supply resolves a nested piece's demanded instances
+  // through the OUTER piece a client watches (server-execution v2 Phase 7).
+  parentPieceRootId?: string;
 };
 
 // Placeholder standing in for an argument slot whose stored raw value is a
@@ -2409,6 +2416,8 @@ export class Runner {
       // Resumed-from-synced-state: hold each action's initial rehydration/run
       // until the space has finished syncing, so consumers don't race the data.
       awaitSyncBeforeInitialRun?: boolean;
+      // See RunnerRunOptions.parentPieceRootId.
+      parentPieceRootId?: string;
     } = {},
   ): Cancel {
     const {
@@ -2489,8 +2498,13 @@ export class Runner {
         ? options.schedulerRehydration ?? this.schedulerRehydrationOptions(
           resultCell,
           options.awaitSyncBeforeInitialRun,
+          options.parentPieceRootId,
         )
-        : this.schedulerRehydrationOptions(resultCell);
+        : this.schedulerRehydrationOptions(
+          resultCell,
+          undefined,
+          options.parentPieceRootId,
+        );
       initialSchedulerRehydrationAvailable = false;
       try {
         for (const node of pattern.nodes) {
@@ -3277,6 +3291,7 @@ export class Runner {
       doNotUpdateOnPatternChange: options.doNotUpdateOnPatternChange,
       schedulePatternUpdate: options.schedulePatternUpdate,
       awaitSyncBeforeInitialRun: options.awaitSyncBeforeInitialRun,
+      parentPieceRootId: options.parentPieceRootId,
     });
   }
 
@@ -3902,8 +3917,41 @@ export class Runner {
     }
   }
 
-  private schedulerObservationIdentity(resultCell: Cell<any>) {
+  /**
+   * The demand-root CHAIN of a piece root (server-execution v2 Phase 7):
+   * the roots of every ancestor piece that instantiated it, ending in
+   * itself. Recorded when a piece starts under a known parent
+   * (`RunnerRunOptions.parentPieceRootId`); a root started with no
+   * parent (a top-level piece, or a resume whose parent is unknown) keeps
+   * whatever chain an earlier parent-driven start recorded, else stands
+   * alone. Only ever grows per root — a nested piece re-started
+   * standalone (a client navigating to it) must not lose the outer
+   * demand it is also served under.
+   */
+  private demandRootChains = new Map<string, readonly string[]>();
+
+  private demandRootChainFor(
+    id: string,
+    parentPieceRootId?: string,
+  ): readonly string[] {
+    const known = this.demandRootChains.get(id);
+    if (parentPieceRootId === undefined || parentPieceRootId === id) {
+      return known ?? [id];
+    }
+    const parentChain = this.demandRootChains.get(parentPieceRootId) ??
+      [parentPieceRootId];
+    const merged = new Set<string>([...(known ?? []), ...parentChain, id]);
+    const chain = [...merged];
+    this.demandRootChains.set(id, chain);
+    return chain;
+  }
+
+  private schedulerObservationIdentity(
+    resultCell: Cell<any>,
+    parentPieceRootId?: string,
+  ) {
     const { space, id, scope } = resultCell.getAsNormalizedFullLink();
+    const demandRootIds = this.demandRootChainFor(id, parentPieceRootId);
     return {
       pieceId: `${resolveScopeKey(scope, this.runtime.scopeKeyIdentity)}:${id}`,
       ownerSpace: space,
@@ -3911,15 +3959,22 @@ export class Runner {
       // run supply (server-execution v2 stage P2-F): the scheduler
       // resolves this piece's demanded instances through it.
       pieceRootId: id,
+      // Phase 7: plus the ancestor roots that instantiated it — a nested
+      // piece is demanded through the outer piece the client watches.
+      ...(demandRootIds.length > 1 ? { demandRootIds } : {}),
     };
   }
 
   private schedulerRehydrationOptions(
     resultCell: Cell<any>,
     awaitSync?: boolean,
+    parentPieceRootId?: string,
   ): SchedulerRehydrationSubscriptionOptions {
     const { space } = resultCell.getAsNormalizedFullLink();
-    const observationIdentity = this.schedulerObservationIdentity(resultCell);
+    const observationIdentity = this.schedulerObservationIdentity(
+      resultCell,
+      parentPieceRootId,
+    );
     // Actions always re-run on resume. When resuming from a synced state,
     // hold the initial run until the space is synced so re-derivations read
     // confirmed-loaded inputs.
@@ -5529,6 +5584,12 @@ export class Runner {
           resultPattern,
           undefined,
           receiptCell,
+          {
+            // Phase 7: a result-as-pattern child's demand roots include
+            // the producing piece's chain (see RunnerRunOptions).
+            parentPieceRootId: patternResultCell.getAsNormalizedFullLink()
+              .id,
+          },
         );
         installedCancel = run.installedCancel;
         cancelDeferredStart = run.cancelDeferredStart;
@@ -7226,6 +7287,10 @@ export class Runner {
         awaitSyncBeforeInitialRun: defersInitialRunUntilSynced(
           schedulerRehydration,
         ),
+        // Phase 7: the child's demand roots include this parent's chain
+        // (the run supply resolves the nested piece's instances through
+        // the outer root a client watches).
+        parentPieceRootId: parentResultCell.getAsNormalizedFullLink().id,
       },
     );
 

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -44,7 +44,11 @@
  * |                            | its identity/session, are the caller's domain)   |
  * | experimental               | per-site (required param — pass                  |
  * |                            | `experimentalOptionsFromEnv(...)`, host data, or |
- * |                            | an explicit `{}`; requiredness is the seal)      |
+ * |                            | an explicit `{}`; requiredness is the seal).     |
+ * |                            | productionServer/remoteClient resolve an unset   |
+ * |                            | `serverExecution` to the first-party default     |
+ * |                            | (ON since Phase 7); the single-process presets   |
+ * |                            | keep the constructor default (OFF)               |
  * | cfcEnforcementMode         | core-pinned `"enforce-explicit"`; overridable in |
  * |                            | patternTest/unitTest (per-test laxer mode) and   |
  * |                            | browserWorker (host-controlled rollout)          |
@@ -97,6 +101,7 @@
  * |                            | it hand-rolls its options deliberately           |
  */
 
+import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
 import type {
   CfcEnforcementMode,
   CfcFlowLabelsMode,
@@ -206,9 +211,12 @@ export const EXPERIMENTAL_ENV_VARS = {
   systemPatternAutoUpdate: "EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE",
   computedCellIds: "EXPERIMENTAL_COMPUTED_CELL_IDS",
   lazyMaterialization: "EXPERIMENTAL_LAZY_MATERIALIZATION",
-  // Server-execution v2 (docs/specs/server-side-execution/): OFF is today
-  // byte-for-byte; the ON arm is the CI second arm from Phase 1 stage A on
-  // (testing.md §2), so every server-side process must be reachable by env.
+  // Server-execution v2 (docs/specs/server-side-execution/): ON by default
+  // since the plan's Phase 7 flip — the deployed-topology presets below
+  // resolve an unset flag to `SERVER_EXECUTION_DEFAULT_ENABLED`; an
+  // explicit "false" selects the OFF arm (the rollback lever, and CI's
+  // regression-guard lanes) until the OFF path is removed. Env-reachable
+  // so every server-side process can be flipped either way.
   serverExecution: "EXPERIMENTAL_SERVER_EXECUTION",
 } as const satisfies Record<keyof ExperimentalOptions, string | null>;
 
@@ -267,6 +275,30 @@ interface CoreParams {
  * modes) get flipped HERE, in one reviewed place, for every preset user at
  * once — the constructor defaults then only govern non-preset constructions.
  */
+/**
+ * The first-party server-execution default for the DEPLOYED-TOPOLOGY
+ * presets (server-execution v2, docs/plans/server-execution-v2.md Phase
+ * 7's flip): `productionServer` and `remoteClient` run against a serving
+ * toolshed, so an UNSET flag resolves to
+ * `SERVER_EXECUTION_DEFAULT_ENABLED` — explicit in the returned options,
+ * which claims the process's ambient flag through the Runtime's enabler.
+ * An explicit value (env "false" — the OFF arm / rollback lever) always
+ * wins. The single-process presets (`patternTest`, `localDev`,
+ * `unitTest`) deliberately do NOT apply it: an emulated-storage runtime
+ * has no serving host, so it runs the derive-and-commit model (the
+ * ambient baseline, OFF) by construction — see
+ * `docs/development/EXPERIMENTAL_OPTIONS.md`.
+ */
+function withServerExecutionDefault(
+  experimental: ExperimentalOptions,
+): ExperimentalOptions {
+  return {
+    ...experimental,
+    serverExecution: experimental.serverExecution ??
+      SERVER_EXECUTION_DEFAULT_ENABLED,
+  };
+}
+
 function coreOptions(params: CoreParams): RuntimeOptions {
   return {
     apiUrl: params.apiUrl,
@@ -361,7 +393,10 @@ export const runtimePresets = {
    */
   productionServer(params: ProductionServerPresetParams): RuntimeOptions {
     return {
-      ...coreOptions(params),
+      ...coreOptions({
+        ...params,
+        experimental: withServerExecutionDefault(params.experimental),
+      }),
       patternEnvironment: { apiUrl: params.patternApiUrl ?? params.apiUrl },
       ...(params.consoleHandler !== undefined
         ? { consoleHandler: params.consoleHandler }
@@ -382,7 +417,10 @@ export const runtimePresets = {
    */
   remoteClient(params: RemoteClientPresetParams): RuntimeOptions {
     return {
-      ...coreOptions(params),
+      ...coreOptions({
+        ...params,
+        experimental: withServerExecutionDefault(params.experimental),
+      }),
       patternEnvironment: { apiUrl: params.apiUrl },
       ...(params.errorHandlers !== undefined
         ? { errorHandlers: params.errorHandlers }

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -804,10 +804,11 @@ export class Runtime {
     | ((tx: IExtendedStorageTransaction, info: ServerRunInfo) => void)
     | undefined;
   // The per-(action × instance) run-supply resolver (installed WITH the
-  // destination, stage P2-F): piece root doc id → the demanded
-  // instances the SpaceServer's registry holds for it.
+  // destination, stage P2-F): an action's demand roots (its piece root
+  // plus the ancestor roots that instantiated it — Phase 7) → the
+  // demanded instances the SpaceServer's registry holds for any of them.
   #serverRunInstanceResolver:
-    | ((pieceRootId: string) => readonly ServerRunInstance[])
+    | ((pieceRootIds: readonly string[]) => readonly ServerRunInstance[])
     | undefined;
   // The client speculation overlay (server-execution v2 Phase 2,
   // speculation.md): the DEFAULT seal destination of every runtime under
@@ -1942,7 +1943,7 @@ export class Runtime {
        * identity). Absent (or returning nothing) the run keeps the
        * wave-level fallback — the Phase-1 cardinality-1 posture. */
       runInstanceResolver?: (
-        pieceRootId: string,
+        pieceRootIds: readonly string[],
       ) => readonly ServerRunInstance[];
     } = {},
   ): void {
@@ -1987,18 +1988,21 @@ export class Runtime {
   }
 
   /**
-   * The demanded instances a scheduler action's piece root currently has
-   * (the per-(action × instance) run SUPPLY, stage P2-F). Undefined
-   * everywhere except a serving runtime whose SpaceServer installed a
-   * resolver — the OFF arm and client speculation pay one undefined
-   * check. The scheduler runs the action once per returned instance
-   * (instances live in keys/basis/stamps, never as extra graph nodes —
-   * C11b); an empty return keeps the single wave-identity run.
+   * The demanded instances a scheduler action's DEMAND ROOTS currently
+   * have (the per-(action × instance) run SUPPLY, stage P2-F): its own
+   * piece root plus every ancestor piece root that instantiated it
+   * (`SchedulerObservationIdentity.demandRootIds`, Phase 7 — a nested
+   * piece is demanded through the outer piece the client watches).
+   * Undefined everywhere except a serving runtime whose SpaceServer
+   * installed a resolver — the OFF arm and client speculation pay one
+   * undefined check. The scheduler runs the action once per returned
+   * instance (instances live in keys/basis/stamps, never as extra graph
+   * nodes — C11b); an empty return keeps the single wave-identity run.
    */
   serverRunInstancesFor(
-    pieceRootId: string,
+    pieceRootIds: readonly string[],
   ): readonly ServerRunInstance[] | undefined {
-    return this.#serverRunInstanceResolver?.(pieceRootId);
+    return this.#serverRunInstanceResolver?.(pieceRootIds);
   }
 
   /**

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -654,6 +654,11 @@ export class Scheduler {
       ...(identity.pieceRootId !== undefined
         ? { pieceRootId: identity.pieceRootId }
         : {}),
+      // Phase 7: the ancestor chain the run supply resolves a nested
+      // piece's demanded instances through (scheduler/types.ts).
+      ...(identity.demandRootIds !== undefined
+        ? { demandRootIds: identity.demandRootIds }
+        : {}),
     };
   }
 

--- a/packages/runner/src/scheduler/run.ts
+++ b/packages/runner/src/scheduler/run.ts
@@ -386,10 +386,18 @@ export async function runSchedulerAction(
   // recomputes converge). Everywhere else (`serverRunInstancesFor`
   // undefined or empty) this is exactly the old single
   // wave-identity run.
-  const pieceRootId = (action as Partial<TelemetryAnnotations>)
-    .schedulerObservationIdentity?.pieceRootId;
-  const demandedInstances = pieceRootId !== undefined
-    ? state.runtime.serverRunInstancesFor(pieceRootId)
+  // The demand roots: the action's own piece root plus its ancestor
+  // chain (Phase 7 — a nested piece's instances resolve through the
+  // outer piece the client watches; see
+  // SchedulerObservationIdentity.demandRootIds).
+  const observationIdentity = (action as Partial<TelemetryAnnotations>)
+    .schedulerObservationIdentity;
+  const demandRootIds = observationIdentity?.demandRootIds ??
+    (observationIdentity?.pieceRootId !== undefined
+      ? [observationIdentity.pieceRootId]
+      : undefined);
+  const demandedInstances = demandRootIds !== undefined
+    ? state.runtime.serverRunInstancesFor(demandRootIds)
     : undefined;
   const runs: readonly (ServerRunInstance | undefined)[] =
     demandedInstances !== undefined && demandedInstances.length > 0

--- a/packages/runner/src/scheduler/types.ts
+++ b/packages/runner/src/scheduler/types.ts
@@ -33,6 +33,18 @@ export interface SchedulerObservationIdentity {
    * demanded instances through this id at the reactive-action choke
    * point. */
   pieceRootId?: string;
+  /** The DEMAND roots this action's instances resolve through (Phase 7):
+   * `pieceRootId` plus every ANCESTOR piece root that instantiated it —
+   * a nested pattern node's or a result-as-pattern child's actions are
+   * demanded through the outer piece the client actually watches, so
+   * the run supply resolves their instances at any root in the chain
+   * (dedupe per instance). Absent means `[pieceRootId]`. Pre-Phase-7 a
+   * nested piece's scoped derivations fell to the wave-level identity —
+   * the serving session's own — and landed in the SERVICE identity's
+   * instances, unread by any demander (the lunch-gate wall's last
+   * mechanism; protocol.md §2's S1: "there is no third source of run
+   * identity"). */
+  demandRootIds?: readonly string[];
 }
 
 export type Action = (tx: IExtendedStorageTransaction) => any;

--- a/packages/runner/src/storage/event-append-queue.ts
+++ b/packages/runner/src/storage/event-append-queue.ts
@@ -210,9 +210,26 @@ export class EventAppendQueue {
     this.#transact = options.transact;
     this.#nextLocalSeq = options.nextLocalSeq;
     this.#onRefused = options.onRefused;
-    this.#pacing = options.pacing === false
+    const pacing = options.pacing === false
       ? undefined
       : options.pacing ?? DEFAULT_EVENT_APPEND_PACING;
+    // A non-positive or non-finite rate/burst cannot pace (the deficit
+    // wait would never end); treat it as unpaced, loudly, rather than
+    // wedge the queue — the bound is a dial, never a trap.
+    if (
+      pacing !== undefined &&
+      !(Number.isFinite(pacing.ratePerSecond) && pacing.ratePerSecond > 0 &&
+        Number.isFinite(pacing.burst) && pacing.burst >= 1)
+    ) {
+      logger.warn("event-queue-pacing-invalid", () => [
+        `event queue pacing for ${options.space} is invalid ` +
+        `(ratePerSecond=${pacing.ratePerSecond}, burst=${pacing.burst}); ` +
+        "running UNPACED",
+      ]);
+      this.#pacing = undefined;
+    } else {
+      this.#pacing = pacing;
+    }
     this.#loaded = this.#store.load(this.#space).then((persisted) => {
       // Intents a dead predecessor replica left in the manager-shared
       // store were fired EARLIER than anything this instance enqueues:

--- a/packages/runner/src/storage/event-append-queue.ts
+++ b/packages/runner/src/storage/event-append-queue.ts
@@ -42,8 +42,6 @@
 import { getLogger } from "@commonfabric/utils/logger";
 import {
   type ClientCommit,
-  decodeMemoryBoundary,
-  encodeMemoryBoundary,
   type EventAppendDecl,
   type StreamEventEntry,
   type StreamLinkRef,

--- a/packages/runner/src/storage/event-append-queue.ts
+++ b/packages/runner/src/storage/event-append-queue.ts
@@ -22,15 +22,22 @@
 // order is the spec's requirement; per-space serialization implies it
 // and keeps the machinery obvious.)
 //
-// Durability (LT9, RULED 2026-08-03): the queue rides an injectable
-// {@link EventAppendQueueStore} — "the same persistence class as
-// `sessionId`" (events.md §5, protocol.md §5). Protocol §5's
-// sessionId-persistence itself is unimplemented spec debt (today's
-// sessionId is process-lifetime), so the DEFAULT store is in-memory —
-// the same class — and a host that persists sessions supplies a durable
-// store through the same seam. The contract tests drive a durable fake
-// across queue instances; the browser adapter lands with the sessionId
-// persistence work it depends on.
+// Persistence class (LT9, RE-RULED 2026-08-15 — owner): the queue is
+// PROCESS-LIFETIME. Queued-but-undischarged intents surviving a client
+// RELOAD is a NON-GOAL this round — in the owner's words, the status quo
+// does not survive a client + server reload either — so the queue rides
+// an injectable {@link EventAppendQueueStore} whose ONE shipped
+// implementation is in-memory and MANAGER-SHARED: it outlives any single
+// SpaceReplica, so an in-process provisional-replica REPLACEMENT hands
+// the successor queue the predecessor's undischarged intents (that
+// in-process loss is machinery loss, not reload loss, and stays fixed).
+// The durable Web-Storage adapter and the reload self-start path that
+// Phase 3 carried for the earlier "durable" ruling are RETIRED with the
+// re-ruling; the recorded future shape, if reload survival is ever
+// wanted, is per-tab persistence + orphan adoption (verification-
+// coverage.md's closed OW20 row). Sessions are per tab: one writer per
+// session by construction, no leader election, no shared persisted
+// session.
 
 import { getLogger } from "@commonfabric/utils/logger";
 import {
@@ -68,14 +75,17 @@ export type EventAppendOutcome =
   | { delivered: true; deduped?: boolean }
   | { delivered: false; refused: string };
 
-/** The LT9 persistence seam. Both methods are best-effort from the
- * queue's view — a failing store degrades durability, never liveness. */
+/** The persistence seam (LT9, process-lifetime — see the header). Both
+ * methods are best-effort from the queue's view — a failing store
+ * degrades replacement survival, never liveness. */
 export interface EventAppendQueueStore {
   load(space: string): Promise<QueuedEventAppend[]>;
   save(space: string, entries: readonly QueuedEventAppend[]): Promise<void>;
 }
 
-/** An in-memory store: the default persistence class (see header). */
+/** The in-memory store: the ONE shipped implementation. The storage
+ * manager holds one per manager (shared across its replicas), which is
+ * what carries a dead predecessor replica's intents to its successor. */
 export const memoryEventAppendQueueStore = (): EventAppendQueueStore => {
   const bySpace = new Map<string, QueuedEventAppend[]>();
   return {
@@ -87,67 +97,43 @@ export const memoryEventAppendQueueStore = (): EventAppendQueueStore => {
   };
 };
 
-/** The subset of the Web Storage API the adapter needs (structural, so
- * hosts can hand in localStorage, sessionStorage, or a shim). */
-export type WebStorageLike = {
-  getItem(key: string): string | null;
-  setItem(key: string, value: string): void;
-  removeItem(key: string): void;
-};
-
-/**
- * A Web-Storage-backed durable store (LT9; verdict blocker,
- * 2026-08-12): reload keeps queued-but-undischarged user intents.
- * Serialized through the memory boundary codec — the SAME encoding the
- * wire uses — so FabricValue payloads (registry symbols included)
- * round-trip with fidelity. `scope` partitions concurrent principals /
- * managers sharing one origin (pass something identity-derived).
- *
- * Hosts wire this through `Options.eventAppendQueueStore` wherever a
- * Storage API exists (browser main thread; Deno with --location). The
- * WORKER-hosted runtime has no Web Storage — its durable adapter is
- * the flagged OW20 follow-up (IndexedDB or a main-thread bridge).
- */
-export const webStorageEventAppendQueueStore = (
-  storage: WebStorageLike,
-  scope: string,
-): EventAppendQueueStore => {
-  const keyOf = (space: string) => `cf:event-append-queue:${scope}:${space}`;
-  return {
-    load: (space) => {
-      try {
-        const raw = storage.getItem(keyOf(space));
-        if (raw === null) return Promise.resolve([]);
-        const decoded = decodeMemoryBoundary(raw);
-        return Promise.resolve(
-          Array.isArray(decoded)
-            ? decoded as unknown as QueuedEventAppend[]
-            : [],
-        );
-      } catch (error) {
-        return Promise.reject(error);
-      }
-    },
-    save: (space, entries) => {
-      try {
-        if (entries.length === 0) {
-          storage.removeItem(keyOf(space));
-        } else {
-          storage.setItem(
-            keyOf(space),
-            encodeMemoryBoundary(entries as unknown as FabricValue),
-          );
-        }
-        return Promise.resolve();
-      } catch (error) {
-        return Promise.reject(error);
-      }
-    },
-  };
-};
-
 const RETRY_BASE_MS = 250;
 const RETRY_CAP_MS = 10_000;
+
+/**
+ * OW27 — event-flood shaping (README §3.8; RULED (a) by the owner
+ * 2026-08-15): the client's send path PACES per stream and never drops.
+ * A per-stream token bucket sits between the queue head and the wire:
+ * `burst` sends pass immediately, sustained sends drain at
+ * `ratePerSecond`, and a flood (key-repeat driving `stream.send()`)
+ * is HELD, in fired order, never coalesced and never dropped — events
+ * are intent, and dropping loses it. Because the queue discharges one
+ * append at a time in fired order (events.md §5), a paced head holds
+ * everything behind it, streams included: cross-stream head-of-line
+ * hold is the accepted cost of keeping fired order exact.
+ *
+ * The bound this imposes on the flooding user's OWN legitimate rapid
+ * interactions is the dial: with N sends queued past the burst the
+ * newest waits ≈ (N − burst) / ratePerSecond seconds. The default —
+ * 20/s sustained, 20 burst — is a starting posture, FLAGGED for the
+ * owner (Phase 7): a person's deliberate clicks never reach it, a
+ * held key (≈30 Hz auto-repeat) is paced to 20 commits/s and clears
+ * within half a second of release. `false` disables pacing (tests;
+ * the OFF arm never constructs this queue).
+ */
+export type EventAppendPacing = {
+  /** Sustained sends per second, per stream. */
+  ratePerSecond: number;
+  /** Bucket capacity: sends that pass immediately after a quiet spell. */
+  burst: number;
+  /** Clock seam (tests). Defaults to `Date.now`. */
+  now?: () => number;
+};
+
+export const DEFAULT_EVENT_APPEND_PACING: Readonly<EventAppendPacing> = {
+  ratePerSecond: 20,
+  burst: 20,
+};
 
 /** Wire-error names that classify a discharge outcome. Everything not
  * named here is treated as TRANSIENT and retried with backoff — the
@@ -194,6 +180,12 @@ export class EventAppendQueue {
    * settle it (clearing the timer alone would leave the loop's await
    * pending forever, wedging dispose-time sanitizers). */
   #retryRelease: (() => void) | undefined;
+  /** OW27 pacing: the per-stream token buckets (keyed by sidecar doc id
+   * — one per stream), or undefined when pacing is disabled. */
+  readonly #pacing: EventAppendPacing | undefined;
+  readonly #buckets = new Map<string, { tokens: number; refilledAt: number }>();
+  /** DIAGNOSTIC (tests): sends held by pacing so far. */
+  #pacedHolds = 0;
   #loaded: Promise<void>;
   /** The tail of the save chain — `persisted` awaits it (tests, and
    * any caller that must observe durability before proceeding). */
@@ -211,15 +203,22 @@ export class EventAppendQueue {
     nextLocalSeq: () => number;
     store?: EventAppendQueueStore;
     onRefused?: (append: QueuedEventAppend, reason: string) => void;
+    /** OW27 per-stream send pacing; absent = the default posture,
+     * `false` = unpaced. */
+    pacing?: EventAppendPacing | false;
   }) {
     this.#space = options.space;
     this.#store = options.store ?? memoryEventAppendQueueStore();
     this.#transact = options.transact;
     this.#nextLocalSeq = options.nextLocalSeq;
     this.#onRefused = options.onRefused;
+    this.#pacing = options.pacing === false
+      ? undefined
+      : options.pacing ?? DEFAULT_EVENT_APPEND_PACING;
     this.#loaded = this.#store.load(this.#space).then((persisted) => {
-      // Persisted intents fired EARLIER than anything this instance
-      // enqueues (they survived a reload): they discharge first.
+      // Intents a dead predecessor replica left in the manager-shared
+      // store were fired EARLIER than anything this instance enqueues:
+      // they discharge first.
       this.#queue.unshift(...persisted);
       for (const entry of persisted) {
         if (entry.clientSeq >= this.#clientSeq) {
@@ -230,7 +229,7 @@ export class EventAppendQueue {
     }).catch((error) => {
       logger.warn("event-queue-load-failed", () => [
         `event queue load for ${this.#space} failed; queued intents ` +
-        "from a previous session (if any) are not recovered",
+        "from a replaced predecessor replica (if any) are not recovered",
         error,
       ]);
     });
@@ -239,6 +238,11 @@ export class EventAppendQueue {
   /** Live entries (pending discharge), fired order. */
   get pending(): readonly QueuedEventAppend[] {
     return this.#queue;
+  }
+
+  /** DIAGNOSTIC (tests): how many sends OW27 pacing has held so far. */
+  get pacedHoldCount(): number {
+    return this.#pacedHolds;
   }
 
   /** Resolves once the persisted backlog (if any) has been loaded. */
@@ -331,8 +335,8 @@ export class EventAppendQueue {
       .then(() => this.#store.save(this.#space, this.#queue))
       .catch((error) => {
         logger.warn("event-queue-save-failed", () => [
-          `event queue save for ${this.#space} failed; a reload before ` +
-          "delivery may lose the queued intent (LT9 durability degraded)",
+          `event queue save for ${this.#space} failed; a replica ` +
+          "replacement before delivery may lose the queued intent",
           error,
         ]);
       });
@@ -348,12 +352,71 @@ export class EventAppendQueue {
     });
   }
 
+  /**
+   * OW27: wait for the head's stream to have a send token. Refills the
+   * stream's bucket from the elapsed time (capped at `burst`), consumes
+   * one token when available, else sleeps for the deficit — a closable
+   * wait on the same release seam as the retry backoff, so close()
+   * settles it. Never reorders: the head is the only send considered.
+   */
+  async #acquireSendToken(streamKey: string): Promise<void> {
+    const pacing = this.#pacing;
+    if (pacing === undefined) return;
+    const now = pacing.now ?? Date.now;
+    for (;;) {
+      if (this.#closed) return;
+      const at = now();
+      let bucket = this.#buckets.get(streamKey);
+      if (bucket === undefined) {
+        bucket = { tokens: pacing.burst, refilledAt: at };
+        this.#buckets.set(streamKey, bucket);
+      } else {
+        const elapsedS = Math.max(0, at - bucket.refilledAt) / 1000;
+        bucket.tokens = Math.min(
+          pacing.burst,
+          bucket.tokens + elapsedS * pacing.ratePerSecond,
+        );
+        bucket.refilledAt = at;
+      }
+      if (bucket.tokens >= 1) {
+        bucket.tokens -= 1;
+        // Housekeeping: a quiet stream's bucket refills to full and can
+        // be forgotten (a fresh bucket starts full).
+        if (this.#buckets.size > 64) {
+          for (const [key, other] of this.#buckets) {
+            if (key !== streamKey && other.tokens >= pacing.burst) {
+              this.#buckets.delete(key);
+            }
+          }
+        }
+        return;
+      }
+      this.#pacedHolds += 1;
+      const deficitMs = Math.max(
+        1,
+        Math.ceil(((1 - bucket.tokens) / pacing.ratePerSecond) * 1000),
+      );
+      await new Promise<void>((resolve) => {
+        this.#retryRelease = resolve;
+        this.#retryTimer = setTimeout(() => {
+          this.#retryTimer = undefined;
+          this.#retryRelease = undefined;
+          resolve();
+        }, deficitMs);
+      });
+    }
+  }
+
   async #drain(): Promise<void> {
     await this.#loaded;
     let attempt = 0;
     while (this.#queue.length > 0 && !this.#closed) {
       const head = this.#queue[0];
       try {
+        // OW27: pace per stream before the send (pace-never-drop; the
+        // head holds everything behind it in fired order).
+        await this.#acquireSendToken(head.sidecarId);
+        if (this.#closed) break;
         await this.#transact(this.#commitFor(head));
         this.#settle(head, { delivered: true });
         attempt = 0;

--- a/packages/runner/src/storage/event-append-queue.ts
+++ b/packages/runner/src/storage/event-append-queue.ts
@@ -17,10 +17,17 @@
 // treats it as delivered rather than re-raising forever (events.md §5's
 // duplicate-submission rule).
 //
-// Ordering: strictly one in-flight append per space, in fired order —
-// events.md §5's "discharge on reconnect in fired order". (Per-stream
-// order is the spec's requirement; per-space serialization implies it
-// and keeps the machinery obvious.)
+// Ordering: strictly one in-flight append per space, PER-STREAM fired
+// order — events.md §5's "discharge on reconnect in fired order" is the
+// per-stream requirement (a stream's sidecar carries that stream's
+// entries; nothing on the wire orders one stream against another).
+// Unpaced, the queue sends the fired-order head, which serializes the
+// whole space in fired order as a consequence. Under OW27 pacing the
+// next send is the earliest-fired entry whose STREAM has a token: a
+// paced stream holds only its own later sends, never an unrelated
+// stream's (no cross-stream head-of-line hold — the P7 review's
+// finding 5, ruled per-stream independence), and one in-flight append
+// per space still holds.
 //
 // Persistence class (LT9, RE-RULED 2026-08-15 — owner): the queue is
 // PROCESS-LIFETIME. Queued-but-undischarged intents surviving a client
@@ -104,11 +111,14 @@ const RETRY_CAP_MS = 10_000;
  * A per-stream token bucket sits between the queue head and the wire:
  * `burst` sends pass immediately, sustained sends drain at
  * `ratePerSecond`, and a flood (key-repeat driving `stream.send()`)
- * is HELD, in fired order, never coalesced and never dropped — events
- * are intent, and dropping loses it. Because the queue discharges one
- * append at a time in fired order (events.md §5), a paced head holds
- * everything behind it, streams included: cross-stream head-of-line
- * hold is the accepted cost of keeping fired order exact.
+ * is HELD, in that stream's fired order, never coalesced and never
+ * dropped — events are intent, and dropping loses it. Streams are
+ * INDEPENDENT: the buckets are per stream and so is the hold — the
+ * drain sends the earliest-fired entry whose stream has a token, so a
+ * paced stream never holds an unrelated stream's sends (no cross-stream
+ * head-of-line hold; ruled with the P7 review's finding 5) while each
+ * stream's own fired order stays exact (its entries share one bucket
+ * and are scanned in fired order).
  *
  * The bound this imposes on the flooding user's OWN legitimate rapid
  * interactions is the dial: with N sends queued past the burst the
@@ -367,57 +377,84 @@ export class EventAppendQueue {
     });
   }
 
+  /** Refill `streamKey`'s bucket from the elapsed time (capped at
+   * `burst`) and report its token balance; a fresh bucket starts full. */
+  #refilledTokens(
+    pacing: EventAppendPacing,
+    streamKey: string,
+    at: number,
+  ): { tokens: number; refilledAt: number } {
+    let bucket = this.#buckets.get(streamKey);
+    if (bucket === undefined) {
+      bucket = { tokens: pacing.burst, refilledAt: at };
+      this.#buckets.set(streamKey, bucket);
+    } else {
+      const elapsedS = Math.max(0, at - bucket.refilledAt) / 1000;
+      bucket.tokens = Math.min(
+        pacing.burst,
+        bucket.tokens + elapsedS * pacing.ratePerSecond,
+      );
+      bucket.refilledAt = at;
+    }
+    return bucket;
+  }
+
   /**
-   * OW27: wait for the head's stream to have a send token. Refills the
-   * stream's bucket from the elapsed time (capped at `burst`), consumes
-   * one token when available, else sleeps for the deficit — a closable
-   * wait on the same release seam as the retry backoff, so close()
-   * settles it. Never reorders: the head is the only send considered.
+   * OW27: the next entry to send — the EARLIEST-FIRED queued entry whose
+   * stream has a send token now, that token consumed. Streams are
+   * independent: an entry whose stream's bucket is empty is skipped for
+   * this pass (and so is every later entry of the same stream — they
+   * share the bucket, which is what keeps a stream's own fired order
+   * exact), and an unrelated stream's entry behind it sends. When no
+   * queued stream has a token the loop sleeps for the smallest deficit —
+   * a closable wait on the same release seam as the retry backoff, so
+   * close() settles it — and re-scans. Unpaced: the fired-order head.
+   * Undefined only once closed (or the queue emptied under it).
    */
-  async #acquireSendToken(streamKey: string): Promise<void> {
+  async #nextSendable(): Promise<QueuedEventAppend | undefined> {
     const pacing = this.#pacing;
-    if (pacing === undefined) return;
-    const now = pacing.now ?? Date.now;
     for (;;) {
-      if (this.#closed) return;
+      if (this.#closed || this.#queue.length === 0) return undefined;
+      if (pacing === undefined) return this.#queue[0];
+      const now = pacing.now ?? Date.now;
       const at = now();
-      let bucket = this.#buckets.get(streamKey);
-      if (bucket === undefined) {
-        bucket = { tokens: pacing.burst, refilledAt: at };
-        this.#buckets.set(streamKey, bucket);
-      } else {
-        const elapsedS = Math.max(0, at - bucket.refilledAt) / 1000;
-        bucket.tokens = Math.min(
-          pacing.burst,
-          bucket.tokens + elapsedS * pacing.ratePerSecond,
-        );
-        bucket.refilledAt = at;
-      }
-      if (bucket.tokens >= 1) {
-        bucket.tokens -= 1;
-        // Housekeeping: a quiet stream's bucket refills to full and can
-        // be forgotten (a fresh bucket starts full).
-        if (this.#buckets.size > 64) {
-          for (const [key, other] of this.#buckets) {
-            if (key !== streamKey && other.tokens >= pacing.burst) {
-              this.#buckets.delete(key);
+      const held = new Set<string>();
+      let minDeficitMs = Infinity;
+      for (const entry of this.#queue) {
+        const streamKey = entry.sidecarId;
+        if (held.has(streamKey)) continue;
+        const bucket = this.#refilledTokens(pacing, streamKey, at);
+        if (bucket.tokens >= 1) {
+          bucket.tokens -= 1;
+          // Housekeeping: a quiet stream's bucket refills to full and
+          // can be forgotten (a fresh bucket starts full).
+          if (this.#buckets.size > 64) {
+            for (const [key, other] of this.#buckets) {
+              if (key !== streamKey && other.tokens >= pacing.burst) {
+                this.#buckets.delete(key);
+              }
             }
           }
+          return entry;
         }
-        return;
+        held.add(streamKey);
+        minDeficitMs = Math.min(
+          minDeficitMs,
+          Math.max(
+            1,
+            Math.ceil(((1 - bucket.tokens) / pacing.ratePerSecond) * 1000),
+          ),
+        );
       }
+      // Every queued stream is paced: hold until the earliest refill.
       this.#pacedHolds += 1;
-      const deficitMs = Math.max(
-        1,
-        Math.ceil(((1 - bucket.tokens) / pacing.ratePerSecond) * 1000),
-      );
       await new Promise<void>((resolve) => {
         this.#retryRelease = resolve;
         this.#retryTimer = setTimeout(() => {
           this.#retryTimer = undefined;
           this.#retryRelease = undefined;
           resolve();
-        }, deficitMs);
+        }, Number.isFinite(minDeficitMs) ? minDeficitMs : 1);
       });
     }
   }
@@ -426,14 +463,13 @@ export class EventAppendQueue {
     await this.#loaded;
     let attempt = 0;
     while (this.#queue.length > 0 && !this.#closed) {
-      const head = this.#queue[0];
+      // OW27: pace per stream before the send (pace-never-drop; a paced
+      // stream holds only its own later sends — see #nextSendable).
+      const next = await this.#nextSendable();
+      if (next === undefined || this.#closed) break;
       try {
-        // OW27: pace per stream before the send (pace-never-drop; the
-        // head holds everything behind it in fired order).
-        await this.#acquireSendToken(head.sidecarId);
-        if (this.#closed) break;
-        await this.#transact(this.#commitFor(head));
-        this.#settle(head, { delivered: true });
+        await this.#transact(this.#commitFor(next));
+        this.#settle(next, { delivered: true });
         attempt = 0;
       } catch (error) {
         const name = (error as { name?: string })?.name ?? "";
@@ -441,24 +477,27 @@ export class EventAppendQueue {
         if (name === "EventAppendDuplicateError") {
           // The first append landed; its consequences are (or will be)
           // the authoritative outcome (events.md §5).
-          this.#settle(head, { delivered: true, deduped: true });
+          this.#settle(next, { delivered: true, deduped: true });
           attempt = 0;
           continue;
         }
         if (REFUSED_ERROR_NAMES.has(name)) {
           logger.warn("event-append-refused", () => [
-            `event append ${head.eventId} refused deterministically; ` +
+            `event append ${next.eventId} refused deterministically; ` +
             "dropped from the queue",
             { name, message },
           ]);
-          this.#settle(head, { delivered: false, refused: message });
-          this.#onRefused?.(head, message);
+          this.#settle(next, { delivered: false, refused: message });
+          this.#onRefused?.(next, message);
           attempt = 0;
           continue;
         }
         // Transient (transport death, session replacement, handshake
-        // in progress): keep the head queued and retry with backoff.
-        // Delivery order holds — nothing behind the head sends first.
+        // in progress): keep the entry queued in place and retry with
+        // backoff. Its stream's delivery order holds — nothing of that
+        // stream behind it sends first (it stays the earliest-fired
+        // entry of its stream, and a token spent on a failed attempt
+        // is one token per WIRE attempt).
         attempt += 1;
         const delay = Math.min(
           RETRY_BASE_MS * 2 ** Math.min(attempt - 1, 10),

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -87,6 +87,7 @@ import type {
 import { SelectorTracker } from "./selector-tracker.ts";
 import {
   type EventAppendOutcome,
+  type EventAppendPacing,
   EventAppendQueue,
   type EventAppendQueueStore,
   memoryEventAppendQueueStore,
@@ -540,13 +541,19 @@ export interface Options {
   /** Space authority used only for fresh named-space ACL genesis. The durable
    *  replica session still authenticates as `as`. */
   spaceIdentity?: Signer;
-  /** The LT9 event-intent persistence seam (server-execution v2 Phase 3;
-   *  events.md §5): where each space's queued-but-undelivered event
-   *  appends live across manager lifetimes. Absent = in-memory (the
-   *  same persistence class as `sessionId` today — protocol.md §5's
-   *  sessionId persistence is itself unbuilt; a host that persists
-   *  sessions supplies a durable store through this seam). */
+  /** The event-intent queue's store seam (server-execution v2 Phase 3;
+   *  events.md §5; LT9 re-ruled 2026-08-15: PROCESS-LIFETIME — reload
+   *  survival is a non-goal this round). Absent = one in-memory store per
+   *  manager, shared across its replicas, so an in-process replica
+   *  replacement carries the predecessor's undischarged intents to the
+   *  successor. Tests inject their own to observe or fail the store. */
   eventAppendQueueStore?: EventAppendQueueStore;
+  /** OW27 (server-execution v2 Phase 7): the client event-append queue's
+   *  per-stream send pacing — pace-never-drop, README §3.8. Absent = the
+   *  default posture (`DEFAULT_EVENT_APPEND_PACING`); `false` = unpaced.
+   *  Lives only in the flag-gated append path (the OFF arm never
+   *  constructs the queue). */
+  eventAppendPacing?: EventAppendPacing | false;
   /** Server-execution v2 Phase 5: declares this manager a SERVING
    *  manager whose home space is `servingHomeSpace`. Providers opened
    *  for OTHER spaces refuse scoped (user/session) reads fail-closed
@@ -785,6 +792,7 @@ export class StorageManager implements IStorageManager {
   #pendingCommitsSubscribers = new Set<(pending: boolean) => void>();
   #sessionFactory: SessionFactory;
   #eventAppendQueueStore?: EventAppendQueueStore;
+  #eventAppendPacing?: EventAppendPacing | false;
   /** Phase 5: the serving manager's home space (Options.servingHomeSpace). */
   #servingHomeSpace?: MemorySpace;
   #spaceIdentities = new Map<MemorySpace, Signer>();
@@ -840,14 +848,15 @@ export class StorageManager implements IStorageManager {
     this.as = options.as;
     this.#settings = options.settings ?? {};
     this.#sessionFactory = sessionFactory;
-    // ONE store per manager even in the in-memory default (verdict
-    // blocker, 2026-08-12 / LT9): the store must outlive any single
-    // SpaceReplica, or a provisional-replica replacement hands the new
-    // queue a FRESH private store and the old queue's undischarged user
-    // intents vanish in-process. A host that persists sessions supplies
-    // a durable adapter through the same seam (see Options).
+    // ONE store per manager (verdict blocker, 2026-08-12 / LT9): the
+    // store must outlive any single SpaceReplica, or a provisional-replica
+    // replacement hands the new queue a FRESH private store and the old
+    // queue's undischarged user intents vanish in-process. That is the
+    // one persistence class the queue has (process-lifetime; LT9
+    // re-ruled 2026-08-15 — see event-append-queue.ts).
     this.#eventAppendQueueStore = options.eventAppendQueueStore ??
       memoryEventAppendQueueStore();
+    this.#eventAppendPacing = options.eventAppendPacing;
     this.#servingHomeSpace = options.servingHomeSpace;
     if (options.spaceIdentity) {
       this.registerSpaceIdentity(options.spaceIdentity);
@@ -1000,6 +1009,7 @@ export class StorageManager implements IStorageManager {
           this.syncCfcSchemaDocument(space, document),
         getTelemetry: () => this.#telemetry,
         eventAppendQueueStore: this.#eventAppendQueueStore,
+        eventAppendPacing: this.#eventAppendPacing,
       });
       this.#providers.set(space, provider);
     }
@@ -1771,6 +1781,8 @@ type ProviderOptions = {
   getTelemetry?: () => TelemetrySink | undefined;
   /** The LT9 event-intent persistence seam (see Options). */
   eventAppendQueueStore?: EventAppendQueueStore;
+  /** OW27 per-stream send pacing (see Options). */
+  eventAppendPacing?: EventAppendPacing | false;
   /** Server-execution v2 Phase 5 (protocol.md §2's grant-scoped read
    * design, RULED 2026-08-13 — the delegated-scoped-read fail-closed
    * precondition): set on a SERVING manager's FOREIGN-space providers.
@@ -2162,6 +2174,7 @@ class SpaceReplica implements ISpaceReplica {
    * offline event queue. */
   #eventAppendQueue?: EventAppendQueue;
   #eventAppendQueueStore?: EventAppendQueueStore;
+  #eventAppendPacing?: EventAppendPacing | false;
   /** Phase 5's producer-side foreign-scoped-read refusal (see
    * ProviderOptions.refuseForeignScopedReads). */
   #refuseForeignScopedReads = false;
@@ -2291,13 +2304,13 @@ class SpaceReplica implements ISpaceReplica {
     this.#routeState = options.routeState;
     this.#routeGeneration = options.routeGeneration;
     this.#eventAppendQueueStore = options.eventAppendQueueStore;
+    this.#eventAppendPacing = options.eventAppendPacing;
     this.#refuseForeignScopedReads = options.refuseForeignScopedReads === true;
-    // Eager queue init (LT9; verdict blocker, 2026-08-12): a persisted
-    // backlog — a dead predecessor's intents in the manager-shared
-    // store, or a durable adapter's reload survivors — must discharge
-    // WITHOUT waiting for a fresh fire. The constructor's load kicks
-    // the drain iff rows exist; an empty load is inert (no session is
-    // established until something discharges).
+    // Eager queue init (LT9; verdict blocker, 2026-08-12): a dead
+    // predecessor replica's intents in the manager-shared store must
+    // discharge WITHOUT waiting for a fresh fire. The constructor's
+    // load kicks the drain iff rows exist; an empty load is inert (no
+    // session is established until something discharges).
     this.#ensureEventAppendQueue();
   }
 
@@ -2652,6 +2665,7 @@ class SpaceReplica implements ISpaceReplica {
         // holds across event appends and ordinary commits alike.
         nextLocalSeq: () => this.#nextLocalSeq++,
         store: this.#eventAppendQueueStore,
+        pacing: this.#eventAppendPacing,
       });
     }
     return this.#eventAppendQueue;

--- a/packages/runner/test/event-append-client.test.ts
+++ b/packages/runner/test/event-append-client.test.ts
@@ -8,9 +8,10 @@
 //   `EventAppendDuplicateError` survives the wire for exactly this);
 //   deterministic refusals dropped loudly; transient failures retried
 //   with backoff, order preserved.
-// - LT9 durability rides the injectable store seam: a queue built over
-//   the same store as a dead predecessor discharges the predecessor's
-//   intents first, in their fired order.
+// - LT9 (process-lifetime, re-ruled 2026-08-15): a queue built over the
+//   same manager-shared store as a dead predecessor replica discharges
+//   the predecessor's intents first, in their fired order (in-process
+//   replacement survival — reload survival is a non-goal this round).
 // - the fire fork commits ONLY for OUTSIDE-the-scheduler sends (the
 //   root fire); a handler's cascade send during the echo commits
 //   NOTHING (the server's authoritative run owns the durable cascade).
@@ -29,7 +30,6 @@ import {
   type EventAppendQueueStore,
   memoryEventAppendQueueStore,
   type QueuedEventAppend,
-  webStorageEventAppendQueueStore,
 } from "../src/storage/event-append-queue.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
 
@@ -364,7 +364,9 @@ describe("event-append queue (events.md §5, LT9)", () => {
       space,
       transact: (commit: ClientCommit) => {
         const entry = ((commit.operations[0] as {
-          patches?: Array<{ values?: Array<{ firedAt?: { clientSeq?: number } }> }>;
+          patches?: Array<
+            { values?: Array<{ firedAt?: { clientSeq?: number } }> }
+          >;
         }).patches ?? [])[0]?.values?.[0];
         sent.push(entry?.firedAt?.clientSeq ?? -1);
         return Promise.resolve();
@@ -387,87 +389,123 @@ describe("event-append queue (events.md §5, LT9)", () => {
     expect(new Set(sent).size).toBe(3);
     queue.close();
   });
+});
 
-  it("webStorageEventAppendQueueStore round-trips FabricValue payloads (symbols included) through the memory boundary codec; an empty save clears the key", async () => {
-    const backing = new Map<string, string>();
-    const fakeStorage = {
-      getItem: (key: string) => backing.get(key) ?? null,
-      setItem: (key: string, value: string) => {
-        backing.set(key, value);
-      },
-      removeItem: (key: string) => {
-        backing.delete(key);
-      },
-    };
-    const store = webStorageEventAppendQueueStore(fakeStorage, "did:test:me");
-    const entries: QueuedEventAppend[] = [
-      { ...appendOf("evt-a"), clientSeq: 0 },
-      {
-        ...appendOf("evt-b"),
-        clientSeq: 1,
-        payload: { tag: Symbol.for("cf:test-tag"), n: 2 },
-      },
-    ];
-    await store.save(space, entries);
-    expect(backing.size).toBe(1);
-    const loaded = await store.load(space);
-    expect(loaded.length).toBe(2);
-    expect(loaded[0].eventId).toBe("evt-a");
-    expect(loaded[1].clientSeq).toBe(1);
-    expect((loaded[1].payload as { tag: symbol }).tag).toBe(
-      Symbol.for("cf:test-tag"),
-    );
-    // Scope partitions principals sharing one origin.
-    const other = webStorageEventAppendQueueStore(fakeStorage, "did:test:you");
-    expect((await other.load(space)).length).toBe(0);
-    // A drained queue clears its key (a queue that empties, LT9).
-    await store.save(space, []);
-    expect(backing.size).toBe(0);
-    expect((await store.load(space)).length).toBe(0);
-  });
+describe("OW27 event-flood shaping — per-stream pacing, pace-never-drop (README §3.8; RULED (a) 2026-08-15)", () => {
+  // A key-repeat flood: N sends on ONE stream in the same tick. The
+  // bucket lets `burst` through immediately and paces the rest at
+  // `ratePerSecond`; every send still commits, in fired order — no
+  // coalescing, no drop. Real clock (the file is on the real-clock list).
+  const floodOf = (n: number, stream = "flood") =>
+    Array.from({ length: n }, (_, i) => ({
+      ...appendOf(`evt-${stream}-${i}`),
+      sidecarId: `of:stream-events:${stream}`,
+    }));
 
-  it("a successor queue over a WEB-STORAGE store discharges a dead predecessor's intents with NO fresh fire (reload self-start; LT9)", async () => {
-    const backing = new Map<string, string>();
-    const fakeStorage = {
-      getItem: (key: string) => backing.get(key) ?? null,
-      setItem: (key: string, value: string) => {
-        backing.set(key, value);
-      },
-      removeItem: (key: string) => {
-        backing.delete(key);
-      },
-    };
-    const store = webStorageEventAppendQueueStore(fakeStorage, "did:test:me");
-    const dead = new EventAppendQueue({
-      space,
-      transact: () => Promise.reject(namedError("ConnectionError", "offline")),
-      nextLocalSeq: () => 1,
-      store,
-    });
-    void dead.enqueue(appendOf("evt-reload-1"));
-    await waitUntil(() => dead.pending.length === 1, "the intent to queue");
-    await dead.persisted;
-    dead.close();
-
-    const sent: string[] = [];
-    const revived = new EventAppendQueue({
+  it("bounds the commit rate of a flood WITHOUT losing or reordering a single intent", async () => {
+    const sentAt: Array<{ id: string; at: number }> = [];
+    const queue = new EventAppendQueue({
       space,
       transact: (commit: ClientCommit) => {
-        sent.push((commit.eventAppends ?? [])[0]?.eventId ?? "?");
+        sentAt.push({
+          id: (commit.eventAppends ?? [])[0]?.eventId ?? "?",
+          at: Date.now(),
+        });
         return Promise.resolve();
       },
       nextLocalSeq: (() => {
         let seq = 1;
         return () => seq++;
       })(),
-      store,
+      pacing: { ratePerSecond: 100, burst: 10 },
     });
-    // NO enqueue: the constructor's load must kick the discharge.
-    await waitUntil(() => sent.length === 1, "the reload self-start");
-    expect(sent).toEqual(["evt-reload-1"]);
-    await revived.persisted;
-    expect(backing.size).toBe(0);
-    revived.close();
+    const flood = floodOf(40);
+    const started = Date.now();
+    const outcomes = await Promise.all(
+      flood.map((entry) => queue.enqueue(entry)),
+    );
+    const elapsed = Date.now() - started;
+    // ZERO loss: every send delivered…
+    expect(outcomes.every((o) => o.delivered)).toBe(true);
+    // …in fired order…
+    expect(sentAt.map((s) => s.id)).toEqual(flood.map((e) => e.eventId));
+    // …at a BOUNDED rate: 10 pass on the burst, the remaining 30 drain at
+    // ≤100/s, so the flood takes ≥ ~300 ms and no 100 ms window carries
+    // more than burst + rate·window (+1 for boundary rounding).
+    expect(elapsed).toBeGreaterThanOrEqual(250);
+    let maxWindow = 0;
+    for (let i = 0; i < sentAt.length; i++) {
+      let count = 0;
+      for (
+        let j = i;
+        j < sentAt.length && sentAt[j].at - sentAt[i].at <= 100;
+        j++
+      ) {
+        count += 1;
+      }
+      maxWindow = Math.max(maxWindow, count);
+    }
+    expect(maxWindow).toBeLessThanOrEqual(21);
+    expect(queue.pacedHoldCount).toBeGreaterThanOrEqual(20);
+    queue.close();
+  });
+
+  it("MUTATION WITNESS: with pacing disabled the same flood is unbounded (every send in one tick)", async () => {
+    // Documents what the guard protects: `pacing: false` is the ablation
+    // the OW27 register row names — the OFF arm never constructs this
+    // queue, so this is the flag-gated path with its bound removed.
+    const sentAt: number[] = [];
+    const queue = new EventAppendQueue({
+      space,
+      transact: () => {
+        sentAt.push(Date.now());
+        return Promise.resolve();
+      },
+      nextLocalSeq: (() => {
+        let seq = 1;
+        return () => seq++;
+      })(),
+      pacing: false,
+    });
+    const started = Date.now();
+    await Promise.all(floodOf(40).map((entry) => queue.enqueue(entry)));
+    expect(sentAt.length).toBe(40);
+    expect(Date.now() - started).toBeLessThan(200);
+    expect(queue.pacedHoldCount).toBe(0);
+    queue.close();
+  });
+
+  it("close() during a pacing hold settles the held outcomes (no dispose-time wedge) and keeps the intents queued for a successor", async () => {
+    const store = memoryEventAppendQueueStore();
+    const queue = new EventAppendQueue({
+      space,
+      transact: () => Promise.resolve(),
+      nextLocalSeq: () => 1,
+      store,
+      // One send per second, burst 1: the second send is HELD.
+      pacing: { ratePerSecond: 1, burst: 1 },
+    });
+    // Same STREAM (pacing is per stream — a second stream would get its
+    // own fresh bucket).
+    const [holdOne, holdTwo] = floodOf(2, "hold");
+    const first = queue.enqueue(holdOne);
+    const second = queue.enqueue(holdTwo);
+    expect(await first).toEqual({ delivered: true });
+    await waitUntil(
+      () => queue.pacedHoldCount >= 1,
+      "the second send to be held",
+    );
+    queue.close();
+    expect(await second).toEqual({
+      delivered: false,
+      refused: "event queue closed",
+    });
+    await queue.persisted;
+    // The held intent is not lost: it stays persisted for the successor
+    // (closed is not refused — the same rule as the retry-backoff close).
+    expect((await store.load(space)).map((e) => e.eventId)).toEqual([
+      holdTwo.eventId,
+    ]);
   });
 });
 

--- a/packages/runner/test/event-append-client.test.ts
+++ b/packages/runner/test/event-append-client.test.ts
@@ -507,6 +507,64 @@ describe("OW27 event-flood shaping — per-stream pacing, pace-never-drop (READM
       holdTwo.eventId,
     ]);
   });
+
+  it("streams are INDEPENDENT: a paced head on stream A does not hold stream B (no cross-stream head-of-line hold), and each stream's own fired order stays exact", async () => {
+    // Adopted from the P7 independent review's cross-stream probe
+    // (finding 5) with the ruled semantics: pacing is PER STREAM (the
+    // buckets are keyed by sidecar), so a stream that has exhausted its
+    // burst holds only ITS OWN later sends — an unrelated stream with a
+    // token in its bucket sends now. Pre-fix the queue sent strictly the
+    // fired-order head, so b1 waited behind a2's ~500 ms hold; a
+    // "send the head only" mutation of #drain turns this red (b1 lands
+    // at ≥400 ms), and a "per-stream order lost" mutation turns the
+    // a1<a2 / b1<b2 assertions red.
+    const sent: Array<{ id: string; at: number }> = [];
+    const queue = new EventAppendQueue({
+      space,
+      transact: (commit: ClientCommit) => {
+        sent.push({
+          id: (commit.eventAppends ?? [])[0]?.eventId ?? "?",
+          at: Date.now(),
+        });
+        return Promise.resolve();
+      },
+      nextLocalSeq: (() => {
+        let seq = 1;
+        return () => seq++;
+      })(),
+      // burst 1, 2/s: a stream's second send is held ~500 ms.
+      pacing: { ratePerSecond: 2, burst: 1 },
+    });
+    const t0 = Date.now();
+    const [a1, a2, a3] = floodOf(3, "A");
+    const [b1, b2] = floodOf(2, "B");
+    // Fired order: a1, a2, b1, b2, a3.
+    const outcomes = await Promise.all([
+      queue.enqueue(a1),
+      queue.enqueue(a2),
+      queue.enqueue(b1),
+      queue.enqueue(b2),
+      queue.enqueue(a3),
+    ]);
+    expect(outcomes.every((o) => o.delivered)).toBe(true);
+    const at = (id: string) => sent.find((s) => s.id === id)!.at - t0;
+    const order = sent.map((s) => s.id);
+    // Within a stream fired order is exact.
+    expect(order.indexOf(a1.eventId)).toBeLessThan(order.indexOf(a2.eventId));
+    expect(order.indexOf(a2.eventId)).toBeLessThan(order.indexOf(a3.eventId));
+    expect(order.indexOf(b1.eventId)).toBeLessThan(order.indexOf(b2.eventId));
+    // b1 (B's burst) sends immediately, NOT behind a2's hold; b2 waits
+    // only on B's own bucket (~500 ms), never on A's.
+    expect(at(b1.eventId)).toBeLessThan(250);
+    expect(at(a2.eventId)).toBeGreaterThanOrEqual(400);
+    expect(at(b2.eventId)).toBeGreaterThanOrEqual(400);
+    // a3 waits for A's SECOND refill (~1 s), independent of B.
+    expect(at(a3.eventId)).toBeGreaterThanOrEqual(900);
+    expect(at(a3.eventId)).toBeLessThan(1500);
+    // Every intent still delivered — pace-never-drop holds across streams.
+    expect(sent.length).toBe(5);
+    queue.close();
+  });
 });
 
 describe("intent outcome consumption (events.md §5's client signal)", () => {

--- a/packages/runner/test/executor-run-supply.test.ts
+++ b/packages/runner/test/executor-run-supply.test.ts
@@ -97,8 +97,8 @@ describe("stage P2-F per-(action × instance) run supply", () => {
     const bobKey = resolveScopeKey("user", bob);
     runtime.installSealDestination(passThroughDestination(), {
       runStamper: recordingStamper,
-      runInstanceResolver: (pieceRootId) =>
-        pieceRootId === rootId
+      runInstanceResolver: (pieceRootIds) =>
+        pieceRootIds.includes(rootId)
           ? [
             { scopeKeyIdentity: alice, actionScopeKey: aliceKey },
             { scopeKeyIdentity: bob, actionScopeKey: bobKey },
@@ -176,6 +176,78 @@ describe("stage P2-F per-(action × instance) run supply", () => {
     );
     expect(derivationStamps.length).toBe(1);
     expect(derivationStamps[0].scopeKeyIdentity).toBeUndefined();
+  });
+
+  it("resolves a NESTED piece's instances through the OUTER root a client demands (Phase 7 demand-root chain): the child's actions run per demanded instance instead of falling to the service identity", async () => {
+    // The lunch-gate wall's last mechanism: a sub-pattern instantiated by
+    // function call gets its OWN result doc as `pieceRootId`, but a client
+    // demands the OUTER piece root — so pre-Phase-7 the child's scoped
+    // derivations ran with NO demanded identity, keyed under the serving
+    // session's (the SERVICE identity's) instances, unread by anyone. The
+    // chain (`demandRootIds`) resolves the child through its parent.
+    const aliceKey = resolveScopeKey("user", alice);
+    const bobKey = resolveScopeKey("user", bob);
+    const parentSource = [
+      "import { computed, pattern } from 'commonfabric';",
+      "const child = pattern<{ n: number }, { doubled: number }>(",
+      "  ({ n }) => ({ doubled: computed(() => n * 2) }),",
+      ");",
+      "export default pattern<{ n: number }, { out: number }>(({ n }) => {",
+      "  const c = child({ n });",
+      "  return { out: c.doubled };",
+      "});",
+      "",
+    ].join("\n");
+    const tx = runtime.edit();
+    const parentPattern = await runtime.patternManager.compilePattern(
+      programOf(parentSource),
+      { space, tx },
+    );
+    const parentCell = runtime.getCell<{ out?: number }>(
+      space,
+      "p2f-nested-parent",
+      undefined,
+      tx,
+    );
+    const parentRootId = parentCell.getAsNormalizedFullLink().id;
+    // The registry knows ONLY the outer root (what a browser watches):
+    // any resolution through the child's own root alone finds nothing.
+    runtime.installSealDestination(passThroughDestination(), {
+      runStamper: recordingStamper,
+      runInstanceResolver: (pieceRootIds) =>
+        pieceRootIds.includes(parentRootId)
+          ? [
+            { scopeKeyIdentity: alice, actionScopeKey: aliceKey },
+            { scopeKeyIdentity: bob, actionScopeKey: bobKey },
+          ]
+          : [],
+    });
+    const running = runtime.runner.run(
+      tx,
+      parentPattern,
+      { n: 21 },
+      parentCell,
+    );
+    expect((await tx.commit()).error).toBeUndefined();
+    await running.pull();
+    await runtime.idle();
+
+    // The child's `computed` ran ONCE PER demanded instance of the OUTER
+    // root, each run stamped with that instance's identity — never the
+    // wave-level (service) fallback.
+    const childRuns = stamped.filter((info) =>
+      info.kind === "derivation" && info.actionId.includes("__cfLift") ||
+      (info.kind === "derivation" && info.actionId.includes("computed"))
+    );
+    const identities = childRuns.map((info) =>
+      info.scopeKeyIdentity?.principal
+    );
+    expect(identities).toContain(alice.principal);
+    expect(identities).toContain(bob.principal);
+    expect(
+      childRuns.every((info) => info.scopeKeyIdentity !== undefined),
+    ).toBe(true);
+    runtime.runner.stop(parentCell);
   });
 
   it("hands the emitting run's identity to the dispatched handler run (LT6: events run as the session they originated from)", async () => {

--- a/packages/runner/test/executor-run-supply.test.ts
+++ b/packages/runner/test/executor-run-supply.test.ts
@@ -250,6 +250,167 @@ describe("stage P2-F per-(action × instance) run supply", () => {
     runtime.runner.stop(parentCell);
   });
 
+  /** The child derivation runs the stamper saw (`computed` lifts to a
+   * `__cfLift_*` derivation), with each run's demanded principal —
+   * undefined = the wave-level (service) fallback. */
+  const childDerivationPrincipals = (): (string | undefined)[] =>
+    stamped
+      .filter((info) =>
+        info.kind === "derivation" &&
+        (info.actionId.includes("__cfLift") ||
+          info.actionId.includes("computed"))
+      )
+      .map((info) => info.scopeKeyIdentity?.principal);
+
+  // Same class as the nested-pattern-node case above, through a different
+  // instantiation site: `builtins/map.ts`, `filter.ts` and `flatmap.ts`
+  // start each element's sub-piece with `runtime.runner.run` directly.
+  // Before this landed those calls carried no `parentPieceRootId`, so a
+  // list item's sub-piece ran its scoped derivations with NO demanded
+  // identity — the service fallback — while the parent's own `raw:map`
+  // action ran per instance (the P7 independent review's probe: alice=0
+  // bob=0 fallback=2). Any per-user state inside a list item's sub-piece
+  // was mis-keyed under the service identity — at cardinality 1 too.
+  const LIST_BUILTIN_CHILD_SOURCES: Record<
+    "map" | "filter" | "flatMap",
+    string
+  > = {
+    map: [
+      "export default pattern<{ items: number[] }, { out: { doubled: number }[] }>(({ items }) => {",
+      "  const out = items.map((n) => child({ n }));",
+      "  return { out };",
+      "});",
+    ].join("\n"),
+    filter: [
+      // The predicate reads the sub-piece's derived field directly (an
+      // expression around it would be lifted into a computed of the
+      // element piece and never instantiate the child).
+      "export default pattern<{ items: number[] }, { out: number[] }>(({ items }) => {",
+      "  const out = items.filter((n) => { const c = child({ n }); return c.keep; });",
+      "  return { out };",
+      "});",
+    ].join("\n"),
+    flatMap: [
+      "export default pattern<{ items: number[] }, { out: { doubled: number }[] }>(({ items }) => {",
+      "  const out = items.flatMap((n) => [child({ n })]);",
+      "  return { out };",
+      "});",
+    ].join("\n"),
+  };
+  for (
+    const builtin of Object.keys(LIST_BUILTIN_CHILD_SOURCES) as Array<
+      keyof typeof LIST_BUILTIN_CHILD_SOURCES
+    >
+  ) {
+    it(`carries the chain through the LIST builtins' child instantiation: a sub-piece a \`${builtin}\` callback starts resolves its instances through the OUTER demanded root (P7 review finding 4)`, async () => {
+      const aliceKey = resolveScopeKey("user", alice);
+      const bobKey = resolveScopeKey("user", bob);
+      const parentSource = [
+        "import { computed, pattern } from 'commonfabric';",
+        "const child = pattern<{ n: number }, { doubled: number; keep: boolean }>(",
+        "  ({ n }) => ({ doubled: computed(() => n * 2), keep: computed(() => n > 1) }),",
+        ");",
+        LIST_BUILTIN_CHILD_SOURCES[builtin],
+        "",
+      ].join("\n");
+      const tx = runtime.edit();
+      const parentPattern = await runtime.patternManager.compilePattern(
+        programOf(parentSource),
+        { space, tx },
+      );
+      const parentCell = runtime.getCell<{ out?: unknown }>(
+        space,
+        `p7-${builtin}-chain-parent`,
+        undefined,
+        tx,
+      );
+      const parentRootId = parentCell.getAsNormalizedFullLink().id;
+      // The registry knows ONLY the outer root (what a browser watches).
+      runtime.installSealDestination(passThroughDestination(), {
+        runStamper: recordingStamper,
+        runInstanceResolver: (pieceRootIds) =>
+          pieceRootIds.includes(parentRootId)
+            ? [
+              { scopeKeyIdentity: alice, actionScopeKey: aliceKey },
+              { scopeKeyIdentity: bob, actionScopeKey: bobKey },
+            ]
+            : [],
+      });
+      const running = runtime.runner.run(
+        tx,
+        parentPattern,
+        { items: [1, 2] },
+        parentCell,
+      );
+      expect((await tx.commit()).error).toBeUndefined();
+      await running.pull();
+      await runtime.idle();
+
+      const principals = childDerivationPrincipals();
+      expect(principals.length).toBeGreaterThan(0);
+      // Every element sub-piece's derivation ran per demanded instance of
+      // the OUTER root — alice and bob both present, no service fallback.
+      expect(principals).toContain(alice.principal);
+      expect(principals).toContain(bob.principal);
+      expect(principals.every((p) => p !== undefined)).toBe(true);
+      runtime.runner.stop(parentCell);
+    });
+  }
+
+  it("composes across two levels: a GRANDCHILD nested pattern node resolves through the outermost demanded root (the chain is transitive)", async () => {
+    // Pinned from the P7 independent review's second probe (it composed
+    // at head): a child of a child carries the whole ancestor chain, so
+    // demand on the outermost root reaches the grandchild's derivations.
+    const aliceKey = resolveScopeKey("user", alice);
+    const bobKey = resolveScopeKey("user", bob);
+    const src = [
+      "import { computed, pattern } from 'commonfabric';",
+      "const grandchild = pattern<{ n: number }, { tripled: number }>(",
+      "  ({ n }) => ({ tripled: computed(() => n * 3) }),",
+      ");",
+      "const child = pattern<{ n: number }, { g: { tripled: number } }>(",
+      "  ({ n }) => ({ g: grandchild({ n }) }),",
+      ");",
+      "export default pattern<{ n: number }, { out: number }>(({ n }) => {",
+      "  const c = child({ n });",
+      "  return { out: c.g.tripled };",
+      "});",
+      "",
+    ].join("\n");
+    const tx = runtime.edit();
+    const parentPattern = await runtime.patternManager.compilePattern(
+      programOf(src),
+      { space, tx },
+    );
+    const parentCell = runtime.getCell<{ out?: number }>(
+      space,
+      "p7-grandchild-parent",
+      undefined,
+      tx,
+    );
+    const parentRootId = parentCell.getAsNormalizedFullLink().id;
+    runtime.installSealDestination(passThroughDestination(), {
+      runStamper: recordingStamper,
+      runInstanceResolver: (pieceRootIds) =>
+        pieceRootIds.includes(parentRootId)
+          ? [
+            { scopeKeyIdentity: alice, actionScopeKey: aliceKey },
+            { scopeKeyIdentity: bob, actionScopeKey: bobKey },
+          ]
+          : [],
+    });
+    const running = runtime.runner.run(tx, parentPattern, { n: 5 }, parentCell);
+    expect((await tx.commit()).error).toBeUndefined();
+    await running.pull();
+    await runtime.idle();
+    const principals = childDerivationPrincipals();
+    expect(principals.length).toBeGreaterThan(0);
+    expect(principals).toContain(alice.principal);
+    expect(principals).toContain(bob.principal);
+    expect(principals.every((p) => p !== undefined)).toBe(true);
+    runtime.runner.stop(parentCell);
+  });
+
   it("hands the emitting run's identity to the dispatched handler run (LT6: events run as the session they originated from)", async () => {
     const aliceKey = resolveScopeKey("user", alice);
     runtime.installSealDestination(passThroughDestination(), {

--- a/packages/runner/test/runtime-presets.test.ts
+++ b/packages/runner/test/runtime-presets.test.ts
@@ -29,6 +29,8 @@ import { Runtime, signer, StorageManager } from "./engine-test-support.ts";
  *    dropped or mis-mapped.
  */
 
+import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
+
 type PresetName = keyof typeof runtimePresets;
 const PRESET_NAMES = Object.keys(runtimePresets) as PresetName[];
 
@@ -128,6 +130,18 @@ describe("runtimePresets conformance (CT-1814)", () => {
             if (key === "experimental" && preset === "unitTest") {
               // unitTest defaulted it; every other preset got the sentinel.
               expect(output.experimental).toEqual({});
+            } else if (
+              key === "experimental" &&
+              (preset === "productionServer" || preset === "remoteClient")
+            ) {
+              // The DEPLOYED-TOPOLOGY presets carry the sentinel PLUS the
+              // first-party server-execution default for an unset flag
+              // (server-execution v2 Phase 7's flip; the single-process
+              // presets keep the constructor default — the OFF baseline).
+              expect(output.experimental).toEqual({
+                ...experimental,
+                serverExecution: SERVER_EXECUTION_DEFAULT_ENABLED,
+              });
             } else {
               expect(output[key], context).toBe(
                 minimalCore[

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -14,7 +14,6 @@ import { PieceController, PiecesController } from "@commonfabric/piece/ops";
 import {
   assertServerExecutionPostureAgreement,
   browserWorkerParamsFromInitializationData,
-  resolveEventAppendQueuePersistence,
   renderConfidentialityResolverFor,
   renderMembershipProviderFor,
   RuntimeProcessor,
@@ -2998,27 +2997,6 @@ describe("worker/host server-execution posture agreement (review 2026-08-11 m7)"
         { experimental: { serverExecution: true } },
       )
     ).toThrow(/posture mismatch/);
-  });
-});
-
-describe("resolveEventAppendQueuePersistence", () => {
-  // The LT9 coupling seam (server-execution v2 Phase 5, rec (c) —
-  // adopted pending veto): the host DECLARES an event-append-queue
-  // persistence kind; the worker honors exactly the in-memory default
-  // in this build and refuses anything else LOUDLY — a durability
-  // declaration must never silently degrade to memory (events.md §5;
-  // the durable worker adapter is verification-coverage.md OW20's
-  // follow-up, landing with protocol §5's sessionId persistence).
-  it("honors absent and memory declarations as the in-memory default", () => {
-    expect(resolveEventAppendQueuePersistence(undefined)).toEqual({});
-    expect(resolveEventAppendQueuePersistence({ kind: "memory" })).toEqual({});
-  });
-
-  it("refuses a kind this build cannot honor, loudly (fail closed)", () => {
-    expect(() => resolveEventAppendQueuePersistence({ kind: "web-storage" }))
-      .toThrow(/not available in the worker runtime/);
-    expect(() => resolveEventAppendQueuePersistence({ kind: "indexeddb" }))
-      .toThrow(/OW20/);
   });
 });
 

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -231,37 +231,6 @@ function resolveBlobUrl(url: string, apiUrl: URL, space: DID): string {
  * that declares nothing and a worker that resolves OFF agree, which is
  * every pre-existing deployment. Exported for testing.
  */
-/**
- * The LT9 worker persistence seam (server-execution v2 Phase 5, rec (c)
- * — ADOPTED-PENDING-VETO; events.md §5, protocol.md §5). Maps the
- * host's DECLARED event-append-queue persistence onto the storage
- * manager's `eventAppendQueueStore` option — the one seam the durable
- * adapter will also ride when sessionId persistence lands (OW20).
- *
- * This build honors: absent, `{ kind: "memory" }` (both the in-memory
- * default — the same persistence class as `sessionId` today). Any other
- * kind REFUSES loudly: the worker realm has no Web Storage, the durable
- * worker adapter is the OW20 follow-up, and silently downgrading a
- * declared durability to memory would lose queued user intents a host
- * believed durable (LT9's ruled requirement). Exported for testing.
- */
-export function resolveEventAppendQueuePersistence(
-  declared: InitializationData["eventAppendQueuePersistence"],
-): Record<never, never> {
-  if (declared === undefined || declared.kind === "memory") {
-    // The manager's own default IS the memory store; declare nothing.
-    return {};
-  }
-  throw new Error(
-    `event-append-queue persistence kind "${declared.kind}" is not ` +
-      "available in the worker runtime: the durable worker adapter " +
-      "lands with protocol §5's sessionId persistence " +
-      "(verification-coverage.md OW20) — refusing initialization " +
-      "rather than silently degrading a durability declaration to " +
-      "memory (events.md §5, LT9)",
-  );
-}
-
 export function assertServerExecutionPostureAgreement(
   declared: InitializationData["experimental"],
   runtime: { experimental: { serverExecution?: boolean | undefined } },
@@ -631,16 +600,6 @@ export class RuntimeProcessor {
         experimentalConcurrentWatchRefresh:
           data.concurrentWatchRefresh === true,
       },
-      // The LT9 coupling seam (server-execution v2 Phase 5, rec (c) —
-      // adopted pending veto): the host's declared event-queue
-      // persistence routes through the SAME manager option the durable
-      // adapter will use when protocol §5's sessionId persistence lands
-      // (OW20). This build honors exactly the in-memory kind; an
-      // undeliverable declaration refuses initialization loudly rather
-      // than silently degrading a durability promise.
-      ...(resolveEventAppendQueuePersistence(
-        data.eventAppendQueuePersistence,
-      )),
     });
 
     // Mirror the durability barrier to the page: `pending` is true while any

--- a/packages/runtime-client/deno.jsonc
+++ b/packages/runtime-client/deno.jsonc
@@ -4,7 +4,7 @@
   "tasks": {
     // --no-check: this package is type-checked by `deno task check` (tasks/check.sh).
     "test": "deno test --no-check --allow-env --allow-read --allow-ffi *.test.ts backends/*.test.ts client/*.test.ts",
-    "integration": "LOG_LEVEL=warn deno test -A $INTEGRATION_TEST_FLAGS ./integration/*.test.ts"
+    "integration": "LOG_LEVEL=warn deno test -A $INTEGRATION_TEST_FLAGS \"./integration/*.test.ts\""
   },
   "exports": {
     ".": "./mod.ts",

--- a/packages/runtime-client/integration/client.test.ts
+++ b/packages/runtime-client/integration/client.test.ts
@@ -17,7 +17,9 @@ import {
   type RuntimeClientOptions,
   type VNode,
 } from "@commonfabric/runtime-client";
+import { experimentalOptionsFromEnv } from "@commonfabric/runner";
 import { rendererVDOMSchema } from "@commonfabric/runner/schemas";
+import { serverExecutionOnStepSkip } from "../../../tasks/server-execution-on-skips.ts";
 import { assertEquals, assertExists, assertRejects } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
 import { Program } from "@commonfabric/js-compiler";
@@ -35,6 +37,39 @@ const keyConfig: IdentityCreateConfig = {
 };
 
 const identity = await Identity.fromPassphrase("test operator", keyConfig);
+
+// The server-execution v2 posture this test process runs (testing.md §2):
+// declared from the environment — the CI ON lane sets
+// EXPERIMENTAL_SERVER_EXECUTION=true — so the worker below really runs the
+// ON client arm; unset = OFF (the first-party default while Phase 7 is
+// landed dark). An undeclared worker resolves OFF and made the ON lane a
+// MIXED posture (P7 review finding 7).
+const SERVER_EXECUTION_FROM_ENV = experimentalOptionsFromEnv(Deno.env.get)
+  .serverExecution;
+
+/**
+ * The ON arm's STEP-level skip guard (tasks/server-execution-on-skips.ts):
+ * a step listed there for this file is skipped ONLY when this process runs
+ * the ON posture, loudly (the entry's reason is printed), and only while
+ * the entry exists — the OFF arm and an unlisted step always run. Never a
+ * silent filter: the CI step prints every entry, and the validator
+ * requires this file to name each listed step and call this guard.
+ */
+function onArmStepSkip(step: string): { ignore: boolean } {
+  if (SERVER_EXECUTION_FROM_ENV !== true) return { ignore: false };
+  const entry = serverExecutionOnStepSkip(
+    "runtime-client",
+    "integration/client.test.ts",
+    step,
+  );
+  if (entry === undefined) return { ignore: false };
+  console.warn(
+    `[server-execution ON arm] runtime-client: SKIPPING STEP ${
+      JSON.stringify(step)
+    } (until ${entry.phase}) — ${entry.reason}`,
+  );
+  return { ignore: true };
+}
 
 const TEST_PROGRAM = `import { Cell, NAME, pattern, UI } from "commonfabric";
 export default pattern((_) => {
@@ -1005,8 +1040,14 @@ export default pattern<State>(({ value }) => {
       cancel();
     });
 
-    it("renders PerUser-derived computed JSX inside cf-screen header slot (CT-1606)", async () => {
-      const scopedHeaderPattern = `import {
+    it({
+      name:
+        "renders PerUser-derived computed JSX inside cf-screen header slot (CT-1606)",
+      ...onArmStepSkip(
+        "renders PerUser-derived computed JSX inside cf-screen header slot (CT-1606)",
+      ),
+      fn: async () => {
+        const scopedHeaderPattern = `import {
   computed,
   Default,
   NAME,
@@ -1049,57 +1090,58 @@ export default pattern<Input, Output>(({ question, myName }) => {
   };
 });`;
 
-      const scopedHeaderProgram: Program = {
-        main: "/main.tsx",
-        files: [{
-          name: "/main.tsx",
-          contents: scopedHeaderPattern,
-        }],
-      };
+        const scopedHeaderProgram: Program = {
+          main: "/main.tsx",
+          files: [{
+            name: "/main.tsx",
+            contents: scopedHeaderPattern,
+          }],
+        };
 
-      const session = await createTestSession();
-      await using rt = await createRuntimeClient(session);
+        const session = await createTestSession();
+        await using rt = await createRuntimeClient(session);
 
-      const page = await rt.createPage(scopedHeaderProgram, session.space, {
-        run: true,
-      });
-      const cell = page.cell() as CellHandle<VNode>;
-      const nameCell = (page.cell() as any).key("myName").asSchema({
-        type: "string",
-        scope: "user",
-      });
-      const mock = new MockDoc(
-        `<!DOCTYPE html><html><body><div id="root"></div></body></html>`,
-      );
-      const { document, renderOptions } = mock;
-      const root = document.getElementById("root")!;
-
-      const cancel = render(root, cell, renderOptions);
-
-      try {
-        await waitFor(
-          () => {
-            const html = root.innerHTML;
-            return Promise.resolve(
-              html.includes("Where should we eat?") &&
-                html.includes("me is: &quot;&quot;") &&
-                html.includes("body renders"),
-            );
-          },
-          { timeout: 15000 },
+        const page = await rt.createPage(scopedHeaderProgram, session.space, {
+          run: true,
+        });
+        const cell = page.cell() as CellHandle<VNode>;
+        const nameCell = (page.cell() as any).key("myName").asSchema({
+          type: "string",
+          scope: "user",
+        });
+        const mock = new MockDoc(
+          `<!DOCTYPE html><html><body><div id="root"></div></body></html>`,
         );
+        const { document, renderOptions } = mock;
+        const root = document.getElementById("root")!;
 
-        await nameCell.set("Alex");
-        await waitFor(
-          () =>
-            Promise.resolve(
-              root.innerHTML.includes("me is: &quot;Alex&quot;"),
-            ),
-          { timeout: 5000 },
-        );
-      } finally {
-        cancel();
-      }
+        const cancel = render(root, cell, renderOptions);
+
+        try {
+          await waitFor(
+            () => {
+              const html = root.innerHTML;
+              return Promise.resolve(
+                html.includes("Where should we eat?") &&
+                  html.includes("me is: &quot;&quot;") &&
+                  html.includes("body renders"),
+              );
+            },
+            { timeout: 15000 },
+          );
+
+          await nameCell.set("Alex");
+          await waitFor(
+            () =>
+              Promise.resolve(
+                root.innerHTML.includes("me is: &quot;Alex&quot;"),
+              ),
+            { timeout: 5000 },
+          );
+        } finally {
+          cancel();
+        }
+      },
     });
 
     it("dispatches click events through rendered page handlers", async () => {
@@ -1333,9 +1375,15 @@ export default pattern<Record<string, never>>(() => {
       cancel();
     });
 
-    it("dispatches one navigateTo when a rendered handler changes local state", async () => {
-      const navigatePattern =
-        `import { Default, computed, handler, NAME, navigateTo, pattern, UI, Writable } from "commonfabric";
+    it({
+      name:
+        "dispatches one navigateTo when a rendered handler changes local state",
+      ...onArmStepSkip(
+        "dispatches one navigateTo when a rendered handler changes local state",
+      ),
+      fn: async () => {
+        const navigatePattern =
+          `import { Default, computed, handler, NAME, navigateTo, pattern, UI, Writable } from "commonfabric";
 
 interface ChildState {
   label: Default<string, "target">;
@@ -1369,50 +1417,51 @@ export default pattern<Record<string, never>>(() => {
   };
 });`;
 
-      const navigateProgram: Program = {
-        main: "/main.tsx",
-        files: [{
-          name: "/main.tsx",
-          contents: navigatePattern,
-        }],
-      };
+        const navigateProgram: Program = {
+          main: "/main.tsx",
+          files: [{
+            name: "/main.tsx",
+            contents: navigatePattern,
+          }],
+        };
 
-      const session = await createTestSession();
-      await using rt = await createRuntimeClient(session);
+        const session = await createTestSession();
+        await using rt = await createRuntimeClient(session);
 
-      const page = await rt.createPage(navigateProgram, session.space, {
-        run: true,
-      });
-      const mock = new MockDoc(
-        `<!DOCTYPE html><html><body><div id="root"></div></body></html>`,
-      );
-      const { document, renderOptions } = mock;
-      const root = document.getElementById("root")!;
-      const navigations: string[] = [];
-      const gotNavigation = defer<void>();
-      rt.on("navigaterequest", ({ cell }) => {
-        navigations.push(cell.id());
-        if (navigations.length > 0) gotNavigation.resolve();
-      });
+        const page = await rt.createPage(navigateProgram, session.space, {
+          run: true,
+        });
+        const mock = new MockDoc(
+          `<!DOCTYPE html><html><body><div id="root"></div></body></html>`,
+        );
+        const { document, renderOptions } = mock;
+        const root = document.getElementById("root")!;
+        const navigations: string[] = [];
+        const gotNavigation = defer<void>();
+        rt.on("navigaterequest", ({ cell }) => {
+          navigations.push(cell.id());
+          if (navigations.length > 0) gotNavigation.resolve();
+        });
 
-      const cancel = render(root, page.cell() as any, renderOptions);
+        const cancel = render(root, page.cell() as any, renderOptions);
 
-      await waitFor(
-        () => Promise.resolve(root.innerHTML.length > 0),
-        { timeout: 5000 },
-      );
+        await waitFor(
+          () => Promise.resolve(root.innerHTML.length > 0),
+          { timeout: 5000 },
+        );
 
-      const button = root.getElementsByTagName("button")[0] as any;
-      assertExists(button);
+        const button = root.getElementsByTagName("button")[0] as any;
+        assertExists(button);
 
-      button.dispatchEvent({ type: "click", target: button });
+        button.dispatchEvent({ type: "click", target: button });
 
-      await gotNavigation.promise;
-      await rt.idle();
+        await gotNavigation.promise;
+        await rt.idle();
 
-      assertEquals(navigations.length, 1);
+        assertEquals(navigations.length, 1);
 
-      cancel();
+        cancel();
+      },
     });
   });
 
@@ -1653,6 +1702,13 @@ async function createRuntimeClient(
     spaceIdentity: session.spaceIdentity,
     spaceDid: session.space,
     spaceName: session.spaceName,
+    // The HOST declares the worker's posture (runtime-client's posture
+    // agreement; the worker refuses to initialize on a mismatch). Only the
+    // server-execution flag is declared: the other experimental keys keep
+    // the worker's own defaults.
+    experimental: SERVER_EXECUTION_FROM_ENV === undefined
+      ? {}
+      : { serverExecution: SERVER_EXECUTION_FROM_ENV },
     ...extraOptions,
   });
 

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -242,24 +242,6 @@ export interface InitializationData {
   // effect on the next runtime (reload), not live. Off by default; the shell
   // dogfood toggle `commonfabric.concurrentWatchRefresh()` sets it.
   concurrentWatchRefresh?: boolean;
-  // The LT9 offline-event-queue persistence declaration for the
-  // WORKER-hosted runtime (server-execution v2 Phase 5, rec (c) —
-  // ADOPTED-PENDING-VETO: the durable store wiring lands COUPLED to
-  // protocol §5's sessionId persistence, and this field IS the coupling
-  // seam — the same declarative surface will carry the session
-  // persistence config when that work lands). Structured-clone-safe by
-  // construction: the host DECLARES a store kind, the worker CONSTRUCTS
-  // the adapter (no live objects cross the IPC boundary).
-  //
-  // - absent / `{ kind: "memory" }`: the in-memory default — the same
-  //   persistence class as `sessionId` today (events.md §5,
-  //   protocol.md §5).
-  // - any other kind: the worker REFUSES initialization loudly. The
-  //   durable worker adapter (IndexedDB or a main-thread bridge) is the
-  //   OW20 follow-up that lands WITH sessionId persistence; declaring a
-  //   kind this build cannot honor must fail closed, never silently
-  //   degrade a durability promise to memory.
-  eventAppendQueuePersistence?: { kind: string };
 }
 
 export interface InitializeRequest extends BaseRequest {

--- a/packages/shell/deno.jsonc
+++ b/packages/shell/deno.jsonc
@@ -7,7 +7,7 @@
     "serve": "deno run -A ../felt/cli.ts serve .",
     "dev": "deno task clean && API_URL=https://toolshed.saga-castor.ts.net deno run -A ../felt/cli.ts dev .",
     "dev-local": "deno task clean && API_URL=http://localhost:$TOOLSHED_PORT deno run -A ../felt/cli.ts dev .",
-    "integration": "LOG_LEVEL=warn deno test -A $INTEGRATION_TEST_FLAGS ./integration/*.test.ts",
+    "integration": "LOG_LEVEL=warn deno test -A $INTEGRATION_TEST_FLAGS \"./integration/*.test.ts\"",
     // --no-check: this package is type-checked by `deno task check` (tasks/check.sh).
     "test": "deno test --no-check --allow-net=127.0.0.1 --allow-read --allow-write --allow-run --allow-env test/*.test.ts"
   },

--- a/packages/shell/src/lib/env.ts
+++ b/packages/shell/src/lib/env.ts
@@ -1,3 +1,5 @@
+import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
+
 declare global {
   var $ENVIRONMENT: string | undefined;
   var $API_URL: string | undefined;
@@ -70,7 +72,12 @@ export const EXPERIMENTAL = {
   // home-golden-replay.test.ts, so the home root no longer needs a second flag.
   systemPatternAutoUpdate:
     flagValue(EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_DEFINE) ?? true,
-  // Server-execution v2 (docs/specs/server-side-execution/). Default OFF —
-  // today's behavior byte-for-byte.
-  serverExecution: flagValue(EXPERIMENTAL_SERVER_EXECUTION_DEFINE),
+  // Server-execution v2 (docs/specs/server-side-execution/): the
+  // first-party default (ON since the plan's Phase 7 flip), overridable
+  // by the build define either way (`EXPERIMENTAL_SERVER_EXECUTION=false`
+  // builds the OFF-arm shell — the rollback lever and CI's regression
+  // guard). The worker refuses to initialize if its resolved posture
+  // disagrees with this declaration (runtime-client's posture agreement).
+  serverExecution: flagValue(EXPERIMENTAL_SERVER_EXECUTION_DEFINE) ??
+    SERVER_EXECUTION_DEFAULT_ENABLED,
 };

--- a/packages/shell/test/env.test.ts
+++ b/packages/shell/test/env.test.ts
@@ -1,4 +1,5 @@
 import { expect } from "@std/expect";
+import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
 
 type ShellEnvGlobals = typeof globalThis & Record<string, string | undefined>;
 
@@ -45,7 +46,34 @@ Deno.test({
       eagerSourceAnnotation: false,
       // Default ON — one flag covers default-app and home roots alike.
       systemPatternAutoUpdate: true,
+      // Server-execution v2: the first-party default (ON since Phase 7's
+      // flip) when the build define is unset.
+      serverExecution: SERVER_EXECUTION_DEFAULT_ENABLED,
     });
+  },
+});
+
+Deno.test({
+  name: "serverExecution: the build define selects the OFF arm (rollback lever) or forces ON",
+  permissions: { read: true },
+  async fn() {
+    const off = await withPatchedGlobals({
+      $API_URL: "http://shell.test/",
+      $EXPERIMENTAL_SERVER_EXECUTION: "false",
+    }, importFreshEnvModule);
+    expect(off.EXPERIMENTAL.serverExecution).toBe(false);
+    const on = await withPatchedGlobals({
+      $API_URL: "http://shell.test/",
+      $EXPERIMENTAL_SERVER_EXECUTION: "true",
+    }, importFreshEnvModule);
+    expect(on.EXPERIMENTAL.serverExecution).toBe(true);
+    const unset = await withPatchedGlobals({
+      $API_URL: "http://shell.test/",
+      $EXPERIMENTAL_SERVER_EXECUTION: undefined,
+    }, importFreshEnvModule);
+    expect(unset.EXPERIMENTAL.serverExecution).toBe(
+      SERVER_EXECUTION_DEFAULT_ENABLED,
+    );
   },
 });
 

--- a/packages/toolshed/lib/build-info.test.ts
+++ b/packages/toolshed/lib/build-info.test.ts
@@ -3,6 +3,7 @@ import env from "@/env.ts";
 import {
   normalize,
   readBuildInfoFrom,
+  readShellServerExecutionDefineFrom,
   resolveGitShaFrom,
 } from "@/lib/build-info.ts";
 
@@ -172,6 +173,81 @@ Deno.test("readBuildInfoFrom", async (t) => {
         builtAt: "now",
       });
     });
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+// The shell's baked server-execution posture rides the same COMPILED marker
+// (tasks/build-binaries.ts writes it from the build environment — the value
+// packages/shell/felt.config.ts bakes as the shell's define). CI's
+// server-execution lanes read it back through /api/meta to verify the
+// posture the binary actually carries; a missing/unset value reads null.
+Deno.test("readShellServerExecutionDefineFrom", async (t) => {
+  const tempDir = await Deno.makeTempDir({ prefix: "build-info-sx-test-" });
+  const pathFor = (name: string) => `${tempDir}/${name}`;
+  try {
+    await t.step(
+      "null when the marker is missing, malformed, or non-object",
+      async () => {
+        assertEquals(readShellServerExecutionDefineFrom(pathFor("nope")), null);
+        await Deno.writeTextFile(pathFor("bad"), "{not json");
+        assertEquals(readShellServerExecutionDefineFrom(pathFor("bad")), null);
+        await Deno.writeTextFile(pathFor("str"), '"abc"');
+        assertEquals(readShellServerExecutionDefineFrom(pathFor("str")), null);
+      },
+    );
+    await t.step(
+      "null when the field is absent, null, or blank (define unset — the shell follows the first-party default)",
+      async () => {
+        await Deno.writeTextFile(
+          pathFor("absent"),
+          JSON.stringify({ commitSha: "abc", builtAt: "now" }),
+        );
+        assertEquals(
+          readShellServerExecutionDefineFrom(pathFor("absent")),
+          null,
+        );
+        await Deno.writeTextFile(
+          pathFor("nullish"),
+          JSON.stringify({ shellServerExecutionDefine: null }),
+        );
+        assertEquals(
+          readShellServerExecutionDefineFrom(pathFor("nullish")),
+          null,
+        );
+        await Deno.writeTextFile(
+          pathFor("blank"),
+          JSON.stringify({ shellServerExecutionDefine: "  " }),
+        );
+        assertEquals(
+          readShellServerExecutionDefineFrom(pathFor("blank")),
+          null,
+        );
+      },
+    );
+    await t.step(
+      'returns the raw baked define, trimmed ("true" for an ON-built shell, "false" for OFF-built)',
+      async () => {
+        await Deno.writeTextFile(
+          pathFor("on"),
+          JSON.stringify({
+            commitSha: "abc",
+            builtAt: "now",
+            shellServerExecutionDefine: " true ",
+          }),
+        );
+        assertEquals(readShellServerExecutionDefineFrom(pathFor("on")), "true");
+        await Deno.writeTextFile(
+          pathFor("off"),
+          JSON.stringify({ shellServerExecutionDefine: "false" }),
+        );
+        assertEquals(
+          readShellServerExecutionDefineFrom(pathFor("off")),
+          "false",
+        );
+      },
+    );
   } finally {
     await Deno.remove(tempDir, { recursive: true });
   }

--- a/packages/toolshed/lib/build-info.ts
+++ b/packages/toolshed/lib/build-info.ts
@@ -23,6 +23,42 @@ const COMPILED_PATH = new URL("../COMPILED", import.meta.url);
 export const buildInfo: BuildInfo = readBuildInfoFrom(COMPILED_PATH);
 
 /**
+ * The raw `EXPERIMENTAL_SERVER_EXECUTION` value present in the build
+ * environment when this binary was built — the value the browser shell
+ * BAKED as its esbuild define (packages/shell/felt.config.ts; the shell
+ * has no serve-time override) — or null when it was unset (the shell then
+ * follows `SERVER_EXECUTION_DEFAULT_ENABLED`) and in a source run. Same
+ * failure posture as `readBuildInfoFrom`: an unreadable or malformed
+ * marker reads as null. Surfaced on `/api/meta` as
+ * `shellServerExecutionDefine` so CI's server-execution lanes can verify
+ * the posture the binary they run actually carries
+ * (docs/specs/server-side-execution/testing.md §2).
+ */
+export function readShellServerExecutionDefineFrom(
+  path: URL | string,
+): string | null {
+  let raw: string;
+  try {
+    raw = Deno.readTextFileSync(path);
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const value = (parsed as { shellServerExecutionDefine?: unknown })
+    .shellServerExecutionDefine;
+  return typeof value === "string" ? normalize(value) : null;
+}
+
+export const shellServerExecutionDefine: string | null =
+  readShellServerExecutionDefineFrom(COMPILED_PATH);
+
+/**
  * Pure precedence function used by `resolveGitSha()`. Exposed so it can be
  * tested without manipulating env or filesystem state.
  */

--- a/packages/toolshed/lib/server-execution-flag.test.ts
+++ b/packages/toolshed/lib/server-execution-flag.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
+import {
+  memoryServiceDidsFor,
+  serverExecutionEnabledFromEnv,
+} from "@/lib/server-execution-flag.ts";
+
+// The toolshed process's ONE flag resolution (server-execution v2 Phase 7,
+// the flip): unset means the FIRST-PARTY DEFAULT — the value of
+// `SERVER_EXECUTION_DEFAULT_ENABLED`, whichever it is — and an explicit
+// "false" is the OFF arm (the rollback lever), an explicit "true" the ON
+// arm. Pinned against the constant, not a literal, so the test states the
+// contract rather than the current default.
+
+const envOf = (values: Record<string, string | undefined>) => (name: string) =>
+  values[name];
+
+describe("serverExecutionEnabledFromEnv", () => {
+  it("resolves an UNSET flag to the first-party default", () => {
+    expect(serverExecutionEnabledFromEnv(envOf({}))).toBe(
+      SERVER_EXECUTION_DEFAULT_ENABLED,
+    );
+  });
+
+  it("honors an explicit value either way (the OFF arm stays selectable)", () => {
+    expect(
+      serverExecutionEnabledFromEnv(
+        envOf({ EXPERIMENTAL_SERVER_EXECUTION: "false" }),
+      ),
+    ).toBe(false);
+    expect(
+      serverExecutionEnabledFromEnv(
+        envOf({ EXPERIMENTAL_SERVER_EXECUTION: "true" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("garbage reads as unset (the canonical mapping's warn-and-ignore), so it resolves to the default", () => {
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      expect(
+        serverExecutionEnabledFromEnv(
+          envOf({ EXPERIMENTAL_SERVER_EXECUTION: "yes" }),
+        ),
+      ).toBe(SERVER_EXECUTION_DEFAULT_ENABLED);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});
+
+// Under the flag the process identity is a memory service principal (the
+// serving loop's loopback plane reads foreign co-hosted spaces as it —
+// protocol.md §2b's free-read row); OFF the flag the operator's configured
+// list is used verbatim.
+describe("memoryServiceDidsFor", () => {
+  const me = "did:key:z6MkToolshedProcess";
+  const operator = "did:key:z6MkOperator";
+
+  it("OFF the flag: the configured list, byte-identical (never the process identity)", () => {
+    expect(
+      memoryServiceDidsFor({
+        configured: [operator],
+        processIdentityDid: me,
+        serverExecution: false,
+      }),
+    ).toEqual([operator]);
+    expect(
+      memoryServiceDidsFor({
+        configured: [],
+        processIdentityDid: me,
+        serverExecution: false,
+      }),
+    ).toEqual([]);
+  });
+
+  it("ON: the process identity joins the configured list exactly once", () => {
+    expect(
+      memoryServiceDidsFor({
+        configured: [operator],
+        processIdentityDid: me,
+        serverExecution: true,
+      }),
+    ).toEqual([operator, me]);
+    // Already configured by the operator: no duplicate.
+    expect(
+      memoryServiceDidsFor({
+        configured: [me, operator],
+        processIdentityDid: me,
+        serverExecution: true,
+      }),
+    ).toEqual([me, operator]);
+  });
+});

--- a/packages/toolshed/lib/server-execution-flag.test.ts
+++ b/packages/toolshed/lib/server-execution-flag.test.ts
@@ -7,22 +7,26 @@ import {
 } from "@/lib/server-execution-flag.ts";
 
 // The toolshed process's ONE flag resolution (server-execution v2 Phase 7,
-// the flip): unset means the FIRST-PARTY DEFAULT — the value of
+// flip-ready): unset means the FIRST-PARTY DEFAULT — the value of
 // `SERVER_EXECUTION_DEFAULT_ENABLED`, whichever it is — and an explicit
-// "false" is the OFF arm (the rollback lever), an explicit "true" the ON
-// arm. Pinned against the constant, not a literal, so the test states the
-// contract rather than the current default.
+// "false" is the OFF arm, an explicit "true" the ON arm. Pinned against
+// the constant, not a literal, so the tests state the contract rather
+// than the current default — except the ONE absolute pin below.
 
 const envOf = (values: Record<string, string | undefined>) => (name: string) =>
   values[name];
 
-describe("the flip (server-execution v2 Phase 7, 2026-08-15)", () => {
-  it("the first-party default IS ON — flipping it back is the documented rollback (docs/plans/server-execution-v2.md Phase 7) and must update this pin, the CI lane roles, and EXPERIMENTAL_OPTIONS.md together", () => {
+describe("the landing posture (server-execution v2 Phase 7, landed dark by owner ruling 2026-08-16)", () => {
+  it("the first-party default IS OFF — the flip to ON is its own separate one-line PR (docs/plans/server-execution-v2.md Phase 7 task 1) and must update this pin, the CI lane roles, and EXPERIMENTAL_OPTIONS.md together", () => {
     // Every other flip pin in the tree is deliberately RELATIVE to the
-    // constant (so the flip is one line); this is the one ABSOLUTE pin,
-    // so a silent revert cannot leave the "ON arm" CI lanes running OFF
-    // with every test still green.
-    expect(SERVER_EXECUTION_DEFAULT_ENABLED).toBe(true);
+    // constant (so the flip PR is one line plus this pin); this is the
+    // one ABSOLUTE pin, so a silent flip in EITHER direction cannot hide
+    // behind green relative pins — flipped silently ON, the REQUIRED
+    // default CI lanes would carry the ON posture (the P7 independent
+    // review's blocker: two two-browser gates red under ON); flipped
+    // silently OFF after the flip PR, the "ON arm" default lanes would
+    // run OFF with every test still green.
+    expect(SERVER_EXECUTION_DEFAULT_ENABLED).toBe(false);
   });
 });
 
@@ -33,7 +37,7 @@ describe("serverExecutionEnabledFromEnv", () => {
     );
   });
 
-  it("honors an explicit value either way (the OFF arm stays selectable)", () => {
+  it("honors an explicit value either way (both arms stay selectable — CI's explicit-`true` lanes run the ON posture on an ON-built binary)", () => {
     expect(
       serverExecutionEnabledFromEnv(
         envOf({ EXPERIMENTAL_SERVER_EXECUTION: "false" }),

--- a/packages/toolshed/lib/server-execution-flag.test.ts
+++ b/packages/toolshed/lib/server-execution-flag.test.ts
@@ -16,6 +16,16 @@ import {
 const envOf = (values: Record<string, string | undefined>) => (name: string) =>
   values[name];
 
+describe("the flip (server-execution v2 Phase 7, 2026-08-15)", () => {
+  it("the first-party default IS ON — flipping it back is the documented rollback (docs/plans/server-execution-v2.md Phase 7) and must update this pin, the CI lane roles, and EXPERIMENTAL_OPTIONS.md together", () => {
+    // Every other flip pin in the tree is deliberately RELATIVE to the
+    // constant (so the flip is one line); this is the one ABSOLUTE pin,
+    // so a silent revert cannot leave the "ON arm" CI lanes running OFF
+    // with every test still green.
+    expect(SERVER_EXECUTION_DEFAULT_ENABLED).toBe(true);
+  });
+});
+
 describe("serverExecutionEnabledFromEnv", () => {
   it("resolves an UNSET flag to the first-party default", () => {
     expect(serverExecutionEnabledFromEnv(envOf({}))).toBe(

--- a/packages/toolshed/lib/server-execution-flag.ts
+++ b/packages/toolshed/lib/server-execution-flag.ts
@@ -1,0 +1,58 @@
+// The toolshed process's ONE resolution of the server-execution v2 flag
+// (docs/specs/server-side-execution/; docs/plans/server-execution-v2.md
+// Phase 7): the environment's explicit `EXPERIMENTAL_SERVER_EXECUTION`
+// value when set, else the first-party default. Both consumers in this
+// process — the serving-host bootstrap (`server-execution.ts`) and the
+// memory server's service-principal grant (`routes/storage/memory.ts`) —
+// read THIS, so they can never disagree about the posture. Kept a leaf
+// module (no runner executor imports) so the memory route can import it
+// without pulling the serving loop.
+
+import {
+  type EnvReader,
+  experimentalOptionsFromEnv,
+} from "@commonfabric/runner";
+import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
+
+/** Whether THIS toolshed process runs the server-execution v2 posture:
+ * the explicit env value if present (`"true"` / `"false"`), else
+ * `SERVER_EXECUTION_DEFAULT_ENABLED`. */
+export function serverExecutionEnabledFromEnv(envGet: EnvReader): boolean {
+  return experimentalOptionsFromEnv(envGet).serverExecution ??
+    SERVER_EXECUTION_DEFAULT_ENABLED;
+}
+
+/**
+ * The memory-server service principals for this process (protocol.md §2b's
+ * "read a foreign doc — free" row; serving-loop.md §3b's cross-space read
+ * "under the piece's granted authority"): the operator-configured
+ * `MEMORY_SERVICE_DIDS` list, PLUS — under the flag — this process's own
+ * identity. The serving loop's per-space runtimes read foreign co-hosted
+ * spaces (a served `#profile` wish reads the DEMANDING user's home space)
+ * on the loopback plane as the process identity, and that plane's
+ * sessions are admitted by the memory server's ordinary ACL. The
+ * co-hosted SpaceServer is ALREADY the party the memory server trusts to
+ * derive every space (its derived commits land through the engine-direct
+ * sink; protocol.md §1's trust footing, FP2's read-row ruling), so under
+ * the flag its identity is a service principal for the loopback plane's
+ * reads too — the posture every deployment checklist already requires of
+ * the operator DID (docs/plans/ingest-channels-journal-sink.md), made
+ * automatic where the loop actually runs. OFF the flag: the configured
+ * list verbatim (byte-identical). Foreign WRITES are NOT widened by this:
+ * the wave's §2b accept gate checks the ACTING identity's structural
+ * grant and deliberately ignores the service-DID blanket
+ * (`foreignWriteAuthorityFor`).
+ */
+export function memoryServiceDidsFor(options: {
+  configured: readonly string[];
+  processIdentityDid: string;
+  serverExecution: boolean;
+}): readonly string[] {
+  const dids = [...options.configured];
+  if (
+    options.serverExecution && !dids.includes(options.processIdentityDid)
+  ) {
+    dids.push(options.processIdentityDid);
+  }
+  return dids;
+}

--- a/packages/toolshed/lib/server-execution-flag.ts
+++ b/packages/toolshed/lib/server-execution-flag.ts
@@ -38,10 +38,27 @@ export function serverExecutionEnabledFromEnv(envGet: EnvReader): boolean {
  * reads too — the posture every deployment checklist already requires of
  * the operator DID (docs/plans/ingest-channels-journal-sink.md), made
  * automatic where the loop actually runs. OFF the flag: the configured
- * list verbatim (byte-identical). Foreign WRITES are NOT widened by this:
- * the wave's §2b accept gate checks the ACTING identity's structural
- * grant and deliberately ignores the service-DID blanket
- * (`foreignWriteAuthorityFor`).
+ * list verbatim (byte-identical).
+ *
+ * WHAT THIS WIDENS, honestly (P7 independent review finding 6; the P7
+ * build's "not a write widening" was overstated): a memory service
+ * principal is implicit OWNER for its sessions on EVERY space
+ * (`packages/memory/v2/server.ts` — transact, queries, watches, ACL-doc
+ * writes, fresh-space genesis; the ACL policy has no read-only service
+ * class). So under the flag the process identity's ORDINARY session
+ * traffic — its own `productionServer` runtime (ingest / webhooks) and
+ * the loopback plane's authored/bookkeeping commits — gains OWNER
+ * everywhere, wherever `MEMORY_SERVICE_DIDS` did not already list it.
+ * Bounded by process trust (the same process already derives every
+ * space), and NOT widened at the wave's foreign-write accept gate, which
+ * checks the ACTING identity's structural grant and deliberately ignores
+ * the service-DID blanket (`foreignWriteAuthorityFor`). The wish's own
+ * bootstrap needs only READ on the demanding user's home space; a
+ * read-only service class in the memory ACL would be the narrower shape,
+ * but that is a memory-ACL policy addition and depends on what the
+ * served create handler's `.inSpace()` provisioning needs at genesis —
+ * FLAGGED as a ruled-posture item for the owner (verification-coverage.md
+ * OW31), not narrowed here.
  */
 export function memoryServiceDidsFor(options: {
   configured: readonly string[];

--- a/packages/toolshed/lib/server-execution.ts
+++ b/packages/toolshed/lib/server-execution.ts
@@ -13,6 +13,7 @@ import {
   experimentalOptionsFromEnv,
   Runtime,
 } from "@commonfabric/runner";
+import { serverExecutionEnabledFromEnv } from "./server-execution-flag.ts";
 import { ExecutorHost } from "@commonfabric/runner/executor/host";
 import { LoopbackStorageManager } from "@commonfabric/runner/executor/loopback-storage";
 import type { Server as MemoryServer } from "@commonfabric/memory/v2/server";
@@ -128,10 +129,14 @@ export function startServerExecutionHost(options: {
   envGet?: EnvReader;
 }): ExecutorHost | undefined {
   const envGet = options.envGet ?? Deno.env.get;
-  const experimental = experimentalOptionsFromEnv(envGet);
-  if (experimental.serverExecution !== true) {
+  // The process's ONE flag resolution (server-execution-flag.ts): the
+  // explicit env value, else the first-party default — the same answer
+  // the memory route used for its service-principal grant.
+  if (!serverExecutionEnabledFromEnv(envGet)) {
     return undefined;
   }
+  // The other experimental flags still reach the serving runtimes from env.
+  const experimental = experimentalOptionsFromEnv(envGet);
   console.log(
     `Server-execution v2: serving loop ON (service ${options.identity.did()})`,
   );

--- a/packages/toolshed/routes/meta/meta.handlers.ts
+++ b/packages/toolshed/routes/meta/meta.handlers.ts
@@ -1,6 +1,6 @@
 import * as HttpStatusCodes from "stoker/http-status-codes";
 import { z } from "zod";
-import { resolveGitSha } from "@/lib/build-info.ts";
+import { resolveGitSha, shellServerExecutionDefine } from "@/lib/build-info.ts";
 import { identity } from "@/lib/identity.ts";
 import type { AppRouteHandler } from "@/lib/types.ts";
 import type { IndexRoute } from "./meta.routes.ts";
@@ -11,6 +11,13 @@ const GIT_SHA = resolveGitSha();
 export const MetaResponseSchema = z.object({
   did: z.string(),
   gitSha: z.string().nullable(),
+  // The server-execution v2 posture the binary's browser shell was BUILT
+  // with (the raw `EXPERIMENTAL_SERVER_EXECUTION` build define: "true",
+  // "false", or null when unset — the shell then follows the first-party
+  // default; null in a source run too). Build provenance like `gitSha`,
+  // read from the compiled marker; CI's server-execution lanes assert on
+  // it (docs/specs/server-side-execution/testing.md §2).
+  shellServerExecutionDefine: z.string().nullable(),
 });
 export type MetaResponse = z.infer<typeof MetaResponseSchema>;
 
@@ -18,6 +25,7 @@ export const index: AppRouteHandler<IndexRoute> = (c) => {
   const response: MetaResponse = {
     did: SERVER_DID,
     gitSha: GIT_SHA,
+    shellServerExecutionDefine,
   };
   return c.json(response, HttpStatusCodes.OK);
 };

--- a/packages/toolshed/routes/meta/meta.test.ts
+++ b/packages/toolshed/routes/meta/meta.test.ts
@@ -21,5 +21,8 @@ Deno.test("meta routes", async (t) => {
       "did:key:z6Mkqqy6FetDFSzm3oegQmJEUWrqBpxAZvWrw3xZTyNqJYj9",
     );
     assertEquals(json.gitSha, null);
+    // A source run has no compiled marker: the shell's baked
+    // server-execution define is unknown (null), like gitSha.
+    assertEquals(json.shellServerExecutionDefine, null);
   });
 });

--- a/packages/toolshed/routes/storage/memory.ts
+++ b/packages/toolshed/routes/storage/memory.ts
@@ -13,8 +13,12 @@ const memoryAudience = identity.did();
 
 // Server-execution v2 (Phase 7): under the flag this process's own identity
 // is a memory service principal — the serving loop's loopback sessions read
-// foreign co-hosted spaces as it (see memoryServiceDidsFor). OFF the flag
-// the operator-configured list is used verbatim.
+// foreign co-hosted spaces as it (see memoryServiceDidsFor, which also
+// states honestly what else that grants: implicit OWNER everywhere for the
+// process identity's ordinary session traffic; the narrower read-only
+// shape is FLAGGED for the owner, verification-coverage.md OW31). OFF the
+// flag — the landed default — the operator-configured list is used
+// verbatim.
 const serverExecutionOn = serverExecutionEnabledFromEnv(Deno.env.get);
 const memoryServiceDids = memoryServiceDidsFor({
   configured: env.MEMORY_SERVICE_DIDS

--- a/packages/toolshed/routes/storage/memory.ts
+++ b/packages/toolshed/routes/storage/memory.ts
@@ -4,8 +4,33 @@ import * as FS from "@std/fs";
 import env from "@/env.ts";
 import { memoryEngineStoreUrl } from "./memory-store-url.ts";
 import { identity } from "@/lib/identity.ts";
+import {
+  memoryServiceDidsFor,
+  serverExecutionEnabledFromEnv,
+} from "@/lib/server-execution-flag.ts";
 
 const memoryAudience = identity.did();
+
+// Server-execution v2 (Phase 7): under the flag this process's own identity
+// is a memory service principal — the serving loop's loopback sessions read
+// foreign co-hosted spaces as it (see memoryServiceDidsFor). OFF the flag
+// the operator-configured list is used verbatim.
+const serverExecutionOn = serverExecutionEnabledFromEnv(Deno.env.get);
+const memoryServiceDids = memoryServiceDidsFor({
+  configured: env.MEMORY_SERVICE_DIDS
+    .split(",")
+    .map((did) => did.trim())
+    .filter((did) => did.length > 0),
+  processIdentityDid: identity.did(),
+  serverExecution: serverExecutionOn,
+});
+if (serverExecutionOn) {
+  console.log(
+    `Memory: server-execution v2 ON — process identity ${identity.did()} ` +
+      "is a memory service principal (loopback serving reads; " +
+      "docs/specs/server-side-execution/protocol.md §2b)",
+  );
+}
 
 // Session.open verification is shared with the standalone server. Toolshed
 // requires the signed invocation to carry its audience DID and the challenge
@@ -34,10 +59,7 @@ export const memoryServer = new MemoryServer.Server({
   },
   acl: {
     mode: env.MEMORY_ACL_MODE,
-    serviceDids: env.MEMORY_SERVICE_DIDS
-      .split(",")
-      .map((did) => did.trim())
-      .filter((did) => did.length > 0),
+    serviceDids: memoryServiceDids,
   },
 });
 export const memory = {

--- a/tasks/build-binaries.test.ts
+++ b/tasks/build-binaries.test.ts
@@ -479,6 +479,14 @@ Deno.test("prepareWorkspace writes the fingerprint; revertWorkspace restores the
       await Deno.readTextFile(cliCompiledPath),
       await Deno.readTextFile(compiledPath),
     );
+    // The marker records the server-execution posture the shell bakes
+    // from this environment (unset here → null: the shell follows the
+    // first-party default); toolshed surfaces it on /api/meta.
+    const marker = JSON.parse(await Deno.readTextFile(compiledPath));
+    assertEquals(
+      marker.shellServerExecutionDefine,
+      Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION") ?? null,
+    );
 
     await revertWorkspace(config);
 

--- a/tasks/build-binaries.ts
+++ b/tasks/build-binaries.ts
@@ -462,6 +462,18 @@ export async function prepareWorkspace(
   const buildInfo = {
     commitSha: Deno.env.get("COMMIT_SHA") ?? "",
     builtAt: new Date().toISOString(),
+    // The server-execution v2 posture the browser shell BAKES (an esbuild
+    // define read from this same environment in packages/shell/felt.config.ts
+    // when buildShell runs below): the raw `EXPERIMENTAL_SERVER_EXECUTION`
+    // value, or null when unset — the shell then follows the first-party
+    // default. Surfaced on toolshed's /api/meta as `shellServerExecutionDefine`
+    // so CI's explicit-ON lanes can verify the binary they run actually
+    // carries an ON-built shell (docs/specs/server-side-execution/testing.md
+    // §2; the shell define is baked, so an ON lane on a default-built binary
+    // would silently be a mixed posture). Written to both markers because
+    // they are one file written twice; only the toolshed embeds the shell.
+    shellServerExecutionDefine: Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION") ??
+      null,
   };
   const serialized = JSON.stringify(buildInfo, null, 2) + "\n";
   await Deno.writeTextFile(config.toolshedEnvPath(), serialized);

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -1,5 +1,5 @@
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
-import { parse as parseYaml } from "jsr:@std/yaml@^1.0.5";
+import { parse as parseYaml } from "@std/yaml";
 import { phaseOf } from "./ci-step-phases.ts";
 import { EXPECTED_COVERAGE_ARTIFACT_NAMES } from "./coverage-check.ts";
 import { PATTERN_INTEGRATION_SHARD_COUNT } from "./select-pattern-integration-files.ts";

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -1,4 +1,5 @@
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { parse as parseYaml } from "jsr:@std/yaml@^1.0.5";
 import { phaseOf } from "./ci-step-phases.ts";
 import { EXPECTED_COVERAGE_ARTIFACT_NAMES } from "./coverage-check.ts";
 import { PATTERN_INTEGRATION_SHARD_COUNT } from "./select-pattern-integration-files.ts";
@@ -144,6 +145,36 @@ function workflowTriggers(contents: string): string {
   assert(concurrencyStart >= 0, "workflow trigger section not found");
   return contents.slice(0, concurrencyStart);
 }
+
+// Every other check in this file reads the workflow files as TEXT (regex over
+// job and step blocks), so none of them can notice that a file has stopped
+// being valid YAML — and a workflow that does not parse produces ZERO jobs on
+// every push while every text-level check here stays green. That happened: an
+// unquoted `default: ` inside two step names turned deno.yml into a nested
+// mapping the runner refused, and CI silently ran nothing for a whole stack of
+// pushes. This is the one check that would have caught it.
+Deno.test("every workflow and composite action is valid YAML", async () => {
+  const broken: string[] = [];
+  for await (const path of githubYamlPaths()) {
+    const contents = await Deno.readTextFile(path);
+    try {
+      parseYaml(contents);
+    } catch (error) {
+      broken.push(
+        `${path.pathname.split("/.github/")[1]}: ${
+          String(error).split("\n")[0]
+        }`,
+      );
+    }
+  }
+  assertEquals(
+    broken,
+    [],
+    "these files under .github do not parse as YAML — the runner will " +
+      "schedule NO jobs from them, and every text-level check in this file " +
+      "stays green while it does",
+  );
+});
 
 Deno.test("Status waits for every pull request validation job", async () => {
   const contents = await workflow("deno.yml");

--- a/tasks/deno.jsonc
+++ b/tasks/deno.jsonc
@@ -1,6 +1,7 @@
 {
   // Dependency guide: ../docs/development/DEPENDENCIES.md
   "imports": {
+    "@std/yaml": "jsr:@std/yaml@^1.0.12",
     "typescript": "npm:typescript@6.0.3"
   },
   "tasks": {

--- a/tasks/server-execution-on-skips.test.ts
+++ b/tasks/server-execution-on-skips.test.ts
@@ -1,11 +1,13 @@
-import { assertEquals, assertMatch } from "@std/assert";
+import { assert, assertEquals, assertMatch } from "@std/assert";
 import {
   isServerExecutionSuite,
   main,
   SERVER_EXECUTION_ON_SKIPS,
+  serverExecutionOnFilterFiles,
   serverExecutionOnIgnoreArg,
   type ServerExecutionOnSkip,
   serverExecutionOnSkipReport,
+  serverExecutionOnStepSkip,
   validateServerExecutionOnSkips,
 } from "./server-execution-on-skips.ts";
 
@@ -126,23 +128,163 @@ Deno.test("main: no arguments behaves like an unknown suite", async () => {
 });
 
 Deno.test("main: empty lists print the report on stderr and nothing on stdout", async () => {
-  // The runner suite's list is empty (patterns carries stage F's
-  // two-deriver-interim entry).
+  // The shell suite's list is empty (patterns and runner carry the
+  // Phase-7 entries).
   const { out, err, io } = captureIo();
-  assertEquals(await main(["runner"], io), 0);
+  assertEquals(await main(["shell"], io), 0);
   assertEquals(out, []);
-  assertMatch(err[0], /runner: no skips — full suite runs/);
+  assertMatch(err[0], /shell: no skips — full suite runs/);
 });
 
-Deno.test("main: the patterns list holds exactly the topics-navigation entry (Phase 4's mixed-posture entry, re-justified by Phase 7: the ON shell build landed with the flip, the inherited red did not lift) — printed loudly, never silent", async () => {
+Deno.test("main: the patterns list holds exactly THREE phase-7 entries — topics-navigation (Phase 4's mixed-posture entry, re-justified by Phase 7) plus the two two-browser gates the P7 independent review found red under the full ON posture (client-side scheduler-non-settling loop, UNATTRIBUTED — OW32) — printed loudly, never silent", async () => {
   const { out, err, io } = captureIo();
   assertEquals(await main(["patterns"], io), 0);
-  assertEquals(out, ["--ignore=integration/topics-navigation.test.ts"]);
+  assertEquals(out, [
+    "--ignore=integration/topics-navigation.test.ts," +
+    "integration/cfc-group-chat-demo-two-browsers.test.ts," +
+    "integration/lunch-poll-vote.test.ts",
+  ]);
+  const report = err[0];
   assertMatch(
-    err[0],
+    report,
     /patterns: SKIP integration\/topics-navigation\.test\.ts \(until phase-7\)/,
   );
-  assertEquals(SERVER_EXECUTION_ON_SKIPS.patterns.length, 1);
+  assertMatch(
+    report,
+    /patterns: SKIP integration\/cfc-group-chat-demo-two-browsers\.test\.ts \(until phase-7\)/,
+  );
+  assertMatch(
+    report,
+    /patterns: SKIP integration\/lunch-poll-vote\.test\.ts \(until phase-7\)/,
+  );
+  // The reason is LOUD and states the mechanism as characterized, not
+  // as attributed: the client-side non-settling loop, the quiet serving
+  // loop, and the owed triage row.
+  for (const gate of ["cfc-group-chat-demo-two-browsers", "lunch-poll-vote"]) {
+    const entry = SERVER_EXECUTION_ON_SKIPS.patterns.find((skip) =>
+      skip.file === `integration/${gate}.test.ts`
+    );
+    if (entry === undefined) throw new Error(`missing ${gate} entry`);
+    assertEquals(entry.phase, "phase-7");
+    assertMatch(entry.reason, /scheduler-non-settling/);
+    assertMatch(entry.reason, /UNATTRIBUTED/);
+    assertMatch(entry.reason, /NOT evidenced as OW17/);
+    assertMatch(entry.reason, /OW32/);
+    assertMatch(entry.reason, /flip PR needs this list EMPTY/);
+  }
+  assertEquals(SERVER_EXECUTION_ON_SKIPS.patterns.length, 3);
+  assertEquals(SERVER_EXECUTION_ON_SKIPS.shell.length, 0);
+});
+
+Deno.test("main: the runtime-client list holds exactly two STEP-level entries in integration/client.test.ts (the file itself RUNS on the ON arm — no --ignore, no --filter drop; the steps are guarded in-file, bound to these entries) — printed loudly, never silent", async () => {
+  const { out, err, io } = captureIo();
+  assertEquals(await main(["runtime-client"], io), 0);
+  // Step entries never drop the file: no --ignore flag on stdout…
+  assertEquals(out, []);
+  // …and the filter shape keeps the file too.
+  const { files, skipped } = serverExecutionOnFilterFiles("runtime-client", [
+    "./integration/client.test.ts",
+  ]);
+  assertEquals(files, ["./integration/client.test.ts"]);
+  assertEquals(skipped, []);
+  // The report names both steps loudly.
+  const report = err[0];
+  assertMatch(
+    report,
+    /runtime-client: SKIP-STEP integration\/client\.test\.ts :: renders PerUser-derived computed JSX inside cf-screen header slot \(CT-1606\) \(until phase-7; the rest of the file runs\)/,
+  );
+  assertMatch(
+    report,
+    /runtime-client: SKIP-STEP integration\/client\.test\.ts :: dispatches one navigateTo when a rendered handler changes local state \(until phase-7; the rest of the file runs\)/,
+  );
+  const entries = SERVER_EXECUTION_ON_SKIPS["runtime-client"];
+  assertEquals(entries.length, 2);
+  for (const entry of entries) {
+    assertEquals(entry.file, "integration/client.test.ts");
+    assertEquals(entry.phase, "phase-7");
+    assert(entry.step !== undefined);
+    assertMatch(entry.reason, /UNATTRIBUTED/);
+    assertMatch(entry.reason, /OW33/);
+    assertMatch(entry.reason, /flip PR needs this list EMPTY/);
+    // The guard lookup the test file calls resolves exactly this entry.
+    assertEquals(
+      serverExecutionOnStepSkip(
+        "runtime-client",
+        "integration/client.test.ts",
+        entry.step,
+      ),
+      entry,
+    );
+  }
+  assertEquals(
+    serverExecutionOnStepSkip(
+      "runtime-client",
+      "integration/client.test.ts",
+      "some step that is not listed",
+    ),
+    undefined,
+  );
+});
+
+Deno.test("validation binds a step entry: the file must name the step and call the guard", async () => {
+  const lists: Record<string, ServerExecutionOnSkip[]> = {
+    patterns: [],
+    runner: [
+      // A real file that neither names this step nor calls the guard.
+      {
+        file: "integration/basic-persistence.test.ts",
+        step: "a step basic-persistence.test.ts does not contain",
+        phase: "phase-7",
+        reason: "placeholder",
+      },
+    ],
+    "runtime-client": [
+      // Duplicate step entries are flagged like duplicate files.
+      {
+        file: "integration/client.test.ts",
+        step:
+          "renders PerUser-derived computed JSX inside cf-screen header slot (CT-1606)",
+        phase: "phase-7",
+        reason: "placeholder",
+      },
+      {
+        file: "integration/client.test.ts",
+        step:
+          "renders PerUser-derived computed JSX inside cf-screen header slot (CT-1606)",
+        phase: "phase-7",
+        reason: "placeholder",
+      },
+    ],
+    shell: [],
+  };
+  const problems = await validateServerExecutionOnSkips(
+    repoRoot,
+    lists as typeof SERVER_EXECUTION_ON_SKIPS,
+  );
+  assertEquals(problems, [
+    'runner: step skip entry names a step integration/basic-persistence.test.ts does not contain: "a step basic-persistence.test.ts does not contain"',
+    "runner: integration/basic-persistence.test.ts carries a step skip entry but never calls serverExecutionOnStepSkip — the entry would be decoration",
+    "runtime-client: duplicate skip entry for integration/client.test.ts :: renders PerUser-derived computed JSX inside cf-screen header slot (CT-1606)",
+  ]);
+});
+
+Deno.test("main: the runner list holds exactly the pattern-and-data-persistence entry — red under the UNIFORM ON posture once the runner integration clients declare it (the lane was MIXED before; OW33) — printed loudly, never silent", async () => {
+  const { out, err, io } = captureIo();
+  assertEquals(await main(["runner"], io), 0);
+  assertEquals(out, [
+    "--ignore=integration/pattern-and-data-persistence.test.ts",
+  ]);
+  assertMatch(
+    err[0],
+    /runner: SKIP integration\/pattern-and-data-persistence\.test\.ts \(until phase-7\)/,
+  );
+  const [entry] = SERVER_EXECUTION_ON_SKIPS.runner;
+  assertEquals(SERVER_EXECUTION_ON_SKIPS.runner.length, 1);
+  assertEquals(entry.phase, "phase-7");
+  assertMatch(entry.reason, /UNIFORM|uniform ON/);
+  assertMatch(entry.reason, /MIXED posture/);
+  assertMatch(entry.reason, /OW33/);
+  assertMatch(entry.reason, /flip PR needs this list EMPTY/);
 });
 
 Deno.test("main: populated lists emit the --ignore flag on stdout", async () => {
@@ -186,5 +328,160 @@ Deno.test("main: a stale entry fails validation before any report", async () => 
     );
   } finally {
     SERVER_EXECUTION_ON_SKIPS.shell = saved;
+  }
+});
+
+Deno.test("--filter: the explicit-file shape drops the suite's skips from a candidate list (normalizing a leading ./), keeps order, and reports only what it dropped from THIS list", () => {
+  const saved = SERVER_EXECUTION_ON_SKIPS.patterns;
+  SERVER_EXECUTION_ON_SKIPS.patterns = [
+    {
+      file: "integration/b.test.ts",
+      phase: "phase-7",
+      reason: "placeholder",
+    },
+    {
+      file: "integration/zzz-elsewhere.test.ts",
+      phase: "phase-7",
+      reason: "in another shard",
+    },
+  ];
+  try {
+    const { files, skipped } = serverExecutionOnFilterFiles("patterns", [
+      "./integration/a.test.ts",
+      "./integration/b.test.ts",
+      "integration/c.test.ts",
+    ]);
+    assertEquals(files, ["./integration/a.test.ts", "integration/c.test.ts"]);
+    assertEquals(skipped.map((skip) => skip.file), ["integration/b.test.ts"]);
+  } finally {
+    SERVER_EXECUTION_ON_SKIPS.patterns = saved;
+  }
+});
+
+Deno.test("main --filter: prints the surviving files on stdout, the report + DROPPED lines on stderr; rejects other extra arguments", async () => {
+  const saved = SERVER_EXECUTION_ON_SKIPS.patterns;
+  SERVER_EXECUTION_ON_SKIPS.patterns = [
+    {
+      file: "integration/counter.test.ts",
+      phase: "phase-7",
+      reason: "placeholder for the filter-shape test",
+    },
+  ];
+  try {
+    const { out, err, io } = captureIo();
+    assertEquals(
+      await main([
+        "patterns",
+        "--filter",
+        "./integration/counter.test.ts",
+        "./integration/other.test.ts",
+      ], io),
+      0,
+    );
+    assertEquals(out, ["./integration/other.test.ts"]);
+    assertMatch(
+      err[0],
+      /SKIP integration\/counter\.test\.ts \(until phase-7\)/,
+    );
+    assertMatch(
+      err[1],
+      /DROPPED integration\/counter\.test\.ts from this file list/,
+    );
+    // Nothing of the list is skip-listed: say so, run everything.
+    const none = captureIo();
+    assertEquals(
+      await main(
+        ["patterns", "--filter", "./integration/other.test.ts"],
+        none.io,
+      ),
+      0,
+    );
+    assertEquals(none.out, ["./integration/other.test.ts"]);
+    assertMatch(none.err[1], /no listed skip is in this file list/);
+    // An unknown extra argument is refused, never silently treated as a file.
+    const bad = captureIo();
+    assertEquals(await main(["patterns", "--bogus"], bad.io), 1);
+    assertMatch(bad.err.at(-1) ?? "", /Unexpected arguments/);
+  } finally {
+    SERVER_EXECUTION_ON_SKIPS.patterns = saved;
+  }
+});
+
+// The mechanism's BINDING, pinned by spawning deno on both shapes (Phase 7
+// fixer, 2026-08-16): `deno test --ignore=<file>` filters only the modules
+// deno DISCOVERS — a glob it expands itself — and silently ignores nothing
+// when the same file arrives as an explicit argument (a shell-expanded glob;
+// the pattern shards' file list). Until this pin, every ON-arm skip since
+// Phase 4 rode a shell-expanded glob and never took effect. If deno's
+// semantics ever change, these two tests say which shape moved.
+async function collectedTestFiles(args: string[], cwd: string) {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["test", "--no-lock", "--no-check", ...args],
+    cwd,
+    // Plain output: the "running N tests from <file>" lines are matched
+    // below and must not carry color escapes.
+    env: { NO_COLOR: "1" },
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const output = await command.output();
+  const text = new TextDecoder().decode(output.stdout) +
+    new TextDecoder().decode(output.stderr);
+  const files = [...text.matchAll(/running \d+ tests? from (\S+)/g)]
+    .map((match) => match[1]).sort();
+  return { files, success: output.success, text };
+}
+
+Deno.test("deno test --ignore BINDS to a QUOTED glob deno expands (the package integration tasks' shape) and NOT to explicit file arguments (why the pattern shards filter the list instead)", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "sx-on-skips-ignore-" });
+  try {
+    await Deno.mkdir(`${dir}/integration`);
+    await Deno.writeTextFile(`${dir}/deno.json`, "{}\n");
+    for (const name of ["a", "b"]) {
+      await Deno.writeTextFile(
+        `${dir}/integration/${name}.test.ts`,
+        `Deno.test("${name}", () => {});\n`,
+      );
+    }
+    // Quoted glob (deno expands): the ignore drops b.
+    const quoted = await collectedTestFiles(
+      ["--ignore=integration/b.test.ts", "./integration/*.test.ts"],
+      dir,
+    );
+    assert(quoted.success, quoted.text);
+    assertEquals(quoted.files, ["./integration/a.test.ts"]);
+    // Explicit files (what a shell-expanded glob or a shard list hands
+    // deno): the SAME ignore flag drops nothing — the shape the pattern
+    // shards therefore avoid.
+    const explicit = await collectedTestFiles(
+      [
+        "--ignore=integration/b.test.ts",
+        "./integration/a.test.ts",
+        "./integration/b.test.ts",
+      ],
+      dir,
+    );
+    assert(explicit.success, explicit.text);
+    assertEquals(explicit.files, [
+      "./integration/a.test.ts",
+      "./integration/b.test.ts",
+    ]);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("the package integration tasks that carry the ON skip list hand deno a QUOTED glob (so --ignore binds); patterns keeps the shell glob because its test config excludes integration/ and the pattern shards filter explicitly", async () => {
+  const root = new URL("../", import.meta.url);
+  for (const suite of ["runner", "runtime-client", "shell"]) {
+    const config = await Deno.readTextFile(
+      new URL(`packages/${suite}/deno.jsonc`, root),
+    );
+    const task = config.match(/"integration": "([^"\\]|\\.)*"/)?.[0] ?? "";
+    assertMatch(
+      task,
+      /\$INTEGRATION_TEST_FLAGS \\"\.\/integration\/\*\.test\.ts\\"/,
+      `${suite}: the integration task must quote its glob: ${task}`,
+    );
   }
 });

--- a/tasks/server-execution-on-skips.test.ts
+++ b/tasks/server-execution-on-skips.test.ts
@@ -134,11 +134,15 @@ Deno.test("main: empty lists print the report on stderr and nothing on stdout", 
   assertMatch(err[0], /runner: no skips — full suite runs/);
 });
 
-Deno.test("main: the patterns list is EMPTY — stage P2-F retired the sx2-serving-loop entry (the demand-cycle terminal state closed the starvation fork), so the ON arm runs the full suite", async () => {
+Deno.test("main: the patterns list holds exactly the topics-navigation entry (Phase 4's mixed-posture entry, re-justified by Phase 7: the ON shell build landed with the flip, the inherited red did not lift) — printed loudly, never silent", async () => {
   const { out, err, io } = captureIo();
   assertEquals(await main(["patterns"], io), 0);
-  assertEquals(out, []);
-  assertMatch(err[0], /patterns: no skips — full suite runs/);
+  assertEquals(out, ["--ignore=integration/topics-navigation.test.ts"]);
+  assertMatch(
+    err[0],
+    /patterns: SKIP integration\/topics-navigation\.test\.ts \(until phase-7\)/,
+  );
+  assertEquals(SERVER_EXECUTION_ON_SKIPS.patterns.length, 1);
 });
 
 Deno.test("main: populated lists emit the --ignore flag on stdout", async () => {

--- a/tasks/server-execution-on-skips.ts
+++ b/tasks/server-execution-on-skips.ts
@@ -2,14 +2,18 @@
 
 // The EXPLICIT per-phase skip lists of the server-execution v2 ON arm
 // (docs/specs/server-side-execution/testing.md §2): in CI the integration
-// suites run twice — since the plan's Phase 7 flip the DEFAULT lanes (flag
-// unset = the first-party default, ON) ARE the ON arm, and the
-// explicit-`EXPERIMENTAL_SERVER_EXECUTION=false` lanes are the OFF
-// regression guard (byte-identical to the pre-flip posture) — and the ON
-// arm may skip a test only by listing it here, with the plan phase whose
-// not-yet-landed surface it exercises and a reason. Never by silent
-// filtering: the CI step prints every skip from this file, and an empty
-// list means the ON arm runs the full suite.
+// suites run twice — the DEFAULT lanes (flag unset = the first-party
+// default, which is OFF: Phase 7 landed flip-READY with the constant
+// `false` by owner ruling 2026-08-16, the flip being its own later PR) and
+// the explicit-`EXPERIMENTAL_SERVER_EXECUTION=true` ON lanes (the toolshed
+// server ON, the test processes ON, AND the binary's baked browser shell
+// ON-built — `build-toolshed-on`) — and the ON arm may skip a test only by
+// listing it here, with the plan phase whose not-yet-landed surface it
+// exercises and a reason. Never by silent filtering: the CI step prints
+// every skip from this file, and an empty list means the ON arm runs the
+// full suite. When the flip PR lands the lane roles swap (default = ON
+// with this list; explicit-`false` = the OFF regression guard on an
+// OFF-built binary) — the flip PR MUST land with this list EMPTY.
 //
 // An entry retires when its phase lands (docs/plans/server-execution-v2.md);
 // a file listed here that no longer exists fails the run, so the lists
@@ -38,10 +42,23 @@ export type ServerExecutionOnSkip = {
   /** Test file, relative to the suite's package root (the directory the
    * suite's `deno test` runs from), e.g. "integration/counter.test.ts". */
   file: string;
-  /** The plan phase that, once landed, unskips this file. */
+  /** The plan phase that, once landed, unskips this file (or step). */
   phase: ServerExecutionPhase;
-  /** Why the ON arm cannot run this file before that phase. */
+  /** Why the ON arm cannot run this file (or step) before that phase. */
   reason: string;
+  /**
+   * STEP-LEVEL entry (Phase 7 fixer, 2026-08-16): the exact name of ONE
+   * `it`/step inside `file` that the ON arm skips while the REST of the
+   * file runs. The file is NOT dropped (`--ignore` / `--filter` leave it
+   * in); instead the test file itself guards that step with
+   * {@link serverExecutionOnStepSkip} — so the guard is BOUND to this entry
+   * (remove the entry and the step runs again) and the validator requires
+   * the file to name the step AND call the guard. For a one-file suite
+   * (runtime-client's `integration/client.test.ts`, 45 steps) this keeps
+   * the ON lane's coverage instead of turning the whole lane vacuous over
+   * one red step. Printed by the CI step like every other entry.
+   */
+  step?: string;
 };
 
 const SUITE_PACKAGE_DIR: Record<ServerExecutionSuite, string> = {
@@ -71,11 +88,55 @@ const SUITE_PACKAGE_DIR: Record<ServerExecutionSuite, string> = {
  * the load pass runs under the flush deadline), so the surface runs —
  * carrying the in-CI amplification-ratio gate and the pattern-updater
  * CHECK-half witness (verification-coverage.md's closed OW19 row).
- * Every list is EMPTY but for the ONE topics-navigation entry below
- * (Phase 4's mixed-posture entry, re-justified by Phase 7 — the ON
- * shell build landed with the flip, the inherited red did not lift):
- * the ON arm otherwise runs the full suites.
+ * Every list is EMPTY but for FOUR `phase-7` entries: three `patterns`
+ * — topics-navigation (Phase 4's mixed-posture entry, re-justified by
+ * Phase 7 — the ON shell build now runs in the ON lanes, the inherited
+ * red did not lift) and, added by the Phase 7 fixer on the independent
+ * review (2026-08-16), the two two-browser gates
+ * `cfc-group-chat-demo-two-browsers` and `lunch-poll-vote`, red under
+ * the FULL ON posture on an UNATTRIBUTED client-side
+ * `scheduler-non-settling` loop (verification-coverage.md OW32) — and
+ * one `runner` entry, `pattern-and-data-persistence`, red once the
+ * runner integration clients DECLARE the ON posture (the lane was mixed
+ * before; verification-coverage.md OW33) — plus two STEP-level
+ * `runtime-client` entries in `integration/client.test.ts` (the CT-1606
+ * PerUser header render, 3/3 red; the single-navigateTo dispatch, 1/3
+ * red) whose file otherwise runs ON. The ON arm otherwise runs the full
+ * suites; the flip PR lands only once this list is empty again.
  */
+/**
+ * The LOUD reason the two two-browser gates carry (Phase 7 fixer,
+ * 2026-08-16, on the independent review's findings 1 and 2). Named once
+ * so the two entries cannot drift apart; the mechanism is stated AS
+ * CHARACTERIZED by the review's evidence, and NOTHING here attributes it.
+ */
+const TWO_BROWSER_NON_SETTLING_REASON =
+  "Phase 7 (2026-08-16): under the FULL ON posture (toolshed server ON, " +
+  "test process ON, browser shell ON-built) this two-browser gate STALLS " +
+  "its 300 s budget — reproduced 2/2 at the Phase-7 head AND at the " +
+  "unmodified Phase-6 base by the P7 independent review " +
+  "(review-p7-logs/tb-*/lunch-* stats + toolshed logs): the SERVING LOOP " +
+  "IS QUIET (waves 20–26, derivedCommits 19–25, events 2/2 " +
+  "appended/processed, watermarkLag 1–2 — no storm; wavesBudgetExhausted " +
+  "12–16 of those waves, but the single-browser counter gate exhausts " +
+  "2/5 with no client loop, so exhaustion alone is not the discriminator) " +
+  "while BOTH browsers run a CLIENT-SIDE `scheduler-non-settling` loop " +
+  "(every ~6.6 s; 40–56 k client action runs / 5 min at head and base; " +
+  "runner/start/resumeCellSync n=458–644 piece re-starts). The mechanism " +
+  "is UNATTRIBUTED — it is NOT evidenced as OW17 (the SpaceReplica " +
+  "scope-name collapse; the 4,427-wave storm signature exists ONLY on the " +
+  "builder's tree with the reverted OW29 extensions applied) — and its " +
+  "TRIAGE IS OWED FIRST in the flip's ordered gates " +
+  "(verification-coverage.md OW32; discriminating experiment: a " +
+  "`commonfabric.detectNonIdempotent()` capture in one browser plus a " +
+  "debug-level `wave-budget-exhausted` trace naming the non-quiescing " +
+  "server actions). Skipped rather than red-by-design so the explicit-ON " +
+  "lane stays green-with-visible-skips and keeps exercising everything " +
+  "else ON; NOT green-by-vacuity — this file is RED under the full ON " +
+  "posture. Lifts when OW32's triage lands and the gate greens 5/5 " +
+  "fresh-store under the full ON posture; the flip PR needs this list " +
+  "EMPTY.";
+
 export const SERVER_EXECUTION_ON_SKIPS: Record<
   ServerExecutionSuite,
   ServerExecutionOnSkip[]
@@ -89,11 +150,14 @@ export const SERVER_EXECUTION_ON_SKIPS: Record<
     {
       file: "integration/topics-navigation.test.ts",
       phase: "phase-7",
-      reason: "Phase 7 (2026-08-15): the ON shell build now LANDS by the " +
-        "flip (the default lane's binary bakes the shell ON), which " +
+      reason: "Phase 7 (2026-08-15; lane roles re-tensed 2026-08-16 — the " +
+        "flip landed DARK, so this runs in the explicit-true ON lanes on " +
+        "the ON-built binary, not in the default lanes): the ON shell " +
+        "build now RUNS in CI (`build-toolshed-on` bakes the shell ON for " +
+        "the ON lanes), which " +
         "discharges the first of this entry's two lifting conditions — " +
         "the second (the inherited red) does NOT lift: under the full " +
-        "post-flip default posture the file fails FAST at the " +
+        "ON posture the file fails FAST at the " +
         "controller's prop set (`updated result does not match its " +
         "write destination: missing required property myName`, " +
         "PiecePropIo.set → validateWriteDestination), reproduced on the " +
@@ -115,9 +179,99 @@ export const SERVER_EXECUTION_ON_SKIPS: Record<
         "lands in CI (verification-coverage.md OW25) AND the " +
         "inherited red is fixed.",
     },
+    {
+      file: "integration/cfc-group-chat-demo-two-browsers.test.ts",
+      phase: "phase-7",
+      reason: TWO_BROWSER_NON_SETTLING_REASON,
+    },
+    {
+      file: "integration/lunch-poll-vote.test.ts",
+      phase: "phase-7",
+      reason: TWO_BROWSER_NON_SETTLING_REASON +
+        " This gate ADDITIONALLY hits, at step 1, the served `#profile` " +
+        "wish running once identity-less and throwing (`home-space " +
+        "resolution on a serving runtime requires the run's demanding " +
+        "identity`; the OW29 space-root-demander gap is live at FIRST " +
+        "demand, not at the join click) while the flag-ON client — " +
+        "reference-only for the served sidecar since P7's fix (2) — waits " +
+        "forever for a sidecar the server cannot produce (`wish/phase/" +
+        "send-error` ~13.6/s; the review's `lunch-head-default-run{1,2}` " +
+        "logs). Fix (2) without OW29 turned a racy-but-rendering client " +
+        "into a wait-forever client; the P7 build's '(1)+(2)+(3) → join " +
+        "UI renders' narrative did NOT reproduce (0/2 at head).",
+    },
   ],
-  runner: [],
-  "runtime-client": [],
+  runner: [
+    {
+      file: "integration/pattern-and-data-persistence.test.ts",
+      phase: "phase-7",
+      reason: "Phase 7 (2026-08-16, P7 fixer on the independent review's " +
+        "finding 7): the runner integration tests that talk to the lane's " +
+        "toolshed now DECLARE the posture from the env, so under the ON lane " +
+        "this Deno client really runs the ON client arm — and this file is " +
+        "RED there (reproduced locally, uniform ON: 13/14 green, this one " +
+        "red; it was 'green ON' only while the lane ran a MIXED posture, an " +
+        "OFF client against an ON server). Mechanism as observed: Phase 3 " +
+        "starts a NEW piece, `pull()`s its result cell and reads " +
+        "`getAsQueryResult().sum` — 15 under the derive-and-commit client " +
+        "(OFF), `undefined` under ON. The test holds no sink on the result " +
+        "(the sink is the demand — serving-loop.md §1: pull-based laziness), " +
+        "so nothing served the derivation, and the ON client's OWN " +
+        "speculative run did not surface the value through this read path " +
+        "either — UNTRIAGED whether the Deno-client speculation overlay " +
+        "should have (verification-coverage.md OW33; the same family shows " +
+        "as `derive_array_leak`'s own 'Counter value is 0, expected 50' " +
+        "warning under ON — green only because that test asserts memory). " +
+        "The remaining runner integration files that serve toolshed's " +
+        "`app.ts` in-process (no ExecutorHost) are single-process harnesses, " +
+        "OFF by construction in either lane. Skipped rather than red-by-" +
+        "design; lifts when OW33 is triaged and this file greens under the " +
+        "uniform ON posture; the flip PR needs this list EMPTY.",
+    },
+  ],
+  "runtime-client": [
+    // STEP-LEVEL entries (the suite is ONE file with 45 steps; dropping the
+    // file would make the runtime-client ON lane vacuous). The rest of
+    // `client.test.ts` runs ON — the worker DECLARES the posture from the
+    // env since the P7 fixer (finding 7); these two steps are red under the
+    // uniform ON posture, reproduced 3/3 and 1/3 respectively against a
+    // local ON toolshed (2026-08-16).
+    {
+      file: "integration/client.test.ts",
+      step:
+        "renders PerUser-derived computed JSX inside cf-screen header slot (CT-1606)",
+      phase: "phase-7",
+      reason: "Phase 7 (2026-08-16, P7 fixer on the independent review's " +
+        "finding 7): with the worker declaring the ON posture this step " +
+        "never reaches its FIRST render within 15 s (3/3 red under uniform " +
+        "ON; green under the mixed posture the lane ran before) — a page " +
+        "whose header renders a `computed` over a `PerUser<myName>` input " +
+        "(the SAME PerUser shape topics-navigation fails on under the full " +
+        "ON posture). Mechanism UNATTRIBUTED — the Deno-worker client's " +
+        "per-user derivation neither speculates into the render nor " +
+        "arrives served in time; folded into verification-coverage.md OW33 " +
+        "(the ON-posture Deno-client family) beside topics-navigation's " +
+        "inherited red. Skipped at STEP granularity so the other 43 steps " +
+        "keep running ON; lifts when OW33's triage greens it 5/5; the flip " +
+        "PR needs this list EMPTY.",
+    },
+    {
+      file: "integration/client.test.ts",
+      step:
+        "dispatches one navigateTo when a rendered handler changes local state",
+      phase: "phase-7",
+      reason: "Phase 7 (2026-08-16, P7 fixer on the independent review's " +
+        "finding 7): under the uniform ON posture this step is FLAKY (1/3 " +
+        "red: expected ONE navigateTo dispatch, observed TWO — the " +
+        "double-dispatch class the F10 handler-fork contract exists to " +
+        "prevent, here on a Deno-worker client whose handler fire commits " +
+        "the event while the served consequence also navigates). " +
+        "UNATTRIBUTED; folded into verification-coverage.md OW33. Skipped " +
+        "at STEP granularity (the other steps keep running ON) rather than " +
+        "left to flake the lane; lifts when OW33's triage greens it 10/10; " +
+        "the flip PR needs this list EMPTY.",
+    },
+  ],
   shell: [],
 };
 
@@ -125,13 +279,78 @@ export const isServerExecutionSuite = (
   value: string,
 ): value is ServerExecutionSuite => value in SUITE_PACKAGE_DIR;
 
-/** The `--ignore=` flag for a suite's `deno test`, or "" with no skips. */
+/**
+ * The `--ignore=` flag for a suite's `deno test`, or "" with no skips.
+ *
+ * BINDS ONLY WHEN DENO DISCOVERS THE FILES ITSELF (Phase 7 fixer,
+ * 2026-08-16 — found while landing the two-browser entries): `deno test
+ * --ignore=<file>` filters DISCOVERED modules (a directory argument, or a
+ * glob Deno expands because it reached deno QUOTED), and silently ignores
+ * nothing when the same file arrives as an EXPLICIT positional argument —
+ * which is what a shell-expanded `./integration/*.test.ts` and the pattern
+ * shards' `"${TEST_FILES[@]}"` both are. So the package `integration`
+ * tasks (runner, runtime-client, shell) quote their glob, and the pattern
+ * shards go through {@link serverExecutionOnFilterFiles} (`--filter`)
+ * instead of this flag; the pins in the test file spawn deno on both
+ * shapes. Before this fix every "skipped" entry since Phase 4 (topics-
+ * navigation) actually RAN — unnoticed because the ON lanes ran a mixed
+ * posture under which it passed.
+ */
 export const serverExecutionOnIgnoreArg = (
   suite: ServerExecutionSuite,
 ): string => {
-  const skips = SERVER_EXECUTION_ON_SKIPS[suite];
+  const skips = SERVER_EXECUTION_ON_SKIPS[suite].filter((skip) =>
+    skip.step === undefined
+  );
   if (skips.length === 0) return "";
   return `--ignore=${skips.map((skip) => skip.file).join(",")}`;
+};
+
+/**
+ * The step-level guard a test FILE calls (see `ServerExecutionOnSkip.step`):
+ * the entry for `step` in `file`, or undefined when the ON arm runs it.
+ * Callers pass `ignore: serverExecutionOnStepSkip(...) !== undefined` only
+ * when the process actually runs the ON posture (they read
+ * EXPERIMENTAL_SERVER_EXECUTION themselves — the OFF arm never skips), and
+ * log the entry's reason when they skip, so the skip is never silent.
+ */
+export const serverExecutionOnStepSkip = (
+  suite: ServerExecutionSuite,
+  file: string,
+  step: string,
+): ServerExecutionOnSkip | undefined =>
+  SERVER_EXECUTION_ON_SKIPS[suite].find((skip) =>
+    skip.file === file && skip.step === step
+  );
+
+/** A candidate test path as the shard selector or a shell prints it
+ * (`./integration/x.test.ts`, `integration/x.test.ts`), normalized to the
+ * skip entries' package-relative form. */
+const normalizeCandidate = (file: string): string => file.replace(/^\.\//, "");
+
+/**
+ * The EXPLICIT-FILE shape (the pattern shards): the candidate files minus
+ * the suite's skip entries, in the input order, plus the entries that
+ * were actually dropped from THIS list (so the run step can print what it
+ * skipped here, not just the whole list). Files are compared after
+ * normalizing a leading `./`.
+ */
+export const serverExecutionOnFilterFiles = (
+  suite: ServerExecutionSuite,
+  candidates: readonly string[],
+): { files: string[]; skipped: ServerExecutionOnSkip[] } => {
+  const skips = SERVER_EXECUTION_ON_SKIPS[suite].filter((skip) =>
+    skip.step === undefined
+  );
+  const byFile = new Map(skips.map((skip) => [skip.file, skip]));
+  const files: string[] = [];
+  const skipped: ServerExecutionOnSkip[] = [];
+  for (const candidate of candidates) {
+    const skip = byFile.get(normalizeCandidate(candidate));
+    if (skip === undefined) files.push(candidate);
+    else if (!skipped.includes(skip)) skipped.push(skip);
+  }
+  return { files, skipped };
 };
 
 /** Human-readable report of a suite's skips, one line per entry. */
@@ -143,7 +362,9 @@ export const serverExecutionOnSkipReport = (
     return `[server-execution ON arm] ${suite}: no skips — full suite runs.`;
   }
   const lines = skips.map((skip) =>
-    `[server-execution ON arm] ${suite}: SKIP ${skip.file} (until ${skip.phase}) — ${skip.reason}`
+    skip.step === undefined
+      ? `[server-execution ON arm] ${suite}: SKIP ${skip.file} (until ${skip.phase}) — ${skip.reason}`
+      : `[server-execution ON arm] ${suite}: SKIP-STEP ${skip.file} :: ${skip.step} (until ${skip.phase}; the rest of the file runs) — ${skip.reason}`
   );
   return lines.join("\n");
 };
@@ -165,20 +386,44 @@ export const validateServerExecutionOnSkips = async (
   ) {
     const seen = new Set<string>();
     for (const skip of skips) {
-      if (seen.has(skip.file)) {
-        problems.push(`${suite}: duplicate skip entry for ${skip.file}`);
+      const key = skip.step === undefined
+        ? skip.file
+        : `${skip.file}\0${skip.step}`;
+      if (seen.has(key)) {
+        problems.push(
+          `${suite}: duplicate skip entry for ${skip.file}` +
+            (skip.step === undefined ? "" : ` :: ${skip.step}`),
+        );
       }
-      seen.add(skip.file);
+      seen.add(key);
       const path = new URL(
         `${SUITE_PACKAGE_DIR[suite]}/${skip.file}`,
         repoRoot,
       );
+      let contents: string | undefined;
       try {
-        await Deno.stat(path);
+        contents = await Deno.readTextFile(path);
       } catch {
         problems.push(
           `${suite}: skip entry names a missing file: ${skip.file}`,
         );
+      }
+      // A step entry must be BOUND: the file names the step and calls the
+      // guard, else the entry is decoration and the step silently runs (or
+      // a renamed step silently unskips).
+      if (skip.step !== undefined && contents !== undefined) {
+        if (!contents.includes(skip.step)) {
+          problems.push(
+            `${suite}: step skip entry names a step ${skip.file} does not ` +
+              `contain: ${JSON.stringify(skip.step)}`,
+          );
+        }
+        if (!contents.includes("serverExecutionOnStepSkip(")) {
+          problems.push(
+            `${suite}: ${skip.file} carries a step skip entry but never ` +
+              "calls serverExecutionOnStepSkip — the entry would be decoration",
+          );
+        }
       }
     }
   }
@@ -189,7 +434,14 @@ export const validateServerExecutionOnSkips = async (
  * CLI body, split from the `import.meta.main` wrapper so tests can drive it
  * in-process (the same coverage-driven split as `tasks/test.ts`). The skip
  * report goes to `io.error` (stderr) so an `$( )` capture in a CI step picks
- * up only the `--ignore` flag from `io.log` (stdout); the step shows both.
+ * up only the payload from `io.log` (stdout); the step shows both.
+ *
+ * Two shapes:
+ * - `<suite>` — prints the `--ignore=` flag (for a `deno test` that
+ *   DISCOVERS its files: the package `integration` tasks' quoted glob);
+ * - `<suite> --filter <file>...` — prints the candidate files minus the
+ *   skips, one per line (for a `deno test` fed EXPLICIT files: the
+ *   pattern shards), reporting on stderr which entries this list dropped.
  */
 export const main = async (
   args: string[],
@@ -214,6 +466,33 @@ export const main = async (
     return 1;
   }
   io.error(serverExecutionOnSkipReport(suite));
+  if (args[1] === "--filter") {
+    const { files, skipped } = serverExecutionOnFilterFiles(
+      suite,
+      args.slice(2),
+    );
+    for (const skip of skipped) {
+      io.error(
+        `[server-execution ON arm] ${suite}: DROPPED ${skip.file} from this ` +
+          `file list (until ${skip.phase})`,
+      );
+    }
+    if (skipped.length === 0) {
+      io.error(
+        `[server-execution ON arm] ${suite}: no listed skip is in this ` +
+          "file list — every candidate runs.",
+      );
+    }
+    for (const file of files) io.log(file);
+    return 0;
+  }
+  if (args.length > 1) {
+    io.error(
+      `Unexpected arguments ${JSON.stringify(args.slice(1))}; expected ` +
+        "<suite> or <suite> --filter <file>...",
+    );
+    return 1;
+  }
   const arg = serverExecutionOnIgnoreArg(suite);
   if (arg !== "") io.log(arg);
   return 0;

--- a/tasks/server-execution-on-skips.ts
+++ b/tasks/server-execution-on-skips.ts
@@ -2,11 +2,14 @@
 
 // The EXPLICIT per-phase skip lists of the server-execution v2 ON arm
 // (docs/specs/server-side-execution/testing.md §2): in CI the integration
-// suites run twice — EXPERIMENTAL_SERVER_EXECUTION off (byte-identical to
-// today) and on — and the ON arm may skip a test only by listing it here,
-// with the plan phase whose not-yet-landed surface it exercises and a
-// reason. Never by silent filtering: the CI step prints every skip from
-// this file, and an empty list means the ON arm runs the full suite.
+// suites run twice — since the plan's Phase 7 flip the DEFAULT lanes (flag
+// unset = the first-party default, ON) ARE the ON arm, and the
+// explicit-`EXPERIMENTAL_SERVER_EXECUTION=false` lanes are the OFF
+// regression guard (byte-identical to the pre-flip posture) — and the ON
+// arm may skip a test only by listing it here, with the plan phase whose
+// not-yet-landed surface it exercises and a reason. Never by silent
+// filtering: the CI step prints every skip from this file, and an empty
+// list means the ON arm runs the full suite.
 //
 // An entry retires when its phase lands (docs/plans/server-execution-v2.md);
 // a file listed here that no longer exists fails the run, so the lists
@@ -68,8 +71,10 @@ const SUITE_PACKAGE_DIR: Record<ServerExecutionSuite, string> = {
  * the load pass runs under the flush deadline), so the surface runs —
  * carrying the in-CI amplification-ratio gate and the pattern-updater
  * CHECK-half witness (verification-coverage.md's closed OW19 row).
- * Every list is EMPTY but for the ONE Phase-4 mixed-posture entry
- * below: the ON arm otherwise runs the full suites.
+ * Every list is EMPTY but for the ONE topics-navigation entry below
+ * (Phase 4's mixed-posture entry, re-justified by Phase 7 — the ON
+ * shell build landed with the flip, the inherited red did not lift):
+ * the ON arm otherwise runs the full suites.
  */
 export const SERVER_EXECUTION_ON_SKIPS: Record<
   ServerExecutionSuite,
@@ -83,8 +88,18 @@ export const SERVER_EXECUTION_ON_SKIPS: Record<
   patterns: [
     {
       file: "integration/topics-navigation.test.ts",
-      phase: "phase-3-followup",
-      reason: "MIXED-POSTURE honesty (Phase 4 fixer, 2026-08-11; the " +
+      phase: "phase-7",
+      reason: "Phase 7 (2026-08-15): the ON shell build now LANDS by the " +
+        "flip (the default lane's binary bakes the shell ON), which " +
+        "discharges the first of this entry's two lifting conditions — " +
+        "the second (the inherited red) does NOT lift: under the full " +
+        "post-flip default posture the file fails FAST at the " +
+        "controller's prop set (`updated result does not match its " +
+        "write destination: missing required property myName`, " +
+        "PiecePropIo.set → validateWriteDestination), reproduced on the " +
+        "Phase-7 tree 2026-08-15; a browser-ON/controller-ON red owed to " +
+        "the flip-follow-up triage. Original entry: " +
+        "MIXED-POSTURE honesty (Phase 4 fixer, 2026-08-11; the " +
         "workflow contract's list-the-affected-tests clause): the " +
         "ON-arm CI lane ships the binary's OFF-built browser shell, " +
         "so its green run of this file exercised an OFF-shell + " +


### PR DESCRIPTION
## Why

**Flip-READY, landed DARK by owner ruling (2026-08-16); the flip is its own PR.** The independent review's verdict on this train's last build was LANDABLE-WITH-FIXES *as a flip-ready mechanism PR with `SERVER_EXECUTION_DEFAULT_ENABLED = false`* and NOT-LANDABLE *as the flip*: with the constant `true` the repository's REQUIRED default CI lanes go red on merge (two two-browser gates stall 300 s under the full ON posture, neither skip-listed), the ON posture today breaks every two-user browser journey (an UNATTRIBUTED client-side scheduler-non-settling loop — OW32) and the piece-creation/compiler surfaces (OW28), and "flip-ready (true) and hold the merge" would park seventeen PRs behind several stages of work. The owner ruled: land with the constant `false` — the OFF posture stays the default everywhere it reaches, the ON posture stays fully selectable and CI-tested; **the flag flip becomes its own separate one-line PR later** (repo convention: a flip is reverted by reverting the PR that only flips), after the ON posture works and is performant. This PR therefore lands the mechanism (OW27 pacing, the read-authority + reference-only-sidecar + demand-root-chain lunch fixes, the LT9 simplification, the one-constant plumbing, the propagation-benchmark leg), the fixer pass on the review's 12 findings, an honest CI shape, and honest records. Base = Phase 6 (stacked; CI runs when the stack retargets main).

## Honest gates (as landed)

| lane / gate | posture | result |
| --- | --- | --- |
| DEFAULT CI lanes (package + pattern integration) | OFF (constant `false`; a ✅ probe pins server-not-serving + shell define unset before each suite) | the pre-P7 OFF-posture shape, green — the regression guard |
| explicit-`EXPERIMENTAL_SERVER_EXECUTION=true` ON lanes | FULL ON on an ON-BUILT binary (`build-toolshed-on`; probe: `/api/meta.shellServerExecutionDefine === "true"` + `servingLoop` present); the Deno-side clients declare the posture from the env (uniform, not mixed) | green EXCEPT the ON-skip-listed entries, each with a loud reason (`tasks/server-execution-on-skips.ts`): patterns `topics-navigation` (OW30 class), `cfc-group-chat-demo-two-browsers` + `lunch-poll-vote` (OW32 — the client loop; NOT evidenced as OW17); runner `pattern-and-data-persistence` (OW33); runtime-client ×2 STEP entries in `client.test.ts` (CT-1606 PerUser header render 3/3 red; single-navigateTo dispatch 1/3 red — OW33). None vacuous: all red under the full ON posture |
| sx2 family (serving-loop / speculation / events / effect-channel / scale) | explicit ON, fresh store each | 5/5 GREEN (fixer re-run) |
| sx2 family | DEFAULT (OFF), fresh store each | 5/5 GREEN; toolshed starts no serving loop |
| runner package integration | DEFAULT / explicit ON (uniform) | 14/14 GREEN / 13/14 GREEN + 1 skipped |
| runtime-client package integration | DEFAULT / explicit ON (uniform) | 45 steps GREEN / 43 steps GREEN + 2 ignored loudly |
| propagation benchmark (plan §1 criterion) | — | leg BUILT, **UNMEASURED**, deferred until the two-user family works (its harness is the two-browsers gate, red on OW32); an honest partial Deno-client number has a shape (recorded), not built |
| the compiled binaries | ON-built and default-built, locally | the CI probes pass end to end against real `deno task build-binaries toolshed` outputs (`shellServerExecutionDefine` "true" / null; `servingLoop` present / absent) |

## What changed (this fixer pass, on top of the build)

- **Landing posture:** `SERVER_EXECUTION_DEFAULT_ENABLED = false` (doc records the ruling and the flip PR's ordered gates); the ONE absolute pin states the default IS OFF (a silent flip either way cannot hide behind the relative pins).
- **CI:** default lanes revert to the OFF-posture shape (+ probe); the explicit-ON lanes return on `build-toolshed-on` (shell define baked `true`) with a posture probe before each suite — `tasks/build-binaries.ts` records the raw define in the COMPILED marker, `/api/meta` surfaces it as `shellServerExecutionDefine`. Status needs follow; the three workflow validators are green.
- **The ON skip list, made EFFECTIVE (found while adding entries):** `deno test --ignore` filters only files deno DISCOVERS and ignores nothing for explicitly listed files — which a shell-expanded `./integration/*.test.ts` and the pattern shards' `"${TEST_FILES[@]}"` both are; every skip since Phase 4 (`topics-navigation`) actually RAN, unnoticed under the mixed posture. Fix: the runner/runtime-client/shell `integration` tasks hand deno a QUOTED glob; the pattern ON shard filters its list through the script's new `--filter` mode; STEP-level entries exist (in-file guard bound to the register, validated); two spawned-deno pins state both shapes.
- **Uniform ON clients (finding 7):** the runner integration tests that talk to the lane's toolshed and the runtime-client worker declare the posture from the env; the 8 runner integration files that serve toolshed's `app.ts` in-process (no ExecutorHost) are single-process harnesses, OFF by construction.
- **Finding 4 (demand-root chain):** map/filter/flatMap now pass `parentPieceRootId` (red-first from the review's probe, parametrized over the three, mutation-verified per site; the grandchild-composes case pinned). The wish-sidecar sites are FLAGGED, not chained (per-demander sidecar vs the whole chain's instances is an unstated semantic — OW29).
- **Finding 5 (OW27):** streams are INDEPENDENT — the drain sends the earliest-fired entry whose stream has a token; no cross-stream head-of-line hold; per-stream fired order exact (red-first from the review's probe; events.md §5 / README §3.8 / register re-tensed: "accepted cost" described a defect).
- **Finding 6:** "not a write widening" corrected everywhere — the service-principal grant is implicit OWNER for the process identity's ordinary session traffic (not the wave's accept gate); narrowing needs a memory-ACL read-only class and depends on genesis needs — FLAGGED for the owner (OW31), inert while the constant is `false`.
- **Finding 3:** the lunch "(1)+(2)+(3) → join UI renders" narrative did NOT reproduce at head (the served `#profile` wish throws identity-less at step 1; fix (2) without OW29 makes the client wait forever) — corrected in the register/plan/skip reasons.
- **Finding 8:** the deployed-topology binaries the presets flip (`background-piece-service`, CLI, cf-harness, `PiecesController` hosts) have no ON gate — recorded as the flip PR's own obligation; with `false` none flips.
- **Records:** OW17 gains the review's CLASS VERDICT (bounded architectural leg — SpaceReplica docKey(id, scope) ~20 sites + SessionSyncUpsert scope key + tx→replica seam; stage-F entityKey precedent; P2-F-sized; NOT the evidenced cause of the two-browser red); NEW OW32 (the client non-settling loop; triage owed FIRST), OW33 (the ON-posture Deno-client family), OW31; OW28 carries the fix shape (compile as an outbox effect kind + completion-class writeback); OW25 discharged; the plan's Phase 7 task 1 = "flip-ready landed dark; the flip is a separate one-line PR after: OW32 triage → OW17 re-keying (+OW29) → OW28 → the honest benchmark → skip list EMPTY + deployed binaries gated ON → the flip"; task 2 stays SPLIT; both criteria unticked; testing.md §2, EXPERIMENTAL_OPTIONS.md, protocol.md §2 (`capabilityRef` vocabulary sentence — finding 11) updated.

## Test plan / bar (fixer, on the fixed tree)

Full runner 1201/6656 (4 foreground chunks) · memory 517 · toolshed 142 · runtime-client 61 · piece 37 · spec-model 23 · shell 59 · background-piece-service 14 · workflow validators (ci-workflow, ci-step-phases, on-skips 17) green with the constant `false` · `deno check` (touched entry points + tests) · `deno task check-docs` 548. Soaks: `executor-serving-loop` 10/10, `executor-effect-channel` 5/5, `executor-space-server` 5/5, `executor-run-supply` 5/5, `executor-events-down` 5/5, wedge pins + queue suites 2/2. Mutation probes: list-builtin chain sites removed → red per site; the head-only drain → red; the review's probes adopted as tests. Pre-existing on the branch line (not this PR): `tasks/select-pattern-integration-files.test.ts` is red because the weights table names `group-chat-adoption-bench.test.ts`, deleted by stage C.2 — a stack-retarget item.

## Flags (owner attention)

1. **OW32 — the client-side scheduler-non-settling loop** is the evidenced, unattributed cause of the two-browser red; its triage is the FIRST flip gate.
2. **OW17 class verdict** — a bounded architectural leg with a known fix shape (with OW29); landing it alone is NOT shown to green the two-user journeys.
3. **OW28** — compile-and-run inert under ON (product regression vs OFF); fix shape recorded.
4. **OW31** — the service-principal write-authority posture (OWNER-everywhere for the process identity's ordinary traffic vs a read-only ACL class): a ruled item before the flip.
5. **OW33** — the ON-posture Deno-client family the uniform lanes surfaced (skip-listed with reasons; untriaged).
6. The wish-sidecar chain question (OW29): unstated semantic, not filled.
7. The OW27 default posture (20/s, burst 20) — a dial; cross-stream independence is now the ruled semantics.
8. `deno test --ignore` was inert for explicitly listed files since Phase 4 — the fix and pins are here; every earlier "skip list EMPTY / one entry" statement described a mechanism that never bit.
9. Finding 8's gate obligation for the deployed-topology binaries belongs to the flip PR.

Reports: `/Users/berni/labs-worktrees/p7-fix-report.md` (this pass), `p7-independent-review.md`, `p7-build-report.md`, `p7-review-report.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
