### PR TITLE
refactor: conform imports in fifteen small packages

### DIFF
--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -46,6 +46,15 @@ about one aspect of the runtime, are indexed in
   the way a reader expects. Where sorting and the grouping above disagree, the
   grouping wins: sort within the standard-library, external, and internal
   blocks, not across them.
+- A bare `import "x";` is there for its side effect, so where it sits is part of
+  what it does. A polyfill, or a setup module that installs globals, running
+  after the code relying on it has already run is a different program, and
+  nothing type-checks that. So grouping, collation and sorting all yield to this
+  one: leave a bare import where it is, and move no other import across it. A
+  bare import of a module the file already imports by name is a separate matter
+  — it adds nothing, since the named import evaluates the module, side effects
+  included. Drop it, and put what it was there for in a comment on the surviving
+  statement.
 - Import a given module in exactly one or two statements. Two shapes are
   allowed:
   - One unified statement, marking any type-only names inline:
@@ -58,10 +67,7 @@ about one aspect of the runtime, are indexed in
   module, or two `import type`s from it. Those represent one dependency as
   though it were two, and the second is easy to miss when the first is being
   edited or removed, so merge their specifier lists. A bare `import "x";` counts
-  toward the total, and adds nothing to a file that already imports `x` by name:
-  the named import evaluates the module, side effects included, so the bare form
-  documents an effect it is not needed to produce. Put that in a comment on the
-  surviving statement.
+  toward the total.
 - Within a package that defines the `@/` import alias, address the aliased tree
   as `@/...` rather than by a `../` path that climbs out of the current
   directory to reach it. The alias exists so that a module's address does not

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -51,10 +51,13 @@ about one aspect of the runtime, are indexed in
   after the code relying on it has already run is a different program, and
   nothing type-checks that. So grouping, collation and sorting all yield to this
   one: leave a bare import where it is, and move no other import across it. A
-  bare import of a module the file already imports by name is a separate matter
-  — it adds nothing, since the named import evaluates the module, side effects
-  included. Drop it, and put what it was there for in a comment on the surviving
-  statement.
+  bare import of a module the file also imports by name is a separate matter,
+  and which way it goes turns on the kind of that named import. Against a value
+  import the bare one adds nothing, since the value import evaluates the module,
+  side effects included: drop it, and put what it was there for in a comment on
+  the surviving statement. Against nothing but an `import type`, it stays — a
+  type-only import is erased and evaluates nothing, so the bare import is the
+  only thing producing the effect.
 - Import a given module in exactly one or two statements. Two shapes are
   allowed:
   - One unified statement, marking any type-only names inline:

--- a/packages/background-piece-service/cast-admin.ts
+++ b/packages/background-piece-service/cast-admin.ts
@@ -1,4 +1,7 @@
 import { parseArgs } from "@std/cli/parse-args";
+
+import { createSession, type DID } from "@commonfabric/identity";
+import type { Identity, Session } from "@commonfabric/identity";
 import { PiecesController } from "@commonfabric/piece/ops";
 import {
   compileAndSavePattern,
@@ -7,15 +10,13 @@ import {
   runtimePresets,
 } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { type DID } from "@commonfabric/identity";
-import { createSession } from "@commonfabric/identity";
+
 import {
   BG_CELL_CAUSE,
   BG_SYSTEM_SPACE_ID,
   BGPieceEntriesSchema,
 } from "./src/schema.ts";
 import { getIdentity } from "./src/utils.ts";
-import type { Identity, Session } from "@commonfabric/identity";
 
 export interface CastAdminDependencies {
   args: string[];

--- a/packages/background-piece-service/src/main.ts
+++ b/packages/background-piece-service/src/main.ts
@@ -1,4 +1,6 @@
 import { parseArgs } from "@std/cli/parse-args";
+
+import type { Identity } from "@commonfabric/identity";
 import {
   type EnvReader,
   experimentalOptionsFromEnv,
@@ -6,12 +8,12 @@ import {
   runtimePresets,
 } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { BackgroundPieceService } from "./service.ts";
-import { getIdentity } from "./utils.ts";
+import { SpanStatusCode } from "@opentelemetry/api";
+
 import { env, type EnvVars } from "./env.ts";
 import { getTracer, initOpenTelemetry, shutdownOpenTelemetry } from "./otel.ts";
-import { SpanStatusCode } from "@opentelemetry/api";
-import type { Identity } from "@commonfabric/identity";
+import { BackgroundPieceService } from "./service.ts";
+import { getIdentity } from "./utils.ts";
 
 // 10 minute timeout
 export const DEFAULT_WORKER_TIMEOUT_MS = 10 * 60000;

--- a/packages/background-piece-service/src/service.ts
+++ b/packages/background-piece-service/src/service.ts
@@ -3,15 +3,16 @@ import {
   type Cell,
   type MemorySpace,
   type Runtime,
+  useCancelGroup,
 } from "@commonfabric/runner";
+
 import {
   BG_CELL_CAUSE,
   BG_SYSTEM_SPACE_ID,
   type BGPieceEntry,
 } from "./schema.ts";
-import { getBGPieces } from "./utils.ts";
 import { SpaceManager } from "./space-manager.ts";
-import { useCancelGroup } from "@commonfabric/runner";
+import { getBGPieces } from "./utils.ts";
 
 type SpaceManagerLike = Pick<SpaceManager, "start" | "stop" | "watch">;
 

--- a/packages/background-piece-service/src/space-manager.ts
+++ b/packages/background-piece-service/src/space-manager.ts
@@ -1,12 +1,12 @@
+import { type Cancel, Cell, useCancelGroup } from "@commonfabric/runner";
 import { sleep } from "@commonfabric/utils/sleep";
-import { Cell } from "@commonfabric/runner";
-import { type Cancel, useCancelGroup } from "@commonfabric/runner";
+
+import { type BGPieceEntry } from "./schema.ts";
 import {
   WorkerController,
   WorkerControllerErrorEvent,
   type WorkerOptions,
 } from "./worker-controller.ts";
-import { type BGPieceEntry } from "./schema.ts";
 
 export interface PieceSchedulerOptions extends WorkerOptions {
   pollingIntervalMs?: number;

--- a/packages/background-piece-service/src/worker-controller.ts
+++ b/packages/background-piece-service/src/worker-controller.ts
@@ -1,7 +1,8 @@
-import { BGPieceEntry } from "./schema.ts";
-import { Cell } from "@commonfabric/runner";
 import { Identity } from "@commonfabric/identity";
+import { Cell } from "@commonfabric/runner";
 import { defer, type Deferred } from "@commonfabric/utils/defer";
+
+import { BGPieceEntry } from "./schema.ts";
 import {
   isWorkerIPCRequest,
   isWorkerIPCResponse,

--- a/packages/background-piece-service/src/worker.ts
+++ b/packages/background-piece-service/src/worker.ts
@@ -1,3 +1,9 @@
+import {
+  createSession,
+  type DID,
+  Identity,
+  Session,
+} from "@commonfabric/identity";
 import { PiecesController } from "@commonfabric/piece/ops";
 import {
   Cell,
@@ -11,8 +17,9 @@ import {
   runtimePresets,
   Stream,
 } from "@commonfabric/runner";
-import { attachRuntimeTelemetryOtelBridge } from "@commonfabric/runner/telemetry-otel-bridge";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { attachRuntimeTelemetryOtelBridge } from "@commonfabric/runner/telemetry-otel-bridge";
+
 import { env } from "./env.ts";
 import {
   getMeter,
@@ -20,13 +27,6 @@ import {
   initOpenTelemetry,
   shutdownOpenTelemetry,
 } from "./otel.ts";
-
-import {
-  createSession,
-  type DID,
-  Identity,
-  Session,
-} from "@commonfabric/identity";
 import {
   InitializationData,
   isWorkerIPCRequest,

--- a/packages/background-piece-service/test/worker-ipc.test.ts
+++ b/packages/background-piece-service/test/worker-ipc.test.ts
@@ -1,7 +1,9 @@
-import { describe, it } from "@std/testing/bdd";
 import { assert } from "@std/assert";
-import { isWorkerIPCRequest } from "../src/worker-ipc.ts";
+import { describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
+
+import { isWorkerIPCRequest } from "../src/worker-ipc.ts";
 
 describe("isWorkerIPCRequest", () => {
   it("validates cleanup messages", () => {

--- a/packages/deno-web-test/browser.ts
+++ b/packages/deno-web-test/browser.ts
@@ -5,12 +5,13 @@ import {
   LaunchOptions,
   Page,
 } from "@astral/astral";
+import { closeAstralBrowser } from "@commonfabric/integration/astral-adapter";
+import { sleep } from "@commonfabric/utils/sleep";
+
+import { DEFAULT_TEST_TIMEOUT_MS, extractAstralConfig } from "./config.ts";
+import { TestResult } from "./interface.ts";
 import { Manifest } from "./manifest.ts";
 import { tsToJs } from "./utils.ts";
-import { TestResult } from "./interface.ts";
-import { DEFAULT_TEST_TIMEOUT_MS, extractAstralConfig } from "./config.ts";
-import { sleep } from "@commonfabric/utils/sleep";
-import { closeAstralBrowser } from "@commonfabric/integration/astral-adapter";
 
 const LAUNCH_RETRY_ATTEMPTS = 5;
 const LAUNCH_RETRYABLE_ETXTBSY = "Text file busy (os error 26)";

--- a/packages/deno-web-test/config.ts
+++ b/packages/deno-web-test/config.ts
@@ -1,7 +1,8 @@
-import { build } from "@commonfabric/felt";
-import { LaunchOptions } from "@astral/astral";
-import * as path from "@std/path";
 import { exists } from "@std/fs/exists";
+import * as path from "@std/path";
+
+import { LaunchOptions } from "@astral/astral";
+import { build } from "@commonfabric/felt";
 
 // These configurations can be applied
 // by placing a `deno-web-test.config.ts` in package root.

--- a/packages/deno-web-test/test/browser.test.ts
+++ b/packages/deno-web-test/test/browser.test.ts
@@ -1,6 +1,8 @@
 import { assertEquals, assertRejects } from "@std/assert";
-import { isRetryableAstralLaunchError, launchWithRetry } from "../browser.ts";
+
 import type { Browser as AstralBrowser, LaunchOptions } from "@astral/astral";
+
+import { isRetryableAstralLaunchError, launchWithRetry } from "../browser.ts";
 
 Deno.test("isRetryableAstralLaunchError matches ETXTBSY browser-launch failures", () => {
   assertEquals(

--- a/packages/deno-web-test/test/success-project/add.test.ts
+++ b/packages/deno-web-test/test/success-project/add.test.ts
@@ -1,5 +1,6 @@
-import { add } from "./mod.ts";
 import { assert } from "@std/assert";
+
+import { add } from "./mod.ts";
 
 Deno.test("add-sync", function () {
   assert(add(5, 10) === 15, "add(5, 10) should equal 15");

--- a/packages/deno-web-test/test/timeout.test.ts
+++ b/packages/deno-web-test/test/timeout.test.ts
@@ -1,6 +1,8 @@
 import { assert, assertEquals, assertThrows } from "@std/assert";
-import { applyDefaults, DEFAULT_TEST_TIMEOUT_MS } from "../config.ts";
+
 import { decode } from "@commonfabric/utils/encoding";
+
+import { applyDefaults, DEFAULT_TEST_TIMEOUT_MS } from "../config.ts";
 import { runDenoWebTest } from "./utils.ts";
 
 // A test that waits on something which never arrives used to take the whole run

--- a/packages/felt/builder.ts
+++ b/packages/felt/builder.ts
@@ -1,14 +1,16 @@
-import * as esbuild from "esbuild";
-import { denoPlugin } from "@deno/esbuild-plugin";
 import { debounce } from "@std/async/debounce";
+import { blue, dim, green, red, yellow } from "@std/fmt/colors";
 import {
   isAbsolute as isAbsolutePath,
   join as joinPath,
   relative as relativePath,
   resolve as resolvePath,
 } from "@std/path";
+
+import { denoPlugin } from "@deno/esbuild-plugin";
+import * as esbuild from "esbuild";
+
 import { ResolvedConfig, ResolvedEntryPoint } from "./interface.ts";
-import { blue, dim, green, red, yellow } from "@std/fmt/colors";
 
 function formatFileSize(bytes: number): string {
   const units = ["B", "KB", "MB", "GB"];

--- a/packages/felt/cli.ts
+++ b/packages/felt/cli.ts
@@ -1,9 +1,11 @@
+import { exists } from "@std/fs/exists";
+import { join } from "@std/path/join";
+
 import { Command } from "@cliffy/command";
 import { HelpCommand } from "@cliffy/command/help";
-import { exists } from "@std/fs/exists";
+
 import { Felt } from "./felt.ts";
 import { Config, FeltCommand, ResolvedConfig } from "./interface.ts";
-import { join } from "@std/path/join";
 
 const command = new Command()
   .name("felt")

--- a/packages/felt/felt.ts
+++ b/packages/felt/felt.ts
@@ -1,8 +1,9 @@
-import { DevServer } from "./dev-server.ts";
-import { Builder } from "./builder.ts";
-import { FeltCommand, ResolvedConfig } from "./interface.ts";
-import { copy } from "@std/fs";
 import { blue, cyan, dim, green, red, yellow } from "@std/fmt/colors";
+import { copy } from "@std/fs";
+
+import { Builder } from "./builder.ts";
+import { DevServer } from "./dev-server.ts";
+import { FeltCommand, ResolvedConfig } from "./interface.ts";
 
 export class Felt {
   constructor(

--- a/packages/fuse/annotations.ts
+++ b/packages/fuse/annotations.ts
@@ -1,7 +1,9 @@
+import { encodeHex } from "@std/encoding/hex";
+
 import { CFC_FUSE_ATOM_CLASS, cfcAtom } from "@commonfabric/api/cfc";
 import { sha256 } from "@commonfabric/content-hash";
 import { isLinkRef } from "@commonfabric/runner/shared";
-import { encodeHex } from "@std/encoding/hex";
+
 import type { CallableKind } from "./callables.ts";
 
 export type CfcProjectionKind =

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -4,11 +4,18 @@
 // Supports multiple spaces with on-demand connection.
 // Subscribes to cell changes and rebuilds subtrees on updates.
 
+import type { JSONSchema } from "@commonfabric/api";
+import type {
+  PieceController,
+  PiecePatternRef,
+  PiecesController,
+} from "@commonfabric/piece/ops";
 import type { Cell } from "@commonfabric/runner";
 import { schemaToTypeString } from "@commonfabric/runner";
-import { linkRefPayload } from "@commonfabric/runner/shared";
-import { nameSchema } from "@commonfabric/runner/schemas";
 import { cfcLabelViewForCell } from "@commonfabric/runner/cfc";
+import { nameSchema } from "@commonfabric/runner/schemas";
+import { linkRefPayload } from "@commonfabric/runner/shared";
+
 import {
   type CfcLabel,
   type CfcLabelView,
@@ -17,14 +24,23 @@ import {
   deriveCfcProjectionGeneration,
   joinLabels,
 } from "./annotations.ts";
-import { FsTree, type TransplantChanges } from "./tree.ts";
+import { parseMountedCallablePath } from "./callable-path.ts";
 import {
   buildCallableScript,
   type CallableKind,
   classifyCallableEntry,
   isHandlerCell,
 } from "./callables.ts";
-import { parseMountedCallablePath } from "./callable-path.ts";
+import {
+  collectVirtualDirectorySnapshot,
+  type DirectorySnapshotEntry,
+} from "./directory-handles.ts";
+import {
+  decodeFuseComponent,
+  decodeFusePathSegments,
+  encodeFuseComponent,
+  encodeFusePathSegments,
+} from "./path-codec.ts";
 import {
   buildFsProjection,
   buildJsonTree,
@@ -35,22 +51,7 @@ import {
   isVNode,
   stringifyEntryValue,
 } from "./tree-builder.ts";
-import {
-  decodeFuseComponent,
-  decodeFusePathSegments,
-  encodeFuseComponent,
-  encodeFusePathSegments,
-} from "./path-codec.ts";
-import {
-  collectVirtualDirectorySnapshot,
-  type DirectorySnapshotEntry,
-} from "./directory-handles.ts";
-import type { JSONSchema } from "@commonfabric/api";
-import type {
-  PieceController,
-  PiecePatternRef,
-  PiecesController,
-} from "@commonfabric/piece/ops";
+import { FsTree, type TransplantChanges } from "./tree.ts";
 
 /** Strip asCell markers from a schema for display as input schema. */
 function getInputSchema(

--- a/packages/fuse/cfc-writeback.ts
+++ b/packages/fuse/cfc-writeback.ts
@@ -1,13 +1,15 @@
-import {
-  type CfcEnforcementMode as RunnerCfcEnforcementMode,
-  DEFAULT_CFC_ENFORCEMENT_MODE,
-} from "@commonfabric/runner/cfc";
+import { encodeHex } from "@std/encoding/hex";
+
 import { sha256 } from "@commonfabric/content-hash";
 import {
   cloneIfNecessary,
   type FabricValue,
 } from "@commonfabric/data-model/fabric-value";
-import { encodeHex } from "@std/encoding/hex";
+import {
+  type CfcEnforcementMode as RunnerCfcEnforcementMode,
+  DEFAULT_CFC_ENFORCEMENT_MODE,
+} from "@commonfabric/runner/cfc";
+
 import {
   canonicalCfcJsonStringify,
   type CfcDerivedSlotsAnnotation,

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -8,17 +8,20 @@
 // Unknown space names are resolved on-demand via lookup.
 
 import { parseArgs } from "@std/cli/parse-args";
+
+import { linkRefFrom } from "@commonfabric/runner/shared";
+
+import {
+  type CfcXattrNamespace,
+  getCfcXattrValue,
+  listCfcXattrNames,
+} from "./annotations.ts";
 import {
   CellBridge,
   type HandlerTarget,
   type SourceWritePath,
   type WritePath,
 } from "./cell-bridge.ts";
-import {
-  type CfcXattrNamespace,
-  getCfcXattrValue,
-  listCfcXattrNames,
-} from "./annotations.ts";
 import {
   applyPreparedCreate,
   applyPreparedExistingWrite,
@@ -47,6 +50,29 @@ import {
   shouldEnableCfcAnnotations,
 } from "./cfc-writeback.ts";
 import {
+  type DirectorySnapshotEntry,
+  replyWithRetainedState,
+  visitDirectoryEntries,
+} from "./directory-handles.ts";
+import {
+  handleHasBufferedContent,
+  handleHasPendingChanges,
+  HandleMap,
+  type HandleState,
+  validateVirtualFileRange,
+} from "./handles.ts";
+import { ReverseInvalidationQueue } from "./invalidation.ts";
+import {
+  buildMountFuseArgs,
+  type MountCacheOptions,
+  resolveMountCacheOptions,
+} from "./mount-options.ts";
+import {
+  closeKernelFileHandle,
+  createFuseOperationState,
+} from "./operation-wiring.ts";
+import { decodeFuseComponent, encodeFusePathSegments } from "./path-codec.ts";
+import {
   EACCES,
   EFBIG,
   EINVAL,
@@ -64,32 +90,8 @@ import {
   O_WRONLY,
   readCString,
 } from "./platform.ts";
-import { linkRefFrom } from "@commonfabric/runner/shared";
-import { FsTree } from "./tree.ts";
-import {
-  handleHasBufferedContent,
-  handleHasPendingChanges,
-  HandleMap,
-  type HandleState,
-  validateVirtualFileRange,
-} from "./handles.ts";
-import {
-  type DirectorySnapshotEntry,
-  replyWithRetainedState,
-  visitDirectoryEntries,
-} from "./directory-handles.ts";
-import {
-  closeKernelFileHandle,
-  createFuseOperationState,
-} from "./operation-wiring.ts";
-import { decodeFuseComponent, encodeFusePathSegments } from "./path-codec.ts";
-import {
-  buildMountFuseArgs,
-  type MountCacheOptions,
-  resolveMountCacheOptions,
-} from "./mount-options.ts";
 import { buildNodeStat, getMountOwnership } from "./stat.ts";
-import { ReverseInvalidationQueue } from "./invalidation.ts";
+import { FsTree } from "./tree.ts";
 
 const encoder = new TextEncoder();
 // Operation ring buffer — last 50 ops for crash diagnostics

--- a/packages/fuse/mount-cli.test.ts
+++ b/packages/fuse/mount-cli.test.ts
@@ -5,9 +5,10 @@
 // checks cannot run in-process: main() reports a rejected flag by exiting.
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
-import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
-import { dirname, fromFileUrl, join } from "@std/path";
 import { existsSync } from "@std/fs";
+import { dirname, fromFileUrl, join } from "@std/path";
+
+import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
 
 const packageDir = dirname(fromFileUrl(import.meta.url));
 const repoRoot = join(packageDir, "..", "..");

--- a/packages/fuse/supervisor-status.test.ts
+++ b/packages/fuse/supervisor-status.test.ts
@@ -9,8 +9,9 @@
 // channel and records it in the status file.
 
 import { assert, assertEquals } from "@std/assert";
-import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
 import { dirname, fromFileUrl, join } from "@std/path";
+
+import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
 
 const packageDir = dirname(fromFileUrl(import.meta.url));
 const repoRoot = join(packageDir, "..", "..");

--- a/packages/fuse/tree-builder.ts
+++ b/packages/fuse/tree-builder.ts
@@ -1,15 +1,16 @@
 // tree-builder.ts — Convert JSON values to FsTree nodes
 
+import { isLinkRef, type SigilLink } from "@commonfabric/runner/shared";
+
+import type { CfcJsonAnnotationContext } from "./annotations.ts";
 import {
   type CallableKind,
   isHandlerCell,
   isStreamValue,
   transformCallableValues,
 } from "./callables.ts";
-import type { CfcJsonAnnotationContext } from "./annotations.ts";
-import { FsTree } from "./tree.ts";
 import { encodeFuseComponent } from "./path-codec.ts";
-import { isLinkRef, type SigilLink } from "@commonfabric/runner/shared";
+import { FsTree } from "./tree.ts";
 
 type JsonPropName = "input" | "result";
 type PendingJsonRootName = ".input.pending" | ".result.pending";

--- a/packages/home-schemas/home.ts
+++ b/packages/home-schemas/home.ts
@@ -1,9 +1,10 @@
+import type { JSONSchema } from "@commonfabric/api";
+import type { Schema } from "@commonfabric/api/schema";
+
 import { favoriteEntrySchema, favoriteListSchema } from "./favorites.ts";
 import { journalEntrySchema, journalSchema } from "./journal.ts";
 import { learnedSectionSchema } from "./learned.ts";
 import { spacesListSchema } from "./spaces.ts";
-import type { JSONSchema } from "@commonfabric/api";
-import type { Schema } from "@commonfabric/api/schema";
 
 export const homeSchema = {
   type: "object",

--- a/packages/identity/src/ed25519/index.ts
+++ b/packages/identity/src/ed25519/index.ts
@@ -1,3 +1,6 @@
+import * as bip39 from "@scure/bip39";
+import { wordlist } from "@scure/bip39/wordlists/english.js";
+
 import {
   AsBytes,
   DIDKey,
@@ -9,8 +12,6 @@ import {
 } from "../interface.ts";
 import { NativeEd25519Signer, NativeEd25519Verifier } from "./native.ts";
 import { NobleEd25519Signer, NobleEd25519Verifier } from "./noble.ts";
-import * as bip39 from "@scure/bip39";
-import { wordlist } from "@scure/bip39/wordlists/english.js";
 import {
   ed25519RawToPkcs8,
   fromPEM,

--- a/packages/identity/src/ed25519/noble.ts
+++ b/packages/identity/src/ed25519/noble.ts
@@ -1,4 +1,6 @@
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import * as ed25519 from "@noble/ed25519";
+
 import {
   AsBytes,
   DIDKey,
@@ -8,7 +10,6 @@ import {
   Signer,
   Verifier,
 } from "../interface.ts";
-import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { AuthorizationError, bytesToDid, didToBytes } from "./utils.ts";
 
 export class NobleEd25519Signer<ID extends DIDKey> implements Signer<ID> {

--- a/packages/identity/src/ed25519/utils.ts
+++ b/packages/identity/src/ed25519/utils.ts
@@ -1,9 +1,10 @@
+import { decode, encode } from "@commonfabric/utils/encoding";
+import * as ed25519 from "@noble/ed25519";
+import { varint } from "multiformats";
 import { base58btc } from "multiformats/bases/base58";
 import { base64pad } from "multiformats/bases/base64";
-import { varint } from "multiformats";
+
 import { DIDKey } from "../interface.ts";
-import * as ed25519 from "@noble/ed25519";
-import { decode, encode } from "@commonfabric/utils/encoding";
 
 export const ED25519_ALG = "Ed25519";
 const ED25519_CODE = 0xed;

--- a/packages/identity/test/ed25519.test.ts
+++ b/packages/identity/test/ed25519.test.ts
@@ -1,3 +1,7 @@
+import { assert, assertThrows } from "@std/assert";
+
+import * as ed25519 from "@noble/ed25519";
+
 import {
   NativeEd25519Signer,
   NativeEd25519Verifier,
@@ -7,10 +11,8 @@ import {
   NobleEd25519Verifier,
 } from "../src/ed25519/noble.ts";
 import { didToBytes, isNativeEd25519Supported } from "../src/ed25519/utils.ts";
-import { assert, assertThrows } from "@std/assert";
-import { bytesEqual } from "./utils.ts";
 import { DIDKey } from "../src/interface.ts";
-import * as ed25519 from "@noble/ed25519";
+import { bytesEqual } from "./utils.ts";
 
 type SignerImpl<ID extends DIDKey> =
   | NativeEd25519Signer<ID>

--- a/packages/identity/test/identity.test.ts
+++ b/packages/identity/test/identity.test.ts
@@ -1,11 +1,13 @@
 import { assert, assertEquals, assertThrows } from "@std/assert";
-import { Identity } from "../src/identity.ts";
-import { isNativeEd25519Supported } from "../src/ed25519/utils.ts";
-import { NobleEd25519Verifier } from "../src/ed25519/noble.ts";
-import type { InsecureCryptoKeyPair } from "../src/interface.ts";
+
 import { decode } from "@commonfabric/utils/encoding";
 import { entropyToMnemonic, mnemonicToEntropy } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english.js";
+
+import { NobleEd25519Verifier } from "../src/ed25519/noble.ts";
+import { isNativeEd25519Supported } from "../src/ed25519/utils.ts";
+import { Identity } from "../src/identity.ts";
+import type { InsecureCryptoKeyPair } from "../src/interface.ts";
 
 Deno.test("Identity generates mnemonics", async () => {
   const [identity, mnemonic] = await Identity.generateMnemonic();

--- a/packages/identity/test/key-store.test.ts
+++ b/packages/identity/test/key-store.test.ts
@@ -1,6 +1,7 @@
+import { assert } from "@std/assert";
+
 import { Identity } from "../src/identity.ts";
 import { KeyStore } from "../src/key-store.ts";
-import { assert } from "@std/assert";
 
 Deno.test("KeyStore can store and recover keys", async () => {
   const store = await KeyStore.open("test-key-store-concurrent");

--- a/packages/iframe-sandbox/test/utils.ts
+++ b/packages/iframe-sandbox/test/utils.ts
@@ -1,6 +1,7 @@
+import { defer } from "@commonfabric/utils/defer";
+
 import { CommonIframeSandboxElement } from "../src/common-iframe-sandbox.ts";
 import { setIframeContextHandler } from "../src/index.ts";
-import { defer } from "@commonfabric/utils/defer";
 
 type Callback = (key: string, value: unknown) => void;
 interface Context {

--- a/packages/integration/page.ts
+++ b/packages/integration/page.ts
@@ -1,3 +1,6 @@
+import { ensureDirSync } from "@std/fs";
+import * as path from "@std/path";
+
 import {
   ConsoleEvent,
   DialogEvent,
@@ -12,6 +15,9 @@ import {
   WaitForOptions,
   WaitForSelectorOptions,
 } from "@astral/astral";
+import { sleep } from "@commonfabric/utils/sleep";
+import { Mutable } from "@commonfabric/utils/types";
+
 import type {
   ElementHandle,
   InteractionObserver,
@@ -24,10 +30,6 @@ import {
   queryPierce,
   waitForPierceSelector,
 } from "./astral-adapter.ts";
-import { sleep } from "@commonfabric/utils/sleep";
-import { Mutable } from "@commonfabric/utils/types";
-import * as path from "@std/path";
-import { ensureDirSync } from "@std/fs";
 import { ConsoleMethod } from "./console.ts";
 
 export interface NavigationOptions {

--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -1,3 +1,12 @@
+import { afterAll, afterEach, beforeAll, beforeEach } from "@std/testing/bdd";
+
+import { ConsoleEvent, PageErrorEvent } from "@astral/astral";
+import {
+  Identity,
+  InsecureCryptoKeyPair,
+  serializeKeyPairRaw,
+  TransferrableInsecureCryptoKeyPair,
+} from "@commonfabric/identity";
 import {
   Browser,
   dismissDialogs,
@@ -6,14 +15,6 @@ import {
   pipeConsole,
   type PresentationParticipant,
 } from "@commonfabric/integration";
-import { getPresentationSession } from "./presentation/session.ts";
-import {
-  Identity,
-  InsecureCryptoKeyPair,
-  serializeKeyPairRaw,
-  TransferrableInsecureCryptoKeyPair,
-} from "@commonfabric/identity";
-import { afterAll, afterEach, beforeAll, beforeEach } from "@std/testing/bdd";
 import {
   AppState,
   AppView,
@@ -21,12 +22,13 @@ import {
   deserialize,
   isAppViewEqual,
 } from "@commonfabric/shell/shared";
-import { waitFor } from "./utils.ts";
+
 import {
   collectPatternCoverage,
   enablePatternCoverage,
 } from "./pattern-coverage.ts";
-import { ConsoleEvent, PageErrorEvent } from "@astral/astral";
+import { getPresentationSession } from "./presentation/session.ts";
+import { waitFor } from "./utils.ts";
 
 import "../shell/src/globals.ts";
 

--- a/packages/js-compiler/program.ts
+++ b/packages/js-compiler/program.ts
@@ -1,5 +1,3 @@
-import { isDeno } from "@commonfabric/utils/env";
-import { ProgramResolver, Source } from "./interface.ts";
 import {
   dirname,
   isAbsolute,
@@ -8,6 +6,10 @@ import {
   relative,
   SEPARATOR,
 } from "@std/path";
+
+import { isDeno } from "@commonfabric/utils/env";
+
+import { ProgramResolver, Source } from "./interface.ts";
 
 function isOutsideRoot(relativePath: string): boolean {
   return relativePath === ".." || relativePath.startsWith(`..${SEPARATOR}`) ||

--- a/packages/js-compiler/source-map.ts
+++ b/packages/js-compiler/source-map.ts
@@ -1,6 +1,7 @@
-import { SourceMap } from "./interface.ts";
-import { MappedPosition, SourceMapConsumer } from "source-map-js";
 import { LRUCache } from "@commonfabric/utils/cache";
+import { MappedPosition, SourceMapConsumer } from "source-map-js";
+
+import { SourceMap } from "./interface.ts";
 
 export type { MappedPosition };
 

--- a/packages/js-compiler/test/source-map.test.ts
+++ b/packages/js-compiler/test/source-map.test.ts
@@ -1,5 +1,9 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { StaticCache } from "@commonfabric/static";
+import { SourceMapConsumer, SourceMapGenerator } from "source-map-js";
+
 import {
   composeBundleSourceMap,
   getTypeScriptEnvironmentTypes,
@@ -9,8 +13,6 @@ import {
   SourceMapParser,
   TypeScriptCompiler,
 } from "../mod.ts";
-import { StaticCache } from "@commonfabric/static";
-import { SourceMapConsumer, SourceMapGenerator } from "source-map-js";
 
 const staticCache = StaticCache.fromFileSystem();
 const types = await getTypeScriptEnvironmentTypes(staticCache);

--- a/packages/js-compiler/test/typescript.compiler.test.ts
+++ b/packages/js-compiler/test/typescript.compiler.test.ts
@@ -1,5 +1,8 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { StaticCache } from "@commonfabric/static";
+
 import {
   CompilerError,
   getTypeScriptEnvironmentTypes,
@@ -8,7 +11,6 @@ import {
   TypeScriptCompiler,
   TypeScriptCompilerOptions,
 } from "../mod.ts";
-import { StaticCache } from "@commonfabric/static";
 
 type TestDef =
   & { name: string; source: string; expectedError?: string }

--- a/packages/js-compiler/typescript/compiler.ts
+++ b/packages/js-compiler/typescript/compiler.ts
@@ -1,4 +1,7 @@
-import { Program, ProgramResolver, Source } from "../interface.ts";
+import * as path from "@std/path";
+
+import { getLogger } from "@commonfabric/utils/logger";
+import { yieldToEventLoop } from "@commonfabric/utils/sleep";
 import type {
   CompilerHost,
   CompilerOptions,
@@ -12,13 +15,10 @@ import type {
   StringLiteralLike,
 } from "typescript";
 import ts from "typescript";
-import * as path from "@std/path";
-import { getLogger } from "@commonfabric/utils/logger";
-import { yieldToEventLoop } from "@commonfabric/utils/sleep";
-import { getCompilerOptions, TARGET } from "./options.ts";
-import { parseSourceMap } from "../source-map.ts";
+
+import { Program, ProgramResolver, Source } from "../interface.ts";
 import type { SourceMap } from "../interface.ts";
-import { resolveProgram } from "./resolver.ts";
+import { parseSourceMap } from "../source-map.ts";
 import {
   Checker,
   type DiagnosticMessageTransformer,
@@ -26,6 +26,8 @@ import {
   TransformerDiagnosticInfo,
   TransformerError,
 } from "./diagnostics/mod.ts";
+import { getCompilerOptions, TARGET } from "./options.ts";
+import { resolveProgram } from "./resolver.ts";
 
 const DEBUG_VIRTUAL_FS = false;
 const VFS_TYPES_DIR = "$types/";

--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -1,11 +1,11 @@
-import { isObjectNotArray } from "@commonfabric/utils/types";
-import type { JSONValue } from "@commonfabric/api";
-import { isPureJson } from "@commonfabric/pure-json";
 import type {
   BuiltInLLMContent,
   BuiltInLLMMessage,
   JSONSchema,
+  JSONValue,
 } from "@commonfabric/api";
+import { isPureJson } from "@commonfabric/pure-json";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 
 // Resolved by the toolshed at startup: prefers gateway:claude-sonnet-4-6 when
 // available, falls back to anthropic:claude-sonnet-4-5 otherwise. See

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -1,21 +1,16 @@
-import ts from "typescript";
-import { isObjectOrArray } from "@commonfabric/utils/types";
-import {
-  type CellWrapperKind,
-  getCellBrand,
-  getCellWrapperInfo,
-  isCellBrand,
-  wrapperKindToBrand,
-} from "../typescript/cell-brand.ts";
-import { isDefaultAliasSymbol } from "../typescript/property-optionality.ts";
-import { numberFromExpression } from "../typescript/numeric-expression.ts";
-import { dedupeByValueEqual } from "../value-equality.ts";
 import type {
   AsCellEntry,
   MutableJSONSchema,
   MutableJSONSchemaObj,
   SchemaScope,
 } from "@commonfabric/api";
+import {
+  CFC_ATOM_TYPE,
+  CFC_CANONICAL_ALIAS_NAMES,
+} from "@commonfabric/api/cfc";
+import { isObjectOrArray } from "@commonfabric/utils/types";
+import ts from "typescript";
+
 import type { GenerationContext, TypeFormatter } from "../interface.ts";
 import type { SchemaGenerator } from "../schema-generator.ts";
 import {
@@ -27,9 +22,15 @@ import {
   type TypeWithInternals,
 } from "../type-utils.ts";
 import {
-  CFC_ATOM_TYPE,
-  CFC_CANONICAL_ALIAS_NAMES,
-} from "@commonfabric/api/cfc";
+  type CellWrapperKind,
+  getCellBrand,
+  getCellWrapperInfo,
+  isCellBrand,
+  wrapperKindToBrand,
+} from "../typescript/cell-brand.ts";
+import { numberFromExpression } from "../typescript/numeric-expression.ts";
+import { isDefaultAliasSymbol } from "../typescript/property-optionality.ts";
+import { dedupeByValueEqual } from "../value-equality.ts";
 
 type WrapperKind = CellWrapperKind;
 const CFC_ALIAS_NAMES: ReadonlySet<string> = new Set(CFC_CANONICAL_ALIAS_NAMES);

--- a/packages/schema-generator/src/formatters/intersection-formatter.ts
+++ b/packages/schema-generator/src/formatters/intersection-formatter.ts
@@ -1,14 +1,15 @@
-import ts from "typescript";
 import type {
   MutableJSONSchema,
   MutableJSONSchemaObj,
 } from "@commonfabric/api";
+import { getLogger } from "@commonfabric/utils/logger";
+import { isObjectOrArray } from "@commonfabric/utils/types";
+import ts from "typescript";
+
+import { attachDocTags, extractDocFromType } from "../doc-utils.ts";
 import type { GenerationContext, TypeFormatter } from "../interface.ts";
 import type { SchemaGenerator } from "../schema-generator.ts";
 import { cloneSchemaDefinition, getNativeTypeSchema } from "../type-utils.ts";
-import { getLogger } from "@commonfabric/utils/logger";
-import { isObjectOrArray } from "@commonfabric/utils/types";
-import { attachDocTags, extractDocFromType } from "../doc-utils.ts";
 import { isCellType } from "../typescript/cell-brand.ts";
 
 const logger = getLogger("schema-generator.intersection");

--- a/packages/schema-generator/src/formatters/object-formatter.ts
+++ b/packages/schema-generator/src/formatters/object-formatter.ts
@@ -1,10 +1,20 @@
-import ts from "typescript";
 import {
   FABRIC_SPECIAL_OBJECT_BRAND,
   type MutableJSONSchema,
   type MutableJSONSchemaObj,
 } from "@commonfabric/api";
+import { getLogger } from "@commonfabric/utils/logger";
+import { isObjectOrArray } from "@commonfabric/utils/types";
+import ts from "typescript";
+
+import {
+  attachDocTags,
+  extractDocFromSymbolAndDecls,
+  getDeclDocs,
+  symbolHasDeprecatedTag,
+} from "../doc-utils.ts";
 import type { GenerationContext, TypeFormatter } from "../interface.ts";
+import type { SchemaGenerator } from "../schema-generator.ts";
 import {
   cloneSchemaDefinition,
   getNativeTypeSchema,
@@ -20,16 +30,7 @@ import {
   isDefaultNodeWithUndefined,
   isOptionalSymbol,
 } from "../typescript/property-optionality.ts";
-import type { SchemaGenerator } from "../schema-generator.ts";
 import { attachUiContract, getUiContractHint } from "../ui-contract.ts";
-import {
-  attachDocTags,
-  extractDocFromSymbolAndDecls,
-  getDeclDocs,
-  symbolHasDeprecatedTag,
-} from "../doc-utils.ts";
-import { getLogger } from "@commonfabric/utils/logger";
-import { isObjectOrArray } from "@commonfabric/utils/types";
 
 const logger = getLogger("schema-generator.object", {
   enabled: true,

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -1,8 +1,11 @@
-import ts from "typescript";
 import type {
   MutableJSONSchema,
   MutableJSONSchemaObj,
 } from "@commonfabric/api";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
+import ts from "typescript";
+
 import type { GenerationContext, TypeFormatter } from "../interface.ts";
 import type { SchemaGenerator } from "../schema-generator.ts";
 import {
@@ -15,8 +18,6 @@ import {
   resolveWrapperNode,
   TypeWithInternals,
 } from "../type-utils.ts";
-import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
-import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { dedupeByValueEqual } from "../value-equality.ts";
 
 // Simple primitive schemas only have these keys (possibly just one)

--- a/packages/schema-generator/test/schema/circular-alias-error.test.ts
+++ b/packages/schema-generator/test/schema/circular-alias-error.test.ts
@@ -1,8 +1,10 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import ts from "typescript";
+
 import { SchemaGenerator } from "../../src/schema-generator.ts";
 import { createTestProgram } from "../utils.ts";
-import ts from "typescript";
 
 describe("Circular alias error handling", () => {
   it("should throw descriptive error for circular Default aliases", async () => {

--- a/packages/state-inspector/conflicts.ts
+++ b/packages/state-inspector/conflicts.ts
@@ -21,13 +21,14 @@
 // invariant violation / corruption, NOT normal "lost update" history. Rejected
 // client commits aren't persisted; we never see them.
 
-import type { SpaceDb } from "./db.ts";
+import type { CellScope, PatchOp } from "@commonfabric/memory/v2";
 import {
   patchOverlapsNonRecursiveRead,
   patchOverlapsRead,
   resolveScopeKey,
 } from "@commonfabric/memory/v2/engine";
-import type { CellScope, PatchOp } from "@commonfabric/memory/v2";
+
+import type { SpaceDb } from "./db.ts";
 import { decodeStored } from "./decode.ts";
 import { parseScope } from "./scopes.ts";
 

--- a/packages/state-inspector/scopes.ts
+++ b/packages/state-inspector/scopes.ts
@@ -22,9 +22,10 @@
 // honest, runtime-true divergence view; prefer it. Scope-key construction reuses
 // the engine's exported `resolveScopeKey` so encoding never drifts.
 
-import type { SpaceDb } from "./db.ts";
-import { resolveScopeKey } from "@commonfabric/memory/v2/engine";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
+import { resolveScopeKey } from "@commonfabric/memory/v2/engine";
+
+import type { SpaceDb } from "./db.ts";
 import { annotate, summarize } from "./decode.ts";
 import {
   type EntityDocument,

--- a/packages/state-inspector/test/clone.test.ts
+++ b/packages/state-inspector/test/clone.test.ts
@@ -4,12 +4,13 @@
 // can tell a clean migration from data loss.
 
 import { assert, assertEquals, assertRejects } from "@std/assert";
-import { Database } from "@db/sqlite";
 import * as Path from "@std/path";
+
 import {
   resolveMemoryEngineStoreRootUrl,
   resolveSpaceStoreUrl,
 } from "@commonfabric/memory/v2/storage-path";
+import { Database } from "@db/sqlite";
 
 import {
   clonePaths,

--- a/packages/state-inspector/test/decode.test.ts
+++ b/packages/state-inspector/test/decode.test.ts
@@ -5,26 +5,27 @@
 // or becoming `{}`. Both are the at-rest shapes a real DB can produce.
 
 import { assert, assertEquals } from "@std/assert";
+
+import {
+  resetModernCellRepConfig,
+  setModernCellRepConfig,
+} from "@commonfabric/data-model/cell-rep";
+import { jsonFromFabricValue } from "@commonfabric/data-model/codecs";
 import {
   FabricError,
   FabricLink,
 } from "@commonfabric/data-model/fabric-instances";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import { jsonFromFabricValue } from "@commonfabric/data-model/codecs";
-import {
-  resetModernCellRepConfig,
-  setModernCellRepConfig,
-} from "@commonfabric/data-model/cell-rep";
 
 import {
   annotate,
   collectLinks,
   decodedLinkOf,
+  decodeStored,
   stringifyInspectorJson,
   summarize,
   summarizeLink,
 } from "../decode.ts";
-import { decodeStored } from "../decode.ts";
 
 Deno.test("decode: modern FabricLink is recognized as a link", () => {
   const link = new FabricLink({ id: "of:target", path: [] });

--- a/packages/state-inspector/test/scheduler.test.ts
+++ b/packages/state-inspector/test/scheduler.test.ts
@@ -1,5 +1,4 @@
 import { assertEquals } from "@std/assert";
-import { Database } from "@db/sqlite";
 import { toFileUrl } from "@std/path";
 
 import {
@@ -8,6 +7,7 @@ import {
   resolveScopeKey,
   upsertSchedulerObservation,
 } from "@commonfabric/memory/v2/engine";
+import { Database } from "@db/sqlite";
 
 import { openSpace } from "../db.ts";
 import { schedulerDetails } from "../scheduler.ts";

--- a/packages/static/cache.ts
+++ b/packages/static/cache.ts
@@ -1,12 +1,14 @@
-import { assets } from "./assets.ts";
-import { decode } from "@commonfabric/utils/encoding";
-import { isDeno } from "@commonfabric/utils/env";
+import { join } from "@std/path/posix/join";
 // Use `posix` path utils specifically so that the path lib
 // does not check `Deno?.build.os` for Windows, which will
 // be true in the `deno-web-test` environment as `Deno.test`
 // is shimmed, causing a fail to access `os` from `undefined`.
 import { toFileUrl } from "@std/path/posix/to-file-url";
-import { join } from "@std/path/posix/join";
+
+import { decode } from "@commonfabric/utils/encoding";
+import { isDeno } from "@commonfabric/utils/env";
+
+import { assets } from "./assets.ts";
 import { generateETag } from "./etag.ts";
 
 const FS_URL = (import.meta.dirname && isDeno())

--- a/packages/static/scripts/generate-cfc-types.ts
+++ b/packages/static/scripts/generate-cfc-types.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env -S deno run --allow-read --allow-env --allow-run --allow-write
-import ts from "typescript";
 import { fromFileUrl, join } from "@std/path";
+
+import ts from "typescript";
 
 /**
  * Generates `packages/static/assets/types/cfc.ts` from the public

--- a/packages/static/test/assets.test.ts
+++ b/packages/static/test/assets.test.ts
@@ -1,5 +1,7 @@
-import { decode } from "@commonfabric/utils/encoding";
 import { assert } from "@std/assert";
+
+import { decode } from "@commonfabric/utils/encoding";
+
 import {
   createTestStaticCache,
   TEST_ASSET,

--- a/scripts/docs-links.ts
+++ b/scripts/docs-links.ts
@@ -4,8 +4,6 @@ import {
   join as joinFileSystemPath,
   relative as relativeFileSystemPath,
 } from "@std/path";
-import { Parser as HtmlParser } from "htmlparser2";
-import { marked, type Token } from "marked";
 import {
   basename as graphPathBasename,
   dirname as graphPathDirname,
@@ -13,6 +11,9 @@ import {
   join as joinGraphPath,
   normalize as normalizeGraphPath,
 } from "@std/path/posix";
+
+import { Parser as HtmlParser } from "htmlparser2";
+import { marked, type Token } from "marked";
 
 interface MarkdownFile {
   readonly name: string;

--- a/tasks/check-skill-facts.test.ts
+++ b/tasks/check-skill-facts.test.ts
@@ -1,6 +1,8 @@
 import { assert, assertEquals, assertRejects } from "@std/assert";
-import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
 import { dirname, fromFileUrl, join } from "@std/path";
+
+import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
+
 import {
   citedPath,
   collectDrift,

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -19,6 +19,9 @@
  *                            coverage artifacts, one subdirectory per name.
  */
 
+import { walk } from "@std/fs/walk";
+import * as path from "@std/path";
+
 import {
   acceptsCoverageDebt,
   aggregateCacheStates,
@@ -67,8 +70,6 @@ import {
   fillMissingFamiliesFromFingerprint,
   inferCurrentRunFallbackState,
 } from "./compile-cache-state.ts";
-import { walk } from "@std/fs/walk";
-import * as path from "@std/path";
 import {
   collectCoverageDebtMetricsFromLcov,
   collectRegressedLines,

--- a/tasks/pattern-vintage-lib.test.ts
+++ b/tasks/pattern-vintage-lib.test.ts
@@ -1,5 +1,18 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { exists } from "@std/fs";
+import { describe, it } from "@std/testing/bdd";
+
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+
+import {
+  schemaRelaxedForComparison,
+  strandedKeys,
+} from "../packages/piece/test/state-continuity-harness.ts";
+import {
+  companionFileName,
+  companionSpace,
+  vintageCompanionDir,
+} from "../packages/piece/test/vintage-layout.ts";
 import {
   armVerdictGuard,
   AUTO,
@@ -40,17 +53,6 @@ import {
   vintageFileName,
   VINTAGES_DIR,
 } from "./pattern-vintage-lib.ts";
-import {
-  schemaRelaxedForComparison,
-  strandedKeys,
-} from "../packages/piece/test/state-continuity-harness.ts";
-import { exists } from "@std/fs";
-import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import {
-  companionFileName,
-  companionSpace,
-  vintageCompanionDir,
-} from "../packages/piece/test/vintage-layout.ts";
 
 const ID_A = "bafyaaaa";
 const ID_B = "bafybbbb";

--- a/tasks/pattern-vintage-lib.ts
+++ b/tasks/pattern-vintage-lib.ts
@@ -72,11 +72,13 @@
  */
 
 import { exists } from "@std/fs";
+
+import { resolveSystemPatternSource } from "@commonfabric/runner";
+
 import {
   VINTAGE_SPACES_SUFFIX,
   vintageCompanionDir,
 } from "../packages/piece/test/vintage-layout.ts";
-import { resolveSystemPatternSource } from "@commonfabric/runner";
 
 /** Root of the committed fixture tree. See the note above on why it is here. */
 export const VINTAGES_DIR = "packages/piece/test/vintages";

--- a/tasks/vintage-adopt.ts
+++ b/tasks/vintage-adopt.ts
@@ -27,6 +27,10 @@
  * prevent, one tool over.
  */
 import { Identity } from "@commonfabric/identity";
+import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { getPatternIdentityRef } from "@commonfabric/runner";
+import type { Cell } from "@commonfabric/runner";
+
 import {
   openFileBackedRuntime,
   readVintageManifest,
@@ -34,9 +38,6 @@ import {
   vintageRoot,
   writeVintageManifest,
 } from "../packages/piece/test/state-continuity-harness.ts";
-import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
-import { getPatternIdentityRef } from "@commonfabric/runner";
-import type { Cell } from "@commonfabric/runner";
 import {
   patternKeyFromMain,
   PINNED,


### PR DESCRIPTION
First of a series applying the `Imports` rules from the Development Guide
(#5852) to the rest of the tree. I (agent working on behalf of @danfuzz) am
splitting along package lines, taking here the fifteen packages with seven or
fewer non-conforming files each.

## What changed

57 source files, all import-block-only, plus the guide change described below:

| Package | Files | | Package | Files |
|---|---:|---|---|---:|
| `background-piece-service` | 7 | | `state-inspector` | 5 |
| `fuse` | 7 | | `felt` | 3 |
| `identity` | 6 | | `static` | 3 |
| `deno-web-test` | 5 | | `integration` | 2 |
| `js-compiler` | 5 | | `llm` | 1 |
| `schema-generator` | 5 | | `home-schemas` | 1 |
| `tasks/` | 5 | | `iframe-sandbox` | 1 |
| | | | `scripts/` | 1 |

Per file: statements merged where a module was named twice, grouped standard
library / external / internal with a blank line between, each package's imports
collated into one contiguous run, and each run sorted.

Sorting is the *suggested* rule rather than a required one, so it is applied
only to files already being reordered for one of the other three — which is what
the rule itself says to do. The 1,359 files across the tree that need nothing
but sorting are deliberately untouched.

## A new rule: bare imports do not move

Sweeping the tree turned up a hazard the `Imports` section had not stated. A
bare `import "x";` runs a module for its side effect, so its **position is part
of what it does** — a polyfill or a globals setup that runs after the code
relying on it is a different program, and nothing type-checks that. There are
114 such imports in the tree, among them `ses`, two `core-js` proposals, and
nine `globals.ts` setups.

So this PR also adds a bullet to the guide: grouping, collation and sorting all
yield to a bare import. Leave it where it is, and move no other import across
it. The one thing the section already said about bare imports — that one naming
a module the file already imports is redundant — moves into that bullet too,
from the "exactly one or two statements" bullet, which is about counting rather
than ordering.

`packages/integration/shell-utils.ts` is the case in this PR: its
`import "../shell/src/globals.ts";` sat after every named import before, and
still does.

The rewriting is conservative in one further way: **a namespace import is never
merged** into another statement, since `import { a }, * as N from "x"` is not
valid.

Where anything other than a comment or a blank line sits between two imports,
the file is skipped rather than guessed at. None of the files here hit that;
twelve elsewhere in the tree do, and they will be done by hand in their own
package's PR.

## Verification

The interesting problem is that this sweep *legitimately* changes import
statements — merging two into one, rewriting `../` to `@/` — so comparing
statement text would flag the intended changes and hide nothing useful.

So the check is semantic: each file's set of imported **bindings**, where a
binding is `(resolved module, type-ness, local name)` and the module is resolved
through the `@/` alias and through relative paths alike. A merge and an alias
rewrite are both no-ops under that definition; a dropped name or a repointed
specifier is not.

- **57 files, zero binding differences.**
- The comparison is not vacuously green: it flags a deliberately dropped named
  import (`createSession` from `cast-admin.ts`) and a deliberately repointed
  specifier (`codec-type-tags.ts` → `interface.ts`), and reports the exact
  binding lost and gained in each case.
- `deno fmt --check`, `deno lint`, `deno task check` all green.
- Each touched package's own `deno task test` passes: `llm` 7, `felt`,
  `js-compiler`, `schema-generator` 56, `state-inspector`, `fuse`,
  `background-piece-service` 14, `identity` 21, `iframe-sandbox` 41,
  `deno-web-test` 29, `static` 23.
- Re-censused after the change: these fifteen packages now read zero on all four
  required rules.

## Series

Remaining, by package: `runner` 242, `ui` 62, `toolshed` 55, `cli` 33,
`ts-transformers` 29, `shell` 22, `memory` 20, `cf-harness` 15, `html` 15,
`piece` 11, `runtime-client` 10.

`packages/patterns` (41 files) is excluded from this series and every future one:
pattern source is compiled and content-addressed, so an edit that looks inert can
move a contract and trip `pattern-compat`. `packages/generated-patterns` is
excluded as generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


