### PR TITLE
Every deferring settle pass says what it held back

### DIFF
--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -166,7 +166,7 @@ cf piece call --piece <board> addTopic \
 {
   "invocation": "0f4c…",
   "status": "settled",
-  "receipt": { "space": "did:key:…", "id": "of:fid1:…", "scope": "space" },
+  "receipt": "/of:fid1:…",
   "result": { "topic": { "$NAME": "Ship the thing", "…": "…" } }
 }
 ```
@@ -181,11 +181,12 @@ or derives structured authorship from the event returns those in its record;
 the caller could not have computed them.
 
 The `receipt` is where that outcome lives: the address of the cell this
-handling wrote it to. Keep it and the result is re-readable without calling
-anything again —
+handling wrote it to, written as one string in the canonical reference syntax
+`--piece` reads. Keep it and the result is re-readable without calling anything
+again —
 
 ```bash
-cf piece get --piece <the receipt id>
+cf piece get --piece "$(echo "$RESULT" | jq -r .receipt)"
 ```
 
 — which is an ordinary read, so the verb's body does not run a second time.
@@ -443,11 +444,11 @@ durable, and only the readback is skipped. The envelope still carries the
 {
   "invocation": "add-1",
   "status": "committed",
-  "receipt": { "space": "did:key:…", "id": "of:fid1:…", "scope": "space" }
+  "receipt": "/of:fid1:…"
 }
 ```
 
-— and collecting the outcome later is `cf piece get --piece <the receipt id>`.
+— and collecting the outcome later is `cf piece get --piece <that string>`.
 Replaying the same id and session recovers it too, but that re-runs the handler
 body: a verb that sends mail or spends a model call does it again. Reading the
 address does not.

--- a/docs/plans/pattern-verb-contract.md
+++ b/docs/plans/pattern-verb-contract.md
@@ -799,8 +799,8 @@ $ cf piece call --url "$TOPICS_BOARD_URL" addTopic \
 $ cf piece call --url "$TOPICS_BOARD_URL" summarize \
     --topic fid1:abc --no-wait
 { "invocation": "inv_9c1b", "status": "committed",
-  "receipt": { "space": "did:key:…", "id": "of:fid1:…", "scope": "space" } }
-$ cf piece get --piece of:fid1:… summary
+  "receipt": "/of:fid1:…" }
+$ cf piece get --piece /of:fid1:… summary
 "..."
 ```
 

--- a/docs/specs/scheduler-v2/README.md
+++ b/docs/specs/scheduler-v2/README.md
@@ -967,10 +967,18 @@ work order is archived with the migration records.
 - Exhaustion (iterations or budget): remaining runnable nodes keep
   `status = invalid` and receive an escalating backoff gate
   (`gate.backoffUntil`, ×2 per consecutive exhaustion, capped); one wake is
-  scheduled; `scheduler.non-settling` telemetry and one author-facing warning
-  fire per episode. The warning names the deferred actions, points to
-  `commonfabric.detectNonIdempotent()`, and does not turn the bounded retry into
-  an action error.
+  scheduled; a `scheduler.non-settling` telemetry marker fires for every such
+  episode, carrying the busy-window summary along with `deferredActions` (the
+  labels of the actions the pass held back, first ten) and
+  `deferredActionCount`, observable through `runtime.telemetry`. A marker says
+  a pass exhausted its budget, which a wave that needs several passes to
+  converge also does; it is not on its own a report that the graph will never
+  converge. The author-facing warning naming those actions and pointing to
+  `commonfabric.detectNonIdempotent()` is emitted at most once per run of
+  settle passes — the latch lives on the settling tracker, which a new
+  continuation replaces, and is the same boundary `scheduler.isNonSettling()`
+  reports — so a permanently non-converging graph does not flood the log.
+  Neither signal turns the bounded retry into an action error.
 
 No node is force-run or force-cleaned. A non-converging subgraph degrades to
 rate-limited convergence attempts while the rest of the system stays

--- a/packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md
+++ b/packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md
@@ -1,7 +1,7 @@
 # cf-harness Implementation Profile
 
 Status: draft conformance statement\
-Profile date: 2026-07-22
+Profile date: 2026-08-17
 
 This document describes `@commonfabric/cf-harness` against the draft Common
 Fabric
@@ -48,9 +48,13 @@ model turn.
 - CFC authority: Common Fabric runner/runtime evidence and trusted sandbox
   sidecars. Harness-local policy logic is conservative transport/enforcement,
   not the source of label meaning.
-- Host execution: unavailable to parent runs. The browser child profile exposes
-  only a constrained host command/script policy bound to an explicit local CDP
-  lease.
+- Host execution: no parent-run shell reaches the host. Two bounded host-side
+  surfaces exist beside the sandbox: the browser child profile's constrained
+  command/script policy, bound to an explicit local CDP lease, and the
+  `run_pattern` tool, which compiles model-authored pattern source and runs it
+  against the configured Fabric space over a trusted host-side session. Neither
+  admits arbitrary host commands, and `run_pattern` is present only when a
+  fabric session is configured.
 - Network: explicit in configuration but still provisional. Sandboxed `bash`
   applies a direct-`curl` destination guard; `web_fetch` and web child profiles
   have their own bounded request policies.
@@ -61,14 +65,16 @@ model turn.
 
 Current selectable parent tools are `bash`, `read_file`, `view_image`,
 `web_fetch`, `read_skill_resource`, `run_skill_script`, `edit_file`,
-`write_file`, and `delegate_task`. Individual runs receive only their configured
-subset; `web_fetch` and `run_skill_script` are not in the ordinary default
-surface. `bash-no-sandbox` exists only as a built-in used by authorized child
-profiles and cannot be selected as a parent CLI tool.
+`write_file`, `delegate_task`, `describe_handle`, and `run_pattern`. Individual
+runs receive only their configured subset; `web_fetch` and `run_skill_script`
+are not in the ordinary default surface, and `run_pattern` additionally requires
+the three `--fabric-*` session flags. `bash-no-sandbox` exists only as a
+built-in used by authorized child profiles and cannot be selected as a parent
+CLI tool.
 
-Current child profiles are `default`, `browser`, `web_fetch`, and `web_search`.
-Each profile supplies an exact tool/network/skill policy. Parent skills and
-authority do not transfer implicitly.
+Current child profiles are `default`, `browser`, `web_fetch`, `web_search`, and
+`pattern-author`. Each profile supplies an exact tool/network/skill policy.
+Parent skills and authority do not transfer implicitly.
 
 ## Lifecycle and evidence
 

--- a/packages/cf-harness/test/prompt-loop-subagent-turn-budget.test.ts
+++ b/packages/cf-harness/test/prompt-loop-subagent-turn-budget.test.ts
@@ -1,0 +1,232 @@
+/**
+ * A delegated child spends its own model-turn budget. The parent's remaining
+ * turns are not an input to it: a parent that delegates on its last available
+ * turn still gets a child that runs to its own limit.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { normalize } from "@std/path/posix";
+import { CfHarnessEngine } from "../src/engine.ts";
+import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
+import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
+import { DEFAULT_SUBAGENT_MAX_MODEL_TURNS } from "../src/contracts/subagent.ts";
+import { responsesBodyFromChatFixture } from "./support/responses-fixture.ts";
+import type {
+  SandboxCommandRequest,
+  SandboxCommandResult,
+  SandboxRuntime,
+  SandboxRuntimeDescription,
+  SandboxShellRequest,
+} from "../src/sandbox/types.ts";
+
+class FakeSandboxRuntime implements SandboxRuntime {
+  describe(): SandboxRuntimeDescription {
+    return {
+      kind: "docker-runsc-cfc",
+      defaultWorkingDirectory: this.defaultWorkingDirectory(),
+      cfc: { runtimeRequested: true, workspaceMountPath: "/workspace" },
+    };
+  }
+
+  resolvePath(path: string, cwd = this.defaultWorkingDirectory()): string {
+    return normalize(path.startsWith("/") ? path : `${cwd}/${path}`);
+  }
+
+  isPathWithinWorkspace(path: string): boolean {
+    return path === "/workspace" || path.startsWith("/workspace/");
+  }
+
+  isPathWithinAllowedRoots(path: string): boolean {
+    return this.isPathWithinWorkspace(path);
+  }
+
+  defaultWorkingDirectory(): string {
+    return "/workspace";
+  }
+
+  run(_request: SandboxCommandRequest): Promise<SandboxCommandResult> {
+    return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+  }
+
+  runShell(request: SandboxShellRequest): Promise<SandboxCommandResult> {
+    if (request.command.includes(CAPABILITY_PROBE_SENTINEL)) {
+      return Promise.resolve({
+        stdout: "bash\tpresent\t/bin/bash\tGNU bash, version 5.2.26(1)-release",
+        stderr: "",
+        exitCode: 0,
+      });
+    }
+    return Promise.resolve({ stdout: "ok", stderr: "", exitCode: 0 });
+  }
+}
+
+const bashCallTurn = (id: string, command: string) => ({
+  choices: [{
+    index: 0,
+    message: {
+      role: "assistant",
+      content: "",
+      tool_calls: [{
+        id,
+        type: "function",
+        function: { name: "bash", arguments: JSON.stringify({ command }) },
+      }],
+    },
+  }],
+});
+
+const delegateCallTurn = (id: string, input: Record<string, unknown>) => ({
+  choices: [{
+    index: 0,
+    message: {
+      role: "assistant",
+      content: "",
+      tool_calls: [{
+        id,
+        type: "function",
+        function: { name: "delegate_task", arguments: JSON.stringify(input) },
+      }],
+    },
+  }],
+});
+
+const finalTurn = (content: string) => ({
+  choices: [{ index: 0, message: { role: "assistant", content } }],
+});
+
+const scriptedFetch = (payloads: readonly unknown[]): typeof fetch => {
+  let served = 0;
+  return () => {
+    const payload = payloads[served];
+    served += 1;
+    if (payload === undefined) {
+      throw new Error("scripted fetch ran out of payloads");
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify(responsesBodyFromChatFixture(payload)), {
+        status: 200,
+      }),
+    );
+  };
+};
+
+interface DelegateTaskOutput {
+  type: string;
+  subagent: {
+    status: string;
+    modelTurns: number;
+    runState: { status: string; terminalReason?: string };
+    manifest: { maxModelTurns: number };
+  };
+}
+
+/**
+ * The parent script: one turn spent on a `bash` call, then a `delegate_task`
+ * call on the parent's last available turn under `maxModelTurns: 2`.
+ */
+const parentTurns = (delegateInput: Record<string, unknown>) => [
+  bashCallTurn("call-parent-warmup", "echo warmup"),
+  delegateCallTurn("call-delegate", delegateInput),
+];
+
+/** A child script of five `bash` turns followed by a final text turn. */
+const childTurns = () => [
+  ...Array.from(
+    { length: 5 },
+    (_value, index) => bashCallTurn(`call-child-${index + 1}`, "echo child"),
+  ),
+  finalTurn("Child done."),
+];
+
+/**
+ * Runs a parent loop capped at two model turns whose second turn delegates,
+ * and returns the `delegate_task` output the child produced. The parent
+ * itself always ends at its turn limit, which is the condition under test.
+ */
+const delegateOutputFromExhaustedParent = async (options: {
+  runId: string;
+  delegateInput: Record<string, unknown>;
+  childPayloads: readonly unknown[];
+}): Promise<DelegateTaskOutput> => {
+  const engine = new CfHarnessEngine({
+    sandboxRuntime: new FakeSandboxRuntime(),
+    runId: options.runId,
+    model: "gpt-5.4",
+    cfcEnforcementMode: "disabled",
+  });
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine,
+    maxModelTurns: 2,
+    fetchFn: scriptedFetch([
+      ...parentTurns(options.delegateInput),
+      ...options.childPayloads,
+    ]),
+  });
+  const outputs: DelegateTaskOutput[] = [];
+
+  await expect(loop.runPrompt({
+    prompt: "Delegate the inspection.",
+    onTranscriptEvent: ({ message }) => {
+      if (
+        message.role === "tool" &&
+        message.content.includes("cf-harness.delegate-task-output")
+      ) {
+        outputs.push(JSON.parse(message.content) as DelegateTaskOutput);
+      }
+    },
+  })).rejects.toThrow("exceeded max model turns (2)");
+
+  expect(outputs.length).toBe(1);
+  return outputs[0]!;
+};
+
+describe("prompt-loop subagent turn budget", () => {
+  it("runs a child to its own final turn when the parent delegates on its last turn", async () => {
+    const output = await delegateOutputFromExhaustedParent({
+      runId: "run-subagent-budget-explicit",
+      delegateInput: {
+        goal: "Inspect the workspace and report.",
+        maxModelTurns: 8,
+      },
+      childPayloads: childTurns(),
+    });
+
+    expect(output.subagent.modelTurns).toBe(6);
+    expect(output.subagent.status).toBe("completed");
+    expect(output.subagent.runState.status).toBe("completed");
+    expect(output.subagent.manifest.maxModelTurns).toBe(8);
+  });
+
+  it("runs a child on the profile default budget to its own final turn when the parent delegates on its last turn", async () => {
+    const output = await delegateOutputFromExhaustedParent({
+      runId: "run-subagent-budget-default",
+      delegateInput: { goal: "Inspect the workspace and report." },
+      childPayloads: childTurns(),
+    });
+
+    expect(output.subagent.modelTurns).toBe(6);
+    expect(output.subagent.status).toBe("completed");
+    expect(output.subagent.runState.status).toBe("completed");
+    expect(output.subagent.manifest.maxModelTurns).toBe(
+      DEFAULT_SUBAGENT_MAX_MODEL_TURNS,
+    );
+  });
+
+  it("stops a child at the budget the delegation named, not at the parent's", async () => {
+    const output = await delegateOutputFromExhaustedParent({
+      runId: "run-subagent-budget-child-limit",
+      delegateInput: {
+        goal: "Inspect the workspace and report.",
+        maxModelTurns: 3,
+      },
+      childPayloads: childTurns(),
+    });
+
+    expect(output.subagent.modelTurns).toBe(3);
+    expect(output.subagent.status).toBe("failed");
+    expect(output.subagent.runState.status).toBe("failed");
+    expect(output.subagent.runState.terminalReason).toBe("max_model_turns");
+  });
+});

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -438,6 +438,14 @@ targeted, the scope follows the id as `@user`/`@session` only when it is not the
 default, and the path follows as ordinary segments. No schema is inlined and no
 write-redirect flag rides along.
 
+**Every address this CLI publishes is that one string** — a `$link` marker's
+value, a `--select` suffix's, a `--show-links` entry's, and the Invocation
+JSON's `receipt`. A caller that reaches into an address for an `id`, a `space`,
+or a `scope` reads the string whole instead, and passes it on whole. The failure
+mode is quiet: these values usually arrive inside an `unknown` or a `JSONValue`,
+so code that indexes them merges cleanly, type-checks, and then reads
+`undefined` at runtime against a real fabric.
+
 The address names the deepest stored link crossed on the way to the marked
 position, plus the segments that remain below that link. Marking `title` under
 each element of a `notes` array whose entries are links returns the note's own

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -163,7 +163,10 @@ The scheduler manages the execution order of reactive updates:
 
 - Ensures updates happen in a predictable order
 - Batches related updates for efficiency
-- Prevents infinite update loops
+- Bounds the scheduling work a non-converging graph can demand, deferring the
+  offending actions rather than running them without limit. This bounds
+  scheduling, not computation: a loop inside a single computation body still
+  runs to completion or not at all
 - Provides hooks for synchronization points via `idle()`
 
 ## Core Components

--- a/packages/runner/src/scheduler/execution.ts
+++ b/packages/runner/src/scheduler/execution.ts
@@ -91,25 +91,43 @@ export function recordExecuteEnd(
   };
 }
 
-export function markNonSettlingEpisode(
+/**
+ * Summarizes the tracker's current busy window without touching its state, so
+ * a caller can report every non-settling episode rather than only the first.
+ */
+export function summarizeNonSettlingWindow(
   tracker: SettlingTracker,
   now = performance.now(),
-): ExecuteEndUpdate["nonSettlingTelemetry"] | undefined {
-  if (tracker.nonSettlingDetected) return undefined;
-
+): NonNullable<ExecuteEndUpdate["nonSettlingTelemetry"]> {
   const windowStart = tracker.windowStart || now;
   const inFlightBusyTime = tracker.isExecuting
     ? Math.max(0, now - tracker.lastExecuteStart)
     : 0;
   const busyTime = tracker.busyTime + inFlightBusyTime;
   const windowDuration = Math.max(1, now - windowStart);
-  tracker.nonSettlingDetected = true;
 
   return {
     busyTime,
     windowDuration,
     busyRatio: Math.min(1, busyTime / windowDuration),
   };
+}
+
+/**
+ * Latches the tracker's non-settling flag, returning the window summary for the
+ * episode that set it and `undefined` for every episode after it. The flag
+ * lives on the tracker, which the scheduler replaces when a continuation
+ * begins, so the latch spans a run of settle passes rather than the runtime.
+ */
+export function markNonSettlingEpisode(
+  tracker: SettlingTracker,
+  now = performance.now(),
+): ExecuteEndUpdate["nonSettlingTelemetry"] | undefined {
+  if (tracker.nonSettlingDetected) return undefined;
+
+  const summary = summarizeNonSettlingWindow(tracker, now);
+  tracker.nonSettlingDetected = true;
+  return summary;
 }
 
 export function buildPullInitialSeeds(state: {

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -95,6 +95,7 @@ import {
   type SchedulerSettleLoopState,
   type SchedulerSettleResult,
   type SettlingTracker,
+  summarizeNonSettlingWindow,
 } from "./execution.ts";
 import { SchedulerGates } from "./gates.ts";
 import {
@@ -2011,19 +2012,28 @@ export class Scheduler {
     settleResult: SchedulerSettleResult,
   ): void {
     if (!settleResult.backoffApplied) return;
-    const nonSettlingTelemetry = markNonSettlingEpisode(this.settlingTracker);
-    if (!nonSettlingTelemetry) return;
 
+    const deferredActions = this.describeDeferredActions(
+      settleResult.backoffActions,
+    );
     this.runtime.telemetry.submit({
       type: "scheduler.non-settling",
-      ...nonSettlingTelemetry,
+      ...summarizeNonSettlingWindow(this.settlingTracker),
+      deferredActions,
+      deferredActionCount: settleResult.backoffActions.length,
     });
-    this.warnNonSettlingActions(settleResult.backoffActions);
+
+    // The marker carries every episode; the warning is a latched
+    // summary so a permanently non-converging graph does not flood the log.
+    if (markNonSettlingEpisode(this.settlingTracker)) {
+      this.warnNonSettlingActions(settleResult.backoffActions, deferredActions);
+    }
   }
 
-  private warnNonSettlingActions(actions: readonly Action[]): void {
+  /** Labels the first few deferred actions, readable name first when known. */
+  private describeDeferredActions(actions: readonly Action[]): string[] {
     const maxListedActions = 10;
-    const labels = actions.slice(0, maxListedActions).map((action) => {
+    return actions.slice(0, maxListedActions).map((action) => {
       const actionId = this.getActionId(action);
       const info = getSchedulerActionTelemetryInfo(action);
       const readableName = info?.moduleName ?? info?.patternName;
@@ -2031,6 +2041,12 @@ export class Scheduler {
         ? `${readableName} (${actionId})`
         : actionId;
     });
+  }
+
+  private warnNonSettlingActions(
+    actions: readonly Action[],
+    labels: readonly string[],
+  ): void {
     const omittedCount = actions.length - labels.length;
     const actionList = labels.length > 0
       ? labels.join(", ") +

--- a/packages/runner/src/telemetry.ts
+++ b/packages/runner/src/telemetry.ts
@@ -257,10 +257,18 @@ export type RuntimeTelemetryMarker = {
   reads: string[]; // cell paths this action reads
   writes: string[]; // cell paths this action writes
 } | {
+  // Emitted for every settle episode whose convergence budget deferred work,
+  // and for a busy window that crosses the wall-clock heuristic. The deferred
+  // fields are present on the convergence-budget path and carry the labels of
+  // the actions the pass held back. A wave that converges over several passes
+  // exhausts a budget too, so a marker reports a bounded pass rather than a
+  // graph that will never settle.
   type: "scheduler.non-settling";
   busyTime: number;
   windowDuration: number;
   busyRatio: number;
+  deferredActions?: string[];
+  deferredActionCount?: number;
 };
 
 export type RuntimeTelemetryMarkerResult = RuntimeTelemetryMarker & {

--- a/packages/runner/test/scheduler-diagnosis.test.ts
+++ b/packages/runner/test/scheduler-diagnosis.test.ts
@@ -6,8 +6,14 @@ import {
   findDifferingWriteKeys,
   findNonIdempotentPair,
   makeAddressKey,
+  runIdempotencyRecheck,
 } from "../src/scheduler/diagnosis.ts";
-import type { IMemorySpaceAddress } from "../src/storage/interface.ts";
+import type { NonIdempotentReport } from "../src/telemetry.ts";
+import type { Action } from "../src/scheduler/types.ts";
+import type {
+  IExtendedStorageTransaction,
+  IMemorySpaceAddress,
+} from "../src/storage/interface.ts";
 
 const SPACE = "did:key:zDiagnosis" as IMemorySpaceAddress["space"];
 
@@ -26,72 +32,144 @@ function record(
   };
 }
 
-describe("makeAddressKey", () => {
-  it("joins space, id, and path with slashes", () => {
-    expect(makeAddressKey(address("of:e1", ["a", "b"]))).toBe(
-      "did:key:zDiagnosis/of:e1/a/b",
-    );
+/**
+ * Minimal transaction stand-in: it answers the two inspection hooks the
+ * recheck consults (its reactivity log and its write details) and remembers
+ * whether it was aborted.
+ */
+function fakeTransaction(
+  writes: readonly { address: IMemorySpaceAddress; value: FabricValue }[] = [],
+): IExtendedStorageTransaction & { readonly wasAborted: () => boolean } {
+  let aborted = false;
+  const tx = {
+    getReactivityLog: () => ({
+      reads: [],
+      shallowReads: [],
+      writes: writes.map((write) => write.address),
+    }),
+    getWriteDetails: (space: IMemorySpaceAddress["space"]) =>
+      writes.filter((write) => write.address.space === space),
+    abort: () => {
+      aborted = true;
+    },
+    wasAborted: () => aborted,
+  };
+  return tx as unknown as
+    & IExtendedStorageTransaction
+    & { readonly wasAborted: () => boolean };
+}
+
+describe("scheduler-diagnosis", () => {
+  describe("makeAddressKey", () => {
+    it("joins space, id, and path with slashes", () => {
+      expect(makeAddressKey(address("of:e1", ["a", "b"]))).toBe(
+        "did:key:zDiagnosis/of:e1/a/b",
+      );
+    });
+
+    it("leaves a trailing slash for an empty path", () => {
+      expect(makeAddressKey(address("of:e1", []))).toBe(
+        "did:key:zDiagnosis/of:e1/",
+      );
+    });
   });
 
-  it("leaves a trailing slash for an empty path", () => {
-    expect(makeAddressKey(address("of:e1", []))).toBe(
-      "did:key:zDiagnosis/of:e1/",
-    );
-  });
-});
+  describe("findDifferingWriteKeys", () => {
+    it("flags keys present in only one map", () => {
+      const previous = new Map<string, FabricValue>([["a", 1]]);
+      const latest = new Map<string, FabricValue>([["b", 2]]);
+      expect(findDifferingWriteKeys(previous, latest).sort()).toEqual([
+        "a",
+        "b",
+      ]);
+    });
 
-describe("findDifferingWriteKeys", () => {
-  it("flags keys present in only one map", () => {
-    const previous = new Map<string, FabricValue>([["a", 1]]);
-    const latest = new Map<string, FabricValue>([["b", 2]]);
-    expect(findDifferingWriteKeys(previous, latest).sort()).toEqual(["a", "b"]);
-  });
+    it("flags keys whose value changed and ignores equal values", () => {
+      const previous = new Map<string, FabricValue>([["a", 1], ["b", {
+        x: 1,
+      }]]);
+      const latest = new Map<string, FabricValue>([["a", 2], ["b", { x: 1 }]]);
+      expect(findDifferingWriteKeys(previous, latest)).toEqual(["a"]);
+    });
 
-  it("flags keys whose value changed and ignores equal values", () => {
-    const previous = new Map<string, FabricValue>([["a", 1], ["b", { x: 1 }]]);
-    const latest = new Map<string, FabricValue>([["a", 2], ["b", { x: 1 }]]);
-    expect(findDifferingWriteKeys(previous, latest)).toEqual(["a"]);
-  });
-
-  it("restricts the compared keys to the latest map when asked", () => {
-    const previous = new Map<string, FabricValue>([["a", 1], ["gone", 9]]);
-    const latest = new Map<string, FabricValue>([["a", 1], ["b", 2]]);
-    // Union counts the key that only the previous map holds; "latest" does not.
-    expect(findDifferingWriteKeys(previous, latest).sort()).toEqual([
-      "b",
-      "gone",
-    ]);
-    expect(
-      findDifferingWriteKeys(previous, latest, { keySet: "latest" }),
-    ).toEqual(["b"]);
-  });
-});
-
-describe("findNonIdempotentPair", () => {
-  it("returns undefined with fewer than two records", () => {
-    expect(findNonIdempotentPair([])).toBeUndefined();
-    expect(findNonIdempotentPair([record({ r: 1 }, { w: 1 })])).toBeUndefined();
+    it("restricts the compared keys to the latest map when asked", () => {
+      const previous = new Map<string, FabricValue>([["a", 1], ["gone", 9]]);
+      const latest = new Map<string, FabricValue>([["a", 1], ["b", 2]]);
+      // Union counts the key that only the previous map holds; "latest" does not.
+      expect(findDifferingWriteKeys(previous, latest).sort()).toEqual([
+        "b",
+        "gone",
+      ]);
+      expect(
+        findDifferingWriteKeys(previous, latest, { keySet: "latest" }),
+      ).toEqual(["b"]);
+    });
   });
 
-  it("finds a pair with equal reads but differing writes", () => {
-    const previous = record({ r: 1 }, { w: 1 });
-    const latest = record({ r: 1 }, { w: 2 });
-    const pair = findNonIdempotentPair([previous, latest]);
-    expect(pair).toBeDefined();
-    expect(pair!.previous).toBe(previous);
-    expect(pair!.latest).toBe(latest);
-    expect(pair!.differingWriteKeys).toEqual(["w"]);
+  describe("findNonIdempotentPair", () => {
+    it("returns undefined with fewer than two records", () => {
+      expect(findNonIdempotentPair([])).toBeUndefined();
+      expect(findNonIdempotentPair([record({ r: 1 }, { w: 1 })]))
+        .toBeUndefined();
+    });
+
+    it("finds a pair with equal reads but differing writes", () => {
+      const previous = record({ r: 1 }, { w: 1 });
+      const latest = record({ r: 1 }, { w: 2 });
+      const pair = findNonIdempotentPair([previous, latest]);
+      expect(pair).toBeDefined();
+      expect(pair!.previous).toBe(previous);
+      expect(pair!.latest).toBe(latest);
+      expect(pair!.differingWriteKeys).toEqual(["w"]);
+    });
+
+    it("returns undefined when reads differ between the runs", () => {
+      const previous = record({ r: 1 }, { w: 1 });
+      const latest = record({ r: 2 }, { w: 2 });
+      expect(findNonIdempotentPair([previous, latest])).toBeUndefined();
+    });
+
+    it("returns undefined when reads and writes both match", () => {
+      const previous = record({ r: 1 }, { w: 1 });
+      const latest = record({ r: 1 }, { w: 1 });
+      expect(findNonIdempotentPair([previous, latest])).toBeUndefined();
+    });
   });
 
-  it("returns undefined when reads differ between the runs", () => {
-    const previous = record({ r: 1 }, { w: 1 });
-    const latest = record({ r: 2 }, { w: 2 });
-    expect(findNonIdempotentPair([previous, latest])).toBeUndefined();
-  });
+  describe("runIdempotencyRecheck", () => {
+    it("returns without a violation and aborts the recheck transaction when the re-invoked action throws", () => {
+      const counted = address("of:e1", ["value", "count"]);
+      const tx = fakeTransaction([{ address: counted, value: 1 }]);
+      const tx2 = fakeTransaction();
+      const violations: NonIdempotentReport[] = [];
+      let invocations = 0;
 
-  it("returns undefined when reads and writes both match", () => {
-    const previous = record({ r: 1 }, { w: 1 });
-    const latest = record({ r: 1 }, { w: 1 });
-    expect(findNonIdempotentPair([previous, latest])).toBeUndefined();
+      const action: Action = () => {
+        invocations++;
+        throw new Error("recheck run failed");
+      };
+
+      const state = {
+        idempotencyViolations: violations,
+        createTx: () => tx2 as IExtendedStorageTransaction,
+        invoke: (fn: () => unknown) => fn(),
+        getActionId: () => "action-1",
+        getActionTelemetryInfo: () => undefined,
+      };
+
+      expect(() =>
+        runIdempotencyRecheck(state, action, tx, {
+          reads: [],
+          shallowReads: [],
+          writes: [counted],
+        })
+      ).not.toThrow();
+
+      expect(invocations).toBe(1);
+      // The first run's write is not evidence of non-idempotency when the
+      // second run produced no writes at all.
+      expect(violations).toEqual([]);
+      expect(tx2.wasAborted()).toBe(true);
+    });
   });
 });

--- a/packages/runner/test/scheduler-settling-telemetry.test.ts
+++ b/packages/runner/test/scheduler-settling-telemetry.test.ts
@@ -12,8 +12,15 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
-import type { SettlingTracker } from "../src/scheduler/execution.ts";
-import type { RuntimeTelemetryEvent } from "../src/telemetry.ts";
+import type {
+  SchedulerSettleResult,
+  SettlingTracker,
+} from "../src/scheduler/execution.ts";
+import type { Action } from "../src/scheduler/types.ts";
+import type {
+  RuntimeTelemetryEvent,
+  RuntimeTelemetryMarker,
+} from "../src/telemetry.ts";
 
 const signer = await Identity.fromPassphrase("settling telemetry test");
 
@@ -23,8 +30,26 @@ const signer = await Identity.fromPassphrase("settling telemetry test");
 type SchedulerInternals = {
   settlingTracker: SettlingTracker;
   recordExecuteEndTelemetry(): void;
+  recordBudgetBackoffTelemetry(settleResult: SchedulerSettleResult): void;
   diagnosisEnabled: boolean;
 };
+
+// A settle result carrying only the fields the backoff telemetry path reads;
+// the rest of the shape is inert here.
+function settleResultWithBackoff(
+  backoffActions: readonly Action[],
+): SchedulerSettleResult {
+  return {
+    settledEarly: false,
+    maxSettleIterations: 10,
+    backoffApplied: backoffActions.length > 0,
+    backoffActionCount: backoffActions.length,
+    backoffActions,
+    iterationsRun: 10,
+    settleDurationMs: 1,
+    workSetSize: backoffActions.length,
+  };
+}
 
 describe("scheduler non-settling telemetry", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
@@ -81,5 +106,80 @@ describe("scheduler non-settling telemetry", () => {
       // Also clears the diagnosis auto-stop timer startDiagnosis armed.
       await runtime.dispose();
     }
+  });
+
+  describe("convergence-budget episodes", () => {
+    it("submits a marker naming the deferred actions for each episode that defers work", async () => {
+      const runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+      });
+      try {
+        const scheduler = runtime.scheduler as unknown as SchedulerInternals;
+        const markers: RuntimeTelemetryMarker[] = [];
+        const listener = (event: Event) => {
+          const { marker } = (event as RuntimeTelemetryEvent).detail;
+          if (marker.type === "scheduler.non-settling") markers.push(marker);
+        };
+        runtime.telemetry.addEventListener("telemetry", listener);
+        try {
+          const firstAction: Action = function firstDeferred() {};
+          const secondAction: Action = function secondDeferred() {};
+
+          scheduler.recordBudgetBackoffTelemetry(
+            settleResultWithBackoff([firstAction]),
+          );
+          scheduler.recordBudgetBackoffTelemetry(
+            settleResultWithBackoff([secondAction, firstAction]),
+          );
+
+          expect(markers.length).toBe(2);
+          expect(
+            markers.map((marker) =>
+              marker.type === "scheduler.non-settling"
+                ? marker.deferredActionCount
+                : undefined
+            ),
+          ).toEqual([1, 2]);
+          const firstLabels = markers[0].type === "scheduler.non-settling"
+            ? markers[0].deferredActions
+            : undefined;
+          expect(firstLabels?.length).toBe(1);
+          // The latch the warning rides still records that this run of settle
+          // passes churned; a new continuation replaces the tracker holding it.
+          expect(runtime.scheduler.isNonSettling()).toBe(true);
+        } finally {
+          runtime.telemetry.removeEventListener("telemetry", listener);
+        }
+      } finally {
+        await runtime.dispose();
+      }
+    });
+
+    it("submits no marker for a settle pass that deferred nothing", async () => {
+      const runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+      });
+      try {
+        const scheduler = runtime.scheduler as unknown as SchedulerInternals;
+        const markers: RuntimeTelemetryMarker[] = [];
+        const listener = (event: Event) => {
+          const { marker } = (event as RuntimeTelemetryEvent).detail;
+          if (marker.type === "scheduler.non-settling") markers.push(marker);
+        };
+        runtime.telemetry.addEventListener("telemetry", listener);
+        try {
+          scheduler.recordBudgetBackoffTelemetry(settleResultWithBackoff([]));
+
+          expect(markers.length).toBe(0);
+          expect(runtime.scheduler.isNonSettling()).toBe(false);
+        } finally {
+          runtime.telemetry.removeEventListener("telemetry", listener);
+        }
+      } finally {
+        await runtime.dispose();
+      }
+    });
   });
 });

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -151,7 +151,7 @@ See `docs/development/EXPERIMENTAL_OPTIONS.md` for available flags.
 | Mint a session     | `export CF_INVOCATION_SESSION="$(deno task cf invocation-session new)"` (once per run; ids deduplicate only within it)       |
 | Replayable call    | `deno task cf piece call --piece ID --invocation my-id-1 handlerName ...` (same pair retries settle on the original outcome) |
 | Detached call      | `deno task cf piece call --piece ID --no-wait --invocation my-id-1 handlerName ...` (exits at commit with `receipt` address) |
-| Collect a receipt  | `deno task cf piece get --piece <receipt id> ...` (the envelope's `receipt.id`, later, from any process)                     |
+| Collect a receipt  | `deno task cf piece get --piece <receipt> ...` (the envelope's `receipt` string, later, from any process)                    |
 | List pieces        | `deno task cf piece ls -i key -a url -s space`                                                                               |
 | Visualize          | `deno task cf piece map ...`                                                                                                 |
 | Rehearse an update | `deno task cf space clone <did> --from <snapshot> --to <dir>` (then `verify` / `reset`)                                      |
@@ -278,27 +278,30 @@ hydrated; ambiguous compositions can retain a wider selector, and schema-less or
 root-union sources need a value-shape read first. CFC behavior is the same as a
 computed pattern expression. Source schema metadata is authoritative; projection
 schemas cannot supply `ifc`, `asCell`, `scope`, or `default`. A projection marks
-a position to get that position's address — `{"id","space","scope","path"}`, all
-four always present, no schema inlined — instead of what is behind it, or beside
-a projection to get both. A JSON `--schema` marks with `"$link": true`; a field
-list marks with a trailing `@`, so `--select 'topic@,topic.title'` returns one
-`topic` carrying its address and its title. A path that is only `@` marks the
-position the read is already at, so `--select '@'` returns the source's own
-address and `--select '@,title'` returns it beside the title. `@` is otherwise
-special only at the end of a segment and `\@` writes a literal one, which keeps
-a field named `user@home` reachable; a leading `@` followed by anything else is
-the `@file` only `--schema` reads. A field list applies to each element wherever
-it crosses an array, an address included, so `--select 'notes@'` returns one
-address per note and is the concise spelling of
-`--schema '{"type":"array","items":{"$link":true}}'`; a marked position holding
-anything else returns its own address. That address is the deepest stored link
-crossed on the way to the marked position plus the segments below it, so marking
-a field under a linked element names that element's own document rather than a
-slot in the collection above it; a position with no link above it keeps the
-source document's own address. A marked position is never fetched, so a marked
-collection costs one document read rather than one per element; the rendered
-`id` is what `--piece` accepts, scheme included, so an emitted address composes
-into the next command unchanged. Neither spelling composes with `--filter`. See
+a position to get that position's address — one string in the canonical
+reference syntax `/[@did/]<id>[@scope][/path]`, where the space rides in front
+only when it differs from the space the command targeted and the scope follows
+the id only when it is not the default, no schema inlined — instead of what is
+behind it, or beside a projection to get both. A JSON `--schema` marks with
+`"$link": true`; a field list marks with a trailing `@`, so
+`--select 'topic@,topic.title'` returns one `topic` carrying its address and its
+title. A path that is only `@` marks the position the read is already at, so
+`--select '@'` returns the source's own address and `--select '@,title'` returns
+it beside the title. `@` is otherwise special only at the end of a segment and
+`\@` writes a literal one, which keeps a field named `user@home` reachable; a
+leading `@` followed by anything else is the `@file` only `--schema` reads. A
+field list applies to each element wherever it crosses an array, an address
+included, so `--select 'notes@'` returns one address per note and is the concise
+spelling of `--schema '{"type":"array","items":{"$link":true}}'`; a marked
+position holding anything else returns its own address. That address is the
+deepest stored link crossed on the way to the marked position plus the segments
+below it, so marking a field under a linked element names that element's own
+document rather than a slot in the collection above it; a position with no link
+above it keeps the source document's own address. A marked position is never
+fetched, so a marked collection costs one document read rather than one per
+element; the rendered address is what `--piece` accepts, scheme included, so an
+emitted address composes into the next command unchanged, without being
+reassembled. Neither spelling composes with `--filter`. See
 `packages/cli/README.md` for the exact syntax and supported schema subset.
 
 `piece call` takes the same three flags, before the callable name, with the same


### PR DESCRIPTION
A settle pass that exhausts its convergence budget defers the offending actions rather than running them without limit. Only the first such episode said so: the telemetry marker and the author-facing warning were both gated on the settling tracker's latch, so a second deferring episode in the same run of passes went unrecorded — which `docs/specs/scheduler-v2/README.md` §7.7 already said should not happen.

The marker now fires for every deferring episode and carries the labels of the actions held back along with how many there were. The warning keeps the latch: a settle pass runs per event wave, and "run `commonfabric.detectNonIdempotent()`" does not become more useful the fortieth time.

### What the signal means, which is narrower than it looks

The spec now states the distinction explicitly. **A marker reports a pass that hit its budget. A wave converging over several passes hits it too.** It is not, on its own, a report that a graph will never settle — the repo's own `scheduler-idle-convergence.test.ts` drives a deliberately healthy wave that reaches its expected value *and* emits markers. A consumer reading the marker as failure would reject correct work.

That distinction is why this PR is smaller than it started. It originally wired `run_pattern` to report the marker to the model as a recoverable error; review established that the gate would fire on healthy multi-pass convergence, that a marker emitted during piece startup was missed entirely, and that runtime-wide attribution would stop the healthy piece while the offending one kept running. The consumer is removed. A correct one needs post-barrier *state* — is anything still convergence-deferred once settling finishes — and attribution to the piece that owns the action, which is its own change.

Scope correction while here: the latch is **not** runtime-lifetime, as an earlier revision of this PR claimed in four places. `resetSettlingTracker()` replaces the tracker when a continuation begins, so it spans a run of settle passes. Every statement of it is corrected.

### Also here

**A regression test retracting a recorded observation.** A delegated child's turn budget was thought to shrink with whatever the parent had left. It does not: a parent delegating on its own last turn hands a child a budget the child spends in full, while a control bounded at three turns stops at three, so the assertion is sensitive rather than vacuous.

**A coverage gap closed with a test rather than a waiver.** The diagnosis recheck's error arm was covered on some CI runs and not others; it is now driven by a test whose point is a throwing re-invocation, verified to hit the line from that test alone.

**A documentation sweep** of five live documents still describing the surface CT-2003 replaced — most sharply `skills/cf/SKILL.md`, which told an agent to read a `receipt.id` that no longer exists and so returns `null`. And `packages/runner/README.md` claimed the scheduler "Prevents infinite update loops"; it bounds scheduling work, not computation, and now says so.

### Evidence

Full runner suite 1204 passed / 0 failed. `deno fmt --check`, `deno lint`, `check-docs` (549 blocks) clean.

Linear-issue: CT-2003

🤖 Generated with [Claude Code](https://claude.com/claude-code)
