### PR TITLE
docs(cli): separate the file header from the first import

### DIFF
--- a/packages/cli/integration/pattern/tracker.tsx
+++ b/packages/cli/integration/pattern/tracker.tsx
@@ -15,6 +15,7 @@
  * `children`, which is what makes an unshaped read of `items` expand the whole
  * tree — the cost that shaped reads exist to bound.
  */
+
 import {
   action,
   type Default,

--- a/packages/cli/integration/pattern/verb-results.tsx
+++ b/packages/cli/integration/pattern/verb-results.tsx
@@ -17,6 +17,7 @@
  * - Every mutating verb throws on an unusable payload, so the walkthrough can
  *   show that a refusal does not spend the caller's invocation id.
  */
+
 import {
   action,
   computed,

--- a/packages/cli/lib/view/actions.ts
+++ b/packages/cli/lib/view/actions.ts
@@ -3,6 +3,7 @@
  * navigation, and scroll clamping. Kept free of terminal I/O so the navigation
  * model can be unit-tested without a TTY.
  */
+
 import type { Document, StructureNode } from "./model.ts";
 import type { Match } from "./render.ts";
 import { cpLen } from "./ansi.ts";

--- a/packages/cli/lib/view/commitmsg.ts
+++ b/packages/cli/lib/view/commitmsg.ts
@@ -4,6 +4,7 @@
  * the `commit`/`Author`/`Date` header and before the diff. `cf view` lets the
  * message of the HEAD commit be edited in place; saving amends that commit.
  */
+
 import { basename, dirname, isAbsolute, join, relative } from "@std/path";
 import {
   decodeLanguageInput,

--- a/packages/cli/lib/view/diffedit.ts
+++ b/packages/cli/lib/view/diffedit.ts
@@ -10,6 +10,7 @@
  * edit makes the diff stop matching disk, which is exactly why it must not be
  * recomputed from the edited text.
  */
+
 import type { Document, Line, Span, ViewMode } from "./model.ts";
 import { cpLen } from "./ansi.ts";
 import {

--- a/packages/cli/lib/view/diffremap.ts
+++ b/packages/cli/lib/view/diffremap.ts
@@ -6,6 +6,7 @@
  * {@link StructureNode} tree any language produces — so the TypeScript and JSON
  * languages share it. Markdown, whose hunk navigation is heading-based, does not.
  */
+
 import type { Definition, StructureNode } from "./model.ts";
 import type { HunkStructureContext } from "./languages/language.ts";
 import { lineIndexOf } from "./lines.ts";

--- a/packages/cli/lib/view/display.ts
+++ b/packages/cli/lib/view/display.ts
@@ -18,6 +18,7 @@
  * carries the source column it stands for, so the renderer can map selection and
  * search ranges — stated in source columns — onto the cells it draws.
  */
+
 import type { Rgb, Style } from "./ansi.ts";
 import type { Line } from "./model.ts";
 import { spanStyle } from "./highlight.ts";

--- a/packages/cli/lib/view/editsource.ts
+++ b/packages/cli/lib/view/editsource.ts
@@ -9,6 +9,7 @@
  * displayed lines may be a rendered projection. The diff source (in
  * `diffedit.ts`) maps the single editable text back onto the files it touches.
  */
+
 import type { Document, Line, ViewMode } from "./model.ts";
 import type { DiffHunk, DiffModel } from "./diff.ts";
 import type { LineEndingProvenance } from "./editbuffer.ts";

--- a/packages/cli/lib/view/filegateway.ts
+++ b/packages/cli/lib/view/filegateway.ts
@@ -4,6 +4,7 @@
  * test injects a fake. Opening a file selects its language from raw bytes, then
  * yields an {@link EditableSource} plus the language-decoded buffer.
  */
+
 import { basename, dirname, join } from "@std/path";
 import { type EditableSource, fileSource } from "./editsource.ts";
 import {

--- a/packages/cli/lib/view/fold.ts
+++ b/packages/cli/lib/view/fold.ts
@@ -6,6 +6,7 @@
  * set of collapsed files into the per-file ranges and the collapsed line list
  * the session renders; the session owns the fold state and the key commands.
  */
+
 import type { Line, Span, TokenClass } from "./model.ts";
 import { parseDiff } from "./diff.ts";
 import { languageForFile } from "./languages/language.ts";

--- a/packages/cli/lib/view/highlight.ts
+++ b/packages/cli/lib/view/highlight.ts
@@ -7,6 +7,7 @@
  * `renderLinePlain` and the concatenated span text of `renderLineColored` are
  * byte-for-byte identical to the document line.
  */
+
 import { paint, type Style } from "./ansi.ts";
 import type { Line, Span } from "./model.ts";
 import { bracketStyle, dialogStyleFor, lineBg, styleFor } from "./theme.ts";

--- a/packages/cli/lib/view/languages/json/json.ts
+++ b/packages/cli/lib/view/languages/json/json.ts
@@ -11,6 +11,7 @@
  * trailing commas are colored, not rejected. Object keys become a navigation
  * tree, so `wasd`/Tab step through a document's structure.
  */
+
 import type {
   Definition,
   Document,

--- a/packages/cli/lib/view/languages/json/language.ts
+++ b/packages/cli/lib/view/languages/json/language.ts
@@ -7,6 +7,7 @@
  * tree of object keys, so its diff-hunk navigation reuses the generic {@link
  * remapStructure} the TypeScript language also uses.
  */
+
 import type { Language } from "../language.ts";
 import { utf8Decoder } from "../decoder.ts";
 import { remapStructure } from "../../diffremap.ts";

--- a/packages/cli/lib/view/languages/language.ts
+++ b/packages/cli/lib/view/languages/language.ts
@@ -16,6 +16,7 @@
  * does not depend on any concrete language at run time; only the selection
  * functions below pull the concrete languages in.
  */
+
 import type {
   Definition,
   Document,

--- a/packages/cli/lib/view/languages/markdown/language.ts
+++ b/packages/cli/lib/view/languages/markdown/language.ts
@@ -6,6 +6,7 @@
  * and its diff-hunk navigation is heading-based rather than the generic node
  * remap, so {@link hunkStructure} routes to {@link markdownHeadingNodes}.
  */
+
 import type { StructureNode } from "../../model.ts";
 import type { HunkStructureContext, Language } from "../language.ts";
 import { utf8Decoder } from "../decoder.ts";

--- a/packages/cli/lib/view/languages/plain-text/language.ts
+++ b/packages/cli/lib/view/languages/plain-text/language.ts
@@ -3,6 +3,7 @@
  * a filename or shebang. It remains last in the language registry and is the
  * registry's fallback.
  */
+
 import type { Language } from "../language.ts";
 import { utf8Decoder } from "../decoder.ts";
 import {

--- a/packages/cli/lib/view/languages/plain-text/plain-text.ts
+++ b/packages/cli/lib/view/languages/plain-text/plain-text.ts
@@ -3,6 +3,7 @@
  * Every non-empty line is one plain span. The document has no structure or
  * definitions.
  */
+
 import type { Document, Line } from "../../model.ts";
 import type { Highlighter } from "../language.ts";
 

--- a/packages/cli/lib/view/languages/python/language.ts
+++ b/packages/cli/lib/view/languages/python/language.ts
@@ -3,6 +3,7 @@
  * for direct files, diffs, and live edits. Python does not provide structure
  * navigation or a semantic layer.
  */
+
 import type { Language } from "../language.ts";
 import { utf8Decoder } from "../decoder.ts";
 import {

--- a/packages/cli/lib/view/languages/python/python.ts
+++ b/packages/cli/lib/view/languages/python/python.ts
@@ -8,6 +8,7 @@
  * determine the color of later lines. It does not execute Python or require a
  * Python installation.
  */
+
 import type { Document, Line, Span, TokenClass } from "../../model.ts";
 import { cpLen } from "../../ansi.ts";
 import { computeLineStarts, lineIndexOf } from "../../lines.ts";

--- a/packages/cli/lib/view/languages/typescript/language.ts
+++ b/packages/cli/lib/view/languages/typescript/language.ts
@@ -6,6 +6,7 @@
  * {@link ./semantics.ts}; this module only adapts them to the {@link Language}
  * contract.
  */
+
 import type { Language } from "../language.ts";
 import { utf8Decoder } from "../decoder.ts";
 import { remapStructure } from "../../diffremap.ts";

--- a/packages/cli/lib/view/languages/typescript/parse.ts
+++ b/packages/cli/lib/view/languages/typescript/parse.ts
@@ -15,6 +15,7 @@
  *      schemas, bindings) for navigation and folding.
  *   3. A name -> {@link Definition} index for go-to-definition peeks.
  */
+
 import ts from "typescript";
 import type {
   Definition,

--- a/packages/cli/lib/view/languages/typescript/vocab.ts
+++ b/packages/cli/lib/view/languages/typescript/vocab.ts
@@ -10,6 +10,7 @@
  * avoid pulling the heavy `ast/call-kind.ts` graph into the pager. A unit test
  * (`test/view/vocab.test.ts`) pins them against the transformer source.
  */
+
 import {
   COMMONFABRIC_BUILDER_EXPORT_NAMES,
   COMMONFABRIC_CALL_EXPORT_NAMES,

--- a/packages/cli/lib/view/languages/yaml/language.ts
+++ b/packages/cli/lib/view/languages/yaml/language.ts
@@ -3,6 +3,7 @@
  * files, diffs, and live edits. YAML does not provide structure navigation or
  * a semantic layer.
  */
+
 import type { Language } from "../language.ts";
 import { utf8Decoder } from "../decoder.ts";
 import {

--- a/packages/cli/lib/view/languages/yaml/yaml.ts
+++ b/packages/cli/lib/view/languages/yaml/yaml.ts
@@ -4,6 +4,7 @@
  * aliases, quoted strings, and block scalars. It accepts incomplete input so
  * files remain highlighted while they are being edited.
  */
+
 import type { Document, Line, Span, TokenClass } from "../../model.ts";
 import { cpLen } from "../../ansi.ts";
 import type { Highlighter } from "../language.ts";

--- a/packages/cli/lib/view/mod.ts
+++ b/packages/cli/lib/view/mod.ts
@@ -9,6 +9,7 @@
  * Other source uses filename and shebang metadata unless an explicit language
  * selects another language.
  */
+
 import { renderLineColored } from "./highlight.ts";
 import { runPager } from "./pager.ts";
 import type { Document, Line } from "./model.ts";

--- a/packages/cli/lib/view/pager.ts
+++ b/packages/cli/lib/view/pager.ts
@@ -9,6 +9,7 @@
  * PagerDeps} so the driver's control flow can be exercised without a real TTY;
  * {@link realPagerDeps} supplies the genuine Deno calls.
  */
+
 import { CSI, term } from "./ansi.ts";
 import type { Document } from "./model.ts";
 import { decodeKeys } from "./keys.ts";

--- a/packages/cli/lib/view/references.ts
+++ b/packages/cli/lib/view/references.ts
@@ -5,6 +5,7 @@
  * the definition index. Pure and dependency-free, so they unit-test easily and
  * power the Enter info card's "uses" and "depends on" sections.
  */
+
 import type { Document, StructureNode, TokenClass } from "./model.ts";
 
 /** Token classes that count as an identifier occurrence of a symbol. */

--- a/packages/cli/lib/view/render.ts
+++ b/packages/cli/lib/view/render.ts
@@ -9,6 +9,7 @@
  * then run-length encoded into ANSI. Horizontal scrolling, the line-number
  * gutter and the structure guide bar are all column maths over that grid.
  */
+
 import { diffContentRowCount, maxPagerTop, maxTop } from "./actions.ts";
 import { cpLen, paint, RESET, type Style } from "./ansi.ts";
 import type { Document, Line, StructureNode, ViewMode } from "./model.ts";

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -5,6 +5,7 @@
  * the renderer. `pager.ts` drives it against a real TTY, but it is fully
  * exercisable from tests by feeding keys and inspecting `view()`.
  */
+
 import type {
   Document,
   Line,

--- a/packages/cli/lib/view/theme.ts
+++ b/packages/cli/lib/view/theme.ts
@@ -8,6 +8,7 @@
  * round it out. The general aesthetic (double-line dialog frames, drop shadows,
  * green buttons) is unchanged — only the colors differ.
  */
+
 import { hex, type Rgb, type Style } from "./ansi.ts";
 import type { Line, TokenClass } from "./model.ts";
 

--- a/packages/cli/lib/view/wrap.ts
+++ b/packages/cli/lib/view/wrap.ts
@@ -2,6 +2,7 @@
  * Screen-row layout for wrapped pager content. A wrapped row identifies
  * the logical line it draws and the display-column offset where that row starts.
  */
+
 import {
   type DisplayCell,
   displayLine,

--- a/packages/cli/test/assert-diagnostics.test.ts
+++ b/packages/cli/test/assert-diagnostics.test.ts
@@ -4,6 +4,7 @@
  * An `assert(...)` assertion carries the operands recorded while it ran, so a
  * failure names them and their values.
  */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { resolve } from "@std/path";

--- a/packages/cli/test/assert-record.test.ts
+++ b/packages/cli/test/assert-record.test.ts
@@ -5,6 +5,7 @@
  * `computed()`, a null, an object missing a field — has to be told apart from a
  * genuine record at that point, and a failed record has to render its operands.
  */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { AssertRecord } from "@commonfabric/api";

--- a/packages/cli/test/fetch-mock.test.ts
+++ b/packages/cli/test/fetch-mock.test.ts
@@ -3,6 +3,7 @@
  * test's `fetchMocks` export, resolving request URLs, matching entries, building
  * mock Responses, and the injected `fetch` wrapper.
  */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {

--- a/packages/cli/test/fixtures/assert-diagnostics/call-shapes.test.tsx
+++ b/packages/cli/test/fixtures/assert-diagnostics/call-shapes.test.tsx
@@ -4,6 +4,7 @@
  * arguments say nothing. Run by assert-diagnostics.test.ts, which expects the
  * failures; it is not a pattern under test.
  */
+
 import { assert, cell, pattern, TESTS } from "commonfabric";
 
 function allPositive(...values: number[]): boolean {

--- a/packages/cli/test/fixtures/assert-diagnostics/control-flow.test.tsx
+++ b/packages/cli/test/fixtures/assert-diagnostics/control-flow.test.tsx
@@ -4,6 +4,7 @@
  * assert-diagnostics.test.ts, which expects the failures; it is not a pattern
  * under test.
  */
+
 import { assert, cell, pattern, TESTS } from "commonfabric";
 
 export default pattern(() => {

--- a/packages/cli/test/fixtures/assert-diagnostics/failing.test.tsx
+++ b/packages/cli/test/fixtures/assert-diagnostics/failing.test.tsx
@@ -3,6 +3,7 @@
  * `assert(...)` can be checked. Run by assert-diagnostics.test.ts, which
  * expects the failures; it is not a pattern under test.
  */
+
 import { assert, cell, pattern, TESTS } from "commonfabric";
 
 function inRange(value: number, low: number, high: number): boolean {

--- a/packages/cli/test/fixtures/assert-diagnostics/proxy-idiom.test.tsx
+++ b/packages/cli/test/fixtures/assert-diagnostics/proxy-idiom.test.tsx
@@ -5,6 +5,7 @@
  * covers recording around them. Run by assert-diagnostics.test.ts, which
  * expects the failures; it is not a pattern under test.
  */
+
 import { action, assert, pattern, TESTS } from "commonfabric";
 import Subject from "./subject.tsx";
 

--- a/packages/cli/test/fixtures/assert-diagnostics/subject.tsx
+++ b/packages/cli/test/fixtures/assert-diagnostics/subject.tsx
@@ -3,6 +3,7 @@
  * assertions read pattern output through reactive proxies rather than through
  * `cell(...).get()`.
  */
+
 import { Cell, Default, handler, pattern } from "commonfabric";
 
 export interface Item {

--- a/packages/cli/test/fixtures/console-capture/console-error-allowed.test.tsx
+++ b/packages/cli/test/fixtures/console-capture/console-error-allowed.test.tsx
@@ -2,6 +2,7 @@
  * Fixture: console.error with allowConsoleErrors: true.
  * The test runner must NOT fail this despite the error.
  */
+
 import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {

--- a/packages/cli/test/fixtures/console-capture/console-error-unallowed.test.tsx
+++ b/packages/cli/test/fixtures/console-capture/console-error-unallowed.test.tsx
@@ -2,6 +2,7 @@
  * Fixture: console.error in a computed handler with NO allowConsoleErrors flag.
  * The test runner must fail this even though the assertion passes.
  */
+
 import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {

--- a/packages/cli/test/fixtures/console-capture/console-warn-allowed.test.tsx
+++ b/packages/cli/test/fixtures/console-capture/console-warn-allowed.test.tsx
@@ -2,6 +2,7 @@
  * Fixture: console.warn with allowConsoleWarnings: true.
  * The test runner must NOT fail this despite the warning.
  */
+
 import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {

--- a/packages/cli/test/fixtures/console-capture/console-warn-unallowed.test.tsx
+++ b/packages/cli/test/fixtures/console-capture/console-warn-unallowed.test.tsx
@@ -2,6 +2,7 @@
  * Fixture: console.warn in a computed handler with NO allowConsoleWarnings flag.
  * The test runner must fail this even though the assertion passes.
  */
+
 import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {

--- a/packages/cli/test/fixtures/expect-non-idempotent/expected-and-violating.test.tsx
+++ b/packages/cli/test/fixtures/expect-non-idempotent/expected-and-violating.test.tsx
@@ -3,6 +3,7 @@
  * (same shape as packages/patterns/test/non-idempotent/accumulator.test.tsx).
  * The detected violation satisfies the expectation, so this test must PASS.
  */
+
 import { assert, computed, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {

--- a/packages/cli/test/fixtures/expect-non-idempotent/expected-but-idempotent.test.tsx
+++ b/packages/cli/test/fixtures/expect-non-idempotent/expected-but-idempotent.test.tsx
@@ -5,6 +5,7 @@
  * FAIL with "expected non-idempotent computation(s), none detected" — a
  * silent pass here is exactly the detection regression the flag guards.
  */
+
 import { assert, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {

--- a/packages/cli/test/fixtures/expect-non-idempotent/multi-user-expected-but-idempotent.test.tsx
+++ b/packages/cli/test/fixtures/expect-non-idempotent/multi-user-expected-but-idempotent.test.tsx
@@ -3,6 +3,7 @@
  * trivially idempotent. No flagged participant sees a violation, so the run
  * must FAIL with the synthetic "expectNonIdempotent" result.
  */
+
 import { assert, multiUserTest, pattern, TESTS, Writable } from "commonfabric";
 
 export const alice = pattern(() => {

--- a/packages/cli/test/fixtures/expect-non-idempotent/multi-user-expected-one-violation.test.tsx
+++ b/packages/cli/test/fixtures/expect-non-idempotent/multi-user-expected-one-violation.test.tsx
@@ -5,6 +5,7 @@
  * seeing a violation satisfies the expectation — the run must PASS even
  * though bob (also flagged) saw none.
  */
+
 import {
   assert,
   computed,

--- a/packages/cli/test/fixtures/expect-non-idempotent/unexpected-violation.test.tsx
+++ b/packages/cli/test/fixtures/expect-non-idempotent/unexpected-violation.test.tsx
@@ -2,6 +2,7 @@
  * A non-idempotent accumulator WITHOUT expectNonIdempotent. The detected
  * violation must FAIL the test (the long-standing default behavior).
  */
+
 import { assert, computed, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {

--- a/packages/cli/test/fixtures/expect-runtime-errors/expected-and-throwing.test.tsx
+++ b/packages/cli/test/fixtures/expect-runtime-errors/expected-and-throwing.test.tsx
@@ -2,6 +2,7 @@
  * Fixture: a throwing action with expectRuntimeErrors: 1.
  * The runner must treat the error as required-and-satisfied — no failure.
  */
+
 import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {

--- a/packages/cli/test/fixtures/expect-runtime-errors/expected-but-silent.test.tsx
+++ b/packages/cli/test/fixtures/expect-runtime-errors/expected-but-silent.test.tsx
@@ -3,6 +3,7 @@
  * The expectation asserts the loudness FIRES — zero errors must fail the run,
  * so a rejection quietly reverting to a silent return cannot pass.
  */
+
 import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {

--- a/packages/cli/test/fixtures/expect-runtime-errors/expected-count-mismatch.test.tsx
+++ b/packages/cli/test/fixtures/expect-runtime-errors/expected-count-mismatch.test.tsx
@@ -2,6 +2,7 @@
  * Fixture: expectRuntimeErrors: 2 but only one throw occurs.
  * A numeric expectation is exact — a count mismatch must fail the run.
  */
+
 import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {

--- a/packages/cli/test/fixtures/multi-user-markers/crosswise-markers.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-markers/crosswise-markers.test.tsx
@@ -5,6 +5,7 @@
  * writes its own marker document, so announcing in that order is
  * conflict-free and both markers arrive.
  */
+
 import { assert, multiUserTest, pattern, TESTS, Writable } from "commonfabric";
 
 export interface MarkerSetup {

--- a/packages/cli/test/fixtures/multi-user-markers/false-assertion.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-markers/false-assertion.test.tsx
@@ -4,6 +4,7 @@
  * compares it against something she never wrote, so the value is settled and
  * the comparison is the failure.
  */
+
 import {
   action,
   assert,

--- a/packages/cli/test/fixtures/multi-user-markers/marker-barrier.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-markers/marker-barrier.test.tsx
@@ -4,6 +4,7 @@
  * `{ label }`. Bob's assertion is read once, so it passes only when the
  * marker brought Alice's write with it.
  */
+
 import {
   action,
   assert,

--- a/packages/cli/test/fixtures/multi-user-markers/settle-step.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-markers/settle-step.test.tsx
@@ -4,6 +4,7 @@
  * already settles before the next, so this settles again at a point the author
  * names; the run then reaches the assertion after it and reports it.
  */
+
 import {
   action,
   assert,

--- a/packages/cli/test/fixtures/multi-user-markers/unannounced-marker.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-markers/unannounced-marker.test.tsx
@@ -4,6 +4,7 @@
  * only unfinished participant and nothing left to release him, which the
  * orchestrator reports as a deadlock.
  */
+
 import { assert, multiUserTest, pattern, TESTS, Writable } from "commonfabric";
 
 export interface MarkerSetup {

--- a/packages/cli/test/fixtures/session-scoped-result.tsx
+++ b/packages/cli/test/fixtures/session-scoped-result.tsx
@@ -8,6 +8,7 @@
  * with `stable` — not void to `undefined` (the lunch-poll deploy-gate bug)
  * and not demand `--step`.
  */
+
 import { computed, pattern, Writable } from "commonfabric";
 
 export default pattern(() => {

--- a/packages/cli/test/fixtures/settle/invalid-step.test.tsx
+++ b/packages/cli/test/fixtures/settle/invalid-step.test.tsx
@@ -2,6 +2,7 @@
  * Fixture: a step with no `action` / `assertion` / `settle` key. The runner must
  * reject it; the error surfaces as a file-level error on the run result.
  */
+
 import { pattern, TESTS } from "commonfabric";
 
 export default pattern(() => {

--- a/packages/cli/test/fixtures/settle/settle-step.test.tsx
+++ b/packages/cli/test/fixtures/settle/settle-step.test.tsx
@@ -4,6 +4,7 @@
  * step. The settle step is transparent: it produces no assertion result and the
  * run passes.
  */
+
 import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {

--- a/packages/cli/test/fixtures/storage-host/counter.test.tsx
+++ b/packages/cli/test/fixtures/storage-host/counter.test.tsx
@@ -4,6 +4,7 @@
  * pattern actually reached to find — which is the whole point of the option
  * (the pattern-vintage capture snapshots the store afterwards).
  */
+
 import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {

--- a/packages/cli/test/multi-user-test-runner.test.ts
+++ b/packages/cli/test/multi-user-test-runner.test.ts
@@ -16,6 +16,7 @@
  * barrier's discriminating coverage is the pattern-test corpus, where removing
  * it fails seven assertions across `topics`, `lobby`, and `cfc-group-chat-demo`.
  */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { resolve } from "@std/path";

--- a/packages/cli/test/piece-render.test.ts
+++ b/packages/cli/test/piece-render.test.ts
@@ -6,6 +6,7 @@
  * and children arrive as cells rather than as plain values. A renderer that
  * cannot follow those cells produces a bare tag with nothing inside it.
  */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";

--- a/packages/cli/test/test-runner-console-capture.test.ts
+++ b/packages/cli/test/test-runner-console-capture.test.ts
@@ -7,6 +7,7 @@
  *
  * Mirrors the design of test-runner-expect-non-idempotent.test.ts.
  */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { resolve } from "@std/path";

--- a/packages/cli/test/test-runner-expect-non-idempotent.test.ts
+++ b/packages/cli/test/test-runner-expect-non-idempotent.test.ts
@@ -10,6 +10,7 @@
  * where ANY flagged participant seeing a violation satisfies the
  * expectation).
  */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { resolve } from "@std/path";

--- a/packages/cli/test/test-runner-expect-runtime-errors.test.ts
+++ b/packages/cli/test/test-runner-expect-runtime-errors.test.ts
@@ -6,6 +6,7 @@
  *
  * Mirrors the design of test-runner-console-capture.test.ts.
  */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { resolve } from "@std/path";

--- a/packages/cli/test/test-runner-render-step.test.ts
+++ b/packages/cli/test/test-runner-render-step.test.ts
@@ -1,6 +1,7 @@
 /**
  * Contract tests for explicit, per-step VDOM materialization in `cf test`.
  */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { join, resolve } from "@std/path";

--- a/packages/cli/test/test-runner-settle.test.ts
+++ b/packages/cli/test/test-runner-settle.test.ts
@@ -4,6 +4,7 @@
  * transparent to the reported results (it is neither an action nor an
  * assertion). Mirrors test-runner-console-capture.test.ts.
  */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { resolve } from "@std/path";

--- a/packages/cli/test/test-runner-storage-host.test.ts
+++ b/packages/cli/test/test-runner-storage-host.test.ts
@@ -15,6 +15,7 @@
  * witnessed through an independent manager in
  * `packages/runner/test/runtime-dispose-keep-storage.test.ts`.
  */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { resolve } from "@std/path";

--- a/packages/cli/test/verb-prose-live.test.ts
+++ b/packages/cli/test/verb-prose-live.test.ts
@@ -11,6 +11,7 @@
  * actually lands. A fixture asserting those positions by hand would agree with
  * any implementation, the one that loses the prose included.
  */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";

--- a/packages/cli/test/verb-prose-overlay.test.ts
+++ b/packages/cli/test/verb-prose-overlay.test.ts
@@ -16,6 +16,7 @@
  * carry — every position class here that a pattern CAN produce is asserted
  * there as well, against output the compiler actually emitted.
  */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { JSONSchema } from "@commonfabric/api";

--- a/packages/cli/test/view-diffedit-cov.test.ts
+++ b/packages/cli/test/view-diffedit-cov.test.ts
@@ -8,6 +8,7 @@
  * original diff, a missing workspace file, a hunk with no room to expand, the
  * read-only (no-disk) source, and the defensive guards in `save`.
  */
+
 import { assert, assertEquals, assertThrows } from "@std/assert";
 import { expect } from "@std/expect";
 import { join } from "@std/path";

--- a/packages/cli/test/view-diffedit-gate.test.ts
+++ b/packages/cli/test/view-diffedit-gate.test.ts
@@ -8,6 +8,7 @@
  * that parses into a real hunk whose recorded path is deliberately absent from
  * `fileText`.
  */
+
 import { assertEquals } from "@std/assert";
 import { type DiffEdit, type DiffWorkspace } from "../lib/view/diffdoc.ts";
 import { diffSource } from "../lib/view/diffedit.ts";

--- a/packages/cli/test/view-diffedit.test.ts
+++ b/packages/cli/test/view-diffedit.test.ts
@@ -4,6 +4,7 @@
  * resurrected, and saving splices the edited lines back into the underlying
  * files. A diff matching no file on disk is read-only.
  */
+
 import { assert, assertEquals, assertThrows } from "@std/assert";
 import { join } from "@std/path";
 import { parseDiff } from "../lib/view/diff.ts";

--- a/packages/cli/test/view-editor.test.ts
+++ b/packages/cli/test/view-editor.test.ts
@@ -5,6 +5,7 @@
  * cursor-free pager behavior lives in view-session.test.ts; the pure edit
  * engine is covered in view-editbuffer.test.ts.
  */
+
 import { assert, assertEquals } from "@std/assert";
 import { parseDocument, promptText } from "./view-helpers.ts";
 import { highlightDocument } from "../lib/view/languages/typescript/parse.ts";

--- a/packages/cli/test/view-editsource-cov.test.ts
+++ b/packages/cli/test/view-editsource-cov.test.ts
@@ -4,6 +4,7 @@
  * These paths are exercised directly on the returned EditableSource so each
  * conditional branch is asserted on its real output.
  */
+
 import { assert, assertEquals } from "@std/assert";
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";

--- a/packages/cli/test/view-filegateway-cov.test.ts
+++ b/packages/cli/test/view-filegateway-cov.test.ts
@@ -4,6 +4,7 @@
  * the actual disk so every branch — successful reads, the catch arms when a
  * path does not exist, and the symlink-resolving directory check — runs.
  */
+
 import { assert, assertEquals } from "@std/assert";
 import { expect } from "@std/expect";
 import { join } from "@std/path";

--- a/packages/cli/test/view-filepicker.test.ts
+++ b/packages/cli/test/view-filepicker.test.ts
@@ -4,6 +4,7 @@
  * buffer), and refusing to discard unsaved edits. A fake {@link FileGateway}
  * stands in for the filesystem so this stays pure.
  */
+
 import { assert, assertEquals } from "@std/assert";
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";

--- a/packages/cli/test/view-helpers.ts
+++ b/packages/cli/test/view-helpers.ts
@@ -2,6 +2,7 @@
  * Shared fixtures and helpers for the `cf view` test suites. Not a test file
  * itself (the test task globs `*.test.ts`), just an import.
  */
+
 import { parseDocument } from "../lib/view/languages/typescript/parse.ts";
 import type { ViewState } from "../lib/view/render.ts";
 import type { Rgb } from "../lib/view/ansi.ts";

--- a/packages/cli/test/view-highlighter.test.ts
+++ b/packages/cli/test/view-highlighter.test.ts
@@ -8,6 +8,7 @@
  * the multi-line constructs (block comment, template, string) whose color
  * spills onto later lines.
  */
+
 import { assert, assertEquals } from "@std/assert";
 import {
   createHighlighter,

--- a/packages/cli/test/view-json.test.ts
+++ b/packages/cli/test/view-json.test.ts
@@ -6,6 +6,7 @@
  * TypeScript parser. The highlighter is hand-written and lenient: malformed
  * input colors without throwing.
  */
+
 import { assert, assertEquals } from "@std/assert";
 import { join } from "@std/path";
 import {

--- a/packages/cli/test/view-jumplist.test.ts
+++ b/packages/cli/test/view-jumplist.test.ts
@@ -4,6 +4,7 @@
  * chosen one. A read-only diff (its files do not resolve on disk) is enough —
  * the list is derived from the diff text itself.
  */
+
 import { assert, assertEquals } from "@std/assert";
 import { Session } from "../lib/view/session.ts";
 import { parseDiff } from "../lib/view/diff.ts";

--- a/packages/cli/test/view-language-fixtures.test.ts
+++ b/packages/cli/test/view-language-fixtures.test.ts
@@ -3,6 +3,7 @@
  * `cf view`. Each corpus entry covers direct source, a diff, an incomplete
  * live edit, and every representative selection route recorded for it.
  */
+
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 

--- a/packages/cli/test/view-language.test.ts
+++ b/packages/cli/test/view-language.test.ts
@@ -5,6 +5,7 @@
  * a diff touches, and `diffSemanticsFor` composes the diff view's semantic layer
  * from the languages present, scoped to each one's files.
  */
+
 import { assert, assertEquals, assertThrows } from "@std/assert";
 import { expect } from "@std/expect";
 import { join } from "@std/path";

--- a/packages/cli/test/view-markdown-cov.test.ts
+++ b/packages/cli/test/view-markdown-cov.test.ts
@@ -6,6 +6,7 @@
  * backtick runs, and a heading tree that opens on a deeper-than-top level —
  * and asserts the real output rather than merely touching the lines.
  */
+
 import { assert, assertEquals } from "@std/assert";
 import {
   createMarkdownHighlighter,

--- a/packages/cli/test/view-markdown.test.ts
+++ b/packages/cli/test/view-markdown.test.ts
@@ -3,6 +3,7 @@
  * colored as Markdown — headings, fenced/inline code, lists, quotes, links —
  * not parsed as TypeScript, and its headings form the navigation tree.
  */
+
 import { assert, assertEquals } from "@std/assert";
 import { expect } from "@std/expect";
 import { join } from "@std/path";

--- a/packages/cli/test/view-mod-cov.test.ts
+++ b/packages/cli/test/view-mod-cov.test.ts
@@ -4,6 +4,7 @@
  * semantic service only when launching the pager, so these call the returned
  * closure directly to exercise both the diff and source semantics paths.
  */
+
 import { assert, assertEquals, assertThrows } from "@std/assert";
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";

--- a/packages/cli/test/view-mod-gate.test.ts
+++ b/packages/cli/test/view-mod-gate.test.ts
@@ -6,6 +6,7 @@
  * removing the process working directory before invoking that closure forces
  * Deno.cwd() to throw NotFound and runs the fallback.
  */
+
 import { assert } from "@std/assert";
 import { buildView } from "../lib/view/mod.ts";
 

--- a/packages/cli/test/view-model-cov.test.ts
+++ b/packages/cli/test/view-model-cov.test.ts
@@ -3,6 +3,7 @@
  * tree into the pre-order sequence that `flatStructure` holds. It is exercised
  * by every parse/markdown/diff document build; this pins its behavior directly.
  */
+
 import { assertEquals } from "@std/assert";
 import { flattenStructure, type StructureNode } from "../lib/view/model.ts";
 

--- a/packages/cli/test/view-pager-cov.test.ts
+++ b/packages/cli/test/view-pager-cov.test.ts
@@ -6,6 +6,7 @@
  * runs without a real terminal. A separate test exercises the real deps' thin
  * wrappers.
  */
+
 import { assert, assertEquals, assertRejects } from "@std/assert";
 import { join } from "@std/path";
 import { parseDocument } from "./view-helpers.ts";

--- a/packages/cli/test/view-pager-pty.test.ts
+++ b/packages/cli/test/view-pager-pty.test.ts
@@ -14,6 +14,7 @@
  * still making progress never trips it, and a silent child fails the test
  * with the captured output. Skipped where `script` is unavailable.
  */
+
 import { assert } from "@std/assert";
 import { join } from "@std/path";
 

--- a/packages/cli/test/view-parse-cov.test.ts
+++ b/packages/cli/test/view-parse-cov.test.ts
@@ -27,6 +27,7 @@
  *     arrow or function initializer is routed to a closure node before
  *     describeInitializer (used only for variable-kind nodes) is ever called.
  */
+
 import { assert, assertEquals } from "@std/assert";
 import {
   createHighlighter,

--- a/packages/cli/test/view-parse-cov2.test.ts
+++ b/packages/cli/test/view-parse-cov2.test.ts
@@ -8,6 +8,7 @@
  * labels, and metadata extraction on malformed input, plus `safe`'s
  * degrade-to-undefined fallback via the test-only `_internal` handle.
  */
+
 import { assert, assertEquals } from "@std/assert";
 import {
   _internal,

--- a/packages/cli/test/view-parse-gate.test.ts
+++ b/packages/cli/test/view-parse-gate.test.ts
@@ -14,6 +14,7 @@
  *   - safe: metadata extraction stays intact on malformed input.
  *   - describeInitializer: an initializer is described by its first line.
  */
+
 import { assert, assertEquals } from "@std/assert";
 import {
   createHighlighter,

--- a/packages/cli/test/view-plain-text.test.ts
+++ b/packages/cli/test/view-plain-text.test.ts
@@ -4,6 +4,7 @@
  * documents, diffs, and live diff edits must preserve the complete input
  * without TypeScript coloring or structure.
  */
+
 import { assertEquals } from "@std/assert";
 import { buildDiffDocument, type DiffWorkspace } from "../lib/view/diffdoc.ts";
 import { parseDiff } from "../lib/view/diff.ts";

--- a/packages/cli/test/view-python.test.ts
+++ b/packages/cli/test/view-python.test.ts
@@ -2,6 +2,7 @@
  * Python highlighting for direct files, diffs, and live edits. The scanner is
  * lenient and lossless, including while multiline strings are incomplete.
  */
+
 import { assert, assertEquals } from "@std/assert";
 import { join } from "@std/path";
 import {

--- a/packages/cli/test/view-semantics-cov.test.ts
+++ b/packages/cli/test/view-semantics-cov.test.ts
@@ -5,6 +5,7 @@
  * small parsing helpers (JSONC stripping, extension classification, real-path
  * containment) that the canonical suite reaches only incidentally.
  */
+
 import { assert, assertEquals } from "@std/assert";
 import { expect } from "@std/expect";
 import { join } from "@std/path";

--- a/packages/cli/test/view-semantics-cov2.test.ts
+++ b/packages/cli/test/view-semantics-cov2.test.ts
@@ -12,6 +12,7 @@
  * touches them. That is exactly the input the module documents itself as being
  * robust against: "every query is wrapped so a failure degrades to `null`".
  */
+
 import { assert, assertEquals } from "@std/assert";
 import { join } from "@std/path";
 import { parseDocument } from "./view-helpers.ts";

--- a/packages/cli/test/view-semantics-gate.test.ts
+++ b/packages/cli/test/view-semantics-gate.test.ts
@@ -9,6 +9,7 @@
  * the surrounding, reachable behavior: the observable degrade-to-null and
  * degrade-to-empty results the failure isolation protects.
  */
+
 import { assert, assertEquals } from "@std/assert";
 import { join } from "@std/path";
 import ts from "typescript";

--- a/packages/cli/test/view-session-cov.test.ts
+++ b/packages/cli/test/view-session-cov.test.ts
@@ -4,6 +4,7 @@
  * and inspecting `view()` / `doc` / `quit`, mirroring the style of
  * `view-session.test.ts`, `view-filepicker.test.ts` and `view-diffedit.test.ts`.
  */
+
 import { assert, assertEquals } from "@std/assert";
 import { join } from "@std/path";
 import { parseDocument, promptText, SAMPLE } from "./view-helpers.ts";

--- a/packages/cli/test/view-session-cov2.test.ts
+++ b/packages/cli/test/view-session-cov2.test.ts
@@ -9,6 +9,7 @@
  * doctored `Document` so the natural card/structure machinery lands in the
  * defensive state being exercised.
  */
+
 import { assert, assertEquals } from "@std/assert";
 import { join } from "@std/path";
 import { parseDocument, SAMPLE } from "./view-helpers.ts";

--- a/packages/cli/test/view-session-gate.test.ts
+++ b/packages/cli/test/view-session-gate.test.ts
@@ -9,6 +9,7 @@
  * specific targets that carry only a start offset (a dependency reference) or no
  * offset at all (a plain use reference), which drive each fallback.
  */
+
 import { assert, assertEquals } from "@std/assert";
 import { parseDocument, SAMPLE } from "./view-helpers.ts";
 import { Session } from "../lib/view/session.ts";

--- a/packages/cli/test/view-session-gate2.test.ts
+++ b/packages/cli/test/view-session-gate2.test.ts
@@ -6,6 +6,7 @@
  * the guards are exercised by invoking the private method directly with the
  * edge input and asserting the method declines gracefully.
  */
+
 import { assertEquals } from "@std/assert";
 import { parseDocument, SAMPLE } from "./view-helpers.ts";
 import { Session } from "../lib/view/session.ts";

--- a/packages/cli/test/view-view-gate.test.ts
+++ b/packages/cli/test/view-view-gate.test.ts
@@ -10,6 +10,7 @@
  * non-zero with the raw error on stderr. Each runs the real CLI as a
  * subprocess, like the other `cf view` command tests.
  */
+
 import { assert, assertEquals } from "@std/assert";
 import { cf } from "./utils.ts";
 

--- a/packages/cli/test/view-yaml.test.ts
+++ b/packages/cli/test/view-yaml.test.ts
@@ -2,6 +2,7 @@
  * The YAML language used by `cf view`. Tests cover direct files, diffs, live
  * edits, common scalar forms, flow collections, and state that crosses lines.
  */
+
 import { assert, assertEquals, assertStrictEquals } from "@std/assert";
 import { join } from "@std/path";
 import {


### PR DESCRIPTION
Second of the file-header series (#5865). I (agent working on behalf of
@danfuzz) am splitting along package lines; this is `packages/cli`, the largest
single share.

## What changed

104 files whose file header ran straight into the first `import`.
`code-comment-style.md` § File headers requires the blank line, and says why:

> The blank line is load-bearing …: it is what keeps the header from being read
> as the doc comment of the first declaration under it.

**The whole change is 104 inserted blank lines, one per file.** The diff adds no
non-blank line and removes nothing — checked mechanically, not by eye.

Five of them — the `multi-user-markers` fixtures — open with a
`/// <cts-enable />` pragma above the header, which the rule expressly allows to
precede it. Those are transformer input, so the `cli` suite that compiles them
is what shows the insertion is inert.

## What is deliberately not touched

Four `cli` files whose top block is `//` rather than `/** */`. The same section
says a `//` block **is not a header form at all** — "it reads as a note about
the line beneath it" — and in at least one case that is exactly what it is:

```ts
// The import below must resolve to the same @std/fmt instance Cliffy uses
// (see the "@std/fmt/colors" pin in packages/cli/deno.jsonc); a second
// instance would leave Cliffy's help/version/usage output colored even when
// this module disables colors.
import { setColorEnabled } from "@std/fmt/colors";
```

A blank line there would orphan the note rather than fix anything.

Tree-wide the split is **219 `/** */` headers** (this series) against **69 `//`
blocks** (not this series). The `//` group is heterogeneous — some are lint
pragmas, some are file descriptions written in the wrong form, and some are
genuine notes about the import — so each needs judgment rather than a sweep.

## Verification

- Diff characterized exactly: 104 added lines, **0 non-blank**, 0 removed.
- `deno fmt --check`, `deno lint`, `deno task check` green.
- `cli` suite: **174 passed, 0 failed**.

## Series

Done: #5865 (guinea pigs + the per-segment clarification), this one.

Remaining, all `/** */` headers: `ts-transformers` 55, `ui` 31, `runner` 22,
then `memory` 2, `tasks/` 2, and one each in `integration`, `piece`, `toolshed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

