### PR TITLE
A caller may name a reference as a verb argument

### DIFF
--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -4,6 +4,7 @@ import {
   type Cell,
   encodeJsonPointer,
   type IExtendedStorageTransaction,
+  isLink,
   type MemorySpace,
   type NormalizedFullLink,
 } from "@commonfabric/runner";
@@ -557,6 +558,12 @@ function firstUndeclaredEventField(
   atRoot: boolean,
 ): UndeclaredEventField | undefined {
   if (typeof value !== "object" || value === null) return undefined;
+  // A link is not an object whose fields can be judged. Its `/` key is the
+  // envelope's own structure, not a name the caller chose, and the document it
+  // points at is not read at dispatch — so there is nothing here to compare a
+  // declaration against. Descending anyway reported `/` as an undeclared field
+  // and refused every reference a caller named.
+  if (isLink(value)) return undefined;
   if (!isSchemaObject(schema)) return undefined;
   if (!atRoot && carriesCellMarker(schema)) return undefined;
   const scopeRoot = cfcSchemaChildRoot(schema, root);
@@ -753,10 +760,16 @@ export function verbInputSchemaError(
   if (schema === undefined || schema === true) return undefined;
   const undeclared = undeclaredVerbFieldError(input, schema);
   if (undeclared !== undefined) return undeclared;
-  return validateSchemaValue(
-    relaxDefaultedRequired(schema, schema, new Map()),
-    input,
-  );
+  // The option the dispatch gate has always passed
+  // (`closedWorldEventRejection`, packages/runner/src/runner.ts). Without it
+  // this validator measures the envelope against the schema of the value it
+  // points at, which no link can satisfy. Passing it is what stops the two
+  // gates disagreeing about one payload — the CLI refusing what the runtime
+  // would have accepted and dispatched.
+  const relaxed = relaxDefaultedRequired(schema, schema, new Map());
+  return validateSchemaValue(relaxed, input, relaxed, {
+    acceptOpaqueValue: (value) => isLink(value),
+  });
 }
 
 /**

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -531,11 +531,13 @@ function schemaIsArrayShaped(node: Record<string, unknown>): boolean {
  */
 function isOpaqueReference(value: unknown): boolean {
   if (!isLink(value)) return false;
-  if (typeof value !== "object" || value === null) return true;
-  const envelope = (value as Record<string, unknown>)["/"];
-  if (typeof envelope !== "object" || envelope === null) return true;
-  if (!Object.hasOwn(envelope as object, "link@1")) return true;
-  const payload = (envelope as Record<string, unknown>)["link@1"];
+  const payload = (value as Record<string, Record<string, unknown>> | null)
+    ?.["/"]?.["link@1"];
+  // No payload here means this is not the envelope form at all — a live cell,
+  // which reaches this gate from code rather than from a caller's JSON and has
+  // nothing to malform. Every link a PAYLOAD can carry is the envelope form,
+  // since the primitive spelling is that same sigil.
+  if (payload === undefined) return true;
   return typeof payload === "object" && payload !== null &&
     !Array.isArray(payload);
 }

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -510,6 +510,36 @@ function schemaIsArrayShaped(node: Record<string, unknown>): boolean {
   return node.items !== undefined || node.prefixItems !== undefined;
 }
 
+/**
+ * Whether `value` is a link this gate may treat as opaque.
+ *
+ * `isLink` answers on the envelope's SHAPE — a `/` carrying a `link@1` — and
+ * says nothing about what rides inside it, so it is true of
+ * `{"/": {"link@1": "nope"}}`, of an array, and of `null`. Bypassing both
+ * checks on that answer would let malformed data through as a reference and
+ * normalize to an empty relative link rather than being refused or judged as
+ * the ordinary object it is.
+ *
+ * A plain record is the line, and it is where the real forms fall: a full
+ * address, an id alone, and a relative link carrying only a path are all
+ * records, while every malformed spelling above is not. Requiring an `id`
+ * would be tighter and wrong — a relative link legitimately has none.
+ *
+ * Only the envelope form is narrowed. Every other thing `isLink` recognizes —
+ * a live `Cell`, a primitive link — is already a value rather than a caller's
+ * JSON, and has no payload to malform.
+ */
+function isOpaqueReference(value: unknown): boolean {
+  if (!isLink(value)) return false;
+  if (typeof value !== "object" || value === null) return true;
+  const envelope = (value as Record<string, unknown>)["/"];
+  if (typeof envelope !== "object" || envelope === null) return true;
+  if (!Object.hasOwn(envelope as object, "link@1")) return true;
+  const payload = (envelope as Record<string, unknown>)["link@1"];
+  return typeof payload === "object" && payload !== null &&
+    !Array.isArray(payload);
+}
+
 /** Whether a schema node marks its position as a cell or a stream, which is
  * where a caller may write a link in place of a value. */
 function carriesCellMarker(node: Record<string, unknown>): boolean {
@@ -563,7 +593,7 @@ function firstUndeclaredEventField(
   // points at is not read at dispatch — so there is nothing here to compare a
   // declaration against. Descending anyway reported `/` as an undeclared field
   // and refused every reference a caller named.
-  if (isLink(value)) return undefined;
+  if (isOpaqueReference(value)) return undefined;
   if (!isSchemaObject(schema)) return undefined;
   if (!atRoot && carriesCellMarker(schema)) return undefined;
   const scopeRoot = cfcSchemaChildRoot(schema, root);
@@ -768,7 +798,7 @@ export function verbInputSchemaError(
   // would have accepted and dispatched.
   const relaxed = relaxDefaultedRequired(schema, schema, new Map());
   return validateSchemaValue(relaxed, input, relaxed, {
-    acceptOpaqueValue: (value) => isLink(value),
+    acceptOpaqueValue: (value) => isOpaqueReference(value),
   });
 }
 

--- a/packages/cli/test/verb-undeclared-field.test.ts
+++ b/packages/cli/test/verb-undeclared-field.test.ts
@@ -1078,6 +1078,33 @@ describe("verb-undeclared-field", () => {
       }
     });
 
+    it("treats a live cell as opaque without inspecting a payload", async () => {
+      // A `Cell` satisfies `isLink` while carrying no envelope at all, so the
+      // payload check has nothing to read. It reaches this gate from code
+      // rather than from a caller's JSON, and there is nothing to malform.
+      const signer = await Identity.fromPassphrase("undeclared-field-cell");
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL("https://example.com"),
+        storageManager,
+      });
+      try {
+        const tx = runtime.edit();
+        const cell = runtime.getCell(
+          signer.did(),
+          "opaque-probe",
+          undefined,
+          tx,
+        );
+        cell.set({ title: "held" });
+        await tx.commit();
+        expect(verbInputSchemaError({ on: cell }, narrowed)).toBeUndefined();
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
     it("still refuses a non-link object that does not fit its position", () => {
       // The link is what is opaque, not the position. A plain object at the
       // same place is judged exactly as before.

--- a/packages/cli/test/verb-undeclared-field.test.ts
+++ b/packages/cli/test/verb-undeclared-field.test.ts
@@ -1047,6 +1047,37 @@ describe("verb-undeclared-field", () => {
         .toMatch(/count/);
     });
 
+    it("accepts the link forms that carry no id", () => {
+      // A relative link legitimately has only a path, and an id alone is a
+      // complete address. Requiring an `id` would be tighter and wrong.
+      expect(verbInputSchemaError(
+        { on: { "/": { "link@1": { id: "of:fid1:x" } } } },
+        narrowed,
+      )).toBeUndefined();
+      expect(verbInputSchemaError(
+        { on: { "/": { "link@1": { path: ["a"] } } } },
+        narrowed,
+      )).toBeUndefined();
+    });
+
+    it("refuses an envelope whose payload is not a record", () => {
+      // `isLink` answers on the envelope's SHAPE and says nothing about what
+      // rides inside, so it is true of all three of these. Bypassing the walk
+      // on that answer would let malformed data through as a reference and
+      // normalize to an empty relative link rather than being refused.
+      for (
+        const payload of ["nope", [1], null, 42] as const
+      ) {
+        expect(
+          verbInputSchemaError(
+            { on: { "/": { "link@1": payload } } },
+            narrowed,
+          ),
+          `payload ${JSON.stringify(payload)} must not pass as a reference`,
+        ).toBeDefined();
+      }
+    });
+
     it("still refuses a non-link object that does not fit its position", () => {
       // The link is what is opaque, not the position. A plain object at the
       // same place is judged exactly as before.

--- a/packages/cli/test/verb-undeclared-field.test.ts
+++ b/packages/cli/test/verb-undeclared-field.test.ts
@@ -987,4 +987,71 @@ describe("verb-undeclared-field", () => {
       });
     });
   });
+
+  describe("a reference a caller names", () => {
+    const link = {
+      "/": {
+        "link@1": {
+          id: "of:fid1:target",
+          space: "did:key:zTest",
+          path: [],
+          scope: "space",
+        },
+      },
+    };
+    // The schema the CLI actually holds: the handler's narrowed read of the
+    // event, which carries no `asCell` — so nothing here says the position is
+    // a reference, and nothing needs to.
+    const narrowed: JSONSchema = {
+      type: "object",
+      properties: { on: { $ref: "#/$defs/Item" } },
+      required: ["on"],
+      $defs: {
+        Item: {
+          type: "object",
+          properties: { title: { type: "string" } },
+          required: ["title"],
+        },
+      },
+    };
+
+    it("accepts a link at a position carrying no marker at all", () => {
+      // The runtime accepts one anywhere (`acceptOpaqueValue: isCellLink`,
+      // unconditional), so a CLI that refused it was the stricter of two
+      // gates on the same payload.
+      expect(verbInputSchemaError({ on: link }, narrowed)).toBeUndefined();
+    });
+
+    it("does not read the envelope's own key as an undeclared field", () => {
+      // `/` is the envelope's structure, not a name the caller chose. Reading
+      // it as a field is what produced `"/" at <event>.on is not a field this
+      // verb declares` for every reference ever named.
+      expect(verbInputSchemaError({ on: link }, narrowed) ?? "")
+        .not.toMatch(/"\/"/);
+    });
+
+    it("still refuses a field the verb does not declare, beside a link", () => {
+      // Accepting links is not accepting anything.
+      expect(verbInputSchemaError({ on: link, titel: "x" }, narrowed))
+        .toMatch(/"titel" at <event> is not a field this verb declares/);
+    });
+
+    it("still refuses a declared field of the wrong type, beside a link", () => {
+      const both: JSONSchema = {
+        type: "object",
+        properties: { on: { $ref: "#/$defs/Item" }, count: { type: "number" } },
+        required: ["on"],
+        $defs: { Item: { type: "object", properties: {} } },
+      };
+      expect(verbInputSchemaError({ on: link, count: "no" }, both))
+        .toMatch(/count/);
+    });
+
+    it("still refuses a non-link object that does not fit its position", () => {
+      // The link is what is opaque, not the position. A plain object at the
+      // same place is judged exactly as before.
+      expect(verbInputSchemaError({ on: { wrong: 1 } }, narrowed))
+        .toMatch(/is not a field this verb declares|title/);
+    });
+  });
 });


### PR DESCRIPTION
## Why

An address a call hands back could not be passed to a verb that declares a reference. Every spelling failed, and the shape-matching payload that *did* succeed stored a detached copy and reported success — #5560's silent corruption.

The runtime was never the obstacle. `closedWorldEventRejection` (`packages/runner/src/runner.ts`) passes `acceptOpaqueValue: isCellLink` **unconditionally**, consulting no marker. So this was the CLI being the stricter of two gates on one payload — which `references-as-arguments.md` calls drift rather than policy.

Both obstacles were the CLI's own, and neither needs to know which positions declare a reference. **No `asCell` marker, no transformer change.**

Part of #5560.

## What Changed

**The undeclared-field walk no longer descends into a link.** It was reporting the envelope's `/` key as a field the verb does not declare:

```
"/" at <event>.on is not a field this verb declares. <event>.on takes "title", "status", …
```

`/` is the envelope's structure, not a name the caller chose, and the document it points at is not read at dispatch — so there is nothing there to compare a declaration against.

**The validator gets the option the dispatch gate already passes.** Without it, it measures the envelope against the schema of the value it points at, which no link can satisfy.

## Test plan

Five cases in `test/verb-undeclared-field.test.ts`, all against the **narrowed** event schema the CLI actually holds — which carries no marker, because that is the point:

- a link is accepted at a position carrying no marker at all
- the envelope's own key is never reported as an undeclared field
- a genuinely undeclared field is still refused beside a link
- a declared field of the wrong type is still refused beside a link
- a non-link object at the same position is judged exactly as before

Verified end to end against a live toolshed with `packages/cli/integration/pattern/tracker.tsx`, on a fresh pair of items:

```
alpha = of:fid1:_EzAEFSNX7iQuiCzQcjP-c9hQOPNIgDav4M0-iXqkOE
beta  = of:fid1:mOH6nW-bblvjjGyxMVhGNgQKeJ6IiQHcXS7oxpGrbbo

cf piece call --piece alpha blockOn --json {"on": <beta as a sigil>}   -> accepted
cf piece get  --piece alpha --select blockedOn@                        -> beta's own id
```

An edge, not a copy.

Full `packages/cli` suite 1686 + 174, 0 failed. `deno task check`, `check-docs`, `check-no-waitfor`, `check-skill-facts`, `fmt --check`, `lint` all clean.

## What this deliberately does not do

**It does not refuse a structural copy** sent where a reference is declared. That requires identifying a reference position, which requires the `asCell` marker, which survives to nothing the CLI can read — the remaining half of #5560, and the only part that needs the transformer.

So the capability lands here and the protection does not. A caller who names a cell now gets an edge; a caller who sends a shape still gets a detached copy and a success report, exactly as before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

