### PR TITLE
Disposal releases what it holds even when it fails

### DIFF
--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1372,83 +1372,94 @@ export class Runtime {
   async dispose(
     { closeStorage = true }: { closeStorage?: boolean } = {},
   ): Promise<void> {
-    // A kept store keeps RECORDING, so this path drains what could still write
-    // into it. In-flight async builtin work is that shape: a fetch / llm call or
-    // a sqlite RPC runs from a post-commit outbox flush and writes its result
-    // back when it lands, and `trackAsyncWork` exists because neither `idle()`
-    // nor `synced()` waits for it. `settled()` is the barrier that does. The
-    // closing path skips it because a caller who let the store close has no
-    // reader left to mislead, and waiting on the network in every teardown is a
-    // real cost; here the caller is about to read what this runtime wrote.
-    //
-    // BEFORE the cancellation below, not after: `stopAll()` and
-    // `scheduler.dispose()` would cut a writeback's reactive cascade midway,
-    // leaving the store holding part of a result — which is worse than either
-    // extreme for a reader trying to learn what state this runtime reached.
-    //
-    // UNCAPPED, deliberately. `settled()`'s default 50 rounds falls out of the
-    // loop and returns — silently, with work still outstanding — which is
-    // exactly the hole this drain exists to close, one layer down. Measured: 60
-    // generations of chained tracked work, and a capped drain returned at
-    // generation 50 while the chain kept running and writing. `settledFor`'s
-    // JSDoc gives the reason a cap is wrong for this question and why removing
-    // it cannot spin: every round awaits real promises, so a runtime that keeps
-    // working keeps the barrier open rather than busy-looping.
-    if (!closeStorage) await this.settled(Infinity);
-    // Abort any pending (not-yet-started) queued jobs so they don't start
-    // after storage is torn down.
-    for (const queue of this.queues.values()) {
-      queue.abortPending();
+    try {
+      // A kept store keeps RECORDING, so this path drains what could still write
+      // into it. In-flight async builtin work is that shape: a fetch / llm call or
+      // a sqlite RPC runs from a post-commit outbox flush and writes its result
+      // back when it lands, and `trackAsyncWork` exists because neither `idle()`
+      // nor `synced()` waits for it. `settled()` is the barrier that does. The
+      // closing path skips it because a caller who let the store close has no
+      // reader left to mislead, and waiting on the network in every teardown is a
+      // real cost; here the caller is about to read what this runtime wrote.
+      //
+      // BEFORE the cancellation below, not after: `stopAll()` and
+      // `scheduler.dispose()` would cut a writeback's reactive cascade midway,
+      // leaving the store holding part of a result — which is worse than either
+      // extreme for a reader trying to learn what state this runtime reached.
+      //
+      // UNCAPPED, deliberately. `settled()`'s default 50 rounds falls out of the
+      // loop and returns — silently, with work still outstanding — which is
+      // exactly the hole this drain exists to close, one layer down. Measured: 60
+      // generations of chained tracked work, and a capped drain returned at
+      // generation 50 while the chain kept running and writing. `settledFor`'s
+      // JSDoc gives the reason a cap is wrong for this question and why removing
+      // it cannot spin: every round awaits real promises, so a runtime that keeps
+      // working keeps the barrier open rather than busy-looping.
+      if (!closeStorage) await this.settled(Infinity);
+      // Abort any pending (not-yet-started) queued jobs so they don't start
+      // after storage is torn down.
+      for (const queue of this.queues.values()) {
+        queue.abortPending();
+      }
+      this.queues.clear();
+      // Stop all running docs
+      this.runner.stopAll();
+
+      // Background source checks are deliberately outside the scheduler. Abort
+      // and settle them before the storage sessions they may write through close.
+      await this.patternUpdater.dispose();
+
+      // Same contract for the runner's unloadable-pointer roll-forward commits
+      // (CT-1923): settle before their storage sessions close. Commits only —
+      // never the watcher pattern LOADS, which can be held/wedged arbitrarily
+      // long and are lifecycle-epoch-guarded instead.
+      await this.runner.settlePointerCommits();
+
+      // Scheduler background work can still be using storage, for example the
+      // lifecycle-guarded boot-time persistent-state listing. Let that finish
+      // before tearing down storage sessions.
+      await this.scheduler.idle();
+
+      // Clear module registry
+      this.moduleRegistry.clear();
+
+      // Cancel all storage operations
+      if (closeStorage) await this.storageManager.close();
+
+      // Wait for any pending operations
+      await this.scheduler.idle();
+    } finally {
+      // Released whatever happened above. `storageManager.close()` can reject
+      // — through a provider's `replica.close()` — and it is the one await here
+      // that can. Every statement below is synchronous field-clearing that
+      // cannot fail in turn, so running them on the error path costs nothing
+      // while skipping them strands the process: the config resets are
+      // PROCESS-GLOBAL, and one skipped leaves a non-default experimental flag
+      // set for every runtime built afterwards, with nothing to put it back.
+      //
+      // The error still propagates. What changes is how much has been released
+      // by the time it does, not whether disposal fails.
+      //
+      // The unsubscribes come last, and after the final `idle()` above, because
+      // a subscriber removed earlier would miss notifications the settling work
+      // still depends on.
+      this.scheduler.dispose();
+      this.runner.dispose();
+
+      // Pop the default frame
+      if (this.defaultFrame) {
+        popFrame(this.defaultFrame);
+        this.defaultFrame = undefined;
+      }
+
+      // Dispose the Engine (clears compiler/runtime state and the console hook)
+      this.harness.dispose();
+
+      // Reset experimental config to defaults.
+      resetModernCellRepConfig();
+      resetPersistentSchedulerStateConfig();
+      resetCommitPreconditionsConfig();
     }
-    this.queues.clear();
-    // Stop all running docs
-    this.runner.stopAll();
-
-    // Background source checks are deliberately outside the scheduler. Abort
-    // and settle them before the storage sessions they may write through close.
-    await this.patternUpdater.dispose();
-
-    // Same contract for the runner's unloadable-pointer roll-forward commits
-    // (CT-1923): settle before their storage sessions close. Commits only —
-    // never the watcher pattern LOADS, which can be held/wedged arbitrarily
-    // long and are lifecycle-epoch-guarded instead.
-    await this.runner.settlePointerCommits();
-
-    // Scheduler background work can still be using storage, for example the
-    // lifecycle-guarded boot-time persistent-state listing. Let that finish
-    // before tearing down storage sessions.
-    await this.scheduler.idle();
-
-    // Clear module registry
-    this.moduleRegistry.clear();
-
-    // Cancel all storage operations
-    if (closeStorage) await this.storageManager.close();
-
-    // Wait for any pending operations
-    await this.scheduler.idle();
-
-    // Clean up scheduler timers, and unregister both storage subscribers.
-    // Last, and after the final `idle()` above, because a subscriber removed
-    // earlier would miss notifications the settling work above still depends
-    // on. It matters most when `closeStorage` is false: the manager outlives
-    // this runtime, and anything it still holds holds a disposed runtime.
-    this.scheduler.dispose();
-    this.runner.dispose();
-
-    // Pop the default frame
-    if (this.defaultFrame) {
-      popFrame(this.defaultFrame);
-      this.defaultFrame = undefined;
-    }
-
-    // Dispose the Engine (clears compiler/runtime state and the console hook)
-    this.harness.dispose();
-
-    // Reset experimental config to defaults.
-    resetModernCellRepConfig();
-    resetPersistentSchedulerStateConfig();
-    resetCommitPreconditionsConfig();
 
     // Clear the current runtime reference
     // Removed setCurrentRuntime call - no longer using singleton pattern

--- a/packages/runner/test/runtime-dispose-keep-storage.test.ts
+++ b/packages/runner/test/runtime-dispose-keep-storage.test.ts
@@ -34,6 +34,11 @@ import {
   type SessionFactory,
   StorageManager,
 } from "../src/storage/v2.ts";
+import {
+  getModernCellRepConfig,
+  resetModernCellRepConfig,
+  setModernCellRepConfig,
+} from "@commonfabric/data-model/cell-rep";
 import { Runtime } from "../src/runtime.ts";
 import {
   TEST_MEMORY_SERVER_AUTH,
@@ -70,9 +75,10 @@ class LoopbackSessionFactory implements SessionFactory {
  */
 class CountingStorageManager extends StorageManager {
   closeCount = 0;
-  /** Subscribers currently registered. The relay inside exposes only
-   * `hasSubscribers()`, and what a leak needs is the COUNT: two per runtime,
-   * so "some are registered" cannot tell a clean teardown from a leaking one. */
+  /** Subscriptions handed to `subscribe` and not yet handed back. Mirrors the
+   * calls reaching the manager, which is what the assertions below are about;
+   * the relay's own membership is private, and its `hasSubscribers()` would
+   * read the same whether teardown was clean or leaked two per runtime. */
   readonly live = new Set<IStorageSubscription>();
   static over(server: MemoryV2Server.Server): CountingStorageManager {
     return new CountingStorageManager(
@@ -91,6 +97,25 @@ class CountingStorageManager extends StorageManager {
   override unsubscribe(subscription: IStorageSubscription): void {
     this.live.delete(subscription);
     super.unsubscribe(subscription);
+  }
+}
+
+/**
+ * Rejects on `close()`, standing in for a provider whose `replica.close()`
+ * fails. That is the ONE await in `Runtime.dispose()` able to reject — every
+ * other one resolves through `Promise.allSettled` or a resolve-only promise —
+ * so this is the only way the error path is reachable at all.
+ */
+class FailingCloseStorageManager extends CountingStorageManager {
+  static failing(server: MemoryV2Server.Server): FailingCloseStorageManager {
+    return new FailingCloseStorageManager(
+      { as: signer, memoryHost: new URL("memory://") } as Options,
+      new LoopbackSessionFactory(server),
+    );
+  }
+  override close(): Promise<void> {
+    this.closeCount++;
+    return Promise.reject(new Error("provider destroy failed"));
   }
 }
 
@@ -315,5 +340,33 @@ describe("runtime.dispose({ closeStorage })", () => {
 
     // Neither disposal closed the store, which is the option's whole point.
     expect(held.closeCount).toBe(0);
+  });
+
+  it("releases what it holds when closing the store rejects", async () => {
+    const failing = FailingCloseStorageManager.failing(server);
+    const runtime = new Runtime({
+      apiUrl: new URL("memory://"),
+      storageManager: failing,
+    });
+    const registered = [...failing.live];
+    expect(registered).toHaveLength(2);
+
+    setModernCellRepConfig(true);
+    try {
+      // The closing path, so `close()` runs and rejects. The rejection still
+      // reaches the caller: releasing on the way out changes what has been
+      // given back by then, not whether disposal fails.
+      await expect(runtime.dispose()).rejects.toThrow(
+        "provider destroy failed",
+      );
+
+      // PROCESS-GLOBAL, which is why this one matters beyond the runtime that
+      // set it: skipped once, a non-default flag reaches every runtime built
+      // afterwards in the same process and nothing puts it back.
+      expect(getModernCellRepConfig()).toBe(false);
+      expect(registered.filter((s) => failing.live.has(s))).toEqual([]);
+    } finally {
+      resetModernCellRepConfig();
+    }
   });
 });


### PR DESCRIPTION
## Why

Closes #5897.

`Runtime.dispose()` ran its teardown as a straight sequence, so a rejection
skipped every step below it. The steps below are all releases, and one of them
is process-global: `resetModernCellRepConfig()` and its two siblings. Skipped
once, a non-default experimental flag outlives the runtime that set it and
reaches every runtime built afterwards in the same process, with nothing to put
it back. `packages/background-piece-service/src/worker.ts` disposes on the
closing path with no `catch`, which is that shape in a long-lived process.

**Read this diff with `git diff -w`.** Wrapping the body in `try` re-indents it,
which is 161 lines of noise over 17 lines of change.

### The error path is narrower than it looks, which is what makes this cheap

Tracing every `await` in the method for a reject path, exactly one can reject:

| Step | Rejects? | Why |
| --- | --- | --- |
| `settled(Infinity)` — `closeStorage: false` only | no | `idleWithPendingCommits()` resolves only; `synced()` resolves through `.finally()`; ends in `Promise.allSettled` |
| `patternUpdater.dispose()` | no | ends in `idle()`, which is `Promise.allSettled` |
| `runner.settlePointerCommits()` | no | `Promise.allSettled` in a loop |
| `scheduler.idle()` (×2) | no | `waitForQuiescence` is `new Promise(resolve => …)` with no reject path |
| `storageManager.close()` — `closeStorage: true` only | **yes** | `Promise.all(providers.map(p => p.destroy()))`, and `destroy()` awaits `replica.close()` |

Everything after that single step is synchronous field-clearing that cannot
fail in turn, so a `finally` is the whole fix. There was no need to choose
between best-effort and fail-fast teardown: with one fallible step there is
nothing to aggregate, and both readings agree the release block should run.

This does not change whether `dispose()` throws. It still throws, with the same
error. What changes is how much has been released by the time it does.

## What Changed

The body is wrapped in `try`, and the five synchronous release steps —
both storage unsubscribes, the default-frame pop, `harness.dispose()`, and the
three config resets — move into a `finally`.

The ordering constraint the previous comment recorded still holds and is
restated: the unsubscribes come last, after the final `idle()`, because a
subscriber removed earlier would miss notifications the settling work depends
on.

One invariant worth knowing before reordering this method: the sole fallible
await sits after everything that must precede it, and everything following it
is infallible release. Introduce a fallible await earlier — a network flush
ahead of `patternUpdater.dispose()`, say — and the method would begin skipping
`storageManager.close()` itself, stranding providers, sockets and replica
sessions. That is a worse leak than the one #5895 fixed.

## Test plan

`runtime-dispose-keep-storage.test.ts` gains `FailingCloseStorageManager`, whose
`close()` rejects, standing in for a provider whose `replica.close()` fails —
the only way the error path is reachable. The test asserts the rejection still
reaches the caller, and that the process-global flag is back at its default and
both subscriptions handed back regardless.

Verified by mutation: disabling the `finally` (keeping the block, dropping the
guarantee) FAILS the new test; restored, it passes. `packages/runner` suite
green. `deno fmt --check`, `deno lint`, `deno task check`,
`deno task check-no-waitfor` all green.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

