### PR TITLE
The type string states what a conjunction declares

### DIFF
--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -559,6 +559,16 @@ describe("parseExecArgs edge cases", () => {
     // And the help page lists it, which is the half a caller reads first.
     const help = renderExecHelp("/mnt/x.handler", spec, {});
     expect(help).toMatch(/--count/);
+
+    // The type block above the flags shows it too. The two are rendered by
+    // DIFFERENT readers — the flag list by the CLI's own, the type block by
+    // the runner's formatter — so one page could state two answers about one
+    // schema, and did. Sliced out rather than matched against the whole page,
+    // because `--count` in the flag list would satisfy a looser match on its
+    // own and the disagreement is exactly what needs catching.
+    const typeBlock = help.split("Input type:")[1]?.split("Flags:")[0] ?? "";
+    expect(typeBlock).toMatch(/note/);
+    expect(typeBlock).toMatch(/count/);
   });
 
   it("follows a reference into the definition a conjunction names", () => {

--- a/packages/runner/src/schema-format.ts
+++ b/packages/runner/src/schema-format.ts
@@ -169,10 +169,15 @@ function conjunctionSources(
     if (depth > MAX_CONJUNCTION_DEPTH) return;
     if (typeof entry !== "object" || entry === null) return;
     let current = entry as Record<string, unknown>;
-    if (typeof current.$ref === "string") {
-      const match = current.$ref.match(/^#\/\$defs\/(.+)$/);
-      if (!match || followed.has(current.$ref)) return;
-      followed.add(current.$ref);
+    // A chain, not a hop: a definition is allowed to be an alias for another,
+    // and stopping after one would collect the alias — which states no field —
+    // instead of what it names. The guard below is what ends a chain that
+    // loops back on itself.
+    while (typeof current.$ref === "string") {
+      const ref = current.$ref;
+      const match = ref.match(/^#\/\$defs\/(.+)$/);
+      if (!match || followed.has(ref)) return;
+      followed.add(ref);
       const def = defs[match[1]];
       if (!def || typeof def !== "object") return;
       current = def as Record<string, unknown>;
@@ -340,7 +345,12 @@ function schemaToTypeStringInner(
   // fields live only in `allOf` states no `type` and no `properties` of its
   // own, and would otherwise not reach that branch at all.
   const sources = Array.isArray(s.allOf) ? conjunctionSources(s, defs) : [s];
-  const conjoined: Record<string, JSONSchema> = {};
+  // Null-prototype, because the keys are field names out of caller JSON and a
+  // schema may legally declare one called `__proto__`. Measured on Deno 2.9.4:
+  // such a key survives a plain `{}` accumulator intact. That is a property of
+  // the engine rather than of this code, and the accumulator states which it
+  // depends on rather than inheriting the question.
+  const conjoined: Record<string, JSONSchema> = Object.create(null);
   const conjoinedRequired: string[] = [];
   for (const source of sources) {
     const sourceProps = source.properties as
@@ -359,10 +369,18 @@ function schemaToTypeStringInner(
     }
   }
 
-  if (type === "object" || s.properties || Object.keys(conjoined).length > 0) {
-    const props = Object.keys(conjoined).length > 0
-      ? conjoined
-      : s.properties as Record<string, JSONSchema> | undefined;
+  // A conjunct saying `type: "object"` makes the whole an object even when it
+  // names no field, and `{}` is what that is. Falling through to `unknown`
+  // would deny a shape the schema states. A conjunct saying `type: "string"`
+  // is a different matter and still falls through: it contributes no field,
+  // and rendering it `{}` would invent an object nothing described.
+  //
+  // For a schema with no `allOf`, `sources` is the schema alone, so this asks
+  // exactly what the object branch has always asked.
+  if (
+    sources.some((source) => source.type === "object" || !!source.properties)
+  ) {
+    const props = conjoined;
     // An index signature (object-valued additionalProperties) carries a value
     // schema worth showing; a bare `additionalProperties: true` does not
     const indexValueSchema = typeof s.additionalProperties === "object" &&

--- a/packages/runner/src/schema-format.ts
+++ b/packages/runner/src/schema-format.ts
@@ -91,6 +91,17 @@ export interface SchemaFormatOptions {
  * schemaToTypeString({ type: ["string", "null"] })   // → "string | null"
  *
  * @example
+ * // A conjunction contributes its members' fields to one object. A
+ * // disjunction stays a union: `anyOf` is a choice between shapes, while
+ * // `allOf` states shapes that hold at once.
+ * schemaToTypeString({
+ *   type: "object",
+ *   properties: { note: { type: "string" } },
+ *   allOf: [{ properties: { count: { type: "number" } } }]
+ * })
+ * // → "{\n  note?: string,\n  count?: number\n}"
+ *
+ * @example
  * // Index signatures (object-valued additionalProperties)
  * schemaToTypeString({
  *   type: "object",
@@ -126,6 +137,53 @@ export function schemaToTypeString(
     (schema as Record<string, unknown>)?.scope,
     rendered,
   );
+}
+
+/** How deep nested `allOf` is followed before a conjunction is left alone. */
+const MAX_CONJUNCTION_DEPTH = 8;
+
+/**
+ * The schemas a conjunction contributes fields from: the schema itself, then
+ * each `allOf` member, depth-first through nested conjunctions, with a
+ * `$defs` reference resolved to what it names.
+ *
+ * Order is what the caller merges by, so it matters: the schema's own
+ * properties come first and win, then earlier members beat later ones. That is
+ * the order `declaredEventFields` in the CLI reads a conjunction in, and
+ * matching it is what keeps a help page's type block and its flag list
+ * agreeing about the same schema.
+ *
+ * A disjunction is not walked. `anyOf` is a union and renders as one; only a
+ * conjunction states fields that all hold at once.
+ */
+function conjunctionSources(
+  schema: Record<string, unknown>,
+  defs: Record<string, JSONSchema>,
+): Record<string, unknown>[] {
+  const sources: Record<string, unknown>[] = [];
+  // Keyed by the reference rather than by the object it resolves to: the same
+  // `$defs` entry reached twice is the cycle worth stopping, and a schema
+  // object's identity is not stable enough to key a guard on.
+  const followed = new Set<string>();
+  const visit = (entry: unknown, depth: number): void => {
+    if (depth > MAX_CONJUNCTION_DEPTH) return;
+    if (typeof entry !== "object" || entry === null) return;
+    let current = entry as Record<string, unknown>;
+    if (typeof current.$ref === "string") {
+      const match = current.$ref.match(/^#\/\$defs\/(.+)$/);
+      if (!match || followed.has(current.$ref)) return;
+      followed.add(current.$ref);
+      const def = defs[match[1]];
+      if (!def || typeof def !== "object") return;
+      current = def as Record<string, unknown>;
+    }
+    sources.push(current);
+    if (Array.isArray(current.allOf)) {
+      for (const member of current.allOf) visit(member, depth + 1);
+    }
+  };
+  visit(schema, 0);
+  return sources;
 }
 
 function schemaToTypeStringInner(
@@ -277,8 +335,34 @@ function schemaToTypeStringInner(
   }
 
   // Handle objects
-  if (type === "object" || s.properties) {
-    const props = s.properties as Record<string, JSONSchema> | undefined;
+  // A conjunction states its fields across its members, so they are gathered
+  // before the object branch decides whether there are any. A schema whose
+  // fields live only in `allOf` states no `type` and no `properties` of its
+  // own, and would otherwise not reach that branch at all.
+  const sources = Array.isArray(s.allOf) ? conjunctionSources(s, defs) : [s];
+  const conjoined: Record<string, JSONSchema> = {};
+  const conjoinedRequired: string[] = [];
+  for (const source of sources) {
+    const sourceProps = source.properties as
+      | Record<string, JSONSchema>
+      | undefined;
+    // First declaration wins, matching how the CLI reads the same conjunction.
+    if (sourceProps) {
+      for (const [name, propSchema] of Object.entries(sourceProps)) {
+        if (!Object.hasOwn(conjoined, name)) conjoined[name] = propSchema;
+      }
+    }
+    // Required is a UNION, not first-wins: every member's constraint holds at
+    // once, so a field any member requires is required of the whole.
+    if (Array.isArray(source.required)) {
+      conjoinedRequired.push(...(source.required as string[]));
+    }
+  }
+
+  if (type === "object" || s.properties || Object.keys(conjoined).length > 0) {
+    const props = Object.keys(conjoined).length > 0
+      ? conjoined
+      : s.properties as Record<string, JSONSchema> | undefined;
     // An index signature (object-valued additionalProperties) carries a value
     // schema worth showing; a bare `additionalProperties: true` does not
     const indexValueSchema = typeof s.additionalProperties === "object" &&
@@ -295,9 +379,7 @@ function schemaToTypeStringInner(
       return "{}";
     }
 
-    const required = new Set(
-      Array.isArray(s.required) ? (s.required as string[]) : [],
-    );
+    const required = new Set(conjoinedRequired);
     const lines: string[] = [];
     const padding = "  ".repeat(indent + 1);
 

--- a/packages/runner/test/schema-format.test.ts
+++ b/packages/runner/test/schema-format.test.ts
@@ -679,3 +679,48 @@ Deno.test("schemaToTypeString does not make an object of a scalar conjunction", 
     "unknown",
   );
 });
+
+Deno.test("schemaToTypeString steps over a conjunct that is not a schema", () => {
+  // `allOf` is caller data and can hold anything. A member that is not an
+  // object contributes no field rather than ending the walk, so the members
+  // beside it are still read.
+  assertEquals(
+    schemaToTypeString({
+      allOf: [null, "nope", { properties: { a: { type: "string" } } }],
+    } as never),
+    "{\n  a?: string\n}",
+  );
+});
+
+Deno.test("schemaToTypeString steps over a conjunct naming a definition that is absent", () => {
+  assertEquals(
+    schemaToTypeString(
+      {
+        type: "object",
+        properties: { a: { type: "string" } },
+        allOf: [{ $ref: "#/$defs/Missing" }],
+      } as never,
+      { defs: {} as never },
+    ),
+    "{\n  a?: string\n}",
+  );
+});
+
+Deno.test("schemaToTypeString stops following a conjunction past its depth bound", () => {
+  // Nested `allOf` is followed 8 levels. The 10th level's field is beyond the
+  // bound and does not appear; the levels within it still do. The bound is
+  // what keeps a pathological schema from walking forever.
+  let deepest: Record<string, unknown> = {
+    properties: { level10: { type: "string" } },
+  };
+  for (let level = 9; level >= 1; level--) {
+    deepest = {
+      properties: { [`level${level}`]: { type: "string" } },
+      allOf: [deepest],
+    };
+  }
+  const rendered = schemaToTypeString(deepest as never, { maxDepth: 99 });
+  assert(rendered.includes("level1"), "the outermost level is read");
+  assert(rendered.includes("level8"), "the level at the bound is read");
+  assert(!rendered.includes("level10"), "the level past the bound is not");
+});

--- a/packages/runner/test/schema-format.test.ts
+++ b/packages/runner/test/schema-format.test.ts
@@ -569,3 +569,113 @@ Deno.test("schemaToTypeString formats fixture-style PatternToolResult without le
     "extraParams internals should stay hidden",
   );
 });
+
+// A conjunction states its fields across its members. These pin that the
+// rendering merges them the way the CLI's reader does, so a help page's type
+// block and its flag list cannot disagree about the same schema.
+
+Deno.test("schemaToTypeString renders a conjunction's fields alongside its own", () => {
+  assertEquals(
+    schemaToTypeString({
+      type: "object",
+      properties: { note: { type: "string" } },
+      allOf: [{ type: "object", properties: { count: { type: "number" } } }],
+    } as never),
+    "{\n  note?: string,\n  count?: number\n}",
+  );
+});
+
+Deno.test("schemaToTypeString renders fields a schema declares only through allOf", () => {
+  // No `type` and no `properties` of its own, so this reaches the object
+  // branch only because the conjunction was gathered before it was chosen.
+  assertEquals(
+    schemaToTypeString({
+      allOf: [{ type: "object", properties: { count: { type: "number" } } }],
+    } as never),
+    "{\n  count?: number\n}",
+  );
+});
+
+Deno.test("schemaToTypeString requires a field any conjunct requires", () => {
+  // Required is a union across members, not first-wins: every member's
+  // constraint holds at once.
+  assertEquals(
+    schemaToTypeString({
+      type: "object",
+      properties: { a: { type: "string" } },
+      allOf: [{ properties: { b: { type: "number" } }, required: ["b"] }],
+    } as never),
+    "{\n  a?: string,\n  b: number\n}",
+  );
+});
+
+Deno.test("schemaToTypeString keeps the first declaration of a repeated field", () => {
+  assertEquals(
+    schemaToTypeString({
+      type: "object",
+      properties: { a: { type: "string" } },
+      allOf: [{ properties: { a: { type: "number" } } }],
+    } as never),
+    "{\n  a?: string\n}",
+  );
+});
+
+Deno.test("schemaToTypeString resolves a $defs reference inside a conjunction", () => {
+  assertEquals(
+    schemaToTypeString(
+      {
+        type: "object",
+        properties: { a: { type: "string" } },
+        allOf: [{ $ref: "#/$defs/B" }],
+      } as never,
+      {
+        defs: {
+          B: { type: "object", properties: { b: { type: "number" } } },
+        } as never,
+      },
+    ),
+    "{\n  a?: string,\n  b?: number\n}",
+  );
+});
+
+Deno.test("schemaToTypeString terminates on a conjunction that references itself", () => {
+  assertEquals(
+    schemaToTypeString(
+      {
+        type: "object",
+        properties: { a: { type: "string" } },
+        allOf: [{ $ref: "#/$defs/C" }],
+      } as never,
+      {
+        defs: {
+          C: {
+            type: "object",
+            properties: { c: { type: "number" } },
+            allOf: [{ $ref: "#/$defs/C" }],
+          },
+        } as never,
+      },
+    ),
+    "{\n  a?: string,\n  c?: number\n}",
+  );
+});
+
+Deno.test("schemaToTypeString leaves a disjunction a union", () => {
+  // Only a conjunction states fields that all hold at once; `anyOf` is a
+  // union and keeps rendering as one.
+  assertEquals(
+    schemaToTypeString({
+      anyOf: [{ type: "string" }, { type: "number" }],
+    } as never),
+    "string | number",
+  );
+});
+
+Deno.test("schemaToTypeString does not make an object of a scalar conjunction", () => {
+  // `allOf: [{type: "string"}]` constrains a scalar and contributes no field.
+  // Rendering it as `{}` would invent an object the schema never described.
+  assertEquals(
+    schemaToTypeString({ allOf: [{ type: "string" }] } as never),
+    "unknown",
+  );
+});

--- a/packages/runner/test/schema-format.test.ts
+++ b/packages/runner/test/schema-format.test.ts
@@ -724,3 +724,49 @@ Deno.test("schemaToTypeString stops following a conjunction past its depth bound
   assert(rendered.includes("level8"), "the level at the bound is read");
   assert(!rendered.includes("level10"), "the level past the bound is not");
 });
+
+Deno.test("schemaToTypeString follows a definition that aliases another", () => {
+  // A definition may be an alias for a second one. Stopping after a single hop
+  // would collect the alias, which states no field, instead of what it names.
+  assertEquals(
+    schemaToTypeString(
+      {
+        type: "object",
+        properties: { a: { type: "string" } },
+        allOf: [{ $ref: "#/$defs/Alias" }],
+      } as never,
+      {
+        defs: {
+          Alias: { $ref: "#/$defs/Real" },
+          Real: { type: "object", properties: { b: { type: "number" } } },
+        } as never,
+      },
+    ),
+    "{\n  a?: string,\n  b?: number\n}",
+  );
+});
+
+Deno.test("schemaToTypeString terminates on a definition that aliases itself", () => {
+  // The chain above has to end somewhere. A definition naming itself is the
+  // shortest loop there is.
+  assertEquals(
+    schemaToTypeString(
+      {
+        type: "object",
+        properties: { a: { type: "string" } },
+        allOf: [{ $ref: "#/$defs/S" }],
+      } as never,
+      { defs: { S: { $ref: "#/$defs/S" } } as never },
+    ),
+    "{\n  a?: string\n}",
+  );
+});
+
+Deno.test("schemaToTypeString renders an object conjunct that names no field", () => {
+  // `type: "object"` makes the whole an object even with nothing named, and
+  // `{}` is what that is. A scalar conjunct is the contrasting case below.
+  assertEquals(
+    schemaToTypeString({ allOf: [{ type: "object" }] } as never),
+    "{}",
+  );
+});


### PR DESCRIPTION
## Why

Closes #5886. Split out of #5861, which fixed the flag list, the usage lines,
the required check and the parse. This is the surface that was left.

`cf exec … --help` renders its **Input type** block through
`schemaToTypeString`, the runner's own formatter, while the flag list beneath
it is rendered by the CLI's reader. The formatter ignored `allOf`, so one page
stated two answers about one schema:

```
Usage:
  cf exec /mnt/x.handler [invoke] --note <string> --count <number>
Input type:
  {
    note?: string          <- count missing
  }
Flags:
  --note <string>   Required.
  --count <number>  Required.
```

A caller reading the type block was told a field did not exist that the line
above and the line below both offered them.

## The decision this needed

#5886 says the choice is the whole of the work: merge a conjunction into one
object literal, or render it as an intersection (`{note} & {count}`). This
merges, for two reasons.

**It matches the reader on the other half of the page.** `declaredEventFields`
already merges a conjunction, first declaration winning. Rendering the same
schema the same way is what makes the two surfaces agree by construction rather
than by coincidence.

**An intersection reads badly here.** Object literals render multi-line, so an
intersection of two of them arrives as `{\n …\n} & {\n …\n}` in the middle of a
help page. The merged literal is what a caller wants to see.

Two rules follow from matching the CLI reader, and they differ from each other:

- **Properties: first declaration wins.** The schema's own come first, then
  earlier `allOf` members beat later ones — the order `declaredEventFields`
  reads in.
- **Required: union.** Every member's constraint holds at once, so a field any
  member requires is required of the whole.

A DISJUNCTION is untouched. `anyOf` is a genuine union and keeps rendering as
one; only a conjunction states fields that all hold together.

## What Changed

`conjunctionSources` walks the schema and its `allOf` members depth-first,
resolving a `$defs` reference to what it names, guarded against a conjunction
that references itself and bounded at 8 levels. The object branch merges what
it returns.

The gathering happens BEFORE the object branch chooses, because a schema whose
fields live only in `allOf` states no `type` and no `properties` of its own and
would otherwise never reach that branch. It sits after the scalar early
returns, so nothing is computed for a string or a number.

A scalar conjunction is deliberately still not an object: `allOf:
[{type: "string"}]` contributes no field, and rendering it `{}` would invent a
shape the schema never described. It renders `unknown`, exactly as before.

## Blast radius

Three consumers, all exercised:

| Consumer | Suite |
| --- | --- |
| `cf exec --help` (`packages/cli/lib/exec-schema.ts`) | 1689 + 174 passed |
| LLM context (`packages/runner/src/builtins/llm-dialog.ts`) | runner suite |
| fuse (`packages/fuse/cell-bridge.ts`) | 366 passed |

Only a schema carrying `allOf` renders differently. For every other schema the
merged map is the schema's own `properties` and the required set is its own
`required`, so the output is unchanged.

## Test plan

Eight cases in `schema-format.test.ts`, of which **five fail without the
change** — the issue's exact case, fields declared only through `allOf`,
required unioning, `$ref` resolution inside a conjunction, and the
self-referencing conjunction. The other three are guards for behaviour that was
already correct (disjunction stays a union, a scalar conjunction stays
`unknown`, first declaration wins) and pass either way; they are there to keep
those from moving, not to demonstrate the fix.

One end-to-end case in `packages/cli/test/exec.test.ts`, extending the test
#5861 left for the flag surfaces so that one test now holds BOTH readers to one
answer about one schema. It slices the type block out between `Input type:` and
`Flags:` rather than matching the whole page, because `--count` in the flag
list would satisfy a looser match on its own and the disagreement is precisely
what needs catching. Verified: it fails without the runner change.

The JSDoc gains a conjunction example, checked by executing it rather than by
reading it.

`schema-format.test.ts` predates the BDD convention in
`docs/development/unit-test-coding-style.md` and uses `Deno.test` throughout;
the new cases match the file rather than mixing two paradigms in one place.
Converting it is a separate, mechanical change.

`deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs` all
green.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

