### PR TITLE
refactor: conform imports in `piece`, `runtime-client`, `html`, `cf-harness`

### DIFF
--- a/packages/cf-harness/src/contracts/cfc-model-context.ts
+++ b/packages/cf-harness/src/contracts/cfc-model-context.ts
@@ -1,5 +1,9 @@
-import type { CfcLabelView, IFCLabel } from "@commonfabric/runner/cfc";
-import type { CfcConfClause } from "@commonfabric/runner/cfc";
+import type {
+  CfcConfClause,
+  CfcLabelView,
+  IFCLabel,
+} from "@commonfabric/runner/cfc";
+
 import type { HarnessCfcInvocationInputLabelPath } from "./cfc-invocation-context.ts";
 import type { ToolOutputId } from "./tool-result.ts";
 

--- a/packages/cf-harness/src/contracts/transcript.ts
+++ b/packages/cf-harness/src/contracts/transcript.ts
@@ -1,6 +1,7 @@
-import type { ToolResultRef } from "./tool-result.ts";
-import type { HarnessImageAttachment } from "./image.ts";
 import type { LLMNativeModelToolResult } from "@commonfabric/llm/types";
+
+import type { HarnessImageAttachment } from "./image.ts";
+import type { ToolResultRef } from "./tool-result.ts";
 
 export interface HarnessToolCall {
   id: string;

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -1,38 +1,23 @@
 import {
-  type HarnessConfig,
-  type ResolvedHarnessConfig,
-  resolveHarnessConfig,
-  type ResolveHarnessConfigOptions,
-} from "./config.ts";
+  dirname,
+  join as joinHostPath,
+  normalize as normalizeHostPath,
+  relative as relativeHostPath,
+} from "@std/path";
+import { normalize as normalizeSandboxPath } from "@std/path/posix";
+
+import type { CfcLabelView } from "@commonfabric/runner/cfc";
+
 import {
   createFileSystemHarnessArtifactStore,
   type HarnessArtifactStore,
 } from "./artifacts.ts";
 import {
-  appendHarnessCfcModelContextObservations,
-  appendHarnessFailureRecord,
-  appendToHarnessRunState,
-  createHarnessRunState,
-  type HarnessRunState,
-  type HarnessRunTerminalReason,
-  patchHarnessRunState,
-  setHarnessRunStatus,
-  setHarnessSubagentRun,
-} from "./run-state.ts";
-import type { HarnessCfcModelContextObservationInput } from "./contracts/cfc-model-context.ts";
-import {
-  classifyBuiltinToolFailure,
-  classifyHarnessPolicyEventFailure,
-  classifyHarnessRunError,
-  type ClassifyHarnessRunErrorOptions,
-  collectHarnessCapabilitySnapshot,
-  createHarnessFailureRecord,
-  type HarnessFailureRecord,
-} from "./diagnostics.ts";
-import {
-  createHarnessPolicyEvent,
-  type HarnessPolicyEvent,
-} from "./contracts/policy.ts";
+  type HarnessConfig,
+  type ResolvedHarnessConfig,
+  resolveHarnessConfig,
+  type ResolveHarnessConfigOptions,
+} from "./config.ts";
 import {
   createHarnessCfcInvocationContext,
   type HarnessCfcInvocationContext,
@@ -40,16 +25,20 @@ import {
   type HarnessCfcInvocationOperation,
   summarizeCfcInvocationRunManifest,
 } from "./contracts/cfc-invocation-context.ts";
+import type { HarnessCfcModelContextObservationInput } from "./contracts/cfc-model-context.ts";
 import type { HarnessCfcPolicySnapshot } from "./contracts/cfc-policy-snapshot.ts";
 import type { HarnessHandleTable } from "./contracts/handle-table.ts";
-import { assertValidHarnessHandleTable } from "./handle-table.ts";
-import { harnessCredentialOwnersEqual } from "./contracts/run-manifest.ts";
 import {
   createHarnessPolicyDecisionRecord,
   type HarnessPolicyDecisionRecord,
   type HarnessPolicyTrace,
 } from "./contracts/policy-trace.ts";
+import {
+  createHarnessPolicyEvent,
+  type HarnessPolicyEvent,
+} from "./contracts/policy.ts";
 import type { PromptSlotBinding } from "./contracts/prompt-slot.ts";
+import { harnessCredentialOwnersEqual } from "./contracts/run-manifest.ts";
 import type { HarnessRunReport } from "./contracts/run-report.ts";
 import type {
   HarnessSkillActivations,
@@ -63,25 +52,47 @@ import type {
   HarnessSubagentRunRef,
 } from "./contracts/subagent.ts";
 import {
+  type DelegateTaskToolInput,
+  type DelegateTaskToolOutput,
+} from "./contracts/subagent.ts";
+import type { BuiltinToolId } from "./contracts/tool-descriptor.ts";
+import {
   createToolResultRef,
   type ToolOutputId,
   type ToolResultRef,
 } from "./contracts/tool-result.ts";
 import type { HarnessTranscriptMessage } from "./contracts/transcript.ts";
-import type { BuiltinToolId } from "./contracts/tool-descriptor.ts";
-import type { CfcLabelView } from "@commonfabric/runner/cfc";
+import {
+  classifyBuiltinToolFailure,
+  classifyHarnessPolicyEventFailure,
+  classifyHarnessRunError,
+  type ClassifyHarnessRunErrorOptions,
+  collectHarnessCapabilitySnapshot,
+  createHarnessFailureRecord,
+  type HarnessFailureRecord,
+} from "./diagnostics.ts";
+import {
+  cacheHarnessFabricSessionFactory,
+  createHarnessFabricSessionFactory,
+  type HarnessFabricSessionFactory,
+} from "./fabric-session.ts";
+import { assertValidHarnessHandleTable } from "./handle-table.ts";
+import {
+  appendHarnessCfcModelContextObservations,
+  appendHarnessFailureRecord,
+  appendToHarnessRunState,
+  createHarnessRunState,
+  type HarnessRunState,
+  type HarnessRunTerminalReason,
+  patchHarnessRunState,
+  setHarnessRunStatus,
+  setHarnessSubagentRun,
+} from "./run-state.ts";
 import {
   assertDockerRunscCfcTransportForMode,
   DockerRunscSandboxRuntime,
   resolveDockerRunscSandboxConfig,
 } from "./sandbox/docker-runsc.ts";
-import {
-  dirname,
-  join as joinHostPath,
-  normalize as normalizeHostPath,
-  relative as relativeHostPath,
-} from "@std/path";
-import { normalize as normalizeSandboxPath } from "@std/path/posix";
 import {
   DenoProcessRunner,
   type ProcessRunner,
@@ -93,10 +104,6 @@ import type {
 } from "./sandbox/types.ts";
 import { type BashToolInput, type BashToolOutput } from "./tools/bash.ts";
 import {
-  type DelegateTaskToolInput,
-  type DelegateTaskToolOutput,
-} from "./contracts/subagent.ts";
-import {
   type EditFileToolInput,
   type EditFileToolOutput,
 } from "./tools/edit-file.ts";
@@ -104,6 +111,19 @@ import {
   type ReadFileToolInput,
   type ReadFileToolOutput,
 } from "./tools/read-file.ts";
+import {
+  type ReadSkillResourceToolInput,
+  type ReadSkillResourceToolOutput,
+} from "./tools/read-skill-resource.ts";
+import { getBuiltinTool } from "./tools/registry.ts";
+import {
+  type RunPatternToolInput,
+  type RunPatternToolOutput,
+} from "./tools/run-pattern.ts";
+import {
+  type RunSkillScriptToolInput,
+  type RunSkillScriptToolOutput,
+} from "./tools/run-skill-script.ts";
 import {
   type ViewImageToolInput,
   type ViewImageToolOutput,
@@ -113,27 +133,9 @@ import {
   type WebFetchToolOutput,
 } from "./tools/web-fetch.ts";
 import {
-  type ReadSkillResourceToolInput,
-  type ReadSkillResourceToolOutput,
-} from "./tools/read-skill-resource.ts";
-import {
-  type RunSkillScriptToolInput,
-  type RunSkillScriptToolOutput,
-} from "./tools/run-skill-script.ts";
-import {
-  type RunPatternToolInput,
-  type RunPatternToolOutput,
-} from "./tools/run-pattern.ts";
-import {
   type WriteFileToolInput,
   type WriteFileToolOutput,
 } from "./tools/write-file.ts";
-import {
-  cacheHarnessFabricSessionFactory,
-  createHarnessFabricSessionFactory,
-  type HarnessFabricSessionFactory,
-} from "./fabric-session.ts";
-import { getBuiltinTool } from "./tools/registry.ts";
 
 export interface BuiltinToolInputMap {
   bash: BashToolInput;

--- a/packages/cf-harness/src/model/responses-protocol.ts
+++ b/packages/cf-harness/src/model/responses-protocol.ts
@@ -1,3 +1,7 @@
+import { encodeHex } from "@std/encoding/hex";
+
+import { sha256 } from "@commonfabric/content-hash";
+
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import type {
   HarnessAssistantTranscriptMessage,
@@ -6,8 +10,6 @@ import type {
   HarnessTranscriptMessage,
 } from "../contracts/transcript.ts";
 import { materializeImageAttachmentContentPart } from "../image-attachments.ts";
-import { sha256 } from "@commonfabric/content-hash";
-import { encodeHex } from "@std/encoding/hex";
 
 /**
  * Shared OpenAI Responses API wire mapping.

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -1,10 +1,4 @@
-import {
-  type BuiltinToolInputMap,
-  CfHarnessEngine,
-  type CreateHarnessEngineOptions,
-} from "./engine.ts";
-import { isHarnessModelProviderId } from "./config.ts";
-import type { HarnessBrowserAccessLease } from "./contracts/browser-access.ts";
+import type { LLMNativeModelToolId } from "@commonfabric/llm/types";
 import {
   type CfcEnforcementMode,
   type CfcSandboxExitCodeObservation,
@@ -12,38 +6,30 @@ import {
   type CfcStreamObservation,
   evaluateHarnessWriteFileAuthorization,
 } from "@commonfabric/runner/cfc";
-import type { LLMNativeModelToolId } from "@commonfabric/llm/types";
-import { OpenAICompatibleGatewayClient } from "./gateway/openai-client.ts";
-import {
-  createObservationDenied as makeObservationDenied,
-  createOpaqueHandle,
-  type ObservationDenied,
-} from "./contracts/observation.ts";
-import type { HarnessImageAttachment } from "./contracts/image.ts";
-import type { PromptSlotBinding } from "./contracts/prompt-slot.ts";
-import { harnessCredentialOwnersEqual } from "./contracts/run-manifest.ts";
+
+import { isHarnessModelProviderId } from "./config.ts";
+import type { HarnessBrowserAccessLease } from "./contracts/browser-access.ts";
+import type { HarnessCfcModelContextObservationInput } from "./contracts/cfc-model-context.ts";
 import {
   createHarnessCfcPolicySnapshot,
   type HarnessParentToolAllowance,
   type HarnessPromptSlotBindingSource,
 } from "./contracts/cfc-policy-snapshot.ts";
-import type { HarnessCfcModelContextObservationInput } from "./contracts/cfc-model-context.ts";
-import type {
-  HarnessToolCall,
-  HarnessToolTranscriptMessage,
-  HarnessTranscriptEvent,
-  HarnessTranscriptMessage,
-} from "./contracts/transcript.ts";
-import type { ToolOutputId, ToolResultRef } from "./contracts/tool-result.ts";
-import type {
-  BuiltinToolId,
-  HarnessToolDescriptor,
-} from "./contracts/tool-descriptor.ts";
-import type { HarnessToolInputSummary } from "./contracts/policy.ts";
+import type { HarnessHandleTable } from "./contracts/handle-table.ts";
+import type { HarnessFetch } from "./contracts/http-fetch.ts";
+import type { HarnessImageAttachment } from "./contracts/image.ts";
+import {
+  createObservationDenied as makeObservationDenied,
+  createOpaqueHandle,
+  type ObservationDenied,
+} from "./contracts/observation.ts";
 import {
   createHarnessPolicyTrace,
   type HarnessPolicyDecisionReasonCode,
 } from "./contracts/policy-trace.ts";
+import type { HarnessToolInputSummary } from "./contracts/policy.ts";
+import type { PromptSlotBinding } from "./contracts/prompt-slot.ts";
+import { harnessCredentialOwnersEqual } from "./contracts/run-manifest.ts";
 import {
   createHarnessRunReport,
   type HarnessModelAttempt,
@@ -72,12 +58,26 @@ import {
   WEB_FETCH_SUBAGENT_PROFILE,
   WEB_SEARCH_SUBAGENT_PROFILE,
 } from "./contracts/subagent.ts";
+import type {
+  BuiltinToolId,
+  HarnessToolDescriptor,
+} from "./contracts/tool-descriptor.ts";
+import { DEFAULT_PARENT_TOOL_IDS as DEFAULT_PROMPT_LOOP_TOOL_IDS } from "./contracts/tool-descriptor.ts";
+import type { ToolOutputId, ToolResultRef } from "./contracts/tool-result.ts";
+import type {
+  HarnessToolCall,
+  HarnessToolTranscriptMessage,
+  HarnessTranscriptEvent,
+  HarnessTranscriptMessage,
+} from "./contracts/transcript.ts";
+import { HarnessControlError } from "./control-errors.ts";
+import type { HarnessFailureRecord } from "./diagnostics.ts";
 import {
-  parseSubagentReturnJson,
-  parseSubagentReturnSchema,
-  validateAndSanitizeSubagentReturn,
-} from "./subagent-return.ts";
-import type { HarnessHandleTable } from "./contracts/handle-table.ts";
+  type BuiltinToolInputMap,
+  CfHarnessEngine,
+  type CreateHarnessEngineOptions,
+} from "./engine.ts";
+import { OpenAICompatibleGatewayClient } from "./gateway/openai-client.ts";
 import {
   createHarnessHandleTable,
   defineOwnEntry,
@@ -85,36 +85,37 @@ import {
   swapLinksForTokens,
   swapTokensForRefs,
 } from "./handle-table.ts";
-import { BUILTIN_TOOLS, getBuiltinTool } from "./tools/registry.ts";
-import {
-  cwdMarkerForOutput,
-  extractFinalWorkingDirectory,
-} from "./tools/shell-cwd.ts";
-import { isEditFileToolSuccessOutput } from "./tools/edit-file.ts";
-import { isReadFileToolSuccessOutput } from "./tools/read-file.ts";
-import { isStructuredFileToolErrorOutput } from "./tools/file-errors.ts";
-import { isViewImageToolSuccessOutput } from "./tools/view-image.ts";
-import { scrubBareFabricIdentifiers } from "./tools/run-pattern.ts";
-import {
-  toModelFacingWebFetchOutput,
-  type WebFetchToolOutput,
-} from "./tools/web-fetch.ts";
-import {
-  isRunSkillScriptToolSuccessOutput,
-  type RunSkillScriptToolOutput,
-} from "./tools/run-skill-script.ts";
-import { loadHarnessSkillContext } from "./skills/registry.ts";
-import type { HarnessFailureRecord } from "./diagnostics.ts";
-import { DEFAULT_PARENT_TOOL_IDS as DEFAULT_PROMPT_LOOP_TOOL_IDS } from "./contracts/tool-descriptor.ts";
-import type { HarnessFetch } from "./contracts/http-fetch.ts";
 import type {
   HarnessModelAttemptDiagnostic,
   HarnessModelClient,
   HarnessModelUsage,
 } from "./model/client.ts";
 import { OpenAICompatibleGatewayModelClient } from "./model/openai-compatible-gateway.ts";
-import { HarnessControlError } from "./control-errors.ts";
 import { sumHarnessModelUsage } from "./model/usage.ts";
+import { loadHarnessSkillContext } from "./skills/registry.ts";
+import {
+  parseSubagentReturnJson,
+  parseSubagentReturnSchema,
+  validateAndSanitizeSubagentReturn,
+} from "./subagent-return.ts";
+import { isEditFileToolSuccessOutput } from "./tools/edit-file.ts";
+import { isStructuredFileToolErrorOutput } from "./tools/file-errors.ts";
+import { isReadFileToolSuccessOutput } from "./tools/read-file.ts";
+import { BUILTIN_TOOLS, getBuiltinTool } from "./tools/registry.ts";
+import { scrubBareFabricIdentifiers } from "./tools/run-pattern.ts";
+import {
+  isRunSkillScriptToolSuccessOutput,
+  type RunSkillScriptToolOutput,
+} from "./tools/run-skill-script.ts";
+import {
+  cwdMarkerForOutput,
+  extractFinalWorkingDirectory,
+} from "./tools/shell-cwd.ts";
+import { isViewImageToolSuccessOutput } from "./tools/view-image.ts";
+import {
+  toModelFacingWebFetchOutput,
+  type WebFetchToolOutput,
+} from "./tools/web-fetch.ts";
 
 const DEFAULT_MAX_MODEL_TURNS = 8;
 const BASH_CWD_MARKER_PREFIX = "__CF_HARNESS_CWD__";

--- a/packages/cf-harness/src/sandbox/docker-runsc.ts
+++ b/packages/cf-harness/src/sandbox/docker-runsc.ts
@@ -7,8 +7,21 @@ import {
   join as joinSandboxPath,
   normalize,
 } from "@std/path/posix";
-import { DenoProcessRunner, type ProcessRunner } from "./process-runner.ts";
+
+import type {
+  CfcEnforcementMode,
+  CfcSandboxJsonValue,
+  CfcSandboxResult,
+  CfcStreamChannel,
+  IFCLabel,
+} from "@commonfabric/runner/cfc";
+import {
+  CFC_ENFORCING_STRICTNESS,
+  cfcEnforcementStrictness,
+} from "@commonfabric/runner/cfc";
+
 import { SandboxPathEscapeError } from "./errors.ts";
+import { DenoProcessRunner, type ProcessRunner } from "./process-runner.ts";
 import type {
   DockerNetworkMode,
   DockerRunscAdditionalMount,
@@ -22,17 +35,6 @@ import type {
   SandboxRuntimeMountDescription,
   SandboxShellRequest,
 } from "./types.ts";
-import type {
-  CfcEnforcementMode,
-  CfcSandboxJsonValue,
-  CfcSandboxResult,
-  CfcStreamChannel,
-  IFCLabel,
-} from "@commonfabric/runner/cfc";
-import {
-  CFC_ENFORCING_STRICTNESS,
-  cfcEnforcementStrictness,
-} from "@commonfabric/runner/cfc";
 
 export const DEFAULT_DOCKER_RUNSC_IMAGE =
   "us-docker.pkg.dev/commontools-core/common-fabric/sandbox-kitchensink:latest";

--- a/packages/cf-harness/src/tools/bash-no-sandbox.ts
+++ b/packages/cf-harness/src/tools/bash-no-sandbox.ts
@@ -1,5 +1,7 @@
-import type { JSONSchema } from "@commonfabric/api";
 import { join, normalize } from "@std/path";
+
+import type { JSONSchema } from "@commonfabric/api";
+
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import type { BashToolInput, BashToolOutput } from "./bash.ts";
 import {

--- a/packages/cf-harness/src/tools/read-skill-resource.ts
+++ b/packages/cf-harness/src/tools/read-skill-resource.ts
@@ -1,6 +1,8 @@
-import type { JSONSchema } from "@commonfabric/api";
 import { isAbsolute, relative } from "@std/path";
 import { normalize as normalizeResourcePath } from "@std/path/posix";
+
+import type { JSONSchema } from "@commonfabric/api";
+
 import type {
   HarnessSkillDiagnostic,
   HarnessSkillRecord,

--- a/packages/cf-harness/src/tools/run-skill-script.ts
+++ b/packages/cf-harness/src/tools/run-skill-script.ts
@@ -1,6 +1,9 @@
+import { basename, isAbsolute, relative } from "@std/path";
+
 import type { JSONSchema } from "@commonfabric/api";
 import type { CfcLabelView, CfcSandboxResult } from "@commonfabric/runner/cfc";
-import { basename, isAbsolute, relative } from "@std/path";
+
+import { validateBrowserAccessLeaseFreshness } from "../contracts/browser-access.ts";
 import type {
   HarnessSkillDiagnostic,
   HarnessSkillRecord,
@@ -11,7 +14,6 @@ import type {
   HarnessSkillScriptRuntime,
 } from "../contracts/skill.ts";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
-import { validateBrowserAccessLeaseFreshness } from "../contracts/browser-access.ts";
 import {
   isSkillScriptAllowlisted,
   normalizeSkillScriptPath,

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -1,11 +1,9 @@
 import { assert, assertEquals, assertThrows } from "@std/assert";
-import {
-  chatViewOfRequest,
-  responsesBodyFromChatFixture,
-} from "./support/responses-fixture.ts";
-import type { CfcSandboxResult } from "@commonfabric/runner/cfc";
 import { join } from "@std/path";
 import { normalize } from "@std/path/posix";
+
+import type { CfcSandboxResult } from "@commonfabric/runner/cfc";
+
 import {
   createFileSystemHarnessArtifactStore,
   readHarnessRunArtifacts,
@@ -13,8 +11,8 @@ import {
   readHarnessRunState,
   readHarnessTranscript,
 } from "../src/artifacts.ts";
-import { CFC_PROMPT_SLOT_BOUND_ATOM_TYPE } from "../src/contracts/prompt-slot.ts";
 import type { HarnessPolicyTrace } from "../src/contracts/policy-trace.ts";
+import { CFC_PROMPT_SLOT_BOUND_ATOM_TYPE } from "../src/contracts/prompt-slot.ts";
 import { createToolOutputId } from "../src/contracts/tool-result.ts";
 import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
@@ -26,6 +24,10 @@ import type {
   SandboxRuntimeDescription,
   SandboxShellRequest,
 } from "../src/sandbox/types.ts";
+import {
+  chatViewOfRequest,
+  responsesBodyFromChatFixture,
+} from "./support/responses-fixture.ts";
 
 class FakeSandboxRuntime implements SandboxRuntime {
   readonly shellRequests: SandboxShellRequest[] = [];

--- a/packages/cf-harness/test/cfc-invocation-context.test.ts
+++ b/packages/cf-harness/test/cfc-invocation-context.test.ts
@@ -1,4 +1,7 @@
 import { assertEquals } from "@std/assert";
+
+import type { CfcLabelView } from "@commonfabric/runner/cfc";
+
 import {
   CF_HARNESS_PROMPT_SLOT_INFLUENCE_ATOM_TYPE,
   createHarnessCfcInvocationContext,
@@ -6,7 +9,6 @@ import {
   summarizeCfcInvocationText,
 } from "../src/contracts/cfc-invocation-context.ts";
 import { CFC_PROMPT_SLOT_BOUND_ATOM_TYPE } from "../src/contracts/prompt-slot.ts";
-import type { CfcLabelView } from "@commonfabric/runner/cfc";
 
 Deno.test("createHarnessCfcInvocationContext summarizes measured invocation inputs without raw values", async () => {
   // Spec: specs/cfc/18-runtime-implementation-profiles.md §18.2.4.1

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -1,11 +1,9 @@
 import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
-import {
-  chatViewOfRequest,
-  responsesBodyFromChatFixture,
-} from "./support/responses-fixture.ts";
-
 import { decodeBase64 } from "@std/encoding/base64";
 import { join } from "@std/path";
+
+import type { HarnessRunArtifacts } from "../src/artifacts.ts";
+import { InMemoryHarnessCredentialStore } from "../src/auth/credential-store.ts";
 import {
   buildCfHarnessBaseSystemPrompt,
   buildCfHarnessBatchSystemPrompt,
@@ -23,18 +21,20 @@ import {
   resolveCfHarnessCliSystemPrompt,
   runCfHarnessCli,
 } from "../src/cli.ts";
-import { CfHarnessEngine } from "../src/engine.ts";
 import { CFC_PROMPT_SLOT_BOUND_ATOM_TYPE } from "../src/contracts/prompt-slot.ts";
+import { HarnessControlError } from "../src/control-errors.ts";
+import { CfHarnessEngine } from "../src/engine.ts";
+import type { HarnessModelClient } from "../src/model/client.ts";
 import {
   CfHarnessPromptLoop,
   type HarnessPromptLoopResult,
   type RunHarnessPromptOptions,
   type RunHarnessTranscriptOptions,
 } from "../src/prompt-loop.ts";
-import { InMemoryHarnessCredentialStore } from "../src/auth/credential-store.ts";
-import type { HarnessRunArtifacts } from "../src/artifacts.ts";
-import type { HarnessModelClient } from "../src/model/client.ts";
-import { HarnessControlError } from "../src/control-errors.ts";
+import {
+  chatViewOfRequest,
+  responsesBodyFromChatFixture,
+} from "./support/responses-fixture.ts";
 
 const ONE_PIXEL_PNG = decodeBase64(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p94AAAAASUVORK5CYII=",

--- a/packages/cf-harness/test/prompt-loop-handles.test.ts
+++ b/packages/cf-harness/test/prompt-loop-handles.test.ts
@@ -5,24 +5,25 @@
  * strings that name addresses come back as tokens.
  */
 
-import { describe, it } from "@std/testing/bdd";
+import { decodeBase64 } from "@std/encoding/base64";
 import { expect } from "@std/expect";
+import { join } from "@std/path";
+import { normalize } from "@std/path/posix";
+import { describe, it } from "@std/testing/bdd";
+
 import { createSession, Identity } from "@commonfabric/identity";
 import { PieceController, PiecesController } from "@commonfabric/piece/ops";
 import { type Cell, isCell, Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { CfHarnessEngine } from "../src/engine.ts";
-import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
+
+import type { HarnessArtifactStore } from "../src/artifacts.ts";
 import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
-import {
-  chatViewOfRequest,
-  responsesBodyFromChatFixture,
-} from "./support/responses-fixture.ts";
+import { CfHarnessEngine } from "../src/engine.ts";
 import {
   createHarnessHandleTable,
   mintAddressHandle,
 } from "../src/handle-table.ts";
-import type { HarnessArtifactStore } from "../src/artifacts.ts";
+import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
 import type {
   SandboxCommandRequest,
   SandboxCommandResult,
@@ -30,9 +31,10 @@ import type {
   SandboxRuntimeDescription,
   SandboxShellRequest,
 } from "../src/sandbox/types.ts";
-import { normalize } from "@std/path/posix";
-import { join } from "@std/path";
-import { decodeBase64 } from "@std/encoding/base64";
+import {
+  chatViewOfRequest,
+  responsesBodyFromChatFixture,
+} from "./support/responses-fixture.ts";
 
 const ONE_PIXEL_PNG = decodeBase64(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p94AAAAASUVORK5CYII=",

--- a/packages/cf-harness/test/prompt-loop-run-pattern.test.ts
+++ b/packages/cf-harness/test/prompt-loop-run-pattern.test.ts
@@ -6,19 +6,19 @@
  * persisted artifact keeps the raw text.
  */
 
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { normalize } from "@std/path/posix";
+import { describe, it } from "@std/testing/bdd";
+
 import { createSession, Identity } from "@commonfabric/identity";
 import { PiecesController } from "@commonfabric/piece/ops";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { normalize } from "@std/path/posix";
+
+import type { HarnessArtifactStore } from "../src/artifacts.ts";
+import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
 import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
-import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
-import { scrubBareFabricIdentifiers } from "../src/tools/run-pattern.ts";
-import { responsesBodyFromChatFixture } from "./support/responses-fixture.ts";
-import type { HarnessArtifactStore } from "../src/artifacts.ts";
 import type {
   SandboxCommandRequest,
   SandboxCommandResult,
@@ -26,6 +26,8 @@ import type {
   SandboxRuntimeDescription,
   SandboxShellRequest,
 } from "../src/sandbox/types.ts";
+import { scrubBareFabricIdentifiers } from "../src/tools/run-pattern.ts";
+import { responsesBodyFromChatFixture } from "./support/responses-fixture.ts";
 
 class FakeSandboxRuntime implements SandboxRuntime {
   describe(): SandboxRuntimeDescription {

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -5,26 +5,34 @@ import {
   assertStringIncludes,
   assertThrows,
 } from "@std/assert";
-import {
-  chatViewOfRequest,
-  responsesBodyFromChatFixture,
-} from "./support/responses-fixture.ts";
-import type { CfcSandboxResult } from "@commonfabric/runner/cfc";
 import { decodeBase64 } from "@std/encoding/base64";
 import { join } from "@std/path";
 import { normalize } from "@std/path/posix";
+
+import type { CfcSandboxResult } from "@commonfabric/runner/cfc";
+
 import type { HarnessArtifactStore } from "../src/artifacts.ts";
-import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
-import { CfHarnessEngine } from "../src/engine.ts";
-import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
-import { ProcessTimeoutError } from "../src/sandbox/process-runner.ts";
-import { SandboxPathEscapeError } from "../src/sandbox/errors.ts";
-import { createHarnessImageAttachment } from "../src/image-attachments.ts";
-import { discoverHarnessSkills } from "../src/skills/registry.ts";
+import { InMemoryHarnessCredentialStore } from "../src/auth/credential-store.ts";
+import { OpenAICodexCredentialResolver } from "../src/auth/openai-codex.ts";
 import {
   CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
   type PromptSlotBinding,
 } from "../src/contracts/prompt-slot.ts";
+import type { HarnessSkillActivations } from "../src/contracts/skill.ts";
+import { createToolOutputId } from "../src/contracts/tool-result.ts";
+import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
+import { CfHarnessEngine } from "../src/engine.ts";
+import {
+  type OpenAIChatCompletionRequest,
+  OpenAICompatibleGatewayClient,
+} from "../src/gateway/openai-client.ts";
+import { createHarnessImageAttachment } from "../src/image-attachments.ts";
+import type { HarnessModelClient } from "../src/model/client.ts";
+import { OpenAICodexResponsesClient } from "../src/model/openai-codex-responses.ts";
+import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
+import type { HarnessRunState } from "../src/run-state.ts";
+import { SandboxPathEscapeError } from "../src/sandbox/errors.ts";
+import { ProcessTimeoutError } from "../src/sandbox/process-runner.ts";
 import type {
   ProcessRunner,
   ProcessRunRequest,
@@ -37,17 +45,11 @@ import type {
   SandboxRuntimeDescription,
   SandboxShellRequest,
 } from "../src/sandbox/types.ts";
-import { createToolOutputId } from "../src/contracts/tool-result.ts";
+import { discoverHarnessSkills } from "../src/skills/registry.ts";
 import {
-  type OpenAIChatCompletionRequest,
-  OpenAICompatibleGatewayClient,
-} from "../src/gateway/openai-client.ts";
-import type { HarnessRunState } from "../src/run-state.ts";
-import type { HarnessSkillActivations } from "../src/contracts/skill.ts";
-import type { HarnessModelClient } from "../src/model/client.ts";
-import { InMemoryHarnessCredentialStore } from "../src/auth/credential-store.ts";
-import { OpenAICodexCredentialResolver } from "../src/auth/openai-codex.ts";
-import { OpenAICodexResponsesClient } from "../src/model/openai-codex-responses.ts";
+  chatViewOfRequest,
+  responsesBodyFromChatFixture,
+} from "./support/responses-fixture.ts";
 
 const directPromptSlotBinding: PromptSlotBinding = {
   type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,

--- a/packages/html/src/jsx-dev-runtime.ts
+++ b/packages/html/src/jsx-dev-runtime.ts
@@ -10,8 +10,9 @@
  * @module jsx-dev-runtime
  */
 
-import { h } from "./h.ts";
 import type { JSXElement, RenderNode, VNode } from "@commonfabric/api";
+
+import { h } from "./h.ts";
 
 /**
  * Props type for JSX elements in development mode, including children and debug info

--- a/packages/html/src/jsx-runtime.ts
+++ b/packages/html/src/jsx-runtime.ts
@@ -7,8 +7,9 @@
  * @module jsx-runtime
  */
 
-import { h } from "./h.ts";
 import type { JSXElement, RenderNode, VNode } from "@commonfabric/api";
+
+import { h } from "./h.ts";
 
 /**
  * Props type for JSX elements, including children

--- a/packages/html/src/main/applicator.ts
+++ b/packages/html/src/main/applicator.ts
@@ -7,12 +7,13 @@
  */
 
 import type { CellRef, RuntimeClient } from "@commonfabric/runtime-client";
+import { CellHandle, cellRefToKey } from "@commonfabric/runtime-client";
+import { getLogger } from "@commonfabric/utils/logger";
+
+import { setPropDefault, type SetPropHandler } from "../render-utils.ts";
+import type { VDomBatch, VDomOp } from "../vdom-ops.ts";
 import { serializeEvent } from "./events.ts";
 import type { DomEventMessage } from "./events.ts";
-import type { VDomBatch, VDomOp } from "../vdom-ops.ts";
-import { CellHandle, cellRefToKey } from "@commonfabric/runtime-client";
-import { setPropDefault, type SetPropHandler } from "../render-utils.ts";
-import { getLogger } from "@commonfabric/utils/logger";
 import {
   clearPieceBoundary,
   provideElementSpace,

--- a/packages/html/src/main/renderer.ts
+++ b/packages/html/src/main/renderer.ts
@@ -13,10 +13,11 @@ import type {
   VDomBatchNotification,
   VDomConnection,
 } from "@commonfabric/runtime-client";
-import type { DomEventMessage } from "./events.ts";
-import { DomApplicator } from "./applicator.ts";
-import type { SetPropHandler } from "../render-utils.ts";
 import { getLogger } from "@commonfabric/utils/logger";
+
+import type { SetPropHandler } from "../render-utils.ts";
+import { DomApplicator } from "./applicator.ts";
+import type { DomEventMessage } from "./events.ts";
 
 const logger = getLogger("vdom-renderer", { enabled: false, level: "debug" });
 

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -19,6 +19,7 @@
  * Nothing does that yet; this note is the marker.
  */
 
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import {
   areLinksSame,
   type Cancel,
@@ -36,11 +37,31 @@ import {
   useCancelGroup,
 } from "@commonfabric/runner";
 import type { CfcConfClause } from "@commonfabric/runner/cfc";
-import type { CfcAtom } from "@commonfabric/api/cfc";
+import {
+  atomsOutsideCeiling,
+  CFC_LABEL_READ_FAILED_ATOM,
+  type CfcLabelView,
+  cfcLabelViewForCell,
+  clauseAlternatives,
+  markRendererTrustedEvent,
+  type RenderConfidentialityResolver,
+  spaceAtomIdsInConfidentiality,
+  type SpaceMembershipProvider,
+} from "@commonfabric/runner/cfc";
 import type { CellRef } from "@commonfabric/runtime-client";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { getLogger } from "@commonfabric/utils/logger";
 import { isObjectOrArray } from "@commonfabric/utils/types";
+
+import {
+  getBindingPropName,
+  getEventType,
+  isBindingProp,
+  isEventHandler,
+  isEventProp,
+} from "../render-utils.ts";
+import type { VDomOp } from "../vdom-ops.ts";
+import { generateChildKeys } from "./keying.ts";
 import type {
   ChildNodeState,
   NodeState,
@@ -58,26 +79,6 @@ import {
   normalizeRenderConfidentialityCeiling,
   normalizeRenderDeclassificationPolicy,
 } from "./types.ts";
-import {
-  atomsOutsideCeiling,
-  CFC_LABEL_READ_FAILED_ATOM,
-  type CfcLabelView,
-  cfcLabelViewForCell,
-  clauseAlternatives,
-  markRendererTrustedEvent,
-  type RenderConfidentialityResolver,
-  spaceAtomIdsInConfidentiality,
-  type SpaceMembershipProvider,
-} from "@commonfabric/runner/cfc";
-import type { VDomOp } from "../vdom-ops.ts";
-import { generateChildKeys } from "./keying.ts";
-import {
-  getBindingPropName,
-  getEventType,
-  isBindingProp,
-  isEventHandler,
-  isEventProp,
-} from "../render-utils.ts";
 
 /** Sentinel key in propSubscriptions for the Cell<Props> subscription itself. */
 const CELL_PROPS_KEY = "__cellProps__";

--- a/packages/html/src/worker/types.ts
+++ b/packages/html/src/worker/types.ts
@@ -5,10 +5,10 @@
  * where cells are accessed synchronously via cell.get() and cell.sink().
  */
 
-import type { Cancel, Cell, JSONSchema } from "@commonfabric/runner";
-import type { CfcConfClause } from "@commonfabric/runner/cfc";
 import type { CfcAtom } from "@commonfabric/api/cfc";
+import type { Cancel, Cell, JSONSchema } from "@commonfabric/runner";
 import type {
+  CfcConfClause,
   RenderConfidentialityResolver,
   SpaceMembershipProvider,
 } from "@commonfabric/runner/cfc";

--- a/packages/html/test/jsx.test.tsx
+++ b/packages/html/test/jsx.test.tsx
@@ -1,10 +1,12 @@
 import { describe, it } from "@std/testing/bdd";
-import * as assert from "./assert.ts";
-import { h } from "../src/h.ts";
+
 import { Identity } from "@commonfabric/identity";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
 import { createCell } from "../../runner/src/cell.ts";
+import { h } from "../src/h.ts";
+import * as assert from "./assert.ts";
 
 describe("jsx dom fragments support", () => {
   it("dom fragments should work", () => {

--- a/packages/html/test/main-applicator.test.ts
+++ b/packages/html/test/main-applicator.test.ts
@@ -11,11 +11,13 @@ import {
   assertNotStrictEquals,
   assertStrictEquals,
 } from "@std/assert";
+
+import { $conn, type CellRef } from "@commonfabric/runtime-client";
+
 import { DomApplicator } from "../src/main/applicator.ts";
 import type { DomEventMessage } from "../src/main/events.ts";
-import type { VDomBatch } from "../src/vdom-ops.ts";
-import { $conn, type CellRef } from "@commonfabric/runtime-client";
 import { getPieceBoundary } from "../src/main/space-context.ts";
+import type { VDomBatch } from "../src/vdom-ops.ts";
 
 // Mock RuntimeClient for testing
 const createMockRuntimeClient = () => {

--- a/packages/html/test/mockdoc.test.ts
+++ b/packages/html/test/mockdoc.test.ts
@@ -1,6 +1,7 @@
-import { describe, it } from "@std/testing/bdd";
-import { MockDoc } from "../src/mock-doc.ts";
 import { assert, assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+
+import { MockDoc } from "../src/mock-doc.ts";
 
 describe("MockDoc", () => {
   it("should render as innerHTML", () => {

--- a/packages/html/test/worker-reconciler-alias-child.test.ts
+++ b/packages/html/test/worker-reconciler-alias-child.test.ts
@@ -9,14 +9,15 @@
  */
 
 import { assertEquals } from "@std/assert";
-import { WorkerReconciler } from "../src/worker/reconciler.ts";
-import type { WorkerRenderNode, WorkerVNode } from "../src/worker/types.ts";
 
-import type { VDomOp } from "../src/vdom-ops.ts";
 import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "@commonfabric/runner";
 import type { Cell } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import type { VDomOp } from "../src/vdom-ops.ts";
+import { WorkerReconciler } from "../src/worker/reconciler.ts";
+import type { WorkerRenderNode, WorkerVNode } from "../src/worker/types.ts";
 
 /**
  * Helper to collect ops emitted by the reconciler.

--- a/packages/html/test/worker-reconciler-cell-child.test.ts
+++ b/packages/html/test/worker-reconciler-cell-child.test.ts
@@ -11,14 +11,15 @@
  */
 
 import { assertEquals } from "@std/assert";
-import { WorkerReconciler } from "../src/worker/reconciler.ts";
-import type { WorkerRenderNode, WorkerVNode } from "../src/worker/types.ts";
 
-import type { VDomOp } from "../src/vdom-ops.ts";
 import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime, UI } from "@commonfabric/runner";
 import type { Cell } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import type { VDomOp } from "../src/vdom-ops.ts";
+import { WorkerReconciler } from "../src/worker/reconciler.ts";
+import type { WorkerRenderNode, WorkerVNode } from "../src/worker/types.ts";
 
 /**
  * Helper to collect ops emitted by the reconciler.

--- a/packages/html/test/worker-reconciler-cell-props.test.ts
+++ b/packages/html/test/worker-reconciler-cell-props.test.ts
@@ -1,13 +1,14 @@
 import { assertEquals } from "@std/assert";
-import { WorkerReconciler } from "../src/worker/reconciler.ts";
-import type { WorkerVNode } from "../src/worker/types.ts";
+
+import { Identity } from "@commonfabric/identity";
+import { KeepAsCell, Runtime } from "@commonfabric/runner";
+import { cfcLabelViewForCell } from "@commonfabric/runner/cfc";
+import { rendererVDOMSchema } from "@commonfabric/runner/schemas";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
 import type { VDomOp } from "../src/vdom-ops.ts";
-import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { KeepAsCell, Runtime } from "@commonfabric/runner";
-import { rendererVDOMSchema } from "@commonfabric/runner/schemas";
-import { cfcLabelViewForCell } from "@commonfabric/runner/cfc";
+import { WorkerReconciler } from "../src/worker/reconciler.ts";
+import type { WorkerVNode } from "../src/worker/types.ts";
 
 /**
  * Helper to collect ops emitted by the reconciler.

--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -1,22 +1,24 @@
 import { assertEquals } from "@std/assert";
+
 import type { CfcAtom } from "@commonfabric/api/cfc";
+import { cfcAtom } from "@commonfabric/api/cfc";
 import { Identity } from "@commonfabric/identity";
 import {
   isCell as isRuntimeCell,
   KeepAsCell,
   Runtime,
 } from "@commonfabric/runner";
-import { rendererVDOMSchema } from "@commonfabric/runner/schemas";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { cfcAtom } from "@commonfabric/api/cfc";
 import {
   createRenderConfidentialityResolver,
   type SpaceMembershipProvider,
 } from "@commonfabric/runner/cfc";
+import { rendererVDOMSchema } from "@commonfabric/runner/schemas";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import type { VDomOp } from "../src/vdom-ops.ts";
+import { WorkerReconciler } from "../src/worker/reconciler.ts";
 import type { WorkerVNode } from "../src/worker/types.ts";
 import { normalizeRenderDeclassificationPolicy } from "../src/worker/types.ts";
-import { WorkerReconciler } from "../src/worker/reconciler.ts";
-import type { VDomOp } from "../src/vdom-ops.ts";
 
 function createOpsCollector() {
   const allOps: VDomOp[] = [];

--- a/packages/html/test/worker-reconciler-diffing.test.ts
+++ b/packages/html/test/worker-reconciler-diffing.test.ts
@@ -10,16 +10,17 @@
  */
 
 import { assertEquals } from "@std/assert";
-import { WorkerReconciler } from "../src/worker/reconciler.ts";
-import type { VDomOp } from "../src/vdom-ops.ts";
-import type { WorkerRenderNode, WorkerVNode } from "../src/worker/types.ts";
 
 // Import the actual Cell implementation to create test cells
 import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "@commonfabric/runner";
 import type { Cell } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
 import type { IExtendedStorageTransaction } from "../../runner/src/storage/interface.ts";
+import type { VDomOp } from "../src/vdom-ops.ts";
+import { WorkerReconciler } from "../src/worker/reconciler.ts";
+import type { WorkerRenderNode, WorkerVNode } from "../src/worker/types.ts";
 
 const signer = await Identity.fromPassphrase("test reconciler diffing");
 const space = signer.did();

--- a/packages/html/test/worker-reconciler-space-stamp.test.ts
+++ b/packages/html/test/worker-reconciler-space-stamp.test.ts
@@ -1,6 +1,10 @@
 import { assertEquals, assertStrictEquals } from "@std/assert";
-import { WorkerReconciler } from "../src/worker/reconciler.ts";
-import type { VDomOp } from "../src/vdom-ops.ts";
+
+import { Identity } from "@commonfabric/identity";
+import { Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import type { CellHandle } from "@commonfabric/runtime-client";
+
 import {
   clearPieceBoundary,
   getPieceBoundary,
@@ -8,10 +12,8 @@ import {
   providePieceBoundary,
   subscribePieceBoundary,
 } from "../src/main/space-context.ts";
-import type { CellHandle } from "@commonfabric/runtime-client";
-import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { Runtime } from "@commonfabric/runner";
+import type { VDomOp } from "../src/vdom-ops.ts";
+import { WorkerReconciler } from "../src/worker/reconciler.ts";
 
 // Space stamping (seefeldb's #4074 design): each create-element op
 // carries the space of the cell whose render produced it, elided when

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -1,3 +1,5 @@
+import type { CellKind, LinkScope } from "@commonfabric/api";
+import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
 import {
   applyPieceSourceTransition,
   Cell,
@@ -35,7 +37,6 @@ import {
   sanitizeSchemaForLinks,
   schemaAcceptsOpaqueCellValue,
 } from "@commonfabric/runner";
-import type { CellKind, LinkScope } from "@commonfabric/api";
 import {
   cfcSchemaChildRoot,
   cfcSchemaMergeIssue,
@@ -45,20 +46,13 @@ import {
   storedSchemaCoversCandidateEnvelope,
   validateSchemaValue,
 } from "@commonfabric/runner/cfc";
-import { pieceId } from "../piece-id.ts";
-import type { PiecesController } from "./pieces-controller.ts";
 import { nameSchema } from "@commonfabric/runner/schemas";
-import { compileProgram } from "./utils.ts";
+
+import { pieceId } from "../piece-id.ts";
 import {
   assertPatternSchemasBackwardCompatible,
   assertSchemaSubset,
 } from "../schema-compatibility.ts";
-import {
-  qualifyFabricOrigin,
-  readPieceOrigin,
-  resolvePieceOriginSource,
-} from "./piece-origin.ts";
-import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
 import {
   cloneInternalManifest,
   pinCloneSnapshotCells,
@@ -67,6 +61,13 @@ import {
   preloadCloneValue,
   snapshotCloneValue,
 } from "./clone-data-snapshot.ts";
+import {
+  qualifyFabricOrigin,
+  readPieceOrigin,
+  resolvePieceOriginSource,
+} from "./piece-origin.ts";
+import type { PiecesController } from "./pieces-controller.ts";
+import { compileProgram } from "./utils.ts";
 
 interface PieceCellIo {
   get(path?: CellPath): Promise<unknown>;

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -1,3 +1,14 @@
+import type { CellScope } from "@commonfabric/api";
+import { cfcAtom } from "@commonfabric/api/cfc";
+import {
+  type EntityRef,
+  entityRefToString,
+  isEntityRef,
+} from "@commonfabric/data-model/cell-rep";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { homeSchema } from "@commonfabric/home-schemas";
+import { createSession, Identity, type Session } from "@commonfabric/identity";
+import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
 import {
   applyPieceSourceTransition,
   type Cell,
@@ -36,36 +47,24 @@ import {
   setPatternSource,
   type SpaceCellContents,
 } from "@commonfabric/runner";
+import { CFC_SCHEMA_MIGRATION_INCOMPATIBLE_REASON } from "@commonfabric/runner/cfc/migration-reason";
 import { hashStringForEntityAddress } from "@commonfabric/runner/entity-kind";
-import type { CellScope } from "@commonfabric/api";
-import { cfcAtom } from "@commonfabric/api/cfc";
-import { StorageManager } from "@commonfabric/runner/storage/cache";
 import {
   type NameSchema,
   nameSchema,
   pieceListSchema,
 } from "@commonfabric/runner/schemas";
-import { CFC_SCHEMA_MIGRATION_INCOMPATIBLE_REASON } from "@commonfabric/runner/cfc/migration-reason";
-import {
-  type EntityRef,
-  entityRefToString,
-  isEntityRef,
-} from "@commonfabric/data-model/cell-rep";
-import { internSchema } from "@commonfabric/data-model/schema-hash";
-import { createSession, Identity, type Session } from "@commonfabric/identity";
-import { isObjectOrArray } from "@commonfabric/utils/types";
-import { getLogger } from "@commonfabric/utils/logger";
+import { StorageManager } from "@commonfabric/runner/storage/cache";
 import { ensureNotRenderThread } from "@commonfabric/utils/env";
-import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
-import { homeSchema } from "@commonfabric/home-schemas";
+import { getLogger } from "@commonfabric/utils/logger";
+import { isObjectOrArray } from "@commonfabric/utils/types";
+
+import { prepareSourceClosureVerification } from "../../../runner/src/compilation-cache/cell-cache.ts";
 import {
   getResultCellWithSourceSchema,
   isLegacyPieceRegistryRoot,
 } from "../../../runner/src/piece-helpers.ts";
-import { prepareSourceClosureVerification } from "../../../runner/src/compilation-cache/cell-cache.ts";
 import { pieceId } from "../piece-id.ts";
-import { PieceController } from "./piece-controller.ts";
-import { compileProgram } from "./utils.ts";
 // System space-root pattern refs, their derivation, and the source→URL
 // resolution live in ../system-pattern-url.ts; re-exported here for existing
 // importers.
@@ -75,6 +74,8 @@ import {
   HOME_PATTERN_SOURCE,
   patternSourceUrl,
 } from "../system-pattern-url.ts";
+import { PieceController } from "./piece-controller.ts";
+import { compileProgram } from "./utils.ts";
 export {
   DEFAULT_APP_PATTERN_SOURCE,
   deriveSystemPatternSource,

--- a/packages/piece/src/system-pattern-url.ts
+++ b/packages/piece/src/system-pattern-url.ts
@@ -1,5 +1,4 @@
-import type { MemorySpace } from "@commonfabric/runner";
-import type { Runtime } from "@commonfabric/runner";
+import type { MemorySpace, Runtime } from "@commonfabric/runner";
 import {
   resolveSystemPatternSource,
   systemPatternSource,

--- a/packages/piece/test/link-reactivity.test.ts
+++ b/packages/piece/test/link-reactivity.test.ts
@@ -1,14 +1,16 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
+import { createSession, Identity } from "@commonfabric/identity";
 import {
   KeepAsCell,
   parseLink,
   resolveCellPath,
   Runtime,
 } from "@commonfabric/runner";
-import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { createSession, Identity } from "@commonfabric/identity";
+
 import { PiecesController } from "../src/ops/pieces-controller.ts";
 
 const signer = await Identity.fromPassphrase("test link reactivity");

--- a/packages/piece/test/piece-address-forms.test.ts
+++ b/packages/piece/test/piece-address-forms.test.ts
@@ -1,9 +1,11 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
 import { createSession, Identity } from "@commonfabric/identity";
 import { type Cell, Runtime } from "@commonfabric/runner";
-import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
 import { createBuilder } from "../../runner/src/builder/factory.ts";
 import { PiecesController } from "../src/ops/pieces-controller.ts";
 import { pieceId } from "../src/piece-id.ts";

--- a/packages/piece/test/piece-origin.test.ts
+++ b/packages/piece/test/piece-origin.test.ts
@@ -1,7 +1,11 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { FabricInstance } from "@commonfabric/data-model/fabric-value";
+import { createSession, Identity } from "@commonfabric/identity";
 import {
   applyPieceSourceTransition,
+  type Cell,
   getPatternIdentityRef,
   getPieceSourceRevisions,
   getPieceSourceSnapshot,
@@ -12,21 +16,11 @@ import {
   Runtime,
 } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { createSession, Identity } from "@commonfabric/identity";
-import {
-  DEFAULT_APP_PATTERN_SOURCE,
-  PiecesController,
-} from "../src/ops/pieces-controller.ts";
+
 import {
   preloadCloneValue,
   snapshotCloneValue,
 } from "../src/ops/clone-data-snapshot.ts";
-import { FabricInstance } from "@commonfabric/data-model/fabric-value";
-
-// The route that ref resolves to.
-const DEFAULT_APP_PATTERN_PATH = resolveSystemPatternSource(
-  DEFAULT_APP_PATTERN_SOURCE,
-)!;
 import {
   classifyOrigin,
   PieceOriginError,
@@ -34,7 +28,15 @@ import {
   readPieceSourceState,
   resolvePieceOriginSource,
 } from "../src/ops/piece-origin.ts";
-import type { Cell } from "@commonfabric/runner";
+import {
+  DEFAULT_APP_PATTERN_SOURCE,
+  PiecesController,
+} from "../src/ops/pieces-controller.ts";
+
+// The route that ref resolves to.
+const DEFAULT_APP_PATTERN_PATH = resolveSystemPatternSource(
+  DEFAULT_APP_PATTERN_SOURCE,
+)!;
 
 const signer = await Identity.fromPassphrase("piece origin");
 

--- a/packages/piece/test/piece-step-slot.test.ts
+++ b/packages/piece/test/piece-step-slot.test.ts
@@ -1,9 +1,11 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { entityRefToString } from "@commonfabric/data-model/cell-rep";
 import { createSession, Identity } from "@commonfabric/identity";
 import { getPatternIdentityRef, Pattern, Runtime } from "@commonfabric/runner";
-import { entityRefToString } from "@commonfabric/data-model/cell-rep";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
 import { PiecesController } from "../src/ops/pieces-controller.ts";
 
 const signer = await Identity.fromPassphrase("piece step slot");

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -1,7 +1,13 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import {
+  entityRefToString,
+  linkRefPayload,
+} from "@commonfabric/data-model/cell-rep";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { createSession, Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import {
   type Cell,
   getPatternIdentityRef,
@@ -17,20 +23,16 @@ import {
   type RuntimeProgram,
 } from "@commonfabric/runner";
 import {
-  entityRefToString,
-  linkRefPayload,
-} from "@commonfabric/data-model/cell-rep";
-import { defer } from "@commonfabric/utils/defer";
+  validateAgainstSchema,
+  validateSchemaValue,
+} from "@commonfabric/runner/cfc";
 import {
   EmulatedStorageManager,
   newLoopbackServer,
   StorageManager,
 } from "@commonfabric/runner/storage/cache.deno";
-import * as MemoryV2Server from "@commonfabric/memory/v2/server";
-import {
-  validateAgainstSchema,
-  validateSchemaValue,
-} from "@commonfabric/runner/cfc";
+import { defer } from "@commonfabric/utils/defer";
+
 import {
   assertSuppliedLinkSchemasCompatible,
   assertWritablePiecePath,

--- a/packages/piece/test/setsrc-retained-capability-link.test.ts
+++ b/packages/piece/test/setsrc-retained-capability-link.test.ts
@@ -23,8 +23,10 @@
  * what `cf piece setsrc` drives.
  */
 
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { entityRefToString } from "@commonfabric/data-model/cell-rep";
 import { createSession, Identity } from "@commonfabric/identity";
 import {
   type Cell,
@@ -34,11 +36,11 @@ import {
   Runtime,
   type RuntimeProgram,
 } from "@commonfabric/runner";
-import { entityRefToString } from "@commonfabric/data-model/cell-rep";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 // Test-only dependency; pinned in this package's deno.jsonc (see the comment
 // on the entry there).
 import { Database } from "@db/sqlite";
+
 import { PieceController } from "../src/ops/piece-controller.ts";
 import { PiecesController } from "../src/ops/pieces-controller.ts";
 

--- a/packages/piece/test/state-continuity-harness.ts
+++ b/packages/piece/test/state-continuity-harness.ts
@@ -29,22 +29,23 @@
  */
 
 import { fromFileUrl } from "@std/path/from-file-url";
+
+// The comparison's two leaf cases. A materialized root is not plain data: at an
+// `asCell`/`asStream` position it holds a live cell, and a durable doc may hold
+// a fabric special object (bytes, an epoch). Neither survives a structural
+// comparison unaided — see `comparableState`.
+import { FabricSpecialObject } from "@commonfabric/data-model/fabric-value";
+import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
 import { Identity } from "@commonfabric/identity";
-import { Database } from "@db/sqlite";
+import type { Signer } from "@commonfabric/memory/interface";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
-import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import {
   listSpaceStores,
   snapshotSpaceStore,
   spaceStorePath,
 } from "@commonfabric/memory/v2/dump";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { resolveSpaceStoreUrl } from "@commonfabric/memory/v2/storage-path";
-import type { Signer } from "@commonfabric/memory/interface";
-import {
-  type Options,
-  type SessionFactory,
-  StorageManager,
-} from "../../runner/src/storage/v2.ts";
 import {
   type Cell,
   CHIP_UI,
@@ -56,25 +57,21 @@ import {
   TILE_UI,
   UI,
 } from "@commonfabric/runner";
-import {
-  companionFileName,
-  companionSpace,
-  vintageCompanionDir,
-} from "./vintage-layout.ts";
 import type { RuntimeProgram } from "@commonfabric/runner";
-// The comparison's two leaf cases. A materialized root is not plain data: at an
-// `asCell`/`asStream` position it holds a live cell, and a durable doc may hold
-// a fabric special object (bytes, an epoch). Neither survives a structural
-// comparison unaided — see `comparableState`.
-import { FabricSpecialObject } from "@commonfabric/data-model/fabric-value";
-import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
+import { Database } from "@db/sqlite";
+
+import type { NormalizedFullLink } from "../../runner/src/link-types.ts";
 // Relative into the runner's internals for the same reason as the test
 // utilities below: `getMetaLink` and the link shape it returns are how the
 // runtime itself reaches a root's argument document, and re-deriving that
 // here would be a second spelling to drift.
 import { getMetaLink } from "../../runner/src/link-utils.ts";
-import type { NormalizedFullLink } from "../../runner/src/link-types.ts";
+import {
+  type Options,
+  type SessionFactory,
+  StorageManager,
+} from "../../runner/src/storage/v2.ts";
 // Relative into the runner's test utilities: they are not part of the runner's
 // public exports, and the loopback-server auth handshake has exactly one
 // correct spelling — duplicating it here would be a second copy to drift.
@@ -82,6 +79,11 @@ import {
   TEST_MEMORY_SERVER_AUTH,
   testPrincipalSessionOpenAuthFactory,
 } from "../../runner/test/memory-v2-test-utils.ts";
+import {
+  companionFileName,
+  companionSpace,
+  vintageCompanionDir,
+} from "./vintage-layout.ts";
 
 class LoopbackSessions implements SessionFactory {
   constructor(private readonly server: () => MemoryV2Server.Server) {}

--- a/packages/piece/test/test.ts
+++ b/packages/piece/test/test.ts
@@ -1,7 +1,9 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { PiecesController } from "../src/ops/pieces-controller.ts";
+import { describe, it } from "@std/testing/bdd";
+
 import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
+
+import { PiecesController } from "../src/ops/pieces-controller.ts";
 
 describe("noop", () => {
 });

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -1,16 +1,38 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
-import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
+import { describe, it } from "@std/testing/bdd";
+
+import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
+import { entityRefFrom } from "@commonfabric/data-model/cell-rep";
+import { FabricError } from "@commonfabric/data-model/fabric-instances";
 import {
   FabricBytes,
   FabricEpochNsec,
 } from "@commonfabric/data-model/fabric-primitives";
-import { FabricError } from "@commonfabric/data-model/fabric-instances";
+import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
+import { Identity } from "@commonfabric/identity";
 import type { MemorySpace, URI } from "@commonfabric/memory/interface";
+import { decodeMemoryBoundary } from "@commonfabric/memory/v2";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { PieceController, PiecesController } from "@commonfabric/piece/ops";
+import {
+  entityIdFrom,
+  Runtime,
+  type RuntimeFetch,
+  runtimePresets,
+  RuntimeTelemetry,
+} from "@commonfabric/runner";
+import { atomsOutsideCeiling } from "@commonfabric/runner/cfc";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { parseLink } from "../../runner/src/link-utils.ts";
+import * as V2Storage from "../../runner/src/storage/v2.ts";
+import {
+  type CellRef,
+  type CfcLabelView,
+  ClientNotificationType,
+  RequestType,
+} from "../protocol/mod.ts";
 import {
   browserWorkerParamsFromInitializationData,
   renderConfidentialityResolverFor,
@@ -18,27 +40,11 @@ import {
   RuntimeProcessor,
   sanitizeForPostMessage,
 } from "./runtime-processor.ts";
-import { atomsOutsideCeiling } from "@commonfabric/runner/cfc";
-import { cfcAtom } from "@commonfabric/api/cfc";
-import { type RuntimeFetch, runtimePresets } from "@commonfabric/runner";
-import {
-  type CellRef,
-  type CfcLabelView,
-  ClientNotificationType,
-  RequestType,
-} from "../protocol/mod.ts";
-import { decodeMemoryBoundary } from "@commonfabric/memory/v2";
-import { entityRefFrom } from "@commonfabric/data-model/cell-rep";
 import {
   cellRefToSigilLink,
   getCell,
   mapCellRefsToSigilLinks,
 } from "./utils.ts";
-import { entityIdFrom, Runtime, RuntimeTelemetry } from "@commonfabric/runner";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
-import * as V2Storage from "../../runner/src/storage/v2.ts";
-import { parseLink } from "../../runner/src/link-utils.ts";
 
 const cfcSigner = await Identity.fromPassphrase(
   "runtime-processor-cfc-label-tests",

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -1,8 +1,23 @@
-import { DID, Identity, type Session } from "@commonfabric/identity";
+import { newDefaultJsonCodecEngine } from "@commonfabric/data-model/codecs";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { FabricSpecialObject } from "@commonfabric/data-model/fabric-value";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
-import { newDefaultJsonCodecEngine } from "@commonfabric/data-model/codecs";
+import {
+  type SiteTable,
+  siteTableCause,
+  siteTableSchema,
+} from "@commonfabric/home-schemas";
+import {
+  normalizeRenderConfidentialityCeiling,
+  normalizeRenderDeclassificationPolicy,
+  type RenderConfidentialityCeiling,
+  type RenderDeclassificationPolicy,
+  WorkerReconciler,
+} from "@commonfabric/html/worker";
+import { DID, Identity, type Session } from "@commonfabric/identity";
+import type { Program } from "@commonfabric/js-compiler";
+import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
+import { setLLMUrl } from "@commonfabric/llm";
 import { type ACL, isACLUser, isCapability } from "@commonfabric/memory/acl";
 import {
   PieceController,
@@ -12,15 +27,6 @@ import {
   readPieceSourceRevision,
   readPieceSourceState,
 } from "@commonfabric/piece/ops";
-import {
-  getLogger,
-  getLoggerCountsBreakdown,
-  getLoggerFlagsBreakdown,
-  getTimingStatsBreakdown,
-  Logger,
-  resetAllCountBaselines,
-  resetAllTimingBaselines,
-} from "@commonfabric/utils/logger";
 import {
   ACLManager,
   type BrowserWorkerPresetParams,
@@ -46,8 +52,7 @@ import {
   SpaceHostValidationError,
   unmarkUiInputBlindWriteTx,
 } from "@commonfabric/runner";
-import { linkRefPayload } from "@commonfabric/runner/shared";
-import { hashStringForEntityAddress } from "@commonfabric/runner/entity-kind";
+import type { JSONValue, RuntimeOptions } from "@commonfabric/runner";
 import {
   cfcLabelViewForCell,
   createRenderConfidentialityResolver,
@@ -58,14 +63,27 @@ import {
   type SpaceMembershipProvider,
   stripSigilCfcLabelViews,
 } from "@commonfabric/runner/cfc";
+import { hashStringForEntityAddress } from "@commonfabric/runner/entity-kind";
 import { NameSchema, rendererVDOMSchema } from "@commonfabric/runner/schemas";
-import { StorageManager } from "../../runner/src/storage/cache.ts";
+import { linkRefPayload } from "@commonfabric/runner/shared";
+import { RemoteResponse } from "@commonfabric/runtime-client";
+import {
+  getLogger,
+  getLoggerCountsBreakdown,
+  getLoggerFlagsBreakdown,
+  getTimingStatsBreakdown,
+  Logger,
+  resetAllCountBaselines,
+  resetAllTimingBaselines,
+} from "@commonfabric/utils/logger";
+
 import {
   getMetaLink,
   KeepAsCell,
   type NormalizedFullLink,
   parseLink,
 } from "../../runner/src/link-utils.ts";
+import { StorageManager } from "../../runner/src/storage/cache.ts";
 import {
   type ActionRunTraceResponse,
   BooleanResponse,
@@ -152,35 +170,18 @@ import {
   type VDomUnmountRequest,
   type WriteStackTraceResponse,
 } from "../protocol/mod.ts";
-import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
-import type { Program } from "@commonfabric/js-compiler";
-import { setLLMUrl } from "@commonfabric/llm";
+import type { VDomOp } from "../protocol/types.ts";
+import { cellRefToKey } from "../shared/utils.ts";
 import {
-  type SiteTable,
-  siteTableCause,
-  siteTableSchema,
-} from "@commonfabric/home-schemas";
+  postContextualRuntimeError,
+  postRuntimeError,
+} from "./runtime-error.ts";
 import {
   createCellRef,
   createPageRef,
   getCell,
   mapCellRefsToSigilLinks,
 } from "./utils.ts";
-import { cellRefToKey } from "../shared/utils.ts";
-import { RemoteResponse } from "@commonfabric/runtime-client";
-import {
-  normalizeRenderConfidentialityCeiling,
-  normalizeRenderDeclassificationPolicy,
-  type RenderConfidentialityCeiling,
-  type RenderDeclassificationPolicy,
-  WorkerReconciler,
-} from "@commonfabric/html/worker";
-import type { VDomOp } from "../protocol/types.ts";
-import type { JSONValue, RuntimeOptions } from "@commonfabric/runner";
-import {
-  postContextualRuntimeError,
-  postRuntimeError,
-} from "./runtime-error.ts";
 
 const MAX_SERIALIZATION_DEPTH = 5;
 const blobUploadCodec = newDefaultJsonCodecEngine();

--- a/packages/runtime-client/backends/utils.ts
+++ b/packages/runtime-client/backends/utils.ts
@@ -3,18 +3,19 @@ import {
   JSONSchema,
   KeepAsCell,
   parseLink,
+  Runtime,
   SigilLink,
 } from "@commonfabric/runner";
 import {
+  type CfcCellLinkRefPayload,
   cfcLabelViewForCell,
   redactCaveatSourcesForDisplay,
   stripSigilCfcLabelViews,
 } from "@commonfabric/runner/cfc";
-import { CellRef, PageRef } from "../protocol/types.ts";
-import { Runtime } from "@commonfabric/runner";
 import { isSigilLink, linkRefFrom } from "@commonfabric/runner/shared";
-import { type CfcCellLinkRefPayload } from "@commonfabric/runner/cfc";
+
 import { isCellRef } from "../protocol/mod.ts";
+import { CellRef, PageRef } from "../protocol/types.ts";
 
 export function mapCellRefsToSigilLinks(value: unknown): any {
   if (

--- a/packages/runtime-client/backends/web-worker/index.ts
+++ b/packages/runtime-client/backends/web-worker/index.ts
@@ -5,8 +5,13 @@
  * Imports from `@commonfabric/runner` may be used freely in this directory.
  */
 import "core-js/proposals/explicit-resource-management";
+
 import "core-js/proposals/async-explicit-resource-management";
 
+import { getLogger } from "@commonfabric/utils/logger";
+import { unrefTimer } from "@commonfabric/utils/sleep";
+
+import { CompilerStackLoadError } from "../../../runner/src/harness/deferred-compiler-stack.ts";
 import {
   IPCRemoteResponse,
   isIPCClientMessage,
@@ -15,9 +20,6 @@ import {
   RuntimeErrorCode,
 } from "../../protocol/mod.ts";
 import { RuntimeProcessor } from "../mod.ts";
-import { getLogger } from "@commonfabric/utils/logger";
-import { unrefTimer } from "@commonfabric/utils/sleep";
-import { CompilerStackLoadError } from "../../../runner/src/harness/deferred-compiler-stack.ts";
 
 // Count-only ledger of request traffic as seen by the worker: one
 // `received/<type>` per request that reached this message handler and one

--- a/packages/runtime-client/backends/web-worker/index.ts
+++ b/packages/runtime-client/backends/web-worker/index.ts
@@ -4,8 +4,8 @@
  *
  * Imports from `@commonfabric/runner` may be used freely in this directory.
  */
-import "core-js/proposals/explicit-resource-management";
 
+import "core-js/proposals/explicit-resource-management";
 import "core-js/proposals/async-explicit-resource-management";
 
 import { getLogger } from "@commonfabric/utils/logger";

--- a/packages/runtime-client/cell-handle.test.ts
+++ b/packages/runtime-client/cell-handle.test.ts
@@ -1,5 +1,12 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import {
+  FabricBytes,
+  FabricEpochNsec,
+} from "@commonfabric/data-model/fabric-primitives";
+import { linkRefPayloadFromString } from "@commonfabric/runner/shared";
+
 import {
   $conn,
   $onCellUpdate,
@@ -10,11 +17,6 @@ import {
   type RuntimeClient,
 } from "./mod.ts";
 import { cellRefToKey } from "./shared/utils.ts";
-import { linkRefPayloadFromString } from "@commonfabric/runner/shared";
-import {
-  FabricBytes,
-  FabricEpochNsec,
-} from "@commonfabric/data-model/fabric-primitives";
 
 describe("CellHandle CFC label IPC", () => {
   it("queries the runtime for the label view behind a cell", async () => {

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -3,6 +3,16 @@
  */
 
 import {
+  FabricSpecialObject,
+  type FabricValue,
+} from "@commonfabric/data-model/fabric-value";
+import { DID } from "@commonfabric/identity";
+import { type CfcCellLinkRefPayload } from "@commonfabric/runner/cfc";
+import {
+  cfcLabelViewsEqual,
+  rebaseCfcLabelView,
+} from "@commonfabric/runner/cfc/label-view-core";
+import {
   type Cancel,
   isSigilLink,
   type JSONSchema,
@@ -11,12 +21,10 @@ import {
   linkRefPayloadToString,
   type SigilLink,
 } from "@commonfabric/runner/shared";
-import {
-  cfcLabelViewsEqual,
-  rebaseCfcLabelView,
-} from "@commonfabric/runner/cfc/label-view-core";
-import { type CfcCellLinkRefPayload } from "@commonfabric/runner/cfc";
-import { $conn, type RuntimeClient } from "./runtime-client.ts";
+import { getLogger } from "@commonfabric/utils/logger";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
+
+import { InitializedRuntimeConnection } from "./client/connection.ts";
 import {
   type CellRef,
   type CfcLabelView,
@@ -24,14 +32,7 @@ import {
   RequestType,
   type WireCellValue,
 } from "./protocol/mod.ts";
-import { DID } from "@commonfabric/identity";
-import {
-  FabricSpecialObject,
-  type FabricValue,
-} from "@commonfabric/data-model/fabric-value";
-import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
-import { InitializedRuntimeConnection } from "./client/connection.ts";
-import { getLogger } from "@commonfabric/utils/logger";
+import { $conn, type RuntimeClient } from "./runtime-client.ts";
 
 // Logger for schema warnings - disabled by default.
 // Enable via: globalThis.commonfabric.logger["cell-handle"].disabled = false

--- a/packages/runtime-client/favorites-manager.ts
+++ b/packages/runtime-client/favorites-manager.ts
@@ -5,10 +5,6 @@
  * defaultPattern through cell operations, without requiring specialized IPC messages.
  */
 
-import { DID } from "@commonfabric/identity";
-import { CellHandle } from "./cell-handle.ts";
-import { RuntimeClient } from "./runtime-client.ts";
-import type { CellRef } from "./protocol/types.ts";
 import {
   FavoriteEntry,
   favoriteKey,
@@ -16,6 +12,11 @@ import {
   Home,
   homeSchema,
 } from "@commonfabric/home-schemas";
+import { DID } from "@commonfabric/identity";
+
+import { CellHandle } from "./cell-handle.ts";
+import type { CellRef } from "./protocol/types.ts";
+import { RuntimeClient } from "./runtime-client.ts";
 import { tagsFromSchema } from "./schema-tags.ts";
 
 type HandlerName = "addFavorite" | "removeFavorite";

--- a/packages/runtime-client/integration/client.test.ts
+++ b/packages/runtime-client/integration/client.test.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env -S deno run -A
 
+import { assertEquals, assertExists, assertRejects } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+
+import { render } from "@commonfabric/html/client";
+import { MockDoc } from "@commonfabric/html/mock-doc";
 import {
   createSession,
   Identity,
@@ -7,7 +12,8 @@ import {
   Session,
 } from "@commonfabric/identity";
 import { env, waitFor } from "@commonfabric/integration";
-import { defer } from "@commonfabric/utils/defer";
+import { Program } from "@commonfabric/js-compiler";
+import { rendererVDOMSchema } from "@commonfabric/runner/schemas";
 import {
   $conn,
   CellHandle,
@@ -17,13 +23,8 @@ import {
   type RuntimeClientOptions,
   type VNode,
 } from "@commonfabric/runtime-client";
-import { rendererVDOMSchema } from "@commonfabric/runner/schemas";
-import { assertEquals, assertExists, assertRejects } from "@std/assert";
-import { describe, it } from "@std/testing/bdd";
-import { Program } from "@commonfabric/js-compiler";
-import { render } from "@commonfabric/html/client";
-import { MockDoc } from "@commonfabric/html/mock-doc";
 import { WebWorkerRuntimeTransport } from "@commonfabric/runtime-client/transports/web-worker";
+import { defer } from "@commonfabric/utils/defer";
 
 const { API_URL } = env;
 

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -1,3 +1,8 @@
+import type { MetaField } from "@commonfabric/api";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { DID, KeyPairRaw } from "@commonfabric/identity";
+import { type Program } from "@commonfabric/js-compiler/interface";
+import type { CfcLabelView } from "@commonfabric/runner/cfc/label-view-core";
 import type {
   ActionRunTraceEntry,
   JSONSchema,
@@ -12,12 +17,7 @@ import type {
   WriteStackTraceEntry,
   WriteStackTraceMatcher,
 } from "@commonfabric/runner/shared";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
-import type { CfcLabelView } from "@commonfabric/runner/cfc/label-view-core";
-import type { DID, KeyPairRaw } from "@commonfabric/identity";
-import { type Program } from "@commonfabric/js-compiler/interface";
 import { RuntimeTelemetryMarkerResult } from "@commonfabric/runtime-client";
-import type { MetaField } from "@commonfabric/api";
 export type { JSONSchema, JSONValue, Program };
 
 export type { CfcLabelView };

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -5,7 +5,10 @@
  * for interacting with cells across the worker boundary.
  */
 
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import type { DID, Identity } from "@commonfabric/identity";
+import { Program } from "@commonfabric/js-compiler/interface";
+import { NameSchema } from "@commonfabric/runner/schemas";
 import type {
   ActionRunTraceEntry,
   JSONSchema,
@@ -19,8 +22,18 @@ import type {
   WriteStackTraceEntry,
   WriteStackTraceMatcher,
 } from "@commonfabric/runner/shared";
-import { Program } from "@commonfabric/js-compiler/interface";
+
 import { CellHandle } from "./cell-handle.ts";
+import {
+  InitializedRuntimeConnection,
+  type PendingRequestDiagnostic,
+  type RequestTimelineEntry,
+  RuntimeConnection,
+  type SubscriptionDiagnostics,
+} from "./client/connection.ts";
+import { EventEmitter } from "./client/emitter.ts";
+import { RuntimeTransport } from "./client/transport.ts";
+import { PageHandle } from "./page-handle.ts";
 import {
   type CellRef,
   ConsoleNotification,
@@ -45,18 +58,6 @@ import {
   TelemetryNotification,
   type UploadBlobResponse,
 } from "./protocol/mod.ts";
-import { NameSchema } from "@commonfabric/runner/schemas";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
-import { RuntimeTransport } from "./client/transport.ts";
-import { EventEmitter } from "./client/emitter.ts";
-import {
-  InitializedRuntimeConnection,
-  type PendingRequestDiagnostic,
-  type RequestTimelineEntry,
-  RuntimeConnection,
-  type SubscriptionDiagnostics,
-} from "./client/connection.ts";
-import { PageHandle } from "./page-handle.ts";
 
 export interface RuntimeClientOptions
   extends Omit<InitializationData, "apiUrl" | "identity" | "spaceIdentity"> {


### PR DESCRIPTION
Second of the series applying the Development Guide's `Imports` rules (#5852)
to the rest of the tree. I (agent working on behalf of @danfuzz) am splitting
along package lines; this one takes four packages from the capability and
deployed-product layers.

Independent of #5854 — different files, no shared base beyond `main`.

## What changed

51 files, import blocks only.

| Package | Files |
|---|---:|
| `html` | 15 |
| `cf-harness` | 15 |
| `piece` | 11 |
| `runtime-client` | 10 |

Per file: statements merged where a module was named twice, grouped standard
library / external / internal with a blank line between, each package's imports
collated into one contiguous run, and each run sorted. Sorting is applied only
to files already being reordered for one of the required rules, which is what
the rule itself says to do.

## The file this PR is careful about

`runtime-client/backends/web-worker/index.ts` opens with two `core-js` polyfill
imports. They are bare, so they are load-bearing **by position** — a polyfill
evaluated after the code relying on it is a different program, and nothing
type-checks that.

```
BEFORE                                        AFTER
 7: import "core-js/proposals/explicit-…"      7: import "core-js/proposals/explicit-…"
 8: import "core-js/proposals/async-…"         9: import "core-js/proposals/async-…"
10: import { … }                              11: import { getLogger } …
17: import { RuntimeProcessor } …             12: import { unrefTimer } …
18: import { getLogger } …                    14: import { CompilerStackLoadError } …
19: import { unrefTimer } …                   15: import { … }
20: import { CompilerStackLoadError } …       22: import { RuntimeProcessor } …
```

Both polyfills still lead the file, in order, with every named import below
them. The rewriting treats a bare import as a hard barrier: it never moves, and
nothing moves across it.

## The two files done by hand

The rewriting refuses to guess when anything other than a comment or blank line
sits between imports, and reports the file instead. Two here:

- **`piece/test/piece-origin.test.ts`** had a `const` in the middle of its
  import block, with further imports below it. Imports hoist, so gathering them
  all above the `const` is behavior-preserving.
- **`runtime-client/protocol/types.ts`** carries an import at line 1123, beside
  the export it feeds, 1,100 lines below the opening block. That one stays
  exactly where it is; only the opening block was ordered.

## Verification

The sweep legitimately changes import statements — merging two into one — so the
check is semantic rather than textual: each file's set of imported **bindings**,
where a binding is `(resolved module, type-ness, local name)` with the module
resolved through the `@/` alias and relative paths alike.

- **51 files, zero binding differences.** The same comparison flags a
  deliberately dropped named import and a deliberately repointed specifier, so
  its silence is a measurement.
- `deno fmt --check`, `deno lint`, `deno task check` all green.
- Package suites: `piece` 37 passed, `runtime-client` 60, `html` 44,
  `cf-harness` 717. All 0 failed.
- Re-censused: these four packages now read zero on all four required rules.

## Series

Done: #5854 (fifteen small packages, 57 files), this one (51).

Remaining: `runner` 242 — split into `src` and `test` — `ui` 62, `toolshed` 55,
`cli` 33, `ts-transformers` 29, `shell` 22, `memory` 20.

`packages/patterns` is excluded from every PR in this series: pattern source is
compiled and content-addressed, so an edit that looks inert can move a contract
and trip `pattern-compat`. `packages/generated-patterns` is excluded as
generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

