### PR TITLE
feat(cf-harness): say which startup blockers are worth waiting out

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -359,12 +359,17 @@ through `--prompt` to send it as prompt text.
 
 Batch startup failures are one `cf-harness.host-failure` JSON object on stderr.
 Interactive startup failures remain on the NDJSON chat protocol so hosts that do
-not consume stderr still receive the stable provider error code. A failure is
-`invalid-request` only while the argv and the recorded binding are still being
-checked; once a run starts being built, an infrastructure fault reports
-`internal-error`, so a host can keep a retry policy keyed on the code. Run
-state, manifests, reports, child manifests, and structured batch results record
-only provider, the non-secret auth-source label, and the fixed owner reference.
+not consume stderr still receive the stable provider error code. Those failures
+carry `retryable` in HTTP's `Retry-After` sense — set only where waiting alone
+can clear the blocker, which among startup blockers means an unreachable
+provider and nothing else. An unauthenticated or unconfigured provider needs
+someone to act before a retry means anything, so it stays unset, as does a host
+that broke unexpectedly and cannot say. A failure is `invalid-request` only
+while the argv and the recorded binding are still being checked; once a run
+starts being built, an infrastructure fault reports `internal-error`, so a host
+can keep a retry policy keyed on the code. Run state, manifests, reports, child
+manifests, and structured batch results record only provider, the non-secret
+auth-source label, and the fixed owner reference.
 
 Hosted or multi-user Loom must not reuse this single-user adapter. A trusted
 multi-user host must instead:

--- a/packages/cf-harness/src/loom-local-host.ts
+++ b/packages/cf-harness/src/loom-local-host.ts
@@ -649,6 +649,14 @@ const defaultHostIo = (): CfHarnessCliIO => ({
  * rather than choosing between codes. A malformed chat request is a separate
  * matter and has the protocol's own `invalid_request`, raised where the
  * request is read.
+ *
+ * `retryable` carries HTTP's `Retry-After` sense: it is set only where waiting
+ * is known to help, so a provider that is unreachable now and may answer later
+ * is the one blocker that gets it. The rest need someone to change something
+ * first — connect a provider, configure one, resume the run it was recorded
+ * against — and an unauthenticated provider is no more retryable here than a
+ * 401 is, whatever the operator can go on to do about it. Absent means
+ * unknown, which is the honest answer for a host that broke unexpectedly.
  */
 const chatError = (failure: CfHarnessHostFailure): HarnessChatError => ({
   code: failure.error.code === "provider-configuration-required" ||
@@ -658,6 +666,7 @@ const chatError = (failure: CfHarnessHostFailure): HarnessChatError => ({
     ? failure.error.code
     : "internal_error",
   message: failure.error.message,
+  ...(failure.error.code === "provider-unavailable" ? { retryable: true } : {}),
 });
 
 /** Keeps the interactive protocol alive long enough to return startup blockers. */

--- a/packages/cf-harness/test/loom-local-host.test.ts
+++ b/packages/cf-harness/test/loom-local-host.test.ts
@@ -1271,6 +1271,68 @@ Deno.test("interactive startup blockers use the chat protocol", async () => {
   assertEquals(response.error.code, "provider-auth-required");
 });
 
+Deno.test("only an unreachable provider marks a startup blocker retryable", async () => {
+  // `retryable` reads as `Retry-After` does: waiting alone can clear this one.
+  // A blocker that needs a provider connected, configured, or matched does not
+  // become true because an operator could go and do that.
+  const blockers: Array<{
+    error: HarnessControlError;
+    code: string;
+    retryable: boolean | undefined;
+  }> = [
+    {
+      error: new HarnessControlError("provider-unavailable", "codex is down"),
+      code: "provider-unavailable",
+      retryable: true,
+    },
+    {
+      error: new HarnessControlError("provider-auth-required", "connect codex"),
+      code: "provider-auth-required",
+      retryable: undefined,
+    },
+    {
+      error: new HarnessControlError(
+        "provider-configuration-required",
+        "configure a provider",
+      ),
+      code: "provider-configuration-required",
+      retryable: undefined,
+    },
+    {
+      error: new HarnessControlError("provider-mismatch", "resume mismatch"),
+      code: "provider-mismatch",
+      retryable: undefined,
+    },
+    {
+      error: new Error("something broke") as HarnessControlError,
+      code: "internal_error",
+      retryable: undefined,
+    },
+  ];
+
+  for (const blocker of blockers) {
+    const request = JSON.stringify({
+      type: "cf-harness.chat.request",
+      protocolVersion: 1,
+      requestId: "request-1",
+      method: "status",
+      params: {},
+    });
+    let output = "";
+    await runLoomLocalInteractiveFailureStdio(blocker.error, {
+      input: new Response(`${request}\n`).body!,
+      output: new WritableStream({
+        write(chunk: Uint8Array) {
+          output += new TextDecoder().decode(chunk);
+        },
+      }),
+    });
+    const error = JSON.parse(output).error;
+    assertEquals(error.code, blocker.code);
+    assertEquals(error.retryable, blocker.retryable, blocker.code);
+  }
+});
+
 Deno.test("local Loom interactive entrypoint returns missing config on stdout protocol", async () => {
   const home = await Deno.makeTempDir();
   const request = JSON.stringify({


### PR DESCRIPTION
## Why

Follows #5875 (merged), which this was stacked on while in review; now rebased onto `main`.

#5873 asked that a host keying retry policy on typed codes not be told a retryable fault is permanent. On the batch side that was a wrong *code*, fixed in #5875. On the interactive side the codes were already right — what's missing is the field that answers the question directly.

`HarnessChatError.retryable` already exists (`contracts/interactive-chat.ts`) and the package already uses it: `activeTurnError` marks a busy turn retryable, because waiting and resending unchanged genuinely works. The startup responder sets `code` and `message` and omits it, so a host gets no signal at all — and the distinction is real. An unreachable Codex preflight is worth retrying; an unconfigured provider never is.

## Which blockers get it, and why that follows HTTP

HTTP has no `retryable` boolean. It answers the question with `Retry-After` (RFC 9110 §10.2.3), sent with 503 and 429 — *the server knows waiting is enough*. Notably it is **not** sent with 401: that status is a challenge, and the client re-makes the request **with credentials** rather than retrying it unchanged. 403 says outright that a client "SHOULD NOT automatically repeat the request with the same credentials." HTTP even tells 4xx responses to state separately "whether it is a temporary or permanent condition" (§15.5) — temporariness is orthogonal to the code, which is exactly the `code` + `retryable` shape here.

Every mainstream derivation agrees: gRPC's conventional retry set is `UNAVAILABLE`/`DEADLINE_EXCEEDED`/`ABORTED` and excludes `UNAUTHENTICATED`; AWS SDKs retry throttling and 5xx while routing expired credentials to a separate refresh-then-retry path.

So:

| Blocker | HTTP analogue | `retryable` |
| --- | --- | --- |
| `provider-unavailable` | 503 | `true` |
| `provider-auth-required` | 401 | unset |
| `provider-configuration-required` | 400/403 | unset |
| `provider-mismatch` | 409 | unset |
| `internal-error` | 500 | unset |

`internal-error` stays unset rather than `true`: `Retry-After` is sent only when the server actually knows, gRPC likewise treats `INTERNAL` as non-retryable, and "something broke unexpectedly" is not grounds to invite a client to hammer it. Absent means unknown, which is true.

## What Changed

- `chatError` (`loom-local-host.ts`) sets `retryable: true` for `provider-unavailable` only, with the `Retry-After` rationale in its doc comment so the meaning is written down once.
- README documents it as part of the interactive wire contract.

## Test plan

- New `loom-local-host.test.ts` case drives all five reachable blockers through `runLoomLocalInteractiveFailureStdio` and asserts both `code` and `retryable`. It pins the rule in both directions: a blanket `true` fails four cases, omitting the field fails one. Verified failing with the change reverted.
- `deno task test` in `packages/cf-harness`: 722 passed, 0 failed.
- `deno check --no-lock src/ test/` (the package is absent from `tasks/check.sh`, so `deno task check` does not cover it), `deno fmt --check`, `deno lint` — clean.

## Related

Reviewing this turned up a pre-existing inconsistency: `browserAccessRequiredError` marks `retryable: true`, but it fires when the caller's request omitted `browserAccess`, so resending unchanged can never succeed. Filed separately rather than changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
