### PR TITLE
docs: separate the file header from the first import (the rest)

### DIFF
--- a/packages/integration/pattern-coverage.ts
+++ b/packages/integration/pattern-coverage.ts
@@ -10,6 +10,7 @@
  *
  * See docs/development/COVERAGE.md.
  */
+
 import { fromFileUrl, join, resolve } from "@std/path";
 import {
   PATTERN_COVERAGE_INTEGRATION_TEST_NAME,

--- a/packages/memory/test/v2-concurrent-watch-refresh.test.ts
+++ b/packages/memory/test/v2-concurrent-watch-refresh.test.ts
@@ -11,6 +11,7 @@
  * Event-driven (no wall-clock sleeps): a deterministic microtask drain settles
  * the loopback pipeline.
  */
+
 import { assertEquals } from "@std/assert";
 import { connect, loopback, type Transport } from "../v2/client.ts";
 import { Server } from "../v2/server.ts";

--- a/packages/memory/v2/session-open-auth.ts
+++ b/packages/memory/v2/session-open-auth.ts
@@ -20,6 +20,7 @@
  *  - **audience** (`aud`): the invocation must carry this server's audience
  *    identity. An open signed for host A cannot be replayed to host B.
  */
+
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { fromDID } from "../util.ts";

--- a/packages/piece/test/legacy-envelope-default-pattern.test.ts
+++ b/packages/piece/test/legacy-envelope-default-pattern.test.ts
@@ -13,6 +13,7 @@
  * CT-1838 in production: the compiled set misses, and only the legacy
  * source docs remain to cold-load from.
  */
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createSession, Identity } from "@commonfabric/identity";

--- a/packages/runner/src/harness/compiler-stack.ts
+++ b/packages/runner/src/harness/compiler-stack.ts
@@ -17,6 +17,7 @@
  * - Add new compiler-stack values HERE and reach them through
  *   `compilerStack()` after an `ensureCompilerStack()` on the owning flow.
  */
+
 import ts from "typescript";
 export { ts };
 export {

--- a/packages/runner/src/harness/deferred-compiler-stack.ts
+++ b/packages/runner/src/harness/deferred-compiler-stack.ts
@@ -7,6 +7,7 @@
  * through `compilerStack()`, which throws — loudly, with the fix — when a
  * flow forgot its ensure. Boot-path code must do neither.
  */
+
 import type * as CompilerStackModule from "./compiler-stack.ts";
 
 export type CompilerStack = typeof CompilerStackModule;

--- a/packages/runner/src/schema-match.ts
+++ b/packages/runner/src/schema-match.ts
@@ -10,6 +10,7 @@
  * themselves. The `matches` callback owns recursion and ref semantics: the
  * matchers differ exactly there ($defs threading vs fail-closed policy refs).
  */
+
 import type { JSONSchema, JSONSchemaObj } from "./builder/types.ts";
 
 export const arrayMatchesPositionally = (

--- a/packages/runner/test/action-overload-types.test.ts
+++ b/packages/runner/test/action-overload-types.test.ts
@@ -19,6 +19,7 @@
  * result. Reorder the overloads, or delete overload 2, and inference starts
  * picking those returns up silently. These assertions fail if that happens.
  */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { Cell, Stream } from "@commonfabric/api";

--- a/packages/runner/test/array-ref-defs-propagation.test.ts
+++ b/packages/runner/test/array-ref-defs-propagation.test.ts
@@ -11,6 +11,7 @@
  * in arrays (e.g., `items: Writable<Default<Item[], []>>` where Item has
  * `name: Default<string, "">`).
  */
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";

--- a/packages/runner/test/cfc-schema-at-path.bench.ts
+++ b/packages/runner/test/cfc-schema-at-path.bench.ts
@@ -7,6 +7,7 @@
  * large homogeneous array: they should share one symbolic `items` derivation,
  * rather than populate one cache entry per index.
  */
+
 import type { JSONSchema, JSONSchemaObj } from "@commonfabric/api";
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import { ContextualFlowControl } from "../src/cfc.ts";

--- a/packages/runner/test/esm-verifier.bench.ts
+++ b/packages/runner/test/esm-verifier.bench.ts
@@ -12,6 +12,7 @@
  *   deno bench --allow-read --allow-write --allow-net --allow-ffi --allow-env \
  *     --no-check packages/runner/test/esm-verifier.bench.ts
  */
+
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Engine } from "../src/harness/engine.ts";

--- a/packages/runner/test/exec-value-node-typing.test.ts
+++ b/packages/runner/test/exec-value-node-typing.test.ts
@@ -16,6 +16,7 @@
  * compile if `JSONValue` ever does accept these, which is what makes this a
  * differential rather than a restatement.
  */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";

--- a/packages/runner/test/focus-types.test.ts
+++ b/packages/runner/test/focus-types.test.ts
@@ -4,6 +4,7 @@
  * These tests verify that key() correctly handles multiple keys.
  * If the types are incorrect, these tests will fail to compile.
  */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type {

--- a/packages/runner/test/frozen-proxy-target.test.ts
+++ b/packages/runner/test/frozen-proxy-target.test.ts
@@ -10,6 +10,7 @@
  * core isolates caller-owned values on write, so pre-freezing inputs is no
  * longer a faithful simulation of post-commit frozen storage state.
  */
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";

--- a/packages/runner/test/handler-overload-types.test.ts
+++ b/packages/runner/test/handler-overload-types.test.ts
@@ -19,6 +19,7 @@
  * Reorder them, or delete one, and inference starts picking those returns up
  * silently. These assertions fail if that happens.
  */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type {

--- a/packages/runner/test/iderivable-type-surface.test.ts
+++ b/packages/runner/test/iderivable-type-surface.test.ts
@@ -4,6 +4,7 @@
  * The runtime assertions are trivial; this file fails if Cell or OpaqueCell
  * stop exposing typed reactive array helpers.
  */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { Cell, OpaqueCell, Reactive } from "@commonfabric/api";

--- a/packages/runner/test/liveness-scaling.profile.ts
+++ b/packages/runner/test/liveness-scaling.profile.ts
@@ -12,6 +12,7 @@
  *
  * Run: deno run -A test/liveness-scaling.profile.ts [sizes...]
  */
+
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";

--- a/packages/runner/test/llm-schema-alignment.test.ts
+++ b/packages/runner/test/llm-schema-alignment.test.ts
@@ -10,6 +10,7 @@
  * run this file to confirm alignment:
  *   deno test --allow-all packages/runner/test/llm-schema-alignment.test.ts
  */
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";

--- a/packages/runner/test/memory-v2-concurrent-watch-refresh.test.ts
+++ b/packages/runner/test/memory-v2-concurrent-watch-refresh.test.ts
@@ -10,6 +10,7 @@
  * on transport signals, and the "nothing more happens" assertions use a
  * deterministic microtask drain, not a timer.
  */
+
 import { assert, assertEquals } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
 import type { URI } from "@commonfabric/memory/interface";

--- a/packages/runner/test/push-pull-patterns.bench.ts
+++ b/packages/runner/test/push-pull-patterns.bench.ts
@@ -6,6 +6,7 @@
  * they exercise the actual map/filter/flatMap machinery instead of synthetic
  * scheduler actions.
  */
+
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import {

--- a/packages/runner/test/reactive-intersection.test.ts
+++ b/packages/runner/test/reactive-intersection.test.ts
@@ -16,6 +16,7 @@
  * NOTE: This is a type-level test. The assertions at runtime are trivial;
  * the real test is that this file compiles successfully.
  */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { OpaqueCell, Reactive } from "@commonfabric/api";

--- a/packages/runner/test/traverse-replay.bench.ts
+++ b/packages/runner/test/traverse-replay.bench.ts
@@ -9,6 +9,7 @@
  * counter totals per fixture on exit — wall-time wins should come with a
  * counter explanation (e.g. anyOfBranches down 80%).
  */
+
 import { listFixturePaths } from "./traverse-replay/goldens.ts";
 import {
   loadFixture,

--- a/packages/runner/test/traverse-replay.test.ts
+++ b/packages/runner/test/traverse-replay.test.ts
@@ -8,6 +8,7 @@
  * test/traverse-replay/regen-goldens.ts) and justify the golden diff in the
  * PR.
  */
+
 import { assert } from "@std/assert";
 import { DATA_URI_MEDIA_TYPE } from "@commonfabric/data-model/data-uri-codec";
 import { linkRefFrom } from "@commonfabric/data-model/cell-rep";

--- a/packages/runner/test/traverse-replay/goldens.ts
+++ b/packages/runner/test/traverse-replay/goldens.ts
@@ -10,6 +10,7 @@
  * (and the regenerated golden diff is the review artifact justifying the
  * change).
  */
+
 import { readMaybeGzippedText, writeGzippedText } from "./gzip.ts";
 import type { ReplayOracle } from "./replay.ts";
 

--- a/packages/runner/test/traverse-replay/profile-target.ts
+++ b/packages/runner/test/traverse-replay/profile-target.ts
@@ -5,6 +5,7 @@
  *   deno run --allow-all test/traverse-replay/profile-driver.ts \
  *     [fixture-name] [rounds]
  */
+
 import { loadFixture, replayFixture } from "./replay.ts";
 
 const name = Deno.args[0] ?? "notebook-test";

--- a/packages/runner/test/traverse-replay/regen-goldens.ts
+++ b/packages/runner/test/traverse-replay/regen-goldens.ts
@@ -7,6 +7,7 @@
  *   deno run --allow-read --allow-write \
  *     test/traverse-replay/regen-goldens.ts
  */
+
 import { listFixturePaths, writeGolden } from "./goldens.ts";
 import { loadFixture, replayFixture } from "./replay.ts";
 

--- a/packages/toolshed/routes/ai/llm/llm.routes.ts
+++ b/packages/toolshed/routes/ai/llm/llm.routes.ts
@@ -7,6 +7,7 @@
  * When modifying these Zod schemas, run the alignment tests to check for drift:
  *   deno test --allow-all packages/runner/test/llm-schema-alignment.test.ts
  */
+
 import { createRoute } from "@hono/zod-openapi";
 import * as HttpStatusCodes from "stoker/http-status-codes";
 import { jsonContent } from "stoker/openapi/helpers";

--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -29,6 +29,7 @@
  * syntax family but require separate ownership classification; consumers
  * should use `classifyArrayMethodCallSite(...)` when that distinction matters.
  */
+
 import ts from "typescript";
 
 import { spellingsWhere } from "@commonfabric/schema-generator/wrapper-names";

--- a/packages/ts-transformers/src/policy/mergeable-push-classification.ts
+++ b/packages/ts-transformers/src/policy/mergeable-push-classification.ts
@@ -27,6 +27,7 @@
  * unstratified check gave every site. Under-approximation demotes to the
  * independent-write message or to silence, never to a wrong recommendation.
  */
+
 import ts from "typescript";
 
 export type MergeablePushMisuseKind =

--- a/packages/ts-transformers/src/transformers/cast-validation.ts
+++ b/packages/ts-transformers/src/transformers/cast-validation.ts
@@ -6,6 +6,7 @@
  * - `as Reactive<...>`: ERROR - framework handles Reactive wrapping automatically
  * - `as Cell<...>` and other cell-like types: ERROR - prefer proper type annotations
  */
+
 import ts from "typescript";
 import { spellingsWhere } from "@commonfabric/schema-generator/wrapper-names";
 import {

--- a/packages/ts-transformers/src/transformers/empty-array-of-validation.ts
+++ b/packages/ts-transformers/src/transformers/empty-array-of-validation.ts
@@ -8,6 +8,7 @@
  * — an array you can never push objects into. The fix is to provide an explicit
  * type argument: `Cell.of<MyType[]>([])`.
  */
+
 import ts from "typescript";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 import { detectCallKind, detectNewExpressionKind } from "../ast/call-kind.ts";

--- a/packages/ts-transformers/src/transformers/mergeable-push-validation.ts
+++ b/packages/ts-transformers/src/transformers/mergeable-push-validation.ts
@@ -28,6 +28,7 @@
  * today (the kept read forces the retry), so this nudges toward the better
  * expression without failing the build.
  */
+
 import ts from "typescript";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 import { getCapabilitySummaryCallbackArgument } from "../ast/mod.ts";

--- a/packages/ts-transformers/src/transformers/pattern-context-validation.ts
+++ b/packages/ts-transformers/src/transformers/pattern-context-validation.ts
@@ -36,6 +36,7 @@
  * - Local computed()/lift() aliases used as plain values in the same
  *   callback: ERROR (use a nested computed()/lift())
  */
+
 import ts from "typescript";
 import { COMMONFABRIC_REACTIVE_ORIGIN_BUILDER_NAMES } from "../core/commonfabric-runtime-registry.ts";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";

--- a/packages/ts-transformers/src/transformers/verb-return-validation.ts
+++ b/packages/ts-transformers/src/transformers/verb-return-validation.ts
@@ -33,6 +33,7 @@
  * types as plain `boolean` — syntax is the only honest signal. Conservative
  * and documented beats clever and silent.
  */
+
 import ts from "typescript";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 import {

--- a/packages/ts-transformers/test/commonfabric-test-types.ts
+++ b/packages/ts-transformers/test/commonfabric-test-types.ts
@@ -4,6 +4,7 @@
  * Loads types from the same source as production: types/commonfabric.d.ts
  * via the static cache (which is a symlink to packages/api/index.ts).
  */
+
 import { StaticCache } from "@commonfabric/static";
 
 const staticCache = StaticCache.fromFileSystem();

--- a/packages/ts-transformers/test/core/legacy-envelope.test.ts
+++ b/packages/ts-transformers/test/core/legacy-envelope.test.ts
@@ -20,6 +20,7 @@
  * (cf-helpers.ts) are a compatibility contract with downstream vendoring
  * gates; these tests double as the seam's regression pin.
  */
+
 import { assert, assertEquals, assertFalse } from "@std/assert";
 import {
   injectCfHelpers,

--- a/packages/ts-transformers/test/diagnostics/probe-array-method-owner-names.ts
+++ b/packages/ts-transformers/test/diagnostics/probe-array-method-owner-names.ts
@@ -40,6 +40,7 @@
  *
  * Diagnostic; not a test. Safe to delete once the owner-set question closes.
  */
+
 import { join } from "@std/path";
 import { walk } from "@std/fs";
 

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.input.tsx
@@ -5,6 +5,7 @@
  * the nested computed expression should still lower locally in JSX without forcing
  * the whole JSX branch through an extra lift-applied wrapper.
  */
+
 import { action, Cell, computed, pattern, UI } from "commonfabric";
 
 interface Card {

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.input.tsx
@@ -5,6 +5,7 @@
  * (not encouraged, but should still work). The action is referenced INSIDE
  * the computed expression, so it must be captured in the lift-applied wrapper.
  */
+
 import { action, Cell, computed, pattern, UI } from "commonfabric";
 
 interface Card {

--- a/packages/ts-transformers/test/fixtures/closures/action-result-not-opaque.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-result-not-opaque.input.tsx
@@ -3,6 +3,7 @@
  * opaque origin but handler results are typically used directly
  * (no property access), so opaque classification doesn't affect them.
  */
+
 import { action, pattern, UI, Writable } from "commonfabric";
 
 interface State {

--- a/packages/ts-transformers/test/fixtures/closures/action-self-closure.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-self-closure.input.tsx
@@ -2,6 +2,7 @@
  * Fixture: action closing over SELF requires inputs with defaults so the
  * piece data always satisfies the output schema's required properties.
  */
+
 import { action, type Default, NAME, pattern, SELF, UI, type VNode, Writable } from "commonfabric";
 
 interface TestOutput {

--- a/packages/ts-transformers/test/fixtures/closures/computed-array-length.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-array-length.input.tsx
@@ -8,6 +8,7 @@
  * The fix ensures the schema is { type: "array", items: { not: true } }
  * rather than { type: "object", properties: { length: { type: "number" } } }
  */
+
 import { computed, NAME, pattern, UI, wish } from "commonfabric";
 
 interface Piece {

--- a/packages/ts-transformers/test/fixtures/closures/computed-destructured-map.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-destructured-map.input.tsx
@@ -5,6 +5,7 @@
  * Inside a lift-applied callback, Reactive values are unwrapped to plain JS,
  * so destructured `tasks` is a plain array.
  */
+
 import { computed, pattern, UI } from "commonfabric";
 
 interface Item {

--- a/packages/ts-transformers/test/fixtures/closures/computed-local-var-map.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-local-var-map.input.tsx
@@ -5,6 +5,7 @@
  * Inside a lift-applied callback, Reactive values are unwrapped to plain JS,
  * so `localVar` is a plain array and .mapWithPattern() doesn't exist on it.
  */
+
 import { computed, pattern, UI } from "commonfabric";
 
 interface Item {

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-input-no-captures.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-input-no-captures.input.tsx
@@ -7,6 +7,7 @@
  * 2. The inner .map() runs on the plain array, so it is NOT rewritten to .mapWithPattern()
  * 3. SchemaInjectionTransformer infers the result type from the computed body
  */
+
 import { Cell, computed, pattern } from "commonfabric";
 
 interface Item {

--- a/packages/ts-transformers/test/fixtures/closures/computed-property-access-map.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-property-access-map.input.tsx
@@ -5,6 +5,7 @@
  * Inside a lift-applied callback, Reactive values are unwrapped to plain JS,
  * so `result.tasks` is a plain array.
  */
+
 import { computed, pattern, UI } from "commonfabric";
 
 interface Item {

--- a/packages/ts-transformers/test/fixtures/closures/computed-result-in-derive-captures.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-result-in-derive-captures.input.tsx
@@ -3,6 +3,7 @@
  * not plain property access. The computed() return value is an
  * Reactive, so rewritePatternBody correctly treats it as opaque.
  */
+
 import { computed, pattern, UI } from "commonfabric";
 
 interface State {

--- a/packages/ts-transformers/test/fixtures/closures/computed-result-property-in-return.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-result-property-in-return.input.tsx
@@ -4,6 +4,7 @@
  * rewritePatternBody correctly rewrites summary.length to
  * summary.key("length").
  */
+
 import { computed, pattern } from "commonfabric";
 
 interface State {

--- a/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.input.tsx
@@ -12,6 +12,7 @@
  * - generated handler state omits captures that the handler body still uses
  *   inside the nested `.then(...)` callback
  */
+
 import { action, Default, pattern, Stream, Writable } from "commonfabric";
 
 function flushLater(

--- a/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.input.tsx
@@ -6,6 +6,7 @@
  * to a handler, and the Cell reference (state.isEditing) must be properly
  * captured in the lift-applied computation created for the computed.
  */
+
 import { Cell, computed, pattern, UI } from "commonfabric";
 
 interface Card {

--- a/packages/ts-transformers/test/fixtures/closures/map-ternary-inside-nested-map.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-ternary-inside-nested-map.input.tsx
@@ -8,6 +8,7 @@
  * This structure mirrors pattern-nested-jsx-map: outer ternary wraps items.map,
  * causing ifElse → lift-applied, then inner ternary is inside nested .map callback.
  */
+
 import { Cell, computed, Default, pattern, UI } from "commonfabric";
 
 interface Tag {

--- a/packages/ts-transformers/test/fixtures/closures/nested-computed-in-ifelse.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/nested-computed-in-ifelse.input.tsx
@@ -9,6 +9,7 @@
  * Bug: secondToggle.get() was returning CellImpl instead of boolean
  * Fix: Added isInsideSafeCallbackWrapper check in rewriteChildExpressions
  */
+
 import { computed, ifElse, pattern, UI, Writable } from "commonfabric";
 
 // FIXTURE: nested-computed-in-ifelse

--- a/packages/ts-transformers/test/fixtures/closures/pattern-nested-jsx-map.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-nested-jsx-map.input.tsx
@@ -9,6 +9,7 @@
  * `mapWithPattern` because `item` comes from a mapWithPattern element,
  * NOT from the lift-applied computation's captures.
  */
+
 import { Cell, computed, Default, pattern, UI } from "commonfabric";
 
 interface Tag {

--- a/packages/ts-transformers/test/fixtures/closures/unless-with-map.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/unless-with-map.input.tsx
@@ -5,6 +5,7 @@
  * When fallback is items.map(...), the map gets transformed to mapWithPattern.
  * Schema injection needs to know the type of the mapWithPattern result.
  */
+
 import { Cell, Default, pattern, UI } from "commonfabric";
 
 interface Item {

--- a/packages/ts-transformers/test/fixtures/closures/when-with-map.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/when-with-map.input.tsx
@@ -5,6 +5,7 @@
  * When value is items.map(...), the map gets transformed to mapWithPattern.
  * Schema injection needs to know the type of the mapWithPattern result.
  */
+
 import { Cell, Default, pattern, UI } from "commonfabric";
 
 interface Item {

--- a/packages/ts-transformers/test/fixtures/closures/writable-of-terminal-methods.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/writable-of-terminal-methods.input.tsx
@@ -4,6 +4,7 @@
  * of opaque classification — new Writable() is an opaque origin and
  * .get()/.set() are terminal methods.
  */
+
 import { action, pattern, UI, Writable } from "commonfabric";
 
 interface State {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/filter-callback-local-consts.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/filter-callback-local-consts.input.tsx
@@ -1,6 +1,7 @@
 /**
  * TRANSFORM REPRO: patternized filter callback should lower callback-local const initializers
  */
+
 import {
   pattern,
   UI,

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/flatmap-callback-expression-statement.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/flatmap-callback-expression-statement.input.tsx
@@ -1,6 +1,7 @@
 /**
  * TRANSFORM REPRO: patternized flatMap callback should lower reactive expression statements
  */
+
 import {
   pattern,
   UI,

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.input.tsx
@@ -6,6 +6,7 @@
  * must not hide the explicit `path -> visible` dependency when later helper-owned
  * derives are created.
  */
+
 import {
   action,
   Default,

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.input.tsx
@@ -5,6 +5,7 @@
  * The final callback array method should lower to mapWithPattern, but the
  * IIFE itself should stay decomposed rather than being blanket-wrapped.
  */
+
 import {
   action,
   Default,

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-filter-capture.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-filter-capture.input.tsx
@@ -1,6 +1,7 @@
 /**
  * TRANSFORM REPRO: helper-owned JSX IIFE final filter callback captures reactive state.
  */
+
 import {
   Default,
   pattern,

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-flatmap-fallback-capture.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-flatmap-fallback-capture.input.tsx
@@ -2,6 +2,7 @@
  * TRANSFORM REPRO: helper-owned JSX IIFE final flatMap callback captures reactive state
  * after the local receiver has been rewritten through a synthetic fallback wrapper.
  */
+
 import { pattern, UI, VNode } from "commonfabric";
 
 interface Entry {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-capture.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-capture.input.tsx
@@ -5,6 +5,7 @@
  * as a plain map call. That is only safe when the callback depends only on the mapped
  * element. If it captures outer reactive state, it must lower through mapWithPattern.
  */
+
 import {
   Default,
   pattern,

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-fallback-capture.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-fallback-capture.input.tsx
@@ -2,6 +2,7 @@
  * TRANSFORM REPRO: helper-owned JSX IIFE final map callback captures reactive state
  * after the local receiver has been rewritten through a synthetic fallback wrapper.
  */
+
 import { pattern, UI, VNode } from "commonfabric";
 
 interface Entry {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.input.tsx
@@ -6,6 +6,7 @@
  * themselves (`tree`, `p`, `unsorted`, `items`) is wrong because they are not
  * in scope at the synthetic lift-applied call site.
  */
+
 import {
   action,
   Default,

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-aliased-const-computation.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-aliased-const-computation.input.tsx
@@ -4,6 +4,7 @@
  * A direct alias may stay structural, but a later computation over that alias
  * should still lower at its own seam.
  */
+
 import {
   Default,
   pattern,

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-array-destructured-alias-computation.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-array-destructured-alias-computation.input.tsx
@@ -4,6 +4,7 @@
  * Destructuring a reactive array-valued field into a local alias should still
  * let later computations lower through that alias.
  */
+
 import {
   Default,
   pattern,

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-direct-alias.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-direct-alias.input.tsx
@@ -5,6 +5,7 @@
  * when it is only forwarded into JSX, because the renderer already knows how
  * to subscribe to structural opaque refs.
  */
+
 import {
   Default,
   pattern,

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-element-property-helper-comparison.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-element-property-helper-comparison.input.tsx
@@ -5,6 +5,7 @@
  * `message.author === senderName(name.get())` must read `message.author`
  * through a reactive field dependency, not as a plain property on the cell.
  */
+
 import {
   Default,
   pattern,

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-expression-statement.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-expression-statement.input.tsx
@@ -5,6 +5,7 @@
  * This bare statement call consumes reactive callback fields and should cross an explicit
  * compute boundary instead of operating directly on `file.key(...)` refs in plain code.
  */
+
 import {
   Default,
   pattern,

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-helper-call-over-alias.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-helper-call-over-alias.input.tsx
@@ -4,6 +4,7 @@
  * A direct alias may stay structural, but an ordinary helper call that consumes
  * that alias should still lower at its own seam.
  */
+
 import {
   Default,
   pattern,

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-local-consts.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-local-consts.input.tsx
@@ -4,6 +4,7 @@
  * These callback-local aliases read reactive fields from the map element. Once the callback
  * becomes `mapWithPattern(pattern(...))`, both initializers should lower at their own seams.
  */
+
 import {
   Default,
   pattern,

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-alias-computation.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-alias-computation.input.tsx
@@ -4,6 +4,7 @@
  * If a reactive field is first packed into a local object aggregate, later
  * computations over that aggregate should still lower correctly.
  */
+
 import {
   Default,
   pattern,

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-plain-sibling-computation.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-plain-sibling-computation.input.tsx
@@ -4,6 +4,7 @@
  * If a local object aggregate mixes reactive and plain fields, later
  * computations over the plain field should stay plain.
  */
+
 import {
   Default,
   pattern,

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-destructured-alias-computation.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-destructured-alias-computation.input.tsx
@@ -4,6 +4,7 @@
  * A destructured alias may remain structural, but later computations over it
  * should still lower at their own seam.
  */
+
 import {
   Default,
   pattern,

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-tuple-aggregate-alias-computation.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-tuple-aggregate-alias-computation.input.tsx
@@ -4,6 +4,7 @@
  * If a reactive field is packed into a local tuple aggregate, later tuple-index
  * computations should still lower correctly.
  */
+
 import {
   Default,
   pattern,

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/wrapped-element-binding-reads.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/wrapped-element-binding-reads.input.tsx
@@ -11,6 +11,7 @@
  * unwrapping wrappers — the dependency was still captured, but in a less
  * structured shape that downstream readers don't expect).
  */
+
 import { pattern, UI, type VNode } from "commonfabric";
 
 type Entry = { name: string };

--- a/packages/ts-transformers/test/fixtures/kitchensink/helper-owned-compute-branches.input.tsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/helper-owned-compute-branches.input.tsx
@@ -9,6 +9,7 @@
  *   Writable array capture
  * - authored ifElse branches still lower safely around the mixed map behavior
  */
+
 import { computed, ifElse, pattern, UI, Writable } from "commonfabric";
 
 interface Badge {

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.input.tsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.input.tsx
@@ -14,6 +14,7 @@
  * - threadRows.map(...) lowers once the flow re-enters pattern-owned UI
  * - closures preserve thread/comment indices, state.lane, and local Writables
  */
+
 import {
   computed,
   handler,

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.input.tsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.input.tsx
@@ -9,6 +9,7 @@
  * - nested ternaries inside task/tag callbacks lower without extra lift-applied noise
  * - handler captures preserve section/task/index/local Writable references
  */
+
 import { computed, handler, ifElse, pattern, UI, Writable } from "commonfabric";
 
 interface Task {

--- a/packages/ts-transformers/test/verb-return-validation.test.ts
+++ b/packages/ts-transformers/test/verb-return-validation.test.ts
@@ -9,6 +9,7 @@
  * `packages/api/index.ts`), so the declared-result cases also prove the
  * `action<E, R>` / `handler<E, T, R>` overloads are reachable from a pattern.
  */
+
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { validateSource } from "./utils.ts";
 import type { TransformationDiagnostic } from "../src/mod.ts";

--- a/packages/ts-transformers/test/verb-tier-mark.test.ts
+++ b/packages/ts-transformers/test/verb-tier-mark.test.ts
@@ -10,6 +10,7 @@
  * pipeline, and the assertions read the emitted result-schema literal — the
  * artifact `cf piece verbs` will consult.
  */
+
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { transformSource } from "./utils.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";

--- a/packages/ui/src/v2/components/cf-button/cf-button.test.ts
+++ b/packages/ui/src/v2/components/cf-button/cf-button.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for CFButton component
  */
+
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import { CFButton } from "./index.ts";

--- a/packages/ui/src/v2/components/cf-calendar/cf-calendar.test.ts
+++ b/packages/ui/src/v2/components/cf-calendar/cf-calendar.test.ts
@@ -8,6 +8,7 @@
  * - Configurable week start (`week-start` attribute): grid leading-day math
  *   and weekday header labels, Sunday-first by default.
  */
+
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import { CFCalendar } from "./index.ts";

--- a/packages/ui/src/v2/components/cf-chart/cf-chart.ts
+++ b/packages/ui/src/v2/components/cf-chart/cf-chart.ts
@@ -20,6 +20,7 @@
  * @fires cf-click - Click with nearest data point
  * @fires cf-leave - Mouse leaves chart area
  */
+
 import { html, svg, PropertyValues } from "lit";
 import { type CellHandle } from "@commonfabric/runtime-client";
 import { BaseElement } from "../../core/base-element.ts";

--- a/packages/ui/src/v2/components/cf-chart/lib/axes.ts
+++ b/packages/ui/src/v2/components/cf-chart/lib/axes.ts
@@ -4,6 +4,7 @@
  * Renders tick marks and labels for x and y axes as SVG groups.
  * Accepts AxisConfig for customization (label, tickFormat, grid, tickCount).
  */
+
 import { svg, type TemplateResult } from "lit";
 // @ts-types="@types/d3-scale"
 import type { ScaleBand } from "d3-scale";

--- a/packages/ui/src/v2/components/cf-chart/lib/interaction.ts
+++ b/packages/ui/src/v2/components/cf-chart/lib/interaction.ts
@@ -1,6 +1,7 @@
 /**
  * Interaction handling for cf-chart: hover, click, crosshair, tooltip.
  */
+
 import { svg, type TemplateResult } from "lit";
 // @ts-types="@types/d3-scale"
 import type { ScaleBand } from "d3-scale";

--- a/packages/ui/src/v2/components/cf-chart/lib/render.ts
+++ b/packages/ui/src/v2/components/cf-chart/lib/render.ts
@@ -3,6 +3,7 @@
  *
  * Uses d3-shape for path generation and Lit's svg template tag.
  */
+
 import { svg, type TemplateResult } from "lit";
 // @ts-types="@types/d3-shape"
 import {

--- a/packages/ui/src/v2/components/cf-chart/marks/base-mark.ts
+++ b/packages/ui/src/v2/components/cf-chart/marks/base-mark.ts
@@ -5,6 +5,7 @@
  * declarative config holders (like <source>, <option>, <track>).
  * The parent cf-chart reads their properties and renders all SVG.
  */
+
 import { css, LitElement, PropertyValues } from "lit";
 import { type CellHandle } from "@commonfabric/runtime-client";
 import { CellController } from "../../../core/cell-controller.ts";

--- a/packages/ui/src/v2/components/cf-chart/marks/cf-area-mark.ts
+++ b/packages/ui/src/v2/components/cf-chart/marks/cf-area-mark.ts
@@ -6,6 +6,7 @@
  *
  * @element cf-area-mark
  */
+
 import type { CurveType, MarkType } from "../types.ts";
 import { MarkElement } from "./base-mark.ts";
 

--- a/packages/ui/src/v2/components/cf-chart/marks/cf-bar-mark.ts
+++ b/packages/ui/src/v2/components/cf-chart/marks/cf-bar-mark.ts
@@ -6,6 +6,7 @@
  *
  * @element cf-bar-mark
  */
+
 import type { MarkType } from "../types.ts";
 import { MarkElement } from "./base-mark.ts";
 

--- a/packages/ui/src/v2/components/cf-chart/marks/cf-dot-mark.ts
+++ b/packages/ui/src/v2/components/cf-chart/marks/cf-dot-mark.ts
@@ -6,6 +6,7 @@
  *
  * @element cf-dot-mark
  */
+
 import type { MarkType } from "../types.ts";
 import { MarkElement } from "./base-mark.ts";
 

--- a/packages/ui/src/v2/components/cf-chart/marks/cf-line-mark.ts
+++ b/packages/ui/src/v2/components/cf-chart/marks/cf-line-mark.ts
@@ -6,6 +6,7 @@
  *
  * @element cf-line-mark
  */
+
 import type { CurveType, MarkType } from "../types.ts";
 import { MarkElement } from "./base-mark.ts";
 

--- a/packages/ui/src/v2/components/cf-checkbox/cf-checkbox.test.ts
+++ b/packages/ui/src/v2/components/cf-checkbox/cf-checkbox.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for CFCheckbox component
  */
+
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import { CFCheckbox } from "./index.ts";

--- a/packages/ui/src/v2/components/cf-copy-button/cf-copy-button.test.ts
+++ b/packages/ui/src/v2/components/cf-copy-button/cf-copy-button.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for CFCopyButton component
  */
+
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import { CFCopyButton } from "./index.ts";

--- a/packages/ui/src/v2/components/cf-empty-state/cf-empty-state.test.ts
+++ b/packages/ui/src/v2/components/cf-empty-state/cf-empty-state.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for CFEmptyState component
  */
+
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import { CFEmptyState } from "./index.ts";

--- a/packages/ui/src/v2/components/cf-field/cf-field.test.ts
+++ b/packages/ui/src/v2/components/cf-field/cf-field.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for CFField component
  */
+
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import { CFField } from "./index.ts";

--- a/packages/ui/src/v2/components/cf-file-download/cf-file-download.test.ts
+++ b/packages/ui/src/v2/components/cf-file-download/cf-file-download.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for CFFileDownload component
  */
+
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { CFFileDownload } from "./index.ts";

--- a/packages/ui/src/v2/components/cf-hstack/cf-hstack.test.ts
+++ b/packages/ui/src/v2/components/cf-hstack/cf-hstack.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for CFHStack component
  */
+
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import { CFHStack } from "./index.ts";

--- a/packages/ui/src/v2/components/cf-image/cf-image.test.ts
+++ b/packages/ui/src/v2/components/cf-image/cf-image.test.ts
@@ -6,6 +6,7 @@
  * for a Blob, so the tests drive `_coerceBytes`, the `willUpdate` object-URL
  * lifecycle, `render`, and cleanup directly.
  */
+
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import { CFImage } from "./index.ts";

--- a/packages/ui/src/v2/components/cf-map/cf-map.test.ts
+++ b/packages/ui/src/v2/components/cf-map/cf-map.test.ts
@@ -7,6 +7,7 @@
  *
  * For full component integration tests, use browser-based testing.
  */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type {

--- a/packages/ui/src/v2/components/cf-modal/styles.ts
+++ b/packages/ui/src/v2/components/cf-modal/styles.ts
@@ -4,6 +4,7 @@
  * Desktop: Centered modal with fade + scale animation
  * Mobile (<480px): Bottom sheet with slide-up animation
  */
+
 import { css } from "lit";
 
 export const modalStyles = css`

--- a/packages/ui/src/v2/components/cf-picker/cf-picker.test.ts
+++ b/packages/ui/src/v2/components/cf-picker/cf-picker.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for CFPicker component
  */
+
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import { CFPicker } from "./index.ts";

--- a/packages/ui/src/v2/components/cf-select/cf-select.test.ts
+++ b/packages/ui/src/v2/components/cf-select/cf-select.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for CFSelect component, including new $value two-way binding functionality
  */
+
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import { CFSelect, type SelectItem } from "./index.ts";

--- a/packages/ui/src/v2/components/cf-svg/sanitize-svg.test.ts
+++ b/packages/ui/src/v2/components/cf-svg/sanitize-svg.test.ts
@@ -12,6 +12,7 @@
  * These tests will fail in a standard Deno test environment because DOMParser
  * is not available outside of a browser context.
  */
+
 import { assert } from "@std/assert";
 import { sanitizeSvg } from "./sanitize-svg.ts";
 

--- a/packages/ui/src/v2/components/cf-text/cf-text.test.ts
+++ b/packages/ui/src/v2/components/cf-text/cf-text.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for CFText component
  */
+
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import { CFText } from "./index.ts";

--- a/packages/ui/src/v2/components/cf-vstack/cf-vstack.test.ts
+++ b/packages/ui/src/v2/components/cf-vstack/cf-vstack.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for CFVStack component
  */
+
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import { layoutSpacingUtilityStyles } from "../../styles/layout-spacing.ts";

--- a/packages/ui/src/v2/components/form/form-context.ts
+++ b/packages/ui/src/v2/components/form/form-context.ts
@@ -5,6 +5,7 @@
  * and flush atomically on submit. This enables transactional form handling
  * without changing the underlying cell binding pattern.
  */
+
 import { createContext } from "@lit/context";
 
 /**

--- a/packages/ui/src/v2/core/base-element.ts
+++ b/packages/ui/src/v2/core/base-element.ts
@@ -2,6 +2,7 @@
  * Minimal base class for web components using Lit
  * Provides the emit() helper for consistent custom events
  */
+
 import { css, CSSResult, LitElement } from "lit";
 import { variablesCSS } from "../styles/variables.ts";
 import { DebugController } from "./debug-controller.ts";

--- a/packages/ui/src/v2/core/cfc-label.ts
+++ b/packages/ui/src/v2/core/cfc-label.ts
@@ -8,6 +8,7 @@
  * scanning every entry) and is the shared home for that concern. A future pass
  * can fold the authorship reader onto these primitives.
  */
+
 import type { CfcLabelView } from "@commonfabric/runner/cfc";
 
 export type { CfcLabelView };

--- a/packages/ui/src/v2/core/form-field-controller.test.ts
+++ b/packages/ui/src/v2/core/form-field-controller.test.ts
@@ -4,6 +4,7 @@
  * Tests the "write gate" pattern where form fields buffer writes locally
  * when inside a cf-form, and flush atomically on submit.
  */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {

--- a/packages/ui/src/v2/core/form-field-controller.ts
+++ b/packages/ui/src/v2/core/form-field-controller.ts
@@ -37,6 +37,7 @@
  * }
  * ```
  */
+
 import { ReactiveController, ReactiveControllerHost } from "lit";
 import { ContextConsumer } from "@lit/context";
 import {

--- a/packages/ui/src/v2/utils/audio-conversion.test.ts
+++ b/packages/ui/src/v2/utils/audio-conversion.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for audio conversion utilities
  */
+
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import {

--- a/tasks/vintage-adopt.test.ts
+++ b/tasks/vintage-adopt.test.ts
@@ -6,6 +6,7 @@
  * supplies by hand what a capture derives mechanically — so every argument is
  * a chance to pin a fixture whose every replay fails.
  */
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";

--- a/tasks/vintage-adopt.ts
+++ b/tasks/vintage-adopt.ts
@@ -26,6 +26,7 @@
  * fixture whose every replay fails — the dead end the capture guard exists to
  * prevent, one tool over.
  */
+
 import { Identity } from "@commonfabric/identity";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { getPatternIdentityRef } from "@commonfabric/runner";


### PR DESCRIPTION
Completes the file-header series (#5865, #5867). I (agent working on behalf of
@danfuzz) am finishing the remaining 115 files in two commits — `ts-transformers`
first, then everything else.

## What changed

115 files whose file header ran straight into the first `import`.
`code-comment-style.md` § File headers requires the blank line, and says why:
it is what keeps the header from being read as the doc comment of the first
declaration under it.

| Package | Files | | Package | Files |
|---|---:|---|---|---:|
| `ts-transformers` | 55 | | `memory` | 2 |
| `ui` | 31 | | `tasks/` | 2 |
| `runner` | 22 | | `integration`, `piece`, `toolshed` | 1 each |

**The whole change is 115 inserted blank lines, one per file** — the diff adds
no non-blank line and removes nothing, checked mechanically rather than by eye.

## The part worth reviewing: 43 transformer fixtures

43 of the `ts-transformers` files are `*.input.tsx` — transformer **input**,
compared against recorded `*.expected.jsx` goldens. A blank line there is only
safe if the golden comparison ignores it, and that is not something to assume.

Two runs settle it:

- With all 55 modified, the suite passes at **1140**, its usual count.
- Renaming one `const` in the very fixture the blank line was added to
  (`isEditing` → `isEditingZz`) turns that into **1139 passed / 1 failed**.

So the goldens do see input content, and do not see a leading blank line. Had
the first run gone red, the answer for those 43 would have been to leave them
alone — not to re-record the goldens.

## Verification

- Diff characterized exactly: **115 added lines, 0 non-blank, 0 removed**.
- `deno fmt --check`, `deno lint`, `deno task check` green.
- Suites: `ts-transformers` 1140, `runner` 1206, `memory` 499, `toolshed` 137,
  `piece` 37, `ui` 52. All 0 failed.

## What stays as it is

- **`packages/patterns` and `packages/generated-patterns`** (216 + 1 files) —
  out of mechanical sweeps, because pattern source is compiled and
  content-addressed, so an edit that looks inert can move a contract.
- **69 files whose top block is `//` rather than `/** */`.** The same section
  says that form is not a header — "it reads as a note about the line beneath
  it" — and sometimes it literally is:

  ```ts
  // The import below must resolve to the same @std/fmt instance Cliffy uses
  import { setColorEnabled } from "@std/fmt/colors";
  ```

  That group is heterogeneous — lint pragmas, file descriptions written in the
  wrong form, and genuine notes about the import — so it wants judgment per
  file rather than a sweep.

With this merged, every `/** */` file header in the tree stands clear of the
first import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

