### PR TITLE
refactor: conform imports in `runner/test`

### DIFF
--- a/packages/runner/test/array-push-default-fields.test.ts
+++ b/packages/runner/test/array-push-default-fields.test.ts
@@ -4,13 +4,16 @@
  * This test specifically checks whether objects with many Default<>-like
  * fields maintain their values correctly when pushed to arrays.
  */
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { expect } from "@std/expect";
-import { Runtime } from "../src/runtime.ts";
-import { createQueryResultProxy } from "../src/query-result-proxy.ts";
-import { popFrame, pushFrame } from "../src/builder/pattern.ts";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { popFrame, pushFrame } from "../src/builder/pattern.ts";
+import { createQueryResultProxy } from "../src/query-result-proxy.ts";
+import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("test operator");

--- a/packages/runner/test/array-push-id-bug.test.ts
+++ b/packages/runner/test/array-push-id-bug.test.ts
@@ -6,14 +6,17 @@
  * result proxies, new items are anchored automatically, ensuring they're
  * stored as separate entity documents rather than inline data.
  */
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { expect } from "@std/expect";
-import { Runtime } from "../src/runtime.ts";
-import { createQueryResultProxy } from "../src/query-result-proxy.ts";
-import { popFrame, pushFrame } from "../src/builder/pattern.ts";
-import { isPrimitiveCellLink } from "../src/link-utils.ts";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { popFrame, pushFrame } from "../src/builder/pattern.ts";
+import { isPrimitiveCellLink } from "../src/link-utils.ts";
+import { createQueryResultProxy } from "../src/query-result-proxy.ts";
+import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("test operator");

--- a/packages/runner/test/attestation-data-uri.test.ts
+++ b/packages/runner/test/attestation-data-uri.test.ts
@@ -5,14 +5,16 @@
  * silently diverge on what a payload means.
  */
 
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
 import { JsonCodecEngine } from "@commonfabric/data-model/codec-json";
 import { jsonFromFabricValue } from "@commonfabric/data-model/codecs";
-import { toUnpaddedBase64url } from "@commonfabric/utils/base64url";
 import { DATA_URI_MEDIA_TYPE } from "@commonfabric/data-model/data-uri-codec";
-import { load } from "../src/storage/transaction/attestation.ts";
+import { toUnpaddedBase64url } from "@commonfabric/utils/base64url";
+
 import type { URI } from "../src/sigil-types.ts";
+import { load } from "../src/storage/transaction/attestation.ts";
 
 /** `data:` cell URI (base64url payload) with the given payload text. */
 const uriOf = (payload: string): URI =>

--- a/packages/runner/test/cell-arrays.test.ts
+++ b/packages/runner/test/cell-arrays.test.ts
@@ -1,8 +1,10 @@
 // Cell array tests: element conversion plus optimized plain-schema traversal.
 
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
-import { DATA_URI_MEDIA_TYPE } from "@commonfabric/data-model/data-uri-codec";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { DATA_URI_MEDIA_TYPE } from "@commonfabric/data-model/data-uri-codec";
+
 import "@commonfabric/utils/equal-ignoring-symbols";
 
 import { Writable } from "@commonfabric/api";
@@ -10,9 +12,10 @@ import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
 import { toCell } from "../src/back-to-cell.ts";
-import { type Cell, elementSchemaFor, isCell } from "../src/cell.ts";
 import { JSONSchema } from "../src/builder/types.ts";
+import { type Cell, elementSchemaFor, isCell } from "../src/cell.ts";
 import { Runtime } from "../src/runtime.ts";
 import { TransactionWrapper } from "../src/storage/extended-storage-transaction.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";

--- a/packages/runner/test/cell-as-cell.test.ts
+++ b/packages/runner/test/cell-as-cell.test.ts
@@ -1,19 +1,24 @@
 // asCell tests: converting values to cells with and without schemas,
 // link resolution, and schema-driven cell creation.
 
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import "@commonfabric/utils/equal-ignoring-symbols";
 
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { isCell } from "../src/cell.ts";
-import { JSONSchema } from "../src/builder/types.ts";
+
 import { popFrame, pushFrame } from "../src/builder/pattern.ts";
+import { JSONSchema } from "../src/builder/types.ts";
+import { isCell } from "../src/cell.ts";
+import {
+  areNormalizedLinksSame,
+  isPrimitiveCellLink,
+  parseLink,
+} from "../src/link-utils.ts";
 import { Runtime } from "../src/runtime.ts";
 import { txToReactivityLog } from "../src/scheduler.ts";
-import { isPrimitiveCellLink, parseLink } from "../src/link-utils.ts";
-import { areNormalizedLinksSame } from "../src/link-utils.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("test operator");

--- a/packages/runner/test/cell-callbacks.test.ts
+++ b/packages/runner/test/cell-callbacks.test.ts
@@ -1,25 +1,28 @@
 // Cell commit callback tests: verifying that onCommit callbacks fire correctly
 // after cell writes reach a final commit result.
 
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
-import { DATA_URI_MEDIA_TYPE } from "@commonfabric/data-model/data-uri-codec";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { DATA_URI_MEDIA_TYPE } from "@commonfabric/data-model/data-uri-codec";
+
 import "@commonfabric/utils/equal-ignoring-symbols";
 
 import { Writable } from "@commonfabric/api";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { isCell } from "../src/cell.ts";
-import { JSONSchema } from "../src/builder/types.ts";
+
 import { popFrame, pushFrame } from "../src/builder/pattern.ts";
+import { JSONSchema } from "../src/builder/types.ts";
+import { isCell } from "../src/cell.ts";
+import { parseLink } from "../src/link-utils.ts";
 import { Runtime } from "../src/runtime.ts";
 import { txToReactivityLog } from "../src/scheduler.ts";
+import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
 import {
   type IExtendedStorageTransaction,
   type IStorageTransaction,
 } from "../src/storage/interface.ts";
-import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
-import { parseLink } from "../src/link-utils.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/cell-static-methods.test.ts
+++ b/packages/runner/test/cell-static-methods.test.ts
@@ -1,20 +1,23 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import "@commonfabric/utils/equal-ignoring-symbols";
-import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import type { JSONSchema } from "../src/builder/types.ts";
-import { Runtime } from "../src/runtime.ts";
-import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import { popFrame, pushFrame } from "../src/builder/pattern.ts";
-import { createBuilder } from "../src/builder/factory.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
+
+import { FabricError } from "@commonfabric/data-model/fabric-instances";
 import {
   FabricBytes,
   FabricEpochNsec,
 } from "@commonfabric/data-model/fabric-primitives";
-import { FabricError } from "@commonfabric/data-model/fabric-instances";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { createBuilder } from "../src/builder/factory.ts";
+import { popFrame, pushFrame } from "../src/builder/pattern.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/cfc-agent-prompt-injection-demo.test.ts
+++ b/packages/runner/test/cfc-agent-prompt-injection-demo.test.ts
@@ -1,22 +1,24 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
-import { cfcAtom } from "@commonfabric/api/cfc";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import {
-  clearMockResponses,
-  loadConversationFixture,
-} from "@commonfabric/llm/client";
+import { describe, it } from "@std/testing/bdd";
+
 import type {
   BuiltInLLMMessage,
   BuiltInLLMTool,
   JSONSchema,
 } from "@commonfabric/api";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { cfcAtom } from "@commonfabric/api/cfc";
+import { Identity } from "@commonfabric/identity";
+import {
+  clearMockResponses,
+  loadConversationFixture,
+} from "@commonfabric/llm/client";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { LLMMessageSchema } from "../src/builtins/llm-schemas.ts";
+import { createLLMFriendlyLink } from "../src/link-types.ts";
 import { Runtime } from "../src/runtime.ts";
 import { waitForLlmMessages } from "./support/llm-result.ts";
-import { createLLMFriendlyLink } from "../src/link-types.ts";
-import { LLMMessageSchema } from "../src/builtins/llm-schemas.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 const signer = await Identity.fromPassphrase(
   "cfc agent prompt injection demo drive",

--- a/packages/runner/test/cfc-agent-tool-input-integrity.test.ts
+++ b/packages/runner/test/cfc-agent-tool-input-integrity.test.ts
@@ -1,16 +1,18 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
-import { cfcAtom } from "@commonfabric/api/cfc";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { enableMockMode } from "@commonfabric/llm/client";
+import { describe, it } from "@std/testing/bdd";
+
 import type { JSONSchema } from "@commonfabric/api";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { Runtime } from "../src/runtime.ts";
-import type { CfcEnforcementMode } from "../src/cfc/types.ts";
-import { cfcLabelViewForCell } from "../src/cfc/label-view.ts";
-import { createLLMFriendlyLink } from "../src/link-types.ts";
+import { cfcAtom } from "@commonfabric/api/cfc";
+import { Identity } from "@commonfabric/identity";
+import { enableMockMode } from "@commonfabric/llm/client";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
 import { llmToolExecutionHelpers } from "../src/builtins/llm-dialog.ts";
+import { cfcLabelViewForCell } from "../src/cfc/label-view.ts";
+import type { CfcEnforcementMode } from "../src/cfc/types.ts";
+import { createLLMFriendlyLink } from "../src/link-types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 const signer = await Identity.fromPassphrase("cfc agent tool-input integrity");
 const space = signer.did();

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -1,26 +1,19 @@
-import { describe, it } from "@std/testing/bdd";
-import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { Identity } from "@commonfabric/identity";
 import type { MemorySpace } from "@commonfabric/memory/interface";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import * as V2Storage from "../src/storage/v2.ts";
-import { raw } from "../src/module.ts";
+
+import type { JSONSchema, Pattern } from "../src/builder/types.ts";
+import { createCell } from "../src/cell.ts";
 import {
   readStoredCfcMetadata,
   storedCfcMetadataAppliesToPath,
 } from "../src/cfc/metadata.ts";
-import { Runtime } from "../src/runtime.ts";
-import { createCell } from "../src/cell.ts";
-import {
-  getDerivedInternalCellLink,
-  getMetaLink,
-  parseLink,
-  toMemorySpaceAddress,
-} from "../src/link-utils.ts";
+import type { IFCLabel } from "../src/cfc/mod.ts";
 import {
   canonicalizeCfcMetadata,
   canonicalizePreparedDigestInput,
@@ -32,12 +25,21 @@ import {
   CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION,
   type CfcEnforcementMode,
 } from "../src/cfc/types.ts";
-import type { JSONSchema, Pattern } from "../src/builder/types.ts";
 import { diffAndUpdate } from "../src/data-updating.ts";
-import { LINK_V1_TAG } from "../src/sigil-types.ts";
-import { ignoreReadForScheduling } from "../src/scheduler.ts";
-import { internalVerifierRead } from "../src/storage/reactivity-log.ts";
+import {
+  getDerivedInternalCellLink,
+  getMetaLink,
+  parseLink,
+  toMemorySpaceAddress,
+} from "../src/link-utils.ts";
+import { raw } from "../src/module.ts";
 import { setResultCell } from "../src/result-utils.ts";
+import { Runtime } from "../src/runtime.ts";
+import { ignoreReadForScheduling } from "../src/scheduler.ts";
+import { LINK_V1_TAG } from "../src/sigil-types.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { internalVerifierRead } from "../src/storage/reactivity-log.ts";
+import * as V2Storage from "../src/storage/v2.ts";
 import {
   TEST_MEMORY_SERVER_AUTH,
   testSessionOpenAuthFactory,

--- a/packages/runner/test/cfc-canonicalize.bench.ts
+++ b/packages/runner/test/cfc-canonicalize.bench.ts
@@ -12,17 +12,18 @@
  * charts on its /bench page.
  */
 
-import { preparedDigestFor, type PreparedDigestInput } from "../src/cfc/mod.ts";
+import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import type { MemorySpace } from "@commonfabric/memory/interface";
+
+import type { JSONSchema } from "../src/builder/types.ts";
 import {
   canonicalizeLogicalPath,
   canonicalizePreparedDigestInput,
 } from "../src/cfc/canonical.ts";
-import { watchIdForEntry } from "../src/storage/v2-watch.ts";
-import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
-import { internSchema } from "@commonfabric/data-model/schema-hash";
-import type { MemorySpace } from "@commonfabric/memory/interface";
+import { preparedDigestFor, type PreparedDigestInput } from "../src/cfc/mod.ts";
 import type { WritePolicyInput } from "../src/cfc/types.ts";
-import type { JSONSchema } from "../src/builder/types.ts";
+import { watchIdForEntry } from "../src/storage/v2-watch.ts";
 
 const SPACE: MemorySpace =
   "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSdoom8Beere1L9DwwTm";

--- a/packages/runner/test/cfc-caveat-source-redaction.test.ts
+++ b/packages/runner/test/cfc-caveat-source-redaction.test.ts
@@ -1,10 +1,12 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+
 import {
   type CfcLabelView,
   redactCaveatSourcesForDisplay,
 } from "../src/cfc/label-view.ts";
-import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 
 // Audit item 28b (inv-12): the pattern-facing introspection surface
 // (`getCfcLabel()` → `handleCellGetCfcLabel`) must not surface `Caveat.source`

--- a/packages/runner/test/cfc-clause-authoring.test.ts
+++ b/packages/runner/test/cfc-clause-authoring.test.ts
@@ -1,17 +1,19 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
-import { readStoredCfcMetadata } from "../src/cfc/metadata.ts";
+import { deepEqual } from "@commonfabric/utils/deep-equal";
+
+import type { JSONSchema, JSONSchemaObj } from "../src/builder/types.ts";
 import { isOrClause } from "../src/cfc/clause.ts";
-import { mergeCfcSchemaEnvelopes } from "../src/cfc/schema-merge.ts";
+import { readStoredCfcMetadata } from "../src/cfc/metadata.ts";
 import {
   CFC_LABEL_READ_FAILED_ATOM,
   cfcObservationFitsCeiling,
 } from "../src/cfc/observation.ts";
-import { deepEqual } from "@commonfabric/utils/deep-equal";
-import type { JSONSchema, JSONSchemaObj } from "../src/builder/types.ts";
+import { mergeCfcSchemaEnvelopes } from "../src/cfc/schema-merge.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-clause-authoring");
 

--- a/packages/runner/test/cfc-clause-join.test.ts
+++ b/packages/runner/test/cfc-clause-join.test.ts
@@ -1,8 +1,12 @@
-import { describe, it } from "@std/testing/bdd";
-import { type CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import {
+  type CfcConfClause,
+  clauseAlternatives,
+  isOrClause,
+} from "../src/cfc/clause.ts";
 import { mergeCfcLabelViews, mergeLabel } from "../src/cfc/label-view-core.ts";
-import { clauseAlternatives, isOrClause } from "../src/cfc/clause.ts";
 
 // Epic A3 (docs/history/plans/cfc-future-work-implementation.md): the confidentiality
 // join is clause CONCATENATION with normalize-on-ingest. It upholds the

--- a/packages/runner/test/cfc-clause-meet.test.ts
+++ b/packages/runner/test/cfc-clause-meet.test.ts
@@ -1,13 +1,17 @@
-import { describe, it } from "@std/testing/bdd";
-import { type CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import {
+  type CfcConfClause,
+  clausesEqual,
+  normalizeClause,
+} from "../src/cfc/clause.ts";
 import {
   CFC_LABEL_READ_FAILED_ATOM,
   cfcObservationFitsCeiling,
   type CfcObservationMaxConfidentiality,
   meetCfcObservationCeilings,
 } from "../src/cfc/observation.ts";
-import { clausesEqual, normalizeClause } from "../src/cfc/clause.ts";
 
 // Decision 6 of docs/history/plans/cfc-future-work-implementation.md (corrected
 // 2026-07-02, #4482): the general clause meet is the pairwise

--- a/packages/runner/test/cfc-clause.test.ts
+++ b/packages/runner/test/cfc-clause.test.ts
@@ -1,7 +1,13 @@
-import { describe, it } from "@std/testing/bdd";
-import type { CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
+
+import {
+  canonicalizeCfcMetadata,
+  canonicalizeWritePolicyInput,
+} from "../src/cfc/canonical.ts";
+import type { CfcConfClause } from "../src/cfc/clause.ts";
 import {
   clauseAlternatives,
   clausesEqual,
@@ -9,10 +15,6 @@ import {
   isOrClause,
   normalizeClause,
 } from "../src/cfc/clause.ts";
-import {
-  canonicalizeCfcMetadata,
-  canonicalizeWritePolicyInput,
-} from "../src/cfc/canonical.ts";
 import type {
   CfcAddress,
   CfcMetadata,

--- a/packages/runner/test/cfc-commitment-matching.test.ts
+++ b/packages/runner/test/cfc-commitment-matching.test.ts
@@ -1,29 +1,31 @@
-import { describe, it } from "@std/testing/bdd";
-import type { CfcAtom } from "@commonfabric/api/cfc";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import {
   CFC_ATOM_TYPE,
   CFC_CONCEPT_KIND,
   cfcAtom,
 } from "@commonfabric/api/cfc";
+
 import { atomEntails, matchAtomPattern } from "../src/cfc/atom-pattern.ts";
 import { clauseSubsumes } from "../src/cfc/clause.ts";
-import {
-  atomsOutsideCeiling,
-  cfcIntegritySatisfiesFloorCoherently,
-} from "../src/cfc/observation.ts";
+import { evaluateExchangeRules } from "../src/cfc/exchange-eval.ts";
 import {
   commitCfcFieldValue,
   transformCfcLabelForCrossSpacePersist,
 } from "../src/cfc/label-representation.ts";
 import {
+  atomsOutsideCeiling,
+  cfcIntegritySatisfiesFloorCoherently,
+} from "../src/cfc/observation.ts";
+import { buildCfcPolicySnapshot } from "../src/cfc/policy.ts";
+import { createRenderConfidentialityResolver } from "../src/cfc/render-ceiling.ts";
+import {
   dischargeMaterialRiskAtoms,
   schemaWithInjectionSafeAnnotations,
 } from "../src/cfc/schema-sanitization.ts";
-import { evaluateExchangeRules } from "../src/cfc/exchange-eval.ts";
-import { buildCfcPolicySnapshot } from "../src/cfc/policy.ts";
 import { STANDARD_PROMPT_CAVEAT_POLICY } from "../src/cfc/standard-profile.ts";
-import { createRenderConfidentialityResolver } from "../src/cfc/render-ceiling.ts";
 
 // Inv-12 Stage 1 same-form matching (SC-25; design §2; spec §4.6.4.1):
 // enforcement keeps working on commitment forms, fail-closed where it

--- a/packages/runner/test/cfc-concept-floor.test.ts
+++ b/packages/runner/test/cfc-concept-floor.test.ts
@@ -1,11 +1,15 @@
-import { describe, it } from "@std/testing/bdd";
-import type { CfcAtom } from "@commonfabric/api/cfc";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
+import { describe, it } from "@std/testing/bdd";
+
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { cfcAtom } from "@commonfabric/api/cfc";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
+import { Identity } from "@commonfabric/identity";
 import { enableMockMode } from "@commonfabric/llm/client";
+
+import type { JSONSchema } from "../src/builder/types.ts";
+import { llmToolExecutionHelpers } from "../src/builtins/llm-dialog.ts";
+import { conceptGuard } from "../src/cfc/atom-pattern.ts";
+import { cfcLabelViewForCell } from "../src/cfc/label-view.ts";
 import {
   cfcIntegritySatisfiesFloor,
   cfcIntegritySatisfiesFloorCoherently,
@@ -16,13 +20,11 @@ import {
   type CfcTrustConfigInput,
   createTrustResolver,
 } from "../src/cfc/trust.ts";
-import { conceptGuard } from "../src/cfc/atom-pattern.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { cfcLabelViewForCell } from "../src/cfc/label-view.ts";
-import { createLLMFriendlyLink } from "../src/link-types.ts";
-import { llmToolExecutionHelpers } from "../src/builtins/llm-dialog.ts";
 import type { CfcEnforcementMode } from "../src/cfc/types.ts";
-import type { JSONSchema } from "../src/builder/types.ts";
+import { createLLMFriendlyLink } from "../src/link-types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-concept-floor");
 enableMockMode();

--- a/packages/runner/test/cfc-cross-space-integrity.test.ts
+++ b/packages/runner/test/cfc-cross-space-integrity.test.ts
@@ -1,21 +1,22 @@
-import { describe, it } from "@std/testing/bdd";
-import type { IFCLabel } from "../src/cfc/mod.ts";
-import { type CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
 import type { MemorySpace, URI } from "@commonfabric/memory/interface";
+
 import type { JSONSchema } from "../src/builder/types.ts";
-import { parseLink } from "../src/link-utils.ts";
-import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
+import { type CfcConfClause, clausesEqual } from "../src/cfc/clause.ts";
 import { evaluateExchangeRules } from "../src/cfc/exchange-eval.ts";
+import type { IFCLabel } from "../src/cfc/mod.ts";
 import {
   buildCfcPolicySnapshot,
   type ExchangeRule,
 } from "../src/cfc/policy.ts";
-import { clausesEqual } from "../src/cfc/clause.ts";
+import { parseLink } from "../src/link-utils.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
 // ===========================================================================
 // Cross-space integrity & declassification — expressing the four scenarios and

--- a/packages/runner/test/cfc-declared-monotonicity.test.ts
+++ b/packages/runner/test/cfc-declared-monotonicity.test.ts
@@ -1,16 +1,18 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
 import type { URI } from "@commonfabric/memory/interface";
+
 import type { JSONSchema } from "../src/builder/types.ts";
+import { stampExternalIngest } from "../src/cfc/external-ingest.ts";
 import {
   cfcCanonicalClauseDigest,
   type CfcDeclaredMonotonicityMode,
   collectDeclaredMonotonicityViolations,
 } from "../src/cfc/mod.ts";
-import { stampExternalIngest } from "../src/cfc/external-ingest.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 import { TransactionWrapper } from "../src/storage/extended-storage-transaction.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-declared-mono");

--- a/packages/runner/test/cfc-exchange-eval.test.ts
+++ b/packages/runner/test/cfc-exchange-eval.test.ts
@@ -1,15 +1,9 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
 import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
-import {
-  DEFAULT_EXCHANGE_FUEL,
-  evaluateExchangeRules,
-} from "../src/cfc/exchange-eval.ts";
-import {
-  buildCfcPolicySnapshot,
-  type ExchangeRule,
-} from "../src/cfc/policy.ts";
-import { buildCfcTrustConfig, createTrustResolver } from "../src/cfc/trust.ts";
+import { deepEqual } from "@commonfabric/utils/deep-equal";
+
 import {
   type CfcConfClause,
   type CfcOrClause,
@@ -17,8 +11,16 @@ import {
   clausesEqual,
   normalizeClause,
 } from "../src/cfc/clause.ts";
+import {
+  DEFAULT_EXCHANGE_FUEL,
+  evaluateExchangeRules,
+} from "../src/cfc/exchange-eval.ts";
 import type { IFCLabel } from "../src/cfc/label-view-core.ts";
-import { deepEqual } from "@commonfabric/utils/deep-equal";
+import {
+  buildCfcPolicySnapshot,
+  type ExchangeRule,
+} from "../src/cfc/policy.ts";
+import { buildCfcTrustConfig, createTrustResolver } from "../src/cfc/trust.ts";
 
 // Epic B4 (docs/history/plans/cfc-future-work-implementation.md §3): the guarded
 // rewrite + fueled fixpoint (spec §4.4.5). Property tests (i)-(vi) from the

--- a/packages/runner/test/cfc-existence-channel.test.ts
+++ b/packages/runner/test/cfc-existence-channel.test.ts
@@ -1,16 +1,18 @@
-import { afterEach, describe, it } from "@std/testing/bdd";
-import type { FabricPlainObject } from "@commonfabric/api";
-import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
+import { afterEach, describe, it } from "@std/testing/bdd";
+
+import type { FabricPlainObject } from "@commonfabric/api";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
-import { Identity } from "@commonfabric/identity";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
-import { resolveLink } from "../src/link-resolution.ts";
-import type { LabelMapEntry } from "../src/cfc/types.ts";
+import { Identity } from "@commonfabric/identity";
+
 import type { JSONSchema } from "../src/builder/types.ts";
+import type { IFCLabel } from "../src/cfc/mod.ts";
+import type { LabelMapEntry } from "../src/cfc/types.ts";
+import { resolveLink } from "../src/link-resolution.ts";
 import type { NormalizedFullLink } from "../src/link-utils.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-existence-channel");
 const space = signer.did();

--- a/packages/runner/test/cfc-external-ingest.test.ts
+++ b/packages/runner/test/cfc-external-ingest.test.ts
@@ -1,13 +1,15 @@
-import { describe, it } from "@std/testing/bdd";
-import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
+import { describe, it } from "@std/testing/bdd";
+
 import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
+import { Identity } from "@commonfabric/identity";
+
 import type { JSONSchema } from "../src/builder/types.ts";
 import { stampExternalIngest } from "../src/cfc/external-ingest.ts";
+import type { IFCLabel } from "../src/cfc/mod.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-external-ingest");
 const space = signer.did();

--- a/packages/runner/test/cfc-flow-integrity.test.ts
+++ b/packages/runner/test/cfc-flow-integrity.test.ts
@@ -1,14 +1,16 @@
-import { describe, it } from "@std/testing/bdd";
-import type { CfcAtom } from "@commonfabric/api/cfc";
-import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
+import { describe, it } from "@std/testing/bdd";
+
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
+import { Identity } from "@commonfabric/identity";
+
 import type { JSONSchema } from "../src/builder/types.ts";
 import { atomPropagationClass } from "../src/cfc/atom-classes.ts";
+import type { IFCLabel } from "../src/cfc/mod.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-flow-integrity");
 const space = signer.did();

--- a/packages/runner/test/cfc-grant-records.test.ts
+++ b/packages/runner/test/cfc-grant-records.test.ts
@@ -1,19 +1,16 @@
-import { describe, it } from "@std/testing/bdd";
-import type { IFCLabel } from "../src/cfc/mod.ts";
-import { type CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
-import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { describe, it } from "@std/testing/bdd";
+
 import { CFC_ATOM_TYPE, type CfcAtom, cfcAtom } from "@commonfabric/api/cfc";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { Identity } from "@commonfabric/identity";
+import type { MemorySpace, URI } from "@commonfabric/memory/interface";
+
+import type { JSONSchema } from "../src/builder/types.ts";
+import { preparedDigestFor } from "../src/cfc/canonical.ts";
+import { type CfcConfClause, clausesEqual } from "../src/cfc/clause.ts";
 import { evaluateExchangeRules } from "../src/cfc/exchange-eval.ts";
 import type { CfcGrantResolverQuery } from "../src/cfc/exchange-eval.ts";
-import {
-  buildCfcPolicySnapshot,
-  type CfcPolicyRecordInput,
-  type ExchangeRule,
-} from "../src/cfc/policy.ts";
 import {
   CFC_GRANT_ABSENT_DIGEST,
   CFC_GRANT_ID_PREFIX,
@@ -25,15 +22,19 @@ import {
   prepareCfcGrantWrite,
   verifyCfcGrantDocument,
 } from "../src/cfc/grants.ts";
+import type { IFCLabel } from "../src/cfc/mod.ts";
+import {
+  buildCfcPolicySnapshot,
+  type CfcPolicyRecordInput,
+  type ExchangeRule,
+} from "../src/cfc/policy.ts";
+import { createFrozenRequestSnapshot } from "../src/cfc/request-snapshot.ts";
+import { enqueueSinkRequestPostCommitEffect } from "../src/cfc/sink-request.ts";
+import type { PreparedDigestInput } from "../src/cfc/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 import { TransactionWrapper } from "../src/storage/extended-storage-transaction.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import { enqueueSinkRequestPostCommitEffect } from "../src/cfc/sink-request.ts";
-import { createFrozenRequestSnapshot } from "../src/cfc/request-snapshot.ts";
-import { preparedDigestFor } from "../src/cfc/canonical.ts";
-import type { PreparedDigestInput } from "../src/cfc/types.ts";
-import type { MemorySpace, URI } from "@commonfabric/memory/interface";
-import type { JSONSchema } from "../src/builder/types.ts";
-import { clausesEqual } from "../src/cfc/clause.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-grant-records");
 

--- a/packages/runner/test/cfc-inspect-conf-label-builtin.test.ts
+++ b/packages/runner/test/cfc-inspect-conf-label-builtin.test.ts
@@ -1,21 +1,23 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import { Identity } from "@commonfabric/identity";
 import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
-import { parseLink } from "../src/link-utils.ts";
-import { readStoredCfcMetadata } from "../src/cfc/metadata.ts";
+import type { URI } from "@commonfabric/memory/interface";
+
+import type { Cell } from "../src/cell.ts";
+import type { InspectConfLabelResult } from "../src/cfc/label-introspection.ts";
 import {
   cfcLabelViewForCell,
   redactCaveatSourcesForDisplay,
 } from "../src/cfc/label-view.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import type { Cell } from "../src/cell.ts";
+import { readStoredCfcMetadata } from "../src/cfc/metadata.ts";
+import { parseLink } from "../src/link-utils.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import type { InspectConfLabelResult } from "../src/cfc/label-introspection.ts";
-import type { URI } from "@commonfabric/memory/interface";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 const signer = await Identity.fromPassphrase(
   "runner-cfc-inspect-conf-label-builtin",

--- a/packages/runner/test/cfc-label-introspection-channel.test.ts
+++ b/packages/runner/test/cfc-label-introspection-channel.test.ts
@@ -1,21 +1,23 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
-import { parseLink } from "../src/link-utils.ts";
-import { deriveFlowJoin } from "../src/cfc/prepare.ts";
+import type { URI } from "@commonfabric/memory/interface";
+
 import {
   canonicalizePreparedDigestInput,
   preparedDigestFor,
 } from "../src/cfc/canonical.ts";
-import { TransactionWrapper } from "../src/storage/extended-storage-transaction.ts";
 import { inspectStoredConfLabel } from "../src/cfc/label-introspection.ts";
 import { readStoredCfcMetadata } from "../src/cfc/metadata.ts";
-import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import { deriveFlowJoin } from "../src/cfc/prepare.ts";
 import type { CfcLabelMetadataObservation } from "../src/cfc/types.ts";
+import { parseLink } from "../src/link-utils.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { TransactionWrapper } from "../src/storage/extended-storage-transaction.ts";
 import type { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
-import type { URI } from "@commonfabric/memory/interface";
 
 const signer = await Identity.fromPassphrase(
   "runner-cfc-label-introspection-channel",

--- a/packages/runner/test/cfc-label-introspection.test.ts
+++ b/packages/runner/test/cfc-label-introspection.test.ts
@@ -1,7 +1,9 @@
-import { describe, it } from "@std/testing/bdd";
-import type { CfcAtom } from "@commonfabric/api/cfc";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+
 import {
   evaluateConfLabelQuery,
   parseConfLabelTargetPath,

--- a/packages/runner/test/cfc-label-metadata-persist.test.ts
+++ b/packages/runner/test/cfc-label-metadata-persist.test.ts
@@ -1,11 +1,13 @@
-import { describe, it } from "@std/testing/bdd";
-import type { CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
+import { describe, it } from "@std/testing/bdd";
+
 import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
+import { Identity } from "@commonfabric/identity";
+
+import type { CfcConfClause } from "../src/cfc/clause.ts";
 import { parseLink } from "../src/link-utils.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-label-metadata");
 

--- a/packages/runner/test/cfc-label-metadata-protection.test.ts
+++ b/packages/runner/test/cfc-label-metadata-protection.test.ts
@@ -1,19 +1,21 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
+import { describe, it } from "@std/testing/bdd";
+
 import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
-import { parseLink } from "../src/link-utils.ts";
-import type { CfcLabelMetadataProtectionMode } from "../src/cfc/mod.ts";
+import { Identity } from "@commonfabric/identity";
+import type { MemorySpace } from "@commonfabric/memory/interface";
+
+import type { JSONSchema } from "../src/builder/types.ts";
+import { stampExternalIngest } from "../src/cfc/external-ingest.ts";
 import {
   commitCfcFieldValue,
   containsCfcFieldCommitment,
 } from "../src/cfc/label-representation.ts";
-import { stampExternalIngest } from "../src/cfc/external-ingest.ts";
-import type { MemorySpace } from "@commonfabric/memory/interface";
-import type { JSONSchema } from "../src/builder/types.ts";
+import type { CfcLabelMetadataProtectionMode } from "../src/cfc/mod.ts";
+import { parseLink } from "../src/link-utils.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
 const signer = await Identity.fromPassphrase(
   "runner-cfc-label-metadata-protection",

--- a/packages/runner/test/cfc-label-view.test.ts
+++ b/packages/runner/test/cfc-label-view.test.ts
@@ -1,26 +1,28 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import { describe, it } from "@std/testing/bdd";
+
+import { linkRefPayload } from "@commonfabric/data-model/cell-rep";
 import { FabricError } from "@commonfabric/data-model/fabric-instances";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { toCell } from "../src/back-to-cell.ts";
+import { type FactoryInput, UI } from "../src/builder/types.ts";
 import {
   cfcLabelViewForCell,
   cfcLabelViewFromMetadata,
 } from "../src/cfc/label-view.ts";
-import { cfcLabelViewFromSchema } from "../src/cfc/schema-label-view.ts";
 import {
   redactSigilCfcLabelViewsForDisplay,
   stripSigilCfcLabelViews,
 } from "../src/cfc/link-label-view.ts";
+import { cfcLabelViewFromSchema } from "../src/cfc/schema-label-view.ts";
 import type { CfcMetadata } from "../src/cfc/types.ts";
-import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { linkRefPayload } from "@commonfabric/data-model/cell-rep";
-import { Runtime } from "../src/runtime.ts";
 import { parseLink } from "../src/link-utils.ts";
-import { toCell } from "../src/back-to-cell.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { type FactoryInput, UI } from "../src/builder/types.ts";
+import { Runtime } from "../src/runtime.ts";
 import { LINK_V1_TAG } from "../src/sigil-types.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 describe("CFC label view helpers", () => {
   it("collects labels that apply to a logical value path", () => {

--- a/packages/runner/test/cfc-llm-derived-stamp.test.ts
+++ b/packages/runner/test/cfc-llm-derived-stamp.test.ts
@@ -1,23 +1,25 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
+import { describe, it } from "@std/testing/bdd";
+
+import type { BuiltInLLMMessage } from "@commonfabric/api";
 import { cfcAtom } from "@commonfabric/api/cfc";
+import { Identity } from "@commonfabric/identity";
 import {
   clearMockResponses,
   enableMockMode,
   loadConversationFixture,
 } from "@commonfabric/llm/client";
-import type { BuiltInLLMMessage } from "@commonfabric/api";
-import { StorageManager } from "../src/storage/cache.deno.ts";
+
 import { popFrame, pushFrame } from "../src/builder/pattern.ts";
-import { Runtime } from "../src/runtime.ts";
+import { type JSONSchema } from "../src/builder/types.ts";
+import { LLMMessageSchema } from "../src/builtins/llm-schemas.ts";
 import { cfcLabelViewForCell } from "../src/cfc/label-view.ts";
 import { readStoredCfcMetadata } from "../src/cfc/metadata.ts";
 import { parseLink } from "../src/link-utils.ts";
-import { type JSONSchema } from "../src/builder/types.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { LLMMessageSchema } from "../src/builtins/llm-schemas.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 import { waitForLlmMessages } from "./support/llm-result.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-llm-derived-stamp");
 

--- a/packages/runner/test/cfc-observation-classes.test.ts
+++ b/packages/runner/test/cfc-observation-classes.test.ts
@@ -1,15 +1,17 @@
-import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
-import { Identity } from "@commonfabric/identity";
+import { afterEach, describe, it } from "@std/testing/bdd";
+
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
+import { Identity } from "@commonfabric/identity";
+
 import type { JSONSchema } from "../src/builder/types.ts";
-import { linkResolutionProbe } from "../src/storage/reactivity-log.ts";
 import { canonicalizeCfcMetadata } from "../src/cfc/canonical.ts";
 import type { LabelMapEntry } from "../src/cfc/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { linkResolutionProbe } from "../src/storage/reactivity-log.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-observation-classes");
 const space = signer.did();

--- a/packages/runner/test/cfc-policy-boundary.test.ts
+++ b/packages/runner/test/cfc-policy-boundary.test.ts
@@ -1,21 +1,23 @@
-import { describe, it } from "@std/testing/bdd";
-import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
-import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { describe, it } from "@std/testing/bdd";
+
 import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { Identity } from "@commonfabric/identity";
+
+import type { JSONSchema } from "../src/builder/types.ts";
+import { preparedDigestFor } from "../src/cfc/canonical.ts";
+import type { IFCLabel } from "../src/cfc/mod.ts";
+import type { CfcPolicyRecordInput, ExchangeRule } from "../src/cfc/policy.ts";
+import { createFrozenRequestSnapshot } from "../src/cfc/request-snapshot.ts";
+import { enqueueSinkRequestPostCommitEffect } from "../src/cfc/sink-request.ts";
+import type { PreparedDigestInput } from "../src/cfc/types.ts";
+import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import {
   ExtendedStorageTransaction,
   TransactionWrapper,
 } from "../src/storage/extended-storage-transaction.ts";
-import { Runtime } from "../src/runtime.ts";
-import { enqueueSinkRequestPostCommitEffect } from "../src/cfc/sink-request.ts";
-import { createFrozenRequestSnapshot } from "../src/cfc/request-snapshot.ts";
-import type { CfcPolicyRecordInput, ExchangeRule } from "../src/cfc/policy.ts";
-import { preparedDigestFor } from "../src/cfc/canonical.ts";
-import type { PreparedDigestInput } from "../src/cfc/types.ts";
-import type { JSONSchema } from "../src/builder/types.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-policy-boundary");
 

--- a/packages/runner/test/cfc-policy-of-label.test.ts
+++ b/packages/runner/test/cfc-policy-of-label.test.ts
@@ -1,24 +1,26 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
-import type { CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
-import {
-  buildCfcPolicyArtifactManifest,
-  cfcPolicyManifestDocId,
-} from "../src/cfc/policy.ts";
-import { readStoredCfcMetadata } from "../src/cfc/metadata.ts";
-import type { Engine } from "../src/harness/engine.ts";
+import { Identity } from "@commonfabric/identity";
+
 import type { JSONSchema } from "../src/builder/types.ts";
+import type { CfcConfClause } from "../src/cfc/clause.ts";
+import { readStoredCfcMetadata } from "../src/cfc/metadata.ts";
 import {
   createTxCfcModulePolicyResolver,
   evaluateExchangeRules,
 } from "../src/cfc/mod.ts";
-import { enqueueSinkRequestPostCommitEffect } from "../src/cfc/sink-request.ts";
+import {
+  buildCfcPolicyArtifactManifest,
+  cfcPolicyManifestDocId,
+} from "../src/cfc/policy.ts";
 import { createFrozenRequestSnapshot } from "../src/cfc/request-snapshot.ts";
+import { enqueueSinkRequestPostCommitEffect } from "../src/cfc/sink-request.ts";
+import type { Engine } from "../src/harness/engine.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
 const signer = await Identity.fromPassphrase("cfc PolicyOf label test");
 const space = signer.did();

--- a/packages/runner/test/cfc-prefix-provenance-stats.test.ts
+++ b/packages/runner/test/cfc-prefix-provenance-stats.test.ts
@@ -1,22 +1,24 @@
-import { describe, it } from "@std/testing/bdd";
-import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
 import type { URI } from "@commonfabric/memory/interface";
+
+import { parsePointer } from "../../memory/v2/path.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
-import type {
-  IExtendedStorageTransaction,
-  IReadActivity,
-} from "../src/storage/interface.ts";
+import type { IFCLabel } from "../src/cfc/mod.ts";
 import {
   CFC_PREFIX_PROVENANCE_MAX_WRITES,
   type CfcPrefixProvenanceSummary,
   prepareBoundaryCommit,
 } from "../src/cfc/mod.ts";
-import { parsePointer } from "../../memory/v2/path.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import type {
+  IExtendedStorageTransaction,
+  IReadActivity,
+} from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-prefix-provenance");
 

--- a/packages/runner/test/cfc-privileged-system-write.test.ts
+++ b/packages/runner/test/cfc-privileged-system-write.test.ts
@@ -1,11 +1,13 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
+import { describe, it } from "@std/testing/bdd";
+
 import { internSchema } from "@commonfabric/data-model/schema-hash";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
+import { Identity } from "@commonfabric/identity";
 import type { URI } from "@commonfabric/memory/interface";
+
 import type { JSONSchema } from "../src/builder/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
 const signer = await Identity.fromPassphrase(
   "runner-cfc-privileged-system-write",

--- a/packages/runner/test/cfc-required-integrity-provenance.test.ts
+++ b/packages/runner/test/cfc-required-integrity-provenance.test.ts
@@ -1,13 +1,15 @@
-import { describe, it } from "@std/testing/bdd";
-import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
-import { parseLink } from "../src/link-utils.ts";
 import type { URI } from "@commonfabric/memory/interface";
+
 import type { JSONSchema } from "../src/builder/types.ts";
+import type { IFCLabel } from "../src/cfc/mod.ts";
+import { parseLink } from "../src/link-utils.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-ri-provenance");
 

--- a/packages/runner/test/cfc-schema-sanitization.test.ts
+++ b/packages/runner/test/cfc-schema-sanitization.test.ts
@@ -1,10 +1,11 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { describe, it } from "@std/testing/bdd";
+
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+
 import type { JSONSchema } from "../src/builder/types.ts";
-import { CELL_KINDS } from "../src/scope.ts";
 import {
   cfcObjectSchemaIsClosed,
   INJECTION_SAFE_ATOM,
@@ -18,6 +19,7 @@ import {
   validateSchemaDefinition,
   validateSchemaValue,
 } from "../src/cfc/mod.ts";
+import { CELL_KINDS } from "../src/scope.ts";
 
 const promptRisk = {
   type: "https://commonfabric.org/cfc/atom/Caveat",

--- a/packages/runner/test/cfc-single-use-grants.test.ts
+++ b/packages/runner/test/cfc-single-use-grants.test.ts
@@ -1,23 +1,15 @@
-import { describe, it } from "@std/testing/bdd";
-import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
-import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { describe, it } from "@std/testing/bdd";
+
 import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { Identity } from "@commonfabric/identity";
+import type { MemorySpace, URI } from "@commonfabric/memory/interface";
 import type * as MemoryV2Server from "@commonfabric/memory/v2/server";
-import {
-  EmulatedStorageManager,
-  StorageManager,
-} from "../src/storage/cache.deno.ts";
-import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
-import { isPermanentRejection } from "../src/storage/rejection.ts";
-import { Runtime } from "../src/runtime.ts";
+
+import type { JSONSchema } from "../src/builder/types.ts";
 import { evaluateExchangeRules } from "../src/cfc/exchange-eval.ts";
 import type { CfcGrantResolverQuery } from "../src/cfc/exchange-eval.ts";
-import {
-  buildCfcPolicySnapshot,
-  type ExchangeRule,
-} from "../src/cfc/policy.ts";
 import {
   CFC_GRANT_ABSENT_DIGEST,
   CFC_GRANT_ID_PREFIX,
@@ -29,10 +21,20 @@ import {
   prepareCfcGrantWrite,
   verifyCfcGrantDocument,
 } from "../src/cfc/grants.ts";
-import { enqueueSinkRequestPostCommitEffect } from "../src/cfc/sink-request.ts";
+import type { IFCLabel } from "../src/cfc/mod.ts";
+import {
+  buildCfcPolicySnapshot,
+  type ExchangeRule,
+} from "../src/cfc/policy.ts";
 import { createFrozenRequestSnapshot } from "../src/cfc/request-snapshot.ts";
-import type { MemorySpace, URI } from "@commonfabric/memory/interface";
-import type { JSONSchema } from "../src/builder/types.ts";
+import { enqueueSinkRequestPostCommitEffect } from "../src/cfc/sink-request.ts";
+import { Runtime } from "../src/runtime.ts";
+import {
+  EmulatedStorageManager,
+  StorageManager,
+} from "../src/storage/cache.deno.ts";
+import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
+import { isPermanentRejection } from "../src/storage/rejection.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-single-use-grants");
 

--- a/packages/runner/test/cfc-sink-ceiling.test.ts
+++ b/packages/runner/test/cfc-sink-ceiling.test.ts
@@ -1,15 +1,17 @@
-import { describe, it } from "@std/testing/bdd";
-import type { CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
+import { describe, it } from "@std/testing/bdd";
+
 import { internSchema } from "@commonfabric/data-model/schema-hash";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
-import { enqueueSinkRequestPostCommitEffect } from "../src/cfc/sink-request.ts";
-import { createFrozenRequestSnapshot } from "../src/cfc/request-snapshot.ts";
-import { CFC_LABEL_READ_FAILED_ATOM } from "../src/cfc/observation.ts";
-import type { SinkMaxConfidentiality } from "../src/cfc/mod.ts";
+import { Identity } from "@commonfabric/identity";
+
 import type { JSONSchema } from "../src/builder/types.ts";
+import type { CfcConfClause } from "../src/cfc/clause.ts";
+import type { SinkMaxConfidentiality } from "../src/cfc/mod.ts";
+import { CFC_LABEL_READ_FAILED_ATOM } from "../src/cfc/observation.ts";
+import { createFrozenRequestSnapshot } from "../src/cfc/request-snapshot.ts";
+import { enqueueSinkRequestPostCommitEffect } from "../src/cfc/sink-request.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-sink-ceiling");
 

--- a/packages/runner/test/cfc-sink-request-policy.test.ts
+++ b/packages/runner/test/cfc-sink-request-policy.test.ts
@@ -1,5 +1,9 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
 import { createFrozenRequestSnapshot } from "../src/cfc/request-snapshot.ts";
 import {
   createSinkRequestPolicyInput,
@@ -7,8 +11,6 @@ import {
   verifySinkRequestRelease,
 } from "../src/cfc/sink-request.ts";
 import { Runtime } from "../src/runtime.ts";
-import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
 const signer = await Identity.fromPassphrase("test cfc sink request policy");
 describe("CFC sink request policy", () => {

--- a/packages/runner/test/cfc-standard-profile.test.ts
+++ b/packages/runner/test/cfc-standard-profile.test.ts
@@ -1,25 +1,31 @@
-import { describe, it } from "@std/testing/bdd";
-import { type CfcConfClause, type CfcOrClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
 import {
   CFC_ATOM_TYPE,
   CFC_CONCEPT_KIND,
   cfcAtom,
 } from "@commonfabric/api/cfc";
-import { buildCfcPolicySnapshot } from "../src/cfc/policy.ts";
+
+import {
+  type CfcConfClause,
+  type CfcOrClause,
+  clauseAlternatives,
+  clausesEqual,
+  normalizeClause,
+} from "../src/cfc/clause.ts";
 import { evaluateExchangeRules } from "../src/cfc/exchange-eval.ts";
+import { uniqueCfcAtoms } from "../src/cfc/observation.ts";
+import { buildCfcPolicySnapshot } from "../src/cfc/policy.ts";
+import {
+  dischargeMaterialRiskAtoms,
+  INJECTION_SAFE_ATOM,
+} from "../src/cfc/schema-sanitization.ts";
 import {
   MATERIAL_RISK_DISCHARGE_KINDS,
   MATERIAL_RISK_DISCHARGE_POLICY,
   STANDARD_PROMPT_CAVEAT_POLICY,
 } from "../src/cfc/standard-profile.ts";
-import {
-  dischargeMaterialRiskAtoms,
-  INJECTION_SAFE_ATOM,
-} from "../src/cfc/schema-sanitization.ts";
-import { clauseAlternatives, clausesEqual } from "../src/cfc/clause.ts";
-import { uniqueCfcAtoms } from "../src/cfc/observation.ts";
-import { normalizeClause } from "../src/cfc/clause.ts";
 
 // Epic B6 (docs/history/plans/cfc-future-work-implementation.md §3): the §10.1
 // standard prompt-caveat profile as PolicyRecords. The goldens prove the

--- a/packages/runner/test/cfc-template-metadata-population.test.ts
+++ b/packages/runner/test/cfc-template-metadata-population.test.ts
@@ -1,28 +1,30 @@
-import { afterEach, describe, it } from "@std/testing/bdd";
-import type { IFCLabel } from "../src/cfc/mod.ts";
-import type { CfcConfClause } from "../src/cfc/clause.ts";
-import type { CfcAtom } from "@commonfabric/api/cfc";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
-import { Identity } from "@commonfabric/identity";
+import { afterEach, describe, it } from "@std/testing/bdd";
+
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
+import { Identity } from "@commonfabric/identity";
+
+import type { JSONSchema } from "../src/builder/types.ts";
 import { canonicalizeCfcMetadata } from "../src/cfc/canonical.ts";
-import {
-  deriveLabelMetadataTemplateEntries,
-  resolveLabelMetadataTemplateConfidentiality,
-} from "../src/cfc/label-metadata-population.ts";
+import type { CfcConfClause } from "../src/cfc/clause.ts";
 import {
   evaluateConfLabelQuery,
   inspectStoredConfLabel,
 } from "../src/cfc/label-introspection.ts";
+import {
+  deriveLabelMetadataTemplateEntries,
+  resolveLabelMetadataTemplateConfidentiality,
+} from "../src/cfc/label-metadata-population.ts";
 import { containsCfcFieldCommitment } from "../src/cfc/label-representation.ts";
 import { cfcLabelViewFromMetadata } from "../src/cfc/label-view-state.ts";
 import { readStoredCfcMetadata } from "../src/cfc/metadata.ts";
-import type { JSONSchema } from "../src/builder/types.ts";
+import type { IFCLabel } from "../src/cfc/mod.ts";
 import type { CfcMetadata, LabelMapEntry } from "../src/cfc/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
 const signer = await Identity.fromPassphrase(
   "runner-cfc-template-metadata-population",

--- a/packages/runner/test/cfc-template-population.test.ts
+++ b/packages/runner/test/cfc-template-population.test.ts
@@ -1,23 +1,25 @@
-import { afterEach, describe, it } from "@std/testing/bdd";
-import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
-import { Identity } from "@commonfabric/identity";
+import { afterEach, describe, it } from "@std/testing/bdd";
+
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
-import {
-  linkResolutionProbe,
-  machineryRead,
-} from "../src/storage/reactivity-log.ts";
+import { Identity } from "@commonfabric/identity";
+
+import type { JSONSchema } from "../src/builder/types.ts";
 import { canonicalizeCfcMetadata } from "../src/cfc/canonical.ts";
 import {
   commitCfcFieldValue,
   containsCfcFieldCommitment,
 } from "../src/cfc/label-representation.ts";
-import type { JSONSchema } from "../src/builder/types.ts";
+import type { IFCLabel } from "../src/cfc/mod.ts";
 import type { LabelMapEntry } from "../src/cfc/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import {
+  linkResolutionProbe,
+  machineryRead,
+} from "../src/storage/reactivity-log.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-template-population");
 const foreignSigner = await Identity.fromPassphrase(

--- a/packages/runner/test/cfc-ui-contract.test.ts
+++ b/packages/runner/test/cfc-ui-contract.test.ts
@@ -1,11 +1,10 @@
-import { afterEach, describe, it } from "@std/testing/bdd";
-import { dataUriFromValue } from "@commonfabric/data-model/data-uri-codec";
 import { expect } from "@std/expect";
+import { afterEach, describe, it } from "@std/testing/bdd";
+
+import { dataUriFromValue } from "@commonfabric/data-model/data-uri-codec";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { Runtime } from "../src/runtime.ts";
-import type { EventHandler } from "../src/scheduler.ts";
-import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
 import {
   markRendererTrustedEvent,
   recordTrustedEventPolicyInputs,
@@ -13,7 +12,10 @@ import {
   uiContractFromSchema,
   uiContractsFromSchema,
 } from "../src/cfc/ui-contract.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { EventHandler } from "../src/scheduler.ts";
 import { LINK_V1_TAG } from "../src/sigil-types.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-ui-contract");
 const space = signer.did();

--- a/packages/runner/test/cfc-write-floor.test.ts
+++ b/packages/runner/test/cfc-write-floor.test.ts
@@ -1,13 +1,14 @@
-import { describe, it } from "@std/testing/bdd";
-import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
 import type { URI } from "@commonfabric/memory/interface";
+
 import type { JSONSchema } from "../src/builder/types.ts";
-import type { CfcWriteFloorMode } from "../src/cfc/mod.ts";
+import type { CfcWriteFloorMode, IFCLabel } from "../src/cfc/mod.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-write-floor");
 

--- a/packages/runner/test/cfc-write-prefix-provenance.test.ts
+++ b/packages/runner/test/cfc-write-prefix-provenance.test.ts
@@ -1,13 +1,15 @@
-import { describe, it } from "@std/testing/bdd";
-import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
 import type { URI } from "@commonfabric/memory/interface";
+
 import type { JSONSchema } from "../src/builder/types.ts";
+import type { IFCLabel } from "../src/cfc/mod.ts";
 import { preparedDigestFor, type PreparedDigestInput } from "../src/cfc/mod.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-write-prefix");
 

--- a/packages/runner/test/cfc-write-reconstruction.test.ts
+++ b/packages/runner/test/cfc-write-reconstruction.test.ts
@@ -1,8 +1,10 @@
 import { assertEquals, assertStrictEquals } from "@std/assert";
-import { writeDetailValueForTarget } from "../src/cfc/prepare.ts";
-import { normalizeCellScope } from "../src/scope.ts";
+
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import type { MemorySpace, URI } from "@commonfabric/memory/interface";
+
+import { writeDetailValueForTarget } from "../src/cfc/prepare.ts";
+import { normalizeCellScope } from "../src/scope.ts";
 import type {
   IExtendedStorageTransaction,
   TransactionWriteDetail,

--- a/packages/runner/test/cfc.test.ts
+++ b/packages/runner/test/cfc.test.ts
@@ -16,13 +16,14 @@
  * rounding them to fixed levels.
  */
 
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
-import { cfcAtom, ContextualFlowControl } from "../src/cfc.ts";
-import { resolveSchema, schemaHasIfc } from "../src/schema.ts";
-import type { JSONSchema } from "../src/builder/types.ts";
+import { describe, it } from "@std/testing/bdd";
+
 import type { JSONSchemaObj } from "@commonfabric/api";
+import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
+
+import type { JSONSchema } from "../src/builder/types.ts";
+import { cfcAtom, ContextualFlowControl } from "../src/cfc.ts";
 import {
   findCfcSchemaRefs,
   pruneCfcSchemaDefinitions,
@@ -31,6 +32,7 @@ import {
   selectReferencedCfcSchemaDefs,
 } from "../src/cfc/schema-refs.ts";
 import { validateSchemaValue } from "../src/cfc/schema-sanitization.ts";
+import { resolveSchema, schemaHasIfc } from "../src/schema.ts";
 
 describe("ContextualFlowControl.schemaAtPath", () => {
   it("rejects leading-zero array index like '01'", () => {

--- a/packages/runner/test/compact-real.bench.ts
+++ b/packages/runner/test/compact-real.bench.ts
@@ -18,11 +18,12 @@
  *     --allow-write=/tmp,/var/folders test/compact-real.bench.ts
  */
 
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
 import { type ChangeSet, compactChangeSet } from "../src/data-updating.ts";
 import { Runtime } from "../src/runtime.ts";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 
 const signer = await Identity.fromPassphrase("compact-real-bench");
 const space = signer.did();

--- a/packages/runner/test/computed-cell-kinds.test.ts
+++ b/packages/runner/test/computed-cell-kinds.test.ts
@@ -1,6 +1,12 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { type Frame, type JSONSchema } from "../src/builder/types.ts";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+
+import {
+  REPLAYABLE_BUILTIN_REFS,
+  SUBPATTERN_ARGUMENT_BUILTIN_REFS,
+} from "../src/builder/builtin-replayability.ts";
 import {
   byRef,
   createNodeFactory,
@@ -9,17 +15,13 @@ import {
 } from "../src/builder/module.ts";
 import { pattern, popFrame, pushFrame } from "../src/builder/pattern.ts";
 import { reactive } from "../src/builder/reactive.ts";
-import {
-  REPLAYABLE_BUILTIN_REFS,
-  SUBPATTERN_ARGUMENT_BUILTIN_REFS,
-} from "../src/builder/builtin-replayability.ts";
+import { type Frame, type JSONSchema } from "../src/builder/types.ts";
 import { registerBuiltins } from "../src/builtins/index.ts";
 import { createRef } from "../src/create-ref.ts";
-import { toURI } from "../src/uri-utils.ts";
 import { getDerivedInternalCellLink } from "../src/link-utils.ts";
 import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Identity } from "@commonfabric/identity";
+import { toURI } from "../src/uri-utils.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/computed-error.test.ts
+++ b/packages/runner/test/computed-error.test.ts
@@ -1,8 +1,10 @@
 import { assertEquals } from "@std/assert";
-import { Runtime } from "../src/runtime.ts";
+
+import { Identity } from "@commonfabric/identity";
+
 import { lift } from "../src/builder/module.ts";
 import { pattern, popFrame, pushFrame } from "../src/builder/pattern.ts";
-import { Identity } from "@commonfabric/identity";
+import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { trustPattern } from "./support/trusted-builder.ts";
 

--- a/packages/runner/test/content-addressed-identity-adversarial.test.ts
+++ b/packages/runner/test/content-addressed-identity-adversarial.test.ts
@@ -1,21 +1,23 @@
-import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { Runtime } from "../src/runtime.ts";
-import { resolvePolicyFacingImplementationIdentity } from "../src/cfc/implementation-identity.ts";
-import {
-  getVerifiedProvenance,
-  recordVerifiedProvenance,
-} from "../src/harness/verified-provenance.ts";
 import { VERIFIED_BINDING_METADATA_FIELD } from "@commonfabric/utils/sandbox-contract";
+
 import {
   brandTrustedBuilderArtifact,
   isTrustedBuilderArtifact,
 } from "../src/builder/pattern-metadata.ts";
-import { ExecutableRegistry } from "../src/harness/executable-registry.ts";
 import type { JSONSchema, Module, Pattern } from "../src/builder/types.ts";
+import { resolvePolicyFacingImplementationIdentity } from "../src/cfc/implementation-identity.ts";
+import { ExecutableRegistry } from "../src/harness/executable-registry.ts";
 import type { HarnessedFunction } from "../src/harness/types.ts";
+import {
+  getVerifiedProvenance,
+  recordVerifiedProvenance,
+} from "../src/harness/verified-provenance.ts";
+import { Runtime } from "../src/runtime.ts";
 
 /**
  * C5 red-team gate for PR C (content-addressed `$implRef` + CFC provenance) of

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -1,6 +1,12 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { popFrame, pushFrame } from "../src/builder/pattern.ts";
 import { JSONSchema } from "../src/builder/types.ts";
+import { createRef } from "../src/create-ref.ts";
 import {
   applyChangeSet,
   type ChangeSet,
@@ -9,10 +15,6 @@ import {
   normalizeAndDiff,
   schemaIfcOverlapsPath,
 } from "../src/data-updating.ts";
-import { popFrame, pushFrame } from "../src/builder/pattern.ts";
-import { createRef } from "../src/create-ref.ts";
-import { toURI } from "../src/uri-utils.ts";
-import { Runtime } from "../src/runtime.ts";
 import {
   areLinksSame,
   areNormalizedLinksSame,
@@ -21,9 +23,9 @@ import {
   isSigilLink,
   parseLink,
 } from "../src/link-utils.ts";
+import { Runtime } from "../src/runtime.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { toURI } from "../src/uri-utils.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/data-uri-inlining.test.ts
+++ b/packages/runner/test/data-uri-inlining.test.ts
@@ -1,16 +1,20 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { entityRefToString } from "@commonfabric/data-model/cell-rep";
+import { FabricError } from "@commonfabric/data-model/fabric-instances";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import {
+  dataUriFromValueWithResolvedLinks,
+  findAndInlineDataUriLinks,
+} from "../src/data-uri.ts";
 import { Runtime } from "../src/runtime.ts";
-import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import { dataUriFromValueWithResolvedLinks } from "../src/data-uri.ts";
-import { findAndInlineDataUriLinks } from "../src/data-uri.ts";
 import { LINK_V1_TAG } from "../src/sigil-types.ts";
-import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import { FabricError } from "@commonfabric/data-model/fabric-instances";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/data-uri.test.ts
+++ b/packages/runner/test/data-uri.test.ts
@@ -14,28 +14,30 @@
  * hold in place.
  */
 
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { fromBase64url } from "@commonfabric/utils/base64url";
-import { seemsLikeJsonEncodedFabricValue } from "@commonfabric/data-model/codec-json";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import {
   linkRefFrom,
   linkRefPayload,
   resetModernCellRepConfig,
   setModernCellRepConfig,
 } from "@commonfabric/data-model/cell-rep";
-import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
 import { UnknownValue } from "@commonfabric/data-model/codec-common";
-import { hashOf } from "@commonfabric/data-model/value-hash";
-import { dataUriFromValueWithResolvedLinks } from "../src/data-uri.ts";
+import { seemsLikeJsonEncodedFabricValue } from "@commonfabric/data-model/codec-json";
 import { valueFromDataUri } from "@commonfabric/data-model/data-uri-codec";
-import { isSigilLink, type NormalizedLink } from "../src/link-utils.ts";
+import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
+import { hashOf } from "@commonfabric/data-model/value-hash";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { LINK_V1_TAG } from "../src/sigil-types.ts";
-import { Runtime } from "../src/runtime.ts";
-import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { fromBase64url } from "@commonfabric/utils/base64url";
+
 import { createCell } from "../src/cell.ts";
+import { dataUriFromValueWithResolvedLinks } from "../src/data-uri.ts";
+import { isSigilLink, type NormalizedLink } from "../src/link-utils.ts";
+import { Runtime } from "../src/runtime.ts";
+import { LINK_V1_TAG } from "../src/sigil-types.ts";
+import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/doc-map.test.ts
+++ b/packages/runner/test/doc-map.test.ts
@@ -1,17 +1,19 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { createRef, entityIdFrom, getEntityId } from "../src/create-ref.ts";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import {
   entityRefToString,
   resetModernCellRepConfig,
   setModernCellRepConfig,
 } from "@commonfabric/data-model/cell-rep";
-import { LINK_V1_TAG } from "../src/sigil-types.ts";
-import { hashOf } from "@commonfabric/data-model/value-hash";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import { Runtime } from "../src/runtime.ts";
+import { hashOf } from "@commonfabric/data-model/value-hash";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { createRef, entityIdFrom, getEntityId } from "../src/create-ref.ts";
+import { Runtime } from "../src/runtime.ts";
+import { LINK_V1_TAG } from "../src/sigil-types.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("test operator");

--- a/packages/runner/test/entity-kind.test.ts
+++ b/packages/runner/test/entity-kind.test.ts
@@ -1,5 +1,8 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
+import { hashOf } from "@commonfabric/data-model/value-hash";
 
 import {
   COMPUTED_URI_SCHEME,
@@ -12,8 +15,6 @@ import {
   stripEntityUriScheme,
   uriSchemeForEntityKind,
 } from "../src/entity-kind.ts";
-import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
-import { hashOf } from "@commonfabric/data-model/value-hash";
 
 describe("entity-kind", () => {
   const base = hashOf({ probe: "entity-kind" });

--- a/packages/runner/test/esm-engine.test.ts
+++ b/packages/runner/test/esm-engine.test.ts
@@ -1,14 +1,15 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
-import { Engine } from "../src/harness/engine.ts";
-import { PatternCoverageCollector } from "../src/pattern-coverage.ts";
-import type { RuntimeProgram } from "../src/harness/types.ts";
+import { Identity } from "@commonfabric/identity";
 import type { PatternCoverageSpan } from "@commonfabric/ts-transformers";
+
 import { buildCfcPolicyArtifactManifest } from "../src/cfc/policy.ts";
+import { Engine } from "../src/harness/engine.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import { PatternCoverageCollector } from "../src/pattern-coverage.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 

--- a/packages/runner/test/esm-source-location.test.ts
+++ b/packages/runner/test/esm-source-location.test.ts
@@ -1,14 +1,15 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
 import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { Runtime } from "../src/runtime.ts";
-import { setEagerSourceAnnotation } from "../src/builder/module.ts";
 import { getComposeBundleSourceMapCallsForTesting } from "@commonfabric/js-compiler/source-map";
-import type { RuntimeProgram } from "../src/harness/types.ts";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { setEagerSourceAnnotation } from "../src/builder/module.ts";
 import type { Module, Pattern } from "../src/builder/types.ts";
 import { resolvePolicyFacingImplementationIdentity } from "../src/cfc/implementation-identity.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import { Runtime } from "../src/runtime.ts";
 
 // Regression: under the ESM module-record loader, a verified handler's
 // `implementation.src` must resolve back to its ORIGINAL authored source

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -4,21 +4,23 @@
  * flags whose consumers are ambient.
  */
 
-import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { Runtime } from "../src/runtime.ts";
+import { afterEach, describe, it } from "@std/testing/bdd";
+
 import {
   getModernCellRepConfig,
   resetModernCellRepConfig,
 } from "@commonfabric/data-model/cell-rep";
+import { Identity } from "@commonfabric/identity";
 import {
   getCommitPreconditionsConfig,
   getPersistentSchedulerStateConfig,
   resetCommitPreconditionsConfig,
   resetPersistentSchedulerStateConfig,
 } from "@commonfabric/memory/v2";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { Runtime } from "../src/runtime.ts";
 
 const signer = await Identity.fromPassphrase("test experimental");
 

--- a/packages/runner/test/factory-input-types.test.ts
+++ b/packages/runner/test/factory-input-types.test.ts
@@ -3,15 +3,18 @@
  *
  * If any type assertion is wrong, this file fails to compile.
  */
-import { describe, it } from "@std/testing/bdd";
+
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import type { Default, Writable } from "@commonfabric/api";
+
 import type {
   FactoryInput,
   HandlerFactory,
   PatternFactory,
   StripCell,
 } from "../src/builder/types.ts";
-import type { Default, Writable } from "@commonfabric/api";
 
 type MustBeTrue<T extends true> = T;
 type AssertAssignable<T, U> = [T] extends [U] ? true : never;

--- a/packages/runner/test/favorites-row-stored-shape.test.ts
+++ b/packages/runner/test/favorites-row-stored-shape.test.ts
@@ -1,12 +1,13 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
 import { fromFileUrl } from "@std/path/from-file-url";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { Runtime } from "../src/runtime.ts";
+
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import { Runtime } from "../src/runtime.ts";
 
 // A pattern that maps over durable data must accept the rows its PRODUCER
 // actually writes. Nothing checks that agreement: the row's element schema

--- a/packages/runner/test/fetch-builtins.test.ts
+++ b/packages/runner/test/fetch-builtins.test.ts
@@ -1,14 +1,16 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import type { JSONSchema } from "@commonfabric/api";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { Runtime } from "../src/runtime.ts";
+
 import { createBuilder } from "../src/builder/factory.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import { setPatternEnvironment } from "../src/env.ts";
 import { schemaWithOpenObjects } from "../src/builtins/fetch.ts";
-import type { JSONSchema } from "@commonfabric/api";
+import { setPatternEnvironment } from "../src/env.ts";
+import { Runtime } from "../src/runtime.ts";
+import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 const signer = await Identity.fromPassphrase("test fetch builtins");
 const space = signer.did();

--- a/packages/runner/test/generate-object-outbox.test.ts
+++ b/packages/runner/test/generate-object-outbox.test.ts
@@ -1,26 +1,28 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import type { BuiltInGenerateObjectParams } from "@commonfabric/api";
 import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { LLMClient } from "@commonfabric/llm";
 import {
   addMockObjectResponse,
   addMockResponse,
   clearMockResponses,
   enableMockMode,
 } from "@commonfabric/llm/client";
-import { LLMClient } from "@commonfabric/llm";
-import type { BuiltInGenerateObjectParams } from "@commonfabric/api";
-import { createBuilder } from "../src/builder/factory.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { waitForLlmSettled } from "./support/llm-result.ts";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { defer } from "@commonfabric/utils/defer";
+
+import { createBuilder } from "../src/builder/factory.ts";
+import { generateObject as rawGenerateObject } from "../src/builtins/llm.ts";
 import { Runtime } from "../src/runtime.ts";
-import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import {
   ExtendedStorageTransaction,
   TransactionWrapper,
 } from "../src/storage/extended-storage-transaction.ts";
-import { generateObject as rawGenerateObject } from "../src/builtins/llm.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { waitForLlmSettled } from "./support/llm-result.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 const signer = await Identity.fromPassphrase("test generate-object outbox");
 const space = signer.did();

--- a/packages/runner/test/generate-object-tools.test.ts
+++ b/packages/runner/test/generate-object-tools.test.ts
@@ -8,10 +8,12 @@
  * 3. Maintains backward compatibility when no tools are provided
  */
 
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import type { BuiltInLLMMessage, BuiltInLLMTool } from "@commonfabric/api";
+import { cfcAtom } from "@commonfabric/api/cfc";
 import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import {
   addMockObjectResponse,
   addMockResponse,
@@ -20,25 +22,25 @@ import {
   loadConversationFixture,
   setMockResponseGate,
 } from "@commonfabric/llm/client";
-import type { BuiltInLLMMessage, BuiltInLLMTool } from "@commonfabric/api";
-import type { Cell, FactoryInput, JSONSchema } from "../src/builder/types.ts";
-import { createBuilder } from "../src/builder/factory.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { waitForLlmSettled } from "./support/llm-result.ts";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { defer } from "@commonfabric/utils/defer";
+
+import { createBuilder } from "../src/builder/factory.ts";
+import type { Cell, FactoryInput, JSONSchema } from "../src/builder/types.ts";
+import { llmToolExecutionHelpers } from "../src/builtins/llm-dialog.ts";
 import { cfcLabelViewForCell } from "../src/cfc/label-view.ts";
-import { cfcAtom } from "@commonfabric/api/cfc";
 import { INJECTION_SAFE_ATOM } from "../src/cfc/schema-sanitization.ts";
+import { getMetaLink, parseLink } from "../src/link-utils.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { waitForLlmSettled } from "./support/llm-result.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 // D1b (cfc-llm-derived-stamp-builtins.test.ts): generateObject stamps LlmDerived
 // on EVERY node of the result schema so the mark rides split child-document
 // writes too. So instruction-inert result paths carry [InjectionSafe, LlmDerived]
 // and non-inert paths carry [LlmDerived].
 const LLM_DERIVED_ATOM = cfcAtom.llmDerived();
-import { llmToolExecutionHelpers } from "../src/builtins/llm-dialog.ts";
-import { Runtime } from "../src/runtime.ts";
-import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import { getMetaLink, parseLink } from "../src/link-utils.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/generate-text-outbox.test.ts
+++ b/packages/runner/test/generate-text-outbox.test.ts
@@ -1,32 +1,34 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import type {
+  BuiltInGenerateTextParams,
+  BuiltInLLMParams,
+} from "@commonfabric/api";
 import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { LLMClient } from "@commonfabric/llm";
 import {
   addMockResponse,
   clearMockResponses,
   enableMockMode,
 } from "@commonfabric/llm/client";
-import { LLMClient } from "@commonfabric/llm";
-import type {
-  BuiltInGenerateTextParams,
-  BuiltInLLMParams,
-} from "@commonfabric/api";
-import { createBuilder } from "../src/builder/factory.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { waitForLlmSettled } from "./support/llm-result.ts";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { defer } from "@commonfabric/utils/defer";
-import { Runtime } from "../src/runtime.ts";
-import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import {
-  ExtendedStorageTransaction,
-  TransactionWrapper,
-} from "../src/storage/extended-storage-transaction.ts";
+
+import { createBuilder } from "../src/builder/factory.ts";
 import {
   generateText as rawGenerateText,
   llm as rawLlm,
 } from "../src/builtins/llm.ts";
 import { createCell } from "../src/cell.ts";
+import { Runtime } from "../src/runtime.ts";
+import {
+  ExtendedStorageTransaction,
+  TransactionWrapper,
+} from "../src/storage/extended-storage-transaction.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { waitForLlmSettled } from "./support/llm-result.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 const signer = await Identity.fromPassphrase("test generate-text outbox");
 const space = signer.did();

--- a/packages/runner/test/host-pseudo-module.test.ts
+++ b/packages/runner/test/host-pseudo-module.test.ts
@@ -1,14 +1,14 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { Runtime } from "../src/runtime.ts";
-import type { Module } from "../src/builder/types.ts";
-import type { toEncodableForm } from "../src/builder/types.ts";
-import { moduleToEncodableForm } from "../src/builder/to-encodable-form.ts";
+
 import { popFrame, pushFrame } from "../src/builder/pattern.ts";
+import { moduleToEncodableForm } from "../src/builder/to-encodable-form.ts";
+import type { Module, toEncodableForm } from "../src/builder/types.ts";
 import { resolvePolicyFacingImplementationIdentity } from "../src/cfc/implementation-identity.ts";
+import { Runtime } from "../src/runtime.ts";
 
 /**
  * Identity E5 (design §5, as decided): host-trusted values ride a minted

--- a/packages/runner/test/link-resolution.test.ts
+++ b/packages/runner/test/link-resolution.test.ts
@@ -1,15 +1,20 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { linkRefPayload } from "@commonfabric/data-model/cell-rep";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
-import { linkRefPayload } from "@commonfabric/data-model/cell-rep";
 import { type JSONSchema } from "../src/builder/types.ts";
 import { resolveLink } from "../src/link-resolution.ts";
+import {
+  areNormalizedLinksSame,
+  isSigilLink,
+  parseAliasBinding,
+  parseLink,
+} from "../src/link-utils.ts";
 import { Runtime } from "../src/runtime.ts";
-import { areNormalizedLinksSame, isSigilLink } from "../src/link-utils.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import { parseAliasBinding, parseLink } from "../src/link-utils.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -1,5 +1,12 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { linkRefPayload } from "@commonfabric/data-model/cell-rep";
+import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import type { JSONSchema } from "../src/builder/types.ts";
 import {
   areLinksSame,
   areNormalizedLinksSame,
@@ -20,13 +27,8 @@ import {
   parseLLMFriendlyLink,
   sanitizeSchemaForLinks,
 } from "../src/link-utils.ts";
-import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { linkRefPayload } from "@commonfabric/data-model/cell-rep";
-import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
-import type { JSONSchema } from "../src/builder/types.ts";
-import { type AliasBinding, LINK_V1_TAG } from "../src/sigil-types.ts";
 import { Runtime } from "../src/runtime.ts";
+import { type AliasBinding, LINK_V1_TAG } from "../src/sigil-types.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("test operator");

--- a/packages/runner/test/list-element-link.test.ts
+++ b/packages/runner/test/list-element-link.test.ts
@@ -1,8 +1,9 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
 import { spy } from "@std/testing/mock";
-import { ContextualFlowControl } from "../src/cfc.ts";
+
 import { listElementLink } from "../src/builtins/list-element-link.ts";
+import { ContextualFlowControl } from "../src/cfc.ts";
 import type { NormalizedFullLink } from "../src/link-types.ts";
 
 const base = (schema?: NormalizedFullLink["schema"]): NormalizedFullLink => ({

--- a/packages/runner/test/list-fresh-init.test.ts
+++ b/packages/runner/test/list-fresh-init.test.ts
@@ -1,16 +1,18 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
+import type { Signer } from "@commonfabric/memory/interface";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import { Runtime } from "../src/runtime.ts";
 import {
   type Options,
   type SessionFactory,
   StorageManager,
 } from "../src/storage/v2.ts";
-import type { Signer } from "@commonfabric/memory/interface";
-import { Runtime } from "../src/runtime.ts";
-import type { RuntimeProgram } from "../src/harness/types.ts";
 import {
   TEST_MEMORY_SERVER_AUTH,
   testPrincipalSessionOpenAuthFactory,

--- a/packages/runner/test/list-resume-container-defer.test.ts
+++ b/packages/runner/test/list-resume-container-defer.test.ts
@@ -1,20 +1,22 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
 import { Identity } from "@commonfabric/identity";
 import type { Signer } from "@commonfabric/memory/interface";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+
+import type { Cell } from "../src/cell.ts";
+import { ENTITY_URI_SCHEMES } from "../src/entity-kind.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import {
   type Options,
   type SessionFactory,
   StorageManager,
 } from "../src/storage/v2.ts";
-import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import { ENTITY_URI_SCHEMES } from "../src/entity-kind.ts";
-import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
-import { Runtime } from "../src/runtime.ts";
-import type { Cell } from "../src/cell.ts";
-import type { RuntimeProgram } from "../src/harness/types.ts";
 import {
   TEST_MEMORY_SERVER_AUTH,
   testPrincipalSessionOpenAuthFactory,

--- a/packages/runner/test/list-shrink-converge.test.ts
+++ b/packages/runner/test/list-shrink-converge.test.ts
@@ -1,16 +1,18 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
+import type { Signer } from "@commonfabric/memory/interface";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import { Runtime } from "../src/runtime.ts";
 import {
   type Options,
   type SessionFactory,
   StorageManager,
 } from "../src/storage/v2.ts";
-import type { Signer } from "@commonfabric/memory/interface";
-import { Runtime } from "../src/runtime.ts";
-import type { RuntimeProgram } from "../src/harness/types.ts";
 import {
   TEST_MEMORY_SERVER_AUTH,
   testPrincipalSessionOpenAuthFactory,

--- a/packages/runner/test/llm-conversation-fixture.test.ts
+++ b/packages/runner/test/llm-conversation-fixture.test.ts
@@ -6,28 +6,30 @@
  * to read, write, and maintain.
  */
 
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { join } from "@std/path";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import type {
+  BuiltInLLMMessage,
+  BuiltInLLMTool,
+  JSONSchema,
+} from "@commonfabric/api";
 import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import {
   clearMockResponses,
   type ConversationFixture,
   loadConversationFixture,
   loadConversationFixtureFile,
 } from "@commonfabric/llm/client";
-import type {
-  BuiltInLLMMessage,
-  BuiltInLLMTool,
-  JSONSchema,
-} from "@commonfabric/api";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
 import { createBuilder } from "../src/builder/factory.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { LLMMessageSchema } from "../src/builtins/llm-schemas.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import { LLMMessageSchema } from "../src/builtins/llm-schemas.ts";
-import { join } from "@std/path";
 import { waitForLlmMessages, waitForLlmSettled } from "./support/llm-result.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 const signer = await Identity.fromPassphrase("test operator fixtures");
 const space = signer.did();

--- a/packages/runner/test/llm-dialog-error-messages.test.ts
+++ b/packages/runner/test/llm-dialog-error-messages.test.ts
@@ -6,22 +6,24 @@
  * and what keeps the array from mixing bare values with links.
  */
 
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import type { BuiltInLLMMessage } from "@commonfabric/api";
 import { Identity } from "@commonfabric/identity";
 import {
   clearMockResponses,
+  LLMClient,
   loadConversationFixture,
 } from "@commonfabric/llm/client";
-import type { BuiltInLLMMessage } from "@commonfabric/api";
-import { LLMClient } from "@commonfabric/llm/client";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { parseLink } from "../src/link-utils.ts";
+
 import { type JSONSchema } from "../src/builder/types.ts";
-import { Runtime } from "../src/runtime.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { LLMMessageSchema } from "../src/builtins/llm-schemas.ts";
+import { parseLink } from "../src/link-utils.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 import { waitForLlmMessages } from "./support/llm-result.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 const signer = await Identity.fromPassphrase("llm dialog error messages");
 

--- a/packages/runner/test/llm-dialog-helpers.test.ts
+++ b/packages/runner/test/llm-dialog-helpers.test.ts
@@ -1,13 +1,15 @@
 import { assert, assertEquals, assertThrows } from "@std/assert";
 import { expect } from "@std/expect";
+
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import type { BuiltInLLMMessage, BuiltInLLMToolCallPart } from "commonfabric";
+
 import {
   llmDialogTestHelpers,
   llmToolExecutionHelpers,
 } from "../src/builtins/llm-dialog.ts";
 import { schemaWithInjectionSafeAnnotations } from "../src/cfc/schema-sanitization.ts";
 import type { NormalizedFullLink } from "../src/link-utils.ts";
-import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 
 const {
   buildAvailableCellsDocumentation,

--- a/packages/runner/test/llm-dialog-special-objects.test.ts
+++ b/packages/runner/test/llm-dialog-special-objects.test.ts
@@ -7,19 +7,18 @@
  * refuses rather than flattening one.
  */
 
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
+import { FabricError } from "@commonfabric/data-model/fabric-instances";
 import {
   FabricBytes,
   FabricEpochNsec,
 } from "@commonfabric/data-model/fabric-primitives";
-import { FabricError } from "@commonfabric/data-model/fabric-instances";
-
+import { FabricInstance } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
-import { FabricInstance } from "@commonfabric/data-model/fabric-value";
 import { llmDialogTestHelpers } from "../src/builtins/llm-dialog.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";

--- a/packages/runner/test/llm-dialog-tool-cancel.test.ts
+++ b/packages/runner/test/llm-dialog-tool-cancel.test.ts
@@ -31,26 +31,28 @@
  * here.
  */
 
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import {
-  clearMockResponses,
-  enableMockMode,
-  loadConversationFixture,
-} from "@commonfabric/llm/client";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import type {
   BuiltInLLMMessage,
   BuiltInLLMTool,
   JSONSchema,
 } from "@commonfabric/api";
-import { createBuilder } from "../src/builder/factory.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { Identity } from "@commonfabric/identity";
 import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
+import {
+  clearMockResponses,
+  enableMockMode,
+  loadConversationFixture,
+} from "@commonfabric/llm/client";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { createBuilder } from "../src/builder/factory.ts";
+import { LLMMessageSchema } from "../src/builtins/llm-schemas.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import { LLMMessageSchema } from "../src/builtins/llm-schemas.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/load-by-identity.test.ts
+++ b/packages/runner/test/load-by-identity.test.ts
@@ -1,20 +1,14 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
+import { Identity } from "@commonfabric/identity";
+import type { Source } from "@commonfabric/js-compiler";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import {
   injectCfHelpers,
   isLegacyInjectedEnvelope,
 } from "@commonfabric/ts-transformers";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { Runtime } from "../src/runtime.ts";
-import { Engine } from "../src/harness/engine.ts";
-import type { CacheableModule, RuntimeProgram } from "../src/harness/types.ts";
-import type { Source } from "@commonfabric/js-compiler";
-import type { CachedCompiledModule } from "../src/sandbox/module-record-compiler.ts";
-import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
-import { computeModuleHashes } from "../src/harness/module-identity.ts";
+
 import {
   getCompileCacheRuntimeVersion,
   loadCompiledClosure,
@@ -22,6 +16,13 @@ import {
   setCompileCacheRuntimeVersionForTesting,
   writeSourceDocs,
 } from "../src/compilation-cache/cell-cache.ts";
+import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
+import { Engine } from "../src/harness/engine.ts";
+import { computeModuleHashes } from "../src/harness/module-identity.ts";
+import type { CacheableModule, RuntimeProgram } from "../src/harness/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { CachedCompiledModule } from "../src/sandbox/module-record-compiler.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("load-by-identity");
 const space = signer.did();

--- a/packages/runner/test/manual-compile-wedge.ts
+++ b/packages/runner/test/manual-compile-wedge.ts
@@ -11,13 +11,15 @@
  * Run: deno run -A packages/runner/test/manual-compile-wedge.ts
  */
 
+import * as path from "@std/path";
+
 import { Identity } from "@commonfabric/identity";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { getTimingStatsBreakdown } from "@commonfabric/utils/logger";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Runtime } from "../src/runtime.ts";
+
 import type { Engine } from "../src/harness/engine.ts";
-import * as path from "@std/path";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
 const repoRoot = path.resolve(
   path.dirname(path.fromFileUrl(import.meta.url)),

--- a/packages/runner/test/memory-v2-native-commit.test.ts
+++ b/packages/runner/test/memory-v2-native-commit.test.ts
@@ -6,18 +6,20 @@ import {
   assertThrows,
 } from "@std/assert";
 import { fromFileUrl } from "@std/path/from-file-url";
-import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "../src/storage/cache.deno.ts";
+import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import type { PatchOp } from "@commonfabric/memory/v2";
+
 import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 import type {
   NativeStorageCommit,
   Result,
   StorageTransactionRejected,
   Unit,
 } from "../src/storage/interface.ts";
-import type { PatchOp } from "@commonfabric/memory/v2";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { assertNoIndexedArrayStructuralOps } from "../src/storage/v2-transaction.ts";
 
 const signer = await Identity.fromPassphrase("memory-v2-native-commit");

--- a/packages/runner/test/memory-v2-pull-reactivity.test.ts
+++ b/packages/runner/test/memory-v2-pull-reactivity.test.ts
@@ -1,15 +1,17 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
+import type { URI } from "@commonfabric/memory/interface";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import type { Server as MemoryV2Server } from "@commonfabric/memory/v2/server";
+
+import { toMemorySpaceAddress } from "../src/link-utils.ts";
 import { Runtime } from "../src/runtime.ts";
+import type { Action } from "../src/scheduler.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import type { Action } from "../src/scheduler.ts";
-import type { URI } from "@commonfabric/memory/interface";
 import { createGraphFixture } from "./memory-v2-graph.fixture.ts";
-import { toMemorySpaceAddress } from "../src/link-utils.ts";
 import { testSessionOpenAuthFactory } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("memory-v2-pull-reactivity");

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -4,13 +4,15 @@ import {
   assertExists,
   assertStrictEquals,
 } from "@std/assert";
+
+import type { FabricValue } from "@commonfabric/api";
+import { EmptyReconstructionContext } from "@commonfabric/data-model/codec-common";
 import {
   fabricFromJsonValue,
   jsonFromFabricValue,
 } from "@commonfabric/data-model/codecs";
 import { FabricEpochNsec } from "@commonfabric/data-model/fabric-primitives";
 import { Identity } from "@commonfabric/identity";
-import type { FabricValue } from "@commonfabric/api";
 import type { MIME, URI } from "@commonfabric/memory/interface";
 import {
   type CommitPrecondition,
@@ -22,31 +24,31 @@ import {
   setPersistentSchedulerStateConfig,
   type SqliteOperation,
 } from "@commonfabric/memory/v2";
-import { EmptyReconstructionContext } from "@commonfabric/data-model/codec-common";
-import {
-  getLogger,
-  getLoggerCountsBreakdown,
-} from "@commonfabric/utils/logger";
 import type {
   ClientCommit,
   ConfirmedRead,
   Operation,
   PendingRead,
 } from "@commonfabric/memory/v2";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import type { AppliedCommit } from "@commonfabric/memory/v2/engine";
+import {
+  getLogger,
+  getLoggerCountsBreakdown,
+} from "@commonfabric/utils/logger";
+
+import { applyPatch } from "../../memory/v2/patch.ts";
 import {
   parentPath,
   parsePointer,
   pathsOverlap,
 } from "../../memory/v2/path.ts";
-import { applyPatch } from "../../memory/v2/patch.ts";
-import * as MemoryV2Client from "@commonfabric/memory/v2/client";
-import type { AppliedCommit } from "@commonfabric/memory/v2/engine";
 import type {
   IStorageProvider,
   StorageNotification,
 } from "../src/storage/interface.ts";
-import type { RuntimeTelemetryMarker } from "../src/telemetry.ts";
 import { setConflictAdmissionMode } from "../src/storage/v2.ts";
+import type { RuntimeTelemetryMarker } from "../src/telemetry.ts";
 import {
   NotificationRecorder,
   ScriptedSessionTransport,

--- a/packages/runner/test/memory-v2-subscription.test.ts
+++ b/packages/runner/test/memory-v2-subscription.test.ts
@@ -1,17 +1,16 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { assertRejects } from "@std/assert";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
-import { defer } from "@commonfabric/utils/defer";
+import type { MIME, URI } from "@commonfabric/memory/interface";
+import type { SessionSync } from "@commonfabric/memory/v2";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import type { Server as MemoryV2Server } from "@commonfabric/memory/v2/server";
-import { StorageManager } from "../src/storage/cache.deno.ts";
-import {
-  type SessionFactory,
-  setConflictAdmissionEnabled,
-  StorageManager as V2StorageManager,
-} from "../src/storage/v2.ts";
+import { defer } from "@commonfabric/utils/defer";
+
 import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 import type {
   IExtendedStorageTransaction,
   IReadActivity,
@@ -19,8 +18,11 @@ import type {
   StorageNotification,
   StorageTransactionRejected,
 } from "../src/storage/interface.ts";
-import type { MIME, URI } from "@commonfabric/memory/interface";
-import type { SessionSync } from "@commonfabric/memory/v2";
+import {
+  type SessionFactory,
+  setConflictAdmissionEnabled,
+  StorageManager as V2StorageManager,
+} from "../src/storage/v2.ts";
 import { createGraphFixture } from "./memory-v2-graph.fixture.ts";
 import { testSessionOpenAuthFactory } from "./memory-v2-test-utils.ts";
 

--- a/packages/runner/test/merge-defaults.test.ts
+++ b/packages/runner/test/merge-defaults.test.ts
@@ -3,17 +3,18 @@
  * a merged `.default` property for use by processDefaultValue/createCell.
  */
 
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
-import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
+import { describe, it } from "@std/testing/bdd";
+
+import { deepFreeze, isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import {
   internSchema,
   isInternedSchema,
 } from "@commonfabric/data-model/schema-hash";
 import { isNontrivialSchema } from "@commonfabric/data-model/schema-utils";
-import { mergeDefaults } from "../src/schema.ts";
+
 import type { JSONSchema, JSONSchemaObj } from "../src/builder/types.ts";
+import { mergeDefaults } from "../src/schema.ts";
 
 /** Narrow a JSONSchema to JSONSchemaObj or fail the test. */
 function expectNontrivial(schema: JSONSchema): JSONSchemaObj {

--- a/packages/runner/test/module-item-classifier.test.ts
+++ b/packages/runner/test/module-item-classifier.test.ts
@@ -1,13 +1,14 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
 
-import { parseFunctionText } from "../src/sandbox/compiled-js-parser.ts";
+import { createFactoryShadowGuardSource } from "@commonfabric/utils/sandbox-contract";
+
 import {
   type BindingInfo,
   classifyModuleItems,
   RESERVED_FACTORY_BINDING_SET,
 } from "../src/sandbox/compiled-bundle-verifier.ts";
-import { createFactoryShadowGuardSource } from "@commonfabric/utils/sandbox-contract";
+import { parseFunctionText } from "../src/sandbox/compiled-js-parser.ts";
 
 // The security classifier is format-agnostic: it classifies a module's top-level
 // items (compiled-CJS form) against a pre-seeded binding env, independent of how

--- a/packages/runner/test/multispace.test.ts
+++ b/packages/runner/test/multispace.test.ts
@@ -1,9 +1,11 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import { Runtime } from "../src/runtime.ts";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { Runtime } from "../src/runtime.ts";
+import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space1 = await Identity.fromPassphrase("space1");

--- a/packages/runner/test/nested_cell_array.test.ts
+++ b/packages/runner/test/nested_cell_array.test.ts
@@ -1,12 +1,14 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import "@commonfabric/utils/equal-ignoring-symbols";
 
-import { isCell } from "../src/cell.ts";
-import { Runtime } from "../src/runtime.ts";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
 import { type JSONSchema } from "../src/builder/types.ts";
+import { isCell } from "../src/cell.ts";
+import { Runtime } from "../src/runtime.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("test operator");

--- a/packages/runner/test/oncommit-race.test.ts
+++ b/packages/runner/test/oncommit-race.test.ts
@@ -5,13 +5,16 @@
  * result: after a transient conflict is retried and lands, or after a
  * non-retryable failure (a local abort) drops the write.
  */
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { expect } from "@std/expect";
-import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import { Runtime } from "../src/runtime.ts";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { getLogger } from "@commonfabric/utils/logger";
+
+import { Runtime } from "../src/runtime.ts";
+import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("test oncommit race");
 const space = signer.did();

--- a/packages/runner/test/pattern-binding.test.ts
+++ b/packages/runner/test/pattern-binding.test.ts
@@ -1,14 +1,13 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import {
-  findAllWriteRedirectCells,
-  opaqueArgumentKeys,
-  sendValueToBinding,
-  unwrapOneLevelAndBindToDoc,
-} from "../src/pattern-binding.ts";
-import { Runtime } from "../src/runtime.ts";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { FabricError } from "@commonfabric/data-model/fabric-instances";
+import { FabricEpochNsec } from "@commonfabric/data-model/fabric-primitives";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { popFrame, pushFrame } from "../src/builder/pattern.ts";
+import { isCell } from "../src/cell.ts";
 import {
   areLinksSame,
   areNormalizedLinksSame,
@@ -17,12 +16,15 @@ import {
   isAliasBinding,
   parseLink,
 } from "../src/link-utils.ts";
+import {
+  findAllWriteRedirectCells,
+  opaqueArgumentKeys,
+  sendValueToBinding,
+  unwrapOneLevelAndBindToDoc,
+} from "../src/pattern-binding.ts";
+import { Runtime } from "../src/runtime.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import { isCell } from "../src/cell.ts";
-import { popFrame, pushFrame } from "../src/builder/pattern.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { FabricEpochNsec } from "@commonfabric/data-model/fabric-primitives";
-import { FabricError } from "@commonfabric/data-model/fabric-instances";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/pattern-ref-boundary.test.ts
+++ b/packages/runner/test/pattern-ref-boundary.test.ts
@@ -1,22 +1,22 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { Runtime } from "../src/runtime.ts";
-import type { RuntimeProgram } from "../src/harness/types.ts";
-import type { Pattern } from "../src/builder/types.ts";
+
 import {
   patternToEncodableForm,
   serializePatternGraph,
   withAliasBindings,
 } from "../src/builder/to-encodable-form.ts";
+import type { FactoryInput, Pattern } from "../src/builder/types.ts";
 import {
   resolveOpPattern,
   resolveStoredPattern,
   resolveStoredPatternAsync,
 } from "../src/builtins/op-pattern-ref.ts";
-import type { FactoryInput } from "../src/builder/types.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import { Runtime } from "../src/runtime.ts";
 
 /**
  * Identity E4 (docs/specs/content-addressed-action-identity.md §7): the JSON

--- a/packages/runner/test/pattern.test.ts
+++ b/packages/runner/test/pattern.test.ts
@@ -1,5 +1,11 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+
+import { lift } from "../src/builder/module.ts";
+import { pattern, popFrame, pushFrame } from "../src/builder/pattern.ts";
+import { reactive } from "../src/builder/reactive.ts";
 import {
   type FactoryInput,
   type Frame,
@@ -9,12 +15,8 @@ import {
   type Module,
   type Pattern,
 } from "../src/builder/types.ts";
-import { lift } from "../src/builder/module.ts";
-import { pattern, popFrame, pushFrame } from "../src/builder/pattern.ts";
-import { reactive } from "../src/builder/reactive.ts";
 import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
-import { Identity } from "@commonfabric/identity";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/patterns-handlers.test.ts
+++ b/packages/runner/test/patterns-handlers.test.ts
@@ -1,20 +1,21 @@
 // Event handlers: defining and invoking handlers, handler metadata,
 // handler-produced side effects, schema-annotated handlers, and handler errors.
 
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { spy } from "@std/testing/mock";
 
 import { Identity } from "@commonfabric/identity";
+import { getPatternIdentityRef } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { type Cell } from "../src/builder/types.ts";
+
 import { createBuilder } from "../src/builder/factory.ts";
 import { setEagerSourceAnnotation } from "../src/builder/module.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { type Cell } from "../src/builder/types.ts";
 import { Runtime } from "../src/runtime.ts";
 import { type ErrorWithContext } from "../src/scheduler.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import { getPatternIdentityRef } from "@commonfabric/runner";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/patterns-lift.test.ts
+++ b/packages/runner/test/patterns-lift.test.ts
@@ -1,20 +1,21 @@
 // Lifted functions: pure transformations via lift(), error and recovery behavior,
 // cell creation inside lifts, reactivity control (sample), and evaluation timing.
 
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
 import { Identity } from "@commonfabric/identity";
+import { getPatternIdentityRef } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { type Cell, type JSONSchema } from "../src/builder/types.ts";
+
 import { createBuilder } from "../src/builder/factory.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { Runtime } from "../src/runtime.ts";
-import { type ErrorWithContext } from "../src/scheduler.ts";
+import { type Cell, type JSONSchema } from "../src/builder/types.ts";
 import { isCell } from "../src/cell.ts";
 import { resolveLink } from "../src/link-resolution.ts";
+import { Runtime } from "../src/runtime.ts";
+import { type ErrorWithContext } from "../src/scheduler.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import { getPatternIdentityRef } from "@commonfabric/runner";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/patterns-self.test.ts
+++ b/packages/runner/test/patterns-self.test.ts
@@ -1,19 +1,19 @@
 // SELF references: patterns that reference their own output cell for
 // self-referential data structures, serialization, and type inference.
 
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-
-import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { type JSONSchema, SELF } from "../src/builder/types.ts";
-import { createBuilder } from "../src/builder/factory.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
 // Import types from public API for compile-time type tests
 import { type Reactive } from "@commonfabric/api";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { createBuilder } from "../src/builder/factory.ts";
+import { type JSONSchema, SELF } from "../src/builder/types.ts";
 import { Runtime } from "../src/runtime.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/pretransform.test.ts
+++ b/packages/runner/test/pretransform.test.ts
@@ -4,15 +4,16 @@ import {
   assertNotMatch,
   assertThrows,
 } from "@std/assert";
+
+import { injectCfHelpers } from "@commonfabric/ts-transformers";
+
+import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
+import { helperInjectionLineOffset } from "../src/harness/engine.ts";
 import {
   preserveLineCount,
   transformInjectHelperModule,
 } from "../src/harness/pretransform.ts";
-import { helperInjectionLineOffset } from "../src/harness/engine.ts";
-import { injectCfHelpers } from "@commonfabric/ts-transformers";
 import type { RuntimeProgram } from "../src/harness/types.ts";
-
-import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
 
 // These tests drive the sync parse internals directly (below the async flow
 // boundaries that normally load the deferred compiler stack), so load it here.

--- a/packages/runner/test/profile-create-real-card-add.test.ts
+++ b/packages/runner/test/profile-create-real-card-add.test.ts
@@ -1,12 +1,13 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { fromFileUrl } from "@std/path";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
-import { fromFileUrl } from "@std/path";
 
-import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 // GOLD-STANDARD end-to-end repro of the profile card-add flow using the REAL

--- a/packages/runner/test/profile-home-bio.test.ts
+++ b/packages/runner/test/profile-home-bio.test.ts
@@ -1,11 +1,12 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
 import { fromFileUrl } from "@std/path";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
-import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import { Runtime } from "../src/runtime.ts";
+import { Identity } from "@commonfabric/identity";
+
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 
 // CT-1648: profiles carry an owner-authored free-text `bio`. It starts empty,
 // is written ONLY through the authorized `setBio` handler (owner-protected like

--- a/packages/runner/test/profile-home-pin-piece.test.ts
+++ b/packages/runner/test/profile-home-pin-piece.test.ts
@@ -1,11 +1,12 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
 import { fromFileUrl } from "@std/path";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
-import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import { Runtime } from "../src/runtime.ts";
+import { Identity } from "@commonfabric/identity";
+
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 
 // CT-1755: a profile card can pin an EXISTING deployed piece. `mutateElements`'s
 // `addPiece` mode stores a real cross-space link to the target piece as the

--- a/packages/runner/test/profile-home-verified-identities.test.ts
+++ b/packages/runner/test/profile-home-verified-identities.test.ts
@@ -1,13 +1,14 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
 import { fromFileUrl } from "@std/path";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
-import { cfcLabelViewForCell } from "../src/cfc/mod.ts";
-import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import { Runtime } from "../src/runtime.ts";
+import { Identity } from "@commonfabric/identity";
+
 import type { JSONSchema } from "../src/builder/types.ts";
+import { cfcLabelViewForCell } from "../src/cfc/mod.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 
 const signer = await Identity.fromPassphrase(
   "profile-home-verified-identities",

--- a/packages/runner/test/profile-space-identity-collision-support.ts
+++ b/packages/runner/test/profile-space-identity-collision-support.ts
@@ -1,10 +1,11 @@
 import { expect } from "@std/expect";
-import { Identity } from "@commonfabric/identity";
 import { fromFileUrl } from "@std/path";
 
-import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import { Runtime } from "../src/runtime.ts";
+import { Identity } from "@commonfabric/identity";
+
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 
 // CT-1650: two DIFFERENT users who create a profile with the SAME display name
 // must end up in DISTINCT profile spaces. Before the fix, profile-create seeded

--- a/packages/runner/test/query-result-proxy-enumeration.test.ts
+++ b/packages/runner/test/query-result-proxy-enumeration.test.ts
@@ -4,14 +4,17 @@
  * Verifies that Object.keys(), spread, Object.entries(), and
  * JSON.stringify work correctly on query result proxies.
  */
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { expect } from "@std/expect";
-import { Runtime } from "../src/runtime.ts";
-import { createQueryResultProxy } from "../src/query-result-proxy.ts";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
 import { popFrame, pushFrame } from "../src/builder/pattern.ts";
+import { createQueryResultProxy } from "../src/query-result-proxy.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/query.test.ts
+++ b/packages/runner/test/query.test.ts
@@ -1,9 +1,25 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { hashOf } from "@commonfabric/data-model/value-hash";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import type { SchemaPathSelector } from "@commonfabric/api";
 import { entityRefToString } from "@commonfabric/data-model/cell-rep";
-import { JSONObject, type JSONSchema } from "../src/index.ts";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { hashOf } from "@commonfabric/data-model/value-hash";
+import { Identity } from "@commonfabric/identity";
+import type {
+  MIME,
+  Revision,
+  State,
+  URI,
+} from "@commonfabric/memory/interface";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { JSONObject, type JSONSchema } from "../src/index.ts";
+import { Runtime } from "../src/runtime.ts";
+import { LINK_V1_TAG } from "../src/sigil-types.ts";
+import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
+import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { StoreObjectManager } from "../src/storage/query.ts";
 import {
   CompoundCycleTracker,
   createTraversalContext,
@@ -12,20 +28,6 @@ import {
   MapSetStringToPathSelectors,
   SchemaObjectTraverser,
 } from "../src/traverse.ts";
-import { LINK_V1_TAG } from "../src/sigil-types.ts";
-import type { SchemaPathSelector } from "@commonfabric/api";
-import type {
-  MIME,
-  Revision,
-  State,
-  URI,
-} from "@commonfabric/memory/interface";
-import { Runtime } from "../src/runtime.ts";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { Identity } from "@commonfabric/identity";
-import { StoreObjectManager } from "../src/storage/query.ts";
-import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/reactive-dependencies.test.ts
+++ b/packages/runner/test/reactive-dependencies.test.ts
@@ -1,5 +1,10 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { FabricMap } from "@commonfabric/data-model/fabric-instances";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { MemorySpace } from "@commonfabric/memory/interface";
+
 import {
   addressesToPathByEntity,
   arraysOverlap,
@@ -8,13 +13,10 @@ import {
   type SortedAndCompactPaths,
 } from "../src/reactive-dependencies.ts";
 import type { Action, SpaceScopeAndURI } from "../src/scheduler.ts";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
-import { FabricMap } from "@commonfabric/data-model/fabric-instances";
 import type {
   IMemorySpaceAddress,
   MemoryAddressPathComponent,
 } from "../src/storage/interface.ts";
-import type { MemorySpace } from "@commonfabric/memory/interface";
 
 // Helper function to create IMemorySpaceAddress for testing
 const createAddress = (

--- a/packages/runner/test/reactive-schema.test.ts
+++ b/packages/runner/test/reactive-schema.test.ts
@@ -1,11 +1,13 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { createBuilder } from "../src/builder/factory.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import type { JSONSchema } from "../src/builder/types.ts";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { Identity } from "@commonfabric/identity";
+
+import { createBuilder } from "../src/builder/factory.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 

--- a/packages/runner/test/reactive.test.ts
+++ b/packages/runner/test/reactive.test.ts
@@ -1,10 +1,12 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { isReactive } from "../src/builder/types.ts";
-import { reactive } from "../src/builder/reactive.ts";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { Identity } from "@commonfabric/identity";
+
+import { reactive } from "../src/builder/reactive.ts";
+import { isReactive } from "../src/builder/types.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 

--- a/packages/runner/test/receipt-schema.test.ts
+++ b/packages/runner/test/receipt-schema.test.ts
@@ -1,3 +1,7 @@
+import { defer } from "@commonfabric/utils/defer";
+
+import { resolveLink } from "../src/link-resolution.ts";
+import { parseLink } from "../src/link-utils.ts";
 // The durable `schema` metadata a settled handler dispatch records on its
 // receipt cell alongside the value (`handleJavaScriptHandlerResult`,
 // `src/runner.ts`). It is descriptive — the root container kind, plus the
@@ -23,9 +27,6 @@ import type {
   SchedulerTestStorageManager,
 } from "./scheduler-test-utils.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { defer } from "@commonfabric/utils/defer";
-import { parseLink } from "../src/link-utils.ts";
-import { resolveLink } from "../src/link-resolution.ts";
 
 // The session a caller-supplied id is chosen within, for the sends whose
 // subject is something else: the pair is what a stream send accepts, and one

--- a/packages/runner/test/rehydrate-internal-default.test.ts
+++ b/packages/runner/test/rehydrate-internal-default.test.ts
@@ -1,16 +1,18 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
 import type * as MemoryV2Server from "@commonfabric/memory/v2/server";
-import { EmulatedStorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { Cell, type Pattern } from "../src/builder/types.ts";
-import { Runtime } from "../src/runtime.ts";
-import { getMetaLink, parseLink } from "../src/link-utils.ts";
-import { trustExecutable } from "./support/trusted-builder.ts";
 import { JSONValue } from "@commonfabric/runner/shared";
+import { EmulatedStorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
+
+import { Cell, type Pattern } from "../src/builder/types.ts";
 import { isPrimitiveCellLink } from "../src/link-types.ts";
+import { getMetaLink, parseLink } from "../src/link-utils.ts";
+import { Runtime } from "../src/runtime.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
+import { trustExecutable } from "./support/trusted-builder.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/reload-rehydration-safety.test.ts
+++ b/packages/runner/test/reload-rehydration-safety.test.ts
@@ -1,20 +1,22 @@
-import type { FabricValue } from "@commonfabric/api";
 import { expect } from "@std/expect";
+
+import type { FabricValue } from "@commonfabric/api";
 import type {
   SchedulerActionSnapshotCursor,
   SchedulerSnapshotListResult,
 } from "@commonfabric/memory/v2";
+
+import type { Cell } from "../src/cell.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import {
+  isSchedulerActionObservation,
+  type SchedulerActionObservation,
+} from "../src/scheduler/persistent-observation.ts";
 import {
   createSchedulerTestRuntime,
   disposeSchedulerTestRuntime,
   space,
 } from "./scheduler-test-utils.ts";
-import type { RuntimeProgram } from "../src/harness/types.ts";
-import type { Cell } from "../src/cell.ts";
-import {
-  isSchedulerActionObservation,
-  type SchedulerActionObservation,
-} from "../src/scheduler/persistent-observation.ts";
 
 const PROGRAM: RuntimeProgram = {
   main: "/main.tsx",

--- a/packages/runner/test/require-defaults.test.ts
+++ b/packages/runner/test/require-defaults.test.ts
@@ -5,14 +5,17 @@
  * StripDefaultBrand<T>, and the Default<T,V> brand detection logic.
  * If any type assertion is wrong, this file will fail to compile.
  */
-import { describe, it } from "@std/testing/bdd";
+
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import type { DeepDefault, Default } from "@commonfabric/api";
+import type { Cell } from "@commonfabric/runner";
+
 import type {
   RequireDefaults,
   StripDefaultBrand,
 } from "../src/builder/types.ts";
-import type { DeepDefault, Default } from "@commonfabric/api";
-import type { Cell } from "@commonfabric/runner";
 
 // ============================================================================
 // Helpers

--- a/packages/runner/test/resolve-schema.test.ts
+++ b/packages/runner/test/resolve-schema.test.ts
@@ -4,18 +4,20 @@
  * so these tests only cover the single-argument form.
  */
 
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { resolveSchema, resolveSchemaForValue } from "../src/schema.ts";
-import type { JSONSchema, JSONSchemaObj } from "../src/builder/types.ts";
-import {
-  isNontrivialSchema,
-  toDeepFrozenSchema,
-} from "@commonfabric/data-model/schema-utils";
+import { describe, it } from "@std/testing/bdd";
+
 import {
   internSchema,
   isInternedSchema,
 } from "@commonfabric/data-model/schema-hash";
+import {
+  isNontrivialSchema,
+  toDeepFrozenSchema,
+} from "@commonfabric/data-model/schema-utils";
+
+import type { JSONSchema, JSONSchemaObj } from "../src/builder/types.ts";
+import { resolveSchema, resolveSchemaForValue } from "../src/schema.ts";
 
 /** Narrow a JSONSchema | undefined to JSONSchemaObj or fail the test. */
 function expectNontrivial(

--- a/packages/runner/test/runner.test.ts
+++ b/packages/runner/test/runner.test.ts
@@ -1,16 +1,26 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
+
 import "@commonfabric/utils/equal-ignoring-symbols";
+
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
 import {
   type JSONSchema,
   type Module,
   NAME,
   type Pattern,
 } from "../src/builder/types.ts";
-import { Runtime } from "../src/runtime.ts";
+import { validateSchemaValue } from "../src/cfc/mod.ts";
+import {
+  areNormalizedLinksSame,
+  getDerivedInternalCell,
+  getMetaLink,
+  isWriteRedirectLink,
+  parseLink,
+} from "../src/link-utils.ts";
 import {
   extractDefaultValues,
   getPatternIdentityRef,
@@ -20,7 +30,7 @@ import {
   schemaAcceptsOpaqueCellValue,
   schemaHasDefaultValue,
 } from "../src/runner.ts";
-import { validateSchemaValue } from "../src/cfc/mod.ts";
+import { Runtime } from "../src/runtime.ts";
 import {
   type ICommitNotification,
   type IExtendedStorageTransaction,
@@ -29,13 +39,6 @@ import {
   type URI,
 } from "../src/storage/interface.ts";
 import { trustExecutable } from "./support/trusted-builder.ts";
-import {
-  areNormalizedLinksSame,
-  getDerivedInternalCell,
-  getMetaLink,
-  isWriteRedirectLink,
-  parseLink,
-} from "../src/link-utils.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/scheduler-cfc-trigger-reads.test.ts
+++ b/packages/runner/test/scheduler-cfc-trigger-reads.test.ts
@@ -1,17 +1,18 @@
-import { describe, expect, it } from "./scheduler-test-utils.ts";
 import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "../src/storage/cache.deno.ts";
+import type { MemorySpace } from "@commonfabric/memory/interface";
+
 import { Runtime } from "../src/runtime.ts";
-import { SchedulerTriggerIndex } from "../src/scheduler/trigger-index.ts";
+import { MAX_RETRIES_FOR_REACTIVE } from "../src/scheduler/constants.ts";
 import {
   markInvalid,
+  processStorageNotification,
   type StorageNotificationState,
 } from "../src/scheduler/invalidation.ts";
-import { processStorageNotification } from "../src/scheduler/invalidation.ts";
-import { watchReactiveActionCommit } from "../src/scheduler/run.ts";
-import { MAX_RETRIES_FOR_REACTIVE } from "../src/scheduler/constants.ts";
 import { NodeRegistry } from "../src/scheduler/node-record.ts";
+import { watchReactiveActionCommit } from "../src/scheduler/run.ts";
+import { SchedulerTriggerIndex } from "../src/scheduler/trigger-index.ts";
 import type { Action } from "../src/scheduler/types.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 import type {
   ChangeGroup,
   IExtendedStorageTransaction,
@@ -20,7 +21,7 @@ import type {
   IStorageTransaction,
   StorageNotification,
 } from "../src/storage/interface.ts";
-import type { MemorySpace } from "@commonfabric/memory/interface";
+import { describe, expect, it } from "./scheduler-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("scheduler-cfc-trigger-reads");
 const space = signer.did() as MemorySpace;

--- a/packages/runner/test/scheduler-cold-replica.test.ts
+++ b/packages/runner/test/scheduler-cold-replica.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
 import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
@@ -8,6 +8,7 @@ import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 import { Runtime } from "../src/runtime.ts";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("scheduler cold replica");
 const space = signer.did();

--- a/packages/runner/test/scheduler-commit-backpressure.test.ts
+++ b/packages/runner/test/scheduler-commit-backpressure.test.ts
@@ -18,6 +18,14 @@
 //   6. Three array appends survive a conflict storm so the durable count reaches
 //      three (the profile-append bug in miniature).
 
+import { defer } from "@commonfabric/utils/defer";
+import { getLoggerCountsBreakdown } from "@commonfabric/utils/logger";
+
+import { resolveLink } from "../src/link-resolution.ts";
+import {
+  computeBackoffDelayMs,
+  resolveCommitBackpressure,
+} from "../src/scheduler/backpressure.ts";
 import {
   afterEach,
   beforeEach,
@@ -37,13 +45,6 @@ import type {
   SchedulerTestStorageManager,
 } from "./scheduler-test-utils.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { defer } from "@commonfabric/utils/defer";
-import { getLoggerCountsBreakdown } from "@commonfabric/utils/logger";
-import { resolveLink } from "../src/link-resolution.ts";
-import {
-  computeBackoffDelayMs,
-  resolveCommitBackpressure,
-} from "../src/scheduler/backpressure.ts";
 
 type TransactMessage = { requestId: string };
 type TransactResponse = {

--- a/packages/runner/test/scheduler-event-identity.test.ts
+++ b/packages/runner/test/scheduler-event-identity.test.ts
@@ -1,11 +1,7 @@
-import {
-  createSchedulerTestRuntime,
-  describe,
-  disposeSchedulerTestRuntime,
-  expect,
-  it,
-  space,
-} from "./scheduler-test-utils.ts";
+import type { MemorySpace } from "@commonfabric/memory/interface";
+
+import type { NormalizedFullLink } from "../src/link-utils.ts";
+import type { Runtime } from "../src/runtime.ts";
 import {
   mintEventId,
   scopeCallerEventId,
@@ -14,11 +10,16 @@ import {
   dropQueuedEvent,
   queueSchedulerEvent,
 } from "../src/scheduler/events.ts";
-import type { NormalizedFullLink } from "../src/link-utils.ts";
-import type { Runtime } from "../src/runtime.ts";
 import type { QueuedEvent } from "../src/scheduler/types.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import type { MemorySpace } from "@commonfabric/memory/interface";
+import {
+  createSchedulerTestRuntime,
+  describe,
+  disposeSchedulerTestRuntime,
+  expect,
+  it,
+  space,
+} from "./scheduler-test-utils.ts";
 
 const eventLink: NormalizedFullLink = {
   id: "of:event-stream",

--- a/packages/runner/test/scheduler-event-receipts.test.ts
+++ b/packages/runner/test/scheduler-event-receipts.test.ts
@@ -1,3 +1,11 @@
+import { entityRefToString } from "@commonfabric/data-model/cell-rep";
+import { Identity } from "@commonfabric/identity";
+
+import { markRuntimeInjectedEventKeys } from "../src/cell.ts";
+import { resolveLink } from "../src/link-resolution.ts";
+import { scopeCallerEventId } from "../src/scheduler/event-identity.ts";
+import { dispatchQueuedEvent } from "../src/scheduler/events.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 import {
   afterEach,
   beforeEach,
@@ -9,7 +17,6 @@ import {
   Runtime,
   space,
 } from "./scheduler-test-utils.ts";
-import { entityRefToString } from "@commonfabric/data-model/cell-rep";
 import type {
   Cell,
   IExtendedStorageTransaction,
@@ -18,12 +25,6 @@ import type {
   SchedulerTestStorageManager,
 } from "./scheduler-test-utils.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { markRuntimeInjectedEventKeys } from "../src/cell.ts";
-import { resolveLink } from "../src/link-resolution.ts";
-import { dispatchQueuedEvent } from "../src/scheduler/events.ts";
-import { scopeCallerEventId } from "../src/scheduler/event-identity.ts";
-import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "../src/storage/cache.deno.ts";
 
 // The session a caller-supplied id is chosen within, for the sends whose
 // subject is something else: the pair is what a stream send accepts, and one

--- a/packages/runner/test/scheduler-observations.test.ts
+++ b/packages/runner/test/scheduler-observations.test.ts
@@ -1,17 +1,7 @@
 import type { FabricValue } from "@commonfabric/api";
-import {
-  createSchedulerTestRuntime as createBaseSchedulerTestRuntime,
-  describe,
-  disposeSchedulerTestRuntime,
-  expect,
-  it,
-  space,
-  toMemorySpaceAddress,
-} from "./scheduler-test-utils.ts";
-import type {
-  IMemorySpaceAddress,
-  TransactionReactivityLog,
-} from "../src/storage/interface.ts";
+import type { SchedulerActionSnapshotResult } from "@commonfabric/memory/v2";
+
+import type { RuntimeProgram } from "../src/harness/types.ts";
 import {
   buildSchedulerActionObservation,
   isSchedulerActionObservation,
@@ -22,15 +12,26 @@ import {
   schedulerImplementationFingerprint,
   schedulerRuntimeFingerprint,
 } from "../src/scheduler/run.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import type { RuntimeProgram } from "../src/harness/types.ts";
+import type {
+  IMemorySpaceAddress,
+  TransactionReactivityLog,
+} from "../src/storage/interface.ts";
+import {
+  createSchedulerTestRuntime as createBaseSchedulerTestRuntime,
+  describe,
+  disposeSchedulerTestRuntime,
+  expect,
+  it,
+  space,
+  toMemorySpaceAddress,
+} from "./scheduler-test-utils.ts";
 import type {
   Action,
   Cell,
   IExtendedStorageTransaction,
   Runtime,
 } from "./scheduler-test-utils.ts";
-import type { SchedulerActionSnapshotResult } from "@commonfabric/memory/v2";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 // Source-backed `value -> doubled` pattern for the clean-restart resume test. A
 // fresh runtime resuming from storage must resolve the piece's pattern by its

--- a/packages/runner/test/scheduler-pull-idempotency.test.ts
+++ b/packages/runner/test/scheduler-pull-idempotency.test.ts
@@ -1,11 +1,12 @@
 // Inline scheduler idempotency check tests.
 
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+
 import {
   captureTransactionWrites,
   findDifferingWriteKeys,
   makeAddressKey,
 } from "../src/scheduler/diagnosis.ts";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import {
   afterEach,
   beforeEach,

--- a/packages/runner/test/scheduler-test-utils.ts
+++ b/packages/runner/test/scheduler-test-utils.ts
@@ -1,23 +1,24 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { assertSpyCall, assertSpyCalls, spy } from "@std/testing/mock";
+
 import { Identity } from "@commonfabric/identity";
 import type { Entity } from "@commonfabric/memory/interface";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { TYPE } from "../src/builder/types.ts";
+import type { Cell, JSONSchema } from "../src/builder/types.ts";
 import { storedCfcMetadataAppliesToPath } from "../src/cfc/metadata.ts";
+import { toMemorySpaceAddress } from "../src/link-utils.ts";
 import {
   type ExperimentalOptions,
   Runtime,
   type RuntimeOptions,
 } from "../src/runtime.ts";
-import { TYPE } from "../src/builder/types.ts";
 import {
   ignoreReadForScheduling,
   txToReactivityLog,
 } from "../src/scheduler.ts";
-import { setSchedulerDependencies } from "../src/scheduler/dependency-updates.ts";
-import { toMemorySpaceAddress } from "../src/link-utils.ts";
-import type { Cell, JSONSchema } from "../src/builder/types.ts";
 import type {
   Action,
   ErrorWithContext,
@@ -25,6 +26,7 @@ import type {
   ReactivityLog,
   TelemetryAnnotations,
 } from "../src/scheduler.ts";
+import { setSchedulerDependencies } from "../src/scheduler/dependency-updates.ts";
 import type {
   IExtendedStorageTransaction,
   IStorageNotification,

--- a/packages/runner/test/scheduler-timing.test.ts
+++ b/packages/runner/test/scheduler-timing.test.ts
@@ -1,5 +1,9 @@
 // Scheduler debounce and throttle tests.
 
+import { BoundedKeyMap } from "@commonfabric/utils/cache";
+
+import { getActionStats, recordActionTime } from "../src/scheduler/timing.ts";
+import type { ActionStats } from "../src/telemetry.ts";
 import {
   afterEach,
   beforeEach,
@@ -17,9 +21,6 @@ import type {
   IExtendedStorageTransaction,
   SchedulerTestStorageManager,
 } from "./scheduler-test-utils.ts";
-import { BoundedKeyMap } from "@commonfabric/utils/cache";
-import type { ActionStats } from "../src/telemetry.ts";
-import { getActionStats, recordActionTime } from "../src/scheduler/timing.ts";
 
 describe("action timing stats", () => {
   // Each action instance gets its own id, so a pattern that keeps creating

--- a/packages/runner/test/scheduler.bench.ts
+++ b/packages/runner/test/scheduler.bench.ts
@@ -4,17 +4,21 @@
  * For cell layer benchmarks, see cell.bench.ts
  * For storage layer benchmarks, see storage.bench.ts
  */
+
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { Runtime } from "../src/runtime.ts";
-import type { Action } from "../src/scheduler.ts";
-import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import type { IMemorySpaceAddress } from "../src/storage/interface.ts";
+
+import { toMemorySpaceAddress } from "../src/link-utils.ts";
 import {
   addressesToPathByEntity,
   sortAndCompactPaths,
 } from "../src/reactive-dependencies.ts";
-import { toMemorySpaceAddress } from "../src/link-utils.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { Action } from "../src/scheduler.ts";
+import type {
+  IExtendedStorageTransaction,
+  IMemorySpaceAddress,
+} from "../src/storage/interface.ts";
 import { benchDiagnostic } from "./bench-diagnostics.ts";
 
 const signer = await Identity.fromPassphrase("bench operator");

--- a/packages/runner/test/schema-lineage.test.ts
+++ b/packages/runner/test/schema-lineage.test.ts
@@ -1,15 +1,17 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import "@commonfabric/utils/equal-ignoring-symbols";
 
-import { type JSONSchema } from "../src/builder/types.ts";
-import { createBuilder } from "../src/builder/factory.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { isCell } from "../src/cell.ts";
-import { Runtime } from "../src/runtime.ts";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { createBuilder } from "../src/builder/factory.ts";
+import { type JSONSchema } from "../src/builder/types.ts";
+import { isCell } from "../src/cell.ts";
+import { Runtime } from "../src/runtime.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/schema-links.test.ts
+++ b/packages/runner/test/schema-links.test.ts
@@ -1,21 +1,23 @@
 // Link resolution tests: array element links, cross-space array links,
 // and validateAndTransform with redirect links.
 
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import "@commonfabric/utils/equal-ignoring-symbols";
+
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { createCell, isCell } from "../src/cell.ts";
-import { type JSONSchema } from "../src/builder/types.ts";
-import { diffAndUpdate } from "../src/data-updating.ts";
-import { parseLink } from "../src/link-utils.ts";
-import { Runtime } from "../src/runtime.ts";
-import { dataUriFromValueWithResolvedLinks } from "../src/data-uri.ts";
-import { areLinksSame } from "../src/link-utils.ts";
+
 import { toCell } from "../src/back-to-cell.ts";
-import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { type JSONSchema } from "../src/builder/types.ts";
+import { createCell, isCell } from "../src/cell.ts";
+import { diffAndUpdate } from "../src/data-updating.ts";
+import { dataUriFromValueWithResolvedLinks } from "../src/data-uri.ts";
+import { areLinksSame, parseLink } from "../src/link-utils.ts";
 import { CellResult } from "../src/query-result-proxy.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/schema-to-ts.test.ts
+++ b/packages/runner/test/schema-to-ts.test.ts
@@ -1,29 +1,34 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import "@commonfabric/utils/equal-ignoring-symbols";
 
-import { handler } from "../src/builder/module.ts";
 // Bring lift's schema-bearing, type-materializing overloads into scope. They live
 // in `@commonfabric/api/schema` (CT-1625) — the facade module that augments
 // LiftFunction. The lift materialization test below is compile-time only and
 // declares a locally-typed `lift` (the facade `lift` is `declare const`, no
 // runtime value). (handler still materializes via its module.ts overloads.)
 import type { LiftFunction } from "@commonfabric/api";
+
+import { handler } from "../src/builder/module.ts";
+
 import "@commonfabric/api/schema";
+
+import type { AsCellType, ReadonlyCell } from "@commonfabric/api";
+import { Identity } from "@commonfabric/identity";
+import { type Cell, Runtime, type Stream } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
 import { createBuilder } from "../src/builder/factory.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { pattern } from "../src/builder/pattern.ts";
 import {
   type AnyCellWrapping,
   type JSONSchema,
   type Reactive,
   Schema,
 } from "../src/builder/types.ts";
-import type { AsCellType, ReadonlyCell } from "@commonfabric/api";
-import { pattern } from "../src/builder/pattern.ts";
-import { type Cell, Runtime, type Stream } from "@commonfabric/runner";
-import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 // This file primarily tests Schema<> & co from commonfabric/api/index.ts, which
 // gets transitively loaded by the above

--- a/packages/runner/test/ses-runtime-source-maps.test.ts
+++ b/packages/runner/test/ses-runtime-source-maps.test.ts
@@ -1,7 +1,9 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { SESRuntime } from "../src/sandbox/ses-runtime.ts";
+import { describe, it } from "@std/testing/bdd";
+
 import { identitySourceMap } from "@commonfabric/js-compiler/source-map";
+
+import { SESRuntime } from "../src/sandbox/ses-runtime.ts";
 
 // The runner-facing source-map surface of the SES runtime: the module-graph boot
 // path registers deferred providers (CT-1819), and both coordinate lookup and

--- a/packages/runner/test/sqlite-builtins.test.ts
+++ b/packages/runner/test/sqlite-builtins.test.ts
@@ -4,17 +4,19 @@
 // not-implemented error (asserted here so the wiring — not fabricated results —
 // is what's tested).
 
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
-import { defer } from "@commonfabric/utils/defer";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { createBuilder } from "../src/builder/factory.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
-import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { defer } from "@commonfabric/utils/defer";
+
+import { createBuilder } from "../src/builder/factory.ts";
 import { createCell } from "../src/cell.ts";
+import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/sqlite-db-owner.test.ts
+++ b/packages/runner/test/sqlite-db-owner.test.ts
@@ -8,15 +8,17 @@
 // most recently. Companion multi-runtime repro:
 // packages/patterns/integration/sqlite-db-owner-multi-runtime.test.ts.
 
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import type { SqliteDbRef } from "@commonfabric/memory/v2";
-import { createBuilder } from "../src/builder/factory.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
+import type { SqliteDbRef } from "@commonfabric/memory/v2";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { createBuilder } from "../src/builder/factory.ts";
 import { Runtime } from "../src/runtime.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/sqlite-handle-multi-runtime.test.ts
+++ b/packages/runner/test/sqlite-handle-multi-runtime.test.ts
@@ -17,18 +17,20 @@
 // when a doc can exist server-side but not in the reading runtime's heap; the
 // single-StorageManager emulate() setup would mask it).
 
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import type { SqliteTableSchemas } from "@commonfabric/api";
 import { Identity } from "@commonfabric/identity";
+import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
 import type * as MemoryV2Server from "@commonfabric/memory/v2/server";
+
+import { createCell } from "../src/cell.ts";
+import { isSigilLink } from "../src/link-utils.ts";
+import { Runtime } from "../src/runtime.ts";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
-import { Runtime } from "../src/runtime.ts";
-import { createCell } from "../src/cell.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
-import { isSigilLink } from "../src/link-utils.ts";
 
 // Fresh identity per RUN: the server derives the on-disk cell-db file from the
 // (causal) db id, so a fixed passphrase would reuse a stale $TMPDIR db across

--- a/packages/runner/test/sqlite-query-rowschema-decode.test.ts
+++ b/packages/runner/test/sqlite-query-rowschema-decode.test.ts
@@ -9,20 +9,22 @@
 // path is the integration test). It proves the runtime half: rowSchema -> stored
 // sigil object -> asCell read -> live Cell.
 
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
 import { table } from "@commonfabric/memory/sqlite/schema";
 import type { SqliteDbRef, SqliteParamsWire } from "@commonfabric/memory/v2";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
 import { createBuilder } from "../src/builder/factory.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { Runtime } from "../src/runtime.ts";
-import { isCell } from "../src/cell.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
-import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { encodeCfLinkValue } from "../src/builtins/sqlite/cf-link.ts";
-import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
+import { isCell } from "../src/cell.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 type QueryState = {
   pending: boolean;

--- a/packages/runner/test/sqlite-row-label-read.test.ts
+++ b/packages/runner/test/sqlite-row-label-read.test.ts
@@ -5,13 +5,9 @@
 // Spec: docs/specs/sqlite-builtin/06-cfc.md ("Read — re-derive per row,
 // attach, ceiling"; "Fail-closed rules").
 
-import { describe, it } from "@std/testing/bdd";
 import { assert, assertEquals, assertThrows } from "@std/assert";
-import {
-  computeRowLabelRead,
-  resolveCeilingPlaceholders,
-} from "../src/builtins/sqlite/row-label-read.ts";
-import { table } from "@commonfabric/memory/sqlite/schema";
+import { describe, it } from "@std/testing/bdd";
+
 import {
   all,
   any,
@@ -22,6 +18,12 @@ import {
   principal,
   whenMatches,
 } from "@commonfabric/memory/sqlite/row-label";
+import { table } from "@commonfabric/memory/sqlite/schema";
+
+import {
+  computeRowLabelRead,
+  resolveCeilingPlaceholders,
+} from "../src/builtins/sqlite/row-label-read.ts";
 
 const ADDR = /[^\s<>,;"]+@[^\s<>,;"]+/g;
 const OWNER = "did:key:zOwner";

--- a/packages/runner/test/sqlite-row-label-write.test.ts
+++ b/packages/runner/test/sqlite-row-label-write.test.ts
@@ -6,10 +6,9 @@
 // follow-up that lifts this).
 // Spec: docs/specs/sqlite-builtin/06-cfc.md ("Write — the runner gate").
 
-import { describe, it } from "@std/testing/bdd";
 import { assert, assertEquals } from "@std/assert";
-import { checkSqliteRowLabelWrite } from "../src/builtins/sqlite/row-label-write.ts";
-import { table } from "@commonfabric/memory/sqlite/schema";
+import { describe, it } from "@std/testing/bdd";
+
 import {
   all,
   authoredBy,
@@ -19,6 +18,9 @@ import {
   principal,
   whenMatches,
 } from "@commonfabric/memory/sqlite/row-label";
+import { table } from "@commonfabric/memory/sqlite/schema";
+
+import { checkSqliteRowLabelWrite } from "../src/builtins/sqlite/row-label-write.ts";
 
 const ADDR = /[^\s<>,;"]+@[^\s<>,;"]+/g;
 const OWNER = "did:key:zOwner";

--- a/packages/runner/test/src-garble-identity-invariant.test.ts
+++ b/packages/runner/test/src-garble-identity-invariant.test.ts
@@ -1,16 +1,20 @@
 import { expect } from "@std/expect";
+
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import type { RuntimeProgram } from "../src/harness/types.ts";
-import type { Module } from "../src/builder/types.ts";
-import type { HarnessedFunction } from "../src/harness/types.ts";
-import { Runtime } from "../src/runtime.ts";
+
 import {
   __setSrcAnnotationTransformForTest,
   setEagerSourceAnnotation,
 } from "../src/builder/module.ts";
-import { recordVerifiedProvenance } from "../src/harness/verified-provenance.ts";
+import type { Module } from "../src/builder/types.ts";
 import { resolvePolicyFacingImplementationIdentity } from "../src/cfc/implementation-identity.ts";
+import type {
+  HarnessedFunction,
+  RuntimeProgram,
+} from "../src/harness/types.ts";
+import { recordVerifiedProvenance } from "../src/harness/verified-provenance.ts";
+import { Runtime } from "../src/runtime.ts";
 
 // `.src`-garbled identity invariant harness (workstream B — content-addressed
 // action identity).

--- a/packages/runner/test/stack-trace-patterns.test.ts
+++ b/packages/runner/test/stack-trace-patterns.test.ts
@@ -7,10 +7,12 @@
 // → source maps → eval → error → parseStack → original line numbers.
 
 import { assertEquals, assertMatch } from "@std/assert";
-import { Runtime } from "../src/runtime.ts";
+
 import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "../src/storage/cache.deno.ts";
+
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/packages/runner/test/storage-close.test.ts
+++ b/packages/runner/test/storage-close.test.ts
@@ -1,11 +1,13 @@
 import { assertEquals } from "@std/assert";
-import { Identity } from "@commonfabric/identity";
+
 import type { SchemaPathSelector } from "@commonfabric/api";
+import { Identity } from "@commonfabric/identity";
 import type { MemorySpace, Signer, URI } from "@commonfabric/memory/interface";
 import type { CellScope } from "@commonfabric/memory/v2";
-import type { Result, Unit } from "../src/storage/interface.ts";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+
+import type { Result, Unit } from "../src/storage/interface.ts";
 import type { SessionFactory } from "../src/storage/v2.ts";
 import {
   TEST_MEMORY_SERVER_AUTH,

--- a/packages/runner/test/storage-synced-authorization.test.ts
+++ b/packages/runner/test/storage-synced-authorization.test.ts
@@ -1,15 +1,17 @@
 import { assert, assertEquals } from "@std/assert";
+
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import type { MemorySpace, Signer, URI } from "@commonfabric/memory/interface";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
-import * as MemoryV2Client from "@commonfabric/memory/v2/client";
-import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import {
   decodeMemoryBoundary,
   encodeMemoryBoundary,
   getMemoryProtocolFlags,
   MEMORY_PROTOCOL,
 } from "@commonfabric/memory/v2";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+
 import type { SessionFactory } from "../src/storage/v2.ts";
 import {
   TEST_MEMORY_SERVER_AUTH,

--- a/packages/runner/test/storage.bench.ts
+++ b/packages/runner/test/storage.bench.ts
@@ -1,12 +1,14 @@
 /**
  * Storage layer benchmarks - measuring raw transaction read/write performance
  */
+
+import type { FabricValue } from "@commonfabric/api";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { deepEqual } from "@commonfabric/utils/deep-equal";
+
 import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import { deepEqual } from "@commonfabric/utils/deep-equal";
-import type { FabricValue } from "@commonfabric/api";
 import {
   largeStringA,
   largeStringB,

--- a/packages/runner/test/stream-data-outbox.test.ts
+++ b/packages/runner/test/stream-data-outbox.test.ts
@@ -1,19 +1,21 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { hashOf } from "@commonfabric/data-model/value-hash";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { Runtime } from "../src/runtime.ts";
+
 import { createBuilder } from "../src/builder/factory.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { setPatternEnvironment } from "../src/env.ts";
 import { streamData as rawStreamData } from "../src/builtins/stream-data.ts";
+import { createCell } from "../src/cell.ts";
+import { createFrozenRequestSnapshot } from "../src/cfc/request-snapshot.ts";
+import { setPatternEnvironment } from "../src/env.ts";
+import { Runtime } from "../src/runtime.ts";
 import {
   ExtendedStorageTransaction,
   TransactionWrapper,
 } from "../src/storage/extended-storage-transaction.ts";
-import { hashOf } from "@commonfabric/data-model/value-hash";
-import { createFrozenRequestSnapshot } from "../src/cfc/request-snapshot.ts";
-import { createCell } from "../src/cell.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 const signer = await Identity.fromPassphrase("test stream-data outbox");
 const space = signer.did();

--- a/packages/runner/test/sync-load-failure-surfacing.test.ts
+++ b/packages/runner/test/sync-load-failure-surfacing.test.ts
@@ -1,17 +1,19 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
+import { getLoggerCountsBreakdown } from "@commonfabric/utils/logger";
+
+import { entityIdFrom } from "../src/create-ref.ts";
+import { dataUriFromValueWithResolvedLinks } from "../src/data-uri.ts";
+import { Runtime } from "../src/runtime.ts";
+import { LINK_V1_TAG } from "../src/sigil-types.ts";
+import type { MemorySpace } from "../src/storage/interface.ts";
 import {
   type Options,
   type SessionFactory,
   StorageManager,
 } from "../src/storage/v2.ts";
-import { Runtime } from "../src/runtime.ts";
-import { entityIdFrom } from "../src/create-ref.ts";
-import { getLoggerCountsBreakdown } from "@commonfabric/utils/logger";
-import { dataUriFromValueWithResolvedLinks } from "../src/data-uri.ts";
-import { LINK_V1_TAG } from "../src/sigil-types.ts";
-import type { MemorySpace } from "../src/storage/interface.ts";
 
 // The silent-collapse pin for sync-layer failures.
 //

--- a/packages/runner/test/transaction-inspection.test.ts
+++ b/packages/runner/test/transaction-inspection.test.ts
@@ -1,26 +1,28 @@
 import { assertEquals, assertExists, assertThrows } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
+
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import type { NormalizedFullLink } from "../src/link-utils.ts";
 import { txToReactivityLog } from "../src/scheduler.ts";
+import {
+  ExtendedStorageTransaction,
+  TransactionWrapper,
+} from "../src/storage/extended-storage-transaction.ts";
 import type {
   IExtendedStorageTransaction,
   ITransactionJournal,
   ITransactionWriteRequest,
   TransactionReactivityLog,
 } from "../src/storage/interface.ts";
-import {
-  ExtendedStorageTransaction,
-  TransactionWrapper,
-} from "../src/storage/extended-storage-transaction.ts";
 import { reactivityLogFromActivities } from "../src/storage/reactivity-log.ts";
 import {
   getTransactionReadActivities,
   getTransactionWriteAttempts,
   getTransactionWriteDetails,
 } from "../src/storage/transaction-inspection.ts";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
-import type { NormalizedFullLink } from "../src/link-utils.ts";
 
 const signer = await Identity.fromPassphrase("transaction-inspection");
 const space = signer.did();

--- a/packages/runner/test/traverse-anyof.bench.ts
+++ b/packages/runner/test/traverse-anyof.bench.ts
@@ -1,20 +1,21 @@
-import { hashOf } from "@commonfabric/data-model/value-hash";
 import type { SchemaPathSelector } from "@commonfabric/api";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { hashOf } from "@commonfabric/data-model/value-hash";
 import type {
   Entity,
   Revision,
   State,
   URI,
 } from "@commonfabric/memory/interface";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+
+import type { JSONSchema, JSONSchemaTypes } from "../src/builder/types.ts";
+import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
+import { StoreObjectManager } from "../src/storage/query.ts";
 import {
   IMemorySpaceValueAttestation,
+  ManagedStorageTransaction,
   SchemaObjectTraverser,
 } from "../src/traverse.ts";
-import { StoreObjectManager } from "../src/storage/query.ts";
-import { ManagedStorageTransaction } from "../src/traverse.ts";
-import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
-import type { JSONSchema, JSONSchemaTypes } from "../src/builder/types.ts";
 
 function getTraverser(
   store: Map<string, Revision<State>>,

--- a/packages/runner/test/traverse-cycle.test.ts
+++ b/packages/runner/test/traverse-cycle.test.ts
@@ -1,25 +1,26 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { hashOf } from "@commonfabric/data-model/value-hash";
+import { describe, it } from "@std/testing/bdd";
+
 import type { SchemaPathSelector } from "@commonfabric/api";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { hashOf } from "@commonfabric/data-model/value-hash";
 import type {
   Entity,
   Revision,
   State,
   URI,
 } from "@commonfabric/memory/interface";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 
+import type { JSONSchema } from "../src/builder/types.ts";
+import { LINK_V1_TAG } from "../src/sigil-types.ts";
+import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
+import { StoreObjectManager } from "../src/storage/query.ts";
 import {
   CompoundCycleTracker,
+  IMemorySpaceValueAttestation,
   ManagedStorageTransaction,
   SchemaObjectTraverser,
 } from "../src/traverse.ts";
-import { StoreObjectManager } from "../src/storage/query.ts";
-import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
-import type { JSONSchema } from "../src/builder/types.ts";
-import { LINK_V1_TAG } from "../src/sigil-types.ts";
-import { IMemorySpaceValueAttestation } from "../src/traverse.ts";
 
 // These tests pin down the cycle-detection fallback in the traverser. When a
 // value is reachable from itself, the traversal of a property eventually visits

--- a/packages/runner/test/traverse-replay/replay.ts
+++ b/packages/runner/test/traverse-replay/replay.ts
@@ -12,10 +12,24 @@
  * - **metrics**: aggregated traverser counters. These are *not* asserted —
  *   they exist so benchmarks can attribute wins (e.g. anyOfBranches -80%).
  */
-import { hashStringOf } from "@commonfabric/data-model/value-hash";
+
+import type { SchemaPathSelector } from "@commonfabric/api";
+import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
-import type { SchemaPathSelector } from "@commonfabric/api";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
+
+import { ExtendedStorageTransaction } from "../../src/storage/extended-storage-transaction.ts";
+import type {
+  IExtendedStorageTransaction,
+  IMemorySpaceAddress,
+  IReadOptions,
+} from "../../src/storage/interface.ts";
+import { load as loadDataURI } from "../../src/storage/transaction/attestation.ts";
+import {
+  fixtureDocKey,
+  type TraverseFixture,
+} from "../../src/traverse-recorder.ts";
 import {
   type BaseMemoryAddress,
   CompoundCycleTracker,
@@ -29,18 +43,6 @@ import {
   SchemaObjectTraverser,
   type TraversalContext,
 } from "../../src/traverse.ts";
-import { ExtendedStorageTransaction } from "../../src/storage/extended-storage-transaction.ts";
-import { load as loadDataURI } from "../../src/storage/transaction/attestation.ts";
-import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
-import type {
-  IExtendedStorageTransaction,
-  IMemorySpaceAddress,
-  IReadOptions,
-} from "../../src/storage/interface.ts";
-import {
-  fixtureDocKey,
-  type TraverseFixture,
-} from "../../src/traverse-recorder.ts";
 import { readMaybeGzippedText } from "./gzip.ts";
 
 export type ReplayInvocationOracle = {

--- a/packages/runner/test/traverse-required-links.test.ts
+++ b/packages/runner/test/traverse-required-links.test.ts
@@ -7,29 +7,31 @@
  * in their schema by making the property optional or accepting `undefined`.
  */
 
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import {
-  getLogger,
-  getLoggerCountsBreakdown,
-} from "@commonfabric/utils/logger";
-import { hashOf } from "@commonfabric/data-model/value-hash";
+import { describe, it } from "@std/testing/bdd";
+
 import type { SchemaPathSelector } from "@commonfabric/api";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { hashOf } from "@commonfabric/data-model/value-hash";
 import type {
   Entity,
   Revision,
   State,
   URI,
 } from "@commonfabric/memory/interface";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import {
+  getLogger,
+  getLoggerCountsBreakdown,
+} from "@commonfabric/utils/logger";
+
+import type { JSONSchema } from "../src/builder/types.ts";
+import { LINK_V1_TAG } from "../src/sigil-types.ts";
+import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
+import { StoreObjectManager } from "../src/storage/query.ts";
 import {
   ManagedStorageTransaction,
   SchemaObjectTraverser,
 } from "../src/traverse.ts";
-import { StoreObjectManager } from "../src/storage/query.ts";
-import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
-import type { JSONSchema } from "../src/builder/types.ts";
-import { LINK_V1_TAG } from "../src/sigil-types.ts";
 
 const TYPE = "application/json" as const;
 const SPACE = "did:null:null";

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -1,17 +1,23 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { hashOf } from "@commonfabric/data-model/value-hash";
+import { describe, it } from "@std/testing/bdd";
+
 import type { SchemaPathSelector } from "@commonfabric/api";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { isInternedSchema } from "@commonfabric/data-model/schema-hash";
+import { internPathSelector } from "@commonfabric/data-model/schema-utils";
+import { hashOf } from "@commonfabric/data-model/value-hash";
 import type {
   Entity,
   Revision,
   State,
   URI,
 } from "@commonfabric/memory/interface";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
-import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import { isInternedSchema } from "@commonfabric/data-model/schema-hash";
-import { internPathSelector } from "@commonfabric/data-model/schema-utils";
+
+import type { JSONSchema } from "../src/builder/types.ts";
+import { LINK_V1_TAG } from "../src/sigil-types.ts";
+import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
+import { StoreObjectManager } from "../src/storage/query.ts";
 import {
   canBranchMatch,
   combineSchema,
@@ -19,6 +25,7 @@ import {
   createDefaultTraversalContext,
   createTraversalContext,
   getAtPath,
+  IMemorySpaceValueAttestation,
   ManagedStorageTransaction,
   MapSet,
   MapSetStringToPathSelectors,
@@ -30,12 +37,6 @@ import {
   setTraverseDiagnostics,
   type TraversalContext,
 } from "../src/traverse.ts";
-import { StoreObjectManager } from "../src/storage/query.ts";
-import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
-import type { JSONSchema } from "../src/builder/types.ts";
-import { LINK_V1_TAG } from "../src/sigil-types.ts";
-
-import { IMemorySpaceValueAttestation } from "../src/traverse.ts";
 
 // Helper function to get the SchemaObjectTraverser backed by a store map
 function getTraverser(

--- a/packages/runner/test/v2-watch-non-schema-selectors.test.ts
+++ b/packages/runner/test/v2-watch-non-schema-selectors.test.ts
@@ -8,12 +8,14 @@
  * nothing.
  */
 
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
 import type { JSONSchema, SchemaPathSelector } from "@commonfabric/api";
-import { watchIdForEntry } from "../src/storage/v2.ts";
-import { normalizeSyncSelector } from "../src/storage/v2-watch.ts";
 import type { MIME, URI } from "@commonfabric/memory/interface";
+
+import { normalizeSyncSelector } from "../src/storage/v2-watch.ts";
+import { watchIdForEntry } from "../src/storage/v2.ts";
 
 const MALFORMED: [label: string, schema: JSONSchema][] = [
   ["additionalProperties holds null", {


### PR DESCRIPTION
Last of the series applying the Development Guide's `Imports` rules (#5852).
I (agent working on behalf of @danfuzz) am splitting along package lines; this
completes `runner`, and with it the sweep.

Independent of the other open PRs — different files, all branched from `main`.

## What changed

148 files under `packages/runner/test`, import blocks only: statements merged
where a module was named twice, grouped standard library / external / internal
with a blank line between, each package's imports collated into one contiguous
run, and each run sorted.

One file, `generate-object-tools.test.ts`, had its imports interleaved with a
`const` carrying a four-line explanatory comment, so its imports are lifted
above that statement. Import declarations hoist and evaluate — in source order
among themselves — before any statement of the module body, so their position
relative to it is not observable. The constant and its comment are untouched.

## Verification

- **148 files, zero binding differences**, where a binding is `(resolved module,
  type-ness, local name, import attributes)`. That comparison flags a
  deliberately dropped named import, a repointed specifier, and a dropped import
  attribute, so its silence is a measurement rather than an absence of signal.
- Audited the branch for both spacing defects: **0** glued file comments, **0**
  blank lines between consecutive bare imports.
- `deno fmt --check`, `deno lint`, `deno task check`, and
  `deno task check-no-waitfor` all green.
- `runner`'s suite: **1206 passed, 0 failed** — the same count as before the
  change, which is what a pure reordering should leave.

## The series, complete

| PR | Scope | Files |
|---|---|---:|
| #5854 | 15 small packages, plus the bare-import rule | 57 |
| #5855 | `piece`, `runtime-client`, `html`, `cf-harness` | 51 |
| #5856 | `memory`, `shell`, `ts-transformers` | 70 |
| #5857 | `cli`, `toolshed` | 88 |
| #5858 | `ui` | 62 |
| #5859 | `runner/src`, `runner/integration` | 94 |
| this | `runner/test` | 148 |

570 files. Once these land, every package in the tree reads zero against the
four required `Imports` rules.

Two exclusions hold throughout. **`packages/patterns`** (41 files): pattern
source is compiled and content-addressed, so an edit that looks inert can move a
contract and trip `pattern-compat`. **`packages/generated-patterns`**: generated.
Also untouched are the 1,359 files that need nothing but sorting, which is the
suggested rule rather than a required one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

