### PR TITLE
An author's prose reaches a created piece's verbs

### DIFF
--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -2067,13 +2067,23 @@ export function declaredVerbProse(
   if (!isObjectOrArray(declared) || !isObjectOrArray(declared.properties)) {
     return prose;
   }
+  // The scope a property's own references resolve in. A `$defs` closure is
+  // local: the definition the root names may carry definitions of its own, and
+  // a reference inside it names THOSE. Resolving at the outer root finds
+  // nothing, or — worse — a same-named definition belonging to someone else.
+  // `cfcSchemaChildRoot` opens the inner scope where there is one and hands
+  // back the outer root where there is not.
+  const declaredRoot = cfcSchemaChildRoot(
+    declared as JSONSchema,
+    resultSchema as JSONSchema,
+  );
   for (const [name, property] of Object.entries(declared.properties)) {
     if (!isObjectOrArray(property)) continue;
     const description = typeof property.description === "string"
       ? property.description
       : undefined;
     const eventSchema = typeof property.$ref === "string"
-      ? resolveCfcSchemaRefs(property, resultSchema as JSONSchema)
+      ? resolveCfcSchemaRefs(property, declaredRoot)
       : property as JSONSchema;
     if (description === undefined && eventSchema === undefined) continue;
     prose.set(name, {

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -2052,12 +2052,22 @@ export function declaredVerbProse(
 ): Map<string, DeclaredVerbProse> {
   const prose = new Map<string, DeclaredVerbProse>();
   const resultSchema = pattern?.resultSchema;
-  if (
-    !isObjectOrArray(resultSchema) || !isObjectOrArray(resultSchema.properties)
-  ) {
+  if (!isObjectOrArray(resultSchema)) return prose;
+  // The ROOT may itself be a reference. A pattern whose result is a named type
+  // compiles to `{$ref: "#/$defs/T", $defs: {T: {properties: …}}}`, and the
+  // properties then live in the definition rather than on the root. That is
+  // every piece a verb CREATES, because a created piece's result is the named
+  // type its author declared — so reading `properties` off the root without
+  // resolving reported every such verb as having no prose at all, while a root
+  // piece, whose result is written inline, kept its own. The `$defs` sit on the
+  // root, so the root is what the reference resolves against.
+  const declared = typeof resultSchema.$ref === "string"
+    ? resolveCfcSchemaRefs(resultSchema, resultSchema as JSONSchema)
+    : resultSchema;
+  if (!isObjectOrArray(declared) || !isObjectOrArray(declared.properties)) {
     return prose;
   }
-  for (const [name, property] of Object.entries(resultSchema.properties)) {
+  for (const [name, property] of Object.entries(declared.properties)) {
     if (!isObjectOrArray(property)) continue;
     const description = typeof property.description === "string"
       ? property.description

--- a/packages/cli/test/verb-prose-overlay.test.ts
+++ b/packages/cli/test/verb-prose-overlay.test.ts
@@ -536,4 +536,53 @@ describe("verb prose", () => {
       expect(declaredVerbProse({ resultSchema: true }).size).toBe(0);
     });
   });
+
+  describe("a result schema that is a reference at its root", () => {
+    it("reads the verbs from the definition the root names", () => {
+      // A pattern whose result is a NAMED type compiles this way, which is
+      // every piece a verb creates: its result is the type its author
+      // declared, so the properties live in `$defs` rather than on the root.
+      // A root piece, whose result is written inline, kept its prose while a
+      // created one lost all of it.
+      const pattern = {
+        resultSchema: {
+          $ref: "#/$defs/Item",
+          $defs: {
+            Item: {
+              type: "object",
+              properties: {
+                blockOn: {
+                  $ref: "#/$defs/BlockOnEvent",
+                  asCell: ["stream"],
+                  description: "Record that this item waits on another.",
+                },
+              },
+            },
+            BlockOnEvent: { type: "object", properties: { on: {} } },
+          },
+        },
+      };
+
+      const prose = declaredVerbProse(pattern);
+      expect(prose.get("blockOn")?.description)
+        .toBe("Record that this item waits on another.");
+    });
+
+    it("still reads an inline result schema", () => {
+      // The root-piece shape, which worked before and must keep working.
+      const pattern = {
+        resultSchema: {
+          type: "object",
+          properties: { addItem: { description: "File a new root item." } },
+        },
+      };
+      expect(declaredVerbProse(pattern).get("addItem")?.description)
+        .toBe("File a new root item.");
+    });
+
+    it("returns nothing for a root reference that resolves to nothing", () => {
+      const pattern = { resultSchema: { $ref: "#/$defs/Absent" } };
+      expect(declaredVerbProse(pattern).size).toBe(0);
+    });
+  });
 });

--- a/packages/cli/test/verb-prose-overlay.test.ts
+++ b/packages/cli/test/verb-prose-overlay.test.ts
@@ -584,5 +584,39 @@ describe("verb prose", () => {
       const pattern = { resultSchema: { $ref: "#/$defs/Absent" } };
       expect(declaredVerbProse(pattern).size).toBe(0);
     });
+
+    it("resolves a property reference in the definition's OWN scope", () => {
+      // A `$defs` closure is local. The definition the root names may carry
+      // definitions of its own, and a property reference inside it names
+      // those — resolving at the outer root finds nothing, or a same-named
+      // definition belonging to someone else. Both roots here declare `Ev`,
+      // and only the inner one is correct for a property of `Item`.
+      const pattern = {
+        resultSchema: {
+          $ref: "#/$defs/Item",
+          $defs: {
+            Item: {
+              type: "object",
+              properties: { act: { $ref: "#/$defs/Ev", description: "Act." } },
+              $defs: {
+                Ev: {
+                  type: "object",
+                  properties: { inner: { type: "string" } },
+                },
+              },
+            },
+            Ev: {
+              type: "object",
+              properties: { outer: { type: "string" } },
+            },
+          },
+        },
+      };
+
+      const eventSchema = declaredVerbProse(pattern).get("act")
+        ?.eventSchema as Record<string, unknown> | undefined;
+      const props = eventSchema?.properties as Record<string, unknown>;
+      expect(Object.keys(props)).toEqual(["inner"]);
+    });
   });
 });


### PR DESCRIPTION
## Why

Row 5a (#5825) made a verb's doc comment reach the caller who asks. It reaches a **root** piece's verbs and not a **created** one's.

Measured against a live toolshed with `packages/cli/integration/pattern/tracker.tsx`:

```
cf piece verbs --piece board     addItem   "File a new root item on the board."
cf piece verbs --piece <item>    addChild  null
                                 archive   null
                                 blockOn   null
                                 finish    null
```

All four carry doc comments in the pattern. `cf piece call --piece <item> blockOn --help` likewise renders `--on <json>  Required.` with no description.

Closes #5876.

## What Changed

`declaredVerbProse` read `resultSchema.properties` off the root and returned an empty map when the root had none. A pattern whose result is a **named type** compiles to `{$ref: "#/$defs/T", $defs: {T: {properties: …}}}`, so the properties live in the definition rather than on the root.

That shape is every piece a verb **creates** — a created piece's result is the type its author declared — while a root piece writes its result inline. So the split fell exactly along "did a verb make this piece".

The root reference now resolves before the properties are read, against the root, because that is where the `$defs` sit. It is the same pairing the per-property resolution immediately below already performs, applied one level up.

## Test plan

Three cases in `test/verb-prose-overlay.test.ts`: the created-piece shape (a root `$ref` into `$defs`), the root-piece shape (inline properties, which worked before and must keep working), and a root reference resolving to nothing.

Verified live: after the change all four item verbs carry their author's words.

Full `packages/cli` suite 1686 + 174, 0 failed. `deno task check`, `fmt --check`, `lint` clean.

One flake seen and dismissed: `test/ingest-command.test.ts` failed once in a full-suite run and passes in isolation both with this change and on a clean `main`. Not related.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

