### PR TITLE
docs: put obvious file headers into doc-comment form

### DIFF
--- a/packages/cli/test/piece-integration.test.ts
+++ b/packages/cli/test/piece-integration.test.ts
@@ -1,10 +1,13 @@
-// Integration tests for `cf piece get` against a live toolshed. The suite
-// runs when API_URL names a running toolshed (as in the CI cli-integration
-// jobs) and is skipped otherwise. A throwaway identity keyfile and space are
-// created per run. Run locally with:
-//   API_URL=http://localhost:8000 deno test --allow-net --allow-ffi \
-//     --allow-read --allow-write --allow-env --allow-run \
-//     test/piece-integration.test.ts
+/**
+ * Integration tests for `cf piece get` against a live toolshed. The suite
+ * runs when API_URL names a running toolshed (as in the CI cli-integration
+ * jobs) and is skipped otherwise. A throwaway identity keyfile and space are
+ * created per run. Run locally with:
+ *   API_URL=http://localhost:8000 deno test --allow-net --allow-ffi \
+ *     --allow-read --allow-write --allow-env --allow-run \
+ *     test/piece-integration.test.ts
+ */
+
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { resolve } from "@std/path";

--- a/packages/dashboard/ctx.test.ts
+++ b/packages/dashboard/ctx.test.ts
@@ -1,6 +1,9 @@
-// Ctx tests: makeCtx() builds the memoized data sources every tile reads. The
-// GitHub API is stubbed with a canned runs response, so these pin the paging,
-// the age cutoff, the cap, and the caching without a network.
+/**
+ * Ctx tests: makeCtx() builds the memoized data sources every tile reads. The
+ * GitHub API is stubbed with a canned runs response, so these pin the paging,
+ * the age cutoff, the cap, and the caching without a network.
+ */
+
 import { assert, assertEquals } from "@std/assert";
 import { makeCtx } from "./ctx.ts";
 import {

--- a/packages/dashboard/gcp-auth.test.ts
+++ b/packages/dashboard/gcp-auth.test.ts
@@ -1,6 +1,9 @@
-// Tests for the two GCP auth routes and the BigQuery call that uses them, with
-// fetch stubbed. Nothing here reaches the network: every request the code makes
-// is captured and inspected, and the responses are canned.
+/**
+ * Tests for the two GCP auth routes and the BigQuery call that uses them, with
+ * fetch stubbed. Nothing here reaches the network: every request the code makes
+ * is captured and inspected, and the responses are canned.
+ */
+
 import { assertEquals, assertRejects } from "@std/assert";
 import { bigQuery, METADATA_TOKEN_URL } from "./gcp.ts";
 

--- a/packages/dashboard/gcp.test.ts
+++ b/packages/dashboard/gcp.test.ts
@@ -1,6 +1,9 @@
-// Tests for the GCP REST helpers: the service-account JWT is signed correctly
-// (verified with the matching public key), and jobs.query responses parse. No
-// network — signing and parsing are exercised directly.
+/**
+ * Tests for the GCP REST helpers: the service-account JWT is signed correctly
+ * (verified with the matching public key), and jobs.query responses parse. No
+ * network — signing and parsing are exercised directly.
+ */
+
 import { assertEquals, assertThrows } from "@std/assert";
 import { bqRows, METADATA_TOKEN_URL, saAssertion } from "./gcp.ts";
 

--- a/packages/dashboard/lib-extra.test.ts
+++ b/packages/dashboard/lib-extra.test.ts
@@ -1,5 +1,8 @@
-// Unit tests for the helpers lib.test.ts does not reach: the GitHub API wrapper
-// and the memo cache. No real network — fetch is stubbed and restored.
+/**
+ * Unit tests for the helpers lib.test.ts does not reach: the GitHub API wrapper
+ * and the memo cache. No real network — fetch is stubbed and restored.
+ */
+
 import { assert, assertEquals, assertRejects } from "@std/assert";
 import { friendlyError, github, memo } from "./lib.ts";
 

--- a/packages/dashboard/lib.test.ts
+++ b/packages/dashboard/lib.test.ts
@@ -1,4 +1,7 @@
-// Unit tests for the pure helpers. No network, subprocess, or filesystem.
+/**
+ * Unit tests for the pure helpers. No network, subprocess, or filesystem.
+ */
+
 import { assert, assertEquals } from "@std/assert";
 import { budgetStatus, clampInt, concDot, daysLabel, durationTag, escapeHtml, friendlyError, humanDur, humanSpan, landingHref, lighten, multiSparkline, readBudget, sparkline, strip, thin, usd } from "./lib.ts";
 

--- a/packages/dashboard/palette.test.ts
+++ b/packages/dashboard/palette.test.ts
@@ -1,8 +1,11 @@
-// The palette's job is to keep four statuses apart, including for a viewer who
-// cannot separate red from green. That is a measurable property rather than a
-// matter of taste, so it is measured here: each color is put through a
-// simulation of dichromatic vision and the pairs are compared in a space where
-// distance matches what a person sees.
+/**
+ * The palette's job is to keep four statuses apart, including for a viewer who
+ * cannot separate red from green. That is a measurable property rather than a
+ * matter of taste, so it is measured here: each color is put through a
+ * simulation of dichromatic vision and the pairs are compared in a space where
+ * distance matches what a person sees.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { Status } from "./types.ts";

--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -1,5 +1,8 @@
-// Rendering tests: renderTile turns a TileView into markup, shell wraps the grid
-// in the page. Pure string work — no server, no network, no subprocess.
+/**
+ * Rendering tests: renderTile turns a TileView into markup, shell wraps the grid
+ * in the page. Pure string work — no server, no network, no subprocess.
+ */
+
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import type { Status, TileView } from "./types.ts";
 import {

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -1,8 +1,11 @@
-// Tests for the generic runtime: the ticker, the SSE fan-out, the routes, and
-// the page. Importing server.ts neither serves nor collects, so nothing here
-// binds a port or reaches a source; the tiles are stand-ins with a canned
-// collect(), registered under the ids the real registry uses so their views
-// reach the page.
+/**
+ * Tests for the generic runtime: the ticker, the SSE fan-out, the routes, and
+ * the page. Importing server.ts neither serves nor collects, so nothing here
+ * binds a port or reaches a source; the tiles are stand-ins with a canned
+ * collect(), registered under the ids the real registry uses so their views
+ * reach the page.
+ */
+
 import {
   assert,
   assertEquals,

--- a/packages/dashboard/test/spend.test.ts
+++ b/packages/dashboard/test/spend.test.ts
@@ -1,8 +1,11 @@
-// spendChart: the shared multi-source daily-spend chart. Each source's line
-// covers only the days that source is known for — reported days plus settled
-// quiet days — so one source's freshness never pads another with zeros. Plus
-// the two readings a tile takes of a source's reports to decide whether the
-// quiet days are quiet at all.
+/**
+ * spendChart: the shared multi-source daily-spend chart. Each source's line
+ * covers only the days that source is known for — reported days plus settled
+ * quiet days — so one source's freshness never pads another with zeros. Plus
+ * the two readings a tile takes of a source's reports to decide whether the
+ * quiet days are quiet at all.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { newestReportedDay, reportLagDays, spendChart } from "../spend.ts";

--- a/packages/dashboard/tiles.test.ts
+++ b/packages/dashboard/tiles.test.ts
@@ -1,6 +1,9 @@
-// Tile tests: each tile is a pure collect(ctx) -> TileView, exercised with a
-// hand-made Ctx. No server, no network, no subprocess — the CI tiles get canned
-// runs and the token-gated tiles get an empty env (their gray-out contract).
+/**
+ * Tile tests: each tile is a pure collect(ctx) -> TileView, exercised with a
+ * hand-made Ctx. No server, no network, no subprocess — the CI tiles get canned
+ * runs and the token-gated tiles get an empty env (their gray-out contract).
+ */
+
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { runSource, type Ctx, type Run } from "./types.ts";
 import { CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, REPO } from "./config.ts";

--- a/packages/dashboard/tiles/benchmark.test.ts
+++ b/packages/dashboard/tiles/benchmark.test.ts
@@ -1,12 +1,15 @@
-// benchmark tile tests. The tile is driven through collect(ctx) and its /bench
-// route with globalThis.fetch stubbed, so the GitHub Actions workflow-run pages,
-// the per-run artifact listings and the artifact zips (real zip bytes, really
-// deflated) are all canned. No network, no files, no subprocess.
-//
-// The tile keeps a persistent cache of each run's results and a module-level
-// snapshot for the drill-down page. The dashboard test runner gives this module
-// a temporary server-data directory. These tests share that state, use distinct
-// run ids, and read snapshots after the collection that filled them.
+/**
+ * benchmark tile tests. The tile is driven through collect(ctx) and its /bench
+ * route with globalThis.fetch stubbed, so the GitHub Actions workflow-run pages,
+ * the per-run artifact listings and the artifact zips (real zip bytes, really
+ * deflated) are all canned. No network, no files, no subprocess.
+ *
+ * The tile keeps a persistent cache of each run's results and a module-level
+ * snapshot for the drill-down page. The dashboard test runner gives this module
+ * a temporary server-data directory. These tests share that state, use distinct
+ * run ids, and read snapshots after the collection that filled them.
+ */
+
 import {
   assert,
   assertEquals,

--- a/packages/dashboard/tiles/ci-duration.test.ts
+++ b/packages/dashboard/tiles/ci-duration.test.ts
@@ -1,7 +1,10 @@
-// ci-duration's drill-down: the Gantt page and the /bench/gantt.svg image behind it.
-// The image handler shells out to scripts/ci-gantt.ts and writes a temp file.
-// The subprocess and the filesystem calls around it are replaced with
-// stubs that record what the handler asked for and hand back a canned result.
+/**
+ * ci-duration's drill-down: the Gantt page and the /bench/gantt.svg image behind it.
+ * The image handler shells out to scripts/ci-gantt.ts and writes a temp file.
+ * The subprocess and the filesystem calls around it are replaced with
+ * stubs that record what the handler asked for and hand back a canned result.
+ */
+
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import type { Ctx, Run } from "../types.ts";
 import { CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, REPO } from "../config.ts";

--- a/packages/dashboard/tiles/common-tools-up.test.ts
+++ b/packages/dashboard/tiles/common-tools-up.test.ts
@@ -1,9 +1,12 @@
-// common.tools uptime tile: a synthetic HTTP check, exercised with a stubbed
-// fetch and a hand-made Ctx. No network.
-//
-// The tile keeps a consecutive-failure counter across collect() calls, and the
-// module holds it for the life of the process. Each test that cares about the
-// counter starts from a reachable check, which resets it to zero.
+/**
+ * common.tools uptime tile: a synthetic HTTP check, exercised with a stubbed
+ * fetch and a hand-made Ctx. No network.
+ *
+ * The tile keeps a consecutive-failure counter across collect() calls, and the
+ * module holds it for the life of the process. Each test that cares about the
+ * counter starts from a reachable check, which resets it to zero.
+ */
+
 import { assert, assertEquals } from "@std/assert";
 import type { Ctx } from "../types.ts";
 import { commonToolsUp } from "./common-tools-up.ts";

--- a/packages/dashboard/tiles/dau.test.ts
+++ b/packages/dashboard/tiles/dau.test.ts
@@ -1,7 +1,10 @@
-// dau tile tests: collect(ctx) -> TileView against a stubbed SigNoz. No network:
-// globalThis.fetch is swapped for the duration of a test and put back afterwards.
-// The pure helpers (foldSeries, parseExcludes) are pinned in
-// ../tiles.test.ts; what is pinned here is the tile's own reading of a response.
+/**
+ * dau tile tests: collect(ctx) -> TileView against a stubbed SigNoz. No network:
+ * globalThis.fetch is swapped for the duration of a test and put back afterwards.
+ * The pure helpers (foldSeries, parseExcludes) are pinned in
+ * ../tiles.test.ts; what is pinned here is the tile's own reading of a response.
+ */
+
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import type { Ctx } from "../types.ts";
 import { dau } from "./dau.ts";

--- a/packages/dashboard/tiles/discord-online.test.ts
+++ b/packages/dashboard/tiles/discord-online.test.ts
@@ -1,8 +1,11 @@
-// discord online: the tile drives a Discord gateway socket, two timers and a
-// history file on disk. All four are replaced with stand-ins here — the socket is
-// driven frame by frame, the timers fire on demand, the clock is fixed, and the
-// file reads and writes are captured in memory. No network, no filesystem, no
-// waiting.
+/**
+ * discord online: the tile drives a Discord gateway socket, two timers and a
+ * history file on disk. All four are replaced with stand-ins here — the socket is
+ * driven frame by frame, the timers fire on demand, the clock is fixed, and the
+ * file reads and writes are captured in memory. No network, no filesystem, no
+ * waiting.
+ */
+
 import {
   assert,
   assertEquals,

--- a/packages/dashboard/tiles/gcp-spend.test.ts
+++ b/packages/dashboard/tiles/gcp-spend.test.ts
@@ -1,5 +1,8 @@
-// Cloud spend tile tests. The clock and BigQuery REST responses are fixed, so
-// projections and highlighted chart windows are deterministic.
+/**
+ * Cloud spend tile tests. The clock and BigQuery REST responses are fixed, so
+ * projections and highlighted chart windows are deterministic.
+ */
+
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import type { Ctx } from "../types.ts";
 import { METADATA_TOKEN_URL } from "../gcp.ts";

--- a/packages/dashboard/tiles/github-ci-spend.test.ts
+++ b/packages/dashboard/tiles/github-ci-spend.test.ts
@@ -1,6 +1,9 @@
-// ci spend tests. The tile is a pure collect(ctx) -> TileView over GitHub and
-// Blacksmith billing data. The tests pin the clock and provide fixed responses
-// for both sources.
+/**
+ * ci spend tests. The tile is a pure collect(ctx) -> TileView over GitHub and
+ * Blacksmith billing data. The tests pin the clock and provide fixed responses
+ * for both sources.
+ */
+
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import type { Ctx, TileView } from "../types.ts";
 import { REPO } from "../config.ts";

--- a/packages/dashboard/tiles/github-members.test.ts
+++ b/packages/dashboard/tiles/github-members.test.ts
@@ -1,6 +1,9 @@
-// github users: GitHub and the history file are replaced with in-memory
-// stand-ins. The tests cover pagination, both organization rosters, retained
-// history, and the gray states for unavailable data.
+/**
+ * github users: GitHub and the history file are replaced with in-memory
+ * stand-ins. The tests cover pagination, both organization rosters, retained
+ * history, and the gray states for unavailable data.
+ */
+
 import {
   assert,
   assertEquals,

--- a/packages/dashboard/tiles/main-build.test.ts
+++ b/packages/dashboard/tiles/main-build.test.ts
@@ -1,5 +1,8 @@
-// The main-build tile's streak: how long the tip conclusion has held on main.
-// Canned runs, no network. See tiles.test.ts for the rest of this tile's contract.
+/**
+ * The main-build tile's streak: how long the tip conclusion has held on main.
+ * Canned runs, no network. See tiles.test.ts for the rest of this tile's contract.
+ */
+
 import {
   assertEquals,
   assertRejects,

--- a/packages/dashboard/tiles/model-spend.test.ts
+++ b/packages/dashboard/tiles/model-spend.test.ts
@@ -1,7 +1,10 @@
-// Tests for the model-spend tile: three provider billing APIs, read through a
-// stubbed fetch. Nothing here touches the network. The day keys are built from the
-// real current UTC date, because the tile reads the clock to decide which days are
-// this month and how far back to ask.
+/**
+ * Tests for the model-spend tile: three provider billing APIs, read through a
+ * stubbed fetch. Nothing here touches the network. The day keys are built from the
+ * real current UTC date, because the tile reads the clock to decide which days are
+ * this month and how far back to ask.
+ */
+
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import type { Ctx } from "../types.ts";
 import { themedChartSeries } from "../theme.ts";

--- a/packages/dashboard/tiles/prod-errors.test.ts
+++ b/packages/dashboard/tiles/prod-errors.test.ts
@@ -1,6 +1,9 @@
-// prod-errors tile tests: collect(ctx) against a stubbed SigNoz v5 query_range.
-// No real network — globalThis.fetch is swapped for the duration of each collect
-// and restored afterwards.
+/**
+ * prod-errors tile tests: collect(ctx) against a stubbed SigNoz v5 query_range.
+ * No real network — globalThis.fetch is swapped for the duration of each collect
+ * and restored afterwards.
+ */
+
 import { assert, assertEquals } from "@std/assert";
 import type { Ctx } from "../types.ts";
 import { prodErrors } from "./prod-errors.ts";

--- a/packages/dashboard/tiles/prod-uptime.test.ts
+++ b/packages/dashboard/tiles/prod-uptime.test.ts
@@ -1,5 +1,8 @@
-// prod-uptime tests use canned HTTP, DNS and SOCKS5 replies. No test reaches
-// the network.
+/**
+ * prod-uptime tests use canned HTTP, DNS and SOCKS5 replies. No test reaches
+ * the network.
+ */
+
 import {
   assert,
   assertEquals,

--- a/packages/memory/test/support/column-origin-download-probe.ts
+++ b/packages/memory/test/support/column-origin-download-probe.ts
@@ -1,6 +1,9 @@
-// Run with an empty plug cache and NO network: the pinned release can't be
-// resolved, so openSource reports the failure instead of binding. Exercises the
-// download-failure catch in openSource.
+/**
+ * Run with an empty plug cache and NO network: the pinned release can't be
+ * resolved, so openSource reports the failure instead of binding. Exercises the
+ * download-failure catch in openSource.
+ */
+
 import { openSource } from "../../v2/sqlite/column-origin.ts";
 const result = await openSource({ kind: "release" });
 console.log(JSON.stringify("problem" in result));

--- a/packages/memory/test/support/column-origin-env-probe.ts
+++ b/packages/memory/test/support/column-origin-env-probe.ts
@@ -1,5 +1,8 @@
-// Run with env access DENIED (no --allow-env): readEnv's Deno.env.get throws,
-// its catch swallows the denied read and reports the var unset, so librarySource
-// falls through to the release. Exercises readEnv's catch under real denial.
+/**
+ * Run with env access DENIED (no --allow-env): readEnv's Deno.env.get throws,
+ * its catch swallows the denied read and reports the var unset, so librarySource
+ * falls through to the release. Exercises readEnv's catch under real denial.
+ */
+
 import { librarySource } from "../../v2/sqlite/column-origin.ts";
 console.log(JSON.stringify(librarySource()));

--- a/packages/memory/test/support/column-origin-server-probe.ts
+++ b/packages/memory/test/support/column-origin-server-probe.ts
@@ -1,7 +1,10 @@
-// @db/sqlite loads its libsqlite3 at import (env still default). Only then do we
-// point DENO_SQLITE_LOCAL at a build column-origin can't derive, so a labeled
-// read's ensureColumnOriginAvailable() fails while @db/sqlite itself keeps
-// working — the one situation the server's fail-loud branch guards.
+/**
+ * @db/sqlite loads its libsqlite3 at import (env still default). Only then do we
+ * point DENO_SQLITE_LOCAL at a build column-origin can't derive, so a labeled
+ * read's ensureColumnOriginAvailable() fails while @db/sqlite itself keeps
+ * working — the one situation the server's fail-loud branch guards.
+ */
+
 import { Server } from "../../v2/server.ts";
 import { connect, loopback } from "../../v2/client.ts";
 import { table } from "../../v2/sqlite/schema.ts";

--- a/packages/runner/test/acl-manager.test.ts
+++ b/packages/runner/test/acl-manager.test.ts
@@ -1,13 +1,16 @@
-// Read-path and validation unit tests for `ACLManager`.
-//
-// Deliberately scoped to logic that a mocked runtime can honestly exercise:
-// document addressing and the validation of already-stored values. The WRITE
-// path is not tested here and must not be — a mocked `editWithRetry` cannot
-// observe the commit the runner actually emits, and that blind spot is exactly
-// how a bug shipped in which every post-genesis ACL mutation was refused by the
-// server while this suite stayed green. Write-path coverage lives in
-// `memory-v2-acl-mutation.test.ts`, against a real memory-v2 server, and
-// asserts the emitted operation shape.
+/**
+ * Read-path and validation unit tests for `ACLManager`.
+ *
+ * Deliberately scoped to logic that a mocked runtime can honestly exercise:
+ * document addressing and the validation of already-stored values. The WRITE
+ * path is not tested here and must not be — a mocked `editWithRetry` cannot
+ * observe the commit the runner actually emits, and that blind spot is exactly
+ * how a bug shipped in which every post-genesis ACL mutation was refused by the
+ * server while this suite stayed green. Write-path coverage lives in
+ * `memory-v2-acl-mutation.test.ts`, against a real memory-v2 server, and
+ * asserts the emitted operation shape.
+ */
+
 import { assertEquals, assertRejects } from "@std/assert";
 import { ACLManager } from "../src/acl-manager.ts";
 import type { Runtime } from "../src/runtime.ts";

--- a/packages/runner/test/ascell-scope-cap.test.ts
+++ b/packages/runner/test/ascell-scope-cap.test.ts
@@ -1,19 +1,22 @@
-// An `asCell` entry's `scope` is a follow cap: it bounds which link scopes a
-// read arriving through that schema may follow (ContextualFlowControl
-// .getSchemaScopeCap). It is what lets a space-scoped list require that every
-// handle in it points somewhere every reader in the space can resolve.
-//
-// The cap has to mean the same thing however the handle is reached. These tests
-// pin the three routes to one answer:
-//
-//   1. the value projection            -- cell.key("handle").get()
-//   2. a key() chain past the handle   -- cell.key("handle", "field").get()
-//   3. an explicit dereference         -- cell.key("handle").resolveAsCell()
-//
-// Before #5230 only (3) consulted the cap: (1) never checked it, and (2) lost
-// it because key() narrows through getSchemaAtPath, which drops the ancestor's
-// asCell entry, leaving resolveLink's schemaScopeForLink() with nothing to
-// check one hop later.
+/**
+ * An `asCell` entry's `scope` is a follow cap: it bounds which link scopes a
+ * read arriving through that schema may follow (ContextualFlowControl
+ * .getSchemaScopeCap). It is what lets a space-scoped list require that every
+ * handle in it points somewhere every reader in the space can resolve.
+ *
+ * The cap has to mean the same thing however the handle is reached. These tests
+ * pin the three routes to one answer:
+ *
+ *   1. the value projection            -- cell.key("handle").get()
+ *   2. a key() chain past the handle   -- cell.key("handle", "field").get()
+ *   3. an explicit dereference         -- cell.key("handle").resolveAsCell()
+ *
+ * Before #5230 only (3) consulted the cap: (1) never checked it, and (2) lost
+ * it because key() narrows through getSchemaAtPath, which drops the ancestor's
+ * asCell entry, leaving resolveLink's schemaScopeForLink() with nothing to
+ * check one hop later.
+ */
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";

--- a/packages/runner/test/cell-notification-shaper-lifecycle.test.ts
+++ b/packages/runner/test/cell-notification-shaper-lifecycle.test.ts
@@ -1,7 +1,10 @@
-// Plan B: the wake shaper's cell path is owned by the scheduler. These tests
-// exercise its runtime lifecycle through the public holdShapedCellNotification
-// seam — that a held notification is not delivered synchronously, that idle()
-// waits for its release, and that dispose() cancels it.
+/**
+ * Plan B: the wake shaper's cell path is owned by the scheduler. These tests
+ * exercise its runtime lifecycle through the public holdShapedCellNotification
+ * seam — that a held notification is not delivered synchronously, that idle()
+ * waits for its release, and that dispose() cancels it.
+ */
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";

--- a/packages/runner/test/commit-callback-release-helper.ts
+++ b/packages/runner/test/commit-callback-release-helper.ts
@@ -1,21 +1,24 @@
-// Helper for commit-callback-release.test.ts. Runs in its own process so it
-// can use `--v8-flags=--expose-gc` and the real clock (WeakRef state only
-// settles across task boundaries, which the package's fake-clock preload
-// would freeze).
-//
-// A commit callback runs exactly once, when its transaction settles. The
-// question here is what the transaction holds afterwards. Callbacks are
-// closures over the machinery that registered them — a child registry, a
-// result cell, an action's captured frame — so a settled transaction that
-// keeps its callback set keeps all of that reachable for as long as anything
-// still references the transaction. Long-lived structures do reference
-// settled transactions (a cell carries the transaction it was created with),
-// so this is a live retention path, not a theoretical one.
-//
-// The helper registers a callback whose closure captures a sentinel object,
-// commits, drops every reference except a WeakRef to the sentinel and a
-// strong reference to the settled transaction, and reports whether the
-// sentinel is still reachable.
+/**
+ * Helper for commit-callback-release.test.ts. Runs in its own process so it
+ * can use `--v8-flags=--expose-gc` and the real clock (WeakRef state only
+ * settles across task boundaries, which the package's fake-clock preload
+ * would freeze).
+ *
+ * A commit callback runs exactly once, when its transaction settles. The
+ * question here is what the transaction holds afterwards. Callbacks are
+ * closures over the machinery that registered them — a child registry, a
+ * result cell, an action's captured frame — so a settled transaction that
+ * keeps its callback set keeps all of that reachable for as long as anything
+ * still references the transaction. Long-lived structures do reference
+ * settled transactions (a cell carries the transaction it was created with),
+ * so this is a live retention path, not a theoretical one.
+ *
+ * The helper registers a callback whose closure captures a sentinel object,
+ * commits, drops every reference except a WeakRef to the sentinel and a
+ * strong reference to the settled transaction, and reports whether the
+ * sentinel is still reachable.
+ */
+
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";

--- a/packages/runner/test/declared-result-e2e.test.ts
+++ b/packages/runner/test/declared-result-e2e.test.ts
@@ -1,20 +1,23 @@
-// A CTS-authored `action<Event, Result>` verb, compiled through the real
-// pipeline (`patternManager.compilePattern` → js-compiler → CTS transformers →
-// SES evaluation), delivers its returned value into the event receipt under
-// the `plainResultReceipts` experimental flag (default-on since the flip) —
-// the composition of this
-// package's plain-return projection (scheduler-event-receipts.test.ts, which
-// exercises only the raw trusted-builder `handler`) with the api's declared-
-// result authoring surface. This is the readback half of WS-C's exit
-// criterion, pinned at the runner in addition to the end-to-end fixture
-// (docs/history/plans/pattern-verb-contract-implementation.md, D4).
-//
-// The incidental-cell-return case pins the receipt write's conversion: `set()`
-// returns its cell for chaining, so an expression-body
-// `action(() => cell.set(...))` returns a live Cell. The receipt write goes
-// through the cell's standard write flow, so that return is recorded as a LINK
-// to the mutated cell — receipts reflect what was returned (a raw write fails
-// the whole handling on the live object instead).
+/**
+ * A CTS-authored `action<Event, Result>` verb, compiled through the real
+ * pipeline (`patternManager.compilePattern` → js-compiler → CTS transformers →
+ * SES evaluation), delivers its returned value into the event receipt under
+ * the `plainResultReceipts` experimental flag (default-on since the flip) —
+ * the composition of this
+ * package's plain-return projection (scheduler-event-receipts.test.ts, which
+ * exercises only the raw trusted-builder `handler`) with the api's declared-
+ * result authoring surface. This is the readback half of WS-C's exit
+ * criterion, pinned at the runner in addition to the end-to-end fixture
+ * (docs/history/plans/pattern-verb-contract-implementation.md, D4).
+ *
+ * The incidental-cell-return case pins the receipt write's conversion: `set()`
+ * returns its cell for chaining, so an expression-body
+ * `action(() => cell.set(...))` returns a live Cell. The receipt write goes
+ * through the cell's standard write flow, so that return is recorded as a LINK
+ * to the mutated cell — receipts reflect what was returned (a raw write fails
+ * the whole handling on the live object instead).
+ */
+
 import {
   afterEach,
   beforeEach,

--- a/packages/runner/test/edit-with-retry-classification.test.ts
+++ b/packages/runner/test/edit-with-retry-classification.test.ts
@@ -1,19 +1,22 @@
-// `Runtime.editWithRetry` retries on an ALLOW-LIST of rejection classes, not on
-// the truthiness of the commit error.
-//
-// Before this, every commit rejection was retried: a deterministic refusal —
-// an ACL `ProtocolError` about operation shape, an `AuthorizationError`, a
-// `PreconditionFailedError` whose own interface doc says "this class is
-// PERMANENT: the client must not retry" — burned the whole budget on identical
-// doomed round-trips, each one emitting a subscriber revert notification from
-// `finalizeRejection`. With the default budget that is 6 attempts; callers size
-// budgets larger (pattern-manager: `Math.max(16, 2 * importEdges + 8)`).
-//
-// These tests therefore assert the COMMIT COUNT, not just the outcome. A
-// classification that got the right final error after five doomed attempts
-// would pass an outcome-only assertion and fail here. The counterpart —
-// a genuine `ConflictError` still exhausting its budget — is asserted here and
-// in compile-cache-writeback-conflict.test.ts.
+/**
+ * `Runtime.editWithRetry` retries on an ALLOW-LIST of rejection classes, not on
+ * the truthiness of the commit error.
+ *
+ * Before this, every commit rejection was retried: a deterministic refusal —
+ * an ACL `ProtocolError` about operation shape, an `AuthorizationError`, a
+ * `PreconditionFailedError` whose own interface doc says "this class is
+ * PERMANENT: the client must not retry" — burned the whole budget on identical
+ * doomed round-trips, each one emitting a subscriber revert notification from
+ * `finalizeRejection`. With the default budget that is 6 attempts; callers size
+ * budgets larger (pattern-manager: `Math.max(16, 2 * importEdges + 8)`).
+ *
+ * These tests therefore assert the COMMIT COUNT, not just the outcome. A
+ * classification that got the right final error after five doomed attempts
+ * would pass an outcome-only assertion and fail here. The counterpart —
+ * a genuine `ConflictError` still exhausting its budget — is asserted here and
+ * in compile-cache-writeback-conflict.test.ts.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { assert, assertEquals } from "@std/assert";

--- a/packages/runner/test/fetch-capability.test.ts
+++ b/packages/runner/test/fetch-capability.test.ts
@@ -1,7 +1,10 @@
-// Channel-7 closure: the sandbox `fetch` is capability-gated (handler-only) and
-// its settlement is coarsened to the wall-clock grid, so a pattern's imperative
-// network access carries no fine clock. See createGatedFetch in
-// sandbox/compartment-globals.ts and docs/specs/sandboxing/TIMING_SIDE_CHANNELS.md.
+/**
+ * Channel-7 closure: the sandbox `fetch` is capability-gated (handler-only) and
+ * its settlement is coarsened to the wall-clock grid, so a pattern's imperative
+ * network access carries no fine clock. See createGatedFetch in
+ * sandbox/compartment-globals.ts and docs/specs/sandboxing/TIMING_SIDE_CHANNELS.md.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {

--- a/packages/runner/test/llm-partial-coarsening.test.ts
+++ b/packages/runner/test/llm-partial-coarsening.test.ts
@@ -1,7 +1,10 @@
-// Channel 6 (builtin progress) coarsening: the LLM partial-streaming batch
-// window is one second (>=1s), so an untrusted pattern cannot watch the partial
-// cell for a sub-second token-arrival cadence. See
-// docs/specs/sandboxing/TIMING_SIDE_CHANNELS.md.
+/**
+ * Channel 6 (builtin progress) coarsening: the LLM partial-streaming batch
+ * window is one second (>=1s), so an untrusted pattern cannot watch the partial
+ * cell for a sub-second token-arrival cadence. See
+ * docs/specs/sandboxing/TIMING_SIDE_CHANNELS.md.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { PARTIAL_BATCH_MS } from "../src/builtins/llm.ts";

--- a/packages/runner/test/memory-v2-acl-mutation.test.ts
+++ b/packages/runner/test/memory-v2-acl-mutation.test.ts
@@ -1,17 +1,20 @@
-// Post-genesis ACL mutation against a real memory-v2 server.
-//
-// The pre-existing `acl-manager.test.ts` mocks the runtime wholesale — fake
-// cell, fake `editWithRetry` — so it cannot observe the commit the runner
-// actually emits. That is precisely how a bug shipped in which every ACL
-// mutation after genesis was refused by the server ("ACL mutations must
-// replace the space-scoped ACL document"): the runner decomposed the write
-// into `op: "patch"`, the server requires a whole-document `op: "set"`, and no
-// test in the suite could see the difference. `memory-v2-acl-bootstrap.test.ts`
-// uses a real server but only ever covers genesis.
-//
-// These tests therefore assert the emitted OPERATION SHAPE, not just a green
-// path. A patch-based "fix" that happened to succeed, or a fix that only
-// succeeded on a retry, would pass a value-only assertion and fail here.
+/**
+ * Post-genesis ACL mutation against a real memory-v2 server.
+ *
+ * The pre-existing `acl-manager.test.ts` mocks the runtime wholesale — fake
+ * cell, fake `editWithRetry` — so it cannot observe the commit the runner
+ * actually emits. That is precisely how a bug shipped in which every ACL
+ * mutation after genesis was refused by the server ("ACL mutations must
+ * replace the space-scoped ACL document"): the runner decomposed the write
+ * into `op: "patch"`, the server requires a whole-document `op: "set"`, and no
+ * test in the suite could see the difference. `memory-v2-acl-bootstrap.test.ts`
+ * uses a real server but only ever covers genesis.
+ *
+ * These tests therefore assert the emitted OPERATION SHAPE, not just a green
+ * path. A patch-based "fix" that happened to succeed, or a fix that only
+ * succeeded on a retry, would pass a value-only assertion and fail here.
+ */
+
 import { assert, assertEquals } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
 import type { MemorySpace, Signer, URI } from "@commonfabric/memory/interface";

--- a/packages/runner/test/pending-commit-durability.test.ts
+++ b/packages/runner/test/pending-commit-durability.test.ts
@@ -1,20 +1,23 @@
-// The storage manager's pending-commit durability barrier and the scheduler's
-// client-facing quiescence built on it.
-//
-// Every write flows through a transaction from `storageManager.edit()`, and
-// `commit()` registers itself with the manager's barrier synchronously at the
-// entry point, so `hasPendingCommits()` is true from the moment a commit is
-// issued until the server confirms (or terminally rejects) it. The scheduler's
-// `idleWithPendingCommits()` — what the client-facing idle awaits — resolves
-// only when reactive quiescence and an empty barrier hold together, so a
-// client that treats "idle" as a safe point to navigate or reload cannot lose
-// an in-flight write. Plain `idle()` (internal reactive quiescence) ignores
-// the barrier by design.
-//
-// These tests drive REAL commits against the emulated server and gate its
-// responses, so they fail if the barrier ever stops observing the actual
-// commit pipeline (e.g. registration decoupled from the real commit promise)
-// and if the joint fixpoint ever stops re-checking after a commit settles.
+/**
+ * The storage manager's pending-commit durability barrier and the scheduler's
+ * client-facing quiescence built on it.
+ *
+ * Every write flows through a transaction from `storageManager.edit()`, and
+ * `commit()` registers itself with the manager's barrier synchronously at the
+ * entry point, so `hasPendingCommits()` is true from the moment a commit is
+ * issued until the server confirms (or terminally rejects) it. The scheduler's
+ * `idleWithPendingCommits()` — what the client-facing idle awaits — resolves
+ * only when reactive quiescence and an empty barrier hold together, so a
+ * client that treats "idle" as a safe point to navigate or reload cannot lose
+ * an in-flight write. Plain `idle()` (internal reactive quiescence) ignores
+ * the barrier by design.
+ *
+ * These tests drive REAL commits against the emulated server and gate its
+ * responses, so they fail if the barrier ever stops observing the actual
+ * commit pipeline (e.g. registration decoupled from the real commit promise)
+ * and if the joint fixpoint ever stops re-checking after a commit settles.
+ */
+
 import {
   afterEach,
   beforeEach,

--- a/packages/runner/test/pull-first-sync-race.test.ts
+++ b/packages/runner/test/pull-first-sync-race.test.ts
@@ -1,23 +1,26 @@
-// pull() must await its own first sync — the root-doc half of the
-// fresh-replica story (fresh-replica-read-asymmetry.test.ts covers the
-// link-target half).
-//
-// pull() used to KICK the cell's first sync without registering it anywhere
-// ("No await, just kicking this off"), then wait only on scheduler idle plus
-// the cross-space load pool. The root doc's own round-trip was in neither, so
-// pull resolved whenever the scheduler quiesced — which over a low-latency
-// link is AFTER the doc arrives, and over a real network is BEFORE. Measured
-// in production shape: a same-id retry's receipt readback (`cf piece call
-// --invocation`, the WS-D collision path reading the winner's receipt via
-// getCellFromLink → pull) returned the original result against a local
-// toolshed and `undefined` against a remote host, every time. sync()'s own
-// doc comment names the trap: code gating on idle() alone can race the
-// deferred sync; register it with trackUntilSettled so pull() awaits it.
-//
-// The gate below makes the race deterministic instead of latency-shaped: the
-// reader's syncCell for the target doc is held until the test has SEEN the
-// reader's scheduler go idle — the exact moment the unregistered kick used to
-// lose — and only then lets the "network" answer.
+/**
+ * pull() must await its own first sync — the root-doc half of the
+ * fresh-replica story (fresh-replica-read-asymmetry.test.ts covers the
+ * link-target half).
+ *
+ * pull() used to KICK the cell's first sync without registering it anywhere
+ * ("No await, just kicking this off"), then wait only on scheduler idle plus
+ * the cross-space load pool. The root doc's own round-trip was in neither, so
+ * pull resolved whenever the scheduler quiesced — which over a low-latency
+ * link is AFTER the doc arrives, and over a real network is BEFORE. Measured
+ * in production shape: a same-id retry's receipt readback (`cf piece call
+ * --invocation`, the WS-D collision path reading the winner's receipt via
+ * getCellFromLink → pull) returned the original result against a local
+ * toolshed and `undefined` against a remote host, every time. sync()'s own
+ * doc comment names the trap: code gating on idle() alone can race the
+ * deferred sync; register it with trackUntilSettled so pull() awaits it.
+ *
+ * The gate below makes the race deterministic instead of latency-shaped: the
+ * reader's syncCell for the target doc is held until the test has SEEN the
+ * reader's scheduler go idle — the exact moment the unregistered kick used to
+ * lose — and only then lets the "network" answer.
+ */
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";

--- a/packages/runner/test/renderer-input-mark.test.ts
+++ b/packages/runner/test/renderer-input-mark.test.ts
@@ -1,8 +1,11 @@
-// Plan B ($value provenance): a renderer keystroke write is marked so the
-// scheduler can recognize it at the storage-notification choke point (via
-// notification.source) and shape the resulting subscriber wake. The mark must
-// survive to commit (unlike the blind-write mark, which is cleared), and must be
-// found on any tx layer, since the notification's source is an inner layer.
+/**
+ * Plan B ($value provenance): a renderer keystroke write is marked so the
+ * scheduler can recognize it at the storage-notification choke point (via
+ * notification.source) and shape the resulting subscriber wake. The mark must
+ * survive to commit (unlike the blind-write mark, which is cleared), and must be
+ * found on any tx layer, since the notification's source is an inner layer.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {

--- a/packages/runner/test/sandbox-timers.test.ts
+++ b/packages/runner/test/sandbox-timers.test.ts
@@ -1,12 +1,15 @@
 /// <reference path="./clock.d.ts" />
-// The SES pattern compartment endows no timers (part of the structural barrier
-// pinned by security-timing.test.ts). Code that wants a delay in both a host
-// context and a compartment must therefore guard its timer use: read
-// `globalThis.setTimeout` (a member access that yields undefined in-sandbox,
-// not a ReferenceError) and no-op when it is absent, so the wait degrades to an
-// immediate return rather than throwing. These tests pin that the compartment
-// omits the timers, that a RAW `setTimeout(...)` call throws inside it, and
-// that the guard resolves immediately there.
+/**
+ * The SES pattern compartment endows no timers (part of the structural barrier
+ * pinned by security-timing.test.ts). Code that wants a delay in both a host
+ * context and a compartment must therefore guard its timer use: read
+ * `globalThis.setTimeout` (a member access that yields undefined in-sandbox,
+ * not a ReferenceError) and no-op when it is absent, so the wait degrades to an
+ * immediate return rather than throwing. These tests pin that the compartment
+ * omits the timers, that a RAW `setTimeout(...)` call throws inside it, and
+ * that the guard resolves immediately there.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {

--- a/packages/runner/test/scheduler-rejection-taxonomy.test.ts
+++ b/packages/runner/test/scheduler-rejection-taxonomy.test.ts
@@ -1,5 +1,8 @@
-// Integration coverage for no-retry behavior lands in work orders 03/04,
-// where the engine can actually emit precondition failures.
+/**
+ * Integration coverage for no-retry behavior lands in work orders 03/04,
+ * where the engine can actually emit precondition failures.
+ */
+
 import { describe, expect, it } from "./scheduler-test-utils.ts";
 import {
   isPermanentRejection,

--- a/packages/runner/test/scheduler-settling-telemetry.test.ts
+++ b/packages/runner/test/scheduler-settling-telemetry.test.ts
@@ -1,9 +1,12 @@
-// The scheduler's non-settling telemetry (facade recordExecuteEndTelemetry)
-// sits behind a wall-clock heuristic: it fires only when a busy window
-// crosses 5s. Integration runs cover it only when a CI machine happens to run
-// slow enough, which made the runner coverage gate flap. This test drives the
-// path deterministically by backdating the private settling tracker — no
-// sleeping, no real busy-looping.
+/**
+ * The scheduler's non-settling telemetry (facade recordExecuteEndTelemetry)
+ * sits behind a wall-clock heuristic: it fires only when a busy window
+ * crosses 5s. Integration runs cover it only when a CI machine happens to run
+ * slow enough, which made the runner coverage gate flap. This test drives the
+ * path deterministically by backdating the private settling tracker — no
+ * sleeping, no real busy-looping.
+ */
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";

--- a/packages/runner/test/w6-intrinsic-escape.test.ts
+++ b/packages/runner/test/w6-intrinsic-escape.test.ts
@@ -1,8 +1,11 @@
-// W6 structural-barrier regression: the gated Date/Math injected into pattern
-// compartments must not be escapable to a real (ungated) clock or entropy via
-// the constructor or prototype chain. Runs a compartment built with the real
-// module globals and NO pattern frame, so every ambient read must be denied and
-// no escape may yield a number (a real clock).
+/**
+ * W6 structural-barrier regression: the gated Date/Math injected into pattern
+ * compartments must not be escapable to a real (ungated) clock or entropy via
+ * the constructor or prototype chain. Runs a compartment built with the real
+ * module globals and NO pattern frame, so every ambient read must be denied and
+ * no escape may yield a number (a real clock).
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {

--- a/packages/runtime-client/backends/cell-set-echo-race.test.ts
+++ b/packages/runtime-client/backends/cell-set-echo-race.test.ts
@@ -1,20 +1,23 @@
-// Pins the main-thread↔worker IPC hop of the CellSet race: a CellUpdate
-// carrying a concurrent value ("blue") is in flight to the main thread when
-// the client blind-sets "green". The worker↔server hop of the same race (the
-// replica rebasing the pending write under the incoming sync) is pinned by
-// packages/runner/test/memory-v2-sync-under-pending.test.ts; here the worker
-// side runs in-process and the test controls IPC delivery order.
-//
-// What must hold on this hop:
-//  1. `set()` applies optimistically and fires the handle's callbacks before
-//     any IPC round trip.
-//  2. The in-flight stale CellUpdate(blue) is applied blindly when it arrives
-//     (there is deliberately no versioning/suppression on this hop) — the
-//     transient flash is accepted behavior.
-//  3. The worker's own commit of green re-fires the subscription sink — the
-//     "we don't echo back to the sender" suppression exists only on the
-//     server↔worker hop — so a CellUpdate(green) follows blue in channel
-//     order and the handle converges to green.
+/**
+ * Pins the main-thread↔worker IPC hop of the CellSet race: a CellUpdate
+ * carrying a concurrent value ("blue") is in flight to the main thread when
+ * the client blind-sets "green". The worker↔server hop of the same race (the
+ * replica rebasing the pending write under the incoming sync) is pinned by
+ * packages/runner/test/memory-v2-sync-under-pending.test.ts; here the worker
+ * side runs in-process and the test controls IPC delivery order.
+ *
+ * What must hold on this hop:
+ *  1. `set()` applies optimistically and fires the handle's callbacks before
+ *     any IPC round trip.
+ *  2. The in-flight stale CellUpdate(blue) is applied blindly when it arrives
+ *     (there is deliberately no versioning/suppression on this hop) — the
+ *     transient flash is accepted behavior.
+ *  3. The worker's own commit of green re-fires the subscription sink — the
+ *     "we don't echo back to the sender" suppression exists only on the
+ *     server↔worker hop — so a CellUpdate(green) follows blue in channel
+ *     order and the handle converges to green.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";

--- a/packages/schema-generator/test/enum-member-hoisting.test.ts
+++ b/packages/schema-generator/test/enum-member-hoisting.test.ts
@@ -1,8 +1,11 @@
-// Pins TS enum-member handling (mapping spec §4/§16.2). Enum members are scalar
-// literal types, not reusable named definitions: keeping them inline prevents
-// their short member names from colliding with members of another enum or with
-// an unrelated named type in $defs. Whole enum declarations remain hoisted and
-// are covered separately by enum-schema-rows.test.ts.
+/**
+ * Pins TS enum-member handling (mapping spec §4/§16.2). Enum members are scalar
+ * literal types, not reusable named definitions: keeping them inline prevents
+ * their short member names from colliding with members of another enum or with
+ * an unrelated named type in $defs. Whole enum declarations remain hoisted and
+ * are covered separately by enum-schema-rows.test.ts.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { SchemaGenerator } from "../src/schema-generator.ts";

--- a/packages/schema-generator/test/literal-encoding-paths.test.ts
+++ b/packages/schema-generator/test/literal-encoding-paths.test.ts
@@ -1,21 +1,24 @@
-// Pins the KNOWN QUIRK in mapping spec §2/§16.7: the two analysis paths
-// encode literals differently for the SAME authored type.
-//   type path  (generateSchema):                 { type, enum: [v] }
-//   node path  (generateSchemaFromSyntheticTypeNode, schema-generator.ts
-//               ~:879-896):                      { type, const: v }
-// For literal unions the divergence is structural, not just spelling:
-//   type path:  { enum: [a, b] }
-//   node path:  { anyOf: [{ const: a }, { const: b }] }
-// The consumer (ts-transformers SchemaGeneratorTransformer) routes a type
-// arg to the node path whenever it is synthetic-and-any OR contains an
-// `any`/`unknown` keyword anywhere, so adding `data: unknown` to a type
-// flips sibling literal encodings. Runner validation treats const and enum
-// equivalently (runner/src/schema.ts matchesConcreteValue), but structural
-// schema equality (runner/src/cfc/prepare.ts schemasEqualIgnoringWriterStamp)
-// does not — the spellings are different schemas to deepEqual.
-//
-// These tests pin today's divergence so a canonicalization fix (e.g. the
-// node path emitting enum-spelling) flips them consciously.
+/**
+ * Pins the KNOWN QUIRK in mapping spec §2/§16.7: the two analysis paths
+ * encode literals differently for the SAME authored type.
+ *   type path  (generateSchema):                 { type, enum: [v] }
+ *   node path  (generateSchemaFromSyntheticTypeNode, schema-generator.ts
+ *               ~:879-896):                      { type, const: v }
+ * For literal unions the divergence is structural, not just spelling:
+ *   type path:  { enum: [a, b] }
+ *   node path:  { anyOf: [{ const: a }, { const: b }] }
+ * The consumer (ts-transformers SchemaGeneratorTransformer) routes a type
+ * arg to the node path whenever it is synthetic-and-any OR contains an
+ * `any`/`unknown` keyword anywhere, so adding `data: unknown` to a type
+ * flips sibling literal encodings. Runner validation treats const and enum
+ * equivalently (runner/src/schema.ts matchesConcreteValue), but structural
+ * schema equality (runner/src/cfc/prepare.ts schemasEqualIgnoringWriterStamp)
+ * does not — the spellings are different schemas to deepEqual.
+ *
+ * These tests pin today's divergence so a canonicalization fix (e.g. the
+ * node path emitting enum-spelling) flips them consciously.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import ts from "typescript";

--- a/packages/schema-generator/test/tuple-emission.test.ts
+++ b/packages/schema-generator/test/tuple-emission.test.ts
@@ -1,14 +1,17 @@
-// Pins fixed-length tuple emission (mapping spec §4, quirk §16.1): tuples
-// emit { type: "array", items: <merged element union> } via the
-// numeric-index fallback (type-utils.ts getArrayElementInfo). Positional
-// structure and arity are LOST — no prefixItems, no minItems/maxItems —
-// so [number, number, number] is indistinguishable from number[], and an
-// optional element leaks "undefined" into the items type array.
-//
-// NOTE this lossiness is load-bearing today: UnionFormatter's empty-array
-// pruning safety argument (union-formatter.ts ~:280-285) explicitly relies
-// on tuple schemas having no length bounds. If prefixItems emission is ever
-// added, gate that pruning first — then update these pins.
+/**
+ * Pins fixed-length tuple emission (mapping spec §4, quirk §16.1): tuples
+ * emit { type: "array", items: <merged element union> } via the
+ * numeric-index fallback (type-utils.ts getArrayElementInfo). Positional
+ * structure and arity are LOST — no prefixItems, no minItems/maxItems —
+ * so [number, number, number] is indistinguishable from number[], and an
+ * optional element leaks "undefined" into the items type array.
+ *
+ * NOTE this lossiness is load-bearing today: UnionFormatter's empty-array
+ * pruning safety argument (union-formatter.ts ~:280-285) explicitly relies
+ * on tuple schemas having no length bounds. If prefixItems emission is ever
+ * added, gate that pruning first — then update these pins.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { SchemaGenerator } from "../src/schema-generator.ts";

--- a/packages/schema-generator/test/widen-literals.test.ts
+++ b/packages/schema-generator/test/widen-literals.test.ts
@@ -1,15 +1,18 @@
-// Pins the CURRENT behavior of the `widenLiterals` generation option
-// (mapping spec §8/§14; quirk §16.3). The flag is consulted by
-// PrimitiveFormatter (single literals) and by the anyOf merge pass
-// (mergeIdenticalSchemas), but NOT by the all-literal-union branch
-// (union-formatter.ts ~:176-214), which runs first. The resulting boundary
-// is incoherent and pinned here so any deliberate fix flips these
-// expectations consciously:
-//   - a pure literal union does NOT widen ("a" | "b" stays an enum), but
-//   - the same literal members DO widen when a non-literal member joins
-//     the union (mixed-union case), and
-//   - inside one object, a single-literal property widens while a
-//     literal-union sibling does not.
+/**
+ * Pins the CURRENT behavior of the `widenLiterals` generation option
+ * (mapping spec §8/§14; quirk §16.3). The flag is consulted by
+ * PrimitiveFormatter (single literals) and by the anyOf merge pass
+ * (mergeIdenticalSchemas), but NOT by the all-literal-union branch
+ * (union-formatter.ts ~:176-214), which runs first. The resulting boundary
+ * is incoherent and pinned here so any deliberate fix flips these
+ * expectations consciously:
+ *   - a pure literal union does NOT widen ("a" | "b" stays an enum), but
+ *   - the same literal members DO widen when a non-literal member joins
+ *     the union (mixed-union case), and
+ *   - inside one object, a single-literal property widens while a
+ *     literal-union sibling does not.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { SchemaGenerator } from "../src/schema-generator.ts";

--- a/packages/shell/src/lib/otel.ts
+++ b/packages/shell/src/lib/otel.ts
@@ -1,14 +1,17 @@
-// Browser-side OpenTelemetry setup for the shell (Phase 3).
-//
-// This is GATED and LAZY: nothing OpenTelemetry-related is imported at module
-// load. `initBrowserOtel` only pulls in the web SDK via dynamic `import(...)`
-// when `localStorage["telemetryEnabled"] === "true"`, mirroring the server's
-// lazy-import pattern in packages/background-piece-service/src/otel.ts. With
-// telemetry disabled the default bundle is untouched and there is zero added
-// network/CPU.
-//
-// Only type-only imports appear at the top; they are erased at build time and
-// never pull the OTel packages into the default bundle.
+/**
+ * Browser-side OpenTelemetry setup for the shell (Phase 3).
+ *
+ * This is GATED and LAZY: nothing OpenTelemetry-related is imported at module
+ * load. `initBrowserOtel` only pulls in the web SDK via dynamic `import(...)`
+ * when `localStorage["telemetryEnabled"] === "true"`, mirroring the server's
+ * lazy-import pattern in packages/background-piece-service/src/otel.ts. With
+ * telemetry disabled the default bundle is untouched and there is zero added
+ * network/CPU.
+ *
+ * Only type-only imports appear at the top; they are erased at build time and
+ * never pull the OTel packages into the default bundle.
+ */
+
 import type { RuntimeTelemetryMarkerResult } from "@commonfabric/runtime-client";
 
 // localStorage key that gates telemetry — the same flag the debugger controller

--- a/packages/toolshed/routes/ingest/ingest.handlers.ts
+++ b/packages/toolshed/routes/ingest/ingest.handlers.ts
@@ -1,13 +1,16 @@
-// The `journal`-sink ingest handler — a thin transport wrapper. It pulls the
-// bearer token and JSON body off the request, then delegates to processIngest
-// (ingest.utils.ts), whose full auth + validation contract is unit-tested
-// against a real runtime. Auth mirrors the webhook ingest path.
-//
-// This is the DATA plane only. Channel lifecycle lives at /api/ingest-channels
-// (a separate prefix, separate auth model), where the confused-deputy risk of a
-// create that names someone else's space is closed by requiring an explicit
-// OWNER grant on that space's ACL. See
-// docs/features/self-serve-ingest-channels.md.
+/**
+ * The `journal`-sink ingest handler — a thin transport wrapper. It pulls the
+ * bearer token and JSON body off the request, then delegates to processIngest
+ * (ingest.utils.ts), whose full auth + validation contract is unit-tested
+ * against a real runtime. Auth mirrors the webhook ingest path.
+ *
+ * This is the DATA plane only. Channel lifecycle lives at /api/ingest-channels
+ * (a separate prefix, separate auth model), where the confused-deputy risk of a
+ * create that names someone else's space is closed by requiring an explicit
+ * OWNER grant on that space's ACL. See
+ * docs/features/self-serve-ingest-channels.md.
+ */
+
 import type { AppRouteHandler } from "@/lib/types.ts";
 import { runtime } from "@/index.ts";
 import { identity } from "@/lib/identity.ts";

--- a/packages/toolshed/routes/webhooks/webhooks.handlers.ts
+++ b/packages/toolshed/routes/webhooks/webhooks.handlers.ts
@@ -1,9 +1,12 @@
-// Design spec: docs/specs/webhook-ingress/README.md
-//
-// Auth note: The list and create endpoints are intentionally unauthed,
-// consistent with all other toolshed admin endpoints (google-oauth, plaid,
-// patterns, etc.). When the platform adds HTTP-level auth
-// infrastructure, these endpoints should adopt it.
+/**
+ * Design spec: docs/specs/webhook-ingress/README.md
+ *
+ * Auth note: The list and create endpoints are intentionally unauthed,
+ * consistent with all other toolshed admin endpoints (google-oauth, plaid,
+ * patterns, etc.). When the platform adds HTTP-level auth
+ * infrastructure, these endpoints should adopt it.
+ */
+
 import env from "@/env.ts";
 import type { AppRouteHandler } from "@/lib/types.ts";
 import type {

--- a/packages/toolshed/scripts/audit-ingest-channels.ts
+++ b/packages/toolshed/scripts/audit-ingest-channels.ts
@@ -1,21 +1,24 @@
-// List every ingest channel this deployment has minted.
-//
-// Why: a minted token is a durable append capability into a user's space, and
-// the registration lives in the toolshed's own service space where no user can
-// see it. Without this, "what have we handed out, to whom, and is any of it
-// still in use" is unanswerable — which matters most on the day the answer
-// determines what has to be retired (see `retire-ingest-channels.ts`).
-//
-// This is the only production reader of the global registration index, which
-// exists precisely so channels are enumerable for audit.
-//
-// Usage:
-//   deno task audit-ingest-channels                  # human-readable
-//   deno task audit-ingest-channels --json           # machine-readable
-//   deno task audit-ingest-channels --repair-indexes # backfill by-space index
-//   deno task audit-ingest-channels --repair-indexes --recover known.txt
-//                                                    # also visit channels the
-//                                                    # index never learned of
+/**
+ * List every ingest channel this deployment has minted.
+ *
+ * Why: a minted token is a durable append capability into a user's space, and
+ * the registration lives in the toolshed's own service space where no user can
+ * see it. Without this, "what have we handed out, to whom, and is any of it
+ * still in use" is unanswerable — which matters most on the day the answer
+ * determines what has to be retired (see `retire-ingest-channels.ts`).
+ *
+ * This is the only production reader of the global registration index, which
+ * exists precisely so channels are enumerable for audit.
+ *
+ * Usage:
+ *   deno task audit-ingest-channels                  # human-readable
+ *   deno task audit-ingest-channels --json           # machine-readable
+ *   deno task audit-ingest-channels --repair-indexes # backfill by-space index
+ *   deno task audit-ingest-channels --repair-indexes --recover known.txt
+ *                                                    # also visit channels the
+ *                                                    # index never learned of
+ */
+
 import { parseArgs } from "@std/cli/parse-args";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";

--- a/packages/toolshed/scripts/provision-ingest-channel.ts
+++ b/packages/toolshed/scripts/provision-ingest-channel.ts
@@ -1,28 +1,31 @@
-// Provision a vouched ingest channel — the OPERATOR / break-glass path.
-//
-// PREFER `cf ingest mint`. Users can now mint their own channels against
-// /api/ingest-channels, signing with their own identity key; the server checks
-// they hold an explicit OWNER grant on the target space's ACL, which is what
-// closes the confused-deputy hole that kept creation out-of-band originally.
-// See docs/features/self-serve-ingest-channels.md.
-//
-// This script remains for the cases the self-serve path cannot cover: minting
-// for a space whose ACL does not (yet) name a concrete owner, and recovery when
-// the control plane itself is unavailable. It bypasses the ownership check
-// entirely — it runs AS the operator identity — so treat it as an admin action.
-//
-// A channel minted here has no verified `owner`, so it does not appear in a
-// user's own `cf ingest ls`. It DOES appear in `cf ingest ls --space <space>`,
-// which lists everything targeting a space its current owner holds — so a
-// break-glass channel is discoverable, and revocable, by that owner.
-//
-// It mints a per-install token, writes the registration into the toolshed
-// service space, and prints the token ONCE. Adding an install = re-run this.
-//
-// Usage:
-//   deno task provision-ingest-channel \
-//     --space did:key:<user-space> --install-id <stable-id> \
-//     [--cause-prefix location] [--name <label>] [--force]
+/**
+ * Provision a vouched ingest channel — the OPERATOR / break-glass path.
+ *
+ * PREFER `cf ingest mint`. Users can now mint their own channels against
+ * /api/ingest-channels, signing with their own identity key; the server checks
+ * they hold an explicit OWNER grant on the target space's ACL, which is what
+ * closes the confused-deputy hole that kept creation out-of-band originally.
+ * See docs/features/self-serve-ingest-channels.md.
+ *
+ * This script remains for the cases the self-serve path cannot cover: minting
+ * for a space whose ACL does not (yet) name a concrete owner, and recovery when
+ * the control plane itself is unavailable. It bypasses the ownership check
+ * entirely — it runs AS the operator identity — so treat it as an admin action.
+ *
+ * A channel minted here has no verified `owner`, so it does not appear in a
+ * user's own `cf ingest ls`. It DOES appear in `cf ingest ls --space <space>`,
+ * which lists everything targeting a space its current owner holds — so a
+ * break-glass channel is discoverable, and revocable, by that owner.
+ *
+ * It mints a per-install token, writes the registration into the toolshed
+ * service space, and prints the token ONCE. Adding an install = re-run this.
+ *
+ * Usage:
+ *   deno task provision-ingest-channel \
+ *     --space did:key:<user-space> --install-id <stable-id> \
+ *     [--cause-prefix location] [--name <label>] [--force]
+ */
+
 import { parseArgs } from "@std/cli/parse-args";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";

--- a/packages/toolshed/scripts/retire-ingest-channels.ts
+++ b/packages/toolshed/scripts/retire-ingest-channels.ts
@@ -1,39 +1,42 @@
-// Mass-revoke ingest channels — the operator lever for a trust event.
-//
-// Why this is a script and not a runtime concept:
-//
-// A minted token is a durable append capability that outlives the conditions
-// which authorized it. The forcing case is the fix to passphrase-derived space
-// keys: until that lands, anyone who knew a space NAME could sign as that
-// space, grant themselves OWNER, and mint entirely legitimately. Fixing the
-// derivation stops new abuse and retracts nothing already issued.
-//
-// The tempting design is a "trust epoch" stamped on every registration and
-// compared on every POST. That buys a declarative, atomic cutover — and pays
-// for it with a field, an env var, and a hot-path branch that live forever to
-// serve an event that happens once. Not worth it.
-//
-// Revocation already does the job, and it is already the right shape: it is
-// fail-closed (the data plane refuses a revoked channel even with a valid
-// token), it is loud (a correct token gets an actionable 403 telling the device
-// to re-pair, not a blank 401), and it retains the registration as an audit
-// record. Retiring a population is therefore just "revoke all of it" — a
-// deliberate operator action, at a moment of the operator's choosing.
-//
-// Re-minting is the manual conversion: an owner runs `cf ingest mint` again,
-// which re-authorizes the channel under the new conditions and clears the
-// revocation while preserving its history.
-//
-// TRADE-OFF, stated so it is a known property rather than a surprise: this is
-// imperative, so it is not atomic. A channel minted between the run and the
-// cutover is missed. Re-run it (it is idempotent) or take the control plane
-// down for the migration, and use `audit-ingest-channels` to confirm.
-//
-// Usage:
-//   deno task retire-ingest-channels --reason "space-key-derivation-fix"
-//   deno task retire-ingest-channels --reason "..." --confirm
-//
-// Dry run by default; nothing is written without --confirm.
+/**
+ * Mass-revoke ingest channels — the operator lever for a trust event.
+ *
+ * Why this is a script and not a runtime concept:
+ *
+ * A minted token is a durable append capability that outlives the conditions
+ * which authorized it. The forcing case is the fix to passphrase-derived space
+ * keys: until that lands, anyone who knew a space NAME could sign as that
+ * space, grant themselves OWNER, and mint entirely legitimately. Fixing the
+ * derivation stops new abuse and retracts nothing already issued.
+ *
+ * The tempting design is a "trust epoch" stamped on every registration and
+ * compared on every POST. That buys a declarative, atomic cutover — and pays
+ * for it with a field, an env var, and a hot-path branch that live forever to
+ * serve an event that happens once. Not worth it.
+ *
+ * Revocation already does the job, and it is already the right shape: it is
+ * fail-closed (the data plane refuses a revoked channel even with a valid
+ * token), it is loud (a correct token gets an actionable 403 telling the device
+ * to re-pair, not a blank 401), and it retains the registration as an audit
+ * record. Retiring a population is therefore just "revoke all of it" — a
+ * deliberate operator action, at a moment of the operator's choosing.
+ *
+ * Re-minting is the manual conversion: an owner runs `cf ingest mint` again,
+ * which re-authorizes the channel under the new conditions and clears the
+ * revocation while preserving its history.
+ *
+ * TRADE-OFF, stated so it is a known property rather than a surprise: this is
+ * imperative, so it is not atomic. A channel minted between the run and the
+ * cutover is missed. Re-run it (it is idempotent) or take the control plane
+ * down for the migration, and use `audit-ingest-channels` to confirm.
+ *
+ * Usage:
+ *   deno task retire-ingest-channels --reason "space-key-derivation-fix"
+ *   deno task retire-ingest-channels --reason "..." --confirm
+ *
+ * Dry run by default; nothing is written without --confirm.
+ */
+
 import { parseArgs } from "@std/cli/parse-args";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";

--- a/tasks/test.ts
+++ b/tasks/test.ts
@@ -1,8 +1,11 @@
 #!/usr/bin/env -S deno run --allow-read --allow-run --allow-env
-// Entry point for the root `deno task test`. The implementation lives in
-// workspace-tests.ts because `deno coverage` skips files whose names end in
-// test.ts, and the coverage-debt metric scores an unmeasured file as fully
-// uncovered.
+/**
+ * Entry point for the root `deno task test`. The implementation lives in
+ * workspace-tests.ts because `deno coverage` skips files whose names end in
+ * test.ts, and the coverage-debt metric scores an unmeasured file as fully
+ * uncovered.
+ */
+
 import { main } from "./workspace-tests.ts";
 
 if (import.meta.main) {

--- a/tasks/workspace-tests.ts
+++ b/tasks/workspace-tests.ts
@@ -1,7 +1,10 @@
-// Implementation of the root `deno task test` runner. The entry point is
-// tasks/test.ts; the logic lives here because `deno coverage` skips files
-// whose names end in test.ts, and the coverage-debt metric scores an
-// unmeasured file as fully uncovered.
+/**
+ * Implementation of the root `deno task test` runner. The entry point is
+ * tasks/test.ts; the logic lives here because `deno coverage` skips files
+ * whose names end in test.ts, and the coverage-debt metric scores an
+ * unmeasured file as fully uncovered.
+ */
+
 import * as path from "@std/path";
 import { parse as parseJsonc } from "@std/jsonc";
 import { decode, encode } from "@commonfabric/utils/encoding";


### PR DESCRIPTION
A follow-up to the file-header series (#5865, #5867, #5868), taking only the
clear-cut part of what was left. I (agent working on behalf of @danfuzz) went
through all 69 remaining candidates by hand and kept 55.

## What changed

55 files opened with a `//` block describing the file, run against the first
`import`. `code-comment-style.md` § File headers is explicit that this is not a
header form:

> A `//` block is not an alternative form of a header: it reads as a note about
> the line beneath it, which is what makes it right for local mechanics and
> wrong for a statement about the whole file.

So they become `/** */`, and pick up the blank line the same section requires.

```diff
-// Unit tests for the pure helpers. No network, subprocess, or filesystem.
+/**
+ * Unit tests for the pure helpers. No network, subprocess, or filesystem.
+ */
+
 import { assert, assertEquals } from "@std/assert";
```

By package: `dashboard` 22, `runner` 16, `toolshed` 5, `schema-generator` 4,
`memory` 3, `tasks/` 2, and one each in `cli`, `runtime-client` and `shell`.

## Only the syntax changed

The prose is byte-identical. Comparing each block's text with its markers
stripped — `// ` on one side, ` * ` on the other — **all 55 match**, and the
check catches a one-word edit when one is introduced deliberately. Separately,
**no changed line in the diff is anything other than a comment or a blank
line.**

A leading shebang or `///` directive stays above the header, which is where the
same section puts it. Two files have one: `tasks/test.ts` and
`runner/test/sandbox-timers.test.ts`.

## The 14 left alone, and why

This is the part worth reviewing — each was excluded for a reason, not for
convenience:

| File(s) | Why |
|---|---|
| `cli/lib/color-mode.ts` | The block **is** a note about the import beneath it — *"The import below must resolve to the same `@std/fmt` instance Cliffy uses"*. A doc comment there would misdescribe it. |
| `html/src/jsx.d.ts`, `static/assets/types/jsx.d.ts` | The block ends in a `deno-lint-ignore-file` pragma, which has to stay a line comment. |
| `js-compiler/…/diagnostics/errors.ts` | The block explains why the import is type-only, not what the file is. |
| The four `fuse` files | Each is titled with its own filename (`// tree.test.ts — Unit tests for FsTree`), which the same section calls a wasted slot. Converting the form alone preserves the shape the rule objects to, and rewording is judgment, not mechanics. |
| Five fixtures | Content feeds a compiler or a golden. |
| `ui/…/cf-chart/lib/scales.ts` | Its top block is already part JSDoc. |

## Verification

- Comment text preserved: **55/55 identical**, with a control confirming the
  comparison detects a single changed word.
- Diff contains **0** changed lines that are not comment or blank.
- `deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs`
  green.
- Suites for every touched package: `dashboard` 665 (+4, +6), `runner` 1206,
  `cli` 174, `toolshed` 137, `memory` 499, `runtime-client` 60,
  `schema-generator` 56, `shell` 58. All 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

