### PR TITLE
fix(data-model): hold codec type tags to the `UpperCamelCase` the spec states

### DIFF
--- a/packages/data-model/src/codec-common/isCodecTypeTag.ts
+++ b/packages/data-model/src/codec-common/isCodecTypeTag.ts
@@ -1,9 +1,11 @@
 /**
  * Syntax of a codec type tag: a type name, `@`, and a version number. The name
- * starts with a letter and continues with letters and digits; the version is a
- * positive integer with no leading zero.
+ * is `UpperCamelCase` -- an uppercase letter followed by letters and digits --
+ * and the version is a positive integer with no leading zero. Section 2 of
+ * `3-json-encoding.md` is where that convention is written down; this is the
+ * check that holds every format to it.
  */
-const CODEC_TYPE_TAG_SYNTAX = /^[A-Za-z][A-Za-z0-9]*@[1-9][0-9]*$/;
+const CODEC_TYPE_TAG_SYNTAX = /^[A-Z][A-Za-z0-9]*@[1-9][0-9]*$/;
 
 /**
  * Indicates whether `value` is a string whose syntax is that of a codec type

--- a/packages/data-model/test/codec-common/CodecRegistry.test.ts
+++ b/packages/data-model/test/codec-common/CodecRegistry.test.ts
@@ -87,9 +87,9 @@ function buildRegistry(
   classSource: Constructor | undefined,
   example: FabricValue,
 ) {
-  const first = new TestCodec("first@1", undefined);
-  const handler = new TestCodec("handler@1", classSource, example);
-  const last = new TestCodec("last@1", undefined);
+  const first = new TestCodec("First@1", undefined);
+  const handler = new TestCodec("Handler@1", classSource, example);
+  const last = new TestCodec("Last@1", undefined);
   const registry = new CodecRegistry(TEST_FORMAT);
   registry.register(first);
   registry.register(handler);
@@ -140,7 +140,7 @@ const UNCLASSIFIABLE_CODEC: FabricCodec<string> = {
   },
 
   get recognizedTypeTag(): string | undefined {
-    return "unclassifiable@1";
+    return "Unclassifiable@1";
   },
 
   canEncode(_value: FabricValue): boolean {
@@ -148,7 +148,7 @@ const UNCLASSIFIABLE_CODEC: FabricCodec<string> = {
   },
 
   tagForValue(_value: FabricValue): string {
-    return "unclassifiable@1";
+    return "Unclassifiable@1";
   },
 
   encode(_value: FabricValue): string {
@@ -180,16 +180,16 @@ describe("CodecRegistry", () => {
     // with the kind is pinned where a walker reads it.
 
     it("reaches a primitive-registered codec by value and by tag", () => {
-      const codec = new TestTerminalCodec("termPrim@1");
+      const codec = new TestTerminalCodec("TermPrim@1");
       const registry = new CodecRegistry(TEST_FORMAT);
       registry.registerPrimitive("bigint", codec);
 
       expect(registry.codecFromValue(914n)).toBe(codec);
-      expect(registry.codecFromTag("termPrim@1")).toBe(codec);
+      expect(registry.codecFromTag("TermPrim@1")).toBe(codec);
     });
 
     it("finds a class's codec when one is passed to `extend()`", () => {
-      const codec = new TestTerminalCodec("viaExtend@1", FabricRegExp);
+      const codec = new TestTerminalCodec("ViaExtend@1", FabricRegExp);
       class Extended {
         static get [TEST_CODEC](): TerminalCodec<string> {
           return codec;
@@ -198,19 +198,19 @@ describe("CodecRegistry", () => {
 
       const registry = new CodecRegistry(TEST_FORMAT).extend([Extended]);
 
-      expect(registry.codecFromTag("viaExtend@1")).toBe(codec);
+      expect(registry.codecFromTag("ViaExtend@1")).toBe(codec);
     });
 
     it("registers codecs of either kind through `extend()`", () => {
-      const nonterminal = new TestCodec("nonterm@1", FabricRegExp);
-      const terminal = new TestTerminalCodec("term@1");
+      const nonterminal = new TestCodec("Nonterm@1", FabricRegExp);
+      const terminal = new TestTerminalCodec("Term@1");
       const registry = new CodecRegistry(TEST_FORMAT).extend(
         nonterminal,
         terminal,
       );
 
-      expect(registry.codecFromTag("nonterm@1")).toBe(nonterminal);
-      expect(registry.codecFromTag("term@1")).toBe(terminal);
+      expect(registry.codecFromTag("Nonterm@1")).toBe(nonterminal);
+      expect(registry.codecFromTag("Term@1")).toBe(terminal);
     });
 
     it("throws given a codec whose recognized tag is empty", () => {
@@ -294,7 +294,7 @@ describe("CodecRegistry", () => {
 
   describe("registerClass()", () => {
     it("registers the codec bound under the format's own symbol", () => {
-      const codec = new TestTerminalCodec("fromFormat@1", FabricRegExp);
+      const codec = new TestTerminalCodec("FromFormat@1", FabricRegExp);
       class Formatted {
         static get [TEST_CODEC](): TerminalCodec<string> {
           return codec;
@@ -304,11 +304,11 @@ describe("CodecRegistry", () => {
 
       registry.registerClass(Formatted);
 
-      expect(registry.codecFromTag("fromFormat@1")).toBe(codec);
+      expect(registry.codecFromTag("FromFormat@1")).toBe(codec);
     });
 
     it("registers a class's `[CODEC]` when it has one", () => {
-      const codec = new TestCodec("fromCodec@1", FabricRegExp);
+      const codec = new TestCodec("FromCodec@1", FabricRegExp);
       class Neutral {
         static get [CODEC](): NonterminalCodec {
           return codec;
@@ -318,14 +318,14 @@ describe("CodecRegistry", () => {
 
       registry.registerClass(Neutral);
 
-      expect(registry.codecFromTag("fromCodec@1")).toBe(codec);
+      expect(registry.codecFromTag("FromCodec@1")).toBe(codec);
     });
 
     it("prefers `[CODEC]` over the format's symbol when a class binds both", () => {
       // The format-neutral codec is the one that serves every format, so it
       // wins wherever a class offers a choice.
-      const neutral = new TestCodec("neutral@1", FabricRegExp);
-      const formatted = new TestTerminalCodec("formatted@1", FabricRegExp);
+      const neutral = new TestCodec("Neutral@1", FabricRegExp);
+      const formatted = new TestTerminalCodec("Formatted@1", FabricRegExp);
       class Both {
         static get [CODEC](): NonterminalCodec {
           return neutral;
@@ -338,8 +338,8 @@ describe("CodecRegistry", () => {
 
       registry.registerClass(Both);
 
-      expect(registry.codecFromTag("neutral@1")).toBe(neutral);
-      expect(registry.codecFromTag("formatted@1")).toBeUndefined();
+      expect(registry.codecFromTag("Neutral@1")).toBe(neutral);
+      expect(registry.codecFromTag("Formatted@1")).toBeUndefined();
     });
 
     it("throws given a class binding neither symbol", () => {
@@ -355,7 +355,7 @@ describe("CodecRegistry", () => {
       // Two formats' symbols on one class is the arrangement this exists to
       // serve; a registry reads only its own.
       const other: unique symbol = Symbol("other.codec");
-      const codec = new TestTerminalCodec("other@1", FabricRegExp);
+      const codec = new TestTerminalCodec("Other@1", FabricRegExp);
       class OtherFormatOnly {
         static get [other](): TerminalCodec<string> {
           return codec;
@@ -485,44 +485,44 @@ describe("CodecRegistry", () => {
 
     it("carries over every kind of registration the base holds", () => {
       const base = new CodecRegistry(TEST_FORMAT);
-      const codec = new TestCodec("carried@1", undefined);
-      const primitive = new TestCodec("prim@1", undefined);
+      const codec = new TestCodec("Carried@1", undefined);
+      const primitive = new TestCodec("Prim@1", undefined);
       base.register(codec);
       base.registerPrimitive("bigint", primitive);
       base.registerSelfRep("string");
 
       const extended = base.extend();
 
-      expect(extended.codecFromTag("carried@1")).toBe(codec);
-      expect(extended.codecFromTag("prim@1")).toBe(primitive);
+      expect(extended.codecFromTag("Carried@1")).toBe(codec);
+      expect(extended.codecFromTag("Prim@1")).toBe(primitive);
       expect(extended.codecFromValue("florp")).toBe(SELF_REP);
     });
 
     it("registers a codec given on its own", () => {
-      const added = new TestCodec("added@1", undefined);
+      const added = new TestCodec("Added@1", undefined);
       const extended = new CodecRegistry(TEST_FORMAT).extend(added);
 
-      expect(extended.codecFromTag("added@1")).toBe(added);
+      expect(extended.codecFromTag("Added@1")).toBe(added);
     });
 
     it("registers codecs given individually and in lists, in any mix", () => {
-      const loose = new TestCodec("loose@1", undefined);
-      const listed = new TestCodec("listed@1", undefined);
-      const alsoListed = new TestCodec("alsoListed@1", undefined);
+      const loose = new TestCodec("Loose@1", undefined);
+      const listed = new TestCodec("Listed@1", undefined);
+      const alsoListed = new TestCodec("AlsoListed@1", undefined);
 
       const extended = new CodecRegistry(TEST_FORMAT)
         .extend(loose, [listed, alsoListed]);
 
-      expect(extended.codecFromTag("loose@1")).toBe(loose);
-      expect(extended.codecFromTag("listed@1")).toBe(listed);
-      expect(extended.codecFromTag("alsoListed@1")).toBe(alsoListed);
+      expect(extended.codecFromTag("Loose@1")).toBe(loose);
+      expect(extended.codecFromTag("Listed@1")).toBe(listed);
+      expect(extended.codecFromTag("AlsoListed@1")).toBe(alsoListed);
     });
 
     it("leaves the base without the added registrations", () => {
       const base = new CodecRegistry(TEST_FORMAT);
-      base.extend(new TestCodec("added@1", undefined));
+      base.extend(new TestCodec("Added@1", undefined));
 
-      expect(base.codecFromTag("added@1")).toBe(undefined);
+      expect(base.codecFromTag("Added@1")).toBe(undefined);
     });
   });
 
@@ -531,14 +531,14 @@ describe("CodecRegistry", () => {
     // has to refuse on its own; these cases pin that each one does.
     it("`register()` throws", () => {
       const registry = Object.freeze(new CodecRegistry(TEST_FORMAT));
-      expect(() => registry.register(new TestCodec("nope@1", undefined)))
+      expect(() => registry.register(new TestCodec("Nope@1", undefined)))
         .toThrow("Cannot modify frozen `CodecRegistry`");
     });
 
     it("`registerPrimitive()` throws", () => {
       const registry = Object.freeze(new CodecRegistry(TEST_FORMAT));
       expect(() =>
-        registry.registerPrimitive("bigint", new TestCodec("nope@1", undefined))
+        registry.registerPrimitive("bigint", new TestCodec("Nope@1", undefined))
       ).toThrow("Cannot modify frozen `CodecRegistry`");
     });
 
@@ -550,11 +550,11 @@ describe("CodecRegistry", () => {
 
     it("still returns a codec for a registered tag", () => {
       const base = new CodecRegistry(TEST_FORMAT);
-      const codec = new TestCodec("readable@1", undefined);
+      const codec = new TestCodec("Readable@1", undefined);
       base.register(codec);
       Object.freeze(base);
 
-      expect(base.codecFromTag("readable@1")).toBe(codec);
+      expect(base.codecFromTag("Readable@1")).toBe(codec);
     });
   });
 

--- a/packages/data-model/test/codec-common/isCodecTypeTag.test.ts
+++ b/packages/data-model/test/codec-common/isCodecTypeTag.test.ts
@@ -52,6 +52,16 @@ describe("isCodecTypeTag", () => {
     expect(isCodecTypeTag("/Bytes@1")).toBe(false);
   });
 
+  it("returns `false` for a name that does not start uppercase", () => {
+    // `UpperCamelCase` is the convention Section 2 of `3-json-encoding.md`
+    // states, and this is what holds every format to it. The case decides
+    // whether an unclaimed tag round-trips as an `UnknownValue` or is refused
+    // as a malformation, so a reader cannot be left to infer it.
+    expect(isCodecTypeTag("bytes@1")).toBe(false);
+    expect(isCodecTypeTag("lowerCamel@1")).toBe(false);
+    expect(isCodecTypeTag("link@1")).toBe(false);
+  });
+
   it("returns `false` for a tag padded with whitespace or a newline", () => {
     // The syntax is anchored at both ends and is not multiline, so padding a
     // tag does not make the string one. The newline pair is the only case in

--- a/packages/data-model/test/valueEquals.test.ts
+++ b/packages/data-model/test/valueEquals.test.ts
@@ -247,7 +247,7 @@ describe("valueEqual()", () => {
       it("short-circuits to unequal without hashing", () => {
         // A fresh `UnknownValue` is not auto-frozen, so the pair skips the
         // both-deep-frozen early hash and reaches the constructor check.
-        const u = new UnknownValue("tag@1", 1);
+        const u = new UnknownValue("Tag@1", 1);
         const fb = new FabricBytes(new Uint8Array([1]));
         expect(valueEqual(u, fb)).toBe(false);
         expect(valueEqual(fb, u)).toBe(false);

--- a/packages/runner/test/data-uri.test.ts
+++ b/packages/runner/test/data-uri.test.ts
@@ -357,12 +357,12 @@ describe("data-uri", () => {
     // behavior (see the `TODO` in the walk) coincide, so this pins only the
     // codec round-trip, not the pass-through itself.
     it("represents a link-free `FabricInstance` via its codec", () => {
-      const inst = new UnknownValue("zzz@1", { a: 1 });
+      const inst = new UnknownValue("Zzz@1", { a: 1 });
       const parsed = valueFromDataUri(
         dataUriFromValueWithResolvedLinks({ inst }),
       );
       expect(parsed.inst).toBeInstanceOf(UnknownValue);
-      expect(parsed.inst.wireTypeTag).toBe("zzz@1");
+      expect(parsed.inst.wireTypeTag).toBe("Zzz@1");
       expect(parsed.inst.state).toEqual({ a: 1 });
     });
 

--- a/packages/runner/test/fabric-special-object.test.ts
+++ b/packages/runner/test/fabric-special-object.test.ts
@@ -61,7 +61,7 @@ describe("fabric-special-object", () => {
         thrownBy("in a pattern binding", value).message;
 
       expect(named(new FabricMap(new Map()))).toContain("`FabricMap`");
-      expect(named(new UnknownValue("zzz@1", { a: 1 }))).toContain(
+      expect(named(new UnknownValue("Zzz@1", { a: 1 }))).toContain(
         "`UnknownValue`",
       );
     });


### PR DESCRIPTION
Section 2 of `3-json-encoding.md` says a codec type tag's type name is
`UpperCamelCase`. `isCodecTypeTag()` accepted any leading letter. I (agent
working on behalf of @danfuzz) am sending the correction on its own because it
is general — it holds every wire format to the written rule, and it reaches
another package.

**This is a behavior change, not a no-op.** It narrows what counts as a
syntactic tag, and that boundary is load-bearing: a tag that is syntactically
valid but claimed by no codec becomes an `UnknownValue` and round-trips, while
one that is not a tag at all is a malformation. So `foo@1` was previously
preserved through a round trip here and would be refused by any implementation
built from the spec. The two now agree.

## What `link@1` is, and why it is untouched

`"link@1"` appears in `packages/data-model/src/`, in `FabricLink.ts` and
`cell-rep.ts`, and looks at a glance like a shipped lowercase tag — which would
have made this a compatibility break against stored data.

It is not a codec type tag. It is the key inside the legacy
`{ "/": { "link@1": … } }` link envelope, a structural form that never passes
through this predicate. `FabricLink`'s actual codec tag is `Link@1`. Left
exactly as it is, and the new test pins `isCodecTypeTag("link@1") === false` so
the distinction stays visible.

## The fallout: 44 test fixtures

Tightening the check turned up 44 fixture tags across two packages that no
encoder here would ever emit — `nope@1`, `term@1`, `zzz@1` and so on. They are
capitalized rather than the rule bent around them.

Nothing in `src/` anywhere in the workspace uses a lowercase-initial codec tag;
I swept for the shape and for the two constructors that validate one
(`UnknownValue`, `ProblematicValue`).

## Verification

Because this changes a primitive shared by every format, the check is
cross-package rather than package-local:

| package | result |
|---|---|
| `data-model` | 54 passed |
| `runner` | 1206 passed |
| `cli` | 174 passed |
| `memory` | 499 passed |
| `state-inspector` | 102 passed |
| `schema-generator` | 56 passed |

`runner` is the one that mattered: two of its tests build
`new UnknownValue("zzz@1", …)`, whose constructor validates the tag, and both
failed before the fixtures were fixed.

`fmt --check`, `lint`, `check`, `check-docs`, `check-skill-facts` and
`check-conflict-markers` are all green.

## One thing the spec still does not say

Neither the prose nor this change settles the version's grammar. The
implementation refuses `Foo@0` and `Foo@01` — a positive integer with no
leading zero — which follows from "natural number, starting at 1" but is not
stated as a rule anyone could implement against. Left alone here; worth a
sentence in the spec someday.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

