### PR TITLE
fix(cf-harness): a missing browser lease is not cleared by waiting

### DIFF
--- a/packages/cf-harness/src/interactive-chat-service.ts
+++ b/packages/cf-harness/src/interactive-chat-service.ts
@@ -109,6 +109,12 @@ class DurableTurnExistsError extends Error {
   }
 }
 
+/**
+ * The one chat error that waiting alone clears: the turn in flight ends on its
+ * own, and the identical request then succeeds. That is what `retryable`
+ * claims, in the sense HTTP's `Retry-After` gives it — not that a caller could
+ * do something about the failure, which is true of most of the errors here.
+ */
 const activeTurnError = (
   requestId: string,
   session: HarnessChatSessionStatus,
@@ -260,13 +266,19 @@ const loomLocalHostBindingsEqual = (
     actual.credentialOwner,
   ) && expected.harnessHomeIdentity === actual.harnessHomeIdentity;
 
+/**
+ * A lease reaches a turn on the request that starts it, or on the one that
+ * started the session; no request adds one to a session already running. So
+ * resending this turn unchanged fails the same way however long the caller
+ * waits, and it carries no `retryable` — the next attempt has to carry the
+ * lease, which makes it a different request.
+ */
 const browserAccessRequiredError = (
   requestId: string,
 ): HarnessChatErrorResponse =>
   createHarnessChatErrorResponse(requestId, {
     code: "browser_access_required",
     message: "Browser Access lease is required for browser profile turns.",
-    retryable: true,
   });
 
 const turnNotFoundError = (

--- a/packages/cf-harness/test/interactive-chat-service.test.ts
+++ b/packages/cf-harness/test/interactive-chat-service.test.ts
@@ -589,6 +589,10 @@ Deno.test("interactive service rejects browser-profile turns without Browser Acc
     turn.ok === false ? turn.error.code : "",
     "browser_access_required",
   );
+  // No request attaches a lease to a running session, so resending this turn
+  // unchanged fails identically forever. Waiting is not the remedy, and the
+  // response must not offer it as one.
+  assertEquals(turn.ok === false ? turn.error.retryable : "unset", undefined);
   assertEquals(createdLoop, false);
   assertEquals(
     service.events("session-1").map((event) => event.event.kind),
@@ -1328,6 +1332,16 @@ Deno.test("interactive service rejects missing sessions and concurrent turns", a
   assertEquals(
     concurrent.ok === false ? concurrent.error.code : "",
     "turn_already_running",
+  );
+  // Waiting is the whole remedy here, and nothing else in this file can say
+  // that: the busy turn ends on its own and the identical request then works.
+  assertEquals(
+    concurrent.ok === false ? concurrent.error.retryable : undefined,
+    true,
+  );
+  assertEquals(
+    missing.ok === false ? missing.error.retryable : "unset",
+    undefined,
   );
   release?.();
   await busyService.waitForTurn("session-1", "turn-1");

--- a/packages/cf-harness/test/interactive-chat.test.ts
+++ b/packages/cf-harness/test/interactive-chat.test.ts
@@ -325,8 +325,8 @@ Deno.test("interactive chat responses carry protocol version and errors", () => 
   });
   assertEquals(
     createHarnessChatErrorResponse("req-2", {
-      code: "browser_access_required",
-      message: "Browser Access lease is required for browser profile turns.",
+      code: "turn_already_running",
+      message: "session session-1 already has active turn turn-1",
       retryable: true,
     }),
     {
@@ -335,8 +335,8 @@ Deno.test("interactive chat responses carry protocol version and errors", () => 
       requestId: "req-2",
       ok: false,
       error: {
-        code: "browser_access_required",
-        message: "Browser Access lease is required for browser profile turns.",
+        code: "turn_already_running",
+        message: "session session-1 already has active turn turn-1",
         retryable: true,
       },
     },


### PR DESCRIPTION
## Why

Closes #5882. Companion to #5881, which pins what `retryable` means on this protocol; this applies the same rule to the one existing usage that contradicts it.

`browserAccessRequiredError` answered `retryable: true`. But a Browser Access lease reaches a turn from only two places — `params.browserAccess` on the `start_turn` request, or `record.status.browserAccess`, which is written solely at `start_session` and never mutated after. The protocol's method set is `start_session`, `start_turn`, `cancel_turn`, `close_session`, `status`, `list_events`, `list_turns`; none of them attaches a lease to a session already running.

So resending the identical `start_turn` fails the same way forever. The attempt that succeeds has to carry the lease — a different request, which is exactly the case HTTP declines to mark retryable: 401 is a challenge to re-make the request with the missing thing, and RFC 9110 §15.5.4 says of the neighbouring 403 that a client "SHOULD NOT automatically repeat the request with the same credentials."

The practical cost: a host reading `retryable: true` backs off and resends until it gives up, never being told the one thing it needed to do. The `message` said it; the flag contradicted it.

## What Changed

- `browserAccessRequiredError` (`interactive-chat-service.ts`) drops `retryable`, and documents why — the lease arrives with a request, so waiting is not the remedy.
- `activeTurnError` keeps it, and now documents why it is the one that legitimately has it: the in-flight turn ends on its own and the identical request then works. Having the contrast written next to both is what stops this drifting back.
- The contract test in `interactive-chat.test.ts` used this error as its sample of a response carrying `retryable` through the envelope. It tests pass-through, not policy, so the sample was harmless mechanically but is now the wrong thing to land on when searching. Switched to the busy-turn error, which is still true.

## Test plan

- `interactive-chat-service.test.ts` now asserts `retryable` on both sides in the tests that already drive these paths: `browser_access_required` is unset, `turn_already_running` is `true`, and `session_not_found` is unset. A blanket `true` and a blanket absence each fail at least one.
- Verified by re-adding `retryable: true` to the constructor: the browser-lease test fails. Restored, all green.
- `deno task test` in `packages/cf-harness`: 722 passed, 0 failed.
- `deno check --no-lock src/ test/` (the package is absent from `tasks/check.sh`, so `deno task check` does not cover it), `deno fmt --check`, `deno lint` — clean.

## Note on ordering

Independent of #5881 in code — different files, no conflict — so either can land first. They share a rationale, not a dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

