### PR TITLE
docs(data-model): correct two claims in the JSON benchmark's header

### DIFF
--- a/packages/data-model/bench/codec-json.bench.ts
+++ b/packages/data-model/bench/codec-json.bench.ts
@@ -5,8 +5,8 @@
  *
  *     deno bench --no-check bench/codec-json.bench.ts
  *
- * The subjects come from `codec-fixtures.ts`, shared with the other formats'
- * benchmarks so that their numbers can be read side by side.
+ * The subjects come from `fixtures/codec-fixtures.ts`, shared with the other
+ * formats' benchmarks so that their numbers can be read side by side.
  *
  * Each group pairs the two directions over one subject, so the encode/decode
  * ratio for that subject reads off a single block. A name repeats its group
@@ -15,8 +15,7 @@
  *
  * Every subject is built before any measurement, and no case has setup to
  * exclude, so these take the plain `fn()` form rather than bracketing with
- * `b.start()` / `b.end()`. Deno ignores that bracketing below 10µs an
- * iteration anyway, which most of these are.
+ * `b.start()` / `b.end()`.
  */
 
 import { fabricFromJsonValue, jsonFromFabricValue } from "../src/codecs.ts";


### PR DESCRIPTION
Two corrections to the JSON benchmark's header comment. I (agent working on
behalf of @danfuzz) am sending them on their own because they are general, and
the branch that surfaced them claims to be a wire format and its hookup and
nothing else — a claim a stray benchmark edit would make false for a reviewer
who checks.

## A reference #5847 left stale

That change factored the benchmark subjects into `codec-fixtures.ts` and wrote
a header line pointing at them; later in the same change it moved the file to
`bench/fixtures/` so the coverage ratchet would stop counting benchmark code as
uncovered source. The comment written earlier was never re-read against the
move made later, so it named a path that no longer resolved.

Swept the tree for others of the same kind: `codec-fixtures` appears in exactly
two places, this comment and the import beside it, and the import was already
correct.

## An unqualified claim about a threshold

The same header said Deno ignores `b.start()` / `b.end()` below 10µs an
iteration, "which most of these are." The first half is right — Deno 2.9.4 says
so in the warning it prints when it declines to honor bracketing — but the
second half asserts as a fixed property of these subjects something that
depends entirely on the machine they run on.

Measuring it also showed the mechanism is friendlier than the sentence implied,
which is worth recording somewhere even though it does not belong in this file:

- The threshold applies to the **whole iteration average**, not to the bracketed
  window. A case with no setup and a ~1.6µs iteration drew the warning; the same
  measured work behind 50µs, 200µs and 800µs of setup did not.
- Where it is honored, exclusion is **complete**: those three measured 1.7µs,
  1.7µs and 1.7µs as the setup grew sixteenfold.
- So the case where bracketing is ignored is the case where there is little
  setup to exclude, and Deno says when it happens rather than doing it silently.

The sentence goes rather than gets qualified, because this file has no setup to
exclude in any case — the bracketing question does not arise here, and the
justification was answering a question nobody reading it needs answered. The
rule is stated where it is load-bearing instead, in the realm-format benchmark
that does bracket.

Comments only; no code changes. `packages/data-model` is at 54 passed / 2439
steps, the benchmark still runs, and `fmt --check`, `lint`, `check`,
`check-docs` and `check-skill-facts` are green.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

