### PR TITLE
refactor: conform imports in `runner/src` and `runner/integration`

### DIFF
--- a/packages/runner/integration/array_push.test.ts
+++ b/packages/runner/integration/array_push.test.ts
@@ -4,8 +4,10 @@
  * Integration test: verify writable-array `.push()` works against the real
  * remote memory transport and toolshed app.
  */
-import app from "../../toolshed/app.ts";
+
 import { Identity } from "@commonfabric/identity";
+
+import app from "../../toolshed/app.ts";
 import { type JSONSchema, Runtime } from "../src/index.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 

--- a/packages/runner/integration/basic-persistence.test.ts
+++ b/packages/runner/integration/basic-persistence.test.ts
@@ -1,10 +1,9 @@
 #!/usr/bin/env -S deno run -A
 
-import { deepEqual, Runtime } from "@commonfabric/runner";
 import { Identity, IdentityCreateConfig } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { type JSONSchema } from "@commonfabric/runner";
 import { env } from "@commonfabric/integration";
+import { deepEqual, type JSONSchema, Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 const { API_URL } = env;
 
 // Create test identity

--- a/packages/runner/integration/derive_array_leak.test.ts
+++ b/packages/runner/integration/derive_array_leak.test.ts
@@ -9,11 +9,13 @@
  * Expected behavior: Memory should stabilize or grow modestly
  * Actual behavior: Memory grows by gigabytes (1GB+ per 100 increments)
  */
+
 import { Identity, Session } from "@commonfabric/identity";
 import { env } from "@commonfabric/integration";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { compileAndSavePattern, Runtime } from "../src/index.ts";
 import { PiecesController } from "@commonfabric/piece/ops";
+
+import { compileAndSavePattern, Runtime } from "../src/index.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
 (Error as any).stackTraceLimit = 100;
 

--- a/packages/runner/integration/memory-v2-reactivity.test.ts
+++ b/packages/runner/integration/memory-v2-reactivity.test.ts
@@ -1,11 +1,13 @@
 #!/usr/bin/env -S deno run -A
 
 import { assertEquals } from "@std/assert";
-import app from "../../toolshed/app.ts";
+
 import { Identity } from "@commonfabric/identity";
 import { type JSONSchema, Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { defer } from "@commonfabric/utils/defer";
+
+import app from "../../toolshed/app.ts";
 
 const createRuntime = (identity: Identity, base: URL) =>
   new Runtime({

--- a/packages/runner/integration/pattern-and-data-persistence.test.ts
+++ b/packages/runner/integration/pattern-and-data-persistence.test.ts
@@ -15,14 +15,15 @@
  */
 
 import { assert, assertEquals } from "@std/assert";
-import { Runtime, type RuntimeProgram } from "@commonfabric/runner";
+
 import { Identity, type IdentityCreateConfig } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { env } from "@commonfabric/integration";
+import { Runtime, type RuntimeProgram } from "@commonfabric/runner";
 import type { Cell, JSONSchema, MemorySpace } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
 /** A content-addressed pattern pointer. */
 type PatternRef = { identity: string; symbol: string };
-import { env } from "@commonfabric/integration";
 
 const API_URL = new URL(env.API_URL);
 

--- a/packages/runner/integration/reconnection.test.ts
+++ b/packages/runner/integration/reconnection.test.ts
@@ -1,11 +1,13 @@
 #!/usr/bin/env -S deno run -A
 
 import { assertEquals } from "@std/assert";
-import app from "../../toolshed/app.ts";
+
 import { Identity } from "@commonfabric/identity";
 import { type JSONSchema, Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { defer } from "@commonfabric/utils/defer";
+
+import app from "../../toolshed/app.ts";
 
 const createRuntime = (identity: Identity, base: URL) =>
   new Runtime({

--- a/packages/runner/integration/sqlite-cfc-commit-eval.test.ts
+++ b/packages/runner/integration/sqlite-cfc-commit-eval.test.ts
@@ -14,11 +14,13 @@
  *    (the old row survives), a valid flip lands and the read side re-derives
  *    the row's label from the NEW value.
  */
-import app from "../../toolshed/app.ts";
+
 import { Identity } from "@commonfabric/identity";
+
+import app from "../../toolshed/app.ts";
+import { cfcLabelViewForDereferenceTraces } from "../src/cfc/label-view.ts";
 import { Runtime } from "../src/index.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
-import { cfcLabelViewForDereferenceTraces } from "../src/cfc/label-view.ts";
 
 async function runTest(base: URL) {
   const account = await Identity.fromPassphrase(

--- a/packages/runner/integration/sqlite-cfc-label-link.test.ts
+++ b/packages/runner/integration/sqlite-cfc-label-link.test.ts
@@ -7,12 +7,14 @@
  * the consumer must (a) inherit the labeled column's confidentiality AND (b)
  * resolve the link column to a live Cell — through the real toolshed server.
  */
-import app from "../../toolshed/app.ts";
+
 import { Identity } from "@commonfabric/identity";
-import { Runtime } from "../src/index.ts";
-import { StorageManager } from "../src/storage/cache.deno.ts";
+
+import app from "../../toolshed/app.ts";
 import { cfcLabelViewForDereferenceTraces } from "../src/cfc/label-view.ts";
 import { cfcConfidentialityForObservationNode } from "../src/cfc/observation.ts";
+import { Runtime } from "../src/index.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
 async function runTest(base: URL) {
   const account = await Identity.fromPassphrase(

--- a/packages/runner/integration/sqlite-cfc-label.test.ts
+++ b/packages/runner/integration/sqlite-cfc-label.test.ts
@@ -9,12 +9,14 @@
  * (`body AS secret`) to also prove labeling keys off the TRUE origin, not the
  * output name.
  */
-import app from "../../toolshed/app.ts";
+
 import { Identity } from "@commonfabric/identity";
-import { Runtime } from "../src/index.ts";
-import { StorageManager } from "../src/storage/cache.deno.ts";
+
+import app from "../../toolshed/app.ts";
 import { cfcLabelViewForDereferenceTraces } from "../src/cfc/label-view.ts";
 import { cfcConfidentialityForObservationNode } from "../src/cfc/observation.ts";
+import { Runtime } from "../src/index.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
 async function runTest(base: URL) {
   const account = await Identity.fromPassphrase(

--- a/packages/runner/integration/sqlite-cfc-row-label.test.ts
+++ b/packages/runner/integration/sqlite-cfc-row-label.test.ts
@@ -10,11 +10,13 @@
  * rule-bearing table fails closed, and a declared output ceiling with
  * onExceed:"skip" returns exactly the fitting rows.
  */
-import app from "../../toolshed/app.ts";
+
 import { Identity } from "@commonfabric/identity";
+
+import app from "../../toolshed/app.ts";
+import { cfcLabelViewForDereferenceTraces } from "../src/cfc/label-view.ts";
 import { Runtime } from "../src/index.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
-import { cfcLabelViewForDereferenceTraces } from "../src/cfc/label-view.ts";
 
 async function runTest(base: URL) {
   const account = await Identity.fromPassphrase(

--- a/packages/runner/integration/sqlite-db-query-decode.test.ts
+++ b/packages/runner/integration/sqlite-db-query-decode.test.ts
@@ -8,8 +8,10 @@
  * exercises the imperative `db.exec` write folded into a handler commit against
  * the real server.
  */
-import app from "../../toolshed/app.ts";
+
 import { Identity } from "@commonfabric/identity";
+
+import app from "../../toolshed/app.ts";
 import { Runtime } from "../src/index.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 

--- a/packages/runner/integration/sync-schema-path.test.ts
+++ b/packages/runner/integration/sync-schema-path.test.ts
@@ -1,12 +1,14 @@
 #!/usr/bin/env -S deno run -A
 
 import { assertEquals } from "@std/assert/equals";
-import { type NormalizedLink, Runtime } from "@commonfabric/runner";
+
 import { Identity, type IdentityCreateConfig } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import type { JSONSchema, MemorySpace, URI } from "@commonfabric/runner";
-import { parseLink } from "../src/link-utils.ts";
 import { env } from "@commonfabric/integration";
+import { type NormalizedLink, Runtime } from "@commonfabric/runner";
+import type { JSONSchema, MemorySpace, URI } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { parseLink } from "../src/link-utils.ts";
 import { IStorageManager } from "../src/storage/interface.ts";
 const { API_URL } = env;
 

--- a/packages/runner/src/builder/built-in.ts
+++ b/packages/runner/src/builder/built-in.ts
@@ -1,15 +1,7 @@
 import { BuiltInLLMDialogState } from "@commonfabric/api";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
-import { createNodeFactory, lift } from "./module.ts";
-import type {
-  FactoryInput,
-  JSONSchema,
-  NodeFactory,
-  PatternFactory,
-  Reactive,
-  Schema,
-} from "./types.ts";
-import type { Cell as CellType } from "./types.ts";
+import { h } from "@commonfabric/html";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import type {
   BuiltInCompileAndRunParams,
   BuiltInCompileAndRunState,
@@ -32,11 +24,20 @@ import type {
   WishParams,
   WishState,
 } from "commonfabric";
-import { h } from "@commonfabric/html";
-import { isObjectOrArray } from "@commonfabric/utils/types";
-import { isCell } from "../cell.ts";
-import { sqliteQueryNodeFactory } from "../builtins/sqlite/query-node.ts";
+
 import { LLMDialogResultSchema } from "../builtins/llm-schemas.ts";
+import { sqliteQueryNodeFactory } from "../builtins/sqlite/query-node.ts";
+import { isCell } from "../cell.ts";
+import { createNodeFactory, lift } from "./module.ts";
+import type {
+  Cell as CellType,
+  FactoryInput,
+  JSONSchema,
+  NodeFactory,
+  PatternFactory,
+  Reactive,
+  Schema,
+} from "./types.ts";
 
 const WISH_ARGUMENT_SCHEMA = internSchema({
   type: "object",

--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -1,41 +1,52 @@
 /**
  * Factory function to create builder functions with runtime dependency injection
  */
-import type {
-  BuilderFunctionsAndConstants,
-  ToSchemaFunction,
-} from "./types.ts";
+
+import { entityRefToString } from "@commonfabric/data-model/cell-rep";
 import {
-  AsCell,
-  AsComparableCell,
-  AsOpaqueCell,
-  AsReadonlyCell,
-  AsStream,
-  AsWriteonlyCell,
-  AuthSchema,
-  CHIP_UI,
-  FS,
-  NAME,
-  schema as schemaIdentity,
-  SELF,
-  TESTS,
-  TILE_UI,
-  TYPE,
-  UI,
-  WebhookConfigSchema,
-} from "./types.ts";
+  FabricError,
+  FabricLink,
+} from "@commonfabric/data-model/fabric-instances";
+import {
+  FabricBytes,
+  FabricEpochDays,
+  FabricEpochNsec,
+  FabricHash,
+  FabricRegExp,
+} from "@commonfabric/data-model/fabric-primitives";
+import {
+  FabricInstance,
+  FabricPrimitive,
+  FabricSpecialObject,
+  valueEqual,
+} from "@commonfabric/data-model/fabric-value";
+import {
+  toCompactDebugString,
+  toIndentedDebugString,
+} from "@commonfabric/data-model/value-debug";
 import { h, UiAction, UiDisclosure, UiPromptSlot } from "@commonfabric/html";
-import { pattern } from "./pattern.ts";
 import {
-  action,
-  assert,
-  assertCapture,
-  assertRenderParts,
-  byRef,
-  computed,
-  handler,
-  lift,
-} from "./module.ts";
+  all as rowLabelAll,
+  any as rowLabelAny,
+  authoredBy as rowLabelAuthoredBy,
+  constant as rowLabelConstant,
+  dbOwner as rowLabelDbOwner,
+  endorsedBy as rowLabelEndorsedBy,
+  intersect as rowLabelIntersect,
+  match as rowLabelMatch,
+  principal as rowLabelPrincipal,
+  whenMatches as rowLabelWhenMatches,
+} from "@commonfabric/memory/sqlite/row-label";
+import { cfLink, table } from "@commonfabric/memory/sqlite/schema";
+
+import { cellConstructorFactory } from "../cell.ts";
+import { getEntityId } from "../create-ref.ts";
+import type { RuntimeProgram } from "../harness/types.ts";
+import { freezeVerifiedPlainData } from "../sandbox/plain-data.ts";
+import {
+  registerUnsafeHostTrustedValue,
+  type UnsafeHostTrust,
+} from "../unsafe-host-trust.ts";
 import {
   cellFromUrl,
   compileAndRun,
@@ -61,51 +72,42 @@ import {
   when,
   wish,
 } from "./built-in.ts";
-import { cfLink, table } from "@commonfabric/memory/sqlite/schema";
-import {
-  all as rowLabelAll,
-  any as rowLabelAny,
-  authoredBy as rowLabelAuthoredBy,
-  constant as rowLabelConstant,
-  dbOwner as rowLabelDbOwner,
-  endorsedBy as rowLabelEndorsedBy,
-  intersect as rowLabelIntersect,
-  match as rowLabelMatch,
-  principal as rowLabelPrincipal,
-  whenMatches as rowLabelWhenMatches,
-} from "@commonfabric/memory/sqlite/row-label";
-import { cellConstructorFactory } from "../cell.ts";
-import { getEntityId } from "../create-ref.ts";
-import { entityRefToString } from "@commonfabric/data-model/cell-rep";
 import { getPatternEnvironment } from "./env.ts";
-import type { RuntimeProgram } from "../harness/types.ts";
+import {
+  action,
+  assert,
+  assertCapture,
+  assertRenderParts,
+  byRef,
+  computed,
+  handler,
+  lift,
+} from "./module.ts";
 import { isTrustedPattern, setPatternProgram } from "./pattern-metadata.ts";
+import { pattern } from "./pattern.ts";
+import type {
+  BuilderFunctionsAndConstants,
+  ToSchemaFunction,
+} from "./types.ts";
 import {
-  FabricInstance,
-  FabricPrimitive,
-  FabricSpecialObject,
-  valueEqual,
-} from "@commonfabric/data-model/fabric-value";
-import {
-  FabricError,
-  FabricLink,
-} from "@commonfabric/data-model/fabric-instances";
-import {
-  FabricBytes,
-  FabricEpochDays,
-  FabricEpochNsec,
-  FabricHash,
-  FabricRegExp,
-} from "@commonfabric/data-model/fabric-primitives";
-import {
-  toCompactDebugString,
-  toIndentedDebugString,
-} from "@commonfabric/data-model/value-debug";
-import { freezeVerifiedPlainData } from "../sandbox/plain-data.ts";
-import {
-  registerUnsafeHostTrustedValue,
-  type UnsafeHostTrust,
-} from "../unsafe-host-trust.ts";
+  AsCell,
+  AsComparableCell,
+  AsOpaqueCell,
+  AsReadonlyCell,
+  AsStream,
+  AsWriteonlyCell,
+  AuthSchema,
+  CHIP_UI,
+  FS,
+  NAME,
+  schema as schemaIdentity,
+  SELF,
+  TESTS,
+  TILE_UI,
+  TYPE,
+  UI,
+  WebhookConfigSchema,
+} from "./types.ts";
 
 // Runtime implementation of toSchema - this should never be called
 // The TypeScript transformer should replace all calls at compile time

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -1,3 +1,22 @@
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+import { getLogger } from "@commonfabric/utils/logger";
+
+import { getVerifiedProvenance } from "../harness/verified-provenance.ts";
+import { hardenVerifiedFunction } from "../sandbox/function-hardening.ts";
+import { generateHandlerSchema } from "../schema.ts";
+import { assertNotInActionExecution } from "./action-context.ts";
+import { toJSONMethod } from "./json-member.ts";
+import {
+  applyArgumentIfcToResult,
+  connectInputAndOutputs,
+} from "./node-utils.ts";
+import {
+  brandTrustedBuilderArtifact,
+  getArtifactEntryRef,
+} from "./pattern-metadata.ts";
+import { getTopFrame } from "./pattern.ts";
+import { reactive, stream } from "./reactive.ts";
+import { moduleToEncodableForm } from "./to-encodable-form.ts";
 import type {
   AssertPart,
   AssertRawPart,
@@ -21,24 +40,6 @@ import type {
   toEncodableForm,
   toJSON,
 } from "./types.ts";
-import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
-import { reactive, stream } from "./reactive.ts";
-import {
-  applyArgumentIfcToResult,
-  connectInputAndOutputs,
-} from "./node-utils.ts";
-import { assertNotInActionExecution } from "./action-context.ts";
-import { moduleToEncodableForm } from "./to-encodable-form.ts";
-import { toJSONMethod } from "./json-member.ts";
-import {
-  brandTrustedBuilderArtifact,
-  getArtifactEntryRef,
-} from "./pattern-metadata.ts";
-import { getVerifiedProvenance } from "../harness/verified-provenance.ts";
-import { getTopFrame } from "./pattern.ts";
-import { generateHandlerSchema } from "../schema.ts";
-import { getLogger } from "@commonfabric/utils/logger";
-import { hardenVerifiedFunction } from "../sandbox/function-hardening.ts";
 
 const sourceLocationLogger = getLogger("builder.source-location", {
   enabled: false,

--- a/packages/runner/src/builder/node-utils.ts
+++ b/packages/runner/src/builder/node-utils.ts
@@ -1,17 +1,18 @@
-import { isObjectOrArray } from "@commonfabric/utils/types";
-import type { CfcConfClause } from "../cfc/clause.ts";
-import { type FactoryInput, type JSONSchema, type NodeRef } from "./types.ts";
-import { ContextualFlowControl } from "../cfc.ts";
 import { FabricInstance } from "@commonfabric/data-model/fabric-value";
+import { isObjectOrArray } from "@commonfabric/utils/types";
+
+import { isCell } from "../cell.ts";
+import { ContextualFlowControl } from "../cfc.ts";
+import type { CfcConfClause } from "../cfc/clause.ts";
 import { refuseFabricInstance } from "../fabric-special-object.ts";
-import { traverseValue } from "./traverse-utils.ts";
 import {
   getCellOrThrow,
   isCellResultForDereferencing,
 } from "../query-result-proxy.ts";
-import { isCell } from "../cell.ts";
 import { closureCaptureErrorMessage } from "./closure-capture-diagnostic.ts";
 import { resolveLocationFromFunctionSource } from "./module.ts";
+import { traverseValue } from "./traverse-utils.ts";
+import { type FactoryInput, type JSONSchema, type NodeRef } from "./types.ts";
 
 export function connectInputAndOutputs(node: NodeRef) {
   function connect(value: any): any {

--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -1,5 +1,22 @@
-import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
+
+import { isCell, setCellUnlinkedSpace } from "../cell.ts";
+import type { ImplementationIdentity } from "../cfc/types.ts";
+import { createRef } from "../create-ref.ts";
+import {
+  getStableInternalPathSegment,
+  KeepAsCell,
+  sanitizeSchemaForLinks,
+} from "../link-utils.ts";
+import {
+  getCellOrThrow,
+  isCellResultForDereferencing,
+} from "../query-result-proxy.ts";
+import { Runtime } from "../runtime.ts";
+import { hardenVerifiedFunction } from "../sandbox/function-hardening.ts";
 import {
   ARRAY_SUBSCHEMA_KEYS,
   RECORD_SUBSCHEMA_KEYS,
@@ -7,8 +24,32 @@ import {
   UNUSED_RECORD_SUBSCHEMA_KEYS,
   UNUSED_SINGLE_SUBSCHEMA_KEYS,
 } from "../schema-walk.ts";
-import { hashStringOf } from "@commonfabric/data-model/value-hash";
-import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+import { type AliasBinding } from "../sigil-types.ts";
+import {
+  IExtendedStorageTransaction,
+  MemorySpace,
+} from "../storage/interface.ts";
+import { toURI } from "../uri-utils.ts";
+import {
+  REPLAYABLE_BUILTIN_REFS,
+  SUBPATTERN_ARGUMENT_BUILTIN_REFS,
+} from "./builtin-replayability.ts";
+import { closureCaptureErrorMessage } from "./closure-capture-diagnostic.ts";
+import { toJSONMethod } from "./json-member.ts";
+import {
+  applyArgumentIfcToResult,
+  applyInputIfcToOutput,
+  connectInputAndOutputs,
+} from "./node-utils.ts";
+import { brandTrustedPattern, noteDerivedCopy } from "./pattern-metadata.ts";
+import { reactive } from "./reactive.ts";
+import {
+  type CellAliasResolver,
+  moduleToEncodableForm,
+  patternToEncodableForm,
+  withAliasBindings,
+} from "./to-encodable-form.ts";
+import { traverseValue } from "./traverse-utils.ts";
 import {
   type CellScope,
   type DerivedInternalCellDescriptor,
@@ -35,46 +76,6 @@ import {
   type toJSON,
   type UnsafeBinding,
 } from "./types.ts";
-import { reactive } from "./reactive.ts";
-import { brandTrustedPattern, noteDerivedCopy } from "./pattern-metadata.ts";
-import {
-  applyArgumentIfcToResult,
-  applyInputIfcToOutput,
-  connectInputAndOutputs,
-} from "./node-utils.ts";
-import {
-  type CellAliasResolver,
-  moduleToEncodableForm,
-  patternToEncodableForm,
-  withAliasBindings,
-} from "./to-encodable-form.ts";
-import { toJSONMethod } from "./json-member.ts";
-import { traverseValue } from "./traverse-utils.ts";
-import {
-  REPLAYABLE_BUILTIN_REFS,
-  SUBPATTERN_ARGUMENT_BUILTIN_REFS,
-} from "./builtin-replayability.ts";
-import {
-  getStableInternalPathSegment,
-  KeepAsCell,
-  sanitizeSchemaForLinks,
-} from "../link-utils.ts";
-import { type AliasBinding } from "../sigil-types.ts";
-import {
-  getCellOrThrow,
-  isCellResultForDereferencing,
-} from "../query-result-proxy.ts";
-import { isCell, setCellUnlinkedSpace } from "../cell.ts";
-import { createRef } from "../create-ref.ts";
-import { toURI } from "../uri-utils.ts";
-import { closureCaptureErrorMessage } from "./closure-capture-diagnostic.ts";
-import { Runtime } from "../runtime.ts";
-import type { ImplementationIdentity } from "../cfc/types.ts";
-import {
-  IExtendedStorageTransaction,
-  MemorySpace,
-} from "../storage/interface.ts";
-import { hardenVerifiedFunction } from "../sandbox/function-hardening.ts";
 
 /** Declare a pattern
  *

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -1,8 +1,3 @@
-import { isObjectOrArray } from "@commonfabric/utils/types";
-import type { EntityKind } from "../entity-kind.ts";
-import type { PatternBuilder } from "./pattern.ts";
-import type { NormalizedFullLink } from "../link-types.ts";
-
 import type {
   ActionFunction,
   AsCell,
@@ -67,15 +62,20 @@ import type {
   WhenFunction,
   WishFunction,
 } from "@commonfabric/api";
-import type { Schema } from "@commonfabric/api/schema";
 import { toSchema } from "@commonfabric/api";
+import type { Schema } from "@commonfabric/api/schema";
+import { isObjectOrArray } from "@commonfabric/utils/types";
+
 import type { ImplementationIdentity } from "../cfc/types.ts";
-import { AuthSchema, WebhookConfigSchema } from "./schema-lib.ts";
+import type { EntityKind } from "../entity-kind.ts";
+import type { NormalizedFullLink } from "../link-types.ts";
+import { type Runtime } from "../runtime.ts";
 import {
   type IExtendedStorageTransaction,
   type MemorySpace,
 } from "../storage/interface.ts";
-import { type Runtime } from "../runtime.ts";
+import type { PatternBuilder } from "./pattern.ts";
+import { AuthSchema, WebhookConfigSchema } from "./schema-lib.ts";
 
 // Define runtime constants here - actual runtime values
 

--- a/packages/runner/src/builtins/cell-from-url.ts
+++ b/packages/runner/src/builtins/cell-from-url.ts
@@ -1,11 +1,13 @@
 import { type Cell } from "../cell.ts";
-import { type Action } from "../scheduler.ts";
-import { type Runtime } from "../runtime.ts";
-import type { IExtendedStorageTransaction } from "../storage/interface.ts";
-import type { MemorySpace } from "../storage/interface.ts";
-import type { URI } from "../sigil-types.ts";
 import { parseFabricUrl } from "../fabric-url.ts";
+import { type Runtime } from "../runtime.ts";
+import { type Action } from "../scheduler.ts";
+import type { URI } from "../sigil-types.ts";
 import { slugIdForSpace } from "../slugs.ts";
+import type {
+  IExtendedStorageTransaction,
+  MemorySpace,
+} from "../storage/interface.ts";
 
 /**
  * cellFromUrl({ url, hosts }) — the cell a URL names, if it names one.

--- a/packages/runner/src/builtins/compile-and-run.ts
+++ b/packages/runner/src/builtins/compile-and-run.ts
@@ -1,14 +1,15 @@
-import { type BuiltInCompileAndRunParams } from "commonfabric";
 import { hashOf } from "@commonfabric/data-model/value-hash";
-import { type Cell } from "../cell.ts";
-import { type Action } from "../scheduler.ts";
-import type { Runtime } from "../runtime.ts";
-import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import type { Program } from "@commonfabric/js-compiler";
 import { CompilerError } from "@commonfabric/js-compiler/errors";
+import { type BuiltInCompileAndRunParams } from "commonfabric";
+
 import type { CellScope } from "../builder/types.ts";
-import { resolvedCellScope, scopedCell } from "./scope-policy.ts";
+import { type Cell } from "../cell.ts";
+import type { Runtime } from "../runtime.ts";
+import { type Action } from "../scheduler.ts";
 import { narrowestScope } from "../scope.ts";
+import type { IExtendedStorageTransaction } from "../storage/interface.ts";
+import { resolvedCellScope, scopedCell } from "./scope-policy.ts";
 
 /**
  * Compile a pattern/module and run it.

--- a/packages/runner/src/builtins/fetch-program.ts
+++ b/packages/runner/src/builtins/fetch-program.ts
@@ -1,15 +1,16 @@
-import { type Cell } from "../cell.ts";
-import { type Action } from "../scheduler.ts";
-import type { Runtime } from "../runtime.ts";
-import type { IExtendedStorageTransaction } from "../storage/interface.ts";
-import type { CellScope } from "../builder/types.ts";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
-import { ensureCompilerStack } from "../harness/deferred-compiler-stack.ts";
+
+import type { CellScope } from "../builder/types.ts";
+import { type Cell } from "../cell.ts";
 import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
 import { enqueueSinkRequestPostCommitEffect } from "../cfc/sink-request.ts";
-import { computeInputHashFromValue } from "./fetch-utils.ts";
+import { ensureCompilerStack } from "../harness/deferred-compiler-stack.ts";
 import { setPatternCell, setResultCell } from "../result-utils.ts";
+import type { Runtime } from "../runtime.ts";
+import { type Action } from "../scheduler.ts";
+import type { IExtendedStorageTransaction } from "../storage/interface.ts";
+import { computeInputHashFromValue } from "./fetch-utils.ts";
 import { scopedCell } from "./scope-policy.ts";
 
 /**

--- a/packages/runner/src/builtins/fetch-utils.ts
+++ b/packages/runner/src/builtins/fetch-utils.ts
@@ -1,10 +1,11 @@
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { stripUndefinedProps } from "@commonfabric/utils/strip-undefined-props";
+
+import type { Schema } from "../builder/types.ts";
 import { type Cell } from "../cell.ts";
 import type { Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
-import type { Schema } from "../builder/types.ts";
-import { internSchema } from "@commonfabric/data-model/schema-hash";
 
 /**
  * How long a claimed request mutex is believed before another replica may take

--- a/packages/runner/src/builtins/fetch.ts
+++ b/packages/runner/src/builtins/fetch.ts
@@ -3,20 +3,21 @@ import type {
   JSONSchema,
   JSONSchemaObj,
 } from "@commonfabric/api";
-import { isObjectOrArray } from "@commonfabric/utils/types";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import { type Cell } from "../cell.ts";
-import { type Action } from "../scheduler.ts";
-import type { Runtime } from "../runtime.ts";
-import { getPatternEnvironment } from "../builder/env.ts";
-import type { IExtendedStorageTransaction } from "../storage/interface.ts";
-import type { Schema } from "../builder/types.ts";
-import type { CellScope } from "../builder/types.ts";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { isObjectOrArray } from "@commonfabric/utils/types";
+
+import { getPatternEnvironment } from "../builder/env.ts";
+import type { CellScope, Schema } from "../builder/types.ts";
+import { type Cell } from "../cell.ts";
 import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
-import { enqueueSinkRequestPostCommitEffect } from "../cfc/sink-request.ts";
 import { validateAgainstSchema } from "../cfc/schema-sanitization.ts";
+import { enqueueSinkRequestPostCommitEffect } from "../cfc/sink-request.ts";
+import { setPatternCell, setResultCell } from "../result-utils.ts";
+import type { Runtime } from "../runtime.ts";
+import { type Action } from "../scheduler.ts";
 import { mapSubschemas } from "../schema-walk.ts";
+import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import {
   isProtectedToolshedFirstPartyRoute,
   isToolshedApiOrigin,
@@ -28,7 +29,6 @@ import {
   tryClaimMutex,
   tryWriteResult,
 } from "./fetch-utils.ts";
-import { setPatternCell, setResultCell } from "../result-utils.ts";
 import { scopedCell } from "./scope-policy.ts";
 
 type FetchRequestOptions = {

--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -1,5 +1,40 @@
-import type { Pattern } from "../builder/types.ts";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { getLogger } from "@commonfabric/utils/logger";
+
+import type { Pattern } from "../builder/types.ts";
+import type { AddCancel } from "../cancel.ts";
+import type { Cell } from "../cell.ts";
+import { resolveLink } from "../link-resolution.ts";
+import type { NormalizedFullLink } from "../link-types.ts";
+import type { RawBuiltinReturnType } from "../module.ts";
+import { setPatternCell, setResultCell } from "../result-utils.ts";
+import type { Runtime } from "../runtime.ts";
+import type { Action } from "../scheduler.ts";
+import type { IExtendedStorageTransaction } from "../storage/interface.ts";
+import {
+  linkResolutionProbe,
+  machineryRead,
+} from "../storage/reactivity-log.ts";
+import {
+  listElementKeys,
+  releaseRemovedElements,
+} from "./list-element-keys.ts";
+import { listElementLink } from "./list-element-link.ts";
+import {
+  type ElementRun,
+  type SetupRecord,
+  trackListSetupRollback,
+} from "./list-element-rollback.ts";
+import { inferListOpArgumentUsage } from "./list-op-argument-usage.ts";
+import { issueResultContainerSetup } from "./list-result-container.ts";
+import { listResultSchema } from "./list-result-schema.ts";
+import { resolveOpPattern } from "./op-pattern-ref.ts";
+import { createResumeRepublisher } from "./resume-republish.ts";
+import {
+  narrowestCellScope,
+  outputSpotFromBinding,
+  scopedCell,
+} from "./scope-policy.ts";
 
 // Presence probe for the result container: slots resolve as cells, so the
 // coordinator can ask "is the container initialized?" without materializing
@@ -20,41 +55,6 @@ const FILTER_INPUT_SCHEMA = internSchema({
   },
   required: ["op"],
 });
-
-import type { Cell } from "../cell.ts";
-import type { Action } from "../scheduler.ts";
-import type { AddCancel } from "../cancel.ts";
-import type { Runtime } from "../runtime.ts";
-import type { IExtendedStorageTransaction } from "../storage/interface.ts";
-import type { RawBuiltinReturnType } from "../module.ts";
-import type { NormalizedFullLink } from "../link-types.ts";
-import { listResultSchema } from "./list-result-schema.ts";
-import { inferListOpArgumentUsage } from "./list-op-argument-usage.ts";
-import { setPatternCell, setResultCell } from "../result-utils.ts";
-import { issueResultContainerSetup } from "./list-result-container.ts";
-import {
-  narrowestCellScope,
-  outputSpotFromBinding,
-  scopedCell,
-} from "./scope-policy.ts";
-import { resolveOpPattern } from "./op-pattern-ref.ts";
-import {
-  type ElementRun,
-  type SetupRecord,
-  trackListSetupRollback,
-} from "./list-element-rollback.ts";
-import {
-  listElementKeys,
-  releaseRemovedElements,
-} from "./list-element-keys.ts";
-import { createResumeRepublisher } from "./resume-republish.ts";
-import {
-  linkResolutionProbe,
-  machineryRead,
-} from "../storage/reactivity-log.ts";
-import { resolveLink } from "../link-resolution.ts";
-import { listElementLink } from "./list-element-link.ts";
-import { getLogger } from "@commonfabric/utils/logger";
 
 const logger = getLogger("runner.filter", { enabled: true, level: "warn" });
 

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -1,5 +1,43 @@
-import type { Pattern } from "../builder/types.ts";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { getLogger } from "@commonfabric/utils/logger";
+
+import type { Pattern } from "../builder/types.ts";
+import type { AddCancel } from "../cancel.ts";
+import type { Cell } from "../cell.ts";
+import { resolveLink } from "../link-resolution.ts";
+import type { NormalizedFullLink } from "../link-types.ts";
+import type { RawBuiltinReturnType } from "../module.ts";
+import { setPatternCell } from "../result-utils.ts";
+import type { Runtime } from "../runtime.ts";
+import type { Action } from "../scheduler.ts";
+import type { IExtendedStorageTransaction } from "../storage/interface.ts";
+import {
+  linkResolutionProbe,
+  machineryRead,
+} from "../storage/reactivity-log.ts";
+import {
+  listElementKeys,
+  releaseRemovedElements,
+} from "./list-element-keys.ts";
+import { listElementLink } from "./list-element-link.ts";
+import {
+  type ElementRun,
+  type SetupRecord,
+  trackListSetupRollback,
+} from "./list-element-rollback.ts";
+import { inferListOpArgumentUsage } from "./list-op-argument-usage.ts";
+import { issueResultContainerSetup } from "./list-result-container.ts";
+import { listResultSchema } from "./list-result-schema.ts";
+import { resolveOpPattern } from "./op-pattern-ref.ts";
+import {
+  createResumeRepublisher,
+  type ElementContribution,
+} from "./resume-republish.ts";
+import {
+  narrowestCellScope,
+  outputSpotFromBinding,
+  scopedCell,
+} from "./scope-policy.ts";
 
 // Presence probe for the result container: slots resolve as cells, so the
 // coordinator can ask "is the container initialized?" without materializing
@@ -20,44 +58,6 @@ const FLATMAP_INPUT_SCHEMA = internSchema({
   },
   required: ["op"],
 });
-
-import type { Cell } from "../cell.ts";
-import type { Action } from "../scheduler.ts";
-import type { AddCancel } from "../cancel.ts";
-import type { Runtime } from "../runtime.ts";
-import type { IExtendedStorageTransaction } from "../storage/interface.ts";
-import type { RawBuiltinReturnType } from "../module.ts";
-import type { NormalizedFullLink } from "../link-types.ts";
-import { listResultSchema } from "./list-result-schema.ts";
-import { inferListOpArgumentUsage } from "./list-op-argument-usage.ts";
-import { setPatternCell } from "../result-utils.ts";
-import { issueResultContainerSetup } from "./list-result-container.ts";
-import {
-  narrowestCellScope,
-  outputSpotFromBinding,
-  scopedCell,
-} from "./scope-policy.ts";
-import { resolveOpPattern } from "./op-pattern-ref.ts";
-import {
-  type ElementRun,
-  type SetupRecord,
-  trackListSetupRollback,
-} from "./list-element-rollback.ts";
-import {
-  listElementKeys,
-  releaseRemovedElements,
-} from "./list-element-keys.ts";
-import {
-  createResumeRepublisher,
-  type ElementContribution,
-} from "./resume-republish.ts";
-import {
-  linkResolutionProbe,
-  machineryRead,
-} from "../storage/reactivity-log.ts";
-import { resolveLink } from "../link-resolution.ts";
-import { listElementLink } from "./list-element-link.ts";
-import { getLogger } from "@commonfabric/utils/logger";
 
 const logger = getLogger("runner.flatmap", { enabled: true, level: "warn" });
 

--- a/packages/runner/src/builtins/if-else.ts
+++ b/packages/runner/src/builtins/if-else.ts
@@ -1,12 +1,13 @@
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+
 import { type Cell } from "../cell.ts";
-import { type Action } from "../scheduler.ts";
+import { resolveLink } from "../link-resolution.ts";
+import { parseLink } from "../link-utils.ts";
 import { type RawBuiltinResult } from "../module.ts";
 import { type Runtime } from "../runtime.ts";
+import { type Action } from "../scheduler.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
-import { resolveLink } from "../link-resolution.ts";
 import { resolvedCellScope, scopedCell } from "./scope-policy.ts";
-import { parseLink } from "../link-utils.ts";
-import { internSchema } from "@commonfabric/data-model/schema-hash";
 
 /**
  * Argument schema for ifElse. The action value-reads ONLY `condition`; the

--- a/packages/runner/src/builtins/index.ts
+++ b/packages/runner/src/builtins/index.ts
@@ -1,32 +1,33 @@
-import { cellFromUrl } from "./cell-from-url.ts";
+import type {
+  BuiltInGenerateObjectParams,
+  BuiltInGenerateTextParams,
+} from "@commonfabric/api";
+
+import type { Cell } from "../cell.ts";
 import { raw } from "../module.ts";
-import { map } from "./map.ts";
-import { filter } from "./filter.ts";
-import { flatMap } from "./flatmap.ts";
+import type { Runtime } from "../runtime.ts";
+import { cellFromUrl } from "./cell-from-url.ts";
+import { compileAndRun } from "./compile-and-run.ts";
+import { fetchProgram } from "./fetch-program.ts";
 import {
   fetchBinary,
   fetchJson,
   fetchJsonUnchecked,
   fetchText,
 } from "./fetch.ts";
-import { fetchProgram } from "./fetch-program.ts";
-import { streamData } from "./stream-data.ts";
-import { generateObject, generateText, llm } from "./llm.ts";
+import { filter } from "./filter.ts";
+import { flatMap } from "./flatmap.ts";
 import { IF_ELSE_ARGUMENT_SCHEMA, ifElse } from "./if-else.ts";
-import { when } from "./when.ts";
-import { unless } from "./unless.ts";
-import type { Runtime } from "../runtime.ts";
-import { compileAndRun } from "./compile-and-run.ts";
-import { sqliteDatabase, sqliteQuery } from "./sqlite-builtins.ts";
-import { navigateTo } from "./navigate-to.ts";
 import { inspectConfLabel } from "./inspect-conf-label.ts";
-import { wish } from "./wish.ts";
-import type { Cell } from "../cell.ts";
-import type {
-  BuiltInGenerateObjectParams,
-  BuiltInGenerateTextParams,
-} from "@commonfabric/api";
 import { llmDialog } from "./llm-dialog.ts";
+import { generateObject, generateText, llm } from "./llm.ts";
+import { map } from "./map.ts";
+import { navigateTo } from "./navigate-to.ts";
+import { sqliteDatabase, sqliteQuery } from "./sqlite-builtins.ts";
+import { streamData } from "./stream-data.ts";
+import { unless } from "./unless.ts";
+import { when } from "./when.ts";
+import { wish } from "./wish.ts";
 
 const WISH_DEBOUNCE_MS = 50;
 

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -1,17 +1,33 @@
+import type { CfcAtom } from "@commonfabric/api/cfc";
+import { cfcAtom } from "@commonfabric/api/cfc";
+import type { Schema } from "@commonfabric/api/schema";
+import {
+  entityRefToString,
+  isEntityRef,
+} from "@commonfabric/data-model/cell-rep";
+import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
 import {
   FabricInstance,
   FabricPrimitive,
   type FabricValue,
 } from "@commonfabric/data-model/fabric-value";
-import { refuseFabricInstance } from "../fabric-special-object.ts";
-import type { CfcConfClause } from "../cfc/clause.ts";
-import type { CfcAtom } from "@commonfabric/api/cfc";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import {
+  isNontrivialSchema,
+  toDeepFrozenSchema,
+} from "@commonfabric/data-model/schema-utils";
 import {
   DEFAULT_MODEL_NAME,
   LLMClient,
   LLMRequest,
   LLMToolCall,
 } from "@commonfabric/llm";
+import { getLogger } from "@commonfabric/utils/logger";
+import {
+  isBoolean,
+  isObjectNotArray,
+  isObjectOrArray,
+} from "@commonfabric/utils/types";
 import type {
   BuiltInLLMMessage,
   BuiltInLLMParams,
@@ -20,41 +36,9 @@ import type {
   BuiltInLLMToolCallPart,
   JSONSchema,
 } from "commonfabric";
-import type { Schema } from "@commonfabric/api/schema";
-import {
-  isNontrivialSchema,
-  toDeepFrozenSchema,
-} from "@commonfabric/data-model/schema-utils";
-import { internSchema } from "@commonfabric/data-model/schema-hash";
-import { cfcAtom } from "@commonfabric/api/cfc";
-import {
-  LLMDialogResultSchema,
-  LLMMessageSchema,
-  LLMParamsSchema,
-  LLMToolSchema,
-} from "./llm-schemas.ts";
-import { getLogger } from "@commonfabric/utils/logger";
-import {
-  isBoolean,
-  isObjectNotArray,
-  isObjectOrArray,
-} from "@commonfabric/utils/types";
-import type { JSONSchemaObj } from "../builder/types.ts";
-import {
-  ARRAY_SUBSCHEMA_KEYS,
-  mapSubschemas,
-  RECORD_SUBSCHEMA_KEYS,
-  SINGLE_SUBSCHEMA_KEYS,
-} from "../schema-walk.ts";
 
-// Message schema that mints the `LlmDerived` provenance stamp (Epic D1).
-// Recorded as the schema write-policy input for each model-produced message's
-// own entity doc, so the CFC persist pass stamps a labelMap integrity entry on
-// exactly that message — see `pushModelMessages`.
-const LLM_DERIVED_MESSAGE_SCHEMA = internSchema({
-  ...LLMMessageSchema,
-  ifc: { addIntegrity: [cfcAtom.llmDerived()] },
-} as JSONSchema);
+import type { JSONSchemaObj } from "../builder/types.ts";
+import { type CellScope, NAME, type Pattern } from "../builder/types.ts";
 import type { Cell, MemorySpace, Stream } from "../cell.ts";
 import {
   isCell,
@@ -62,45 +46,12 @@ import {
   markRuntimeInjectedEventKeys,
   recordRelevantSchemaWritePolicyInput,
 } from "../cell.ts";
-import { resolveLinkScope } from "../scope.ts";
-import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
-import { type CellScope, NAME, type Pattern } from "../builder/types.ts";
-import { resolveStoredPatternAsync } from "./op-pattern-ref.ts";
-import { getEntityId } from "../create-ref.ts";
-import {
-  entityRefToString,
-  isEntityRef,
-} from "@commonfabric/data-model/cell-rep";
-import { entityUriSchemePrefix } from "../entity-kind.ts";
-import { type Action, ignoreReadForScheduling } from "../scheduler.ts";
-import { Runtime } from "../runtime.ts";
-import { spaceCellSchema } from "../runtime.ts";
-import type { IExtendedStorageTransaction } from "../storage/interface.ts";
-import { getResultCellWithSourceSchema } from "../piece-helpers.ts";
-import { schemaToTypeString } from "../schema-format.ts";
-import { formatTransactionSummary } from "../storage/transaction-summary.ts";
-import {
-  createLLMFriendlyLink,
-  getMetaLink,
-  matchLLMFriendlyLink,
-  type NormalizedFullLink,
-  parseLink,
-  parseLLMFriendlyLink,
-  sanitizeSchemaForLinks,
-} from "../link-utils.ts";
-import {
-  getCellOrThrow,
-  isCellResultForDereferencing,
-} from "../query-result-proxy.ts";
 import { ContextualFlowControl } from "../cfc.ts";
+import type { CfcConfClause } from "../cfc/clause.ts";
 import {
   type CfcLabelView,
   cfcLabelViewForCellFailClosed,
 } from "../cfc/label-view.ts";
-import {
-  CFC_ENFORCING_STRICTNESS,
-  cfcEnforcementStrictness,
-} from "../cfc/types.ts";
 import {
   cfcConfidentialityForObservationNode,
   type CfcFloorTrustContext,
@@ -111,14 +62,63 @@ import {
   meetCfcObservationCeilings,
   uniqueCfcAtoms,
 } from "../cfc/observation.ts";
-import { createTrustResolver } from "../cfc/trust.ts";
-import { cfcSchemaToObject, resolveCfcSchemaRefs } from "../cfc/schema-refs.ts";
 import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
+import { cfcSchemaToObject, resolveCfcSchemaRefs } from "../cfc/schema-refs.ts";
 import { enqueueSinkRequestPostCommitEffect } from "../cfc/sink-request.ts";
+import { createTrustResolver } from "../cfc/trust.ts";
+import {
+  CFC_ENFORCING_STRICTNESS,
+  cfcEnforcementStrictness,
+} from "../cfc/types.ts";
+import { getEntityId } from "../create-ref.ts";
+import { entityUriSchemePrefix } from "../entity-kind.ts";
+import { refuseFabricInstance } from "../fabric-special-object.ts";
 import { resolveLink } from "../link-resolution.ts";
-import { internalVerifierRead } from "../storage/reactivity-log.ts";
+import {
+  createLLMFriendlyLink,
+  getMetaLink,
+  matchLLMFriendlyLink,
+  type NormalizedFullLink,
+  parseLink,
+  parseLLMFriendlyLink,
+  sanitizeSchemaForLinks,
+} from "../link-utils.ts";
 import type { RawBuiltinResult } from "../module.ts";
+import { getResultCellWithSourceSchema } from "../piece-helpers.ts";
+import {
+  getCellOrThrow,
+  isCellResultForDereferencing,
+} from "../query-result-proxy.ts";
+import { Runtime, spaceCellSchema } from "../runtime.ts";
+import { type Action, ignoreReadForScheduling } from "../scheduler.ts";
+import { schemaToTypeString } from "../schema-format.ts";
+import {
+  ARRAY_SUBSCHEMA_KEYS,
+  mapSubschemas,
+  RECORD_SUBSCHEMA_KEYS,
+  SINGLE_SUBSCHEMA_KEYS,
+} from "../schema-walk.ts";
+import { resolveLinkScope } from "../scope.ts";
+import type { IExtendedStorageTransaction } from "../storage/interface.ts";
+import { internalVerifierRead } from "../storage/reactivity-log.ts";
+import { formatTransactionSummary } from "../storage/transaction-summary.ts";
+import {
+  LLMDialogResultSchema,
+  LLMMessageSchema,
+  LLMParamsSchema,
+  LLMToolSchema,
+} from "./llm-schemas.ts";
+import { resolveStoredPatternAsync } from "./op-pattern-ref.ts";
 import { scopedCell } from "./scope-policy.ts";
+
+// Message schema that mints the `LlmDerived` provenance stamp (Epic D1).
+// Recorded as the schema write-policy input for each model-produced message's
+// own entity doc, so the CFC persist pass stamps a labelMap integrity entry on
+// exactly that message — see `pushModelMessages`.
+const LLM_DERIVED_MESSAGE_SCHEMA = internSchema({
+  ...LLMMessageSchema,
+  ifc: { addIntegrity: [cfcAtom.llmDerived()] },
+} as JSONSchema);
 
 // Avoid importing from @commonfabric/piece to prevent circular deps in tests
 

--- a/packages/runner/src/builtins/llm-schemas.ts
+++ b/packages/runner/src/builtins/llm-schemas.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema } from "@commonfabric/api";
-import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { cfcAtom } from "@commonfabric/api/cfc";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 
 // Epic D1b (docs/history/plans/cfc-future-work-implementation.md): model output written
 // by the `llm`, `generateText`, and `generateObject` builtins carries an

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -1,5 +1,14 @@
-import { getLogger } from "@commonfabric/utils/logger";
-import type { CfcConfClause } from "../cfc/clause.ts";
+import {
+  BuiltInGenerateObjectParams,
+  BuiltInGenerateTextParams,
+  BuiltInLLMMessage,
+  BuiltInLLMParams,
+} from "@commonfabric/api";
+import { cfcAtom } from "@commonfabric/api/cfc";
+import type { Schema } from "@commonfabric/api/schema";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
+import { hashOf } from "@commonfabric/data-model/value-hash";
 import {
   DEFAULT_GENERATE_OBJECT_MODELS,
   DEFAULT_MODEL_NAME,
@@ -11,34 +20,29 @@ import {
   LLMRequest,
   LLMResponse,
 } from "@commonfabric/llm";
-import {
-  BuiltInGenerateObjectParams,
-  BuiltInGenerateTextParams,
-  BuiltInLLMMessage,
-  BuiltInLLMParams,
-} from "@commonfabric/api";
-import type { Schema } from "@commonfabric/api/schema";
-import type { JSONSchema, JSONSchemaObj } from "../builder/types.ts";
-import { mapSubschemas } from "../schema-walk.ts";
-import { cfcAtom } from "@commonfabric/api/cfc";
-import { hashOf } from "@commonfabric/data-model/value-hash";
-import { internSchema } from "@commonfabric/data-model/schema-hash";
-import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
-import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
+import { getLogger } from "@commonfabric/utils/logger";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
+
+import type { CellScope, JSONSchema, JSONSchemaObj } from "../builder/types.ts";
+import { type Cell, isCell } from "../cell.ts";
+import type { CfcConfClause } from "../cfc/clause.ts";
 import { cfcLabelViewForCellFailClosed } from "../cfc/label-view.ts";
+import { uniqueCfcAtoms } from "../cfc/observation.ts";
+import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
 import {
   schemaWithInjectionSafeAnnotations,
   validateAgainstSchema,
 } from "../cfc/schema-sanitization.ts";
-import { uniqueCfcAtoms } from "../cfc/observation.ts";
 import { enqueueSinkRequestPostCommitEffect } from "../cfc/sink-request.ts";
-import { type Cell, isCell } from "../cell.ts";
-import { type Action } from "../scheduler.ts";
+import {
+  getCellOrThrow,
+  isCellResultForDereferencing,
+} from "../query-result-proxy.ts";
 import type { Runtime } from "../runtime.ts";
+import { type Action } from "../scheduler.ts";
+import { mapSubschemas } from "../schema-walk.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
-import type { CellScope } from "../builder/types.ts";
 import { llmToolExecutionHelpers } from "./llm-dialog.ts";
-import { scopedCell } from "./scope-policy.ts";
 import {
   GenerateObjectParamsSchema,
   GenerateObjectResultSchema,
@@ -49,11 +53,7 @@ import {
   LLMResultSchema,
   LLMToolSchema,
 } from "./llm-schemas.ts";
-import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
-import {
-  getCellOrThrow,
-  isCellResultForDereferencing,
-} from "../query-result-proxy.ts";
+import { scopedCell } from "./scope-policy.ts";
 
 const logger = getLogger("llm", {
   enabled: true,

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -1,5 +1,39 @@
-import { type Pattern } from "../builder/types.ts";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { getLogger } from "@commonfabric/utils/logger";
+
+import { type Pattern } from "../builder/types.ts";
+import { type AddCancel } from "../cancel.ts";
+import { type Cell } from "../cell.ts";
+import { resolveLink } from "../link-resolution.ts";
+import type { NormalizedFullLink } from "../link-types.ts";
+import type { RawBuiltinReturnType } from "../module.ts";
+import { setPatternCell, setResultCell } from "../result-utils.ts";
+import type { Runtime } from "../runtime.ts";
+import { type Action } from "../scheduler.ts";
+import type { IExtendedStorageTransaction } from "../storage/interface.ts";
+import {
+  linkResolutionProbe,
+  machineryRead,
+} from "../storage/reactivity-log.ts";
+import {
+  listElementKeys,
+  releaseRemovedElements,
+} from "./list-element-keys.ts";
+import { listElementLink } from "./list-element-link.ts";
+import {
+  type ElementRun,
+  type SetupRecord,
+  trackListSetupRollback,
+} from "./list-element-rollback.ts";
+import { inferListOpArgumentUsage } from "./list-op-argument-usage.ts";
+import { issueResultContainerSetup } from "./list-result-container.ts";
+import { listResultSchema } from "./list-result-schema.ts";
+import { resolveOpPattern } from "./op-pattern-ref.ts";
+import {
+  exposedResultCell,
+  outputSpotFromBinding,
+  scopedCell,
+} from "./scope-policy.ts";
 
 const MAP_INPUT_SCHEMA = internSchema({
   type: "object",
@@ -22,37 +56,6 @@ const RESULT_PRESENCE_SCHEMA = internSchema({
   type: "array",
   items: { asCell: ["cell"], type: "unknown" },
 });
-
-import { type Cell } from "../cell.ts";
-import { type Action } from "../scheduler.ts";
-import { type AddCancel } from "../cancel.ts";
-import type { Runtime } from "../runtime.ts";
-import type { IExtendedStorageTransaction } from "../storage/interface.ts";
-import type { RawBuiltinReturnType } from "../module.ts";
-import type { NormalizedFullLink } from "../link-types.ts";
-import { outputSpotFromBinding } from "./scope-policy.ts";
-import { listResultSchema } from "./list-result-schema.ts";
-import { inferListOpArgumentUsage } from "./list-op-argument-usage.ts";
-import { setPatternCell, setResultCell } from "../result-utils.ts";
-import { issueResultContainerSetup } from "./list-result-container.ts";
-import { exposedResultCell, scopedCell } from "./scope-policy.ts";
-import { resolveLink } from "../link-resolution.ts";
-import { listElementLink } from "./list-element-link.ts";
-import {
-  listElementKeys,
-  releaseRemovedElements,
-} from "./list-element-keys.ts";
-import {
-  linkResolutionProbe,
-  machineryRead,
-} from "../storage/reactivity-log.ts";
-import { resolveOpPattern } from "./op-pattern-ref.ts";
-import {
-  type ElementRun,
-  type SetupRecord,
-  trackListSetupRollback,
-} from "./list-element-rollback.ts";
-import { getLogger } from "@commonfabric/utils/logger";
 
 const logger = getLogger("runner.map", { enabled: true, level: "warn" });
 

--- a/packages/runner/src/builtins/resume-republish.ts
+++ b/packages/runner/src/builtins/resume-republish.ts
@@ -1,13 +1,14 @@
+import type { Logger } from "@commonfabric/utils/logger";
+
+import type { JSONSchema } from "../builder/types.ts";
 import type { Cell } from "../cell.ts";
 import type { Runtime } from "../runtime.ts";
-import type { Logger } from "@commonfabric/utils/logger";
-import type { JSONSchema } from "../builder/types.ts";
-import type { ElementRun } from "./list-element-rollback.ts";
-import { cellIdentityKey } from "./scope-policy.ts";
 import {
   linkResolutionProbe,
   machineryRead,
 } from "../storage/reactivity-log.ts";
+import type { ElementRun } from "./list-element-rollback.ts";
+import { cellIdentityKey } from "./scope-policy.ts";
 
 type ElementRuns = Map<string, ElementRun>;
 

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -19,35 +19,36 @@
 // multi-tab write mutex is the handle-cell `rev` bump in db.exec (cell.ts), not
 // this read path.
 
-import { type Cell, createCell, encodeSqliteParams } from "../cell.ts";
-import type { CfcConfClause } from "../cfc/clause.ts";
 import type { CfcAtom } from "@commonfabric/api/cfc";
-import { parseLink } from "../link-utils.ts";
-import {
-  computeRowLabelRead,
-  resolveCeilingPlaceholders,
-} from "./sqlite/row-label-read.ts";
-import { type Action } from "../scheduler.ts";
-import { type RawBuiltinResult } from "../module.ts";
-import { type Runtime } from "../runtime.ts";
-import type { IExtendedStorageTransaction } from "../storage/interface.ts";
-import type { NormalizedFullLink } from "../link-types.ts";
-import type { CellScope } from "../builder/types.ts";
-import { setPatternCell, setResultCell } from "../result-utils.ts";
-import { isCellScope, narrowestScope } from "../scope.ts";
-import { computeInputHashFromValue } from "./fetch-utils.ts";
-import { parseCfLinkToSigil } from "./sqlite/cf-link.ts";
-import { type IFCLabel, mergeLabel } from "../cfc/label-view-core.ts";
-import { cloneIfNecessary } from "@commonfabric/data-model/value-clone";
 import { fabricFromNativeValue } from "@commonfabric/data-model/fabric-value";
-import { stripEntityUriScheme } from "../entity-kind.ts";
+import { cloneIfNecessary } from "@commonfabric/data-model/value-clone";
+import { validateRowLabelSpec } from "@commonfabric/memory/sqlite/row-label";
 import {
   columnDeclaresIfc,
   type SqliteDbRef as WireSqliteDbRef,
   type SqliteParamsWire,
 } from "@commonfabric/memory/v2";
-import { validateRowLabelSpec } from "@commonfabric/memory/sqlite/row-label";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
+
+import type { CellScope } from "../builder/types.ts";
+import { type Cell, createCell, encodeSqliteParams } from "../cell.ts";
+import type { CfcConfClause } from "../cfc/clause.ts";
+import { type IFCLabel, mergeLabel } from "../cfc/label-view-core.ts";
+import { stripEntityUriScheme } from "../entity-kind.ts";
+import type { NormalizedFullLink } from "../link-types.ts";
+import { parseLink } from "../link-utils.ts";
+import { type RawBuiltinResult } from "../module.ts";
+import { setPatternCell, setResultCell } from "../result-utils.ts";
+import { type Runtime } from "../runtime.ts";
+import { type Action } from "../scheduler.ts";
+import { isCellScope, narrowestScope } from "../scope.ts";
+import type { IExtendedStorageTransaction } from "../storage/interface.ts";
+import { computeInputHashFromValue } from "./fetch-utils.ts";
+import { parseCfLinkToSigil } from "./sqlite/cf-link.ts";
+import {
+  computeRowLabelRead,
+  resolveCeilingPlaceholders,
+} from "./sqlite/row-label-read.ts";
 
 // The wire shape (`id`, `tables`, `scope`, `owner`) is the memory protocol's
 // own `SqliteDbRef`; only `rev` is added here.

--- a/packages/runner/src/builtins/sqlite/row-label-read.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-read.ts
@@ -6,6 +6,7 @@
 // Spec: docs/specs/sqlite-builtin/06-cfc.md ("Read — re-derive per row,
 // attach, ceiling"; "Fail-closed rules").
 
+import type { CfcAtom, CfcAtomObject } from "@commonfabric/api/cfc";
 import {
   atomKey,
   evaluateRowLabel,
@@ -15,12 +16,11 @@ import {
   ruleInputFields,
   validateRowLabelSpec,
 } from "@commonfabric/memory/sqlite/row-label";
-import type { CfcAtomObject } from "@commonfabric/api/cfc";
-import type { CfcAtom } from "@commonfabric/api/cfc";
 import { tableDeclaresRowLabel } from "@commonfabric/memory/v2";
+
 import type { CfcConfClause } from "../../cfc/clause.ts";
-import { cfcObservationFitsCeiling } from "../../cfc/observation.ts";
 import { clauseAlternatives } from "../../cfc/clause.ts";
+import { cfcObservationFitsCeiling } from "../../cfc/observation.ts";
 
 interface ResultColumn {
   output: string;

--- a/packages/runner/src/builtins/sqlite/row-label-write.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-write.ts
@@ -21,25 +21,26 @@
 //
 // Zero cost when no table declares a rule.
 
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import {
   evaluateRowLabel,
   type RowLabelSpec,
   ruleInputFields,
   validateRowLabelSpec,
 } from "@commonfabric/memory/sqlite/row-label";
-import type { CfcConfClause } from "../../cfc/clause.ts";
-import type { CfcAtom } from "@commonfabric/api/cfc";
-import {
-  type SqliteDbRef,
-  tableDeclaresRowLabel,
-} from "@commonfabric/memory/v2";
-import { cfcObservationFitsCeiling } from "../../cfc/observation.ts";
 import {
   blankWriteSql,
   parseUpdateSetColumns,
   parseWriteParamColumns,
   parseWriteTable,
 } from "@commonfabric/memory/sqlite/write-targets";
+import {
+  type SqliteDbRef,
+  tableDeclaresRowLabel,
+} from "@commonfabric/memory/v2";
+
+import type { CfcConfClause } from "../../cfc/clause.ts";
+import { cfcObservationFitsCeiling } from "../../cfc/observation.ts";
 
 /** One written row's computed label — recorded as the write's CFC policy
  *  input (sink-request) before the commit. */

--- a/packages/runner/src/builtins/sqlite/write-ceiling.ts
+++ b/packages/runner/src/builtins/sqlite/write-ceiling.ts
@@ -8,13 +8,14 @@
 // is rejected rather than let through unverified. Unlabeled values and columns
 // without a ceiling are unaffected (zero behavior change until `ifc` is used).
 
-import { cfcObservationFitsCeiling } from "../../cfc/observation.ts";
-import type { CfcConfClause } from "../../cfc/clause.ts";
 import {
   blankWriteSql,
   parseWriteParamColumns,
   parseWriteTable,
 } from "@commonfabric/memory/sqlite/write-targets";
+
+import type { CfcConfClause } from "../../cfc/clause.ts";
+import { cfcObservationFitsCeiling } from "../../cfc/observation.ts";
 
 interface ColumnIfc {
   maxConfidentiality?: readonly CfcConfClause[];

--- a/packages/runner/src/builtins/stream-data.ts
+++ b/packages/runner/src/builtins/stream-data.ts
@@ -1,13 +1,14 @@
-import { type Cell } from "../cell.ts";
-import { type Action } from "../scheduler.ts";
-import type { Runtime } from "../runtime.ts";
-import type { IExtendedStorageTransaction } from "../storage/interface.ts";
-import type { CellScope } from "../builder/types.ts";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { hashOf } from "@commonfabric/data-model/value-hash";
+
+import type { CellScope } from "../builder/types.ts";
+import { type Cell } from "../cell.ts";
 import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
 import { enqueueSinkRequestPostCommitEffect } from "../cfc/sink-request.ts";
 import { setPatternCell, setResultCell } from "../result-utils.ts";
+import type { Runtime } from "../runtime.ts";
+import { type Action } from "../scheduler.ts";
+import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { scopedCell } from "./scope-policy.ts";
 
 /**

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -1,18 +1,23 @@
-import { LRUCache } from "@commonfabric/utils/cache";
 import {
   type VNode,
   type WishParams,
   type WishState,
   type WishTag,
 } from "@commonfabric/api";
-import { h } from "@commonfabric/html";
+import {
+  deepFrozenCloneAndInternSchema,
+  hashSchema,
+  internSchema,
+} from "@commonfabric/data-model/schema-hash";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { favoriteListSchema } from "@commonfabric/home-schemas";
+import { h } from "@commonfabric/html";
 import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
-import { type Cell } from "../cell.ts";
 import type { MemorySpace } from "@commonfabric/memory/interface";
-import { type Action, type ReactivityLog } from "../scheduler.ts";
-import { type Runtime, spaceCellSchema } from "../runtime.ts";
-import type { IExtendedStorageTransaction } from "../storage/interface.ts";
+import { LRUCache } from "@commonfabric/utils/cache";
+import { extractHashtags } from "@commonfabric/utils/hashtags";
+import { getLogger } from "@commonfabric/utils/logger";
+
 import {
   type CellScope,
   type JSONSchema,
@@ -20,24 +25,20 @@ import {
   type Pattern,
   UI,
 } from "../builder/types.ts";
-import {
-  deepFrozenCloneAndInternSchema,
-  hashSchema,
-  internSchema,
-} from "@commonfabric/data-model/schema-hash";
-import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
-import { extractHashtags } from "@commonfabric/utils/hashtags";
+import { type Cell } from "../cell.ts";
 import { getPatternEnvironment } from "../env.ts";
-import { getLogger } from "@commonfabric/utils/logger";
 import {
   createSigilLinkFromParsedLink,
   getMetaLink,
   toMemorySpaceAddress,
 } from "../link-utils.ts";
-import { setRunnableName } from "../runner-utils.ts";
-import { isCellScope, narrowestScope } from "../scope.ts";
-import { scopedCell } from "./scope-policy.ts";
 import { isLegacyPieceRegistryRoot } from "../piece-helpers.ts";
+import { setRunnableName } from "../runner-utils.ts";
+import { type Runtime, spaceCellSchema } from "../runtime.ts";
+import { type Action, type ReactivityLog } from "../scheduler.ts";
+import { isCellScope, narrowestScope } from "../scope.ts";
+import type { IExtendedStorageTransaction } from "../storage/interface.ts";
+import { scopedCell } from "./scope-policy.ts";
 
 const wishFlowLogger = getLogger("runner.wish-flow", {
   enabled: true,

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1,10 +1,10 @@
+import type { ReadonlyCell } from "@commonfabric/api";
+import { MetaField } from "@commonfabric/api";
 import {
-  type Immutable,
-  isFunction,
-  isObjectNotArray,
-  isObjectOrArray,
-  isPlainContainer,
-} from "@commonfabric/utils/types";
+  type EntityRef,
+  entityRefFromString,
+  linkRefFrom,
+} from "@commonfabric/data-model/cell-rep";
 import {
   cloneIfNecessary,
   fabricFromNativeValue,
@@ -19,33 +19,29 @@ import {
   shallowFabricFromNativeValue,
   valueEqual,
 } from "@commonfabric/data-model/fabric-value";
-import { hashStringOf } from "@commonfabric/data-model/value-hash";
-import {
-  type EntityRef,
-  entityRefFromString,
-  linkRefFrom,
-} from "@commonfabric/data-model/cell-rep";
-import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
-import { refuseFabricInstance } from "./fabric-special-object.ts";
 import {
   deepFrozenCloneAndInternSchema,
   internSchema,
   isInternedSchema,
 } from "@commonfabric/data-model/schema-hash";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import type { MemorySpace } from "@commonfabric/memory/interface";
-import type { ReadonlyCell } from "@commonfabric/api";
-import type { SqliteDbRef, SqliteParamsWire } from "@commonfabric/memory/v2";
 import { isCfLinkColumn } from "@commonfabric/memory/sqlite/columns";
-import { encodeCellToSigilString } from "./builtins/sqlite/cf-link-codec.ts";
-import { sqliteQueryNodeFactory } from "./builtins/sqlite/query-node.ts";
-import { checkSqliteWriteCeiling } from "./builtins/sqlite/write-ceiling.ts";
-import { checkSqliteRowLabelWrite } from "./builtins/sqlite/row-label-write.ts";
-import { scopeCallerEventId } from "./scheduler/event-identity.ts";
-import { recordSinkRequestPolicyInput } from "./cfc/sink-request.ts";
-import { cfcLabelViewForCell } from "./cfc/label-view.ts";
-import { cfcConfidentialityForObservationNode } from "./cfc/observation.ts";
-import { assertNoReservedCauseKeys, getTopFrame } from "./builder/pattern.ts";
+import type { SqliteDbRef, SqliteParamsWire } from "@commonfabric/memory/v2";
+import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
+import { ensureNotRenderThread } from "@commonfabric/utils/env";
+import { getLogger } from "@commonfabric/utils/logger";
+import {
+  type Immutable,
+  isFunction,
+  isObjectNotArray,
+  isObjectOrArray,
+  isPlainContainer,
+} from "@commonfabric/utils/types";
+
+import { toCell } from "./back-to-cell.ts";
 import { createNodeFactory, lift } from "./builder/module.ts";
+import { assertNoReservedCauseKeys, getTopFrame } from "./builder/pattern.ts";
 import {
   type AnyCell,
   type AnyCellWrapping,
@@ -58,6 +54,7 @@ import {
   type Frame,
   type HKT,
   type ICell,
+  isReactiveMarker,
   isStreamValue,
   type IsThisObject,
   type IStreamable,
@@ -73,74 +70,12 @@ import {
   type Stream,
   type StripDefaultBrand,
 } from "./builder/types.ts";
-import { toCell } from "./back-to-cell.ts";
-import { isReactiveMarker } from "./builder/types.ts";
-import {
-  type CellResult,
-  createQueryResultProxy,
-  getCellOrThrow,
-  isCellResultForDereferencing,
-} from "./query-result-proxy.ts";
-import { diffAndUpdate } from "./data-updating.ts";
-import { type LastNode, resolveLink } from "./link-resolution.ts";
-import {
-  type Action,
-  ignoreReadForScheduling,
-  txToReactivityLog,
-} from "./scheduler.ts";
-import {
-  allowMutableTransactionRead,
-  internalVerifierRead,
-  markReadAsAttemptedWrite,
-  mergeableOpRead,
-} from "./storage/reactivity-log.ts";
+import { listResultSchema } from "./builtins/list-result-schema.ts";
+import { encodeCellToSigilString } from "./builtins/sqlite/cf-link-codec.ts";
+import { sqliteQueryNodeFactory } from "./builtins/sqlite/query-node.ts";
+import { checkSqliteRowLabelWrite } from "./builtins/sqlite/row-label-write.ts";
+import { checkSqliteWriteCeiling } from "./builtins/sqlite/write-ceiling.ts";
 import { type Cancel, isCancel, useCancelGroup } from "./cancel.ts";
-import {
-  type CellViewRef,
-  processDefaultValue,
-  resolveSchema,
-  schemaHasIfc,
-  validateAndTransform,
-} from "./schema.ts";
-import {
-  readStoredCfcMetadata,
-  storedCfcMetadataAppliesToPath,
-} from "./cfc/metadata.ts";
-import { toURI } from "./uri-utils.ts";
-import { createRef } from "./create-ref.ts";
-import { flattenBuilderArtifacts } from "./storage-preflight.ts";
-import {
-  type SigilLink,
-  type SigilWriteRedirectLink,
-  type URI,
-} from "./sigil-types.ts";
-import type { Runtime } from "./runtime.ts";
-import {
-  dataUriFromValueWithResolvedLinks,
-  findAndInlineDataUriLinks,
-} from "./data-uri.ts";
-import {
-  areLinksSame,
-  createSigilLinkFromParsedLink,
-  isCellLink,
-  KeepAsCell,
-  type NormalizedFullLink,
-  type NormalizedLink,
-  parseLink,
-  toMemorySpaceAddress,
-} from "./link-utils.ts";
-import { isCellScope, narrowerScopeCap, normalizeCellScope } from "./scope.ts";
-import type {
-  ChangeGroup,
-  IExtendedStorageTransaction,
-  IMemorySpaceAddress,
-  IReadOptions,
-} from "./storage/interface.ts";
-import {
-  createChildCellTransaction,
-  createNonReactiveTransaction,
-} from "./storage/extended-storage-transaction.ts";
-import { fromURI } from "./uri-utils.ts";
 import { ContextualFlowControl } from "./cfc.ts";
 import {
   type CfcLabelView,
@@ -151,12 +86,77 @@ import {
   mergeCfcLabelViews,
   rebaseCfcLabelView,
 } from "./cfc/label-view-state.ts";
+import { cfcLabelViewForCell } from "./cfc/label-view.ts";
 import { setLinkCfcLabelView } from "./cfc/link-label-view.ts";
-import { listResultSchema } from "./builtins/list-result-schema.ts";
+import {
+  readStoredCfcMetadata,
+  storedCfcMetadataAppliesToPath,
+} from "./cfc/metadata.ts";
+import { cfcConfidentialityForObservationNode } from "./cfc/observation.ts";
+import { recordSinkRequestPolicyInput } from "./cfc/sink-request.ts";
 import { propagateRendererTrustedEvent } from "./cfc/ui-contract.ts";
-import { getLogger } from "@commonfabric/utils/logger";
-import { ensureNotRenderThread } from "@commonfabric/utils/env";
-import { MetaField } from "@commonfabric/api";
+import { createRef } from "./create-ref.ts";
+import { diffAndUpdate } from "./data-updating.ts";
+import {
+  dataUriFromValueWithResolvedLinks,
+  findAndInlineDataUriLinks,
+} from "./data-uri.ts";
+import { refuseFabricInstance } from "./fabric-special-object.ts";
+import { type LastNode, resolveLink } from "./link-resolution.ts";
+import {
+  areLinksSame,
+  createSigilLinkFromParsedLink,
+  isCellLink,
+  KeepAsCell,
+  type NormalizedFullLink,
+  type NormalizedLink,
+  parseLink,
+  toMemorySpaceAddress,
+} from "./link-utils.ts";
+import {
+  type CellResult,
+  createQueryResultProxy,
+  getCellOrThrow,
+  isCellResultForDereferencing,
+} from "./query-result-proxy.ts";
+import type { Runtime } from "./runtime.ts";
+import {
+  type Action,
+  ignoreReadForScheduling,
+  txToReactivityLog,
+} from "./scheduler.ts";
+import { scopeCallerEventId } from "./scheduler/event-identity.ts";
+import {
+  type CellViewRef,
+  processDefaultValue,
+  resolveSchema,
+  schemaHasIfc,
+  validateAndTransform,
+} from "./schema.ts";
+import { isCellScope, narrowerScopeCap, normalizeCellScope } from "./scope.ts";
+import {
+  type SigilLink,
+  type SigilWriteRedirectLink,
+  type URI,
+} from "./sigil-types.ts";
+import { flattenBuilderArtifacts } from "./storage-preflight.ts";
+import {
+  createChildCellTransaction,
+  createNonReactiveTransaction,
+} from "./storage/extended-storage-transaction.ts";
+import type {
+  ChangeGroup,
+  IExtendedStorageTransaction,
+  IMemorySpaceAddress,
+  IReadOptions,
+} from "./storage/interface.ts";
+import {
+  allowMutableTransactionRead,
+  internalVerifierRead,
+  markReadAsAttemptedWrite,
+  mergeableOpRead,
+} from "./storage/reactivity-log.ts";
+import { fromURI, toURI } from "./uri-utils.ts";
 ensureNotRenderThread();
 
 const logger = getLogger("cell", { level: "warn" });

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -1,16 +1,16 @@
 import { JSONSchemaObj, type JSONValue } from "@commonfabric/api";
-import type { CfcConfClause } from "./cfc/clause.ts";
-import { isObjectOrArray } from "@commonfabric/utils/types";
-import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
+import { isObjectOrArray } from "@commonfabric/utils/types";
+
 import type {
   AsCellEntry,
   CellKind,
   JSONSchema,
   SchemaScope,
 } from "./builder/types.ts";
-import { isSchemaScope, narrowerScopeCap } from "./scope.ts";
-import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
+import type { CfcConfClause } from "./cfc/clause.ts";
 import { uniqueCfcAtoms } from "./cfc/observation.ts";
 import {
   cfcSchemaChildRoot,
@@ -26,6 +26,7 @@ import {
   selectReferencedCfcSchemaDefs,
 } from "./cfc/schema-refs.ts";
 import { forEachSubschema } from "./schema-walk.ts";
+import { isSchemaScope, narrowerScopeCap } from "./scope.ts";
 export {
   CFC_ATOM_TYPE,
   CFC_CONCEPT_KIND,

--- a/packages/runner/src/cfc/exchange-eval.ts
+++ b/packages/runner/src/cfc/exchange-eval.ts
@@ -1,5 +1,12 @@
+import {
+  CFC_ATOM_TYPE,
+  type CfcAtom,
+  type CfcModulePolicyRefAtom,
+} from "@commonfabric/api/cfc";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import { utf8Compare } from "@commonfabric/utils/utf8";
+
 import {
   type AtomPatternBindings,
   conceptGuard,
@@ -8,12 +15,6 @@ import {
   matchAtomPattern,
   matchAtomPatternAgainstAtoms,
 } from "./atom-pattern.ts";
-import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
-import {
-  CFC_ATOM_TYPE,
-  type CfcAtom,
-  type CfcModulePolicyRefAtom,
-} from "@commonfabric/api/cfc";
 import {
   type CfcConfClause,
   type CfcOrClause,
@@ -21,11 +22,11 @@ import {
   isOrClause,
   normalizeClause,
 } from "./clause.ts";
-import type { IFCLabel } from "./label-view-core.ts";
 import {
   commitmentAwareEquals,
   isCfcFieldCommitment,
 } from "./label-representation.ts";
+import type { IFCLabel } from "./label-view-core.ts";
 import {
   type ExchangeRule,
   lowerCfcPolicyTemplateRules,

--- a/packages/runner/src/cfc/implementation-identity.ts
+++ b/packages/runner/src/cfc/implementation-identity.ts
@@ -1,8 +1,9 @@
+import { hashOf } from "@commonfabric/data-model/value-hash";
+
 import type { Module } from "../builder/types.ts";
 import type { HarnessedFunction } from "../harness/types.ts";
-import type { ImplementationIdentity } from "./types.ts";
-import { hashOf } from "@commonfabric/data-model/value-hash";
 import { getVerifiedProvenance } from "../harness/verified-provenance.ts";
+import type { ImplementationIdentity } from "./types.ts";
 import { normalizeIdentitySource } from "./writer-claim-correspondence.ts";
 
 /**

--- a/packages/runner/src/cfc/label-introspection.ts
+++ b/packages/runner/src/cfc/label-introspection.ts
@@ -1,11 +1,12 @@
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
-import type { CfcConfClause } from "./clause.ts";
 import { isObjectOrArray } from "@commonfabric/utils/types";
+
 import { encodePointer, parsePointer } from "../../../memory/v2/path.ts";
 import type { NormalizedFullLink } from "../link-utils.ts";
 import { normalizeCellScope } from "../scope.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { canonicalizeLogicalPath } from "./canonical.ts";
+import type { CfcConfClause } from "./clause.ts";
 import { clauseAlternatives } from "./clause.ts";
 import {
   cfcEntryHasDerivedContainment,

--- a/packages/runner/src/cfc/label-representation.ts
+++ b/packages/runner/src/cfc/label-representation.ts
@@ -1,8 +1,9 @@
-import { deepEqual } from "@commonfabric/utils/deep-equal";
-import type { CfcConfClause } from "./clause.ts";
 import type { CfcAtom } from "@commonfabric/api/cfc";
-import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
+import { deepEqual } from "@commonfabric/utils/deep-equal";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
+
+import type { CfcConfClause } from "./clause.ts";
 import {
   CLASSIFIED_KIND_FAMILIES,
   classifyAtomField,

--- a/packages/runner/src/cfc/label-view-core.ts
+++ b/packages/runner/src/cfc/label-view-core.ts
@@ -1,9 +1,10 @@
-import { encodePointer } from "../../../memory/v2/path.ts";
 import type { CfcAtom } from "@commonfabric/api/cfc";
-import type { CfcConfClause } from "./clause.ts";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
-import { uniqueCfcAtoms } from "./observation.ts";
+
+import { encodePointer } from "../../../memory/v2/path.ts";
+import type { CfcConfClause } from "./clause.ts";
 import { normalizeClause } from "./clause.ts";
+import { uniqueCfcAtoms } from "./observation.ts";
 
 export type IFCLabel = {
   confidentiality?: CfcConfClause[];

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1,35 +1,41 @@
+import { isFabricPrimitiveSchemaType } from "@commonfabric/api";
+import type { FabricValue } from "@commonfabric/api";
 import {
   CFC_ATOM_TYPE,
   CFC_COMPILED_BY_ATOM_PREFIX,
   type CfcAtom,
   cfcAtom,
 } from "@commonfabric/api/cfc";
+import { schemaTypeOfFabricPrimitive } from "@commonfabric/data-model/fabric-primitives";
+import {
+  cloneForMutation,
+  type CloneForMutationResult,
+  FabricPrimitive,
+  isFabricObjectOrArray,
+  valueEqual,
+} from "@commonfabric/data-model/fabric-value";
 import {
   internSchema,
   internSchemaAsTaggedHashString,
 } from "@commonfabric/data-model/schema-hash";
 import { emptySchemaObject } from "@commonfabric/data-model/schema-utils";
-import {
-  FabricPrimitive,
-  isFabricObjectOrArray,
-} from "@commonfabric/data-model/fabric-value";
-import { schemaTypeOfFabricPrimitive } from "@commonfabric/data-model/fabric-primitives";
-import { isFabricPrimitiveSchemaType } from "@commonfabric/api";
-import {
-  cloneForMutation,
-  type CloneForMutationResult,
-  valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+import type { MemorySpace, URI } from "@commonfabric/memory/interface";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
-import { normalizeIdentitySource } from "./writer-claim-correspondence.ts";
-import type { FabricValue } from "@commonfabric/api";
-import type { MemorySpace, URI } from "@commonfabric/memory/interface";
 import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
+
+import { encodePointer } from "../../../memory/v2/path.ts";
 import type { JSONSchema } from "../builder/types.ts";
+import { ContextualFlowControl } from "../cfc.ts";
+import {
+  isPrimitiveCellLink,
+  isWriteRedirectLink,
+  parseLink,
+} from "../link-utils.ts";
+import { getValueAtPath, setValueAtPath } from "../path-utils.ts";
+import { ignoreReadForScheduling } from "../scheduler.ts";
 import { arrayMatchesPositionally } from "../schema-match.ts";
 import { normalizeCellScope } from "../scope.ts";
-import { ignoreReadForScheduling } from "../scheduler.ts";
 import type {
   IExtendedStorageTransaction,
   MediaType,
@@ -41,14 +47,6 @@ import {
   isMachineryRead,
   isSchedulerDependencyRead,
 } from "../storage/reactivity-log.ts";
-import {
-  isPrimitiveCellLink,
-  isWriteRedirectLink,
-  parseLink,
-} from "../link-utils.ts";
-import { getValueAtPath, setValueAtPath } from "../path-utils.ts";
-import { encodePointer } from "../../../memory/v2/path.ts";
-import { ContextualFlowControl } from "../cfc.ts";
 import { atomPropagationClass } from "./atom-classes.ts";
 import {
   canonicalizeCfcMetadata,
@@ -62,24 +60,15 @@ import {
   normalizeClause,
 } from "./clause.ts";
 import { collectDeclaredMonotonicityViolations } from "./declared-monotonicity.ts";
-import { externalIngestStamp } from "./external-ingest.ts";
-import {
-  atomsOutsideCeiling,
-  type CfcFloorTrustContext,
-  cfcIntegritySatisfiesFloor,
-  cfcIntegritySatisfiesFloorCoherently,
-  uniqueCfcAtoms,
-} from "./observation.ts";
 import {
   type CfcGrantConsumptionContext,
   evaluateExchangeRules,
 } from "./exchange-eval.ts";
+import { externalIngestStamp } from "./external-ingest.ts";
 import {
   createTxCfcGrantResolver,
   flushCfcGrantConsumptionClaims,
 } from "./grants.ts";
-import { createTxCfcModulePolicyResolver } from "./policy-resolver.ts";
-import { cfcLabelViewFromMetadata } from "./label-view-state.ts";
 import {
   deriveLabelMetadataTemplateEntries,
   isLabelMetadataTemplateEntry,
@@ -89,18 +78,27 @@ import {
   containsCfcFieldCommitment,
   transformCfcLabelForCrossSpacePersist,
 } from "./label-representation.ts";
-import { createTrustResolver } from "./trust.ts";
+import { cfcLabelViewFromMetadata } from "./label-view-state.ts";
+import {
+  CFC_SCHEMA_MIGRATION_INCOMPATIBLE_REASON,
+  CfcSchemaMigrationError,
+} from "./migration-reason.ts";
 import {
   type ReadClassSelection,
   readConsumesEntry,
   type ReadObservationShape,
 } from "./observation-classes.ts";
+import {
+  atomsOutsideCeiling,
+  type CfcFloorTrustContext,
+  cfcIntegritySatisfiesFloor,
+  cfcIntegritySatisfiesFloorCoherently,
+  uniqueCfcAtoms,
+} from "./observation.ts";
+import { createTxCfcModulePolicyResolver } from "./policy-resolver.ts";
 import { cfcSchemaEntries } from "./schema-label-view.ts";
 import { mergeCfcSchemaEnvelopes } from "./schema-merge.ts";
-import {
-  CFC_SCHEMA_MIGRATION_INCOMPATIBLE_REASON,
-  CfcSchemaMigrationError,
-} from "./migration-reason.ts";
+import { createTrustResolver } from "./trust.ts";
 import {
   CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
   CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION,
@@ -117,6 +115,7 @@ import {
   recordedTrustedEventProvenanceMatchesUiContract,
   uiContractsFromSchema,
 } from "./ui-contract.ts";
+import { normalizeIdentitySource } from "./writer-claim-correspondence.ts";
 
 const INTERNAL_VERIFIER_META = {
   ...ignoreReadForScheduling,

--- a/packages/runner/src/cfc/render-ceiling.ts
+++ b/packages/runner/src/cfc/render-ceiling.ts
@@ -1,18 +1,19 @@
 import { CFC_ATOM_TYPE, type CfcAtom, cfcAtom } from "@commonfabric/api/cfc";
-import type { CfcConfClause } from "./clause.ts";
 import { isObjectOrArray } from "@commonfabric/utils/types";
+
+import type { CfcConfClause } from "./clause.ts";
+import { clauseAlternatives } from "./clause.ts";
+import {
+  type CfcGrantResolver,
+  evaluateExchangeRules,
+} from "./exchange-eval.ts";
 import {
   buildCfcPolicySnapshot,
   type ExchangeRule,
   type PolicySnapshot,
 } from "./policy.ts";
-import {
-  type CfcGrantResolver,
-  evaluateExchangeRules,
-} from "./exchange-eval.ts";
-import { clauseAlternatives } from "./clause.ts";
-import { type CfcTrustConfig, createTrustResolver } from "./trust.ts";
 import type { SpaceMembershipProvider } from "./space-membership.ts";
+import { type CfcTrustConfig, createTrustResolver } from "./trust.ts";
 
 /**
  * Display-sink render ceiling resolution (Epic H3b of

--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -1,13 +1,14 @@
-import { internSchema } from "@commonfabric/data-model/schema-hash";
 import type { CfcAtom } from "@commonfabric/api/cfc";
-import type { CfcConfClause } from "./clause.ts";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import {
   isObjectOrArray,
   isReadonlyObjectOrArray,
 } from "@commonfabric/utils/types";
+
 import type { JSONSchema, JSONSchemaObj } from "../builder/types.ts";
 import { forEachSubschema } from "../schema-walk.ts";
+import type { CfcConfClause } from "./clause.ts";
 import { normalizeClause } from "./clause.ts";
 import { CfcSchemaMigrationError } from "./migration-reason.ts";
 import { writerClaimFilesCorrespond } from "./writer-claim-correspondence.ts";

--- a/packages/runner/src/cfc/schema-refs.ts
+++ b/packages/runner/src/cfc/schema-refs.ts
@@ -1,9 +1,13 @@
 import type { JSONSchema, JSONSchemaObj } from "@commonfabric/api";
-import { isObjectOrArray } from "@commonfabric/utils/types";
-import { getLogger } from "@commonfabric/utils/logger";
-import { utf8Compare } from "@commonfabric/utils/utf8";
 import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+import { rendererVDOMSchema, vnodeSchema } from "@commonfabric/runner/schemas";
+import { getLogger } from "@commonfabric/utils/logger";
+import { isObjectOrArray } from "@commonfabric/utils/types";
+import { utf8Compare } from "@commonfabric/utils/utf8";
+
+import { decodeJsonPointer, encodeJsonPointer } from "../link-types.ts";
 import {
   forEachSubschema,
   isSubschema,
@@ -17,9 +21,6 @@ import {
 // everywhere in this module. (`$defs` bodies stay dormant — reached through the
 // definition-scope logic, not this flag.)
 const ALL_SUBSCHEMAS: SchemaWalkOptions = { includeUnused: true };
-import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
-import { rendererVDOMSchema, vnodeSchema } from "@commonfabric/runner/schemas";
-import { decodeJsonPointer, encodeJsonPointer } from "../link-types.ts";
 
 const logger = getLogger("cfc");
 

--- a/packages/runner/src/cfc/schema-sanitization.ts
+++ b/packages/runner/src/cfc/schema-sanitization.ts
@@ -5,8 +5,8 @@ import {
   type JSONSchema,
   type JSONValue,
 } from "@commonfabric/api";
-import type { CfcConfClause } from "./clause.ts";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import { schemaTypeOfFabricPrimitive } from "@commonfabric/data-model/fabric-primitives";
 import {
   cloneIfNecessary,
   type FabricPlainObject,
@@ -15,17 +15,24 @@ import {
   isFabricPlainObject,
   valueEqual,
 } from "@commonfabric/data-model/fabric-value";
-import { schemaTypeOfFabricPrimitive } from "@commonfabric/data-model/fabric-primitives";
 import { deepFrozenCloneAndInternSchema } from "@commonfabric/data-model/schema-hash";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
+
+import { isSubschema } from "../schema-walk.ts";
 import {
   hasOwnEnumerableDataProperty,
   isCellKind,
   isSchemaScope,
 } from "../scope.ts";
-import { isSubschema } from "../schema-walk.ts";
+import type { CfcConfClause } from "./clause.ts";
+import { clauseAlternatives, isOrClause } from "./clause.ts";
+import {
+  DEFAULT_EXCHANGE_FUEL,
+  evaluateExchangeRules,
+} from "./exchange-eval.ts";
 import { uniqueCfcAtoms } from "./observation.ts";
+import { buildCfcPolicySnapshot } from "./policy.ts";
 import {
   cfcSchemaChildRoot,
   isEmbeddedCfcSchemaRef,
@@ -33,12 +40,6 @@ import {
   resolveCfcSchemaRefRoot,
   resolveCfcSchemaRefs,
 } from "./schema-refs.ts";
-import {
-  DEFAULT_EXCHANGE_FUEL,
-  evaluateExchangeRules,
-} from "./exchange-eval.ts";
-import { buildCfcPolicySnapshot } from "./policy.ts";
-import { clauseAlternatives, isOrClause } from "./clause.ts";
 import {
   MATERIAL_RISK_DISCHARGE_KINDS,
   MATERIAL_RISK_DISCHARGE_POLICY,

--- a/packages/runner/src/cfc/trust.ts
+++ b/packages/runner/src/cfc/trust.ts
@@ -1,7 +1,8 @@
-import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import type { CfcAtom } from "@commonfabric/api/cfc";
+import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { isObjectNotArray } from "@commonfabric/utils/types";
+
 import { type AtomPattern, matchAtomPattern } from "./atom-pattern.ts";
 
 /**

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -1,10 +1,11 @@
-import type { CellScope, JSONSchema } from "../builder/types.ts";
-import type { CfcConfClause } from "./clause.ts";
 import type { FabricValue } from "@commonfabric/api";
 import type { CfcModulePolicyRefAtom } from "@commonfabric/api/cfc";
 import type { MemorySpace } from "@commonfabric/memory/interface";
 import type { Immutable } from "@commonfabric/utils/types";
+
+import type { CellScope, JSONSchema } from "../builder/types.ts";
 import type { Metadata } from "../storage/interface.ts";
+import type { CfcConfClause } from "./clause.ts";
 import type {
   CfcLabelView,
   IFCLabel,

--- a/packages/runner/src/cfc/ui-contract.ts
+++ b/packages/runner/src/cfc/ui-contract.ts
@@ -1,15 +1,16 @@
-import { isObjectOrArray } from "@commonfabric/utils/types";
-import type { CellScope, FabricValue, JSONSchema } from "../builder/types.ts";
-import { type NormalizedFullLink, parseLink } from "../link-utils.ts";
-import type { IExtendedStorageTransaction } from "../storage/interface.ts";
-import { findAndInlineDataUriLinks } from "../data-uri.ts";
 import {
   isFabricDataUri,
   valueFromDataUri,
 } from "@commonfabric/data-model/data-uri-codec";
+import { isObjectOrArray } from "@commonfabric/utils/types";
+
+import type { CellScope, FabricValue, JSONSchema } from "../builder/types.ts";
 import { ContextualFlowControl } from "../cfc.ts";
-import type { CfcAddress } from "./types.ts";
+import { findAndInlineDataUriLinks } from "../data-uri.ts";
 import { isNormalizedFullLink } from "../link-types.ts";
+import { type NormalizedFullLink, parseLink } from "../link-utils.ts";
+import type { IExtendedStorageTransaction } from "../storage/interface.ts";
+import type { CfcAddress } from "./types.ts";
 
 type UiContractTrustRequirements = {
   trustedPattern?: string;

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -1,31 +1,33 @@
-import { getLogger } from "@commonfabric/utils/logger";
-import { isObjectOrArray } from "@commonfabric/utils/types";
+import { normalize } from "@std/path/posix";
+
 import { CFC_COMPILED_BY_ATOM } from "@commonfabric/api/cfc";
 import type { PatternCoverageSpan } from "@commonfabric/ts-transformers";
-import { normalize } from "@std/path/posix";
-import { computeModuleHashes } from "../harness/module-identity.ts";
-import { ensureCompilerStack } from "../harness/deferred-compiler-stack.ts";
-import {
-  deriveModuleRecordFields,
-  SOURCE_ROOT_SPECIFIER,
-} from "../sandbox/module-record-compiler.ts";
-import type { CacheableModule } from "../harness/types.ts";
-import type { MemorySpace, Runtime } from "../runtime.ts";
-import type { IExtendedStorageTransaction } from "../storage/interface.ts";
-import { type Cell, isCell } from "../cell.ts";
-import { snapshotQueryResult } from "../query-result-proxy.ts";
+import { getLogger } from "@commonfabric/utils/logger";
+import { isObjectOrArray } from "@commonfabric/utils/types";
+
 import type { JSONSchema } from "../builder/types.ts";
+import { type Cell, isCell } from "../cell.ts";
 import { readStoredCfcMetadata } from "../cfc/metadata.ts";
+import { validateCfcPolicyArtifactManifest } from "../cfc/policy.ts";
+import { ensureCompilerStack } from "../harness/deferred-compiler-stack.ts";
+import { computeModuleHashes } from "../harness/module-identity.ts";
+import type { CacheableModule } from "../harness/types.ts";
+import { snapshotQueryResult } from "../query-result-proxy.ts";
+import type { MemorySpace, Runtime } from "../runtime.ts";
 import {
   isFabricImportSpecifier,
   parseFabricRef,
   pinnedIdentity,
 } from "../sandbox/fabric-import-specifier.ts";
 import {
+  deriveModuleRecordFields,
+  SOURCE_ROOT_SPECIFIER,
+} from "../sandbox/module-record-compiler.ts";
+import type { IExtendedStorageTransaction } from "../storage/interface.ts";
+import {
   COMPILE_CACHE_RUNTIME_VERSION,
   SOURCE_COMPILE_CACHE_RUNTIME_VERSION,
 } from "./compile-cache-version.ts";
-import { validateCfcPolicyArtifactManifest } from "../cfc/policy.ts";
 
 const logger = getLogger("cell-cache");
 

--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -1,26 +1,27 @@
-import { hashOf } from "@commonfabric/data-model/value-hash";
-import { encodableFormOf } from "./encodable-form.ts";
-import {
-  hasEntityUriScheme,
-  hashStringForEntityAddress,
-} from "./entity-kind.ts";
-import { BaseFabricPrimitive } from "@commonfabric/data-model/codec-common";
-import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
 import {
   type EntityRef,
   entityRefFrom,
   entityRefFromString,
   isEntityRef,
 } from "@commonfabric/data-model/cell-rep";
+import { BaseFabricPrimitive } from "@commonfabric/data-model/codec-common";
+import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
+import { hashOf } from "@commonfabric/data-model/value-hash";
 import { isObjectOrArray } from "@commonfabric/utils/types";
+
 import { isReactive } from "./builder/types.ts";
+import { isCell } from "./cell.ts";
+import { encodableFormOf } from "./encodable-form.ts";
+import {
+  hasEntityUriScheme,
+  hashStringForEntityAddress,
+} from "./entity-kind.ts";
+import { isSigilLink, parseLink } from "./link-utils.ts";
 import {
   getCellOrThrow,
   isCellResultForDereferencing,
 } from "./query-result-proxy.ts";
-import { isCell } from "./cell.ts";
 import { fromURI } from "./uri-utils.ts";
-import { isSigilLink, parseLink } from "./link-utils.ts";
 
 declare const ENTITY_ID_BRAND: unique symbol;
 

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -1,7 +1,7 @@
-import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
-import type { CfcConfClause } from "./cfc/clause.ts";
+import type { JSONSchemaObj } from "@commonfabric/api";
 import type { CfcAtom } from "@commonfabric/api/cfc";
-import { forEachSubschema } from "./schema-walk.ts";
+import { linkRefFrom, linkRefPayload } from "@commonfabric/data-model/cell-rep";
+import { isFabricDataUri } from "@commonfabric/data-model/data-uri-codec";
 import {
   fabricFromNativeValue,
   type FabricPlainObject,
@@ -9,22 +9,40 @@ import {
   type FabricValue,
   shallowFabricFromNativeValue,
 } from "@commonfabric/data-model/fabric-value";
-import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { getLogger } from "@commonfabric/utils/logger";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
+
 import { type CellScope, type JSONSchema } from "./builder/types.ts";
-import type { JSONSchemaObj } from "@commonfabric/api";
-import { ContextualFlowControl } from "./cfc.ts";
-import { isCellScope, scopeRank } from "./scope.ts";
-import { createRef } from "./create-ref.ts";
-import { flattenBuilderArtifacts } from "./storage-preflight.ts";
 import {
   CellImpl,
   isCell,
   recordRelevantSchemaWritePolicyInput,
 } from "./cell.ts";
+import { ContextualFlowControl } from "./cfc.ts";
+import { canonicalizeLogicalPath } from "./cfc/canonical.ts";
+import type { CfcConfClause } from "./cfc/clause.ts";
+import {
+  type CfcLabelView,
+  cloneCfcLabelView,
+  getCarriedCfcLabelView,
+} from "./cfc/label-view-state.ts";
+import {
+  type CfcCellLinkRefPayload,
+  linkCfcLabelView,
+} from "./cfc/link-label-view.ts";
+import {
+  readStoredCfcMetadata,
+  storedCfcMetadataAppliesToPath,
+} from "./cfc/metadata.ts";
+import {
+  CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
+  type CfcAddress,
+} from "./cfc/types.ts";
+import { createRef } from "./create-ref.ts";
+import { findAndInlineDataUriLinks } from "./data-uri.ts";
 import { resolveLink } from "./link-resolution.ts";
-import { resolveSchemaRefsCanonical, schemaAcceptsType } from "./traverse.ts";
 import {
   areLinksSame,
   areMaybeLinkAndNormalizedLinkSame,
@@ -37,43 +55,26 @@ import {
   type NormalizedFullLink,
   parseLink,
 } from "./link-utils.ts";
-import { findAndInlineDataUriLinks } from "./data-uri.ts";
-import {
-  type CfcCellLinkRefPayload,
-  linkCfcLabelView,
-} from "./cfc/link-label-view.ts";
 import {
   getCellOrThrow,
   isCellResultForDereferencing,
 } from "./query-result-proxy.ts";
-import { resolveSchema, resolveSchemaForValue } from "./schema.ts";
-import type {
-  IExtendedStorageTransaction,
-  IReadOptions,
-} from "./storage/interface.ts";
 import { type Runtime } from "./runtime.ts";
-import { isFabricDataUri } from "@commonfabric/data-model/data-uri-codec";
-import { toURI } from "./uri-utils.ts";
 import {
   allowMutableTransactionRead,
   markReadAsAttemptedWrite,
 } from "./scheduler.ts";
+import { forEachSubschema } from "./schema-walk.ts";
+import { resolveSchema, resolveSchemaForValue } from "./schema.ts";
+import { isCellScope, scopeRank } from "./scope.ts";
+import { flattenBuilderArtifacts } from "./storage-preflight.ts";
+import type {
+  IExtendedStorageTransaction,
+  IReadOptions,
+} from "./storage/interface.ts";
 import { ignoreReadForScheduling } from "./storage/reactivity-log.ts";
-import {
-  readStoredCfcMetadata,
-  storedCfcMetadataAppliesToPath,
-} from "./cfc/metadata.ts";
-import { canonicalizeLogicalPath } from "./cfc/canonical.ts";
-import {
-  type CfcLabelView,
-  cloneCfcLabelView,
-  getCarriedCfcLabelView,
-} from "./cfc/label-view-state.ts";
-import {
-  CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
-  type CfcAddress,
-} from "./cfc/types.ts";
-import { linkRefFrom, linkRefPayload } from "@commonfabric/data-model/cell-rep";
+import { resolveSchemaRefsCanonical, schemaAcceptsType } from "./traverse.ts";
+import { toURI } from "./uri-utils.ts";
 
 const diffLogger = getLogger("normalizeAndDiff", {
   enabled: false,

--- a/packages/runner/src/data-uri.ts
+++ b/packages/runner/src/data-uri.ts
@@ -24,13 +24,20 @@
  */
 
 import {
+  dataUriFromValue,
+  isFabricDataUri,
+  valueFromDataUri,
+} from "@commonfabric/data-model/data-uri-codec";
+import {
   FabricInstance,
   FabricPrimitive,
   type FabricValue,
 } from "@commonfabric/data-model/fabric-value";
 import { isObjectOrArray } from "@commonfabric/utils/types";
-import { refuseFabricInstance } from "./fabric-special-object.ts";
+
 import { type Cell, isCell } from "./cell.ts";
+import { ContextualFlowControl } from "./cfc.ts";
+import { refuseFabricInstance } from "./fabric-special-object.ts";
 import { isPrimitiveCellLink, type NormalizedLink } from "./link-types.ts";
 import {
   createSigilLinkFromParsedLink,
@@ -38,13 +45,7 @@ import {
   KeepAsCell,
   parseLink,
 } from "./link-utils.ts";
-import { ContextualFlowControl } from "./cfc.ts";
 import type { URI } from "./sigil-types.ts";
-import {
-  dataUriFromValue,
-  isFabricDataUri,
-  valueFromDataUri,
-} from "@commonfabric/data-model/data-uri-codec";
 
 /**
  * Makes a `data:` URI that names a cell whose content is carried in the id

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -1,49 +1,50 @@
-import { Console } from "./console.ts";
-import {
-  type CacheableModule,
-  type CompiledModuleArtifact,
-  type EvaluateResult,
-  type Exports,
-  type HarnessedFunction,
-  type ResolvedFabricPin,
-  type RuntimeProgram,
-  type TypeScriptHarnessProcessOptions,
-} from "./types.ts";
+import { hashOf } from "@commonfabric/data-model/value-hash";
 import type {
   MappedPosition,
   Program,
   ProgramResolver,
   Source,
+  SourceMap,
   TypeScriptCompiler,
   TypeScriptCompilerOptions,
 } from "@commonfabric/js-compiler";
 import { InMemoryProgram } from "@commonfabric/js-compiler/program";
+import {
+  composeBundleSourceMap,
+  identitySourceMap,
+} from "@commonfabric/js-compiler/source-map";
+import type { StaticCache } from "@commonfabric/static";
 import type { PatternCoverageOptions } from "@commonfabric/ts-transformers";
 import {
   findFirstContentLineIndex,
   PATTERN_COVERAGE_GLOBAL,
   sourceDisablesCfTransform,
 } from "@commonfabric/ts-transformers/runtime-contract";
-import {
-  compilerStack,
-  ensureCompilerStack,
-} from "./deferred-compiler-stack.ts";
 import { getLogger } from "@commonfabric/utils/logger";
-import {
-  COMPILE_INTERLEAVES_EVENT_LOOP,
-  interleaveCompileYield,
-} from "./compile-interleave.ts";
+
+import { isTrustedBuilderArtifact } from "../builder/pattern-metadata.ts";
+import { popFrame, pushFrame } from "../builder/pattern.ts";
+import { validateCfcPolicyArtifactManifest } from "../cfc/policy.ts";
+import type { PatternCoverageCollector } from "../pattern-coverage.ts";
 import { type MemorySpace, Runtime } from "../runtime.ts";
-import { hashOf } from "@commonfabric/data-model/value-hash";
-import type { StaticCache } from "@commonfabric/static";
 import {
-  pretransformProgramForModules,
-  transformInjectHelperModule,
-} from "./pretransform.ts";
+  createModuleCompartmentGlobals,
+  createSafeConsoleGlobal,
+} from "../sandbox/compartment-globals.ts";
 import {
-  type ModuleImportEdges,
-  resolveModuleImports,
-} from "./module-identity.ts";
+  loadModuleGraph,
+  runtimeModuleRecords,
+  type VirtualModuleRecord,
+} from "../sandbox/esm-module-loader.ts";
+import { isFabricImportSpecifier } from "../sandbox/fabric-import-specifier.ts";
+import {
+  ensureSESLockdown,
+  getRuntimeModuleExports,
+  getRuntimeModuleTypes,
+  isRuntimeModuleIdentifier,
+  RuntimeModuleIdentifiers,
+  SESRuntime,
+} from "../sandbox/mod.ts";
 import {
   buildRecordsFromCompiled,
   type CachedCompiledModule,
@@ -56,44 +57,44 @@ import {
   sourceRootSpecifier,
 } from "../sandbox/module-record-compiler.ts";
 import {
-  composeBundleSourceMap,
-  identitySourceMap,
-} from "@commonfabric/js-compiler/source-map";
-import type { SourceMap } from "@commonfabric/js-compiler";
-import {
-  loadModuleGraph,
-  runtimeModuleRecords,
-  type VirtualModuleRecord,
-} from "../sandbox/esm-module-loader.ts";
-import {
   verifyCompiledModuleBody,
   verifyModuleGraph,
 } from "../sandbox/module-record-verifier.ts";
-import { popFrame, pushFrame } from "../builder/pattern.ts";
-import type { PatternCoverageCollector } from "../pattern-coverage.ts";
-import {
-  ensureSESLockdown,
-  getRuntimeModuleExports,
-  getRuntimeModuleTypes,
-  isRuntimeModuleIdentifier,
-  RuntimeModuleIdentifiers,
-  SESRuntime,
-} from "../sandbox/mod.ts";
-import {
-  createModuleCompartmentGlobals,
-  createSafeConsoleGlobal,
-} from "../sandbox/compartment-globals.ts";
 import type { UnsafeHostTrustOptions } from "../unsafe-host-trust.ts";
+import {
+  COMPILE_INTERLEAVES_EVENT_LOOP,
+  interleaveCompileYield,
+} from "./compile-interleave.ts";
+import { Console } from "./console.ts";
+import {
+  compilerStack,
+  ensureCompilerStack,
+} from "./deferred-compiler-stack.ts";
 import { ExecutableRegistry } from "./executable-registry.ts";
-import { isTrustedBuilderArtifact } from "../builder/pattern-metadata.ts";
+import { FabricAwareResolver } from "./fabric-resolver.ts";
+import {
+  type ModuleImportEdges,
+  resolveModuleImports,
+} from "./module-identity.ts";
+import {
+  pretransformProgramForModules,
+  transformInjectHelperModule,
+} from "./pretransform.ts";
+import {
+  type CacheableModule,
+  type CompiledModuleArtifact,
+  type EvaluateResult,
+  type Exports,
+  type HarnessedFunction,
+  type ResolvedFabricPin,
+  type RuntimeProgram,
+  type TypeScriptHarnessProcessOptions,
+} from "./types.ts";
 import {
   getDefiningModule,
   readBindingIdentity,
   recordVerifiedProvenance,
 } from "./verified-provenance.ts";
-import { FabricAwareResolver } from "./fabric-resolver.ts";
-import { isFabricImportSpecifier } from "../sandbox/fabric-import-specifier.ts";
-import { validateCfcPolicyArtifactManifest } from "../cfc/policy.ts";
 
 const logger = getLogger("engine");
 

--- a/packages/runner/src/harness/fabric-resolver.ts
+++ b/packages/runner/src/harness/fabric-resolver.ts
@@ -1,10 +1,11 @@
 import type { ProgramResolver, Source } from "@commonfabric/js-compiler";
-import { compilerStack } from "./deferred-compiler-stack.ts";
 import { getLogger } from "@commonfabric/utils/logger";
+
 import {
   loadVerifiedSourceClosure,
   type SourceDoc,
 } from "../compilation-cache/cell-cache.ts";
+import { resolveFabricRefToIdentity } from "../fabric-ref-resolution.ts";
 import type { MemorySpace, Runtime } from "../runtime.ts";
 import {
   parseFabricRef,
@@ -14,7 +15,7 @@ import {
   FABRIC_MOUNT_ROOT,
   type FabricMount,
 } from "../sandbox/module-record-compiler.ts";
-import { resolveFabricRefToIdentity } from "../fabric-ref-resolution.ts";
+import { compilerStack } from "./deferred-compiler-stack.ts";
 import type { FabricImportOptions, ResolvedFabricPin } from "./types.ts";
 
 const MAX_FABRIC_MOUNTS = 32;

--- a/packages/runner/src/harness/module-identity.ts
+++ b/packages/runner/src/harness/module-identity.ts
@@ -1,7 +1,8 @@
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import type { Program } from "@commonfabric/js-compiler";
 import { resolveImportSpecifier } from "@commonfabric/js-compiler/specifier";
+
 import { compilerStack } from "./deferred-compiler-stack.ts";
-import { hashStringOf } from "@commonfabric/data-model/value-hash";
 
 /**
  * Per-module content-addressed identity.

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -1,7 +1,10 @@
+import { MetaLinkField } from "@commonfabric/api";
+import { linkRefFrom, linkRefPayload } from "@commonfabric/data-model/cell-rep";
+import { deepFreeze, isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
+import { isNontrivialSchema } from "@commonfabric/data-model/schema-utils";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { isObjectOrArray } from "@commonfabric/utils/types";
-import { isNontrivialSchema } from "@commonfabric/data-model/schema-utils";
-import { deepFreeze, isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
+
 import {
   type AnyCell,
   type DerivedInternalCellDescriptor,
@@ -15,21 +18,9 @@ import {
   type MemorySpace,
   type Stream,
 } from "./cell.ts";
-import { type CellLinkRefPayload, type SigilLink } from "./sigil-types.ts";
-import { linkRefFrom, linkRefPayload } from "@commonfabric/data-model/cell-rep";
-import { toURI } from "./uri-utils.ts";
-import {
-  CellResultInternals,
-  getCellOrThrow,
-  isCellResultForDereferencing,
-} from "./query-result-proxy.ts";
 import { ContextualFlowControl } from "./cfc.ts";
+import { createRef } from "./create-ref.ts";
 import { resolveLink } from "./link-resolution.ts";
-import {
-  IExtendedStorageTransaction,
-  IMemorySpaceAddress,
-} from "./storage/interface.ts";
-import type { Runtime } from "./runtime.ts";
 import {
   areNormalizedLinksSame,
   isNormalizedFullLink,
@@ -40,9 +31,19 @@ import {
   parseLinkPrimitive,
   PrimitiveCellLink,
 } from "./link-types.ts";
-import { MetaLinkField } from "@commonfabric/api";
+import {
+  CellResultInternals,
+  getCellOrThrow,
+  isCellResultForDereferencing,
+} from "./query-result-proxy.ts";
+import type { Runtime } from "./runtime.ts";
 import { ignoreReadForScheduling } from "./scheduler.ts";
-import { createRef } from "./create-ref.ts";
+import { type CellLinkRefPayload, type SigilLink } from "./sigil-types.ts";
+import {
+  IExtendedStorageTransaction,
+  IMemorySpaceAddress,
+} from "./storage/interface.ts";
+import { toURI } from "./uri-utils.ts";
 
 export * from "./link-types.ts";
 

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -1,7 +1,7 @@
-import { getLogger } from "@commonfabric/utils/logger";
 import type { Source } from "@commonfabric/js-compiler";
-import { compilerStack } from "./harness/deferred-compiler-stack.ts";
-import { Module, Pattern } from "./builder/types.ts";
+import { getLogger } from "@commonfabric/utils/logger";
+import { isObjectOrArray } from "@commonfabric/utils/types";
+
 import {
   brandTrustedPattern,
   getArtifactEntryRef,
@@ -13,25 +13,9 @@ import {
   setPatternProgram,
   setPatternSourcePath,
 } from "./builder/pattern-metadata.ts";
-import type { MemorySpace, Runtime } from "./runtime.ts";
-import type { PatternCoverageCollector } from "./pattern-coverage.ts";
-import { createRef } from "./create-ref.ts";
-import type {
-  CacheableModule,
-  CompiledModuleArtifact,
-  EvaluateResult,
-  Exports,
-  TypeScriptHarnessProcessOptions,
-} from "./harness/types.ts";
-import { RuntimeProgram } from "./harness/types.ts";
-import {
-  type CachedCompiledModule,
-  SOURCE_ROOT_SPECIFIER,
-} from "./sandbox/module-record-compiler.ts";
-import type {
-  CommitError,
-  IExtendedStorageTransaction,
-} from "./storage/interface.ts";
+import { Module, Pattern } from "./builder/types.ts";
+import { readStoredCfcMetadata } from "./cfc/metadata.ts";
+import type { CfcMetadata } from "./cfc/types.ts";
 import {
   buildSourceDocs,
   COMPILED_INTEGRITY_ATOM,
@@ -50,16 +34,33 @@ import {
   writeSourceAndCompiledDocs,
   writeSourceDocs,
 } from "./compilation-cache/cell-cache.ts";
-import { readStoredCfcMetadata } from "./cfc/metadata.ts";
-import type { CfcMetadata } from "./cfc/types.ts";
+import { createRef } from "./create-ref.ts";
+import { interleaveCompileYield } from "./harness/compile-interleave.ts";
+import { compilerStack } from "./harness/deferred-compiler-stack.ts";
+import type {
+  CacheableModule,
+  CompiledModuleArtifact,
+  EvaluateResult,
+  Exports,
+  TypeScriptHarnessProcessOptions,
+} from "./harness/types.ts";
+import { RuntimeProgram } from "./harness/types.ts";
+import type { PatternCoverageCollector } from "./pattern-coverage.ts";
+import type { MemorySpace, Runtime } from "./runtime.ts";
 import {
   isFabricImportSpecifier,
   parseFabricRef,
   pinnedIdentity,
 } from "./sandbox/fabric-import-specifier.ts";
+import {
+  type CachedCompiledModule,
+  SOURCE_ROOT_SPECIFIER,
+} from "./sandbox/module-record-compiler.ts";
+import type {
+  CommitError,
+  IExtendedStorageTransaction,
+} from "./storage/interface.ts";
 import { fromURI, toURI } from "./uri-utils.ts";
-import { isObjectOrArray } from "@commonfabric/utils/types";
-import { interleaveCompileYield } from "./harness/compile-interleave.ts";
 
 const logger = getLogger("pattern-manager");
 

--- a/packages/runner/src/pattern-updater.ts
+++ b/packages/runner/src/pattern-updater.ts
@@ -1,7 +1,14 @@
 import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
+import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { getLogger } from "@commonfabric/utils/logger";
+
+import type { Pattern } from "./builder/types.ts";
 import type { Cell } from "./cell.ts";
-import type { IExtendedStorageTransaction } from "./storage/interface.ts";
+import {
+  normalizePatternSource,
+  resolveSystemPatternSource,
+  systemPatternSourceForModuleName,
+} from "./pattern-source-scheme.ts";
 import {
   applyPieceSourceTransition,
   getPatternIdentityRef,
@@ -14,19 +21,13 @@ import {
   type PieceSourceTransitionBaseline,
   preparePieceSourceTransitionBaseline,
 } from "./runner.ts";
-import type { Pattern } from "./builder/types.ts";
+import type { Runtime } from "./runtime.ts";
 import {
   parseFabricRef,
   pinnedIdentity,
 } from "./sandbox/fabric-import-specifier.ts";
-import {
-  normalizePatternSource,
-  resolveSystemPatternSource,
-  systemPatternSourceForModuleName,
-} from "./pattern-source-scheme.ts";
-import type { Runtime } from "./runtime.ts";
-import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { fabricAuthorityMatchesSpaceHost } from "./space-host.ts";
+import type { IExtendedStorageTransaction } from "./storage/interface.ts";
 import {
   isConflictRejection,
   isStorageTransactionInconsistent,

--- a/packages/runner/src/piece-helpers.ts
+++ b/packages/runner/src/piece-helpers.ts
@@ -2,25 +2,28 @@ import {
   entityRefToString,
   isEntityRef,
 } from "@commonfabric/data-model/cell-rep";
+
+import { getLogger } from "../../utils/src/logger.ts";
 // Relative import (not "@commonfabric/utils/types") for the same rollup
 // reason as traverse.ts.
 import { isObjectOrArray } from "../../utils/src/types.ts";
-import { getLogger } from "../../utils/src/logger.ts";
+import type { JSONSchema, Pattern } from "./builder/types.ts";
 import { type Cell, isCell, isStream } from "./cell.ts";
+import { ContextualFlowControl } from "./cfc.ts";
+import type { RuntimeProgram } from "./harness/types.ts";
+import { resolveLink } from "./link-resolution.ts";
 import { isSigilLink, linkPathSegmentToCellPathSegment } from "./link-types.ts";
 import { parseLink } from "./link-utils.ts";
 import {
   normalizePatternSource,
   systemPatternSource,
 } from "./pattern-source-scheme.ts";
-import { resolveLink } from "./link-resolution.ts";
-import { ContextualFlowControl } from "./cfc.ts";
-import { DEFAULT_CELL_SCOPE, scopeRank } from "./scope.ts";
-import type { IExtendedStorageTransaction } from "./storage/interface.ts";
-import type { MemorySpace } from "./storage/interface.ts";
-import type { JSONSchema, Pattern } from "./builder/types.ts";
 import type { Runtime } from "./runtime.ts";
-import type { RuntimeProgram } from "./harness/types.ts";
+import { DEFAULT_CELL_SCOPE, scopeRank } from "./scope.ts";
+import type {
+  IExtendedStorageTransaction,
+  MemorySpace,
+} from "./storage/interface.ts";
 
 const logger = getLogger("piece-helpers");
 

--- a/packages/runner/src/result-utils.ts
+++ b/packages/runner/src/result-utils.ts
@@ -1,5 +1,6 @@
-import type { Cell } from "./cell.ts";
 import type { FabricValue } from "@commonfabric/api";
+
+import type { Cell } from "./cell.ts";
 
 /**
  * @param resultCell The cell whose meta pattern will be set

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1,3 +1,4 @@
+import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import {
   fabricFromNativeValue,
   FabricInstance,
@@ -5,26 +6,26 @@ import {
   nativeFromFabricValue,
   valueEqual,
 } from "@commonfabric/data-model/fabric-value";
-import { refuseFabricInstance } from "./fabric-special-object.ts";
-import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+import { hashOf, hashStringOf } from "@commonfabric/data-model/value-hash";
 import {
   getPersistentSchedulerStateConfig,
   type SchedulerActionSnapshotCursor,
 } from "@commonfabric/memory/v2";
-import type { EntityKind } from "./entity-kind.ts";
-import { ContextualFlowControl } from "./cfc.ts";
-import { hashOf } from "@commonfabric/data-model/value-hash";
-import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+import { BoundedKeyMap } from "@commonfabric/utils/cache";
+import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { getLogger } from "@commonfabric/utils/logger";
 import {
   isObjectNotArray,
   isObjectOrArray,
   isPlainObject,
 } from "@commonfabric/utils/types";
-import { BoundedKeyMap } from "@commonfabric/utils/cache";
-import { PatternManager } from "./pattern-manager.ts";
-import { rendererVDOMSchema } from "./schemas.ts";
-import { forEachSubschema } from "./schema-walk.ts";
+
+import {
+  patternFromFrame,
+  popFrame,
+  pushFrameFromCause,
+} from "./builder/pattern.ts";
 import {
   type CellScope,
   type FabricExecValue,
@@ -42,23 +43,17 @@ import {
   UI,
 } from "./builder/types.ts";
 import {
-  patternFromFrame,
-  popFrame,
-  pushFrameFromCause,
-} from "./builder/pattern.ts";
+  type AddCancel,
+  type Cancel,
+  type DeferredCancelOwnership,
+  useCancelGroup,
+  useDeferredCancelOwnership,
+} from "./cancel.ts";
 import { type Cell, createCell, isCell } from "./cell.ts";
+import { ContextualFlowControl } from "./cfc.ts";
 import { findAndInlineDataUriLinks } from "./data-uri.ts";
-import { type Action } from "./scheduler.ts";
-import {
-  isSchedulerActionObservation,
-  type PersistedSchedulerObservationSnapshot,
-} from "./scheduler/persistent-observation.ts";
-import { RetryImmediately } from "./scheduler/retry-immediately.ts";
-import {
-  findAllWriteRedirectCells,
-  opaqueArgumentKeys,
-  unwrapOneLevelAndBindToDoc,
-} from "./pattern-binding.ts";
+import type { EntityKind } from "./entity-kind.ts";
+import { refuseFabricInstance } from "./fabric-special-object.ts";
 import { resolveLink } from "./link-resolution.ts";
 import {
   areNormalizedLinksSame,
@@ -77,19 +72,27 @@ import {
   parseLink,
   toMemorySpaceAddress,
 } from "./link-utils.ts";
-import { deepEqual } from "@commonfabric/utils/deep-equal";
-import { sendValueToBinding } from "./pattern-binding.ts";
-import { flattenBuilderArtifacts } from "./storage-preflight.ts";
-import { isCellResultForDereferencing } from "./query-result-proxy.ts";
-import { hashStringOf } from "@commonfabric/data-model/value-hash";
+import { isRawBuiltinResult, type RawBuiltinReturnType } from "./module.ts";
 import {
-  type AddCancel,
-  type Cancel,
-  type DeferredCancelOwnership,
-  useCancelGroup,
-  useDeferredCancelOwnership,
-} from "./cancel.ts";
+  findAllWriteRedirectCells,
+  opaqueArgumentKeys,
+  sendValueToBinding,
+  unwrapOneLevelAndBindToDoc,
+} from "./pattern-binding.ts";
+import { PatternManager } from "./pattern-manager.ts";
+import { isCellResultForDereferencing } from "./query-result-proxy.ts";
 import type { Runtime } from "./runtime.ts";
+import { type Action, ignoreReadForScheduling } from "./scheduler.ts";
+import {
+  isSchedulerActionObservation,
+  type PersistedSchedulerObservationSnapshot,
+} from "./scheduler/persistent-observation.ts";
+import { RetryImmediately } from "./scheduler/retry-immediately.ts";
+import { isSchemaMismatchError } from "./schema-view.ts";
+import { forEachSubschema } from "./schema-walk.ts";
+import { rendererVDOMSchema } from "./schemas.ts";
+import { flattenBuilderArtifacts } from "./storage-preflight.ts";
+import { TransactionWrapper } from "./storage/extended-storage-transaction.ts";
 import type {
   IExtendedStorageTransaction,
   IStorageProvider,
@@ -97,20 +100,46 @@ import type {
   MemorySpace,
   URI,
 } from "./storage/interface.ts";
-import { TransactionWrapper } from "./storage/extended-storage-transaction.ts";
-import { isSchemaMismatchError } from "./schema-view.ts";
-import {
-  isConflictRejection,
-  isStorageTransactionInconsistent,
-} from "./storage/rejection.ts";
-import { ignoreReadForScheduling } from "./scheduler.ts";
 import {
   machineryRead,
   schedulerDependencyRead,
 } from "./storage/reactivity-log.ts";
-import { isRawBuiltinResult, type RawBuiltinReturnType } from "./module.ts";
+import {
+  isConflictRejection,
+  isStorageTransactionInconsistent,
+} from "./storage/rejection.ts";
+
 import "./builtins/index.ts";
-import { isCellScope, narrowestScope } from "./scope.ts";
+
+import { runInActionExecution } from "./builder/action-context.ts";
+import {
+  getArtifactEntryRef,
+  getPatternProgram,
+  getPatternSourcePath,
+  isTrustedBuilderArtifact,
+  resolveOriginal,
+} from "./builder/pattern-metadata.ts";
+import {
+  resolveBuiltinImplementationIdentity,
+  resolvePolicyFacingImplementationIdentity,
+} from "./cfc/implementation-identity.ts";
+import {
+  localRefTarget,
+  relaxDefaultedRequired,
+  validateSchemaValue,
+} from "./cfc/schema-sanitization.ts";
+import {
+  CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION,
+  type ImplementationIdentity,
+} from "./cfc/types.ts";
+import {
+  prepareSourceClosureVerification,
+  readVerifiedSourceClosure,
+} from "./compilation-cache/cell-cache.ts";
+import { createRef } from "./create-ref.ts";
+import { diffAndUpdate } from "./data-updating.ts";
+import { getVerifiedProvenance } from "./harness/verified-provenance.ts";
+import { setResultCell } from "./result-utils.ts";
 import {
   describePatternOrModule,
   extractDefaultValues,
@@ -120,36 +149,8 @@ import {
   setRunnableName,
 } from "./runner-utils.ts";
 import { normalizeSandboxResult } from "./sandbox/result-normalization.ts";
-import {
-  resolveBuiltinImplementationIdentity,
-  resolvePolicyFacingImplementationIdentity,
-} from "./cfc/implementation-identity.ts";
-import {
-  CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION,
-  type ImplementationIdentity,
-} from "./cfc/types.ts";
-import {
-  localRefTarget,
-  relaxDefaultedRequired,
-  validateSchemaValue,
-} from "./cfc/schema-sanitization.ts";
-import { runInActionExecution } from "./builder/action-context.ts";
-import { getVerifiedProvenance } from "./harness/verified-provenance.ts";
-import {
-  getArtifactEntryRef,
-  getPatternProgram,
-  getPatternSourcePath,
-  isTrustedBuilderArtifact,
-  resolveOriginal,
-} from "./builder/pattern-metadata.ts";
-import { diffAndUpdate } from "./data-updating.ts";
-import { setResultCell } from "./result-utils.ts";
+import { isCellScope, narrowestScope } from "./scope.ts";
 import { SigilLink } from "./sigil-types.ts";
-import {
-  prepareSourceClosureVerification,
-  readVerifiedSourceClosure,
-} from "./compilation-cache/cell-cache.ts";
-import { createRef } from "./create-ref.ts";
 import { toURI } from "./uri-utils.ts";
 export {
   extractDefaultValues,

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1,23 +1,14 @@
-import { StaticCache } from "@commonfabric/static";
-import { RuntimeTelemetry } from "@commonfabric/runner";
-import { fabricFromNativeValue } from "@commonfabric/data-model/fabric-value";
-import { dataUriFromValue } from "@commonfabric/data-model/data-uri-codec";
-import { flattenBuilderArtifacts } from "./storage-preflight.ts";
-import type { NonIdempotentReport } from "./telemetry.ts";
-import type {
-  AnyCell,
-  JSONSchema,
-  Module,
-  NodeFactory,
-  Pattern,
-  Schema,
-} from "./builder/types.ts";
 import {
   getModernCellRepConfig,
   resetModernCellRepConfig,
   setModernCellRepConfig,
 } from "@commonfabric/data-model/cell-rep";
+import { dataUriFromValue } from "@commonfabric/data-model/data-uri-codec";
+import { fabricFromNativeValue } from "@commonfabric/data-model/fabric-value";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { createSession, Identity } from "@commonfabric/identity";
 import {
+  commitPreconditionValueHash,
   getCommitPreconditionsConfig,
   getPersistentSchedulerStateConfig,
   resetCommitPreconditionsConfig,
@@ -25,22 +16,31 @@ import {
   setCommitPreconditionsConfig,
   setPersistentSchedulerStateConfig,
 } from "@commonfabric/memory/v2";
+import { RuntimeTelemetry } from "@commonfabric/runner";
+import { StaticCache } from "@commonfabric/static";
+import {
+  type AsyncLocalStore,
+  FallbackAsyncLocalStore,
+} from "@commonfabric/utils/async-local-store";
+import { deepEqual } from "@commonfabric/utils/deep-equal";
+import { isDeno } from "@commonfabric/utils/env";
+
 import { PatternEnvironment, setPatternEnvironment } from "./builder/env.ts";
 import {
   isEagerSourceAnnotationEnabled,
   setEagerSourceAnnotation,
 } from "./builder/module.ts";
-import { AsyncSemaphoreQueue, type QueueConfig } from "./queue.ts";
-import type { PatternCoverageCollector } from "./pattern-coverage.ts";
+import { popFrame, pushFrame } from "./builder/pattern.ts";
 import type {
-  ChangeGroup,
-  CommitError,
-  DID,
-  IExtendedStorageTransaction,
-  IStorageManager,
-  MemorySpace,
-  URI,
-} from "./storage/interface.ts";
+  AnyCell,
+  Frame,
+  JSONSchema,
+  Module,
+  NodeFactory,
+  Pattern,
+  Schema,
+} from "./builder/types.ts";
+import { registerBuiltins } from "./builtins/index.ts";
 import {
   type Cell,
   createCell,
@@ -48,25 +48,6 @@ import {
   isCell,
   schemaCellScope,
 } from "./cell.ts";
-import { createRef, EntityId } from "./create-ref.ts";
-import { createSession, Identity } from "@commonfabric/identity";
-import { Action, Scheduler } from "./scheduler.ts";
-import {
-  type CommitBackpressurePolicy,
-  resolveCommitBackpressure,
-} from "./scheduler/backpressure.ts";
-import { Engine } from "./harness/index.ts";
-import {
-  CellLink,
-  isCellLink,
-  isNormalizedFullLink,
-  isSigilLink,
-  type NormalizedFullLink,
-  NormalizedLink,
-  parseLink,
-} from "./link-utils.ts";
-import { addressKey } from "./link-types.ts";
-import { internSchema } from "@commonfabric/data-model/schema-hash";
 import {
   buildCfcPolicySnapshot,
   buildCfcTrustConfig,
@@ -96,28 +77,47 @@ import {
   type PolicyArtifactManifestV1,
   validateCfcPolicyArtifactManifest,
 } from "./cfc/policy.ts";
-import { deepEqual } from "@commonfabric/utils/deep-equal";
-import { commitPreconditionValueHash } from "@commonfabric/memory/v2";
-import { snapshotQueryResult } from "./query-result-proxy.ts";
+import { createRef, EntityId } from "./create-ref.ts";
+import type { ConsoleMethod } from "./harness/console.ts";
+import { Engine } from "./harness/index.ts";
+import type { CompiledModuleArtifact } from "./harness/types.ts";
+import type { ConsoleMessage } from "./interface.ts";
+import { addressKey } from "./link-types.ts";
+import {
+  CellLink,
+  isCellLink,
+  isNormalizedFullLink,
+  isSigilLink,
+  type NormalizedFullLink,
+  NormalizedLink,
+  parseLink,
+} from "./link-utils.ts";
+import { ModuleRegistry } from "./module.ts";
+import type { PatternCoverageCollector } from "./pattern-coverage.ts";
 import { PatternManager } from "./pattern-manager.ts";
 import { PatternUpdater } from "./pattern-updater.ts";
-import type { CompiledModuleArtifact } from "./harness/types.ts";
-import { ModuleRegistry } from "./module.ts";
+import { snapshotQueryResult } from "./query-result-proxy.ts";
+import { AsyncSemaphoreQueue, type QueueConfig } from "./queue.ts";
 import { type PieceSourceTransition, Runner } from "./runner.ts";
-import { registerBuiltins } from "./builtins/index.ts";
-import { ExtendedStorageTransaction } from "./storage/extended-storage-transaction.ts";
-import { isRetryableCommitRejection } from "./storage/rejection.ts";
-import { isCellScope, normalizeCellScope } from "./scope.ts";
-import { toURI } from "./uri-utils.ts";
-import { isDeno } from "@commonfabric/utils/env";
+import { Action, Scheduler } from "./scheduler.ts";
 import {
-  type AsyncLocalStore,
-  FallbackAsyncLocalStore,
-} from "@commonfabric/utils/async-local-store";
-import { popFrame, pushFrame } from "./builder/pattern.ts";
-import type { Frame } from "./builder/types.ts";
-import type { ConsoleMessage } from "./interface.ts";
-import type { ConsoleMethod } from "./harness/console.ts";
+  type CommitBackpressurePolicy,
+  resolveCommitBackpressure,
+} from "./scheduler/backpressure.ts";
+import { isCellScope, normalizeCellScope } from "./scope.ts";
+import { normalizeSpaceHost, SpaceHostValidationError } from "./space-host.ts";
+import { flattenBuilderArtifacts } from "./storage-preflight.ts";
+import { ExtendedStorageTransaction } from "./storage/extended-storage-transaction.ts";
+import type {
+  ChangeGroup,
+  CommitError,
+  DID,
+  IExtendedStorageTransaction,
+  IStorageManager,
+  MemorySpace,
+  URI,
+} from "./storage/interface.ts";
+import { isRetryableCommitRejection } from "./storage/rejection.ts";
 import type {
   WriteStackTraceEntry,
   WriteStackTraceMatcher,
@@ -126,12 +126,13 @@ import {
   getWriteStackTrace,
   setWriteStackTraceMatchers,
 } from "./storage/write-stack-trace.ts";
+import type { NonIdempotentReport } from "./telemetry.ts";
 import {
   createUnsafeHostTrustToken,
   type UnsafeHostTrust,
   type UnsafeHostTrustOptions,
 } from "./unsafe-host-trust.ts";
-import { normalizeSpaceHost, SpaceHostValidationError } from "./space-host.ts";
+import { toURI } from "./uri-utils.ts";
 
 const isFullNormalizedLinkShape = (
   value: unknown,

--- a/packages/runner/src/sandbox/compiled-bundle-verifier.ts
+++ b/packages/runner/src/sandbox/compiled-bundle-verifier.ts
@@ -1,3 +1,17 @@
+import { getLogger } from "@commonfabric/utils/logger";
+import {
+  BINDING_IDENTITY_HELPER_NAME,
+  createBindingIdentityHelperSource,
+  createFunctionHardeningHelperSource,
+  RESERVED_FACTORY_BINDINGS,
+} from "@commonfabric/utils/sandbox-contract";
+
+import {
+  isIdentifierStartCode,
+  isSimpleIdentifierText,
+  readIdentifierEnd,
+  startsWithStatementWord,
+} from "./compiled-js-identifiers.ts";
 import {
   CompiledJsParseError,
   findTopLevelArrow,
@@ -13,13 +27,6 @@ import {
   trimRange,
   tryParseCallExpression,
 } from "./compiled-js-parser.ts";
-import {
-  isIdentifierStartCode,
-  isSimpleIdentifierText,
-  readIdentifierEnd,
-  startsWithStatementWord,
-} from "./compiled-js-identifiers.ts";
-import { getLogger } from "@commonfabric/utils/logger";
 import { ModuleVerificationError } from "./module-verification-error.ts";
 import {
   isTrustedBuilder,
@@ -27,12 +34,6 @@ import {
   SAFE_GLOBAL_IDENTIFIERS,
   TOP_LEVEL_CALL_RESULT_ERROR,
 } from "./policy.ts";
-import {
-  BINDING_IDENTITY_HELPER_NAME,
-  createBindingIdentityHelperSource,
-  createFunctionHardeningHelperSource,
-  RESERVED_FACTORY_BINDINGS,
-} from "@commonfabric/utils/sandbox-contract";
 
 export type BindingKind =
   | "builder"

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -1,8 +1,9 @@
-import type ts from "typescript";
-import { getLogger } from "@commonfabric/utils/logger";
 import type { Source, SourceMap } from "@commonfabric/js-compiler";
-import type { PatternCoverageSpan } from "@commonfabric/ts-transformers";
 import { resolveImportSpecifier } from "@commonfabric/js-compiler/specifier";
+import type { PatternCoverageSpan } from "@commonfabric/ts-transformers";
+import { getLogger } from "@commonfabric/utils/logger";
+import type ts from "typescript";
+
 import { compilerStack } from "../harness/deferred-compiler-stack.ts";
 import {
   computeModuleHashes,

--- a/packages/runner/src/sandbox/result-normalization.ts
+++ b/packages/runner/src/sandbox/result-normalization.ts
@@ -1,17 +1,17 @@
-import {
-  fabricFromNativeValue,
-  type FabricValue,
-} from "@commonfabric/data-model/fabric-value";
 import { FabricError } from "@commonfabric/data-model/fabric-instances";
-import { hasEncodableForm } from "../encodable-form.ts";
 import {
   FabricBytes,
   FabricEpochNsec,
   FabricRegExp,
 } from "@commonfabric/data-model/fabric-primitives";
+import {
+  fabricFromNativeValue,
+  type FabricValue,
+} from "@commonfabric/data-model/fabric-value";
 import { isNativeError } from "@commonfabric/data-model/native-type-tags";
 
 import { isReactive } from "../builder/types.ts";
+import { hasEncodableForm } from "../encodable-form.ts";
 import { isCellLink } from "../link-utils.ts";
 
 export interface NormalizedSandboxResult {

--- a/packages/runner/src/sandbox/runtime-modules.ts
+++ b/packages/runner/src/sandbox/runtime-modules.ts
@@ -1,8 +1,9 @@
-import { createBuilder } from "../builder/factory.ts";
+import * as cfcModule from "@commonfabric/api/cfc-authoring";
 import type { StaticCache } from "@commonfabric/static";
 import turndown from "turndown";
+
+import { createBuilder } from "../builder/factory.ts";
 import { freezeSandboxValue } from "./hardening.ts";
-import * as cfcModule from "@commonfabric/api/cfc-authoring";
 export type { RuntimeModuleIdentifier } from "./runtime-module-policy.ts";
 export {
   isRuntimeModuleIdentifier,

--- a/packages/runner/src/scheduler/execution.ts
+++ b/packages/runner/src/scheduler/execution.ts
@@ -1,6 +1,4 @@
 import type { IMemorySpaceAddress } from "../storage/interface.ts";
-import { assessPullWork, type PullSchedulingState } from "./work-oracle.ts";
-import type { SpaceScopeAndURI } from "./types.ts";
 import {
   BACKOFF_BASE_MS,
   BACKOFF_MAX_MS,
@@ -13,7 +11,9 @@ import type {
   ReactivityLog,
   SettleIterationStats,
   SettleStats,
+  SpaceScopeAndURI,
 } from "./types.ts";
+import { assessPullWork, type PullSchedulingState } from "./work-oracle.ts";
 
 export interface SettlingTracker {
   windowStart: number;

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -1,18 +1,21 @@
 import { BoundedKeyMap } from "@commonfabric/utils/cache";
+import { ensureNotRenderThread } from "@commonfabric/utils/env";
 import { getLogger } from "@commonfabric/utils/logger";
-import type { Cancel } from "../cancel.ts";
+
 import { getTopFrame } from "../builder/pattern.ts";
+import type { Cancel } from "../cancel.ts";
 import { ConsoleEvent } from "../harness/console.ts";
+import {
+  areNormalizedLinksSame,
+  type NormalizedFullLink,
+} from "../link-utils.ts";
 import type {
   ConsoleHandler,
   ErrorHandler,
   ErrorWithContext,
   Runtime,
 } from "../runtime.ts";
-import {
-  areNormalizedLinksSame,
-  type NormalizedFullLink,
-} from "../link-utils.ts";
+import { getCommitLocalSeq } from "../storage/commit-identity.ts";
 import type {
   ChangeGroup,
   IExtendedStorageTransaction,
@@ -39,6 +42,25 @@ import {
   MAX_ACTION_STATS,
   MAX_SETTLE_STATS_HISTORY,
 } from "./constants.ts";
+import type { ExecuteContinuationState } from "./continuation.ts";
+import { applyPullExecuteContinuation } from "./continuation.ts";
+import {
+  type DependencyGraphState,
+  isLive,
+  notifyNodeLivenessChange,
+  registerDependentsForWriterSurface,
+  setNodeProvisionalDemand,
+  updateDependentEdgesForLog,
+} from "./dependency-graph.ts";
+import { type DependencyUpdateState } from "./dependency-updates.ts";
+import {
+  type DiagnosisRecord,
+  runSchedulerDiagnosis,
+  runSchedulerIdempotencyCheck,
+  type SchedulerDiagnosisControlState,
+  startSchedulerDiagnosis,
+  stopSchedulerDiagnosis,
+} from "./diagnosis.ts";
 import {
   getPieceMetadataFromFrame,
   getSchedulerActionId,
@@ -49,51 +71,20 @@ import {
   type SchedulerActionIdentityState,
 } from "./diagnostics.ts";
 import {
-  type DiagnosisRecord,
-  runSchedulerDiagnosis,
-  runSchedulerIdempotencyCheck,
-  type SchedulerDiagnosisControlState,
-  startSchedulerDiagnosis,
-  stopSchedulerDiagnosis,
-} from "./diagnosis.ts";
-import {
-  type DependencyGraphState,
-  isLive,
-  notifyNodeLivenessChange,
-  registerDependentsForWriterSurface,
-  setNodeProvisionalDemand,
-  updateDependentEdgesForLog,
-} from "./dependency-graph.ts";
-import { SchedulerMaterializers } from "./materializers.ts";
-import {
-  CELL_GROUP_PREFIX,
-  type DeliverFn,
-  holdShapedCell,
-  holdShapedEvent,
-  shaperInstanceGroupKey,
-  shouldShapeDelivery,
-  WakeShaper,
-} from "./wake-shaping.ts";
-import { type DependencyUpdateState } from "./dependency-updates.ts";
-import { SchedulerWriteIndex } from "./scheduling-writes.ts";
-import { NodeRegistry, type SchedulerNode } from "./node-record.ts";
-import {
-  SchedulerTriggerIndex,
-  SchedulerTriggerSubscriptions,
-  type TriggerSubscriptionState,
-} from "./trigger-index.ts";
-import {
   collectInvalidUpstreamForLog as collectInvalidUpstreamForLogState,
   collectPendingLoadParkKeys as collectPendingLoadParkKeysState,
   type EventPreflightDependencyState,
   snapshotEventPreflightTraceContext,
 } from "./event-preflight-dependencies.ts";
 import {
-  runSchedulerAction,
-  type SchedulerActionRunState,
-  schedulerImplementationFingerprint,
-  schedulerRuntimeFingerprint,
-} from "./run.ts";
+  addSchedulerEventHandler,
+  dropQueuedEvent,
+  isHeadEventParked as isHeadEventParkedState,
+  processPullQueuedEventDuringExecute,
+  queueSchedulerEvent,
+  type SchedulerEventExecutionState,
+  type SchedulerEventQueueState,
+} from "./events.ts";
 import {
   buildPullInitialSeeds,
   createSettlingTracker,
@@ -105,59 +96,54 @@ import {
   type SchedulerSettleResult,
   type SettlingTracker,
 } from "./execution.ts";
-import { runPullSchedulerSettleLoop } from "./settle.ts";
+import { SchedulerGates } from "./gates.ts";
+import {
+  buildSchedulerGraphSnapshot,
+  type SchedulerGraphSnapshotState,
+} from "./graph-snapshot.ts";
+import {
+  markInvalid as markInvalidRecord,
+  processStorageNotification,
+  type StorageNotificationState,
+} from "./invalidation.ts";
+import { entityKey } from "./keys.ts";
+import { SpeculationLineage } from "./lineage.ts";
+import { SchedulerMaterializers } from "./materializers.ts";
+import { NodeRegistry, type SchedulerNode } from "./node-record.ts";
 import {
   isSchedulerActionObservation,
   type PersistedSchedulerObservationSnapshot,
   type SchedulerActionObservation,
 } from "./persistent-observation.ts";
-import { collectPullIterationSeeds as collectPullIterationSeedsState } from "./settle.ts";
-import {
-  type DirtyPullRunnableState,
-  type DirtyPullRunnableStateWithDebounce,
-  hasIdleBlockingDeferredPullWork as hasIdleBlockingDeferredPullWorkState,
-  hasRunnablePullWork as hasRunnablePullWorkState,
-  type PendingPullRunnableState,
-  type PullSchedulingState,
-} from "./work-oracle.ts";
-import type { ExecuteContinuationState } from "./continuation.ts";
-import { applyPullExecuteContinuation } from "./continuation.ts";
-import { SchedulerGates } from "./gates.ts";
-import {
-  markInvalid as markInvalidRecord,
-  type StorageNotificationState,
-} from "./invalidation.ts";
-import { processStorageNotification } from "./invalidation.ts";
-import {
-  type SchedulerSubscribeActionState,
-  type SchedulerSubscriptionState,
-  type SchedulerUnsubscribeActionState,
-  unsubscribeSchedulerAction,
-} from "./registration.ts";
 import {
   resolveRegistrationSurface,
   resubscribePullSchedulerAction,
+  type SchedulerSubscribeActionState,
+  type SchedulerSubscriptionState,
+  type SchedulerUnsubscribeActionState,
   subscribePullSchedulerAction,
+  unsubscribeSchedulerAction,
 } from "./registration.ts";
+import {
+  runSchedulerAction,
+  type SchedulerActionRunState,
+  schedulerImplementationFingerprint,
+  schedulerRuntimeFingerprint,
+} from "./run.ts";
+import { SchedulerWriteIndex } from "./scheduling-writes.ts";
+import {
+  collectPullIterationSeeds as collectPullIterationSeedsState,
+  runPullSchedulerSettleLoop,
+} from "./settle.ts";
 import {
   type ActionTimingState,
   getActionStats as getActionStatsFromState,
 } from "./timing.ts";
-import { getCommitLocalSeq } from "../storage/commit-identity.ts";
 import {
-  addSchedulerEventHandler,
-  dropQueuedEvent,
-  isHeadEventParked as isHeadEventParkedState,
-  queueSchedulerEvent,
-  type SchedulerEventExecutionState,
-  type SchedulerEventQueueState,
-} from "./events.ts";
-import { SpeculationLineage } from "./lineage.ts";
-import { processPullQueuedEventDuringExecute } from "./events.ts";
-import {
-  buildSchedulerGraphSnapshot,
-  type SchedulerGraphSnapshotState,
-} from "./graph-snapshot.ts";
+  SchedulerTriggerIndex,
+  SchedulerTriggerSubscriptions,
+  type TriggerSubscriptionState,
+} from "./trigger-index.ts";
 import type {
   Action,
   ActionRunTraceEntry,
@@ -171,8 +157,23 @@ import type {
   TelemetryAnnotations,
   TriggerTraceEntry,
 } from "./types.ts";
-import { ensureNotRenderThread } from "@commonfabric/utils/env";
-import { entityKey } from "./keys.ts";
+import {
+  CELL_GROUP_PREFIX,
+  type DeliverFn,
+  holdShapedCell,
+  holdShapedEvent,
+  shaperInstanceGroupKey,
+  shouldShapeDelivery,
+  WakeShaper,
+} from "./wake-shaping.ts";
+import {
+  type DirtyPullRunnableState,
+  type DirtyPullRunnableStateWithDebounce,
+  hasIdleBlockingDeferredPullWork as hasIdleBlockingDeferredPullWorkState,
+  hasRunnablePullWork as hasRunnablePullWorkState,
+  type PendingPullRunnableState,
+  type PullSchedulingState,
+} from "./work-oracle.ts";
 
 ensureNotRenderThread();
 

--- a/packages/runner/src/scheduler/persistent-observation.ts
+++ b/packages/runner/src/scheduler/persistent-observation.ts
@@ -1,9 +1,10 @@
+import type { SchedulerExecutionContextKey } from "@commonfabric/memory/v2";
+
+import { isCellScope } from "../scope.ts";
 import type {
   IMemorySpaceAddress,
   TransactionReactivityLog,
 } from "../storage/interface.ts";
-import type { SchedulerExecutionContextKey } from "@commonfabric/memory/v2";
-import { isCellScope } from "../scope.ts";
 
 export type SchedulerActionKind =
   | "computation"

--- a/packages/runner/src/scheduler/registration.ts
+++ b/packages/runner/src/scheduler/registration.ts
@@ -1,9 +1,9 @@
 import { getLogger } from "@commonfabric/utils/logger";
+
 import type { Cancel } from "../cancel.ts";
 import { toMemorySpaceAddress } from "../link-utils.ts";
 import { sortAndCompactPaths } from "../reactive-dependencies.ts";
-import type { IMemorySpaceAddress } from "../storage/interface.ts";
-import type { ChangeGroup } from "../storage/interface.ts";
+import type { ChangeGroup, IMemorySpaceAddress } from "../storage/interface.ts";
 import {
   type DependencyGraphState,
   hasInvalidUpstream,
@@ -16,13 +16,13 @@ import {
   type DependencyUpdateState,
   setSchedulerDependencies,
 } from "./dependency-updates.ts";
-import { filterIgnoredAddresses } from "./reactivity.ts";
-import { type WriterIndexState } from "./scheduling-writes.ts";
 import {
   type NodeKind,
   NodeRegistry,
   type SchedulerNode,
 } from "./node-record.ts";
+import { filterIgnoredAddresses } from "./reactivity.ts";
+import { type WriterIndexState } from "./scheduling-writes.ts";
 import {
   applyActionReadDelta,
   ensureCancelForActionTriggers,

--- a/packages/runner/src/scheduler/trigger-index.ts
+++ b/packages/runner/src/scheduler/trigger-index.ts
@@ -1,3 +1,6 @@
+import type { MemorySpace } from "@commonfabric/memory/interface";
+
+import type { Cancel } from "../cancel.ts";
 import {
   addressesToPathByEntity,
   arraysOverlap,
@@ -5,8 +8,6 @@ import {
   nonRecursiveReadMayOverlapWrite,
   type SortedAndCompactPaths,
 } from "../reactive-dependencies.ts";
-import type { Cancel } from "../cancel.ts";
-import type { MemorySpace } from "@commonfabric/memory/interface";
 import type {
   IMemoryChange,
   IMemorySpaceAddress,

--- a/packages/runner/src/schema-format.ts
+++ b/packages/runner/src/schema-format.ts
@@ -6,9 +6,10 @@
  * including in LLM context/prompts.
  */
 
-import type { JSONSchema } from "commonfabric";
-import { ContextualFlowControl } from "./cfc.ts";
 import { AsCellType } from "@commonfabric/api";
+import type { JSONSchema } from "commonfabric";
+
+import { ContextualFlowControl } from "./cfc.ts";
 
 export interface SchemaFormatOptions {
   /** Definitions map for resolving $ref references */

--- a/packages/runner/src/schema-view.ts
+++ b/packages/runner/src/schema-view.ts
@@ -40,19 +40,24 @@ import type {
   JSONSchemaObj,
   JSONSchemaTypes,
 } from "@commonfabric/api";
+import { schemaTypeOfFabricPrimitive } from "@commonfabric/data-model/fabric-primitives";
 import { FabricPrimitive } from "@commonfabric/data-model/fabric-value";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
-import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
+import { getLogger } from "@commonfabric/utils/logger";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
+
+import { toCell } from "./back-to-cell.ts";
+import { type Cell, createCell } from "./cell.ts";
 import { ContextualFlowControl } from "./cfc.ts";
 import {
   type CfcLabelView,
   rebaseCfcLabelView,
 } from "./cfc/label-view-state.ts";
-import { type Cell, createCell } from "./cell.ts";
-import { toCell } from "./back-to-cell.ts";
-import { type NormalizedFullLink } from "./link-utils.ts";
+import { dataUriFromValueWithResolvedLinks } from "./data-uri.ts";
+import { isSigilLink, type NormalizedFullLink } from "./link-utils.ts";
 import { type Runtime } from "./runtime.ts";
+import { processDefaultValue, validateAndTransform } from "./schema.ts";
 import { type IExtendedStorageTransaction } from "./storage/interface.ts";
 import {
   canBranchMatch,
@@ -62,11 +67,6 @@ import {
   SchemaObjectTraverser,
   schemaTypeMatchesValueType,
 } from "./traverse.ts";
-import { dataUriFromValueWithResolvedLinks } from "./data-uri.ts";
-import { isSigilLink } from "./link-utils.ts";
-import { schemaTypeOfFabricPrimitive } from "@commonfabric/data-model/fabric-primitives";
-import { processDefaultValue, validateAndTransform } from "./schema.ts";
-import { getLogger } from "@commonfabric/utils/logger";
 
 const logger = getLogger("schema-view", { enabled: false, level: "warn" });
 

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -1,52 +1,18 @@
 import { AnyCellWrapping } from "@commonfabric/api";
-import { deepEqual } from "@commonfabric/utils/deep-equal";
-import { getLogger } from "@commonfabric/utils/logger";
-import {
-  isObjectNotArray,
-  isObjectOrArray,
-  isReadonlyObjectOrArray,
-} from "@commonfabric/utils/types";
-import { storedCfcMetadataAppliesToPath } from "./cfc/metadata.ts";
-import { ContextualFlowControl } from "./cfc.ts";
-import { type JSONSchema, type SchemaScope } from "./builder/types.ts";
 import type { JSONSchemaObj, JSONValue } from "@commonfabric/api";
-import {
-  cloneIfNecessary,
-  type FabricValue,
-  shallowMutableClone,
-} from "@commonfabric/data-model/fabric-value";
 import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import {
+  cloneIfNecessary,
   FabricInstance,
   FabricPrimitive,
+  type FabricValue,
+  shallowMutableClone,
 } from "@commonfabric/data-model/fabric-value";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import {
   isNontrivialSchema,
   schemaWithProperties,
 } from "@commonfabric/data-model/schema-utils";
-import { createCell, isCell } from "./cell.ts";
-import { canFollowScopedLink } from "./scope.ts";
-import { forEachSubschema } from "./schema-walk.ts";
-import { arrayMatchesPositionally } from "./schema-match.ts";
-import {
-  readMaybeLink,
-  resolveLink,
-  undefinedDataLink,
-} from "./link-resolution.ts";
-import { type IExtendedStorageTransaction } from "./storage/interface.ts";
-import { getTransactionForChildCells } from "./storage/extended-storage-transaction.ts";
-import { type Runtime } from "./runtime.ts";
-import {
-  type IMemorySpaceValueAddress,
-  type NormalizedFullLink,
-} from "./link-utils.ts";
-import {
-  createQueryResultProxy,
-  isCellResultForDereferencing,
-} from "./query-result-proxy.ts";
-import { toCell } from "./back-to-cell.ts";
-import { materializeSchemaView } from "./schema-view.ts";
 import {
   canBranchMatch,
   combineOptionalSchema,
@@ -57,9 +23,19 @@ import {
   mergeSchemaFlags,
   SchemaObjectTraverser,
 } from "@commonfabric/runner/traverse";
-import { ignoreReadForScheduling } from "./scheduler.ts";
-import { internalVerifierRead } from "./storage/reactivity-log.ts";
+import { deepEqual } from "@commonfabric/utils/deep-equal";
+import { getLogger } from "@commonfabric/utils/logger";
+import {
+  isObjectNotArray,
+  isObjectOrArray,
+  isReadonlyObjectOrArray,
+} from "@commonfabric/utils/types";
+
 import { toMemorySpaceAddress } from "../src/link-utils.ts";
+import { toCell } from "./back-to-cell.ts";
+import { type JSONSchema, type SchemaScope } from "./builder/types.ts";
+import { createCell, isCell } from "./cell.ts";
+import { ContextualFlowControl } from "./cfc.ts";
 import {
   type CfcLabelView,
   cfcLabelViewForDereference,
@@ -68,12 +44,34 @@ import {
   mergeCfcLabelViews,
   rebaseCfcLabelView,
 } from "./cfc/label-view-state.ts";
-import type { CfcAddress } from "./cfc/types.ts";
-import { isCellScope } from "./scope.ts";
+import { storedCfcMetadataAppliesToPath } from "./cfc/metadata.ts";
 import {
   cfcSchemaChildRoot,
   resolveCfcSchemaRefRoot,
 } from "./cfc/schema-refs.ts";
+import type { CfcAddress } from "./cfc/types.ts";
+import {
+  readMaybeLink,
+  resolveLink,
+  undefinedDataLink,
+} from "./link-resolution.ts";
+import {
+  type IMemorySpaceValueAddress,
+  type NormalizedFullLink,
+} from "./link-utils.ts";
+import {
+  createQueryResultProxy,
+  isCellResultForDereferencing,
+} from "./query-result-proxy.ts";
+import { type Runtime } from "./runtime.ts";
+import { ignoreReadForScheduling } from "./scheduler.ts";
+import { arrayMatchesPositionally } from "./schema-match.ts";
+import { materializeSchemaView } from "./schema-view.ts";
+import { forEachSubschema } from "./schema-walk.ts";
+import { canFollowScopedLink, isCellScope } from "./scope.ts";
+import { getTransactionForChildCells } from "./storage/extended-storage-transaction.ts";
+import { type IExtendedStorageTransaction } from "./storage/interface.ts";
+import { internalVerifierRead } from "./storage/reactivity-log.ts";
 
 const logger = getLogger("validateAndTransform", {
   enabled: true,

--- a/packages/runner/src/schemas.ts
+++ b/packages/runner/src/schemas.ts
@@ -4,8 +4,9 @@
  * /!\ interfaces and utilities.
  */
 
-import { NAME, type Schema, UI } from "./shared.ts";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
+
+import { NAME, type Schema, UI } from "./shared.ts";
 
 export const rendererVDOMSchema = internSchema(
   {

--- a/packages/runner/src/sigil-types.ts
+++ b/packages/runner/src/sigil-types.ts
@@ -4,13 +4,13 @@ import type {
   JSONValue,
   LinkScope,
 } from "@commonfabric/api";
-import type { MemorySpace } from "@commonfabric/memory/interface";
-import type { URI } from "@commonfabric/memory/interface";
 import {
   LINK_V1_TAG,
   type LinkRef,
   type WireLinkRefPayload,
 } from "@commonfabric/data-model/cell-rep";
+import type { MemorySpace, URI } from "@commonfabric/memory/interface";
+
 import { isLinkScope } from "./scope.ts";
 
 export type { URI } from "@commonfabric/memory/interface";

--- a/packages/runner/src/storage/differential.ts
+++ b/packages/runner/src/storage/differential.ts
@@ -1,11 +1,12 @@
-import { unclaimed } from "@commonfabric/memory/fact";
-import type { FabricPlainObject } from "@commonfabric/api";
-import { isFabricObjectOrArray } from "@commonfabric/data-model/fabric-value";
-import type { FabricValue } from "@commonfabric/api";
+import type { FabricPlainObject, FabricValue } from "@commonfabric/api";
 import {
   FabricSpecialObject,
+  isFabricObjectOrArray,
   valueEqual,
 } from "@commonfabric/data-model/fabric-value";
+import { unclaimed } from "@commonfabric/memory/fact";
+
+import { normalizeCellScope } from "../scope.ts";
 import type {
   IMemoryAddress,
   IMemoryChange,
@@ -13,7 +14,6 @@ import type {
   State,
 } from "./interface.ts";
 import * as Address from "./transaction/address.ts";
-import { normalizeCellScope } from "../scope.ts";
 
 export const create = () => new Changes();
 

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -1,72 +1,21 @@
-import { isObjectOrArray } from "@commonfabric/utils/types";
-import { deepEqual } from "@commonfabric/utils/deep-equal";
-import { getLogger } from "@commonfabric/utils/logger";
+import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import {
   type FabricPlainObject,
   type FabricValue,
   type MutableFabricPlainObjectLayer,
   shallowMutableClone,
 } from "@commonfabric/data-model/fabric-value";
-import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { aclDocId } from "@commonfabric/memory/acl";
-import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
-import type {
-  CommitError,
-  IAttestation,
-  IExtendedStorageTransaction,
-  IMemorySpaceAddress,
-  InactiveTransactionError,
-  INotFoundError,
-  IReadActivity,
-  IReadOptions,
-  IStorageTransaction,
-  ITransactionJournal,
-  IWriteAttempt,
-  IWriteOptions,
-  MemorySpace,
-  Metadata,
-  ReadError,
-  Result,
-  StorageTransactionFailed,
-  StorageTransactionStatus,
-  TransactionCommitOptions,
-  TransactionReactivityLog,
-  TransactionWriteDetail,
-  Unit,
-  WriteError,
-  WriterError,
-} from "./interface.ts";
-import { createReadOnlyTransactionError, toThrowable } from "./interface.ts";
 import type {
   CommitPrecondition,
   SqliteOperation,
 } from "@commonfabric/memory/v2";
-import type { MergeableOpDelta } from "./mergeable-ops.ts";
-import { TransactionAborted } from "./transaction-errors.ts";
-import {
-  getDirectTransactionReactivityLog,
-  getTransactionReadActivities,
-  getTransactionWriteAttempts,
-  getTransactionWriteDetails,
-} from "./transaction-inspection.ts";
-import {
-  clearSchemaRefusalTx,
-  isInternalVerifierRead,
-  isLazyMaterializationTx,
-  markLazyMaterializationTx,
-  noteSchemaRefusalTx,
-  reactivityLogFromActivities,
-  takeSchemaRefusalTx,
-  unmarkLazyMaterializationTx,
-} from "./reactivity-log.ts";
+import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
+import { deepEqual } from "@commonfabric/utils/deep-equal";
+import { getLogger } from "@commonfabric/utils/logger";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 
-import {
-  type NormalizedFullLink,
-  toMemorySpaceAddress,
-} from "../link-types.ts";
-import { normalizeCellScope, scopeRank } from "../scope.ts";
 import type { CellScope } from "../builder/types.ts";
-import { ignoreReadForScheduling } from "../scheduler.ts";
 import {
   type AttemptedWrite,
   canonicalizeLogicalPath,
@@ -114,6 +63,57 @@ import {
   type WritePolicyInput,
 } from "../cfc/mod.ts";
 import { CFC_POLICY_MANIFEST_ID_PREFIX } from "../cfc/policy.ts";
+import {
+  type NormalizedFullLink,
+  toMemorySpaceAddress,
+} from "../link-types.ts";
+import { ignoreReadForScheduling } from "../scheduler.ts";
+import { normalizeCellScope, scopeRank } from "../scope.ts";
+import type {
+  CommitError,
+  IAttestation,
+  IExtendedStorageTransaction,
+  IMemorySpaceAddress,
+  InactiveTransactionError,
+  INotFoundError,
+  IReadActivity,
+  IReadOptions,
+  IStorageTransaction,
+  ITransactionJournal,
+  IWriteAttempt,
+  IWriteOptions,
+  MemorySpace,
+  Metadata,
+  ReadError,
+  Result,
+  StorageTransactionFailed,
+  StorageTransactionStatus,
+  TransactionCommitOptions,
+  TransactionReactivityLog,
+  TransactionWriteDetail,
+  Unit,
+  WriteError,
+  WriterError,
+} from "./interface.ts";
+import { createReadOnlyTransactionError, toThrowable } from "./interface.ts";
+import type { MergeableOpDelta } from "./mergeable-ops.ts";
+import {
+  clearSchemaRefusalTx,
+  isInternalVerifierRead,
+  isLazyMaterializationTx,
+  markLazyMaterializationTx,
+  noteSchemaRefusalTx,
+  reactivityLogFromActivities,
+  takeSchemaRefusalTx,
+  unmarkLazyMaterializationTx,
+} from "./reactivity-log.ts";
+import { TransactionAborted } from "./transaction-errors.ts";
+import {
+  getDirectTransactionReactivityLog,
+  getTransactionReadActivities,
+  getTransactionWriteAttempts,
+  getTransactionWriteDetails,
+} from "./transaction-inspection.ts";
 
 const logger = getLogger("extended-storage-transaction", {
   enabled: false,

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -1,26 +1,8 @@
-import type { Immutable } from "@commonfabric/utils/types";
 import type {
   CellScope,
   FabricValue,
   SchemaPathSelector,
 } from "@commonfabric/api";
-import type {
-  CommitPrecondition,
-  EntityDocument,
-  EntityIdListOptions,
-  EntityIdListResult,
-  PatchOp,
-  SchedulerActionSnapshotQuery,
-  SchedulerExecutionContextKey,
-  SchedulerSnapshotListResult,
-  SqliteDbRef,
-  SqliteOperation,
-  SqliteParamsWire,
-  SqliteQueryResult,
-  SqliteRegisterDiskSourceResult,
-} from "@commonfabric/memory/v2";
-import type { EntityId } from "../create-ref.ts";
-import type { MergeableOpDelta } from "./mergeable-ops.ts";
 import {
   type AuthorizationError as IAuthorizationError,
   type ConflictError as IConflictError,
@@ -37,7 +19,24 @@ import {
   type URI,
   type Variant,
 } from "@commonfabric/memory/interface";
+import type {
+  CommitPrecondition,
+  EntityDocument,
+  EntityIdListOptions,
+  EntityIdListResult,
+  PatchOp,
+  SchedulerActionSnapshotQuery,
+  SchedulerExecutionContextKey,
+  SchedulerSnapshotListResult,
+  SqliteDbRef,
+  SqliteOperation,
+  SqliteParamsWire,
+  SqliteQueryResult,
+  SqliteRegisterDiskSourceResult,
+} from "@commonfabric/memory/v2";
 import { BaseMemoryAddress } from "@commonfabric/runner/traverse";
+import type { Immutable } from "@commonfabric/utils/types";
+
 import { Cell } from "../cell.ts";
 import type {
   CfcAddress,
@@ -60,7 +59,9 @@ import type {
   TrustSnapshot,
   WritePolicyInput,
 } from "../cfc/mod.ts";
+import type { EntityId } from "../create-ref.ts";
 import type { NormalizedFullLink } from "../link-types.ts";
+import type { MergeableOpDelta } from "./mergeable-ops.ts";
 
 export type { DID, MediaType, MemorySpace, Result, Signer, State, Unit, URI };
 export type ChangeGroup = unknown;

--- a/packages/runner/src/storage/selector-tracker.ts
+++ b/packages/runner/src/storage/selector-tracker.ts
@@ -1,10 +1,11 @@
-import { LRUCache } from "@commonfabric/utils/cache";
+import type { FabricValue, SchemaPathSelector } from "@commonfabric/api";
 import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import { hashSchema, internSchema } from "@commonfabric/data-model/schema-hash";
 import { schemaWithProperties } from "@commonfabric/data-model/schema-utils";
-import type { FabricValue, SchemaPathSelector } from "@commonfabric/api";
 import type { Result, Unit } from "@commonfabric/memory/interface";
+import { LRUCache } from "@commonfabric/utils/cache";
 import { isObjectOrArray } from "@commonfabric/utils/types";
+
 import type { JSONSchema } from "../builder/types.ts";
 import { ContextualFlowControl } from "../cfc.ts";
 import { BaseMemoryAddress, MapSetStringToStrings } from "../traverse.ts";

--- a/packages/runner/src/storage/transaction-summary.ts
+++ b/packages/runner/src/storage/transaction-summary.ts
@@ -5,13 +5,14 @@
  * into concise summaries suitable for LLMs to help humans debug software behavior.
  */
 
-import { entityUriSchemePrefix } from "../entity-kind.ts";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+
+import { entityUriSchemePrefix } from "../entity-kind.ts";
+import type { MemorySpace } from "../runtime.ts";
 import type {
   IExtendedStorageTransaction,
   IMemorySpaceAddress,
 } from "./interface.ts";
-import type { MemorySpace } from "../runtime.ts";
 import {
   getDirectTransactionReactivityLog,
   getTransactionWriteDetails,

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -1,10 +1,20 @@
-import { isObjectOrArray } from "@commonfabric/utils/types";
+import {
+  extractDataUriPayloadText,
+  isDataUriMediaType,
+  isFabricDataUri,
+  valueFromDataUriPayloadText,
+} from "@commonfabric/data-model/data-uri-codec";
 import {
   type FabricPlainObject,
   type FabricValue,
   valueEqual,
 } from "@commonfabric/data-model/fabric-value";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+import { unclaimed } from "@commonfabric/memory/fact";
+import { LRUCache } from "@commonfabric/utils/cache";
+import { getLogger } from "@commonfabric/utils/logger";
+import { isObjectOrArray } from "@commonfabric/utils/types";
+
 import type {
   IAttestation,
   IInvalidDataURIError,
@@ -19,16 +29,7 @@ import type {
   Result,
   State,
 } from "../interface.ts";
-import { unclaimed } from "@commonfabric/memory/fact";
-import { getLogger } from "@commonfabric/utils/logger";
-import { LRUCache } from "@commonfabric/utils/cache";
 import { toTransactionDocumentValue } from "../v2-document.ts";
-import {
-  extractDataUriPayloadText,
-  isDataUriMediaType,
-  isFabricDataUri,
-  valueFromDataUriPayloadText,
-} from "@commonfabric/data-model/data-uri-codec";
 
 const logger = getLogger("attestation", {
   enabled: false,

--- a/packages/runner/src/storage/v2-path.ts
+++ b/packages/runner/src/storage/v2-path.ts
@@ -1,5 +1,5 @@
-import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import type { FabricValue } from "@commonfabric/api";
+import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { isObjectOrArray } from "@commonfabric/utils/types";
 
 export type ReadPathOptions = {

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -1,27 +1,31 @@
+import type { FabricValue } from "@commonfabric/api";
+import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
+import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import {
   cloneIfNecessary,
   valueEqual,
 } from "@commonfabric/data-model/fabric-value";
-import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
-import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import type {
   CommitPrecondition,
   PatchOp,
   SqliteOperation,
 } from "@commonfabric/memory/v2";
+import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
+import { getLogger } from "@commonfabric/utils/logger";
+import { PathKeyMap } from "@commonfabric/utils/path-key-map";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
+
+import {
+  patchOpIsStructural,
+  patchOpPointerFields,
+} from "../../../memory/v2/patch.ts";
 import {
   encodePointer,
   parsePointer,
   pathsOverlap,
 } from "../../../memory/v2/path.ts";
-import {
-  patchOpIsStructural,
-  patchOpPointerFields,
-} from "../../../memory/v2/patch.ts";
-import { PathKeyMap } from "@commonfabric/utils/path-key-map";
-import type { FabricValue } from "@commonfabric/api";
-import { getLogger } from "@commonfabric/utils/logger";
-import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
+import type { CellScope } from "../builder/types.ts";
+import { normalizeCellScope } from "../scope.ts";
 import type {
   Activity,
   ChangeGroup,
@@ -59,6 +63,31 @@ import type {
 } from "./interface.ts";
 import { createReadOnlyTransactionError } from "./interface.ts";
 import {
+  buildMergeableIntent,
+  foldMergeableIntent,
+  isNoopMergeableDelta,
+  type MergeableBuildContext,
+  type MergeableOpDelta,
+  type MergeableOpIntent,
+  mergeableOpPayloadContains,
+  type OpSuppression,
+} from "./mergeable-ops.ts";
+import {
+  ignoreReadForCommit,
+  isMutableTransactionReadAllowed,
+  isReadIgnoredForScheduling,
+  isReadMarkedAsAttemptedWrite,
+  isUiInputBlindWriteTx,
+  registerCommitRejectionListener,
+  takeCoverageWaits,
+} from "./reactivity-log.ts";
+import {
+  ReadOnlyAddressError,
+  TransactionAborted,
+  TransactionCompleteError,
+  WriteIsolationError,
+} from "./transaction-errors.ts";
+import {
   claim,
   load as loadInline,
   read as readAttestation,
@@ -69,37 +98,9 @@ import {
   getValueTypeName,
   isContainerValue,
 } from "./transaction/mutable-path-write.ts";
-import {
-  ReadOnlyAddressError,
-  TransactionAborted,
-  TransactionCompleteError,
-  WriteIsolationError,
-} from "./transaction-errors.ts";
-import {
-  ignoreReadForCommit,
-  isMutableTransactionReadAllowed,
-  isReadIgnoredForScheduling,
-  isReadMarkedAsAttemptedWrite,
-  isUiInputBlindWriteTx,
-  registerCommitRejectionListener,
-  takeCoverageWaits,
-} from "./reactivity-log.ts";
-import { hasValueAtPath, readValueAtPath } from "./v2-path.ts";
 import { toTransactionDocumentValue } from "./v2-document.ts";
-import {
-  buildMergeableIntent,
-  foldMergeableIntent,
-  isNoopMergeableDelta,
-  type MergeableBuildContext,
-  type MergeableOpDelta,
-  type MergeableOpIntent,
-  mergeableOpPayloadContains,
-  type OpSuppression,
-} from "./mergeable-ops.ts";
+import { hasValueAtPath, readValueAtPath } from "./v2-path.ts";
 import { recordWriteStackTrace } from "./write-stack-trace.ts";
-import { normalizeCellScope } from "../scope.ts";
-import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
-import type { CellScope } from "../builder/types.ts";
 
 type RootAttestation = IAttestation;
 

--- a/packages/runner/src/storage/v2-watch.ts
+++ b/packages/runner/src/storage/v2-watch.ts
@@ -1,15 +1,16 @@
+import type { SchemaPathSelector } from "@commonfabric/api";
 import { hashSchema } from "@commonfabric/data-model/schema-hash";
 import {
   internPathSelector,
   REJECTING_SELECTOR,
 } from "@commonfabric/data-model/schema-utils";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import type { MIME } from "@commonfabric/memory/interface";
 import type { CellScope } from "@commonfabric/memory/v2";
-import { hashStringOf } from "@commonfabric/data-model/value-hash";
+
 import { pruneCfcSchemaDefinitions } from "../cfc/schema-refs.ts";
-import { SelectorTracker } from "./selector-tracker.ts";
-import type { SchemaPathSelector } from "@commonfabric/api";
 import type { PullError, Result, Unit, URI } from "./interface.ts";
+import { SelectorTracker } from "./selector-tracker.ts";
 
 const DOCUMENT_MIME = "application/json" as const;
 type ScopedWatchAddress = { id: URI; type: MIME; scope?: CellScope };

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1,7 +1,13 @@
-import { cloneIfNecessary } from "@commonfabric/data-model/fabric-value";
 import type { FabricValue, SchemaPathSelector } from "@commonfabric/api";
+import {
+  hasDataUriScheme,
+  valueFromDataUri,
+} from "@commonfabric/data-model/data-uri-codec";
+import { cloneIfNecessary } from "@commonfabric/data-model/fabric-value";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
+import { aclDocId } from "@commonfabric/memory/acl";
+import { assert, unclaimed } from "@commonfabric/memory/fact";
 import type { Entity } from "@commonfabric/memory/interface";
-import type { RuntimeTelemetryMarker } from "../telemetry.ts";
 import {
   type AuthorizationError as IAuthorizationError,
   type ConflictError as IConflictError,
@@ -12,9 +18,6 @@ import {
   type TransactionError,
   type URI,
 } from "@commonfabric/memory/interface";
-import { assert, unclaimed } from "@commonfabric/memory/fact";
-import { aclDocId } from "@commonfabric/memory/acl";
-import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import {
   type CellScope,
   type ClientCommit,
@@ -37,26 +40,29 @@ import {
   type SqliteRegisterDiskSourceResult,
   toDocumentPath,
 } from "@commonfabric/memory/v2";
-import {
-  applyPatchToDocument,
-  PatchApplyError,
-} from "../../../memory/v2/patch.ts";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import type { AppliedCommit } from "@commonfabric/memory/v2/engine";
 import { BoundedKeyMap } from "@commonfabric/utils/cache";
 import { getLogger } from "@commonfabric/utils/logger";
 import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
-import type { Cell } from "../cell.ts";
+
+import {
+  applyPatchToDocument,
+  PatchApplyError,
+} from "../../../memory/v2/patch.ts";
 import type { JSONSchema } from "../builder/types.ts";
+import type { Cancel } from "../cancel.ts";
+import type { Cell } from "../cell.ts";
 import { ContextualFlowControl } from "../cfc.ts";
-import { hashStringOf } from "@commonfabric/data-model/value-hash";
-import { sortAndCompactPaths } from "../reactive-dependencies.ts";
-import { valueFromDataUri } from "@commonfabric/data-model/data-uri-codec";
 import {
   isPrimitiveCellLink,
   type NormalizedLink,
   parseLinkPrimitive,
 } from "../link-types.ts";
-import type { Cancel } from "../cancel.ts";
+import { sortAndCompactPaths } from "../reactive-dependencies.ts";
+import { normalizeCellScope } from "../scope.ts";
+import { normalizeSpaceHost, SpaceHostValidationError } from "../space-host.ts";
+import type { RuntimeTelemetryMarker } from "../telemetry.ts";
 import { recordCommitLocalSeq } from "./commit-identity.ts";
 import * as Differential from "./differential.ts";
 import type {
@@ -82,12 +88,6 @@ import type {
   TransactionCommitOptions,
   Unit,
 } from "./interface.ts";
-import { SelectorTracker } from "./selector-tracker.ts";
-import * as SubscriptionManager from "./subscription.ts";
-import {
-  getDirectTransactionMergeableOpAddresses,
-  getDirectTransactionReadActivities,
-} from "./transaction-inspection.ts";
 import {
   getBlindStructuralTarget,
   isMergeableOpRead,
@@ -97,6 +97,27 @@ import {
   notifyCommitRejected,
   recordCoverageWait,
 } from "./reactivity-log.ts";
+import { SelectorTracker } from "./selector-tracker.ts";
+import * as SubscriptionManager from "./subscription.ts";
+import {
+  getDirectTransactionMergeableOpAddresses,
+  getDirectTransactionReadActivities,
+} from "./transaction-inspection.ts";
+import { toTransactionDocumentValue } from "./v2-document.ts";
+import {
+  createStorageAddressResolver,
+  RemoteSessionFactory,
+  type SessionFactory,
+  storageAddressForHost,
+  toWebSocketAddress,
+} from "./v2-remote-session.ts";
+import * as V2Transaction from "./v2-transaction.ts";
+import {
+  compactWatchEntries,
+  normalizeSyncEntries,
+  normalizeSyncSelector,
+  watchIdForEntry,
+} from "./v2-watch.ts";
 
 // A cell's CFC write-policy label lives at ["cfc"]. A mergeable write reads it as
 // part of the write; that read is dropped from its conflict set.
@@ -127,24 +148,6 @@ const isArrayLengthChildPath = (
   path.length === arrayPath.length + 1 &&
   path[arrayPath.length] === "length" &&
   arrayPath.every((segment, index) => path[index] === segment);
-import { toTransactionDocumentValue } from "./v2-document.ts";
-import {
-  compactWatchEntries,
-  normalizeSyncEntries,
-  normalizeSyncSelector,
-  watchIdForEntry,
-} from "./v2-watch.ts";
-import {
-  createStorageAddressResolver,
-  RemoteSessionFactory,
-  type SessionFactory,
-  storageAddressForHost,
-  toWebSocketAddress,
-} from "./v2-remote-session.ts";
-import * as V2Transaction from "./v2-transaction.ts";
-import { normalizeCellScope } from "../scope.ts";
-import { normalizeSpaceHost, SpaceHostValidationError } from "../space-host.ts";
-import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
 
 export { watchIdForEntry } from "./v2-watch.ts";
 export type { SessionFactory } from "./v2-remote-session.ts";

--- a/packages/runner/src/traverse-recorder.ts
+++ b/packages/runner/src/traverse-recorder.ts
@@ -1,10 +1,11 @@
-import { hashStringOf } from "@commonfabric/data-model/value-hash";
-import { cloneIfNecessary } from "@commonfabric/data-model/value-clone";
 import type { SchemaPathSelector } from "@commonfabric/api";
+import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { cloneIfNecessary } from "@commonfabric/data-model/value-clone";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
+
 import { getLogger } from "../../utils/src/logger.ts";
 import type { NormalizedFullLink } from "./link-utils.ts";
-import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
 import type {
   IExtendedStorageTransaction,
   IMemorySpaceAddress,

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -1,6 +1,18 @@
-import { toIndentedDebugString } from "@commonfabric/data-model/value-debug";
-import { hashStringOf } from "@commonfabric/data-model/value-hash";
+import {
+  FABRIC_SPECIAL_OBJECT_BRAND,
+  isFabricPrimitiveSchemaType,
+  type JSONSchemaObj,
+  type SchemaPathSelector,
+} from "@commonfabric/api";
+import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
 import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
+import { schemaTypeOfFabricPrimitive } from "@commonfabric/data-model/fabric-primitives";
+import {
+  FabricInstance,
+  FabricPrimitive,
+  FabricSpecialObject,
+  type FabricValue,
+} from "@commonfabric/data-model/fabric-value";
 import {
   hashSchema,
   internSchema,
@@ -8,21 +20,19 @@ import {
   isInternedSchema,
 } from "@commonfabric/data-model/schema-hash";
 import {
-  FABRIC_SPECIAL_OBJECT_BRAND,
-  isFabricPrimitiveSchemaType,
-  type JSONSchemaObj,
-  type SchemaPathSelector,
-} from "@commonfabric/api";
+  DEFAULT_SELECTOR,
+  internPathSelector,
+  internSchemaPairAsKey,
+  REJECTING_SELECTOR,
+  schemaWithProperties,
+} from "@commonfabric/data-model/schema-utils";
+import { toIndentedDebugString } from "@commonfabric/data-model/value-debug";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import type { MemorySpace, Result, Unit } from "@commonfabric/memory/interface";
-import {
-  FabricInstance,
-  FabricPrimitive,
-  FabricSpecialObject,
-  type FabricValue,
-} from "@commonfabric/data-model/fabric-value";
-import { schemaTypeOfFabricPrimitive } from "@commonfabric/data-model/fabric-primitives";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
+
+import { getLogger } from "../../utils/src/logger.ts";
 // TODO(@ubik2): Ideally this would import from "@commonfabric/utils/types",
 // but rollup has issues
 import {
@@ -32,15 +42,6 @@ import {
   isObjectOrArray,
   isString,
 } from "../../utils/src/types.ts";
-import { getLogger } from "../../utils/src/logger.ts";
-import { ContextualFlowControl } from "./cfc.ts";
-import {
-  DEFAULT_SELECTOR,
-  internPathSelector,
-  internSchemaPairAsKey,
-  REJECTING_SELECTOR,
-  schemaWithProperties,
-} from "@commonfabric/data-model/schema-utils";
 import type {
   CellScope,
   JSONObject,
@@ -48,13 +49,24 @@ import type {
   JSONSchemaTypes,
   SchemaScope,
 } from "./builder/types.ts";
+import { ContextualFlowControl } from "./cfc.ts";
 import { dataUriFromValueWithResolvedLinks } from "./data-uri.ts";
+import type { LastNode } from "./link-resolution.ts";
+import {
+  type IMemorySpaceValueAddress,
+  isSigilLink,
+  isWriteRedirectLink,
+  type ValuePath,
+} from "./link-types.ts";
 import { addressKey, NormalizedFullLink, parseLink } from "./link-utils.ts";
 import { canFollowScopedLink } from "./scope.ts";
+import { type CellLinkRefPayload, SigilLink } from "./sigil-types.ts";
 import type {
   Activity,
   CommitError,
+  IAttestation,
   IExtendedStorageTransaction,
+  IMemoryAddress,
   IMemorySpaceAddress,
   InactiveTransactionError,
   IReadOptions,
@@ -71,16 +83,6 @@ import {
   ignoreReadForScheduling,
 } from "./storage/reactivity-log.ts";
 import { resolve } from "./storage/transaction/attestation.ts";
-import {
-  type IMemorySpaceValueAddress,
-  isSigilLink,
-  isWriteRedirectLink,
-  type ValuePath,
-} from "./link-types.ts";
-import type { LastNode } from "./link-resolution.ts";
-import type { IAttestation, IMemoryAddress } from "./storage/interface.ts";
-import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
-import { type CellLinkRefPayload, SigilLink } from "./sigil-types.ts";
 import {
   recordTraverseInvocation,
   wrapTxForTraverseCapture,

--- a/packages/runner/src/uri-utils.ts
+++ b/packages/runner/src/uri-utils.ts
@@ -1,17 +1,18 @@
 import {
+  entityRefToString,
+  isEntityRef,
+} from "@commonfabric/data-model/cell-rep";
+import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
+import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+import { hashOf } from "@commonfabric/data-model/value-hash";
+
+import {
   type EntityKind,
   entityUriSchemePrefix,
   hasEntityUriScheme,
   uriSchemeForEntityKind,
 } from "./entity-kind.ts";
-import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
-import { hashOf } from "@commonfabric/data-model/value-hash";
-import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
-import {
-  entityRefToString,
-  isEntityRef,
-} from "@commonfabric/data-model/cell-rep";
-import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
 import type { URI } from "./sigil-types.ts";
 
 /**


### PR DESCRIPTION
Sixth of the series applying the Development Guide's `Imports` rules (#5852).
I (agent working on behalf of @danfuzz) am splitting along package lines;
`runner` is large enough to need splitting again, so this is `src` and
`integration`, with `test` (~148 files) to follow.

Independent of the other open PRs in the series — different files, all branched
from `main`.

## What changed

94 files, import blocks only: statements merged where a module was named twice,
grouped standard library / external / internal with a blank line between, each
package's imports collated into one contiguous run, and each run sorted.

## Seven files needed lifting, and why that is safe

These are the first files in the series whose imports were **interleaved with
other statements**, so the block could not simply be reordered where it sat:

- `src/builtins/filter.ts`, `flatmap.ts`, `map.ts`, `llm-dialog.ts`
- `src/cfc/schema-refs.ts`
- `src/storage/v2.ts`
- `integration/pattern-and-data-persistence.test.ts`

Each has a couple of imports, then schema constants carrying their own
explanatory comments, then a second and larger import block below. Their imports
are lifted above those statements.

**That is behavior-preserving, not merely tidier.** Import declarations hoist:
they are evaluated — in source order among themselves — before any statement of
the module body runs. Moving one above a `const` therefore changes neither the
order the modules evaluate in nor their order relative to the body. Bare
side-effect imports hoist the same way, and their order relative to each other
is preserved regardless.

Everything else is untouched. In `filter.ts` the only non-import lines appearing
in the diff are the continuation lines of the import statements themselves, and
the `RESULT_PRESENCE_SCHEMA` comment still sits directly above its constant.

Until this PR the rewriting simply **refused** these files and reported them,
rather than guessing; lifting is now an explicit opt-in applied file by file.

## Import attributes

`src/builder/env.ts` carries:

```ts
import ports from "@commonfabric/ports" with { type: "json" };
```

Intact. An earlier revision of the tooling dropped such a clause (fixed in
#5856); the binding comparison now carries import attributes so a drop is caught
rather than shipped.

## Verification

- **94 files, zero binding differences**, where a binding is `(resolved module,
  type-ness, local name, import attributes)`.
- Audited the branch for both spacing defects: **0** glued file comments, **0**
  blank lines between consecutive bare imports.
- `deno fmt --check`, `deno lint`, `deno task check` all green.
- `runner`'s suite: **1206 passed, 0 failed**.

## Series

Done: #5854 (merged), #5855 (merged), #5856, #5857, #5858 (open), this one.

Remaining: `runner/test`, ~148 files — the last of it.

`packages/patterns` is excluded from every PR in this series: pattern source is
compiled and content-addressed, so an edit that looks inert can move a contract
and trip `pattern-compat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

