### PR TITLE
fix(cf-harness): a parse failure quotes the credential store back at you

### DIFF
--- a/packages/cf-harness/src/auth/credential-store.ts
+++ b/packages/cf-harness/src/auth/credential-store.ts
@@ -262,7 +262,14 @@ const isHealth = (value: unknown): value is HarnessCredentialHealth => {
 };
 
 const parseDocument = (text: string): CredentialDocument => {
-  const parsed = JSON.parse(text) as unknown;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text) as unknown;
+  } catch {
+    // A parse error quotes the surrounding source text, which here is the
+    // stored token.
+    throw new Error("credential store is not valid JSON");
+  }
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
     throw new Error("credential store must contain a JSON object");
   }

--- a/packages/cf-harness/src/auth/credential-store.ts
+++ b/packages/cf-harness/src/auth/credential-store.ts
@@ -266,8 +266,8 @@ const parseDocument = (text: string): CredentialDocument => {
   try {
     parsed = JSON.parse(text) as unknown;
   } catch {
-    // A parse error quotes the surrounding source text, which here is the
-    // stored token.
+    // A parse error quotes the source text around the failure, which in this
+    // file can be the stored token.
     throw new Error("credential store is not valid JSON");
   }
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {

--- a/packages/cf-harness/test/credential-store.test.ts
+++ b/packages/cf-harness/test/credential-store.test.ts
@@ -19,6 +19,13 @@ const credential = (
   accountId: `account-${owner}`,
 });
 
+/** Every `size`-character slice of `text`, for "quotes none of this" checks. */
+function* windows(text: string, size: number): Generator<string> {
+  for (let index = 0; index + size <= text.length; index += 1) {
+    yield text.slice(index, index + size);
+  }
+}
+
 const assertQueuedUpdateCanAbort = async (
   store: HarnessCredentialStore,
 ): Promise<void> => {
@@ -273,6 +280,32 @@ Deno.test("file credential store surfaces malformed storage without overwriting 
   );
   assertEquals(await Deno.readTextFile(path), "{malformed");
   assertEquals(store.lastValidSnapshot(), lastValid);
+});
+
+Deno.test("file credential store keeps stored bytes out of its read failure", async () => {
+  const root = await Deno.makeTempDir();
+  const path = join(root, "auth.json");
+  const refreshToken = "rt-EXTREMELY-SECRET-REFRESH-VALUE";
+  const store = new FileHarnessCredentialStore({ path });
+  await store.set("local", "openai-codex", credential("local", refreshToken));
+  // Unquoting the token is what an external truncation looks like to the
+  // parser: it fails on the token itself, so the token is what it quotes back.
+  const corrupted = (await Deno.readTextFile(path)).replace(
+    `"${refreshToken}"`,
+    refreshToken,
+  );
+  await Deno.writeTextFile(path, corrupted);
+
+  const error = await assertRejects(
+    () => store.get("local", "openai-codex"),
+    Error,
+    "failed to read credential store",
+  );
+  assertEquals(error.message.includes(refreshToken), false, error.message);
+  const echoed = [...windows(corrupted, 8)].filter((window) =>
+    error.message.includes(window)
+  );
+  assertEquals(echoed, [], `error echoed stored bytes: ${error.message}`);
 });
 
 Deno.test("file credential store rejects malformed owners and expiries fail-closed", async () => {


### PR DESCRIPTION
## Why

Closes #5872, filed from a Loom-side adversarial review of the vendored pin.

`JSON.parse` embeds a ~30-character window of its input in the message it throws, and `FileHarnessCredentialStore`'s read path interpolated that message verbatim. Against an externally truncated or corrupted `auth.json`, that window lands on the stored refresh token — and human-mode `cf-harness auth status|login|logout` writes the message straight to stderr.

Reproduced, not theorized: the regression test added here fails on `main` with the error echoing exactly the token bytes.

```
failed to read credential store: Unexpected token 'r', ..."shToken": rt-REFRESH"... is not valid JSON
```

`--json` mode was never exposed — that path catches and emits a generic `provider-unavailable` envelope — so Loom's own integration is unaffected. The exposed path is the one a developer hits hand-running the auth controls against a damaged store.

The trigger is external corruption (the store's own writes are atomic), so this is an edge path, not a routine one.

## What Changed

`parseDocument` now catches the parse failure and reports a generic one, keeping the source text out of the error entirely. This is what `provider-settings.ts` already does, and what the store's other rejections ("credential store must contain a JSON object", "unsupported credential store format") already did — the bare `JSON.parse` was the single outlier in the package. `openai-codex.ts` swallows both of its parse errors too.

## Test plan

- New `credential-store.test.ts` case stores a distinctive refresh token, unquotes it in the file so the parser fails *on the token*, and asserts the error message contains neither the token nor any 8-character window of the file. Verified failing before the fix (it lists the leaked windows), passing after.
- The existing malformed-storage case keeps its own subject — surfacing the failure without overwriting the file.
- `deno task test` in `packages/cf-harness`: 718 passed, 0 failed.
- `deno task check`, `deno fmt --check`, `deno lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

