### PR TITLE
docs(development): one `import` statement per module, and `@/` over `../`

### DIFF
--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -33,6 +33,19 @@ about one aspect of the runtime, are indexed in
 - Destructure when importing multiple names from the same module.
 - Import either from `@commonfabric/api` (internal API) or
   `@commonfabric/api/interface` (external API), but not both.
+- Collate a package's imports. Every specifier naming the same top-level
+  package, or the same namespace-and-package pair, sits in one contiguous run:
+  `@commonfabric/utils/base64url` next to `@commonfabric/utils/types`,
+  `@std/testing/bdd` next to `@std/testing/time`. A package that appears in two
+  places in the list reads as two dependencies, and the second appearance hides
+  from anyone scanning for what the file rests on.
+- Alpha-sorting each run is strongly suggested. Sorting is what makes a list
+  scannable rather than merely grouped, and it answers by rule the question of
+  where a new import goes. Sort on the specifier, comparing without regard to
+  case, so that `codec-type-tags.ts` precedes `EmptyReconstructionContext.ts`
+  the way a reader expects. Where sorting and the grouping above disagree, the
+  grouping wins: sort within the standard-library, external, and internal
+  blocks, not across them.
 - Import a given module in exactly one or two statements. Two shapes are
   allowed:
   - One unified statement, marking any type-only names inline:
@@ -59,19 +72,6 @@ about one aspect of the runtime, are indexed in
   where it reads better. A `../` path whose target lies outside the aliased tree
   has no `@/` form at all, and stays as it is — a `bench/` or `test/` file
   reaching a fixture in its own tree, in a package whose alias covers `src/`.
-- Collate a package's imports. Every specifier naming the same top-level
-  package, or the same namespace-and-package pair, sits in one contiguous run:
-  `@commonfabric/utils/base64url` next to `@commonfabric/utils/types`,
-  `@std/testing/bdd` next to `@std/testing/time`. A package that appears in two
-  places in the list reads as two dependencies, and the second appearance hides
-  from anyone scanning for what the file rests on.
-- Alpha-sorting each run is strongly suggested. Sorting is what makes a list
-  scannable rather than merely grouped, and it answers by rule the question of
-  where a new import goes. Sort on the specifier, comparing without regard to
-  case, so that `codec-type-tags.ts` precedes `EmptyReconstructionContext.ts`
-  the way a reader expects. Where sorting and the grouping above disagree, the
-  grouping wins: sort within the standard-library, external, and internal
-  blocks, not across them.
 
 ### Classes
 

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -27,9 +27,7 @@ about one aspect of the runtime, are indexed in
 ### Imports
 
 - Group imports by source: standard library, external, then internal, with a
-  blank line between the groups. Add the blank lines when writing a file, or
-  when reordering its imports for some other reason; a file whose imports are
-  otherwise correct is not worth touching for them alone.
+  blank line between the groups.
 - Prefer named exports over default exports.
 - Use package names for internal imports.
 - Destructure when importing multiple names from the same module.

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -50,11 +50,12 @@ about one aspect of the runtime, are indexed in
   as `@/...` rather than by a `../` path that climbs out of the current
   directory to reach it. The alias exists so that a module's address does not
   depend on where the importing file sits, and a `../` path spends that. The
-  rule reaches `../` alone: a `./` path, which addresses something at or below
-  the importing file, is outside it. So is a `../` path whose target lies
-  outside the aliased tree, which has no `@/` form at all — a `bench/` or
-  `test/` file reaching a fixture in its own tree, in a package whose alias
-  covers `src/`.
+  rule is about `../` and nothing else. A `./` path addresses something at or
+  below the importing file, so no climbing is involved and no address depends on
+  the file's own position; `./` and `@/` are both fine, and a file may use each
+  where it reads better. A `../` path whose target lies outside the aliased tree
+  has no `@/` form at all, and stays as it is — a `bench/` or `test/` file
+  reaching a fixture in its own tree, in a package whose alias covers `src/`.
 - Collate a package's imports. Every specifier naming the same top-level
   package, or the same namespace-and-package pair, sits in one contiguous run:
   `@commonfabric/utils/base64url` next to `@commonfabric/utils/types`,

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -33,20 +33,22 @@ about one aspect of the runtime, are indexed in
 - Destructure when importing multiple names from the same module.
 - Import either from `@commonfabric/api` (internal API) or
   `@commonfabric/api/interface` (external API), but not both.
-- Import a given module in one statement. Two statements naming the same module
-  represent one dependency as though it were two, and the second is easy to miss
-  when the first is being edited or removed. Merge the specifier lists instead.
-  Two details:
-  - Splitting a module's type imports from its value imports is the carve-out,
-    and needs no justification: `import type { ... } from "x";` alongside
-    `import { ... } from "x";` states one dependency in the two forms the type
-    system distinguishes. Keep the two statements adjacent. That split is the
-    whole of the exception — two value imports from one module, or two
-    `import type`s from it, are what this rule is about.
-  - A bare `import "x";` adds nothing to a file that already imports `x` by
-    name. The named import evaluates the module, side effects included, so the
-    bare form documents an effect it is not needed to produce. Put that in a
-    comment on the surviving statement.
+- Import a given module in exactly one or two statements. Two shapes are
+  allowed:
+  - One unified statement, marking any type-only names inline:
+    `import { type Foo, bar } from "x";`.
+  - One statement of each kind, kept adjacent:
+    `import type { Foo } from "x";` above `import { bar } from "x";`.
+
+  A file uses whichever reads better; neither is preferred. What neither shape
+  allows is a second statement of the same kind — two value imports from one
+  module, or two `import type`s from it. Those represent one dependency as
+  though it were two, and the second is easy to miss when the first is being
+  edited or removed, so merge their specifier lists. A bare `import "x";` counts
+  toward the total, and adds nothing to a file that already imports `x` by name:
+  the named import evaluates the module, side effects included, so the bare form
+  documents an effect it is not needed to produce. Put that in a comment on the
+  surviving statement.
 - Within a package that defines the `@/` import alias, address the aliased tree
   as `@/...` rather than by a `../` path that climbs out of the current
   directory to reach it. The alias exists so that a module's address does not

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -66,12 +66,13 @@ about one aspect of the runtime, are indexed in
   as `@/...` rather than by a `../` path that climbs out of the current
   directory to reach it. The alias exists so that a module's address does not
   depend on where the importing file sits, and a `../` path spends that. The
-  rule is about `../` and nothing else. A `./` path addresses something at or
-  below the importing file, so no climbing is involved and no address depends on
-  the file's own position; `./` and `@/` are both fine, and a file may use each
-  where it reads better. A `../` path whose target lies outside the aliased tree
-  has no `@/` form at all, and stays as it is — a `bench/` or `test/` file
-  reaching a fixture in its own tree, in a package whose alias covers `src/`.
+  rule is about `../` and nothing else: a `./` path addresses the importing
+  file's own directory or something under it, and so never states how two
+  directories sit relative to each other. `./` and `@/` are both fine, and a
+  file may use each where it reads better. A `../` path whose target lies
+  outside the aliased tree has no `@/` form at all, and stays as it is — a
+  `bench/` or `test/` file reaching a fixture in its own tree, in a package
+  whose alias covers `src/`.
 
 ### Classes
 

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -32,6 +32,29 @@ about one aspect of the runtime, are indexed in
 - Destructure when importing multiple names from the same module.
 - Import either from `@commonfabric/api` (internal API) or
   `@commonfabric/api/interface` (external API), but not both.
+- Import a given module in one statement. Two statements naming the same module
+  represent one dependency as though it were two, and the second is easy to miss
+  when the first is being edited or removed. Merge the specifier lists instead.
+  Two details:
+  - Splitting a module's type imports from its value imports is the carve-out,
+    and needs no justification: `import type { ... } from "x";` alongside
+    `import { ... } from "x";` states one dependency in the two forms the type
+    system distinguishes. Keep the two statements adjacent. That split is the
+    whole of the exception — two value imports from one module, or two
+    `import type`s from it, are what this rule is about.
+  - A bare `import "x";` adds nothing to a file that already imports `x` by
+    name. The named import evaluates the module, side effects included, so the
+    bare form documents an effect it is not needed to produce. Put that in a
+    comment on the surviving statement.
+- Within a package that defines the `@/` import alias, address the aliased tree
+  as `@/...` rather than by a `../` path that climbs out of the current
+  directory to reach it. The alias exists so that a module's address does not
+  depend on where the importing file sits, and a `../` path spends that. The
+  rule reaches `../` alone: a `./` path, which addresses something at or below
+  the importing file, is outside it. So is a `../` path whose target lies
+  outside the aliased tree, which has no `@/` form at all — a `bench/` or
+  `test/` file reaching a fixture in its own tree, in a package whose alias
+  covers `src/`.
 
 ### Classes
 

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -55,6 +55,22 @@ about one aspect of the runtime, are indexed in
   outside the aliased tree, which has no `@/` form at all — a `bench/` or
   `test/` file reaching a fixture in its own tree, in a package whose alias
   covers `src/`.
+- Collate a package's imports. Every specifier naming the same top-level
+  package, or the same namespace-and-package pair, sits in one contiguous run:
+  `@commonfabric/utils/base64url` next to `@commonfabric/utils/types`,
+  `@std/testing/bdd` next to `@std/testing/time`. A package that appears in two
+  places in the list reads as two dependencies, and the second appearance hides
+  from anyone scanning for what the file rests on.
+- Alpha-sorting each run is strongly suggested. Sorting is what makes a list
+  scannable rather than merely grouped, and it answers by rule the question of
+  where a new import goes. Sort on the specifier, comparing without regard to
+  case, so that `codec-type-tags.ts` precedes `EmptyReconstructionContext.ts`
+  the way a reader expects. Where sorting and the grouping above disagree, the
+  grouping wins: sort within the standard-library, external, and internal
+  blocks, not across them.
+- Separate those three blocks with a blank line. Do it when writing a file, or
+  when reordering its imports for some other reason; a file whose imports are
+  otherwise correct is not worth touching for this alone.
 
 ### Classes
 

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -26,7 +26,10 @@ about one aspect of the runtime, are indexed in
 
 ### Imports
 
-- Group imports by source: standard library, external, then internal.
+- Group imports by source: standard library, external, then internal, with a
+  blank line between the groups. Add the blank lines when writing a file, or
+  when reordering its imports for some other reason; a file whose imports are
+  otherwise correct is not worth touching for them alone.
 - Prefer named exports over default exports.
 - Use package names for internal imports.
 - Destructure when importing multiple names from the same module.
@@ -69,9 +72,6 @@ about one aspect of the runtime, are indexed in
   the way a reader expects. Where sorting and the grouping above disagree, the
   grouping wins: sort within the standard-library, external, and internal
   blocks, not across them.
-- Separate those three blocks with a blank line. Do it when writing a file, or
-  when reordering its imports for some other reason; a file whose imports are
-  otherwise correct is not worth touching for this alone.
 
 ### Classes
 

--- a/packages/data-model/bench/codec-json.bench.ts
+++ b/packages/data-model/bench/codec-json.bench.ts
@@ -19,7 +19,7 @@
  * iteration anyway, which most of these are.
  */
 
-import { fabricFromJsonValue, jsonFromFabricValue } from "../src/codecs.ts";
+import { fabricFromJsonValue, jsonFromFabricValue } from "@/codecs.ts";
 import {
   ARRAYS,
   groupKey,

--- a/packages/data-model/bench/fixtures/codec-fixtures.ts
+++ b/packages/data-model/bench/fixtures/codec-fixtures.ts
@@ -16,11 +16,11 @@
  * and several codecs all appear at once.
  */
 
-import type { FabricValue } from "../../src/interface.ts";
-import { FabricBytes } from "../../src/fabric-primitives/FabricBytes.ts";
-import { FabricEpochNsec } from "../../src/fabric-primitives/FabricEpochNsec.ts";
-import { FabricRegExp } from "../../src/fabric-primitives/FabricRegExp.ts";
-import { FabricError } from "../../src/fabric-instances/FabricError.ts";
+import type { FabricValue } from "@/interface.ts";
+import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
+import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
+import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
+import { FabricError } from "@/fabric-instances/FabricError.ts";
 
 /** Container sizes: the empty case, then five orders of magnitude. */
 export const SIZES = [0, 1, 10, 100, 1000, 10000, 100000] as const;

--- a/packages/data-model/bench/hashing.bench.ts
+++ b/packages/data-model/bench/hashing.bench.ts
@@ -7,8 +7,8 @@
  *       --allow-env --no-check bench/hashing.bench.ts
  */
 
-import { hashOf } from "../src/value-hash.ts";
-import { deepFreeze } from "../src/deep-freeze.ts";
+import { hashOf } from "@/value-hash.ts";
+import { deepFreeze } from "@/deep-freeze.ts";
 
 //
 // Pre-generated test data

--- a/packages/data-model/bench/value-identity-shapes.bench.ts
+++ b/packages/data-model/bench/value-identity-shapes.bench.ts
@@ -20,8 +20,8 @@
  *       --allow-env --no-check bench/value-identity-shapes.bench.ts
  */
 
-import { hashOf } from "../src/value-hash.ts";
-import { deepFreeze, isDeepFrozen } from "../src/deep-freeze.ts";
+import { hashOf } from "@/value-hash.ts";
+import { deepFreeze, isDeepFrozen } from "@/deep-freeze.ts";
 
 //
 // Doc-shaped test data, mirroring the default-app integration:

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -17,27 +17,27 @@ import type {
   FabricError as ApiFabricError,
   FabricErrorConstructor as ApiFabricErrorConstructor,
 } from "@commonfabric/api";
+import { isUnsafeObjectKey } from "@commonfabric/utils/types";
 
-import type { FabricValue } from "@/interface.ts";
+import { FabricNativeWrapper } from "./FabricNativeWrapper.ts";
 import {
   DEEP_CLONE_CORE,
   DEEP_FREEZE,
   IS_DEEP_FROZEN,
   SHALLOW_UNFROZEN_CLONE,
 } from "@/codec-common/BaseFabricInstance.ts";
+import { BaseNonterminalCodec } from "@/codec-interface/BaseNonterminalCodec.ts";
+import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
+import { EmptyReconstructionContext } from "@/codec-interface/EmptyReconstructionContext.ts";
 import {
   CODEC,
   type NonterminalCodec,
   type ReconstructionContext,
 } from "@/codec-interface/interface.ts";
-import { BaseNonterminalCodec } from "@/codec-interface/BaseNonterminalCodec.ts";
 import { deepFreeze } from "@/deep-freeze.ts";
-import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 import { FrozenSet } from "@/frozen-builtins.ts";
-import { EmptyReconstructionContext } from "@/codec-interface/EmptyReconstructionContext.ts";
-import { FabricNativeWrapper } from "./FabricNativeWrapper.ts";
+import type { FabricValue } from "@/interface.ts";
 import { errorClassFromType } from "@/native-conversion.ts";
-import { isUnsafeObjectKey } from "@commonfabric/utils/types";
 
 /**
  * Reserved key set for `FabricError`'s extras bag: these names belong to the

--- a/packages/data-model/src/fabric-primitives/FabricBytes.ts
+++ b/packages/data-model/src/fabric-primitives/FabricBytes.ts
@@ -10,10 +10,10 @@ import { BaseTerminalCodec } from "@/codec-interface/BaseTerminalCodec.ts";
 import type { JsonCodecValue } from "@/codec-json/interface.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 import {
+  JSON_CODEC,
   ReconstructionContext,
   TerminalCodec,
 } from "@/codec-interface/interface.ts";
-import { JSON_CODEC } from "@/codec-interface/interface.ts";
 
 /**
  * Immutable byte sequence in the fabric type system.

--- a/packages/data-model/src/fabric-primitives/FabricEpochDays.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochDays.ts
@@ -12,10 +12,10 @@ import { BaseFabricPrimitive } from "@/codec-common/BaseFabricPrimitive.ts";
 import { BaseTerminalCodec } from "@/codec-interface/BaseTerminalCodec.ts";
 import type { JsonCodecValue } from "@/codec-json/interface.ts";
 import {
+  JSON_CODEC,
   type ReconstructionContext,
   type TerminalCodec,
 } from "@/codec-interface/interface.ts";
-import { JSON_CODEC } from "@/codec-interface/interface.ts";
 import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 

--- a/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
@@ -12,10 +12,10 @@ import { BaseFabricPrimitive } from "@/codec-common/BaseFabricPrimitive.ts";
 import { BaseTerminalCodec } from "@/codec-interface/BaseTerminalCodec.ts";
 import type { JsonCodecValue } from "@/codec-json/interface.ts";
 import {
+  JSON_CODEC,
   type ReconstructionContext,
   type TerminalCodec,
 } from "@/codec-interface/interface.ts";
-import { JSON_CODEC } from "@/codec-interface/interface.ts";
 import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 

--- a/packages/data-model/src/fabric-primitives/FabricHash.ts
+++ b/packages/data-model/src/fabric-primitives/FabricHash.ts
@@ -14,10 +14,10 @@ import type { FabricValue } from "@/interface.ts";
 import { BaseFabricPrimitive } from "@/codec-common/BaseFabricPrimitive.ts";
 import { BaseNonterminalCodec } from "@/codec-interface/BaseNonterminalCodec.ts";
 import {
+  JSON_CODEC,
   type NonterminalCodec,
   type ReconstructionContext,
 } from "@/codec-interface/interface.ts";
-import { JSON_CODEC } from "@/codec-interface/interface.ts";
 import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 

--- a/packages/data-model/src/fabric-primitives/FabricHash.ts
+++ b/packages/data-model/src/fabric-primitives/FabricHash.ts
@@ -1,4 +1,3 @@
-import { backtickQuote } from "@commonfabric/utils/markdown";
 import type {
   FabricHash as ApiFabricHash,
   FabricHashConstructor as ApiFabricHashConstructor,
@@ -8,18 +7,19 @@ import {
   toUnpaddedBase64url,
 } from "@commonfabric/utils/base64url";
 import { toOwnedUint8Array } from "@commonfabric/utils/buffers";
+import { backtickQuote } from "@commonfabric/utils/markdown";
 import { isPlainObject } from "@commonfabric/utils/types";
 
-import type { FabricValue } from "@/interface.ts";
 import { BaseFabricPrimitive } from "@/codec-common/BaseFabricPrimitive.ts";
+import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
 import { BaseNonterminalCodec } from "@/codec-interface/BaseNonterminalCodec.ts";
+import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 import {
   JSON_CODEC,
   type NonterminalCodec,
   type ReconstructionContext,
 } from "@/codec-interface/interface.ts";
-import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
-import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
+import type { FabricValue } from "@/interface.ts";
 
 /**
  * Content-addressed identifier: a hash digest paired with an algorithm tag.

--- a/packages/data-model/src/fabric-primitives/FabricRegExp.ts
+++ b/packages/data-model/src/fabric-primitives/FabricRegExp.ts
@@ -8,10 +8,10 @@ import type { FabricValue } from "@/interface.ts";
 import { BaseFabricPrimitive } from "@/codec-common/BaseFabricPrimitive.ts";
 import { BaseNonterminalCodec } from "@/codec-interface/BaseNonterminalCodec.ts";
 import {
+  JSON_CODEC,
   type NonterminalCodec,
   type ReconstructionContext,
 } from "@/codec-interface/interface.ts";
-import { JSON_CODEC } from "@/codec-interface/interface.ts";
 import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 import { isPlainObject } from "@commonfabric/utils/types";

--- a/packages/data-model/src/fabric-primitives/FabricRegExp.ts
+++ b/packages/data-model/src/fabric-primitives/FabricRegExp.ts
@@ -1,20 +1,20 @@
-import { backtickQuote } from "@commonfabric/utils/markdown";
 import type {
   FabricRegExp as ApiFabricRegExp,
   FabricRegExpConstructor as ApiFabricRegExpConstructor,
 } from "@commonfabric/api";
+import { backtickQuote } from "@commonfabric/utils/markdown";
+import { isPlainObject } from "@commonfabric/utils/types";
 
-import type { FabricValue } from "@/interface.ts";
 import { BaseFabricPrimitive } from "@/codec-common/BaseFabricPrimitive.ts";
+import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
 import { BaseNonterminalCodec } from "@/codec-interface/BaseNonterminalCodec.ts";
+import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 import {
   JSON_CODEC,
   type NonterminalCodec,
   type ReconstructionContext,
 } from "@/codec-interface/interface.ts";
-import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
-import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
-import { isPlainObject } from "@commonfabric/utils/types";
+import type { FabricValue } from "@/interface.ts";
 
 /** The only regex flavor currently representable as a native `RegExp`. */
 const DEFAULT_FLAVOR = "es2025";

--- a/packages/data-model/src/value-hash.ts
+++ b/packages/data-model/src/value-hash.ts
@@ -7,7 +7,6 @@
  * the full algorithm.
  */
 
-import { backtickQuote } from "@commonfabric/utils/markdown";
 import {
   createHasher,
   type IncrementalHasher,
@@ -16,16 +15,17 @@ import {
 import { encodeULEB128 } from "@commonfabric/leb128";
 import { bigintToMinimalTwosComplement } from "@commonfabric/utils/bigint";
 import { LRUCache } from "@commonfabric/utils/cache";
+import { backtickQuote } from "@commonfabric/utils/markdown";
 import { utf8SortedKeysOf } from "@commonfabric/utils/utf8";
 
 import { isDeepFrozen } from "./deep-freeze.ts";
-import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
-import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
-import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
-import { BaseFabricInstance } from "@/codec-common/BaseFabricInstance.ts";
-import { codecOf } from "@/codec-common/index.ts";
 import { shallowFabricFromNativeValue } from "./native-conversion.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
+import { BaseFabricInstance } from "@/codec-common/BaseFabricInstance.ts";
+import { codecOf } from "@/codec-common/index.ts";
+import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
+import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
+import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 
 //
 // Type tag bytes (Section 2 of the byte-level spec)

--- a/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
@@ -11,15 +11,15 @@
  * offset is at or past the end copies nothing rather than failing.
  */
 
-import { JSON_CODEC } from "@/codec-interface/interface.ts";
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
 
-import { FabricInstance, FabricPrimitive } from "@/interface.ts";
-import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
+import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/codec-interface/EmptyReconstructionContext.ts";
-import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
+import { JSON_CODEC } from "@/codec-interface/interface.ts";
+import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
+import { FabricInstance, FabricPrimitive } from "@/interface.ts";
 
 describe("FabricBytes", () => {
   // Pure type-identity / supertype check: cross-cutting carve-out per the

--- a/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
@@ -11,16 +11,16 @@
  * Malformed state decodes to a `ProblematicValue` rather than throwing.
  */
 
-import { JSON_CODEC } from "@/codec-interface/interface.ts";
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
 
-import { FabricEpochDays } from "@/fabric-primitives/FabricEpochDays.ts";
-import { FabricInstance, FabricPrimitive } from "@/interface.ts";
-import { shallowFabricFromNativeValue } from "@/fabric-value.ts";
+import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/codec-interface/EmptyReconstructionContext.ts";
-import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
+import { JSON_CODEC } from "@/codec-interface/interface.ts";
+import { FabricEpochDays } from "@/fabric-primitives/FabricEpochDays.ts";
+import { shallowFabricFromNativeValue } from "@/fabric-value.ts";
+import { FabricInstance, FabricPrimitive } from "@/interface.ts";
 
 describe("FabricEpochDays", () => {
   // Pure type-identity / supertype checks: cross-cutting carve-out per the

--- a/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
@@ -11,16 +11,16 @@
  * conversion leaves an instance alone even when asked for something mutable.
  */
 
-import { JSON_CODEC } from "@/codec-interface/interface.ts";
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
 
-import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
-import { FabricInstance, FabricPrimitive } from "@/interface.ts";
-import { shallowFabricFromNativeValue } from "@/fabric-value.ts";
+import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/codec-interface/EmptyReconstructionContext.ts";
-import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
+import { JSON_CODEC } from "@/codec-interface/interface.ts";
+import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
+import { shallowFabricFromNativeValue } from "@/fabric-value.ts";
+import { FabricInstance, FabricPrimitive } from "@/interface.ts";
 
 describe("FabricEpochNsec", () => {
   // Pure type-identity / supertype checks: cross-cutting carve-out per the

--- a/packages/data-model/test/fabric-primitives/FabricHash.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricHash.test.ts
@@ -11,14 +11,14 @@
  * when a caller explicitly transfers it.
  */
 
-import { JSON_CODEC } from "@/codec-interface/interface.ts";
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
 
-import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
+import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/codec-interface/EmptyReconstructionContext.ts";
-import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
+import { JSON_CODEC } from "@/codec-interface/interface.ts";
+import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
 
 /** A fixed 32-byte hash for deterministic tests. */
 const SAMPLE_HASH = new Uint8Array(32);

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -15,26 +15,26 @@
  * as well -- two values differing only in it hash differently.
  */
 
-import { JSON_CODEC } from "@/codec-interface/interface.ts";
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
 
-import { FabricInstance, FabricPrimitive } from "@/interface.ts";
-import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
+import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/codec-interface/EmptyReconstructionContext.ts";
-import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
-import { isConvertibleNativeInstance } from "@/native-conversion.ts";
+import { JSON_CODEC } from "@/codec-interface/interface.ts";
+import { fabricFromJsonValue, jsonFromFabricValue } from "@/codecs.ts";
+import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 import {
   isFabricCompatible,
   shallowFabricFromNativeValue,
 } from "@/fabric-value.ts";
+import { FabricInstance, FabricPrimitive } from "@/interface.ts";
+import { isConvertibleNativeInstance } from "@/native-conversion.ts";
 import {
   NATIVE_TAGS,
   tagFromNativeClass,
   tagFromNativeValue,
 } from "@/native-type-tags.ts";
-import { fabricFromJsonValue, jsonFromFabricValue } from "@/codecs.ts";
 import { hashOf } from "@/value-hash.ts";
 
 describe("FabricRegExp", () => {

--- a/packages/data-model/test/message-quoting.test.ts
+++ b/packages/data-model/test/message-quoting.test.ts
@@ -9,15 +9,16 @@
  * having its quoting broken by its own content.
  */
 
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
 
-import { cloneIfNecessary } from "@/value-clone.ts";
-import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
-import { hashOf } from "@/value-hash.ts";
-import { newDefaultJsonCodecEngine } from "@/codecs.ts";
-import { EmptyReconstructionContext } from "@/codec-common/index.ts";
 import { backtickQuote } from "@commonfabric/utils/markdown";
+
+import { EmptyReconstructionContext } from "@/codec-common/index.ts";
+import { newDefaultJsonCodecEngine } from "@/codecs.ts";
+import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
+import { cloneIfNecessary } from "@/value-clone.ts";
+import { hashOf } from "@/value-hash.ts";
 
 /**
  * Builds a class instance whose `constructor.name` holds the given text.

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -21,22 +21,37 @@
  * own properties across.
  */
 
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
 
+import { isArrayWithOnlyIndexProperties } from "@commonfabric/utils/arrays";
+import { isInertPlainObject } from "@commonfabric/utils/objects";
+
+import { DummyReconstructionContext } from "./fabric-instances/fixtures.ts";
 import {
-  FabricInstance,
-  type FabricOrConvertibleNativeValue,
-  type FabricValue,
-} from "@/interface.ts";
-import { CODEC } from "@/codec-interface/interface.ts";
+  BaseFabricInstance,
+  DEEP_CLONE_CORE,
+  DEEP_FREEZE,
+  IS_DEEP_FROZEN,
+  SHALLOW_UNFROZEN_CLONE,
+} from "@/codec-common/BaseFabricInstance.ts";
+import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
+import { UnknownValue } from "@/codec-common/UnknownValue.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
+import { CODEC } from "@/codec-interface/interface.ts";
+import { deepFreeze, isDeepFrozen } from "@/deep-freeze.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
 import { FabricMap } from "@/fabric-instances/FabricMap.ts";
 import { FabricSet } from "@/fabric-instances/FabricSet.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
+import { FrozenMap, FrozenSet } from "@/frozen-builtins.ts";
+import {
+  FabricInstance,
+  type FabricOrConvertibleNativeValue,
+  type FabricValue,
+} from "@/interface.ts";
 import {
   fabricFromNativeValue,
   isConvertibleNativeInstance,
@@ -46,20 +61,6 @@ import {
   shallowCleanPlainObject,
   shallowFabricFromNativeValue,
 } from "@/native-conversion.ts";
-import { isArrayWithOnlyIndexProperties } from "@commonfabric/utils/arrays";
-import { isInertPlainObject } from "@commonfabric/utils/objects";
-import { FrozenMap, FrozenSet } from "@/frozen-builtins.ts";
-import { UnknownValue } from "@/codec-common/UnknownValue.ts";
-import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
-import {
-  BaseFabricInstance,
-  DEEP_CLONE_CORE,
-  DEEP_FREEZE,
-  IS_DEEP_FROZEN,
-  SHALLOW_UNFROZEN_CLONE,
-} from "@/codec-common/BaseFabricInstance.ts";
-import { deepFreeze, isDeepFrozen } from "@/deep-freeze.ts";
-import { DummyReconstructionContext } from "./fabric-instances/fixtures.ts";
 
 /**
  * Helper for the round-trip tests, which encodes a value to fabric form via

--- a/packages/utils/test/bigint.test.ts
+++ b/packages/utils/test/bigint.test.ts
@@ -1,11 +1,17 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import {
+  fromBase64url,
+  toUnpaddedBase64url,
+} from "@commonfabric/utils/base64url";
 import {
   bigintFromMinimalTwosComplement,
   bigintFromUnpaddedBase64url,
   bigintToMinimalTwosComplement,
   bigintToUnpaddedBase64url,
 } from "@commonfabric/utils/bigint";
+
 import {
   bigintFromMtcDirect,
   bigintToMtcDirect,
@@ -14,10 +20,6 @@ import {
   bigintFromMtcHex,
   bigintToMtcHex,
 } from "../src/bigint-uint8-hex-string.ts";
-import {
-  fromBase64url,
-  toUnpaddedBase64url,
-} from "@commonfabric/utils/base64url";
 
 //
 // Reference encoder

--- a/packages/utils/test/equal-ignoring-symbols.test.ts
+++ b/packages/utils/test/equal-ignoring-symbols.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+// Importing this module also registers the custom matcher it defines.
 import { stripSymbols } from "../src/equal-ignoring-symbols.ts";
-import "../src/equal-ignoring-symbols.ts"; // Import to register the custom matcher
 
 const testSymbol1 = Symbol("test1");
 const testSymbol2 = Symbol("test2");

--- a/packages/utils/test/sleep.test.ts
+++ b/packages/utils/test/sleep.test.ts
@@ -1,6 +1,7 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
 import { FakeTime } from "@std/testing/time";
+
 import {
   sleep,
   timeout,


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) audited every `import` statement in the
workspace, and this change writes down the rules that audit implies, then
conforms the guinea-pig packages to them.

## The rules

Four bullets added to the Development Guide's `Imports` section, and one
existing bullet extended. The section now runs arrangement first -- group,
collate, sort -- and then the rules about a single module: how many statements
may name it, and how its path is written. Listed here in that order.

**Separate the three groups with a blank line.** This extends the existing
"group imports by source: standard library, external, then internal" bullet
rather than standing on its own, since that is the line naming the three groups.
The grouping itself is unchanged.

**Collate a package's imports.** Every specifier naming the same top-level
package, or the same namespace-and-package pair, sits in one contiguous run:
`@commonfabric/utils/base64url` next to `@commonfabric/utils/types`,
`@std/testing/bdd` next to `@std/testing/time`.

**Alpha-sorting each run is strongly suggested**, comparing specifiers without
regard to case so that `codec-type-tags.ts` precedes
`EmptyReconstructionContext.ts` the way a reader expects. Where sorting and the
grouping disagree, the grouping wins: sort inside the standard-library,
external, and internal blocks, not across them.

**Import a given module in exactly one or two statements**, in one of two
shapes:

- One unified statement, marking any type-only names inline:
  `import { type Foo, bar } from "x";`
- One statement of each kind, kept adjacent: `import type { Foo } from "x";`
  above `import { bar } from "x";`

A file uses whichever reads better. What neither shape allows is a second
statement of the same kind -- two value imports from one module, or two
`import type`s from it -- which represents one dependency as though it were two,
where the second is easy to miss when the first is being edited or removed. A
bare `import "x";` counts toward the total, and adds nothing to a file that
already imports `x` by name, since the named import evaluates the module, side
effects included.

**In a package that defines `@/`, address the aliased tree as `@/...`**, rather
than by a `../` path that climbs out of the current directory to reach it. The
alias exists so a module's address does not depend on where the importing file
sits.

The rule is about `../` and nothing else. `./` and `@/` are both fine, and a
file may use each where it reads better -- see below. A `../` path whose target
lies outside the aliased tree has no `@/` form at all and stays as it is: a
`bench/` or `test/` file reaching a fixture in its own tree, in a package whose
alias covers `src/`.

All of these are aspirational, as the section's rules generally are, so none
carries a note about when it is worth conforming an existing file. That is a
question about sequencing a sweep, and it lives in the backlog rather than in
the guide.

## `./` and `@/` may be mixed

The `@/` rule is about `../` and nothing else. A `./` path addresses the
importing file's own directory or something under it, and so never states how
two directories sit relative to each other -- which is the whole of what a `../`
path does. Both forms are fine, including in the same file, and the guide says
so affirmatively rather than leaving `./` merely unmentioned.

(An earlier draft justified this by saying a `./` path means no address depends
on the importing file's position. That was false -- `./c.ts` resolves differently
from `src/a/b.ts` than from `src/a/d/b.ts` -- and cubic caught it. Fixed in
68b22589b.)

That the packages using the alias each settled somewhere different is therefore
not a problem to fix:

| Package | `@/` | of those, at a same-dir sibling | `./` |
|---|---:|---:|---:|
| `data-model` | 439 | 1 | 139 |
| `content-hash` | 23 | 13 | 2 |
| `toolshed` | 247 | 36 | 119 |

Sorting the internal block does put `./` ahead of `@/`, but only as a
consequence of the specifier text; it takes no position on which form an import
should use. Across the whole branch the count of `./` specifiers is unchanged
from `main` at 151, so nothing here converted one form into the other. `../`
falls 24 to 14 and `@/` rises 439 to 444 -- the ten `bench` conversions, less
the five merged duplicate imports.

## Conformance

Across the guinea-pig set -- `leb128`, `pure-json`, `content-hash`, `utils`,
`data-model` -- 24 files. `leb128` and `pure-json` needed nothing.

One statement per module, and `@/` over `../`:

- **`data-model`, five `fabric-primitives` files**: each merged a second value
  import of `@/codec-interface/interface.ts` into the first.
- **`data-model`, four `bench` files**: `../src/...` and `../../src/...` become
  `@/...`. `bench/` was the only subtree of the package not already using the
  alias.
- **`utils`, one test file**: dropped a bare `import` of a module the file
  already imports by name, keeping what it documented as a comment.

Collation and grouping, 13 files: four had a package's imports split apart, and
ten had an external import sitting inside or after the internal block -- which
the pre-existing grouping bullet already ruled out. `FabricRegExp.ts` had both.

`content-hash` needed no change. Its one `../` import reaches `test/fixtures.ts`
from `bench/`, which the alias cannot address, and correctly stays as it is.

## Verification

- **The 13 reordered files are pure reorders.** Reordering is where a bad diff
  hides, so the multiset of import statements per file is compared before and
  after, normalized for whitespace: all 13 identical. The checker is not
  vacuously green -- run across the previous commit it flags all 10 files whose
  import sets genuinely changed there.
- No `bench` file had used `@/` before, so that it resolves from `bench/` was an
  assumption rather than a known. Type-checked all four, and ran
  `hashing.bench.ts` to completion -- it produces results.
- The `utils` change removes a side-effect import, so a green suite is only
  evidence if something exercises the matcher that import registered. The file
  calls `toEqualIgnoringSymbols` six times and passes.
- `deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs` all
  green; `data-model` (54 files) and `utils` (99 files) suites pass.
- Re-ran the audit against this branch: across the five packages, zero duplicate
  imports, zero collation breaks, zero group-order breaks. The same detectors
  still find 471 duplicate-import, 127 collation and 522 group-order breaks
  across the rest of the tree, so the zeros here are measurements rather than a
  broken instrument.
- Restating the first rule as "exactly one or two statements" exposed a gap in
  the duplicate-import detector: it skipped any group mixing type and value
  imports, so a three-statement group was invisible to it. Tightened, it finds 8
  of those in the rest of the tree, and still none in the five packages.

## Scope left for later

Deliberately not swept, because these are per-package changes:

- **One or two statements per module**: 99 violations in 87 files, heaviest in
  `runner` (53), `ui` (13, one copy-pasted shape across the component barrels),
  `cli` and `patterns` (5 each), `runtime-client` and `shell` (4 each).
- **`@/` over `../`**: `toolshed` has 12, eight of them the same
  `../oauth2-common/oauth2-common.types.ts` line in the OAuth descriptors.
- **Collation and grouping**: 127 and 522 respectively, tree-wide.
- **Alpha-sorting**: suggested rather than required, and 95% of files in the
  guinea-pig set alone were unsorted, so only the 13 files already being
  reordered here were sorted.

Worth noting separately: `ts-transformers`' 372 golden `*.expected.jsx` files
each carry a duplicate `commonfabric` import, because the transformer emits
`import { __cfHelpers } from "commonfabric";` above the fixture's own import.
That is the emitter's output, not editable source, and it is not covered by
these rules.

Deno ships no built-in `no-duplicate-imports`, but this repo already runs a
custom lint plugin (`tasks/lint-bench-console.ts`), so these rules could become
mechanical once the sweeps land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


