### PR TITLE
docs(development): the import rules apply per bare-import segment

### DIFF
--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -50,14 +50,17 @@ about one aspect of the runtime, are indexed in
   what it does. A polyfill, or a setup module that installs globals, running
   after the code relying on it has already run is a different program, and
   nothing type-checks that. So grouping, collation and sorting all yield to this
-  one: leave a bare import where it is, and move no other import across it. A
-  bare import of a module the file also imports by name is a separate matter,
-  and which way it goes turns on the kind of that named import. Against a value
-  import the bare one adds nothing, since the value import evaluates the module,
-  side effects included: drop it, and put what it was there for in a comment on
-  the surviving statement. Against nothing but an `import type`, it stays — a
-  type-only import is erased and evaluates nothing, so the bare import is the
-  only thing producing the effect.
+  one: leave a bare import where it is, and move no other import across it. They
+  then apply to each run of imports between bare ones rather than to the file as
+  a whole — a file with a bare import in the middle has two groupings, two
+  collations and two sorts, and a checker that reads it as one will call correct
+  code wrong. A bare import of a module the file also imports by name is a
+  separate matter, and which way it goes turns on the kind of that named import.
+  Against a value import the bare one adds nothing, since the value import
+  evaluates the module, side effects included: drop it, and put what it was
+  there for in a comment on the surviving statement. Against nothing but an
+  `import type`, it stays — a type-only import is erased and evaluates nothing,
+  so the bare import is the only thing producing the effect.
 - Import a given module in exactly one or two statements. Two shapes are
   allowed:
   - One unified statement, marking any type-only names inline:

--- a/packages/utils/src/zod-utils.ts
+++ b/packages/utils/src/zod-utils.ts
@@ -27,6 +27,7 @@
  * export type UserCreatePayload = z.infer<typeof UserCreateSchema>
  * ```
  */
+
 import * as z from "zod";
 
 /**


### PR DESCRIPTION
Opens a series on the file-header blank line, and carries a clarification the
just-finished import series turned up. I (agent working on behalf of @danfuzz)
am splitting along package lines as usual, starting with the guinea-pig set.

## The clarification: the import rules are per-segment

`DEVELOPMENT.md` § Imports says grouping, collation and sorting all yield to a
bare `import "x";` — it never moves, and nothing may cross it. What it did not
say is the consequence: **those rules then apply to each run of imports between
bare ones, not to the file as a whole.** A file with a bare import in the middle
has two groupings, two collations and two sorts.

That is not pedantry. On `main` after the import series, a whole-file reading of
the four required rules reports **17 files** — of which **15 are exactly this
shape and correct**:

| File | Bare imports | Segments |
|---|---:|---:|
| `shell/src/index.ts` | 6 | 7 |
| `ui/…/cf-chat-message.ts` | 4 | 5 |
| `runner/test/schema-to-ts.test.ts` | 2 | 3 |
| …11 more | 1–2 | 2–3 |

(The other 2 are deliberate: an import kept beside the export it feeds in
`ts-transformers/src/ast/utils.ts:397`, and a fixture directory excluded from
the sweep.)

A checker built on the whole-file reading fails those 15 correct files on its
first run and then gets switched off. Since a gate is the natural end state for
this family of rules, the guide should say what a gate has to compute.

## The series: file-header blank line

`code-comment-style.md` § File headers already requires it:

> A file gets a doc comment of its own, and it goes at the very top … with
> nothing between it and them but a blank line. … The blank line is
> load-bearing …: it is what keeps the header from being read as the doc
> comment of the first declaration under it.

Nothing enforces it, and **506 files** in the tree are missing it. Excluding
`packages/patterns` (216) and `packages/generated-patterns` (1), which stay out
of mechanical sweeps because pattern source is compiled and content-addressed,
that leaves **289 files** in scope:

| Package | Files | | Package | Files |
|---|---:|---|---|---:|
| `cli` | 108 | | `memory` | 5 |
| `ts-transformers` | 57 | | `fuse` | 4 |
| `runner` | 39 | | `schema-generator` | 4 |
| `ui` | 32 | | `tasks/` | 4 |
| `dashboard` | 22 | | 8 packages with 1 each | 8 |
| `toolshed` | 6 | | | |

## This PR: the guinea pigs

Of `leb128`, `pure-json`, `content-hash`, `utils` and `data-model`, only `utils`
had one — `src/zod-utils.ts`, whose header ran straight into
`import * as z from "zod";`. The other four were already conformant across all
184 of their files, so this PR is one blank line plus the doc change.

## Verification

- Re-scanned the guinea-pig set: **184 files, 0 glued**.
- `deno fmt --check`, `deno lint`, `deno task check-docs` green.
- `utils` suite: 99 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

