### PR TITLE
bench,refactor(data-model): bulk `bytes` and `bigint` series, and one empty context

### DIFF
--- a/packages/data-model/bench/codec-json.bench.ts
+++ b/packages/data-model/bench/codec-json.bench.ts
@@ -19,8 +19,11 @@
  */
 
 import { fabricFromJsonValue, jsonFromFabricValue } from "@/codecs.ts";
+import type { FabricValue } from "@/interface.ts";
 import {
   ARRAYS,
+  BIGINTS,
+  BYTES,
   groupKey,
   JSON_PASS_THROUGH_OMNIBUSES,
   OBJECTS,
@@ -41,6 +44,10 @@ const SPARSE_JSON = SPARSE.map(([n, v]) =>
   [n, jsonFromFabricValue(v)] as const
 );
 const OBJECTS_JSON = OBJECTS.map(([n, v]) =>
+  [n, jsonFromFabricValue(v)] as const
+);
+const BYTES_JSON = BYTES.map(([n, v]) => [n, jsonFromFabricValue(v)] as const);
+const BIGINTS_JSON = BIGINTS.map(([n, v]) =>
   [n, jsonFromFabricValue(v)] as const
 );
 const OMNIBUSES_JSON = OMNIBUSES.map(([n, v]) =>
@@ -162,6 +169,43 @@ for (const [size, json] of OBJECTS_JSON) {
       fabricFromJsonValue(json);
     },
   });
+}
+
+//
+// Bulk payloads by magnitude: bytes as base64url text, `bigint` as decimal
+// text. Sized in bytes so the two columns answer the same question of each.
+//
+
+const BULK: readonly (readonly [
+  string,
+  readonly (readonly [number, FabricValue])[],
+  readonly (readonly [number, string])[],
+])[] = [
+  ["bytes", BYTES, BYTES_JSON],
+  ["bigint", BIGINTS, BIGINTS_JSON],
+];
+
+for (const [prefix, subjects, encodedForms] of BULK) {
+  for (const [size, value] of subjects) {
+    Deno.bench({
+      name: `encode ${groupKey(prefix, size)}`,
+      group: groupKey(prefix, size),
+      baseline: true,
+      fn() {
+        jsonFromFabricValue(value);
+      },
+    });
+  }
+
+  for (const [size, json] of encodedForms) {
+    Deno.bench({
+      name: `decode ${groupKey(prefix, size)}`,
+      group: groupKey(prefix, size),
+      fn() {
+        fabricFromJsonValue(json);
+      },
+    });
+  }
 }
 
 //

--- a/packages/data-model/bench/codec-json.bench.ts
+++ b/packages/data-model/bench/codec-json.bench.ts
@@ -172,8 +172,10 @@ for (const [size, json] of OBJECTS_JSON) {
 }
 
 //
-// Bulk payloads by magnitude: bytes as base64url text, `bigint` as decimal
-// text. Sized in bytes so the two columns answer the same question of each.
+// Bulk payloads by magnitude, both reaching base64url text of a byte string
+// of the same length. Sized in bytes so the two columns answer the same
+// question of each; what separates them is the trip a `bigint` takes through
+// `toString(16)` to become bytes in the first place.
 //
 
 const BULK: readonly (readonly [

--- a/packages/data-model/bench/fixtures/codec-fixtures.ts
+++ b/packages/data-model/bench/fixtures/codec-fixtures.ts
@@ -33,6 +33,28 @@ export const SIZES = [0, 1, 10, 100, 1000, 10000, 100000] as const;
 export const SPARSE_SIZES = SIZES.filter((size) => size >= 10);
 
 /**
+ * Payload sizes **in bytes** for the two series that carry bulk data rather
+ * than structure, one magnitude further than the containers reach.
+ *
+ * Bytes rather than elements, and the same ladder for both, because the point
+ * of these two series is to be read against each other. A `FabricBytes` and a
+ * `bigint` of the same size carry the same quantity of data through formats
+ * that treat them oppositely: cloning takes each as itself, where JSON must
+ * reach text for both -- base64url for one, decimal for the other -- and the
+ * two text encodings do not cost alike.
+ */
+export const BYTE_SIZES = [
+  0,
+  1,
+  10,
+  100,
+  1000,
+  10000,
+  100000,
+  1000000,
+] as const;
+
+/**
  * One subject per interesting path through the codec system: the
  * self-representing cases, the four JavaScript types JSON cannot carry, a
  * terminal and a nonterminal fabric codec, and both structural escapes.
@@ -112,6 +134,48 @@ export function makeSparseArray(size: number): FabricValue {
   }
 
   return Object.freeze(result);
+}
+
+/**
+ * Builds a `FabricBytes` of `size` bytes.
+ *
+ * The content is a repeating byte ramp rather than zeroes, unlike the
+ * containers: base64url costs the same either way, but a run of zeroes is the
+ * one input a future encoder might reasonably special-case, and a series meant
+ * to price bulk data should not be measuring a shortcut.
+ */
+export function makeBytes(size: number): FabricValue {
+  const bytes = new Uint8Array(size);
+
+  for (let i = 0; i < size; i++) {
+    bytes[i] = i & 0xff;
+  }
+
+  return new FabricBytes(bytes, true);
+}
+
+/**
+ * Builds a positive `bigint` occupying `size` bytes, and as sparse as one that
+ * size can be: the lowest bit set and the highest, nothing between them.
+ *
+ * The high bit is what makes the byte count exact -- a value with leading zero
+ * bytes would carry less data than its size claims -- and the low bit is what
+ * keeps the value from being a power of two, which is the shape an
+ * implementation is likeliest to have a shortcut for. Between them the value
+ * is all zeroes, so nothing here is measuring dense magnitude when it means to
+ * be measuring size. `size` of zero gives `0n`, the ladder's empty case.
+ *
+ * Positive throughout: sign is stored apart from magnitude, so a negative
+ * counterpart would cost what these do, and JSON's decimal form would gain a
+ * single character.
+ *
+ * That decimal form runs about 2.41 digits per byte, which is the number to
+ * have in hand when reading this series against the byte one under JSON: the
+ * two are not carrying the same amount of *text* even where they carry the
+ * same amount of data.
+ */
+export function makeBigint(size: number): FabricValue {
+  return (size === 0) ? 0n : (1n << BigInt((8 * size) - 1)) | 1n;
 }
 
 /** Builds a plain object of `size` distinct keys, every value zero. */
@@ -283,6 +347,16 @@ export const SPARSE = SPARSE_SIZES.map(
   (size) => [size, makeSparseArray(size)] as const,
 );
 export const OBJECTS = SIZES.map((size) => [size, makeObject(size)] as const);
+
+/** Byte payloads by magnitude. */
+export const BYTES = BYTE_SIZES.map(
+  (size) => [size, makeBytes(size)] as const,
+);
+
+/** `bigint` payloads by magnitude, sized in bytes to match {@link BYTES}. */
+export const BIGINTS = BYTE_SIZES.map(
+  (size) => [size, makeBigint(size)] as const,
+);
 /** Leaf counts for every omnibus series, so the three are read against each other. */
 const OMNIBUS_SIZES = [10, 100, 1000] as const;
 

--- a/packages/data-model/bench/fixtures/codec-fixtures.ts
+++ b/packages/data-model/bench/fixtures/codec-fixtures.ts
@@ -39,9 +39,9 @@ export const SPARSE_SIZES = SIZES.filter((size) => size >= 10);
  * Bytes rather than elements, and the same ladder for both, because the point
  * of these two series is to be read against each other. A `FabricBytes` and a
  * `bigint` of the same size carry the same quantity of data through formats
- * that treat them oppositely: cloning takes each as itself, where JSON must
- * reach text for both -- base64url for one, decimal for the other -- and the
- * two text encodings do not cost alike.
+ * that treat them oppositely: cloning takes each as itself, where JSON writes
+ * both as base64url of the same byte count -- the same wire text, to within a
+ * character or two -- and still does not spend alike getting there.
  */
 export const BYTE_SIZES = [
   0,
@@ -165,14 +165,16 @@ export function makeBytes(size: number): FabricValue {
  * is all zeroes, so nothing here is measuring dense magnitude when it means to
  * be measuring size. `size` of zero gives `0n`, the ladder's empty case.
  *
- * Positive throughout: sign is stored apart from magnitude, so a negative
- * counterpart would cost what these do, and JSON's decimal form would gain a
- * single character.
+ * Positive throughout, sign being stored apart from magnitude, so a negative
+ * counterpart would cost what these do.
  *
- * That decimal form runs about 2.41 digits per byte, which is the number to
- * have in hand when reading this series against the byte one under JSON: the
- * two are not carrying the same amount of *text* even where they carry the
- * same amount of data.
+ * What to have in hand when reading this series against the byte one under
+ * JSON: the two reach the *same* wire form, base64url of a two's-complement
+ * byte string, and at these sizes the same length to within a character. What
+ * separates them is the cost of getting a `bigint`'s bytes out of the runtime
+ * at all, which goes through `toString(16)` and a hex parse -- linear, base 16
+ * being a power of two, but several times what handing over a `Uint8Array`
+ * costs.
  */
 export function makeBigint(size: number): FabricValue {
   return (size === 0) ? 0n : (1n << BigInt((8 * size) - 1)) | 1n;

--- a/packages/data-model/src/codecs.ts
+++ b/packages/data-model/src/codecs.ts
@@ -18,7 +18,7 @@ import { isInstance } from "@commonfabric/utils/types";
 
 import type { FabricValue } from "./fabric-value.ts";
 import type { ReconstructionContext } from "./codec-interface/interface.ts";
-import { EmptyReconstructionContext } from "./codec-interface/EmptyReconstructionContext.ts";
+import { EMPTY_RECONSTRUCTION_CONTEXT } from "./codec-interface/EmptyReconstructionContext.ts";
 import type { CodecRegistry } from "./codec-common/CodecRegistry.ts";
 import type { JsonCodecValue } from "./codec-json/interface.ts";
 import { JsonCodecEngine } from "./codec-json/JsonCodecEngine.ts";
@@ -68,22 +68,6 @@ export function newDefaultJsonCodecEngine(
 const jsonCodecEngine = newDefaultJsonCodecEngine();
 
 /**
- * Shared empty `ReconstructionContext` used when a JSON decode is requested
- * without a runtime context. Behaviorally identical to the bare empty
- * singleton (`shouldDeepFreeze` is `true`); only the `getCell()` throw
- * message is decode-framed, so an unexpected cell reference during a
- * context-less decode produces a message that names the situation. This
- * single instance covers both public entry points (`fabricFromJsonValue()` and
- * `plainObjectFromJson()`, the latter delegating to the former).
- */
-const JSON_DECODE_EMPTY_CONTEXT = Object.freeze(
-  new EmptyReconstructionContext(
-    true,
-    "no runtime context (JSON decode); a cell reference cannot be reconstructed.",
-  ),
-);
-
-/**
  * Encodes a fabric value to a JSON string in the standard `FabricValue`
  * JSON-embedded encoding, prefixed with the format-identifying tag `fvj1:`.
  */
@@ -123,16 +107,12 @@ export function plainObjectFromJson<T extends object = object>(
 
 /**
  * Decodes a string in the `FabricValue` JSON-embedded encoding format. If
- * `context` is omitted, the shared decode-framed empty context
- * (`JSON_DECODE_EMPTY_CONTEXT`) is substituted, which throws if any
- * reconstruction is needed.
+ * `context` is omitted, {@link EMPTY_RECONSTRUCTION_CONTEXT} is substituted,
+ * which throws if any reconstruction is needed.
  */
 export function fabricFromJsonValue(
   json: string,
   context?: ReconstructionContext | undefined,
 ): FabricValue {
-  return jsonCodecEngine.decode(
-    json,
-    context ?? JSON_DECODE_EMPTY_CONTEXT,
-  );
+  return jsonCodecEngine.decode(json, context ?? EMPTY_RECONSTRUCTION_CONTEXT);
 }


### PR DESCRIPTION
Two changes that are general rather than about any one wire format, carved out of `danfuzz/codec-realm` (#5823) ahead of it. I (agent working on behalf of @danfuzz) am opening this so that branch stays scoped to the realm format itself.

## The size series

Neither `FabricBytes` nor `bigint` had one. Both appeared once, at a fixed small size, so nothing said what either costs as a *payload* rather than as a type. Both now run the magnitude ladder to 1000000.

**Sized in bytes for both**, which is the point: a `FabricBytes` and a `bigint` of the same size carry the same quantity of data. The `bigint` subjects are maximally sparse — lowest bit set and highest, nothing between. The high bit pins the byte count exactly; the low bit keeps the value off a power of two, which is the shape an implementation is likeliest to have a shortcut for.

Both reach the **same** JSON wire form: base64url of a two's-complement byte string. At 1000000 bytes those come out 1,333,356 and 1,333,354 characters — the same text, to within two characters. What separates the columns is not the encoding but the cost of getting a `bigint`'s bytes out of the runtime at all, timed by stage:

| at 1000000 bytes | |
|---|---|
| whole `bytes` encode | 0.17ms |
| `bigint` → bytes (`bigintToMinimalTwosComplement`) | 0.95ms |
| …of which `toString(16)` | 0.73ms |
| base64url of the resulting bytes | 0.04ms |

That conversion is linear, base 16 being a power of two. The fixtures are shared, so the realm format's numbers on #5823 come from these same subjects — and there a `bigint` encodes in constant time at every size, cloning carrying one as itself.

## The empty context

`fabricFromJsonValue()` carried its own frozen `EmptyReconstructionContext`, identical to the shared singleton but for a `getCell()` message naming the decode. @danfuzz's call that it is not worth a constant: the engine is evident from the stack when one throws.

Worth adding that the situation the message framed is one this package cannot produce on its own — nothing under `data-model` calls `getCell()` during a decode, the context being a hook a consumer supplies. Whoever reaches it has the whole call stack, which says rather more than the message did.

## Verification

Beyond `data-model`, since the entry point has callers elsewhere:

- `data-model` 54 passed
- `memory` 499 passed
- `state-inspector` 102 passed
- `check`, `lint`, `fmt --check` clean
- The JSON benchmark emits its 32 new rows and no bracketing warnings

Neither removed message was asserted anywhere.

*(An earlier revision of this description said JSON writes a `bigint` as decimal text. It does not; the measurements above replace that account. The series' numbers were unaffected — only the explanation of them was wrong.)*
