### PR TITLE
Every flag surface reads what a conjunction declares

### DIFF
--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -404,6 +404,12 @@ interface DeclaredFieldSource {
 interface DeclaredFields {
   sources: DeclaredFieldSource[];
   honorsUndeclared: boolean;
+  /** Every name any reached member marks required. A conjunction constrains
+   * one value from all its members at once, so a name any of them requires is
+   * required of the payload. A DISJUNCTION contributes none — a payload
+   * satisfies one branch, so no branch's requirement binds it, and the walk
+   * stops at one rather than reading its members. */
+  required: Set<string>;
 }
 
 /**
@@ -432,7 +438,11 @@ interface DeclaredFields {
 function declaredFieldsAt(
   node: Record<string, unknown>,
   root: JSONSchema,
-  into: DeclaredFields = { sources: [], honorsUndeclared: false },
+  into: DeclaredFields = {
+    sources: [],
+    honorsUndeclared: false,
+    required: new Set<string>(),
+  },
   followed: Map<JSONSchema, Set<string>> = new Map(),
 ): DeclaredFields {
   if (isSchemaObject(node.properties as JSONSchema)) {
@@ -451,6 +461,11 @@ function declaredFieldsAt(
     node.additionalProperties !== false
   ) {
     into.honorsUndeclared = true;
+  }
+  if (Array.isArray(node.required)) {
+    for (const name of node.required as unknown[]) {
+      if (typeof name === "string") into.required.add(name);
+    }
   }
   if (!Array.isArray(node.allOf)) return into;
   for (const member of node.allOf as JSONSchema[]) {
@@ -660,6 +675,59 @@ function firstUndeclaredEventField(
     if (found !== undefined) return found;
   }
   return undefined;
+}
+
+/** Every flag-facing surface's view of what a verb's event declares. */
+export interface DeclaredEventFields {
+  /** The declared properties, merged across every conjunction member. A name
+   * declared more than once keeps its FIRST account, in declaration order,
+   * which is the rule the refusal vocabulary already follows. */
+  properties: Record<string, JSONSchema>;
+  /** Names any member marks required. */
+  required: Set<string>;
+}
+
+/**
+ * What a verb's event schema declares at its root, reading a conjunction.
+ *
+ * `properties` alone answers for the common schema and misses every field an
+ * `allOf` member contributes — which the payload door has always read and the
+ * flag surfaces never did, so a field could be judged on one door and invisible
+ * on the other. This is the one reader both can share.
+ *
+ * `null` where the position is not object-shaped at all, which is a verb taking
+ * a single value rather than fields.
+ *
+ * A DISJUNCTION contributes nothing, deliberately. A payload need satisfy only
+ * one branch, so no single flag list describes the position and no branch's
+ * `required` binds it — `declaredFieldsAt` stops at one rather than reading its
+ * members, and this inherits that.
+ */
+export function declaredEventFields(
+  schema: JSONSchema | undefined,
+): DeclaredEventFields | null {
+  if (!isSchemaObject(schema)) return null;
+  // The gate the flag surfaces have always applied, widened by exactly one
+  // term. A position stating `type: "object"` or carrying `properties` is a
+  // fields position, and now so is one carrying `allOf` — because that is
+  // where its fields live. A root `$ref` is deliberately NOT resolved here:
+  // doing so would give flags to verbs that have never had them, which is a
+  // wider change than reading a conjunction and belongs to whoever wants it.
+  if (
+    schema.type !== "object" && !schema.properties &&
+    !Array.isArray(schema.allOf)
+  ) {
+    return null;
+  }
+  if (schema.anyOf !== undefined || schema.oneOf !== undefined) return null;
+  const declared = declaredFieldsAt(schema, cfcSchemaChildRoot(schema, schema));
+  const properties: Record<string, JSONSchema> = {};
+  for (const source of declared.sources) {
+    for (const [name, property] of Object.entries(source.properties)) {
+      if (!Object.hasOwn(properties, name)) properties[name] = property;
+    }
+  }
+  return { properties, required: declared.required };
 }
 
 /**

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -713,12 +713,8 @@ export function declaredEventFields(
   // where its fields live. A root `$ref` is deliberately NOT resolved here:
   // doing so would give flags to verbs that have never had them, which is a
   // wider change than reading a conjunction and belongs to whoever wants it.
-  if (
-    schema.type !== "object" && !schema.properties &&
-    !Array.isArray(schema.allOf)
-  ) {
-    return null;
-  }
+  const statesItsOwnFields = schema.type === "object" || !!schema.properties;
+  if (!statesItsOwnFields && !Array.isArray(schema.allOf)) return null;
   // A disjunction BESIDE properties is not a reason to report none. It adds
   // constraints the flag surfaces cannot express, but the properties it sits
   // next to are still declared and still typed, and refusing to name them
@@ -726,6 +722,13 @@ export function declaredEventFields(
   // conjunction and steps over the disjunction, which is the whole of what is
   // wanted here — a root check would only discard the fields beside it.
   const declared = declaredFieldsAt(schema, cfcSchemaChildRoot(schema, schema));
+  // A conjunction earns the object path only by CONTRIBUTING fields. `allOf:
+  // [{type: "string"}]` constrains a scalar, and admitting it here would route
+  // a single-value verb through flag parsing and offer it a vocabulary of
+  // none. A schema that states its own fields keeps the path either way, even
+  // when it names no field — that is a fields position that happens to be
+  // empty, which is a different thing from not being one.
+  if (!statesItsOwnFields && declared.sources.length === 0) return null;
   const properties: Record<string, JSONSchema> = {};
   for (const source of declared.sources) {
     for (const [name, property] of Object.entries(source.properties)) {

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -719,7 +719,12 @@ export function declaredEventFields(
   ) {
     return null;
   }
-  if (schema.anyOf !== undefined || schema.oneOf !== undefined) return null;
+  // A disjunction BESIDE properties is not a reason to report none. It adds
+  // constraints the flag surfaces cannot express, but the properties it sits
+  // next to are still declared and still typed, and refusing to name them
+  // would take away flags that already worked. `declaredFieldsAt` reads the
+  // conjunction and steps over the disjunction, which is the whole of what is
+  // wanted here — a root check would only discard the fields beside it.
   const declared = declaredFieldsAt(schema, cfcSchemaChildRoot(schema, schema));
   const properties: Record<string, JSONSchema> = {};
   for (const source of declared.sources) {

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -4,7 +4,10 @@ import { schemaToTypeString } from "@commonfabric/runner";
 import { cliCommand } from "./cli-name.ts";
 // A value import back to callable.ts, whose own import of this module is
 // type-only and therefore erased — so this creates no runtime cycle.
-import { eventSchemaJudgesRootFields } from "./callable.ts";
+import {
+  declaredEventFields,
+  eventSchemaJudgesRootFields,
+} from "./callable.ts";
 import { EVENT_ROOT_POSITION, nearestName } from "./refusal.ts";
 
 export interface ExecCommandSpec {
@@ -79,26 +82,28 @@ function isSchemaObject(schema: JSONSchema): schema is Record<string, unknown> {
     !Array.isArray(schema);
 }
 
+/**
+ * The fields a verb declares, as every flag-facing surface reads them.
+ *
+ * Delegates to `declaredEventFields`, which merges what a conjunction's
+ * members contribute and follows a `$ref` into the definition that carries
+ * them. Reading `schema.properties` alone — which this did — made an
+ * `allOf`-declared field invisible here while the payload door judged it: the
+ * help page omitted it, `required` did not enforce it, and a flag naming it
+ * was refused as undeclared. One reader is what keeps the two doors from
+ * disagreeing about what a verb declares.
+ *
+ * `null` still means "not a position with fields", which is the signal the
+ * single-value paths key off.
+ */
 function objectProperties(
   schema: JSONSchema,
 ): Record<string, JSONSchema> | null {
-  if (!isSchemaObject(schema)) return null;
-  if (schema.type !== "object" && !schema.properties) return null;
-  const properties = schema.properties;
-  if (
-    typeof properties !== "object" || properties === null ||
-    Array.isArray(properties)
-  ) {
-    return {};
-  }
-  return properties as Record<string, JSONSchema>;
+  return declaredEventFields(schema)?.properties ?? null;
 }
 
 function requiredFlags(schema: JSONSchema): Set<string> {
-  if (!isSchemaObject(schema) || !Array.isArray(schema.required)) {
-    return new Set();
-  }
-  return new Set(schema.required as string[]);
+  return declaredEventFields(schema)?.required ?? new Set();
 }
 
 function schemaType(schema: JSONSchema): string | undefined {

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -612,6 +612,25 @@ describe("parseExecArgs edge cases", () => {
       .toBeUndefined();
   });
 
+  it("keeps the flags beside a disjunction it cannot express", () => {
+    // A root `anyOf` adds constraints no flag list can express, but the
+    // properties beside it are still declared and still typed. Reporting none
+    // because a disjunction is present would take away flags that already
+    // worked — the disjunction is stepped over, not treated as a veto.
+    const spec = makeSpec("handler", {
+      type: "object",
+      properties: { note: { type: "string" }, count: { type: "number" } },
+      anyOf: [
+        { required: ["note"] },
+        { required: ["count"] },
+      ],
+    });
+
+    expect(parseExecArgs(spec, ["invoke", "--note", "a", "--count", "2"]).input)
+      .toEqual({ note: "a", count: 2 });
+    expect(renderExecHelp("/mnt/x.handler", spec, {})).toMatch(/--note/);
+  });
+
   it("accepts an undeclared flag exactly where the payload door accepts the field", () => {
     // The two doors are one gate asked in two spellings, so what they let
     // through must not depend on which the caller reached for. Both

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -530,6 +530,88 @@ describe("parseExecArgs edge cases", () => {
     expect(() => parseExecArgs(spec, ["--query"])).toThrow(/Missing value/);
   });
 
+  it("reads a field a conjunction declares, on every flag surface", () => {
+    // `properties` alone missed what an `allOf` member contributes, while the
+    // payload door read it — so one door judged a field the other could not
+    // see. A caller was refused at dispatch for omitting something no surface
+    // had shown them.
+    const spec = makeSpec("handler", {
+      type: "object",
+      properties: { note: { type: "string" } },
+      required: ["note"],
+      allOf: [{
+        type: "object",
+        properties: { count: { type: "number" } },
+        required: ["count"],
+      }],
+    });
+
+    // The flag parses, and to its DECLARED type rather than a string.
+    expect(
+      parseExecArgs(spec, ["invoke", "--note", "hi", "--count", "5"]).input,
+    )
+      .toEqual({ note: "hi", count: 5 });
+
+    // Required is enforced from the member that declares it.
+    expect(() => parseExecArgs(spec, ["invoke", "--note", "hi"]))
+      .toThrow(/Missing required flag --count/);
+
+    // And the help page lists it, which is the half a caller reads first.
+    const help = renderExecHelp("/mnt/x.handler", spec, {});
+    expect(help).toMatch(/--count/);
+  });
+
+  it("follows a reference into the definition a conjunction names", () => {
+    const spec = makeSpec("handler", {
+      type: "object",
+      properties: { note: { type: "string" } },
+      allOf: [{ $ref: "#/$defs/Extra" }],
+      $defs: {
+        Extra: {
+          type: "object",
+          properties: { count: { type: "number" } },
+          required: ["count"],
+        },
+      },
+    });
+    expect(parseExecArgs(spec, ["invoke", "--note", "a", "--count", "2"]).input)
+      .toEqual({ note: "a", count: 2 });
+  });
+
+  it("does not pull a field out of a disjunction", () => {
+    // A payload satisfies ONE branch of an `anyOf`, so no single flag list
+    // describes the position and no branch's `required` binds it. Offering
+    // `--only-here` would advertise a flag that fits one branch and breaks the
+    // other.
+    const spec = makeSpec("handler", {
+      type: "object",
+      properties: { note: { type: "string" } },
+      allOf: [{
+        anyOf: [{
+          type: "object",
+          properties: { onlyHere: { type: "string" } },
+          required: ["onlyHere"],
+        }],
+      }],
+    });
+
+    // It is not in the DECLARED vocabulary: the help page does not advertise
+    // it, and its `required` does not bind a payload that omits it.
+    const help = renderExecHelp("/mnt/x.handler", spec, {});
+    expect(help).not.toMatch(/--only-here/);
+    expect(parseExecArgs(spec, ["invoke", "--note", "a"]).input)
+      .toEqual({ note: "a" });
+
+    // A disjunction leaves the position unjudgeable, so BOTH doors fail open
+    // and take an unnamed flag rather than refusing what they cannot assess.
+    // Agreeing is the property worth pinning; which way they agree follows
+    // from the design's "a call wrongly refused cannot be made at all".
+    expect(parseExecArgs(spec, ["invoke", "--only-here", "x"]).input)
+      .toEqual({ "only-here": "x" });
+    expect(undeclaredVerbFieldError({ onlyHere: "x" }, spec.inputSchema))
+      .toBeUndefined();
+  });
+
   it("accepts an undeclared flag exactly where the payload door accepts the field", () => {
     // The two doors are one gate asked in two spellings, so what they let
     // through must not depend on which the caller reached for. Both

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -612,6 +612,16 @@ describe("parseExecArgs edge cases", () => {
       .toBeUndefined();
   });
 
+  it("leaves a conjunction over a scalar on the single-value path", () => {
+    // `allOf` earns the object path by CONTRIBUTING fields. A conjunction
+    // constraining a scalar contributes none, and routing it through flag
+    // parsing would offer a single-value verb a vocabulary of nothing.
+    const spec = makeSpec("tool", { allOf: [{ type: "string" }] });
+    expect(parseExecArgs(spec, ["run", "--value", "hi"]).input).toBe("hi");
+    expect(() => parseExecArgs(spec, ["run", "--anything", "x"]))
+      .toThrow(/is not a flag this verb takes/);
+  });
+
   it("keeps the flags beside a disjunction it cannot express", () => {
     // A root `anyOf` adds constraints no flag list can express, but the
     // properties beside it are still declared and still typed. Reporting none


### PR DESCRIPTION
## Why

`objectProperties` read `schema.properties` and nothing else — across **fifteen** call sites: the flag parser, the help page, the JSON help, the usage lines, the required check. `requiredFlags` read `schema.required` the same way.

So a field an `allOf` member contributes was invisible to every one of them, while the payload door read it perfectly well. Measured on a verb declaring `note` directly and `count` through a conjunction:

```
--help                 Flags:  --note <string>  Required.        ← count missing entirely
cf exec … --note hi    ACCEPTED                                   ← count's `required` not enforced
  then, at dispatch:   missing required property count            ← refused for omitting what nothing showed
cf exec … --count 5    "--count" is not a field this verb declares
```

A caller was refused at dispatch for omitting a field no surface had shown them. Closes #5861.

## What Changed

Both readers delegate to `declaredEventFields`, which merges what the members contribute and follows a `$ref` into the definition carrying them.

It **reuses `declaredFieldsAt`** — the walk the payload door already used — rather than adding a second reader that could drift. That walk already carries the two things this needs and is easy to get wrong: a `$ref` guard keyed on the `(root, $ref)` pair, since one reference in two scopes names two targets; and a refusal to descend into a disjunction. It gains the `required` collection it was missing.

**A disjunction contributes nothing, deliberately.** A payload satisfies one branch, so no single flag list describes the position and no branch's `required` binds it. Both doors then fail open on a position neither can judge — which is the direction `references-as-arguments.md` asks to be wrong in, since a call wrongly refused cannot be made at all.

**Scoped to the conjunction.** A root `$ref` is deliberately not resolved: doing so gives flags to verbs that have never had them, which three landed tests in `piece-call.test.ts` caught when I first widened too far. That is a separate change and belongs to whoever wants it.

## Test plan

Three cases in `test/exec.test.ts`:

- a conjunction-declared field parses to its **declared type** (`--count 5` → `5`, not `"5"`), its `required` is enforced, and the help page lists it
- the same through a `$ref` into `$defs`
- a disjunction's field is **not** advertised in help and its `required` does not bind — and both doors are asserted to agree on failing open, since agreeing is the property worth pinning

Full `packages/cli` suite 1686 + 174, 0 failed. `deno task check`, `check-docs`, `check-no-waitfor`, `check-skill-facts`, `check-conflict-markers`, `fmt --check`, `lint` all clean.

## Not fixed here

The help page's **"Input type" block** renders through `schemaToTypeString`, the runner's own formatter, which ignores `allOf` too — verified directly. The Flags list and the parse are correct; that block still shows only the direct properties. Fixing it is a change to `packages/runner` and deserves its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

