### PR TITLE
feat(cli): a --piece reference that names its space supplies it

### DIFF
--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -237,10 +237,13 @@ cf exec --select comment.writtenAt \
 
 A tool prints its result on stdout as it always did, with the result cell's
 address on stderr. The line spells out the whole command that reads it back,
-`--space` beside `--piece`: an address has three parts, and `cf piece get`
-takes the space on its own flag. `cf exec` gets its space from the mount it ran
-through, while `cf piece get` falls back to whichever space the caller has
-configured, so the two name the same cell only when the line says which.
+and the address is one token that carries all three parts — space, id, and
+scope — as the canonical `/@did:.../of:...` reference `--piece` takes whole.
+Naming the space inside the token is what makes the command portable: `cf exec`
+gets its space from the mount it ran through, while `cf piece get` falls back
+to whichever space the caller has configured, so an address that named only id
+and scope would read the right cell only for a reader configured for the same
+space.
 
 `packages/cli/README.md` has the grammar and the supported schema subset.
 

--- a/docs/tutorial/06-workflow.md
+++ b/docs/tutorial/06-workflow.md
@@ -122,6 +122,14 @@ deno task cf piece link <srcID>/items <dstID>/items    # wire two pieces
 deno task cf piece set-slug myslug <ID>                # pretty URL
 ```
 
+`--piece` takes an id (`fid1:abc...`), a slug, or the canonical fabric
+reference other commands print (`/of:fid1:...`). The canonical form can carry
+its space — `/@did:key:.../of:fid1:...` — and a reference that does needs no
+`-s` beside it: the embedded space supplies the target, and a `-s` that
+disagrees with it is refused. So an address copied off one command's output
+drives the next command unchanged, even from a shell configured for a
+different space.
+
 One subtlety: neither `piece set` nor `piece call` refreshes *computed*
 outputs. `set` writes the cell without running anything; `call` runs the
 handler (so the handler's own writes land and sync), but the scheduler is

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -78,7 +78,12 @@ Commands that take a piece accept two textual reference forms:
   `/[@did:.../]of:fid1:<id>[@scope][/path]`. This is the one reference syntax of
   the fabric — the same string names the same cell in patterns, in the shell,
   and here. A path embedded in a canonical `--piece` reference prefixes the
-  command's positional path argument.
+  command's positional path argument. A space embedded in it names the target
+  space: it supplies the space when `--space` is absent, and when both are given
+  they must agree — a mismatch is refused rather than resolved, at parse time
+  against a `--space` DID and once the session opens against a `--space` name.
+  An address printed by one command therefore composes into the next with no
+  flag beside it, whatever space the reader has configured.
 - The CLI's bare form: `pieceId[@scope]`, `pieceId[@scope]/path` at link
   endpoints, and slugs. This is a convenience alias for interactive use.
 

--- a/packages/cli/commands/exec.ts
+++ b/packages/cli/commands/exec.ts
@@ -1,7 +1,7 @@
 import { Command } from "@cliffy/command";
 import { executeMountedCallableFile } from "../lib/exec.ts";
 import { cliText } from "../lib/cli-name.ts";
-import { addressArgument, type InvocationPhase } from "../lib/callable.ts";
+import { canonicalAddress, type InvocationPhase } from "../lib/callable.ts";
 import {
   exitPieceCallFailure,
   exitWithDataError,
@@ -43,13 +43,12 @@ export interface ExecCommandOptions {
  * piece address, and that is the whole of the difference between them.
  *
  * **The result cell's address goes to stderr, written the way the next command
- * takes it.** An address has three parts, and the line spells all three where
- * that command wants them: `addressArgument` renders id and scope as the one
- * token `--piece` parses, and the space rides its own `--space` flag, because
- * that is where `cf piece get` reads it from. Naming the space is not
- * decoration — `cf exec` takes its space from the mount, while `cf piece get`
- * falls back to whatever space the caller has configured, so a line that
- * omitted it would suggest a command that reads a different cell.
+ * takes it.** An address has three parts, and `canonicalAddress` renders all
+ * three as the one token `--piece` parses, the space embedded as its
+ * `/@did:.../` prefix. Naming the space is not decoration — `cf exec` takes
+ * its space from the mount, while `cf piece get` falls back to whatever space
+ * the caller has configured, so a token that omitted it would suggest a
+ * command that reads a different cell.
  *
  * Extracted from the action body so it is unit-coverable: command action
  * bodies never execute under the unit suite (docs/development/COVERAGE.md).
@@ -70,10 +69,10 @@ export function renderExecOutcome(
   if (result.outputText) {
     write(result.outputText);
     if (result.resultRef) {
-      const address = addressArgument(result.resultRef);
+      const address = canonicalAddress(result.resultRef);
       writeError(
         `Tool result cell: ${address} (read it back with \`cf piece get ` +
-          `--space ${result.resultRef.space} --piece ${address}\`)`,
+          `--piece ${address}\`)`,
       );
     }
     return;

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -740,9 +740,11 @@ export function renderPieceCallOutcome(
       // asked for the bare result.
       //
       // Written as an address argument, which is the same spelling the
-      // receipt hint below uses and the same one `cf exec` prints: a caller
-      // reads the address off one command and passes it to the next without
-      // taking it apart first.
+      // receipt hint below uses: a caller reads the address off one command
+      // and passes it to the next without taking it apart first. It stays
+      // bare because the readback runs under the same configured space as
+      // the call; `cf exec`, whose space comes from the mount instead,
+      // prints the space-carrying canonical form.
       const ref = addressArgument(result.resultRef);
       hintOut(
         `Tool result cell: ${ref} (read it back with ` +
@@ -1047,7 +1049,9 @@ const EX_COMP = `--api-url ${RAW_EX_COMP.apiUrl} --space ${RAW_EX_COMP.space}`;
 const EX_COMP_PIECE = `${EX_COMP} --piece ${RAW_EX_COMP.piece!}`;
 const PIECE_OPTION_HELP =
   "The target piece: an id, slug, or canonical LLM-friendly reference " +
-  "(/of:fid1:.../).";
+  "(/of:fid1:.../). A space embedded in the reference (/@did:.../of:.../) " +
+  "supplies --space when the flag is absent, and must agree with it when " +
+  "both are given.";
 const PIECE_OPTION_PATH_HELP = `${PIECE_OPTION_HELP} A path embedded in ` +
   `the reference prefixes the positional path.`;
 const PIECE_REGISTRY_LINK_EXAMPLE = [
@@ -2537,6 +2541,12 @@ export function parsePieceOptions(
 // ways of defining service components, we cannot make the options
 // "required" with cliffy. Ensure that all required values are
 // available after parsing both args and env vars.
+//
+// The space can arrive three ways: `--url` embeds it, `--space` names it, and
+// a canonical `--piece` reference may carry it as a `/@did:.../` prefix. A
+// reference's space fills an absent `--space`; a present one must agree —
+// checked at parse time when `--space` is a DID, and at session open through
+// `validateEmbeddedSpaces` when it is a name still to be resolved.
 export function parseSpaceOptions(
   input: PieceCLIOptions,
 ): SpaceConfig {
@@ -2574,12 +2584,6 @@ export function parseSpaceOptions(
       { exitCode: 1 },
     );
   }
-  if (!input.space) {
-    throw new ValidationError(
-      `Missing required option: "--space".`,
-      { exitCode: 1 },
-    );
-  }
 
   if (input.piece) {
     // Do not validate here -- piece is only
@@ -2591,7 +2595,10 @@ export function parseSpaceOptions(
       output.piece = llmRef.pieceId;
       if (llmRef.scope) output.pieceScope = llmRef.scope;
       if (llmRef.path.length > 0) output.piecePath = llmRef.path;
-      if (llmRef.embeddedSpace) output.embeddedSpaces = [llmRef.embeddedSpace];
+      if (llmRef.embeddedSpace) {
+        output.embeddedSpaces = [llmRef.embeddedSpace];
+        if (!input.space) output.space = llmRef.embeddedSpace;
+      }
     } else {
       const parsedPiece = parseScopedId(input.piece);
       output.piece = parsedPiece.id;
@@ -2599,15 +2606,15 @@ export function parseSpaceOptions(
     }
   }
 
-  output.apiUrl = normalizeApiUrl(input.apiUrl);
-  output.space = input.space;
-
-  if (!input.identity) {
+  if (input.space) output.space = input.space;
+  if (!output.space) {
     throw new ValidationError(
-      `Missing required option: "--identity", or "CF_IDENTITY".`,
+      `Missing required option: "--space".`,
       { exitCode: 1 },
     );
   }
+
+  output.apiUrl = normalizeApiUrl(input.apiUrl);
   return output as PieceConfig;
 }
 

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -232,11 +232,23 @@ export interface CallableResultRef {
  * a different cell.
  *
  * The space is not part of it: an address argument is read against the space
- * the command is connected to, and a caller carrying one across spaces names
- * the other with `--space` rather than inside the id.
+ * the command is connected to. A caller carrying one across spaces writes
+ * {@link canonicalAddress}, the spelling whose reference names its own space.
  */
 export function addressArgument(ref: CallableResultRef): string {
   return ref.scope === "space" ? ref.id : `${ref.id}@${ref.scope}`;
+}
+
+/**
+ * `ref` written as the canonical fabric reference with its space embedded —
+ * `/@<space>/<id>[@scope]` — the one token that names the cell from any
+ * configuration. `--piece` takes it whole: the embedded space supplies the
+ * target space when `--space` is absent, and is checked against it when both
+ * are named. The id-and-scope segment is {@link addressArgument}'s, so the
+ * two spellings of an address cannot drift apart.
+ */
+export function canonicalAddress(ref: CallableResultRef): string {
+  return encodeJsonPointer(["", `@${ref.space}`, addressArgument(ref)]);
 }
 
 export interface ExecutedCallable {

--- a/packages/cli/test/exec-read-options.test.ts
+++ b/packages/cli/test/exec-read-options.test.ts
@@ -364,19 +364,21 @@ describe("cf exec read options", () => {
       { write: (text) => out.push(text), writeError: (text) => err.push(text) },
     );
 
-    // stdout stays exactly the tool's result; the address rides stderr in the
-    // `<id>@<scope>` form `--piece` parses, rather than the prose spelling
-    // `<id> (space <space>, scope <scope>)` that no command accepts.
+    // stdout stays exactly the tool's result; the address rides stderr as the
+    // canonical `/@<space>/<id>@<scope>` reference `--piece` parses, rather
+    // than the prose spelling `<id> (space <space>, scope <scope>)` that no
+    // command accepts.
     expect(out).toEqual(["{}"]);
     expect(err).toHaveLength(1);
-    expect(err[0]).toContain("of:tool-result@user");
     expect(err[0]).not.toContain("(space ");
-    // All three parts of the address, each where the reading command takes it.
-    // Dropping the space leaves a command that runs and reads whichever space
-    // the caller happens to have configured, which is the failure a spelling
-    // no command accepts at least could not cause.
+    // All three parts of the address inside the one token. Dropping the space
+    // leaves a command that runs and reads whichever space the caller happens
+    // to have configured — `cf exec` takes its space from the mount, so the
+    // two need not agree. The token carrying it is what lets the suggested
+    // command name no `--space` at all.
+    expect(err[0]).not.toContain("--space");
     expect(err[0]).toContain(
-      "cf piece get --space did:key:test-home --piece of:tool-result@user",
+      "cf piece get --piece /@did:key:test-home/of:tool-result@user",
     );
   });
 
@@ -396,7 +398,7 @@ describe("cf exec read options", () => {
     );
 
     expect(err[0]).toContain(
-      "cf piece get --space did:key:test-home --piece of:tool-result`)",
+      "cf piece get --piece /@did:key:test-home/of:tool-result`)",
     );
     expect(err[0]).not.toContain("@space");
   });

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -4772,8 +4772,10 @@ describe("renderPieceCallOutcome", () => {
     assertEquals(hinted.length, 1);
     assertStringIncludes(hinted[0], "of:x");
     // The address argument the next command takes, not the three-part prose
-    // that named the same cell in a spelling nothing parses. `cf exec` prints
-    // the same shape for the same cell.
+    // that named the same cell in a spelling nothing parses. The token stays
+    // bare because the readback runs under the same configured space as the
+    // call; `cf exec`, whose space comes from the mount instead, prints the
+    // space-carrying canonical form for the same cell.
     assertStringIncludes(hinted[0], "cf piece get --piece of:x");
     expect(hinted[0]).not.toContain("(space did:key:s");
   });

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -390,6 +390,33 @@ describe("cli piece parsing", () => {
     });
   });
 
+  it("parseSpaceOptions() takes the space a canonical reference carries when --space is absent", () => {
+    const base = { apiUrl: API_URL, identity: ID };
+    expect(parseSpaceOptions({
+      ...base,
+      piece: `/@${SPACE_DID}/${LLM_HANDLE}`,
+    })).toMatchObject({
+      space: SPACE_DID,
+      piece: LLM_HANDLE,
+      embeddedSpaces: [SPACE_DID],
+    });
+    // The scope suffix and embedded path ride the same space-carrying token.
+    expect(parsePieceOptions(
+      { ...base, piece: `/@${SPACE_DID}/${LLM_HANDLE}@user/items/0` },
+      { acceptsPath: true },
+    )).toMatchObject({
+      space: SPACE_DID,
+      piece: LLM_HANDLE,
+      pieceScope: "user",
+      piecePath: ["items", 0],
+    });
+    // A reference that names no space supplies none: the requirement stands.
+    expect(() => parseSpaceOptions({ ...base, piece: `/${LLM_HANDLE}` }))
+      .toThrow(/--space/);
+    expect(() => parseSpaceOptions({ ...base, piece: PIECE }))
+      .toThrow(/--space/);
+  });
+
   it("parsePieceOptions() throws on incomplete input", () => {
     expect(() =>
       parsePieceOptions({


### PR DESCRIPTION
## Why

CLI surface shape, step 3 (`docs/plans/cli-surface-shape.md`). The canonical reference form already parsed — `--piece /of:fid1:…` worked — but a reference carrying its own space did not supply it: `--piece /@did:key:…/of:fid1:…` failed with `Missing required option: "--space"`, because `parseSpaceOptions` resolved the space before `--piece` was parsed and discarded the embedded DID. The plan's justification for this step is that an emitted address composes into the next command; without this, it did not compose across spaces.

The concrete cost was `cf exec`'s result hint, which had to spell `cf piece get --space <did> --piece <addr>` — two flags that must travel together, because `cf exec` takes its space from the mount while `cf piece get` falls back to whatever the caller has configured. (#5844 dropped the space from that hint and two tests pinned the regression; #5850 put it back as a second flag. This closes the shape properly: the address is one token that cannot lose its space.)

## What changed

- `parseSpaceOptions` (`packages/cli/commands/piece.ts`): a canonical `--piece` reference's `/@did:…/` prefix fills an absent `--space`. When both are given they must agree — refused at parse time against a `--space` DID, and at session open (`validateEmbeddedSpaces`, unchanged) against a `--space` name. Silently picking either side is how a caller reads the wrong space without knowing, so conflict stays a refusal. Also drops a dead duplicate `--identity` check.
- `canonicalAddress` (`packages/cli/lib/callable.ts`): the space-carrying spelling beside `addressArgument`, composed over the runner's `encodeJsonPointer` and `addressArgument` itself so the two spellings cannot drift. `addressArgument`'s doc comment is rewritten — "names the other with `--space`" is no longer the only way.
- `renderExecOutcome` (`packages/cli/commands/exec.ts`): the result hint collapses to the one spaced token: `cf piece get --piece /@did/of:…@scope`. `cf piece call`'s own hint stays bare deliberately (readback runs under the same configured space as the call); the comments claiming the two print the same shape are updated to say why they differ.
- Docs owed by step 3: `packages/cli/README.md` (Piece references), `docs/tutorial/06-workflow.md` (where `--piece` is taught), `docs/common/verbs-over-the-cli.md` (the readback paragraph).

Not changed: `--url` beside a space-carrying `--piece` still ignores `--piece` entirely (pre-existing; the `--url` early return never reaches the piece parse). Bare references gain nothing — new reference-syntax capability lands in the canonical form only, per the ordering rule in `lib/llm-friendly-ref.ts`.

## Test plan

- New unit case: `parseSpaceOptions()` takes the space a canonical reference carries when `--space` is absent (plus scope/path riding the same token, and the missing-`--space` refusal standing for space-less references).
- Updated the two `exec-read-options` tests that pinned the two-flag hint.
- Full `packages/cli` suite: 174 passed, 0 failed. Repo-wide `deno fmt --check`, `deno lint`, `deno task check-docs` green.
- Coverage delta vs `origin/main`, same suite both sides: −2 zero-hit lines for `packages/cli`.
- Measured live against a local toolshed: address-only read works; conflicting `--space` DID refused at parse; matching `--space` name passes; wrong `--space` name refused at session open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

