### PR TITLE
refactor: conform imports in `memory`, `shell`, `ts-transformers`

### DIFF
--- a/packages/memory/fact.ts
+++ b/packages/memory/fact.ts
@@ -1,6 +1,8 @@
-import type { URI } from "./interface.ts";
 import type { FabricValue } from "@commonfabric/api";
 import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
+import { hashOf } from "@commonfabric/data-model/value-hash";
+
+import type { URI } from "./interface.ts";
 import {
   Assertion,
   Fact,
@@ -10,7 +12,6 @@ import {
   State,
   Unclaimed,
 } from "./interface.ts";
-import { hashOf } from "@commonfabric/data-model/value-hash";
 
 /**
  * Creates an unclaimed fact.

--- a/packages/memory/test/cellset-structural-precondition.test.ts
+++ b/packages/memory/test/cellset-structural-precondition.test.ts
@@ -25,6 +25,10 @@
 
 import { assertEquals, assertThrows } from "@std/assert";
 import { toFileUrl } from "@std/path";
+
+import type { FabricValue } from "@commonfabric/api";
+
+import { type EntityDocument, toDocumentPath } from "../v2.ts";
 import {
   applyCommit,
   close,
@@ -33,8 +37,6 @@ import {
   open,
   read,
 } from "../v2/engine.ts";
-import { type EntityDocument, toDocumentPath } from "../v2.ts";
-import type { FabricValue } from "@commonfabric/api";
 
 const toEntityDocument = (value: FabricValue): EntityDocument => ({ value });
 

--- a/packages/memory/test/dump.test.ts
+++ b/packages/memory/test/dump.test.ts
@@ -6,15 +6,17 @@
 // root) rather than a hand-simplified path.
 
 import { assertEquals } from "@std/assert";
-import { Database } from "@db/sqlite";
 import * as Path from "@std/path";
-import { resolveSpaceStoreUrl } from "../v2/storage-path.ts";
+
+import { Database } from "@db/sqlite";
+
 import type { MemorySpace } from "../interface.ts";
 import {
   listSpaceStores,
   snapshotSpaceStore,
   spaceStorePath,
 } from "../v2/dump.ts";
+import { resolveSpaceStoreUrl } from "../v2/storage-path.ts";
 
 const SPACE_A = "did:key:z6MkDumpHelperSpaceAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 const SPACE_B = "did:key:z6MkDumpHelperSpaceBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";

--- a/packages/memory/test/session-open-auth.test.ts
+++ b/packages/memory/test/session-open-auth.test.ts
@@ -1,13 +1,15 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
-import { alice, bob, mallory, space } from "./principal.ts";
-import { MEMORY_PROTOCOL } from "../v2.ts";
-import { hashOf } from "@commonfabric/data-model/value-hash";
+
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import { hashOf } from "@commonfabric/data-model/value-hash";
+
+import { MEMORY_PROTOCOL } from "../v2.ts";
 import {
   verifySessionOpenAuthorization,
   wireAuthorizationOf,
 } from "../v2/session-open-auth.ts";
+import { alice, bob, mallory, space } from "./principal.ts";
 
 const now = 1_000_000;
 const audience = bob.did();

--- a/packages/memory/test/v2-commit-preconditions.test.ts
+++ b/packages/memory/test/v2-commit-preconditions.test.ts
@@ -1,5 +1,14 @@
 import { assertEquals, assertRejects, assertThrows } from "@std/assert";
 import { toFileUrl } from "@std/path";
+
+import type { FabricValue } from "@commonfabric/api";
+
+import {
+  commitPreconditionValueHash,
+  type EntityDocument,
+  toDocumentPath,
+} from "../v2.ts";
+import { connect, loopback } from "../v2/client.ts";
 import {
   applyCommit,
   close,
@@ -12,13 +21,6 @@ import {
   type SchedulerActionObservation,
 } from "../v2/engine.ts";
 import { Server } from "../v2/server.ts";
-import { connect, loopback } from "../v2/client.ts";
-import {
-  commitPreconditionValueHash,
-  type EntityDocument,
-  toDocumentPath,
-} from "../v2.ts";
-import type { FabricValue } from "@commonfabric/api";
 import {
   testSessionOpenAuthFactory,
   testSessionOpenServerOptions,

--- a/packages/memory/test/v2-engine.test.ts
+++ b/packages/memory/test/v2-engine.test.ts
@@ -4,14 +4,23 @@ import {
   assertMatch,
   assertThrows,
 } from "@std/assert";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { toFileUrl } from "@std/path";
+
 import {
   type EntityRef,
   entityRefFromString,
   LINK_V1_TAG,
 } from "@commonfabric/data-model/cell-rep";
-import { toFileUrl } from "@std/path";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Database } from "@db/sqlite";
+
+import {
+  decodeMemoryBoundary,
+  DEFAULT_BRANCH,
+  encodeMemoryBoundary,
+  type EntityDocument,
+  toDocumentPath,
+} from "../v2.ts";
 import {
   applyCommit,
   close,
@@ -27,13 +36,6 @@ import {
   ProtocolError,
   read,
 } from "../v2/engine.ts";
-import {
-  decodeMemoryBoundary,
-  DEFAULT_BRANCH,
-  encodeMemoryBoundary,
-  type EntityDocument,
-  toDocumentPath,
-} from "../v2.ts";
 
 const createEngine = async (): Promise<{
   engine: Engine;

--- a/packages/memory/test/v2-manual-flush.test.ts
+++ b/packages/memory/test/v2-manual-flush.test.ts
@@ -1,6 +1,7 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { FakeTime } from "@std/testing/time";
+
 import {
   encodeMemoryBoundary,
   getMemoryProtocolFlags,

--- a/packages/memory/test/v2-patch.test.ts
+++ b/packages/memory/test/v2-patch.test.ts
@@ -16,11 +16,15 @@ import {
   assertStrictEquals,
   assertThrows,
 } from "@std/assert";
-import { applyPatch, applyPatchToDocument } from "../v2/patch.ts";
+
 import { FabricError } from "@commonfabric/data-model/fabric-instances";
+import {
+  FabricBytes,
+  FabricEpochNsec,
+} from "@commonfabric/data-model/fabric-primitives";
 import { FabricInstance } from "@commonfabric/data-model/fabric-value";
-import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import { FabricEpochNsec } from "@commonfabric/data-model/fabric-primitives";
+
+import { applyPatch, applyPatchToDocument } from "../v2/patch.ts";
 
 Deno.test("memory v2 patch preserves `FabricInstance` values with full fidelity", () => {
   const placements = [

--- a/packages/memory/test/v2-sparse-pending-dependencies.test.ts
+++ b/packages/memory/test/v2-sparse-pending-dependencies.test.ts
@@ -13,9 +13,14 @@
  * future change cannot quietly forbid the sparse shape or quietly re-trust
  * client discipline.
  */
-import { describe, it } from "@std/testing/bdd";
+
 import { expect } from "@std/expect";
 import { toFileUrl } from "@std/path";
+import { describe, it } from "@std/testing/bdd";
+
+import type { FabricValue } from "@commonfabric/api";
+
+import { type EntityDocument, toDocumentPath } from "../v2.ts";
 import {
   applyCommit,
   close,
@@ -24,8 +29,6 @@ import {
   open,
   read,
 } from "../v2/engine.ts";
-import { type EntityDocument, toDocumentPath } from "../v2.ts";
-import type { FabricValue } from "@commonfabric/api";
 
 const toEntityDocument = (value: FabricValue): EntityDocument => ({ value });
 

--- a/packages/memory/test/v2-sqlite-commit-eval.test.ts
+++ b/packages/memory/test/v2-sqlite-commit-eval.test.ts
@@ -8,8 +8,16 @@
 
 import { assert, assertEquals, assertThrows } from "@std/assert";
 import { toFileUrl } from "@std/path";
+
 import { Database } from "@db/sqlite";
+
+import type { Operation, SqliteDbRef, SqliteParamsWire } from "../v2.ts";
 import { applyCommit, open, read } from "../v2/engine.ts";
+import {
+  applySqliteCommitWrite,
+  MAX_ROW_LABEL_EVAL_ROWS,
+  RowLabelCommitError,
+} from "../v2/sqlite/commit-eval.ts";
 import {
   aliasForDbId,
   attachDatabase,
@@ -17,8 +25,7 @@ import {
   ensureTables,
   runQuery,
 } from "../v2/sqlite/exec.ts";
-import { table } from "../v2/sqlite/schema.ts";
-import type { SqliteDbRef, SqliteParamsWire } from "../v2.ts";
+import * as sqliteBarrel from "../v2/sqlite/mod.ts";
 import {
   all,
   authoredBy,
@@ -27,13 +34,7 @@ import {
   principal,
   whenMatches,
 } from "../v2/sqlite/row-label.ts";
-import {
-  applySqliteCommitWrite,
-  MAX_ROW_LABEL_EVAL_ROWS,
-  RowLabelCommitError,
-} from "../v2/sqlite/commit-eval.ts";
-import * as sqliteBarrel from "../v2/sqlite/mod.ts";
-import type { Operation } from "../v2.ts";
+import { table } from "../v2/sqlite/schema.ts";
 
 const ADDR = /[^\s<>,;"]+@[^\s<>,;"]+/g;
 

--- a/packages/memory/util.ts
+++ b/packages/memory/util.ts
@@ -1,5 +1,6 @@
-import { AsyncResult, DID, DIDKey } from "./interface.ts";
 import { VerifierIdentity } from "@commonfabric/identity";
+
+import { AsyncResult, DID, DIDKey } from "./interface.ts";
 
 const DID_PREFIX = "did:";
 const DID_KEY_PREFIX = `did:key:`;

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -1,20 +1,20 @@
-import {
-  type EntityRef,
-  getModernCellRepConfig,
-} from "@commonfabric/data-model/cell-rep";
-import {
-  fabricFromJsonValue,
-  jsonFromFabricValue,
-} from "@commonfabric/data-model/codecs";
-import { internPathSelector } from "@commonfabric/data-model/schema-utils";
 import type {
   FabricPlainObject,
   FabricValue,
   SchemaPathSelector,
 } from "@commonfabric/api";
+import {
+  type EntityRef,
+  getModernCellRepConfig,
+} from "@commonfabric/data-model/cell-rep";
 import { EmptyReconstructionContext } from "@commonfabric/data-model/codec-common";
-import { isObjectNotArray } from "@commonfabric/utils/types";
+import {
+  fabricFromJsonValue,
+  jsonFromFabricValue,
+} from "@commonfabric/data-model/codecs";
+import { internPathSelector } from "@commonfabric/data-model/schema-utils";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 
 export const MEMORY_PROTOCOL = "memory" as const;
 export const DEFAULT_BRANCH = "" as const;

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -1,4 +1,6 @@
 import type { FabricPlainObject, FabricValue } from "@commonfabric/api";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+
 import {
   type ClientCommit,
   compatibleMemoryProtocolFlags,
@@ -34,11 +36,10 @@ import {
   type WatchSetResult,
   type WatchSpec,
 } from "../v2.ts";
-import type { Server } from "./server.ts";
 import type { AppliedCommit } from "./engine.ts";
-import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
-import { expandServerMessageSchemas } from "./sync-schema-table.ts";
+import type { Server } from "./server.ts";
 import { containsReservedSchemaRefSubstring } from "./sync-schema-ref.ts";
+import { expandServerMessageSchemas } from "./sync-schema-table.ts";
 import { type ArmedTurn, armTurn } from "./turn.ts";
 
 export type Transport = {

--- a/packages/memory/v2/dump.ts
+++ b/packages/memory/v2/dump.ts
@@ -16,14 +16,16 @@
 // so we MUST resolve through the same helper rather than assuming files sit
 // directly under `store` — directory mode nests them one more `engine-v3/` deep.
 
-import { Database } from "@db/sqlite";
 import * as Path from "@std/path";
+
+import { Database } from "@db/sqlite";
+
+import type { MemorySpace } from "../interface.ts";
 import {
   resolveSpaceStoreDirUrl,
   resolveSpaceStoreUrl,
   spaceFromStoreFilename,
 } from "./storage-path.ts";
-import type { MemorySpace } from "../interface.ts";
 
 const SQLITE_SUFFIX = ".sqlite";
 

--- a/packages/memory/v2/handshake.ts
+++ b/packages/memory/v2/handshake.ts
@@ -1,3 +1,5 @@
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+
 import {
   compatibleMemoryProtocolFlags,
   getMemoryProtocolFlags,
@@ -8,7 +10,6 @@ import {
   type ServerMessage,
   wireMemoryProtocolFlags,
 } from "../v2.ts";
-import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 
 type TypedError = {
   name: string;

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -1,3 +1,5 @@
+import type { FabricValue } from "@commonfabric/api";
+import { internPathSelector } from "@commonfabric/data-model/schema-utils";
 import {
   CompoundCycleTracker,
   createSchemaMemo,
@@ -14,12 +16,11 @@ import {
   schemaTrackerCoversSelector,
   type TraversalContext,
 } from "@commonfabric/runner/traverse";
+import { isObjectNotArray } from "@commonfabric/utils/types";
+
 import type { JSONSchema } from "../../runner/src/builder/types.ts";
 import { ExtendedStorageTransaction } from "../../runner/src/storage/extended-storage-transaction.ts";
-import { isObjectNotArray } from "@commonfabric/utils/types";
-import type { FabricValue } from "@commonfabric/api";
 import type { MemorySpace, MIME, URI } from "../interface.ts";
-import { internPathSelector } from "@commonfabric/data-model/schema-utils";
 import {
   type CellScope,
   type EntitySnapshot,

--- a/packages/memory/v2/schema-table-links.ts
+++ b/packages/memory/v2/schema-table-links.ts
@@ -1,9 +1,9 @@
+import type { FabricPlainObject, FabricValue } from "@commonfabric/api";
 import {
   isLinkRef,
   linkRefFrom,
   linkRefPayload,
 } from "@commonfabric/data-model/cell-rep";
-import type { FabricPlainObject, FabricValue } from "@commonfabric/api";
 import type { MutableFabricPlainObjectLayer } from "@commonfabric/data-model/fabric-value";
 import { isPlainObject } from "@commonfabric/utils/types";
 

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -1,7 +1,17 @@
-import type { FabricPlainObject } from "@commonfabric/api";
 import * as FS from "@std/fs";
 import * as Path from "@std/path";
-import { resolveSpaceStoreUrl } from "./storage-path.ts";
+
+import type { FabricPlainObject } from "@commonfabric/api";
+import { SpanStatusCode, trace } from "@opentelemetry/api";
+
+import {
+  aclDocId,
+  ANYONE_USER,
+  type Capability,
+  hasConcreteOwner,
+  isACL,
+  isCapable,
+} from "../acl.ts";
 import {
   type CellScope,
   type ClientCommit,
@@ -56,29 +66,7 @@ import {
 } from "../v2.ts";
 import { classifyCommitTelemetry } from "./commit-telemetry.ts";
 import * as Engine from "./engine.ts";
-import {
-  aclDocId,
-  ANYONE_USER,
-  type Capability,
-  hasConcreteOwner,
-  isACL,
-  isCapable,
-} from "../acl.ts";
-import {
-  aliasForDbId,
-  attachDatabase,
-  detachDatabase,
-  ensureTables,
-} from "./sqlite/exec.ts";
-import { assertReadOnly } from "./sqlite/guard.ts";
-import { RowLabelCommitError } from "./sqlite/commit-eval.ts";
-import type { TableSchema } from "./sqlite/schema.ts";
-import { DiskSourceRegistry } from "./sqlite/disk-source.ts";
-import { ReadConnectionPool } from "./sqlite/read-pool.ts";
-import {
-  columnOriginUnavailableReason,
-  ensureColumnOriginAvailable,
-} from "./sqlite/column-origin.ts";
+import { respondToHello } from "./handshake.ts";
 import {
   cloneTrackedGraphState,
   extendTrackedGraph,
@@ -90,8 +78,6 @@ import {
   type TrackedGraphState,
   trackGraph,
 } from "./query.ts";
-import { respondToHello } from "./handshake.ts";
-import { compressServerMessageSchemas } from "./sync-schema-table.ts";
 import {
   buildDiffSync,
   buildFullSync,
@@ -105,10 +91,26 @@ import {
   toCacheEntry,
   trackedIdsFromEntries,
 } from "./server-sync.ts";
-import { SessionRegistry, type SessionState } from "./session-registry.ts";
 import { authorizationError } from "./session-open-auth.ts";
+import { SessionRegistry, type SessionState } from "./session-registry.ts";
+import {
+  columnOriginUnavailableReason,
+  ensureColumnOriginAvailable,
+} from "./sqlite/column-origin.ts";
+import { RowLabelCommitError } from "./sqlite/commit-eval.ts";
+import { DiskSourceRegistry } from "./sqlite/disk-source.ts";
+import {
+  aliasForDbId,
+  attachDatabase,
+  detachDatabase,
+  ensureTables,
+} from "./sqlite/exec.ts";
+import { assertReadOnly } from "./sqlite/guard.ts";
+import { ReadConnectionPool } from "./sqlite/read-pool.ts";
+import type { TableSchema } from "./sqlite/schema.ts";
+import { resolveSpaceStoreUrl } from "./storage-path.ts";
+import { compressServerMessageSchemas } from "./sync-schema-table.ts";
 import { type ArmedTurn, armTurn } from "./turn.ts";
-import { SpanStatusCode, trace } from "@opentelemetry/api";
 
 export { SessionRegistry } from "./session-registry.ts";
 

--- a/packages/memory/v2/standalone.ts
+++ b/packages/memory/v2/standalone.ts
@@ -12,10 +12,11 @@
  * bundles.
  */
 
+import { Identity } from "@commonfabric/identity";
+
 import { encodeMemoryBoundary } from "../v2.ts";
 import * as MemoryServer from "./server.ts";
 import { verifySessionOpenAuthorization } from "./session-open-auth.ts";
-import { Identity } from "@commonfabric/identity";
 
 const standaloneMemoryAudience = (await Identity.fromPassphrase(
   "common tools standalone memory audience",

--- a/packages/memory/v2/sync-schema-table.ts
+++ b/packages/memory/v2/sync-schema-table.ts
@@ -1,17 +1,18 @@
 import type { FabricValue, JSONSchema } from "@commonfabric/api";
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { isPlainObject } from "@commonfabric/utils/types";
+
 import type {
   ServerMessage,
   SessionEffectMessage,
   SessionSync,
 } from "../v2.ts";
-import { isPlainObject } from "@commonfabric/utils/types";
+import { mapLinkSchemas } from "./schema-table-links.ts";
 import {
   findSyncSchemaRef,
   SYNC_SCHEMA_REF_PREFIX,
 } from "./sync-schema-ref.ts";
-import { mapLinkSchemas } from "./schema-table-links.ts";
 
 type SchemaTable = Record<string, JSONSchema>;
 

--- a/packages/shell/felt.config.ts
+++ b/packages/shell/felt.config.ts
@@ -1,6 +1,7 @@
 import { type Config } from "@commonfabric/felt";
-import { computeCurrentCompilerVersion } from "../runner/src/compilation-cache/compiler-fingerprint.deno.ts";
 import ports from "@commonfabric/ports" with { type: "json" };
+
+import { computeCurrentCompilerVersion } from "../runner/src/compilation-cache/compiler-fingerprint.deno.ts";
 
 const PRODUCTION = !!Deno.env.get("PRODUCTION");
 const ENVIRONMENT = PRODUCTION ? "production" : "development";

--- a/packages/shell/integration/header-menu.test.ts
+++ b/packages/shell/integration/header-menu.test.ts
@@ -1,9 +1,11 @@
-import { env, waitForCondition } from "@commonfabric/integration";
-import { ShellIntegration } from "@commonfabric/integration/shell-utils";
-import { describe, it } from "@std/testing/bdd";
 import { assert, assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
+import { env, waitForCondition } from "@commonfabric/integration";
 import type { Page } from "@commonfabric/integration";
+import { ShellIntegration } from "@commonfabric/integration/shell-utils";
+
 import "../src/globals.ts";
 
 const { FRONTEND_URL, SPACE_NAME } = env;

--- a/packages/shell/integration/load-errors.test.ts
+++ b/packages/shell/integration/load-errors.test.ts
@@ -1,7 +1,9 @@
+import { describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
 import { env, waitForCondition } from "@commonfabric/integration";
 import { ShellIntegration } from "@commonfabric/integration/shell-utils";
-import { Identity } from "@commonfabric/identity";
-import { describe, it } from "@std/testing/bdd";
+
 import "../src/globals.ts";
 
 const { FRONTEND_URL, SPACE_NAME } = env;

--- a/packages/shell/integration/login.test.ts
+++ b/packages/shell/integration/login.test.ts
@@ -1,6 +1,8 @@
-import { env, waitForCondition } from "@commonfabric/integration";
-import { describe, it } from "@std/testing/bdd";
 import { assert } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+
+import { env, waitForCondition } from "@commonfabric/integration";
+
 import { ShellIntegration } from "../../integration/shell-utils.ts";
 import { clickPierce, pierce } from "./shadow-dom.ts";
 

--- a/packages/shell/integration/piece-menu.test.ts
+++ b/packages/shell/integration/piece-menu.test.ts
@@ -1,10 +1,13 @@
+import { expect } from "@std/expect";
+import { join, resolve } from "@std/path";
+import { describe, it } from "@std/testing/bdd";
+
 import { env, waitForCondition } from "@commonfabric/integration";
 import { ShellIntegration } from "@commonfabric/integration/shell-utils";
 import { writeTempIdentity } from "@commonfabric/integration/temp-identity";
-import { expect } from "@std/expect";
-import { describe, it } from "@std/testing/bdd";
-import { join, resolve } from "@std/path";
+
 import "../src/globals.ts";
+
 import { clickPierce } from "./shadow-dom.ts";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;

--- a/packages/shell/integration/piece.test.ts
+++ b/packages/shell/integration/piece.test.ts
@@ -1,13 +1,18 @@
+import { join, resolve } from "@std/path";
+import { describe, it } from "@std/testing/bdd";
+
 import { env, waitFor, waitForCondition } from "@commonfabric/integration";
 import { ShellIntegration } from "@commonfabric/integration/shell-utils";
 import { writeTempIdentity } from "@commonfabric/integration/temp-identity";
 import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
-import { describe, it } from "@std/testing/bdd";
-import { join, resolve } from "@std/path";
+
 import "../src/globals.ts";
-import { PieceController, PiecesController } from "@commonfabric/piece/ops";
-import { clickPierce } from "./shadow-dom.ts";
+
 import { expect } from "@std/expect";
+
+import { PieceController, PiecesController } from "@commonfabric/piece/ops";
+
+import { clickPierce } from "./shadow-dom.ts";
 
 const { API_URL, SPACE_NAME, FRONTEND_URL } = env;
 const REPO_ROOT = resolve(import.meta.dirname!, "../../..");

--- a/packages/shell/integration/worker-runtime.test.ts
+++ b/packages/shell/integration/worker-runtime.test.ts
@@ -1,8 +1,9 @@
-import { env } from "@commonfabric/integration";
-import { ShellIntegration } from "@commonfabric/integration/shell-utils";
-import { Identity } from "@commonfabric/identity";
 import { assertEquals } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+import { env } from "@commonfabric/integration";
+import { ShellIntegration } from "@commonfabric/integration/shell-utils";
 
 const { FRONTEND_URL } = env;
 

--- a/packages/shell/shared/navigate.ts
+++ b/packages/shell/shared/navigate.ts
@@ -1,3 +1,5 @@
+import { getLogger } from "@commonfabric/utils/logger";
+
 import {
   AppView,
   appViewToUrlPath,
@@ -5,7 +7,6 @@ import {
   ShellApp,
   urlToAppView,
 } from "./app/mod.ts";
-import { getLogger } from "@commonfabric/utils/logger";
 
 const logger = getLogger("shell.navigation", {
   enabled: false,

--- a/packages/shell/src/globals.ts
+++ b/packages/shell/src/globals.ts
@@ -1,5 +1,6 @@
-import type { ShellApp } from "../shared/mod.ts";
 import { type RuntimeClient } from "@commonfabric/runtime-client";
+
+import type { ShellApp } from "../shared/mod.ts";
 declare global {
   var app: ShellApp;
   var commonfabric: {

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -1,9 +1,7 @@
 import "core-js/proposals/explicit-resource-management";
 import "core-js/proposals/async-explicit-resource-management";
 import "@commonfabric/ui";
-import { API_URL, COMMIT_SHA, ENVIRONMENT } from "./lib/env.ts";
-import { setupHostToggles } from "./lib/host-toggles.ts";
-import { consumeDeviceLinkFragment } from "./lib/device-link.ts";
+
 // Statically imported, deliberately. A dynamic `await import()` here pushes
 // `shared/app/*` into esbuild's lazy `__esm` wrappers, and esbuild then emits
 // one of those wrappers as a NON-async function containing a top-level await —
@@ -13,12 +11,19 @@ import { consumeDeviceLinkFragment } from "./lib/device-link.ts";
 // `index` entry sets `splitting: false`, so esbuild inlines dynamic imports
 // rather than emitting a chunk.
 import { handleDeviceLink } from "./lib/device-link-login.ts";
+import { consumeDeviceLinkFragment } from "./lib/device-link.ts";
+import { API_URL, COMMIT_SHA, ENVIRONMENT } from "./lib/env.ts";
+import { setupHostToggles } from "./lib/host-toggles.ts";
+
 import "./components/index.ts";
 import "./views/index.ts";
-import { Navigation } from "../shared/mod.ts";
-import type { XRootView } from "./views/RootView.ts";
-import { ROOT_KEY } from "./lib/root-key.ts";
+
 import { KeyStore } from "@commonfabric/identity";
+
+import { Navigation } from "../shared/mod.ts";
+import { ROOT_KEY } from "./lib/root-key.ts";
+import type { XRootView } from "./views/RootView.ts";
+
 import "./globals.ts";
 
 // Device-link login: /#k=<base64url 32-byte BIP39 entropy>.

--- a/packages/shell/src/lib/cell-event-target.ts
+++ b/packages/shell/src/lib/cell-event-target.ts
@@ -1,6 +1,6 @@
-import { Cancel } from "@commonfabric/runtime-client";
-import { CellHandle } from "@commonfabric/runtime-client";
 import { assert } from "@std/assert";
+
+import { Cancel, CellHandle } from "@commonfabric/runtime-client";
 
 export class CellUpdateEvent<T> extends CustomEvent<T> {
   constructor(value: T) {

--- a/packages/shell/src/lib/debugger-controller.ts
+++ b/packages/shell/src/lib/debugger-controller.ts
@@ -1,5 +1,3 @@
-import { ReactiveController, ReactiveControllerHost } from "lit";
-import type { RuntimeInternals } from "./runtime.ts";
 import type {
   LoggerFlagsData,
   PatternSourceInfo,
@@ -8,6 +6,9 @@ import type {
   SchedulerGraphEdge,
   SchedulerGraphSnapshot,
 } from "@commonfabric/runtime-client";
+import { ReactiveController, ReactiveControllerHost } from "lit";
+
+import type { RuntimeInternals } from "./runtime.ts";
 
 const STORAGE_KEY = "showDebuggerView";
 const TELEMETRY_ENABLED_KEY = "telemetryEnabled";

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -1,27 +1,28 @@
-import { css, html, nothing } from "lit";
-import { property, state } from "lit/decorators.js";
-import { BaseView, createDefaultAppState } from "./BaseView.ts";
 import { type DID, KeyStore } from "@commonfabric/identity";
-import { slugIdForSpace, validateSlug } from "@commonfabric/runner/slugs";
-import { RuntimeInternals } from "../lib/runtime.ts";
-import { DebuggerController } from "../lib/debugger-controller.ts";
-import { Task, TaskStatus } from "@lit/task";
-import { CellEventTarget, CellUpdateEvent } from "../lib/cell-event-target.ts";
 import { type NameSchema, stringSchema } from "@commonfabric/runner/schemas";
-import {
-  isEmbeddedView,
-  isViewingDefaultPatternView,
-  replaceNavigation,
-  updatePageTitle,
-} from "../../shared/mod.ts";
-import { GlobalShortcutsController } from "../lib/global-shortcuts-controller.ts";
+import { slugIdForSpace, validateSlug } from "@commonfabric/runner/slugs";
 import {
   type Cancel,
   type ErrorNotification,
   NAME,
   PageHandle,
 } from "@commonfabric/runtime-client";
+import { Task, TaskStatus } from "@lit/task";
+import { css, html, nothing } from "lit";
+import { property, state } from "lit/decorators.js";
+
+import {
+  isEmbeddedView,
+  isViewingDefaultPatternView,
+  replaceNavigation,
+  updatePageTitle,
+} from "../../shared/mod.ts";
+import { CellEventTarget, CellUpdateEvent } from "../lib/cell-event-target.ts";
+import { DebuggerController } from "../lib/debugger-controller.ts";
+import { GlobalShortcutsController } from "../lib/global-shortcuts-controller.ts";
 import { prepareNamedSpace } from "../lib/named-space.ts";
+import { RuntimeInternals } from "../lib/runtime.ts";
+import { BaseView, createDefaultAppState } from "./BaseView.ts";
 import type { LoadError } from "./BodyView.ts";
 
 export class XAppView extends BaseView {

--- a/packages/shell/src/views/BaseView.ts
+++ b/packages/shell/src/views/BaseView.ts
@@ -1,12 +1,13 @@
-import { LitElement } from "lit";
 import type { Identity } from "@commonfabric/identity";
+import { DebugController } from "@commonfabric/ui";
+import { LitElement } from "lit";
+
 import {
   AppStateConfigKey,
   AppView,
   createAppState,
   urlToAppView,
 } from "../../shared/mod.ts";
-import { DebugController } from "@commonfabric/ui";
 import { API_URL } from "../lib/env.ts";
 
 // Set to `true` to render outlines everytime a

--- a/packages/shell/src/views/BodyView.ts
+++ b/packages/shell/src/views/BodyView.ts
@@ -1,12 +1,15 @@
+import { Task } from "@lit/task";
 import { css, html } from "lit";
 import { property } from "lit/decorators.js";
-import { Task } from "@lit/task";
-import { BaseView } from "./BaseView.ts";
+
 import { RuntimeInternals } from "../lib/runtime.ts";
+import { BaseView } from "./BaseView.ts";
+
 import "../components/OmniLayout.ts";
-import { CellHandle, PageHandle, VNode } from "@commonfabric/runtime-client";
+
 import { rendererVDOMSchema } from "@commonfabric/runner/schemas";
 import type { JSONSchema } from "@commonfabric/runner/shared";
+import { CellHandle, PageHandle, VNode } from "@commonfabric/runtime-client";
 
 type SubPages = {
   sidebarUI?: VNode;

--- a/packages/shell/src/views/DebuggerView.ts
+++ b/packages/shell/src/views/DebuggerView.ts
@@ -1,14 +1,17 @@
-import { css, html, LitElement, TemplateResult } from "lit";
-import { property, state } from "lit/decorators.js";
-import { ResizableDrawerController } from "../lib/resizable-drawer-controller.ts";
 import type {
   LoggerMetadata,
   RuntimeTelemetryMarkerResult,
   TimingStats,
 } from "@commonfabric/runtime-client";
 import { isObjectOrArray } from "@commonfabric/utils/types";
+import { css, html, LitElement, TemplateResult } from "lit";
+import { property, state } from "lit/decorators.js";
+
 import type { DebuggerController } from "../lib/debugger-controller.ts";
-import "./SchedulerGraphView.ts"; // Register x-scheduler-graph component
+import { ResizableDrawerController } from "../lib/resizable-drawer-controller.ts";
+
+import "./SchedulerGraphView.ts";
+
 import type { Logger, LoggerBreakdown } from "@commonfabric/utils/logger";
 
 /**

--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -1,15 +1,17 @@
-import { css, html, nothing, type PropertyValues } from "lit";
-import { property, state } from "lit/decorators.js";
+import type { FavoriteEntry } from "@commonfabric/home-schemas";
 import { type DID, KeyStore } from "@commonfabric/identity";
 import { hasEntityUriScheme } from "@commonfabric/runner/entity-kind";
-import { BaseView } from "./BaseView.ts";
-import { RuntimeInternals } from "../lib/runtime.ts";
-import { navigate } from "../../shared/mod.ts";
-import { Task } from "@lit/task";
 import { type CellHandle } from "@commonfabric/runtime-client";
-import type { FavoriteEntry } from "@commonfabric/home-schemas";
+import { Task } from "@lit/task";
+import { css, html, nothing, type PropertyValues } from "lit";
+import { property, state } from "lit/decorators.js";
+
+import { navigate } from "../../shared/mod.ts";
+import { RuntimeInternals } from "../lib/runtime.ts";
+import { BaseView } from "./BaseView.ts";
+
 import "../components/PieceList.ts";
-import { type PieceItem } from "../components/PieceList.ts";
+
 import {
   iconArrowLeft,
   iconBug,
@@ -22,6 +24,7 @@ import {
   iconStar,
   iconThemeToggle,
 } from "../components/icons.ts";
+import { type PieceItem } from "../components/PieceList.ts";
 import { getEffectiveTheme, toggleTheme } from "../lib/theme-preference.ts";
 
 type ConnectionStatus =

--- a/packages/shell/src/views/QuickJumpView.ts
+++ b/packages/shell/src/views/QuickJumpView.ts
@@ -1,11 +1,12 @@
+import type { DID } from "@commonfabric/identity";
+import { PageHandle } from "@commonfabric/runtime-client";
+import { Task } from "@lit/task";
 import { css, html } from "lit";
 import { property, state } from "lit/decorators.js";
-import { BaseView } from "./BaseView.ts";
-import { RuntimeInternals } from "../lib/runtime.ts";
-import type { DID } from "@commonfabric/identity";
-import { Task } from "@lit/task";
+
 import { navigate } from "../../shared/mod.ts";
-import { PageHandle } from "@commonfabric/runtime-client";
+import { RuntimeInternals } from "../lib/runtime.ts";
+import { BaseView } from "./BaseView.ts";
 
 type PieceItem = { id: string; name: string };
 

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -1,4 +1,21 @@
+import {
+  type DID,
+  type Identity,
+  KeyStore,
+  type TransferrableInsecureCryptoKeyPair,
+} from "@commonfabric/identity";
+import { resolveSpaceDid, RuntimeInternals } from "@commonfabric/lib-shell";
+import {
+  type ErrorNotification,
+  type RuntimeClient,
+  RuntimeErrorCode,
+} from "@commonfabric/runtime-client";
+import { runtimeContext, spaceContext } from "@commonfabric/ui";
+import { provide } from "@lit/context";
+import { Task, TaskStatus } from "@lit/task";
 import { css, html, PropertyValues } from "lit";
+import { property, state } from "lit/decorators.js";
+
 import {
   AppState,
   AppStateConfigKey,
@@ -14,40 +31,24 @@ import {
   ShellApp,
 } from "../../shared/mod.ts";
 import {
+  clearRuntimeDebugGlobals,
+  type CommonfabricDebugState,
+  exposeCommonfabricGlobals,
+} from "../lib/debug-utils.ts";
+import { COMMIT_SHA, ENVIRONMENT, EXPERIMENTAL } from "../lib/env.ts";
+import { runtimeHostFlags } from "../lib/host-toggles.ts";
+import { type BrowserTelemetry, initBrowserOtel } from "../lib/otel.ts";
+import { shouldRecreateRuntime } from "../lib/runtime-lifecycle.ts";
+import {
+  getThemePreference,
+  type ThemePreference,
+} from "../lib/theme-preference.ts";
+import {
   BaseView,
   type Command,
   createDefaultAppState,
   SHELL_COMMAND,
 } from "./BaseView.ts";
-import {
-  type Identity,
-  KeyStore,
-  type TransferrableInsecureCryptoKeyPair,
-} from "@commonfabric/identity";
-import { property, state } from "lit/decorators.js";
-import { Task, TaskStatus } from "@lit/task";
-import {
-  type ErrorNotification,
-  type RuntimeClient,
-  RuntimeErrorCode,
-} from "@commonfabric/runtime-client";
-import { type DID } from "@commonfabric/identity";
-import { resolveSpaceDid, RuntimeInternals } from "@commonfabric/lib-shell";
-import { shouldRecreateRuntime } from "../lib/runtime-lifecycle.ts";
-import {
-  clearRuntimeDebugGlobals,
-  type CommonfabricDebugState,
-  exposeCommonfabricGlobals,
-} from "../lib/debug-utils.ts";
-import { runtimeContext, spaceContext } from "@commonfabric/ui";
-import { provide } from "@lit/context";
-import {
-  getThemePreference,
-  type ThemePreference,
-} from "../lib/theme-preference.ts";
-import { COMMIT_SHA, ENVIRONMENT, EXPERIMENTAL } from "../lib/env.ts";
-import { runtimeHostFlags } from "../lib/host-toggles.ts";
-import { type BrowserTelemetry, initBrowserOtel } from "../lib/otel.ts";
 import type { LoadError } from "./BodyView.ts";
 
 function getCommonfabricGlobal(): typeof globalThis & {

--- a/packages/shell/src/views/SchedulerGraphView.ts
+++ b/packages/shell/src/views/SchedulerGraphView.ts
@@ -1,16 +1,19 @@
+import { ENTITY_URI_SCHEMES } from "@commonfabric/runner/entity-kind";
+import type { SchedulerGraphNode } from "@commonfabric/runtime-client";
+import dagre from "dagre";
 // Note: deno fmt can crash on deeply nested ternaries in html/svg templates - see renderBaselineStats
 import { css, html, LitElement, svg as svgTag, TemplateResult } from "lit";
-import { ENTITY_URI_SCHEMES } from "@commonfabric/runner/entity-kind";
 import { property, query, state } from "lit/decorators.js";
-import dagre from "dagre";
+
 import type { DebuggerController } from "../lib/debugger-controller.ts";
-import type { SchedulerGraphNode } from "@commonfabric/runtime-client";
+
 import "./SchedulerSourceView.ts";
+
+import { entityUriFromActionId } from "../lib/scheduler-graph-identity.ts";
 import {
   parseActionLocation,
   type SourceViewNode,
 } from "./SchedulerSourceView.ts";
-import { entityUriFromActionId } from "../lib/scheduler-graph-identity.ts";
 
 interface LayoutNode {
   id: string;

--- a/packages/shell/test/app-state.test.ts
+++ b/packages/shell/test/app-state.test.ts
@@ -1,4 +1,7 @@
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
+
+import { Identity, serializeKeyPairRaw } from "@commonfabric/identity";
 import {
   AppState,
   AppStateSerialized,
@@ -14,8 +17,6 @@ import {
   serialize,
   urlToAppView,
 } from "@commonfabric/shell/shared";
-import { Identity, serializeKeyPairRaw } from "@commonfabric/identity";
-import { assert, assertEquals, assertThrows } from "@std/assert";
 
 const API_URL = "http://common.test/";
 const SPACE_NAME = "common-knowledge";

--- a/packages/shell/test/debug-utils.test.ts
+++ b/packages/shell/test/debug-utils.test.ts
@@ -1,6 +1,12 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
+
+import type {
+  RuntimeClient,
+  TriggerTraceEntry,
+} from "@commonfabric/runtime-client";
+
 import {
   clearRuntimeDebugGlobals,
   type CommonfabricDebugState,
@@ -9,10 +15,6 @@ import {
   summarizeDebugValue,
   summarizeTriggerTraceEntries,
 } from "../src/lib/debug-utils.ts";
-import type {
-  RuntimeClient,
-  TriggerTraceEntry,
-} from "@commonfabric/runtime-client";
 
 describe("debug utils", () => {
   it("summarizeDebugValue classifies common metadata/result shapes", () => {

--- a/packages/ts-transformers/src/ast/utils.ts
+++ b/packages/ts-transformers/src/ast/utils.ts
@@ -1,4 +1,5 @@
 import * as ts from "typescript";
+
 import { getEnclosingFunctionLikeDeclaration } from "./function-predicates.ts";
 
 const nodeTextCache = new WeakMap<ts.Node, string>();

--- a/packages/ts-transformers/src/cf-pipeline.ts
+++ b/packages/ts-transformers/src/cf-pipeline.ts
@@ -1,3 +1,14 @@
+import ts from "typescript";
+
+import { ClosureTransformer } from "./closures/transformer.ts";
+import {
+  CrossStageState,
+  TransformationDiagnostic,
+  TransformationOptions,
+  Transformer,
+} from "./core/mod.ts";
+import type { CfcPolicyCompilerManifestV1 } from "./core/runtime-contract.ts";
+import { LiftLoweringTransformer } from "./lift/transformer.ts";
 import {
   AssertDiagnosticsTransformer,
   BuilderCallHoistingTransformer,
@@ -23,16 +34,6 @@ import {
   VerbTierMarkTransformer,
   WriteAuthorizedByValidationTransformer,
 } from "./transformers/mod.ts";
-import { ClosureTransformer } from "./closures/transformer.ts";
-import ts from "typescript";
-import { LiftLoweringTransformer } from "./lift/transformer.ts";
-import {
-  CrossStageState,
-  TransformationDiagnostic,
-  TransformationOptions,
-  Transformer,
-} from "./core/mod.ts";
-import type { CfcPolicyCompilerManifestV1 } from "./core/runtime-contract.ts";
 
 type TransformerStage = new (options: TransformationOptions) => Transformer;
 

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -1,8 +1,10 @@
-import ts from "typescript";
 import {
   MERGEABLE_OP_METHODS,
   type MergeableOpMethodKind,
 } from "@commonfabric/api";
+import { type CellBrand } from "@commonfabric/schema-generator/cell-brand";
+import ts from "typescript";
+
 import {
   classifyArrayCallbackContainerCall,
   getNodeText,
@@ -17,10 +19,9 @@ import {
   type UnreadableCellArgument,
 } from "../core/mod.ts";
 import { isBrandedCellType } from "../transformers/cell-type.ts";
-import { type CellBrand } from "@commonfabric/schema-generator/cell-brand";
-import { getKnownComputedKeyPathSegment } from "../utils/reactive-keys.ts";
-import { decodePath, encodePath } from "../utils/path-serialization.ts";
 import { unwrapExpression } from "../utils/expression.ts";
+import { decodePath, encodePath } from "../utils/path-serialization.ts";
+import { getKnownComputedKeyPathSegment } from "../utils/reactive-keys.ts";
 import {
   createMergeablePushClassifier,
   type MergeableCollectionSite,

--- a/packages/ts-transformers/src/transformers/expression-rewrite/types.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/types.ts
@@ -1,7 +1,10 @@
 import ts from "typescript";
 
-import type { DataFlowAnalysis, NormalizedDataFlow } from "../../ast/mod.ts";
-import type { ReactiveContextKind } from "../../ast/mod.ts";
+import type {
+  DataFlowAnalysis,
+  NormalizedDataFlow,
+  ReactiveContextKind,
+} from "../../ast/mod.ts";
 import { TransformationContext } from "../../core/mod.ts";
 import type { ExpressionContainerKind } from "../expression-site-types.ts";
 

--- a/packages/ts-transformers/src/transformers/module-scope-shadowing.ts
+++ b/packages/ts-transformers/src/transformers/module-scope-shadowing.ts
@@ -1,6 +1,7 @@
-import ts from "typescript";
-import { TransformationContext, Transformer } from "../core/mod.ts";
 import { SHADOWED_FACTORY_BINDINGS } from "@commonfabric/utils/sandbox-contract";
+import ts from "typescript";
+
+import { TransformationContext, Transformer } from "../core/mod.ts";
 
 export class ModuleScopeShadowingTransformer extends Transformer {
   override transform(context: TransformationContext): ts.SourceFile {

--- a/packages/ts-transformers/src/transformers/opaque-get-validation.ts
+++ b/packages/ts-transformers/src/transformers/opaque-get-validation.ts
@@ -8,11 +8,13 @@
  * This transformer provides a clear, actionable error message before TypeScript
  * produces its complex type error about the missing .get() method.
  */
-import ts from "typescript";
-import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
+
 import { getCellKind } from "@commonfabric/schema-generator/cell-brand";
+import ts from "typescript";
+
 import { detectCallKind, isReactiveOriginCall } from "../ast/call-kind.ts";
 import { getNodeText } from "../ast/mod.ts";
+import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 
 export class OpaqueGetValidationTransformer extends HelpersOnlyTransformer {
   transform(context: TransformationContext): ts.SourceFile {

--- a/packages/ts-transformers/src/transformers/schema-generator.ts
+++ b/packages/ts-transformers/src/transformers/schema-generator.ts
@@ -1,19 +1,20 @@
-import ts from "typescript";
-import {
-  CF_HELPERS_IDENTIFIER,
-  HelpersOnlyTransformer,
-  TransformationContext,
-} from "../core/mod.ts";
 import {
   type SchemaGenerationOptions,
   SchemaGenerator,
 } from "@commonfabric/schema-generator";
 import { numberFromExpression } from "@commonfabric/schema-generator/numeric-expression";
+import ts from "typescript";
+
 import {
   getNodeText,
   getTypeFromTypeNodeWithFallback,
   visitEachChildWithJsx,
 } from "../ast/mod.ts";
+import {
+  CF_HELPERS_IDENTIFIER,
+  HelpersOnlyTransformer,
+  TransformationContext,
+} from "../core/mod.ts";
 import { createPropertyName } from "../utils/identifiers.ts";
 import { normalizeWriterIdentityFile } from "../utils/writer-identity-file.ts";
 import { compileCfcPolicyManifestsForSource } from "./cfc-policy-authoring.ts";

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -1,12 +1,5 @@
-import ts from "typescript";
-import {
-  cloneTypeNode,
-  createRegisteredTypeLiteral,
-  getDeclaredTypeNodeForBindingElement,
-  reportUnknownReactiveType,
-  shouldPreserveBindingDeclaredTypeNode,
-} from "../ast/type-building.ts";
 import { FUNCTION_HARDENING_HELPER_NAME } from "@commonfabric/utils/sandbox-contract";
+import ts from "typescript";
 
 import {
   classifyArrayMethodCall,
@@ -34,7 +27,13 @@ import {
   unwrapCellLikeType,
   widenLiteralType,
 } from "../ast/mod.ts";
-import { unwrapExpression } from "../utils/expression.ts";
+import {
+  cloneTypeNode,
+  createRegisteredTypeLiteral,
+  getDeclaredTypeNodeForBindingElement,
+  reportUnknownReactiveType,
+  shouldPreserveBindingDeclaredTypeNode,
+} from "../ast/type-building.ts";
 import {
   type CapabilityParamSummary,
   type FunctionCapabilitySummary,
@@ -45,6 +44,8 @@ import {
   type TypeRegistry,
 } from "../core/mod.ts";
 import { analyzeFunctionCapabilities } from "../policy/mod.ts";
+import { unwrapExpression } from "../utils/expression.ts";
+import { isPatternFactoryCalleeExpression } from "./structural-reactive-factory.ts";
 import {
   applyShrinkAndWrap,
   type CapabilitySummaryApplicationMode,
@@ -53,7 +54,6 @@ import {
   preservedWrapperFor,
   printTypeNode,
 } from "./type-shrinking.ts";
-import { isPatternFactoryCalleeExpression } from "./structural-reactive-factory.ts";
 
 type UiContractHint = NonNullable<SchemaHint["cfcUiContract"]>;
 type CellScope = "space" | "user" | "session";

--- a/packages/ts-transformers/test/cfc-authoring.test.ts
+++ b/packages/ts-transformers/test/cfc-authoring.test.ts
@@ -1,17 +1,22 @@
 import { assertEquals, assertThrows } from "@std/assert";
+
 import ts from "typescript";
-import { transformCfDirective } from "../src/mod.ts";
+
+import { CFC_CANONICAL_ALIAS_NAMES } from "../src/cfc-authoring.ts";
+import {
+  CrossStageState,
+  SchemaInjectionTransformer,
+  transformCfDirective,
+} from "../src/mod.ts";
+import type { CfcPolicyCompilerManifestV1 } from "../src/mod.ts";
+import { compileCfcPolicyManifestsForSource } from "../src/transformers/cfc-policy-authoring.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
 import {
   transformFiles,
   transformSource,
   validateFiles,
   validateSource,
 } from "./utils.ts";
-import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
-import { CFC_CANONICAL_ALIAS_NAMES } from "../src/cfc-authoring.ts";
-import { CrossStageState, SchemaInjectionTransformer } from "../src/mod.ts";
-import type { CfcPolicyCompilerManifestV1 } from "../src/mod.ts";
-import { compileCfcPolicyManifestsForSource } from "../src/transformers/cfc-policy-authoring.ts";
 
 function normalizePrintedNode(
   node: ts.Node,

--- a/packages/ts-transformers/test/core/cf-helpers-coverage.test.ts
+++ b/packages/ts-transformers/test/core/cf-helpers-coverage.test.ts
@@ -11,8 +11,11 @@
  * feeding a source whose import differs in exactly one respect and asserting
  * whether the helper is detected.
  */
-import ts from "typescript";
+
 import { assert, assertEquals, assertFalse, assertThrows } from "@std/assert";
+
+import ts from "typescript";
+
 import {
   CF_HELPERS_IDENTIFIER,
   CFHelpers,

--- a/packages/ts-transformers/test/core/common-fabric-symbols.test.ts
+++ b/packages/ts-transformers/test/core/common-fabric-symbols.test.ts
@@ -5,9 +5,12 @@
  * Fabric Default<T,V> from `@commonfabric/api`. A user type named "Default"
  * does not trigger the same special handling.
  */
-import ts from "typescript";
-import { describe, it } from "@std/testing/bdd";
+
 import { assert, assertEquals, assertFalse } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+
+import ts from "typescript";
+
 import {
   getImportTypeModuleName,
   isCommonFabricDeclaration,

--- a/packages/ts-transformers/test/core/commonfabric-runtime-registry.test.ts
+++ b/packages/ts-transformers/test/core/commonfabric-runtime-registry.test.ts
@@ -1,6 +1,7 @@
-import ts from "typescript";
-import { describe, it } from "@std/testing/bdd";
 import { assert, assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+
+import ts from "typescript";
 
 import { COMMONFABRIC_RUNTIME_EXPORTS_BY_NAME } from "../../src/core/commonfabric-runtime-registry.ts";
 

--- a/packages/ts-transformers/test/diagnostics/probe-element-param-analyzer.ts
+++ b/packages/ts-transformers/test/diagnostics/probe-element-param-analyzer.ts
@@ -17,12 +17,14 @@
  * THIS IS NOT A TEST. It does not assert anything. It is a one-shot diagnostic
  * tool used during the Phase 1 investigation. Safe to delete after Phase 2.
  */
-import ts from "typescript";
-import { join } from "@std/path";
-import { walk } from "@std/fs";
 
-import { batchTypeCheckFixtures } from "../utils.ts";
+import { walk } from "@std/fs";
+import { join } from "@std/path";
+
+import ts from "typescript";
+
 import { createDataFlowAnalyzer } from "../../src/ast/dataflow.ts";
+import { batchTypeCheckFixtures } from "../utils.ts";
 
 interface Probe {
   fixture: string;

--- a/packages/ts-transformers/test/fixture-based.test.ts
+++ b/packages/ts-transformers/test/fixture-based.test.ts
@@ -1,17 +1,18 @@
+import { resolve } from "@std/path";
+
+import { StaticCache } from "@commonfabric/static";
 import {
   createUnifiedDiff,
   defineFixtureSuite,
 } from "@commonfabric/test-support/fixture-runner";
-import { StaticCache } from "@commonfabric/static";
-import { resolve } from "@std/path";
 import ts from "typescript";
 
+import type { TransformationDiagnostic } from "../src/mod.ts";
 import {
   batchTypeCheckFixtures,
   loadFixture,
   transformFixture,
 } from "./utils.ts";
-import type { TransformationDiagnostic } from "../src/mod.ts";
 
 interface FixtureConfig {
   directory: string;

--- a/packages/ts-transformers/test/lineage-regression.test.ts
+++ b/packages/ts-transformers/test/lineage-regression.test.ts
@@ -1,8 +1,10 @@
-import ts from "typescript";
 import { assert, assertEquals } from "@std/assert";
+
+import ts from "typescript";
+
 import { CommonFabricTransformerPipeline } from "../src/mod.ts";
-import { batchTypeCheckFixtures } from "./utils.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import { batchTypeCheckFixtures } from "./utils.ts";
 
 /**
  * CT-1868 lineage regression — the hermetic, tracked form of the transform-time

--- a/packages/ts-transformers/test/misc-emitters-flap-coverage.test.ts
+++ b/packages/ts-transformers/test/misc-emitters-flap-coverage.test.ts
@@ -1,15 +1,16 @@
-import ts from "typescript";
 import { assert, assertEquals } from "@std/assert";
-import { StaticCache } from "@commonfabric/static";
 
+import { StaticCache } from "@commonfabric/static";
+import ts from "typescript";
+
+import { unwrapOpaqueLikeType } from "../src/ast/type-inference.ts";
+import { shouldTransformArrayMethod } from "../src/closures/strategies/array-method-policy.ts";
+import { symbolDeclaresCommonFabricDefault } from "../src/core/common-fabric-symbols.ts";
 import { TransformationContext } from "../src/core/context.ts";
 import { transformCfDirective } from "../src/mod.ts";
-import { shouldTransformArrayMethod } from "../src/closures/strategies/array-method-policy.ts";
-import { findPreferredNestedLowerableExpressionSite } from "../src/transformers/expression-site-policy.ts";
-import { unwrapOpaqueLikeType } from "../src/ast/type-inference.ts";
-import { symbolDeclaresCommonFabricDefault } from "../src/core/common-fabric-symbols.ts";
 import { emitElementAccessExpression } from "../src/transformers/expression-rewrite/emitters/element-access-expression.ts";
 import type { EmitterContext } from "../src/transformers/expression-rewrite/types.ts";
+import { findPreferredNestedLowerableExpressionSite } from "../src/transformers/expression-site-policy.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
 
 // Each branch exercised here otherwise runs only while a pattern compiles cold

--- a/packages/ts-transformers/test/opaque-roots-coverage.test.ts
+++ b/packages/ts-transformers/test/opaque-roots-coverage.test.ts
@@ -12,8 +12,10 @@
  * - `addBindingTargetSymbols` — collects the declared symbols of a binding name,
  *   descending into array/object binding patterns and skipping holes.
  */
-import ts from "typescript";
+
 import { assert, assertEquals, assertFalse } from "@std/assert";
+
+import ts from "typescript";
 
 import type { TransformationContext } from "../src/core/mod.ts";
 import {

--- a/packages/ts-transformers/test/pattern-coverage-transformer.test.ts
+++ b/packages/ts-transformers/test/pattern-coverage-transformer.test.ts
@@ -1,9 +1,7 @@
-import ts from "typescript";
 import { assert, assertEquals, assertMatch } from "@std/assert";
-import {
-  PatternCoverageTransformer,
-} from "../src/transformers/pattern-coverage.ts";
-import { collect, literalToValue, parseModule } from "./transformed-ast.ts";
+
+import ts from "typescript";
+
 import { CommonFabricTransformerPipeline } from "../src/cf-pipeline.ts";
 import {
   type PatternCoverageOptions,
@@ -11,6 +9,10 @@ import {
   TransformationContext,
   type TransformationDiagnostic,
 } from "../src/core/mod.ts";
+import {
+  PatternCoverageTransformer,
+} from "../src/transformers/pattern-coverage.ts";
+import { collect, literalToValue, parseModule } from "./transformed-ast.ts";
 
 interface TransformResult {
   output: string;

--- a/packages/ts-transformers/test/policy/capability-analysis-coverage.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis-coverage.test.ts
@@ -1,5 +1,7 @@
-import ts from "typescript";
 import { assert, assertEquals } from "@std/assert";
+
+import ts from "typescript";
+
 import { analyzeFunctionCapabilities } from "../../src/policy/mod.ts";
 
 // These tests drive `analyzeFunctionCapabilities` through parameter-summary

--- a/packages/ts-transformers/test/policy/capability-analysis-flap-coverage.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis-flap-coverage.test.ts
@@ -1,5 +1,7 @@
-import ts from "typescript";
 import { assert, assertEquals } from "@std/assert";
+
+import ts from "typescript";
+
 import { analyzeFunctionCapabilities } from "../../src/policy/mod.ts";
 
 // These cases drive `analyzeFunctionCapabilities` through three branches that

--- a/packages/ts-transformers/test/policy/capability-analysis-interprocedural.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis-interprocedural.test.ts
@@ -1,5 +1,7 @@
-import ts from "typescript";
 import { assert, assertEquals } from "@std/assert";
+
+import ts from "typescript";
+
 import { analyzeFunctionCapabilities } from "../../src/policy/mod.ts";
 
 // These tests drive `analyzeFunctionCapabilities` through interprocedural

--- a/packages/ts-transformers/test/policy/capability-analysis.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis.test.ts
@@ -1,5 +1,7 @@
-import ts from "typescript";
 import { assert, assertEquals } from "@std/assert";
+
+import ts from "typescript";
+
 import {
   analyzeFunctionCapabilities,
   type MergeablePushMisuse,

--- a/packages/ts-transformers/test/policy/rewrite-policy.test.ts
+++ b/packages/ts-transformers/test/policy/rewrite-policy.test.ts
@@ -1,5 +1,7 @@
-import ts from "typescript";
 import { assertEquals } from "@std/assert";
+
+import ts from "typescript";
+
 import {
   shouldLowerLogicalExpression,
   shouldRewriteCollectionMethod,

--- a/packages/ts-transformers/test/reactive/dataflow.test.ts
+++ b/packages/ts-transformers/test/reactive/dataflow.test.ts
@@ -1,6 +1,7 @@
-import ts from "typescript";
-import { describe, it } from "@std/testing/bdd";
 import { assert, assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+
+import ts from "typescript";
 
 import {
   classifyArrayMethodResultSinkCall,

--- a/packages/ts-transformers/test/schema-injection-coverage.test.ts
+++ b/packages/ts-transformers/test/schema-injection-coverage.test.ts
@@ -1,6 +1,7 @@
-import ts from "typescript";
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
-import { transformSource, validateSource } from "./utils.ts";
+
+import ts from "typescript";
+
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
 import {
   callSchemas,
@@ -11,6 +12,7 @@ import {
   parseModule,
   patternSchemas,
 } from "./transformed-ast.ts";
+import { transformSource, validateSource } from "./utils.ts";
 
 // Unit coverage for schema-injection.ts. These tests drive the whole
 // transformer pipeline with `/// <cts-enable />` pattern sources that exercise

--- a/packages/ts-transformers/test/transform.test.ts
+++ b/packages/ts-transformers/test/transform.test.ts
@@ -1,7 +1,8 @@
-import ts from "typescript";
-import { describe, it } from "@std/testing/bdd";
 import { assert, assertEquals, assertRejects } from "@std/assert";
-import { transformFiles } from "./utils.ts";
+import { describe, it } from "@std/testing/bdd";
+
+import ts from "typescript";
+
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
 import {
   callsMatching,
@@ -12,6 +13,7 @@ import {
   literalToValue,
   parseModule,
 } from "./transformed-ast.ts";
+import { transformFiles } from "./utils.ts";
 
 /**
  * True when some emitted `.for(...)` call is attached directly to a

--- a/packages/ts-transformers/test/utils.ts
+++ b/packages/ts-transformers/test/utils.ts
@@ -1,13 +1,15 @@
-import ts from "typescript";
+import { assert } from "@std/assert";
 import { dirname, join } from "@std/path";
+
 import { StaticCache } from "@commonfabric/static";
+import ts from "typescript";
+
 import {
   CommonFabricTransformerPipeline,
   CrossStageState,
   TransformationDiagnostic,
   transformCfDirective,
 } from "../src/mod.ts";
-import { assert } from "@std/assert";
 
 const ENV_TYPE_ENTRIES = ["es2023", "dom", "jsx"] as const;
 

--- a/packages/ts-transformers/test/utils/expression.test.ts
+++ b/packages/ts-transformers/test/utils/expression.test.ts
@@ -1,5 +1,7 @@
-import ts from "typescript";
 import { assert, assertEquals } from "@std/assert";
+
+import ts from "typescript";
+
 import { unwrapExpression } from "../../src/utils/expression.ts";
 
 Deno.test("unwrapExpression unwraps a partially emitted expression", () => {


### PR DESCRIPTION
Third of the series applying the Development Guide's `Imports` rules (#5852).
I (agent working on behalf of @danfuzz) am splitting along package lines.

Independent of #5855 — different files, both branched from `main`.

## What changed

70 files, import blocks only.

| Package | Files |
|---|---:|
| `ts-transformers` | 28 |
| `shell` | 22 |
| `memory` | 20 |

Per file: statements merged where a module was named twice, grouped standard
library / external / internal with a blank line between, each package's imports
collated into one contiguous run, and each run sorted.

## Two bugs in the sweep tooling, both found here

Worth calling out, because the second was found by a **test failure rather than
by my own checks**.

**Import attributes were being dropped.** The rewriting's statement pattern
stopped at the specifier, so `with { type: "json" }` was left outside the
statement text and lost. `packages/shell/felt.config.ts` imports
`@commonfabric/ports` that way, and `shell`'s suite failed with
`Attempted to load JSON module without specifying "type": "json"`.

The binding checker did **not** catch it: it compared module and names, not
attributes. Both are fixed — the pattern now captures the attribute clause, a
merge is refused outright when either statement carries one, and the checker
carries attributes in the binding tuple. Confirmed by re-running the fixed
checker against the broken tree, where it reports the lost
`with { type: "json" }` precisely. `shell` now passes 58 / 0, up from 57 / 1.

Six files downstream would have hit this: `toolshed/routes/shell/shell.index.ts`,
`runner/src/builder/env.ts`, and three in `cli`.

**Spacing**, per review feedback on #5855: a blank line now follows a
top-of-file comment, and consecutive bare imports run together. The former is
not a new convention — `docs/development/code-comment-style.md` § File headers
already requires it, and says why: "the blank line is load-bearing … it is what
keeps the header from being read as the doc comment of the first declaration
under it." The tooling was violating an existing rule.

## Files handled carefully

- **`shell`'s four browser integration tests** each carry a bare
  `import "../src/globals.ts";`, load-bearing by position. It stays put, and the
  imports on either side are ordered as two independent runs. Nothing crosses a
  bare import.
- **Two `ts-transformers` files by hand**, each with an import far down the file
  beside the export it feeds — `src/ast/utils.ts:397` and
  `test/policy/capability-analysis-interprocedural.test.ts:351`. Those stay put;
  only the opening block was ordered.
- **`ts-transformers/test/fixtures/` is left alone entirely.** Fixture content
  is input to a content-sensitive pipeline. The one file in there that the
  census flagged is a standalone diagnostic script rather than a fixture, but it
  is not worth the distinction.

## Verification

- **70 files, zero binding differences**, where a binding is `(resolved module,
  type-ness, local name, import attributes)`. The comparison flags a
  deliberately dropped import, a repointed specifier, and now a dropped
  attribute.
- Audited this branch for the spacing defects: 0 glued file comments, 0 blank
  lines between consecutive bare imports.
- `deno fmt --check`, `deno lint`, `deno task check` green.
- Suites: `memory` 499 passed, `shell` 58, `ts-transformers` 1140. All 0 failed.

## Series

Done: #5854 (15 small packages, merged), #5855 (4 packages, open), this one.

Remaining: `runner` 242 — split `src` and `test` — `ui` 62, `toolshed` 55,
`cli` 33.

`packages/patterns` is excluded from every PR in this series: pattern source is
compiled and content-addressed, so an edit that looks inert can move a contract
and trip `pattern-compat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

