### PR TITLE
A durable write is judged on what it reaches, not what the producer links

### DIFF
--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -2278,13 +2278,14 @@ export function omitMissingProjectionAliases(
   pieces: PiecesController,
   schemaViewPresent = true,
   changedPaths: readonly (readonly (string | number)[])[] = [],
+  acceptOpaqueValue:
+    | ((value: unknown, schema: JSONSchema) => boolean)
+    | undefined = undefined,
   resolving = new Set<string>(),
 ): unknown | typeof MISSING_PROJECTION_ALIAS {
   if (isLink(raw)) {
-    if (
-      isCell(schemaView) &&
-      !changedPaths.some((path) => path.length > 0)
-    ) {
+    const reachesNothingBelow = !changedPaths.some((path) => path.length > 0);
+    if (isCell(schemaView) && reachesNothingBelow) {
       // Schema-aware reads preserve declared Cell/Stream projections as
       // handles. Keep that opaque proof in the staged producer root instead
       // of replacing it with the target's untyped payload; unrelated Stream
@@ -2293,6 +2294,27 @@ export function omitMissingProjectionAliases(
       // descendant write is the exception: materialize that producer value so
       // staging preserves its unchanged siblings.
       return schemaView;
+    }
+    // Settling this link on the link alone needs two things. The caller must
+    // settle a bare link wherever one appears: the probe asks its predicate at
+    // the most permissive point, which is enough because the one predicate
+    // that reaches here answers on the link alone, while
+    // `schemaAcceptsOpaqueCellValue` wants a Cell and says no — so a second
+    // call site cannot enable this by passing a boolean it did not mean. And
+    // the node must not be one the missing-alias sentinel below could claim,
+    // whose precondition is an absent target under a materialization and a
+    // schema view that both came back absent.
+    //
+    // Settled means settled whole. `acceptOpaqueValue` is consulted at a node
+    // ahead of the keywords there, so nothing the link's own schema says, and
+    // nothing a schema below it says, is measured against the target; a
+    // keyword the containing object or array evaluates — `const`, `enum`,
+    // `oneOf` discrimination, `uniqueItems` — additionally sees a link where
+    // the target's value would have been.
+    const settlesOnTheLink = reachesNothingBelow &&
+      acceptOpaqueValue?.(raw, true) === true;
+    if (settlesOnTheLink && (materialized !== undefined || schemaViewPresent)) {
+      return raw;
     }
     const resolvedSchemaView = isCell(schemaView) && !isStream(schemaView)
       ? schemaView.get()
@@ -2328,6 +2350,9 @@ export function omitMissingProjectionAliases(
       ) {
         return MISSING_PROJECTION_ALIAS;
       }
+      // Resolved only to learn the target exists; that answered, the link
+      // settles the rest on its own.
+      if (settlesOnTheLink) return raw;
       const resolvedCell = pieces.runtime.getCellFromLink(
         { ...resolved, schema: undefined },
         undefined,
@@ -2341,6 +2366,7 @@ export function omitMissingProjectionAliases(
         pieces,
         schemaViewPresent,
         changedPaths,
+        acceptOpaqueValue,
         resolving,
       );
     } finally {
@@ -2383,6 +2409,7 @@ export function omitMissingProjectionAliases(
       pieces,
       childViewPresent,
       childChangedPaths,
+      acceptOpaqueValue,
       resolving,
     );
     if (reconciled === MISSING_PROJECTION_ALIAS) {
@@ -2394,6 +2421,25 @@ export function omitMissingProjectionAliases(
   return result;
 }
 
+/**
+ * Prove that storing `nextValue` leaves every producer-owned document that
+ * exposes the destination valid against the schema its producer declared.
+ *
+ * The staged root is the whole document, not the written path: a producer root
+ * constrains its members jointly, so a payload that satisfies the schema at its
+ * own path can still leave a sibling, a container bound, or a `required` member
+ * unsatisfiable.
+ *
+ * What it does not stage is the contents of a link the write does not reach.
+ * Such a link is staged as itself and accepted whole, subtree included: nothing
+ * its own schema says, and nothing a schema below it says, is measured against
+ * the target. That is the price of not materializing another document, and
+ * everything that one links in turn, to judge a write that never reaches it.
+ *
+ * One thing is still asked of an unreached link — whether it has a target at
+ * all. A projection alias with nothing behind it drops out of the staged root,
+ * so `required` still refuses it.
+ */
 function validateDurableSourceRoots(
   destination: DurableSourceContract,
   nextValue: unknown,
@@ -2445,6 +2491,7 @@ function validateDurableSourceRoots(
       pieces,
       true,
       group.paths,
+      acceptOpaqueValue,
     );
     if (candidate === MISSING_PROJECTION_ALIAS) candidate = undefined;
     for (const path of group.paths) {

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -1625,6 +1625,7 @@ describe("piece pull materialization", () => {
           pieces,
           true,
           [],
+          undefined,
           resolving,
         ),
       ).toBe("already-materialized");
@@ -3443,6 +3444,121 @@ describe("piece pull materialization", () => {
         event: source.key("event"),
       }),
     ).rejects.toThrow(/input link.*schema is not compatible/);
+  });
+
+  it("ignores a producer document the write does not reach", async () => {
+    const far = await pieces.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: { type: "object", properties: {} },
+        resultSchema: {
+          type: "object",
+          properties: { n: { type: "number" } },
+          required: ["n"],
+        },
+        result: { n: 1 },
+        nodes: [],
+      }),
+      {},
+      undefined,
+      { start: true },
+    );
+    const payload = {
+      type: "object",
+      properties: { n: { type: "number" } },
+      required: ["n"],
+    } as const;
+    const producer = await pieces.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: {
+          type: "object",
+          properties: { obj: payload, linked: { type: "number" } },
+          required: ["obj", "linked"],
+        },
+        resultSchema: {
+          type: "object",
+          properties: { obj: payload, linked: { type: "number" } },
+          required: ["obj", "linked"],
+        },
+        result: {
+          obj: { $alias: { cell: "argument", path: ["obj"] } },
+          linked: { $alias: { cell: "argument", path: ["linked"] } },
+        },
+        nodes: [],
+      }),
+      { obj: { n: 1 }, linked: 2 },
+      undefined,
+      { start: true },
+    );
+    await new PieceController(pieces, producer).input.set(
+      far.key("n"),
+      ["linked"],
+    );
+    // The producer now links a document its own schema refuses. Nothing the
+    // consumer writes below reaches it.
+    await runtime.editWithRetry((tx) => {
+      far.withTx(tx).key("n").setRawUntyped("bad");
+    });
+
+    const consumer = await pieces.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: {
+          type: "object",
+          properties: {
+            slot: {
+              type: "object",
+              properties: { n: { type: ["number", "string"] } },
+              required: ["n"],
+            },
+          },
+          required: ["slot"],
+        },
+        resultSchema: { type: "object", properties: {} },
+        result: {},
+        nodes: [],
+      }),
+      { slot: { n: 0 } },
+      undefined,
+      { start: true },
+    );
+    const controller = new PieceController(pieces, consumer);
+    await controller.input.set(producer.key("obj"), ["slot"]);
+
+    await controller.input.set(5, ["slot", "n"]);
+    expect(pieces.getArgument(producer).getRaw()).toMatchObject({
+      obj: { n: 5 },
+    });
+
+    // The producer's contract still decides the path the write does reach,
+    // even though the consumer declares it wider.
+    await expect(controller.input.set("bad", ["slot", "n"])).rejects.toThrow(
+      /^updated input does not match its write destination: value does not match type number$/,
+    );
+    expect(pieces.getArgument(producer).getRaw()).toMatchObject({
+      obj: { n: 5 },
+    });
+
+    // A target that exists but reads as undefined is still a target: the link
+    // settles it, and the write goes through.
+    await runtime.editWithRetry((tx) => {
+      far.withTx(tx).key("n").setRawUntyped(undefined);
+    });
+    await controller.input.set(7, ["slot", "n"]);
+    expect(pieces.getArgument(producer).getRaw()).toMatchObject({
+      obj: { n: 7 },
+    });
+
+    // Having no target at all is the case the link cannot settle: empty the far
+    // document and the producer's `linked` member has nothing behind it, so
+    // `required` refuses.
+    await runtime.editWithRetry((tx) => {
+      far.withTx(tx).setRawUntyped({});
+    });
+    await expect(controller.input.set(8, ["slot", "n"])).rejects.toThrow(
+      /updated input does not match its write destination: missing required property linked/,
+    );
+    expect(pieces.getArgument(producer).getRaw()).toMatchObject({
+      obj: { n: 7 },
+    });
   });
 
   it("rejects descendant writes through Stream wrappers", async () => {


### PR DESCRIPTION
## Why

Proving one Piece write valid against its producer's contract cost O(everything the producer links).

`validateDurableSourceRoots` stages the written value into the producer's whole document and validates it. Building that staged root materialized every link in the document — and every document those linked in turn. Profiled on the Topics board (`packages/patterns/topics/main.tsx`), adding one topic to a 32-topic board spent **~1.5s of pure CPU** there, and the walk grew linearly with the topics already on the board:

| topics on the board | staged nodes | time |
|---|---|---|
| 7 | 15,275 | 212ms |
| 15 | 15,275 | 532ms |
| 31 | — | 1503ms |

~45ms × N per write, on a board whose payload is one small event. The fan-out is real: each topic carries `mentionable`, the board's own list, so the board's document reaches every topic and every topic reaches back.

## What Changed

A link the write does not reach needs no such walk. The caller's `acceptOpaqueValue` settles a link on the link alone, so the value behind one changes no verdict the link node itself decides.

What the staged root *does* need is the write's own spine. A descendant write is judged by the container it lands in, and that container's bound depends on what it currently holds — `validates linked descendant writes against producer containers` pins exactly this: a write at `["arr", 1]` must answer to `maxItems` on `["arr"]`. `omitMissingProjectionAliases` already tracks that spine as `changedPaths`; it just never used it to stop.

Two things keep the shortcut honest.

**It asks the caller's own predicate**, probed with the permissive schema, rather than taking a boolean a second call site could set without meaning it. The Piece's own result validation next door reads `schemaAcceptsOpaqueCellValue`, which wants a Cell and refuses a bare link — so it keeps materializing, and cannot be switched over by accident. Applying this globally fails four missing-alias tests; that asymmetry is measured, not assumed.

**It yields to the missing-alias sentinel.** A link whose target may be absent is still resolved far enough to say so, so a projection alias with nothing behind it drops out of the staged root and `required` refuses it. Skipping that check outright — the first version of this change — accepted a write into a producer whose `required` member had a dangling alias, where `main` refuses it. That is now pinned by a test.

### What is given up

Stated at the shortcut, because it is real and it is not small. `acceptOpaqueValue` is consulted at a node *ahead of* the keywords there, so an unreached link is accepted **whole, subtree included**: nothing the link's own schema says, and nothing a schema below it says, is measured against the target. Concretely — disable the shortcut and this PR's own test fails on `linked: value does not match type number`, the link node's own `type`; and a `required` member missing inside a linked document, where the link itself resolves fine, no longer refuses the write.

On top of that, a keyword the *containing* object or array evaluates — `const`, `enum`, `oneOf` discrimination, `uniqueItems` — sees a link where the target's value would have been. For a container `enum` that is a false *rejection*, not a loosening.

Exposure for that second, container-level class is empirically nil: across all 338 committed baselines there are 320 leaf `enum` nodes and **zero** container-level `enum`, zero object/array `const`, and zero occurrences of `oneOf` / `if` / `uniqueItems` / `contains` / `dependentSchemas` / `propertyNames` / `not`; `home-schemas` likewise. `anyOf` is monotone here. Independently, this repo already refuses to plant a link under such a keyword — `LINK_PATH_SAFE_ANCESTOR_KEYS`, whose failure message is literally "correlates the linked field with its parent value" — the same distinction drawn for a different reason.

The first class — the link's own schema and everything below it — has no such bound, and is the deliberate trade: a producer document drifting behind a link the write never touches no longer blocks that write.

## Result

The producer group of a topic add is now flat in what the board already holds:

| topics on the board | before | after |
|---|---|---|
| 7 | 15,275 nodes → 212ms | **137 nodes → 5ms** |
| 15 | 15,275 nodes → 532ms | **137 nodes → 5ms** |
| 31 | → 1503ms | **137 nodes → 4ms** |

End to end over 32 adds: 76 → 31 ms/item, 46.7s → 25.2s. The residual slope is reactive-graph settling, not this check.

## Tests

`ignores a producer document the write does not reach` — a producer that links a document its own schema refuses; a write that does not reach that link is judged on the producer's own shape, the path the write *does* reach still answers to the producer's contract even though the consumer declares it wider, and emptying the linked document still makes `required` refuse the write.

Mutation-tested three ways:
- removing the shortcut → the new test fails
- settling every link, on-spine included → `materializes Cell ancestors when staging descendant result writes` fails
- settling before the missing-alias presence check → the new test's dangling-alias assertion fails

## Verification

- `deno task check`
- `packages/piece` — 37 passed, 450 steps, 0 failed
- `packages/runner` — 1206 passed, 6529 steps, 0 failed
- `deno task integration pattern-tests --filter topics` — 3/3
- `deno task integration patterns --filter topics-navigation` — pass
- `deno fmt --check`, `deno lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
