### PR TITLE
fix(cf-harness): the local Loom host's batch argv is a prompt, or a refusal

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -353,7 +353,9 @@ Batch argv is a prompt run and nothing else. `--help` and
 other argv is bound and executed, so argv led by a CLI subcommand — `auth`,
 `config`, `models`, `whoami` — is rejected as `invalid-request` rather than
 billed as a prompt whose text happens to read like a command. Run those against
-the cf-harness CLI itself.
+the cf-harness CLI itself. The leading token is what decides, so positional
+prompt text opening on one of those four words is refused the same way; pass it
+through `--prompt` to send it as prompt text.
 
 Batch startup failures are one `cf-harness.host-failure` JSON object on stderr.
 Interactive startup failures remain on the NDJSON chat protocol so hosts that do

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -348,11 +348,21 @@ binding existed are deliberately not resumable through the local adapter; it
 fails closed instead of guessing which credential home or billing route created
 them.
 
+Batch argv is a prompt run and nothing else. `--help` and
+`--describe-capabilities` answer without reading provider or auth state; every
+other argv is bound and executed, so argv led by a CLI subcommand — `auth`,
+`config`, `models`, `whoami` — is rejected as `invalid-request` rather than
+billed as a prompt whose text happens to read like a command. Run those against
+the cf-harness CLI itself.
+
 Batch startup failures are one `cf-harness.host-failure` JSON object on stderr.
 Interactive startup failures remain on the NDJSON chat protocol so hosts that do
-not consume stderr still receive the stable provider error code. Run state,
-manifests, reports, child manifests, and structured batch results record only
-provider, the non-secret auth-source label, and the fixed owner reference.
+not consume stderr still receive the stable provider error code. A failure is
+`invalid-request` only while the argv and the recorded binding are still being
+checked; once a run starts being built, an infrastructure fault reports
+`internal-error`, so a host can keep a retry policy keyed on the code. Run
+state, manifests, reports, child manifests, and structured batch results record
+only provider, the non-secret auth-source label, and the fixed owner reference.
 
 Hosted or multi-user Loom must not reuse this single-user adapter. A trusted
 multi-user host must instead:

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -2899,7 +2899,14 @@ export const runCfHarnessCli = async (
     };
     if (parsed.resumeRun !== undefined) {
       const readRunArtifacts = deps.readRunArtifacts ?? readHarnessRunArtifacts;
-      const artifacts = await readRunArtifacts(parsed.resumeRun);
+      const artifacts = await readRunArtifacts(parsed.resumeRun).catch(
+        (error: unknown) => {
+          // Naming a run that is not there is a bad request. A run that is
+          // there and will not read is infrastructure, whatever the argv said.
+          if (!(error instanceof Deno.errors.NotFound)) requestAccepted = true;
+          throw error;
+        },
+      );
       if (artifacts.runState.lineage?.role === "subagent") {
         throw new Error(
           `Cannot resume subagent run ${artifacts.runState.runId} as a top-level run; resume root run ${artifacts.runState.lineage.rootRunId} instead.`,

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -2788,6 +2788,10 @@ export const runCfHarnessCli = async (
   setProvenanceCommand(cfHarnessCliCommandName(argv));
   const io = deps.io ?? defaultCliIo();
   let activeEngine: CfHarnessEngine | undefined;
+  // Set once the argv and the run's recorded binding have both been accepted.
+  // Past that point a fault is infrastructure, not a client error, and a host
+  // keying its retry policy on the reported code needs to tell them apart.
+  let requestAccepted = false;
   let signalCleanup: (() => void) | undefined;
   const activateEngine = (engine: CfHarnessEngine) => {
     activeEngine = engine;
@@ -2968,6 +2972,7 @@ export const runCfHarnessCli = async (
           "Loom openai-codex runs require an authenticated credential owner reference",
         );
       }
+      requestAccepted = true;
       const engine = new CfHarnessEngine({
         runState: artifacts.runState,
         artifactRoot: parsed.artifactRoot,
@@ -3125,6 +3130,7 @@ export const runCfHarnessCli = async (
           "Loom openai-codex runs require an authenticated credential owner reference",
         );
       }
+      requestAccepted = true;
       const modelClient = await createSelectedModelClient({
         provider: modelProvider,
         credentialOwner,
@@ -3282,10 +3288,10 @@ export const runCfHarnessCli = async (
     const hostError = deps.structuredHostFailures &&
         !(error instanceof HarnessControlError)
       ? new HarnessControlError(
-        activeEngine === undefined ? "invalid-request" : "internal-error",
-        activeEngine === undefined
-          ? "The cf-harness request is invalid"
-          : "The local cf-harness host operation failed",
+        requestAccepted ? "internal-error" : "invalid-request",
+        requestAccepted
+          ? "The local cf-harness host operation failed"
+          : "The cf-harness request is invalid",
       )
       : error;
     io.stderr(

--- a/packages/cf-harness/src/loom-local-host.ts
+++ b/packages/cf-harness/src/loom-local-host.ts
@@ -641,12 +641,14 @@ const defaultHostIo = (): CfHarnessCliIO => ({
 });
 
 /**
- * A startup blocker as the chat protocol states it. The provider codes carry
- * across by name. `invalid-request` and `operation-canceled` report as
- * `internal_error` rather than through the protocol's own `invalid_request`
- * and `turn_canceled`: those two describe the chat request being answered,
- * and a startup blocker is about the host process instead — its argv, or its
- * cancellation — so reporting them would blame a caller whose request is fine.
+ * A startup blocker as the chat protocol states it. Only the provider codes
+ * and `internal-error` reach here: this answers a failure raised before the
+ * host was serving, while `invalid-request` and `operation-canceled` belong to
+ * the batch and control paths, which answer on stderr instead. The provider
+ * codes carry across by name, so the remaining branch totals the mapping
+ * rather than choosing between codes. A malformed chat request is a separate
+ * matter and has the protocol's own `invalid_request`, raised where the
+ * request is read.
  */
 const chatError = (failure: CfHarnessHostFailure): HarnessChatError => ({
   code: failure.error.code === "provider-configuration-required" ||

--- a/packages/cf-harness/src/loom-local-host.ts
+++ b/packages/cf-harness/src/loom-local-host.ts
@@ -502,14 +502,16 @@ export const createLoomLocalCfHarnessHost = async (
       const io = options.cliDependencies?.io ?? defaultHostIo();
       // Batch argv reaches the CLI behind a prepended --model-provider, which
       // shifts a leading subcommand out of the CLI's own dispatch and into the
-      // prompt text. Reject it here rather than bill a run for it.
+      // prompt text. Reject it here rather than bill a run for it. Positional
+      // text opening on one of those words is caught too, so the message names
+      // the flag that says "prompt" unambiguously.
       const command = cfHarnessCliCommandName(argv);
       if (command !== "prompt") {
         io.stderr(`${
           JSON.stringify(createCfHarnessHostFailure(
             new HarnessControlError(
               "invalid-request",
-              `the local Loom host runs prompts only; "${command}" is a cf-harness CLI command`,
+              `the local Loom host runs prompts only; a leading "${command}" is a cf-harness CLI command — use --prompt to send it as prompt text`,
             ),
           ))
         }\n`);
@@ -640,9 +642,11 @@ const defaultHostIo = (): CfHarnessCliIO => ({
 
 /**
  * A startup blocker as the chat protocol states it. The provider codes carry
- * across by name; `invalid-request` and `operation-canceled` report as
- * `internal_error`, because a startup blocker precedes any request or turn the
- * protocol's own `invalid_request` and `turn_canceled` would be about.
+ * across by name. `invalid-request` and `operation-canceled` report as
+ * `internal_error` rather than through the protocol's own `invalid_request`
+ * and `turn_canceled`: those two describe the chat request being answered,
+ * and a startup blocker is about the host process instead — its argv, or its
+ * cancellation — so reporting them would blame a caller whose request is fine.
  */
 const chatError = (failure: CfHarnessHostFailure): HarnessChatError => ({
   code: failure.error.code === "provider-configuration-required" ||

--- a/packages/cf-harness/src/loom-local-host.ts
+++ b/packages/cf-harness/src/loom-local-host.ts
@@ -18,6 +18,7 @@ import {
   resolveHarnessModelProviderPreference,
 } from "./auth/provider-settings.ts";
 import {
+  cfHarnessCliCommandName,
   cfHarnessCliInformationalControl,
   type CfHarnessCliIO,
   type CfHarnessHostFailure,
@@ -498,11 +499,26 @@ export const createLoomLocalCfHarnessHost = async (
           structuredHostFailures: true,
         });
       }
+      const io = options.cliDependencies?.io ?? defaultHostIo();
+      // Batch argv reaches the CLI behind a prepended --model-provider, which
+      // shifts a leading subcommand out of the CLI's own dispatch and into the
+      // prompt text. Reject it here rather than bill a run for it.
+      const command = cfHarnessCliCommandName(argv);
+      if (command !== "prompt") {
+        io.stderr(`${
+          JSON.stringify(createCfHarnessHostFailure(
+            new HarnessControlError(
+              "invalid-request",
+              `the local Loom host runs prompts only; "${command}" is a cf-harness CLI command`,
+            ),
+          ))
+        }\n`);
+        return 1;
+      }
       let resolved;
       try {
         resolved = await resolveBinding(argv);
       } catch (error) {
-        const io = options.cliDependencies?.io ?? defaultHostIo();
         io.stderr(`${JSON.stringify(createCfHarnessHostFailure(error))}\n`);
         return 1;
       }
@@ -622,14 +638,18 @@ const defaultHostIo = (): CfHarnessCliIO => ({
   stderr: (text) => Deno.stderr.writeSync(new TextEncoder().encode(text)),
 });
 
+/**
+ * A startup blocker as the chat protocol states it. The provider codes carry
+ * across by name; `invalid-request` and `operation-canceled` report as
+ * `internal_error`, because a startup blocker precedes any request or turn the
+ * protocol's own `invalid_request` and `turn_canceled` would be about.
+ */
 const chatError = (failure: CfHarnessHostFailure): HarnessChatError => ({
   code: failure.error.code === "provider-configuration-required" ||
       failure.error.code === "provider-auth-required" ||
       failure.error.code === "provider-mismatch" ||
       failure.error.code === "provider-unavailable"
     ? failure.error.code
-    : failure.error.code === "internal-error"
-    ? "internal_error"
     : "internal_error",
   message: failure.error.message,
 });

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -5536,3 +5536,34 @@ Deno.test("a startup fault is internal, and only bad argv is an invalid request"
   assertEquals(failure.error.code, "internal-error");
   assertEquals(JSON.stringify(failure).includes("artifact store"), false);
 });
+
+Deno.test("a resume reads a missing run as bad argv and an unreadable one as internal", async () => {
+  const workspace = await Deno.makeTempDir();
+  const run = async (
+    error: Error,
+  ): Promise<{ code: string; message: string }> => {
+    const buffers = createIoBuffers();
+    assertEquals(
+      await runCfHarnessCli(["--resume-run", "/runs/one"], {
+        cwd: workspace,
+        env: {},
+        io: buffers.io,
+        structuredHostFailures: true,
+        readRunArtifacts: () => Promise.reject(error),
+      }),
+      1,
+    );
+    return JSON.parse(buffers.stderr[0]).error;
+  };
+
+  // Naming a run that was never written is the caller's mistake, and no retry
+  // will change it. A run that exists and will not read is the host's problem,
+  // and the argv that asked for it was fine.
+  assertEquals(
+    (await run(new Deno.errors.NotFound("no such run"))).code,
+    "invalid-request",
+  );
+  const unreadable = await run(new Deno.errors.PermissionDenied("run-state"));
+  assertEquals(unreadable.code, "internal-error");
+  assertEquals(unreadable.message.includes("run-state"), false);
+});

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -5483,3 +5483,56 @@ Deno.test("local Loom binding conflicts become structured provider mismatches be
   assertEquals(failure.error.code, "provider-mismatch");
   assertStringIncludes(failure.error.message, "provider");
 });
+
+Deno.test("a startup fault is internal, and only bad argv is an invalid request", async () => {
+  const workspace = await Deno.makeTempDir();
+
+  const rejected = createIoBuffers();
+  assertEquals(
+    await runCfHarnessCli(["--model-provider", "unsupported", "hello"], {
+      cwd: workspace,
+      env: {},
+      io: rejected.io,
+      structuredHostFailures: true,
+    }),
+    1,
+  );
+  assertEquals(JSON.parse(rejected.stderr[0]).error.code, "invalid-request");
+
+  // The argv is well-formed and the binding holds; only building the run
+  // fails. A host that retries on `internal-error` and gives up on
+  // `invalid-request` needs this one classified as the transient it is.
+  const startup = createIoBuffers();
+  let promptLoopsCreated = 0;
+  assertEquals(
+    await runCfHarnessCli(
+      [
+        "--workspace",
+        workspace,
+        "--model-provider",
+        "openai-codex",
+        "--cfc-enforcement-mode",
+        "disabled",
+        "hello",
+      ],
+      {
+        cwd: workspace,
+        env: {},
+        io: startup.io,
+        structuredHostFailures: true,
+        createModelClient: () =>
+          Promise.reject(new Error("artifact store unavailable")),
+        createPromptLoop: () => {
+          promptLoopsCreated += 1;
+          throw new Error("must not construct a prompt loop");
+        },
+      },
+    ),
+    1,
+  );
+  assertEquals(promptLoopsCreated, 0);
+  assertEquals(startup.stdout, []);
+  const failure = JSON.parse(startup.stderr[0]);
+  assertEquals(failure.error.code, "internal-error");
+  assertEquals(JSON.stringify(failure).includes("artifact store"), false);
+});

--- a/packages/cf-harness/test/loom-local-host-controls.test.ts
+++ b/packages/cf-harness/test/loom-local-host-controls.test.ts
@@ -180,7 +180,63 @@ Deno.test("local Loom batch rejects control argv before it bills a prompt run", 
       failure.error.message,
       argv[0] === "--" ? argv[1] : argv[0],
     );
+    assertStringIncludes(failure.error.message, "--prompt");
   }
+});
+
+Deno.test("local Loom batch runs a prompt whose own first word is a subcommand", async () => {
+  // The guard reads the leading token, so `--prompt` is what separates "run
+  // the models subcommand" from "ask the model about models". The rejection
+  // above names this flag; a caller who follows it has to get a run.
+  const home = await Deno.makeTempDir();
+  const io = ioBuffers();
+  let prompt: string | undefined;
+  const host = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: {
+      CF_HARNESS_GATEWAY_BASE_URL: "https://gateway.example/",
+      CF_HARNESS_GATEWAY_AUTH_MODE: "none",
+    },
+    providerSettingsStore: {
+      inspect: () =>
+        Promise.resolve({
+          state: "configured" as const,
+          settings: {
+            version: 1 as const,
+            modelProvider: "openai-compatible-gateway" as const,
+          },
+        }),
+    },
+    cliDependencies: {
+      cwd: home,
+      io: io.io,
+      createPromptLoop: (options: CreateHarnessPromptLoopOptions) => ({
+        runPrompt: (request: { prompt: string }) => {
+          prompt = request.prompt;
+          return Promise.resolve<HarnessPromptLoopResult>({
+            model: options.model ?? "gpt-5.6-terra",
+            finalAssistantText: "answered",
+            transcript: [],
+            modelTurns: 1,
+            runState: options.engine!.getRunState(),
+          });
+        },
+        runTranscript: () => Promise.reject(new Error("unexpected resume")),
+      }),
+    },
+  });
+
+  assertEquals(
+    await host.runBatch([
+      "--prompt",
+      "models are great",
+      "--cfc-enforcement-mode",
+      "disabled",
+    ]),
+    0,
+    io.stderr.join(""),
+  );
+  assertEquals(prompt, "models are great");
 });
 
 Deno.test("local Loom batch executable exposes help and capabilities before setup", async () => {

--- a/packages/cf-harness/test/loom-local-host-controls.test.ts
+++ b/packages/cf-harness/test/loom-local-host-controls.test.ts
@@ -8,6 +8,10 @@ import {
 } from "../src/cli.ts";
 import { createLoomLocalCfHarnessHost } from "../src/loom-local-host.ts";
 import { runLoomLocalCfHarnessHostMain } from "../src/loom-local-host-main.ts";
+import type {
+  CreateHarnessPromptLoopOptions,
+  HarnessPromptLoopResult,
+} from "../src/prompt-loop.ts";
 
 const ioBuffers = (): {
   io: CfHarnessCliIO;
@@ -103,6 +107,80 @@ Deno.test("local Loom batch control-looking prompt text does not bypass binding"
     JSON.parse(io.stderr.join("")).error.code,
     "provider-configuration-required",
   );
+});
+
+Deno.test("local Loom batch rejects control argv before it bills a prompt run", async () => {
+  const controlArgv: ReadonlyArray<readonly string[]> = [
+    ["auth", "status", "openai-codex"],
+    ["config", "set", "model-provider", "openai-codex"],
+    ["models", "list"],
+    ["whoami"],
+    ["--", "auth", "status", "openai-codex"],
+  ];
+
+  for (const argv of controlArgv) {
+    const label = argv.join(" ");
+    const home = await Deno.makeTempDir();
+    let promptLoops = 0;
+    let providerReads = 0;
+    let providerRequests = 0;
+    const io = ioBuffers();
+    const host = await createLoomLocalCfHarnessHost({
+      harnessHome: home,
+      env: {
+        CF_HARNESS_GATEWAY_BASE_URL: "https://gateway.example/",
+        CF_HARNESS_GATEWAY_AUTH_MODE: "none",
+      },
+      providerSettingsStore: {
+        inspect: () => {
+          providerReads += 1;
+          return Promise.resolve({
+            state: "configured" as const,
+            settings: {
+              version: 1 as const,
+              modelProvider: "openai-compatible-gateway" as const,
+            },
+          });
+        },
+      },
+      fetchFn: () => {
+        providerRequests += 1;
+        return Promise.reject(new Error("provider traffic must not occur"));
+      },
+      cliDependencies: {
+        cwd: home,
+        io: io.io,
+        // A billable run would succeed here, so an unguarded control argv
+        // reports exit 0 for a model call nobody asked for.
+        createPromptLoop: (options: CreateHarnessPromptLoopOptions) => {
+          promptLoops += 1;
+          const result: HarnessPromptLoopResult = {
+            model: options.model ?? "gpt-5.6-terra",
+            finalAssistantText: "billed",
+            transcript: [],
+            modelTurns: 1,
+            runState: options.engine!.getRunState(),
+          };
+          return {
+            runPrompt: () => Promise.resolve(result),
+            runTranscript: () => Promise.reject(new Error("unexpected resume")),
+          };
+        },
+      },
+    });
+
+    assertEquals(await host.runBatch(argv), 1, label);
+    assertEquals(promptLoops, 0, label);
+    assertEquals(providerReads, 0, label);
+    assertEquals(providerRequests, 0, label);
+    assertEquals(io.stdout, [], label);
+    const failure = JSON.parse(io.stderr.join(""));
+    assertEquals(failure.error.code, "invalid-request", label);
+    assertStringIncludes(
+      failure.error.message,
+      argv[0] === "--" ? argv[1] : argv[0],
+    );
+  }
 });
 
 Deno.test("local Loom batch executable exposes help and capabilities before setup", async () => {


### PR DESCRIPTION
## Why

Closes #5873, filed from a Loom-side adversarial review of the vendored pin. Neither finding is fail-open — the no-fallback provider invariant held — these are contract and classification defects.

**1. Any argv that isn't `--help`/`--describe-capabilities` executed as a billable prompt run.** `runBatch` prepends `--model-provider <resolved>` to argv, which shifts a leading subcommand out of `cfHarnessCliCommandName`'s view. So `runBatch(["auth", "status", "openai-codex"])` never reached the CLI's `auth` dispatcher — it became the *prompt text* of a real model call, and returned **exit 0** with no stderr. Correctly bound provider and owner throughout, so no security or provider-confusion hole; but a stray management argv billed a run and reported fabricated success. Reproduced by the test added here, which fails on `main` at the exit code.

**2. Infra faults during startup misclassified as `invalid-request`.** The typed-failure split turned on whether `activeEngine` was set — but `activateEngine()` runs only *after* `new CfHarnessEngine(...)` and `createSelectedModelClient(...)` both succeed. A filesystem error building the artifact store, a sandbox/docker-runsc config failure, or a model-client construction fault therefore reported as a permanent client error. A host keying retry/backoff on these codes gives up on faults that are retryable.

## What Changed

- **`loom-local-host.ts`** — batch argv led by a CLI subcommand (`auth`, `config`, `models`, `whoami`, with or without a leading `--`) is rejected as a typed `invalid-request` before any provider read. The informational controls are untouched and still answer without touching provider or auth state.
- **`cli.ts`** — the `invalid-request`/`internal-error` split now turns on whether the *request* was accepted, set once argv and the recorded binding have both passed. Construction faults past that point report `internal-error`. Genuine argv errors still report `invalid-request`.
- **`loom-local-host.ts`** — `chatError` had a dead ternary arm (`internal-error ? "internal_error" : "internal_error"`) hiding the interactive collapse the issue asked be documented. Replaced with a doc comment stating it: `invalid-request` and `operation-canceled` report `internal_error` because a startup blocker precedes any request or turn the protocol's own `invalid_request`/`turn_canceled` would describe. Behavior unchanged.
- **`README.md`** — both contracts documented in the "Loom subscription binding" section.

### One design call left to you

The chat protocol *does* define `invalid_request` and `turn_canceled` (`contracts/interactive-chat.ts:239,245`), so the interactive collapse is a choice rather than a limitation — and it points the opposite way from finding 2: a permanent client error reported under a code a host may retry. The issue marked it accepted-by-design, so I documented it rather than changing it. Say the word if you'd rather map them through.

## Test plan

- New `loom-local-host-controls.test.ts` case runs five control argv shapes through `runBatch` with a prompt loop that *would* succeed, asserting exit 1, zero prompt loops constructed, zero provider reads, zero provider traffic, empty stdout, and a typed `invalid-request` naming the command. Verified: on `main` the first case returns 0.
- New `cli.test.ts` case pins both sides of the split — bad argv stays `invalid-request`, an injected model-client construction fault becomes `internal-error` with no prompt loop constructed and no fault detail in the envelope. Verified failing before the fix.
- `deno task test` in `packages/cf-harness`: 719 passed, 0 failed.
- `deno task check`, `check-skill-facts`, `check-conflict-markers`, `check-no-waitfor`, `deno fmt --check`, `deno lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

