### PR TITLE
Row 14's capability is on main, and its refusal is not

### DIFF
--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -295,14 +295,22 @@ and the marker reaches nothing the CLI can read: the served event schema is the
 handler's narrowed read, and the stored pattern's declared schema has lost it
 too. #5560 carries the measurements.
 
-*The refusal is drift, not policy.* `closedWorldEventRejection`
-(`packages/runner/src/runner.ts`) validates a present event payload with
-`acceptOpaqueValue: (value) => isCellLink(value)` — a link passes unjudged,
-because its target cannot be read at dispatch. `verbInputSchemaError`
-(`packages/cli/lib/callable.ts`) calls the same `validateSchemaValue` with two
-arguments, so the options object defaults to `{}`. Same validator; the outer
-gate never got the option. The design is
+*The refusal was drift, not policy, and #5880 removed it.*
+`closedWorldEventRejection` (`packages/runner/src/runner.ts`) has always
+validated a present event payload with `acceptOpaqueValue` — a link passes
+unjudged, because its target cannot be read at dispatch. `verbInputSchemaError`
+(`packages/cli/lib/callable.ts`) called the same `validateSchemaValue` without
+that option, so the outer gate refused what the inner one accepted. It passes
+it now, through `isOpaqueReference`, which additionally requires the envelope's
+payload to be a record: `isLink` answers on shape alone and is true of
+`{"/": {"link@1": "nope"}}`. The design is
 [references as arguments](references-as-arguments.md).
+
+The second obstacle was the CLI's own, and neither the design nor this plan
+predicted it: the undeclared-field walk descended INTO the link envelope and
+reported `/` as a field the verb does not declare. Neither fix needs to know
+which positions declare a reference, which is why the capability landed with no
+`asCell` marker and no transformer change.
 
 *Measured: `send()` already resolves a native sigil.* A raw sigil link riding
 an event payload reaches the handler as the **resolved target**, not an
@@ -352,10 +360,15 @@ shape a read emits, or a caller cannot submit the address it was just handed.
 *CFC gets a notification, not a ruling* — an existing capability widening from
 the user's own model session to external principals.
 
-*Exit:* `cf piece call --piece <root> addPiece '{"piece": <address>}'` registers
-the piece — the root pattern's own verb, reachable today by `pieces.add` from
-inside the runtime and by a model through the dialog builtin, and by no other
-caller.
+*Exit, met by #5880:* `cf piece call --piece <root> addPiece
+'{"piece": <address>}'` registers the piece. That verb was reachable by
+`pieces.add` from inside the runtime and by a model through the dialog builtin,
+and by no other caller; a CLI caller now reaches it too, and the edge that comes
+back is the target rather than a copy of it.
+
+*The exit the item still owes:* the same call sending the target's SHAPE rather
+than its address is refused, instead of storing a detached copy and reporting
+success.
 
 **12. `cf` refuses an undeclared field on a call.** *(S)* **On main as
 #5835.** The failure it removes: a payload carrying a field the verb does not

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -53,7 +53,7 @@ without reconstructing it.
 | 2. an unrecognized projection key is refused | on main (#5817); design landed (#5753) |
 | 3. a rejection propagates up through what holds it | on main (#5701) |
 | 5. `cf wish` and `cf exec` take the read options | on main (#5844) |
-| 11. a caller may name a reference | not started; sequenced, gated on one measurement |
+| 11. a caller may name a reference | **capability on main** (#5880); the refusal that protects it is not built |
 
 Item 9 is split because its two halves have different fates: the marks landed,
 the emission is parked.
@@ -277,13 +277,23 @@ adding a fourth.
 *Exit:* the same cell, reached four ways, renders identically under the same
 selection.
 
-**11. A caller may name a reference.** *(M)* A verb whose event declares
-`Writable<T>` is callable by a model and by nothing else. `traverseAndCellify`
-(`packages/runner/src/builtins/llm-dialog.ts`) resolves `{"@link": …}` into a
-live cell before dispatch, so the LLM boundary has a complete round trip; the
-CLI rejects the address and the webhook path forwards it unresolved. The
-shape-matching payload the CLI *does* accept stores a detached copy and reports
-success.
+**11. A caller may name a reference.** *(M)* **The capability is on main
+as #5880.** A caller names an existing cell where a verb declares a reference,
+and the edge that comes back is the target rather than a copy of it.
+
+What it removes: a verb whose event declared `Writable<T>` was callable by a
+model and by nothing else. `traverseAndCellify`
+(`packages/runner/src/builtins/llm-dialog.ts`) resolved `{"@link": …}` into a
+live cell before dispatch, so the LLM boundary had a complete round trip while
+the CLI rejected the address and the webhook path forwarded it unresolved.
+
+**The refusal that protects it is not built.** A shape-matching payload is
+still accepted, still stores a detached copy, and still reports success — so a
+caller who sends the shape rather than the address is told it worked. Refusing
+that needs to identify a reference position, which needs the `asCell` marker,
+and the marker reaches nothing the CLI can read: the served event schema is the
+handler's narrowed read, and the stored pattern's declared schema has lost it
+too. #5560 carries the measurements.
 
 *The refusal is drift, not policy.* `closedWorldEventRejection`
 (`packages/runner/src/runner.ts`) validates a present event payload with
@@ -476,7 +486,7 @@ its own track.
 | 12 | An unrecognized projection key is refused | **on main** (#5817) — item 2 | 9 | The largest remaining step, and the one carrying design surface, since it couples the projection reader to the compatibility checker's annotation keys. Its design is [projection keys, and the schema a read is handed](../history/plans/projection-key-classification.md) |
 | 12a | `cf` refuses an undeclared field on a call | **on main** (#5835) — item 12 | — | Same refusal shape as the step above and independent of it, so it can go either side; building them together is what keeps one vocabulary for what a refusal says. Built against #5817's wording rather than its code, since that branch is unmerged |
 | 13 | `cf wish` and `cf exec` take the read options | **on main** (#5844) — item 5 | 11, 12 | Last by construction: it spreads the vocabulary to two more starting points, so the vocabulary should have stopped moving — and it now has. No resolving marker is planned, so the grammar step 13 spreads is the grammar that exists |
-| 14 | A caller may name a reference | item 11, #5560 | — | Item 11 has carried this since the State table was written and the ordering never gave it a step, so nothing scheduled it. Sequenced last only because it is unstarted, not because anything gates it — and it is the most consequential thing open: the shape-matching payload the CLI does accept **stores a detached copy and reports success**, so a caller relating two pieces is told it worked |
+| 14 | A caller may name a reference | **capability on main** (#5880) — item 11, #5560 | — | A caller can now name an existing cell where a verb declares a reference, and the edge that comes back is the target rather than a copy of it. What remains is the REFUSAL that protects it: a shape-matching payload still **stores a detached copy and reports success**, so a caller who sends the shape instead of the address is still told it worked. Refusing it needs to identify a reference position, which needs the `asCell` marker, which reaches nothing the CLI can read — see #5560 for the measurements |
 
 **`--show-links` is not redundant, and nothing should schedule its removal
 yet.** [Verb result selection](verb-result-selection.md) prices it as a stopgap


### PR DESCRIPTION
## Why

#5880 landed the capability — a caller names an existing cell where a verb declares a reference, and the edge that comes back is the target rather than a copy of it. The plan still read `not started; sequenced, gated on one measurement`.

That measurement is done, and it moved the item rather than merely unblocking it. Three of item 11's four parts turned out to share one cause, and the capability reached `main` without solving any of them: the runtime accepts a link anywhere (`acceptOpaqueValue: isCellLink`, unconditional), so the only obstacle was the CLI's own undeclared-field walk descending into the link envelope and reading `/` as a field.

## What Changed

Three places, all saying the same two things — what landed, and what did not.

**What did not is the half a reader will act on.** The refusal that protects the capability is not built: a shape-matching payload is still accepted, still stores a detached copy, and still reports success, so a caller who sends the shape rather than the address is told it worked. Refusing that needs to identify a reference position, which needs the `asCell` marker, and the marker reaches nothing the CLI can read — the served event schema is the handler's narrowed read, and the stored pattern's declared schema has lost it too.

#5560 carries the measurements behind each of those claims.

## Test plan

`deno task check-docs` and `deno fmt --check` clean. No code changes.

## Note

This is the fifth correction to this document's status this week, after #5864 fixed four rows naming merged PRs as "in review". The general form — a gate reading every `(#NNNN)` in the file against its PR state, the way `check-docs-history-index` reads the index — is still unwritten, and this row would not have caught it anyway: nothing was stale about the PR number, the sizing itself had changed under it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

