### PR TITLE
A typo inside a negated flag earns the same near miss

### DIFF
--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -278,9 +278,35 @@ function undeclaredFlagError(
   descriptors: Map<string, FlagDescriptor>,
 ): string {
   const declared = [...descriptors.keys()];
+  const opening = `"--${rawFlag}" at ${EVENT_ROOT_POSITION} is not a field ` +
+    "this verb declares. ";
+
+  // A caller who wrote `--no-something` is asking to negate, and only a
+  // boolean can be negated. Both halves of the answer narrow accordingly:
+  // the near miss is searched against the negatable names, and the
+  // vocabulary lists those rather than every field. Offering `--no-title`
+  // for a string `title` would name a spelling that fails just as surely.
+  //
+  // The prefix is stripped before matching because it is three edits of pure
+  // noise against the declared name, and the threshold scales with the
+  // misspelling's length — so leaving it on makes the match HARDER precisely
+  // because the caller typed more.
+  if (rawFlag.startsWith("no-")) {
+    const negatable = declared.filter((name) =>
+      schemaType(descriptors.get(name)!.schema) === "boolean"
+    );
+    const nearest = nearestName(rawFlag.slice(3), negatable);
+    return opening +
+      (nearest === undefined ? "" : `Did you mean "--no-${nearest}"? `) +
+      (negatable.length === 0
+        ? "Only a boolean field can be negated, and this verb declares none"
+        : `Only a boolean field can be negated, and this verb declares ${
+          negatable.map((name) => `"--${name}"`).join(", ")
+        }`);
+  }
+
   const nearest = nearestName(rawFlag, declared);
-  return `"--${rawFlag}" at ${EVENT_ROOT_POSITION} is not a field this verb ` +
-    "declares. " +
+  return opening +
     (nearest === undefined ? "" : `Did you mean "--${nearest}"? `) +
     (declared.length === 0
       ? `${EVENT_ROOT_POSITION} declares no fields at all`

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -585,6 +585,56 @@ describe("parseExecArgs edge cases", () => {
     ).toEqual({ titel: "x" });
   });
 
+  it("offers a negated near miss, and only over fields that can be negated", () => {
+    const spec = makeSpec("handler", {
+      type: "object",
+      properties: {
+        title: { type: "boolean" },
+        done: { type: "boolean" },
+        body: { type: "string" },
+      },
+    });
+
+    // The case the caller actually hits: a typo inside the negated name. The
+    // `no-` prefix is stripped before matching, because otherwise it is three
+    // edits of noise and the threshold scales with the misspelling's length —
+    // so it would get HARDER to match precisely because they typed more.
+    expect(() => parseExecArgs(spec, ["invoke", "--no-titel"]))
+      .toThrow(/Did you mean "--no-title"\?/);
+
+    // Only booleans are offered, because only a boolean can be negated.
+    expect(() => parseExecArgs(spec, ["invoke", "--no-titel"]))
+      .toThrow(
+        /Only a boolean field can be negated, and this verb declares "--title", "--done"/,
+      );
+
+    // A near miss toward a NON-boolean is withheld: `--no-body` would fail
+    // too, so naming it sends the caller to a spelling that does not work.
+    expect(() => parseExecArgs(spec, ["invoke", "--no-bodi"]))
+      .not.toThrow(/Did you mean/);
+
+    // The unnegated door is untouched, and still lists every field.
+    expect(() => parseExecArgs(spec, ["invoke", "--titel", "x"]))
+      .toThrow(
+        /Did you mean "--title"\? <event> takes "--title", "--done", "--body"/,
+      );
+
+    // A valid negation still works.
+    expect(parseExecArgs(spec, ["invoke", "--no-title"]).input)
+      .toEqual({ title: false });
+  });
+
+  it("says so when a verb declares nothing that can be negated", () => {
+    const spec = makeSpec("handler", {
+      type: "object",
+      properties: { body: { type: "string" } },
+    });
+    expect(() => parseExecArgs(spec, ["invoke", "--no-body-x"]))
+      .toThrow(
+        /Only a boolean field can be negated, and this verb declares none/,
+      );
+  });
+
   it("refuses a declared field typed in its schema spelling, not aliases it", () => {
     // The permissive path turns on whether the SCHEMA judges its fields, not
     // on whether a NAME is declared. Asking the second would read `--fooBar`


### PR DESCRIPTION
## Why

`--titel` is told it probably meant `--title`. `--no-titel` was told nothing — the same slip, in the spelling where it is *more* likely, since `--no-` doubles the surface to mistype.

The cause is that the near miss searched the raw flag. Measured:

```
editDistance("no-titel", "title") = 4
threshold for a name of length 8  = 2      // max(1, floor(8 / 4))
editDistance("titel",    "title") = 1      // once the prefix is stripped
```

The prefix is three edits of pure noise, and the threshold scales with the *misspelling* length — so leaving it on makes the match harder precisely because the caller typed more.

Closes #5851.

## What Changed

`undeclaredFlagError` detects the `no-` spelling, strips it before matching, and renders the suggestion back with the prefix. Both halves of the answer narrow to what can actually be negated:

```
--no-titel  ->  "--no-titel" at <event> is not a field this verb declares.
                Did you mean "--no-title"?
                Only a boolean field can be negated, and this verb declares "--title", "--done"
```

Two deliberate restrictions:

- **The search runs over the boolean fields only.** A near miss toward a non-boolean is withheld — `--no-body` against a string `body` fails too, so naming it sends the caller to a spelling that does not work either.
- **The vocabulary lists the negatable subset**, not every field, for the same reason. Previously a `--no-` refusal listed fields that could never be negated.

The unnegated door is untouched, and `--no-body` against a declared non-boolean keeps its own message — the field exists, so the vocabulary would send the caller looking for a name they already found.

## Test plan

Seven cases pinned: the valid negation still works; the negated typo suggests; the suggestion is withheld toward a non-boolean; nothing close gets nothing; the unnegated path still lists every field; a verb with no booleans says so rather than trailing an empty list.

Full `packages/cli` suite 1686 + 174, 0 failed. `deno task check`, `fmt --check`, `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

