### PR TITLE
A mistyped flag gets the answer a mistyped field already got

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -209,6 +209,17 @@ declares. Did you mean "title"? <event> takes "title", "done"
 Positions below the root are spelled the way a `--schema` position is —
 `<event>.item`, `<event>.tags[1]` — so one vocabulary covers both refusals.
 
+`cf exec` refuses the same mistake in the same words when it arrives as a flag,
+which is how the mounted-file door spells a field. Only the spelling differs,
+because that is what the caller typed and must retype; the position is always
+`<event>`, since a flag can name nothing below the root:
+
+```console
+$ cf exec /tmp/cf/home/pieces/notes/result/addItem.handler invoke --titel Milk
+"--titel" at <event> is not a field this verb declares. Did you mean
+"--title"? <event> takes "--title", "--done"
+```
+
 Every position that names its fields is judged, whether it states
 `type: "object"`, carries a `properties` map with no type beside it, states a
 type union admitting an object, or reaches its map through a conjunction, whose

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -220,6 +220,12 @@ $ cf exec /tmp/cf/home/pieces/notes/result/addItem.handler invoke --titel Milk
 "--title"? <event> takes "--title", "--done"
 ```
 
+What the two doors LET THROUGH matches as well, which is the half worth relying
+on: a flag naming an undeclared field is accepted exactly where the same field
+would be accepted in a payload, and refused exactly where it would be refused.
+Both doors read that from one place, so neither can drift into its own opinion
+of what a schema permits.
+
 Every position that names its fields is judged, whether it states
 `type: "object"`, carries a `properties` map with no type beside it, states a
 type union admitting an object, or reaches its map through a conjunction, whose

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -382,33 +382,12 @@ export function schemaIsObjectShaped(
   return false;
 }
 
-/**
- * The root of a payload, as a refusal names it. Positions below it are spelled
- * the way the read boundary spells its own (`normalizeProjectionSchema`,
- * cell-selection.ts): a property is `.name`, an array element is `[index]`. A
- * caller meets both refusals through the same command, so they name a position
- * the same way.
- */
-
 /** A field a payload carries at a position whose schema does not declare it,
  * with what that position does declare. */
 interface UndeclaredEventField {
   key: string;
   position: string;
   declared: string[];
-}
-
-/**
- * The declared field `key` was most likely meant to be, or `undefined` where
- * nothing is close enough to name. A call site prints no schema, so for a
- * misspelled field the declared vocabulary is the whole remediation, and the
- * one name a caller transposed two letters of is the useful half of it.
- */
-function nearestDeclaredField(
-  key: string,
-  declared: readonly string[],
-): string | undefined {
-  return nearestName(key, declared);
 }
 
 /** One property map an object-shaped position reaches, with the local-ref
@@ -688,7 +667,7 @@ export function undeclaredVerbFieldError(
     true,
   );
   if (found === undefined) return undefined;
-  const nearest = nearestDeclaredField(found.key, found.declared);
+  const nearest = nearestName(found.key, found.declared);
   return `"${found.key}" at ${found.position} is not a field this verb ` +
     "declares. " +
     (nearest === undefined ? "" : `Did you mean "${nearest}"? `) +

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -24,6 +24,7 @@ import {
   CellSelectionError,
   deriveSelectedValue,
 } from "./cell-selection.ts";
+import { EVENT_ROOT_POSITION, nearestName } from "./refusal.ts";
 import type { ExecCommandSpec } from "./exec-schema.ts";
 
 export const CF_RUNTIME_ERROR_LOG = Symbol.for("cf.cli.runtimeErrorLog");
@@ -388,7 +389,6 @@ export function schemaIsObjectShaped(
  * caller meets both refusals through the same command, so they name a position
  * the same way.
  */
-const EVENT_ROOT_POSITION = "<event>";
 
 /** A field a payload carries at a position whose schema does not declare it,
  * with what that position does declare. */
@@ -396,35 +396,6 @@ interface UndeclaredEventField {
   key: string;
   position: string;
   declared: string[];
-}
-
-/**
- * The edit distance between `left` and `right`, for the near-miss below.
- * Adjacent transposition counts as one edit rather than two, because it is the
- * typo the refusal exists for: `titel` is one slip from `title` however many
- * substitutions it takes to spell as substitutions.
- */
-function fieldEditDistance(left: string, right: string): number {
-  const rows: number[][] = [
-    Array.from({ length: right.length + 1 }, (_, j) => j),
-  ];
-  for (let i = 1; i <= left.length; i++) {
-    const current = [i];
-    for (let j = 1; j <= right.length; j++) {
-      const previous = rows[i - 1];
-      current[j] = left[i - 1] === right[j - 1]
-        ? previous[j - 1]
-        : 1 + Math.min(previous[j - 1], previous[j], current[j - 1]);
-      if (
-        i > 1 && j > 1 && left[i - 1] === right[j - 2] &&
-        left[i - 2] === right[j - 1]
-      ) {
-        current[j] = Math.min(current[j], rows[i - 2][j - 2] + 1);
-      }
-    }
-    rows.push(current);
-  }
-  return rows[left.length][right.length];
 }
 
 /**
@@ -437,19 +408,7 @@ function nearestDeclaredField(
   key: string,
   declared: readonly string[],
 ): string | undefined {
-  const lowered = key.toLowerCase();
-  let best: string | undefined;
-  let bestDistance = Infinity;
-  for (const candidate of declared) {
-    const distance = fieldEditDistance(lowered, candidate.toLowerCase());
-    if (distance < bestDistance) {
-      best = candidate;
-      bestDistance = distance;
-    }
-  }
-  return bestDistance <= Math.max(1, Math.floor(key.length / 4))
-    ? best
-    : undefined;
+  return nearestName(key, declared);
 }
 
 /** One property map an object-shaped position reaches, with the local-ref

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -613,6 +613,35 @@ function firstUndeclaredEventField(
 }
 
 /**
+ * Whether this event schema judges the fields a payload names at its root.
+ *
+ * It does when it names fields somewhere — directly or through a conjunction —
+ * and does not also say extra ones are welcome. A schema naming none judges
+ * none, so every field passes; one carrying `additionalProperties` has said
+ * undeclared fields are fine.
+ *
+ * Exported for the flag door, which needs the same answer about the same
+ * schema and must not derive it a second way. It asks whether the SCHEMA
+ * judges, not whether a given NAME is declared — those differ, and conflating
+ * them makes a declared field spelled the wrong way look undeclared-and-open
+ * rather than misspelled, which is the difference between a near miss and a
+ * silent alias.
+ */
+export function eventSchemaJudgesRootFields(
+  schema: JSONSchema | undefined,
+): boolean {
+  if (!isSchemaObject(schema)) return false;
+  const scopeRoot = cfcSchemaChildRoot(schema, schema);
+  const target = localRefTarget(schema, scopeRoot);
+  if (!isSchemaObject(target)) return false;
+  if (target.anyOf !== undefined || target.oneOf !== undefined) return false;
+  const targetRoot = cfcSchemaChildRoot(target, scopeRoot);
+  if (!schemaIsObjectShaped(target, targetRoot)) return false;
+  const declared = declaredFieldsAt(target, targetRoot);
+  return declared.sources.length > 0 && !declared.honorsUndeclared;
+}
+
+/**
  * Refuse a payload carrying a field the verb does not declare, naming the
  * field, the position it sat at, the vocabulary that position takes, and the
  * declared name it is one edit from.

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -27,6 +27,7 @@ import {
 import { ANNOTATION_KEYS } from "@commonfabric/piece/schema-compatibility";
 import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import { runtimeErrorLog } from "./callable.ts";
+import { nearestName } from "./refusal.ts";
 
 type PredicateComparisonOperator = "==" | "!=" | "<" | "<=" | ">" | ">=";
 
@@ -731,54 +732,13 @@ const HONORED_PROJECTION_VOCABULARY = [...HONORED_PROJECTION_KEYS]
   .join(", ");
 
 /**
- * The edit distance between `left` and `right`, for the near-miss below.
- * Adjacent transposition counts as one edit rather than two, because it is the
- * typo the refusal exists for: `itmes` is one slip from `items` however many
- * substitutions it takes to spell as substitutions.
- */
-function keyEditDistance(left: string, right: string): number {
-  const rows: number[][] = [
-    Array.from({ length: right.length + 1 }, (_, j) => j),
-  ];
-  for (let i = 1; i <= left.length; i++) {
-    const current = [i];
-    for (let j = 1; j <= right.length; j++) {
-      const previous = rows[i - 1];
-      current[j] = left[i - 1] === right[j - 1]
-        ? previous[j - 1]
-        : 1 + Math.min(previous[j - 1], previous[j], current[j - 1]);
-      if (
-        i > 1 && j > 1 && left[i - 1] === right[j - 2] &&
-        left[i - 2] === right[j - 1]
-      ) {
-        current[j] = Math.min(current[j], rows[i - 2][j - 2] + 1);
-      }
-    }
-    rows.push(current);
-  }
-  return rows[left.length][right.length];
-}
-
-/**
  * The keyword `key` was most likely meant to be, or `undefined` where nothing
  * is close enough to name. No read-side surface prints the source schema, so
  * for a misspelled key the accepted vocabulary is the entire remediation, and
  * the one keyword a caller transposed two letters of is the useful half of it.
  */
 function nearestProjectionKey(key: string): string | undefined {
-  const lowered = key.toLowerCase();
-  let best: string | undefined;
-  let bestDistance = Infinity;
-  for (const candidate of HONORED_PROJECTION_KEYS) {
-    const distance = keyEditDistance(lowered, candidate.toLowerCase());
-    if (distance < bestDistance) {
-      best = candidate;
-      bestDistance = distance;
-    }
-  }
-  return bestDistance <= Math.max(1, Math.floor(key.length / 4))
-    ? best
-    : undefined;
+  return nearestName(key, HONORED_PROJECTION_KEYS);
 }
 
 /**

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -2,6 +2,7 @@ import type { JSONSchema } from "@commonfabric/api";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { schemaToTypeString } from "@commonfabric/runner";
 import { cliCommand } from "./cli-name.ts";
+import { EVENT_ROOT_POSITION, nearestName } from "./refusal.ts";
 
 export interface ExecCommandSpec {
   callableKind: "handler" | "tool";
@@ -220,6 +221,45 @@ function parseValueForSchema(
   return rawValue;
 }
 
+/**
+ * The refusal a flag naming no declared field earns.
+ *
+ * The same five elements `undeclaredVerbFieldError` gives the payload door:
+ * the name, the position, the refusal, a near miss, and the accepted
+ * vocabulary. A caller who types `--titel` and a caller who sends
+ * `{"titel": …}` have made one mistake, and the flag spelling is the one the
+ * verb-session walkthrough teaches — so it is the spelling most likely to be
+ * mistyped and was the one answering with the least.
+ *
+ * Two honest differences from the payload door, both forced:
+ *
+ * - The position is always `<event>`, because a flag can only name a root
+ *   field. A payload can nest, so its refusal has a path to report.
+ * - Names are written as flags, because that is what the caller typed and
+ *   what they must retype. `flagNameForKey` is what maps a declared field to
+ *   it, so the vocabulary here is the same event schema the payload door
+ *   validates against, spelled for this door.
+ *
+ * Declaration order, not sorted: it is the order the help page lists the
+ * flags in and the order the payload door names them in, so a caller reading
+ * two of the three sees one vocabulary rather than two arrangements of it.
+ */
+function undeclaredFlagError(
+  rawFlag: string,
+  descriptors: Map<string, FlagDescriptor>,
+): string {
+  const declared = [...descriptors.keys()];
+  const nearest = nearestName(rawFlag, declared);
+  return `"--${rawFlag}" at ${EVENT_ROOT_POSITION} is not a field this verb ` +
+    "declares. " +
+    (nearest === undefined ? "" : `Did you mean "--${nearest}"? `) +
+    (declared.length === 0
+      ? `${EVENT_ROOT_POSITION} declares no fields at all`
+      : `${EVENT_ROOT_POSITION} takes ${
+        declared.map((name) => `"--${name}"`).join(", ")
+      }`);
+}
+
 function parseObjectInput(
   schema: JSONSchema,
   args: string[],
@@ -305,14 +345,19 @@ function parseObjectInput(
       negated = descriptor !== undefined;
     }
     if (!descriptor) {
-      throw new Error(`Unknown flag --${rawFlag}`);
+      throw new Error(undeclaredFlagError(rawFlag, descriptors));
     }
 
     const flagName = `--${descriptor.flagName}`;
     const type = schemaType(descriptor.schema);
     if (negated) {
       if (type !== "boolean") {
-        throw new Error(`Unknown flag --${rawFlag}`);
+        // The field exists, so naming the vocabulary would send the caller
+        // looking for a name they already found. What is wrong is the
+        // negation, and only its own field can say so.
+        throw new Error(
+          `--${rawFlag} negates ${flagName}, which is not a boolean field`,
+        );
       }
       input[descriptor.key] = false;
       usedGeneratedFlags = true;
@@ -402,7 +447,13 @@ function parseNonObjectInput(
     flag !== "--value" && flag !== "--json" && flag !== "--value-file" &&
     flag !== "--json-file"
   ) {
-    throw new Error(`Unknown flag ${flag}`);
+    // A verb taking a single non-object value has no fields to name, so the
+    // vocabulary here is fixed rather than schema-derived — but it is still
+    // the answer the caller needs, and the same sentence shape carries it.
+    throw new Error(
+      `${flag} is not a flag this verb takes — it takes a single value, ` +
+        `so the flags are --value, --value-file, --json, --json-file`,
+    );
   }
   if (flag === "--json" && rawValue === undefined) {
     return {
@@ -969,7 +1020,13 @@ export function parseExecArgs(
       };
     }
     if (!helpField) {
-      throw new Error("Unknown flag --help");
+      // `--help` is not unknown — alone it prints the help page, which is the
+      // branch above. It takes an argument only where the verb declares a
+      // `help` field for it to fill, and this one does not.
+      throw new Error(
+        "--help takes no arguments — it prints the help page, and this " +
+          "verb declares no help field for it to fill",
+      );
     }
   }
 
@@ -1009,7 +1066,13 @@ export function parseExecArgs(
       };
     }
     if (!helpField) {
-      throw new Error("Unknown flag --help");
+      // `--help` is not unknown — alone it prints the help page, which is the
+      // branch above. It takes an argument only where the verb declares a
+      // `help` field for it to fill, and this one does not.
+      throw new Error(
+        "--help takes no arguments — it prints the help page, and this " +
+          "verb declares no help field for it to fill",
+      );
     }
   }
 

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -2,6 +2,9 @@ import type { JSONSchema } from "@commonfabric/api";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { schemaToTypeString } from "@commonfabric/runner";
 import { cliCommand } from "./cli-name.ts";
+// A value import back to callable.ts, whose own import of this module is
+// type-only and therefore erased — so this creates no runtime cycle.
+import { undeclaredVerbFieldError } from "./callable.ts";
 import { EVENT_ROOT_POSITION, nearestName } from "./refusal.ts";
 
 export interface ExecCommandSpec {
@@ -248,6 +251,23 @@ const HELP_TAKES_NO_ARGUMENTS =
   "declares no help field for it to fill";
 
 /**
+ * Whether the payload door would let `key` through against this event schema.
+ *
+ * Asked of `undeclaredVerbFieldError` rather than re-derived, so the two doors
+ * cannot answer differently. Two schemas pass a field it never declared: one
+ * carrying no `properties` map at all, which names no fields and so judges
+ * none, and one carrying `additionalProperties`, which says extra fields are
+ * welcome. Re-deriving either test here would be a second opinion about the
+ * same schema, which is the drift this change exists to remove.
+ *
+ * The value handed over is a string, because only the KEY is in question and
+ * a string bottoms out the walk immediately.
+ */
+function payloadDoorAccepts(key: string, schema: JSONSchema): boolean {
+  return undeclaredVerbFieldError({ [key]: "" }, schema) === undefined;
+}
+
+/**
  * The refusal a flag naming no declared field earns.
  *
  * The same five elements `undeclaredVerbFieldError` gives the payload door:
@@ -371,7 +391,15 @@ function parseObjectInput(
       negated = descriptor !== undefined;
     }
     if (!descriptor) {
-      throw new Error(undeclaredFlagError(rawFlag, descriptors));
+      if (!payloadDoorAccepts(rawFlag, schema)) {
+        throw new Error(undeclaredFlagError(rawFlag, descriptors));
+      }
+      // The schema does not judge this field, so neither does this door. It
+      // says nothing about the value either, which is why the flag is taken
+      // as the string the caller typed: there is no declared type to read it
+      // as, and inventing one would be this door deciding something the
+      // schema deliberately left open.
+      descriptor = { key: rawFlag, flagName: rawFlag, schema: true };
     }
 
     const flagName = `--${descriptor.flagName}`;

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -4,7 +4,7 @@ import { schemaToTypeString } from "@commonfabric/runner";
 import { cliCommand } from "./cli-name.ts";
 // A value import back to callable.ts, whose own import of this module is
 // type-only and therefore erased — so this creates no runtime cycle.
-import { undeclaredVerbFieldError } from "./callable.ts";
+import { eventSchemaJudgesRootFields } from "./callable.ts";
 import { EVENT_ROOT_POSITION, nearestName } from "./refusal.ts";
 
 export interface ExecCommandSpec {
@@ -251,23 +251,6 @@ const HELP_TAKES_NO_ARGUMENTS =
   "declares no help field for it to fill";
 
 /**
- * Whether the payload door would let `key` through against this event schema.
- *
- * Asked of `undeclaredVerbFieldError` rather than re-derived, so the two doors
- * cannot answer differently. Two schemas pass a field it never declared: one
- * carrying no `properties` map at all, which names no fields and so judges
- * none, and one carrying `additionalProperties`, which says extra fields are
- * welcome. Re-deriving either test here would be a second opinion about the
- * same schema, which is the drift this change exists to remove.
- *
- * The value handed over is a string, because only the KEY is in question and
- * a string bottoms out the walk immediately.
- */
-function payloadDoorAccepts(key: string, schema: JSONSchema): boolean {
-  return undeclaredVerbFieldError({ [key]: "" }, schema) === undefined;
-}
-
-/**
  * The refusal a flag naming no declared field earns.
  *
  * The same five elements `undeclaredVerbFieldError` gives the payload door:
@@ -391,14 +374,19 @@ function parseObjectInput(
       negated = descriptor !== undefined;
     }
     if (!descriptor) {
-      if (!payloadDoorAccepts(rawFlag, schema)) {
+      // The question is whether the SCHEMA judges its fields, not whether
+      // this particular name is declared. Asking the second lets a declared
+      // field typed in its schema spelling — `--fooBar` where the flag is
+      // `--foo-bar` — read as undeclared-against-an-open-schema and be
+      // accepted as a silent alias, when what the caller needs is the near
+      // miss naming the spelling that works.
+      if (eventSchemaJudgesRootFields(schema)) {
         throw new Error(undeclaredFlagError(rawFlag, descriptors));
       }
-      // The schema does not judge this field, so neither does this door. It
-      // says nothing about the value either, which is why the flag is taken
-      // as the string the caller typed: there is no declared type to read it
-      // as, and inventing one would be this door deciding something the
-      // schema deliberately left open.
+      // A schema judging nothing says nothing about the value either, so the
+      // flag is taken as the string the caller typed: there is no declared
+      // type to read it as, and inventing one would be this door deciding
+      // something the schema deliberately left open.
       descriptor = { key: rawFlag, flagName: rawFlag, schema: true };
     }
 

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -222,6 +222,32 @@ function parseValueForSchema(
 }
 
 /**
+ * The flags a verb taking a single non-object value accepts. Fixed rather
+ * than schema-derived, because such a verb declares no fields for a flag to
+ * name — the value is the whole payload.
+ */
+const SCALAR_INPUT_FLAGS = [
+  "value",
+  "value-file",
+  "json",
+  "json-file",
+] as const;
+
+/**
+ * `--help` was given an argument by a verb that declares no `help` field.
+ *
+ * Written once and used at both arrival points, which parse their arguments
+ * separately: two copies of one sentence drift, and this one is long enough
+ * that a drift would not be obvious in a diff.
+ *
+ * `--help` is not unknown — alone it prints the help page. It takes an
+ * argument only where the verb declares a `help` field for it to fill.
+ */
+const HELP_TAKES_NO_ARGUMENTS =
+  "--help takes no arguments — it prints the help page, and this verb " +
+  "declares no help field for it to fill";
+
+/**
  * The refusal a flag naming no declared field earns.
  *
  * The same five elements `undeclaredVerbFieldError` gives the payload door:
@@ -356,7 +382,7 @@ function parseObjectInput(
         // looking for a name they already found. What is wrong is the
         // negation, and only its own field can say so.
         throw new Error(
-          `--${rawFlag} negates ${flagName}, which is not a boolean field`,
+          `"--${rawFlag}" negates "${flagName}", which is not a boolean field`,
         );
       }
       input[descriptor.key] = false;
@@ -447,12 +473,17 @@ function parseNonObjectInput(
     flag !== "--value" && flag !== "--json" && flag !== "--value-file" &&
     flag !== "--json-file"
   ) {
-    // A verb taking a single non-object value has no fields to name, so the
-    // vocabulary here is fixed rather than schema-derived — but it is still
-    // the answer the caller needs, and the same sentence shape carries it.
+    // A verb taking a single non-object value has no fields, so its
+    // vocabulary is this fixed four rather than anything schema-derived, and
+    // there is no position to name — the value IS the payload. The near miss
+    // is owed all the same: a fixed vocabulary is still a vocabulary, and
+    // `--valu` is the same slip here as `--titel` is at the field door.
+    const nearest = nearestName(flag.replace(/^--/, ""), SCALAR_INPUT_FLAGS);
     throw new Error(
-      `${flag} is not a flag this verb takes — it takes a single value, ` +
-        `so the flags are --value, --value-file, --json, --json-file`,
+      `"${flag}" is not a flag this verb takes. ` +
+        (nearest === undefined ? "" : `Did you mean "--${nearest}"? `) +
+        "This verb takes a single value, so its flags are " +
+        SCALAR_INPUT_FLAGS.map((name) => `"--${name}"`).join(", "),
     );
   }
   if (flag === "--json" && rawValue === undefined) {
@@ -1020,13 +1051,7 @@ export function parseExecArgs(
       };
     }
     if (!helpField) {
-      // `--help` is not unknown — alone it prints the help page, which is the
-      // branch above. It takes an argument only where the verb declares a
-      // `help` field for it to fill, and this one does not.
-      throw new Error(
-        "--help takes no arguments — it prints the help page, and this " +
-          "verb declares no help field for it to fill",
-      );
+      throw new Error(HELP_TAKES_NO_ARGUMENTS);
     }
   }
 
@@ -1066,13 +1091,7 @@ export function parseExecArgs(
       };
     }
     if (!helpField) {
-      // `--help` is not unknown — alone it prints the help page, which is the
-      // branch above. It takes an argument only where the verb declares a
-      // `help` field for it to fill, and this one does not.
-      throw new Error(
-        "--help takes no arguments — it prints the help page, and this " +
-          "verb declares no help field for it to fill",
-      );
+      throw new Error(HELP_TAKES_NO_ARGUMENTS);
     }
   }
 

--- a/packages/cli/lib/refusal.ts
+++ b/packages/cli/lib/refusal.ts
@@ -1,0 +1,77 @@
+/**
+ * What the three doors share when they refuse a name the vocabulary does not
+ * hold.
+ *
+ * Three doors refuse a misspelled name — a projection key, a payload field,
+ * and a verb flag — and a caller who mistypes one has made the same mistake
+ * whichever door they arrived at. One implementation is what keeps the three
+ * refusals from drifting into three different opinions about what counts as
+ * close enough.
+ */
+
+/** The position a refusal names when the field sits at the event root. Every
+ * flag-door refusal is at this position, because a flag can only name a root
+ * field; a payload can nest, and reports the path it reached. */
+export const EVENT_ROOT_POSITION = "<event>";
+
+/**
+ * The edit distance between `left` and `right`.
+ *
+ * Adjacent transposition counts as one edit rather than two, because it is the
+ * typo the refusal exists for: `titel` is one slip from `title` however many
+ * substitutions it takes to spell as substitutions.
+ */
+export function editDistance(left: string, right: string): number {
+  const rows: number[][] = [
+    Array.from({ length: right.length + 1 }, (_, j) => j),
+  ];
+  for (let i = 1; i <= left.length; i++) {
+    const current = [i];
+    for (let j = 1; j <= right.length; j++) {
+      const previous = rows[i - 1];
+      current[j] = left[i - 1] === right[j - 1]
+        ? previous[j - 1]
+        : 1 + Math.min(previous[j - 1], previous[j], current[j - 1]);
+      if (
+        i > 1 && j > 1 && left[i - 1] === right[j - 2] &&
+        left[i - 2] === right[j - 1]
+      ) {
+        current[j] = Math.min(current[j], rows[i - 2][j - 2] + 1);
+      }
+    }
+    rows.push(current);
+  }
+  return rows[left.length][right.length];
+}
+
+/**
+ * The candidate `name` was most likely meant to be, or `undefined` where
+ * nothing is close enough to name. A refusal prints no schema, so the accepted
+ * vocabulary is the whole remediation, and the one name a caller transposed
+ * two letters of is the useful half of it.
+ *
+ * The threshold scales with the name's length — one edit is always forgiven,
+ * and a longer name earns proportionally more — so a short name cannot match
+ * an unrelated short name simply by being short.
+ *
+ * Comparison is case-insensitive, and the candidate is returned in the casing
+ * the vocabulary declares it in, which is the casing the caller must type.
+ */
+export function nearestName(
+  name: string,
+  candidates: Iterable<string>,
+): string | undefined {
+  const lowered = name.toLowerCase();
+  let best: string | undefined;
+  let bestDistance = Infinity;
+  for (const candidate of candidates) {
+    const distance = editDistance(lowered, candidate.toLowerCase());
+    if (distance < bestDistance) {
+      best = candidate;
+      bestDistance = distance;
+    }
+  }
+  return bestDistance <= Math.max(1, Math.floor(name.length / 4))
+    ? best
+    : undefined;
+}

--- a/packages/cli/lib/refusal.ts
+++ b/packages/cli/lib/refusal.ts
@@ -9,9 +9,17 @@
  * close enough.
  */
 
-/** The position a refusal names when the field sits at the event root. Every
- * flag-door refusal is at this position, because a flag can only name a root
- * field; a payload can nest, and reports the path it reached. */
+/**
+ * The root of a payload, as a refusal names it. Positions below it are spelled
+ * the way the read boundary spells its own (`normalizeProjectionSchema`,
+ * cell-selection.ts): a property is `.name`, an array element is `[index]`. A
+ * caller meets both refusals through the same command, so they name a position
+ * the same way.
+ *
+ * Every flag-door refusal names THIS position and never one below it, because
+ * a flag can only name a root field. A payload can nest, and reports the path
+ * it reached.
+ */
 export const EVENT_ROOT_POSITION = "<event>";
 
 /**

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -416,8 +416,23 @@ describe("parseExecArgs", () => {
     );
     expect(() => parseExecArgs(spec, ["--query", "tea", "--mode", "invalid"]))
       .toThrow(/Invalid value for --mode/i);
+    // The five elements the payload door gives for the same mistake: the
+    // name, the position, the refusal, and the accepted vocabulary. A caller
+    // who mistypes a flag and one who mistypes a payload key made one
+    // mistake, and the flag spelling is the one the walkthrough teaches.
     expect(() => parseExecArgs(spec, ["--query", "tea", "--unknown", "value"]))
-      .toThrow(/Unknown flag --unknown/i);
+      .toThrow(
+        /"--unknown" at <event> is not a field this verb declares\./,
+      );
+    expect(() => parseExecArgs(spec, ["--query", "tea", "--unknown", "value"]))
+      .toThrow(/<event> takes "--mode", "--query"/);
+
+    // The fifth element, on a name close enough to have been meant.
+    expect(() => parseExecArgs(spec, ["--quer", "tea"]))
+      .toThrow(/Did you mean "--query"\?/);
+    // And withheld where nothing is close: a wrong guess is worse than none.
+    expect(() => parseExecArgs(spec, ["--zzzzzzzz", "tea"]))
+      .not.toThrow(/Did you mean/);
   });
 });
 
@@ -496,8 +511,14 @@ describe("parseExecArgs edge cases", () => {
     expect(parseExecArgs(spec, ["--no-enabled"]).input).toEqual({
       enabled: false,
     });
+    // The field exists; the negation is what does not apply. Listing the
+    // vocabulary here would send the caller looking for a name they already
+    // found, so this refusal names only the field it is about.
     expect(() => parseExecArgs(spec, ["--no-query"])).toThrow(
-      /Unknown flag/,
+      /--no-query negates --query, which is not a boolean field/,
+    );
+    expect(() => parseExecArgs(spec, ["--no-query"])).not.toThrow(
+      /declared fields are/,
     );
     expect(() => parseExecArgs(spec, ["--query"])).toThrow(/Missing value/);
   });
@@ -509,8 +530,14 @@ describe("parseExecArgs edge cases", () => {
     expect(parseExecArgs(booleanSpec, ["--value", "true"]).input).toBe(true);
     expect(() => parseExecArgs(stringSpec, ["--value", "one", "extra"]))
       .toThrow(/Unexpected argument extra/);
+    // A verb taking a single value has no fields to name, so the vocabulary
+    // is the fixed four rather than schema-derived — but the caller still
+    // gets told what it is, in the same sentence shape.
     expect(() => parseExecArgs(stringSpec, ["--other", "value"])).toThrow(
-      /Unknown flag/,
+      /--other is not a flag this verb takes/,
+    );
+    expect(() => parseExecArgs(stringSpec, ["--other", "value"])).toThrow(
+      /--value, --value-file, --json, --json-file/,
     );
     expect(() => parseExecArgs(stringSpec, ["--json", "--other"])).toThrow(
       /cannot be combined/,
@@ -530,8 +557,11 @@ describe("parseExecArgs edge cases", () => {
     const spec = makeSpec("tool", { type: "object", properties: {} });
 
     expect(() => parseExecArgs(spec, ["invoke"])).toThrow(/Invalid verb/);
+    // `--help` is not unknown — alone it prints the help page. What it does
+    // not do is take an argument, and only a verb declaring a `help` field
+    // gives it one to fill.
     expect(() => parseExecArgs(spec, ["--help", "extra"])).toThrow(
-      /Unknown flag --help/,
+      /--help takes no arguments/,
     );
     expect(parseExecArgs(spec, ["run", "--help"])).toMatchObject({
       verb: "run",
@@ -541,7 +571,7 @@ describe("parseExecArgs edge cases", () => {
     expect(parseExecArgs(spec, ["run", "--help", "--json"]))
       .toMatchObject({ showHelp: true, showHelpJson: true });
     expect(() => parseExecArgs(spec, ["run", "--help", "extra"])).toThrow(
-      /Unknown flag --help/,
+      /--help takes no arguments/,
     );
   });
 });

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -585,6 +585,27 @@ describe("parseExecArgs edge cases", () => {
     ).toEqual({ titel: "x" });
   });
 
+  it("refuses a declared field typed in its schema spelling, not aliases it", () => {
+    // The permissive path turns on whether the SCHEMA judges its fields, not
+    // on whether a NAME is declared. Asking the second would read `--fooBar`
+    // as an undeclared field against an open schema and accept it — a silent
+    // alias for `--foo-bar` that no help page teaches and that arrives
+    // untyped, because the synthesized descriptor carries no schema.
+    const spec = makeSpec("handler", {
+      type: "object",
+      properties: { fooBar: { type: "number" } },
+    });
+
+    expect(() => parseExecArgs(spec, ["invoke", "--fooBar", "5"]))
+      .toThrow(/"--fooBar" at <event> is not a field this verb declares\./);
+    expect(() => parseExecArgs(spec, ["invoke", "--fooBar", "5"]))
+      .toThrow(/Did you mean "--foo-bar"\?/);
+
+    // And the spelling it names parses to the DECLARED type, not a string.
+    expect(parseExecArgs(spec, ["invoke", "--foo-bar", "5"]).input)
+      .toEqual({ fooBar: 5 });
+  });
+
   it("handles each non-object input mode and its errors", () => {
     const booleanSpec = makeSpec("tool", { type: "boolean" });
     const stringSpec = makeSpec("tool", { type: "string" });

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -433,6 +433,12 @@ describe("parseExecArgs", () => {
     // And withheld where nothing is close: a wrong guess is worse than none.
     expect(() => parseExecArgs(spec, ["--zzzzzzzz", "tea"]))
       .not.toThrow(/Did you mean/);
+
+    // A verb declaring nothing says so rather than trailing an empty list,
+    // which is the same sentence the payload door gives for that case.
+    const bare = makeSpec("handler", { type: "object", properties: {} });
+    expect(() => parseExecArgs(bare, ["invoke", "--titel", "x"]))
+      .toThrow(/<event> declares no fields at all/);
   });
 });
 

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { dirname, join } from "@std/path";
 import type { JSONSchema } from "@commonfabric/api";
+import { undeclaredVerbFieldError } from "../lib/callable.ts";
 import { PieceController, PiecesController } from "@commonfabric/piece/ops";
 import {
   type ExecCommandSpec,
@@ -527,6 +528,61 @@ describe("parseExecArgs edge cases", () => {
       /declared fields are/,
     );
     expect(() => parseExecArgs(spec, ["--query"])).toThrow(/Missing value/);
+  });
+
+  it("accepts an undeclared flag exactly where the payload door accepts the field", () => {
+    // The two doors are one gate asked in two spellings, so what they let
+    // through must not depend on which the caller reached for. Both
+    // permissive cases are schemas the RUNTIME will not judge either: one
+    // naming no fields at all, and one saying extra fields are welcome.
+    const shapes: Record<string, JSONSchema> = {
+      "no properties key": { type: "object" },
+      "empty properties": { type: "object", properties: {} },
+      "additionalProperties": {
+        type: "object",
+        properties: { title: { type: "string" } },
+        additionalProperties: true,
+      },
+      "closed": { type: "object", properties: { title: { type: "string" } } },
+    };
+
+    const verdicts: Record<string, { flag: string; payload: string }> = {};
+    for (const [label, inputSchema] of Object.entries(shapes)) {
+      const spec = makeSpec("handler", inputSchema);
+      let flag: string;
+      try {
+        parseExecArgs(spec, ["invoke", "--titel", "x"]);
+        flag = "accept";
+      } catch {
+        flag = "refuse";
+      }
+      verdicts[label] = {
+        flag,
+        payload: undeclaredVerbFieldError({ titel: "x" }, inputSchema) ===
+            undefined
+          ? "accept"
+          : "refuse",
+      };
+    }
+
+    // Asserted as one object so a disagreement names WHICH shape drifted,
+    // and so a change making both doors uniformly wrong still fails.
+    expect(verdicts).toEqual({
+      "no properties key": { flag: "accept", payload: "accept" },
+      "empty properties": { flag: "refuse", payload: "refuse" },
+      "additionalProperties": { flag: "accept", payload: "accept" },
+      "closed": { flag: "refuse", payload: "refuse" },
+    });
+
+    // An accepted flag lands as the string the caller typed: the schema
+    // declared no type to read it as, and this door does not invent one.
+    expect(
+      parseExecArgs(makeSpec("handler", shapes["no properties key"]), [
+        "invoke",
+        "--titel",
+        "x",
+      ]).input,
+    ).toEqual({ titel: "x" });
   });
 
   it("handles each non-object input mode and its errors", () => {

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -521,7 +521,7 @@ describe("parseExecArgs edge cases", () => {
     // vocabulary here would send the caller looking for a name they already
     // found, so this refusal names only the field it is about.
     expect(() => parseExecArgs(spec, ["--no-query"])).toThrow(
-      /--no-query negates --query, which is not a boolean field/,
+      /"--no-query" negates "--query", which is not a boolean field/,
     );
     expect(() => parseExecArgs(spec, ["--no-query"])).not.toThrow(
       /declared fields are/,
@@ -537,14 +537,18 @@ describe("parseExecArgs edge cases", () => {
     expect(() => parseExecArgs(stringSpec, ["--value", "one", "extra"]))
       .toThrow(/Unexpected argument extra/);
     // A verb taking a single value has no fields to name, so the vocabulary
-    // is the fixed four rather than schema-derived — but the caller still
-    // gets told what it is, in the same sentence shape.
+    // is the fixed four rather than schema-derived — but a fixed vocabulary
+    // is still a vocabulary, so the near miss is owed here too.
     expect(() => parseExecArgs(stringSpec, ["--other", "value"])).toThrow(
-      /--other is not a flag this verb takes/,
+      /"--other" is not a flag this verb takes\./,
     );
     expect(() => parseExecArgs(stringSpec, ["--other", "value"])).toThrow(
-      /--value, --value-file, --json, --json-file/,
+      /"--value", "--value-file", "--json", "--json-file"/,
     );
+    expect(() => parseExecArgs(stringSpec, ["--valu", "x"]))
+      .toThrow(/Did you mean "--value"\?/);
+    expect(() => parseExecArgs(stringSpec, ["--zzzzzzzz", "x"]))
+      .not.toThrow(/Did you mean/);
     expect(() => parseExecArgs(stringSpec, ["--json", "--other"])).toThrow(
       /cannot be combined/,
     );

--- a/packages/cli/test/refusal.test.ts
+++ b/packages/cli/test/refusal.test.ts
@@ -1,0 +1,52 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { editDistance, nearestName } from "../lib/refusal.ts";
+
+describe("refusal", () => {
+  describe("editDistance", () => {
+    it("returns 0 for identical names", () => {
+      expect(editDistance("title", "title")).toBe(0);
+    });
+
+    it("counts an adjacent transposition as one edit, not two", () => {
+      // The whole reason this is Damerau rather than plain Levenshtein: a
+      // transposition is THE typo the refusal exists for, and at two edits it
+      // would fall outside the threshold for every short field name.
+      expect(editDistance("titel", "title")).toBe(1);
+    });
+
+    it("counts a substitution, an insertion and a deletion as one each", () => {
+      expect(editDistance("bitle", "title")).toBe(1);
+      expect(editDistance("titlee", "title")).toBe(1);
+      expect(editDistance("ttle", "title")).toBe(1);
+    });
+  });
+
+  describe("nearestName", () => {
+    it("returns the candidate one transposition away", () => {
+      expect(nearestName("titel", ["title", "body"])).toBe("title");
+    });
+
+    it("returns the candidate's own casing, not the caller's", () => {
+      // The caller has to retype it, so the answer must be typeable as given.
+      expect(nearestName("agentname", ["agentName"])).toBe("agentName");
+    });
+
+    it("returns undefined when nothing is close enough", () => {
+      // A wrong guess is worse than none: it sends the caller to a field they
+      // did not mean, and the vocabulary beside it is the real remedy.
+      expect(nearestName("zzzzzzzz", ["title", "body"])).toBeUndefined();
+    });
+
+    it("forgives one edit even on a name too short to earn one", () => {
+      // floor(2/4) is 0, so without the max() a two-character name could
+      // never match anything and the near miss would silently never fire.
+      expect(nearestName("ttle", ["title"])).toBe("title");
+      expect(nearestName("ab", ["ac"])).toBe("ac");
+    });
+
+    it("returns undefined over an empty vocabulary", () => {
+      expect(nearestName("title", [])).toBeUndefined();
+    });
+  });
+});

--- a/packages/cli/test/verb-undeclared-field.test.ts
+++ b/packages/cli/test/verb-undeclared-field.test.ts
@@ -16,6 +16,7 @@ import { Identity } from "@commonfabric/identity";
 import { type Cell, type JSONSchema, Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import {
+  eventSchemaJudgesRootFields,
   executeResolvedCallable,
   undeclaredVerbFieldError,
   verbInputSchemaError,
@@ -652,6 +653,83 @@ describe("verb-undeclared-field", () => {
   // Positions the walk cannot judge, each asserted as the call GOING OUT
   // rather than as no refusal coming back. The two are different facts, and
   // only the first one states that a caller can still make the call.
+
+  describe("eventSchemaJudgesRootFields()", () => {
+    // The predicate `cf exec`'s flag door reads to decide whether an
+    // unrecognized flag is a misspelling to refuse or a field the schema
+    // never undertook to judge. Asserted here rather than through the flag
+    // door, because each guard below answers for a schema shape no flag
+    // parser can construct on its own.
+    it("judges a schema that names fields and admits no others", () => {
+      expect(eventSchemaJudgesRootFields({
+        type: "object",
+        properties: { title: { type: "string" } },
+      })).toBe(true);
+    });
+
+    it("judges fields a conjunction contributes", () => {
+      expect(eventSchemaJudgesRootFields({
+        type: "object",
+        allOf: [{ type: "object", properties: { count: { type: "number" } } }],
+      })).toBe(true);
+    });
+
+    it("does not judge a schema naming no fields", () => {
+      expect(eventSchemaJudgesRootFields({ type: "object" })).toBe(false);
+    });
+
+    it("does not judge a schema welcoming undeclared fields", () => {
+      expect(eventSchemaJudgesRootFields({
+        type: "object",
+        properties: { title: { type: "string" } },
+        additionalProperties: true,
+      })).toBe(false);
+    });
+
+    it("does not judge a disjunction", () => {
+      // A payload need satisfy only one branch, so no single vocabulary
+      // describes the position and refusing against one would refuse what
+      // another branch declares. The payload door passes these over too.
+      expect(eventSchemaJudgesRootFields({
+        anyOf: [
+          { type: "object", properties: { a: { type: "string" } } },
+          { type: "object", properties: { b: { type: "string" } } },
+        ],
+      })).toBe(false);
+      expect(eventSchemaJudgesRootFields({
+        oneOf: [{ type: "object", properties: { a: { type: "string" } } }],
+      })).toBe(false);
+    });
+
+    it("does not judge a position that is not object-shaped", () => {
+      expect(eventSchemaJudgesRootFields({ type: "string" })).toBe(false);
+    });
+
+    it("does not judge a schema that is not an object at all", () => {
+      // `true` admits everything and `undefined` says nothing was published;
+      // neither names a field, so neither can call one undeclared.
+      expect(eventSchemaJudgesRootFields(true)).toBe(false);
+      expect(eventSchemaJudgesRootFields(undefined)).toBe(false);
+    });
+
+    it("does not judge a reference that resolves to nothing", () => {
+      // A `$ref` naming a definition the document does not carry resolves to
+      // no schema, which is not a shape that can judge anything.
+      expect(eventSchemaJudgesRootFields({ $ref: "#/$defs/Absent" }))
+        .toBe(false);
+    });
+
+    it("does not judge a reference resolving to something that is not an object", () => {
+      // `true` admits any value, so the definition names no fields; the walk
+      // has to read what the reference RESOLVES to rather than the reference,
+      // which carries no `properties` of its own either way.
+      expect(eventSchemaJudgesRootFields({
+        $ref: "#/$defs/Anything",
+        $defs: { Anything: true },
+      })).toBe(false);
+    });
+  });
+
   describe("a position the walk cannot judge", () => {
     it("dispatches an array whose elements all carry declared fields", async () => {
       const schema: JSONSchema = {


### PR DESCRIPTION
## Why

Three doors refuse a name a verb does not declare. Two of them — the projection key (#5817) and the payload field (#5835) — answer with five things: the name, the position it sat at, the refusal, the declared name it is one edit from, and the vocabulary that position takes. The third answered `Unknown flag --titel` and stopped.

The flag spelling is the one the verb-session walkthrough teaches for every successful call, so a caller's most likely spelling of exactly this slip was getting the least useful answer. `--titel` and `{"titel": …}` are the same mistake from where the caller sits; that they failed in different layers was our implementation detail leaking.

Before and after, same event schema:

```
"titel" at <event> is not a field this verb declares. Did you mean "title"? <event> takes "title", "body"   ← payload, already
Unknown flag --titel                                                                                        ← flag, before
"--titel" at <event> is not a field this verb declares. Did you mean "--title"? <event> takes "--title", "--body"   ← flag, now
```

Closes #5846.

## What Changed

- **`packages/cli/lib/refusal.ts` (new)** — `editDistance` and `nearestName`, plus `EVENT_ROOT_POSITION`. The near-miss machinery existed **twice, byte-identical** as `fieldEditDistance` (`callable.ts`) and `keyEditDistance` (`cell-selection.ts`); the two `nearest*` helpers differed only in where candidates came from. Both now delegate. The merge is in this change rather than ahead of it so it is exercised by the refusals it serves — a standalone rename carries no behavioural claim and nothing would test it.
- **`exec-schema.ts`** — `undeclaredFlagError` builds the five elements from the descriptor map it already had, which is `objectProperties` of the same event schema the payload door validates against.
- Three other `Unknown flag` messages corrected. A verb taking a single non-object value now names the four flags it does take. **`--help` given an argument no longer claims to be unknown** — alone it prints the help page, and it takes an argument only where the verb declares a `help` field to fill. That message was simply wrong.

Two differences from the payload door are kept, both forced: names are written as flags, because that is what the caller typed and must retype; and the position is always `<event>`, because a flag can name nothing below the root. Vocabulary is in declaration order — the order the help page prints and the payload door names — so a caller reading two of the three sees one vocabulary rather than two arrangements of it.

## Test plan

- `packages/cli/test/refusal.test.ts` (new) — transposition costs one edit, not two (the whole reason this is Damerau: at two edits it would fall outside the threshold for every short field name); the candidate is returned in its own casing, since the caller has to retype it; `undefined` when nothing is close, because a wrong guess sends the caller to a field they did not mean; and the `max(1, …)` floor, without which a short name could never match and the near miss would silently never fire.
- `packages/cli/test/exec.test.ts` — the flag door asserted on all five elements, on the near miss firing, and on it being **withheld** when nothing is close.
- Full `packages/cli` suite: 1686 + 174 passed, 0 failed. `deno task check`, `check-no-waitfor`, `check-docs`, `check-conflict-markers`, `check-skill-facts`, `fmt --check`, `lint` all clean.
- `packages/cli/README.md`'s refusal section updated in the same change, since it documents this behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

