### PR TITLE
additionalProperties: false is the one value that closes a schema

### DIFF
--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -628,8 +628,9 @@ function firstUndeclaredEventField(
  *
  * It does when it names fields somewhere — directly or through a conjunction —
  * and does not also say extra ones are welcome. A schema naming none judges
- * none, so every field passes; one carrying `additionalProperties` has said
- * undeclared fields are fine.
+ * none, so every field passes; one carrying `additionalProperties` set to
+ * anything but `false` has said undeclared fields are fine. `false` is the
+ * one value that says the opposite, so a schema carrying it judges.
  *
  * Exported for the flag door, which needs the same answer about the same
  * schema and must not derive it a second way. It asks whether the SCHEMA

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -440,7 +440,17 @@ function declaredFieldsAt(
       root,
     });
   }
-  if (node.additionalProperties !== undefined) into.honorsUndeclared = true;
+  // `false` is the one value that does NOT honor undeclared fields — it is
+  // the schema saying no extra field is permitted. Reading mere presence as
+  // permission inverts the strictest spelling into the most permissive one,
+  // and the field is then dropped by the runtime and the call reported
+  // settled, which is the silent loss this refusal exists to prevent.
+  if (
+    node.additionalProperties !== undefined &&
+    node.additionalProperties !== false
+  ) {
+    into.honorsUndeclared = true;
+  }
   if (!Array.isArray(node.allOf)) return into;
   for (const member of node.allOf as JSONSchema[]) {
     const memberRoot = cfcSchemaChildRoot(member, root);

--- a/packages/cli/test/verb-undeclared-field.test.ts
+++ b/packages/cli/test/verb-undeclared-field.test.ts
@@ -654,6 +654,18 @@ describe("verb-undeclared-field", () => {
   // rather than as no refusal coming back. The two are different facts, and
   // only the first one states that a caller can still make the call.
 
+  describe("a schema that forbids undeclared fields", () => {
+    it("refuses the undeclared field rather than letting it be dropped", () => {
+      const schema: JSONSchema = {
+        type: "object",
+        properties: { title: { type: "string" } },
+        additionalProperties: false,
+      };
+      expect(undeclaredVerbFieldError({ titel: "x" }, schema))
+        .toMatch(/"titel" at <event> is not a field this verb declares/);
+    });
+  });
+
   describe("eventSchemaJudgesRootFields()", () => {
     // The predicate `cf exec`'s flag door reads to decide whether an
     // unrecognized flag is a misspelling to refuse or a field the schema
@@ -684,6 +696,24 @@ describe("verb-undeclared-field", () => {
         properties: { title: { type: "string" } },
         additionalProperties: true,
       })).toBe(false);
+      // A schema for the extra fields is still permission to send them.
+      expect(eventSchemaJudgesRootFields({
+        type: "object",
+        properties: { title: { type: "string" } },
+        additionalProperties: { type: "string" },
+      })).toBe(false);
+    });
+
+    it("judges a schema that forbids undeclared fields", () => {
+      // `false` is the one value that does NOT welcome them, so reading mere
+      // presence of the keyword as permission turns the strictest spelling
+      // into the most permissive one. A caller's extra field would then be
+      // accepted here, dropped by the runtime, and the call reported settled.
+      expect(eventSchemaJudgesRootFields({
+        type: "object",
+        properties: { title: { type: "string" } },
+        additionalProperties: false,
+      })).toBe(true);
     });
 
     it("does not judge a disjunction", () => {


### PR DESCRIPTION
## Why

`declaredFieldsAt` (`packages/cli/lib/callable.ts`) recorded that a schema welcomes undeclared fields whenever `additionalProperties` was **present**, without reading what it said. `false` means the opposite — no extra field is permitted — so the strictest spelling a schema has was read as the most permissive one there is.

Measured before the fix, against `{type:"object", properties:{title}, additionalProperties:false}`:

```
payload {"titel":"x"}   ->  accepted     (expected: refused, naming the field)
flag    --titel x       ->  accepted     (follows the same predicate)
```

The field is then dropped by the runtime and the caller told the call settled — precisely the silent loss the undeclared-field refusal exists to prevent. `honorsUndeclared` was true exactly when the schema said it was not, which is the kind of inversion that survives a long time behind a name that reads correctly.

Closes #5863.

## What Changed

One guard. Both doors read this predicate — `firstUndeclaredEventField` for a payload, `eventSchemaJudgesRootFields` for a flag — so correcting it corrects them together rather than needing two fixes that could drift.

After, across every spelling:

| Schema | judges | payload | flag |
| --- | --- | --- | --- |
| `additionalProperties: false` | yes | refuse | refuse |
| `additionalProperties: true` | no | accept | accept |
| `additionalProperties: {…}` | no | accept | accept |
| no `additionalProperties` | yes | refuse | refuse |

A schema *for* the extra fields is still permission to send them; only `false` is not.

## Test plan

- `eventSchemaJudgesRootFields` gains a case for `false` and one for the schema-valued spelling, beside the existing `true` case.
- The refusal itself is pinned on the door a caller meets, so the test fails if the predicate is right and the message never arrives.
- Full `packages/cli` suite 1686 + 174, 0 failed. `deno task check`, `fmt --check`, `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

