### PR TITLE
A disposed runtime takes its storage subscribers with it

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1337,8 +1337,31 @@ export class Runner {
     MemorySpace[]
   >();
 
+  /** The subscriber registered below, kept so disposal can hand it back.
+   * `subscribe` returns nothing, so the ARGUMENT is the only handle there
+   * will ever be — building one inline leaves it unreachable. */
+  readonly #storageSubscription: IStorageSubscription;
+
   constructor(readonly runtime: Runtime) {
-    this.runtime.storageManager.subscribe(this.createStorageSubscription());
+    this.#storageSubscription = this.createStorageSubscription();
+    this.runtime.storageManager.subscribe(this.#storageSubscription);
+  }
+
+  /**
+   * Unregister from storage notifications.
+   *
+   * A storage manager outliving this runner keeps every subscriber it was
+   * given, and each one holds its runner reachable — so a process reusing one
+   * manager across runtimes (`Runtime.dispose({ closeStorage: false })`, which
+   * exists for exactly that) accumulates them. The subscription cannot retire
+   * itself either: its `next` returns `{ done: false }` unconditionally, and
+   * `{ done: true }` is the only self-cancelling answer the contract has.
+   *
+   * `unsubscribe` is optional on the capability, so a manager that does not
+   * implement it is left as it was rather than crashing a disposal.
+   */
+  dispose(): void {
+    this.runtime.storageManager.unsubscribe?.(this.#storageSubscription);
   }
 
   /**

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1428,8 +1428,13 @@ export class Runtime {
     // Wait for any pending operations
     await this.scheduler.idle();
 
-    // Clean up scheduler timers
+    // Clean up scheduler timers, and unregister both storage subscribers.
+    // Last, and after the final `idle()` above, because a subscriber removed
+    // earlier would miss notifications the settling work above still depends
+    // on. It matters most when `closeStorage` is false: the manager outlives
+    // this runtime, and anything it still holds holds a disposed runtime.
     this.scheduler.dispose();
+    this.runner.dispose();
 
     // Pop the default frame
     if (this.defaultFrame) {

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -552,7 +552,7 @@ export class Scheduler {
   private unsubscribeState!: SchedulerUnsubscribeActionState;
   /** The storage subscriber registered in the constructor, kept so `dispose`
    * can hand it back. */
-  private readonly storageSubscription: IStorageSubscription;
+  readonly #storageSubscription: IStorageSubscription;
 
   private idlePromises: (() => void)[] = [];
   private backgroundTasks = new Set<Promise<unknown>>();
@@ -626,8 +626,8 @@ export class Scheduler {
     // Subscribe to storage notifications. The subscriber is retained because
     // `subscribe` returns nothing — the argument is the only handle disposal
     // will ever have to hand back, and one built inline is unreachable.
-    this.storageSubscription = this.createStorageSubscription();
-    this.runtime.storageManager.subscribe(this.storageSubscription);
+    this.#storageSubscription = this.createStorageSubscription();
+    this.runtime.storageManager.subscribe(this.#storageSubscription);
 
     // Set up harness event listeners
     this.runtime.harness.addEventListener("console", (e: Event) => {
@@ -1869,7 +1869,7 @@ export class Scheduler {
     // `{ done: true }` is the only self-cancelling answer the contract has.
     // `unsubscribe` is optional on the capability, so a manager without one is
     // left as it was rather than crashing a disposal.
-    this.runtime.storageManager.unsubscribe?.(this.storageSubscription);
+    this.runtime.storageManager.unsubscribe?.(this.#storageSubscription);
     this.headEventLoadPark = null;
     this.headEventLoadParkHistory = null;
     this.disposed = true;

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -550,6 +550,9 @@ export class Scheduler {
   private subscriptionState!: SchedulerSubscriptionState;
   private subscribeActionState!: SchedulerSubscribeActionState;
   private unsubscribeState!: SchedulerUnsubscribeActionState;
+  /** The storage subscriber registered in the constructor, kept so `dispose`
+   * can hand it back. */
+  private readonly storageSubscription: IStorageSubscription;
 
   private idlePromises: (() => void)[] = [];
   private backgroundTasks = new Set<Promise<unknown>>();
@@ -620,10 +623,11 @@ export class Scheduler {
       errorHandlers.forEach((handler) => this.errorHandlers.add(handler));
     }
 
-    // Subscribe to storage notifications
-    this.runtime.storageManager.subscribe(
-      this.createStorageSubscription(),
-    );
+    // Subscribe to storage notifications. The subscriber is retained because
+    // `subscribe` returns nothing — the argument is the only handle disposal
+    // will ever have to hand back, and one built inline is unreachable.
+    this.storageSubscription = this.createStorageSubscription();
+    this.runtime.storageManager.subscribe(this.storageSubscription);
 
     // Set up harness event listeners
     this.runtime.harness.addEventListener("console", (e: Event) => {
@@ -1859,6 +1863,13 @@ export class Scheduler {
    * Should be called when the scheduler is being torn down.
    */
   dispose(): void {
+    // A storage manager outliving this scheduler keeps every subscriber it was
+    // given, and each holds its scheduler reachable. The subscription does not
+    // retire itself: its `next` returns `{ done: false }` unconditionally, and
+    // `{ done: true }` is the only self-cancelling answer the contract has.
+    // `unsubscribe` is optional on the capability, so a manager without one is
+    // left as it was rather than crashing a disposal.
+    this.runtime.storageManager.unsubscribe?.(this.storageSubscription);
     this.headEventLoadPark = null;
     this.headEventLoadParkHistory = null;
     this.disposed = true;

--- a/packages/runner/test/runtime-dispose-keep-storage.test.ts
+++ b/packages/runner/test/runtime-dispose-keep-storage.test.ts
@@ -28,6 +28,7 @@ import { Identity } from "@commonfabric/identity";
 import type { MemorySpace, Signer } from "@commonfabric/memory/interface";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import type { IStorageSubscription } from "../src/storage/interface.ts";
 import {
   type Options,
   type SessionFactory,
@@ -69,6 +70,10 @@ class LoopbackSessionFactory implements SessionFactory {
  */
 class CountingStorageManager extends StorageManager {
   closeCount = 0;
+  /** Subscribers currently registered. The relay inside exposes only
+   * `hasSubscribers()`, and what a leak needs is the COUNT: two per runtime,
+   * so "some are registered" cannot tell a clean teardown from a leaking one. */
+  readonly live = new Set<IStorageSubscription>();
   static over(server: MemoryV2Server.Server): CountingStorageManager {
     return new CountingStorageManager(
       { as: signer, memoryHost: new URL("memory://") } as Options,
@@ -78,6 +83,14 @@ class CountingStorageManager extends StorageManager {
   override close(): Promise<void> {
     this.closeCount++;
     return super.close();
+  }
+  override subscribe(subscription: IStorageSubscription): void {
+    this.live.add(subscription);
+    super.subscribe(subscription);
+  }
+  override unsubscribe(subscription: IStorageSubscription): void {
+    this.live.delete(subscription);
+    super.unsubscribe(subscription);
   }
 }
 
@@ -254,5 +267,38 @@ describe("runtime.dispose({ closeStorage })", () => {
     // Verified by mutation: with `settled()` left at its default cap this reads
     // 50, and the chain is still running after dispose returned.
     expect(reached).toBe(GENERATIONS);
+  });
+
+  it("leaves no storage subscriber behind on a store it does not close", async () => {
+    // `Scheduler` and `Runner` each register one at construction. `subscribe`
+    // returns nothing, so the argument is the only handle there will ever be —
+    // a subscription built inline is unreachable and can never be handed back.
+    // Nor can it retire itself: both return `{ done: false }` unconditionally,
+    // and `{ done: true }` is the contract's only self-cancelling answer.
+    //
+    // The count matters, not the presence. A manager outliving its runtimes
+    // accumulates two per runtime, each holding a disposed scheduler or runner
+    // reachable, and `hasSubscribers()` reads the same either way.
+    const baseline = held.live.size;
+
+    const first = new Runtime({
+      apiUrl: new URL("memory://"),
+      storageManager: held,
+    });
+    expect(held.live.size).toBe(baseline + 2);
+    await first.dispose({ closeStorage: false });
+    expect(held.live.size).toBe(baseline);
+
+    // And across several, because one runtime returning to baseline would also
+    // hold if disposal removed a subscriber some OTHER runtime had registered.
+    for (let i = 0; i < 3; i++) {
+      const runtime = new Runtime({
+        apiUrl: new URL("memory://"),
+        storageManager: held,
+      });
+      await runtime.dispose({ closeStorage: false });
+    }
+    expect(held.live.size).toBe(baseline);
+    expect(held.closeCount).toBe(0);
   });
 });

--- a/packages/runner/test/runtime-dispose-keep-storage.test.ts
+++ b/packages/runner/test/runtime-dispose-keep-storage.test.ts
@@ -276,29 +276,44 @@ describe("runtime.dispose({ closeStorage })", () => {
     // Nor can it retire itself: both return `{ done: false }` unconditionally,
     // and `{ done: true }` is the contract's only self-cancelling answer.
     //
-    // The count matters, not the presence. A manager outliving its runtimes
-    // accumulates two per runtime, each holding a disposed scheduler or runner
-    // reachable, and `hasSubscribers()` reads the same either way.
-    const baseline = held.live.size;
+    // What is asserted is the CALLERS' half of the contract — that each keeps
+    // its subscription and returns it — because that is the half in question.
+    // `live` mirrors the subscribe/unsubscribe calls reaching the manager, not
+    // the relay's membership: the relay is private and its `hasSubscribers()`
+    // is not surfaced, and it would answer the wrong question anyway, reading
+    // the same whether teardown was clean or leaked two per runtime.
+    const baseline = new Set(held.live);
+    const addedBy = (built: Set<IStorageSubscription>) =>
+      [...held.live].filter((s) => !built.has(s));
 
     const first = new Runtime({
       apiUrl: new URL("memory://"),
       storageManager: held,
     });
-    expect(held.live.size).toBe(baseline + 2);
-    await first.dispose({ closeStorage: false });
-    expect(held.live.size).toBe(baseline);
+    const firstPair = addedBy(baseline);
+    expect(firstPair).toHaveLength(2);
 
-    // And across several, because one runtime returning to baseline would also
-    // hold if disposal removed a subscriber some OTHER runtime had registered.
-    for (let i = 0; i < 3; i++) {
-      const runtime = new Runtime({
-        apiUrl: new URL("memory://"),
-        storageManager: held,
-      });
-      await runtime.dispose({ closeStorage: false });
-    }
-    expect(held.live.size).toBe(baseline);
+    // The two runtimes OVERLAP, and the assertions name WHICH subscriptions are
+    // handed back rather than how many. Sequential construct-dispose rounds
+    // would not: neither round ever has another runtime's subscription to
+    // return by mistake, so a disposal that gave back the wrong one still ends
+    // at baseline.
+    const second = new Runtime({
+      apiUrl: new URL("memory://"),
+      storageManager: held,
+    });
+    const secondPair = addedBy(new Set([...baseline, ...firstPair]));
+    expect(secondPair).toHaveLength(2);
+
+    await first.dispose({ closeStorage: false });
+    expect(firstPair.filter((s) => held.live.has(s))).toEqual([]);
+    expect(secondPair.filter((s) => held.live.has(s))).toEqual(secondPair);
+
+    await second.dispose({ closeStorage: false });
+    expect(secondPair.filter((s) => held.live.has(s))).toEqual([]);
+    expect(held.live).toEqual(baseline);
+
+    // Neither disposal closed the store, which is the option's whole point.
     expect(held.closeCount).toBe(0);
   });
 });


### PR DESCRIPTION
## Why

Closes #5892.

`Scheduler` and `Runner` each register a storage-notification subscriber when
they are constructed, and nothing ever takes it back. A `StorageManager` that
outlives the runtimes built over it therefore accumulates two subscribers per
runtime, and each one holds a disposed scheduler or runner reachable.

`Runtime.dispose({ closeStorage: false })` is the case that matters, because it
exists precisely so one storage manager can be reused across runtimes. A
long-lived process doing that repeatedly grows without bound.

Neither subscription can retire itself. The contract cancels a subscription
whose `next` returns `{ done: true }` or throws
(`IStorageNotification`, `storage/interface.ts`), and both return
`{ done: false }` unconditionally.

The capability to fix it was already there: `StorageManager.unsubscribe`
(`storage/v2.ts`, delegating to the relay in `storage/subscription.ts`) takes
the subscription object back. What was missing was a reference to hand it —
both call sites built their subscription inline as an argument. `subscribe`
returns `void`, so the argument is the only handle that will ever exist, and
one built inline is unreachable the moment the call returns.

## What Changed

- `Scheduler` retains its subscription and unsubscribes in `dispose()`.
- `Runner` retains its subscription and gains a `dispose()` that unsubscribes.
  A new method rather than folding it into `stopAll()`: `stopAll` has one
  caller today, but its name does not promise disposal-only, and a future
  second caller would silently deafen a live runner.
- `Runtime.dispose()` calls `runner.dispose()` alongside the existing
  `scheduler.dispose()` — last, after the final `idle()`, so a subscriber
  removed early cannot miss notifications the settling work still depends on.

`unsubscribe` is optional on `IStorageNotificationCapability`, so both calls
use `?.` and a manager without one is left as it was rather than crashing a
disposal.

## Test plan

`runtime-dispose-keep-storage.test.ts` gains a case that counts subscribers on
the manager across four runtimes constructed and disposed against it, and
asserts the count returns to its starting value. It counts rather than asking
`hasSubscribers()`, because a leak of two-per-runtime reads identically to a
clean teardown through that predicate.

Verified by mutation, one fix at a time:

- Drop `runner.dispose()` from `Runtime.dispose` → FAILED.
- Drop the `unsubscribe` from `Scheduler.dispose` → FAILED.

Both restored, test green. `packages/runner` suite green; `deno fmt --check`,
`deno lint`, `deno task check`, `deno task check-no-waitfor` all green.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

