### PR TITLE
feat(cli): positional addresses and the #argument suffix

### DIFF
--- a/docs/tutorial/06-workflow.md
+++ b/docs/tutorial/06-workflow.md
@@ -130,6 +130,11 @@ disagrees with it is refused. So an address copied off one command's output
 drives the next command unchanged, even from a shell configured for a
 different space.
 
+On `get`, `set`, and `call`, the canonical reference can also sit in the
+first positional instead of the flag — `cf piece get /of:fid1:.../items` —
+and a trailing `#argument` selects the piece's arguments cell the way
+`--input` does.
+
 One subtlety: neither `piece set` nor `piece call` refreshes *computed*
 outputs. `set` writes the cell without running anything; `call` runs the
 handler (so the handler's own writes land and sync), but the scheduler is

--- a/docs/tutorial/06-workflow.md
+++ b/docs/tutorial/06-workflow.md
@@ -131,9 +131,10 @@ drives the next command unchanged, even from a shell configured for a
 different space.
 
 On `get`, `set`, and `call`, the canonical reference can also sit in the
-first positional instead of the flag — `cf piece get /of:fid1:.../items` —
-and a trailing `#argument` selects the piece's arguments cell the way
-`--input` does.
+first positional instead of the flag — `cf piece get /of:fid1:.../items`. On
+the commands that take `--input` (`get` and `set` here), a trailing
+`#argument` selects the piece's arguments cell the way that flag does;
+`call` takes no `--input` and refuses the suffix.
 
 One subtlety: neither `piece set` nor `piece call` refreshes *computed*
 outputs. `set` writes the cell without running anything; `call` runs the

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -90,6 +90,18 @@ Commands that take a piece accept two textual reference forms:
 New reference-syntax capabilities land in the canonical form first; the alias
 does not grow a capability the canonical form lacks.
 
+On `piece get`, `piece set`, and `piece call`, a canonical reference can sit in
+the first positional instead of riding `--piece`: an address begins with `/` and
+a relative path never does, so the two positions cannot collide. The bare and
+slug spellings stay on `--piece`, where no path competes for the position.
+Naming the target twice — `--piece` beside a positional address — is refused
+rather than resolved.
+
+A canonical reference may also end in `#argument`, which selects the piece's
+arguments cell the way `--input` does. Only commands that take `--input` accept
+it; `#` is reserved for the suffix, so a path key containing `#` needs the
+positional path spelling.
+
 ## Piece discovery
 
 `cf piece ls` lists the pieces in the selected space's piece registry. It reads
@@ -138,9 +150,10 @@ standard error and continues searching that piece and the rest of the space.
 ## Piece CFC labels
 
 `cf piece get-label` returns the effective CFC label view for a result path.
-Pass `--input` to select the input cell. The paths in the returned view are
-relative to the selected path, and the view includes declared, derived, and
-link-carried labels. An unlabeled value returns JSON `null`.
+Pass `--input` to select the input cell — a `--piece` reference ending in
+`#argument` selects it too. The paths in the returned view are relative to the
+selected path, and the view includes declared, derived, and link-carried labels.
+An unlabeled value returns JSON `null`.
 
 ```bash
 cf piece get-label --piece ID messages/0/body

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -2756,8 +2756,11 @@ export function readCallTarget(
 // The space can arrive three ways: `--url` embeds it, `--space` names it, and
 // a canonical `--piece` reference may carry it as a `/@did:.../` prefix. A
 // reference's space fills an absent `--space`; a present one must agree —
-// checked at parse time when `--space` is a DID, and at session open through
-// `validateEmbeddedSpaces` when it is a name still to be resolved.
+// checked at parse time when the target space is a DID, and at session open
+// through `validateEmbeddedSpaces` when it is a name still to be resolved.
+// The piece arrives through `--piece` (or the positional address it carries)
+// or inside the `--url`: a URL that names one excludes the flag, and a
+// piece-less URL composes with it.
 export function parseSpaceOptions(
   input: PieceCLIOptions,
 ): SpaceConfig {
@@ -2780,27 +2783,40 @@ export function parseSpaceOptions(
   };
   if (input.json) output.jsonOutput = true;
 
+  // The space the piece reference below is checked against: `--space`, or
+  // the space a `--url` embeds.
+  let targetSpace = input.space;
+
   if (input.url) {
     const { apiUrl, space, piece, pieceScope } = parseUrl(input.url);
     output.apiUrl = apiUrl;
     output.space = space;
-    output.piece = piece;
-    if (pieceScope) output.pieceScope = pieceScope;
-    return output as PieceConfig;
-  }
-
-  if (!input.apiUrl) {
-    throw new ValidationError(
-      `Missing required option: "--api-url", or "CF_API_URL".`,
-      { exitCode: 1 },
-    );
+    targetSpace = space;
+    if (piece) {
+      // Two pieces named at once is refused rather than resolved, the same
+      // rule "--space" beside "--url" follows: silently preferring either
+      // one is how a caller reads a target they did not name. `input.piece`
+      // may carry a positional address, so the message names both spellings.
+      if (input.piece) {
+        throw new ValidationError(
+          `A piece reference ("--piece" or a positional address) cannot ` +
+            `be provided when the "--url" names a piece.`,
+          { exitCode: 1 },
+        );
+      }
+      output.piece = piece;
+      if (pieceScope) output.pieceScope = pieceScope;
+      return output as PieceConfig;
+    }
+    // A piece-less URL supplies the host and space; the piece may still
+    // arrive through "--piece" (or the positional address it carries).
   }
 
   if (input.piece) {
     // Do not validate here -- piece is only
     // required via `parsePieceOptions`
     const llmRef = normalizeLLMFriendlyRef(input.piece, {
-      space: input.space,
+      space: targetSpace,
     });
     if (llmRef) {
       output.piece = llmRef.pieceId;
@@ -2809,7 +2825,7 @@ export function parseSpaceOptions(
       if (llmRef.input) output.pieceInput = true;
       if (llmRef.embeddedSpace) {
         output.embeddedSpaces = [llmRef.embeddedSpace];
-        if (!input.space) output.space = llmRef.embeddedSpace;
+        if (!targetSpace) output.space = llmRef.embeddedSpace;
       }
     } else {
       // The alias grammar has no fragments, and letting one through would
@@ -2827,6 +2843,14 @@ export function parseSpaceOptions(
     }
   }
 
+  if (input.url) return output as PieceConfig;
+
+  if (!input.apiUrl) {
+    throw new ValidationError(
+      `Missing required option: "--api-url", or "CF_API_URL".`,
+      { exitCode: 1 },
+    );
+  }
   if (input.space) output.space = input.space;
   if (!output.space) {
     throw new ValidationError(

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -7,7 +7,10 @@ import type {
 } from "@commonfabric/piece/ops";
 import ports from "@commonfabric/ports" with { type: "json" };
 import { parseCellPath, UI } from "@commonfabric/runner";
-import { parseScopedIdSegment } from "@commonfabric/runner/shared";
+import {
+  matchLLMFriendlyLink,
+  parseScopedIdSegment,
+} from "@commonfabric/runner/shared";
 import { decode } from "@commonfabric/utils/encoding";
 
 import { addressArgument, VerbInputValidationError } from "../lib/callable.ts";
@@ -1684,12 +1687,27 @@ well-known IDs. See docs/common/concepts/well-known-ids.md for IDs and usage.`,
     `Get a value from a piece at a specific path. Omit path to return the full result.
 
 PATH FORMAT: Use forward slashes and numeric indices for arrays.
-  ✓ items/0/name    ✓ config/db/host    ✗ items[0].name`,
+  ✓ items/0/name    ✓ config/db/host    ✗ items[0].name
+
+ADDRESS: The target can sit in the first positional instead of --piece when
+written as a canonical reference (it begins with "/"): cf piece get
+/of:fid1:.../items 0/name. A trailing #argument selects the arguments cell
+the way --input does.`,
   )
-  .usage(`${pieceUsage} [path]`)
+  .usage(`${pieceUsage} [addressOrPath] [path]`)
   .example(
     cliText(`cf piece get ${EX_ID} ${EX_COMP_PIECE} name`),
     `Get the "name" field from piece result "${RAW_EX_COMP.piece!}".`,
+  )
+  .example(
+    cliText(`cf piece get ${EX_ID} ${EX_COMP} /of:fid1:abc.../items 0/name`),
+    "Read through a positional canonical address; its embedded path applies.",
+  )
+  .example(
+    cliText(
+      `cf piece get ${EX_ID} ${EX_COMP} '/of:fid1:abc...#argument' draft`,
+    ),
+    `Read the piece's arguments cell ("#argument" spells --input).`,
   )
   .example(
     cliText(
@@ -1738,7 +1756,11 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
     "Return each item's address instead of its contents.",
   )
   .option("-c,--piece <piece:string>", PIECE_OPTION_PATH_HELP)
-  .option("--input", "Read from the piece's input cell instead of result cell")
+  .option(
+    "--input",
+    "Read from the piece's input cell instead of result cell (the " +
+      '"#argument" reference suffix spells the same selection)',
+  )
   .option(
     "--step",
     "Start and recompute the piece in this session before reading",
@@ -1765,35 +1787,8 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
     // said which shape it wants. Refuse before the read rather than pick.
     { conflicts: ["select"] },
   )
-  .arguments("[path:string]")
-  .action(async (options, pathString) => {
-    setQuietMode(!!options.quiet);
-    const pieceConfig = {
-      ...parsePieceOptions(options, { acceptsPath: true }),
-      jsonOutput: true,
-    };
-    const pathSegments = mergePiecePath(pieceConfig, pathString);
-    try {
-      const selection = await parseCellSelectionOptions(options);
-      const value = await getCellValue(pieceConfig, pathSegments, {
-        input: options.input,
-        step: options.step,
-        ...(selection === undefined ? {} : { selection }),
-      });
-      render(value, { json: true });
-    } catch (error) {
-      // A read that fails on a data condition — the path doesn't resolve, or
-      // the result schema can't project the stored data (PieceResultProjection
-      // Error) — is a data error, not a usage error. Report it on stderr
-      // instead of letting Cliffy dump the help screen over it.
-      const report = pieceGetDataErrorReport(error, {
-        input: options.input,
-        piece: pieceConfig.piece,
-      });
-      if (report) exitWithDataError(report);
-      throw error;
-    }
-  })
+  .arguments("[addressOrPath:string] [path:string]")
+  .action(getCellValueFromCommand)
   /* piece get-label */
   .command(
     "get-label",
@@ -1812,7 +1807,11 @@ declared, derived, and link-carried labels. Omit path to inspect the root.`,
     "Get the effective label on an input value.",
   )
   .option("-c,--piece <piece:string>", PIECE_OPTION_PATH_HELP)
-  .option("--input", "Read from the piece's input cell instead of result cell")
+  .option(
+    "--input",
+    "Read from the piece's input cell instead of result cell (the " +
+      '"#argument" reference suffix spells the same selection)',
+  )
   .option(
     "--json",
     "Select JSON output explicitly. This command always outputs JSON.",
@@ -1848,7 +1847,11 @@ updated effective label view.`),
     "Remove declared integrity claims from an input value.",
   )
   .option("-c,--piece <piece:string>", PIECE_OPTION_PATH_HELP)
-  .option("--input", "Write to the piece's input cell instead of result cell")
+  .option(
+    "--input",
+    "Write to the piece's input cell instead of result cell (the " +
+      '"#argument" reference suffix spells the same selection)',
+  )
   .option(
     "--json",
     "Select JSON output explicitly. This command always outputs JSON.",
@@ -1863,9 +1866,14 @@ updated effective label view.`),
 PATH FORMAT: Use forward slashes and numeric indices for arrays.
   ✓ items/0/name    ✓ config/db/host    ✗ items[0].name
 
-JSON VALUES: Strings need quotes: echo '"hello"' | cf piece set ...`),
+JSON VALUES: Strings need quotes: echo '"hello"' | cf piece set ...
+
+ADDRESS: The target can sit in the first positional instead of --piece when
+written as a canonical reference (it begins with "/"): a path embedded in it
+counts, so cf piece set /of:fid1:.../title needs no path argument. A trailing
+#argument selects the arguments cell the way --input does.`),
   )
-  .usage(`${pieceUsage} <path>`)
+  .usage(`${pieceUsage} [addressOrPath] [path]`)
   .example(
     cliText(`echo '"New Name"' | cf piece set ${EX_ID} ${EX_COMP_PIECE} name`),
     `Set the "name" field in piece result "${RAW_EX_COMP.piece!}".`,
@@ -1876,24 +1884,20 @@ JSON VALUES: Strings need quotes: echo '"hello"' | cf piece set ...`),
     ),
     `Set a nested object value in piece input "${RAW_EX_COMP.piece!}".`,
   )
+  .example(
+    cliText(
+      `echo '"Milk"' | cf piece set ${EX_ID} ${EX_COMP} /of:fid1:abc.../title`,
+    ),
+    "Write through a positional canonical address; the embedded path is the path.",
+  )
   .option("-c,--piece <piece:string>", PIECE_OPTION_PATH_HELP)
-  .option("--input", "Write to the piece's input cell instead of result cell")
-  .arguments("<path:string>")
-  .action(async (options, pathString) => {
-    setQuietMode(!!options.quiet);
-    const pieceConfig = parsePieceOptions(options, { acceptsPath: true });
-    const pathSegments = mergePiecePath(pieceConfig, pathString);
-    const value = await drainStdin();
-    await setCellValue(pieceConfig, pathSegments, value, {
-      input: options.input,
-    });
-    render(`Set value at path: ${pathSegments.join("/")}`);
-    hint(
-      cliText(
-        `TIP: Computed values may be stale. Run 'cf piece step --piece ${pieceConfig.piece} ...' to trigger recomputation.`,
-      ),
-    );
-  })
+  .option(
+    "--input",
+    "Write to the piece's input cell instead of result cell (the " +
+      '"#argument" reference suffix spells the same selection)',
+  )
+  .arguments("[addressOrPath:string] [path:string]")
+  .action(setCellValueFromCommand)
   /* piece map */
   .command("map", "Show registered pieces and the connections between them")
   .usage(spaceUsage)
@@ -1927,9 +1931,13 @@ Arguments after the callable use the same parser as cf exec. Use --json with an
 optional inline value for complete JSON input; bare --json reads JSON from
 stdin. A single positional JSON value or "-" stdin sentinel is also accepted.
 Use --help --json for machine-readable schema help. Put schema-derived flags
-after --. Handlers interpret piped input when no input argument is present.`,
+after --. Handlers interpret piped input when no input argument is present.
+
+ADDRESS: The target can precede the callable name instead of riding --piece
+when written as a canonical reference (it begins with "/"):
+cf piece call /of:fid1:... addItem '{"title":"Milk"}'.`,
   )
-  .usage(`${pieceUsage} <callable> [input]`)
+  .usage(`${pieceUsage} [address] <callable> [input]`)
   .example(
     cliText(`cf piece call ${EX_ID} ${EX_COMP_PIECE} increment`),
     `Call the "increment" handler on piece "${RAW_EX_COMP.piece!}".`,
@@ -1956,6 +1964,12 @@ after --. Handlers interpret piped input when no input argument is present.`,
   .example(
     cliText(`cf piece call ${EX_ID} ${EX_COMP_PIECE} search -- --query milk`),
     `Run the "search" tool using schema-derived flags after "--".`,
+  )
+  .example(
+    cliText(
+      `cf piece call ${EX_ID} ${EX_COMP} /of:fid1:abc... addItem '{"title":"Milk"}'`,
+    ),
+    "Name the target as a positional canonical address before the callable.",
   )
   .example(
     cliText(
@@ -2059,7 +2073,14 @@ after --. Handlers interpret piped input when no input argument is present.`,
   )
   .stopEarly()
   .arguments("<callable:string> [tail...:string]")
-  .action(async function (options, callableName, ...tail) {
+  .action(async function (options, callableArg, ...tailArgs) {
+    // Positional-address intake first: it is a fact about the argv alone,
+    // so a refusal here names no invocation and no phase.
+    const { piece, callableName, tail } = readCallTarget(
+      options,
+      callableArg,
+      tailArgs,
+    );
     const identity = resolveInvocationIdentity(
       options.invocation,
       options.invocationSession,
@@ -2097,6 +2118,7 @@ after --. Handlers interpret piped input when no input argument is present.`,
       );
       const pieceConfig = parsePieceOptions({
         ...options,
+        ...(piece !== undefined && { piece }),
         json: invocation.jsonOutput,
       });
       const result = await boundedSettlement(
@@ -2335,6 +2357,113 @@ export interface PieceLabelCommandDependencies {
   render?: typeof render;
 }
 
+export interface PieceGetCLIOptions extends PieceLabelCLIOptions {
+  step?: boolean;
+  filter?: string;
+  select?: string;
+  schema?: string;
+}
+
+export interface PieceCellCommandDependencies {
+  getCellValue?: typeof getCellValue;
+  setCellValue?: typeof setCellValue;
+  drainStdin?: typeof drainStdin;
+  render?: typeof render;
+  hint?: typeof hint;
+  exitWithDataError?: typeof exitWithDataError;
+}
+
+/**
+ * The `cf piece get` action: the target may ride `--piece` or sit in the
+ * first positional as a canonical address ({@link readTargetPositionals}
+ * decides which the positionals name), and either spelling may end in
+ * `#argument`, which reads the arguments cell the way `--input` does.
+ *
+ * A named export with seams rather than an inline action body because action
+ * bodies never execute under the unit suite (docs/development/COVERAGE.md).
+ */
+export async function getCellValueFromCommand(
+  options: PieceGetCLIOptions,
+  first?: string,
+  second?: string,
+  deps: PieceCellCommandDependencies = {},
+): Promise<void> {
+  setQuietMode(!!options.quiet);
+  const target = readTargetPositionals(options, first, second);
+  const pieceConfig = {
+    ...parsePieceOptions(
+      target.address ? { ...options, piece: target.address } : options,
+      { acceptsPath: true, acceptsArgument: true },
+    ),
+    jsonOutput: true,
+  };
+  const pathSegments = mergePiecePath(pieceConfig, target.pathString);
+  const input = options.input || pieceConfig.pieceInput;
+  try {
+    const selection = await parseCellSelectionOptions(options);
+    const value = await (deps.getCellValue ?? getCellValue)(
+      pieceConfig,
+      pathSegments,
+      {
+        input,
+        step: options.step,
+        ...(selection === undefined ? {} : { selection }),
+      },
+    );
+    (deps.render ?? render)(value, { json: true });
+  } catch (error) {
+    // A read that fails on a data condition — the path doesn't resolve, or
+    // the result schema can't project the stored data (PieceResultProjection
+    // Error) — is a data error, not a usage error. Report it on stderr
+    // instead of letting Cliffy dump the help screen over it.
+    const report = pieceGetDataErrorReport(error, {
+      input,
+      piece: pieceConfig.piece,
+    });
+    if (report) (deps.exitWithDataError ?? exitWithDataError)(report);
+    throw error;
+  }
+}
+
+/**
+ * The `cf piece set` action, with the same positional-address intake as
+ * {@link getCellValueFromCommand}. The write must land at a path — the
+ * root is `piece apply`'s job — and the path may arrive embedded in the
+ * address, positionally, or both, so the emptiness check runs on the merge
+ * rather than on any one spelling.
+ */
+export async function setCellValueFromCommand(
+  options: PieceLabelCLIOptions,
+  first?: string,
+  second?: string,
+  deps: PieceCellCommandDependencies = {},
+): Promise<void> {
+  setQuietMode(!!options.quiet);
+  const target = readTargetPositionals(options, first, second);
+  const pieceConfig = parsePieceOptions(
+    target.address ? { ...options, piece: target.address } : options,
+    { acceptsPath: true, acceptsArgument: true },
+  );
+  const pathSegments = mergePiecePath(pieceConfig, target.pathString);
+  if (pathSegments.length === 0) {
+    throw new ValidationError(
+      `A path is required: embed it in the address (/of:.../title) or ` +
+        `pass it as an argument.`,
+      { exitCode: 1 },
+    );
+  }
+  const value = await (deps.drainStdin ?? drainStdin)();
+  await (deps.setCellValue ?? setCellValue)(pieceConfig, pathSegments, value, {
+    input: options.input || pieceConfig.pieceInput,
+  });
+  (deps.render ?? render)(`Set value at path: ${pathSegments.join("/")}`);
+  (deps.hint ?? hint)(
+    cliText(
+      `TIP: Computed values may be stale. Run 'cf piece step --piece ${pieceConfig.piece} ...' to trigger recomputation.`,
+    ),
+  );
+}
+
 export async function getCellCfcLabelFromCommand(
   options: PieceLabelCLIOptions,
   pathString?: string,
@@ -2342,14 +2471,14 @@ export async function getCellCfcLabelFromCommand(
 ): Promise<void> {
   setQuietMode(!!options.quiet);
   const pieceConfig = {
-    ...parsePieceOptions(options, { acceptsPath: true }),
+    ...parsePieceOptions(options, { acceptsPath: true, acceptsArgument: true }),
     jsonOutput: true,
   };
   const pathSegments = mergePiecePath(pieceConfig, pathString);
   const label = await (deps.getCellCfcLabel ?? getCellCfcLabel)(
     pieceConfig,
     pathSegments,
-    { input: options.input },
+    { input: options.input || pieceConfig.pieceInput },
   );
   (deps.render ?? render)(label, { json: true });
 }
@@ -2361,7 +2490,7 @@ export async function setCellCfcLabelFromCommand(
 ): Promise<void> {
   setQuietMode(!!options.quiet);
   const pieceConfig = {
-    ...parsePieceOptions(options, { acceptsPath: true }),
+    ...parsePieceOptions(options, { acceptsPath: true, acceptsArgument: true }),
     jsonOutput: true,
   };
   const pathSegments = mergePiecePath(pieceConfig, pathString);
@@ -2370,7 +2499,7 @@ export async function setCellCfcLabelFromCommand(
     pieceConfig,
     pathSegments,
     update,
-    { input: options.input },
+    { input: options.input || pieceConfig.pieceInput },
   );
   (deps.render ?? render)(label, { json: true });
 }
@@ -2516,7 +2645,7 @@ function parseSetHomeOptions(
 
 export function parsePieceOptions(
   input: PieceCLIOptions,
-  parseOptions?: { acceptsPath?: boolean },
+  parseOptions?: { acceptsPath?: boolean; acceptsArgument?: boolean },
 ): PieceConfig {
   const options = parseSpaceOptions(input);
   if (!("piece" in options) || !options.piece) {
@@ -2534,7 +2663,89 @@ export function parsePieceOptions(
       { exitCode: 1 },
     );
   }
+  if (config.pieceInput && !parseOptions?.acceptsArgument) {
+    throw new ValidationError(
+      `The piece reference selects the arguments cell ("#argument") but ` +
+        `this command does not take "--input".`,
+      { exitCode: 1 },
+    );
+  }
   return config;
+}
+
+/**
+ * Decide what a read or write command's positionals name: an address, a
+ * path, or nothing.
+ *
+ * The deciding grammar: a positional address is written in the canonical
+ * reference form, which begins with `/` (`matchLLMFriendlyLink`), and a
+ * relative cell path never does. The bare id, slug, and scoped spellings
+ * stay on `--piece`, where no path competes for the position — a slug and a
+ * path's first segment are indistinguishable.
+ *
+ * A caller naming the target twice — `--piece` beside a positional address —
+ * is refused rather than resolved, the same rule `--space` beside `--url`
+ * follows. So is a second positional behind a path: only an address earns a
+ * path after it.
+ */
+export function readTargetPositionals(
+  options: { piece?: string },
+  first?: string,
+  second?: string,
+): { address?: string; pathString?: string } {
+  if (first === undefined) return {};
+  if (matchLLMFriendlyLink.test(first.trim())) {
+    if (options.piece) {
+      throw new ValidationError(
+        `"--piece" cannot be provided when the address is positional.`,
+        { exitCode: 1 },
+      );
+    }
+    return {
+      address: first,
+      ...(second !== undefined && { pathString: second }),
+    };
+  }
+  if (second !== undefined) {
+    throw new ValidationError(
+      `Unexpected argument "${second}": a second positional belongs after ` +
+        `an address (/of:fid1:...), and "${first}" is a path.`,
+      { exitCode: 1 },
+    );
+  }
+  return { pathString: first };
+}
+
+/**
+ * `cf piece call`'s positional intake: when the first positional is a
+ * canonical address it replaces `--piece`, and the callable name follows
+ * it. The same `/`-leading grammar decides as in
+ * {@link readTargetPositionals}; a bare callable name can never match it.
+ */
+export function readCallTarget(
+  options: { piece?: string },
+  callableName: string,
+  tail: string[],
+): { piece?: string; callableName: string; tail: string[] } {
+  if (!matchLLMFriendlyLink.test(callableName.trim())) {
+    return { callableName, tail };
+  }
+  if (options.piece) {
+    throw new ValidationError(
+      `"--piece" cannot be provided when the address is positional.`,
+      { exitCode: 1 },
+    );
+  }
+  const [nextCallable, ...rest] = tail;
+  if (nextCallable === undefined) {
+    throw new ValidationError(
+      `Missing argument "callable": the positional address ` +
+        `"${callableName}" replaces "--piece", and the callable name ` +
+        `follows it.`,
+      { exitCode: 1 },
+    );
+  }
+  return { piece: callableName, callableName: nextCallable, tail: rest };
 }
 
 // With args and env vars shadowing each other, and multiple
@@ -2595,11 +2806,21 @@ export function parseSpaceOptions(
       output.piece = llmRef.pieceId;
       if (llmRef.scope) output.pieceScope = llmRef.scope;
       if (llmRef.path.length > 0) output.piecePath = llmRef.path;
+      if (llmRef.input) output.pieceInput = true;
       if (llmRef.embeddedSpace) {
         output.embeddedSpaces = [llmRef.embeddedSpace];
         if (!input.space) output.space = llmRef.embeddedSpace;
       }
     } else {
+      // The alias grammar has no fragments, and letting one through would
+      // bury the suffix inside the id and fail as an unknown piece later.
+      if (input.piece.includes("#")) {
+        throw new ValidationError(
+          `The "#argument" suffix rides the canonical reference form ` +
+            `(/of:fid1:...#argument), not the bare piece id.`,
+          { exitCode: 1 },
+        );
+      }
       const parsedPiece = parseScopedId(input.piece);
       output.piece = parsedPiece.id;
       if (parsedPiece.scope) output.pieceScope = parsedPiece.scope;
@@ -2659,6 +2880,12 @@ export function parseLink(
 } {
   const llmRef = normalizeLLMFriendlyRef(ref, { space: options?.space });
   if (llmRef) {
+    if (llmRef.input) {
+      throw new ValidationError(
+        `The "#argument" suffix does not apply to a link endpoint.`,
+        { exitCode: 1 },
+      );
+    }
     return {
       pieceId: llmRef.pieceId,
       ...(llmRef.scope && { scope: llmRef.scope }),

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -2427,10 +2427,12 @@ export async function getCellValueFromCommand(
 
 /**
  * The `cf piece set` action, with the same positional-address intake as
- * {@link getCellValueFromCommand}. The write must land at a path — the
- * root is `piece apply`'s job — and the path may arrive embedded in the
- * address, positionally, or both, so the emptiness check runs on the merge
- * rather than on any one spelling.
+ * {@link getCellValueFromCommand}. The write needs a path spelled somewhere
+ * — embedded in the address, positionally, or both — and an explicit empty
+ * positional (`""`) is a spelling: it has always named the root, and the
+ * fuse integration writes a whole input cell with it. What is refused is a
+ * bare positional address with no path anywhere, so a pasted address cannot
+ * silently overwrite a whole cell.
  */
 export async function setCellValueFromCommand(
   options: PieceLabelCLIOptions,
@@ -2445,10 +2447,10 @@ export async function setCellValueFromCommand(
     { acceptsPath: true, acceptsArgument: true },
   );
   const pathSegments = mergePiecePath(pieceConfig, target.pathString);
-  if (pathSegments.length === 0) {
+  if (pathSegments.length === 0 && target.pathString === undefined) {
     throw new ValidationError(
       `A path is required: embed it in the address (/of:.../title) or ` +
-        `pass it as an argument.`,
+        `pass it as an argument ("" writes the root).`,
       { exitCode: 1 },
     );
   }

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -350,8 +350,13 @@ const ARGUMENT_PROVIDERS: Readonly<
   Record<string, (line: CompletionLine) => Promise<ProviderResult>>
 > = {
   "piece call:callable": callableCandidates,
+  // The first positional of `piece get`/`piece set` is a cell path unless the
+  // caller writes a canonical address there, and an address is pasted rather
+  // than completed — so the path candidates serve the slot either way.
+  "piece get:addressOrPath": cellPathCandidates,
   "piece get:path": cellPathCandidates,
   "piece get-label:path": cellPathCandidates,
+  "piece set:addressOrPath": cellPathCandidates,
   "piece set:path": cellPathCandidates,
   "piece set-label:path": cellPathCandidates,
   "piece link:source": linkEndpointCandidates,

--- a/packages/cli/lib/llm-friendly-ref.ts
+++ b/packages/cli/lib/llm-friendly-ref.ts
@@ -2,7 +2,9 @@
  * The LLM-friendly link form — `/[@did:.../]of:fid1:<id>[@scope][/path]`,
  * the runner's `parseLLMFriendlyLink` grammar — is the canonical reference
  * syntax of the fabric: the same string names the same cell in patterns, in
- * the shell, and at this CLI's intake seams. The CLI's bare grammar
+ * the shell, and at this CLI's intake seams. At those seams the reference
+ * may additionally end in the `#argument` suffix, which selects the piece's
+ * arguments cell the way `--input` does. The CLI's bare grammar
  * (`pieceId[@scope]`, `pieceId[@scope]/path` at link endpoints, and slugs)
  * is a convenience alias for interactive use. New reference-syntax
  * capabilities land in the canonical form first, and the alias must not
@@ -22,6 +24,12 @@ import {
 export interface NormalizedLLMFriendlyRef {
   pieceId: string;
   scope?: CellScope;
+  /**
+   * True when the reference ended in the `#argument` suffix: the caller
+   * selected the piece's arguments cell, the same selection `--input`
+   * spells as a flag. Only commands that take `--input` accept it.
+   */
+  input?: boolean;
   /**
    * The space DID embedded in the reference, when the command's target
    * space is a name (or absent) rather than a DID. A name only resolves to
@@ -79,16 +87,38 @@ export function validateEmbeddedSpaces(
  * name (or absent), the embedded DID comes back as `embeddedSpace` for the
  * caller to validate through `validateEmbeddedSpaces` once the session has
  * resolved the name.
+ *
+ * The one addition to the runner's grammar is the trailing `#argument`
+ * suffix, which comes back as `input`. `#` is reserved for it: a reference
+ * carrying any other fragment is refused, so a path key containing `#` needs
+ * the positional path spelling rather than the embedded one.
  */
 export function normalizeLLMFriendlyRef(
   ref: string,
   options: { space?: string } = {},
 ): NormalizedLLMFriendlyRef | undefined {
-  if (!matchLLMFriendlyLink.test(ref.trim())) return undefined;
+  let trimmed = ref.trim();
+  if (!matchLLMFriendlyLink.test(trimmed)) return undefined;
+
+  let input = false;
+  const hash = trimmed.indexOf("#");
+  if (hash !== -1) {
+    const suffix = trimmed.slice(hash);
+    if (suffix !== "#argument") {
+      throw new ValidationError(
+        `Unknown reference suffix "${suffix}". The one supported suffix ` +
+          `is "#argument", which selects the piece's arguments cell the ` +
+          `way "--input" does.`,
+        { exitCode: 1 },
+      );
+    }
+    input = true;
+    trimmed = trimmed.slice(0, hash);
+  }
 
   let parsed;
   try {
-    parsed = parseLLMFriendlyLink(ref);
+    parsed = parseLLMFriendlyLink(trimmed);
   } catch (error) {
     throw new ValidationError(
       error instanceof Error ? error.message : String(error),
@@ -115,6 +145,7 @@ export function normalizeLLMFriendlyRef(
     pieceId,
     ...(parsed.scope && { scope: parsed.scope as CellScope }),
     ...(embeddedSpace !== undefined && { embeddedSpace }),
+    ...(input && { input: true }),
     path: parsed.path.map(linkPathSegmentToCellPathSegment),
   };
 }

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -140,6 +140,13 @@ export interface PieceConfig extends SpaceConfig {
    * carries them.
    */
   piecePath?: (string | number)[];
+  /**
+   * True when the reference carried the `#argument` suffix: the caller
+   * selected the piece's arguments cell. A command that takes `--input`
+   * honors it as that flag; every other command rejects a reference that
+   * carries it.
+   */
+  pieceInput?: boolean;
 }
 
 export interface SetPiecePatternOptions {

--- a/packages/cli/test/completion-line.test.ts
+++ b/packages/cli/test/completion-line.test.ts
@@ -110,11 +110,11 @@ Deno.test("resolve: options already typed are captured for provider context", ()
 });
 
 Deno.test("resolve: bundled short flags do not shift the argument index", () => {
-  // `-qs team` is `-q` plus `-s team`. Mis-parsing it would make `path` look
-  // like the second positional and select the wrong provider.
+  // `-qs team` is `-q` plus `-s team`. Mis-parsing it would make the first
+  // positional look like the second and select the wrong provider.
   const line = resolve("cf piece get -qs team ");
   assert(line.slot?.kind === "argument");
-  assertEquals(line.slot.argument.name, "path");
+  assertEquals(line.slot.argument.name, "addressOrPath");
   assertEquals(line.slot.index, 0);
   assertEquals(line.options.get("space"), "team");
   assert(line.flags.has("quiet"));

--- a/packages/cli/test/llm-friendly-ref.test.ts
+++ b/packages/cli/test/llm-friendly-ref.test.ts
@@ -113,4 +113,36 @@ describe("llm-friendly-ref", () => {
       /must use handles/,
     );
   });
+
+  it('reads a trailing "#argument" as the arguments-cell selection', () => {
+    expect(normalizeLLMFriendlyRef(`/${HANDLE}#argument`)).toEqual({
+      pieceId: HANDLE,
+      input: true,
+      path: [],
+    });
+    // The suffix closes the whole reference: scope, space, and an embedded
+    // path all sit before it.
+    expect(
+      normalizeLLMFriendlyRef(`/@${DID}/${HANDLE}@user/draft#argument`, {
+        space: "my-space",
+      }),
+    ).toEqual({
+      pieceId: HANDLE,
+      scope: "user",
+      embeddedSpace: DID,
+      input: true,
+      path: ["draft"],
+    });
+  });
+
+  it("rejects any fragment other than #argument", () => {
+    expect(() => normalizeLLMFriendlyRef(`/${HANDLE}#result`)).toThrow(
+      /Unknown reference suffix "#result"/,
+    );
+    // "#" is reserved for the suffix, so a path key containing it is not an
+    // embedded-path spelling.
+    expect(() => normalizeLLMFriendlyRef(`/${HANDLE}/we#ird`)).toThrow(
+      /Unknown reference suffix/,
+    );
+  });
 });

--- a/packages/cli/test/main-command.test.ts
+++ b/packages/cli/test/main-command.test.ts
@@ -108,7 +108,8 @@ describe("main command", () => {
     );
     const call = piece.getCommand("call")!;
     const expectedUsage =
-      "--identity <identity> --url <url> --api-url <api-url> --space <space> --piece <piece> <callable> [input]";
+      "--identity <identity> --url <url> --api-url <api-url> --space <space> " +
+      "--piece <piece> [address] <callable> [input]";
 
     expect(call.getArgsDefinition()).toBe(
       "<callable:string> [tail...:string]",

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -587,7 +587,20 @@ describe("cli piece parsing", () => {
       { input: undefined },
     ]);
     expect(hints[0]).toContain("cf piece step");
-    // A pathless write is apply's job, whichever spelling carried the target.
+    // An explicit empty positional has always named the root — the fuse
+    // integration writes a whole input cell with `piece set "" --input` —
+    // so it stays a valid spelling, in both target forms.
+    await setCellValueFromCommand(
+      { ...base, piece: `/${LLM_HANDLE}`, input: true },
+      "",
+      undefined,
+      deps,
+    );
+    expect(writes[1]?.slice(1)).toEqual([[], "Milk", { input: true }]);
+    await setCellValueFromCommand(base, `/${LLM_HANDLE}`, "", deps);
+    expect(writes[2]?.slice(1)).toEqual([[], "Milk", { input: undefined }]);
+    // What stays refused is no path in any spelling: a bare pasted address
+    // must not silently overwrite a whole cell.
     await expect(
       setCellValueFromCommand(base, `/${LLM_HANDLE}`, undefined, deps),
     )

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -480,6 +480,51 @@ describe("cli piece parsing", () => {
       .toThrow(/does not apply to a link endpoint/);
   });
 
+  it("parseSpaceOptions() refuses a piece reference beside a URL that names a piece", () => {
+    // Silently preferring either target is how a caller reads a piece they
+    // did not name; before this rule the URL's piece won without a word.
+    expect(() =>
+      parseSpaceOptions({ url: FULL_URL, identity: ID, piece: PIECE })
+    ).toThrow(/cannot be provided when the "--url" names a piece/);
+    expect(() =>
+      parseSpaceOptions({
+        url: FULL_URL,
+        identity: ID,
+        piece: `/${LLM_HANDLE}`,
+      })
+    ).toThrow(/cannot be provided when the "--url" names a piece/);
+  });
+
+  it("parseSpaceOptions() composes a piece-less URL with a piece reference", () => {
+    expect(parsePieceOptions({
+      url: NO_PIECE_FULL_URL,
+      identity: ID,
+      piece: PIECE,
+    })).toMatchObject({
+      apiUrl: API_URL,
+      space: SPACE,
+      piece: PIECE,
+    });
+    // The canonical reference keeps its whole grammar in this position: the
+    // embedded path and scope ride along, and an embedded space DID defers
+    // to the session check because the URL names the space as a name.
+    expect(parsePieceOptions(
+      {
+        url: NO_PIECE_FULL_URL,
+        identity: ID,
+        piece: `/@${SPACE_DID}/${LLM_HANDLE}@user/items/0`,
+      },
+      { acceptsPath: true },
+    )).toMatchObject({
+      apiUrl: API_URL,
+      space: SPACE,
+      piece: LLM_HANDLE,
+      pieceScope: "user",
+      piecePath: ["items", 0],
+      embeddedSpaces: [SPACE_DID],
+    });
+  });
+
   it("getCellValueFromCommand() reads through a positional address, honoring #argument", async () => {
     const base = { apiUrl: API_URL, space: SPACE, identity: ID, quiet: true };
     const reads: unknown[][] = [];

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -26,6 +26,7 @@ import {
   checkPieceSourceFromCommand,
   formatPatternIdentity,
   formatPatternRef,
+  getCellValueFromCommand,
   localPatternEntry,
   mergePiecePath,
   normalizeApiUrl,
@@ -33,6 +34,9 @@ import {
   parsePieceOptions,
   parseSpaceOptions,
   piece,
+  readCallTarget,
+  readTargetPositionals,
+  setCellValueFromCommand,
   setPieceSourceFromCommand,
 } from "../commands/piece.ts";
 import {
@@ -415,6 +419,142 @@ describe("cli piece parsing", () => {
       .toThrow(/--space/);
     expect(() => parseSpaceOptions({ ...base, piece: PIECE }))
       .toThrow(/--space/);
+  });
+
+  it('parsePieceOptions() honors "#argument" only where a command takes --input', () => {
+    const base = { apiUrl: API_URL, space: SPACE, identity: ID };
+    expect(parsePieceOptions(
+      { ...base, piece: `/${LLM_HANDLE}#argument` },
+      { acceptsArgument: true },
+    )).toMatchObject({
+      piece: LLM_HANDLE,
+      pieceInput: true,
+    });
+    expect(() =>
+      parsePieceOptions({ ...base, piece: `/${LLM_HANDLE}#argument` })
+    )
+      .toThrow(/does not take "--input"/);
+    // The alias grammar has no fragments; refusing loudly beats burying the
+    // suffix inside an id that later fails as unknown.
+    expect(() => parseSpaceOptions({ ...base, piece: `${PIECE}#argument` }))
+      .toThrow(/canonical reference form/);
+  });
+
+  it("readTargetPositionals() reads a leading canonical reference as the address", () => {
+    expect(readTargetPositionals({}, undefined, undefined)).toEqual({});
+    expect(readTargetPositionals({}, "items/0", undefined)).toEqual({
+      pathString: "items/0",
+    });
+    expect(readTargetPositionals({}, `/${LLM_HANDLE}`, "items/0")).toEqual({
+      address: `/${LLM_HANDLE}`,
+      pathString: "items/0",
+    });
+    // Naming the target twice is refused, like --space beside --url.
+    expect(() => readTargetPositionals({ piece: PIECE }, `/${LLM_HANDLE}`))
+      .toThrow(/"--piece" cannot be provided/);
+    // Only an address earns a second positional.
+    expect(() => readTargetPositionals({}, "items/0", "title"))
+      .toThrow(/Unexpected argument "title"/);
+  });
+
+  it("readCallTarget() lets a canonical reference precede the callable name", () => {
+    expect(readCallTarget({}, "addItem", ["{}"])).toEqual({
+      callableName: "addItem",
+      tail: ["{}"],
+    });
+    expect(readCallTarget({}, `/${LLM_HANDLE}`, ["addItem", "{}"])).toEqual({
+      piece: `/${LLM_HANDLE}`,
+      callableName: "addItem",
+      tail: ["{}"],
+    });
+    expect(() =>
+      readCallTarget({ piece: PIECE }, `/${LLM_HANDLE}`, ["addItem"])
+    )
+      .toThrow(/"--piece" cannot be provided/);
+    expect(() => readCallTarget({}, `/${LLM_HANDLE}`, []))
+      .toThrow(/callable name/);
+  });
+
+  it('parseLink() rejects the "#argument" suffix on a link endpoint', () => {
+    expect(() => parseLink(`/${LLM_HANDLE}#argument`))
+      .toThrow(/does not apply to a link endpoint/);
+  });
+
+  it("getCellValueFromCommand() reads through a positional address, honoring #argument", async () => {
+    const base = { apiUrl: API_URL, space: SPACE, identity: ID, quiet: true };
+    const reads: unknown[][] = [];
+    const rendered: unknown[] = [];
+    const deps = {
+      getCellValue: ((...args: unknown[]) => {
+        reads.push(args);
+        return Promise.resolve({ ok: true });
+      }) as never,
+      render: ((value: unknown) => {
+        rendered.push(value);
+      }) as never,
+    };
+    await getCellValueFromCommand(
+      base,
+      `/${LLM_HANDLE}/items/0`,
+      "title",
+      deps,
+    );
+    expect(reads[0]?.[0]).toMatchObject({ piece: LLM_HANDLE });
+    expect(reads[0]?.slice(1)).toEqual([
+      ["items", 0, "title"],
+      { input: undefined, step: undefined },
+    ]);
+    await getCellValueFromCommand(
+      base,
+      `/${LLM_HANDLE}#argument`,
+      undefined,
+      deps,
+    );
+    expect(reads[1]?.slice(1)).toEqual([[], { input: true, step: undefined }]);
+    expect(rendered).toEqual([{ ok: true }, { ok: true }]);
+  });
+
+  it("setCellValueFromCommand() writes through a positional address and requires a path", async () => {
+    const base = { apiUrl: API_URL, space: SPACE, identity: ID, quiet: true };
+    const writes: unknown[][] = [];
+    const hints: string[] = [];
+    const deps = {
+      drainStdin: (() => Promise.resolve("Milk")) as never,
+      setCellValue: ((...args: unknown[]) => {
+        writes.push(args);
+        return Promise.resolve();
+      }) as never,
+      render: (() => {}) as never,
+      hint: ((text: string) => {
+        hints.push(text);
+      }) as never,
+    };
+    // The embedded path alone satisfies the path requirement.
+    await setCellValueFromCommand(
+      base,
+      `/${LLM_HANDLE}/title`,
+      undefined,
+      deps,
+    );
+    expect(writes[0]?.slice(1)).toEqual([
+      ["title"],
+      "Milk",
+      { input: undefined },
+    ]);
+    expect(hints[0]).toContain("cf piece step");
+    // A pathless write is apply's job, whichever spelling carried the target.
+    await expect(
+      setCellValueFromCommand(base, `/${LLM_HANDLE}`, undefined, deps),
+    )
+      .rejects.toThrow(/A path is required/);
+    await expect(
+      setCellValueFromCommand(
+        { ...base, piece: `/${LLM_HANDLE}` },
+        undefined,
+        undefined,
+        deps,
+      ),
+    ).rejects.toThrow(/A path is required/);
   });
 
   it("parsePieceOptions() throws on incomplete input", () => {


### PR DESCRIPTION
## Why

CLI surface shape, step 4 (`docs/plans/cli-surface-shape.md`), stacked on #5894 (step 3). The plan's target grammar reads `cf get <addr> [path]` — reading is one operation reached from several starting points, and the address deserves the primary position rather than a flag spelling. This step adds the positional spelling and the `#argument` suffix beside the existing flags; nothing is removed, both spellings keep working.

The ambiguity the plan's step warns about — `piece get` already takes a positional path, and a slug is indistinguishable from a path's first segment — is resolved by grammar, written down in the README and in `readTargetPositionals`'s doc comment: **a positional address is written in the canonical reference form, which begins with `/`; a relative path never does.** The bare and slug spellings stay on `--piece`, so the two positions cannot collide. Naming the target twice (`--piece` beside a positional address) is refused rather than resolved, the same rule `--space` beside `--url` follows.

## What changed

- `readTargetPositionals` / `readCallTarget` (`packages/cli/commands/piece.ts`): the positional intake for `piece get`/`piece set` and `piece call`. For `call`, the address slots in front of the callable name; `.stopEarly()` semantics are untouched because flags already had to precede the first positional. `cf exec` is deliberately unchanged — its positional is a mounted file, not an address, and the pinned subprocess test in `test/exec-read-options.test.ts` still guards that boundary.
- `#argument` (`packages/cli/lib/llm-friendly-ref.ts`): a canonical reference may end in `#argument`, coming back as `input` — the arguments-cell selection `--input` spells as a flag. `#` is reserved: any other fragment is refused, a bare-form reference containing `#` is refused with a pointer at the canonical form (rather than burying the suffix in an id that later fails as unknown), and a link endpoint refuses it. Commands without `--input` refuse it through the same `parsePieceOptions` shape that already refuses embedded paths on id-only commands; `get`, `set`, `get-label`, `set-label` honor it.
- `piece set` now accepts the path embedded in the address (`cf piece set /of:…/title` needs no path argument); a write with no path in either spelling is refused — the root is `piece apply`'s job.
- The `piece get`/`piece set` action bodies move into `getCellValueFromCommand`/`setCellValueFromCommand`, named exports with dependency seams like the label commands, so the new intake is unit-covered instead of new action-body debt.
- Completion: the renamed first positional keeps cell-path candidates (`lib/completion/providers.ts`); the pinned slot name in `test/completion-line.test.ts` is updated.
- Docs owed by step 4: README "Piece references" (the grammar rule and the suffix), the tutorial's workflow chapter, and `#argument` beside the one live `--input` teaching site (README's CFC labels section). Usage strings and help examples updated on all three commands; cliffy's help renderer re-tokenizes `[--flag <val>]` groups, so usage lines follow the file's existing unbracketed-flag precedent.

## Test plan

- Unit: fragment grammar (`llm-friendly-ref.test.ts`), suffix wiring and refusals, both positional-intake helpers, and the extracted actions driven through their seams (`piece.test.ts`).
- Full `packages/cli` suite: 174 passed, 0 failed. Repo-wide `deno fmt --check`, `deno lint`, `deno task check-docs` green.
- Coverage delta vs the step-3 base, same suite both sides: **−37** zero-hit lines for `packages/cli` (the action-body extraction moves previously uncoverable lines under test).
- Measured live against a local toolshed: positional reads (with and without an embedded space, including no `--space` at all), positional `set` write and readback, positional `call` dispatching a verb, `#argument` reading the arguments cell identically to `--input`, and all four refusals (two addresses, two paths, unknown fragment, `#argument` on a command without `--input`).

One run of the suite under coverage collection failed once and passed on rerun and on every other run (5 green runs total today); I could not reproduce or identify the failing test from the truncated output. Flagging rather than hiding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

