### PR TITLE
An event is not stored, so no producer root is staged for it

### DIFF
--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -2655,10 +2655,7 @@ class PiecePropIo implements PieceCellIo {
           );
         }
         const destination = durableDestination;
-        let localizedDestination: {
-          contracts: PathSchemaContract[];
-          isStream: boolean;
-        };
+        let localizedDestination: { contracts: PathSchemaContract[] };
         try {
           const destinationRootCell = pieces.runtime.getCellFromLink(
             { ...resolved, path: [], schema: undefined },
@@ -2672,12 +2669,14 @@ class PiecePropIo implements PieceCellIo {
               nextValue,
             )
           );
-          const isStream = resolveDeclaredStreamCapability(
+          // Called for the agreement it asserts: contracts that disagree on
+          // Stream capability throw here. What it returns is the capability the
+          // producer declares, which no one below asks about.
+          resolveDeclaredStreamCapability(
             localized.map((entry) => entry.declaredStream),
           );
           localizedDestination = {
             contracts: localized.flatMap((entry) => entry.contracts),
-            isStream,
           };
           const links = suppliedLinks(nextValue);
           if (
@@ -2720,7 +2719,14 @@ class PiecePropIo implements PieceCellIo {
           );
           if (issue !== undefined) break;
         }
-        if (issue === undefined) {
+        // A Stream destination consumes the value as an event: the write below
+        // sends it instead of storing it, and `Cell.set()` reaches that decision
+        // through this same predicate on this same cell. Nothing is stored, so
+        // no producer document changes and no producer root's validity can
+        // change. What the event itself owes — the producer's own event
+        // contract, at every producer-owned projection of the destination — the
+        // loop above has already proven.
+        if (issue === undefined && !isStream(txCell)) {
           issue = validateDurableSourceRoots(
             destination,
             nextValue,

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -3561,6 +3561,108 @@ describe("piece pull materialization", () => {
     });
   });
 
+  it("sends a stream event past an invalid producer sibling", async () => {
+    const members = {
+      other: { type: "number" },
+      spare: { type: "number" },
+    } as const;
+    const piece = await pieces.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: {
+          type: "object",
+          properties: {
+            event: { type: "number", asCell: ["stream"] },
+            ...members,
+          },
+          required: ["event", "other", "spare"],
+        },
+        // The result declares the same stream with its payload unconstrained,
+        // so a payload only the producer refuses reaches the producer contract
+        // instead of stopping at this Piece's own result schema.
+        resultSchema: {
+          type: "object",
+          properties: { event: { asCell: ["stream"] }, ...members },
+          required: ["event", "other", "spare"],
+        },
+        result: {
+          event: { $alias: { cell: "argument", path: ["event"] } },
+          other: { $alias: { cell: "argument", path: ["other"] } },
+          spare: { $alias: { cell: "argument", path: ["spare"] } },
+        },
+        nodes: [],
+      }),
+      { event: { $stream: true }, other: 1, spare: 2 },
+      undefined,
+      { start: true },
+    );
+    const controller = new PieceController(pieces, piece);
+    const argument = pieces.getArgument(piece);
+    // A producer member that no write below touches, holding a value the
+    // producer's own schema refuses.
+    await runtime.editWithRetry((tx) => {
+      argument.withTx(tx).key("spare").setRawUntyped("bad");
+    });
+
+    const stream = argument.key("event");
+    const events: unknown[] = [];
+    const removeHandler = runtime.scheduler.addEventHandler((_tx, event) => {
+      events.push(event);
+    }, stream.getAsNormalizedFullLink());
+    try {
+      await controller.result.set(7, ["event"]);
+      await runtime.idle();
+      expect(events).toEqual([7]);
+      // The premise the skip rests on: sending stores nothing, so the producer
+      // document the root pass would have judged is the one it already was.
+      expect(argument.getRawUntyped()).toEqual({
+        event: { $stream: true },
+        other: 1,
+        spare: "bad",
+      });
+
+      // Bypassing the root pass does not excuse a payload the producer's own
+      // event contract refuses: nothing further reaches the stream.
+      await expect(controller.result.set("bad", ["event"])).rejects.toThrow(
+        /does not match its write destination: value does not match type number/,
+      );
+      await runtime.idle();
+      expect(events).toEqual([7]);
+    } finally {
+      removeHandler();
+    }
+  });
+
+  it("drops a raw key the materialized view does not carry", async () => {
+    // `omitMissingProjectionAliases` reconciles two views of one document. A
+    // raw key with no counterpart in the materialized view is not a missing
+    // alias to resolve — there is nothing on the materialized side to keep — so
+    // it is skipped rather than recursed into.
+    const piece = await pieces.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: { type: "object", properties: {} },
+        resultSchema: { type: "object", properties: {} },
+        result: {},
+        nodes: [],
+      }),
+      {},
+      undefined,
+      { start: true },
+    );
+    const result = omitMissingProjectionAliases(
+      { kept: 1 },
+      { kept: 1, absentFromMaterialized: 2 },
+      undefined,
+      pieces.getResult(piece),
+      pieces,
+    );
+    // `toEqual` treats a present undefined as absent, so ask about the key
+    // itself: recursing would have set it, to undefined.
+    expect(Object.hasOwn(result as object, "absentFromMaterialized")).toBe(
+      false,
+    );
+    expect(result).toEqual({ kept: 1 });
+  });
+
   it("rejects descendant writes through Stream wrappers", async () => {
     const event = {
       type: "object",


### PR DESCRIPTION
## Why

A write through a Stream destination is delivered as an event. `Cell.set` resolves the destination, finds a stream, and sends — nothing is stored at the destination, and no producer document changes.

`validateDurableSourceRoots` staged that event into the producer's root anyway, as though it were the value now living at the stream's path, and judged the whole document on the result. That asks whether a document state which never exists would be valid, and it answers by refusing an event whenever some unrelated member of the producer's document happens to be invalid — something the event can neither have caused nor repair.

Reproduced: a Piece whose result aliases its argument, with one producer member corrupted to a value the schema refuses. Sending a perfectly valid event to an unrelated stream is refused with

```
updated result does not match its write destination: spare: value does not match type number
```

`spare` is not the stream, is not on the write path, and is not touched by delivering the event.

## What Changed

```ts
if (issue === undefined && !isStream(txCell)) {
```

`isStream(txCell)` is not a guess about the destination — it is the same predicate `Cell.set` itself evaluates to decide send-versus-store, on the same cell, resolved the same way. When it holds, the write below sends; when it does not, the write stores and the root check runs exactly as before.

The event's own contract is untouched: it is proven against every producer-owned projection of the destination by the localized-contract loop directly above, and a payload the producer refuses is still refused there. The Piece's own result validation further down already draws this same line for the same reason, and reads the same predicate to draw it.

## Tests

`sends a stream event past an invalid producer sibling` — a producer with a member its own schema refuses; an event to an unrelated stream is delivered, and a payload the event contract refuses is still refused with nothing reaching the stream.

The result schema deliberately declares the same stream with its payload unconstrained, so a payload only the *producer* refuses reaches the producer contract instead of stopping at this Piece's own result schema — otherwise that half of the test is a free rider on a check this PR does not touch.

Mutation-tested three ways:
- reverting the guard → the test fails on exactly the message quoted above
- skipping *all* of `validateWriteDestination` for streams (dropping the localized-contract loop with it) → the test fails
- removing the root check for every write → the pre-existing `validates linked descendant writes against producer containers` fails

## Also here

`localizedDestination.isStream` is deleted rather than renamed. It held the capability the producer's *contracts* declare — a different question from what this cell will do with the value, which is what the guard asks — and it sat one scope away from the imported `isStream()` predicate under the same name. Nothing ever read it. A dead field is exactly what a later reader unifies with the guard, because nothing shows them what it was for; the `resolveDeclaredStreamCapability` call stays, for the disagreement it asserts.

## Note on scope

This is a behavior change, not a performance change — it is deliberately split from #5887, which makes the same check proportional to the write without altering what it accepts.

Two things it does **not** do. The input branch's own whole-argument validation has no equivalent stream carve-out, so an event sent through `input.set` is still refused when an argument sibling is invalid; that is pre-existing and left alone rather than widened into here. Note that the guard itself is in the shared `validateWriteDestination`, so it *does* drop the producer-root check for input stream writes too — instrumenting the guard across the whole `packages/piece` suite shows zero such writes today, so that half of the change is reasoned rather than exercised. And skipping the root pass also drops its reads of the producer document from the send's transaction, so a stream send no longer contends with a concurrent write elsewhere in that document — a consequence worth naming, not a goal.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
