### PR TITLE
refactor: conform imports in `cli` and `toolshed`

### DIFF
--- a/packages/cli/commands/acl.ts
+++ b/packages/cli/commands/acl.ts
@@ -1,10 +1,11 @@
 import { Command } from "@cliffy/command";
 import { Table } from "@cliffy/table";
+import { isCapability } from "@commonfabric/memory";
+
 import { getAcl, removeAclEntry, setAclEntry } from "../lib/acl.ts";
-import { parseSpaceOptions } from "./piece.ts";
 import { cliText } from "../lib/cli-name.ts";
 import { render } from "../lib/render.ts";
-import { isCapability } from "@commonfabric/memory";
+import { parseSpaceOptions } from "./piece.ts";
 
 // Usage patterns for examples
 const spaceUsage = `--identity <identity> --api-url <api-url> --space <space>`;

--- a/packages/cli/commands/deps.ts
+++ b/packages/cli/commands/deps.ts
@@ -1,16 +1,18 @@
-import { Command } from "@cliffy/command";
 import { dirname, join } from "@std/path";
+
+import { Command } from "@cliffy/command";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
-import { loadPieces } from "../lib/piece.ts";
+
+import { cliText } from "../lib/cli-name.ts";
 import { collectLocalProgram } from "../lib/dev.ts";
-import { parseSpaceOptions } from "./piece.ts";
 import {
   pinProgramFabricImports,
   renderPinRewrite,
 } from "../lib/fabric-deps.ts";
-import { absPath } from "../lib/utils.ts";
+import { loadPieces } from "../lib/piece.ts";
 import { render } from "../lib/render.ts";
-import { cliText } from "../lib/cli-name.ts";
+import { absPath } from "../lib/utils.ts";
+import { parseSpaceOptions } from "./piece.ts";
 
 // Typed as Command<any> because cliffy's accumulated option generics don't
 // survive registration in main.ts (the same idiom as the check command).

--- a/packages/cli/commands/dev.ts
+++ b/packages/cli/commands/dev.ts
@@ -1,8 +1,10 @@
-import { Command } from "@cliffy/command";
 import { isAbsolute, join } from "@std/path";
-import { render } from "../lib/render.ts";
-import { process } from "../lib/dev.ts";
+
+import { Command } from "@cliffy/command";
+
 import { cliText } from "../lib/cli-name.ts";
+import { process } from "../lib/dev.ts";
+import { render } from "../lib/render.ts";
 
 const description = cliText(`Compile and execute patterns for debugging.
 

--- a/packages/cli/commands/fuse.ts
+++ b/packages/cli/commands/fuse.ts
@@ -1,6 +1,10 @@
-import { Command } from "@cliffy/command";
 import { basename, resolve } from "@std/path";
+
+import { Command } from "@cliffy/command";
 import ports from "@commonfabric/ports" with { type: "json" };
+
+import { parseAttrcacheTimeoutSeconds } from "../../fuse/mount-options.ts";
+import { cliText } from "../lib/cli-name.ts";
 import {
   buildBackgroundSupervisorDenoArgs,
   buildFuseBinaryArgs,
@@ -19,8 +23,6 @@ import {
   removeMountStateFile,
   writeMountState,
 } from "../lib/fuse.ts";
-import { parseAttrcacheTimeoutSeconds } from "../../fuse/mount-options.ts";
-import { cliText } from "../lib/cli-name.ts";
 
 export function isFuseProcessCommand(command: string): boolean {
   return command.includes("packages/fuse/mod.ts") ||

--- a/packages/cli/commands/init.ts
+++ b/packages/cli/commands/init.ts
@@ -1,9 +1,10 @@
-import { Command } from "@cliffy/command";
-import { Engine } from "@commonfabric/runner";
-import { join } from "@std/path/join";
-import { getCompilerOptions } from "@commonfabric/js-compiler/typescript";
-import { StaticCache } from "@commonfabric/static";
 import { dirname } from "@std/path/dirname";
+import { join } from "@std/path/join";
+
+import { Command } from "@cliffy/command";
+import { getCompilerOptions } from "@commonfabric/js-compiler/typescript";
+import { Engine } from "@commonfabric/runner";
+import { StaticCache } from "@commonfabric/static";
 
 export const init = new Command()
   .name("init")

--- a/packages/cli/commands/main.ts
+++ b/packages/cli/commands/main.ts
@@ -1,27 +1,28 @@
 import { Command, ValidationError } from "@cliffy/command";
 import { HelpCommand } from "@cliffy/command/help";
-import { acl } from "./acl.ts";
-import { ingest } from "./ingest.ts";
-import { check } from "./dev.ts";
-import { completion } from "./completion.ts";
-import { deps } from "./deps.ts";
-import { exec } from "./exec.ts";
-import { fuse } from "./fuse.ts";
-import { init } from "./init.ts";
-import { inspect } from "./inspect.ts";
-import { invocationSession } from "./invocation-session.ts";
-import { piece } from "./piece.ts";
-import { space } from "./space.ts";
-import { identity } from "./identity.ts";
-import { test } from "./test-command.ts";
-import { view } from "./view.ts";
-import { wish } from "./wish.ts";
 import ports from "@commonfabric/ports" with { type: "json" };
+
 import { cliName, cliText } from "../lib/cli-name.ts";
 import {
   hasJsonArgument,
   reservesStdoutForCommandOutput,
 } from "../lib/json-output.ts";
+import { acl } from "./acl.ts";
+import { completion } from "./completion.ts";
+import { deps } from "./deps.ts";
+import { check } from "./dev.ts";
+import { exec } from "./exec.ts";
+import { fuse } from "./fuse.ts";
+import { identity } from "./identity.ts";
+import { ingest } from "./ingest.ts";
+import { init } from "./init.ts";
+import { inspect } from "./inspect.ts";
+import { invocationSession } from "./invocation-session.ts";
+import { piece } from "./piece.ts";
+import { space } from "./space.ts";
+import { test } from "./test-command.ts";
+import { view } from "./view.ts";
+import { wish } from "./wish.ts";
 
 function envStatus(): string {
   const identity = Deno.env.get("CF_IDENTITY");

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1,6 +1,30 @@
-import { Table } from "@cliffy/table";
 import { Command, ValidationError } from "@cliffy/command";
+import { Table } from "@cliffy/table";
+import type { CellScope } from "@commonfabric/api";
+import type {
+  PatternCompatibilityReport,
+  PiecePatternRef,
+} from "@commonfabric/piece/ops";
+import ports from "@commonfabric/ports" with { type: "json" };
+import { parseCellPath, UI } from "@commonfabric/runner";
+import { parseScopedIdSegment } from "@commonfabric/runner/shared";
+import { decode } from "@commonfabric/utils/encoding";
+
 import { addressArgument, VerbInputValidationError } from "../lib/callable.ts";
+import type {
+  InvocationIdentity,
+  InvocationOutcome,
+  InvocationPhase,
+} from "../lib/callable.ts";
+import {
+  type CellSelection,
+  CellSelectionError,
+  parseCellSelectionOptions,
+} from "../lib/cell-selection.ts";
+import { cliText } from "../lib/cli-name.ts";
+import { reservesStdoutForCommandOutput } from "../lib/json-output.ts";
+import { normalizeLLMFriendlyRef } from "../lib/llm-friendly-ref.ts";
+import { renderPiece } from "../lib/piece-render.ts";
 import {
   applyPieceInput,
   checkPiecePattern,
@@ -40,32 +64,10 @@ import type {
   ExecutedPieceCallable,
   PieceCallablesListing,
 } from "../lib/piece.ts";
-import type { PatternCompatibilityReport } from "@commonfabric/piece/ops";
-import type {
-  InvocationIdentity,
-  InvocationOutcome,
-  InvocationPhase,
-} from "../lib/callable.ts";
-import { newSessionId } from "../lib/session.ts";
-import { normalizeLLMFriendlyRef } from "../lib/llm-friendly-ref.ts";
-import { renderPiece } from "../lib/piece-render.ts";
-import { parseSqliteSource } from "../lib/sqlite-source.ts";
 import { render, safeStringify } from "../lib/render.ts";
-import { decode } from "@commonfabric/utils/encoding";
-import { cliText } from "../lib/cli-name.ts";
+import { newSessionId } from "../lib/session.ts";
+import { parseSqliteSource } from "../lib/sqlite-source.ts";
 import { absPath } from "../lib/utils.ts";
-import type { CellScope } from "@commonfabric/api";
-import { parseCellPath } from "@commonfabric/runner";
-import { parseScopedIdSegment } from "@commonfabric/runner/shared";
-import { UI } from "@commonfabric/runner";
-import ports from "@commonfabric/ports" with { type: "json" };
-import type { PiecePatternRef } from "@commonfabric/piece/ops";
-import { reservesStdoutForCommandOutput } from "../lib/json-output.ts";
-import {
-  type CellSelection,
-  CellSelectionError,
-  parseCellSelectionOptions,
-} from "../lib/cell-selection.ts";
 
 // Hint system: print helpful next-step suggestions after operations
 let quietMode = false;

--- a/packages/cli/commands/space.ts
+++ b/packages/cli/commands/space.ts
@@ -19,6 +19,7 @@
 import { Command, ValidationError } from "@cliffy/command";
 import {
   clonePaths,
+  contentFingerprint,
   createClone,
   openSpace,
   readManifest,
@@ -27,7 +28,7 @@ import {
   verifyClone,
   type VerifyResult,
 } from "@commonfabric/state-inspector";
-import { contentFingerprint } from "@commonfabric/state-inspector";
+
 import { hasJsonArgument } from "../lib/json-output.ts";
 
 function out(json: boolean, data: unknown, render: () => void): void {

--- a/packages/cli/commands/test-command.ts
+++ b/packages/cli/commands/test-command.ts
@@ -1,6 +1,8 @@
-import { Command } from "@cliffy/command";
-import { resolve } from "@std/path";
 import { expandGlob } from "@std/fs";
+import { resolve } from "@std/path";
+
+import { Command } from "@cliffy/command";
+
 import { cliText } from "../lib/cli-name.ts";
 import { discoverTestFiles, runTests } from "../lib/test-runner.ts";
 

--- a/packages/cli/lib/build-info.ts
+++ b/packages/cli/lib/build-info.ts
@@ -10,11 +10,12 @@
 // binary build is in flight (or after an interrupted one), so its presence
 // says nothing about how this invocation is running.
 
+import { dirname, fromFileUrl, join } from "@std/path";
+
 import {
   type BuildInfo,
   readBuildInfoFrom,
 } from "@commonfabric/utils/build-info";
-import { dirname, fromFileUrl, join } from "@std/path";
 
 const COMPILED_PATH = new URL("../COMPILED", import.meta.url);
 

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -7,13 +7,14 @@ import {
   type MemorySpace,
   type NormalizedFullLink,
 } from "@commonfabric/runner";
-import { isInstance } from "@commonfabric/utils/types";
+import { cfcSchemaChildRoot } from "@commonfabric/runner/cfc/schema-refs";
 import {
   localRefTarget,
   relaxDefaultedRequired,
   validateSchemaValue,
 } from "@commonfabric/runner/cfc/schema-sanitization";
-import { cfcSchemaChildRoot } from "@commonfabric/runner/cfc/schema-refs";
+import { isInstance } from "@commonfabric/utils/types";
+
 import {
   type CallableKind,
   classifyCallableEntry,

--- a/packages/cli/lib/exec.ts
+++ b/packages/cli/lib/exec.ts
@@ -1,14 +1,17 @@
+import { basename, dirname, join, relative, resolve } from "@std/path";
+
 import {
   PieceController,
   type PiecePatternRef,
   PiecesController,
 } from "@commonfabric/piece/ops";
 import type { Cell } from "@commonfabric/runner";
-import { basename, dirname, join, relative, resolve } from "@std/path";
+
 import {
   type MountedCallablePath,
   parseMountedCallablePath,
 } from "../../fuse/callable-path.ts";
+import { executeCallableCommand } from "./callable-command.ts";
 import {
   callableCommandSpec,
   type CallableExecutionDeps,
@@ -18,9 +21,7 @@ import {
   type InvocationOutcome,
   type InvocationPhase,
 } from "./callable.ts";
-import { executeCallableCommand } from "./callable-command.ts";
 import type { CellSelection } from "./cell-selection.ts";
-import { newSessionId } from "./session.ts";
 import {
   type ExecCommandSpec,
   type ParsedExecArgs,
@@ -33,6 +34,7 @@ import {
   type MountStateEntry,
 } from "./fuse.ts";
 import { loadPieces, type SpaceConfig } from "./piece.ts";
+import { newSessionId } from "./session.ts";
 
 export interface MountedPieceMeta {
   id: string;

--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -28,6 +28,12 @@
  */
 
 import {
+  createSession,
+  Identity,
+  type KeyPairRaw,
+} from "@commonfabric/identity";
+import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import {
   type Cell,
   type ConsoleHandler,
   ConsoleMethod,
@@ -41,25 +47,20 @@ import {
   TESTS,
   writePatternCoverageLcov,
 } from "@commonfabric/runner";
-import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { defer } from "@commonfabric/utils/defer";
+
+import { assertionOutcome } from "./assert-record.ts";
 import {
   flushDefaultModuleByteCache,
   getDefaultModuleByteCache,
 } from "./compile-byte-cache.ts";
-import { buildActionEvent } from "./trusted-test-event.ts";
 import {
   appendLoggerDeltaMessages,
   type LoggerErrorWarnSnapshot,
   snapshotLoggerErrorWarnCounts,
 } from "./console-capture.ts";
-import {
-  createSession,
-  Identity,
-  type KeyPairRaw,
-} from "@commonfabric/identity";
-import { defer } from "@commonfabric/utils/defer";
-import { assertionOutcome } from "./assert-record.ts";
 import { materializeTestVDOM, mountTestVDOM } from "./materialize-test-vdom.ts";
+import { buildActionEvent } from "./trusted-test-event.ts";
 
 export interface WorkerRequest {
   id: number;

--- a/packages/cli/lib/piece-render.ts
+++ b/packages/cli/lib/piece-render.ts
@@ -2,9 +2,10 @@ import { renderInProcess } from "@commonfabric/html/in-process";
 import { MockDoc } from "@commonfabric/html/mock-doc";
 import { type Cell, UI } from "@commonfabric/runner";
 import { rendererVDOMSchema } from "@commonfabric/runner/schemas";
+import { getLogger } from "@commonfabric/utils/logger";
+
 import { loadPieces } from "./piece.ts";
 import type { PieceConfig } from "./piece.ts";
-import { getLogger } from "@commonfabric/utils/logger";
 
 const logger = getLogger("piece-render", { level: "info", enabled: false });
 

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1,7 +1,29 @@
-import { createSession, isDID, Session } from "@commonfabric/identity";
 import { ensureDir } from "@std/fs";
-import { caseFold } from "unicode-case-folding";
-import { loadIdentity } from "./identity.ts";
+import { common, dirname, join } from "@std/path";
+
+import type { CellScope, JSONSchema } from "@commonfabric/api";
+import { codecOf } from "@commonfabric/data-model/codec-common";
+import {
+  FabricPrimitive,
+  FabricSpecialObject,
+} from "@commonfabric/data-model/fabric-value";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
+import { createSession, isDID, Session } from "@commonfabric/identity";
+import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { setLLMUrl } from "@commonfabric/llm";
+import {
+  assignSlug,
+  pieceId,
+  resolvePieceAddress as resolveStoredPieceAddress,
+  resolveSlugTargetCell,
+  setSlugLink,
+  SlugResolutionError,
+} from "@commonfabric/piece";
+import {
+  type PatternCompatibilityReport,
+  type PiecePatternRef,
+  PiecesController,
+} from "@commonfabric/piece/ops";
 import {
   Cell,
   deepEqual,
@@ -37,36 +59,14 @@ import {
   resolveCfcSchemaRefs,
   validateSchemaValue,
 } from "@commonfabric/runner/cfc";
-import type { CellScope, JSONSchema } from "@commonfabric/api";
-import { utf8Compare } from "@commonfabric/utils/utf8";
 import { StorageManager } from "@commonfabric/runner/storage/cache";
-import {
-  assignSlug,
-  pieceId,
-  resolvePieceAddress as resolveStoredPieceAddress,
-  resolveSlugTargetCell,
-  setSlugLink,
-  SlugResolutionError,
-} from "@commonfabric/piece";
-import {
-  type PatternCompatibilityReport,
-  type PiecePatternRef,
-  PiecesController,
-} from "@commonfabric/piece/ops";
-import { common, dirname, join } from "@std/path";
-import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
-import { setLLMUrl } from "@commonfabric/llm";
-import {
-  FabricPrimitive,
-  FabricSpecialObject,
-} from "@commonfabric/data-model/fabric-value";
-import { codecOf } from "@commonfabric/data-model/codec-common";
-import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { isObjectOrArray, isPlainObject } from "@commonfabric/utils/types";
-import { pinProgramFabricImports, renderPinRewrite } from "./fabric-deps.ts";
+import { utf8Compare } from "@commonfabric/utils/utf8";
+import { caseFold } from "unicode-case-folding";
+
 import { isHandlerCell, isStreamValue } from "../../fuse/callables.ts";
-import { throwOnSpaceAuthorizationError } from "./utils.ts";
+import { executeCallableCommand } from "./callable-command.ts";
 import {
   callableCommandSpec,
   type CallableExecutionDeps,
@@ -79,23 +79,25 @@ import {
   type InvocationOutcome,
   runtimeErrorLog,
 } from "./callable.ts";
-import { executeCallableCommand } from "./callable-command.ts";
+import {
+  type CellSelection,
+  CellSelectionError,
+  deriveSelectedValue,
+} from "./cell-selection.ts";
+import { cliCommand } from "./cli-name.ts";
 import {
   type ExecCommandSpec,
   type ParsedExecArgs,
   renderExecHelpJson,
   renderPieceCallHelp,
 } from "./exec-schema.ts";
-import { cliCommand } from "./cli-name.ts";
-import { deriveDiskHandleId } from "./sqlite-source.ts";
-import { startVersionCheck } from "./version-check.ts";
+import { pinProgramFabricImports, renderPinRewrite } from "./fabric-deps.ts";
+import { loadIdentity } from "./identity.ts";
 import { stderrConsoleHandler } from "./json-output.ts";
-import {
-  type CellSelection,
-  CellSelectionError,
-  deriveSelectedValue,
-} from "./cell-selection.ts";
 import { validateEmbeddedSpaces } from "./llm-friendly-ref.ts";
+import { deriveDiskHandleId } from "./sqlite-source.ts";
+import { throwOnSpaceAuthorizationError } from "./utils.ts";
+import { startVersionCheck } from "./version-check.ts";
 
 export interface EntryConfig {
   mainPath: string;

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -25,7 +25,12 @@
  * use the --root option to specify a common ancestor directory.
  */
 
+import { basename } from "@std/path";
+
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { Identity } from "@commonfabric/identity";
+import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import {
   ConsoleMethod,
   experimentalOptionsFromEnv,
@@ -49,28 +54,6 @@ import type {
   Stream,
 } from "@commonfabric/runner";
 import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
-import { getDefaultModuleByteCache } from "./compile-byte-cache.ts";
-import { assertionOutcome } from "./assert-record.ts";
-import { internSchema } from "@commonfabric/data-model/schema-hash";
-import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
-import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
-import { basename } from "@std/path";
-import { timeout } from "@commonfabric/utils/sleep";
-import {
-  appendLoggerDeltaMessages,
-  snapshotLoggerErrorWarnCounts,
-} from "./console-capture.ts";
-import { buildActionEvent } from "./trusted-test-event.ts";
-import {
-  multiUserDescriptorMeta,
-  runMultiUserTestPattern,
-} from "./multi-user-test-runner.ts";
-import {
-  type FetchMockEntry,
-  makeMockFetch,
-  readFetchMocks,
-} from "./fetch-mock.ts";
-import { materializeTestVDOM, mountTestVDOM } from "./materialize-test-vdom.ts";
 import {
   type CDFPoint,
   getLogger,
@@ -81,6 +64,25 @@ import {
   resetAllTimingBaselines,
   resetAllTimingStats,
 } from "@commonfabric/utils/logger";
+import { timeout } from "@commonfabric/utils/sleep";
+
+import { assertionOutcome } from "./assert-record.ts";
+import { getDefaultModuleByteCache } from "./compile-byte-cache.ts";
+import {
+  appendLoggerDeltaMessages,
+  snapshotLoggerErrorWarnCounts,
+} from "./console-capture.ts";
+import {
+  type FetchMockEntry,
+  makeMockFetch,
+  readFetchMocks,
+} from "./fetch-mock.ts";
+import { materializeTestVDOM, mountTestVDOM } from "./materialize-test-vdom.ts";
+import {
+  multiUserDescriptorMeta,
+  runMultiUserTestPattern,
+} from "./multi-user-test-runner.ts";
+import { buildActionEvent } from "./trusted-test-event.ts";
 
 const phaseLogger = getLogger("test-runner-phase", {
   enabled: false,

--- a/packages/cli/lib/view/card.ts
+++ b/packages/cli/lib/view/card.ts
@@ -7,6 +7,11 @@
  * Pure: produces model {@link Line}s (the same shape the renderer already draws)
  * with token classes chosen so the existing theme colors everything coherently.
  */
+
+import { basename } from "@std/path";
+
+import { cpLen } from "./ansi.ts";
+import type { Semantics } from "./languages/language.ts";
 import type {
   Document,
   Line,
@@ -24,9 +29,6 @@ import {
   findReferences,
   type IdentUse,
 } from "./references.ts";
-import { basename } from "@std/path";
-import { cpLen } from "./ansi.ts";
-import type { Semantics } from "./languages/language.ts";
 
 /** A selectable cross-reference line that jumps the main view when invoked. */
 export interface CardTarget {

--- a/packages/cli/lib/view/diffdoc.ts
+++ b/packages/cli/lib/view/diffdoc.ts
@@ -16,6 +16,22 @@
  * the info card navigate the same patterns/builders/schemas the source view
  * would show, scoped to what the diff touches.
  */
+
+import { dirname, isAbsolute, join, relative } from "@std/path";
+
+import { spawnSync } from "@node/child_process";
+
+import { cpLen } from "./ansi.ts";
+import { type DiffFile, type DiffHunk, type DiffModel } from "./diff.ts";
+import type { Language } from "./languages/language.ts";
+import {
+  canRenderDiffLines,
+  decodeLanguageInput,
+  languageForFile,
+  readOnlyReasonFor,
+  renderedLinesFor,
+} from "./languages/language.ts";
+import { computeLineStarts, lineIndexOf } from "./lines.ts";
 import type {
   Definition,
   Document,
@@ -25,19 +41,6 @@ import type {
   ViewMode,
 } from "./model.ts";
 import { flattenStructure } from "./model.ts";
-import { type DiffFile, type DiffHunk, type DiffModel } from "./diff.ts";
-import { computeLineStarts, lineIndexOf } from "./lines.ts";
-import type { Language } from "./languages/language.ts";
-import {
-  canRenderDiffLines,
-  decodeLanguageInput,
-  languageForFile,
-  readOnlyReasonFor,
-  renderedLinesFor,
-} from "./languages/language.ts";
-import { cpLen } from "./ansi.ts";
-import { dirname, isAbsolute, join, relative } from "@std/path";
-import { spawnSync } from "@node/child_process";
 
 /** How the diff document reaches the workspace. Injectable for tests. */
 export interface DiffWorkspace {

--- a/packages/cli/lib/view/languages/markdown/markdown.ts
+++ b/packages/cli/lib/view/languages/markdown/markdown.ts
@@ -10,6 +10,12 @@
  * It is line-oriented (the only cross-line state is whether a fenced code block
  * is open), so re-highlighting is cheap enough to redo whole on every keystroke.
  */
+
+import { decodeHTMLStrict as decodeEntities } from "entities";
+import { Lexer } from "marked";
+
+import { cpLen } from "../../ansi.ts";
+import { computeLineStarts, lineIndexOf } from "../../lines.ts";
 import type {
   Document,
   Line,
@@ -19,10 +25,6 @@ import type {
 } from "../../model.ts";
 import { flattenStructure } from "../../model.ts";
 import type { Highlighter } from "../language.ts";
-import { cpLen } from "../../ansi.ts";
-import { computeLineStarts, lineIndexOf } from "../../lines.ts";
-import { Lexer } from "marked";
-import { decodeHTMLStrict as decodeEntities } from "entities";
 
 /** Color Markdown text into rendered lines. */
 export function highlightMarkdownLines(text: string): Line[] {

--- a/packages/cli/lib/view/languages/typescript/semantics.ts
+++ b/packages/cli/lib/view/languages/typescript/semantics.ts
@@ -18,11 +18,15 @@
  * pure parser remains the authoritative, dependency-free path for everything
  * else.
  */
-import ts from "typescript";
-import { dirname, fromFileUrl, isAbsolute, join, relative } from "@std/path";
+
 import { parse as parseJsonc } from "@std/jsonc";
-import type { Line } from "../../model.ts";
+import { dirname, fromFileUrl, isAbsolute, join, relative } from "@std/path";
+
+import ts from "typescript";
+
+import { cpLen } from "../../ansi.ts";
 import type { DiffMaps } from "../../diffdoc.ts";
+import type { Line } from "../../model.ts";
 import type {
   DefTarget,
   Semantics,
@@ -33,7 +37,6 @@ import {
   languageForFile,
   readOnlyReasonFor,
 } from "../language.ts";
-import { cpLen } from "../../ansi.ts";
 
 interface SectionFile {
   /** Virtual file name (the section header path, or `fileName`). */

--- a/packages/cli/mod.ts
+++ b/packages/cli/mod.ts
@@ -1,12 +1,13 @@
-import { parse } from "./commands/mod.ts";
-import { main as rootCommand } from "./commands/main.ts";
-import { CompilerError, TransformerError } from "@commonfabric/js-compiler";
 import { ValidationError } from "@cliffy/command";
+import { CompilerError, TransformerError } from "@commonfabric/js-compiler";
+
+import { main as rootCommand } from "./commands/main.ts";
+import { parse } from "./commands/mod.ts";
 import { VerbInputValidationError } from "./lib/callable.ts";
 import { cliName } from "./lib/cli-name.ts";
-import { applyLogLevel } from "./lib/log-level.ts";
 import { applyColorMode } from "./lib/color-mode.ts";
 import { reservesStdoutForCommandOutput } from "./lib/json-output.ts";
+import { applyLogLevel } from "./lib/log-level.ts";
 
 /**
  * The value to print for a top-level CLI failure. Validation, transformer,

--- a/packages/cli/test/fabric-deps.test.ts
+++ b/packages/cli/test/fabric-deps.test.ts
@@ -1,12 +1,14 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
+import { InMemoryProgram } from "@commonfabric/js-compiler";
 import { entityIdFrom, Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
 import { slugIdForSpace } from "../../runner/src/slugs.ts";
-import { InMemoryProgram } from "@commonfabric/js-compiler";
-import { pinProgramFabricImports } from "../lib/fabric-deps.ts";
 import { collectLocalProgram } from "../lib/dev.ts";
+import { pinProgramFabricImports } from "../lib/fabric-deps.ts";
 import { cf, stripAnsi } from "./utils.ts";
 
 const signer = await Identity.fromPassphrase("cli fabric deps test");

--- a/packages/cli/test/fuse.test.ts
+++ b/packages/cli/test/fuse.test.ts
@@ -1,7 +1,9 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { FakeTime } from "@std/testing/time";
 import { basename, join, resolve, toFileUrl } from "@std/path";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { FakeTime } from "@std/testing/time";
+
+import { writeFailedSupervisorStartupStatus } from "../../fuse/mod.ts";
 import {
   awaitBackgroundMountStartup,
   awaitForegroundMountExit,
@@ -14,6 +16,16 @@ import {
   mountStatusHeader,
   runUnmount,
 } from "../commands/fuse.ts";
+import {
+  parseSupervisorArgs,
+  supervisorHelp,
+} from "../lib/fuse-mount-flags.ts";
+import {
+  buildFuseChildCommand,
+  cleanupFuseChild,
+  recordFuseMountState,
+  runFuseSupervisor,
+} from "../lib/fuse-supervisor.ts";
 import {
   buildBackgroundSupervisorDenoArgs,
   buildFuseBinaryArgs,
@@ -34,17 +46,6 @@ import {
   STATFS_SIZE,
   writeMountState,
 } from "../lib/fuse.ts";
-import {
-  buildFuseChildCommand,
-  cleanupFuseChild,
-  recordFuseMountState,
-  runFuseSupervisor,
-} from "../lib/fuse-supervisor.ts";
-import {
-  parseSupervisorArgs,
-  supervisorHelp,
-} from "../lib/fuse-mount-flags.ts";
-import { writeFailedSupervisorStartupStatus } from "../../fuse/mod.ts";
 import { withEnv } from "./utils.ts";
 
 const CHILD_PID = 321;

--- a/packages/cli/test/id.test.ts
+++ b/packages/cli/test/id.test.ts
@@ -1,8 +1,10 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { encode } from "@commonfabric/utils/encoding";
-import { cf, checkStderr } from "./utils.ts";
+import { describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
+import { encode } from "@commonfabric/utils/encoding";
+
+import { cf, checkStderr } from "./utils.ts";
 
 const PKCS8_KEY = `-----BEGIN PRIVATE KEY-----
 MMC4CAQAwBQYDK2VwBCIEICWSvx4QOW+mogjWSsjInQaPpmjErsDBqf2ZOoK+Y4IO

--- a/packages/cli/test/json-command.test.ts
+++ b/packages/cli/test/json-command.test.ts
@@ -1,18 +1,20 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { ConsoleMethod } from "@commonfabric/runner";
+
 import {
   handlePieceRenderNoUi,
   pieceCallRawArgs,
   writePieceRenderStatus,
 } from "../commands/piece.ts";
-import { cf, stripAnsi } from "./utils.ts";
-import { ConsoleMethod } from "@commonfabric/runner";
 import {
   hasJsonArgument,
   reservesStdoutForCommandOutput,
   stderrConsoleHandler,
 } from "../lib/json-output.ts";
 import { safeStringify } from "../lib/render.ts";
+import { cf, stripAnsi } from "./utils.ts";
 
 describe("JSON command contracts", () => {
   it("redirects runtime consoles without changing the console method", () => {

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -1,6 +1,8 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { ValidationError } from "@cliffy/command";
 import type { JSONSchema } from "@commonfabric/api";
 import { Identity } from "@commonfabric/identity";
 import {
@@ -11,24 +13,7 @@ import {
   Runtime,
 } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import {
-  type CallableResolution,
-  CF_RUNTIME_ERROR_LOG,
-  collectInvocationResultLinks,
-  executeResolvedCallable,
-  normalizeAbsentVerbPayload,
-  runtimeErrorLog,
-  schemaIsObjectShaped,
-  verbInputSchemaError,
-  VerbInputValidationError,
-} from "../lib/callable.ts";
-import {
-  executePieceCallable,
-  PieceResultProjectionError,
-  PieceVerbReadError,
-} from "../lib/piece.ts";
-import type { ExecutedPieceCallable } from "../lib/piece.ts";
-import { ValidationError } from "@cliffy/command";
+
 import {
   boundedSettlement,
   exitPieceCallFailure,
@@ -49,13 +34,30 @@ import {
   verbInputErrorReport,
   WaitBoundExpired,
 } from "../commands/piece.ts";
-import { LinkValidationError } from "../lib/piece.ts";
+import {
+  type CallableResolution,
+  CF_RUNTIME_ERROR_LOG,
+  collectInvocationResultLinks,
+  executeResolvedCallable,
+  normalizeAbsentVerbPayload,
+  runtimeErrorLog,
+  schemaIsObjectShaped,
+  verbInputSchemaError,
+  VerbInputValidationError,
+} from "../lib/callable.ts";
 import {
   type CellSelection,
   CellSelectionError,
   type deriveSelectedValue,
   parseCellSelectionOptions,
 } from "../lib/cell-selection.ts";
+import {
+  executePieceCallable,
+  LinkValidationError,
+  PieceResultProjectionError,
+  PieceVerbReadError,
+} from "../lib/piece.ts";
+import type { ExecutedPieceCallable } from "../lib/piece.ts";
 import { cf, stripAnsi } from "./utils.ts";
 
 /**

--- a/packages/cli/test/piece-source-package.test.ts
+++ b/packages/cli/test/piece-source-package.test.ts
@@ -1,14 +1,16 @@
 import { expect } from "@std/expect";
+import { dirname, join } from "@std/path";
 import { describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
 import type {
   Program,
   ProgramResolver,
   Source,
 } from "@commonfabric/js-compiler";
-import { dirname, join } from "@std/path";
-import { Identity } from "@commonfabric/identity";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
 import { getProgramFromFile } from "../lib/piece.ts";
 
 describe("piece source package", () => {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -1,6 +1,11 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { FabricError } from "@commonfabric/data-model/fabric-instances";
+import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
+import { FabricSpecialObject } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
+import { pieceId, SlugResolutionError } from "@commonfabric/piece";
 import {
   type Cell,
   getCellOrThrow,
@@ -14,10 +19,28 @@ import {
   newLoopbackServer,
   StorageManager,
 } from "@commonfabric/runner/storage/cache.deno";
-import { FabricError } from "@commonfabric/data-model/fabric-instances";
-import { FabricSpecialObject } from "@commonfabric/data-model/fabric-value";
-import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
-import { cf, checkStderr, stripAnsi } from "./utils.ts";
+
+import { toCell } from "../../runner/src/back-to-cell.ts";
+import { setResultCell } from "../../runner/src/result-utils.ts";
+import {
+  checkPieceSourceFromCommand,
+  formatPatternIdentity,
+  formatPatternRef,
+  localPatternEntry,
+  mergePiecePath,
+  normalizeApiUrl,
+  parseLink,
+  parsePieceOptions,
+  parseSpaceOptions,
+  piece,
+  setPieceSourceFromCommand,
+} from "../commands/piece.ts";
+import {
+  CellSelectionError,
+  parseCellSelectionOptions,
+  parseSelectionFilter,
+  parseSelectionProjection,
+} from "../lib/cell-selection.ts";
 import {
   checkPiecePattern,
   getCellValue,
@@ -35,29 +58,8 @@ import {
   type SpaceConfig,
   withRuntimeCleanupOnFailure,
 } from "../lib/piece.ts";
-import { pieceId, SlugResolutionError } from "@commonfabric/piece";
-import { setResultCell } from "../../runner/src/result-utils.ts";
-import { toCell } from "../../runner/src/back-to-cell.ts";
-import {
-  checkPieceSourceFromCommand,
-  formatPatternIdentity,
-  formatPatternRef,
-  localPatternEntry,
-  mergePiecePath,
-  normalizeApiUrl,
-  parseLink,
-  parsePieceOptions,
-  parseSpaceOptions,
-  piece,
-  setPieceSourceFromCommand,
-} from "../commands/piece.ts";
 import { safeStringify } from "../lib/render.ts";
-import {
-  CellSelectionError,
-  parseCellSelectionOptions,
-  parseSelectionFilter,
-  parseSelectionProjection,
-} from "../lib/cell-selection.ts";
+import { cf, checkStderr, stripAnsi } from "./utils.ts";
 
 const API_URL = "https://cf.dev";
 const SPACE = "common-knowledge";

--- a/packages/cli/test/utils.ts
+++ b/packages/cli/test/utils.ts
@@ -1,6 +1,7 @@
-import { decode, encode } from "@commonfabric/utils/encoding";
-import { join } from "@std/path";
 import { expect } from "@std/expect/expect";
+import { join } from "@std/path";
+
+import { decode, encode } from "@commonfabric/utils/encoding";
 
 // Decodes a `Uint8Array` into an array of strings for each line.
 export function bytesToLines(stream: Uint8Array): string[] {

--- a/packages/cli/test/view-cli.test.ts
+++ b/packages/cli/test/view-cli.test.ts
@@ -5,13 +5,16 @@
  * these exercise the command wiring, argument handling, input reading and the
  * print path without a terminal.
  */
+
 import { assert, assertEquals } from "@std/assert";
-import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
 import { expect } from "@std/expect";
 import { join } from "@std/path";
 import { describe, it } from "@std/testing/bdd";
-import { cf } from "./utils.ts";
+
+import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
+
 import { MAX_BINARY_VIEW_BYTES } from "../lib/view/languages/binary/binary.ts";
+import { cf } from "./utils.ts";
 
 const SRC = "export const x = pattern(() => ({ value: 1 }));\nconst y = x;\n";
 const CLI_PACKAGE_DIR = join(import.meta.dirname!, "..");

--- a/packages/cli/test/view-procfs.test.ts
+++ b/packages/cli/test/view-procfs.test.ts
@@ -1,8 +1,10 @@
 import { assert } from "@std/assert";
-import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
 import { expect } from "@std/expect";
-import { describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
+import { describe, it } from "@std/testing/bdd";
+
+import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
+
 import { realFileGateway } from "../lib/view/filegateway.ts";
 import { loadViewInput } from "../lib/view/loadinput.ts";
 

--- a/packages/cli/test/view-render.test.ts
+++ b/packages/cli/test/view-render.test.ts
@@ -1,15 +1,16 @@
 import { assert, assertEquals } from "@std/assert";
-import { bgCode, fgCode, parseDocument, SAMPLE } from "./view-helpers.ts";
+
+import { stripAnsi, visibleWidth } from "../lib/view/ansi.ts";
+import { renderLineColored } from "../lib/view/highlight.ts";
 import {
+  _internal,
   labeledDiffMetadataLine,
   overlayBox,
   renderFrame,
   type ViewState,
 } from "../lib/view/render.ts";
-import { _internal } from "../lib/view/render.ts";
-import { stripAnsi, visibleWidth } from "../lib/view/ansi.ts";
-import { renderLineColored } from "../lib/view/highlight.ts";
 import { lineBg, styleFor, ui } from "../lib/view/theme.ts";
+import { bgCode, fgCode, parseDocument, SAMPLE } from "./view-helpers.ts";
 
 function baseView(over: Partial<ViewState> = {}): ViewState {
   return {

--- a/packages/cli/test/view-vocab.test.ts
+++ b/packages/cli/test/view-vocab.test.ts
@@ -1,4 +1,10 @@
 import { assert, assertEquals } from "@std/assert";
+
+import {
+  COMMONFABRIC_BUILDER_EXPORT_NAMES,
+  COMMONFABRIC_CALL_EXPORT_NAMES,
+} from "@commonfabric/ts-transformers/runtime-registry";
+
 import {
   BUILDER_NAMES,
   CALL_NAMES,
@@ -12,10 +18,6 @@ import {
   SYNTHETIC_MODULE_CALLBACK_PREFIX,
   SYNTHETIC_PATTERN_HOIST_PREFIX,
 } from "../lib/view/languages/typescript/vocab.ts";
-import {
-  COMMONFABRIC_BUILDER_EXPORT_NAMES,
-  COMMONFABRIC_CALL_EXPORT_NAMES,
-} from "@commonfabric/ts-transformers/runtime-registry";
 
 Deno.test("vocab: builders and calls come straight from the transformer registry", () => {
   // Drift guard: the pager's name sets ARE the transformer's registry sets.

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -1,5 +1,6 @@
-import { z } from "zod";
 import * as Path from "@std/path";
+
+import { z } from "zod";
 
 // Parse CLI args for --port (needed because deno --watch doesn't pass env vars)
 function parseCliArgs(): Record<string, string> {

--- a/packages/toolshed/index.ts
+++ b/packages/toolshed/index.ts
@@ -1,5 +1,7 @@
+import type { Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
 import app from "@/app.ts";
-import env from "@/env.ts";
 import {
   backgroundLogFile,
   classifyLaunch,
@@ -8,13 +10,12 @@ import {
   runBackgroundParent,
   writeListeningMarker,
 } from "@/background.ts";
+import env from "@/env.ts";
 import { announceCloneIfServed } from "@/lib/clone-banner.ts";
 import { identity } from "@/lib/identity.ts";
-import type { Runtime } from "@commonfabric/runner";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { createToolshedRuntime } from "@/runtime-options.ts";
-import { memory } from "@/routes/storage/memory.ts";
 import { shutdownOpenTelemetry } from "@/lib/otel.ts";
+import { memory } from "@/routes/storage/memory.ts";
+import { createToolshedRuntime } from "@/runtime-options.ts";
 
 // Create a global runtime instance for the server
 let runtime: Runtime;

--- a/packages/toolshed/lib/otel.ts
+++ b/packages/toolshed/lib/otel.ts
@@ -1,15 +1,16 @@
+import { OpenInferenceBatchSpanProcessor } from "@arizeai/openinference-vercel";
 import { context, diag, trace } from "@opentelemetry/api";
-import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
+import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import {
   defaultResource,
   resourceFromAttributes,
 } from "@opentelemetry/resources";
-import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
-import env from "@/env.ts";
+import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
 import { registerTelemetry } from "ai";
+
+import env from "@/env.ts";
 import { createAiSdkTelemetry } from "@/lib/ai-telemetry.ts";
-import { OpenInferenceBatchSpanProcessor } from "@arizeai/openinference-vercel";
 import { samplerFromEnv } from "@/lib/otel-sampler.ts";
 import { detachRuntimeOtelBridgeIfAttached } from "@/runtime-options.ts";
 

--- a/packages/toolshed/routes/agent-tools/web-read/web-read.handlers.ts
+++ b/packages/toolshed/routes/agent-tools/web-read/web-read.handlers.ts
@@ -1,8 +1,9 @@
-import type { AppRouteHandler } from "@/lib/types.ts";
+import { ensureDir } from "@std/fs";
+
 import type { WebReadRoute } from "./web-read.routes.ts";
 import env from "@/env.ts";
 import { sha256 } from "@/lib/sha2.ts";
-import { ensureDir } from "@std/fs";
+import type { AppRouteHandler } from "@/lib/types.ts";
 
 const CACHE_DIR = `${env.CACHE_DIR}/agent-tools-web-read`;
 const JINA_API_ENDPOINT = `https://r.jina.ai/`;

--- a/packages/toolshed/routes/agent-tools/web-search/web-search.handlers.ts
+++ b/packages/toolshed/routes/agent-tools/web-search/web-search.handlers.ts
@@ -1,9 +1,10 @@
-import type { AppRouteHandler } from "@/lib/types.ts";
+import { ensureDir } from "@std/fs";
+
 import type { WebSearchRoute } from "./web-search.routes.ts";
 import env from "@/env.ts";
-import { sha256 } from "@/lib/sha2.ts";
 import { gatewayProvenanceHeaders } from "@/lib/gateway-provenance.ts";
-import { ensureDir } from "@std/fs";
+import { sha256 } from "@/lib/sha2.ts";
+import type { AppRouteHandler } from "@/lib/types.ts";
 
 const CACHE_DIR = `${env.CACHE_DIR}/agent-tools-web-search`;
 const CACHE_TTL = 10 * 60 * 1000; // 10 minutes in milliseconds

--- a/packages/toolshed/routes/ai/img/img.handlers.ts
+++ b/packages/toolshed/routes/ai/img/img.handlers.ts
@@ -1,12 +1,14 @@
+import { ensureDir } from "@std/fs";
+
 import { fal } from "@fal-ai/client";
-import type { AppRouteHandler } from "@/lib/types.ts";
+
 import type {
   GenerateImageAdvancedRoute,
   GenerateImageRoute,
 } from "./img.routes.ts";
 import env from "@/env.ts";
 import { sha256 } from "@/lib/sha2.ts";
-import { ensureDir } from "@std/fs";
+import type { AppRouteHandler } from "@/lib/types.ts";
 
 // Configure FAL client
 fal.config({ credentials: env.FAL_API_KEY });

--- a/packages/toolshed/routes/ai/img/img.index.ts
+++ b/packages/toolshed/routes/ai/img/img.index.ts
@@ -1,7 +1,8 @@
-import { createRouter } from "@/lib/create-app.ts";
+import { cors } from "@hono/hono/cors";
+
 import * as handlers from "./img.handlers.ts";
 import * as routes from "./img.routes.ts";
-import { cors } from "@hono/hono/cors";
+import { createRouter } from "@/lib/create-app.ts";
 
 const router = createRouter()
   .openapi(routes.generateImage, handlers.generateImage)

--- a/packages/toolshed/routes/ai/llm/cache.ts
+++ b/packages/toolshed/routes/ai/llm/cache.ts
@@ -1,7 +1,9 @@
 import { ensureDir } from "@std/fs";
+
+import { type BuiltInLLMMessage } from "@commonfabric/api";
+
 import { colors, timestamp } from "./cli.ts";
 import env from "@/env.ts";
-import { type BuiltInLLMMessage } from "@commonfabric/api";
 
 export const CACHE_DIR = `${env.CACHE_DIR}/llm-api-cache`;
 

--- a/packages/toolshed/routes/ai/llm/generateObject.ts
+++ b/packages/toolshed/routes/ai/llm/generateObject.ts
@@ -1,17 +1,18 @@
+import { DEFAULT_GENERATE_OBJECT_MODELS } from "@commonfabric/llm";
 import {
   type LLMGenerateObjectRequest,
   type LLMGenerateObjectResponse,
 } from "@commonfabric/llm/types";
-import { LLMRequestError } from "./errors.ts";
-import { resolveModel } from "./models.ts";
+import { trace } from "@opentelemetry/api";
 import {
   generateObject as generateObjectCore,
   jsonSchema,
   type ModelMessage,
 } from "ai";
 import { Ajv } from "ajv";
-import { DEFAULT_GENERATE_OBJECT_MODELS } from "@commonfabric/llm";
-import { trace } from "@opentelemetry/api";
+
+import { LLMRequestError } from "./errors.ts";
+import { resolveModel } from "./models.ts";
 import { normalizeSchemaForProvider } from "./schema.ts";
 import { withGatewayOperation } from "@/lib/gateway-provenance.ts";
 

--- a/packages/toolshed/routes/ai/llm/llm.handlers.ts
+++ b/packages/toolshed/routes/ai/llm/llm.handlers.ts
@@ -1,25 +1,27 @@
+import { type BuiltInLLMMessage } from "@commonfabric/api";
+import { isLLMRequest } from "@commonfabric/llm/types";
+import type { Context } from "@hono/hono";
 import * as HttpStatusCodes from "stoker/http-status-codes";
-import type { AppRouteHandler } from "@/lib/types.ts";
+
+import { CacheItem, hashKey, loadFromCache, saveToCache } from "./cache.ts";
+import { httpStatusForError } from "./errors.ts";
+import { generateObject as generateObjectCore } from "./generateObject.ts";
+import { generateText as generateTextCore } from "./generateText.ts";
 import type {
   GenerateObjectRoute,
   GenerateTextRoute,
   GetModelsRoute,
 } from "./llm.routes.ts";
-import { httpStatusForError } from "./errors.ts";
 import {
   ALIAS_NAMES,
+  findModel,
   ModelList,
   MODELS,
+  resolveModel,
   TASK_MODELS,
   whenModelsReady,
 } from "./models.ts";
-import { CacheItem, hashKey, loadFromCache, saveToCache } from "./cache.ts";
-import type { Context } from "@hono/hono";
-import { generateText as generateTextCore } from "./generateText.ts";
-import { generateObject as generateObjectCore } from "./generateObject.ts";
-import { findModel, resolveModel } from "./models.ts";
-import { isLLMRequest } from "@commonfabric/llm/types";
-import { type BuiltInLLMMessage } from "@commonfabric/api";
+import type { AppRouteHandler } from "@/lib/types.ts";
 
 const removeNonCacheableFields = (
   obj: object,

--- a/packages/toolshed/routes/ai/llm/llm.index.ts
+++ b/packages/toolshed/routes/ai/llm/llm.index.ts
@@ -1,7 +1,8 @@
-import { createRouter } from "@/lib/create-app.ts";
+import { cors } from "@hono/hono/cors";
+
 import * as handlers from "./llm.handlers.ts";
 import * as routes from "./llm.routes.ts";
-import { cors } from "@hono/hono/cors";
+import { createRouter } from "@/lib/create-app.ts";
 
 const router = createRouter();
 

--- a/packages/toolshed/routes/ai/llm/models.ts
+++ b/packages/toolshed/routes/ai/llm/models.ts
@@ -1,14 +1,13 @@
 import { anthropic, createAnthropic } from "@ai-sdk/anthropic";
-import { createOpenAI } from "@ai-sdk/openai";
-import { createGroq, groq } from "@ai-sdk/groq";
-import { openai } from "@ai-sdk/openai";
 import { createVertex, vertex } from "@ai-sdk/google-vertex";
-import type { LanguageModel } from "ai";
+import { createGroq, groq } from "@ai-sdk/groq";
+import { createOpenAI, openai } from "@ai-sdk/openai";
 import {
   GOOGLE_SEARCH_NATIVE_MODEL_TOOL,
   isLLMNativeModelToolId,
   type LLMNativeModelToolId,
 } from "@commonfabric/llm/types";
+import type { LanguageModel } from "ai";
 
 import env from "@/env.ts";
 import {

--- a/packages/toolshed/routes/ai/voice/voice.handlers.ts
+++ b/packages/toolshed/routes/ai/voice/voice.handlers.ts
@@ -1,15 +1,17 @@
+import { crypto } from "@std/crypto";
+import { ensureDir } from "@std/fs";
+
 import { fal } from "@fal-ai/client";
-import type { AppRouteHandler } from "@/lib/types.ts";
+import type { Logger } from "pino";
+import { z } from "zod";
+
 import type {
   SuccessResponseSchema,
   TranscribeVoiceRoute,
   TranscriptionChunk,
 } from "./voice.routes.ts";
 import env from "@/env.ts";
-import { ensureDir } from "@std/fs";
-import { crypto } from "@std/crypto";
-import { z } from "zod";
-import type { Logger } from "pino";
+import type { AppRouteHandler } from "@/lib/types.ts";
 
 // Configure FAL client
 fal.config({ credentials: env.FAL_API_KEY });

--- a/packages/toolshed/routes/ai/voice/voice.index.ts
+++ b/packages/toolshed/routes/ai/voice/voice.index.ts
@@ -1,7 +1,8 @@
-import { createRouter } from "@/lib/create-app.ts";
+import { cors } from "@hono/hono/cors";
+
 import * as handlers from "./voice.handlers.ts";
 import * as routes from "./voice.routes.ts";
-import { cors } from "@hono/hono/cors";
+import { createRouter } from "@/lib/create-app.ts";
 const router = createRouter()
   .openapi(routes.transcribeVoice, handlers.transcribeVoice);
 

--- a/packages/toolshed/routes/blobs/blobs.index.ts
+++ b/packages/toolshed/routes/blobs/blobs.index.ts
@@ -1,16 +1,17 @@
+import { EmptyReconstructionContext } from "@commonfabric/data-model/codec-common";
+import { newDefaultJsonCodecEngine } from "@commonfabric/data-model/codecs";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import { hashOf } from "@commonfabric/data-model/value-hash";
+import { isDID } from "@commonfabric/identity";
+import { decodeMemoryBoundary } from "@commonfabric/memory/v2";
+import type { Context } from "@hono/hono";
+
 // Blob routes are intentionally unauthenticated for the MVP. Anyone can POST a
 // blob into any space DID; content addressing prevents overwriting a different
 // payload, but callers can inject blobs and consume storage. Anyone with a hash
 // can GET the blob. Revisit this before any production exposure.
 import { createRouter } from "@/lib/create-app.ts";
 import { memoryServer } from "@/routes/storage/memory.ts";
-import { isDID } from "@commonfabric/identity";
-import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import { hashOf } from "@commonfabric/data-model/value-hash";
-import { newDefaultJsonCodecEngine } from "@commonfabric/data-model/codecs";
-import { EmptyReconstructionContext } from "@commonfabric/data-model/codec-common";
-import { decodeMemoryBoundary } from "@commonfabric/memory/v2";
-import type { Context } from "@hono/hono";
 
 const router = createRouter();
 const blobUploadCodec = newDefaultJsonCodecEngine();

--- a/packages/toolshed/routes/blobs/blobs.test.ts
+++ b/packages/toolshed/routes/blobs/blobs.test.ts
@@ -1,18 +1,20 @@
-import { afterAll, afterEach, beforeAll, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import createApp from "@/lib/create-app.ts";
-import router from "./blobs.index.ts";
-import memory from "@/routes/storage/memory/memory.index.ts";
-import { memoryServer } from "@/routes/storage/memory.ts";
-import env from "@/env.ts";
-import { Identity } from "@commonfabric/identity";
+import { afterAll, afterEach, beforeAll, describe, it } from "@std/testing/bdd";
+
+import { newDefaultJsonCodecEngine } from "@commonfabric/data-model/codecs";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { hashOf } from "@commonfabric/data-model/value-hash";
-import { newDefaultJsonCodecEngine } from "@commonfabric/data-model/codecs";
-import { encodeMemoryBoundary } from "@commonfabric/memory/v2";
+import { Identity } from "@commonfabric/identity";
 import type { URI } from "@commonfabric/memory/interface";
+import { encodeMemoryBoundary } from "@commonfabric/memory/v2";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import router from "./blobs.index.ts";
+import env from "@/env.ts";
+import createApp from "@/lib/create-app.ts";
+import { memoryServer } from "@/routes/storage/memory.ts";
+import memory from "@/routes/storage/memory/memory.index.ts";
 
 if (env.ENV !== "test") {
   throw new Error("ENV must be 'test'");

--- a/packages/toolshed/routes/health/health.handlers.ts
+++ b/packages/toolshed/routes/health/health.handlers.ts
@@ -1,14 +1,14 @@
-import * as HttpStatusCodes from "stoker/http-status-codes";
-import { z } from "zod";
-
-import { resolveGitSha } from "@/lib/build-info.ts";
-import type { AppRouteHandler } from "@/lib/types.ts";
-import type { DashRoute, IndexRoute, StatsRoute } from "./health.routes.ts";
 import { getSlowQueries } from "@commonfabric/memory/v2/server";
 import {
   getLoggerCountsBreakdown,
   getTimingStatsBreakdown,
 } from "@commonfabric/utils/logger";
+import * as HttpStatusCodes from "stoker/http-status-codes";
+import { z } from "zod";
+
+import type { DashRoute, IndexRoute, StatsRoute } from "./health.routes.ts";
+import { resolveGitSha } from "@/lib/build-info.ts";
+import type { AppRouteHandler } from "@/lib/types.ts";
 
 export const HealthResponseSchema = z.object({
   status: z.literal("OK"),

--- a/packages/toolshed/routes/health/health.index.ts
+++ b/packages/toolshed/routes/health/health.index.ts
@@ -1,8 +1,8 @@
-import { createRouter } from "@/lib/create-app.ts";
 import { cors } from "@hono/hono/cors";
 
 import * as handlers from "./health.handlers.ts";
 import * as routes from "./health.routes.ts";
+import { createRouter } from "@/lib/create-app.ts";
 
 const router = createRouter();
 

--- a/packages/toolshed/routes/ingest-channels/ingest-channels.index.ts
+++ b/packages/toolshed/routes/ingest-channels/ingest-channels.index.ts
@@ -1,11 +1,12 @@
-import { createRouter } from "@/lib/create-app.ts";
-import env from "@/env.ts";
 import { bodyLimit } from "@hono/hono/body-limit";
-import { requireFirstPartyHttpAuth } from "@/middlewares/first-party-http-auth.ts";
-import { createRateLimiter, rateLimit } from "@/middlewares/rate-limit.ts";
+
 import { ingestGate } from "./gate.ts";
 import * as handlers from "./ingest-channels.handlers.ts";
 import * as routes from "./ingest-channels.routes.ts";
+import env from "@/env.ts";
+import { createRouter } from "@/lib/create-app.ts";
+import { requireFirstPartyHttpAuth } from "@/middlewares/first-party-http-auth.ts";
+import { createRateLimiter, rateLimit } from "@/middlewares/rate-limit.ts";
 
 const router = createRouter();
 

--- a/packages/toolshed/routes/ingest/ingest.index.ts
+++ b/packages/toolshed/routes/ingest/ingest.index.ts
@@ -1,8 +1,9 @@
-import { createRouter } from "@/lib/create-app.ts";
+import { bodyLimit } from "@hono/hono/body-limit";
+import { cors } from "@hono/hono/cors";
+
 import * as handlers from "./ingest.handlers.ts";
 import * as routes from "./ingest.routes.ts";
-import { cors } from "@hono/hono/cors";
-import { bodyLimit } from "@hono/hono/body-limit";
+import { createRouter } from "@/lib/create-app.ts";
 
 const router = createRouter();
 

--- a/packages/toolshed/routes/ingest/ingest.utils.ts
+++ b/packages/toolshed/routes/ingest/ingest.utils.ts
@@ -1,12 +1,13 @@
+import { sha256 } from "@commonfabric/content-hash";
 import type { JSONSchema, MemorySpace, Runtime } from "@commonfabric/runner";
 import { isLink } from "@commonfabric/runner";
+import { toUnpaddedBase64url } from "@commonfabric/utils/base64url";
+
 import {
   custodyIngest,
   durableSet,
   type VouchedChannel,
 } from "@/lib/custody-ingest.ts";
-import { sha256 } from "@commonfabric/content-hash";
-import { toUnpaddedBase64url } from "@commonfabric/utils/base64url";
 
 // The `journal` sink of a vouched ingest channel: a durable, append-only,
 // ExternalIngest-marked record log. This is the generic capability — location

--- a/packages/toolshed/routes/integrations/airtable-oauth/airtable.descriptor.ts
+++ b/packages/toolshed/routes/integrations/airtable-oauth/airtable.descriptor.ts
@@ -20,8 +20,9 @@
  * Note: Airtable uses HTTP Basic auth for the token endpoint (client_id:client_secret
  * base64-encoded in the Authorization header), hence tokenAuthMethod: "basic".
  */
+
 import env from "@/env.ts";
-import type { ProviderDescriptor } from "../oauth2-common/oauth2-common.types.ts";
+import type { ProviderDescriptor } from "@/routes/integrations/oauth2-common/oauth2-common.types.ts";
 
 export const AirtableDescriptor: ProviderDescriptor = {
   name: "airtable",

--- a/packages/toolshed/routes/integrations/discord-oauth/discord.descriptor.ts
+++ b/packages/toolshed/routes/integrations/discord-oauth/discord.descriptor.ts
@@ -11,8 +11,9 @@
  *      DISCORD_CLIENT_SECRET=<your client secret>
  * 4. Restart the dev servers
  */
+
 import env from "@/env.ts";
-import type { ProviderDescriptor } from "../oauth2-common/oauth2-common.types.ts";
+import type { ProviderDescriptor } from "@/routes/integrations/oauth2-common/oauth2-common.types.ts";
 
 export const DiscordDescriptor: ProviderDescriptor = {
   name: "discord",

--- a/packages/toolshed/routes/integrations/github-oauth/github.descriptor.ts
+++ b/packages/toolshed/routes/integrations/github-oauth/github.descriptor.ts
@@ -11,8 +11,9 @@
  *      GITHUB_CLIENT_SECRET=<your client secret>
  * 4. Restart the dev servers
  */
+
 import env from "@/env.ts";
-import type { ProviderDescriptor } from "../oauth2-common/oauth2-common.types.ts";
+import type { ProviderDescriptor } from "@/routes/integrations/oauth2-common/oauth2-common.types.ts";
 
 export const GitHubDescriptor: ProviderDescriptor = {
   name: "github",

--- a/packages/toolshed/routes/integrations/google-oauth/google.descriptor.ts
+++ b/packages/toolshed/routes/integrations/google-oauth/google.descriptor.ts
@@ -5,13 +5,15 @@
  * compatibility with existing consuming patterns. The custom tokenMapper
  * and emptyAuthData handle this.
  */
-import env from "@/env.ts";
+
 import { AuthSchema } from "@commonfabric/runner";
 import type { JSONSchema } from "@commonfabric/runner";
+
+import env from "@/env.ts";
 import type {
   OAuth2Tokens,
   ProviderDescriptor,
-} from "../oauth2-common/oauth2-common.types.ts";
+} from "@/routes/integrations/oauth2-common/oauth2-common.types.ts";
 
 function tokenToAuthData(
   token: OAuth2Tokens,

--- a/packages/toolshed/routes/integrations/linear-oauth/linear.descriptor.ts
+++ b/packages/toolshed/routes/integrations/linear-oauth/linear.descriptor.ts
@@ -14,8 +14,9 @@
  * Note: Linear's user info requires a GraphQL POST to /graphql which the
  * common handler doesn't support, so userInfoEndpoint is omitted for now.
  */
+
 import env from "@/env.ts";
-import type { ProviderDescriptor } from "../oauth2-common/oauth2-common.types.ts";
+import type { ProviderDescriptor } from "@/routes/integrations/oauth2-common/oauth2-common.types.ts";
 
 export const LinearDescriptor: ProviderDescriptor = {
   name: "linear",

--- a/packages/toolshed/routes/integrations/notion-oauth/notion.descriptor.ts
+++ b/packages/toolshed/routes/integrations/notion-oauth/notion.descriptor.ts
@@ -16,8 +16,9 @@
  * use scopes — capabilities are configured in the integration dashboard.
  * Notion embeds owner info in the token response; we extract it via tokenMapper.
  */
+
 import env from "@/env.ts";
-import type { ProviderDescriptor } from "../oauth2-common/oauth2-common.types.ts";
+import type { ProviderDescriptor } from "@/routes/integrations/oauth2-common/oauth2-common.types.ts";
 
 export const NotionDescriptor: ProviderDescriptor = {
   name: "notion",

--- a/packages/toolshed/routes/integrations/oauth2-common/oauth2-common.handlers.ts
+++ b/packages/toolshed/routes/integrations/oauth2-common/oauth2-common.handlers.ts
@@ -1,10 +1,10 @@
 import type { Tokens } from "@cmd-johnson/oauth2-client";
-import type { Context } from "@hono/hono";
-import { getLogger } from "@commonfabric/utils/logger";
 import { setBGPiece } from "@commonfabric/background-piece";
-import { runtime } from "@/index.ts";
 import { OAuth2TokenSchema } from "@commonfabric/runner";
 import type { JSONSchema } from "@commonfabric/runner";
+import { getLogger } from "@commonfabric/utils/logger";
+import type { Context } from "@hono/hono";
+
 import type {
   CallbackResult,
   OAuth2HandlerOptions,
@@ -28,6 +28,7 @@ import {
   persistTokens,
   tokenToGenericAuthData,
 } from "./oauth2-common.utils.ts";
+import { runtime } from "@/index.ts";
 
 /**
  * Strip the `schema` field from a serialized cell-link JSON string.

--- a/packages/toolshed/routes/integrations/oauth2-common/oauth2-common.utils.ts
+++ b/packages/toolshed/routes/integrations/oauth2-common/oauth2-common.utils.ts
@@ -1,18 +1,19 @@
 import { OAuth2Client, type Tokens } from "@cmd-johnson/oauth2-client";
-import type { Context } from "@hono/hono";
-import { getLogger } from "@commonfabric/utils/logger";
-import { runtime } from "@/index.ts";
 import type { JSONSchema } from "@commonfabric/runner";
-import {
-  custodyIngest,
-  durableSet,
-  type VouchedChannel,
-} from "@/lib/custody-ingest.ts";
+import { getLogger } from "@commonfabric/utils/logger";
+import type { Context } from "@hono/hono";
+
 import type {
   OAuth2ProviderConfig,
   OAuth2Tokens,
   UserInfo,
 } from "./oauth2-common.types.ts";
+import { runtime } from "@/index.ts";
+import {
+  custodyIngest,
+  durableSet,
+  type VouchedChannel,
+} from "@/lib/custody-ingest.ts";
 
 const logger = getLogger("oauth2-common");
 

--- a/packages/toolshed/routes/integrations/plaid-oauth/plaid-oauth.handlers.ts
+++ b/packages/toolshed/routes/integrations/plaid-oauth/plaid-oauth.handlers.ts
@@ -1,4 +1,17 @@
-import type { AppRouteHandler } from "@/lib/types.ts";
+import { setBGPiece } from "@commonfabric/background-piece";
+import {
+  type NormalizedLink,
+  parseLink,
+  type SigilLink,
+} from "@commonfabric/runner";
+import {
+  CountryCode,
+  LinkTokenCreateRequest,
+  Transaction,
+  TransactionsSyncRequest,
+} from "plaid";
+
+import { plaidErrorFrom } from "./plaid-oauth.error.ts";
 import type {
   BackgroundIntegrationRoute,
   CreateLinkTokenRoute,
@@ -15,21 +28,9 @@ import {
   removePlaidItem,
   upsertPlaidItem,
 } from "./plaid-oauth.utils.ts";
-import { setBGPiece } from "@commonfabric/background-piece";
-import {
-  type NormalizedLink,
-  parseLink,
-  type SigilLink,
-} from "@commonfabric/runner";
-import { runtime } from "@/index.ts";
 import env from "@/env.ts";
-import {
-  CountryCode,
-  LinkTokenCreateRequest,
-  Transaction,
-  TransactionsSyncRequest,
-} from "plaid";
-import { plaidErrorFrom } from "./plaid-oauth.error.ts";
+import { runtime } from "@/index.ts";
+import type { AppRouteHandler } from "@/lib/types.ts";
 
 /**
  * Plaid Create Link Token Handler

--- a/packages/toolshed/routes/integrations/plaid-oauth/plaid-oauth.index.ts
+++ b/packages/toolshed/routes/integrations/plaid-oauth/plaid-oauth.index.ts
@@ -1,7 +1,8 @@
-import { createRouter } from "@/lib/create-app.ts";
+import { cors } from "@hono/hono/cors";
+
 import * as handlers from "./plaid-oauth.handlers.ts";
 import * as routes from "./plaid-oauth.routes.ts";
-import { cors } from "@hono/hono/cors";
+import { createRouter } from "@/lib/create-app.ts";
 
 const router = createRouter()
   .openapi(routes.createLinkToken, handlers.createLinkToken)

--- a/packages/toolshed/routes/integrations/plaid-oauth/plaid-oauth.utils.ts
+++ b/packages/toolshed/routes/integrations/plaid-oauth/plaid-oauth.utils.ts
@@ -1,12 +1,13 @@
-import { type SigilLink } from "@commonfabric/runner";
-import { runtime } from "@/index.ts";
 import {
   type JSONSchema,
   type Mutable,
   type Schema,
+  type SigilLink,
 } from "@commonfabric/runner";
 import { Configuration, PlaidApi, PlaidEnvironments } from "plaid";
+
 import env from "@/env.ts";
+import { runtime } from "@/index.ts";
 import {
   custodyIngest,
   durableUpdate,

--- a/packages/toolshed/routes/integrations/provider-registry.ts
+++ b/packages/toolshed/routes/integrations/provider-registry.ts
@@ -13,9 +13,15 @@
  * first provider router with valid credentials.
  */
 
-import { createRouter } from "@/lib/create-app.ts";
-import type { AppRouteHandler } from "@/lib/types.ts";
+import { getLogger } from "@commonfabric/utils/logger";
 import { cors } from "@hono/hono/cors";
+
+import { AirtableDescriptor } from "./airtable-oauth/airtable.descriptor.ts";
+import { DiscordDescriptor } from "./discord-oauth/discord.descriptor.ts";
+import { GitHubDescriptor } from "./github-oauth/github.descriptor.ts";
+import { GoogleDescriptor } from "./google-oauth/google.descriptor.ts";
+import { LinearDescriptor } from "./linear-oauth/linear.descriptor.ts";
+import { NotionDescriptor } from "./notion-oauth/notion.descriptor.ts";
 import {
   createOAuth2Handlers,
 } from "./oauth2-common/oauth2-common.handlers.ts";
@@ -27,20 +33,15 @@ import {
   type OAuth2LogoutRoute,
   type OAuth2RefreshRoute,
 } from "./oauth2-common/oauth2-common.routes.ts";
-import { discoverProviderConfig } from "./oauth2-common/oauth2-common.utils.ts";
 import type {
   OAuth2ProviderConfig,
   ProviderDescriptor,
 } from "./oauth2-common/oauth2-common.types.ts";
-import { AirtableDescriptor } from "./airtable-oauth/airtable.descriptor.ts";
-import { DiscordDescriptor } from "./discord-oauth/discord.descriptor.ts";
-import { GitHubDescriptor } from "./github-oauth/github.descriptor.ts";
-import { GoogleDescriptor } from "./google-oauth/google.descriptor.ts";
-import { LinearDescriptor } from "./linear-oauth/linear.descriptor.ts";
-import { NotionDescriptor } from "./notion-oauth/notion.descriptor.ts";
+import { discoverProviderConfig } from "./oauth2-common/oauth2-common.utils.ts";
 import { SpotifyDescriptor } from "./spotify-oauth/spotify.descriptor.ts";
 import { StravaDescriptor } from "./strava-oauth/strava.descriptor.ts";
-import { getLogger } from "@commonfabric/utils/logger";
+import { createRouter } from "@/lib/create-app.ts";
+import type { AppRouteHandler } from "@/lib/types.ts";
 
 const logger = getLogger("provider-registry");
 

--- a/packages/toolshed/routes/integrations/spotify-oauth/spotify.descriptor.ts
+++ b/packages/toolshed/routes/integrations/spotify-oauth/spotify.descriptor.ts
@@ -13,8 +13,9 @@
  *
  * Note: Spotify requires HTTP Basic auth for the token endpoint.
  */
+
 import env from "@/env.ts";
-import type { ProviderDescriptor } from "../oauth2-common/oauth2-common.types.ts";
+import type { ProviderDescriptor } from "@/routes/integrations/oauth2-common/oauth2-common.types.ts";
 
 export const SpotifyDescriptor: ProviderDescriptor = {
   name: "spotify",

--- a/packages/toolshed/routes/integrations/strava-oauth/strava.descriptor.ts
+++ b/packages/toolshed/routes/integrations/strava-oauth/strava.descriptor.ts
@@ -13,8 +13,9 @@
  *
  * Note: Strava uses comma-separated scopes (not space-separated).
  */
+
 import env from "@/env.ts";
-import type { ProviderDescriptor } from "../oauth2-common/oauth2-common.types.ts";
+import type { ProviderDescriptor } from "@/routes/integrations/oauth2-common/oauth2-common.types.ts";
 
 export const StravaDescriptor: ProviderDescriptor = {
   name: "strava",

--- a/packages/toolshed/routes/link-preview/link-preview.handlers.ts
+++ b/packages/toolshed/routes/link-preview/link-preview.handlers.ts
@@ -1,8 +1,9 @@
-import type { AppRouteHandler } from "@/lib/types.ts";
+import { ensureDir } from "@std/fs";
+
 import type { GetLinkPreviewRoute } from "./link-preview.routes.ts";
 import env from "@/env.ts";
 import { sha256 } from "@/lib/sha2.ts";
-import { ensureDir } from "@std/fs";
+import type { AppRouteHandler } from "@/lib/types.ts";
 
 const CACHE_DIR = `${env.CACHE_DIR}/link-preview`;
 const JINA_API_ENDPOINT = "https://r.jina.ai/";

--- a/packages/toolshed/routes/link-preview/link-preview.index.ts
+++ b/packages/toolshed/routes/link-preview/link-preview.index.ts
@@ -1,7 +1,8 @@
-import { createRouter } from "@/lib/create-app.ts";
+import { cors } from "@hono/hono/cors";
+
 import * as handlers from "./link-preview.handlers.ts";
 import * as routes from "./link-preview.routes.ts";
-import { cors } from "@hono/hono/cors";
+import { createRouter } from "@/lib/create-app.ts";
 
 const router = createRouter();
 

--- a/packages/toolshed/routes/patterns/patterns-identity-parity.test.ts
+++ b/packages/toolshed/routes/patterns/patterns-identity-parity.test.ts
@@ -1,11 +1,13 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { join } from "@std/path/join";
+import { toFileUrl } from "@std/path/to-file-url";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
+import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
 import { Engine, Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
-import { toFileUrl } from "@std/path/to-file-url";
-import { join } from "@std/path/join";
+
 import { PatternsServer } from "@/routes/patterns/patterns-server.ts";
 
 /**

--- a/packages/toolshed/routes/patterns/patterns-server.ts
+++ b/packages/toolshed/routes/patterns/patterns-server.ts
@@ -1,10 +1,11 @@
-import { decode } from "@commonfabric/utils/encoding";
 import { join } from "@std/path/join";
 import { toFileUrl } from "@std/path/to-file-url";
+
 import {
   PATTERNS_ROUTE_PREFIX,
   resolveEntryIdentity,
 } from "@commonfabric/runner";
+import { decode } from "@commonfabric/utils/encoding";
 
 // The prefix this route serves patterns under is the runner's constant, not
 // this route's own. A pattern's content identity folds in each module's

--- a/packages/toolshed/routes/patterns/patterns.index.ts
+++ b/packages/toolshed/routes/patterns/patterns.index.ts
@@ -1,8 +1,8 @@
-import { createRouter } from "@/lib/create-app.ts";
 import { cors } from "@hono/hono/cors";
 
 import * as handlers from "./patterns.handlers.ts";
 import * as routes from "./patterns.routes.ts";
+import { createRouter } from "@/lib/create-app.ts";
 
 const router = createRouter();
 

--- a/packages/toolshed/routes/shell/shell-static.ts
+++ b/packages/toolshed/routes/shell/shell-static.ts
@@ -1,11 +1,13 @@
 import * as path from "@std/path";
-import { createRouter } from "@/lib/create-app.ts";
-import { getMimeType } from "@/lib/mime-type.ts";
+
 import {
   compareETags,
   createCacheHeaders,
   generateETag,
 } from "@commonfabric/static/etag";
+
+import { createRouter } from "@/lib/create-app.ts";
+import { getMimeType } from "@/lib/mime-type.ts";
 
 /**
  * Inputs the static router reads files and computes ETags with. Injectable so

--- a/packages/toolshed/routes/shell/shell.index.ts
+++ b/packages/toolshed/routes/shell/shell.index.ts
@@ -1,10 +1,12 @@
 import { exists } from "@std/fs";
-import ports from "@commonfabric/ports" with { type: "json" };
 import * as path from "@std/path";
-import { createRouter } from "@/lib/create-app.ts";
+
+import ports from "@commonfabric/ports" with { type: "json" };
 import { cors } from "@hono/hono/cors";
+
 import env from "@/env.ts";
 import { buildInfo } from "@/lib/build-info.ts";
+import { createRouter } from "@/lib/create-app.ts";
 import {
   createShellStaticRouter,
   StaticResponse,

--- a/packages/toolshed/routes/static/static.index.ts
+++ b/packages/toolshed/routes/static/static.index.ts
@@ -1,8 +1,9 @@
-import { createRouter } from "@/lib/create-app.ts";
-import { cors } from "@hono/hono/cors";
 import { StaticCache } from "@commonfabric/static";
-import { getMimeType } from "@/lib/mime-type.ts";
 import { compareETags, createCacheHeaders } from "@commonfabric/static/etag";
+import { cors } from "@hono/hono/cors";
+
+import { createRouter } from "@/lib/create-app.ts";
+import { getMimeType } from "@/lib/mime-type.ts";
 
 const router = createRouter();
 

--- a/packages/toolshed/routes/static/static.test.ts
+++ b/packages/toolshed/routes/static/static.test.ts
@@ -1,10 +1,12 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { TEST_ASSET, TEST_ASSET_CONTENT } from "@commonfabric/static/utils";
+
 import env from "@/env.ts";
 import createApp from "@/lib/create-app.ts";
-import router from "@/routes/static/static.index.ts";
 import { getMimeType } from "@/lib/mime-type.ts";
-import { TEST_ASSET, TEST_ASSET_CONTENT } from "@commonfabric/static/utils";
+import router from "@/routes/static/static.index.ts";
 
 if (env.ENV !== "test") {
   throw new Error("ENV must be 'test'");

--- a/packages/toolshed/routes/storage/memory.ts
+++ b/packages/toolshed/routes/storage/memory.ts
@@ -1,8 +1,10 @@
+import * as FS from "@std/fs";
+
 import * as MemoryServer from "@commonfabric/memory/v2/server";
 import { verifySessionOpenAuthorization } from "@commonfabric/memory/v2/session-open-auth";
-import * as FS from "@std/fs";
-import env from "@/env.ts";
+
 import { memoryEngineStoreUrl } from "./memory-store-url.ts";
+import env from "@/env.ts";
 import { identity } from "@/lib/identity.ts";
 
 const memoryAudience = identity.did();

--- a/packages/toolshed/routes/storage/memory/memory-dump-disabled.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory-dump-disabled.test.ts
@@ -4,11 +4,12 @@
 // imported, and the routes must 404 as if they never existed — even for a
 // validly signed, allowlisted caller.
 
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import * as Path from "@std/path";
+import { describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
 import { signFirstPartyHttpRequest } from "@commonfabric/runner/toolshed-http-auth";
-import * as Path from "@std/path";
 
 const DUMP_BASE = "/api/storage/memory/dump";
 

--- a/packages/toolshed/routes/storage/memory/memory-dump.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory-dump.test.ts
@@ -8,14 +8,15 @@
 // `memoryEngineStoreUrl` the live server uses, so it lands at the exact path the
 // route resolves (directory mode nests one `engine-v3/` deeper than MEMORY_DIR).
 
-import { afterAll, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
-import { signFirstPartyHttpRequest } from "@commonfabric/runner/toolshed-http-auth";
-import { resolveSpaceStoreUrl } from "@commonfabric/memory/v2/storage-path";
-import type { MemorySpace } from "@commonfabric/memory/interface";
-import { Database } from "@db/sqlite";
 import * as Path from "@std/path";
+import { afterAll, describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+import type { MemorySpace } from "@commonfabric/memory/interface";
+import { resolveSpaceStoreUrl } from "@commonfabric/memory/v2/storage-path";
+import { signFirstPartyHttpRequest } from "@commonfabric/runner/toolshed-http-auth";
+import { Database } from "@db/sqlite";
 
 const SQLITE_MAGIC = "SQLite format 3\0";
 const DUMP_BASE = "/api/storage/memory/dump";

--- a/packages/toolshed/routes/storage/memory/memory.handlers.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory.handlers.test.ts
@@ -1,5 +1,5 @@
-import { afterAll, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterAll, describe, it } from "@std/testing/bdd";
 
 import {
   decodeMemoryBoundary,
@@ -7,11 +7,12 @@ import {
   getMemoryProtocolFlags,
   MEMORY_PROTOCOL,
 } from "@commonfabric/memory/v2";
+
 import {
   attachMemorySocketPipeline,
   bufferTextMessagesUntilNegotiated,
 } from "./memory.handlers.ts";
-import { memoryServer } from "../memory.ts";
+import { memoryServer } from "@/routes/storage/memory.ts";
 
 const HELLO = encodeMemoryBoundary({
   type: "hello",

--- a/packages/toolshed/routes/storage/memory/memory.handlers.ts
+++ b/packages/toolshed/routes/storage/memory/memory.handlers.ts
@@ -1,10 +1,11 @@
-import type { AppRouteHandler } from "@/lib/types.ts";
 import { encodeMemoryBoundary } from "@commonfabric/memory/v2";
 import * as MemoryServer from "@commonfabric/memory/v2/server";
+
 import type * as Routes from "./memory.routes.ts";
-import { memoryServer } from "../memory.ts";
-import { createSpan } from "@/middlewares/opentelemetry.ts";
 import { formatMemWriteTrace, type MemWriteOp } from "./memwrite-trace.ts";
+import type { AppRouteHandler } from "@/lib/types.ts";
+import { createSpan } from "@/middlewares/opentelemetry.ts";
+import { memoryServer } from "@/routes/storage/memory.ts";
 
 type NegotiatedSocketHandlers = {
   onMessage: (message: string) => void;

--- a/packages/toolshed/routes/storage/memory/memory.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory.test.ts
@@ -1,7 +1,9 @@
 import { assert, assertEquals } from "@std/assert";
-import app from "../../../app.ts";
-import { memoryServer } from "../memory.ts";
+
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { hashOf } from "@commonfabric/data-model/value-hash";
+import { createSession, Identity } from "@commonfabric/identity";
 import {
   decodeMemoryBoundary,
   encodeMemoryBoundary,
@@ -9,12 +11,12 @@ import {
   MEMORY_PROTOCOL,
   type SessionOpenChallenge,
 } from "@commonfabric/memory/v2";
-import { hashOf } from "@commonfabric/data-model/value-hash";
-import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import { createSession, Identity } from "@commonfabric/identity";
 import { type JSONSchema, Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { defer } from "@commonfabric/utils/defer";
+
+import app from "@/app.ts";
+import { memoryServer } from "@/routes/storage/memory.ts";
 
 const HELLO = {
   type: "hello",

--- a/packages/toolshed/routes/telemetry/telemetry.index.ts
+++ b/packages/toolshed/routes/telemetry/telemetry.index.ts
@@ -1,7 +1,7 @@
-import { createRouter } from "@/lib/create-app.ts";
 import { cors } from "@hono/hono/cors";
 
 import { forwardOtlp } from "./telemetry.handlers.ts";
+import { createRouter } from "@/lib/create-app.ts";
 
 const router = createRouter();
 

--- a/packages/toolshed/routes/webhooks/webhooks.index.ts
+++ b/packages/toolshed/routes/webhooks/webhooks.index.ts
@@ -1,8 +1,9 @@
-import { createRouter } from "@/lib/create-app.ts";
+import { bodyLimit } from "@hono/hono/body-limit";
+import { cors } from "@hono/hono/cors";
+
 import * as handlers from "./webhooks.handlers.ts";
 import * as routes from "./webhooks.routes.ts";
-import { cors } from "@hono/hono/cors";
-import { bodyLimit } from "@hono/hono/body-limit";
+import { createRouter } from "@/lib/create-app.ts";
 
 const router = createRouter();
 

--- a/packages/toolshed/routes/webhooks/webhooks.test.ts
+++ b/packages/toolshed/routes/webhooks/webhooks.test.ts
@@ -1,8 +1,8 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import env from "@/env.ts";
-import { sha256 } from "@/lib/sha2.ts";
+import { describe, it } from "@std/testing/bdd";
+
 import { linkRefPayloadToString } from "@commonfabric/runner/shared";
+
 import {
   extractSpaceFromCellLink,
   generateWebhookId,
@@ -10,6 +10,8 @@ import {
   verifyWebhookSecret,
   webhookEntityId,
 } from "./webhooks.utils.ts";
+import env from "@/env.ts";
+import { sha256 } from "@/lib/sha2.ts";
 
 if (env.ENV !== "test") {
   throw new Error("ENV must be 'test'");

--- a/packages/toolshed/routes/webhooks/webhooks.utils.ts
+++ b/packages/toolshed/routes/webhooks/webhooks.utils.ts
@@ -1,7 +1,3 @@
-import { getLogger } from "@commonfabric/utils/logger";
-import { sha256 } from "@/lib/sha2.ts";
-import { runtime } from "@/index.ts";
-import { identity } from "@/lib/identity.ts";
 import { WebhookConfigSchema } from "@commonfabric/runner";
 import {
   assertWebhookCellLinkRefPayload,
@@ -9,6 +5,11 @@ import {
   linkRefPayload,
   linkRefPayloadFromString,
 } from "@commonfabric/runner/shared";
+import { getLogger } from "@commonfabric/utils/logger";
+
+import { runtime } from "@/index.ts";
+import { identity } from "@/lib/identity.ts";
+import { sha256 } from "@/lib/sha2.ts";
 
 const _logger = getLogger("webhooks.utils");
 

--- a/packages/toolshed/routes/whoami/whoami.index.ts
+++ b/packages/toolshed/routes/whoami/whoami.index.ts
@@ -1,7 +1,8 @@
-import { createRouter } from "@/lib/create-app.ts";
+import { cors } from "@hono/hono/cors";
+
 import * as handlers from "./whoami.handlers.ts";
 import * as routes from "./whoami.routes.ts";
-import { cors } from "@hono/hono/cors";
+import { createRouter } from "@/lib/create-app.ts";
 
 const router = createRouter();
 


### PR DESCRIPTION
Fourth of the series applying the Development Guide's `Imports` rules (#5852).
I (agent working on behalf of @danfuzz) am splitting along package lines.

Independent of #5856 — different files, both branched from `main`.

## What changed

88 files, import blocks only: `toolshed` 55, `cli` 33. Statements merged where a
module was named twice, grouped standard library / external / internal with a
blank line between, each package's imports collated into one contiguous run, and
each run sorted.

This pair exercises two rules the earlier PRs in the series did not.

## The `@/` alias rule — all eleven instances in the tree are here

`toolshed` is the only package with `@/` violations, and this PR has all of
them:

- **Eight OAuth provider descriptors** (`airtable`, `discord`, `github`,
  `google`, `linear`, `notion`, `spotify`, `strava`) each pairing `@/env.ts`
  with `../oauth2-common/oauth2-common.types.ts` — the same file, addressed two
  ways in one statement block.
- **Three files under `routes/storage/memory/`** reaching `../memory.ts` and
  `../../../app.ts`.

Each becomes the `@/` form naming the same file. `@/` resolves to the package
root in `toolshed`, so `../memory.ts` from `routes/storage/memory/` becomes
`@/routes/storage/memory.ts`.

## Import attributes — the case that broke, now proven

`cli` and `toolshed` hold **four of the tree's nine** imports carrying an
attribute:

```ts
import ports from "@commonfabric/ports" with { type: "json" };
```

Three `cli` commands and `routes/shell/shell.index.ts`. An earlier revision of
the sweep tooling dropped that clause outright — its statement pattern stopped
at the specifier — which surfaced as a `shell` test failure and is fixed in
#5856. These four files are exactly the ones that would have broken next.

All four are intact, and the binding comparison now carries import attributes,
so a future drop is caught rather than shipped.

## Verification

- **88 files, zero binding differences**, where a binding is `(resolved module,
  type-ness, local name, import attributes)`.
- Audited the branch for both spacing defects: **0** glued file comments, **0**
  blank lines between consecutive bare imports.
- `deno fmt --check`, `deno lint`, `deno task check` all green.
- Suites: `cli` 174 passed, `toolshed` 137 passed. Both 0 failed.
- Re-censused: both packages read zero on all four required rules.

## Series

Done: #5854 (merged), #5855 (merged), #5856 (open), this one.

Remaining: `runner` 242, split into `src` (~95) and `test` (~147), and `ui` 62.

`packages/patterns` is excluded from every PR in this series: pattern source is
compiled and content-addressed, so an edit that looks inert can move a contract
and trip `pattern-compat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

