### PR TITLE
feat(cli): cf get, cf set, and cf call

### DIFF
--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -1,7 +1,9 @@
 # Verbs over the CLI
 
 A **verb** is a pattern's callable surface: a `Stream` property a caller invokes
-with `cf piece call`. This document is about what a caller gets *back*.
+with `cf piece call` — or `cf call`, the same command mounted at top level, so
+every `cf piece call` in this document works as `cf call` too. This document is
+about what a caller gets *back*.
 
 A verb can declare a result, and the caller reads it off the call. That turns a
 sequence of "mutate, then go looking for what happened" into a single

--- a/docs/tutorial/06-workflow.md
+++ b/docs/tutorial/06-workflow.md
@@ -134,7 +134,10 @@ On `get`, `set`, and `call`, the canonical reference can also sit in the
 first positional instead of the flag — `cf piece get /of:fid1:.../items`. On
 the commands that take `--input` (`get` and `set` here), a trailing
 `#argument` selects the piece's arguments cell the way that flag does;
-`call` takes no `--input` and refuses the suffix.
+`call` takes no `--input` and refuses the suffix. These three are also
+mounted at top level, so `cf get /of:fid1:.../items` is the same command
+with a shorter name: reading and writing cells is not really a
+piece-management concern, and the spelling says so.
 
 One subtlety: neither `piece set` nor `piece call` refreshes *computed*
 outputs. `set` writes the cell without running anything; `call` runs the

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -97,6 +97,12 @@ slug spellings stay on `--piece`, where no path competes for the position.
 Naming the target twice — `--piece` beside a positional address — is refused
 rather than resolved.
 
+Those three commands are also mounted at top level as `cf get`, `cf set`, and
+`cf call`: reading and writing cells is not a piece-management concern, and the
+spelling says so. Each pair is one definition mounted twice, so the two
+spellings take the same flags, behave identically, and complete identically;
+both keep working.
+
 A canonical reference may also end in `#argument`, which selects the piece's
 arguments cell the way `--input` does. Only commands that take `--input` accept
 it; `#` is reserved for the suffix, so a path key containing `#` needs the

--- a/packages/cli/commands/main.ts
+++ b/packages/cli/commands/main.ts
@@ -18,7 +18,7 @@ import { ingest } from "./ingest.ts";
 import { init } from "./init.ts";
 import { inspect } from "./inspect.ts";
 import { invocationSession } from "./invocation-session.ts";
-import { piece } from "./piece.ts";
+import { piece, pieceDataCommand } from "./piece.ts";
 import { space } from "./space.ts";
 import { test } from "./test-command.ts";
 import { view } from "./view.ts";
@@ -173,4 +173,14 @@ export const main = new Command()
   .command("init", init)
   .command("invocation-session", invocationSession)
   .command("test", test)
-  .command("wish", wish);
+  .command("wish", wish)
+  // The top-level spellings of the piece data commands: the same builders
+  // the `piece` chain mounts under the same names, so `cf get` and
+  // `cf piece get` are one definition parsed two ways
+  // (docs/plans/cli-surface-shape.md, step 5).
+  // @ts-ignore for the above type issue
+  .command("get", pieceDataCommand("get"))
+  // @ts-ignore for the above type issue
+  .command("set", pieceDataCommand("set"))
+  // @ts-ignore for the above type issue
+  .command("call", pieceDataCommand("call"));

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1097,30 +1097,503 @@ TIPS:
   • Path format: forward slashes only (items/0/name, not items[0].name)
   • JSON values: strings need quotes: echo '"hello"' | cf piece set ...`);
 
-export const piece = new Command()
-  .name("piece")
-  .description(pieceDescription)
-  .error((error, command) => {
-    const args = command.getMainCommand().getRawArgs();
-    if (reservesStdoutForCommandOutput(args)) {
-      throw error;
-    }
-  })
-  .default("help")
-  .globalOption("-q,--quiet", "Suppress hints and next-step suggestions")
-  .globalOption(
-    "-u,--url <url:string>",
-    "URL representing a host, space, and piece.",
-  )
-  .globalEnv("CF_API_URL=<url:string>", "URL of the fabric instance.", {
-    prefix: "CF_",
-  })
-  .globalOption("-a,--api-url <url:string>", "URL of the fabric instance.")
-  .globalEnv("CF_IDENTITY=<path:string>", "Path to an identity keyfile.", {
-    prefix: "CF_",
-  })
-  .globalOption("-i,--identity <path:string>", "Path to an identity keyfile.")
-  .globalOption("-s,--space <space:string>", "The space name or DID")
+/**
+ * The target-selection surface every piece data command carries: quiet, the
+ * combined URL, the API URL and identity with their environment fallbacks,
+ * and the space. One function defines them for both surfaces that must
+ * agree — `piece` declares them as globals its subcommands inherit, and the
+ * top-level `cf get`/`cf set`/`cf call` instances carry them as their own,
+ * having no parent globals to inherit — so the two spellings of a command
+ * cannot drift apart in what they accept.
+ */
+export function targetOptions(
+  // deno-lint-ignore no-explicit-any
+  cmd: Command<any>,
+  opts: { global: boolean },
+  // deno-lint-ignore no-explicit-any
+): Command<any> {
+  const option = (flags: string, description: string) =>
+    opts.global
+      ? cmd.globalOption(flags, description)
+      : cmd.option(flags, description);
+  const env = (name: string, description: string) =>
+    opts.global
+      ? cmd.globalEnv(name, description, { prefix: "CF_" })
+      : cmd.env(name, description, { prefix: "CF_" });
+  option("-q,--quiet", "Suppress hints and next-step suggestions");
+  option("-u,--url <url:string>", "URL representing a host, space, and piece.");
+  env("CF_API_URL=<url:string>", "URL of the fabric instance.");
+  option("-a,--api-url <url:string>", "URL of the fabric instance.");
+  env("CF_IDENTITY=<path:string>", "Path to an identity keyfile.");
+  option("-i,--identity <path:string>", "Path to an identity keyfile.");
+  option("-s,--space <space:string>", "The space name or DID");
+  return cmd;
+}
+
+/**
+ * The one definition of `get`, mounted under `cf piece` and, through
+ * {@link pieceDataCommand}, at top level as `cf get`. `spelling` is only
+ * how the command names itself in its own help.
+ */
+// deno-lint-ignore no-explicit-any
+function buildGetCommand(spelling = "piece get"): Command<any> {
+  return new Command()
+    .description(
+      `Get a value from a piece at a specific path. Omit path to return the full result.
+
+PATH FORMAT: Use forward slashes and numeric indices for arrays.
+  ✓ items/0/name    ✓ config/db/host    ✗ items[0].name
+
+ADDRESS: The target can sit in the first positional instead of --piece when
+written as a canonical reference (it begins with "/"): cf ${spelling}
+/of:fid1:.../items 0/name. A trailing #argument selects the arguments cell
+the way --input does.`,
+    )
+    .usage(`${pieceUsage} [addressOrPath] [path]`)
+    .example(
+      cliText(`cf ${spelling} ${EX_ID} ${EX_COMP_PIECE} name`),
+      `Get the "name" field from piece result "${RAW_EX_COMP.piece!}".`,
+    )
+    .example(
+      cliText(
+        `cf ${spelling} ${EX_ID} ${EX_COMP} /of:fid1:abc.../items 0/name`,
+      ),
+      "Read through a positional canonical address; its embedded path applies.",
+    )
+    .example(
+      cliText(
+        `cf ${spelling} ${EX_ID} ${EX_COMP} '/of:fid1:abc...#argument' draft`,
+      ),
+      `Read the piece's arguments cell ("#argument" spells --input).`,
+    )
+    .example(
+      cliText(
+        `cf ${spelling} ${EX_ID} ${EX_COMP_PIECE} data/users/0/email --input`,
+      ),
+      `Get a nested field value from piece input "${RAW_EX_COMP.piece!}".`,
+    )
+    .example(
+      cliText(
+        `cf ${spelling} ${EX_ID} ${EX_COMP} --piece ${RAW_EX_COMP
+          .piece!}@session draft`,
+      ),
+      `Get a value from a session-scoped piece instance.`,
+    )
+    .example(
+      cliText(`cf ${spelling} ${EX_ID} ${EX_COMP_PIECE}`),
+      `Get the full result of piece "${RAW_EX_COMP.piece!}".`,
+    )
+    .example(
+      cliText(`cf ${spelling} ${EX_ID} ${EX_COMP_PIECE} --step`),
+      `Start, recompute, and get the result in one CLI session.`,
+    )
+    .example(
+      cliText(
+        `cf ${spelling} ${EX_ID} ${EX_COMP_PIECE} items --filter '.status == "open"'`,
+      ),
+      "Return only matching items from an array.",
+    )
+    .example(
+      cliText(
+        `cf ${spelling} ${EX_ID} ${EX_COMP_PIECE} items --select id,title`,
+      ),
+      "Project each returned item to selected fields.",
+    )
+    .example(
+      cliText(
+        `cf ${spelling} ${EX_ID} ${EX_COMP_PIECE} --select 'topic@,topic.title'`,
+      ),
+      "Return a field's address, and the fields asked for beside it.",
+    )
+    .example(
+      cliText(
+        `cf ${spelling} ${EX_ID} ${EX_COMP_PIECE} items ` +
+          `--schema '{"type":"array","items":{"$link":true}}'`,
+      ),
+      "Return each item's address instead of its contents.",
+    )
+    .option("-c,--piece <piece:string>", PIECE_OPTION_PATH_HELP)
+    .option(
+      "--input",
+      "Read from the piece's input cell instead of result cell (the " +
+        '"#argument" reference suffix spells the same selection)',
+    )
+    .option(
+      "--step",
+      "Start and recompute the piece in this session before reading",
+    )
+    .option(
+      "--json",
+      "Select JSON output explicitly. This command always outputs JSON.",
+    )
+    .option(
+      "--filter <predicate:string>",
+      "Filter an array with a jq-inspired predicate",
+    )
+    .option(
+      "--select <fields:string>",
+      "Project output to comma-separated field paths; a trailing @ asks for " +
+        "a position's address, and @ alone for the source's own. An address " +
+        "comes back as one reference string, which --piece takes back in",
+    )
+    .option(
+      "--schema <schema:string>",
+      "Project output with an inline JSON Schema, @file, or the --select " +
+        "field list",
+      // Both flags carry the one projection, so a command naming both has not
+      // said which shape it wants. Refuse before the read rather than pick.
+      { conflicts: ["select"] },
+    )
+    .arguments("[addressOrPath:string] [path:string]")
+    .action(getCellValueFromCommand);
+}
+
+/**
+ * The one definition of `set`; see {@link buildGetCommand} for the shape.
+ */
+// deno-lint-ignore no-explicit-any
+function buildSetCommand(spelling = "piece set"): Command<any> {
+  return new Command()
+    .description(
+      cliText(
+        `Set a value in a piece at a specific path. Reads JSON from stdin.
+
+PATH FORMAT: Use forward slashes and numeric indices for arrays.
+  ✓ items/0/name    ✓ config/db/host    ✗ items[0].name
+
+JSON VALUES: Strings need quotes: echo '"hello"' | cf ${spelling} ...
+
+ADDRESS: The target can sit in the first positional instead of --piece when
+written as a canonical reference (it begins with "/"): a path embedded in it
+counts, so cf ${spelling} /of:fid1:.../title needs no path argument. A trailing
+#argument selects the arguments cell the way --input does.`,
+      ),
+    )
+    .usage(`${pieceUsage} [addressOrPath] [path]`)
+    .example(
+      cliText(
+        `echo '"New Name"' | cf ${spelling} ${EX_ID} ${EX_COMP_PIECE} name`,
+      ),
+      `Set the "name" field in piece result "${RAW_EX_COMP.piece!}".`,
+    )
+    .example(
+      cliText(
+        `echo '{"foo": "bar"}' | cf ${spelling} ${EX_ID} ${EX_COMP_PIECE} config --input`,
+      ),
+      `Set a nested object value in piece input "${RAW_EX_COMP.piece!}".`,
+    )
+    .example(
+      cliText(
+        `echo '"Milk"' | cf ${spelling} ${EX_ID} ${EX_COMP} /of:fid1:abc.../title`,
+      ),
+      "Write through a positional canonical address; the embedded path is the path.",
+    )
+    .option("-c,--piece <piece:string>", PIECE_OPTION_PATH_HELP)
+    .option(
+      "--input",
+      "Write to the piece's input cell instead of result cell (the " +
+        '"#argument" reference suffix spells the same selection)',
+    )
+    .arguments("[addressOrPath:string] [path:string]")
+    .action(setCellValueFromCommand);
+}
+
+/**
+ * The one definition of `call`; see {@link buildGetCommand} for the
+ * shape.
+ */
+// deno-lint-ignore no-explicit-any
+function buildCallCommand(spelling = "piece call"): Command<any> {
+  return new Command()
+    .description(
+      `Invoke a callable within a piece.
+
+The callable name separates piece-call options from the callable's arguments.
+Arguments after the callable use the same parser as cf exec. Use --json with an
+optional inline value for complete JSON input; bare --json reads JSON from
+stdin. A single positional JSON value or "-" stdin sentinel is also accepted.
+Use --help --json for machine-readable schema help. Put schema-derived flags
+after --. Handlers interpret piped input when no input argument is present.
+
+ADDRESS: The target can precede the callable name instead of riding --piece
+when written as a canonical reference (it begins with "/"):
+cf ${spelling} /of:fid1:... addItem '{"title":"Milk"}'.`,
+    )
+    .usage(`${pieceUsage} [address] <callable> [input]`)
+    .example(
+      cliText(`cf ${spelling} ${EX_ID} ${EX_COMP_PIECE} increment`),
+      `Call the "increment" handler on piece "${RAW_EX_COMP.piece!}".`,
+    )
+    .example(
+      cliText(
+        `cf ${spelling} ${EX_ID} ${EX_COMP_PIECE} setName '{"value":"My Name"}'`,
+      ),
+      `Call the "setName" handler with JSON arguments on piece "${RAW_EX_COMP
+        .piece!}".`,
+    )
+    .example(
+      cliText(
+        `echo '{"value":"My Name"}' | cf ${spelling} ${EX_ID} ${EX_COMP_PIECE} setName -`,
+      ),
+      `Read the JSON payload from stdin ("-" is the stdin sentinel).`,
+    )
+    .example(
+      cliText(
+        `cf ${spelling} ${EX_ID} ${EX_COMP_PIECE} setName --json '{"value":"My Name"}'`,
+      ),
+      "Call a handler with explicit inline JSON input.",
+    )
+    .example(
+      cliText(
+        `cf ${spelling} ${EX_ID} ${EX_COMP_PIECE} search -- --query milk`,
+      ),
+      `Run the "search" tool using schema-derived flags after "--".`,
+    )
+    .example(
+      cliText(
+        `cf ${spelling} ${EX_ID} ${EX_COMP} /of:fid1:abc... addItem '{"title":"Milk"}'`,
+      ),
+      "Name the target as a positional canonical address before the callable.",
+    )
+    .example(
+      cliText(
+        `cf ${spelling} ${EX_ID} ${EX_COMP_PIECE} --select topic.title addTopic ` +
+          `'{"title":"Ship it"}'`,
+      ),
+      "Return only the selected fields of the verb's result.",
+    )
+    .example(
+      cliText(
+        `cf ${spelling} ${EX_ID} ${EX_COMP_PIECE} ` +
+          `--schema '{"properties":{"topic":{"$link":true}}}' addTopic ` +
+          `'{"title":"Ship it"}'`,
+      ),
+      "Return the address of what the verb returned instead of its contents.",
+    )
+    .option("-c,--piece <piece:string>", PIECE_OPTION_HELP)
+    .option(
+      "--invocation <id:string>",
+      "Idempotency key for a handler call (before the callable name), and " +
+        "requires an invocation session. A retry naming the same pair cannot " +
+        "commit twice — it settles on the original outcome — but the " +
+        "handler body does re-run, so effects outside the transaction " +
+        "repeat. Both are minted for the one call when neither is given.",
+    )
+    .env(
+      "CF_INVOCATION_SESSION=<id:string>",
+      "Invocation session that this run's invocation ids belong to. The form " +
+        "to reach for: a session is what makes an outcome's address " +
+        "unguessable, and an environment variable stays out of the process " +
+        "listing an argument shows up in.",
+      { prefix: "CF_" },
+    )
+    .option(
+      "--invocation-session <id:string>",
+      "Override CF_INVOCATION_SESSION for this one call (before the callable " +
+        "name): the session this call's invocation id was chosen within, " +
+        "since an invocation id is the caller's own word and another caller " +
+        "can pick the same one. The pair decides which outcome a replay " +
+        "reads, so the same id under another session is another invocation. " +
+        "Mint a session per agent run with `cf invocation-session new`, and " +
+        "carry that one session on every call of the run.",
+    )
+    .option(
+      "--verbose",
+      "Print per-phase wall-clock timings to stderr (before the callable " +
+        "name). stdout still carries only the command output.",
+    )
+    .option(
+      "--await",
+      "Wait for settlement and receipt readback (before the callable name). " +
+        "This is the default; the flag exists so a script can say so " +
+        "explicitly. Contradicts --no-wait.",
+    )
+    .option(
+      "--wait <seconds:number>",
+      "Bound the settlement wait by a chosen patience, in seconds (before " +
+        "the callable name). On expiry the exit is nonzero with the " +
+        "invocation id and furthest phase on stderr; the invocation may not " +
+        "have executed or committed. Re-invoking under the same id and " +
+        "session cannot commit twice — but it runs the handler body again, " +
+        "so effects outside the transaction repeat. An expiry is exactly the " +
+        "case where you cannot tell whether it committed.",
+    )
+    .option(
+      "--no-wait",
+      "Exit once this handling's commit is acknowledged (before the callable " +
+        "name), skipping only the receipt readback: stdout reports status " +
+        '"committed" plus the receipt address, so `cf piece get --piece <that ' +
+        "address>` collects the outcome later without re-running the handler; " +
+        "a call naming the same session and --invocation recovers it too, but " +
+        "runs the handler body again. The handler still executes here and its " +
+        "commit is durable. Handler invocations only.",
+    )
+    .option(
+      "--show-links",
+      "Annotate the Invocation JSON with a links dictionary mapping result " +
+        "paths to their backing cell addresses, each one reference string " +
+        "--piece takes back in (before the callable name). " +
+        'The root "/" entry is the result\'s own backing document — the ' +
+        "receipt, unless the result is itself a reference, in which case a " +
+        'separate "receipt" entry keeps the receipt address; other entries ' +
+        "appear only where a path is backed by a different document. Handler " +
+        "invocations only — a tool already reports its result cell on stderr.",
+    )
+    .option(
+      "--filter <predicate:string>",
+      "Filter an array with a jq-inspired predicate",
+    )
+    .option(
+      "--select <fields:string>",
+      "Project output to comma-separated field paths",
+    )
+    .option(
+      "--schema <schema:string>",
+      "Project output with an inline JSON Schema, @file, or the --select " +
+        "field list",
+      // Both flags carry the one projection, so a command naming both has not
+      // said which shape it wants. Refuse before the call rather than pick.
+      { conflicts: ["select"] },
+    )
+    .stopEarly()
+    .arguments("<callable:string> [tail...:string]")
+    .action(async function (
+      // Spelled out because this builder stands alone: the target options
+      // arrive as `piece` globals on one mount and as own options on the
+      // other, so neither inference sees the whole surface.
+      options:
+        & PieceCLIOptions
+        & PieceCallReadbackFlags
+        & {
+          quiet?: boolean;
+          verbose?: boolean;
+          await?: boolean;
+          wait?: number | boolean;
+          invocation?: string;
+          invocationSession?: string;
+        },
+      callableArg: string,
+      ...tailArgs: string[]
+    ) {
+      // Positional-address intake first: it is a fact about the argv alone,
+      // so a refusal here names no invocation and no phase.
+      const { piece, callableName, tail } = readCallTarget(
+        options,
+        callableArg,
+        tailArgs,
+      );
+      const identity = resolveInvocationIdentity(
+        options.invocation,
+        options.invocationSession,
+      );
+      const invocationId = identity.id;
+      const waitControl = resolveWaitControl(options);
+      let phase: InvocationPhase = "initial_sync";
+      const observer = pieceCallPhaseObserver(
+        !!options.verbose,
+        (next) => phase = next,
+      );
+      setQuietMode(!!options.quiet);
+      // Read outside the invocation's failure wrapper below. Nothing is
+      // dispatched here — no callable resolved, no id spent — so a malformed
+      // selection is a data error about the flags, the same one `cf piece get`
+      // reports. Inside the wrapper it would name an id and a phase to retry
+      // from for a call that was never made; a selection that fails against a
+      // RESULT does sit inside it, and does name one.
+      let selection: CellSelection | undefined;
+      try {
+        selection = await parsePieceCallSelection(options);
+      } catch (error) {
+        // Both exits below leave without reaching the action's catch, so the
+        // verbose in-flight span is closed here.
+        observer.finish("failed");
+        if (error instanceof CellSelectionError) {
+          exitWithDataError({ message: error.message });
+        }
+        throw error;
+      }
+      try {
+        const invocation = pieceCallInvocation(
+          tail,
+          this.getLiteralArgs(),
+        );
+        const pieceConfig = parsePieceOptions({
+          ...options,
+          ...(piece !== undefined && { piece }),
+          json: invocation.jsonOutput,
+        });
+        const result = await boundedSettlement(
+          executePieceCallable(
+            pieceConfig,
+            callableName,
+            invocation.rawArgs,
+            {
+              invocation: identity,
+              skipReadback: waitControl.mode === "commit",
+              showLinks: !!options.showLinks,
+              ...(selection === undefined ? {} : { selection }),
+              onPhase: invocationPhaseReporter(
+                identity,
+                observer.onPhase,
+                undefined,
+                Boolean(Deno.env.get("CF_TEST_ANNOUNCE_INVOCATION_PHASES")),
+              ),
+            },
+          ).catch((error) =>
+            reportVerbInputErrorOrRethrow(
+              error,
+              pieceConfig.piece,
+              undefined,
+              observer,
+            )
+          ),
+          waitControl.boundSeconds,
+        );
+        renderPieceCallOutcome(
+          observer,
+          result,
+          callableName,
+          pieceConfig.piece,
+          {},
+          { detached: waitControl.mode === "commit", invocation: identity },
+        );
+      } catch (error) {
+        exitPieceCallFailure(observer, error, invocationId, phase);
+      }
+    });
+}
+
+/**
+ * A top-level instance of a piece data command: the same builder the
+ * `piece` chain mounts under the same name, carrying the target options
+ * itself. `cf get`, `cf set`, and `cf call` are these — one definition per
+ * command, two spellings that parse and behave identically
+ * (docs/plans/cli-surface-shape.md, step 5). Deprecating the `cf piece`
+ * spellings later means touching the piece-mounted instances only.
+ */
+// deno-lint-ignore no-explicit-any
+export function pieceDataCommand(name: "get" | "set" | "call"): Command<any> {
+  const builders = {
+    get: buildGetCommand,
+    set: buildSetCommand,
+    call: buildCallCommand,
+  };
+  return targetOptions(builders[name](name), { global: false });
+}
+
+export const piece = targetOptions(
+  new Command()
+    .name("piece")
+    .description(pieceDescription)
+    .error((error, command) => {
+      const args = command.getMainCommand().getRawArgs();
+      if (reservesStdoutForCommandOutput(args)) {
+        throw error;
+      }
+    })
+    .default("help"),
+  { global: true },
+)
   /* piece ls */
   .command("ls", "List pieces registered in the space.")
   .usage(spaceUsage)
@@ -1682,113 +2155,7 @@ well-known IDs. See docs/common/concepts/well-known-ids.md for IDs and usage.`,
   → Inspect target piece:  cf piece inspect --piece ${target.pieceId} ...`));
   })
   /* piece get */
-  .command(
-    "get",
-    `Get a value from a piece at a specific path. Omit path to return the full result.
-
-PATH FORMAT: Use forward slashes and numeric indices for arrays.
-  ✓ items/0/name    ✓ config/db/host    ✗ items[0].name
-
-ADDRESS: The target can sit in the first positional instead of --piece when
-written as a canonical reference (it begins with "/"): cf piece get
-/of:fid1:.../items 0/name. A trailing #argument selects the arguments cell
-the way --input does.`,
-  )
-  .usage(`${pieceUsage} [addressOrPath] [path]`)
-  .example(
-    cliText(`cf piece get ${EX_ID} ${EX_COMP_PIECE} name`),
-    `Get the "name" field from piece result "${RAW_EX_COMP.piece!}".`,
-  )
-  .example(
-    cliText(`cf piece get ${EX_ID} ${EX_COMP} /of:fid1:abc.../items 0/name`),
-    "Read through a positional canonical address; its embedded path applies.",
-  )
-  .example(
-    cliText(
-      `cf piece get ${EX_ID} ${EX_COMP} '/of:fid1:abc...#argument' draft`,
-    ),
-    `Read the piece's arguments cell ("#argument" spells --input).`,
-  )
-  .example(
-    cliText(
-      `cf piece get ${EX_ID} ${EX_COMP_PIECE} data/users/0/email --input`,
-    ),
-    `Get a nested field value from piece input "${RAW_EX_COMP.piece!}".`,
-  )
-  .example(
-    cliText(
-      `cf piece get ${EX_ID} ${EX_COMP} --piece ${RAW_EX_COMP
-        .piece!}@session draft`,
-    ),
-    `Get a value from a session-scoped piece instance.`,
-  )
-  .example(
-    cliText(`cf piece get ${EX_ID} ${EX_COMP_PIECE}`),
-    `Get the full result of piece "${RAW_EX_COMP.piece!}".`,
-  )
-  .example(
-    cliText(`cf piece get ${EX_ID} ${EX_COMP_PIECE} --step`),
-    `Start, recompute, and get the result in one CLI session.`,
-  )
-  .example(
-    cliText(
-      `cf piece get ${EX_ID} ${EX_COMP_PIECE} items --filter '.status == "open"'`,
-    ),
-    "Return only matching items from an array.",
-  )
-  .example(
-    cliText(
-      `cf piece get ${EX_ID} ${EX_COMP_PIECE} items --select id,title`,
-    ),
-    "Project each returned item to selected fields.",
-  )
-  .example(
-    cliText(
-      `cf piece get ${EX_ID} ${EX_COMP_PIECE} --select 'topic@,topic.title'`,
-    ),
-    "Return a field's address, and the fields asked for beside it.",
-  )
-  .example(
-    cliText(
-      `cf piece get ${EX_ID} ${EX_COMP_PIECE} items ` +
-        `--schema '{"type":"array","items":{"$link":true}}'`,
-    ),
-    "Return each item's address instead of its contents.",
-  )
-  .option("-c,--piece <piece:string>", PIECE_OPTION_PATH_HELP)
-  .option(
-    "--input",
-    "Read from the piece's input cell instead of result cell (the " +
-      '"#argument" reference suffix spells the same selection)',
-  )
-  .option(
-    "--step",
-    "Start and recompute the piece in this session before reading",
-  )
-  .option(
-    "--json",
-    "Select JSON output explicitly. This command always outputs JSON.",
-  )
-  .option(
-    "--filter <predicate:string>",
-    "Filter an array with a jq-inspired predicate",
-  )
-  .option(
-    "--select <fields:string>",
-    "Project output to comma-separated field paths; a trailing @ asks for a " +
-      "position's address, and @ alone for the source's own. An address " +
-      "comes back as one reference string, which --piece takes back in",
-  )
-  .option(
-    "--schema <schema:string>",
-    "Project output with an inline JSON Schema, @file, or the --select " +
-      "field list",
-    // Both flags carry the one projection, so a command naming both has not
-    // said which shape it wants. Refuse before the read rather than pick.
-    { conflicts: ["select"] },
-  )
-  .arguments("[addressOrPath:string] [path:string]")
-  .action(getCellValueFromCommand)
+  .command("get", buildGetCommand())
   /* piece get-label */
   .command(
     "get-label",
@@ -1859,45 +2226,7 @@ updated effective label view.`),
   .arguments("[path:string]")
   .action(setCellCfcLabelFromCommand)
   /* piece set */
-  .command(
-    "set",
-    cliText(`Set a value in a piece at a specific path. Reads JSON from stdin.
-
-PATH FORMAT: Use forward slashes and numeric indices for arrays.
-  ✓ items/0/name    ✓ config/db/host    ✗ items[0].name
-
-JSON VALUES: Strings need quotes: echo '"hello"' | cf piece set ...
-
-ADDRESS: The target can sit in the first positional instead of --piece when
-written as a canonical reference (it begins with "/"): a path embedded in it
-counts, so cf piece set /of:fid1:.../title needs no path argument. A trailing
-#argument selects the arguments cell the way --input does.`),
-  )
-  .usage(`${pieceUsage} [addressOrPath] [path]`)
-  .example(
-    cliText(`echo '"New Name"' | cf piece set ${EX_ID} ${EX_COMP_PIECE} name`),
-    `Set the "name" field in piece result "${RAW_EX_COMP.piece!}".`,
-  )
-  .example(
-    cliText(
-      `echo '{"foo": "bar"}' | cf piece set ${EX_ID} ${EX_COMP_PIECE} config --input`,
-    ),
-    `Set a nested object value in piece input "${RAW_EX_COMP.piece!}".`,
-  )
-  .example(
-    cliText(
-      `echo '"Milk"' | cf piece set ${EX_ID} ${EX_COMP} /of:fid1:abc.../title`,
-    ),
-    "Write through a positional canonical address; the embedded path is the path.",
-  )
-  .option("-c,--piece <piece:string>", PIECE_OPTION_PATH_HELP)
-  .option(
-    "--input",
-    "Write to the piece's input cell instead of result cell (the " +
-      '"#argument" reference suffix spells the same selection)',
-  )
-  .arguments("[addressOrPath:string] [path:string]")
-  .action(setCellValueFromCommand)
+  .command("set", buildSetCommand())
   /* piece map */
   .command("map", "Show registered pieces and the connections between them")
   .usage(spaceUsage)
@@ -1922,244 +2251,7 @@ counts, so cf piece set /of:fid1:.../title needs no path argument. A trailing
     render(map);
   })
   /* piece call */
-  .command(
-    "call",
-    `Invoke a callable within a piece.
-
-The callable name separates piece-call options from the callable's arguments.
-Arguments after the callable use the same parser as cf exec. Use --json with an
-optional inline value for complete JSON input; bare --json reads JSON from
-stdin. A single positional JSON value or "-" stdin sentinel is also accepted.
-Use --help --json for machine-readable schema help. Put schema-derived flags
-after --. Handlers interpret piped input when no input argument is present.
-
-ADDRESS: The target can precede the callable name instead of riding --piece
-when written as a canonical reference (it begins with "/"):
-cf piece call /of:fid1:... addItem '{"title":"Milk"}'.`,
-  )
-  .usage(`${pieceUsage} [address] <callable> [input]`)
-  .example(
-    cliText(`cf piece call ${EX_ID} ${EX_COMP_PIECE} increment`),
-    `Call the "increment" handler on piece "${RAW_EX_COMP.piece!}".`,
-  )
-  .example(
-    cliText(
-      `cf piece call ${EX_ID} ${EX_COMP_PIECE} setName '{"value":"My Name"}'`,
-    ),
-    `Call the "setName" handler with JSON arguments on piece "${RAW_EX_COMP
-      .piece!}".`,
-  )
-  .example(
-    cliText(
-      `echo '{"value":"My Name"}' | cf piece call ${EX_ID} ${EX_COMP_PIECE} setName -`,
-    ),
-    `Read the JSON payload from stdin ("-" is the stdin sentinel).`,
-  )
-  .example(
-    cliText(
-      `cf piece call ${EX_ID} ${EX_COMP_PIECE} setName --json '{"value":"My Name"}'`,
-    ),
-    "Call a handler with explicit inline JSON input.",
-  )
-  .example(
-    cliText(`cf piece call ${EX_ID} ${EX_COMP_PIECE} search -- --query milk`),
-    `Run the "search" tool using schema-derived flags after "--".`,
-  )
-  .example(
-    cliText(
-      `cf piece call ${EX_ID} ${EX_COMP} /of:fid1:abc... addItem '{"title":"Milk"}'`,
-    ),
-    "Name the target as a positional canonical address before the callable.",
-  )
-  .example(
-    cliText(
-      `cf piece call ${EX_ID} ${EX_COMP_PIECE} --select topic.title addTopic ` +
-        `'{"title":"Ship it"}'`,
-    ),
-    "Return only the selected fields of the verb's result.",
-  )
-  .example(
-    cliText(
-      `cf piece call ${EX_ID} ${EX_COMP_PIECE} ` +
-        `--schema '{"properties":{"topic":{"$link":true}}}' addTopic ` +
-        `'{"title":"Ship it"}'`,
-    ),
-    "Return the address of what the verb returned instead of its contents.",
-  )
-  .option("-c,--piece <piece:string>", PIECE_OPTION_HELP)
-  .option(
-    "--invocation <id:string>",
-    "Idempotency key for a handler call (before the callable name), and " +
-      "requires an invocation session. A retry naming the same pair cannot " +
-      "commit twice — it settles on the original outcome — but the " +
-      "handler body does re-run, so effects outside the transaction " +
-      "repeat. Both are minted for the one call when neither is given.",
-  )
-  .env(
-    "CF_INVOCATION_SESSION=<id:string>",
-    "Invocation session that this run's invocation ids belong to. The form " +
-      "to reach for: a session is what makes an outcome's address " +
-      "unguessable, and an environment variable stays out of the process " +
-      "listing an argument shows up in.",
-    { prefix: "CF_" },
-  )
-  .option(
-    "--invocation-session <id:string>",
-    "Override CF_INVOCATION_SESSION for this one call (before the callable " +
-      "name): the session this call's invocation id was chosen within, " +
-      "since an invocation id is the caller's own word and another caller " +
-      "can pick the same one. The pair decides which outcome a replay " +
-      "reads, so the same id under another session is another invocation. " +
-      "Mint a session per agent run with `cf invocation-session new`, and " +
-      "carry that one session on every call of the run.",
-  )
-  .option(
-    "--verbose",
-    "Print per-phase wall-clock timings to stderr (before the callable " +
-      "name). stdout still carries only the command output.",
-  )
-  .option(
-    "--await",
-    "Wait for settlement and receipt readback (before the callable name). " +
-      "This is the default; the flag exists so a script can say so " +
-      "explicitly. Contradicts --no-wait.",
-  )
-  .option(
-    "--wait <seconds:number>",
-    "Bound the settlement wait by a chosen patience, in seconds (before " +
-      "the callable name). On expiry the exit is nonzero with the " +
-      "invocation id and furthest phase on stderr; the invocation may not " +
-      "have executed or committed. Re-invoking under the same id and " +
-      "session cannot commit twice — but it runs the handler body again, " +
-      "so effects outside the transaction repeat. An expiry is exactly the " +
-      "case where you cannot tell whether it committed.",
-  )
-  .option(
-    "--no-wait",
-    "Exit once this handling's commit is acknowledged (before the callable " +
-      "name), skipping only the receipt readback: stdout reports status " +
-      '"committed" plus the receipt address, so `cf piece get --piece <that ' +
-      "address>` collects the outcome later without re-running the handler; " +
-      "a call naming the same session and --invocation recovers it too, but " +
-      "runs the handler body again. The handler still executes here and its " +
-      "commit is durable. Handler invocations only.",
-  )
-  .option(
-    "--show-links",
-    "Annotate the Invocation JSON with a links dictionary mapping result " +
-      "paths to their backing cell addresses, each one reference string " +
-      "--piece takes back in (before the callable name). " +
-      'The root "/" entry is the result\'s own backing document — the ' +
-      "receipt, unless the result is itself a reference, in which case a " +
-      'separate "receipt" entry keeps the receipt address; other entries ' +
-      "appear only where a path is backed by a different document. Handler " +
-      "invocations only — a tool already reports its result cell on stderr.",
-  )
-  .option(
-    "--filter <predicate:string>",
-    "Filter an array with a jq-inspired predicate",
-  )
-  .option(
-    "--select <fields:string>",
-    "Project output to comma-separated field paths",
-  )
-  .option(
-    "--schema <schema:string>",
-    "Project output with an inline JSON Schema, @file, or the --select " +
-      "field list",
-    // Both flags carry the one projection, so a command naming both has not
-    // said which shape it wants. Refuse before the call rather than pick.
-    { conflicts: ["select"] },
-  )
-  .stopEarly()
-  .arguments("<callable:string> [tail...:string]")
-  .action(async function (options, callableArg, ...tailArgs) {
-    // Positional-address intake first: it is a fact about the argv alone,
-    // so a refusal here names no invocation and no phase.
-    const { piece, callableName, tail } = readCallTarget(
-      options,
-      callableArg,
-      tailArgs,
-    );
-    const identity = resolveInvocationIdentity(
-      options.invocation,
-      options.invocationSession,
-    );
-    const invocationId = identity.id;
-    const waitControl = resolveWaitControl(options);
-    let phase: InvocationPhase = "initial_sync";
-    const observer = pieceCallPhaseObserver(
-      !!options.verbose,
-      (next) => phase = next,
-    );
-    setQuietMode(!!options.quiet);
-    // Read outside the invocation's failure wrapper below. Nothing is
-    // dispatched here — no callable resolved, no id spent — so a malformed
-    // selection is a data error about the flags, the same one `cf piece get`
-    // reports. Inside the wrapper it would name an id and a phase to retry
-    // from for a call that was never made; a selection that fails against a
-    // RESULT does sit inside it, and does name one.
-    let selection: CellSelection | undefined;
-    try {
-      selection = await parsePieceCallSelection(options);
-    } catch (error) {
-      // Both exits below leave without reaching the action's catch, so the
-      // verbose in-flight span is closed here.
-      observer.finish("failed");
-      if (error instanceof CellSelectionError) {
-        exitWithDataError({ message: error.message });
-      }
-      throw error;
-    }
-    try {
-      const invocation = pieceCallInvocation(
-        tail,
-        this.getLiteralArgs(),
-      );
-      const pieceConfig = parsePieceOptions({
-        ...options,
-        ...(piece !== undefined && { piece }),
-        json: invocation.jsonOutput,
-      });
-      const result = await boundedSettlement(
-        executePieceCallable(
-          pieceConfig,
-          callableName,
-          invocation.rawArgs,
-          {
-            invocation: identity,
-            skipReadback: waitControl.mode === "commit",
-            showLinks: !!options.showLinks,
-            ...(selection === undefined ? {} : { selection }),
-            onPhase: invocationPhaseReporter(
-              identity,
-              observer.onPhase,
-              undefined,
-              Boolean(Deno.env.get("CF_TEST_ANNOUNCE_INVOCATION_PHASES")),
-            ),
-          },
-        ).catch((error) =>
-          reportVerbInputErrorOrRethrow(
-            error,
-            pieceConfig.piece,
-            undefined,
-            observer,
-          )
-        ),
-        waitControl.boundSeconds,
-      );
-      renderPieceCallOutcome(
-        observer,
-        result,
-        callableName,
-        pieceConfig.piece,
-        {},
-        { detached: waitControl.mode === "commit", invocation: identity },
-      );
-    } catch (error) {
-      exitPieceCallFailure(observer, error, invocationId, phase);
-    }
-  })
+  .command("call", buildCallCommand())
   /* piece verbs */
   .command(
     "verbs",

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -352,13 +352,20 @@ const ARGUMENT_PROVIDERS: Readonly<
   "piece call:callable": callableCandidates,
   // The first positional of `piece get`/`piece set` is a cell path unless the
   // caller writes a canonical address there, and an address is pasted rather
-  // than completed — so the path candidates serve the slot either way.
+  // than completed — so the path candidates serve the slot either way. The
+  // top-level spellings are the same commands mounted at top level, and
+  // their entries keep the two spellings completing identically.
   "piece get:addressOrPath": cellPathCandidates,
   "piece get:path": cellPathCandidates,
   "piece get-label:path": cellPathCandidates,
   "piece set:addressOrPath": cellPathCandidates,
   "piece set:path": cellPathCandidates,
   "piece set-label:path": cellPathCandidates,
+  "call:callable": callableCandidates,
+  "get:addressOrPath": cellPathCandidates,
+  "get:path": cellPathCandidates,
+  "set:addressOrPath": cellPathCandidates,
+  "set:path": cellPathCandidates,
   "piece link:source": linkEndpointCandidates,
   "piece link:target": linkEndpointCandidates,
   "piece new:main": patternFiles,

--- a/packages/cli/lib/json-output.ts
+++ b/packages/cli/lib/json-output.ts
@@ -77,6 +77,10 @@ export function reservesStdoutForCommandOutput(
   }
   if (args[0] === "exec") return true;
   if (args[0] === "wish") return true;
+  // The top-level spellings reserve stdout exactly as their `cf piece`
+  // counterparts below do. `set` is absent from both lists for the same
+  // reason: it writes prose, not a machine surface.
+  if (args[0] === "get" || args[0] === "call") return true;
   const subcommand = pieceSubcommand(args);
   return subcommand === "get" || subcommand === "get-label" ||
     subcommand === "set-label" || subcommand === "call";

--- a/packages/cli/test/json-command.test.ts
+++ b/packages/cli/test/json-command.test.ts
@@ -43,6 +43,11 @@ describe("JSON command contracts", () => {
     ).toBe(true);
     expect(reservesStdoutForCommandOutput(["piece", "get", "path"]))
       .toBe(true);
+    // The top-level spellings reserve stdout exactly as their piece
+    // counterparts: get and call do, set does not.
+    expect(reservesStdoutForCommandOutput(["get", "path"])).toBe(true);
+    expect(reservesStdoutForCommandOutput(["call", "search"])).toBe(true);
+    expect(reservesStdoutForCommandOutput(["set", "path"])).toBe(false);
     expect(reservesStdoutForCommandOutput(["piece", "get-label", "path"]))
       .toBe(true);
     expect(reservesStdoutForCommandOutput(["piece", "set-label", "path"]))

--- a/packages/cli/test/main-command.test.ts
+++ b/packages/cli/test/main-command.test.ts
@@ -55,7 +55,7 @@ describe("main command", () => {
     );
     const commands = [main];
     const mismatchedUsage: string[] = [];
-    const customUsageCommands = new Set(["cf piece call"]);
+    const customUsageCommands = new Set(["cf piece call", "cf call"]);
 
     for (const command of commands) {
       commands.push(...command.getCommands());

--- a/packages/cli/test/piece-data-spellings.test.ts
+++ b/packages/cli/test/piece-data-spellings.test.ts
@@ -15,19 +15,25 @@ import { cf, stripAnsi } from "./utils.ts";
 describe("piece-data-spellings", () => {
   const SPELLINGS = ["get", "set", "call"] as const;
 
-  /** Option names visible on a command, inherited globals included, minus
-   * the help machinery every command carries. */
+  /** The option surface visible on a command, inherited globals included,
+   * minus the help machinery every command carries. Each option contributes
+   * its full signature — every flag spelling plus the value grammar — so a
+   * mount that renamed a short flag or retyped a value diverges here, not
+   * only one that dropped an option outright. */
   // deno-lint-ignore no-explicit-any
-  function effectiveOptionNames(command: any): string[] {
-    const own = command.getOptions(true).map((option: { name: string }) =>
-      option.name
+  function effectiveOptionSurface(command: any): string[] {
+    const signature = (
+      option: { name: string; flags: string[]; typeDefinition?: string },
+    ) =>
+      `${[...option.flags].sort().join(",")} ${option.typeDefinition ?? ""}`
+        .trim();
+    const visible = [
+      ...command.getOptions(true),
+      ...command.getGlobalOptions(true),
+    ].filter((option: { name: string }) =>
+      option.name !== "help" && option.name !== "version"
     );
-    const inherited = command.getGlobalOptions(true).map((
-      option: { name: string },
-    ) => option.name);
-    return [...new Set([...own, ...inherited])]
-      .filter((name) => name !== "help" && name !== "version")
-      .sort();
+    return [...new Set(visible.map(signature))].sort();
   }
 
   it("mounts each command at top level with the piece mount's exact surface", async () => {
@@ -42,7 +48,9 @@ describe("piece-data-spellings", () => {
       expect(nested).toBeDefined();
       expect(top!.getArgsDefinition()).toBe(nested!.getArgsDefinition());
       expect(top!.getUsage()).toBe(nested!.getUsage());
-      expect(effectiveOptionNames(top)).toEqual(effectiveOptionNames(nested));
+      expect(effectiveOptionSurface(top)).toEqual(
+        effectiveOptionSurface(nested),
+      );
       // The description differs only by how the command names itself.
       expect(top!.getDescription()).toBe(
         nested!.getDescription().replaceAll(`cf piece ${name}`, `cf ${name}`),

--- a/packages/cli/test/piece-data-spellings.test.ts
+++ b/packages/cli/test/piece-data-spellings.test.ts
@@ -1,0 +1,74 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { cf, stripAnsi } from "./utils.ts";
+
+/**
+ * `cf get`/`cf set`/`cf call` and their `cf piece` counterparts are one
+ * definition each, mounted twice (docs/plans/cli-surface-shape.md, step 5).
+ * These tests compare the two mounts of each command directly, so a change
+ * that reaches one spelling and not the other names itself here instead of
+ * hiding behind two green per-surface tests. The target options arrive
+ * differently by design — as `piece` globals on one mount, as own options
+ * on the other — which is exactly why the comparison is over the EFFECTIVE
+ * surface (own plus inherited), not over where each option is declared.
+ */
+describe("piece-data-spellings", () => {
+  const SPELLINGS = ["get", "set", "call"] as const;
+
+  /** Option names visible on a command, inherited globals included, minus
+   * the help machinery every command carries. */
+  // deno-lint-ignore no-explicit-any
+  function effectiveOptionNames(command: any): string[] {
+    const own = command.getOptions(true).map((option: { name: string }) =>
+      option.name
+    );
+    const inherited = command.getGlobalOptions(true).map((
+      option: { name: string },
+    ) => option.name);
+    return [...new Set([...own, ...inherited])]
+      .filter((name) => name !== "help" && name !== "version")
+      .sort();
+  }
+
+  it("mounts each command at top level with the piece mount's exact surface", async () => {
+    const { main } = await import(
+      "../commands/main.ts?piece-data-spellings-surface"
+    );
+    const piece = main.getCommand("piece")!;
+    for (const name of SPELLINGS) {
+      const top = main.getCommand(name);
+      const nested = piece.getCommand(name);
+      expect(top).toBeDefined();
+      expect(nested).toBeDefined();
+      expect(top!.getArgsDefinition()).toBe(nested!.getArgsDefinition());
+      expect(top!.getUsage()).toBe(nested!.getUsage());
+      expect(effectiveOptionNames(top)).toEqual(effectiveOptionNames(nested));
+      // The description differs only by how the command names itself.
+      expect(top!.getDescription()).toBe(
+        nested!.getDescription().replaceAll(`cf piece ${name}`, `cf ${name}`),
+      );
+    }
+  });
+
+  it("refuses a configuration-free run identically under both spellings", async () => {
+    // End to end through real Cliffy parsing in a subprocess with no fabric
+    // configuration: the refusal text and exit code are the behavior a
+    // script sees first, and the two spellings must not diverge in it. The
+    // deno task banner echoes the argv and so differs by construction.
+    const refusal = (stderr: string[]) =>
+      stderr.map((line) => stripAnsi(line))
+        .filter((line) => !line.startsWith("Task "))
+        .join("\n");
+    for (const name of SPELLINGS) {
+      const top = await cf(name);
+      const nested = await cf(`piece ${name}`);
+      expect(top.code).toBe(nested.code);
+      expect(refusal(top.stderr)).toBe(refusal(nested.stderr));
+      // `get` and `set` refuse on the missing identity, `call` on the
+      // missing callable argument — either way a refusal happened, which is
+      // what keeps the equality above from passing vacuously on two silent
+      // successes.
+      expect(refusal(top.stderr)).toContain("Missing");
+    }
+  });
+});


### PR DESCRIPTION
## Why

CLI surface shape, step 5 (`docs/plans/cli-surface-shape.md`), stacked on #5896 (step 4; step 3 is #5894). Reading and writing cells is not a piece-management concern, and the surface now says so: the three piece data commands exist at top level under their honest names — `cf get`, `cf set`, `cf call` — beside the `cf piece` spellings, which keep working unchanged.

The structure was chosen to make step 6 (deprecating the old spellings) as small as possible. Cliffy rebinds a subcommand's parent at registration, so one command instance cannot be mounted under two parents; a raw-argv forwarder was the alternative, but it leaves the implementation under the `piece` spelling — the one due for deprecation — and flipping ownership later is real work. Instead, each command's definition moves into a builder (`buildGetCommand`/`buildSetCommand`/`buildCallCommand` in `packages/cli/commands/piece.ts`), and both surfaces mount instances of it. Deprecating the `cf piece` spellings later touches only the piece-mounted instances; the doc sweep is the rest.

## What changed

- `targetOptions` factory: the `-q/-u/-a/-i/-s` surface with its `CF_API_URL`/`CF_IDENTITY` env fallbacks, defined once — the `piece` chain declares them as globals its subcommands inherit, the top-level instances carry them as their own. One source, so the two spellings cannot drift in what they accept.
- The builders take a `spelling` parameter used only in their own help text, so `cf get --help` says `Usage: cf get …` and its examples use the short spelling, while `cf piece get --help` is unchanged.
- Stdout reservation (`lib/json-output.ts`): `cf get` and `cf call` reserve stdout exactly as `cf piece get`/`cf piece call` do; `set` stays unreserved on both surfaces, as it writes prose.
- Completion: the top-level names complete with their descriptions, and their positional/callable slots complete identically to the `piece` spellings (`lib/completion/providers.ts`).
- Docs owed by step 5: the new spellings beside the old ones in the CLI README, the tutorial's workflow chapter, and `docs/common/verbs-over-the-cli.md`.

## Test plan

- New `test/piece-data-spellings.test.ts`: compares the two mounts of each command directly — argument definition, usage, description (modulo self-naming), and the *effective* option surface (own plus inherited globals) — plus a subprocess check that a configuration-free run refuses identically under both spellings. A change reaching one spelling and not the other fails here by name, rather than hiding behind two green per-surface tests.
- Stdout-reservation cases for the top-level names in `test/json-command.test.ts`.
- Full `packages/cli` suite: 174 passed, 0 failed. Repo-wide `deno fmt --check`, `deno lint`, `deno task check-docs` green.
- Coverage delta vs the step-4 base, same suite both sides: −3 zero-hit lines for `packages/cli` (cumulative across the three stacked PRs: −42).
- Measured live against a local toolshed: `cf get` (flag, positional, and space-carrying addresses), `cf set` write with readback, `cf call` dispatching a verb and printing the Invocation JSON, misplaced-flag refusals identical across spellings, and completion output identical across spellings (paths and callables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

