### PR TITLE
refactor: conform imports in `ui`

### DIFF
--- a/packages/ui/src/v2/components/cf-accordion/index.ts
+++ b/packages/ui/src/v2/components/cf-accordion/index.ts
@@ -1,6 +1,4 @@
-import { CFAccordion } from "./cf-accordion.ts";
-
-import { AccordionType } from "./cf-accordion.ts";
+import { AccordionType, CFAccordion } from "./cf-accordion.ts";
 
 if (!customElements.get("cf-accordion")) {
   customElements.define("cf-accordion", CFAccordion);

--- a/packages/ui/src/v2/components/cf-attachments-bar/cf-attachments-bar.ts
+++ b/packages/ui/src/v2/components/cf-attachments-bar/cf-attachments-bar.ts
@@ -1,7 +1,10 @@
 import { css, html } from "lit";
 import { property } from "lit/decorators.js";
+
 import { BaseElement } from "../../core/base-element.ts";
+
 import "../cf-chip/index.ts";
+
 import { isCellHandle } from "@commonfabric/runtime-client";
 
 /**

--- a/packages/ui/src/v2/components/cf-autocomplete/cf-autocomplete.ts
+++ b/packages/ui/src/v2/components/cf-autocomplete/cf-autocomplete.ts
@@ -1,18 +1,19 @@
+import type { Schema } from "@commonfabric/api/schema";
+import { stringArraySchema, stringSchema } from "@commonfabric/runner/schemas";
+import { type CellHandle, type JSONSchema } from "@commonfabric/runtime-client";
+import { consume } from "@lit/context";
 import { css, html, nothing, PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
+
 import { BaseElement } from "../../core/base-element.ts";
-import { consume } from "@lit/context";
+import { createCellController } from "../../core/cell-controller.ts";
 import {
   applyThemeToElement,
   type CFTheme,
   cfThemeContext,
   defaultTheme,
 } from "../theme-context.ts";
-import { type CellHandle, type JSONSchema } from "@commonfabric/runtime-client";
-import type { Schema } from "@commonfabric/api/schema";
-import { stringArraySchema, stringSchema } from "@commonfabric/runner/schemas";
-import { createCellController } from "../../core/cell-controller.ts";
 
 // TODO(v2-token-migration): Migrate this component to component-level tokens,
 // matching the prior phase-1 token migration pattern.

--- a/packages/ui/src/v2/components/cf-autocomplete/index.ts
+++ b/packages/ui/src/v2/components/cf-autocomplete/index.ts
@@ -1,6 +1,4 @@
-import { CFAutocomplete } from "./cf-autocomplete.ts";
-
-import { type AutocompleteItem } from "./cf-autocomplete.ts";
+import { type AutocompleteItem, CFAutocomplete } from "./cf-autocomplete.ts";
 
 if (!customElements.get("cf-autocomplete")) {
   customElements.define("cf-autocomplete", CFAutocomplete);

--- a/packages/ui/src/v2/components/cf-badge/index.ts
+++ b/packages/ui/src/v2/components/cf-badge/index.ts
@@ -1,6 +1,4 @@
-import { CFBadge } from "./cf-badge.ts";
-
-import { BadgeVariant } from "./cf-badge.ts";
+import { BadgeVariant, CFBadge } from "./cf-badge.ts";
 
 if (!customElements.get("cf-badge")) {
   customElements.define("cf-badge", CFBadge);

--- a/packages/ui/src/v2/components/cf-button/cf-button.ts
+++ b/packages/ui/src/v2/components/cf-button/cf-button.ts
@@ -1,8 +1,8 @@
+import { consume } from "@lit/context";
 import { html, type PropertyValues } from "lit";
-import { styles } from "./styles.ts";
 import { property } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
-import { consume } from "@lit/context";
+
 import { BaseElement } from "../../core/base-element.ts";
 import { oneOf } from "../../core/property-guards.ts";
 import {
@@ -13,6 +13,7 @@ import {
   type ComponentSize,
   defaultTheme,
 } from "../theme-context.ts";
+import { styles } from "./styles.ts";
 
 /**
  * CFButton - Interactive button element with multiple variants and sizes

--- a/packages/ui/src/v2/components/cf-button/index.ts
+++ b/packages/ui/src/v2/components/cf-button/index.ts
@@ -1,7 +1,5 @@
-import { CFButton } from "./cf-button.ts";
-
-import { ButtonSize, ButtonVariant } from "./cf-button.ts";
 import type { ColorIntent } from "../theme-context.ts";
+import { ButtonSize, ButtonVariant, CFButton } from "./cf-button.ts";
 
 if (!customElements.get("cf-button")) {
   customElements.define("cf-button", CFButton);

--- a/packages/ui/src/v2/components/cf-calendar/cf-calendar.ts
+++ b/packages/ui/src/v2/components/cf-calendar/cf-calendar.ts
@@ -1,10 +1,11 @@
+import { type CellHandle } from "@commonfabric/runtime-client";
 import { css, html, PropertyValues } from "lit";
+
 import { BaseElement } from "../../core/base-element.ts";
 import {
   createArrayCellController,
   createCellController,
 } from "../../core/cell-controller.ts";
-import { type CellHandle } from "@commonfabric/runtime-client";
 
 // TODO(v2-token-migration): Migrate this component to component-level tokens,
 // matching the prior phase-1 token migration pattern.

--- a/packages/ui/src/v2/components/cf-cell-context/cf-cell-context.ts
+++ b/packages/ui/src/v2/components/cf-cell-context/cf-cell-context.ts
@@ -1,7 +1,8 @@
-import { css } from "lit";
-import { RetiredElement } from "../../core/retired-element.ts";
 import type { CellHandle } from "@commonfabric/runtime-client";
+import { css } from "lit";
 import { property } from "lit/decorators.js";
+
+import { RetiredElement } from "../../core/retired-element.ts";
 
 /**
  * CFCellContext — RETIRED (#5132), kept as an inert passthrough.

--- a/packages/ui/src/v2/components/cf-cell-link/cf-cell-link.test.ts
+++ b/packages/ui/src/v2/components/cf-cell-link/cf-cell-link.test.ts
@@ -1,10 +1,12 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { CFCellLink } from "./index.ts";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import type { CellRef } from "@commonfabric/runtime-client";
+
+import { endDrag, getCurrentDrag, isDragging } from "../../core/drag-state.ts";
 import { installMockDocument } from "../../test-utils/mock-document.ts";
 import { createRenderableCellHandle } from "../../test-utils/mock-vdom-connection.ts";
-import { endDrag, getCurrentDrag, isDragging } from "../../core/drag-state.ts";
+import { CFCellLink } from "./index.ts";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;

--- a/packages/ui/src/v2/components/cf-cell-link/cf-cell-link.ts
+++ b/packages/ui/src/v2/components/cf-cell-link/cf-cell-link.ts
@@ -1,8 +1,12 @@
+import { consume } from "@lit/context";
 import { css, html, PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
-import { consume } from "@lit/context";
+
 import { BaseElement } from "../../core/base-element.ts";
+
 import "../cf-chip/index.ts";
+
+import type { DID } from "@commonfabric/identity";
 import {
   type CellHandle,
   CellRef,
@@ -11,15 +15,15 @@ import {
   parseLLMFriendlyLink,
   type RuntimeClient,
 } from "@commonfabric/runtime-client";
-import type { DID } from "@commonfabric/identity";
-import { runtimeContext, spaceContext } from "../../runtime-context.ts";
 import { navigate, openInNewTab } from "@commonfabric/shell/shared";
+
 import {
   createDragPreview,
   endDrag,
   startDrag,
   updateDragPointer,
 } from "../../core/drag-state.ts";
+import { runtimeContext, spaceContext } from "../../runtime-context.ts";
 
 /**
  * CFCellLink - Renders a link or cell as a clickable, draggable pill

--- a/packages/ui/src/v2/components/cf-cfc-authorship/cf-cfc-authorship.test.ts
+++ b/packages/ui/src/v2/components/cf-cfc-authorship/cf-cfc-authorship.test.ts
@@ -1,6 +1,7 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
 import { FakeTime } from "@std/testing/time";
+
 import {
   authorshipStateForLabel,
   CFCFCAuthorship,

--- a/packages/ui/src/v2/components/cf-cfc-authorship/cf-cfc-authorship.ts
+++ b/packages/ui/src/v2/components/cf-cfc-authorship/cf-cfc-authorship.ts
@@ -1,7 +1,8 @@
+import type { CfcLabelView } from "@commonfabric/runner/cfc";
 import { css, html } from "lit";
+
 import { BaseElement } from "../../core/base-element.ts";
 import { initialsForName } from "../cf-avatar/index.ts";
-import type { CfcLabelView } from "@commonfabric/runner/cfc";
 
 export type CfcAuthorshipState = "verified" | "unverified" | "unknown";
 

--- a/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.ts
+++ b/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.ts
@@ -1,6 +1,7 @@
-import { css, html } from "lit";
-import { BaseElement } from "../../core/base-element.ts";
 import type { CfcLabelView } from "@commonfabric/runtime-client";
+import { css, html } from "lit";
+
+import { BaseElement } from "../../core/base-element.ts";
 
 type LabelKey = "confidentiality" | "integrity";
 

--- a/packages/ui/src/v2/components/cf-chat-message/cf-chat-message.ts
+++ b/packages/ui/src/v2/components/cf-chat-message/cf-chat-message.ts
@@ -1,11 +1,14 @@
+import { consume } from "@lit/context";
 import { css, html } from "lit";
 import { property } from "lit/decorators.js";
-import { consume } from "@lit/context";
+
 import { BaseElement } from "../../core/base-element.ts";
+
 import "../cf-tool-call/index.ts";
 import "../cf-button/index.ts";
 import "../cf-copy-button/index.ts";
 import "../cf-markdown/index.ts";
+
 import type {
   BuiltInLLMContent,
   BuiltInLLMTextPart,
@@ -13,6 +16,7 @@ import type {
   BuiltInLLMToolResultPart,
 } from "@commonfabric/api";
 import { type CellHandle, isCellHandle } from "@commonfabric/runtime-client";
+
 import {
   applyThemeToElement,
   type CFTheme,

--- a/packages/ui/src/v2/components/cf-chat/cf-chat.ts
+++ b/packages/ui/src/v2/components/cf-chat/cf-chat.ts
@@ -1,16 +1,20 @@
+import { type CellHandle, type JSONSchema } from "@commonfabric/runtime-client";
+import { consume } from "@lit/context";
 import { css, html } from "lit";
 import { property } from "lit/decorators.js";
-import { consume } from "@lit/context";
+
 import { BaseElement } from "../../core/base-element.ts";
-import { type CellHandle, type JSONSchema } from "@commonfabric/runtime-client";
 import { createCellController } from "../../core/cell-controller.ts";
+
 import "../cf-chat-message/index.ts";
 import "../cf-tool-call/index.ts";
+
 import type {
   BuiltInLLMMessage,
   BuiltInLLMToolCallPart,
   BuiltInLLMToolResultPart,
 } from "@commonfabric/api";
+
 import {
   applyThemeToElement,
   type CFTheme,

--- a/packages/ui/src/v2/components/cf-checkbox/cf-checkbox.ts
+++ b/packages/ui/src/v2/components/cf-checkbox/cf-checkbox.ts
@@ -1,8 +1,9 @@
+import { booleanSchema } from "@commonfabric/runner/schemas";
+import { type CellHandle } from "@commonfabric/runtime-client";
 import { css, html, LitElement } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
+
 import { BaseElement } from "../../core/base-element.ts";
-import { type CellHandle } from "@commonfabric/runtime-client";
-import { booleanSchema } from "@commonfabric/runner/schemas";
 import { createBooleanCellController } from "../../core/cell-controller.ts";
 import { createFormFieldController } from "../../core/form-field-controller.ts";
 

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -1,7 +1,45 @@
-import { html, PropertyValues } from "lit";
-import { property } from "lit/decorators.js";
-import { BaseElement } from "../../core/base-element.ts";
-import { styles } from "./styles.ts";
+import {
+  autocompletion,
+  closeBrackets,
+  closeBracketsKeymap,
+  Completion,
+  CompletionContext,
+  completionKeymap,
+  CompletionResult,
+  completionStatus,
+  startCompletion,
+} from "@codemirror/autocomplete";
+import {
+  defaultKeymap,
+  history,
+  historyKeymap,
+  indentWithTab,
+} from "@codemirror/commands";
+import { css as createCss } from "@codemirror/lang-css";
+import { html as createHtml } from "@codemirror/lang-html";
+import { javascript as createJavaScript } from "@codemirror/lang-javascript";
+import { json as createJson } from "@codemirror/lang-json";
+import { markdown as createMarkdown } from "@codemirror/lang-markdown";
+import {
+  bracketMatching,
+  defaultHighlightStyle,
+  foldGutter,
+  foldKeymap,
+  indentOnInput,
+  indentUnit,
+  LanguageSupport,
+  syntaxHighlighting,
+} from "@codemirror/language";
+import { lintKeymap } from "@codemirror/lint";
+import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
+import {
+  Annotation,
+  Compartment,
+  EditorState,
+  Extension,
+  Prec,
+} from "@codemirror/state";
+import { oneDark } from "@codemirror/theme-one-dark";
 import {
   crosshairCursor,
   drawSelection,
@@ -15,70 +53,23 @@ import {
   placeholder,
   rectangularSelection,
 } from "@codemirror/view";
-import {
-  defaultKeymap,
-  history,
-  historyKeymap,
-  indentWithTab,
-} from "@codemirror/commands";
-import {
-  Annotation,
-  Compartment,
-  EditorState,
-  Extension,
-  Prec,
-} from "@codemirror/state";
-import {
-  bracketMatching,
-  defaultHighlightStyle,
-  foldGutter,
-  foldKeymap,
-  indentOnInput,
-  indentUnit,
-  LanguageSupport,
-  syntaxHighlighting,
-} from "@codemirror/language";
-import { javascript as createJavaScript } from "@codemirror/lang-javascript";
-import { markdown as createMarkdown } from "@codemirror/lang-markdown";
-import { GFM } from "@lezer/markdown";
-import { css as createCss } from "@codemirror/lang-css";
-import { html as createHtml } from "@codemirror/lang-html";
-import { json as createJson } from "@codemirror/lang-json";
-import { oneDark } from "@codemirror/theme-one-dark";
-
-import {
-  autocompletion,
-  closeBrackets,
-  closeBracketsKeymap,
-  Completion,
-  CompletionContext,
-  completionKeymap,
-  CompletionResult,
-  completionStatus,
-  startCompletion,
-} from "@codemirror/autocomplete";
-import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
-import { lintKeymap } from "@codemirror/lint";
+import type { DID } from "@commonfabric/identity";
+import { parseFabricUrl } from "@commonfabric/runner/fabric-url";
+import { stringSchema } from "@commonfabric/runner/schemas";
 import {
   type CellHandle,
   isCellHandle,
   NAME,
   type RuntimeClient,
 } from "@commonfabric/runtime-client";
-import { stringSchema } from "@commonfabric/runner/schemas";
-import { type InputTimingOptions } from "../../core/input-timing-controller.ts";
-import { createStringCellController } from "../../core/cell-controller.ts";
+import { GFM } from "@lezer/markdown";
 import { consume } from "@lit/context";
-import { runtimeContext, spaceContext } from "../../runtime-context.ts";
-import type { DID } from "@commonfabric/identity";
-import { type StoredFile, uploadFile } from "../../utils/file-cell-storage.ts";
-import { mentionIdFromCellId } from "../../utils/mention-id.ts";
-import {
-  Mentionable,
-  MentionableArray,
-  MentionableArraySchema,
-  MentionableSchema,
-} from "../../core/mentionable.ts";
+import { html, PropertyValues } from "lit";
+import { property } from "lit/decorators.js";
+
+import { BaseElement } from "../../core/base-element.ts";
+import { createStringCellController } from "../../core/cell-controller.ts";
+import { type InputTimingOptions } from "../../core/input-timing-controller.ts";
 import {
   dedupeByDestination,
   labelForToken,
@@ -88,12 +79,20 @@ import {
   mintRefKey,
 } from "../../core/mention-refs.ts";
 import {
+  Mentionable,
+  MentionableArray,
+  MentionableArraySchema,
+  MentionableSchema,
+} from "../../core/mentionable.ts";
+import { runtimeContext, spaceContext } from "../../runtime-context.ts";
+import { type StoredFile, uploadFile } from "../../utils/file-cell-storage.ts";
+import { mentionIdFromCellId } from "../../utils/mention-id.ts";
+import {
   atomicBacklinkRanges,
   backlinkEditFilter,
   backlinkField,
   createBacklinkDecorationPlugin,
 } from "./features/backlinks.ts";
-import { parseFabricUrl } from "@commonfabric/runner/fabric-url";
 import {
   atomicMentionRefRanges,
   createMentionRefDecorationPlugin,
@@ -106,6 +105,7 @@ import {
   setKnownRefKeys,
 } from "./features/mention-refs.ts";
 import { createProseMarkdownPlugin } from "./features/prose-markdown.ts";
+import { styles } from "./styles.ts";
 
 /** A unique noteId, so notes created from a mention do not collide. */
 function generateNoteId(): string {

--- a/packages/ui/src/v2/components/cf-code-editor/index.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/index.ts
@@ -1,6 +1,4 @@
-import { CFCodeEditor } from "./cf-code-editor.ts";
-
-import { MimeType } from "./cf-code-editor.ts";
+import { CFCodeEditor, MimeType } from "./cf-code-editor.ts";
 
 if (!customElements.get("cf-code-editor")) {
   customElements.define("cf-code-editor", CFCodeEditor);

--- a/packages/ui/src/v2/components/cf-drag-source/cf-drag-source.ts
+++ b/packages/ui/src/v2/components/cf-drag-source/cf-drag-source.ts
@@ -1,5 +1,7 @@
+import type { CellHandle } from "@commonfabric/runtime-client";
 import { css, html, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
+
 import { BaseElement } from "../../core/base-element.ts";
 import {
   createDragPreview,
@@ -7,7 +9,6 @@ import {
   startDrag,
   updateDragPointer,
 } from "../../core/drag-state.ts";
-import type { CellHandle } from "@commonfabric/runtime-client";
 
 /**
  * CFDragSource - Wraps draggable content and initiates drag operations

--- a/packages/ui/src/v2/components/cf-fab/cf-fab.ts
+++ b/packages/ui/src/v2/components/cf-fab/cf-fab.ts
@@ -1,10 +1,12 @@
-import { css, html, nothing } from "lit";
-import { property, state } from "lit/decorators.js";
-import { BaseElement } from "../../core/base-element.ts";
+import { stringSchema } from "@commonfabric/runner/schemas";
 import type { CellHandle } from "@commonfabric/runtime-client";
 import { isCellHandle } from "@commonfabric/runtime-client";
+import { css, html, nothing } from "lit";
+import { property, state } from "lit/decorators.js";
+
+import { BaseElement } from "../../core/base-element.ts";
 import { fabAnimations } from "./styles.ts";
-import { stringSchema } from "@commonfabric/runner/schemas";
+
 // Side-effect import to ensure cf-message-beads is registered
 import "../cf-message-beads/index.ts";
 

--- a/packages/ui/src/v2/components/cf-file-download/cf-file-download.ts
+++ b/packages/ui/src/v2/components/cf-file-download/cf-file-download.ts
@@ -1,8 +1,10 @@
+import { type CellHandle } from "@commonfabric/runtime-client";
 import { css, html, type PropertyValues } from "lit";
 import { state } from "lit/decorators.js";
+
 import { BaseElement } from "../../core/base-element.ts";
-import { type CellHandle } from "@commonfabric/runtime-client";
 import { createStringCellController } from "../../core/cell-controller.ts";
+
 import "../cf-button/index.ts";
 
 /**

--- a/packages/ui/src/v2/components/cf-file-input/cf-file-input.ts
+++ b/packages/ui/src/v2/components/cf-file-input/cf-file-input.ts
@@ -1,23 +1,25 @@
-import { css, html, type TemplateResult } from "lit";
-import { property, state } from "lit/decorators.js";
-import { BaseElement } from "../../core/base-element.ts";
-import type { ButtonSize, ButtonVariant } from "../cf-button/cf-button.ts";
+import type { DID } from "@commonfabric/identity";
 import type { RuntimeClient } from "@commonfabric/runtime-client";
 import { consume } from "@lit/context";
+import { css, html, type TemplateResult } from "lit";
+import { property, state } from "lit/decorators.js";
+
+import { BaseElement } from "../../core/base-element.ts";
+import { runtimeContext, spaceContext } from "../../runtime-context.ts";
+import {
+  type StoredFile,
+  type StoreFileOptions,
+  uploadFile,
+} from "../../utils/file-cell-storage.ts";
+import { formatFileSize } from "../../utils/image-compression.ts";
+import type { ButtonSize, ButtonVariant } from "../cf-button/cf-button.ts";
 import {
   applyThemeToElement,
   type CFTheme,
   cfThemeContext,
   defaultTheme,
 } from "../theme-context.ts";
-import { formatFileSize } from "../../utils/image-compression.ts";
-import { runtimeContext, spaceContext } from "../../runtime-context.ts";
-import type { DID } from "@commonfabric/identity";
-import {
-  type StoredFile,
-  type StoreFileOptions,
-  uploadFile,
-} from "../../utils/file-cell-storage.ts";
+
 import "../cf-button/index.ts";
 
 export type FileData = StoredFile;

--- a/packages/ui/src/v2/components/cf-heading/cf-heading.ts
+++ b/packages/ui/src/v2/components/cf-heading/cf-heading.ts
@@ -1,7 +1,8 @@
+import { consume } from "@lit/context";
 import { css, html } from "lit";
 import { property } from "lit/decorators.js";
+
 import { BaseElement } from "../../core/base-element.ts";
-import { consume } from "@lit/context";
 import {
   applyThemeToElement,
   type CFTheme,

--- a/packages/ui/src/v2/components/cf-iframe/cf-iframe.ts
+++ b/packages/ui/src/v2/components/cf-iframe/cf-iframe.ts
@@ -1,9 +1,10 @@
-import { css, html } from "lit";
-import { BaseElement } from "../../core/base-element.ts";
 import {
   CommonIframeSandboxElement as _,
   IPC,
 } from "@commonfabric/iframe-sandbox";
+import { css, html } from "lit";
+
+import { BaseElement } from "../../core/base-element.ts";
 
 /**
  * CFIframe - An iframe to execute arbitrary scripts

--- a/packages/ui/src/v2/components/cf-input/cf-input.ts
+++ b/packages/ui/src/v2/components/cf-input/cf-input.ts
@@ -1,8 +1,14 @@
-import { css, html } from "lit";
-import { ifDefined } from "lit/directives/if-defined.js";
-import { property } from "lit/decorators.js";
-import { BaseElement } from "../../core/base-element.ts";
+import { stringSchema } from "@commonfabric/runner/schemas";
+import { type CellHandle } from "@commonfabric/runtime-client";
 import { consume } from "@lit/context";
+import { css, html } from "lit";
+import { property } from "lit/decorators.js";
+import { ifDefined } from "lit/directives/if-defined.js";
+
+import { BaseElement } from "../../core/base-element.ts";
+import { createStringCellController } from "../../core/cell-controller.ts";
+import { createFormFieldController } from "../../core/form-field-controller.ts";
+import { type InputTimingOptions } from "../../core/input-timing-controller.ts";
 import {
   applyThemeToElement,
   type CFTheme,
@@ -10,11 +16,6 @@ import {
   type ComponentSize,
   defaultTheme,
 } from "../theme-context.ts";
-import { type CellHandle } from "@commonfabric/runtime-client";
-import { stringSchema } from "@commonfabric/runner/schemas";
-import { type InputTimingOptions } from "../../core/input-timing-controller.ts";
-import { createStringCellController } from "../../core/cell-controller.ts";
-import { createFormFieldController } from "../../core/form-field-controller.ts";
 
 /**
  * CFInput - Enhanced input field with support for various types, validation patterns, and reactive data binding

--- a/packages/ui/src/v2/components/cf-input/index.ts
+++ b/packages/ui/src/v2/components/cf-input/index.ts
@@ -1,6 +1,4 @@
-import { CFInput } from "./cf-input.ts";
-
-import { InputType } from "./cf-input.ts";
+import { CFInput, InputType } from "./cf-input.ts";
 
 if (!customElements.get("cf-input")) {
   customElements.define("cf-input", CFInput);

--- a/packages/ui/src/v2/components/cf-loader/index.ts
+++ b/packages/ui/src/v2/components/cf-loader/index.ts
@@ -1,6 +1,4 @@
-import { CFLoader } from "./cf-loader.ts";
-
-import { LoaderSize } from "./cf-loader.ts";
+import { CFLoader, LoaderSize } from "./cf-loader.ts";
 
 if (!customElements.get("cf-loader")) {
   customElements.define("cf-loader", CFLoader);

--- a/packages/ui/src/v2/components/cf-location/cf-location.ts
+++ b/packages/ui/src/v2/components/cf-location/cf-location.ts
@@ -1,17 +1,18 @@
+import type { Schema } from "@commonfabric/api/schema";
+import { type CellHandle, type JSONSchema } from "@commonfabric/runtime-client";
+import { consume } from "@lit/context";
 import { css, html } from "lit";
 import { property, state } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
+
 import { BaseElement } from "../../core/base-element.ts";
-import { type CellHandle, type JSONSchema } from "@commonfabric/runtime-client";
-import type { Schema } from "@commonfabric/api/schema";
 import { createCellController } from "../../core/cell-controller.ts";
-import { consume } from "@lit/context";
 import {
   applyThemeToElement,
   type CFTheme,
   cfThemeContext,
   defaultTheme,
 } from "../theme-context.ts";
-import { classMap } from "lit/directives/class-map.js";
 
 // Schema for LocationData
 const LocationDataSchema = {

--- a/packages/ui/src/v2/components/cf-map/cf-map.ts
+++ b/packages/ui/src/v2/components/cf-map/cf-map.ts
@@ -5,13 +5,14 @@
  * Uses OpenStreetMap tiles (no API key required).
  */
 
-import { html, PropertyValues } from "lit";
-import { BaseElement } from "../../core/base-element.ts";
-import { styles } from "./styles.ts";
+import { type CellHandle, type JSONSchema } from "@commonfabric/runtime-client";
 // @ts-types="@types/leaflet"
 import * as L from "leaflet";
-import { type CellHandle, type JSONSchema } from "@commonfabric/runtime-client";
+import { html, PropertyValues } from "lit";
+
+import { BaseElement } from "../../core/base-element.ts";
 import { createCellController } from "../../core/cell-controller.ts";
+import { styles } from "./styles.ts";
 import type {
   Bounds,
   CfBoundsChangeDetail,
@@ -25,6 +26,7 @@ import type {
   MapPolyline,
   MapValue,
 } from "./types.ts";
+
 import "../cf-render/index.ts";
 
 // Default map configuration

--- a/packages/ui/src/v2/components/cf-markdown/cf-markdown.ts
+++ b/packages/ui/src/v2/components/cf-markdown/cf-markdown.ts
@@ -1,20 +1,24 @@
+import { consume } from "@lit/context";
 import { css, html } from "lit";
 import { property } from "lit/decorators.js";
-import { consume } from "@lit/context";
-import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { classMap } from "lit/directives/class-map.js";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { marked } from "marked";
-import { HeadingIdRenderer } from "./heading-id.ts";
+
 import { BaseElement } from "../../core/base-element.ts";
+import { HeadingIdRenderer } from "./heading-id.ts";
+
 import "../cf-copy-button/index.ts";
 import "../cf-cell-link/index.ts";
+
+import { type CellHandle, isCellHandle } from "@commonfabric/runtime-client";
+
 import {
   applyThemeToElement,
   type CFTheme,
   cfThemeContext,
   defaultTheme,
 } from "../theme-context.ts";
-import { type CellHandle, isCellHandle } from "@commonfabric/runtime-client";
 
 export type MarkdownVariant = "default" | "inverse";
 

--- a/packages/ui/src/v2/components/cf-message-beads/cf-message-beads.ts
+++ b/packages/ui/src/v2/components/cf-message-beads/cf-message-beads.ts
@@ -1,14 +1,15 @@
-import { css, html, nothing, render } from "lit";
-import { property } from "lit/decorators.js";
-import { BaseElement } from "../../core/base-element.ts";
-import { type CellHandle, type JSONSchema } from "@commonfabric/runtime-client";
-import { createCellController } from "../../core/cell-controller.ts";
 import type {
   BuiltInLLMContentPart,
   BuiltInLLMMessage,
   BuiltInLLMToolCallPart,
   BuiltInLLMToolResultPart,
 } from "@commonfabric/api";
+import { type CellHandle, type JSONSchema } from "@commonfabric/runtime-client";
+import { css, html, nothing, render } from "lit";
+import { property } from "lit/decorators.js";
+
+import { BaseElement } from "../../core/base-element.ts";
+import { createCellController } from "../../core/cell-controller.ts";
 
 const MessagesSchema = {
   type: "array",

--- a/packages/ui/src/v2/components/cf-modal/cf-modal.ts
+++ b/packages/ui/src/v2/components/cf-modal/cf-modal.ts
@@ -51,12 +51,14 @@
  * </cf-modal>
  * ```
  */
+
+import { CellHandle } from "@commonfabric/runtime-client";
 import { html, nothing, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
+
 import { BaseElement } from "../../core/base-element.ts";
 import { createBooleanCellController } from "../../core/cell-controller.ts";
 import { modalStyles } from "./styles.ts";
-import { CellHandle } from "@commonfabric/runtime-client";
 
 /** Z-index for an open modal: the `--cf-z-layer-overlay` token's value. */
 const MODAL_Z_INDEX = 1000;

--- a/packages/ui/src/v2/components/cf-oauth/cf-oauth.ts
+++ b/packages/ui/src/v2/components/cf-oauth/cf-oauth.ts
@@ -1,6 +1,7 @@
-import { css, html } from "lit";
-import { BaseElement } from "../../core/base-element.ts";
 import type { CellHandle } from "@commonfabric/runtime-client";
+import { css, html } from "lit";
+
+import { BaseElement } from "../../core/base-element.ts";
 import { CFPiece } from "../cf-piece/index.ts";
 
 export interface OAuthData {

--- a/packages/ui/src/v2/components/cf-picker/cf-picker.ts
+++ b/packages/ui/src/v2/components/cf-picker/cf-picker.ts
@@ -1,11 +1,13 @@
+import { numberSchema } from "@commonfabric/runner/schemas";
+import { type CellHandle } from "@commonfabric/runtime-client";
 import { css, html, PropertyValues } from "lit";
+
 import { BaseElement } from "../../core/base-element.ts";
 import {
   createArrayCellController,
   createCellController,
 } from "../../core/cell-controller.ts";
-import { type CellHandle } from "@commonfabric/runtime-client";
-import { numberSchema } from "@commonfabric/runner/schemas";
+
 import "../cf-render/index.ts";
 
 /**

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
@@ -1,7 +1,10 @@
-import { css, html, nothing, type TemplateResult } from "lit";
-import { state } from "lit/decorators.js";
-import { live } from "lit/directives/live.js";
-import { BaseElement } from "../../core/base-element.ts";
+import {
+  getPieceBoundary,
+  subscribePieceBoundary,
+} from "@commonfabric/html/client";
+import type { DID } from "@commonfabric/identity";
+import { isDID } from "@commonfabric/identity";
+import { parseFabricRef } from "@commonfabric/runner/shared";
 import {
   $conn,
   CellHandle,
@@ -17,9 +20,6 @@ import type {
   SpaceAclCapability,
   SpaceAclView,
 } from "@commonfabric/runtime-client";
-import type { DID } from "@commonfabric/identity";
-import { isDID } from "@commonfabric/identity";
-import { parseFabricRef } from "@commonfabric/runner/shared";
 import {
   appViewToUrlPath,
   navigate,
@@ -28,10 +28,11 @@ import {
   preserveAppViewMode,
   urlToAppView,
 } from "@commonfabric/shell/shared";
-import {
-  getPieceBoundary,
-  subscribePieceBoundary,
-} from "@commonfabric/html/client";
+import { css, html, nothing, type TemplateResult } from "lit";
+import { state } from "lit/decorators.js";
+import { live } from "lit/directives/live.js";
+
+import { BaseElement } from "../../core/base-element.ts";
 import {
   describeOrigin,
   formatTimestamp,

--- a/packages/ui/src/v2/components/cf-plaid-link/cf-plaid-link.ts
+++ b/packages/ui/src/v2/components/cf-plaid-link/cf-plaid-link.ts
@@ -1,6 +1,7 @@
-import { css, html } from "lit";
-import { BaseElement } from "../../core/base-element.ts";
 import { CellHandle } from "@commonfabric/runtime-client";
+import { css, html } from "lit";
+
+import { BaseElement } from "../../core/base-element.ts";
 import { CFPiece } from "../cf-piece/index.ts";
 
 declare global {

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -1,19 +1,23 @@
+import { consume } from "@lit/context";
 import { css, html, nothing, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
-import { consume } from "@lit/context";
+
 import { BaseElement } from "../../core/base-element.ts";
+
 import "../cf-avatar/index.ts";
-import type { AvatarSize } from "../cf-avatar/cf-avatar.ts";
+
+import type { DID } from "@commonfabric/identity";
 import {
   type CellHandle,
   type CfcLabelView,
   NAME,
   type RuntimeClient,
 } from "@commonfabric/runtime-client";
-import type { DID } from "@commonfabric/identity";
 import { navigate, openInNewTab } from "@commonfabric/shell/shared";
-import { runtimeContext, spaceContext } from "../../runtime-context.ts";
+
 import { ownerPrincipalFromLabel } from "../../core/cfc-label.ts";
+import { runtimeContext, spaceContext } from "../../runtime-context.ts";
+import type { AvatarSize } from "../cf-avatar/cf-avatar.ts";
 import { type IdentitySeal, identitySeal } from "./identity-seal.ts";
 import {
   registerSeal,

--- a/packages/ui/src/v2/components/cf-radio-group/cf-radio-group.ts
+++ b/packages/ui/src/v2/components/cf-radio-group/cf-radio-group.ts
@@ -63,12 +63,12 @@
  * - clear() - Clear the selection
  */
 
+import { type CellHandle } from "@commonfabric/runtime-client";
+import { consume } from "@lit/context";
 import { html, PropertyValues, unsafeCSS } from "lit";
 import { property } from "lit/decorators.js";
-import { consume } from "@lit/context";
+
 import { BaseElement } from "../../core/base-element.ts";
-import { radioGroupStyles } from "./styles.ts";
-import { type CellHandle } from "@commonfabric/runtime-client";
 import { createCellController } from "../../core/cell-controller.ts";
 import {
   applyThemeToElement,
@@ -76,6 +76,7 @@ import {
   cfThemeContext,
   defaultTheme,
 } from "../theme-context.ts";
+import { radioGroupStyles } from "./styles.ts";
 
 // TODO(v2-token-migration): Migrate this component to component-level tokens,
 // matching the prior phase-1 token migration pattern.

--- a/packages/ui/src/v2/components/cf-render/cf-render.test.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.test.ts
@@ -1,9 +1,11 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { defer } from "@commonfabric/utils/defer";
-import { createMockCellHandle } from "../../test-utils/mock-cell-handle.ts";
+import { describe, it } from "@std/testing/bdd";
+
 import type { CellHandle } from "@commonfabric/runtime-client";
+import { defer } from "@commonfabric/utils/defer";
+
 import { providePieceBoundary } from "../../../../../html/src/main/space-context.ts";
+import { createMockCellHandle } from "../../test-utils/mock-cell-handle.ts";
 import {
   CFRender,
   hasVariantValue,

--- a/packages/ui/src/v2/components/cf-render/cf-render.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.ts
@@ -1,8 +1,5 @@
-import { css, html, PropertyValues } from "lit";
-import { createRef, type Ref, ref } from "lit/directives/ref.js";
-import { state } from "lit/decorators.js";
-import { BaseElement } from "../../core/base-element.ts";
 import { getPieceBoundary, render } from "@commonfabric/html/client";
+import type { DID } from "@commonfabric/identity";
 import {
   type CellHandle,
   CHIP_UI,
@@ -11,10 +8,16 @@ import {
   type VNode,
 } from "@commonfabric/runtime-client";
 import { navigate, openInNewTab } from "@commonfabric/shell/shared";
-import type { DID } from "@commonfabric/identity";
+import { css, html, PropertyValues } from "lit";
+import { state } from "lit/decorators.js";
+import { createRef, type Ref, ref } from "lit/directives/ref.js";
+
+import { BaseElement } from "../../core/base-element.ts";
+
 import "../cf-loader/index.ts";
 import "../cf-cell-link/index.ts";
 import "../cf-piece-menu/index.ts";
+
 import {
   closePieceMenuFor,
   openPieceMenu,

--- a/packages/ui/src/v2/components/cf-router/cf-router.ts
+++ b/packages/ui/src/v2/components/cf-router/cf-router.ts
@@ -1,7 +1,8 @@
-import { html } from "lit";
-import { BaseElement } from "../../core/base-element.ts";
-import { property } from "lit/decorators.js";
 import { type CellHandle, isCellHandle } from "@commonfabric/runtime-client";
+import { html } from "lit";
+import { property } from "lit/decorators.js";
+
+import { BaseElement } from "../../core/base-element.ts";
 
 export class CFRouter extends BaseElement {
   @property({ attribute: false })

--- a/packages/ui/src/v2/components/cf-scroll-area/index.ts
+++ b/packages/ui/src/v2/components/cf-scroll-area/index.ts
@@ -1,6 +1,4 @@
-import { CFScrollArea } from "./cf-scroll-area.ts";
-
-import { ScrollOrientation } from "./cf-scroll-area.ts";
+import { CFScrollArea, ScrollOrientation } from "./cf-scroll-area.ts";
 
 if (!customElements.get("cf-scroll-area")) {
   customElements.define("cf-scroll-area", CFScrollArea);

--- a/packages/ui/src/v2/components/cf-select/cf-select.ts
+++ b/packages/ui/src/v2/components/cf-select/cf-select.ts
@@ -1,8 +1,12 @@
+import { type CellHandle } from "@commonfabric/runtime-client";
+import { consume } from "@lit/context";
 import { css, html, nothing } from "lit";
 import { property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
+
 import { BaseElement } from "../../core/base-element.ts";
-import { consume } from "@lit/context";
+import { createCellController } from "../../core/cell-controller.ts";
+import { createFormFieldController } from "../../core/form-field-controller.ts";
 import {
   applyThemeToElement,
   type CFTheme,
@@ -10,9 +14,6 @@ import {
   type ComponentSize,
   defaultTheme,
 } from "../theme-context.ts";
-import { type CellHandle } from "@commonfabric/runtime-client";
-import { createCellController } from "../../core/cell-controller.ts";
-import { createFormFieldController } from "../../core/form-field-controller.ts";
 
 /**
  * CFSelect – Dropdown/select component that accepts an array of generic JS objects

--- a/packages/ui/src/v2/components/cf-separator/index.ts
+++ b/packages/ui/src/v2/components/cf-separator/index.ts
@@ -1,6 +1,4 @@
-import { CFSeparator } from "./cf-separator.ts";
-
-import { SeparatorOrientation } from "./cf-separator.ts";
+import { CFSeparator, SeparatorOrientation } from "./cf-separator.ts";
 
 if (!customElements.get("cf-separator")) {
   customElements.define("cf-separator", CFSeparator);

--- a/packages/ui/src/v2/components/cf-skeleton/index.ts
+++ b/packages/ui/src/v2/components/cf-skeleton/index.ts
@@ -1,6 +1,4 @@
-import { CFSkeleton } from "./cf-skeleton.ts";
-
-import { SkeletonVariant } from "./cf-skeleton.ts";
+import { CFSkeleton, SkeletonVariant } from "./cf-skeleton.ts";
 import { skeletonStyles } from "./styles.ts";
 
 if (!customElements.get("cf-skeleton")) {

--- a/packages/ui/src/v2/components/cf-slider/index.ts
+++ b/packages/ui/src/v2/components/cf-slider/index.ts
@@ -1,6 +1,4 @@
-import { CFSlider } from "./cf-slider.ts";
-
-import { SliderOrientation } from "./cf-slider.ts";
+import { CFSlider, SliderOrientation } from "./cf-slider.ts";
 
 if (!customElements.get("cf-slider")) {
   customElements.define("cf-slider", CFSlider);

--- a/packages/ui/src/v2/components/cf-space-link/cf-space-link.ts
+++ b/packages/ui/src/v2/components/cf-space-link/cf-space-link.ts
@@ -1,7 +1,10 @@
 import { css, html } from "lit";
 import { property } from "lit/decorators.js";
+
 import { BaseElement } from "../../core/base-element.ts";
+
 import "../cf-chip/index.ts";
+
 import type { DID } from "@commonfabric/identity";
 import { navigate } from "@commonfabric/shell/shared";
 

--- a/packages/ui/src/v2/components/cf-svg/cf-svg.ts
+++ b/packages/ui/src/v2/components/cf-svg/cf-svg.ts
@@ -1,8 +1,9 @@
+import { type CellHandle, isCellHandle } from "@commonfabric/runtime-client";
 import { css, html } from "lit";
 import { property } from "lit/decorators.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
+
 import { BaseElement } from "../../core/base-element.ts";
-import { type CellHandle, isCellHandle } from "@commonfabric/runtime-client";
 import { sanitizeSvg } from "./sanitize-svg.ts";
 
 // TODO(v2-token-migration): Migrate this component to component-level tokens,

--- a/packages/ui/src/v2/components/cf-switch/cf-switch.ts
+++ b/packages/ui/src/v2/components/cf-switch/cf-switch.ts
@@ -1,8 +1,9 @@
+import { booleanSchema } from "@commonfabric/runner/schemas";
+import { type CellHandle } from "@commonfabric/runtime-client";
 import { css, html, LitElement } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
+
 import { BaseElement } from "../../core/base-element.ts";
-import { type CellHandle } from "@commonfabric/runtime-client";
-import { booleanSchema } from "@commonfabric/runner/schemas";
 import { createBooleanCellController } from "../../core/cell-controller.ts";
 
 /**

--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
@@ -137,14 +137,16 @@ g.cancelAnimationFrame = () => {};
 
 // ---------------------------------------------------------------------------
 
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
 import { stringSchema } from "@commonfabric/runner/schemas";
+import type { CellHandle } from "@commonfabric/runtime-client";
+
 import {
   createMockCellHandle,
   pushUpdate,
 } from "../../test-utils/mock-cell-handle.ts";
-import type { CellHandle } from "@commonfabric/runtime-client";
 import { CFTabs } from "./index.ts";
 
 /**

--- a/packages/ui/src/v2/components/cf-textarea/cf-textarea.ts
+++ b/packages/ui/src/v2/components/cf-textarea/cf-textarea.ts
@@ -1,8 +1,13 @@
+import { stringSchema } from "@commonfabric/runner/schemas";
+import { type CellHandle } from "@commonfabric/runtime-client";
+import { consume } from "@lit/context";
 import { css, html } from "lit";
 import { property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
+
 import { BaseElement } from "../../core/base-element.ts";
-import { consume } from "@lit/context";
+import { createStringCellController } from "../../core/cell-controller.ts";
+import { createFormFieldController } from "../../core/form-field-controller.ts";
 import {
   applyThemeToElement,
   type CFTheme,
@@ -10,10 +15,6 @@ import {
   type ComponentSize,
   defaultTheme,
 } from "../theme-context.ts";
-import { type CellHandle } from "@commonfabric/runtime-client";
-import { stringSchema } from "@commonfabric/runner/schemas";
-import { createStringCellController } from "../../core/cell-controller.ts";
-import { createFormFieldController } from "../../core/form-field-controller.ts";
 
 export type TimingStrategy = "immediate" | "debounce" | "throttle" | "blur";
 

--- a/packages/ui/src/v2/components/cf-theme/cf-theme.ts
+++ b/packages/ui/src/v2/components/cf-theme/cf-theme.ts
@@ -1,6 +1,8 @@
+import { type CellHandle, isCellHandle } from "@commonfabric/runtime-client";
+import { provide } from "@lit/context";
 import { css, html } from "lit";
 import { property } from "lit/decorators.js";
-import { provide } from "@lit/context";
+
 import { BaseElement } from "../../core/base-element.ts";
 import {
   applyThemeToElement,
@@ -9,7 +11,6 @@ import {
   defaultTheme,
   mergeWithDefaultTheme,
 } from "../theme-context.ts";
-import { type CellHandle, isCellHandle } from "@commonfabric/runtime-client";
 
 export function unwrapThemeCellValues(
   value: unknown,

--- a/packages/ui/src/v2/components/cf-toggle-group/index.ts
+++ b/packages/ui/src/v2/components/cf-toggle-group/index.ts
@@ -1,6 +1,4 @@
-import { CFToggleGroup } from "./cf-toggle-group.ts";
-
-import { ToggleGroupType } from "./cf-toggle-group.ts";
+import { CFToggleGroup, ToggleGroupType } from "./cf-toggle-group.ts";
 
 if (!customElements.get("cf-toggle-group")) {
   customElements.define("cf-toggle-group", CFToggleGroup);

--- a/packages/ui/src/v2/components/cf-toggle/index.ts
+++ b/packages/ui/src/v2/components/cf-toggle/index.ts
@@ -1,6 +1,4 @@
-import { CFToggle } from "./cf-toggle.ts";
-
-import { ToggleSize, ToggleVariant } from "./cf-toggle.ts";
+import { CFToggle, ToggleSize, ToggleVariant } from "./cf-toggle.ts";
 
 if (!customElements.get("cf-toggle")) {
   customElements.define("cf-toggle", CFToggle);

--- a/packages/ui/src/v2/components/cf-tool-call/cf-tool-call.ts
+++ b/packages/ui/src/v2/components/cf-tool-call/cf-tool-call.ts
@@ -1,11 +1,12 @@
-import { css, html } from "lit";
-import { property } from "lit/decorators.js";
-import { consume } from "@lit/context";
-import { BaseElement } from "../../core/base-element.ts";
 import type {
   BuiltInLLMToolCallPart,
   BuiltInLLMToolResultPart,
 } from "@commonfabric/api";
+import { consume } from "@lit/context";
+import { css, html } from "lit";
+import { property } from "lit/decorators.js";
+
+import { BaseElement } from "../../core/base-element.ts";
 import {
   applyThemeToElement,
   type CFTheme,

--- a/packages/ui/src/v2/components/cf-tools-chip/cf-tools-chip.ts
+++ b/packages/ui/src/v2/components/cf-tools-chip/cf-tools-chip.ts
@@ -1,8 +1,9 @@
+import { type CellHandle, type JSONSchema } from "@commonfabric/runtime-client";
+import { consume } from "@lit/context";
 import { css, html, nothing, render } from "lit";
 import { property, state } from "lit/decorators.js";
+
 import { BaseElement } from "../../core/base-element.ts";
-import { consume } from "@lit/context";
-import { type CellHandle, type JSONSchema } from "@commonfabric/runtime-client";
 import { createCellController } from "../../core/cell-controller.ts";
 import {
   applyThemeToElement,

--- a/packages/ui/src/v2/components/cf-updater/cf-updater.ts
+++ b/packages/ui/src/v2/components/cf-updater/cf-updater.ts
@@ -1,7 +1,8 @@
+import { CellHandle } from "@commonfabric/runtime-client";
 import { css, html } from "lit";
+
 import { BaseElement } from "../../core/base-element.ts";
 import { CFPiece } from "../cf-piece/index.ts";
-import { CellHandle } from "@commonfabric/runtime-client";
 
 /**
  * CFUpdater - Button component for registering pieces for background updates

--- a/packages/ui/src/v2/components/cf-voice-input/cf-voice-input.ts
+++ b/packages/ui/src/v2/components/cf-voice-input/cf-voice-input.ts
@@ -1,21 +1,24 @@
+import type { Schema } from "@commonfabric/api/schema";
+import { type CellHandle, type JSONSchema } from "@commonfabric/runtime-client";
+import { consume } from "@lit/context";
 import { css, html } from "lit";
 import { property } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
 import { createRef, type Ref, ref } from "lit/directives/ref.js";
+
 import { BaseElement } from "../../core/base-element.ts";
-import { type CellHandle, type JSONSchema } from "@commonfabric/runtime-client";
-import type { Schema } from "@commonfabric/api/schema";
 import { createCellController } from "../../core/cell-controller.ts";
-import { consume } from "@lit/context";
 import {
   applyThemeToElement,
   type CFTheme,
   cfThemeContext,
   defaultTheme,
 } from "../theme-context.ts";
-import { classMap } from "lit/directives/class-map.js";
+
 import "../cf-audio-visualizer/index.ts";
-import type { CFAudioVisualizer } from "../cf-audio-visualizer/cf-audio-visualizer.ts";
+
 import { convertToWav } from "../../utils/audio-conversion.ts";
+import type { CFAudioVisualizer } from "../cf-audio-visualizer/cf-audio-visualizer.ts";
 
 // Schema for TranscriptionData
 const TranscriptionDataSchema = {

--- a/packages/ui/src/v2/components/cf-webhook/cf-webhook.ts
+++ b/packages/ui/src/v2/components/cf-webhook/cf-webhook.ts
@@ -1,6 +1,8 @@
-import { css, html } from "lit";
-import { BaseElement } from "../../core/base-element.ts";
 import { CellHandle } from "@commonfabric/runtime-client";
+import { css, html } from "lit";
+
+import { BaseElement } from "../../core/base-element.ts";
+
 import "../cf-button/index.ts";
 import "../cf-secret-viewer/index.ts";
 

--- a/packages/ui/src/v2/core/cell-controller.test.ts
+++ b/packages/ui/src/v2/core/cell-controller.test.ts
@@ -1,12 +1,14 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { FakeTime } from "@std/testing/time";
-import type { ReactiveControllerHost } from "lit";
+
 import {
   CellHandle,
   type CellRef,
   isCellHandle,
 } from "@commonfabric/runtime-client";
+import type { ReactiveControllerHost } from "lit";
+
 import {
   createMockCellHandle,
   pushUpdate,

--- a/packages/ui/src/v2/core/input-timing-controller.test.ts
+++ b/packages/ui/src/v2/core/input-timing-controller.test.ts
@@ -1,7 +1,9 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { FakeTime } from "@std/testing/time";
+
 import type { ReactiveControllerHost } from "lit";
+
 import { InputTimingController } from "./input-timing-controller.ts";
 
 function createMockHost(): ReactiveControllerHost {


### PR DESCRIPTION
Fifth of the series applying the Development Guide's `Imports` rules (#5852).
I (agent working on behalf of @danfuzz) am splitting along package lines.

Independent of #5856 and #5857 — different files, all branched from `main`.

## What changed

62 files in `packages/ui`, import blocks only. Two shapes dominate.

### Thirteen barrels, one copy-pasted duplication

Every component barrel carried the same shape — one module named twice, two
lines apart:

```ts
import { CFButton } from "./cf-button.ts";

import { ButtonSize, ButtonVariant } from "./cf-button.ts";
import type { ColorIntent } from "../theme-context.ts";
```

becomes

```ts
import type { ColorIntent } from "../theme-context.ts";
import { ButtonSize, ButtonVariant, CFButton } from "./cf-button.ts";
```

`cf-accordion`, `cf-autocomplete`, `cf-badge`, `cf-button`, `cf-code-editor`,
`cf-input`, `cf-loader`, `cf-scroll-area`, `cf-separator`, `cf-skeleton`,
`cf-slider`, `cf-toggle`, `cf-toggle-group`.

### Fifteen files with bare component registrations

Several in runs of three or four:

```ts
import { BaseElement } from "../../core/base-element.ts";

import "../cf-tool-call/index.ts";
import "../cf-button/index.ts";
import "../cf-copy-button/index.ts";
import "../cf-markdown/index.ts";

import type { BuiltInLLMContent, … } from "@commonfabric/api";
```

Two deliberate properties there:

- **They run together**, with no blank line between them. A blank line between
  imports means a group boundary, and there is none between consecutive bare
  imports.
- **They are not sorted.** A bare import is a barrier — it never moves, and
  nothing moves across it. Nothing here establishes that the registration order
  is irrelevant, and the cost of assuming wrongly is a runtime failure that no
  type-check would catch.

## Verification

- **62 files, zero binding differences**, where a binding is `(resolved module,
  type-ness, local name, import attributes)`.
- Audited the branch for both spacing defects: **0** glued file comments, **0**
  blank lines between consecutive bare imports.
- `deno fmt --check`, `deno lint`, `deno task check` all green.
- Suites: 160 passed and 52 passed, both 0 failed.
- Re-censused: `ui` reads zero on all four required rules.

## Series

Done: #5854 (merged), #5855 (merged), #5856 (open), #5857 (open), this one.

Remaining after this: `runner` only — 242 files, to be split into `src` (~95)
and `test` (~147).

`packages/patterns` is excluded from every PR in this series: pattern source is
compiled and content-addressed, so an edit that looks inert can move a contract
and trip `pattern-compat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

