### PR TITLE
feat: server-execution v2 fan-out stage A — instance-keyed serving replica + wire (OW17), client arrival gate

### DIFF
--- a/docs/plans/server-execution-v2.md
+++ b/docs/plans/server-execution-v2.md
@@ -863,8 +863,20 @@ Tasks:
       lands only after these ORDERED GATES, in this order:** (1) OW32 —
       the client-side scheduler-non-settling loop TRIAGED and fixed (the
       two two-browser gates green 5/5 fresh-store under the full ON
-      posture); (2) OW17 — the SpaceReplica per-instance re-keying (with
-      OW29's space-root demanders + arrival re-runs; P2-F-sized); (3)
+      posture) — *triaged 2026-08-16 (a client speculation
+      retire-to-nothing loop on per-user derivations, cause = the
+      identity-less space-root demand); the client ARRIVAL GATE landed
+      with fan-out stage A (the symptom); the cause is stage B's*;
+      (2) OW17 — the SpaceReplica per-instance re-keying (with
+      OW29's space-root demanders + arrival re-runs; P2-F-sized) — *SPLIT
+      by the fan-out design (owner-ruled 2026-08-16): STAGE A = the
+      instance-keyed serving replica + wire + tx→replica seam + scheduler
+      union/name-keyed indexes + S4 by full instance address — LANDED
+      (`claude/server-exec-v2-fanout-a`); STAGE B = the fan-out run
+      supply (identity on space-root demands, demanders resolver,
+      known-scope ratchet + discovery/arrival re-arms, per-demander demand
+      walk + wish-sidecar chain, output-scope attribution, B7) — NEXT;
+      STAGE C = closeout (un-skip the gates, the honest benchmark)*; (3)
       OW28 — compile-and-run as an outbox effect kind + completion-class
       writeback; (4) the HONEST propagation benchmark (criterion below)
       once the two-user family works; (5) the ON skip list EMPTY and the

--- a/docs/specs/server-side-execution/key-vocabulary.md
+++ b/docs/specs/server-side-execution/key-vocabulary.md
@@ -188,12 +188,19 @@ resolving `scope` against its identity. The vocabulary:
   with it (the event preflight's park cross-matches per instance).
 - **Wire** — `SessionSyncUpsert.scopeKey` / `SessionSyncRemove.scopeKey`
   / `EntitySnapshot.scopeKey` (`packages/memory/v2.ts`), populated
-  ONLY on frames/results to a session whose lease-holder read
-  exemption is live (`toWireUpsert(entry, keyed)`, `buildFullSync` /
-  `buildDiffSync(…, keyed)`, `queryGraph({keyedSnapshots})`); the
-  collapse guard (`#denyExplicitInstanceReads`) refuses two instances
-  of one (branch, id, scope) for NON-holders only; `WatchView.applySync`
-  keys by `scopeKey ?? scope`.
+  ONLY on frames/results to a session that has been admitted an
+  explicit-instance read — its STICKY wire vocabulary (`SessionState.
+  leaseHolderReads`, kept for the session's life; amended 2026-08-17,
+  the stage-A review's finding 1: keying never hangs from the live
+  lease, so a keyed delivery is always keyed-retracted; the DELIVERY of
+  foreign instances is the per-pass live-lease question, with the
+  lapse recorded and re-armed — `leaseHolderReadsLapsed`,
+  `noteLeaseReacquired`) (`toWireUpsert(entry, keyed)`, `toWireRemove`,
+  `buildFullSync` / `buildDiffSync(…, keyed)`,
+  `queryGraph({keyedSnapshots})`); the collapse guard
+  (`#denyExplicitInstanceReads`) refuses two instances of one (branch,
+  id, scope) for NON-holders only; `WatchView.applySync` keys by
+  `scopeKey ?? scope`.
 - **Scheduler** — `entityKey(address, identity)` prefers
   `address.scopeKey` (dependency/trigger keys per instance);
   `sortAndCompactPaths` compacts per instance; the WRITER index and the
@@ -273,8 +280,8 @@ identity, partition-unchanged at cardinality 1 per §2's argument):
   `${branch}\0${scope_key}\0${id}` (`server-sync.ts`), with the
   wire upserts STRIPPED back to scope names (`toWireUpsert`) so
   frames stay byte-identical — EXCEPT (fan-out stage A, §3b) frames to
-  a session whose lease-holder read exemption is live, which keep the
-  key. This was scopes.md §7 M4 itself: dirtiness AND delivery now key
+  a session admitted explicit-instance reads, which keep the key for
+  the session's life. This was scopes.md §7 M4 itself: dirtiness AND delivery now key
   by instance, and one principal's commit touches only sessions
   tracking THAT instance.
 

--- a/docs/specs/server-side-execution/key-vocabulary.md
+++ b/docs/specs/server-side-execution/key-vocabulary.md
@@ -134,6 +134,90 @@ Plan Phase 1 stage E LANDED on this ruling: the definition move
 (one shared constructor, engine re-exports) ahead of the nine-site
 re-keying, exactly as ruled.
 
+### 3b. The instance-keyed replica and wire (fan-out stage A, OW17 — 2026-08-16)
+
+The last name-keyed LAYER — the serving runtime's local view and
+the wire that fills it — is re-keyed on stage E's shape: instance
+keys built from an explicitly supplied identity, partition unchanged
+at cardinality 1. The unifying device is an OPTIONAL EXPLICIT
+INSTANCE on the address type — `IMemoryAddress.scopeKey?: ScopeKey`
+(`packages/runner/src/storage/interface.ts`) — ABSENT everywhere off
+the serving path (every client, the whole OFF arm), so no key, frame,
+or serialized notification moves by a byte when it is absent, and SET
+only where a serving runtime knows the instance is not the ambient
+one. Every consumer that builds a key from an address PREFERS it over
+resolving `scope` against its identity. The vocabulary:
+
+- **Replica** — `SpaceReplica`'s local doc key is `docKey(id,
+  instance)` (`storage/v2.ts`), `instance` = the address's explicit
+  key, else the reading/sealing run's identity resolved over the
+  scope name, else the replica's own (memoized per scope name — the
+  hot path pays a map lookup, never a per-read resolve); an
+  unresolvable scope keys by NAME (an anonymous session's user-scoped
+  read, as before). One replica holds the service instance AND
+  per-principal instances of one doc. Every seal, verdict, frame, and
+  notification threads the instance: `sealNative(…, {identity})` and
+  its in-flight entry (confirm/rollback settle exactly that
+  identity's layers), `getDocument(id, scope, identity)`, keyed
+  frames applied under `upsert.scopeKey`, and the differential's
+  states/addresses carrying `scopeKey` (`storage/differential.ts`,
+  `storage/transaction/address.ts` — the change address is what the
+  scheduler keys per instance).
+- **Transaction** — `IStorageTransaction.scopeKeyIdentity` (set once,
+  by `stampWaveRunContext`, before the first read; a second, different
+  identity throws — one transaction serves one identity, the tx's own
+  doc cache being name-keyed) is the tx→replica seam: reads, the
+  commit-time claim, and the seal resolve against it, and the
+  reactivity log's scoped addresses carry `scopeKey` so the
+  scheduler's dependency/trigger keys (`entityKey`) key the read to
+  ITS instance; space-scope addresses carry none.
+- **The runner's explicit-instance read** — a per-instance run's
+  read of a scoped instance the replica has never seen kicks an
+  instance-NAMED load: `Cell.sync` with the cell's transaction
+  identity, `IStorageManager.syncCell(cell, {scopeKeyIdentity})` /
+  `syncInstance(address, identity)`, the transaction layer's kick in
+  `V2StorageTransaction.loadRoot` (reserved once per (space,
+  instance, id) — `shouldPullDoc(…, identity)`), the traversal's
+  absent-target kick (`Runtime.ensureLinkedDocLoaded(link, space,
+  identity)`), and the served event's presync/preflight as the
+  event's actor. The watch root carries `entityScopeKey` (protocol.md
+  §2's read row — lease-holder-only, exactly who issues one), the
+  watch id and the selector tracker (`SelectorTracker.toKey`,
+  `watchIdForEntry`, the pull dedupe key, the provider's replay map)
+  key by the instance, and the pending-load ledger keys the address
+  with it (the event preflight's park cross-matches per instance).
+- **Wire** — `SessionSyncUpsert.scopeKey` / `SessionSyncRemove.scopeKey`
+  / `EntitySnapshot.scopeKey` (`packages/memory/v2.ts`), populated
+  ONLY on frames/results to a session whose lease-holder read
+  exemption is live (`toWireUpsert(entry, keyed)`, `buildFullSync` /
+  `buildDiffSync(…, keyed)`, `queryGraph({keyedSnapshots})`); the
+  collapse guard (`#denyExplicitInstanceReads`) refuses two instances
+  of one (branch, id, scope) for NON-holders only; `WatchView.applySync`
+  keys by `scopeKey ?? scope`.
+- **Scheduler** — `entityKey(address, identity)` prefers
+  `address.scopeKey` (dependency/trigger keys per instance);
+  `sortAndCompactPaths` compacts per instance; the WRITER index and the
+  MATERIALIZER index are NAME-keyed (`entityNameKey`) — reader→writer
+  is a node-level topology relation (one node writes all instances of
+  its declared surface, C11b), so the edge between a user-scoped-declared
+  writer and a reader running as any principal holds; the N-run loop
+  resubscribes ONCE to the UNION of its instance logs (a per-run
+  resubscribe kept only the last instance's reads); instance-precise
+  dirtiness across the name-keyed fan-in is stage B's B7 (O(N) re-runs
+  per input change, equality cutoffs absorbing siblings — recorded, not
+  a correctness need).
+- **Basis rows** — keyed by the run's FULL instance address (S4 as
+  amended, serving-loop.md §3b): the discovered scope resolved against
+  the run identity, with the stamped and broader-chain keys cleared.
+
+The seed-memo site (§1 site 4) keys under the RUN's identity
+(`tx.tx.scopeKeyIdentity ?? runtime.scopeKeyIdentity`); the
+result-pattern cache (site 2) and the wake-shaper pieceId buckets keep
+the runtime's identity DELIBERATELY — the piece registry and the
+shaper group are per PIECE, and a piece is one (C11b), not per
+instance. Audited list and per-site OFF-arm argument: the stage-A build
+report.
+
 ## 4. Tripwires
 
 FORBIDDEN once stage E lands:
@@ -175,20 +259,35 @@ identity, partition-unchanged at cardinality 1 per §2's argument):
 
 - `storage/selector-tracker.ts` — `toKey` is now an instance method
   over the tracker's BOUND identity (constructor-injected thunk):
-  `${scope_key}\0${id}`. The failure it closed: A's watch deduped
-  B's, so B never subscribed.
+  `${scope_key}\0${id}` — and, since fan-out stage A, an address that
+  NAMES its instance (`scopeKey`) keys by it. The failure it closed:
+  A's watch deduped B's, so B never subscribed.
 - `storage/v2.ts` — `#docPullKicks` keys build in `#pullKickKey`
-  via the manager's own identity. The failure it closed: A's kick
-  suppressed B's pull, and B's doc never loaded.
+  via the manager's own identity, or the explicit foreign instance a
+  served per-instance read names (stage A). The failure it closed:
+  A's kick suppressed B's pull, and B's doc never loaded.
 - the server's wake/sync dirty keys — `toDirtyKey` =
   `${scope_key}\0${id}` (`packages/memory/v2/query.ts`), marked at
   admission from the COMMITTING session's resolved instance; the
   per-session sync cache carries `scopeKey` on its entries and keys
   `${branch}\0${scope_key}\0${id}` (`server-sync.ts`), with the
   wire upserts STRIPPED back to scope names (`toWireUpsert`) so
-  frames stay byte-identical. This was scopes.md §7 M4 itself:
-  dirtiness AND delivery now key by instance, and one principal's
-  commit touches only sessions tracking THAT instance.
+  frames stay byte-identical — EXCEPT (fan-out stage A, §3b) frames to
+  a session whose lease-holder read exemption is live, which keep the
+  key. This was scopes.md §7 M4 itself: dirtiness AND delivery now key
+  by instance, and one principal's commit touches only sessions
+  tracking THAT instance.
+
+**Fan-out stage A (OW17) — RE-KEYED 2026-08-16** (§3b): the serving
+replica's local doc keys (`SpaceReplica` `docKey`, formerly
+`${scope-name}\0${id}` — the last name-keyed layer, the P7 review's
+CLASS VERDICT), the wire upserts/removes/snapshots to a live lease
+holder, `WatchView`'s entity keys, the transaction's root addresses
+and logged addresses, the watch ids and pull dedupe keys, and the
+scheduler's writer/materializer indexes (name-keyed by DESIGN — the
+one deliberate fan-in, see §3b). Each carries the address's explicit
+`scopeKey` where the serving path names one and is byte-identical
+without it.
 
 **Stage-F serving-identity sites — RE-KEYED at stage F** (M1
 territory; keys construct from the runtime's identity today and take

--- a/docs/specs/server-side-execution/protocol.md
+++ b/docs/specs/server-side-execution/protocol.md
@@ -564,15 +564,29 @@ the target's `eventWatermark` makes processing exactly-once.
   This pairs with scopes.md §7 M4's re-keying: the push path must
   key dirtiness by `scope_key`, and the same key decides delivery.
   *(Fan-out stage A, 2026-08-16 — the ONE wire addition on the push
-  side: frames to a session whose lease-holder read exemption is LIVE
-  (§2's read row armed it) carry `scope_key` on every upsert and
-  remove (`SessionSyncUpsert.scopeKey`, `SessionSyncRemove.scopeKey`;
+  side: frames to a session that has been ADMITTED an explicit-instance
+  read (§2's read row) carry `scope_key` on every upsert and remove
+  (`SessionSyncUpsert.scopeKey`, `SessionSyncRemove.scopeKey`;
   graph.query snapshots to such a session carry `EntitySnapshot.scopeKey`),
   because that session legitimately receives EVERY instance it serves
   and may hold two instances of one (branch, id, scope) — the serving
   replica keys them apart by it. Every other session's frames carry
   scope NAMES only and resolve instances from the session, exactly as
-  before — the OFF-arm wire is byte-identical.)*
+  before — the OFF-arm wire is byte-identical. Amended 2026-08-17 (the
+  stage-A independent review's finding 1): the keying is the session's
+  STICKY wire vocabulary — armed by the admission, kept for the
+  session's life, never hung from the live lease — so an instance
+  delivered keyed is always retracted keyed (an unkeyed remove would
+  name the client's OWN instance: a former holder's catch-up wiped the
+  service's doc and kept the stale foreign one). Whether FOREIGN
+  instances are DELIVERED stays the per-pass live-lease question of
+  §2's read row: a lapse withholds them (incremental) or retracts them
+  keyed (full evaluation), and the first live pass afterwards RE-ARMS
+  with a full evaluation that re-delivers what the lapse withheld — a
+  renewal blip the SpaceServer survives in-process reports the reacquire
+  so that pass runs promptly (`Server.noteLeaseReacquired`), rather
+  than leaving the serving replica silently stale until an unrelated
+  write.)*
 - **Basis-index rows are NOT part of the pushed commit** (T2). They
   ride the loopback store TRANSACTION only (serving-loop.md §1 plane
   (a), §3b); nothing about them crosses the wire to a subscriber,

--- a/docs/specs/server-side-execution/protocol.md
+++ b/docs/specs/server-side-execution/protocol.md
@@ -272,7 +272,7 @@ load-bearing enforcement; commit-level identity is not load-bearing
 | `authored`, server-produced (outbox event append, `.inSpace` provisioning) | commit metadata carries the acting identity (`actingPrincipal` + `actingSession` — the ORIGINATING chain actor, events.md §2) + `capabilityRef` → admission validates that capability grant against the target doc/stream (a delegated-capability check, NEVER session-identity impersonation) → for event appends, `firedAt` stamps from the validated acting identity (the stamping paragraph below) → CAS. *(Phase-1 bound, stage D/F: the landed validation is carriage PRESENCE + COMPLETENESS — authored class only, non-empty `actingPrincipal` + `capabilityRef`, a sessionless batch refused for session-scoped writes (scopes.md §5) — with scoped writes keyed from the carried identity; RESOLVING the grant against the target doc/stream awaits per-doc grants, which today's ACL model does not hold, and is the named owed hardening — verification-coverage.md OW13.)* |
 | `derived` | producer holds the live `execution_lease` for the space (one equality check) → CAS |
 | `system` | unchanged from today |
-| READ naming an explicit `entity_scope_key` (not a commit — the read side of R-Q6b; S1; widened by FP2, RULED 2026-08-03) | requester holds A live `execution_lease` on the co-hosted memory server — its OWN space's lease, not necessarily the read space's (the read-side twin of §2's inter-server trust ruling: a home SpaceServer reads FOREIGN scoped instances for cross-space derivations, closing the silent-empty-instance trap cross-space) → the named instance is read. A non-lease-holder naming a `scope_key` is REJECTED (today the wire cannot even express one); a request naming none resolves from the authenticated session as today (the shared `resolveScopeKey`, `packages/memory/v2.ts:120-147`) |
+| READ naming an explicit `entity_scope_key` (not a commit — the read side of R-Q6b; S1; widened by FP2, RULED 2026-08-03) | requester holds A live `execution_lease` on the co-hosted memory server — its OWN space's lease, not necessarily the read space's (the read-side twin of §2's inter-server trust ruling: a home SpaceServer reads FOREIGN scoped instances for cross-space derivations, closing the silent-empty-instance trap cross-space) → the named instance is read. A non-lease-holder naming a `scope_key` is REJECTED (today the wire cannot even express one); a request naming none resolves from the authenticated session as today (the shared `resolveScopeKey`, `packages/memory/v2.ts:120-147`). *(Fan-out stage A, 2026-08-16 — the runner ISSUES these: a serving runtime's per-instance run whose read of a scoped doc names an instance other than the runtime's own — the demand-supplied identity's — loads it as an explicit-instance read (`Cell.sync`/`syncCell` with the run identity, the transaction layer's kick for a never-loaded instance, the presync of a served event's inputs as the event's actor), so the serving replica holds that principal's instance keyed apart from the service's; own-identity reads name nothing and keep the no-key admission fast path. A live lease holder may name TWO instances of one (branch, id, scope) — its frames carry `scope_key` (§3) — the wire collapse guard now applies to non-holders only.)* |
 
 That is the ENTIRE admission surface — the last row is the one
 READ-side check; every row above it is commit admission. No scope
@@ -563,6 +563,16 @@ the target's `eventWatermark` makes processing exactly-once.
   invisible to that subscriber: not redacted, not empty — absent.
   This pairs with scopes.md §7 M4's re-keying: the push path must
   key dirtiness by `scope_key`, and the same key decides delivery.
+  *(Fan-out stage A, 2026-08-16 — the ONE wire addition on the push
+  side: frames to a session whose lease-holder read exemption is LIVE
+  (§2's read row armed it) carry `scope_key` on every upsert and
+  remove (`SessionSyncUpsert.scopeKey`, `SessionSyncRemove.scopeKey`;
+  graph.query snapshots to such a session carry `EntitySnapshot.scopeKey`),
+  because that session legitimately receives EVERY instance it serves
+  and may hold two instances of one (branch, id, scope) — the serving
+  replica keys them apart by it. Every other session's frames carry
+  scope NAMES only and resolve instances from the session, exactly as
+  before — the OFF-arm wire is byte-identical.)*
 - **Basis-index rows are NOT part of the pushed commit** (T2). They
   ride the loopback store TRANSACTION only (serving-loop.md §1 plane
   (a), §3b); nothing about them crosses the wire to a subscriber,

--- a/docs/specs/server-side-execution/scopes.md
+++ b/docs/specs/server-side-execution/scopes.md
@@ -159,16 +159,30 @@ faced them:
   scheduler. Do NOT port client-era cardinality assumptions into
   the fan-out path.
 
-**Monotonicity (owner-ruled): narrowing is for everyone or no one.**
-User-scoped for one user means user-scoped for ALL users; within a
-user, session-scoped for one session means session-scoped for all
-of that user's sessions. The reason is structural, not policy: the
-link INTO the narrower scope is itself shared state AT the broader
-scope — all of a user's sessions read the same user-level doc, all
-users read the same space-level doc — so one written redirect
-narrows the node for every reader of that address at once. Instance
-sets are therefore CLEAN PRODUCTS over principals, NEVER ragged
-(narrow for some principals, broad for others).
+**Monotonicity (owner-ruled; AMENDED — RULED 2026-08-16, the fan-out
+design panel's Lens 1): narrowing is for everyone or no one AT THE
+SPACE→USER HOP; below it, narrowing may be RAGGED per principal.**
+User-scoped for one user means user-scoped for ALL users, and the
+reason is structural: the link INTO the user scope is shared state AT
+the space scope — all users read the same space-level doc — so one
+written redirect narrows the node for every reader of that address at
+once. The second hop is NOT structural: the link INTO a session
+instance is written into ONE user's instance (`X/user:A` → session),
+and another user's instance (`X/user:B`) is a different doc that
+carries no such link — so a node whose per-user branch reads
+session-scoped state for A and only user-scoped state for B is
+session-scoped for A and user-scoped for B, simultaneously and stably
+(reachable by ordinary data-dependent code: a per-user flag deciding
+whether a per-session value is read). Within ONE user, sessions still
+narrow together (a user-level fact reaches all of that user's
+sessions). Instance sets are therefore clean products over principals
+at the top hop and MAY be ragged below it; a per-node scope level
+cannot represent that — instance addresses carry the FULL
+(scope-kind, principal) address, which is what the serving replica,
+the wire, and the basis index key by (fan-out stage A, OW17), and
+"the node's known scope only narrows" is a POLICY over such
+addresses (stage B's run supply), never a structural fact below the
+top hop.
 
 **Permanence (ruled by code): narrowing NEVER widens back.** A
 written redirect is permanent. Rewrites MUST NOT strip stored

--- a/docs/specs/server-side-execution/serving-loop.md
+++ b/docs/specs/server-side-execution/serving-loop.md
@@ -448,15 +448,28 @@ Rules the shape carries, binding:
   closed: basis rows are engine table rows on the loopback store
   transaction, never commit metadata, never pushed, never read at
   admission.
-- **Narrowing DELETES the rows it stranded** (S4, binding): a run
-  whose DISCOVERED scope is narrower than the instance key its rows
-  are recorded under MUST delete that key's rows for that action, in
-  the SAME wave transaction that writes the narrowed rows. Without
-  this the old key's rows survive forever and §6's re-mark rule
-  re-dirties a zombie at every activation — and a `space`-key zombie
-  has no runnable identity, so it can never overwrite its own rows
-  and never stops being dirty. Deleting is sound for the same reason
-  overwriting is: the rows are a basis cache, not history.
+- **Narrowing DELETES the rows it stranded** (S4, binding; AMENDED
+  2026-08-16 with scopes.md §2's ragged ruling — fan-out stage A): a
+  run's rows are recorded under its FULL instance address — its
+  DISCOVERED scope resolved against its identity (`space`,
+  `user:<p>`, `session:<p>:<s>`), the instance it actually served —
+  never under the demand's stamp alone; and every key the run's
+  address STRANDS — the stamp when it differs (a user-scoped watch's
+  `user:<p>` on a node that discovered `space`; a session-scoped
+  watch's `session:<p>:<s>` on a node that discovered `user`, the
+  ragged case) and every strictly-broader key on the run's own chain
+  (`space`; `user:<p>` under a session address) — MUST be cleared for
+  that action in the SAME wave transaction, in both directions
+  (narrower-than-stamp and broader-than-stamp), a real row set already
+  recorded in the wave under a key never being overwritten by a
+  clearance. Without this the stranded key's rows survive forever and
+  §6's re-mark rule re-dirties a zombie at every activation — a
+  `space`-key zombie has no runnable identity, so it can never
+  overwrite its own rows and never stops being dirty; a departed
+  session's over-keyed rows have none either. Sound by monotonicity at
+  the top hop and within one principal (scopes.md §2 as amended), and
+  for the same reason overwriting is: the rows are a basis cache, not
+  history.
 - **Interim retention is UNBOUNDED, and that is accepted** (S8).
   Rows at `space` and `user:<p>` keys are touched by no session
   retirement; main's 32-per-action execution-context cap

--- a/docs/specs/server-side-execution/speculation.md
+++ b/docs/specs/server-side-execution/speculation.md
@@ -144,7 +144,19 @@ own value (correct rendering; no durability of per-user derived values,
 of which there was none before either); an unchanged authoritative
 value (equality cutoff — no rewrite, so the doc's seq stays below the
 floor) leaves the echo standing rather than retiring it, which is
-value-identical. Two riders ride with the gate: SUPERSEDE-BY-NEWER — a
+value-identical. Stated as an ASSUMPTION, not a guarantee (fan-out stage
+A's independent review, finding 7): the sweep has no arrival trigger of
+its own — it runs on the watermark sink, the origin-ack observer, and
+chained settlements — so "retires the moment its derived value arrives"
+holds because a wave's derived doc and its watermark advance ride ONE
+frame per session and the replica applies every record of a frame before
+it notifies; a written doc that arrived in a LATER frame than the
+covering watermark, or one the client never watched, keeps its echo
+until the next watermark event (value-identical when the values agree;
+otherwise the echo hides the authoritative value that long). An arrival
+re-sweep is the owed follow-up if that coupling ever loosens (recorded
+in verification-coverage.md's stage-A delta). Two riders ride with the
+gate: SUPERSEDE-BY-NEWER — a
 newer entry of the same writer whose WHOLE-DOC ops cover every doc an
 older entry wrote retires the older one at seal (the drop of a lower
 layer under an upper whole-doc layer is invisible; a patch is

--- a/docs/specs/server-side-execution/speculation.md
+++ b/docs/specs/server-side-execution/speculation.md
@@ -85,10 +85,15 @@ On each pushed `derived` commit with `derivedThrough = W` and
    the authoritative consequences (or, for a dropped event, its
    notice — events.md §5) now exist; the echo's job is done.
 3. Retire overlay entries whose `origin` is `input` once their authored
-   commit is acked AND `W ≥` that commit's seq — regardless of value
-   agreement (the store wins); keep live-input echoes whose authored
-   commit is still unacked or not yet covered by `W` (the user is
-   mid-typing).
+   commit is acked AND `W ≥` that commit's seq AND — the ARRIVAL GATE
+   (RULED 2026-08-16, landed with fan-out stage A) — every doc INSTANCE
+   the entry wrote holds a CONFIRMED value at seq `≥` that floor (the
+   authoritative derivation for the instance this client reads has
+   ARRIVED) — regardless of value agreement (the store wins); keep
+   live-input echoes whose authored commit is still unacked or not yet
+   covered by `W` (the user is mid-typing), and keep echoes whose
+   written instance the store has not yet spoken for (nothing to win
+   with — see the arrival-gate paragraph below).
 4. If any local intents remain un-consequenced (offline queue, in-flight
    events), re-run their speculation against the fresh store state so
    the echo rebases instead of going stale.
@@ -101,16 +106,65 @@ suppression beyond what rebasing gives.
 Stated honestly (RULED 2026-08-07; owed from the wedge round), and
 scoped to step 3's INPUT-origin entries — step 2's intent-origin
 entries retire on their event appearing in `consequenceOf`, which IS
-the authoritative consequence arriving: an input-origin entry retires
-on watermark coverage of its BASIS, not on value ARRIVAL — "the store
-wins" carries no by-construction guarantee that the store HOLDS what
+the authoritative consequence arriving: coverage of an entry's BASIS
+alone carries no by-construction guarantee that the store HOLDS what
 won at withdrawal time (W covers DEMANDED derivations; nothing about
 an entry's own output riding the covering wave is implied). What makes
-retirement safe is the serving loop's first-round reliability
-machinery — the demanded-structure loads with their counted, retried
-deferrals (serving-loop.md §7's `structureLoadDeferred` /
-`structureLoadFailures` counters over §1/§3's per-cycle load pass) —
-which makes the demanded derivation exist and land.
+coverage-based retirement safe is the serving loop's first-round
+reliability machinery — the demanded-structure loads with their
+counted, retried deferrals (serving-loop.md §7's
+`structureLoadDeferred` / `structureLoadFailures` counters over §1/§3's
+per-cycle load pass) — which makes the demanded derivation exist and
+land. That premise is FALSE for a scoped instance the server never
+serves (before the fan-out run supply, every per-user derivation is
+such an instance — the demand registry keeps no identity for a
+space-scoped root; and after it, any per-user subtree the demand walk
+does not reach), and coverage without arrival is then the
+retire-to-nothing loop the P7 review recorded as OW32: the echo dropped
+to nothing, the writer — a reader of its own output through the
+scope-narrowing write path — re-derived, re-speculated, retired,
+forever, at ~80 ms cycles bounded per pass only by the scheduler's
+budget.
+
+**The arrival gate (RULED 2026-08-16 — owner, on the fan-out design
+panel's recommendation; landed with fan-out stage A):** step 3
+additionally requires ARRIVAL — every doc instance the entry wrote
+holds a confirmed value at seq ≥ the entry's floor. The panel's
+rationale: the gate is the client's BACKSTOP for demand-walk coverage
+gaps (fan-out design §E residual 4) and the first-demand transient (§E
+residual 1 — a node whose basis W already covers at speculation time
+retires before the server's first wave lands), and it is independent
+of the server half: it treats the SYMPTOM (a never-served instance
+flips to nothing) while stage B's fan-out run supply fixes the CAUSE
+(the instance is never served). Consequences, exact: a served node
+still retires the moment its derived value arrives — the watermark
+write rides the same wave commit, so the covering sweep sees the
+value; an echo whose instance nobody serves persists as the client's
+own value (correct rendering; no durability of per-user derived values,
+of which there was none before either); an unchanged authoritative
+value (equality cutoff — no rewrite, so the doc's seq stays below the
+floor) leaves the echo standing rather than retiring it, which is
+value-identical. Two riders ride with the gate: SUPERSEDE-BY-NEWER — a
+newer entry of the same writer whose WHOLE-DOC ops cover every doc an
+older entry wrote retires the older one at seal (the drop of a lower
+layer under an upper whole-doc layer is invisible; a patch is
+path-relative to the layer beneath and never supersedes), bounding
+entry growth for a never-served instance that keeps changing; and
+OWN-RETIREMENT-IS-NOT-A-TRIGGER — the `integrate` a retiring echo
+produces carries the echo's own transaction as its source, so the
+scheduler treats the flip of an action's own output like its own
+commit and does not re-run the writer for it (a divergent
+authoritative value would otherwise re-derive, re-speculate, retire,
+and flip forever); downstream readers are unaffected. Impl:
+`packages/runner/src/speculation/overlay-destination.ts` (`#sweep`'s
+gate, `#supersedeOlderEntries`), the replica's superseded flip
+(`finalizeSupersededSpeculation` — `IIntegrateNotification.source`),
+and the scheduler's own-source skip (`scheduler/invalidation.ts`);
+pinned in `speculation-arrival-gate.test.ts` (each with its mutation).
+The measured effect that motivated the ruling (the OW32 triage's
+prototype, 2026-08-16): 45–56 k → 55–137 client action runs per
+5-minute two-browser gate, zero non-settling episodes, `runtime:idle`
+resolving, both two-browser gates booting in < 3 s.
 
 ## 5. Offline
 

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -1108,6 +1108,79 @@ nod, 2026-08-07; recorded in the plan's stage list):**
   wave-level fallback still runs a demanded piece before any
   identity-bearing demand exists and leaves the `user:<serviceDID>`
   garbage instance (stage B's B5 residual).
+  **Independent review + fix round (2026-08-17; review verdict
+  LANDABLE-WITH-FIXES, 24 mutations / 17 caught / 7 untested; fixer:
+  every finding dispositioned, 24/24 archived mutations + M1 caught).**
+  CLOSED by the fix round: (1) the review's MAJOR correctness finding —
+  the keyed wire hung from a bit any lapsed push pass cleared and only
+  a fresh admission re-armed, so a former/blipped holder's
+  full-evaluation catch-up sent UNKEYED removes for keyed-delivered
+  foreign instances (the runner replica wiped its OWN instance and kept
+  the stale foreign one — reproduced end to end) and a survived
+  renew-blip left the loopback session's foreign instances withheld for
+  the session's life (silent-stale). Invariant as landed: the session's
+  keying is STICKY wire vocabulary (a keyed delivery is always keyed-
+  retracted); foreign-instance DELIVERY stays the per-pass live-lease
+  question; a lapse is recorded and the first live pass RE-ARMS with a
+  full evaluation; the SpaceServer's renew arm reports a survived blip
+  (`noteLeaseReacquired`) so that pass runs promptly (protocol.md §3 as
+  amended). Pinned red-first: memory `v2-explicit-read.test.ts` (keyed
+  retraction with the own instance untouched; the re-arm via the notice
+  and via the first evaluating pass; the notice inert when nothing
+  lapsed), `storage-instance-keying.test.ts` (the replica half),
+  `executor-space-server.test.ts` (the renew arm's notice — once per
+  blip, never on a plain tick, never on a park),
+  `executor-instance-keyed-replica.test.ts` (the lapse withholds Alice's
+  write, the notice re-delivers it keyed to the serving replica, her
+  instance re-derives, Bob's untouched); each half mutation-verified.
+  (2) The TRUE R7 shape (type, then save; no derivation ever loaded the
+  actor's draft instance) is now pinned — the shipped R7 pin was
+  green with the presync AND preflight actor identity removed (a
+  derivation had pre-loaded the instance); the new pin asserts the
+  no-load precondition and goes red with both removed. (3) S4's
+  clearance half is pinned in BOTH directions with pre-existing
+  stranded rows plus the same-wave real-row guard
+  (`executor-wave.test.ts`); the earlier "pinned in both directions"
+  claim was an over-claim (only not-written was asserted). (4) The A3
+  seed-memo re-key is pinned (Bob's default seeded after Alice's run
+  memoized presence). (5) The individually-redundant seams have their
+  own pins (served preflight/presync identity, `Cell.sync` identity,
+  the traversal kick identity, `buildReads` identity, `WatchView` key).
+  Residuals SHARPENED, still flagged: (i) effect completion — the
+  writeback tx is unstamped, so its hash-guard reads resolve the
+  service's instances while the seal is under the carriage identity;
+  `buildReads` then attests the CARRIAGE identity's records (a never-
+  loaded record yields seq-0 confirmed reads); the engine does not
+  reject a mis-attested basis on derived commits today, so the
+  consequence is confined to local cascade/hash-guard tracking — but
+  any per-user node with an effect is served with an unattested basis;
+  fix shape: stamp the completion tx with the carriage identity at
+  `markEffectCompletion` (needs the runtime's outbox carriage — a
+  stamper hook, threaded through the builtins), NOT filled here;
+  trigger: before stage B adds per-user effect nodes. (v) The served
+  event stamp sets a NON-RESOLVING identity for a userless `firedAt`
+  (`{session:"server"}`) while preflight/presync read the own instance
+  — deliberately NOT aligned: the non-resolving identity is what makes
+  a userless run's scoped WRITE fail closed (`resolveScopeKey` throws;
+  the events.md §2 sessionless-actor class), dropping it would key the
+  write under the service silently, and aligning the guards the other
+  way buys nothing (loads land only in resolvable instances); the shape
+  itself — a declared sessionless space-scope chain touching user
+  scope — is illegal and its reads are empty either way. (vi) The
+  arrival gate's sweep has no arrival trigger of its own (speculation.md
+  §4 now states the frame-coupling assumption); an arrival re-sweep is
+  owed if that coupling loosens. (vii) Two PRE-EXISTING SpaceServer
+  blip-window shapes surfaced by the fix round's E2E, not stage A's and
+  not filled: (a) with the lease row expired but the in-process tenure
+  live, the loop re-attempts its watermark advance every cycle and each
+  is refused by the engine's derived-class rule (a hot spin — 471
+  `wave-commit-rejected` in 2.7 s observed) until the row is live again
+  or the tick parks; (b) an EMPTY seal (a read probe, a no-op
+  derivation) opens a `#currentWave` that outlives zero-delta cycles
+  with the pre-blip tenure, so the first real seal after a same-process
+  reacquire aborts `lease-lost` and PARKS the space — the "survived
+  blip keeps serving" path is reachable only on a space quiet across the
+  tick; owner: the P7 renew-blip / wedge arms.
 - OW19 — the demand-cycle terminal state: CLOSED by stage P2-F
   (2026-08-13; the RULED 2026-08-07 direction, built whole). A
   demanded root CONFIRMED synced with no pattern meta parks TERMINAL
@@ -2274,7 +2347,14 @@ delta):
   red-first ("lease-holder push exemption dies with the lease" +
   the resume revalidation test, `v2-explicit-read.test.ts`). The
   half (ii) wire-upsert scope-name mitigation (forced full resync)
-  stands unchanged and keeps its comment.
+  stands unchanged and keeps its comment. *(Superseded in part by
+  fan-out stage A's fix round, 2026-08-17: "lease loss clears the
+  persisted bit" is no longer the mechanism — the bit is the session's
+  sticky WIRE VOCABULARY (keyed frames for its life; a keyed delivery is
+  keyed-retracted), the exemption still re-verifies on CURRENT
+  holdership at every push-path use, a lapse is recorded and re-armed on
+  the first live pass; the post-handover tests still hold — a former
+  holder receives no foreign instance — see OW17.)*
 - OW17 — RE-TAGGED with the Phase-5 posture (flag-don't-fill upheld):
   the trigger anticipated foreign scoped instances making the
   replica's scope-name collapse load-bearing; Phase 5 instead
@@ -2517,10 +2597,19 @@ Delta 2026-08-15 — Phase 6 independent-review fixes (same PR):
   stage A's read seam, and the per-user derived state of real users
   needs stage B's supply — record the two-browser gates' status
   honestly at each stage (stage A's build report carries the runs).
-- OW34 — served handler runs carry NO renderer-trusted event mark, so
-  their writes to UI-contract-gated (owner-protected) cells are refused
-  by CFC — the two-browsers gate's NEXT wall, UNMASKED by fan-out stage A
-  (2026-08-16/17): with the R7 read seam closed, Alice's served save
+- OW34 — a CFC-serving POLICY item: served handler runs carry NO
+  renderer-trusted event mark, so a per-user served handler's write to a
+  UI-contract-gated (owner-protected) cell is refused by CFC at prepare
+  ("missing trusted-event policy input") — the two-browsers gate's NEXT
+  wall, UNMASKED by fan-out stage A and NOT caused by it (the stage-A
+  independent review's characterization, 2026-08-17: stage A changed
+  nothing the CFC ladder sees; it made the handler read Alice's draft
+  and reach the write; pre-stage-A the same handler wrote nothing).
+  Owning layer: stage B's attribution work or a CFC policy-input rule
+  for actor-stamped served entries — with its own spec sentence (cfc +
+  events.md) before it is wired; the two-browsers gate's ON-skip reason
+  names it alongside OW32. Evidence (2026-08-16/17): with the R7 read
+  seam closed, Alice's served save
   handler reads her draft and WRITES the shared `profiles` cell, and the
   wave refuses the commit three times and drops it — `CFC enforcement
   rejected commit: relevant transaction was not prepared: missing
@@ -2706,18 +2795,28 @@ serving replica + wire; the client arrival gate):
 - protocol.md §3: +1 binding clause (lease-holder frames/snapshots carry
   `scope_key`; every other session's wire byte-identical) — pinned in
   the same memory test (keyed frames on watch.set/add/query/push; no
-  key on a non-holder's frames).
+  key on a non-holder's frames). AMENDED 2026-08-17 (the fix round on
+  the review's finding 1): the keying is the admitted session's STICKY
+  wire vocabulary — a keyed delivery is always keyed-retracted — and the
+  foreign-instance delivery re-arms after a lapse — pinned in
+  `v2-explicit-read.test.ts` ("finding 1" ×3), `storage-instance-keying.
+  test.ts` (the replica half), `executor-space-server.test.ts` (the
+  renew arm's notice), `executor-instance-keyed-replica.test.ts` (the
+  lapse E2E); mutation-verified per half.
 - scopes.md §2 Monotonicity AMENDED (RULED 2026-08-16): structural at
   the space→user hop only; ragged per principal below it; instance
   addresses carry the full (scope-kind, principal) address; "k only
   narrows" is stage B's policy — a ruling, no impl-gate of its own; its
   consequence for the basis index is the S4 amendment below.
 - serving-loop.md §3b's S4 AMENDED (+1 binding sentence set): rows keyed
-  by the run's FULL instance address, stranded stamp and broader-chain
-  keys cleared in both directions — pinned in
+  by the run's FULL instance address — pinned in
   `executor-instance-keyed-replica.test.ts` (S4 step) with the two P2-F
   pins moved to the same truth (`executor-serving-loop.test.ts`,
-  `executor-space-server.test.ts`).
+  `executor-space-server.test.ts`); the stranded stamp and broader-chain
+  keys cleared in BOTH directions — pinned 2026-08-17 in
+  `executor-wave.test.ts` ("S4 clearance in BOTH directions", with
+  pre-existing stranded rows and the same-wave real-row guard; the
+  earlier "pinned" claim covered not-written only — corrected).
 - key-vocabulary.md §3b (new inventory section) + §5's list: the
   instance-keyed replica/wire vocabulary and `IMemoryAddress.scopeKey`;
   §4's first tripwire covers the list — pinned in
@@ -2737,6 +2836,15 @@ serving replica + wire; the client arrival gate):
   `markAuthoritativeWrites`), park/backoff, the B-1 barrier, the
   renew-blip, and C10/T_flush suites ran green under the re-key (the
   stage-A build report carries the counts).
+- Fix round (2026-08-17, on the independent review): the seams the
+  review found untested each carry a discriminating pin — the true-R7
+  no-load shape (`executor-instance-keyed-replica.test.ts`), the A3
+  seed memo, the served preflight/presync identity, `Cell.sync`, the
+  traversal kick, `buildReads`, and the OFF-arm serialized-form witness
+  (`storage-instance-keying.test.ts`), `WatchView` keying
+  (`v2-client-watch.test.ts`); speculation.md §4 states the arrival
+  gate's frame-coupling assumption; the two-browsers gate's ON-skip
+  reason names OW34 alongside OW32; residuals sharpened in OW17.
 
 ## 4. Standing rule
 

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -1047,6 +1047,67 @@ nod, 2026-08-07; recorded in the plan's stage list):**
   Trigger, re-stated: the flip's ordered gates (plan Phase 7 task 1):
   OW32 triage → THIS leg (with OW29) → OW28 → the honest benchmark →
   the flip PR.
+  **IN PROGRESS — leg 1 of 2 LANDED (fan-out stage A, 2026-08-16;
+  owner-ruled 2026-08-16 on the fan-out design + panel).** The
+  serving replica and the wire are INSTANCE-keyed: `SpaceReplica`
+  keys every local doc by `scope_key` (`docKey(id, instance)`;
+  key-vocabulary.md §3b) — one replica holds the service instance
+  AND per-principal instances of one doc; the wire carries
+  `scope_key` on lease-holder frames/snapshots only, the collapse
+  guard is scoped to non-holders, `WatchView` keys by instance; the
+  tx→replica identity seam threads the run's demand-supplied identity
+  (`IStorageTransaction.scopeKeyIdentity`, set by the wave stamp)
+  through reads, the commit-time claim, seals and verdicts, the
+  reactivity log (`IMemoryAddress.scopeKey` — the scheduler's
+  dependency/trigger keys per instance), and the runner's
+  explicit-instance loads (`Cell.sync` / `syncCell` / `syncInstance`
+  / the transaction-layer kick / `ensureLinkedDocLoaded` / the served
+  event's presync+preflight as its actor); the writer and
+  materializer indexes are NAME-keyed by design (the one fan-in);
+  the N-run loop resubscribes once to the union of its instance logs
+  (the last-instance-wins replacement gone); S4 keys basis rows by
+  the run's FULL instance address and clears the stranded stamp and
+  broader-chain keys in both directions (the RAGGED amendment,
+  scopes.md §2 — narrowing below the space→user hop is per
+  principal). Pinned red-first at the P7 head:
+  `executor-instance-keyed-replica.test.ts` (two demanded runs read
+  their OWN per-user inputs → divergent per-instance derived rows
+  with the right values and the serving replica holds both instances
+  — the VALUE half CLOSED; **R7** — Alice's authored draft + save
+  event → the served handler runs as Alice, reads HER draft, writes
+  her per-user consequence with the typed value; the resubscribe path
+  instance-aware — Bob's input change wakes the node; S4 — a
+  session-scoped demand on a user-discovering node records `user:<p>`
+  rows and no session-keyed zombie, a space-discovering node records
+  `space`), `storage-instance-keying.test.ts` (OFF-arm neutrality per
+  site: keys/compaction/logged addresses/notification addresses
+  byte-identical without an explicit instance; the two-instance
+  replica; the union resubscribe; per-instance watches and kicks),
+  memory `v2-explicit-read.test.ts` (a lease holder names two
+  instances of one (branch, id, scope) and receives both KEYED on
+  watch.set/watch.add/graph.query/push; a non-holder's read set is
+  still refused; a non-holder's frames carry no key). What REMAINS
+  (leg 2, stage B): the fan-out run SUPPLY — identity on space-scoped
+  demand rows, the demanders resolver, the known-scope ratchet with
+  discovery/arrival re-arms, the per-demander demand walk (+ the
+  wish-sidecar `parentPieceRootId` chain), output-scope-derived
+  attribution, and B7 precise dirtiness (the name-keyed fan-in's O(N)
+  cost is recorded, not a correctness need). Stage-A residuals,
+  FLAGGED (not filled): (i) an effect COMPLETION for a per-instance
+  run seals its local layer under the outbox carriage's identity
+  (matching its engine row) but the writeback transaction is unstamped,
+  so its hash-guard READS resolve the service's instances — a
+  per-instance node's effect completion is unpinned; (ii) a
+  handler-only write to a never-written PerUser slot lands at the
+  slot's base scope (the handler's handle carries no scope cap until
+  the slot redirects — pre-existing OFF behavior, verified at OFF;
+  the group-chat drafts avoid it because the client types first);
+  (iii) two P2-F basis-key pins moved to the S4 truth (a demanded run
+  reading only space input keys `space`, its `user:<p>` stamp cleared
+  — the acting annotations still witness the supply); (iv) the
+  wave-level fallback still runs a demanded piece before any
+  identity-bearing demand exists and leaves the `user:<serviceDID>`
+  garbage instance (stage B's B5 residual).
 - OW19 — the demand-cycle terminal state: CLOSED by stage P2-F
   (2026-08-13; the RULED 2026-08-07 direction, built whole). A
   demanded root CONFIRMED synced with no pattern meta parks TERMINAL
@@ -2428,6 +2489,34 @@ Delta 2026-08-15 — Phase 6 independent-review fixes (same PR):
   execution-on-skips.ts`), red under the full ON posture, NOT green-by-
   vacuity. Trigger: first of the flip's ordered gates (plan Phase 7 task
   1); the flip PR needs the skip list EMPTY.
+  **TRIAGED (2026-08-16) and the SYMPTOM treated — row stays OPEN
+  until stage B.** The triage attributed the loop: a purely
+  CLIENT-side speculation retire-to-nothing loop on scope-narrowed
+  (per-user) derivations — the overlay retires the echo on watermark
+  coverage of its basis (~1 ms after the seal), the store holds
+  NOTHING for the instance (the server derived it under the SERVICE
+  identity's instance — F1's identity-less space-root demand), the
+  flip is an `integrate` and the writer reads its own output, so it
+  re-derives; seal → retire → flip → re-run at ~80 ms cycles. Cause =
+  the demand registry drops identity for space roots (stage B's run
+  supply fixes it). The CLIENT ARRIVAL GATE (speculation.md §4, RULED
+  2026-08-16 on the panel's recommendation — a backstop for demand-walk
+  coverage gaps and the first-demand transient, independent of the
+  server half) LANDED with fan-out stage A as its own commit: an
+  input-origin entry retires only once every doc instance it wrote
+  holds a confirmed value at seq ≥ its floor; riders
+  supersede-by-newer and own-retirement-is-not-a-trigger. Pinned:
+  `speculation-arrival-gate.test.ts` (the OW32 shape — covering
+  watermark, no store value → the echo stays, bounded runs, no
+  non-settling; gate removed → the entry retires to nothing; arrival
+  retires it and the store value renders; the own-retirement mechanism
+  with its mutation; supersede-by-newer scripted). The triage's
+  measured effect: 45–56 k → 55–137 client runs / 5 min, both
+  two-browser gates booting < 3 s. The gates stay ON-skip-listed:
+  the gate treats the symptom; the R7 wall behind it is closed by
+  stage A's read seam, and the per-user derived state of real users
+  needs stage B's supply — record the two-browser gates' status
+  honestly at each stage (stage A's build report carries the runs).
 - OW33 — the ON-posture DENO-CLIENT family, surfaced by making the ON
   lanes UNIFORM (P7 independent review finding 7; fixer 2026-08-16):
   once the runner integration tests that talk to the lane's toolshed
@@ -2579,6 +2668,51 @@ findings; the OWNER RULING — the flip lands DARK):
   a byte-identical cross-user propagation number for the Deno client
   posture today. Recorded in the plan; the browser number waits for the
   two-user family.
+
+Delta 2026-08-16 — fan-out stage A (OW17 leg 1: the instance-keyed
+serving replica + wire; the client arrival gate):
+
+- protocol.md §2's read row: +1 binding clause (the runner ISSUES
+  explicit-instance reads for a served per-instance run's non-own
+  scoped reads; a live lease holder may name two instances of one
+  (branch, id, scope)) — pinned in memory `v2-explicit-read.test.ts`
+  ("stage A: a lease holder names two instances…", red-first at the P7
+  head) and `executor-instance-keyed-replica.test.ts` (the serving
+  replica holds both instances).
+- protocol.md §3: +1 binding clause (lease-holder frames/snapshots carry
+  `scope_key`; every other session's wire byte-identical) — pinned in
+  the same memory test (keyed frames on watch.set/add/query/push; no
+  key on a non-holder's frames).
+- scopes.md §2 Monotonicity AMENDED (RULED 2026-08-16): structural at
+  the space→user hop only; ragged per principal below it; instance
+  addresses carry the full (scope-kind, principal) address; "k only
+  narrows" is stage B's policy — a ruling, no impl-gate of its own; its
+  consequence for the basis index is the S4 amendment below.
+- serving-loop.md §3b's S4 AMENDED (+1 binding sentence set): rows keyed
+  by the run's FULL instance address, stranded stamp and broader-chain
+  keys cleared in both directions — pinned in
+  `executor-instance-keyed-replica.test.ts` (S4 step) with the two P2-F
+  pins moved to the same truth (`executor-serving-loop.test.ts`,
+  `executor-space-server.test.ts`).
+- key-vocabulary.md §3b (new inventory section) + §5's list: the
+  instance-keyed replica/wire vocabulary and `IMemoryAddress.scopeKey`;
+  §4's first tripwire covers the list — pinned in
+  `storage-instance-keying.test.ts` (OFF-arm neutrality per site).
+- speculation.md §4 step 3 + the arrival-gate paragraph (RULED
+  2026-08-16): +1 binding sentence set (the gate, its two riders) —
+  pinned in `speculation-arrival-gate.test.ts` (each with its
+  mutation); OW32's row carries the disposition.
+- Danger-zone note (storage/v2.ts near the wedge machinery): the
+  re-key touched `sealNative`/`sealOperations`, `settleSealedCommit`,
+  `confirmPending`, `finalizeRejection`, `finalizeSupersededSpeculation`,
+  `applySessionSync`, `buildReads`, `record`/`visibleVersion` and the
+  sink/notify paths — ONLY to thread the instance key/identity into
+  the doc-key resolution and the touched-doc entries; no ordering,
+  parking, marker, or shadow-floor logic moved. The wedge pins
+  (`settleSealedCommit → confirmPending` at verdict, `whenApplied`,
+  `markAuthoritativeWrites`), park/backoff, the B-1 barrier, the
+  renew-blip, and C10/T_flush suites ran green under the re-key (the
+  stage-A build report carries the counts).
 
 ## 4. Standing rule
 

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -2517,6 +2517,30 @@ Delta 2026-08-15 — Phase 6 independent-review fixes (same PR):
   stage A's read seam, and the per-user derived state of real users
   needs stage B's supply — record the two-browser gates' status
   honestly at each stage (stage A's build report carries the runs).
+- OW34 — served handler runs carry NO renderer-trusted event mark, so
+  their writes to UI-contract-gated (owner-protected) cells are refused
+  by CFC — the two-browsers gate's NEXT wall, UNMASKED by fan-out stage A
+  (2026-08-16/17): with the R7 read seam closed, Alice's served save
+  handler reads her draft and WRITES the shared `profiles` cell, and the
+  wave refuses the commit three times and drops it — `CFC enforcement
+  rejected commit: relevant transaction was not prepared: missing
+  trusted-event policy input for <profiles doc> at /` (both stage-A ON
+  runs, `store-on{2,3}/toolshed.log`). Mechanism: the client's fire marks
+  the UI event renderer-trusted in an in-process WeakSet
+  (`cfc/ui-contract.ts` `markRendererTrustedEvent`), and
+  `recordTrustedEventPolicyInputs` at dispatch matches only such events;
+  a drained stream entry's payload is a fresh object, so the served
+  dispatch records no trusted-event policy input and
+  `verifyTrustedEventRequirements` refuses at prepare. Pre-stage-A the
+  same handler read the service instance's EMPTY draft and wrote nothing,
+  so the refusal never fired. Not stage A's scope (flag-don't-fill): the
+  fix shape is a CFC-serving design question — carry the fired event's
+  trust provenance on the durable stream entry (the append is admitted
+  under the actor's authority; events.md §1) and re-mark it at the served
+  dispatch, or a serving-side trust rule for actor-stamped entries — with
+  its own spec sentence (cfc + events.md) before it is wired. Trigger:
+  before the two-browsers gate can green under ON (with stage B for the
+  per-user derived state of the second user); the gates stay skip-listed.
 - OW33 — the ON-posture DENO-CLIENT family, surfaced by making the ON
   lanes UNIFORM (P7 independent review finding 7; fixer 2026-08-16):
   once the runner integration tests that talk to the lane's toolshed

--- a/packages/memory/test/v2-client-watch.test.ts
+++ b/packages/memory/test/v2-client-watch.test.ts
@@ -51,6 +51,108 @@ Deno.test("memory v2 watch view keeps same id snapshots in different scopes", ()
   );
 });
 
+Deno.test("memory v2 watch view keys KEYED entries by instance: two instances of one (branch, id, scope) stay apart, a keyed remove drops exactly the named one, and an unkeyed frame keys by scope name as before (fan-out stage A's wire leg; mutation: key ignores scopeKey → red)", () => {
+  const aliceKey = "user:did%3Akey%3Aalice";
+  const bobKey = "user:did%3Akey%3Abob";
+  const view = WatchView.fromSync({
+    type: "sync",
+    fromSeq: 0,
+    toSeq: 2,
+    upserts: [
+      {
+        branch: "",
+        id: "of:keyed-watch-view",
+        scope: "user",
+        scopeKey: aliceKey as never,
+        seq: 1,
+        doc: { value: { who: "alice" } },
+      },
+      {
+        branch: "",
+        id: "of:keyed-watch-view",
+        scope: "user",
+        scopeKey: bobKey as never,
+        seq: 2,
+        doc: { value: { who: "bob" } },
+      },
+    ],
+    removes: [],
+  });
+  const snapshotOf = () =>
+    view.entities.map(({ id, scope, scopeKey, document }) => ({
+      id,
+      scope,
+      scopeKey,
+      document,
+    }));
+  assertEquals(snapshotOf(), [
+    {
+      id: "of:keyed-watch-view",
+      scope: "user",
+      scopeKey: aliceKey,
+      document: { value: { who: "alice" } },
+    },
+    {
+      id: "of:keyed-watch-view",
+      scope: "user",
+      scopeKey: bobKey,
+      document: { value: { who: "bob" } },
+    },
+  ]);
+  // A keyed remove of Alice's instance leaves Bob's.
+  view.applySync({
+    type: "sync",
+    fromSeq: 2,
+    toSeq: 3,
+    upserts: [],
+    removes: [{
+      branch: "",
+      id: "of:keyed-watch-view",
+      scope: "user",
+      scopeKey: aliceKey as never,
+    }],
+  }, false);
+  assertEquals(snapshotOf(), [
+    {
+      id: "of:keyed-watch-view",
+      scope: "user",
+      scopeKey: bobKey,
+      document: { value: { who: "bob" } },
+    },
+  ]);
+  // An unkeyed upsert of the same (branch, id, scope) is a DIFFERENT
+  // entry (keyed by the scope name), and an unkeyed remove drops only it.
+  view.applySync({
+    type: "sync",
+    fromSeq: 3,
+    toSeq: 4,
+    upserts: [{
+      branch: "",
+      id: "of:keyed-watch-view",
+      scope: "user",
+      seq: 4,
+      doc: { value: { who: "own" } },
+    }],
+    removes: [],
+  }, false);
+  assertEquals(snapshotOf().length, 2);
+  view.applySync({
+    type: "sync",
+    fromSeq: 4,
+    toSeq: 5,
+    upserts: [],
+    removes: [{ branch: "", id: "of:keyed-watch-view", scope: "user" }],
+  }, false);
+  assertEquals(snapshotOf(), [
+    {
+      id: "of:keyed-watch-view",
+      scope: "user",
+      scopeKey: bobKey,
+      document: { value: { who: "bob" } },
+    },
+  ]);
+});
+
 Deno.test("memory v2 client installs a watch set and receives live updates", async () => {
   const server = new Server({
     ...testSessionOpenServerOptions,

--- a/packages/memory/test/v2-explicit-read.test.ts
+++ b/packages/memory/test/v2-explicit-read.test.ts
@@ -903,7 +903,7 @@ const writeOwnProfile = async (
   assertExists(write.ok, JSON.stringify(write.error));
 };
 
-Deno.test("finding 1 (wire half): a former holder's catch-up RETRACTS a keyed-delivered foreign instance BY KEY — its own instance of the same doc is never named; and a foreign write after the retraction still evaluates the session (the watch stays tracked) so a re-armed lease re-delivers it keyed", async () => {
+Deno.test("finding 1 (wire half): a former holder's catch-up RETRACTS a keyed-delivered foreign instance BY KEY — its own instance of the same doc is never named; and once the lease is back, the next foreign write's pass re-arms and re-delivers the instance keyed (no re-issued watch)", async () => {
   const server = newServer("memory://explicit-read-keyed-retract");
   setServerExecutionConfig(true);
   try {
@@ -1004,11 +1004,11 @@ Deno.test("finding 1 (wire half): a former holder's catch-up RETRACTS a keyed-de
 
     // The lease comes back to the SAME holder (the in-process reacquire).
     // Alice's watch never left the session's watch set — only its
-    // delivery was withheld — so her next write must still EVALUATE the
-    // session (its dirty key stays tracked across the retraction) and,
-    // the lease being live again, re-deliver her instance KEYED. Pre-fix
-    // the retraction also dropped her key from the session's tracked
-    // set, so this write touched nothing and never re-delivered.
+    // delivery was withheld — so her next write's pass finds the lease
+    // live and the session lapsed, RE-ARMS (a full evaluation), and
+    // re-delivers her instance KEYED. Pre-fix the lapse had cleared the
+    // bit for the session's life: this write was filtered again, and
+    // nothing short of a fresh explicit-instance admission re-armed it.
     assertEquals(
       acquireExecutionLease(engine, { space: SPACE, holder, ttlMs: 600_000 }),
       true,

--- a/packages/memory/test/v2-explicit-read.test.ts
+++ b/packages/memory/test/v2-explicit-read.test.ts
@@ -845,6 +845,411 @@ Deno.test("stage A: a lease holder names two instances of one (branch, id, scope
   }
 });
 
+// ---------------------------------------------------------------------------
+// The exemption LIFECYCLE under the keyed wire (fan-out stage A's
+// independent review, finding 1 — 2026-08-17). Two halves of one
+// invariant: (i) a session's wire vocabulary is STICKY once it was
+// admitted explicit-instance reads — an instance delivered KEYED is
+// always retracted KEYED, so a former holder's catch-up names exactly the
+// foreign instances it retracts and never the session's own (an unkeyed
+// remove resolves against the client's OWN instance: the wipe); (ii) the
+// DELIVERY of foreign instances is live-lease-gated per pass, and a lapse
+// RE-ARMS on the first live pass with a full evaluation that re-delivers
+// what the lapse withheld — a renewal blip the SpaceServer survives
+// in-process must not leave its serving replica silently stale.
+// ---------------------------------------------------------------------------
+
+/** Every session/effect frame's upserts at or past `from`, with keys. */
+const effectUpserts = (
+  messages: ServerMessage[],
+  from: number,
+): Array<{ id: string; scopeKey?: string; doc?: { value?: unknown } }> =>
+  messages.slice(from)
+    .filter((message) =>
+      (message as { type?: string }).type === "session/effect"
+    )
+    .flatMap((message) =>
+      (message as {
+        effect?: {
+          upserts?: Array<
+            { id: string; scopeKey?: string; doc?: { value?: unknown } }
+          >;
+        };
+      }).effect?.upserts ?? []
+    );
+
+const writeOwnProfile = async (
+  server: Server,
+  sessionId: string,
+  localSeq: number,
+  value: Record<string, string>,
+): Promise<void> => {
+  const write = await server.transact({
+    type: "transact",
+    requestId: nextRequestId("own-write"),
+    space: SPACE,
+    sessionId,
+    commit: {
+      localSeq,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: "of:profile",
+        scope: "user",
+        value: { value },
+      }],
+    },
+  });
+  assertExists(write.ok, JSON.stringify(write.error));
+};
+
+Deno.test("finding 1 (wire half): a former holder's catch-up RETRACTS a keyed-delivered foreign instance BY KEY — its own instance of the same doc is never named; and a foreign write after the retraction still evaluates the session (the watch stays tracked) so a re-armed lease re-delivers it keyed", async () => {
+  const server = newServer("memory://explicit-read-keyed-retract");
+  setServerExecutionConfig(true);
+  try {
+    const alice = await connect(server);
+    const { sessionId: aliceSession } = await openSession(alice, ALICE);
+    await writeAliceProfile(server, aliceSession, 1, { name: "alice" });
+    const aliceKey = resolveScopeKey("user", { principal: ALICE });
+
+    const service = await connect(server);
+    const opened = await openSession(service, SERVICE);
+    // The service writes ITS OWN instance of the same doc — the stage-A
+    // serving-replica shape: the own instance and a demander's instance
+    // of one (branch, id, scope) held side by side.
+    await writeOwnProfile(server, opened.sessionId, 1, {
+      name: "service-own",
+    });
+    const serviceKey = resolveScopeKey("user", { principal: SERVICE });
+
+    const engine = await server.engineForSpace(SPACE);
+    const holder = executionLeaseHolder(SERVICE);
+    assertEquals(
+      acquireExecutionLease(engine, { space: SPACE, holder, ttlMs: 600_000 }),
+      true,
+    );
+    // The holder watches BOTH: its own instance (a keyless root) and
+    // Alice's (a keyed root).
+    const watch = await server.watchSet({
+      type: "session.watch.set",
+      requestId: nextRequestId("watch-both"),
+      space: SPACE,
+      sessionId: opened.sessionId,
+      watches: [{
+        id: "w-both",
+        kind: "graph",
+        query: {
+          roots: [
+            {
+              id: "of:profile",
+              scope: "user",
+              selector: { path: [], schema: false },
+            },
+            {
+              id: "of:profile",
+              scope: "user",
+              entityScopeKey: aliceKey as never,
+              selector: { path: [], schema: false },
+            },
+          ],
+        },
+      }],
+    }) as ResponseMessage<WatchSetResult>;
+    assertExists(watch.ok, JSON.stringify(watch.error));
+    assertEquals(
+      watch.ok.sync.upserts.map((upsert) => upsert.scopeKey).toSorted(),
+      [aliceKey, serviceKey].toSorted(),
+      "both instances delivered, each keyed",
+    );
+
+    // The connection dies and the lease lapses while detached; foreign
+    // state moves (so the catch-up diff has something to retract).
+    service.connection.close();
+    expireLease(engine, holder);
+    await writeAliceProfile(server, aliceSession, 2, { name: "alice-2" });
+    await drainDelivery(server, () => false);
+
+    // Resume without a live lease: the catch-up is a full evaluation
+    // that DROPS Alice's instance (protocol.md §3's filter) and retracts
+    // it — the retraction MUST carry her key. Pre-fix the frame keying
+    // hung from the live verdict, so the remove went out UNKEYED and the
+    // client resolved it against its OWN instance (the service's doc
+    // wiped, Alice's stale instance kept).
+    const resumedHarness = await connect(server);
+    const resumed = await openSession(resumedHarness, SERVICE, {
+      sessionId: opened.sessionId,
+      sessionToken: opened.sessionToken,
+    });
+    assertEquals(resumed.sessionId, opened.sessionId);
+    const sync = resumed.sync as {
+      upserts?: Array<{ id: string; scope?: string; scopeKey?: string }>;
+      removes?: Array<{ id: string; scope?: string; scopeKey?: string }>;
+    } | undefined;
+    const removes = (sync?.removes ?? []).filter((remove) =>
+      remove.id === "of:profile"
+    );
+    assertEquals(removes.length, 1, "exactly Alice's instance is retracted");
+    assertEquals(
+      removes[0].scopeKey,
+      aliceKey,
+      "a keyed-delivered foreign instance is retracted BY KEY (an unkeyed " +
+        "remove would name the session's OWN instance in its replica)",
+    );
+    assertEquals(
+      (sync?.upserts ?? []).filter((upsert) => upsert.id === "of:profile"),
+      [],
+      "the own instance is untouched by the catch-up (not re-sent, not " +
+        "retracted)",
+    );
+
+    // The lease comes back to the SAME holder (the in-process reacquire).
+    // Alice's watch never left the session's watch set — only its
+    // delivery was withheld — so her next write must still EVALUATE the
+    // session (its dirty key stays tracked across the retraction) and,
+    // the lease being live again, re-deliver her instance KEYED. Pre-fix
+    // the retraction also dropped her key from the session's tracked
+    // set, so this write touched nothing and never re-delivered.
+    assertEquals(
+      acquireExecutionLease(engine, { space: SPACE, holder, ttlMs: 600_000 }),
+      true,
+    );
+    const from = resumedHarness.messages.length;
+    await writeAliceProfile(server, aliceSession, 3, { name: "alice-3" });
+    await drainDelivery(
+      server,
+      () =>
+        effectUpserts(resumedHarness.messages, from).some((upsert) =>
+          upsert.id === "of:profile"
+        ),
+    );
+    const redelivered = effectUpserts(resumedHarness.messages, from).filter(
+      (upsert) => upsert.id === "of:profile",
+    );
+    assertEquals(redelivered.length, 1);
+    assertEquals(redelivered[0].scopeKey, aliceKey);
+    assertEquals(redelivered[0].doc?.value, { name: "alice-3" });
+
+    alice.connection.close();
+    resumedHarness.connection.close();
+  } finally {
+    resetServerExecutionConfig();
+    await server.close();
+  }
+});
+
+Deno.test("finding 1 (silent-stale half): a survived lease blip RE-ARMS the exemption on the next pass with NO re-issued watch — the SpaceServer's reacquire notice schedules that pass, and the update the lapse withheld is redelivered KEYED", async () => {
+  const server = newServer("memory://explicit-read-blip-rearm");
+  setServerExecutionConfig(true);
+  try {
+    const alice = await connect(server);
+    const { sessionId: aliceSession } = await openSession(alice, ALICE);
+    await writeAliceProfile(server, aliceSession, 1, { name: "alice" });
+    const aliceKey = resolveScopeKey("user", { principal: ALICE });
+
+    const service = await connect(server);
+    const { sessionId: serviceSession } = await openSession(service, SERVICE);
+    const engine = await server.engineForSpace(SPACE);
+    const holder = executionLeaseHolder(SERVICE);
+    assertEquals(
+      acquireExecutionLease(engine, { space: SPACE, holder, ttlMs: 600_000 }),
+      true,
+    );
+    const watch = await server.watchSet(
+      watchAliceInstance(serviceSession, aliceKey),
+    ) as ResponseMessage<WatchSetResult>;
+    assertExists(watch.ok, JSON.stringify(watch.error));
+
+    // The blip: the lease lapses; Alice's write inside it is WITHHELD
+    // (the P0 rule — and never cached as delivered).
+    expireLease(engine, holder);
+    const lapsedFrom = service.messages.length;
+    await writeAliceProfile(server, aliceSession, 2, { name: "alice-2" });
+    await drainDelivery(server, () => false);
+    assertEquals(
+      effectUpserts(service.messages, lapsedFrom).filter((upsert) =>
+        upsert.id === "of:profile"
+      ),
+      [],
+      "withheld while the lease is lapsed",
+    );
+
+    // The same holder reacquires (serving-loop.md §2's same-process
+    // reacquire) and — as the SpaceServer's renew arm does — reports it.
+    // NO watch is re-issued: the exemption re-arms by itself, and the
+    // notice is what schedules the pass (nothing else dirties the
+    // session's tracked set here). Pre-fix the lapse CLEARED the bit and
+    // only a fresh explicit-instance admission re-armed it, so the
+    // serving replica kept Alice's stale instance for as long as no
+    // per-instance read happened to re-admit — silently.
+    assertEquals(
+      acquireExecutionLease(engine, { space: SPACE, holder, ttlMs: 600_000 }),
+      true,
+    );
+    const rearmFrom = service.messages.length;
+    server.noteLeaseReacquired({ space: SPACE, principal: SERVICE });
+    await drainDelivery(
+      server,
+      () =>
+        effectUpserts(service.messages, rearmFrom).some((upsert) =>
+          upsert.id === "of:profile"
+        ),
+    );
+    const rearmed = effectUpserts(service.messages, rearmFrom).filter(
+      (upsert) => upsert.id === "of:profile",
+    );
+    assertEquals(rearmed.length, 1, "the withheld update is redelivered");
+    assertEquals(rearmed[0].scopeKey, aliceKey, "keyed");
+    assertEquals(rearmed[0].doc?.value, { name: "alice-2" });
+
+    // Steady state after the re-arm: later foreign updates flow
+    // incrementally, keyed.
+    const laterFrom = service.messages.length;
+    await writeAliceProfile(server, aliceSession, 3, { name: "alice-3" });
+    await drainDelivery(
+      server,
+      () =>
+        effectUpserts(service.messages, laterFrom).some((upsert) =>
+          upsert.id === "of:profile"
+        ),
+    );
+    const later = effectUpserts(service.messages, laterFrom).filter(
+      (upsert) => upsert.id === "of:profile",
+    );
+    assertEquals(later.length, 1);
+    assertEquals(later[0].scopeKey, aliceKey);
+    assertEquals(later[0].doc?.value, { name: "alice-3" });
+
+    // And the notice is inert when nothing lapsed (the OFF-arm and
+    // steady-state shape): no frame follows.
+    const idleFrom = service.messages.length;
+    server.noteLeaseReacquired({ space: SPACE, principal: SERVICE });
+    await drainDelivery(server, () => false);
+    assertEquals(effectUpserts(service.messages, idleFrom), []);
+
+    alice.connection.close();
+    service.connection.close();
+  } finally {
+    resetServerExecutionConfig();
+    await server.close();
+  }
+});
+
+Deno.test("finding 1 (silent-stale half, no notice): with the lease live again, the FIRST pass that evaluates the lapsed session — here, an unrelated write to a doc it tracks — re-arms with a full evaluation, so the update the lapse withheld rides along keyed", async () => {
+  const server = newServer("memory://explicit-read-blip-rearm-on-pass");
+  setServerExecutionConfig(true);
+  try {
+    const alice = await connect(server);
+    const { sessionId: aliceSession } = await openSession(alice, ALICE);
+    await writeAliceProfile(server, aliceSession, 1, { name: "alice" });
+    const aliceKey = resolveScopeKey("user", { principal: ALICE });
+
+    const service = await connect(server);
+    const { sessionId: serviceSession } = await openSession(service, SERVICE);
+    // The service's own SPACE doc — the unrelated tracked doc.
+    const settings = await server.transact({
+      type: "transact",
+      requestId: nextRequestId("settings"),
+      space: SPACE,
+      sessionId: serviceSession,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "of:settings",
+          value: { value: { v: 1 } },
+        }],
+      },
+    });
+    assertExists(settings.ok, JSON.stringify(settings.error));
+    const engine = await server.engineForSpace(SPACE);
+    const holder = executionLeaseHolder(SERVICE);
+    assertEquals(
+      acquireExecutionLease(engine, { space: SPACE, holder, ttlMs: 600_000 }),
+      true,
+    );
+    const watch = await server.watchSet({
+      type: "session.watch.set",
+      requestId: nextRequestId("watch-alice-and-settings"),
+      space: SPACE,
+      sessionId: serviceSession,
+      watches: [{
+        id: "w-both",
+        kind: "graph",
+        query: {
+          roots: [
+            {
+              id: "of:profile",
+              scope: "user",
+              entityScopeKey: aliceKey as never,
+              selector: { path: [], schema: false },
+            },
+            { id: "of:settings", selector: { path: [], schema: false } },
+          ],
+        },
+      }],
+    }) as ResponseMessage<WatchSetResult>;
+    assertExists(watch.ok, JSON.stringify(watch.error));
+
+    // Lapse; Alice's write inside it is withheld.
+    expireLease(engine, holder);
+    const lapsedFrom = service.messages.length;
+    await writeAliceProfile(server, aliceSession, 2, { name: "alice-2" });
+    await drainDelivery(server, () => false);
+    assertEquals(
+      effectUpserts(service.messages, lapsedFrom).filter((upsert) =>
+        upsert.id === "of:profile"
+      ),
+      [],
+    );
+
+    // Reacquire, then a write to the UNRELATED tracked doc: the pass it
+    // triggers finds the lease live and the session lapsed → a FULL
+    // evaluation, whose diff carries Alice's withheld update alongside
+    // the settings change. An incremental pass (pre-fix) would have
+    // carried the settings change alone — Alice's doc was not dirty.
+    assertEquals(
+      acquireExecutionLease(engine, { space: SPACE, holder, ttlMs: 600_000 }),
+      true,
+    );
+    const from = service.messages.length;
+    const settings2 = await server.transact({
+      type: "transact",
+      requestId: nextRequestId("settings-2"),
+      space: SPACE,
+      sessionId: serviceSession,
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "of:settings",
+          value: { value: { v: 2 } },
+        }],
+      },
+    });
+    assertExists(settings2.ok, JSON.stringify(settings2.error));
+    await drainDelivery(
+      server,
+      () =>
+        effectUpserts(service.messages, from).some((upsert) =>
+          upsert.id === "of:profile"
+        ),
+    );
+    const upserts = effectUpserts(service.messages, from);
+    const profile = upserts.filter((upsert) => upsert.id === "of:profile");
+    assertEquals(profile.length, 1, "the withheld update rides the re-arm");
+    assertEquals(profile[0].scopeKey, aliceKey);
+    assertEquals(profile[0].doc?.value, { name: "alice-2" });
+
+    alice.connection.close();
+    service.connection.close();
+  } finally {
+    resetServerExecutionConfig();
+    await server.close();
+  }
+});
+
 Deno.test("watch.add with a changed entityScopeKey on an existing watch id is a changed spec, not silently the old instance", async () => {
   const server = newServer("memory://explicit-read-changed-key");
   setServerExecutionConfig(true);

--- a/packages/memory/test/v2-explicit-read.test.ts
+++ b/packages/memory/test/v2-explicit-read.test.ts
@@ -592,33 +592,65 @@ Deno.test("the persisted lease-holder exemption does not survive session resume 
 // spec, never silently the same watch.
 // ---------------------------------------------------------------------------
 
-Deno.test("a read resolving two instances of one (branch, id, scope) is refused: the wire cannot express the distinction", async () => {
-  const server = newServer("memory://explicit-read-ambiguous");
+// ---------------------------------------------------------------------------
+// OW17's wire leg (server-execution v2 stage A, 2026-08-16): a LIVE lease
+// holder may name two instances of one (branch, id, scope) — its frames and
+// query results carry the instance key (`scopeKey`) per entry, so the two
+// stay apart on its wire and in its replica (the serving replica holding
+// BOTH the service instance and a demander's instance of one doc). The
+// wire collapse guard stays for everyone else: a NON-holder's wire carries
+// scope names only, so its ambiguous read set is still refused loudly.
+// ---------------------------------------------------------------------------
+
+Deno.test("stage A: a lease holder names two instances of one (branch, id, scope) and receives BOTH, keyed — watch.set, watch.add, graph.query, and the push frame; the collapse guard still refuses a non-holder (OW17's wire leg)", async () => {
+  const server = newServer("memory://explicit-read-two-instances");
   setServerExecutionConfig(true);
   try {
+    // Alice's and Bob's own instances of one doc.
+    const alice = await connect(server);
+    const { sessionId: aliceSession } = await openSession(alice, ALICE);
+    await writeAliceProfile(server, aliceSession, 1, { name: "alice" });
+    const bob = await connect(server);
+    const { sessionId: bobSession } = await openSession(bob, BOB);
+    const bobWrite = await server.transact({
+      type: "transact",
+      requestId: nextRequestId("bob-write"),
+      space: SPACE,
+      sessionId: bobSession,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "of:profile",
+          scope: "user",
+          value: { value: { name: "bob" } },
+        }],
+      },
+    });
+    assertExists(bobWrite.ok, JSON.stringify(bobWrite.error));
+
     const service = await connect(server);
     const { sessionId: serviceSession } = await openSession(service, SERVICE);
     const engine = await server.engineForSpace(SPACE);
     const holder = executionLeaseHolder(SERVICE);
     assertEquals(
-      // Long TTL: a test lease is never renewed, and assertions about a
-      // LIVE holder must not race the wall clock.
       acquireExecutionLease(engine, { space: SPACE, holder, ttlMs: 600_000 }),
       true,
     );
     const aliceKey = resolveScopeKey("user", { principal: ALICE });
     const bobKey = resolveScopeKey("user", { principal: BOB });
 
-    // Two explicit instances of the same (id, scope) in ONE watch set:
-    // both frames would serialize as (branch, id, scope: "user") and the
-    // client cache keeps only one. Refused loudly instead.
-    const ambiguous = await server.watchSet({
+    // watch.set naming BOTH instances of one (id, scope): admitted; the
+    // full sync carries two upserts, each KEYED with its instance and
+    // carrying that instance's document.
+    const both = await server.watchSet({
       type: "session.watch.set",
-      requestId: nextRequestId("ambiguous"),
+      requestId: nextRequestId("both"),
       space: SPACE,
       sessionId: serviceSession,
       watches: [{
-        id: "w-ambiguous",
+        id: "w-both",
         kind: "graph",
         query: {
           roots: [
@@ -638,40 +670,46 @@ Deno.test("a read resolving two instances of one (branch, id, scope) is refused:
         },
       }],
     }) as ResponseMessage<WatchSetResult>;
-    assertEquals(ambiguous.error?.name, "ProtocolError");
+    assertExists(both.ok, JSON.stringify(both.error));
+    const byKey = new Map(
+      both.ok.sync.upserts.map((upsert) => [upsert.scopeKey, upsert]),
+    );
+    assertEquals([...byKey.keys()].toSorted(), [aliceKey, bobKey].toSorted());
+    assertEquals(byKey.get(aliceKey)?.doc?.value, { name: "alice" });
+    assertEquals(byKey.get(bobKey)?.doc?.value, { name: "bob" });
+    // Every keyed upsert still carries the scope NAME (the pre-existing
+    // fields are untouched; the key is an addition).
+    for (const upsert of both.ok.sync.upserts) {
+      assertEquals(upsert.scope, "user");
+      assertEquals(upsert.id, "of:profile");
+    }
 
     // The same ambiguity split across an existing watch and a watch.add
-    // is refused too: the session's watch SET is the delivery unit.
-    const first = await server.watchSet(
-      watchAliceInstance(serviceSession, aliceKey, "w-first"),
-    ) as ResponseMessage<WatchSetResult>;
-    assertExists(first.ok, JSON.stringify(first.error));
+    // is admitted for the holder too (the delivery unit is keyed).
     const added = await server.watchAdd({
       type: "session.watch.add",
-      requestId: nextRequestId("add-ambiguous"),
+      requestId: nextRequestId("add-second"),
       space: SPACE,
       sessionId: serviceSession,
       watches: [{
-        id: "w-second",
+        id: "w-alice-again",
         kind: "graph",
         query: {
           roots: [{
             id: "of:profile",
             scope: "user",
-            entityScopeKey: bobKey,
+            entityScopeKey: aliceKey,
             selector: { path: [], schema: false },
           }],
         },
       }],
     });
-    assertEquals(added.error?.name, "ProtocolError");
+    assertExists(added.ok, JSON.stringify(added.error));
 
-    // A graph.query naming both instances at once is the same wire
-    // collapse (GraphQueryResult entities key by (branch, id, scope) in
-    // the client's WatchView) — refused identically.
+    // graph.query naming both: two snapshots, each keyed.
     const query = await server.graphQuery({
       type: "graph.query",
-      requestId: nextRequestId("query-ambiguous"),
+      requestId: nextRequestId("query-both"),
       space: SPACE,
       sessionId: serviceSession,
       query: {
@@ -690,10 +728,117 @@ Deno.test("a read resolving two instances of one (branch, id, scope) is refused:
           },
         ],
       },
+    }) as ResponseMessage<GraphQueryResult>;
+    assertExists(query.ok, JSON.stringify(query.error));
+    assertEquals(
+      query.ok.entities.map((entity) => entity.scopeKey).toSorted(),
+      [aliceKey, bobKey].toSorted(),
+    );
+
+    // The PUSH frame after Bob's next write names his instance — the
+    // holder's replica can tell whose doc moved.
+    const before = service.messages.length;
+    const bobAgain = await server.transact({
+      type: "transact",
+      requestId: nextRequestId("bob-write-2"),
+      space: SPACE,
+      sessionId: bobSession,
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "of:profile",
+          scope: "user",
+          value: { value: { name: "bob-2" } },
+        }],
+      },
     });
-    assertEquals(query.error?.name, "ProtocolError");
+    assertExists(bobAgain.ok, JSON.stringify(bobAgain.error));
+    await drainDelivery(
+      server,
+      () => effectUpsertIds(service.messages, before).length > 0,
+    );
+    const pushed = service.messages.slice(before)
+      .filter((message) =>
+        (message as { type?: string }).type ===
+          "session/effect"
+      )
+      .flatMap((message) =>
+        (message as {
+          effect?: { upserts?: Array<{ scopeKey?: string; doc?: unknown }> };
+        }).effect?.upserts ?? []
+      );
+    assertEquals(pushed.length, 1);
+    assertEquals(pushed[0].scopeKey, bobKey);
+    assertEquals(
+      (pushed[0].doc as { value?: unknown } | undefined)?.value,
+      { name: "bob-2" },
+    );
+
+    // The collapse guard is UNCHANGED for a non-holder: Bob's own session
+    // naming two instances is refused with the collapse message (his wire
+    // carries names only, and he could not name a foreign instance
+    // anyway).
+    const refused = await server.watchSet({
+      type: "session.watch.set",
+      requestId: nextRequestId("non-holder-both"),
+      space: SPACE,
+      sessionId: bobSession,
+      watches: [{
+        id: "w-bob-both",
+        kind: "graph",
+        query: {
+          roots: [
+            {
+              id: "of:profile",
+              scope: "user",
+              entityScopeKey: aliceKey,
+              selector: { path: [], schema: false },
+            },
+            {
+              id: "of:profile",
+              scope: "user",
+              entityScopeKey: bobKey,
+              selector: { path: [], schema: false },
+            },
+          ],
+        },
+      }],
+    }) as ResponseMessage<WatchSetResult>;
+    assertEquals(refused.error?.name, "ProtocolError");
+    assertEquals(
+      refused.error?.message.includes("resolves two instances"),
+      true,
+    );
+
+    // And a non-holder's UNKEYED frames stay byte-identical: no
+    // `scopeKey` field anywhere in Bob's own watch of his own instance.
+    const bobOwn = await server.watchSet({
+      type: "session.watch.set",
+      requestId: nextRequestId("bob-own"),
+      space: SPACE,
+      sessionId: bobSession,
+      watches: [{
+        id: "w-bob-own",
+        kind: "graph",
+        query: {
+          roots: [{
+            id: "of:profile",
+            scope: "user",
+            selector: { path: [], schema: false },
+          }],
+        },
+      }],
+    }) as ResponseMessage<WatchSetResult>;
+    assertExists(bobOwn.ok, JSON.stringify(bobOwn.error));
+    assertEquals(bobOwn.ok.sync.upserts.length, 1);
+    assertEquals("scopeKey" in bobOwn.ok.sync.upserts[0], false);
+    assertEquals(bobOwn.ok.sync.upserts[0].doc?.value, { name: "bob-2" });
 
     service.connection.close();
+    alice.connection.close();
+    bob.connection.close();
   } finally {
     resetServerExecutionConfig();
     await server.close();

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -971,6 +971,17 @@ export type EntitySnapshot = {
   branch: BranchName;
   id: EntityId;
   scope?: CellScope;
+  /**
+   * The scope INSTANCE this snapshot is of (server-execution v2 stage A,
+   * OW17's wire leg): present ONLY in responses to a lease-holder session
+   * that named explicit instances (`GraphQueryRoot.entityScopeKey`), so
+   * two instances of one (branch, id, scope) — which such a session may
+   * legitimately hold at once — stay distinguishable. Every other
+   * session's responses carry scope NAMES only and resolve instances from
+   * their own identity as always (protocol.md §1); the OFF-arm wire is
+   * byte-identical.
+   */
+  scopeKey?: ScopeKey;
   seq: number;
   document: EntityDocument | null;
 };
@@ -1018,6 +1029,19 @@ export type SessionSyncUpsert = {
   branch: BranchName;
   id: EntityId;
   scope?: CellScope;
+  /**
+   * The scope INSTANCE this upsert is of (server-execution v2 stage A,
+   * OW17's wire leg — the ONE write-side addition to the frame shape).
+   * Populated ONLY on frames to a session whose lease-holder read
+   * exemption is live (`SessionState.leaseHolderReads`, armed by an
+   * admitted `entityScopeKey` read — protocol.md §2's read row): that
+   * session legitimately receives EVERY instance it serves, including
+   * two instances of one (branch, id, scope), which the scope NAME alone
+   * cannot distinguish. Every other session's frames carry names only
+   * and resolve instances from their own identity as always
+   * (protocol.md §1, §3); the OFF-arm wire is byte-identical.
+   */
+  scopeKey?: ScopeKey;
   seq: number;
   doc?: EntityDocument;
   deleted?: true;
@@ -1027,6 +1051,8 @@ export type SessionSyncRemove = {
   branch: BranchName;
   id: EntityId;
   scope?: CellScope;
+  /** As on {@link SessionSyncUpsert}: the instance, lease-holder frames only. */
+  scopeKey?: ScopeKey;
 };
 
 export type SessionSync = {

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -92,11 +92,17 @@ const reconnectDelayMs = (attempt: number): number => {
   );
 };
 
+// The view's entity key: per scope INSTANCE where the frame names one
+// (server-execution v2 stage A, OW17's wire leg — lease-holder frames
+// carry `scopeKey`, and such a session may hold two instances of one
+// (branch, id, scope) at once), else per scope NAME as always. An unkeyed
+// frame's key text is byte-identical to before.
 const watchKey = (
   branch: string,
   id: string,
   scope: string | undefined,
-): string => `${branch}\0${scope ?? "space"}\0${id}`;
+  scopeKey?: string,
+): string => `${branch}\0${scopeKey ?? scope ?? "space"}\0${id}`;
 
 const compareEntitySnapshot = (
   left: EntitySnapshot,
@@ -1489,18 +1495,29 @@ export class WatchView {
   applySync(sync: SessionSync, emit: boolean): void {
     const upserts = new Map<string, EntitySnapshot>();
     for (const upsert of sync.upserts) {
-      upserts.set(watchKey(upsert.branch, upsert.id, upsert.scope), {
-        branch: upsert.branch,
-        id: upsert.id,
-        ...(upsert.scope !== undefined ? { scope: upsert.scope } : {}),
-        seq: upsert.seq,
-        document: upsert.doc ?? null,
-      });
+      upserts.set(
+        watchKey(upsert.branch, upsert.id, upsert.scope, upsert.scopeKey),
+        {
+          branch: upsert.branch,
+          id: upsert.id,
+          ...(upsert.scope !== undefined ? { scope: upsert.scope } : {}),
+          ...(upsert.scopeKey !== undefined
+            ? { scopeKey: upsert.scopeKey }
+            : {}),
+          seq: upsert.seq,
+          document: upsert.doc ?? null,
+        },
+      );
     }
 
     const removeKeys = new Set<string>();
     for (const remove of sync.removes) {
-      const key = watchKey(remove.branch, remove.id, remove.scope);
+      const key = watchKey(
+        remove.branch,
+        remove.id,
+        remove.scope,
+        remove.scopeKey,
+      );
       removeKeys.add(key);
     }
 

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -275,6 +275,15 @@ export type TrackGraphOptions = {
   readSeq?: number;
   principal?: string;
   sessionId?: string;
+  /**
+   * `queryGraph` only (server-execution v2 stage A, OW17's wire leg):
+   * annotate every returned snapshot with its scope INSTANCE
+   * (`EntitySnapshot.scopeKey`). Set for a session whose lease-holder
+   * read exemption is live — the one session class whose result may
+   * legitimately hold two instances of one (branch, id, scope) — and
+   * never otherwise, so the OFF-arm result shape is unchanged.
+   */
+  keyedSnapshots?: boolean;
 };
 
 export const cloneTrackedGraphState = (
@@ -567,9 +576,15 @@ export const queryGraph = (
     ...options,
     readSeq: query.atSeq,
   });
+  const entities = options.keyedSnapshots === true
+    ? [...tracked.state.entities.entries()].map(([key, snapshot]) => ({
+      ...snapshot,
+      scopeKey: fromDocKey(key as QueryDocKey).scopeKey,
+    }))
+    : [...tracked.state.entities.values()];
   return {
     serverSeq: tracked.serverSeq,
-    entities: [...tracked.state.entities.values()]
+    entities: entities
       .toSorted((left, right) => left.id.localeCompare(right.id)),
   };
 };

--- a/packages/memory/v2/server-sync.ts
+++ b/packages/memory/v2/server-sync.ts
@@ -7,6 +7,7 @@ import {
   type ScopeKey,
   type ScopeKeyIdentity,
   type SessionSync,
+  type SessionSyncRemove,
   type SessionSyncUpsert,
   type WatchSpec,
 } from "../v2.ts";
@@ -100,9 +101,18 @@ export const trackedIdsFromEntries = (
  * receive keys). Every path that puts cache entries into a `SessionSync`
  * frame goes through this, so the instance keying stays server-internal
  * and the OFF-arm wire is byte-identical.
+ *
+ * `keyed` (server-execution v2 stage A, OW17's wire leg): a frame to a
+ * session whose lease-holder read exemption is LIVE keeps the instance
+ * key on every entry — that session may hold two instances of one
+ * (branch, id, scope) at once (its explicit-instance reads name them),
+ * and the scope name alone cannot tell them apart. The field is added
+ * AFTER the pre-existing fields, so a keyed frame is the byte-identical
+ * unkeyed frame plus one field per entry; an unkeyed frame is unchanged.
  */
 export const toWireUpsert = (
   entry: SessionCacheEntry,
+  keyed = false,
 ): SessionSyncUpsert => {
   // Field order matches the pre-instance-keying cache entry exactly
   // (branch, id, scope, seq, then deleted|doc), so serialized frames are
@@ -114,6 +124,7 @@ export const toWireUpsert = (
       scope: entry.scope,
       seq: entry.seq,
       deleted: true,
+      ...(keyed ? { scopeKey: entry.scopeKey } : {}),
     };
   }
   return {
@@ -122,8 +133,21 @@ export const toWireUpsert = (
     scope: entry.scope,
     seq: entry.seq,
     ...(entry.doc === undefined ? {} : { doc: entry.doc }),
+    ...(keyed ? { scopeKey: entry.scopeKey } : {}),
   };
 };
+
+/** The wire form of a removed cache entry — `keyed` as on
+ * {@link toWireUpsert}. */
+export const toWireRemove = (
+  entry: SessionCacheEntry,
+  keyed = false,
+): SessionSyncRemove => ({
+  branch: entry.branch,
+  id: entry.id,
+  scope: entry.scope,
+  ...(keyed ? { scopeKey: entry.scopeKey } : {}),
+});
 
 const compareSyncAddress = (
   left: { branch: string; id: string; scope?: CellScope },
@@ -200,6 +224,8 @@ export const buildFullSync = (
   next: ReadonlyMap<string, SessionCacheEntry>,
   fromSeq: number,
   toSeq: number,
+  // Lease-holder frames carry instance keys (see toWireUpsert).
+  keyed = false,
 ): SessionSync => {
   const removes = [...previous.values()]
     .filter((entry) =>
@@ -207,14 +233,10 @@ export const buildFullSync = (
         cacheKeyForEntity(entry.branch, entry.id, entry.scopeKey),
       )
     )
-    .map((entry) => ({
-      branch: entry.branch,
-      id: entry.id,
-      scope: entry.scope,
-    }))
+    .map((entry) => toWireRemove(entry, keyed))
     .sort(compareSyncAddress);
   const upserts = [...next.values()].sort(compareSyncAddress)
-    .map(toWireUpsert);
+    .map((entry) => toWireUpsert(entry, keyed));
   return {
     type: "sync",
     fromSeq,
@@ -238,6 +260,8 @@ export const buildDiffSync = (
     upserts: SessionCacheEntry[];
     removes: SessionCacheEntry[];
   },
+  // Lease-holder frames carry instance keys (see toWireUpsert).
+  keyed = false,
 ): SessionSync => {
   const upserts: SessionCacheEntry[] = [];
   for (const [key, current] of next.entries()) {
@@ -249,11 +273,7 @@ export const buildDiffSync = (
     .filter(([key]) => !next.has(key))
     .map(([, entry]) => entry);
   const removes = removedEntries
-    .map((entry) => ({
-      branch: entry.branch,
-      id: entry.id,
-      scope: entry.scope,
-    }))
+    .map((entry) => toWireRemove(entry, keyed))
     .sort(compareSyncAddress);
   if (delivered !== undefined) {
     delivered.upserts.push(...upserts);
@@ -263,7 +283,9 @@ export const buildDiffSync = (
     type: "sync",
     fromSeq,
     toSeq,
-    upserts: upserts.toSorted(compareSyncAddress).map(toWireUpsert),
+    upserts: upserts.toSorted(compareSyncAddress).map((entry) =>
+      toWireUpsert(entry, keyed)
+    ),
     removes,
   };
 };

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -3905,14 +3905,6 @@ export class Server {
               sessionId,
             },
           );
-          // The tracked dirty keys come from the evaluation BEFORE the
-          // filter below: a lapsed holder's watches still NAME its
-          // foreign instances — only their delivery is withheld — so a
-          // later change to one must still evaluate this session (else
-          // the re-arm above never runs on that change and the update
-          // the lapse withheld never re-delivers). For every other
-          // session the filter removes nothing, so the set is the same.
-          const evaluatedTrackedIds = trackedIdsFromEntries(entities.values());
           // protocol.md §3's applicable-set filter on the FULL
           // evaluation path: explicit foreign instances enter `entities`
           // only through admitted lease-holder reads, and the exemption
@@ -3946,6 +3938,12 @@ export class Server {
           // frame is built, so a throw leaves the diff recomputable. The
           // empty-sync branch commits first — its frame carries no doc
           // novelty, and the marker counters are restored by the catch.
+          // (A lapsed holder's retracted foreign entries leave its
+          // tracked set here; the re-arm above runs on the session's
+          // NEXT pass regardless of what dirtied it — every session of
+          // the space is offered every batch — so no tracked key is
+          // needed to bring the withheld instances back.)
+          const evaluatedTrackedIds = trackedIdsFromEntries(entities.values());
           const commitWatchState = () => {
             session.graphs = graphs;
             session.entities = entities;

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -2900,6 +2900,12 @@ export class Server {
           {
             principal: session.principal,
             sessionId: message.sessionId,
+            // Stage A (OW17's wire leg): a live lease holder's snapshots
+            // carry their instance key (it may name two instances of one
+            // doc); every other session's result is byte-identical.
+            ...(session.leaseHolderReads === true
+              ? { keyedSnapshots: true }
+              : {}),
           },
         ),
       };
@@ -3135,6 +3141,12 @@ export class Server {
         entities,
         session.seenSeq,
         serverSeq,
+        // Stage A (OW17's wire leg): a session whose lease-holder read
+        // exemption is live receives instance-KEYED frames — it may
+        // name two instances of one (branch, id, scope), which the
+        // scope name alone cannot distinguish. Every other session's
+        // frames are byte-identical to before.
+        session.leaseHolderReads === true,
       );
       session.watches = message.watches;
       session.graphs = graphs;
@@ -3356,7 +3368,11 @@ export class Server {
             upserts: upserts.toSorted((left, right) =>
               left.branch.localeCompare(right.branch) ||
               left.id.localeCompare(right.id)
-            ).map(toWireUpsert),
+            ).map((entry) =>
+              // Keyed for a live lease-holder session (stage A, OW17's
+              // wire leg; see watchSet).
+              toWireUpsert(entry, session.leaseHolderReads === true)
+            ),
             removes: [],
           },
         },
@@ -3377,7 +3393,11 @@ export class Server {
     query: GraphQuery,
     engine?: Engine.Engine,
     reuse?: QueryGraphReuseContext,
-    scopeContext: { principal?: string; sessionId?: string } = {},
+    scopeContext: {
+      principal?: string;
+      sessionId?: string;
+      keyedSnapshots?: boolean;
+    } = {},
   ): Promise<GraphQueryResult> {
     const startedAt = performance.now();
     const result = queryGraph(
@@ -3521,7 +3541,10 @@ export class Server {
       return;
     }
     for (const upsert of sync.upserts) {
-      const scopeKey = instanceKeyFor(upsert.scope);
+      // A keyed frame (stage A: lease-holder frames carry the instance)
+      // names its own instance; the session-identity recovery is the
+      // fallback for unkeyed frames.
+      const scopeKey = upsert.scopeKey ?? instanceKeyFor(upsert.scope);
       if (scopeKey === undefined) continue;
       session.entities.delete(
         cacheKeyForEntity(upsert.branch, upsert.id, scopeKey),
@@ -3545,7 +3568,7 @@ export class Server {
       // emits removes, so only a full re-diff (tombstone present, entity
       // absent) regenerates the removal for the client.
       const scope = declaredScope(remove.scope);
-      const scopeKey = instanceKeyFor(remove.scope);
+      const scopeKey = remove.scopeKey ?? instanceKeyFor(remove.scope);
       if (scopeKey === undefined) continue;
       session.entities.set(
         cacheKeyForEntity(remove.branch, remove.id, scopeKey),
@@ -3813,7 +3836,14 @@ export class Server {
               upserts: upserts.toSorted((left, right) =>
                 left.branch.localeCompare(right.branch) ||
                 left.id.localeCompare(right.id)
-              ).map(toWireUpsert),
+              ).map((entry) =>
+                // Keyed exactly when the exemption is LIVE this pass
+                // (stage A, OW17's wire leg): the exempt session receives
+                // every instance it serves, and the key is what keeps two
+                // instances of one (branch, id, scope) apart in its
+                // replica. Non-exempt frames are byte-identical to before.
+                toWireUpsert(entry, leaseHolderExempt)
+              ),
               removes: [],
             });
             // The wire frame strips instance keys; retain the frame's
@@ -3843,7 +3873,11 @@ export class Server {
           // is keyed on CURRENT holdership — a former holder's foreign
           // entries are dropped here, and their previously delivered
           // predecessors diff out as removes below.
-          if (!(await this.#currentLeaseHolderExemption(space, session))) {
+          const fullEvalExempt = await this.#currentLeaseHolderExemption(
+            space,
+            session,
+          );
+          if (!fullEvalExempt) {
             const identity = this.#sessionScopeIdentity(session);
             for (const [key, entry] of [...entities]) {
               if (!scopeKeyApplicableTo(entry.scopeKey, identity)) {
@@ -3861,6 +3895,9 @@ export class Server {
             session.lastSyncedSeq,
             serverSeq,
             delivered,
+            // Keyed for a live lease-holder session (stage A, OW17's wire
+            // leg; see the incremental branch above).
+            fullEvalExempt,
           );
           // As above: commit the re-evaluated watch state only once the
           // frame is built, so a throw leaves the diff recomputable. The
@@ -4199,15 +4236,24 @@ export class Server {
     // microtask boundary — the request's authorization and evaluation
     // keep sharing one engine turn (the ACL revocation-race invariant).
     let named = false;
-    // The wire collapse guard: frames and query results carry scope
-    // NAMES, so two instances of one (branch, id, scope) are
-    // indistinguishable on the wire and the client cache keeps only one
-    // (WatchView keys by branch/id/scope). Refuse the shape loudly at
-    // admission instead of silently losing an instance. Keyless roots
-    // resolve to the session's own instance, so an explicit key equal to
-    // it is fine — only two DIFFERENT effective instances conflict.
+    // The wire collapse guard, NON-holders only (server-execution v2
+    // stage A, OW17's wire leg): a non-holder's frames and query results
+    // carry scope NAMES, so two instances of one (branch, id, scope)
+    // would be indistinguishable on its wire and its client cache would
+    // keep only one (WatchView keys by branch/id/scope) — refused loudly
+    // at admission instead of silently losing an instance. A LIVE lease
+    // holder is exempt: its frames carry `scope_key` per entry (the
+    // exemption armed below is what keys them), and its query results
+    // carry `scopeKey` per snapshot, so it may legitimately name two
+    // instances of one doc — that IS the serving replica holding both
+    // the service instance and a demander's instance of one doc.
+    // Keyless roots resolve to the session's own instance, so an
+    // explicit key equal to it is fine — only two DIFFERENT effective
+    // instances conflict. Evaluated synchronously (before the holdership
+    // await) and RAISED only on the non-holder arm.
     const identity = this.#sessionScopeIdentity(session);
     const instanceByAddress = new Map<string, string>();
+    let collapse: V2Error | undefined;
     for (const { branch, root } of entries) {
       if (root.entityScopeKey !== undefined) {
         named = true;
@@ -4219,6 +4265,7 @@ export class Server {
           );
         }
       }
+      if (collapse !== undefined) continue;
       const scopeName = root.scope ?? "space";
       const instanceKey = root.entityScopeKey ??
         (canResolveScopeKey(root.scope, identity)
@@ -4230,16 +4277,18 @@ export class Server {
       if (existing === undefined) {
         instanceByAddress.set(addressKey, instanceKey);
       } else if (existing !== instanceKey) {
-        return toError(
+        collapse = toError(
           "ProtocolError",
           `read set resolves two instances of (${root.id}, ${scopeName}) ` +
-            `— "${existing}" and "${instanceKey}" — which the wire ` +
-            "cannot distinguish (frames carry scope names, protocol.md " +
-            "§1); name one instance per (branch, id, scope)",
+            `— "${existing}" and "${instanceKey}" — which this session's ` +
+            "wire cannot distinguish (frames carry scope names for a " +
+            "non-holder, protocol.md §1); name one instance per (branch, " +
+            "id, scope), or hold the execution lease (protocol.md §2's " +
+            "read row: lease-holder frames carry scope_key)",
         );
       }
     }
-    if (!named) return undefined;
+    if (!named) return collapse;
     if (!getServerExecutionConfig()) {
       return toError(
         "ProtocolError",
@@ -4261,7 +4310,9 @@ export class Server {
       (session.principal !== undefined &&
         this.#liveCoHostedLeaseSpaceFor(session.principal) !== undefined);
     if (!holdsCoHosted) {
-      return toError(
+      // The collapse refusal is the more specific message for a
+      // non-holder whose read set is ambiguous on its (unkeyed) wire.
+      return collapse ?? toError(
         "ProtocolError",
         "read naming an entity_scope_key rejected: requester does not " +
           "hold a live execution_lease on this memory server " +

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -2367,17 +2367,15 @@ export class Server {
           "taken-over",
         );
       }
-      if (opened.resumed === true) {
-        // Resume revalidates the persisted lease-holder read exemption
-        // BEFORE any catch-up evaluation runs: the bit is an
-        // authorization tied to a LIVE execution lease (protocol.md §2's
-        // read row), and a resume must never inherit it across a lapsed
-        // or moved lease. Clears the stale bit as a side effect.
-        const resumed = this.#sessions.get(message.space, opened.sessionId);
-        if (resumed !== null) {
-          await this.#currentLeaseHolderExemption(message.space, resumed);
-        }
-      }
+      // A resumed session's catch-up (below) is a FULL watch evaluation,
+      // and every evaluation pass judges the lease-holder read exemption
+      // against the CURRENT lease before it builds a frame
+      // (syncSessionForConnection → #currentLeaseHolderExemption): a
+      // resume never inherits foreign-instance delivery across a lapsed
+      // or moved lease — the catch-up frame RETRACTS the foreign
+      // instances instead, KEYED (the session's wire vocabulary is
+      // sticky), so the retraction names exactly them and never the
+      // session's own instance.
       const catchup = opened.resumed === true
         ? await this.syncSessionForConnection(
           message.space,
@@ -3624,6 +3622,10 @@ export class Server {
     const preCallCaughtUp = session.caughtUpLocalSeq;
     const preCallPending = session.pendingCaughtUpLocalSeq;
     const preCallForceFullResync = session.forceFullResync;
+    // Whether THIS pass re-armed a lapsed lease-holder exemption (see
+    // below); restored on a throw so the re-arm's full evaluation is
+    // not lost with the failed pass.
+    let rearmedLeaseHolder = false;
     if (session.forceFullResync) {
       // Rollback re-inserted tombstones for a lost frame's removes; only a
       // full evaluation re-diffs them out. Self-clearing (restored by the
@@ -3689,10 +3691,49 @@ export class Server {
           if (session.watches.length === 0) {
             return await emptyCatchUp();
           }
+          // The lease-holder read exemption for THIS pass, judged ONCE
+          // on CURRENT holdership (protocol.md §2's read row is
+          // live-lease admission) and BEFORE the branch choice: it
+          // decides whether FOREIGN instances are delivered on either
+          // branch, and a lapse it ends is what forces the full
+          // evaluation below. A session never admitted explicit-instance
+          // reads takes the synchronous fast path — no added await on
+          // the ordinary push path.
+          const leaseHolderExempt = session.leaseHolderReads === true
+            ? await this.#currentLeaseHolderExemption(space, session)
+            : false;
+          if (leaseHolderExempt && session.leaseHolderReadsLapsed === true) {
+            // The RE-ARM (fan-out stage A's independent review, finding
+            // 1): an earlier pass found the lease lapsed and withheld or
+            // retracted this session's foreign instances; the lease is
+            // live again (a renewal blip the SpaceServer survived
+            // in-process, or a reacquire), so run a FULL evaluation
+            // NOW — the incremental branch would re-deliver only what
+            // becomes dirty from here on, leaving every instance the
+            // lapse withheld silently stale in the serving replica.
+            session.leaseHolderReadsLapsed = false;
+            rearmedLeaseHolder = true;
+            dirtyIds = undefined;
+            dirtyOrigins = undefined;
+          }
+          // The session's WIRE VOCABULARY (fan-out stage A, OW17's wire
+          // leg; protocol.md §3): a session admitted explicit-instance
+          // reads is keyed for its life — upserts AND removes — so an
+          // instance delivered keyed is always retracted keyed. Keying
+          // never hangs from the live verdict above: a former holder's
+          // catch-up must retract its foreign instances BY KEY (an
+          // unkeyed remove names the session's own instance in its
+          // replica — the wipe). Every other session's frames are
+          // byte-identical to before.
+          const keyed = session.leaseHolderReads === true;
           if (dirtyIds !== undefined) {
+            // Bound once for the closures below (the re-arm above is the
+            // one assignment after this point, and it never runs on this
+            // branch).
+            const batchDirtyIds = dirtyIds;
             const startedAt = performance.now();
             let touched = false;
-            for (const dirtyId of dirtyIds) {
+            for (const dirtyId of batchDirtyIds) {
               if (session.trackedIds.has(dirtyId)) {
                 touched = true;
                 break;
@@ -3718,7 +3759,7 @@ export class Server {
                       space,
                       engine,
                       graph,
-                      dirtyIds,
+                      batchDirtyIds,
                     );
                   } finally {
                     watchSpan.end();
@@ -3742,13 +3783,10 @@ export class Server {
               return await emptyCatchUp();
             }
 
-            // The lease-holder exemption is keyed on CURRENT holdership,
-            // once per pass: a former holder's foreign instances are
-            // filtered like any other session's (protocol.md §2's read
-            // row is live-lease admission; the check also clears a stale
-            // persisted bit).
-            const leaseHolderExempt = await this
-              .#currentLeaseHolderExemption(space, session);
+            // The lease-holder exemption was judged on CURRENT holdership
+            // above, once per pass: a former holder's foreign instances
+            // are filtered like any other session's (protocol.md §2's
+            // read row is live-lease admission).
             const filteredKeys: string[] = [];
             const upserts: SessionCacheEntry[] = [];
             for (const [key, entry] of updates) {
@@ -3837,18 +3875,18 @@ export class Server {
                 left.branch.localeCompare(right.branch) ||
                 left.id.localeCompare(right.id)
               ).map((entry) =>
-                // Keyed exactly when the exemption is LIVE this pass
-                // (stage A, OW17's wire leg): the exempt session receives
-                // every instance it serves, and the key is what keeps two
-                // instances of one (branch, id, scope) apart in its
-                // replica. Non-exempt frames are byte-identical to before.
-                toWireUpsert(entry, leaseHolderExempt)
+                // Keyed by the session's wire vocabulary (stage A, OW17's
+                // wire leg — see `keyed` above): the key is what keeps
+                // two instances of one (branch, id, scope) apart in the
+                // serving replica. Unkeyed frames are byte-identical to
+                // before.
+                toWireUpsert(entry, keyed)
               ),
               removes: [],
             });
-            // The wire frame strips instance keys; retain the frame's
-            // true instance-keyed entries so a delivery failure rolls
-            // back the EXACT instances (rollbackUndeliveredSync).
+            // An unkeyed wire frame strips instance keys; retain the
+            // frame's true instance-keyed entries so a delivery failure
+            // rolls back the EXACT instances (rollbackUndeliveredSync).
             this.#deliveredFrameEntries.set(message, {
               upserts: [...upserts],
               removes: [],
@@ -3867,17 +3905,24 @@ export class Server {
               sessionId,
             },
           );
+          // The tracked dirty keys come from the evaluation BEFORE the
+          // filter below: a lapsed holder's watches still NAME its
+          // foreign instances — only their delivery is withheld — so a
+          // later change to one must still evaluate this session (else
+          // the re-arm above never runs on that change and the update
+          // the lapse withheld never re-delivers). For every other
+          // session the filter removes nothing, so the set is the same.
+          const evaluatedTrackedIds = trackedIdsFromEntries(entities.values());
           // protocol.md §3's applicable-set filter on the FULL
           // evaluation path: explicit foreign instances enter `entities`
           // only through admitted lease-holder reads, and the exemption
-          // is keyed on CURRENT holdership — a former holder's foreign
-          // entries are dropped here, and their previously delivered
-          // predecessors diff out as removes below.
-          const fullEvalExempt = await this.#currentLeaseHolderExemption(
-            space,
-            session,
-          );
-          if (!fullEvalExempt) {
+          // is keyed on CURRENT holdership (judged above) — a former
+          // holder's foreign entries are dropped here, and their
+          // previously delivered predecessors diff out as removes below,
+          // KEYED (`keyed`, the session's sticky wire vocabulary), so
+          // the client retracts exactly those instances and its own
+          // instance survives.
+          if (!leaseHolderExempt) {
             const identity = this.#sessionScopeIdentity(session);
             for (const [key, entry] of [...entities]) {
               if (!scopeKeyApplicableTo(entry.scopeKey, identity)) {
@@ -3895,15 +3940,12 @@ export class Server {
             session.lastSyncedSeq,
             serverSeq,
             delivered,
-            // Keyed for a live lease-holder session (stage A, OW17's wire
-            // leg; see the incremental branch above).
-            fullEvalExempt,
+            keyed,
           );
           // As above: commit the re-evaluated watch state only once the
           // frame is built, so a throw leaves the diff recomputable. The
           // empty-sync branch commits first — its frame carries no doc
           // novelty, and the marker counters are restored by the catch.
-          const evaluatedTrackedIds = trackedIdsFromEntries(entities.values());
           const commitWatchState = () => {
             session.graphs = graphs;
             session.entities = entities;
@@ -3934,6 +3976,9 @@ export class Server {
           );
           session.forceFullResync = session.forceFullResync ||
             preCallForceFullResync;
+          // A re-arm consumed by a throwing pass re-stages: the next
+          // pass runs the full evaluation the lapse still owes.
+          if (rearmedLeaseHolder) session.leaseHolderReadsLapsed = true;
           throw error;
         } finally {
           span.end();
@@ -4327,22 +4372,34 @@ export class Server {
    * Whether the session's lease-holder read exemption (protocol.md §2's
    * read row) is valid NOW. The exemption is an authorization tied to
    * holding a LIVE execution lease, so every use re-keys on CURRENT
-   * holdership: a lapsed or moved lease invalidates the persisted bit —
-   * cleared here, so lease loss clears the exemption — and only a fresh
-   * explicit-instance admission (#denyExplicitInstanceReads) re-arms it.
-   * Consulted by the push path's applicable-set filter (both the
-   * incremental and the full-evaluation branch) and by session resume,
-   * so a former holder receives no foreign scoped instances anywhere.
+   * holdership: a lapsed or moved lease means NO foreign instance is
+   * delivered — the push pass filters (incremental) or retracts (full
+   * evaluation) them — until the lease is live again. Consulted once
+   * per push pass (syncSessionForConnection, before the branch choice;
+   * a session resume's catch-up is such a pass), so a former holder
+   * receives no foreign scoped instances anywhere.
+   *
+   * What a lapse does NOT do (fan-out stage A's independent review,
+   * finding 1): it does not clear `leaseHolderReads`. That bit is the
+   * session's sticky WIRE VOCABULARY — its frames stay keyed so the
+   * retraction of a keyed-delivered foreign instance is keyed too (an
+   * unkeyed remove would wipe the session's OWN instance in its
+   * replica) — and it is what lets the exemption RE-ARM: the lapse is
+   * recorded (`leaseHolderReadsLapsed`), and the first pass that finds
+   * the lease live again runs a full evaluation that re-delivers what
+   * the lapse withheld (a renewal blip survived in-process, or a
+   * reacquire; `noteLeaseReacquired` schedules that pass promptly). A
+   * fresh explicit-instance admission (#denyExplicitInstanceReads) is
+   * no longer the only way back.
    */
   async #currentLeaseHolderExemption(
     space: string,
     session: SessionState,
   ): Promise<boolean> {
     if (session.leaseHolderReads !== true) return false;
-    if (session.principal === undefined) {
-      session.leaseHolderReads = false;
-      return false;
-    }
+    // Unreachable for an admitted session (admission needs a principal
+    // to build the full holder); a principal-less bit is simply inert.
+    if (session.principal === undefined) return false;
     // The same holdership the admission accepts (Phase 5): the read
     // space's own lease, or — FP2's widening — any live co-hosted
     // lease held by THIS process's full DR1 holder (a home SpaceServer
@@ -4357,10 +4414,42 @@ export class Server {
       !holdsReadSpace &&
       this.#liveCoHostedLeaseSpaceFor(session.principal) === undefined
     ) {
-      session.leaseHolderReads = false;
+      session.leaseHolderReadsLapsed = true;
       return false;
     }
     return true;
+  }
+
+  /**
+   * The co-hosted SpaceServer reports it (re)acquired a space's lease
+   * after a renewal blip (serving-loop.md §2's same-process reacquire).
+   * A push pass that ran inside the blip found the serving identity's
+   * lease-holder sessions lapsed and withheld or retracted their foreign
+   * instances; their exemption re-arms on the next pass — schedule that
+   * pass NOW (an empty dirty batch: every other session of the space
+   * evaluates as untouched, the lapsed sessions run their full
+   * evaluation) instead of waiting for an unrelated write to touch them.
+   * Covers the identity's sessions on every space (FP2's cross-space
+   * serving reads hang from the same lease). Nothing to do when no
+   * session lapsed — the common case, and every OFF-arm call.
+   */
+  noteLeaseReacquired(
+    notice: { space: string; principal: string },
+  ): void {
+    const lapsedSpaces = new Set<string>();
+    for (
+      const session of this.#sessions.sessionsForPrincipal(notice.principal)
+    ) {
+      if (
+        session.leaseHolderReads === true &&
+        session.leaseHolderReadsLapsed === true
+      ) {
+        lapsedSpaces.add(session.space);
+      }
+    }
+    for (const space of lapsedSpaces) {
+      this.markSpaceDirty(space, []);
+    }
   }
 
   /** Whether any read root names an explicit instance — the sync gate

--- a/packages/memory/v2/session-registry.ts
+++ b/packages/memory/v2/session-registry.ts
@@ -21,10 +21,26 @@ export type SessionState = {
    * them out (CT-1927 review, round 7). Self-clearing. */
   forceFullResync: boolean;
   /** Set once this session was admitted an explicit `entity_scope_key`
-   * read (protocol.md §2's read row — lease holders only): the push
-   * path's applicable-set filter (protocol.md §3) exempts it, since the
-   * lease holder legitimately reads and receives every instance. */
+   * read (protocol.md §2's read row — lease holders only), and STICKY
+   * for the session's life: it selects the session's WIRE VOCABULARY
+   * (fan-out stage A, protocol.md §3) — every upsert, remove, and
+   * snapshot to it carries the instance key from then on, so an
+   * instance delivered KEYED is always retracted KEYED (an unkeyed
+   * remove names the session's OWN instance in its replica: the
+   * former-holder wipe, fan-out stage A's independent review, finding
+   * 1). Whether FOREIGN instances are DELIVERED is a separate, per-pass
+   * question answered against the LIVE lease
+   * (`Server.#currentLeaseHolderExemption`); this bit alone never
+   * admits one. */
   leaseHolderReads?: boolean;
+  /** Set by a push pass (or a resume catch-up) that found
+   * `leaseHolderReads` armed but no live lease: that pass withheld or
+   * retracted the session's foreign instances. The first pass that
+   * finds the lease live again RE-ARMS by running a FULL watch
+   * evaluation, which re-delivers every instance the lapse withheld —
+   * a renewal blip the SpaceServer survives in-process must not leave
+   * its serving replica silently stale. Cleared by that pass. */
+  leaseHolderReadsLapsed?: boolean;
   expiresAt: number | null;
   ownerConnectionId: string | null;
   principal?: string;
@@ -121,6 +137,9 @@ export class SessionRegistry {
       ...(existing?.leaseHolderReads === true
         ? { leaseHolderReads: true }
         : {}),
+      ...(existing?.leaseHolderReadsLapsed === true
+        ? { leaseHolderReadsLapsed: true }
+        : {}),
       expiresAt: null,
       ownerConnectionId,
       principal: existing?.principal ?? principal,
@@ -161,6 +180,20 @@ export class SessionRegistry {
     const sessions: SessionState[] = [];
     for (const session of this.#sessions.values()) {
       if (session.space === space) {
+        sessions.push(session);
+      }
+    }
+    return sessions;
+  }
+
+  /** Every live session of one principal across ALL spaces — the
+   * co-hosted serving identity's loopback sessions (its own space's and,
+   * under FP2's cross-space reads, foreign spaces'). */
+  sessionsForPrincipal(principal: string): SessionState[] {
+    this.#prune();
+    const sessions: SessionState[] = [];
+    for (const session of this.#sessions.values()) {
+      if (session.principal === principal) {
         sessions.push(session);
       }
     }

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -2768,7 +2768,19 @@ export class CellImpl<T extends FabricValue>
   sync(): Promise<Cell<T>> {
     this.synced = true;
     logger.info("sync", this.link);
-    return this.runtime.storageManager.syncCell<T>(this as unknown as Cell<T>);
+    // The runner's explicit-instance read (server-execution v2 stage A —
+    // OW17's tx→replica seam): a cell read inside a SERVED per-instance
+    // run — its transaction carries the demand-supplied identity — loads
+    // THAT principal's instance of a scoped doc, keyed apart in the
+    // serving replica; a cell with no run identity (every client, the OFF
+    // arm) loads exactly as before. The manager decides whether the
+    // identity names anything (own identity and space scope name
+    // nothing).
+    const identity = this.tx?.tx?.scopeKeyIdentity;
+    return this.runtime.storageManager.syncCell<T>(
+      this as unknown as Cell<T>,
+      identity !== undefined ? { scopeKeyIdentity: identity } : undefined,
+    );
   }
 
   sinkMeta(

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -846,8 +846,18 @@ export function normalizeAndDiff(
       // cell skip it — the check would otherwise run on EVERY defaulted-cell
       // serialization, a measurable hot-path cost (the CI perf check caught
       // +22–36% on the CLI integration suites for the unmemoized version).
+      // The memo keys per INSTANCE under the RUN's identity (server-
+      // execution v2 stage A — key-vocabulary.md §1 site 4's audit): a
+      // served per-instance run's tx carries its demand-supplied
+      // identity, so Alice's presence check memoizes under Alice's
+      // instance and never suppresses Bob's seed of HIS default (one
+      // user's presence must not suppress another's). Absent identity —
+      // every client, the OFF arm — resolves the runtime's own, as before.
       !seededDocs(runtime).has(
-        seedMemoKey(seedTarget, runtime.scopeKeyIdentity),
+        seedMemoKey(
+          seedTarget,
+          tx.tx.scopeKeyIdentity ?? runtime.scopeKeyIdentity,
+        ),
       )
     ) {
       // Don't subscribe the serializing action to the seed doc — mirror
@@ -857,7 +867,10 @@ export function normalizeAndDiff(
       }) === undefined;
       if (!absent) {
         seededDocs(runtime).add(
-          seedMemoKey(seedTarget, runtime.scopeKeyIdentity),
+          seedMemoKey(
+            seedTarget,
+            tx.tx.scopeKeyIdentity ?? runtime.scopeKeyIdentity,
+          ),
         );
       }
       if (absent) {

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -1407,7 +1407,20 @@ export class SpaceServer implements TransactionSealDestination {
       ]);
       if (!lease.acquire()) {
         void this.park("lease-lost");
+        return;
       }
+      // Survived the blip in-process. Any push pass that ran inside it
+      // judged this runtime's loopback session a FORMER holder and
+      // withheld or retracted its foreign instances (protocol.md §2's
+      // read row is live-lease admission); tell the co-hosted memory
+      // server the lease is live again so the session's exemption
+      // re-arms NOW — a full re-evaluation that re-delivers what the
+      // blip withheld — rather than on the next unrelated write (fan-out
+      // stage A's independent review, finding 1: the silent-stale half).
+      this.#options.server.noteLeaseReacquired({
+        space: this.#options.space,
+        principal: this.#options.serviceIdentity,
+      });
     }
   }
 

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -1235,7 +1235,22 @@ export class SpaceServer implements TransactionSealDestination {
         const { promise, resolve } = Promise.withResolvers<
           SealedCommitVerdict
         >();
-        const sealed = replica.sealNative(native, source, promise);
+        // Stage A (OW17): the completion's local pending layer lands on
+        // the CARRIAGE identity's instances — the same instances its
+        // engine rows are annotated with below — so the demanded run's
+        // instance sees the served result locally at verdict, not only
+        // through the wire. Residual, FLAGGED (not filled): the writeback
+        // transaction itself is unstamped, so its hash-guard READS resolve
+        // against the service's instances; a per-instance node's effect
+        // completion is unpinned in this stage.
+        const sealed = replica.sealNative(
+          native,
+          source,
+          promise,
+          carriage?.scopeKeyIdentity !== undefined
+            ? { identity: carriage.scopeKeyIdentity }
+            : undefined,
+        );
         sealedSpaces.push({ space, sealed, resolveVerdict: resolve });
         return Promise.resolve({ ok: {} });
       },

--- a/packages/runner/src/executor/wave.ts
+++ b/packages/runner/src/executor/wave.ts
@@ -55,6 +55,7 @@ import type {
 } from "../storage/interface.ts";
 import { parsePointer, pathsOverlap } from "../../../memory/v2/path.ts";
 import { getLogger } from "@commonfabric/utils/logger";
+import { normalizeCellScope, scopeRank } from "../scope.ts";
 
 const logger = getLogger("wave-accumulator", {
   enabled: true,
@@ -167,6 +168,17 @@ export function stampWaveRunContext(
   context: WaveRunContext,
 ): void {
   waveRunContexts.set(tx, context);
+  // The tx→replica identity seam (server-execution v2 stage A, OW17): the
+  // run's demand-supplied identity rides the STORAGE transaction too, so
+  // its scoped reads resolve against ITS instance in the replica (one
+  // local doc per instance) and its logged addresses name that instance
+  // for the scheduler's per-instance dependency keys. Set exactly once
+  // per transaction, before the run's first read (the storage tx
+  // enforces both). A context without an identity — the wave-level
+  // fallback, bookkeeping — leaves the manager's own in force.
+  if (context.scopeKeyIdentity !== undefined) {
+    tx.tx.scopeKeyIdentity = context.scopeKeyIdentity;
+  }
 }
 
 export function waveRunContextOf(
@@ -402,6 +414,13 @@ interface WaveContribution {
    * ride (its event replays and re-emits, the model's committed-only
    * `cascadesCross` fold). */
   outboundAppends: OutboxAppendRow[];
+  /** The run's DISCOVERED scope at seal (scopes.md §2 S1 — the
+   * transaction's read-scope ratchet, learned by running): the narrowest
+   * scope of anything the run read, its diff bases and redirect slots
+   * included. With the run identity it names the FULL instance address
+   * the run actually served, which keys its basis rows (S4 —
+   * server-execution v2 stage A). */
+  discoveredScope: CellScope;
 }
 
 interface SealedSpaceContribution {
@@ -457,6 +476,7 @@ interface PendingAssembly {
   context: WaveRunContext | undefined;
   spaces: SealedSpaceContribution[];
   readOnlyReadKeys: Set<string>;
+  discoveredScope: CellScope;
 }
 
 /**
@@ -702,6 +722,10 @@ export class WaveAccumulator
       context,
       spaces: [],
       readOnlyReadKeys: new Set(),
+      // Read BEFORE sealInto: the seal's own bookkeeping reads nothing
+      // scoped, and the ratchet is complete once the action body and its
+      // result write have run.
+      discoveredScope: normalizeCellScope(tx.getNarrowestReadScope?.()),
     };
     try {
       const result = await inner.sealInto(this);
@@ -770,6 +794,7 @@ export class WaveAccumulator
         // Copied: a (refused) post-seal enqueue must not be able to
         // mutate the sealed contribution through the shared array.
         outboundAppends: [...pendingAppends],
+        discoveredScope: assembly.discoveredScope,
       });
       waveSettlements.set(
         tx,
@@ -1032,7 +1057,17 @@ export class WaveAccumulator
       });
     }
     const { promise, resolve } = Promise.withResolvers<SealedCommitVerdict>();
-    const sealed = replica.sealNative(native, source, promise);
+    // The tx→replica identity seam (server-execution v2 stage A, OW17):
+    // the run's ops apply to ITS identity's local instances — the
+    // replica's own when the context carries none (the wave-level
+    // fallback, bookkeeping), byte-identical to before.
+    const identity = assembly.context?.scopeKeyIdentity;
+    const sealed = replica.sealNative(
+      native,
+      source,
+      promise,
+      identity !== undefined ? { identity } : undefined,
+    );
     assembly.spaces.push({
       space,
       native,
@@ -1886,12 +1921,44 @@ export class WaveAccumulator
       // Every survivor lands its basis rows — including one whose writes
       // were dropped per-doc as superseded: its reads are true, and no
       // recompute-owed mark exists (§3d, RULED 2026-08-05).
-      const actionScopeKey = context.actionScopeKey ?? "space";
-      basisInstances.set(`${context.actionId} ${actionScopeKey}`, {
+      //
+      // S4 (serving-loop.md §3b; server-execution v2 stage A — basis
+      // rows keyed by the FULL instance address the run served): the
+      // rows land under the run's DISCOVERED scope resolved against its
+      // identity — the instance address the run actually computed —
+      // rather than under the demand's stamp. A user-scoped watch stamps
+      // `user:<p>` on a node that discovered `space` (over-keyed rows,
+      // F10), and a session-scoped watch stamps `session:<p>:<s>` on a
+      // node that discovered `user` — the RAGGED case (narrowing below
+      // the space→user hop is per principal, scopes.md §2 as amended
+      // 2026-08-16): a departed session then leaves rows no run can ever
+      // overwrite, a zombie the re-mark re-dirties at every activation.
+      // The stamped key and every BROADER key on the run's own chain
+      // (`space`, and `user:<p>` under a session instance) that differ
+      // from the true key are cleared with an EMPTY replacement in the
+      // SAME wave transaction — the "narrowing DELETES the rows it
+      // stranded" rule, sound in both directions by monotonicity at the
+      // top hop and within one principal (an instance narrower than
+      // `space` for anyone is narrower for everyone; a principal's
+      // sessions narrow together). A real row set already recorded in
+      // this wave under a key is never overwritten by a clearance (map
+      // insertion below is guarded), so in-wave order cannot lose rows.
+      const trueKey = this.#trueBasisKey(contribution);
+      basisInstances.set(`${context.actionId} ${trueKey}`, {
         action: context.actionId,
-        actionScopeKey,
+        actionScopeKey: trueKey,
         rows: this.#basisRowsFor(contribution),
       });
+      for (const stranded of this.#strandedBasisKeys(contribution, trueKey)) {
+        const clearanceKey = `${context.actionId} ${stranded}`;
+        if (!basisInstances.has(clearanceKey)) {
+          basisInstances.set(clearanceKey, {
+            action: context.actionId,
+            actionScopeKey: stranded,
+            rows: [],
+          });
+        }
+      }
     }
     // Same-space emitted entries (LT1): every surviving op that appends
     // a seq-LESS entry into a stream sidecar carries a NEW event — the
@@ -2148,13 +2215,60 @@ export class WaveAccumulator
     return [...batches.entries()].map(([key, batch]) => ({ key, batch }));
   }
 
+  /**
+   * The basis-row instance key of a contribution (S4, stage A): the run's
+   * DISCOVERED scope resolved against its identity — the full instance
+   * address it served. `space` for a run that read nothing scoped; the
+   * stamped identity's user or session instance otherwise. A discovered
+   * scope the identity cannot resolve (a session-scoped read under a
+   * sessionless actor — events.md §2's sessionless-actor shape) falls
+   * back to the stamped key: the run could not have served an instance
+   * it cannot name.
+   */
+  #trueBasisKey(contribution: WaveContribution): ScopeKey {
+    const context = contribution.context;
+    const stamped = context.actionScopeKey ?? "space";
+    const identity = context.scopeKeyIdentity ?? this.#scopeKeyIdentity;
+    try {
+      return resolveScopeKey(contribution.discoveredScope, identity);
+    } catch {
+      return stamped;
+    }
+  }
+
+  /** The keys S4 clears for a contribution whose true key differs from
+   * what the demand stamped (see commitWave): the stamp itself, and every
+   * strictly-broader key on the run's own chain. */
+  #strandedBasisKeys(
+    contribution: WaveContribution,
+    trueKey: ScopeKey,
+  ): ScopeKey[] {
+    const context = contribution.context;
+    const stranded = new Set<ScopeKey>();
+    const stamped = context.actionScopeKey ?? "space";
+    if (stamped !== trueKey) stranded.add(stamped);
+    const identity = context.scopeKeyIdentity ?? this.#scopeKeyIdentity;
+    const discovered = contribution.discoveredScope;
+    if (scopeRank(discovered) > scopeRank("space")) stranded.add("space");
+    if (scopeRank(discovered) > scopeRank("user")) {
+      try {
+        stranded.add(resolveScopeKey("user", identity));
+      } catch {
+        // an unresolvable user instance has no rows to strand
+      }
+    }
+    stranded.delete(trueKey);
+    return [...stranded];
+  }
+
   /** Basis rows (§3b) for one surviving contribution: doc-granular
    * ids + seqs from the sealed commit's read set — confirmed reads carry
    * their store version; in-wave pending reads share the wave's own
-   * commit seq (`seq: null`, filled by the sink). */
+   * commit seq (`seq: null`, filled by the sink). Keyed by the run's
+   * TRUE instance key (S4, stage A — see #trueBasisKey). */
   #basisRowsFor(contribution: WaveContribution): SchedulerBasisRow[] {
     const context = contribution.context;
-    const actionScopeKey = context.actionScopeKey ?? "space";
+    const actionScopeKey = this.#trueBasisKey(contribution);
     const rows = new Map<string, SchedulerBasisRow>();
     for (const spaceContribution of contribution.spaces) {
       const reads = spaceContribution.sealed.commit.reads;

--- a/packages/runner/src/reactive-dependencies.ts
+++ b/packages/runner/src/reactive-dependencies.ts
@@ -43,11 +43,19 @@ export function sortAndCompactPaths(
 ): IMemorySpaceAddress[] {
   if (unsorted.length === 0) return [];
 
+  // The instance segment: an address that NAMES its instance
+  // (`scopeKey`, server-execution v2 stage A — a served per-instance
+  // run's logged read) compares by that key, so the union of one node's
+  // N instance runs' logs keeps N reads of one doc apart instead of
+  // compacting them into one; an address without one compares by scope
+  // NAME as before (byte-identical ordering and compaction OFF).
+  const instanceOf = (address: IMemorySpaceAddress): string =>
+    address.scopeKey ?? normalizeCellScope(address.scope);
   const sorted = unsorted.toSorted((a, b) => {
     if (a.space !== b.space) return a.space < b.space ? -1 : 1;
     if (a.id !== b.id) return a.id < b.id ? -1 : 1;
-    const aScope = normalizeCellScope(a.scope);
-    const bScope = normalizeCellScope(b.scope);
+    const aScope = instanceOf(a);
+    const bScope = instanceOf(b);
     if (aScope !== bScope) return aScope < bScope ? -1 : 1;
     return comparePaths(a.path, b.path);
   });
@@ -57,8 +65,7 @@ export function sortAndCompactPaths(
     if (
       sorted[i].space === previous.space &&
       sorted[i].id === previous.id &&
-      normalizeCellScope(sorted[i].scope) ===
-        normalizeCellScope(previous.scope) &&
+      instanceOf(sorted[i]) === instanceOf(previous) &&
       // Is the previous path a prefix of the current path?
       previous.path.every((value, index) => value === sorted[i].path[index]) &&
       // If we compactifyChildren, or the paths are identical, skip this

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -73,7 +73,11 @@ import { sendValueToBinding } from "./pattern-binding.ts";
 import { flattenBuilderArtifacts } from "./storage-preflight.ts";
 import { isCellResultForDereferencing } from "./query-result-proxy.ts";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
-import { resolveScopeKey, type ScopeKey } from "@commonfabric/memory/v2";
+import {
+  resolveScopeKey,
+  type ScopeKey,
+  type ScopeKeyIdentity,
+} from "@commonfabric/memory/v2";
 import { waveRunContextOf } from "./executor/wave.ts";
 import { speculationRunContextOf } from "./speculation/overlay-destination.ts";
 import {
@@ -6124,7 +6128,7 @@ export class Runner {
     // behind link VALUES like a builtin's result handle. Steady-state this is
     // ~free: covered selectors resolve without a server round trip.
     const presyncInputs = module.argumentSchema !== undefined
-      ? async (event: any): Promise<void> => {
+      ? async (event: any, identity?: ScopeKeyIdentity): Promise<void> => {
         const eventInputs = {
           ...(inputs as Record<string, any>),
           $event: event,
@@ -6140,7 +6144,16 @@ export class Runner {
         const collect = (value: unknown, depth: number): void => {
           if (depth > 16) return;
           if (isCell(value)) {
-            promises.push(value.sync());
+            promises.push(
+              identity === undefined
+                ? value.sync()
+                // A served event's presync loads the ACTOR's instances of
+                // the handler's scoped inputs (stage A — the runner's
+                // explicit-instance read; see EventHandler.presyncInputs).
+                : this.runtime.storageManager.syncCell(value, {
+                  scopeKeyIdentity: identity,
+                }),
+            );
             return;
           }
           // NOTE: materialized records all carry the back-to-cell symbol, so

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -2059,17 +2059,23 @@ export class Runtime {
   ensureLinkedDocLoaded(
     link: NormalizedFullLink,
     sourceSpace?: MemorySpace,
+    /** The reading run's identity when the read is a served per-instance
+     * run's (server-execution v2 stage A — the runner's explicit-instance
+     * read): the load then NAMES that principal's instance, keyed apart
+     * from the runtime's own. Absent = the runtime's own identity, the
+     * pre-stage-A path byte for byte. */
+    identity?: ScopeKeyIdentity,
   ): void {
     const { space, id, scope } = link;
     // Kick keys are per scope INSTANCE (key-vocabulary.md §5's stage-F
     // serving-hazard list): name-keyed, A's kick suppressed B's load and
     // B's absent read never healed at cardinality > 1. Resolved against
     // the runtime's own identity — the OFF arm's one identity, so the
-    // partition is unchanged at cardinality 1 (key-vocabulary.md §2);
-    // served per-run reads arrive with stage F's run contexts and pull
-    // through the demand path, not this dedup set.
+    // partition is unchanged at cardinality 1 (key-vocabulary.md §2) — or
+    // against the served run's identity for a per-instance read (stage
+    // A): each demanded instance's absent read kicks its own load.
     const key = `${space}\0${
-      resolveScopeKey(scope, this.scopeKeyIdentity)
+      resolveScopeKey(scope, identity ?? this.scopeKeyIdentity)
     }\0${id}`;
     if (this.missingDocLoadKicks.has(key)) return;
     // A same-space target the replica already has state for (or a manager
@@ -2077,17 +2083,25 @@ export class Runtime {
     const sameSpace = sourceSpace === space;
     const mgr = this.storageManager;
     const reserved = sameSpace &&
-      mgr.shouldPullDoc?.(space, id, scope) === true;
+      mgr.shouldPullDoc?.(space, id, scope, identity) === true;
     if (sameSpace && !reserved) return;
     this.missingDocLoadKicks.add(key);
+    const load = identity === undefined
+      ? this.getCellFromLink(link).sync()
+      // The instance-named load: the storage manager names the run's
+      // instance on the wire (lease-holder-only at admission) and lands
+      // the doc under it; an own-identity run takes the ordinary sync.
+      : mgr.syncCell(this.getCellFromLink(link), {
+        scopeKeyIdentity: identity,
+      });
     mgr.trackUntilSettled(
-      this.getCellFromLink(link).sync().catch(() => {
+      load.catch(() => {
         // Allow a retry on failure (e.g. transient disconnect): clear this
         // dedup set, and hand back the storage manager's reservation when
         // THIS kick took it — a cross-space kick never reserved, and must
         // not clear a reservation a concurrent same-space read holds.
         this.missingDocLoadKicks.delete(key);
-        if (reserved) mgr.retractDocPullKick?.(space, id, scope);
+        if (reserved) mgr.retractDocPullKick?.(space, id, scope, identity);
       }),
     );
   }

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -651,6 +651,21 @@ export function preflightQueuedEventDependencies(state: {
   // Get the handler's dependencies (read-only, just capturing what will be read)
   const depTx = state.runtime.edit();
   depTx.setReadOnly?.("scheduler.populateDependencies()");
+  // A SERVED event's dependency probe reads AS the event's server-stamped
+  // actor (server-execution v2 stage A — OW17's tx→replica identity seam,
+  // LD1): the handler run will read that actor's instances of every
+  // scoped input, so the probe must name the SAME instances — its absent
+  // reads then kick instance-named loads, and the pending-load park below
+  // holds the head event on exactly those loads (an at-most-once handler
+  // must not run against the service instance's empty draft — the R7
+  // wall). Absent on every client-side event, byte-identical there.
+  const firedAt = queuedEvent.served?.firedAt;
+  if (firedAt?.user !== undefined) {
+    depTx.tx.scopeKeyIdentity = {
+      principal: firedAt.user,
+      sessionId: firedAt.session === "server" ? undefined : firedAt.session,
+    } as never;
+  }
   let stepStart = performance.now();
   logger.timeStart(
     "scheduler",
@@ -1012,7 +1027,21 @@ export async function dispatchQueuedEvent(state: {
   // surface as the handler's own read failure, not silently drop the event.
   if (typeof handler.presyncInputs === "function") {
     try {
-      await handler.presyncInputs(eventValue);
+      // A served event's presync loads the event actor's instances (stage
+      // A — see EventHandler.presyncInputs); a client-side event passes
+      // nothing, byte-identical to before.
+      const firedAt = queuedEvent.served?.firedAt;
+      await handler.presyncInputs(
+        eventValue,
+        firedAt?.user !== undefined
+          ? {
+            principal: firedAt.user,
+            sessionId: firedAt.session === "server"
+              ? undefined
+              : firedAt.session,
+          } as never
+          : undefined,
+      );
     } catch (error) {
       logger.warn(
         "scheduler",

--- a/packages/runner/src/scheduler/graph-snapshot.ts
+++ b/packages/runner/src/scheduler/graph-snapshot.ts
@@ -258,7 +258,10 @@ function formatAddress(
   address: IMemorySpaceAddress,
   identity: ScopeKeyIdentity,
 ): string {
+  // An address that NAMES its instance (`scopeKey`, server-execution v2
+  // stage A — a served per-instance run's logged read) renders that
+  // instance; the runtime's identity resolves the rest, as before.
   return `${address.space}/${address.id}/${
-    resolveScopeKey(address.scope, identity)
+    address.scopeKey ?? resolveScopeKey(address.scope, identity)
   }/${address.path.join("/")}`;
 }

--- a/packages/runner/src/scheduler/invalidation.ts
+++ b/packages/runner/src/scheduler/invalidation.ts
@@ -157,7 +157,14 @@ export function processStorageNotification(
       const actionType = actionIsEffect ? "effect" : "computation";
       const pendingBefore = state.pending.has(action);
       const dirtyBefore = state.isInvalid(action);
-      const isOwnCommitSource = notification.type === "commit" &&
+      // Own-commit-source skip (spec scheduler-v2 P5), and its
+      // speculation twin (server-execution v2, speculation.md §4 — the
+      // "own retirement is not a trigger" rider, RULED 2026-08-16): the
+      // `integrate` a retiring echo produces carries the echo's own
+      // transaction as `source`, so the writer does not re-run for the
+      // flip of its OWN output to the authoritative value.
+      const isOwnCommitSource =
+        (notification.type === "commit" || notification.type === "integrate") &&
         notification.source !== undefined &&
         notification.source.sourceAction === action;
       const plan = planPullTriggeredAction({

--- a/packages/runner/src/scheduler/keys.ts
+++ b/packages/runner/src/scheduler/keys.ts
@@ -2,6 +2,7 @@ import {
   resolveScopeKey,
   type ScopeKeyIdentity,
 } from "@commonfabric/memory/v2";
+import { normalizeCellScope } from "../scope.ts";
 import type { IMemorySpaceAddress } from "../storage/interface.ts";
 import type { SpaceScopeAndURI } from "./types.ts";
 
@@ -19,15 +20,46 @@ import type { SpaceScopeAndURI } from "./types.ts";
  * re-keyed string partitions state exactly as the scope-NAME string did
  * (key-vocabulary.md §2).
  *
+ * An address that NAMES its instance (`address.scopeKey`, server-execution
+ * v2 stage A — a served per-instance run's logged read, a keyed
+ * notification address) is keyed by that instance and the identity is
+ * not consulted: on a serving runtime one node's N instance runs log
+ * reads of N different instances of one doc, and each must key to ITS
+ * instance rather than to whatever the runtime's own identity would
+ * resolve. Absent (every client, the whole OFF arm) the identity resolves
+ * it as before, so the field's absence keeps the key text byte-identical.
+ *
  * This is also the composite `${space}/${scope_key}/${id}` constructor for
  * every map that shares the format (the storage manager's pending-load
  * keys cross-match these strings in `collectPendingLoadParkKeys`).
  */
 export function entityKey(
-  address: Pick<IMemorySpaceAddress, "space" | "id" | "scope">,
+  address: Pick<IMemorySpaceAddress, "space" | "id" | "scope" | "scopeKey">,
   identity: ScopeKeyIdentity,
 ): SpaceScopeAndURI {
   return `${address.space}/${
-    resolveScopeKey(address.scope, identity)
+    address.scopeKey ?? resolveScopeKey(address.scope, identity)
   }/${address.id}`;
+}
+
+/**
+ * The scope-NAME-keyed twin of {@link entityKey}, for the scheduler's
+ * reader→writer TOPOLOGY relations (the writer index and the materializer
+ * write index — server-execution v2 stage A, key-vocabulary.md §1 site 1's
+ * split): a writer's DECLARED write surface names scope NAMES and one node
+ * writes ALL instances of that surface (C11b's singular node), so the edge
+ * between a user-scoped-declared writer and a reader running as any
+ * principal must hold regardless of which instance the reader's logged
+ * read names. Keying that index per instance would drop the edge the
+ * moment reads carry non-own instances (today both sides collapse to the
+ * runtime's own instance and match by accident). Dirtiness — the
+ * dependency and trigger keys — stays per instance via {@link entityKey};
+ * instance-precise dirtiness across this fan-in is stage B's B7.
+ */
+export function entityNameKey(
+  address: Pick<IMemorySpaceAddress, "space" | "id" | "scope">,
+): SpaceScopeAndURI {
+  return `${address.space}/${
+    normalizeCellScope(address.scope)
+  }/${address.id}` as SpaceScopeAndURI;
 }

--- a/packages/runner/src/scheduler/materializers.ts
+++ b/packages/runner/src/scheduler/materializers.ts
@@ -3,7 +3,7 @@ import { sortAndCompactPaths } from "../reactive-dependencies.ts";
 import type { NormalizedFullLink } from "../link-utils.ts";
 import { toMemorySpaceAddress } from "../link-utils.ts";
 import type { IMemorySpaceAddress } from "../storage/interface.ts";
-import { entityKey } from "./keys.ts";
+import { entityNameKey } from "./keys.ts";
 import { readsOverlapWrites } from "./scheduling-writes.ts";
 import type { Action, ReactivityLog, SpaceScopeAndURI } from "./types.ts";
 
@@ -60,9 +60,13 @@ export class SchedulerMaterializers implements MaterializerIndexState {
     this.writeEnvelopes.set(action, writes);
 
     const entities = new Set<SpaceScopeAndURI>();
-    const identity = this.scopeKeyIdentity();
+    // Reader→writer TOPOLOGY, keyed by scope NAME (server-execution v2
+    // stage A; see entityNameKey): a materializer's envelope covers every
+    // instance of its declared surface, so a reader running as any
+    // principal must find it. Overlap is decided by name (readsOverlapWrites)
+    // as before; only the index key stops resolving an instance.
     for (const write of writes) {
-      const entity = entityKey(write, identity);
+      const entity = entityNameKey(write);
       entities.add(entity);
       let materializers = this.materializersByEntity.get(entity);
       if (!materializers) {
@@ -108,10 +112,9 @@ export function collectMaterializerWritersForLog(
 ): Set<Action> {
   const writers = new Set<Action>();
   const reads = [...log.reads, ...log.shallowReads];
-  const identity = state.scopeKeyIdentity();
   for (const read of reads) {
     const candidates = state.materializersByEntity.get(
-      entityKey(read, identity),
+      entityNameKey(read),
     );
     if (!candidates) continue;
 

--- a/packages/runner/src/scheduler/run.ts
+++ b/packages/runner/src/scheduler/run.ts
@@ -404,6 +404,18 @@ export async function runSchedulerAction(
       ? demandedInstances
       : [undefined];
 
+  // The N-run loop's subscription (server-execution v2 stage A — OW17's
+  // scheduler leg): with several instance runs, each run's log is
+  // COLLECTED and the node resubscribes ONCE to their union after the
+  // last instance — never per run, which replaced the subscription each
+  // time so only the LAST instance's reads survived ("last instance
+  // wins": Bob's input change would not wake the node once Alice's run
+  // ran after his). The single-run path — every client, the OFF arm, and
+  // a served action with one or no demanded instance — resubscribes
+  // inside its own finalize exactly as before.
+  const unionSubscription = runs.length > 1;
+  const instanceLogs: ReactivityLog[] = [];
+
   const runOnce = (
     instance: ServerRunInstance | undefined,
   ): Promise<unknown> => {
@@ -455,6 +467,9 @@ export async function runSchedulerAction(
           result,
           error,
           resolve,
+          ...(unionSubscription
+            ? { collectLog: (log: ReactivityLog) => instanceLogs.push(log) }
+            : {}),
         });
       };
 
@@ -487,6 +502,23 @@ export async function runSchedulerAction(
     for (const instance of runs) {
       lastResult = await runOnce(instance);
     }
+    if (unionSubscription && instanceLogs.length > 0) {
+      // The union of the instance runs' logs: each read carries ITS
+      // instance (the transaction's stamped identity puts the scope key
+      // on scoped addresses), so the trigger index registers N reads of
+      // one doc — one per instance — and any instance's change wakes the
+      // node. sortAndCompactPaths keeps them apart by instance.
+      logger.timeStart("scheduler", "run", "resubscribe");
+      try {
+        state.resubscribe(action, {
+          reads: instanceLogs.flatMap((log) => log.reads),
+          shallowReads: instanceLogs.flatMap((log) => log.shallowReads),
+          writes: instanceLogs.flatMap((log) => log.writes),
+        });
+      } finally {
+        logger.timeEnd("scheduler", "run", "resubscribe");
+      }
+    }
     return lastResult;
   })();
   state.setRunningPromise(nextRunningPromise);
@@ -508,6 +540,11 @@ function finalizeSchedulerAction(
     readonly result: unknown;
     readonly error?: unknown;
     readonly resolve: (value: unknown) => void;
+    /** Present for one run of an N-instance loop (stage A): the run's
+     * committed log is handed here and the loop resubscribes once to
+     * the union after its last instance, instead of this run
+     * resubscribing (which would replace the previous instances'). */
+    readonly collectLog?: (log: ReactivityLog) => void;
   },
 ): void {
   // Record action execution time for cycle-aware scheduling
@@ -600,6 +637,7 @@ function finalizeReactiveActionCommit(
     readonly invalidCauses: readonly IMemorySpaceAddress[] | undefined;
     readonly result: unknown;
     readonly resolve: (value: unknown) => void;
+    readonly collectLog?: (log: ReactivityLog) => void;
   },
   elapsed: number,
 ): void {
@@ -684,11 +722,17 @@ function finalizeReactiveActionCommit(
 
   recordOptionalActionRunDiagnostics(state, args, committedLog, elapsed);
 
-  logger.timeStart("scheduler", "run", "resubscribe");
-  try {
-    state.resubscribe(args.action, committedLog);
-  } finally {
-    logger.timeEnd("scheduler", "run", "resubscribe");
+  if (args.collectLog !== undefined) {
+    // One run of an N-instance loop: the loop resubscribes once to the
+    // union after its last instance (see runSchedulerAction).
+    args.collectLog(committedLog);
+  } else {
+    logger.timeStart("scheduler", "run", "resubscribe");
+    try {
+      state.resubscribe(args.action, committedLog);
+    } finally {
+      logger.timeEnd("scheduler", "run", "resubscribe");
+    }
   }
   args.resolve(args.result);
 }

--- a/packages/runner/src/scheduler/scheduling-writes.ts
+++ b/packages/runner/src/scheduler/scheduling-writes.ts
@@ -5,7 +5,7 @@ import {
 } from "../reactive-dependencies.ts";
 import { normalizeCellScope } from "../scope.ts";
 import type { IMemorySpaceAddress } from "../storage/interface.ts";
-import { entityKey } from "./keys.ts";
+import { entityNameKey } from "./keys.ts";
 import type { Action, SpaceScopeAndURI } from "./types.ts";
 
 export interface WriterIndexState {
@@ -41,7 +41,20 @@ export class SchedulerWriteIndex
   // Current-known writes are the action's static declared write surface.
   readonly currentKnownWrites = new WeakMap<Action, IMemorySpaceAddress[]>();
   // Index: entity -> actions that write to it (for fast dependency lookup).
-  // Updated from the active scheduling write set.
+  // Updated from the active scheduling write set. Keyed by scope NAME
+  // (entityNameKey — server-execution v2 stage A, the instance-AGNOSTIC
+  // writer index): the reader→writer relation is a NODE-level topology
+  // relation — under C11b one node writes ALL instances of its declared
+  // surface — so a reader whose logged read names one principal's
+  // instance must still find the writer whose surface declares the scope
+  // by name. An instance-keyed index would drop that edge the moment
+  // reads carry non-own instances (today both sides collapse to the
+  // runtime's own instance and match by accident). Cost of the fan-in:
+  // any instance's change re-dirties the (singular) node, so all N
+  // instances re-run — O(N) per input change, equality cutoffs absorb the
+  // unchanged siblings; instance-precise dirtiness is stage B's B7 and
+  // is never a correctness need here (dirtiness/dependency keys stay per
+  // instance via entityKey).
   readonly writersByEntity = new Map<SpaceScopeAndURI, Set<Action>>();
   // Reverse index: action -> entities it writes to (for cleanup).
   readonly actionWriteEntities = new WeakMap<
@@ -76,9 +89,8 @@ export class SchedulerWriteIndex
     const addedEntities = new Set<SpaceScopeAndURI>();
     const removedEntities = new Set<SpaceScopeAndURI>();
 
-    const identity = this.scopeKeyIdentity();
     for (const write of nextSchedulingWrites) {
-      const entity = entityKey(write, identity);
+      const entity = entityNameKey(write);
       nextEntities.add(entity);
       if (!existingEntities.has(entity)) {
         addedEntities.add(entity);
@@ -219,12 +231,13 @@ export function forEachOverlappingWriter(
     readonly onCandidate?: (writer: Action) => void;
   } = {},
 ): void {
-  const identity = state.scopeKeyIdentity();
   const scan = (
     read: IMemorySpaceAddress,
     shallow: boolean,
   ): boolean => {
-    const writers = state.writersByEntity.get(entityKey(read, identity));
+    // Looked up by NAME (see writersByEntity): the read's instance is
+    // irrelevant to WHICH node writes the doc.
+    const writers = state.writersByEntity.get(entityNameKey(read));
     if (!writers) return false;
     for (const writer of writers) {
       if (hooks.filter && !hooks.filter(writer)) continue;

--- a/packages/runner/src/scheduler/types.ts
+++ b/packages/runner/src/scheduler/types.ts
@@ -1,5 +1,5 @@
 import type { MemorySpace, URI } from "@commonfabric/memory/interface";
-import type { ScopeKey } from "@commonfabric/memory/v2";
+import type { ScopeKey, ScopeKeyIdentity } from "@commonfabric/memory/v2";
 import type { Module, Pattern } from "../builder/types.ts";
 import type { NormalizedFullLink } from "../link-utils.ts";
 import type {
@@ -69,9 +69,19 @@ export type EventHandler =
      * inputs (e.g. a SqliteDb handle) synchronously from the local replica;
      * the scheduler awaits this before dispatching the event so those reads
      * don't race the doc-carrying storage responses. The event is passed so
-     * inputs reachable only through the event can be covered too.
+     * inputs reachable only through the event can be covered too. A SERVED
+     * event's dispatch passes the event's server-stamped actor as
+     * `identity` (server-execution v2 stage A — the runner's
+     * explicit-instance read): the handler runs AS that actor (LD1) and
+     * reads that actor's instances of its scoped inputs, so the presync
+     * loads THOSE instances — the served save handler must find the
+     * actor's own draft, not the service instance's empty one (the R7
+     * wall). Absent on every client-side event.
      */
-    presyncInputs?: (event: any) => Promise<void>;
+    presyncInputs?: (
+      event: any,
+      identity?: ScopeKeyIdentity,
+    ) => Promise<void>;
   };
 export type AnnotatedEventHandler = EventHandler & TelemetryAnnotations;
 

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -1331,24 +1331,32 @@ export function validateAndTransform(
 
   // TODO(@ubik2): these constructor parameters are complex enough that we should
   // use an options struct
+  // The traversal's acting identity (key-vocabulary.md §1 sites 5-6): a
+  // served run's DEMAND-SUPPLIED identity when the wave run context
+  // carries one (M1's per-run threading, server-execution v2 Phase 2) —
+  // or when the STORAGE transaction carries one (stage A: the event
+  // preflight's dependency probe runs under the event's actor without a
+  // wave stamp) — else the runtime's own session. `runIdentity` stays
+  // undefined for an own-identity traversal, so its absent-target loads
+  // take the ordinary path.
+  const runIdentity =
+    waveRunContextOf(tx as IExtendedStorageTransaction)?.scopeKeyIdentity ??
+      (tx as IExtendedStorageTransaction).tx?.scopeKeyIdentity;
   const traverser = new SchemaObjectTraverser<any>(
     tx!,
     selector,
     createDefaultTraversalContext(
-      // The traversal's acting identity (key-vocabulary.md §1 sites
-      // 5-6): a served run's DEMAND-SUPPLIED identity when the wave run
-      // context carries one (M1's per-run threading, server-execution
-      // v2 Phase 2), else the runtime's own session.
-      waveRunContextOf(tx as IExtendedStorageTransaction)
-        ?.scopeKeyIdentity ?? runtime.scopeKeyIdentity,
+      runIdentity ?? runtime.scopeKeyIdentity,
       options?.traverseCells ?? false,
       undefined,
       undefined,
       // Absent link targets get an async load kicked (cross-space always;
       // same-space only when the replica has never seen the doc); the
-      // tracked read re-runs the reader on arrival.
+      // tracked read re-runs the reader on arrival. A served per-instance
+      // run's absent target loads AS that run's instance (stage A — the
+      // runner's explicit-instance read).
       (missing, sourceSpace) =>
-        runtime.ensureLinkedDocLoaded(missing, sourceSpace),
+        runtime.ensureLinkedDocLoaded(missing, sourceSpace, runIdentity),
     ),
     objectCreator,
   );

--- a/packages/runner/src/speculation/overlay-destination.ts
+++ b/packages/runner/src/speculation/overlay-destination.ts
@@ -150,6 +150,33 @@ type OverlayEntry = {
    * lower speculation, a rejected input) contributes no floor — the
    * store won upstream and the confirmed basis governs. */
   originLocalSeqs: number[];
+  /** The doc instances this run WROTE (speculation.md §4's arrival-gated
+   * retirement, RULED 2026-08-16): the entry retires only once every one
+   * of them holds a CONFIRMED value at seq ≥ the entry's floor — the
+   * authoritative derivation for the instance this client reads has
+   * ARRIVED — not on watermark coverage of the basis alone. Coverage
+   * without arrival is exactly the retire-to-nothing loop (OW32): the
+   * echo dropped to nothing, the writer (subscribed to its own output
+   * through the scope-narrowing write path) re-derived, re-speculated,
+   * retired, forever, whenever the server never served THIS instance
+   * (a per-user node the demand walk did not reach; a served node's
+   * first wave not yet landed at boot). Empty for a run that sealed no
+   * document ops — such an entry retires on coverage as before. */
+  writtenDocs: Array<{
+    id: URI;
+    scope?: CellScope;
+    /** Whether the run's op on the doc is a whole-doc set/delete (the
+     * supersede-by-newer rider may drop an OLDER entry's layer under it
+     * invisibly) or a patch (path-relative — never dropped under). */
+    wholeDoc: boolean;
+  }>;
+  /** The scheduler action whose run sealed this entry (the writer), for
+   * the supersede-by-newer rider: a NEWER entry of the same writer whose
+   * whole-doc ops cover every doc of an older entry retires the older one
+   * (the drop of a lower layer under an upper whole-doc layer is
+   * invisible — no flip), bounding entry growth for a never-served
+   * instance that keeps changing. */
+  sourceAction?: object;
   /** Resolves when the entry's verdict has been APPLIED (pending
    * dropped). Retirement chains a re-sweep on it: a chained entry
    * blocked on this one unblocks only after the drop, which is async
@@ -347,6 +374,31 @@ export class SpeculationOverlayDestination
             for (const layer of layers) originLocalSeqs.add(layer);
           }
         }
+        // The written doc instances (arrival-gated retirement): every
+        // document op of the sealed commit, whole-doc or patch.
+        const writtenDocs = new Map<
+          string,
+          { id: URI; scope?: CellScope; wholeDoc: boolean }
+        >();
+        for (
+          const op of sealed.commit.operations as Array<
+            { id?: string; scope?: CellScope; op?: string }
+          >
+        ) {
+          if (typeof op.id !== "string") continue;
+          const key = `${op.scope ?? ""}\0${op.id}`;
+          const wholeDoc = op.op === "set" || op.op === "delete";
+          const existing = writtenDocs.get(key);
+          if (existing === undefined) {
+            writtenDocs.set(key, {
+              id: op.id as URI,
+              scope: op.scope,
+              wholeDoc,
+            });
+          } else if (!wholeDoc) {
+            existing.wholeDoc = false;
+          }
+        }
         const entry: OverlayEntry = {
           space,
           localSeq: sealed.localSeq,
@@ -354,6 +406,10 @@ export class SpeculationOverlayDestination
           confirmedFloor,
           pendingReadDocs: [...pendingDocs.values()],
           originLocalSeqs: [...originLocalSeqs],
+          writtenDocs: [...writtenDocs.values()],
+          ...(source?.sourceAction !== undefined
+            ? { sourceAction: source.sourceAction }
+            : {}),
           settled: sealed.settled.catch(() => undefined),
           ...(context?.kind === "event-handler" &&
               context.eventId !== undefined
@@ -427,6 +483,7 @@ export class SpeculationOverlayDestination
         entries = new Map();
         this.#entries.set(space, entries);
       }
+      this.#supersedeOlderEntries(entries, entry);
       entries.set(entry.localSeq, entry);
       this.#ensureWatermarkSink(space);
     }
@@ -778,6 +835,56 @@ export class SpeculationOverlayDestination
     if (entries.size === 0) this.#entries.delete(space);
   }
 
+  /**
+   * The supersede-by-newer rider (speculation.md §4, RULED 2026-08-16):
+   * a NEWER entry of the same writer whose WHOLE-DOC ops cover every doc
+   * an older entry wrote retires the older one at seal — dropping a
+   * lower layer under an upper whole-doc layer is invisible (the view
+   * reads the upper `set`/`delete` either way; no flip, no
+   * re-derivation), and it bounds entry growth for a never-served
+   * instance that keeps changing (the arrival gate above keeps such
+   * entries alive on purpose). An older entry any of whose docs the
+   * newer one PATCHES is kept: a patch is path-relative to the layer
+   * beneath it, so dropping that layer would change what the patch
+   * applies over.
+   */
+  #supersedeOlderEntries(
+    entries: Map<number, OverlayEntry>,
+    entry: OverlayEntry,
+  ): void {
+    if (entry.sourceAction === undefined || entry.writtenDocs.length === 0) {
+      return;
+    }
+    const covered = new Set(
+      entry.writtenDocs
+        .filter((doc) => doc.wholeDoc)
+        .map((doc) => `${doc.scope ?? ""}\0${doc.id}`),
+    );
+    if (covered.size === 0) return;
+    for (const older of [...entries.values()]) {
+      if (
+        older === entry || older.localSeq >= entry.localSeq ||
+        older.sourceAction !== entry.sourceAction ||
+        older.eventId !== undefined || older.writtenDocs.length === 0
+      ) {
+        continue;
+      }
+      const allCovered = older.writtenDocs.every((doc) =>
+        covered.has(`${doc.scope ?? ""}\0${doc.id}`)
+      );
+      if (!allCovered) continue;
+      entries.delete(older.localSeq);
+      older.resolveVerdict({
+        withdrawn: {
+          message: "speculation superseded by a newer speculation of the " +
+            "same writer over the same instances (speculation.md §4's " +
+            "supersede-by-newer rider)",
+          superseded: true,
+        },
+      });
+    }
+  }
+
   #ensureWatermarkSink(space: MemorySpace): void {
     this.#ensureAckObserver(space);
     if (this.#watermarkSinks.has(space)) return;
@@ -900,6 +1007,28 @@ export class SpeculationOverlayDestination
           }
         }
         if (blocked || watermark < floor) continue;
+        // The ARRIVAL gate (speculation.md §4, RULED 2026-08-16): coverage
+        // of the basis is necessary, not sufficient — every doc instance
+        // this run wrote must hold a CONFIRMED value at seq ≥ floor, i.e.
+        // the store has actually spoken for the instance this client
+        // reads. Otherwise dropping the layer flips the doc to nothing
+        // (or to a stale value) and the writer — a reader of its own
+        // output through the scope-narrowing write path — re-derives
+        // forever (the OW32 client loop). The echo stays until the
+        // authoritative value lands; a served node still retires the
+        // moment its derived value arrives (the watermark write rides the
+        // same wave commit, so the watermark sink re-sweeps at arrival).
+        // Backstop for the demand walk's coverage gaps (fan-out design
+        // §E residual 4) and the first-demand transient (§E residual 1).
+        let arrived = true;
+        for (const doc of entry.writtenDocs) {
+          const state = view(doc.id, doc.scope);
+          if (state.confirmedSeq === 0 || state.confirmedSeq < floor) {
+            arrived = false;
+            break;
+          }
+        }
+        if (!arrived) continue;
         entries.delete(entry.localSeq);
         entry.resolveVerdict({
           withdrawn: {

--- a/packages/runner/src/storage/differential.ts
+++ b/packages/runner/src/storage/differential.ts
@@ -31,14 +31,34 @@ interface Memory {
   get(entry: IMemoryAddress): State | undefined;
 }
 
+type ScopedState = State & Pick<IMemoryAddress, "scope" | "scopeKey">;
+
 const stateScope = (state: State) =>
-  normalizeCellScope((state as State & Pick<IMemoryAddress, "scope">).scope);
+  normalizeCellScope((state as ScopedState).scope);
+
+// The explicit scope INSTANCE a state names (server-execution v2 stage A,
+// OW17's instance-keyed replica): a serving replica that holds several
+// instances of one doc snapshots each with its key, so one notification
+// batch keeps them apart and its change addresses carry the instance to
+// the scheduler's per-instance dependency keys. Absent everywhere else
+// (every client, the OFF arm): the batch identity resolves the name, and
+// the change address is byte-identical to before.
+const stateScopeKey = (state: State): string | undefined =>
+  (state as ScopedState).scopeKey;
 
 const unclaimedWithScope = (state: State): State =>
-  ({ ...unclaimed(state), scope: stateScope(state) }) as State;
+  ({
+    ...unclaimed(state),
+    scope: stateScope(state),
+    ...(stateScopeKey(state) !== undefined
+      ? { scopeKey: stateScopeKey(state) }
+      : {}),
+  }) as State;
 
 const toKey = (state: State, identity: ScopeKeyIdentity) =>
-  `/${resolveScopeKey(stateScope(state), identity)}/${state.the}/${state.of}`;
+  `/${
+    stateScopeKey(state) ?? resolveScopeKey(stateScope(state), identity)
+  }/${state.the}/${state.of}`;
 const toAddress = (
   state: State,
   path: readonly string[] = [],
@@ -46,6 +66,9 @@ const toAddress = (
   id: state.of,
   type: state.the,
   scope: stateScope(state),
+  ...(stateScopeKey(state) !== undefined
+    ? { scopeKey: stateScopeKey(state) as IMemoryAddress["scopeKey"] }
+    : {}),
   path: [...path],
 });
 

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -11,6 +11,7 @@ import type {
   EntityIdListOptions,
   EntityIdListResult,
   PatchOp,
+  ScopeKey,
   ScopeKeyIdentity,
   SqliteDbRef,
   SqliteOperation,
@@ -292,7 +293,15 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
    * the link-resolution hop loop). Optional: managers without lazy remote
    * replication (e.g. test mocks) simply don't implement it.
    */
-  shouldPullDoc?(space: MemorySpace, id: URI, scope?: CellScope): boolean;
+  shouldPullDoc?(
+    space: MemorySpace,
+    id: URI,
+    scope?: CellScope,
+    /** The reading run's identity when it is not the manager's own
+     * (server-execution v2 stage A): the reservation and the "has this
+     * replica seen the doc" check are then per that INSTANCE. */
+    identity?: ScopeKeyIdentity,
+  ): boolean;
 
   /**
    * Undo a `shouldPullDoc` reservation after the kicked sync FAILED, so a
@@ -301,7 +310,12 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
    * taken before the async pull settles). No-op when the doc was never
    * reserved. Callers pair it with the failure path of the sync they kicked.
    */
-  retractDocPullKick?(space: MemorySpace, id: URI, scope?: CellScope): void;
+  retractDocPullKick?(
+    space: MemorySpace,
+    id: URI,
+    scope?: CellScope,
+    identity?: ScopeKeyIdentity,
+  ): void;
 
   /**
    * Wait for the currently pending cross-space promises (and any they
@@ -345,7 +359,35 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
    *
    * @returns Promise that resolves when the cell sync is complete.
    */
-  syncCell<T>(cell: Cell<T>): Promise<Cell<T>>;
+  syncCell<T>(
+    cell: Cell<T>,
+    options?: {
+      /** The reading run's identity when it is not the manager's own
+       * (server-execution v2 stage A — the runner's explicit-instance
+       * read): the load NAMES that instance on the wire
+       * (`GraphQueryRoot.entityScopeKey`, lease-holder-only) and lands
+       * it in the replica under that instance's key. Absent (every
+       * client, the OFF arm), the load resolves from the manager's own
+       * session exactly as before. */
+      scopeKeyIdentity?: ScopeKeyIdentity;
+    },
+  ): Promise<Cell<T>>;
+
+  /**
+   * Load ONE scope INSTANCE of a document by address (server-execution v2
+   * stage A — the runner's explicit-instance read at the transaction
+   * layer): a served per-instance run's read of a scoped doc that its
+   * identity's instance has never been loaded for kicks this — the load
+   * names that instance on the wire (lease-holder-only at admission) and
+   * lands it under that instance's key, registered as a pending load like
+   * `syncCell` (so the event preflight can park on it) and tracked until
+   * settled. Optional: managers without lazy remote replication (test
+   * mocks) simply don't implement it; the OFF arm never calls it.
+   */
+  syncInstance?(
+    address: { space: MemorySpace; id: URI; scope?: CellScope },
+    identity: ScopeKeyIdentity,
+  ): Promise<void>;
 }
 
 export interface IRemoteStorageProviderSettings {
@@ -376,6 +418,13 @@ export interface IStorageProvider {
     uri: URI,
     selector?: SchemaPathSelector,
     scope?: CellScope,
+    /** The explicit scope INSTANCE to load (server-execution v2 stage A):
+     * a serving runtime's per-instance read names an instance other than
+     * the manager's own; the watch root then carries
+     * `entityScopeKey` (lease-holder-only on the wire) and the replica
+     * keys the arriving doc under that instance. Absent = the manager's
+     * own instance, exactly as before. */
+    instance?: ScopeKey,
   ): Promise<Result<Unit, Error>>;
 
   /**
@@ -743,6 +792,20 @@ export interface IStorageTransaction {
    * across instances.
    */
   sourceAction?: object;
+  /**
+   * The scope INSTANCE identity this transaction's scoped reads and writes
+   * resolve against when it is NOT the storage manager's own session
+   * (server-execution v2 stage A — OW17's tx→replica identity seam,
+   * scopes.md §5: a served per-instance run reads and writes ITS instance
+   * of every scoped doc, not the service's and not a sibling's). Set once,
+   * by the wave run stamp (`stampWaveRunContext`), before the run's first
+   * read; absent for every client transaction and the whole OFF arm, where
+   * the manager's own identity applies as before. ONE identity per
+   * transaction: the transaction's own document cache is name-keyed, so a
+   * transaction may never serve two identities (the runner mints one
+   * transaction per instance run — `runOnce`).
+   */
+  scopeKeyIdentity?: ScopeKeyIdentity;
   /**
    * Opt the transaction into writing to more than one memory space. By default
    * a transaction may write to a single space only. When enabled, commit()
@@ -1860,6 +1923,26 @@ export type IMemoryAddress = {
    */
   scope?: CellScope;
   /**
+   * The explicit scope INSTANCE this address names (server-execution v2
+   * stage A — OW17's instance-keyed replica and wire; key-vocabulary.md
+   * §5). ABSENT everywhere off the serving path: an address without one
+   * resolves its instance from the ambient identity (the runtime's own
+   * authenticated session in the OFF arm — key-vocabulary.md §2), exactly
+   * as before the field existed, so no key, frame, or serialized
+   * notification moves by a byte when it is absent. SET only where a
+   * serving runtime knows the instance is not the ambient one: a
+   * per-instance run's logged reads/writes (its transaction carries the
+   * demand-supplied identity), the replica's notification differentials
+   * for a keyed instance, and instance-named loads. Every consumer that
+   * builds a key from an address PREFERS this over resolving `scope`
+   * against its identity (`entityKey`, the replica's doc keys, the
+   * selector tracker, the differential's address identity). It is a
+   * resolved key — never a positional index or a "current user" (the §4
+   * tripwires) — and it must never enter a persisted value (links carry
+   * scope NAMES; instances resolve at the reader).
+   */
+  scopeKey?: ScopeKey;
+  /**
    * Intra-value path to the {@link FabricValue} being referenced by this
    * address. It is a path within the `is` field of the fact in memory protocol.
    */
@@ -1931,7 +2014,20 @@ export interface ISpaceReplica extends ISpace {
    */
   get(entry: BaseMemoryAddress): State | undefined;
 
-  getDocument(id: URI, scope?: CellScope): EntityDocument | undefined;
+  /**
+   * The doc's visible document (confirmed + this replica's pending
+   * overlay). `identity` (server-execution v2 stage A — OW17's instance-
+   * keyed replica): the reading run's identity when it is not the
+   * replica's own; the replica holds one local doc PER INSTANCE, so a run
+   * stamped as one principal reads that principal's instance and never
+   * the service's or a sibling's. Absent = the replica's own identity,
+   * exactly the pre-stage-A read.
+   */
+  getDocument(
+    id: URI,
+    scope?: CellScope,
+    identity?: ScopeKeyIdentity,
+  ): EntityDocument | undefined;
 
   commitNative?(
     transaction: NativeStorageCommit,
@@ -1966,6 +2062,13 @@ export interface ISpaceReplica extends ISpace {
        * (reset sweeps and origin-drop cascades reach it) — is the
        * ordinary sealed-commit machinery. */
       readonly speculative?: boolean;
+      /** Server-execution v2 stage A (OW17's tx→replica identity seam):
+       * the sealing run's identity when it is not the replica's own. Its
+       * operations apply to — and its verdict promotes or rolls back —
+       * THAT identity's local instances of every scoped doc, and its
+       * read set is built against those instances' pending stacks.
+       * Absent = the replica's own identity, exactly as before. */
+      readonly identity?: ScopeKeyIdentity;
     },
   ): SealedNativeCommit;
 

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -674,6 +674,21 @@ export interface IIntegrateNotification {
   type: "integrate";
   space: MemorySpace;
   changes: IMergedChanges;
+  /**
+   * Present ONLY on the flip a SPECULATION retirement produces
+   * (server-execution v2, speculation.md §4's arrival-gated retirement,
+   * RULED 2026-08-16 — the "own retirement is not a trigger" rider): the
+   * retiring entry's own transaction, so the scheduler treats the flip
+   * of an action's OWN echo like its own commit source and does not
+   * re-run the writer for it. A writer subscribed to its own output
+   * (the scope-narrowing write path reads the redirect slot and its
+   * diff base) would otherwise re-derive on every retirement whose
+   * authoritative value differs from its echo — re-speculate, retire,
+   * flip, forever. Downstream readers of the doc are unaffected (they
+   * are not the source). Absent on every other integrate (foreign
+   * novelty, watch refreshes) — byte-identical there.
+   */
+  source?: IStorageTransaction;
 }
 
 /**

--- a/packages/runner/src/storage/selector-tracker.ts
+++ b/packages/runner/src/storage/selector-tracker.ts
@@ -90,8 +90,11 @@ export class SelectorTracker<T = Result<Unit, Error>> {
     this.#identity = identity;
   }
 
-  private toKey({ id, scope }: BaseMemoryAddress): string {
-    return `${resolveScopeKey(scope, this.#identity())}\0${id}`;
+  private toKey({ id, scope, scopeKey }: BaseMemoryAddress): string {
+    // An address that NAMES its instance (server-execution v2 stage A —
+    // an instance-named load) keys by it; else the bound identity
+    // resolves the scope name as before.
+    return `${scopeKey ?? resolveScopeKey(scope, this.#identity())}\0${id}`;
   }
 
   add(

--- a/packages/runner/src/storage/transaction/address.ts
+++ b/packages/runner/src/storage/transaction/address.ts
@@ -11,13 +11,15 @@ import { normalizeCellScope } from "../../scope.ts";
  * acting identity of the transaction/notification context the address
  * belongs to — one action tx may carry writes to several instances of one
  * doc (its own narrow instance plus the broad redirect slot), and those
- * must not collapse to one entry. No space segment: the string is
- * per-space by construction.
+ * must not collapse to one entry. An address that NAMES its instance
+ * (`scopeKey`, server-execution v2 stage A — a keyed notification address
+ * on a serving replica) is keyed by it; the identity resolves the rest.
+ * No space segment: the string is per-space by construction.
  */
 export const toString = (address: IMemoryAddress, identity: ScopeKeyIdentity) =>
-  `/${resolveScopeKey(address.scope, identity)}/${address.id}/${
-    JSON.stringify(address.path)
-  }`;
+  `/${
+    address.scopeKey ?? resolveScopeKey(address.scope, identity)
+  }/${address.id}/${JSON.stringify(address.path)}`;
 
 /**
  * Returns true if `candidate` address references location within the

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -20,6 +20,7 @@ import type {
   State,
 } from "../interface.ts";
 import { unclaimed } from "@commonfabric/memory/fact";
+import type { ScopeKeyIdentity } from "@commonfabric/memory/v2";
 import { getLogger } from "@commonfabric/utils/logger";
 import { LRUCache } from "@commonfabric/utils/cache";
 import { toTransactionDocumentValue } from "../v2-document.ts";
@@ -139,6 +140,10 @@ export const attest = (
 export const claim = (
   { address, value: expected }: IAttestation,
   replica: ISpaceReplica,
+  // The reading transaction's scope-instance identity (server-execution v2
+  // stage A — OW17's tx→replica seam): the claim re-reads the SAME instance
+  // the load came from; absent = the replica's own, as before.
+  identity?: ScopeKeyIdentity,
 ): Result<State, IStorageTransactionInconsistent> => {
   const type = address.type ?? "application/json";
   const state = replica.get(address) ??
@@ -148,7 +153,7 @@ export const claim = (
       address.path.length === 0 &&
       typeof replica.getDocument === "function"
     ? toTransactionDocumentValue(
-      replica.getDocument(address.id, address.scope),
+      replica.getDocument(address.id, address.scope, identity),
     )
     : read(source, address)?.ok?.value;
 

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -4,10 +4,14 @@ import {
 } from "@commonfabric/data-model/fabric-value";
 import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
-import type {
-  CommitPrecondition,
-  PatchOp,
-  SqliteOperation,
+import {
+  canResolveScopeKey,
+  type CommitPrecondition,
+  type PatchOp,
+  resolveScopeKey,
+  type ScopeKey,
+  type ScopeKeyIdentity,
+  type SqliteOperation,
 } from "@commonfabric/memory/v2";
 import {
   encodePointer,
@@ -143,6 +147,7 @@ type WritableDocumentEntry = {
 type DocumentEntry = ReadDocumentEntry | WritableDocumentEntry;
 
 type SpaceBranch = {
+  space: MemorySpace;
   replica: ReturnType<IStorageManager["open"]>["replica"];
   docs: Map<string, DocumentEntry>;
 };
@@ -827,6 +832,47 @@ class V2TransactionJournal implements ITransactionJournal {
 export class V2StorageTransaction implements IStorageTransaction {
   changeGroup?: ChangeGroup;
   immediate?: boolean;
+  /**
+   * The scope INSTANCE identity this transaction's scoped reads and
+   * writes resolve against (IStorageTransaction.scopeKeyIdentity —
+   * server-execution v2 stage A, OW17's tx→replica identity seam). Set
+   * ONCE by the wave run stamp before the first read; a later different
+   * value throws, and a change after a document was loaded throws too:
+   * the transaction's document cache is name-keyed, so one transaction
+   * serves exactly one identity (the runner mints one per instance run).
+   */
+  get scopeKeyIdentity(): ScopeKeyIdentity | undefined {
+    return this.#scopeKeyIdentity;
+  }
+  set scopeKeyIdentity(identity: ScopeKeyIdentity | undefined) {
+    if (identity === undefined) return;
+    const current = this.#scopeKeyIdentity;
+    if (current !== undefined) {
+      if (
+        current.principal !== identity.principal ||
+        current.sessionId !== identity.sessionId
+      ) {
+        throw new Error(
+          "storage transaction already carries a different scope-key " +
+            "identity: one transaction serves one identity (server-execution " +
+            "v2 stage A, OW17's tx→replica seam — mint one transaction per " +
+            "instance run)",
+        );
+      }
+      return;
+    }
+    if (this.#loadedUnderIdentity) {
+      throw new Error(
+        "storage transaction already loaded documents under the storage " +
+          "manager's own identity; a scope-key identity must be set before " +
+          "the first read (server-execution v2 stage A, OW17's tx→replica " +
+          "seam)",
+      );
+    }
+    this.#scopeKeyIdentity = identity;
+  }
+  #scopeKeyIdentity: ScopeKeyIdentity | undefined;
+  #loadedUnderIdentity = false;
 
   readonly journal = new V2TransactionJournal(this);
 
@@ -2383,6 +2429,26 @@ export class V2StorageTransaction implements IStorageTransaction {
     this.#reactivityLogCache = undefined;
   }
 
+  /**
+   * The explicit instance a logged scoped address names when this
+   * transaction carries a run identity (server-execution v2 stage A):
+   * the scheduler's dependency/trigger keys then key the read to THAT
+   * instance (`entityKey` prefers it), so one node's N instance runs
+   * register N distinct reads of one doc and a change to one instance
+   * wakes exactly its readers. Absent for space-scope addresses (one
+   * instance) and for every transaction without a run identity — the
+   * logged address is then byte-identical to before.
+   */
+  #instanceOf(scope: CellScope | undefined): ScopeKey | undefined {
+    const identity = this.#scopeKeyIdentity;
+    if (identity === undefined) return undefined;
+    const name = normalizeCellScope(scope);
+    if (name === "space" || !canResolveScopeKey(name, identity)) {
+      return undefined;
+    }
+    return resolveScopeKey(name, identity);
+  }
+
   private buildReactivityLog(): TransactionReactivityLog {
     const reads: IMemorySpaceAddress[] = [];
     const shallowReads: IMemorySpaceAddress[] = [];
@@ -2394,10 +2460,12 @@ export class V2StorageTransaction implements IStorageTransaction {
         continue;
       }
 
+      const instance = this.#instanceOf(read.scope);
       const address = {
         space: read.space,
         scope: read.scope,
         id: read.id,
+        ...(instance !== undefined ? { scopeKey: instance } : {}),
         path: read.path,
       };
 
@@ -2434,6 +2502,7 @@ export class V2StorageTransaction implements IStorageTransaction {
           }
         }
 
+        const instance = this.#instanceOf(scope);
         for (
           const path of [...reactivityPaths.values()].sort(compareDocPaths)
         ) {
@@ -2441,6 +2510,7 @@ export class V2StorageTransaction implements IStorageTransaction {
             space,
             scope,
             id,
+            ...(instance !== undefined ? { scopeKey: instance } : {}),
             path,
           });
         }
@@ -2483,6 +2553,7 @@ export class V2StorageTransaction implements IStorageTransaction {
     let branch = this.#branches.get(space);
     if (!branch) {
       branch = {
+        space,
         replica: this.storage.open(space).replica,
         docs: new Map(),
       };
@@ -2545,16 +2616,59 @@ export class V2StorageTransaction implements IStorageTransaction {
       return loaded.ok as RootAttestation;
     }
 
+    // The tx→replica identity seam (server-execution v2 stage A, OW17):
+    // a served per-instance run reads ITS instance of a scoped doc — the
+    // replica holds one local doc per instance. Absent (every client,
+    // the OFF arm) the replica resolves its own, exactly as before.
+    this.#loadedUnderIdentity = true;
+    const identity = this.#scopeKeyIdentity;
     const value = toTransactionDocumentValue(
-      branch.replica.getDocument(address.id, address.scope),
+      branch.replica.getDocument(address.id, address.scope, identity),
     );
+    // The runner's explicit-instance read, transaction layer (stage A): a
+    // per-instance run's read of a scoped instance the replica has NEVER
+    // seen kicks an instance-named load — the serving replica only ever
+    // receives the SERVICE's instances through its own watches (the
+    // memory server resolves a root's scoped links against the loopback
+    // session), so a demander's instance arrives only when a read names
+    // it. The read itself stays absent; the read is logged under that
+    // instance, so the reader re-runs when the doc lands. Reserved once
+    // per (space, instance, id) per manager (`shouldPullDoc`), like the
+    // link-target kick in `Runtime.ensureLinkedDocLoaded`. Never on the
+    // OFF arm (no identity) — byte-identical read path.
+    if (
+      value === undefined && identity !== undefined &&
+      normalizeCellScope(address.scope) !== "space" &&
+      typeof this.storage.syncInstance === "function" &&
+      this.storage.shouldPullDoc?.(
+          branch.space,
+          address.id,
+          address.scope,
+          identity,
+        ) === true
+    ) {
+      this.storage.trackUntilSettled(
+        this.storage.syncInstance(
+          { space: branch.space, id: address.id, scope: address.scope },
+          identity,
+        ).catch(() => {
+          // A failed load surfaces through the sync-failure log and the
+          // pending-load ledger; the kick reservation was handed back.
+        }),
+      );
+    }
 
+    // The root address names the loaded INSTANCE (stage A) so the
+    // commit-time claim re-reads exactly it (`claim` → `replica.get`);
+    // absent for the manager's own identity — byte-identical address.
+    const instance = this.#instanceOf(address.scope);
     return {
       address: {
         id: address.id,
         type,
         path: [],
         scope: normalizeCellScope(address.scope),
+        ...(instance !== undefined ? { scopeKey: instance } : {}),
       },
       value,
     };
@@ -2568,7 +2682,11 @@ export class V2StorageTransaction implements IStorageTransaction {
         if (firstDocument !== undefined) {
           const { address, value: expected } = firstDocument.initial;
           const actual = toTransactionDocumentValue(
-            currentReplica.getDocument(address.id as URI, address.scope),
+            currentReplica.getDocument(
+              address.id as URI,
+              address.scope,
+              this.#scopeKeyIdentity,
+            ),
           );
           return {
             error: StateInconsistency({
@@ -2594,7 +2712,11 @@ export class V2StorageTransaction implements IStorageTransaction {
         if (!doc.validated) {
           continue;
         }
-        const result = claim(doc.initial, branch.replica);
+        const result = claim(
+          doc.initial,
+          branch.replica,
+          this.#scopeKeyIdentity,
+        );
         if (result.error) {
           return { error: result.error };
         }

--- a/packages/runner/src/storage/v2-watch.ts
+++ b/packages/runner/src/storage/v2-watch.ts
@@ -4,7 +4,11 @@ import {
   REJECTING_SELECTOR,
 } from "@commonfabric/data-model/schema-utils";
 import type { MIME } from "@commonfabric/memory/interface";
-import type { CellScope, ScopeKeyIdentity } from "@commonfabric/memory/v2";
+import type {
+  CellScope,
+  ScopeKey,
+  ScopeKeyIdentity,
+} from "@commonfabric/memory/v2";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { pruneCfcSchemaDefinitions } from "../cfc/schema-refs.ts";
 import { SelectorTracker } from "./selector-tracker.ts";
@@ -12,7 +16,14 @@ import type { SchemaPathSelector } from "@commonfabric/api";
 import type { PullError, Result, Unit, URI } from "./interface.ts";
 
 const DOCUMENT_MIME = "application/json" as const;
-type ScopedWatchAddress = { id: URI; type: MIME; scope?: CellScope };
+type ScopedWatchAddress = {
+  id: URI;
+  type: MIME;
+  scope?: CellScope;
+  /** The explicit scope INSTANCE an instance-named load targets
+   * (server-execution v2 stage A); absent = the session's own. */
+  scopeKey?: ScopeKey;
+};
 
 export const normalizeSyncSelector = (
   selector: SchemaPathSelector | undefined,
@@ -49,6 +60,7 @@ export const compactWatchEntries = (
       type: DOCUMENT_MIME,
       path: [],
       scope: address.scope ?? "space",
+      ...(address.scopeKey !== undefined ? { scopeKey: address.scopeKey } : {}),
     };
     const [superset] = tracker.getSupersetSelector(
       baseAddress,
@@ -88,5 +100,9 @@ export const watchIdForEntry = (
       scope: address.scope ?? "space",
       type: DOCUMENT_MIME,
       selector: selectorIdentity(selector),
+      // The explicit instance (stage A) is watch identity: two instances
+      // of one doc are two watches, never merged by id. Absent from the
+      // hashed object when unnamed, so the OFF-arm id is byte-identical.
+      ...(address.scopeKey !== undefined ? { scopeKey: address.scopeKey } : {}),
     })
   }`;

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -16,6 +16,7 @@ import { assert, unclaimed } from "@commonfabric/memory/fact";
 import { aclDocId } from "@commonfabric/memory/acl";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import {
+  canResolveScopeKey,
   type CellScope,
   type ClientCommit,
   type CommitPrecondition,
@@ -28,6 +29,7 @@ import {
   getServerExecutionConfig,
   type PatchOp,
   resolveScopeKey,
+  type ScopeKey,
   type ScopeKeyIdentity,
   type SessionSync,
   type SqliteDbRef,
@@ -1325,11 +1327,17 @@ export class StorageManager implements IStorageManager {
     }
   }
 
-  shouldPullDoc(space: MemorySpace, id: URI, scope?: CellScope): boolean {
+  shouldPullDoc(
+    space: MemorySpace,
+    id: URI,
+    scope?: CellScope,
+    identity?: ScopeKeyIdentity,
+  ): boolean {
     if (hasDataUriScheme(id)) {
       return false;
     }
-    const key = `${space}\0${this.#pullKickKey(id, scope)}`;
+    const instance = this.#foreignInstanceKey(scope, identity);
+    const key = `${space}\0${this.#pullKickKey(id, scope, instance)}`;
     if (this.#docPullKicks.has(key)) {
       return false;
     }
@@ -1342,20 +1350,63 @@ export class StorageManager implements IStorageManager {
       id,
       type: DOCUMENT_MIME as MIME,
       scope,
+      ...(instance !== undefined ? { scopeKey: instance } : {}),
     }) === undefined;
   }
 
-  retractDocPullKick(space: MemorySpace, id: URI, scope?: CellScope): void {
-    this.#docPullKicks.delete(`${space}\0${this.#pullKickKey(id, scope)}`);
+  retractDocPullKick(
+    space: MemorySpace,
+    id: URI,
+    scope?: CellScope,
+    identity?: ScopeKeyIdentity,
+  ): void {
+    this.#docPullKicks.delete(
+      `${space}\0${
+        this.#pullKickKey(id, scope, this.#foreignInstanceKey(scope, identity))
+      }`,
+    );
   }
 
   /** Pull-kick keys are per scope INSTANCE (key-vocabulary.md §5's
    * M4-coupled list, stage F): name-keyed, A's kick suppressed B's pull
    * and B's doc never loaded at cardinality > 1. Resolved against the
    * manager's own identity — partition-unchanged at cardinality 1
-   * (key-vocabulary.md §2). */
-  #pullKickKey(id: URI, scope?: CellScope): string {
-    return `${resolveScopeKey(scope, this.scopeKeyIdentity())}\0${id}`;
+   * (key-vocabulary.md §2) — or the explicit foreign instance a served
+   * per-instance read names (server-execution v2 stage A). */
+  #pullKickKey(id: URI, scope?: CellScope, instance?: ScopeKey): string {
+    return `${
+      instance ?? resolveScopeKey(scope, this.scopeKeyIdentity())
+    }\0${id}`;
+  }
+
+  /**
+   * The explicit instance a read under `identity` names when — and only
+   * when — it differs from this manager's own resolution of `scope`
+   * (server-execution v2 stage A — the runner's explicit-instance read):
+   * a served per-instance run's read of a scoped doc names THAT
+   * principal's instance on the wire and in the replica; an own-identity
+   * read (every client, the OFF arm, and a served run whose identity IS
+   * the service's) names nothing and keeps the fast own-instance path.
+   * Undefined for `space` (one instance) and for a scope the identity
+   * cannot resolve (the anonymous-session name fallback).
+   */
+  #foreignInstanceKey(
+    scope: CellScope | undefined,
+    identity: ScopeKeyIdentity | undefined,
+  ): ScopeKey | undefined {
+    if (identity === undefined) return undefined;
+    const name = normalizeCellScope(scope);
+    if (name === "space" || !canResolveScopeKey(name, identity)) {
+      return undefined;
+    }
+    const instance = resolveScopeKey(name, identity);
+    const own = this.scopeKeyIdentity();
+    if (
+      canResolveScopeKey(name, own) && resolveScopeKey(name, own) === instance
+    ) {
+      return undefined;
+    }
+    return instance;
   }
 
   addCrossSpacePromise(promise: Promise<void>): void {
@@ -1379,7 +1430,12 @@ export class StorageManager implements IStorageManager {
   #pendingLoads = new Map<string, {
     count: number;
     generation: number;
-    address: { space: MemorySpace; scope: CellScope; id: URI };
+    address: {
+      space: MemorySpace;
+      scope: CellScope;
+      id: URI;
+      scopeKey?: ScopeKey;
+    };
     failure: unknown;
     waiters: Set<(failure: unknown) => void>;
   }>();
@@ -1391,7 +1447,15 @@ export class StorageManager implements IStorageManager {
   #loggedSyncFailures = new Set<string>();
 
   private registerPendingLoad(
-    address: { space: MemorySpace; scope: CellScope; id: URI },
+    address: {
+      space: MemorySpace;
+      scope: CellScope;
+      id: URI;
+      /** The explicit instance an instance-named load targets (stage A);
+       * the key — and the address the scheduler's park machinery
+       * cross-matches — is then per THAT instance. */
+      scopeKey?: ScopeKey;
+    },
   ): (failure?: unknown) => void {
     const key = entityKey(address, this.scopeKeyIdentity());
     const entry = this.#pendingLoads.get(key) ??
@@ -1444,6 +1508,7 @@ export class StorageManager implements IStorageManager {
     space: MemorySpace;
     scope: CellScope;
     id: URI;
+    scopeKey?: ScopeKey;
   }[] {
     return [...this.#pendingLoads.values()].map((entry) => entry.address);
   }
@@ -1501,7 +1566,10 @@ export class StorageManager implements IStorageManager {
     this.#subscription.unsubscribe(subscription);
   }
 
-  async syncCell<T>(cell: Cell<T>): Promise<Cell<T>> {
+  async syncCell<T>(
+    cell: Cell<T>,
+    options?: { scopeKeyIdentity?: ScopeKeyIdentity },
+  ): Promise<Cell<T>> {
     const { space, id, schema, scope } = cell.getAsNormalizedFullLink();
     if (!space) {
       throw new Error("No space set");
@@ -1512,17 +1580,29 @@ export class StorageManager implements IStorageManager {
     }
 
     const provider = this.open(space);
+    // The runner's explicit-instance read (server-execution v2 stage A):
+    // a served per-instance run's load of a scoped doc NAMES that
+    // principal's instance — the load registers, travels, and lands per
+    // instance. Own-identity loads (every client, the OFF arm) name
+    // nothing and take exactly the pre-stage-A path.
+    const instance = this.#foreignInstanceKey(scope, options?.scopeKeyIdentity);
     const releaseLoad = this.registerPendingLoad({
       space,
       scope: normalizeCellScope(scope),
       id,
+      ...(instance !== undefined ? { scopeKey: instance } : {}),
     });
     let loadFailure: unknown;
     try {
-      const result = await provider.sync(id, {
-        path: cell.path.map((segment) => segment.toString()),
-        schema: schema ?? false,
-      }, scope);
+      const result = await provider.sync(
+        id,
+        {
+          path: cell.path.map((segment) => segment.toString()),
+          schema: schema ?? false,
+        },
+        scope,
+        instance,
+      );
       loadFailure = result.error;
       const schemaFailure = await this.syncCfcSchemaDocument(
         space,
@@ -1542,6 +1622,52 @@ export class StorageManager implements IStorageManager {
       return cell;
     } catch (error) {
       loadFailure = error;
+      throw error;
+    } finally {
+      releaseLoad(loadFailure);
+    }
+  }
+
+  /**
+   * The explicit-instance load by address (IStorageManager.syncInstance —
+   * server-execution v2 stage A): the transaction layer's kick for a
+   * served per-instance run's read of a scoped instance the replica has
+   * never seen. Registered like syncCell's load (the preflight park
+   * cross-matches the instance-keyed address) and named on the wire.
+   * Own-identity or space-scope addresses name nothing and take the
+   * ordinary root pull; a load that fails hands back the pull-kick
+   * reservation so a later read may retry.
+   */
+  async syncInstance(
+    address: { space: MemorySpace; id: URI; scope?: CellScope },
+    identity: ScopeKeyIdentity,
+  ): Promise<void> {
+    if (hasDataUriScheme(address.id)) return;
+    const scope = normalizeCellScope(address.scope);
+    const instance = this.#foreignInstanceKey(scope, identity);
+    const provider = this.open(address.space);
+    const releaseLoad = this.registerPendingLoad({
+      space: address.space,
+      scope,
+      id: address.id,
+      ...(instance !== undefined ? { scopeKey: instance } : {}),
+    });
+    let loadFailure: unknown;
+    try {
+      const result = await provider.sync(
+        address.id,
+        { path: [], schema: false },
+        scope,
+        instance,
+      );
+      loadFailure = result.error;
+      if (loadFailure !== undefined) {
+        this.logSyncLoadFailure(address.space, address.id, loadFailure);
+        this.retractDocPullKick(address.space, address.id, scope, identity);
+      }
+    } catch (error) {
+      loadFailure = error;
+      this.retractDocPullKick(address.space, address.id, scope, identity);
       throw error;
     } finally {
       releaseLoad(loadFailure);
@@ -1803,6 +1929,8 @@ type ProviderSyncRequest = {
   uri: URI;
   selector: SchemaPathSelector;
   scope?: CellScope;
+  /** The explicit instance an instance-named load targets (stage A). */
+  instance?: ScopeKey;
 };
 
 /**
@@ -1856,9 +1984,12 @@ class Provider implements IStorageProvider {
     uri: URI,
     selector?: SchemaPathSelector,
     scope?: CellScope,
+    instance?: ScopeKey,
   ): Promise<Result<Unit, Error>> {
     const normalizedSelector = normalizeSyncSelector(selector);
-    const key = docKey(uri, scope);
+    // Replay requests are per (doc, instance): an instance-named load
+    // (stage A) must replay as that instance on a replacement replica.
+    const key = docKey(uri, instance ?? normalizeCellScope(scope));
     let requests = this.#syncRequests.get(key);
     if (requests === undefined) {
       requests = new Map();
@@ -1868,8 +1999,14 @@ class Provider implements IStorageProvider {
       uri,
       selector: normalizedSelector,
       scope,
+      ...(instance !== undefined ? { instance } : {}),
     });
-    return this.replica.sync(uri, normalizedSelector, scope) as Promise<
+    return this.replica.sync(
+      uri,
+      normalizedSelector,
+      scope,
+      instance,
+    ) as Promise<
       Result<Unit, Error>
     >;
   }
@@ -1879,8 +2016,9 @@ class Provider implements IStorageProvider {
     uri: URI,
     selector: SchemaPathSelector,
     scope?: CellScope,
+    instance?: ScopeKey,
   ): Promise<Result<Unit, PullError>> {
-    const result = await replica.sync(uri, selector, scope);
+    const result = await replica.sync(uri, selector, scope, instance);
     if (result.error !== undefined || uri.startsWith("cid:")) {
       return result;
     }
@@ -1925,16 +2063,16 @@ class Provider implements IStorageProvider {
     this.#routeAbort = new AbortController();
     const replacement = this.createReplica();
     this.replica = replacement;
-    previous.redirectOverlappingReadsTo((uri, selector, scope) =>
-      this.replaySync(replacement, uri, selector, scope)
+    previous.redirectOverlappingReadsTo((uri, selector, scope, instance) =>
+      this.replaySync(replacement, uri, selector, scope, instance)
     );
     previous.reset();
     previous.closeNow();
     const requests = [...this.#syncRequests.values()]
       .flatMap((bySelector) => [...bySelector.values()]);
     await Promise.all(
-      requests.map(({ uri, selector, scope }) =>
-        this.replaySync(replacement, uri, selector, scope)
+      requests.map(({ uri, selector, scope, instance }) =>
+        this.replaySync(replacement, uri, selector, scope, instance)
       ),
     );
   }
@@ -2024,17 +2162,22 @@ class Provider implements IStorageProvider {
   }
 }
 
+type WatchAddress = {
+  id: URI;
+  type: MIME;
+  scope?: CellScope;
+  /** The explicit instance an instance-named load targets (stage A). */
+  scopeKey?: ScopeKey;
+};
+
 type SyncTask = {
-  entries: [{ id: URI; type: MIME; scope?: CellScope }, SchemaPathSelector][];
+  entries: [WatchAddress, SchemaPathSelector][];
   promise: Promise<Result<Unit, PullError>>;
 };
 
 type WatchRefreshBatch = {
   type: "pull" | "integrate";
-  entries: Map<
-    string,
-    [{ id: URI; type: MIME; scope?: CellScope }, SchemaPathSelector]
-  >;
+  entries: Map<string, [WatchAddress, SchemaPathSelector]>;
   pending: PromiseWithResolvers<Result<Unit, PullError>>;
 };
 
@@ -2086,6 +2229,10 @@ type InFlightCommit = {
   readonly operations: NativeCommitOperation[];
   readonly source?: IStorageTransaction;
   readonly commit: ClientCommit;
+  /** The identity the commit's operations were applied under (a served
+   * per-instance run's; absent = the replica's own) — its verdict
+   * promotes or drops exactly those instances' pending layers. */
+  readonly identity?: ScopeKeyIdentity;
   /**
    * Resolves when a rejection is fabricated locally for this commit (a
    * pending dependency was dropped, or the replica reset). Raced against the
@@ -2103,13 +2250,39 @@ type InFlightCommit = {
   settled: boolean;
 };
 
-const docKey = (id: URI, scope?: CellScope): string =>
-  `${normalizeCellScope(scope)}\0${id}`;
+/**
+ * The replica's local doc key: per scope INSTANCE (server-execution v2
+ * stage A — OW17's instance-keyed serving replica; key-vocabulary.md §5).
+ * `instance` is the shared `scope_key` — `space`, `user:<p>`,
+ * `session:<p>:<s>` — resolved by the caller through
+ * {@link SpaceReplica.instanceKey}: from an explicit key (a keyed frame,
+ * a keyed address), else from the reading/sealing run's identity, else
+ * from the replica's own identity. At cardinality 1 (every client, the
+ * whole OFF arm) every key resolves from the replica's own identity, so
+ * the re-keyed string partitions the local docs exactly as the scope-NAME
+ * string did (key-vocabulary.md §2's argument): nothing distinct merges,
+ * nothing merged separates. On a serving runtime the replica can now hold
+ * BOTH the service instance and per-principal instances of one doc, and a
+ * per-instance run reads and writes ITS instance. The one name-keyed
+ * fallback: a scope the identity cannot resolve (an anonymous session's
+ * user-scoped read) keys by the scope NAME, exactly as before.
+ */
+const docKey = (id: URI, instance: string): string => `${instance}\0${id}`;
+
+/** A local address the replica keys: the scope name plus, where the
+ * caller knows it, the explicit instance key. */
+type LocalDocAddress = { id: URI; scope?: CellScope; scopeKey?: ScopeKey };
 
 class SpaceReplica implements ISpaceReplica {
   readonly #space: MemorySpace;
   readonly #subscription: IStorageSubscription;
   readonly #scopeKeyIdentity: () => ScopeKeyIdentity;
+  /** The replica's OWN instance keys per scope name, resolved once (the
+   * manager's identity is stable for the manager's live span — `close()`
+   * ends it and the replicas with it): the doc-key hot path resolves an
+   * own-identity address with a map lookup, never a per-read
+   * `resolveScopeKey`. A scope the identity cannot resolve keys by NAME. */
+  #ownInstanceKeys: Map<string, string> | undefined;
   readonly #createSession: () => Promise<{
     client: MemoryV2Client.Client;
     session: MemoryV2Client.SpaceSession;
@@ -2289,6 +2462,7 @@ class SpaceReplica implements ISpaceReplica {
       uri: URI,
       selector: SchemaPathSelector,
       scope?: CellScope,
+      instance?: ScopeKey,
     ) => Promise<Result<Unit, PullError>>)
     | undefined;
 
@@ -2318,39 +2492,122 @@ class SpaceReplica implements ISpaceReplica {
     return this.#space;
   }
 
+  /**
+   * The scope INSTANCE key a local address keys under (see `docKey`):
+   * the address's explicit `scopeKey` when it names one; else the scope
+   * name resolved against `identity` (a served run's demand-supplied
+   * identity — the tx→replica seam) when given; else against the
+   * replica's own identity (every client, the OFF arm). An unresolvable
+   * scope keys by NAME.
+   */
+  instanceKey(
+    scope: CellScope | undefined,
+    identity?: ScopeKeyIdentity,
+    explicit?: ScopeKey,
+  ): string {
+    if (explicit !== undefined) return explicit;
+    const name = normalizeCellScope(scope);
+    if (identity !== undefined) {
+      return canResolveScopeKey(name, identity)
+        ? resolveScopeKey(name, identity)
+        : name;
+    }
+    return this.#ownInstanceKey(name);
+  }
+
+  #ownInstanceKey(name: CellScope): string {
+    let keys = this.#ownInstanceKeys;
+    if (keys === undefined) {
+      keys = new Map();
+      const own = this.#scopeKeyIdentity();
+      for (const scope of ["space", "user", "session"] as const) {
+        keys.set(
+          scope,
+          canResolveScopeKey(scope, own) ? resolveScopeKey(scope, own) : scope,
+        );
+      }
+      this.#ownInstanceKeys = keys;
+    }
+    return keys.get(name) ?? name;
+  }
+
+  /** The doc key of a local address under `identity` (see instanceKey). */
+  #docKeyOf(address: LocalDocAddress, identity?: ScopeKeyIdentity): string {
+    return docKey(
+      address.id,
+      this.instanceKey(address.scope, identity, address.scopeKey),
+    );
+  }
+
+  /**
+   * The touched-doc entries of one operation batch (seal, verdict, frame):
+   * each carries the instance it applies to, so the notification
+   * differential snapshots THAT instance and the change addresses carry
+   * it. The key is attached only where the batch names an instance
+   * explicitly (an explicit run identity, a keyed frame) AND the scope is
+   * not `space` — never for own-identity batches, so an OFF-arm
+   * notification address is byte-identical to before.
+   */
+  #touchedOf(
+    operations: readonly { id: URI; scope?: CellScope; scopeKey?: ScopeKey }[],
+    identity?: ScopeKeyIdentity,
+  ): LocalDocAddress[] {
+    return operations.map((operation) => {
+      const explicit = operation.scopeKey ??
+        (identity !== undefined &&
+            normalizeCellScope(operation.scope) !== "space"
+          ? this.instanceKey(operation.scope, identity) as ScopeKey
+          : undefined);
+      return explicit === undefined
+        ? { id: operation.id, scope: operation.scope }
+        : { id: operation.id, scope: operation.scope, scopeKey: explicit };
+    });
+  }
+
   redirectOverlappingReadsTo(
     replacementRead: (
       uri: URI,
       selector: SchemaPathSelector,
       scope?: CellScope,
+      instance?: ScopeKey,
     ) => Promise<Result<Unit, PullError>>,
   ): void {
     this.#replacementRead = replacementRead;
   }
 
   get(entry: IMemoryAddress): State | undefined {
-    return this.getState(entry.id as URI, entry.scope);
+    return this.getState(
+      entry.id as URI,
+      entry.scope,
+      undefined,
+      entry.scopeKey,
+    );
   }
 
   async sync(
     uri: URI,
     selector?: SchemaPathSelector,
     scope?: CellScope,
+    instance?: ScopeKey,
   ): Promise<Result<Unit, PullError>> {
     const replacementAtStart = this.#replacementRead;
-    const result = await this.pull([[
-      { id: uri, type: DOCUMENT_MIME as MIME, scope },
-      selector,
-    ]]);
+    // An instance-named load (stage A) carries its instance on the pull
+    // entry's address, so the watch root names it on the wire and the
+    // arriving doc keys under it; a plain load carries none.
+    const address = {
+      id: uri,
+      type: DOCUMENT_MIME as MIME,
+      scope,
+      ...(instance !== undefined ? { scopeKey: instance } : {}),
+    };
+    const result = await this.pull([[address, selector]]);
     const replacement = this.#replacementRead;
     if (replacementAtStart === undefined && replacement !== undefined) {
       return await replacement(
         uri,
-        normalizeSyncEntries([[
-          { id: uri, type: DOCUMENT_MIME, scope },
-          selector,
-        ]])[0][1],
+        normalizeSyncEntries([[address, selector]])[0][1],
         scope,
+        instance,
       );
     }
     return result;
@@ -2360,7 +2617,7 @@ class SpaceReplica implements ISpaceReplica {
     uri: URI,
     callback: (document: EntityDocument | undefined) => void,
   ): Cancel {
-    const key = docKey(uri);
+    const key = docKey(uri, "space");
     let subscribers = this.#sinks.get(key);
     if (!subscribers) {
       subscribers = new Set();
@@ -2556,15 +2813,19 @@ class SpaceReplica implements ISpaceReplica {
     );
   }
 
-  getDocument(uri: URI, scope?: CellScope): EntityDocument | undefined {
-    return this.visibleDocument(uri, scope);
+  getDocument(
+    uri: URI,
+    scope?: CellScope,
+    identity?: ScopeKeyIdentity,
+  ): EntityDocument | undefined {
+    return this.visibleDocument(uri, scope, identity);
   }
 
   /** Whether an optimistic local write for this doc is still pending — not
    *  yet promoted into the confirmed mirror (a parked accept keeps it
    *  pending until its marker arrives; CT-1927). */
   hasPendingWrite(id: URI, scope?: CellScope): boolean {
-    const record = this.#docs.get(docKey(id, scope));
+    const record = this.#docs.get(this.#docKeyOf({ id, scope }));
     return record !== undefined && record.pending.length > 0;
   }
 
@@ -2576,7 +2837,7 @@ class SpaceReplica implements ISpaceReplica {
     id: URI,
     scope?: CellScope,
   ): { confirmedSeq: number; pendingLocalSeqs: number[] } {
-    const record = this.#docs.get(docKey(id, scope));
+    const record = this.#docs.get(this.#docKeyOf({ id, scope }));
     if (record === undefined) {
       return { confirmedSeq: 0, pendingLocalSeqs: [] };
     }
@@ -2903,13 +3164,12 @@ class SpaceReplica implements ISpaceReplica {
   }
 
   async load(
-    entries: [
-      { id: URI; type: MIME; scope?: CellScope },
-      SchemaPathSelector | undefined,
-    ][],
+    entries: [WatchAddress, SchemaPathSelector | undefined][],
   ): Promise<Result<Unit, PullError>> {
     const known = entries
-      .map(([address]) => this.getState(address.id, address.scope))
+      .map(([address]) =>
+        this.getState(address.id, address.scope, undefined, address.scopeKey)
+      )
       .filter((state): state is State => state !== undefined);
     this.#subscription.next({
       type: "load",
@@ -2920,10 +3180,7 @@ class SpaceReplica implements ISpaceReplica {
   }
 
   async pull(
-    entries: [
-      { id: URI; type: MIME; scope?: CellScope },
-      SchemaPathSelector | undefined,
-    ][],
+    entries: [WatchAddress, SchemaPathSelector | undefined][],
   ): Promise<Result<Unit, PullError>> {
     if (entries.length === 0) {
       return { ok: {} };
@@ -2973,6 +3230,10 @@ class SpaceReplica implements ISpaceReplica {
         normalizeCellScope(address.scope) ?? null,
         selector === undefined ? null : selector.path,
         selector?.schema === undefined ? null : hashStringOf(selector.schema),
+        // The explicit instance (stage A) is part of the sync identity:
+        // two instances of one doc are two syncs. `null` for the
+        // universal keyless case keeps the OFF-arm key text identical.
+        address.scopeKey ?? null,
       ]),
     );
     const existing = this.#syncTasks.get(key);
@@ -2997,6 +3258,9 @@ class SpaceReplica implements ISpaceReplica {
         id: address.id,
         type: DOCUMENT_MIME,
         scope: normalizeCellScope(address.scope),
+        ...(address.scopeKey !== undefined
+          ? { scopeKey: address.scopeKey }
+          : {}),
       };
       const [superset, supersetPromise] = this.#watchSelectorTracker
         .getSupersetSelector(
@@ -3039,6 +3303,9 @@ class SpaceReplica implements ISpaceReplica {
         id: address.id,
         type: DOCUMENT_MIME,
         scope: normalizeCellScope(address.scope),
+        ...(address.scopeKey !== undefined
+          ? { scopeKey: address.scopeKey }
+          : {}),
       };
       // The tracker promise is what FUTURE pulls covered by these selectors
       // await: their data is available once THIS fetch lands, independent of
@@ -3065,6 +3332,9 @@ class SpaceReplica implements ISpaceReplica {
             id: address.id,
             type: DOCUMENT_MIME,
             scope: normalizeCellScope(address.scope),
+            ...(address.scopeKey !== undefined
+              ? { scopeKey: address.scopeKey }
+              : {}),
           };
           this.#watchSelectorTracker.delete(
             baseAddress,
@@ -3198,15 +3468,25 @@ class SpaceReplica implements ISpaceReplica {
     preconditions: readonly CommitPrecondition[],
     sqliteOps: readonly SqliteOperation[],
     verdict: Promise<SealedCommitVerdict>,
-    options?: { readonly speculative?: boolean },
+    options?: {
+      readonly speculative?: boolean;
+      readonly identity?: ScopeKeyIdentity;
+    },
   ): SealedNativeCommit {
+    // The tx→replica identity seam (server-execution v2 stage A, OW17): a
+    // served per-instance run seals under ITS identity — its ops apply to
+    // that identity's local instances, its read set is built against
+    // those instances' pending stacks, and its verdict settles exactly
+    // them (the in-flight entry remembers the identity). Absent = the
+    // replica's own, byte-identical to before.
+    const identity = options?.identity;
     const localSeq = this.#nextLocalSeq++;
     if (source !== undefined) {
       recordCommitLocalSeq(source, this.#space, localSeq);
     }
     const commit: ClientCommit = {
       localSeq,
-      reads: this.buildReads(source, localSeq),
+      reads: this.buildReads(source, localSeq, identity),
       // Cell ops first, folded SQLite ops last — the same commit shape
       // commitOperations builds, so the wave batch is made of ordinary
       // client commits.
@@ -3237,10 +3517,7 @@ class SpaceReplica implements ISpaceReplica {
         ? { preconditions: [...preconditions] }
         : {}),
     };
-    const touched = operations.map((operation) => ({
-      id: operation.id,
-      scope: operation.scope,
-    }));
+    const touched = this.#touchedOf(operations, identity);
     const hasSemanticOperations = operations.length > 0;
     const shouldNotifySubscribers = hasSemanticOperations &&
       this.hasNotificationSubscribers();
@@ -3249,13 +3526,15 @@ class SpaceReplica implements ISpaceReplica {
     const before = shouldNotifySubscribers
       ? Differential.checkout(
         this,
-        touched.map(({ id, scope }) => snapshotState(this, id, scope)),
+        touched.map(({ id, scope, scopeKey }) =>
+          snapshotState(this, id, scope, scopeKey)
+        ),
         this.#scopeKeyIdentity(),
       )
       : undefined;
 
     for (const operation of operations) {
-      this.applyPending(operation, localSeq);
+      this.applyPending(operation, localSeq, identity);
     }
 
     if (before !== undefined) {
@@ -3279,6 +3558,7 @@ class SpaceReplica implements ISpaceReplica {
       commit,
       source,
       verdict,
+      identity,
     );
     if (options?.speculative !== true) {
       // Durable sealed commits (the wave's) join the synced() barrier
@@ -3320,6 +3600,7 @@ class SpaceReplica implements ISpaceReplica {
     commit: ClientCommit,
     source: IStorageTransaction | undefined,
     verdict: Promise<SealedCommitVerdict>,
+    identity?: ScopeKeyIdentity,
   ): Promise<Result<Unit, StorageTransactionRejected>> {
     // Registered unconditionally — unlike a pushed commit, a sealed commit
     // needs the entry even with zero pending reads: reset() sweeps
@@ -3332,7 +3613,7 @@ class SpaceReplica implements ISpaceReplica {
       operations,
       commit,
       source,
-      { alwaysRegister: true },
+      { alwaysRegister: true, identity },
     )!;
     try {
       const outcome = await Promise.race([
@@ -3372,6 +3653,7 @@ class SpaceReplica implements ISpaceReplica {
           operations,
           source,
           outcome.rejection,
+          identity,
         );
       }
       const v = outcome.verdict;
@@ -3390,6 +3672,7 @@ class SpaceReplica implements ISpaceReplica {
             localSeq,
             operations,
             source,
+            identity,
           );
         }
         return await this.finalizeRejection(
@@ -3397,6 +3680,7 @@ class SpaceReplica implements ISpaceReplica {
           operations,
           source,
           this.makeLocalRejection(commit, v.withdrawn.message),
+          identity,
         );
       }
       // Locally-committed verdicts confirm IMMEDIATELY — never parked
@@ -3426,7 +3710,7 @@ class SpaceReplica implements ISpaceReplica {
         seq: v.committed.seq,
         branch: commit.branch ?? DEFAULT_BRANCH,
         revisions: [],
-      });
+      }, identity);
       return { ok: {} };
     } finally {
       this.settleInFlightCommit(localSeq);
@@ -3460,9 +3744,7 @@ class SpaceReplica implements ISpaceReplica {
   }
 
   private async refreshWatchSet(
-    entries: Iterable<
-      [{ id: URI; type: MIME; scope?: CellScope }, SchemaPathSelector]
-    >,
+    entries: Iterable<[WatchAddress, SchemaPathSelector]>,
     type: "pull" | "integrate" = "pull",
   ): Promise<Result<Unit, PullError>> {
     try {
@@ -3524,6 +3806,16 @@ class SpaceReplica implements ISpaceReplica {
           roots: [{
             id: address.id,
             scope: normalizeCellScope(address.scope),
+            // The runner's explicit-instance read (server-execution v2
+            // stage A): an instance-named load names its instance on the
+            // wire — lease-holder-only at admission (protocol.md §2's
+            // read row), which is exactly who issues one (a serving
+            // runtime's per-instance run). Own-identity loads name
+            // nothing: byte-identical roots, the no-key admission fast
+            // path.
+            ...(address.scopeKey !== undefined
+              ? { entityScopeKey: address.scopeKey }
+              : {}),
             selector,
           }],
         },
@@ -3558,7 +3850,7 @@ class SpaceReplica implements ISpaceReplica {
 
   private enqueueWatchRefresh(
     type: "pull" | "integrate",
-    entries: [{ id: URI; type: MIME; scope?: CellScope }, SchemaPathSelector][],
+    entries: [WatchAddress, SchemaPathSelector][],
   ): Promise<Result<Unit, PullError>> {
     if (this.#queuedWatchRefresh !== null) {
       for (const [address, selector] of entries) {
@@ -3574,10 +3866,7 @@ class SpaceReplica implements ISpaceReplica {
       type,
       entries: new Map(entries.map(([address, selector]) => [
         watchIdForEntry(address, selector, ""),
-        [address, selector] as [
-          { id: URI; type: MIME; scope?: CellScope },
-          SchemaPathSelector,
-        ],
+        [address, selector] as [WatchAddress, SchemaPathSelector],
       ])),
       pending: Promise.withResolvers<Result<Unit, PullError>>(),
     };
@@ -3762,7 +4051,9 @@ class SpaceReplica implements ISpaceReplica {
       }
       return { error: rejection };
     }
-    const touched = operations.map((operation) => ({
+    // A pushed commit is the replica's own identity's (every client, the
+    // OFF arm): touched entries carry no explicit instance.
+    const touched: LocalDocAddress[] = operations.map((operation) => ({
       id: operation.id,
       scope: operation.scope,
     }));
@@ -3777,7 +4068,9 @@ class SpaceReplica implements ISpaceReplica {
         shouldNotifySubscribers
           ? Differential.checkout(
             this,
-            touched.map(({ id, scope }) => snapshotState(this, id, scope)),
+            touched.map(({ id, scope, scopeKey }) =>
+              snapshotState(this, id, scope, scopeKey)
+            ),
             this.#scopeKeyIdentity(),
           )
           : undefined,
@@ -3847,7 +4140,7 @@ class SpaceReplica implements ISpaceReplica {
     operations: NativeCommitOperation[],
     commit: ClientCommit,
     source?: IStorageTransaction,
-    options: { alwaysRegister?: boolean } = {},
+    options: { alwaysRegister?: boolean; identity?: ScopeKeyIdentity } = {},
   ): InFlightCommit | undefined {
     if (
       commit.reads.pending.length === 0 && options.alwaysRegister !== true
@@ -3870,6 +4163,7 @@ class SpaceReplica implements ISpaceReplica {
       operations,
       source,
       commit,
+      ...(options.identity !== undefined ? { identity: options.identity } : {}),
       localRejection: Promise.withResolvers<StorageTransactionRejected>(),
       settled: false,
     };
@@ -4286,11 +4580,9 @@ class SpaceReplica implements ISpaceReplica {
     localSeq: number,
     operations: NativeCommitOperation[],
     _source: IStorageTransaction | undefined,
+    identity?: ScopeKeyIdentity,
   ): Result<Unit, StorageTransactionRejected> {
-    const touched = operations.map((operation) => ({
-      id: operation.id,
-      scope: operation.scope,
-    }));
+    const touched = this.#touchedOf(operations, identity);
     const hasSemanticOperations = operations.length > 0;
     const shouldNotifySubscribers = hasSemanticOperations &&
       this.hasNotificationSubscribers();
@@ -4299,7 +4591,9 @@ class SpaceReplica implements ISpaceReplica {
     const before = shouldNotifySubscribers
       ? Differential.checkout(
         this,
-        touched.map(({ id, scope }) => snapshotState(this, id, scope)),
+        touched.map(({ id, scope, scopeKey }) =>
+          snapshotState(this, id, scope, scopeKey)
+        ),
         this.#scopeKeyIdentity(),
       )
       : undefined;
@@ -4330,6 +4624,7 @@ class SpaceReplica implements ISpaceReplica {
     operations: NativeCommitOperation[],
     source: IStorageTransaction | undefined,
     rejection: StorageTransactionRejected,
+    identity?: ScopeKeyIdentity,
   ): Promise<Result<Unit, StorageTransactionRejected>> {
     // The fate is sealed here. The verdict-gated effect layer (verdict
     // callbacks, outbox clearing) fires on this notification; the
@@ -4338,10 +4633,7 @@ class SpaceReplica implements ISpaceReplica {
     if (source !== undefined) {
       notifyCommitRejected(source, rejection);
     }
-    const touched = operations.map((operation) => ({
-      id: operation.id,
-      scope: operation.scope,
-    }));
+    const touched = this.#touchedOf(operations, identity);
     const hasSemanticOperations = operations.length > 0;
     const shouldNotifySubscribers = hasSemanticOperations &&
       this.hasNotificationSubscribers();
@@ -4350,7 +4642,9 @@ class SpaceReplica implements ISpaceReplica {
     const before = shouldNotifySubscribers
       ? Differential.checkout(
         this,
-        touched.map(({ id, scope }) => snapshotState(this, id, scope)),
+        touched.map(({ id, scope, scopeKey }) =>
+          snapshotState(this, id, scope, scopeKey)
+        ),
         this.#scopeKeyIdentity(),
       )
       : undefined;
@@ -4389,6 +4683,9 @@ class SpaceReplica implements ISpaceReplica {
   private buildReads(
     source: IStorageTransaction | undefined,
     localSeq: number,
+    // The reading run's identity (a served per-instance seal): each read's
+    // pending layers and confirmed seq come from THAT instance's record.
+    identity?: ScopeKeyIdentity,
   ) {
     const confirmed: ConfirmedCommitRead[] = [];
     const pending: PendingCommitRead[] = [];
@@ -4421,7 +4718,9 @@ class SpaceReplica implements ISpaceReplica {
       nonRecursive: boolean,
       confirmedSeq?: number,
     ) => {
-      const record = this.#docs.get(docKey(id, scope));
+      const record = this.#docs.get(
+        docKey(id, this.instanceKey(scope, identity)),
+      );
       // The read's materialized view sat on EVERY lower pending layer, not
       // just the nearest one: name them ALL (ascending; the last element is
       // the doc's top-of-stack below this commit) so a dropped deeper layer
@@ -4591,14 +4890,20 @@ class SpaceReplica implements ISpaceReplica {
       return;
     }
 
-    const touched = [
+    // A keyed frame (a lease-holder session's — server-execution v2 stage
+    // A, OW17's wire leg) names each entry's instance; the replica keys
+    // the doc under it. An unkeyed frame resolves from the replica's own
+    // identity exactly as before.
+    const touched: LocalDocAddress[] = [
       ...sync.upserts.map((upsert) => ({
         id: upsert.id as URI,
         scope: upsert.scope,
+        ...(upsert.scopeKey !== undefined ? { scopeKey: upsert.scopeKey } : {}),
       })),
       ...sync.removes.map((remove) => ({
         id: remove.id as URI,
         scope: remove.scope,
+        ...(remove.scopeKey !== undefined ? { scopeKey: remove.scopeKey } : {}),
       })),
     ];
 
@@ -4607,13 +4912,20 @@ class SpaceReplica implements ISpaceReplica {
     const before = shouldNotifySubscribers
       ? Differential.checkout(
         this,
-        touched.map(({ id, scope }) => snapshotState(this, id, scope)),
+        touched.map(({ id, scope, scopeKey }) =>
+          snapshotState(this, id, scope, scopeKey)
+        ),
         this.#scopeKeyIdentity(),
       )
       : undefined;
 
     for (const upsert of sync.upserts) {
-      const record = this.record(upsert.id as URI, upsert.scope);
+      const record = this.record(
+        upsert.id as URI,
+        upsert.scope,
+        undefined,
+        upsert.scopeKey,
+      );
       // Watch refreshes can arrive after local confirmations. Never move the
       // confirmed base backwards; pending replay depends on monotonic bases.
       if (upsert.seq < record.confirmed.seq) {
@@ -4625,7 +4937,10 @@ class SpaceReplica implements ISpaceReplica {
         upsert.deleted === true ? undefined : upsert.doc,
       );
       record.materialized = undefined;
-      const key = docKey(upsert.id as URI, upsert.scope);
+      const key = docKey(
+        upsert.id as URI,
+        this.instanceKey(upsert.scope, undefined, upsert.scopeKey),
+      );
       this.#watchedIds.add(key);
       // The settle input barrier's shadow case (Phase 2 revisit (a)):
       // a FOREIGN value integrating UNDER an own pending write is
@@ -4672,10 +4987,13 @@ class SpaceReplica implements ISpaceReplica {
     }
     for (const remove of sync.removes) {
       const id = remove.id as URI;
-      const record = this.record(id, remove.scope);
+      const record = this.record(id, remove.scope, undefined, remove.scopeKey);
       record.confirmed = confirmedVersion(0, undefined);
       record.materialized = undefined;
-      const key = docKey(id, remove.scope);
+      const key = docKey(
+        id,
+        this.instanceKey(remove.scope, undefined, remove.scopeKey),
+      );
       this.#watchedIds.delete(key);
       if (record.pending.length > 0) {
         // A shadowed remove carries no seq on the wire: the sentinel 1
@@ -4719,7 +5037,7 @@ class SpaceReplica implements ISpaceReplica {
   // server stages as the post-conflict catch-up point for these ids.
   private recordStaleFloor(commit: ClientCommit, localSeq: number): void {
     const mark = (id: string, scope?: CellScope) => {
-      const key = docKey(id as URI, scope);
+      const key = this.#docKeyOf({ id: id as URI, scope });
       const current = this.#staleFloor.get(key);
       if (current === undefined || current < localSeq) {
         this.#staleFloor.set(key, localSeq);
@@ -4747,7 +5065,9 @@ class SpaceReplica implements ISpaceReplica {
     }
     let threshold: number | undefined;
     const consider = (id: string, scope?: CellScope) => {
-      const floor = this.#staleFloor.get(docKey(id as URI, scope));
+      const floor = this.#staleFloor.get(
+        this.#docKeyOf({ id: id as URI, scope }),
+      );
       if (floor !== undefined && floor > this.#caughtUpLocalSeq) {
         threshold = threshold === undefined
           ? floor
@@ -4972,8 +5292,13 @@ class SpaceReplica implements ISpaceReplica {
     }
   }
 
-  private record(id: URI, scope?: CellScope): DocumentRecord {
-    const key = docKey(id, scope);
+  private record(
+    id: URI,
+    scope?: CellScope,
+    identity?: ScopeKeyIdentity,
+    explicit?: ScopeKey,
+  ): DocumentRecord {
+    const key = docKey(id, this.instanceKey(scope, identity, explicit));
     let record = this.#docs.get(key);
     if (!record) {
       record = {
@@ -4989,9 +5314,10 @@ class SpaceReplica implements ISpaceReplica {
   private applyPending(
     operation: NativeCommitOperation,
     localSeq: number,
+    identity?: ScopeKeyIdentity,
   ): void {
     const { id, scope, ...pending } = operation;
-    const record = this.record(id, scope);
+    const record = this.record(id, scope, identity);
     record.pending.push(pendingVersion(localSeq, pending));
   }
 
@@ -5031,7 +5357,7 @@ class SpaceReplica implements ISpaceReplica {
     // echo intact — r3739139487), or a quiet serving loop would clamp
     // W forever against its own echo.
     for (const operation of operations) {
-      const key = docKey(operation.id, operation.scope);
+      const key = this.#docKeyOf(operation);
       const seqs = this.#shadowedForeignSeqs.get(key);
       if (seqs !== undefined && seqs.delete(applied.seq) && seqs.size === 0) {
         this.#shadowedForeignSeqs.delete(key);
@@ -5123,14 +5449,17 @@ class SpaceReplica implements ISpaceReplica {
     localSeq: number,
     operations: NativeCommitOperation[],
     applied: AppliedCommit,
+    // The identity the operations were sealed under (F1a's sealed-commit
+    // confirm; a pushed commit's is the replica's own).
+    identity?: ScopeKeyIdentity,
   ): void {
     // The accept is being applied (immediately at verdict, or promoted
     // off the parked set): release any read-barrier waiter (whenApplied).
     this.resolveAppliedWaiter(localSeq);
     const keys = new Map(
-      operations.map((operation) => [
-        docKey(operation.id, operation.scope),
-        { id: operation.id, scope: operation.scope },
+      this.#touchedOf(operations, identity).map((touched) => [
+        this.#docKeyOf(touched),
+        touched,
       ]),
     );
     // The settle input barrier's SHADOW FLIP (Phase 2 revisit (a), flag
@@ -5157,12 +5486,14 @@ class SpaceReplica implements ISpaceReplica {
     const shadowBefore = shouldNotifyShadowSubscribers
       ? Differential.checkout(
         this,
-        shadowTouched.map(({ id, scope }) => snapshotState(this, id, scope)),
+        shadowTouched.map(({ id, scope, scopeKey }) =>
+          snapshotState(this, id, scope, scopeKey)
+        ),
         this.#scopeKeyIdentity(),
       )
       : undefined;
-    for (const { id, scope } of keys.values()) {
-      const record = this.record(id, scope);
+    for (const { id, scope, scopeKey } of keys.values()) {
+      const record = this.record(id, scope, undefined, scopeKey);
       const pendingIndexes = record.pending.flatMap((entry, index) =>
         entry.localSeq === localSeq ? [index] : []
       );
@@ -5303,11 +5634,18 @@ class SpaceReplica implements ISpaceReplica {
     }
   }
 
-  private visibleVersion(id: URI, scope?: CellScope): {
+  private visibleVersion(
+    id: URI,
+    scope?: CellScope,
+    identity?: ScopeKeyIdentity,
+    explicit?: ScopeKey,
+  ): {
     record: DocumentRecord;
     version: MaterializedVersion;
   } | undefined {
-    const record = this.#docs.get(docKey(id, scope));
+    const record = this.#docs.get(
+      docKey(id, this.instanceKey(scope, identity, explicit)),
+    );
     if (!record) {
       return undefined;
     }
@@ -5321,16 +5659,25 @@ class SpaceReplica implements ISpaceReplica {
     };
   }
 
-  private visibleValue(id: URI, scope?: CellScope): FabricValue | undefined {
-    const visible = this.visibleVersion(id, scope);
+  private visibleValue(
+    id: URI,
+    scope?: CellScope,
+    identity?: ScopeKeyIdentity,
+  ): FabricValue | undefined {
+    const visible = this.visibleVersion(id, scope, identity);
     if (!visible) {
       return undefined;
     }
     return transactionValueForVersion(visible.version);
   }
 
-  private getState(id: URI, scope?: CellScope): State | undefined {
-    const visible = this.visibleVersion(id, scope);
+  private getState(
+    id: URI,
+    scope?: CellScope,
+    identity?: ScopeKeyIdentity,
+    explicit?: ScopeKey,
+  ): State | undefined {
+    const visible = this.visibleVersion(id, scope, identity, explicit);
     if (!visible) {
       return undefined;
     }
@@ -5346,6 +5693,10 @@ class SpaceReplica implements ISpaceReplica {
         cause: null,
       }),
       scope: normalizeCellScope(scope),
+      // The explicit instance rides the state ONLY when the caller named
+      // one, so the differential keys and addresses it per instance; an
+      // own-identity read's state is byte-identical to before.
+      ...(explicit !== undefined ? { scopeKey: explicit } : {}),
       since: visible.record.confirmed.seq,
     } as State;
   }
@@ -5353,26 +5704,36 @@ class SpaceReplica implements ISpaceReplica {
   private visibleDocument(
     id: URI,
     scope?: CellScope,
+    identity?: ScopeKeyIdentity,
   ): EntityDocument | undefined {
-    return this.visibleVersion(id, scope)?.version.value;
+    return this.visibleVersion(id, scope, identity)?.version.value;
   }
 
   private notifySinks(changes: IMergedChanges): void {
-    const touched = new Map<string, { id: URI; scope?: CellScope }>();
+    const touched = new Map<string, LocalDocAddress>();
     for (const change of changes) {
       const id = change.address.id as URI;
       const scope = change.address.scope;
-      touched.set(docKey(id, scope), { id, scope });
+      const scopeKey = change.address.scopeKey;
+      touched.set(
+        this.#docKeyOf({ id, scope, scopeKey }),
+        scopeKey === undefined ? { id, scope } : { id, scope, scopeKey },
+      );
     }
     this.notifySinksForIds(touched.values());
   }
 
   private notifySinksForIds(
-    entries: Iterable<{ id: URI; scope?: CellScope }>,
+    entries: Iterable<LocalDocAddress>,
   ): void {
-    for (const { id, scope } of entries) {
-      const current = this.visibleDocument(id, scope);
-      for (const callback of this.#sinks.get(docKey(id, scope)) ?? []) {
+    for (const { id, scope, scopeKey } of entries) {
+      const current = this.visibleVersion(id, scope, undefined, scopeKey)
+        ?.version.value;
+      for (
+        const callback
+          of this.#sinks.get(this.#docKeyOf({ id, scope, scopeKey })) ??
+            []
+      ) {
         try {
           callback(current);
         } catch (error) {
@@ -5393,10 +5754,10 @@ class SpaceReplica implements ISpaceReplica {
   }
 
   private hasSinkSubscribers(
-    entries: Iterable<{ id: URI; scope?: CellScope }>,
+    entries: Iterable<LocalDocAddress>,
   ): boolean {
-    for (const { id, scope } of entries) {
-      if ((this.#sinks.get(docKey(id, scope))?.size ?? 0) > 0) {
+    for (const entry of entries) {
+      if ((this.#sinks.get(this.#docKeyOf(entry))?.size ?? 0) > 0) {
         return true;
       }
     }
@@ -5460,11 +5821,19 @@ const snapshotState = (
   replica: SpaceReplica,
   id: URI,
   scope?: CellScope,
+  scopeKey?: ScopeKey,
 ): State => {
-  return replica.get({ id, type: DOCUMENT_MIME, path: [], scope }) ??
+  return replica.get({
+    id,
+    type: DOCUMENT_MIME,
+    path: [],
+    scope,
+    ...(scopeKey !== undefined ? { scopeKey } : {}),
+  }) ??
     ({
       ...unclaimed({ of: id, the: DOCUMENT_MIME }),
       scope: normalizeCellScope(scope),
+      ...(scopeKey !== undefined ? { scopeKey } : {}),
     } as State);
 };
 

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -4579,7 +4579,7 @@ class SpaceReplica implements ISpaceReplica {
   private finalizeSupersededSpeculation(
     localSeq: number,
     operations: NativeCommitOperation[],
-    _source: IStorageTransaction | undefined,
+    source: IStorageTransaction | undefined,
     identity?: ScopeKeyIdentity,
   ): Result<Unit, StorageTransactionRejected> {
     const touched = this.#touchedOf(operations, identity);
@@ -4601,10 +4601,14 @@ class SpaceReplica implements ISpaceReplica {
     if (before !== undefined) {
       const changes = before.compare(this);
       if ([...changes].length > 0) {
+        // The flip carries the retiring echo's own transaction as its
+        // source (speculation.md §4's "own retirement is not a trigger"
+        // rider): the writer's scheduler node skips its own flip.
         this.#subscription.next({
           type: "integrate",
           space: this.#space,
           changes,
+          ...(source !== undefined ? { source } : {}),
         } as StorageNotification);
         if (shouldNotifySinks) {
           this.notifySinks(changes);

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -3232,7 +3232,10 @@ class SpaceReplica implements ISpaceReplica {
         selector?.schema === undefined ? null : hashStringOf(selector.schema),
         // The explicit instance (stage A) is part of the sync identity:
         // two instances of one doc are two syncs. `null` for the
-        // universal keyless case keeps the OFF-arm key text identical.
+        // universal keyless case — the OFF-arm key TEXT gains a trailing
+        // `,null` per entry (this map is private, single-producer, never
+        // serialized; the PARTITION is unchanged: every keyless entry
+        // still dedupes exactly as before).
         address.scopeKey ?? null,
       ]),
     );

--- a/packages/runner/test/clock-preload.ts
+++ b/packages/runner/test/clock-preload.ts
@@ -62,6 +62,10 @@ installFakeClock({
     // wall-clock policies; it waits on store/replica edges with bounded
     // timeouts.
     "executor-instance-keyed-replica",
+    // The speculation arrival-gate suite drives a live memory server and
+    // waits on push/watermark edges with bounded timeouts, and its
+    // "would-be loop" window is a real-time observation.
+    "speculation-arrival-gate",
     // The Phase-4 client-effect-channel suite drives a live
     // ExecutorHost (the served navigateTo → intent → enact/ack →
     // retirement journeys) under the same wall-clock policies — the

--- a/packages/runner/test/clock-preload.ts
+++ b/packages/runner/test/clock-preload.ts
@@ -57,6 +57,11 @@ installFakeClock({
     // The Phase-3 serving-side events-down suite drives a live
     // ExecutorHost under the same wall-clock policies.
     "executor-events-down",
+    // The fan-out stage-A suite (OW17's instance-keyed replica) drives a
+    // live ExecutorHost with two flag-ON clients under the same
+    // wall-clock policies; it waits on store/replica edges with bounded
+    // timeouts.
+    "executor-instance-keyed-replica",
     // The Phase-4 client-effect-channel suite drives a live
     // ExecutorHost (the served navigateTo → intent → enact/ack →
     // retirement journeys) under the same wall-clock policies — the

--- a/packages/runner/test/executor-instance-keyed-replica.test.ts
+++ b/packages/runner/test/executor-instance-keyed-replica.test.ts
@@ -32,11 +32,38 @@ import {
   type ScopeKeyIdentity,
   type StreamEventsDocValue,
 } from "@commonfabric/memory/v2";
+import {
+  acquireExecutionLease,
+  releaseExecutionLease,
+} from "@commonfabric/memory/v2/execution-lease";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { MemorySpace } from "../src/storage/interface.ts";
 import { ExecutorHost } from "../src/executor/host.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
+
+/** The serving runtime's storage manager, with the serving-loop suite's
+ * settle-gate seam: while `settleGate` is set, the loop's settle hangs
+ * at its `inputSynced` barrier BEFORE any seal, so a cycle can be held
+ * open across a lease tick with NO wave open (no tenure captured) —
+ * the same-process reacquire then keeps the loop serving instead of
+ * parking on a mid-wave abort. Undefined everywhere else. */
+class GatedStorageManager extends EmulatedStorageManager {
+  static override connectTo(
+    server: MemoryV2Server.Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): GatedStorageManager {
+    return super.connectTo(server, options) as GatedStorageManager;
+  }
+
+  settleGate: Promise<void> | undefined;
+
+  override async inputSynced(): Promise<void> {
+    await super.inputSynced();
+    if (this.settleGate !== undefined) await this.settleGate;
+  }
+}
 
 const spaceSigner = await Identity.fromPassphrase("instance-keyed replica");
 const space = spaceSigner.did() as MemorySpace;
@@ -137,16 +164,20 @@ describe("stage A: the instance-keyed serving replica (OW17)", () => {
   let managers: EmulatedStorageManager[];
   let runtimes: Runtime[];
   let servingRuntime: Runtime | undefined;
+  let servingManager: GatedStorageManager | undefined;
 
-  const newHost = (): ExecutorHost =>
+  const newHost = (
+    policy: ConstructorParameters<typeof ExecutorHost>[0]["policy"] = {},
+  ): ExecutorHost =>
     new ExecutorHost({
       server,
       serviceIdentity: serviceSigner.did(),
       // deno-lint-ignore require-await
       createRuntime: async () => {
-        const manager = EmulatedStorageManager.connectTo(server, {
+        const manager = GatedStorageManager.connectTo(server, {
           as: serviceSigner,
         });
+        servingManager = manager;
         const runtime = new Runtime({
           apiUrl: new URL(import.meta.url),
           storageManager: manager,
@@ -165,7 +196,7 @@ describe("stage A: the instance-keyed serving replica (OW17)", () => {
           },
         };
       },
-      policy: { flushDeadlineMs: 5_000, idleParkMs: 600_000 },
+      policy: { flushDeadlineMs: 5_000, idleParkMs: 600_000, ...policy },
     });
 
   beforeEach(() => {
@@ -173,6 +204,7 @@ describe("stage A: the instance-keyed serving replica (OW17)", () => {
     managers = [];
     runtimes = [];
     servingRuntime = undefined;
+    servingManager = undefined;
   });
 
   afterEach(async () => {
@@ -205,10 +237,11 @@ describe("stage A: the instance-keyed serving replica (OW17)", () => {
   const standUpTwoUsers = async (options: {
     bobScope: "user" | "session";
     names: { arg: string; result: string };
+    hostPolicy?: ConstructorParameters<typeof ExecutorHost>[0]["policy"];
   }) => {
     // The host first: activation is triggered by session open / admission
     // (serving-loop.md §1), so the clients open against a live host.
-    host = newHost();
+    host = newHost(options.hostPolicy);
     const alice = openClient(aliceSigner);
     const bob = openClient(bobSigner);
     const engine = await server.engineForSpace(space);
@@ -511,6 +544,116 @@ describe("stage A: the instance-keyed serving replica (OW17)", () => {
       "alice's instance to re-derive from her changed draft",
     );
     expect(instanceHolds(engine, bobKey, '"echo:A2"')).toBe(false);
+    setup.cancel();
+  });
+
+  it("a lease lapse the SpaceServer survives in-process does not leave the serving replica silently stale: Alice's write inside the lapse is withheld, then — on the reacquire notice, with NO further write — re-delivered KEYED by the re-arm, her instance re-derives from it, and Bob's instance is untouched (finding 1's silent-stale half, end to end through the serving replica)", async () => {
+    // The tick itself is not driven here (see the note below); the renew
+    // interval is parked out of the way so no tick can interleave.
+    const setup = await standUpTwoUsers({
+      bobScope: "user",
+      names: { arg: "ika-blip-arg", result: "ika-blip-result" },
+      hostPolicy: { renewIntervalMs: 600_000, flushDeadlineMs: 3_000 },
+    });
+    const { engine, aliceKey, bobKey, alice, argId, typedAliceArg } = setup;
+    await waitUntil(
+      () =>
+        instanceHolds(engine, aliceKey, '"echo:A"') &&
+        instanceHolds(engine, bobKey, '"echo:B"'),
+      "both instances derived once",
+    );
+    const spaceServer = host!.spaceServer(space)!;
+    const replica = servingRuntime!.storageManager.open(space).replica;
+    const readDraft = (identity: ScopeKeyIdentity | undefined) =>
+      (replica.getDocument(argId as never, "user", identity)?.value as
+        | { draft?: string }
+        | undefined)?.draft;
+    expect(readDraft({ principal: aliceSigner.did() })).toBe("A");
+    expect(readDraft({ principal: bobSigner.did() })).toBe("B");
+
+    // Hold the loop's next cycle in its settle (before any seal): the
+    // cycle Alice's write triggers must not attempt its watermark
+    // advance against the expired row — a derived commit under an
+    // expired row is refused (engine.ts's derived-class rule) and the
+    // loop re-attempts it every cycle until the row is live again
+    // (a PRE-EXISTING blip-window shape, recorded in the stage-A fix
+    // report; not stage A's and not exercised here).
+    const gate = Promise.withResolvers<void>();
+    servingManager!.settleGate = gate.promise;
+
+    // THE LAPSE: the lease row expires (an expired row matches nobody —
+    // liveness is judged by expiry, serving-loop.md §2). Every push pass
+    // now judges the loopback session a FORMER holder.
+    releaseExecutionLease(engine, { space, holder: spaceServer.holder });
+    expect(
+      acquireExecutionLease(engine, {
+        space,
+        holder: spaceServer.holder,
+        now: Date.now() - 60_000,
+        ttlMs: 1,
+      }),
+    ).toBe(true);
+    // Alice types inside the lapse: the push pass WITHHOLDS her
+    // instance from the loopback session (protocol.md §3's filter under
+    // a lapsed lease — the P0 rule; never cached as delivered), so the
+    // serving replica still reads "A" once the server has drained it.
+    {
+      const tx = alice.edit();
+      typedAliceArg.key("draft").withTx(tx).set("A-blip");
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    await alice.idle();
+    await alice.storageManager.synced();
+    await server.idle();
+    expect(instanceHolds(engine, aliceKey, '"A-blip"')).toBe(true);
+    expect(readDraft({ principal: aliceSigner.did() })).toBe("A");
+
+    // The reacquire, as the SpaceServer's renew arm performs it on a
+    // survived blip (serving-loop.md §2's same-process reacquire): the
+    // same holder restores the row, then reports it to the memory
+    // server (`noteLeaseReacquired` — the arm's own call is pinned in
+    // `executor-space-server.test.ts`; the tick is not driven here
+    // because two pre-existing SpaceServer shapes make a tick-driven
+    // survived blip non-deterministic in this fixture: the rejection
+    // spin above, and an EMPTY seal — a read probe or a no-op
+    // derivation — opening a `#currentWave` that outlives zero-delta
+    // cycles with the pre-blip tenure, so the first real seal after the
+    // reacquire aborts lease-lost and parks; both recorded in the fix
+    // report as flagged residuals). NO watch is re-issued and NOTHING
+    // else is written.
+    expect(
+      acquireExecutionLease(engine, {
+        space,
+        holder: spaceServer.holder,
+        ttlMs: 600_000,
+      }),
+    ).toBe(true);
+    server.noteLeaseReacquired({ space, principal: serviceSigner.did() });
+    // The re-arm's full evaluation re-delivers the withheld instance,
+    // keyed. Pre-fix the lapse cleared the exemption for the session's
+    // life; the replica kept "A" and every later per-user run of Alice
+    // read a stale draft — silently.
+    await waitUntil(
+      () => readDraft({ principal: aliceSigner.did() }) === "A-blip",
+      () =>
+        `the withheld write to reach the serving replica (reads ${
+          readDraft({ principal: aliceSigner.did() })
+        })`,
+    );
+    // Release the held cycle: Alice's instance re-derives from the
+    // re-delivered draft (the served per-user run reads the CURRENT
+    // instance).
+    gate.resolve();
+    servingManager!.settleGate = undefined;
+    await waitUntil(
+      () => instanceHolds(engine, aliceKey, '"echo:A-blip"'),
+      "alice's instance to re-derive from the re-delivered draft",
+    );
+    // Bob's instance and Alice's key never crossed: the re-arm named
+    // instances, it did not collapse them; the loop kept serving.
+    expect(readDraft({ principal: bobSigner.did() })).toBe("B");
+    expect(instanceHolds(engine, bobKey, '"echo:A-blip"')).toBe(false);
+    expect(host!.spaceServer(space)?.active).toBe(true);
     setup.cancel();
   });
 

--- a/packages/runner/test/executor-instance-keyed-replica.test.ts
+++ b/packages/runner/test/executor-instance-keyed-replica.test.ts
@@ -1,0 +1,557 @@
+// Server-execution v2 fan-out stage A — OW17's instance-keyed serving
+// replica, wire, and tx→replica identity seam, END TO END against a real
+// memory server, a live ExecutorHost, and TWO flag-ON clients (Alice,
+// Bob):
+//
+// - the serving replica holds BOTH principals' instances of one scoped
+//   doc, and each demanded run reads ITS instance — divergent per-user
+//   inputs land divergent per-instance engine rows with the RIGHT
+//   values (the OW17 VALUE half; pre-stage-A both runs read the one
+//   scope-NAME-keyed local doc, the service's collapsed instance);
+// - the R7 wall: Alice's authored per-user draft plus her save event →
+//   the served handler runs AS Alice, reads HER draft (not the service
+//   instance's empty one), and writes her per-user consequence with the
+//   typed value (pre-stage-A: consequenced with zero writes);
+// - the resubscribe path is instance-aware: after both instances ran,
+//   BOB's input change wakes the node (the N-run loop resubscribes once
+//   to the UNION of the instance logs — pre-stage-A the last instance's
+//   subscription replaced the others);
+// - S4 (basis rows keyed by the FULL instance address): a demand stamp
+//   broader or narrower than the run's discovered instance leaves no
+//   stranded rows — a session-scoped watch on a user-discovering node
+//   records `user:<p>` rows, never `session:<p>:<s>` (the ragged case's
+//   zombie), and a space-discovering node records `space`.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import * as Engine from "@commonfabric/memory/v2/engine";
+import {
+  resolveScopeKey,
+  type ScopeKeyIdentity,
+  type StreamEventsDocValue,
+} from "@commonfabric/memory/v2";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { MemorySpace } from "../src/storage/interface.ts";
+import { ExecutorHost } from "../src/executor/host.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
+
+const spaceSigner = await Identity.fromPassphrase("instance-keyed replica");
+const space = spaceSigner.did() as MemorySpace;
+const serviceSigner = await Identity.fromPassphrase(
+  "instance-keyed replica service",
+);
+const aliceSigner = await Identity.fromPassphrase(
+  "instance-keyed replica alice",
+);
+const bobSigner = await Identity.fromPassphrase("instance-keyed replica bob");
+
+const waitUntil = async (
+  predicate: () => boolean,
+  label: string | (() => string),
+  timeoutMs = 20_000,
+): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      const rendered = typeof label === "function" ? label() : label;
+      throw new Error(`timed out waiting for ${rendered}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+};
+
+/** A piece with per-user state on both sides of the run: a PerUser
+ * draft the derivations READ, a PerUser save slot the handler WRITES,
+ * and one space-only derivation (`label`) whose basis rows must key
+ * `space` regardless of who demanded it. */
+const PER_USER_PATTERN = [
+  "import { computed, Default, handler, pattern, PerUser, Stream, Writable } from 'commonfabric';",
+  "type Draft = Writable<string | Default<''>>;",
+  "const draftText = (draft: Draft): string =>",
+  "  (draft.get() as string | undefined) ?? '';",
+  "const save = handler<unknown, { draft: Draft; saved: Draft }>(",
+  "  (_ev, { draft, saved }) => {",
+  "    const text = draftText(draft).trim();",
+  "    if (text.length > 0) saved.set('saved:' + text);",
+  "  },",
+  ");",
+  "export default pattern<",
+  "  { draft?: PerUser<Draft>; saved?: PerUser<Draft>; n?: number },",
+  "  { echo: string; savedEcho: string; label: string; save: Stream<unknown> }",
+  ">(({ draft, saved, n }) => {",
+  "  const draftCell: Draft = draft!;",
+  "  const savedCell: Draft = saved!;",
+  "  return {",
+  "    echo: computed(() => 'echo:' + draftText(draftCell)),",
+  "    savedEcho: computed(() => 'saved-echo:' + draftText(savedCell)),",
+  "    label: computed(() => 'label:' + String(n ?? 0)),",
+  "    save: save({ draft: draftCell, saved: savedCell }),",
+  "  };",
+  "});",
+].join("\n");
+
+const sidecarIdsIn = (engine: Engine.Engine): string[] =>
+  (engine.database.prepare(
+    `SELECT id FROM head WHERE id LIKE 'of:stream-events:%' AND op != 'delete'`,
+  ).all() as Array<{ id: string }>).map((row) => row.id);
+
+/** Every current row of one scope INSTANCE: id → document value. */
+const rowsUnder = (
+  engine: Engine.Engine,
+  scopeKey: string,
+): Map<string, unknown> => {
+  const rows = engine.database.prepare(
+    `SELECT id FROM head WHERE scope_key = :scope_key AND op != 'delete'`,
+  ).all({ scope_key: scopeKey }) as Array<{ id: string }>;
+  const out = new Map<string, unknown>();
+  for (const { id } of rows) {
+    out.set(id, Engine.read(engine, { id, scopeKey } as never)?.value);
+  }
+  return out;
+};
+
+const instanceHolds = (
+  engine: Engine.Engine,
+  scopeKey: string,
+  needle: string,
+): boolean =>
+  [...rowsUnder(engine, scopeKey).values()].some((value) =>
+    JSON.stringify(value ?? null).includes(needle)
+  );
+
+const basisKeys = (engine: Engine.Engine): Set<string> =>
+  new Set(
+    (engine.database.prepare(
+      `SELECT DISTINCT action_scope_key FROM scheduler_basis`,
+    ).all() as Array<{ action_scope_key: string }>).map((row) =>
+      row.action_scope_key
+    ),
+  );
+
+describe("stage A: the instance-keyed serving replica (OW17)", () => {
+  let server: MemoryV2Server.Server;
+  let host: ExecutorHost | undefined;
+  let managers: EmulatedStorageManager[];
+  let runtimes: Runtime[];
+  let servingRuntime: Runtime | undefined;
+
+  const newHost = (): ExecutorHost =>
+    new ExecutorHost({
+      server,
+      serviceIdentity: serviceSigner.did(),
+      // deno-lint-ignore require-await
+      createRuntime: async () => {
+        const manager = EmulatedStorageManager.connectTo(server, {
+          as: serviceSigner,
+        });
+        const runtime = new Runtime({
+          apiUrl: new URL(import.meta.url),
+          storageManager: manager,
+          servingPosture: true,
+          experimental: {
+            serverExecution: true,
+            systemPatternAutoUpdate: false,
+          },
+        });
+        servingRuntime = runtime;
+        return {
+          runtime,
+          dispose: async () => {
+            await runtime.dispose();
+            await manager.close();
+          },
+        };
+      },
+      policy: { flushDeadlineMs: 5_000, idleParkMs: 600_000 },
+    });
+
+  beforeEach(() => {
+    server = newSharedServer({ subscriptionRefreshDelayMs: 0 });
+    managers = [];
+    runtimes = [];
+    servingRuntime = undefined;
+  });
+
+  afterEach(async () => {
+    await host?.close();
+    host = undefined;
+    for (const runtime of runtimes) await runtime.dispose();
+    for (const manager of managers) await manager.close();
+    await server.close();
+  });
+
+  const openClient = (signer: Identity): Runtime => {
+    const manager = EmulatedStorageManager.connectTo(server, { as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: manager,
+      experimental: { serverExecution: true },
+    });
+    managers.push(manager);
+    runtimes.push(runtime);
+    return runtime;
+  };
+
+  /** Alice stands the piece up; Bob joins it. Each principal registers
+   * BOTH demand halves: the space watch (the value pull) and an
+   * identity-bearing scoped watch on the result doc (the demand row the
+   * run supply consumes — P2-F's existing supply, which is how stage A
+   * reaches cardinality 2 without stage B's space-root demanders). Each
+   * writes a DIVERGENT per-user draft through the argument schema (the
+   * narrowing write lands it in that principal's instance). */
+  const standUpTwoUsers = async (options: {
+    bobScope: "user" | "session";
+    names: { arg: string; result: string };
+  }) => {
+    // The host first: activation is triggered by session open / admission
+    // (serving-loop.md §1), so the clients open against a live host.
+    host = newHost();
+    const alice = openClient(aliceSigner);
+    const bob = openClient(bobSigner);
+    const engine = await server.engineForSpace(space);
+
+    const compiled = await alice.patternManager.compilePattern({
+      main: "/main.tsx",
+      files: [{ name: "/main.tsx", contents: PER_USER_PATTERN }],
+    }, { space });
+    const aliceArg = alice.getCell<Record<string, unknown>>(
+      space,
+      options.names.arg,
+      undefined,
+    );
+    const aliceResult = alice.getCell<Record<string, unknown>>(
+      space,
+      options.names.result,
+      compiled.resultSchema,
+    );
+    await aliceArg.sync();
+    await aliceResult.sync();
+    {
+      const seed = alice.edit();
+      aliceArg.withTx(seed).set({ n: 1 });
+      expect((await seed.commit()).error).toBeUndefined();
+    }
+    {
+      const tx = alice.edit();
+      alice.run(tx, compiled, aliceArg, aliceResult);
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    await alice.idle();
+    await alice.storageManager.synced();
+    const argId = aliceArg.getAsNormalizedFullLink().id;
+    const resultId = aliceResult.getAsNormalizedFullLink().id;
+
+    // Demand FIRST (P2-F's supply — stage B's arrival re-arm is what
+    // would let a demander who arrives after a clean run be served; here
+    // the input change below is what re-runs the node): the space watch
+    // (value pull) plus the identity-bearing scoped watch per principal.
+    const bobResult = bob.getCell<Record<string, unknown>>(
+      space,
+      options.names.result,
+      undefined,
+    );
+    await bobResult.sync();
+    const cancelAlice = aliceResult.sink(() => {});
+    const cancelBob = bobResult.sink(() => {});
+    await alice.getCellFromLink<unknown>({
+      ...aliceResult.getAsNormalizedFullLink(),
+      scope: "user",
+    }).sync();
+    await bob.getCellFromLink<unknown>({
+      ...bobResult.getAsNormalizedFullLink(),
+      scope: options.bobScope,
+    }).sync();
+    await waitUntil(
+      () => host!.spaceServer(space)?.active === true,
+      "space activation",
+    );
+    await waitUntil(
+      () => {
+        const demanded = host!.spaceServer(space)?.demandedIdentitiesOf(
+          resultId,
+        ) ?? [];
+        return demanded.some((i) => i.principal === aliceSigner.did()) &&
+          demanded.some((i) => i.principal === bobSigner.did());
+      },
+      "both demanders in the registry",
+    );
+
+    // Divergent per-user drafts, written THROUGH the argument schema so
+    // the PerUser slot narrows into each writer's own instance. Each is
+    // an authored input change that re-runs the demanded node — once
+    // per demanded instance.
+    const typedAliceArg = alice.getCell<{ draft: string; saved: string }>(
+      space,
+      options.names.arg,
+      compiled.argumentSchema,
+    );
+    {
+      const tx = alice.edit();
+      typedAliceArg.key("draft").withTx(tx).set("A");
+      // Alice's `saved` slot exists in HER instance before any handler
+      // touches it: a handler-only write to a never-written PerUser slot
+      // lands at the slot's base scope (pre-existing OFF behavior — the
+      // handler's handle carries no scope cap until the slot redirects;
+      // flagged in the stage-A report, not stage A's), while a write to
+      // an already-narrowed slot follows the sticky redirect into the
+      // writer's instance (scopes.md §2 Permanence) — the group-chat
+      // shape, where the client types the draft first.
+      typedAliceArg.key("saved").withTx(tx).set("");
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    const typedBobArg = bob.getCell<{ draft: string }>(
+      space,
+      options.names.arg,
+      compiled.argumentSchema,
+    );
+    await typedBobArg.sync();
+    {
+      const tx = bob.edit();
+      typedBobArg.key("draft").withTx(tx).set("B");
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    await alice.idle();
+    await bob.idle();
+    await alice.storageManager.synced();
+    await bob.storageManager.synced();
+    const aliceKey = resolveScopeKey("user", { principal: aliceSigner.did() });
+    const bobKey = resolveScopeKey("user", { principal: bobSigner.did() });
+    await waitUntil(
+      () =>
+        instanceHolds(engine, aliceKey, '"A"') &&
+        instanceHolds(engine, bobKey, '"B"'),
+      "both per-user drafts to land in their own instances",
+    );
+
+    return {
+      alice,
+      bob,
+      engine,
+      compiled,
+      argId,
+      resultId,
+      aliceKey,
+      bobKey,
+      aliceResult,
+      bobResult,
+      typedAliceArg,
+      typedBobArg,
+      cancel: () => {
+        cancelAlice();
+        cancelBob();
+      },
+    };
+  };
+
+  it("two demanded runs read their OWN per-user inputs through the instance-keyed replica: divergent inputs land divergent per-instance derived rows with the right values, and the serving replica holds both instances of the doc (OW17's value half; the R7 read shape)", async () => {
+    const setup = await standUpTwoUsers({
+      bobScope: "user",
+      names: { arg: "ika-a-arg", result: "ika-a-result" },
+    });
+    const { engine, aliceKey, bobKey, argId } = setup;
+
+    // THE ARBITRATION: each principal's instance of the echo doc holds
+    // ITS OWN input's echo. Pre-stage-A both instance runs read the one
+    // scope-NAME-keyed local doc — the service instance's (empty)
+    // draft — and wrote "echo:" under both keys.
+    await waitUntil(
+      () =>
+        instanceHolds(engine, aliceKey, '"echo:A"') &&
+        instanceHolds(engine, bobKey, '"echo:B"'),
+      () =>
+        "each instance's echo of its own draft (alice: " +
+        `${instanceHolds(engine, aliceKey, '"echo:A"')}, bob: ${
+          instanceHolds(engine, bobKey, '"echo:B"')
+        })`,
+    );
+    // Never the sibling's value, never the collapsed empty one.
+    expect(instanceHolds(engine, aliceKey, '"echo:B"')).toBe(false);
+    expect(instanceHolds(engine, bobKey, '"echo:A"')).toBe(false);
+    // The service identity's instance never received a DEMANDED run's
+    // value (a pre-demand wave-level fallback run may have left the
+    // empty "echo:" there — stage B's B5 residual; never a demander's).
+    const serviceKey = resolveScopeKey("user", {
+      principal: serviceSigner.did(),
+    });
+    expect(instanceHolds(engine, serviceKey, '"echo:A"')).toBe(false);
+    expect(instanceHolds(engine, serviceKey, '"echo:B"')).toBe(false);
+
+    // The serving replica HOLDS both instances of the argument doc,
+    // keyed apart, each with its own draft — the read seam's premise.
+    const replica = servingRuntime!.storageManager.open(space).replica;
+    const readDraft = (identity: ScopeKeyIdentity | undefined) => {
+      const doc = replica.getDocument(argId as never, "user", identity);
+      return (doc?.value as { draft?: string } | undefined)?.draft;
+    };
+    expect(readDraft({ principal: aliceSigner.did() })).toBe("A");
+    expect(readDraft({ principal: bobSigner.did() })).toBe("B");
+    // And the replica's OWN (service) instance is not either of them.
+    expect(readDraft(undefined)).not.toBe("A");
+    expect(readDraft(undefined)).not.toBe("B");
+
+    setup.cancel();
+  });
+
+  it("R7: Alice's authored per-user draft + her save event → the served handler runs AS Alice, reads HER draft through the instance-keyed replica, and writes her per-user consequence with the typed value (pre-stage-A: consequenced with zero writes)", async () => {
+    const setup = await standUpTwoUsers({
+      bobScope: "user",
+      names: { arg: "ika-r7-arg", result: "ika-r7-result" },
+    });
+    const { engine, aliceKey, bobKey, alice, aliceResult } = setup;
+    // Let the derivations settle first (the save reads the same draft
+    // instance the echo run already loaded — and the handler must read
+    // it correctly whether or not a prior load happened).
+    await waitUntil(
+      () => instanceHolds(engine, aliceKey, '"echo:A"'),
+      "alice's echo before the save",
+    );
+
+    const before = Engine.serverSeq(engine);
+    (aliceResult.key("save") as unknown as { send(value: unknown): unknown })
+      .send({});
+    await alice.idle();
+    await alice.storageManager.synced();
+
+    await waitUntil(
+      () => sidecarIdsIn(engine).length === 1,
+      "the save event append to land",
+    );
+    const sidecarId = sidecarIdsIn(engine)[0];
+    await waitUntil(
+      () => {
+        const value = Engine.read(engine, { id: sidecarId })?.value as
+          | StreamEventsDocValue
+          | undefined;
+        return (value?.entries?.length ?? 0) >= 1 &&
+          value!.entries!.every((entry) => entry.consequenced === true);
+      },
+      "the save event to consequence",
+    );
+    const entries =
+      (Engine.read(engine, { id: sidecarId })?.value as StreamEventsDocValue)
+        .entries!;
+    expect(entries[0].firedAt?.user).toBe(aliceSigner.did());
+    expect(entries[0].error).toBeUndefined();
+
+    // THE R7 ARBITRATION: the consequence exists, under Alice's instance,
+    // with the value she typed — the handler read HER draft, not the
+    // service instance's empty one (which writes nothing).
+    await waitUntil(
+      () => instanceHolds(engine, aliceKey, '"saved:A"'),
+      "alice's saved consequence under her instance",
+    );
+    // Under HER instance exactly: the arg doc's user instance holds both
+    // her draft and the typed consequence; the space slot holds the
+    // redirect, never the value.
+    expect(rowsUnder(engine, aliceKey).get(setup.argId)).toEqual({
+      draft: "A",
+      saved: "saved:A",
+    });
+    expect(
+      (rowsUnder(engine, "space").get(setup.argId) as { saved?: unknown })
+        ?.saved,
+    ).not.toBe("saved:A");
+    expect(instanceHolds(engine, bobKey, '"saved:')).toBe(false);
+    // The consequence rode a derived commit after the append.
+    const consequenceRows = engine.database.prepare(
+      `SELECT seq FROM "commit"
+       WHERE seq > :from_seq AND class = 'derived'
+         AND consequence_of IS NOT NULL`,
+    ).all({ from_seq: before }) as Array<{ seq: number }>;
+    expect(consequenceRows.length).toBeGreaterThanOrEqual(1);
+    // And the per-user derivation over the SAVED slot re-derived for
+    // Alice from her new instance value.
+    await waitUntil(
+      () => instanceHolds(engine, aliceKey, '"saved-echo:saved:A"'),
+      "alice's saved-echo derived from her consequence",
+    );
+    setup.cancel();
+  });
+
+  it("the resubscribe path is instance-aware: after both instances ran, BOB's input change wakes the node and his instance re-derives (the union of instance logs; pre-stage-A the last instance's subscription won)", async () => {
+    const setup = await standUpTwoUsers({
+      bobScope: "user",
+      names: { arg: "ika-resub-arg", result: "ika-resub-result" },
+    });
+    const { engine, aliceKey, bobKey, bob, typedBobArg } = setup;
+    await waitUntil(
+      () =>
+        instanceHolds(engine, aliceKey, '"echo:A"') &&
+        instanceHolds(engine, bobKey, '"echo:B"'),
+      "both instances derived once",
+    );
+    // Both instances ran; whichever ran LAST holds the subscription
+    // under the pre-stage-A "last instance wins" replacement. Change the
+    // input of BOTH, one at a time, and require each to re-derive: the
+    // one whose run was NOT last is the mutation target.
+    {
+      const tx = bob.edit();
+      typedBobArg.key("draft").withTx(tx).set("B2");
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    await bob.idle();
+    await bob.storageManager.synced();
+    await waitUntil(
+      () => instanceHolds(engine, bobKey, '"echo:B2"'),
+      "bob's instance to re-derive from his changed draft",
+    );
+    expect(instanceHolds(engine, aliceKey, '"echo:B2"')).toBe(false);
+    {
+      const tx = setup.alice.edit();
+      setup.typedAliceArg.key("draft").withTx(tx).set("A2");
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    await setup.alice.idle();
+    await setup.alice.storageManager.synced();
+    await waitUntil(
+      () => instanceHolds(engine, aliceKey, '"echo:A2"'),
+      "alice's instance to re-derive from her changed draft",
+    );
+    expect(instanceHolds(engine, bobKey, '"echo:A2"')).toBe(false);
+    setup.cancel();
+  });
+
+  it("S4: basis rows key by the run's FULL instance address — a session-scoped demand on a user-discovering node records user rows and NO session-keyed zombie; a space-discovering node records `space` under any demand stamp", async () => {
+    const setup = await standUpTwoUsers({
+      bobScope: "session",
+      names: { arg: "ika-s4-arg", result: "ika-s4-result" },
+    });
+    const { engine, aliceKey, bobKey } = setup;
+    await waitUntil(
+      () =>
+        instanceHolds(engine, aliceKey, '"echo:A"') &&
+        instanceHolds(engine, bobKey, '"echo:B"'),
+      "both instances derived",
+    );
+    await waitUntil(
+      () => {
+        const keys = basisKeys(engine);
+        return keys.has(aliceKey) && keys.has(bobKey) && keys.has("space");
+      },
+      () => `basis keys ${[...basisKeys(engine)].join(", ")}`,
+    );
+    const keys = basisKeys(engine);
+    // Bob demanded through a SESSION-scoped watch: his runs are STAMPED
+    // `session:<bob>:<s>`, but every node he ran discovered `user` (the
+    // per-user draft) or `space` (`label`) — nothing session-scoped — so
+    // no row is recorded under a session key (the ragged case's zombie:
+    // rows a departed session could never overwrite).
+    expect([...keys].some((key) => key.startsWith("session:"))).toBe(false);
+    // The user-discovering derivations recorded rows under each
+    // principal's USER instance — the address they actually served.
+    expect(keys.has(aliceKey)).toBe(true);
+    expect(keys.has(bobKey)).toBe(true);
+    // The space-only `label` derivation recorded `space` (never
+    // over-keyed under a demander's stamp).
+    expect(keys.has("space")).toBe(true);
+    // No row under the service identity's user instance: no demanded
+    // node ran as the service.
+    expect(
+      keys.has(resolveScopeKey("user", { principal: serviceSigner.did() })),
+    ).toBe(false);
+    setup.cancel();
+  });
+});

--- a/packages/runner/test/executor-instance-keyed-replica.test.ts
+++ b/packages/runner/test/executor-instance-keyed-replica.test.ts
@@ -120,6 +120,18 @@ const PER_USER_PATTERN = [
   "});",
 ].join("\n");
 
+/** The same surface with derivations that read NOTHING per-user: no
+ * demanded run ever loads a principal's draft instance into the serving
+ * replica, so the served save handler's read of Alice's draft is the
+ * FIRST touch of her instance — the true R7 shape (group chat: type,
+ * then save; the server may never have loaded the draft). */
+const PER_USER_PATTERN_HANDLER_ONLY = PER_USER_PATTERN
+  .replace("'echo:' + draftText(draftCell)", "'echo:const'")
+  .replace("'saved-echo:' + draftText(savedCell)", "'saved-echo:const'");
+if (PER_USER_PATTERN_HANDLER_ONLY === PER_USER_PATTERN) {
+  throw new Error("handler-only pattern did not derive from the base");
+}
+
 const sidecarIdsIn = (engine: Engine.Engine): string[] =>
   (engine.database.prepare(
     `SELECT id FROM head WHERE id LIKE 'of:stream-events:%' AND op != 'delete'`,
@@ -238,6 +250,7 @@ describe("stage A: the instance-keyed serving replica (OW17)", () => {
     bobScope: "user" | "session";
     names: { arg: string; result: string };
     hostPolicy?: ConstructorParameters<typeof ExecutorHost>[0]["policy"];
+    pattern?: string;
   }) => {
     // The host first: activation is triggered by session open / admission
     // (serving-loop.md §1), so the clients open against a live host.
@@ -248,7 +261,10 @@ describe("stage A: the instance-keyed serving replica (OW17)", () => {
 
     const compiled = await alice.patternManager.compilePattern({
       main: "/main.tsx",
-      files: [{ name: "/main.tsx", contents: PER_USER_PATTERN }],
+      files: [{
+        name: "/main.tsx",
+        contents: options.pattern ?? PER_USER_PATTERN,
+      }],
     }, { space });
     const aliceArg = alice.getCell<Record<string, unknown>>(
       space,
@@ -501,6 +517,76 @@ describe("stage A: the instance-keyed serving replica (OW17)", () => {
       () => instanceHolds(engine, aliceKey, '"saved-echo:saved:A"'),
       "alice's saved-echo derived from her consequence",
     );
+    setup.cancel();
+  });
+
+  it("R7, the true shape: NO derivation ever loaded Alice's draft instance on the serving replica — type, then save — and the served handler still reads HER draft (the presync/preflight AS THE ACTOR is what loads it) and writes her per-user consequence with the typed value", async () => {
+    // The pin the shipped R7 test above cannot be: there, Alice's echo
+    // derivation had already loaded her instance into the serving
+    // replica before the save, so the handler's actor-identity presync
+    // and preflight were redundant backstops (the independent review's
+    // M15/M16/M17 — each removable, all three together removable, and
+    // that test stayed green). Here no demanded run reads the draft, so
+    // the served handler's read of Alice's instance is the FIRST — and
+    // the presync/preflight as the actor is load-bearing: with both
+    // removed the handler reads the service instance's empty draft and
+    // writes nothing (this test goes red).
+    const setup = await standUpTwoUsers({
+      bobScope: "user",
+      names: { arg: "ika-r7-noload-arg", result: "ika-r7-noload-result" },
+      pattern: PER_USER_PATTERN_HANDLER_ONLY,
+    });
+    const { engine, aliceKey, bobKey, alice, aliceResult } = setup;
+    // (The constant derivations discover `space` and key their rows
+    // there — S4 as amended — and load NO draft instance.)
+    const replica = servingRuntime!.storageManager.open(space).replica;
+    // THE PRECONDITION that makes this the true R7 shape: the serving
+    // replica has NOT loaded Alice's instance of the argument doc.
+    expect(
+      replica.getDocument(setup.argId as never, "user", {
+        principal: aliceSigner.did(),
+      }),
+    ).toBeUndefined();
+
+    (aliceResult.key("save") as unknown as { send(value: unknown): unknown })
+      .send({});
+    await alice.idle();
+    await alice.storageManager.synced();
+    await waitUntil(
+      () => sidecarIdsIn(engine).length === 1,
+      "the save event append to land",
+    );
+    const sidecarId = sidecarIdsIn(engine)[0];
+    await waitUntil(
+      () => {
+        const value = Engine.read(engine, { id: sidecarId })?.value as
+          | StreamEventsDocValue
+          | undefined;
+        return (value?.entries?.length ?? 0) >= 1 &&
+          value!.entries!.every((entry) => entry.consequenced === true);
+      },
+      "the save event to consequence",
+    );
+    const entries =
+      (Engine.read(engine, { id: sidecarId })?.value as StreamEventsDocValue)
+        .entries!;
+    expect(entries[0].firedAt?.user).toBe(aliceSigner.did());
+    expect(entries[0].error).toBeUndefined();
+    // THE R7 ARBITRATION under the true shape: the handler read HER
+    // draft — loaded by its own actor-identity presync/preflight — and
+    // wrote the typed consequence under her instance.
+    await waitUntil(
+      () => instanceHolds(engine, aliceKey, '"saved:A"'),
+      () =>
+        "alice's saved consequence under her instance; rows now: " +
+        JSON.stringify([...rowsUnder(engine, aliceKey).entries()]),
+      10_000,
+    );
+    expect(rowsUnder(engine, aliceKey).get(setup.argId)).toEqual({
+      draft: "A",
+      saved: "saved:A",
+    });
+    expect(instanceHolds(engine, bobKey, '"saved:')).toBe(false);
     setup.cancel();
   });
 

--- a/packages/runner/test/executor-serving-loop.test.ts
+++ b/packages/runner/test/executor-serving-loop.test.ts
@@ -2979,9 +2979,14 @@ describe("stage F serving loop", () => {
       ),
     ).toBe(true);
 
-    // Basis rows key per (action, INSTANCE): the demanded run's rows
-    // land under alice's instance key (serving-loop.md §3b's
-    // action_scope_key), never only the wave identity's.
+    // Basis rows key per (action, INSTANCE) — the run's TRUE instance
+    // (S4, server-execution v2 stage A): the demanded run's DISCOVERED
+    // scope resolved against its identity. This derivation reads only the
+    // SPACE-scoped `n`, so its rows land under `space` and the demand's
+    // `user:<alice>` STAMP is cleared (the over-keyed row F10 named), not
+    // recorded — a demanded run that reads scoped state keys under alice's
+    // instance (`executor-instance-keyed-replica.test.ts` pins that
+    // shape). Pre-stage-A the stamp was recorded verbatim.
     const basisKeys = new Set(
       (engine.database.prepare(
         `SELECT DISTINCT action_scope_key FROM scheduler_basis`,
@@ -2989,6 +2994,7 @@ describe("stage F serving loop", () => {
         row.action_scope_key
       ),
     );
-    expect(basisKeys.has(expectedInstanceKey)).toBe(true);
+    expect(basisKeys.has("space")).toBe(true);
+    expect(basisKeys.has(expectedInstanceKey)).toBe(false);
   });
 });

--- a/packages/runner/test/executor-space-server.test.ts
+++ b/packages/runner/test/executor-space-server.test.ts
@@ -1020,9 +1020,14 @@ describe("stage G SpaceServer recovery seams", () => {
       ),
     ).toBe(true);
 
-    // The same run's basis rows key under the demander's INSTANCE
-    // (serving-loop.md §3b's action_scope_key) — the supply reached
-    // keys, not only stamps.
+    // The same run's basis rows key under the run's TRUE instance (S4,
+    // server-execution v2 stage A): its DISCOVERED scope resolved against
+    // the demander's identity. This derivation reads only space-scoped
+    // input, so its rows key `space` and the demand's `user:<demander>`
+    // stamp is cleared rather than recorded (the F10 over-keyed row);
+    // the supply's identity is witnessed by the acting annotations above,
+    // and a scoped-reading demanded run keys under the demander's
+    // instance (`executor-instance-keyed-replica.test.ts`).
     const expectedInstanceKey = resolveScopeKey("user", demander as never);
     const basisKeys = new Set(
       (engine.database.prepare(
@@ -1031,7 +1036,8 @@ describe("stage G SpaceServer recovery seams", () => {
         row.action_scope_key
       ),
     );
-    expect(basisKeys.has(expectedInstanceKey)).toBe(true);
+    expect(basisKeys.has("space")).toBe(true);
+    expect(basisKeys.has(expectedInstanceKey)).toBe(false);
 
     // The argument-doc demand RESOLVED (started through the owning
     // root) — it neither terminalized nor failed.
@@ -1233,9 +1239,7 @@ describe("stage G SpaceServer recovery seams", () => {
       );
       // And the userless arm never manufactured an actor anywhere.
       expect(
-        actingAnnotations().every((a) =>
-          a.actingUser === demander.principal
-        ),
+        actingAnnotations().every((a) => a.actingUser === demander.principal),
       ).toBe(true);
     } finally {
       for (const cancel of cancels) cancel();

--- a/packages/runner/test/executor-space-server.test.ts
+++ b/packages/runner/test/executor-space-server.test.ts
@@ -25,7 +25,12 @@ import {
   insertExecutionOutboxRows,
   selectPendingExecutionOutboxRows,
 } from "@commonfabric/memory/v2/execution-outbox";
-import { liveExecutionLeaseHolder } from "@commonfabric/memory/v2/execution-lease";
+import {
+  acquireExecutionLease,
+  executionLeaseHolder,
+  liveExecutionLeaseHolder,
+  releaseExecutionLease,
+} from "@commonfabric/memory/v2/execution-lease";
 import {
   decodeMemoryBoundary,
   resolveScopeKey,
@@ -617,6 +622,67 @@ describe("stage G SpaceServer recovery seams", () => {
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(flushed).toBe(0);
     expect(Engine.serverSeq(engine)).toBe(seqBefore);
+  });
+
+  it("reports a survived renewal blip to the memory server: the renew arm's same-process reacquire calls noteLeaseReacquired with the space and the service identity — once per blip, never on a plain renewal, never when the reacquire fails and the space parks (fan-out stage A's finding 1, the re-arm's trigger)", async () => {
+    // A Proxy facade over the real server that records the notice; every
+    // other call passes through (the sx2 facade pattern above).
+    const notices: Array<{ space: string; principal: string }> = [];
+    const spy = new Proxy(server, {
+      get(target, prop, receiver) {
+        if (prop === "noteLeaseReacquired") {
+          return (notice: { space: string; principal: string }) => {
+            notices.push(notice);
+            return target.noteLeaseReacquired(notice);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as typeof server;
+    const stats = emptyServingLoopStats();
+    const created = newSpaceServer({
+      serverFacade: spy,
+      stats,
+      policy: {
+        flushDeadlineMs: 2_000,
+        idleParkMs: 600_000,
+        renewIntervalMs: 25,
+      },
+    });
+    expect(await created.activate()).toBe(true);
+    // Plain renewals report nothing.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(notices).toEqual([]);
+    expect(stats.lease.lost).toBe(0);
+
+    // The blip: the row vanishes with NO rival, so the next tick's
+    // renewal FAILS and the same-process reacquire SUCCEEDS.
+    releaseExecutionLease(engine, { space, holder: created.holder });
+    await waitUntil(() => stats.lease.lost >= 1, "the renew tick to fail");
+    await waitUntil(
+      () => liveExecutionLeaseHolder(engine, space) === created.holder,
+      "the reacquire to restore the row",
+    );
+    await waitUntil(() => notices.length >= 1, "the reacquire notice");
+    expect(notices).toEqual([{ space, principal: serviceSigner.did() }]);
+    expect(created.active).toBe(true);
+    // Later plain renewals still report nothing (one notice per blip).
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(notices.length).toBe(1);
+
+    // A blip the reacquire LOSES (a rival took the row) parks the space
+    // and reports nothing: there is no live lease to re-arm under.
+    releaseExecutionLease(engine, { space, holder: created.holder });
+    expect(
+      acquireExecutionLease(engine, {
+        space,
+        holder: executionLeaseHolder("did:key:rival-process"),
+        ttlMs: 600_000,
+      }),
+    ).toBe(true);
+    await waitUntil(() => created.active !== true, "the space to park");
+    expect(notices.length).toBe(1);
   });
 
   // ---- stage P2-F: late-notice accounting (the sx2 unskip flake) ----

--- a/packages/runner/test/executor-wave.test.ts
+++ b/packages/runner/test/executor-wave.test.ts
@@ -2706,6 +2706,136 @@ describe("stage D seal-into-wave", () => {
     expect(misKeyed).toEqual([]);
   });
 
+  it("stage A: S4 clearance in BOTH directions — an action whose TRUE key changes across waves has its stranded rows cleared (user→space clears the stamped user key; space→user clears the broader `space` key), and a real row set in the same wave under a stranded key is never overwritten by a clearance (mutations: no clearance / no guard → red)", async () => {
+    // The independent review's finding 3: the shipped S4 pins asserted
+    // only that rows are not WRITTEN under a stranded key; none had a
+    // previously-stranded row to CLEAR. Here the same action (one
+    // actionId, one demand stamp `user:bob`) discovers a different scope
+    // in successive waves, and each wave must clear the rows the previous
+    // one left under the key that is now stranded.
+    const lease = liveLease();
+    // One sink for the whole test: the engine's replay guard keys on the
+    // sink's (session, localSeq), so per-wave sinks would collide.
+    const sink = newSink();
+    const bobIdentity = { principal: "did:key:s4-bob", sessionId: "bob-s1" };
+    const bobKey = resolveScopeKey("user", bobIdentity);
+    const spaceDoc = runtime.getCell<{ value: number }>(
+      space,
+      "wave-s4-clear-space-input",
+      undefined,
+    );
+    const userDoc = runtime.getCell<{ value: number }>(
+      space,
+      "wave-s4-clear-user-input",
+      undefined,
+      undefined,
+      "user",
+    );
+    const output = runtime.getCell<{ value: number }>(
+      space,
+      "wave-s4-clear-output",
+      undefined,
+    );
+    {
+      const seedTx = runtime.edit();
+      spaceDoc.withTx(seedTx).set({ value: 1 });
+      expect((await seedTx.commit()).error).toBeUndefined();
+    }
+    const runOnce = async (
+      actionId: string,
+      reads: "space" | "user",
+      valueOut: number,
+    ) => {
+      const wave = newWave({ lease });
+      runtime.installSealDestination(wave);
+      const tx = runtime.edit();
+      stampWaveRunContext(tx, {
+        actionId,
+        kind: "derivation",
+        scopeKeyIdentity: bobIdentity,
+        // Bob's demand stamps his USER instance in every wave.
+        actionScopeKey: bobKey,
+      });
+      if (reads === "space") {
+        spaceDoc.withTx(tx).get();
+      } else {
+        userDoc.withTx(tx).get(); // discovers `user` (Bob's instance)
+      }
+      // The write stays space-scoped so only the READS decide the
+      // discovered scope (the tx ratchet is read-driven).
+      output.withTx(tx).set({ value: valueOut });
+      expect((await tx.commit()).error).toBeUndefined();
+      runtime.clearSealDestination();
+      const outcome = await wave.commitWave(sink);
+      await wave.settled();
+      expect(outcome.aborted).toBeUndefined();
+    };
+    const rowsUnder = (actionId: string, key: string) =>
+      selectSchedulerBasisRows(engine, {
+        branch: "",
+        action: actionId,
+        actionScopeKey: key,
+      });
+
+    // Direction 1 (user → space): wave 1 discovers Bob's user instance →
+    // rows under `user:bob`; wave 2 reads only space → true key `space`,
+    // and the stamped `user:bob` is now stranded → its rows are CLEARED.
+    await runOnce("s4-clear-broaden", "user", 1);
+    expect(rowsUnder("s4-clear-broaden", bobKey).length).toBeGreaterThan(0);
+    await runOnce("s4-clear-broaden", "space", 2);
+    expect(rowsUnder("s4-clear-broaden", "space").length).toBeGreaterThan(0);
+    expect(rowsUnder("s4-clear-broaden", bobKey)).toEqual([]);
+
+    // Direction 2 (space → user): wave 1 reads only space → rows under
+    // `space`; wave 2 discovers Bob's user instance → true key `user:bob`,
+    // and the broader `space` key on his chain is stranded → CLEARED.
+    await runOnce("s4-clear-narrow", "space", 1);
+    expect(rowsUnder("s4-clear-narrow", "space").length).toBeGreaterThan(0);
+    await runOnce("s4-clear-narrow", "user", 2);
+    expect(rowsUnder("s4-clear-narrow", bobKey).length).toBeGreaterThan(0);
+    expect(rowsUnder("s4-clear-narrow", "space")).toEqual([]);
+
+    // The guard: two contributions of ONE action in ONE wave — a
+    // space-discovering run (real rows under `space`) sealed FIRST, then
+    // Bob's user-discovering run whose stranded set names `space`. The
+    // clearance must not overwrite the real row set already recorded in
+    // this wave under that key.
+    {
+      const wave = newWave({ lease });
+      runtime.installSealDestination(wave);
+      const spaceRun = runtime.edit();
+      stampWaveRunContext(spaceRun, {
+        actionId: "s4-clear-guard",
+        kind: "derivation",
+        // The wave-level identity, no per-run stamp: true key `space`.
+      });
+      spaceDoc.withTx(spaceRun).get();
+      output.withTx(spaceRun).set({ value: 10 });
+      expect((await spaceRun.commit()).error).toBeUndefined();
+      const bobRun = runtime.edit();
+      stampWaveRunContext(bobRun, {
+        actionId: "s4-clear-guard",
+        kind: "derivation",
+        scopeKeyIdentity: bobIdentity,
+        actionScopeKey: bobKey,
+      });
+      userDoc.withTx(bobRun).get();
+      const bobOut = runtime.getCell<{ value: number }>(
+        space,
+        "wave-s4-clear-guard-bob-output",
+        undefined,
+      );
+      bobOut.withTx(bobRun).set({ value: 11 });
+      expect((await bobRun.commit()).error).toBeUndefined();
+      runtime.clearSealDestination();
+      const outcome = await wave.commitWave(sink);
+      await wave.settled();
+      expect(outcome.aborted).toBeUndefined();
+      expect(rowsUnder("s4-clear-guard", "space").length).toBeGreaterThan(0);
+      expect(rowsUnder("s4-clear-guard", bobKey).length).toBeGreaterThan(0);
+    }
+  });
+
   it("stage F: M1 — the run context survives sample()/sink() transaction wrappers (r3739139477: the stamp is on the ORIGINAL tx; a wrapped scoped read must not fall back to the service identity)", async () => {
     const tx = runtime.edit();
     const context = {

--- a/packages/runner/test/speculation-arrival-gate.test.ts
+++ b/packages/runner/test/speculation-arrival-gate.test.ts
@@ -1,0 +1,507 @@
+// Server-execution v2 — the client speculation ARRIVAL GATE
+// (speculation.md §4, RULED 2026-08-16; landed with fan-out stage A as
+// its own commit): an input-origin overlay entry retires on ARRIVAL of
+// the authoritative value for every doc instance it wrote — a CONFIRMED
+// value at seq ≥ the entry's floor — not on watermark coverage of its
+// basis alone. Coverage without arrival is the OW32 retire-to-nothing
+// loop: the echo dropped to nothing, the writer (subscribed to its own
+// output through the scope-narrowing write path) re-derived,
+// re-speculated, retired, forever, on any instance the server never
+// served (a per-user node the demand walk did not reach; a served node's
+// first wave not yet landed at boot).
+//
+// - the OW32 shape (the triage's probe): a flag-ON client with NO serving
+//   host, a `computed` over a PerUser input (its output scope-narrows
+//   into `computed:X/user:<self>`), a watermark that covers the basis
+//   with NO store value for the instance → the echo STAYS (bounded runs,
+//   entry live, the client value renders, no non-settling episode);
+//   mutation (gate removed) → the loop returns;
+// - arrival: the store's value for the instance lands at seq ≥ floor,
+//   the covering watermark re-sweeps → the entry retires and the store
+//   value renders;
+// - rider "own retirement is not a trigger": the flip a retiring echo
+//   produces carries the echo's own transaction as its source, and the
+//   scheduler does not re-dirty that transaction's action for it — a
+//   writer subscribed to its own output does not re-derive on a
+//   divergent authoritative value, re-speculate, and loop through the
+//   gate (mutation: the `integrate` arm of the own-source skip removed →
+//   the writer re-dirties);
+// - rider "supersede-by-newer" (destination-level, scripted): a newer
+//   entry of the same writer whose whole-doc ops cover an older entry's
+//   docs retires the older one at seal; a PATCH does not; another writer
+//   does not.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import * as Engine from "@commonfabric/memory/v2/engine";
+import {
+  resolveScopeKey,
+  SERVER_EXECUTION_WATERMARK_DOC_ID,
+} from "@commonfabric/memory/v2";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { Runtime } from "../src/runtime.ts";
+import type {
+  IExtendedStorageTransaction,
+  MemorySpace,
+} from "../src/storage/interface.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
+import {
+  SpeculationOverlayDestination,
+  stampSpeculationRunContext,
+} from "../src/speculation/overlay-destination.ts";
+
+const spaceSigner = await Identity.fromPassphrase("arrival gate space");
+const space = spaceSigner.did() as MemorySpace;
+const aliceSigner = await Identity.fromPassphrase("arrival gate alice");
+
+const waitUntil = async (
+  predicate: () => boolean,
+  label: string,
+  timeoutMs = 20_000,
+): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${label}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+};
+
+/** A per-user derivation: `echo` reads a PerUser draft, so its output
+ * narrows into the reader's user instance — exactly the shape whose
+ * echo the OW32 loop retired to nothing. */
+const PER_USER_PATTERN = [
+  "import { computed, Default, pattern, PerUser, Writable } from 'commonfabric';",
+  "type Draft = Writable<string | Default<''>>;",
+  "export default pattern<",
+  "  { draft?: PerUser<Draft> },",
+  "  { echo: string }",
+  ">(({ draft }) => {",
+  "  const draftCell: Draft = draft!;",
+  "  return {",
+  "    echo: computed(() => 'echo:' + ((draftCell.get() as string | undefined) ?? '')),",
+  "  };",
+  "});",
+].join("\n");
+
+describe("speculation arrival gate (speculation.md §4, RULED 2026-08-16)", () => {
+  let server: MemoryV2Server.Server;
+  let managers: EmulatedStorageManager[];
+  let runtimes: Runtime[];
+
+  beforeEach(() => {
+    server = newSharedServer({ subscriptionRefreshDelayMs: 0 });
+    managers = [];
+    runtimes = [];
+  });
+
+  afterEach(async () => {
+    for (const runtime of runtimes) await runtime.dispose();
+    for (const manager of managers) await manager.close();
+    await server.close();
+  });
+
+  const openClient = (signer: Identity): Runtime => {
+    const manager = EmulatedStorageManager.connectTo(server, { as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: manager,
+      experimental: { serverExecution: true },
+    });
+    managers.push(manager);
+    runtimes.push(runtime);
+    return runtime;
+  };
+
+  /** Write the watermark doc from a second session (no serving host in
+   * these tests): the client's watermark sink sees `{seq}` and sweeps. */
+  const pushWatermark = async (writer: Runtime, seq: number) => {
+    const wm = writer.getCellFromLink<{ seq: number }>({
+      space,
+      id: SERVER_EXECUTION_WATERMARK_DOC_ID as never,
+      scope: "space",
+      path: [],
+    });
+    const tx = writer.edit();
+    wm.withTx(tx).set({ seq });
+    expect((await tx.commit()).error).toBeUndefined();
+    await writer.storageManager.synced();
+  };
+
+  /** Total runs of the piece's lifts (the per-user `echo` derivation is
+   * the only lift): the loop's signature is this count climbing. */
+  const echoRunCount = (runtime: Runtime): number =>
+    runtime.scheduler.getGraphSnapshot().nodes
+      .filter((node) => node.id.includes("cfLift"))
+      .reduce((total, node) => total + (node.stats?.runCount ?? 0), 0);
+
+  it("the OW32 shape: a covering watermark with NO store value for the written instance leaves the echo in place — bounded runs, live entry, the client value renders (mutation: gate removed → the retire-to-nothing loop returns); then arrival retires it and the store value renders; own-retirement is not a trigger even when the values diverge", async () => {
+    const alice = openClient(aliceSigner);
+    const engine = await server.engineForSpace(space);
+    const compiled = await alice.patternManager.compilePattern({
+      main: "/main.tsx",
+      files: [{ name: "/main.tsx", contents: PER_USER_PATTERN }],
+    }, { space });
+    const arg = alice.getCell<Record<string, unknown>>(
+      space,
+      "ag-arg",
+      undefined,
+    );
+    const result = alice.getCell<{ echo: string }>(
+      space,
+      "ag-result",
+      compiled.resultSchema,
+    );
+    await arg.sync();
+    await result.sync();
+    {
+      const tx = alice.edit();
+      arg.withTx(tx).set({});
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    {
+      const tx = alice.edit();
+      alice.run(tx, compiled, arg, result);
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    await alice.idle();
+    await alice.storageManager.synced();
+    // Demand: a live reader.
+    const cancelDemand = result.sink(() => {});
+    // The per-user input, through the argument schema (narrows into
+    // alice's instance).
+    const typedArg = alice.getCell<{ draft: string }>(
+      space,
+      "ag-arg",
+      compiled.argumentSchema,
+    );
+    {
+      const tx = alice.edit();
+      typedArg.key("draft").withTx(tx).set("A");
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    await alice.idle();
+    await alice.storageManager.synced();
+    // The ECHO: the client's speculative run rendered it, with NO server.
+    await waitUntil(
+      () => result.key("echo").get() === "echo:A",
+      "the speculative echo to render",
+    );
+    const overlay = alice.speculationOverlay!;
+    expect(overlay.entryCount(space)).toBeGreaterThanOrEqual(1);
+    const runsAfterEcho = echoRunCount(alice);
+
+    // A watermark that COVERS the basis (the input's seq and everything
+    // before it) — with NO store value for computed:X/user:<alice>.
+    const writer = openClient(spaceSigner);
+    const coverSeq = Engine.serverSeq(engine);
+    await pushWatermark(writer, coverSeq);
+    await alice.idle();
+    await alice.storageManager.synced();
+    // Give a would-be loop time to show itself (pre-fix: ~80 ms cycles,
+    // MAX_ITERS per pass, then backoff — dozens of runs in this window).
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+    await alice.idle();
+
+    // THE GATE: the echo stays — the entry is live, the client value
+    // renders, and the lift ran a bounded number of times (no
+    // retire-to-nothing loop, no non-settling episode).
+    expect(overlay.entryCount(space)).toBeGreaterThanOrEqual(1);
+    expect(result.key("echo").get()).toBe("echo:A");
+    expect(echoRunCount(alice) - runsAfterEcho).toBeLessThanOrEqual(2);
+    expect(alice.scheduler.isNonSettling()).toBe(false);
+    // And the store still holds nothing for the instance (nobody served
+    // it) — the exact OW32 substrate.
+    const aliceKey = resolveScopeKey("user", { principal: aliceSigner.did() });
+    const echoDocs = (engine.database.prepare(
+      `SELECT id FROM head WHERE scope_key = :scope_key AND op != 'delete'
+       AND id LIKE 'computed:%'`,
+    ).all({ scope_key: aliceKey }) as Array<{ id: string }>).map((r) => r.id);
+    expect(echoDocs.length).toBe(0);
+
+    // ARRIVAL: the store's value for the instance lands — as a second
+    // session of the same principal (the authoritative writer would be
+    // the serving loop; its value need not equal the echo), then a
+    // covering watermark re-sweeps. Find the echo doc's id from the
+    // client's own view of the result.
+    const echoLink = result.key("echo").getAsNormalizedFullLink();
+    const echoTarget = alice.getCellFromLink<unknown>({
+      ...echoLink,
+      schema: undefined,
+    }).getRaw({ lastNode: "writeRedirect" }) as
+      | { "/": { "link@1": { id?: string } } }
+      | undefined;
+    const echoDocId = echoTarget?.["/"]?.["link@1"]?.id ??
+      (() => {
+        // The result slot may hold the computed link directly.
+        const raw = alice.getCellFromLink<unknown>({
+          ...result.getAsNormalizedFullLink(),
+          schema: undefined,
+        }).getRaw() as { echo?: { "/": { "link@1": { id?: string } } } };
+        return raw?.echo?.["/"]?.["link@1"]?.id;
+      })();
+    expect(echoDocId).toBeDefined();
+    const aliceAgain = openClient(aliceSigner);
+    const authoritative = aliceAgain.getCellFromLink<unknown>({
+      space,
+      id: echoDocId as never,
+      scope: "user",
+      path: [],
+    });
+    const authoritativeSlot = aliceAgain.getCellFromLink<unknown>({
+      space,
+      id: echoDocId as never,
+      scope: "space",
+      path: [],
+    });
+    await authoritative.sync();
+    await authoritativeSlot.sync();
+    {
+      // A DIVERGENT authoritative value: the store says something the
+      // echo did not — BOTH docs the speculation wrote (the served
+      // narrowing writes exactly these two: the value at the user
+      // instance and the redirect at the space slot). The redirect's
+      // REPRESENTATION differs from the client's too (an explicit `id`,
+      // the shape a served narrowing writes — the triage's §6
+      // observation), so the retirement flips the space slot the writer
+      // reads: without the own-retirement rider, that flip re-runs the
+      // writer, which re-speculates its own shape, which the gate retires
+      // at once (the instance HAS arrived), which flips again — forever.
+      const tx = aliceAgain.edit();
+      authoritative.withTx(tx).set("echo:server" as never);
+      authoritativeSlot.withTx(tx).set(
+        {
+          "/": {
+            "link@1": {
+              id: echoDocId,
+              overwrite: "redirect",
+              path: [],
+              scope: "user",
+            },
+          },
+        } as never,
+      );
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    await aliceAgain.storageManager.synced();
+    const runsBeforeArrival = echoRunCount(alice);
+    await pushWatermark(writer, Engine.serverSeq(engine));
+    await waitUntil(
+      () => overlay.entryCount(space) === 0,
+      "the entry to retire on arrival",
+    );
+    await waitUntil(
+      () => result.key("echo").get() === "echo:server",
+      "the authoritative value to render",
+    );
+    await alice.idle();
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    await alice.idle();
+    // The flip to the (divergent) authoritative value did not start a
+    // re-speculate/re-retire loop: no re-derivation, no live entry, the
+    // store value stands. Stated honestly: in THIS fixture the writer's
+    // registered reads do not include its own user-instance output (only
+    // the space slot's redirect, whose semantic value the arrival did
+    // not change), so the divergence loop the own-retirement rider closes
+    // is not reachable here — the rider's mechanism is pinned by the
+    // next test with its own mutation; this assertion is the end-to-end
+    // shape.
+    expect(overlay.entryCount(space)).toBe(0);
+    expect(echoRunCount(alice) - runsBeforeArrival).toBeLessThanOrEqual(1);
+    expect(result.key("echo").get()).toBe("echo:server");
+    expect(alice.scheduler.isNonSettling()).toBe(false);
+    cancelDemand();
+  });
+
+  it("own retirement is not a trigger (mechanism): the flip a superseded speculation produces carries the echo's own transaction as its source, and the scheduler does not re-dirty that transaction's action for it (mutation: no source → the writer re-dirties)", async () => {
+    // A flag-ON, non-serving runtime (client posture) on an emulated
+    // store: no wave destination — the speculation overlay is the
+    // default seal destination, but this pin drives the replica seam
+    // directly with a scripted verdict.
+    const { StorageManager } = await import(
+      "@commonfabric/runner/storage/cache.deno"
+    );
+    const manager = StorageManager.emulate({ as: aliceSigner });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: manager,
+      experimental: { serverExecution: true },
+    });
+    try {
+      const doc = runtime.getCell<{ value: string }>(
+        space,
+        "own-retirement-doc",
+        undefined,
+        undefined,
+        "user",
+      );
+      // A LIVE reader of the doc — an effect, so it re-runs on every
+      // change to what it read — standing in for the writer subscribed to
+      // its own output.
+      let runs = 0;
+      const writer = (tx: IExtendedStorageTransaction) => {
+        runs += 1;
+        doc.withTx(tx).get();
+      };
+      runtime.scheduler.subscribe(writer, {
+        reads: [],
+        shallowReads: [],
+        writes: [],
+      }, { isEffect: true });
+      await runtime.idle();
+      expect(runs).toBe(1);
+
+      const replica = manager.open(space).replica;
+      const docId = doc.getAsNormalizedFullLink().id;
+      const sealSpeculative = (value: string, sourceAction: object) => {
+        const sourceTx = runtime.edit();
+        sourceTx.tx.sourceAction = sourceAction;
+        const { promise, resolve } = Promise.withResolvers<
+          { withdrawn: { message: string; superseded: true } }
+        >();
+        const sealed = replica.sealNative!(
+          {
+            operations: [{
+              op: "set",
+              id: docId,
+              type: "application/json",
+              scope: "user",
+              value: { value: { value } } as never,
+            }],
+            preconditions: [],
+          } as never,
+          sourceTx.tx,
+          promise,
+          { speculative: true },
+        );
+        return {
+          retire: async () => {
+            resolve({
+              withdrawn: { message: "superseded (test)", superseded: true },
+            });
+            await sealed.settled;
+          },
+          abort: () => sourceTx.abort(),
+        };
+      };
+
+      // The writer's OWN echo retires: the flip carries the echo's source,
+      // the writer is not re-dirtied.
+      const own = sealSpeculative("own-echo", writer);
+      await runtime.idle();
+      const runsAfterOwnSeal = runs;
+      await own.retire();
+      await runtime.idle();
+      expect(runs).toBe(runsAfterOwnSeal);
+      own.abort();
+
+      // A DIFFERENT action's echo retiring on the same doc DOES re-dirty
+      // the writer (it is a reader of that doc, not the source).
+      const other = () => {};
+      const foreign = sealSpeculative("other-echo", other);
+      await runtime.idle();
+      const runsAfterForeignSeal = runs;
+      await foreign.retire();
+      await runtime.idle();
+      expect(runs).toBeGreaterThan(runsAfterForeignSeal);
+      foreign.abort();
+    } finally {
+      await runtime.dispose();
+      await manager.close();
+    }
+  });
+
+  it("supersede-by-newer (destination-level): a newer whole-doc entry of the same writer retires the older entry over the same instances at seal; a patch does not; another writer does not", async () => {
+    const doc = "of:supersede" as never;
+    let nextLocalSeq = 10;
+    const replica = {
+      sealNative: (
+        native: { operations: Array<Record<string, unknown>> },
+        _source: unknown,
+        verdict: Promise<unknown>,
+      ) => {
+        const localSeq = nextLocalSeq++;
+        return {
+          localSeq,
+          commit: {
+            localSeq,
+            reads: { confirmed: [], pending: [] },
+            operations: native.operations,
+          },
+          settled: verdict.then(() => undefined, () => undefined),
+        };
+      },
+      speculationRetirementView: () => ({
+        confirmedSeq: 0,
+        pendingLocalSeqs: [] as number[],
+      }),
+      ackedSeqOf: () => undefined,
+      speculationAckObserver: undefined as (() => void) | undefined,
+    };
+    const runtime = {
+      storageManager: { open: () => ({ replica }) },
+      getCellFromLink: () => ({ sink: () => () => {} }),
+    } as unknown as Runtime;
+    const destination = new SpeculationOverlayDestination(runtime);
+    const writerA = { name: "writer-a" };
+    const writerB = { name: "writer-b" };
+    const seal = (
+      writer: object,
+      operations: Array<Record<string, unknown>>,
+    ) => {
+      const tx = {
+        tx: {
+          sourceAction: writer,
+          sealInto: (collector: {
+            sealSpaceCommit: (
+              space: MemorySpace,
+              native: unknown,
+              source: unknown,
+            ) => Promise<unknown>;
+          }) =>
+            collector.sealSpaceCommit(
+              space,
+              { operations, preconditions: [] },
+              { sourceAction: writer },
+            ).then(() => ({ ok: {} })),
+        },
+      } as unknown as IExtendedStorageTransaction;
+      stampSpeculationRunContext(tx, {
+        actionId: "supersede",
+        kind: "derivation",
+      });
+      return destination.seal(tx);
+    };
+    const set = { op: "set", id: doc, scope: "user", value: { value: 1 } };
+    const patch = {
+      op: "patch",
+      id: doc,
+      scope: "user",
+      patches: [{ op: "replace", path: "/value", value: 2 }],
+    };
+    // Entry 1 (A, set) then entry 2 (A, set over the same instance): 1
+    // is superseded at 2's seal.
+    expect((await seal(writerA, [set])).ok).toBeDefined();
+    expect(destination.entryCount(space)).toBe(1);
+    expect((await seal(writerA, [set])).ok).toBeDefined();
+    expect(destination.entryCount(space)).toBe(1);
+    // Entry 3 (A, PATCH): the older whole-doc entry is KEPT (the patch is
+    // path-relative to the layer beneath it).
+    expect((await seal(writerA, [patch])).ok).toBeDefined();
+    expect(destination.entryCount(space)).toBe(2);
+    // Entry 4 (B, set): another writer never supersedes A's entries.
+    expect((await seal(writerB, [set])).ok).toBeDefined();
+    expect(destination.entryCount(space)).toBe(3);
+    // Entry 5 (A, set) supersedes A's set-entry (2) — but NOT the patch
+    // entry (3): a patch's docs are covered by a whole-doc set... entry 3
+    // wrote `doc` too, by patch; the newer set covers its DOC, so it is
+    // superseded (dropping a patch layer under a whole-doc set is
+    // invisible); B's entry stays.
+    expect((await seal(writerA, [set])).ok).toBeDefined();
+    expect(destination.entryCount(space)).toBe(2);
+    destination.close();
+  });
+});

--- a/packages/runner/test/storage-instance-keying.test.ts
+++ b/packages/runner/test/storage-instance-keying.test.ts
@@ -15,7 +15,16 @@
 //   (mutation: per-run resubscribe → only the last instance's read
 //   survives);
 // - two instance-named loads of one doc are two watches (distinct watch
-//   ids), and the pull-kick reservation is per instance.
+//   ids), and the pull-kick reservation is per instance;
+// - the seam pins the independent review found UNTESTED (fan-out stage
+//   A's fix round, 2026-08-17 — each goes red under the review's
+//   mutation): the served event's presync AND preflight carry the
+//   event's actor; `Cell.sync` names the cell's transaction identity;
+//   the traversal's absent-target kick names the run identity; a seal's
+//   read basis is built from the SEALING identity's records; the A3
+//   seed memo keys under the RUN's identity (Alice's presence never
+//   suppresses Bob's seed); a keyed retraction drops exactly the named
+//   instance.
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
@@ -37,6 +46,7 @@ import type {
   TransactionSealDestination,
 } from "../src/storage/interface.ts";
 import { txToReactivityLog } from "../src/scheduler/reactivity.ts";
+import type { EventHandler } from "../src/scheduler/types.ts";
 
 const signer = await Identity.fromPassphrase("stage A instance keying");
 const space = signer.did() as MemorySpace;
@@ -523,6 +533,320 @@ describe("stage A: instance keying — unit pins", () => {
         edge.from === writerId && edge.to === readerId
       ),
     ).toBe(true);
+  });
+
+  it("seam pin (M16+M17): a SERVED event's dependency preflight runs under the event's actor and its presync receives the actor — a client-side event passes neither (mutations: either identity dropped → red)", async () => {
+    // Every mechanism the served handler's actor-instance read rides on
+    // (the true-R7 E2E pins the composite; each half here): the
+    // preflight's dependency probe tx carries the actor as its
+    // `scopeKeyIdentity` (so its absent reads kick instance-named loads
+    // and the pending-load park cross-matches them), and `presyncInputs`
+    // is handed the same actor (so the handler's inputs load AS the
+    // actor). Absent on client-side events, byte-identical there.
+    runtime.installSealDestination(
+      { seal: (tx: IExtendedStorageTransaction) => tx.tx.commit() },
+      {
+        runStamper: (tx: IExtendedStorageTransaction, info: ServerRunInfo) => {
+          stampWaveRunContext(tx, {
+            actionId: info.actionId,
+            kind: info.kind,
+            ...(info.scopeKeyIdentity !== undefined
+              ? { scopeKeyIdentity: info.scopeKeyIdentity }
+              : {}),
+            ...(info.actionScopeKey !== undefined
+              ? { actionScopeKey: info.actionScopeKey }
+              : {}),
+          });
+        },
+      },
+    );
+    const stream = runtime.getCell<unknown>(space, "stagea-served-stream");
+    const seen: {
+      preflight: Array<ScopeKeyIdentity | undefined>;
+      presync: Array<ScopeKeyIdentity | undefined>;
+      handled: number;
+    } = { preflight: [], presync: [], handled: 0 };
+    const handler: EventHandler = Object.assign(
+      (_tx: IExtendedStorageTransaction, _event: unknown) => {
+        seen.handled += 1;
+      },
+      {
+        populateDependencies: (depTx: IExtendedStorageTransaction) => {
+          seen.preflight.push(depTx.tx.scopeKeyIdentity);
+        },
+        presyncInputs: (_event: unknown, identity?: ScopeKeyIdentity) => {
+          seen.presync.push(identity);
+          return Promise.resolve();
+        },
+      },
+    );
+    runtime.scheduler.addEventHandler(
+      handler,
+      stream.getAsNormalizedFullLink(),
+    );
+    // A served event, fired at Alice (the SpaceServer drain's carriage).
+    runtime.scheduler.queueEvent(
+      stream.getAsNormalizedFullLink(),
+      { n: 1 },
+      true,
+      undefined,
+      false,
+      {
+        served: {
+          firedAt: { user: alice.principal, session: alice.sessionId },
+        },
+      },
+    );
+    await runtime.idle();
+    expect(seen.handled).toBe(1);
+    expect(seen.preflight).toEqual([alice]);
+    expect(seen.presync).toEqual([alice]);
+    // A client-side event of the same stream: no identity anywhere.
+    runtime.scheduler.queueEvent(stream.getAsNormalizedFullLink(), {
+      n: 2,
+    });
+    await runtime.idle();
+    expect(seen.handled).toBe(2);
+    expect(seen.preflight[1]).toBeUndefined();
+    expect(seen.presync[1]).toBeUndefined();
+    runtime.clearSealDestination();
+  });
+
+  it("seam pin (M15): Cell.sync names the cell's TRANSACTION identity — a cell bound to a run stamped as Alice loads through syncCell with her identity, and the load registers under her instance; an unbound cell passes no options (mutation: identity dropped → red)", async () => {
+    const calls: Array<{ scopeKeyIdentity?: ScopeKeyIdentity } | undefined> =
+      [];
+    const original = storageManager.syncCell.bind(storageManager);
+    (storageManager as { syncCell: typeof storageManager.syncCell })
+      .syncCell = (cell, options) => {
+        calls.push(options);
+        return original(cell, options);
+      };
+    const scoped = runtime.getCell<{ value: number }>(
+      space,
+      "stagea-cell-sync-identity",
+      undefined,
+      undefined,
+      "user",
+    );
+    // Bound to a transaction stamped as Alice: the sync names her.
+    const aliceTx = runtime.edit();
+    stampWaveRunContext(aliceTx, {
+      actionId: "stagea-cell-sync",
+      kind: "derivation",
+      scopeKeyIdentity: alice,
+      actionScopeKey: resolveScopeKey("user", alice),
+    });
+    const bound = scoped.withTx(aliceTx);
+    const load = bound.sync();
+    // The pending-load ledger keys the in-flight load under HER instance
+    // (the address the event preflight's park cross-matches).
+    const inFlight = storageManager.pendingLoadAddresses?.() ?? [];
+    expect(
+      inFlight.some((address) =>
+        address.id === scoped.getAsNormalizedFullLink().id &&
+        (address as { scopeKey?: string }).scopeKey ===
+          resolveScopeKey("user", alice)
+      ),
+    ).toBe(true);
+    await load.catch(() => undefined);
+    expect(calls).toEqual([{ scopeKeyIdentity: alice }]);
+    aliceTx.abort();
+    // The same cell with no transaction: the pre-stage-A call, no options.
+    await scoped.sync().catch(() => undefined);
+    expect(calls[1]).toBeUndefined();
+  });
+
+  it("seam pin (M23): the traversal's absent-target kick names the RUN identity — a read inside a run stamped as Alice that meets a link to a never-loaded scoped doc kicks the load AS Alice (mutation: identity dropped → the runtime's own)", async () => {
+    // A doc holding a link to a user-scoped target the replica has never
+    // seen; a schema-driven read follows the link, finds the target
+    // absent, and kicks `ensureLinkedDocLoaded` — the stage-A site
+    // threads the traversal's run identity into that kick.
+    const target = runtime.getCell<{ label: string }>(
+      space,
+      "stagea-kick-target",
+      undefined,
+      undefined,
+      "user",
+    );
+    const holder = runtime.getCell<{ ref: { label: string } }>(
+      space,
+      "stagea-kick-holder",
+      undefined,
+    );
+    const seedTx = runtime.edit();
+    holder.withTx(seedTx).setRawUntyped({ ref: target.getAsLink() });
+    expect((await seedTx.commit()).error).toBeUndefined();
+
+    const kicks: Array<ScopeKeyIdentity | undefined> = [];
+    const originalKick = runtime.ensureLinkedDocLoaded;
+    runtime.ensureLinkedDocLoaded = (link, sourceSpace, identity) => {
+      if (link.id === target.getAsNormalizedFullLink().id) {
+        kicks.push(identity);
+      }
+      return originalKick.call(runtime, link, sourceSpace, identity);
+    };
+    try {
+      const aliceTx = runtime.edit();
+      stampWaveRunContext(aliceTx, {
+        actionId: "stagea-kick",
+        kind: "derivation",
+        scopeKeyIdentity: alice,
+        actionScopeKey: resolveScopeKey("user", alice),
+      });
+      const typed = runtime.getCell<{ ref: { label: string } }>(
+        space,
+        "stagea-kick-holder",
+        {
+          type: "object",
+          properties: {
+            ref: {
+              type: "object",
+              properties: { label: { type: "string" } },
+            },
+          },
+        } as const,
+        aliceTx,
+      );
+      typed.get();
+      aliceTx.abort();
+      expect(kicks).toEqual([alice]);
+      // The kick reserved ALICE's instance, not the runtime's own: a
+      // later own-identity read of the same target still gets its kick.
+      expect(
+        storageManager.shouldPullDoc(
+          space,
+          target.getAsNormalizedFullLink().id,
+          "user",
+          alice,
+        ),
+      ).toBe(false);
+      expect(
+        storageManager.shouldPullDoc(
+          space,
+          target.getAsNormalizedFullLink().id,
+          "user",
+        ),
+      ).toBe(true);
+    } finally {
+      runtime.ensureLinkedDocLoaded = originalKick;
+    }
+  });
+
+  it("seam pin (M19): a seal's read basis is built from the SEALING identity's records — a run as Alice that read HER instance at seq 5 seals a confirmed read at seq 5, not the own instance's absent seq 0 (mutation: identity dropped → red)", async () => {
+    const replica = storageManager.open(space).replica;
+    const scoped = runtime.getCell<{ value: string }>(
+      space,
+      "stagea-buildreads-cell",
+      undefined,
+      undefined,
+      "user",
+    );
+    const docId = scoped.getAsNormalizedFullLink().id;
+    // Alice's instance arrives KEYED at seq 5; the replica's own instance
+    // of the doc is never loaded (seq 0).
+    (replica as unknown as {
+      applySessionSync: (sync: unknown, type: "pull" | "integrate") => void;
+    }).applySessionSync({
+      type: "sync",
+      fromSeq: 0,
+      toSeq: 5,
+      upserts: [{
+        branch: "",
+        id: docId,
+        scope: "user",
+        scopeKey: resolveScopeKey("user", alice),
+        seq: 5,
+        doc: { value: { value: "alice" } },
+      }],
+      removes: [],
+    }, "integrate");
+    const aliceTx = runtime.edit();
+    stampWaveRunContext(aliceTx, {
+      actionId: "stagea-buildreads",
+      kind: "derivation",
+      scopeKeyIdentity: alice,
+      actionScopeKey: resolveScopeKey("user", alice),
+    });
+    // The run reads HER instance (the tx→replica seam) ...
+    expect(scoped.withTx(aliceTx).get()).toEqual({ value: "alice" });
+    // ... and seals under her identity: the commit's confirmed read of
+    // the doc names the seq HER record holds.
+    const { promise, resolve } = Promise.withResolvers<
+      { committed: { seq: number } }
+    >();
+    const sealed = replica.sealNative!(
+      {
+        operations: [{
+          op: "set",
+          id: docId,
+          type: "application/json",
+          scope: "user",
+          value: { value: { value: "alice-2" } } as never,
+        }],
+        preconditions: [],
+      } as never,
+      aliceTx.tx,
+      promise,
+      { identity: alice },
+    );
+    const read = sealed.commit.reads.confirmed.find((entry) =>
+      entry.id === docId
+    );
+    expect(read?.seq).toBe(5);
+    resolve({ committed: { seq: 6 } } as never);
+    await sealed.settled;
+    aliceTx.abort();
+  });
+
+  it("seam pin (M9, the A3 seed-memo site): a `Writable(initial)`-shaped cell serialized inside Alice's run seeds HER instance and memoizes under HER key — a later run as Bob still seeds HIS default (mutation: memo keyed by the runtime's identity → Alice's presence suppresses Bob's seed)", () => {
+    // The runtime-constructed `Writable(value)` shape: a ROOT-linked
+    // scoped cell whose schema carries the default. Serializing it as a
+    // value into another doc is the seed site (data-updating.ts): the
+    // seed writes the default into the target when absent, memoized per
+    // (space, INSTANCE, id) under the writing run's identity.
+    const seedCell = runtime.getCell<string>(
+      space,
+      "stagea-seed-target",
+      { type: "string", default: "hello" } as const,
+      undefined,
+      "user",
+    );
+    const seedLink = seedCell.getAsNormalizedFullLink();
+    const holder = runtime.getCell<{ slot: unknown }>(
+      space,
+      "stagea-seed-holder",
+      undefined,
+    );
+    const readSeed = (tx: IExtendedStorageTransaction) =>
+      tx.readValueOrThrow({ ...seedLink, path: [] });
+
+    // Alice's run serializes the cell: her instance is seeded.
+    const aliceTx = runtime.edit();
+    stampWaveRunContext(aliceTx, {
+      actionId: "stagea-seed-alice",
+      kind: "derivation",
+      scopeKeyIdentity: alice,
+      actionScopeKey: resolveScopeKey("user", alice),
+    });
+    holder.withTx(aliceTx).set({ slot: seedCell });
+    expect(readSeed(aliceTx)).toBe("hello");
+
+    // Bob's run serializes the same cell: HIS instance is absent, so it
+    // must be seeded too. Pre-fix the memo keyed under the runtime's own
+    // identity for every run — Alice's presence check had already
+    // memoized the doc, Bob's check was skipped, and his default never
+    // landed (the panel's Lens 2d hazard).
+    const bobTx = runtime.edit();
+    stampWaveRunContext(bobTx, {
+      actionId: "stagea-seed-bob",
+      kind: "derivation",
+      scopeKeyIdentity: bob,
+      actionScopeKey: resolveScopeKey("user", bob),
+    });
+    holder.withTx(bobTx).set({ slot: seedCell });
+    expect(readSeed(bobTx)).toBe("hello");
+    aliceTx.abort();
+    bobTx.abort();
   });
 
   it("two instance-named loads of one doc are two watches, and the pull-kick reservation is per instance", () => {

--- a/packages/runner/test/storage-instance-keying.test.ts
+++ b/packages/runner/test/storage-instance-keying.test.ts
@@ -888,3 +888,117 @@ describe("stage A: instance keying — unit pins", () => {
     expect(storageManager.shouldPullDoc(space, address.id, "user")).toBe(true);
   });
 });
+
+// The OFF-arm serialized-form witness the stage-A build report claimed
+// and the independent review found unpinned (finding 9): with the flag OFF
+// and no serving posture — every client today — no storage notification
+// change address, reactivity-log address, replica state, or replica
+// document carries a `scopeKey` own-property. Adopted from the review's
+// probe (`zz-review-off-notification-probe`).
+describe("stage A: OFF-arm serialized forms carry no scopeKey", () => {
+  let offManager: ReturnType<typeof StorageManager.emulate>;
+  let offRuntime: Runtime;
+
+  beforeEach(() => {
+    offManager = StorageManager.emulate({ as: signer });
+    offRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: offManager,
+      // OFF: no experimental flag, no serving posture.
+    });
+  });
+
+  afterEach(async () => {
+    await offRuntime.dispose();
+    await offManager.close();
+  });
+
+  const walk = (
+    value: unknown,
+    path: string,
+    hits: string[],
+    seen = new Set<unknown>(),
+    depth = 0,
+  ): void => {
+    if (
+      value === null || typeof value !== "object" || seen.has(value) ||
+      depth > 12
+    ) {
+      return;
+    }
+    seen.add(value);
+    if (Object.hasOwn(value as object, "scopeKey")) hits.push(path);
+    for (
+      const [key, child] of Object.entries(value as Record<string, unknown>)
+    ) {
+      if (key === "scopeKey") continue;
+      walk(child, `${path}.${key}`, hits, seen, depth + 1);
+    }
+  };
+
+  it("a scoped commit at OFF: zero scopeKey own-properties anywhere in the notifications, the reactivity log, the replica states, or the replica documents", async () => {
+    const hits: string[] = [];
+    let notifications = 0;
+    offManager.subscribe({
+      next: (notification: unknown) => {
+        notifications += 1;
+        const changes = (notification as { changes?: Iterable<unknown> })
+          .changes;
+        if (changes !== undefined) {
+          for (const change of changes) walk(change, "change", hits);
+        }
+        walk(
+          { ...(notification as object), changes: undefined },
+          "notification",
+          hits,
+        );
+        return { done: false };
+      },
+    } as never);
+    const userCell = offRuntime.getCell<{ value: string }>(
+      space,
+      "stagea-off-user",
+      undefined,
+      undefined,
+      "user",
+    );
+    const sessionCell = offRuntime.getCell<{ value: string }>(
+      space,
+      "stagea-off-session",
+      undefined,
+      undefined,
+      "session",
+    );
+    const spaceCell = offRuntime.getCell<{ value: string }>(
+      space,
+      "stagea-off-space",
+      undefined,
+    );
+    const tx = offRuntime.edit();
+    userCell.withTx(tx).set({ value: "u" });
+    sessionCell.withTx(tx).set({ value: "s" });
+    spaceCell.withTx(tx).set({ value: "sp" });
+    userCell.withTx(tx).get();
+    walk(txToReactivityLog(tx), "log", hits);
+    expect((await tx.commit()).error).toBeUndefined();
+    await offRuntime.idle();
+    await offManager.synced();
+    const replica = offManager.open(space).replica;
+    for (const cell of [userCell, sessionCell, spaceCell]) {
+      const link = cell.getAsNormalizedFullLink();
+      walk(
+        replica.get({
+          id: link.id,
+          type: "application/json",
+          path: [],
+          scope: link.scope,
+        } as never),
+        "state",
+        hits,
+      );
+      walk(replica.getDocument(link.id as never, link.scope), "doc", hits);
+    }
+    expect(notifications).toBeGreaterThan(0);
+    expect(hits).toEqual([]);
+  });
+});

--- a/packages/runner/test/storage-instance-keying.test.ts
+++ b/packages/runner/test/storage-instance-keying.test.ts
@@ -20,7 +20,10 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
-import { resolveScopeKey } from "@commonfabric/memory/v2";
+import {
+  resolveScopeKey,
+  type ScopeKeyIdentity,
+} from "@commonfabric/memory/v2";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime, type ServerRunInfo } from "../src/runtime.ts";
 import { stampWaveRunContext } from "../src/executor/wave.ts";
@@ -77,9 +80,11 @@ describe("stage A: instance keying — unit pins", () => {
       `${space}/user:x/of:stagea-doc`,
     );
     // The name-keyed twin (the writer/materializer index) ignores both.
-    expect(entityNameKey({ ...address, scopeKey: "user:x" })).toBe(
-      `${space}/user/of:stagea-doc`,
-    );
+    expect(
+      entityNameKey(
+        { ...address, scopeKey: "user:x" } as IMemorySpaceAddress,
+      ),
+    ).toBe(`${space}/user/of:stagea-doc`);
     expect(entityNameKey(address)).toBe(entityNameKey({ ...address }));
 
     // Compaction: two name-equal reads compact as before; two reads of
@@ -178,7 +183,7 @@ describe("stage A: instance keying — unit pins", () => {
     ownCell.withTx(ownTx).set({ value: "own" });
     expect((await ownTx.commit()).error).toBeUndefined();
     const docId = ownCell.getAsNormalizedFullLink().id;
-    const readAs = (identity: typeof alice | undefined) =>
+    const readAs = (identity: ScopeKeyIdentity | undefined) =>
       (replica.getDocument(docId, "user", identity)?.value as
         | { value?: string }
         | undefined)?.value;

--- a/packages/runner/test/storage-instance-keying.test.ts
+++ b/packages/runner/test/storage-instance-keying.test.ts
@@ -334,6 +334,96 @@ describe("stage A: instance keying — unit pins", () => {
     ).toBe(1);
   });
 
+  it("the writer index is instance-AGNOSTIC: a user-scoped-DECLARED writer and a reader running as Alice keep their dependent edge (mutation: an instance-keyed writer index loses it)", async () => {
+    const rootId = "of:stagea-edge-root";
+    runtime.installSealDestination(
+      { seal: (tx: IExtendedStorageTransaction) => tx.tx.commit() },
+      {
+        runStamper: (
+          tx: IExtendedStorageTransaction,
+          info: ServerRunInfo,
+        ) => {
+          stampWaveRunContext(tx, {
+            actionId: info.actionId,
+            kind: info.kind,
+            ...(info.scopeKeyIdentity !== undefined
+              ? { scopeKeyIdentity: info.scopeKeyIdentity }
+              : {}),
+            ...(info.actionScopeKey !== undefined
+              ? { actionScopeKey: info.actionScopeKey }
+              : {}),
+          });
+        },
+        runInstanceResolver: (pieceRootIds) =>
+          pieceRootIds.includes(rootId)
+            ? [{
+              scopeKeyIdentity: alice,
+              actionScopeKey: resolveScopeKey("user", alice),
+            }]
+            : [],
+      },
+    );
+    const shared = runtime.getCell<{ value: number }>(
+      space,
+      "stagea-edge-doc",
+      undefined,
+      undefined,
+      "user",
+    );
+    const sharedLink = shared.getAsNormalizedFullLink();
+    // The WRITER: a node whose DECLARED surface is the doc at USER scope
+    // (scope NAME — a declared surface never names an instance; one node
+    // writes every instance of it, C11b).
+    const writer = Object.assign((_tx: IExtendedStorageTransaction) => {}, {
+      schedulerObservationIdentity: { pieceId: "space:writer" },
+    });
+    runtime.scheduler.subscribe(writer, {
+      reads: [],
+      shallowReads: [],
+      writes: [{
+        space,
+        id: sharedLink.id,
+        scope: "user",
+        path: [],
+      }],
+    });
+    // The READER: runs AS ALICE (the demanded instance), so its logged
+    // read of the doc names `user:<alice>` — not the runtime's own
+    // instance the writer's surface resolves to at cardinality 1.
+    const reader = Object.assign(
+      (tx: IExtendedStorageTransaction) => {
+        shared.withTx(tx).get();
+      },
+      {
+        schedulerObservationIdentity: {
+          pieceId: `space:${rootId}`,
+          pieceRootId: rootId,
+        },
+      },
+    );
+    await runtime.scheduler.run(reader);
+    await runtime.idle();
+    const snapshot = runtime.scheduler.getGraphSnapshot();
+    const writerId = snapshot.nodes.find((node) =>
+      node.writes?.some((write) => write.includes(sharedLink.id))
+    )?.id;
+    const readerId = snapshot.nodes.find((node) =>
+      node.reads?.some((read) =>
+        read.includes(sharedLink.id) &&
+        read.includes(resolveScopeKey("user", alice))
+      )
+    )?.id;
+    expect(writerId).toBeDefined();
+    expect(readerId).toBeDefined();
+    // THE EDGE: writer → reader survives although the reader's read
+    // names Alice's instance and the writer's surface names the scope.
+    expect(
+      snapshot.edges.some((edge) =>
+        edge.from === writerId && edge.to === readerId
+      ),
+    ).toBe(true);
+  });
+
   it("two instance-named loads of one doc are two watches, and the pull-kick reservation is per instance", () => {
     const address = {
       id: "of:stagea-watch" as never,

--- a/packages/runner/test/storage-instance-keying.test.ts
+++ b/packages/runner/test/storage-instance-keying.test.ts
@@ -1,0 +1,366 @@
+// Server-execution v2 fan-out stage A — OW17's instance-keyed replica and
+// wire, the UNIT-level pins the E2E suite (executor-instance-keyed-
+// replica.test.ts) rides on:
+//
+// - OFF-arm neutrality per re-keyed site: with no explicit instance
+//   anywhere — every client, the whole OFF arm — the dependency key,
+//   the compaction, the reactivity log, the notification addresses, and
+//   the replica reads are byte-identical to the scope-NAME keying (the
+//   `scopeKey` field is ABSENT, never `undefined`-valued);
+// - the replica holds two instances of one doc: a seal under one
+//   principal's identity leaves the other principal's — and the
+//   replica's own — local doc untouched, and each identity reads its own;
+// - the N-run loop resubscribes ONCE to the UNION of the instance logs:
+//   after two instance runs, BOTH instances' reads are registered
+//   (mutation: per-run resubscribe → only the last instance's read
+//   survives);
+// - two instance-named loads of one doc are two watches (distinct watch
+//   ids), and the pull-kick reservation is per instance.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { resolveScopeKey } from "@commonfabric/memory/v2";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime, type ServerRunInfo } from "../src/runtime.ts";
+import { stampWaveRunContext } from "../src/executor/wave.ts";
+import { entityKey, entityNameKey } from "../src/scheduler/keys.ts";
+import { sortAndCompactPaths } from "../src/reactive-dependencies.ts";
+import { watchIdForEntry } from "../src/storage/v2-watch.ts";
+import type {
+  IExtendedStorageTransaction,
+  IMemorySpaceAddress,
+  MemorySpace,
+  TransactionSealDestination,
+} from "../src/storage/interface.ts";
+import { txToReactivityLog } from "../src/scheduler/reactivity.ts";
+
+const signer = await Identity.fromPassphrase("stage A instance keying");
+const space = signer.did() as MemorySpace;
+const alice = { principal: "did:key:z6Mk-stagea-alice", sessionId: "a-s1" };
+const bob = { principal: "did:key:z6Mk-stagea-bob", sessionId: "b-s1" };
+
+describe("stage A: instance keying — unit pins", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      servingPosture: true,
+      experimental: { serverExecution: true },
+    });
+  });
+
+  afterEach(async () => {
+    runtime.clearSealDestination();
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  it("OFF-arm neutrality: keys, compaction, and logged addresses without an explicit instance are byte-identical to the scope-NAME keying; an explicit instance is preferred where present", () => {
+    const own = runtime.scopeKeyIdentity;
+    const address: IMemorySpaceAddress = {
+      space,
+      id: "of:stagea-doc" as never,
+      scope: "user",
+      path: ["a"],
+    };
+    // Without `scopeKey`: exactly the pre-stage-A string.
+    expect(entityKey(address, own)).toBe(
+      `${space}/${resolveScopeKey("user", own)}/of:stagea-doc`,
+    );
+    // With one: the instance, the identity not consulted.
+    expect(entityKey({ ...address, scopeKey: "user:x" }, own)).toBe(
+      `${space}/user:x/of:stagea-doc`,
+    );
+    // The name-keyed twin (the writer/materializer index) ignores both.
+    expect(entityNameKey({ ...address, scopeKey: "user:x" })).toBe(
+      `${space}/user/of:stagea-doc`,
+    );
+    expect(entityNameKey(address)).toBe(entityNameKey({ ...address }));
+
+    // Compaction: two name-equal reads compact as before; two reads of
+    // DIFFERENT instances stay apart (the union of an N-run loop's logs).
+    const compacted = sortAndCompactPaths([
+      { ...address, path: ["a"] },
+      { ...address, path: ["a", "b"] },
+    ]);
+    expect(compacted.length).toBe(1);
+    expect(Object.hasOwn(compacted[0], "scopeKey")).toBe(false);
+    const twoInstances = sortAndCompactPaths([
+      { ...address, scopeKey: resolveScopeKey("user", alice) },
+      { ...address, scopeKey: resolveScopeKey("user", bob) },
+    ]);
+    expect(twoInstances.length).toBe(2);
+    expect(
+      twoInstances.map((read) => read.scopeKey).toSorted(),
+    ).toEqual(
+      [resolveScopeKey("user", alice), resolveScopeKey("user", bob)]
+        .toSorted(),
+    );
+  });
+
+  it("OFF-arm neutrality: a transaction with no run identity logs addresses without any `scopeKey` property; a stamped run's SCOPED reads carry its instance and its space reads do not", () => {
+    const cell = runtime.getCell<{ value: number }>(
+      space,
+      "stagea-log-scoped",
+      undefined,
+      undefined,
+      "user",
+    );
+    const spaceCell = runtime.getCell<{ value: number }>(
+      space,
+      "stagea-log-space",
+      undefined,
+    );
+    // Unstamped (every client, the OFF arm).
+    const plain = runtime.edit();
+    cell.withTx(plain).get();
+    spaceCell.withTx(plain).get();
+    const plainLog = txToReactivityLog(plain);
+    expect(plainLog.reads.length).toBeGreaterThan(0);
+    for (const read of plainLog.reads) {
+      expect(Object.hasOwn(read, "scopeKey")).toBe(false);
+    }
+    expect(plain.tx.scopeKeyIdentity).toBeUndefined();
+    plain.abort();
+
+    // Stamped as Alice (a served per-instance run).
+    const stamped = runtime.edit();
+    stampWaveRunContext(stamped, {
+      actionId: "stagea-log",
+      kind: "derivation",
+      scopeKeyIdentity: alice,
+      actionScopeKey: resolveScopeKey("user", alice),
+    });
+    expect(stamped.tx.scopeKeyIdentity).toEqual(alice);
+    cell.withTx(stamped).get();
+    spaceCell.withTx(stamped).get();
+    const stampedLog = txToReactivityLog(stamped);
+    const scopedReads = stampedLog.reads.filter((read) =>
+      read.scope === "user"
+    );
+    const spaceReads = stampedLog.reads.filter((read) =>
+      (read.scope ?? "space") === "space"
+    );
+    expect(scopedReads.length).toBeGreaterThan(0);
+    for (const read of scopedReads) {
+      expect(read.scopeKey).toBe(resolveScopeKey("user", alice));
+    }
+    expect(spaceReads.length).toBeGreaterThan(0);
+    for (const read of spaceReads) {
+      expect(Object.hasOwn(read, "scopeKey")).toBe(false);
+    }
+    // One identity per transaction: a DIFFERENT identity is refused.
+    expect(() => {
+      stamped.tx.scopeKeyIdentity = bob;
+    }).toThrow(/one transaction serves one identity/);
+    // The same identity again is idempotent.
+    stamped.tx.scopeKeyIdentity = { ...alice };
+    stamped.abort();
+  });
+
+  it("the replica holds two instances of one doc: a seal as Alice leaves Bob's and the replica's own local doc untouched, and each identity reads its own (the R7 read shape at the replica level)", async () => {
+    const replica = storageManager.open(space).replica;
+    // Own-identity write (the OFF path): lands in the replica's own
+    // instance only.
+    const ownCell = runtime.getCell<{ value: string }>(
+      space,
+      "stagea-two-instances-cell",
+      undefined,
+      undefined,
+      "user",
+    );
+    const ownTx = runtime.edit();
+    ownCell.withTx(ownTx).set({ value: "own" });
+    expect((await ownTx.commit()).error).toBeUndefined();
+    const docId = ownCell.getAsNormalizedFullLink().id;
+    const readAs = (identity: typeof alice | undefined) =>
+      (replica.getDocument(docId, "user", identity)?.value as
+        | { value?: string }
+        | undefined)?.value;
+    expect(readAs(undefined)).toBe("own");
+    expect(readAs(runtime.scopeKeyIdentity)).toBe("own");
+    expect(readAs(alice)).toBeUndefined();
+    expect(readAs(bob)).toBeUndefined();
+
+    // A seal under Alice's identity through the wave stamp: the pending
+    // layer lands on ALICE's instance and nowhere else.
+    const seals: IExtendedStorageTransaction[] = [];
+    const destination: TransactionSealDestination = {
+      seal: (tx) => {
+        seals.push(tx);
+        return tx.tx.commit();
+      },
+    };
+    runtime.installSealDestination(destination, {
+      runStamper: (tx: IExtendedStorageTransaction, info: ServerRunInfo) => {
+        stampWaveRunContext(tx, {
+          actionId: info.actionId,
+          kind: info.kind,
+          scopeKeyIdentity: alice,
+          actionScopeKey: resolveScopeKey("user", alice),
+        });
+      },
+    });
+    // Drive the write through the replica's own sealNative with the
+    // identity option — the exact seam the wave uses.
+    const aliceTx = runtime.edit();
+    stampWaveRunContext(aliceTx, {
+      actionId: "stagea-seal-alice",
+      kind: "derivation",
+      scopeKeyIdentity: alice,
+      actionScopeKey: resolveScopeKey("user", alice),
+    });
+    const { promise, resolve } = Promise.withResolvers<
+      { committed: { seq: number } }
+    >();
+    const sealed = replica.sealNative!(
+      {
+        operations: [{
+          op: "set",
+          id: docId,
+          type: "application/json",
+          scope: "user",
+          value: { value: { value: "alice-pending" } } as never,
+        }],
+        preconditions: [],
+      } as never,
+      aliceTx.tx,
+      promise,
+      { identity: alice },
+    );
+    expect(sealed.localSeq).toBeGreaterThan(0);
+    // Visible through Alice's instance, invisible to Bob and to the
+    // replica's own instance.
+    expect(readAs(alice)).toBe("alice-pending");
+    expect(readAs(bob)).toBeUndefined();
+    expect(readAs(undefined)).toBe("own");
+    // The verdict confirms exactly Alice's layer (F1a: sealed commits
+    // confirm at verdict), still keyed apart from the replica's own.
+    resolve({ committed: { seq: 999 } } as never);
+    await sealed.settled;
+    expect(readAs(alice)).toBe("alice-pending");
+    expect(readAs(undefined)).toBe("own");
+    expect(readAs(bob)).toBeUndefined();
+    aliceTx.abort();
+    runtime.clearSealDestination();
+  });
+
+  it("the N-run loop resubscribes ONCE to the union of its instance logs: after two instance runs both instances' reads are registered (mutation: per-run replacement keeps only the last)", async () => {
+    const rootId = "of:stagea-union-root";
+    runtime.installSealDestination(
+      { seal: (tx: IExtendedStorageTransaction) => tx.tx.commit() },
+      {
+        runStamper: (
+          tx: IExtendedStorageTransaction,
+          info: ServerRunInfo,
+        ) => {
+          stampWaveRunContext(tx, {
+            actionId: info.actionId,
+            kind: info.kind,
+            ...(info.scopeKeyIdentity !== undefined
+              ? { scopeKeyIdentity: info.scopeKeyIdentity }
+              : {}),
+            ...(info.actionScopeKey !== undefined
+              ? { actionScopeKey: info.actionScopeKey }
+              : {}),
+          });
+        },
+        runInstanceResolver: (pieceRootIds) =>
+          pieceRootIds.includes(rootId)
+            ? [
+              {
+                scopeKeyIdentity: alice,
+                actionScopeKey: resolveScopeKey("user", alice),
+              },
+              {
+                scopeKeyIdentity: bob,
+                actionScopeKey: resolveScopeKey("user", bob),
+              },
+            ]
+            : [],
+      },
+    );
+    const scoped = runtime.getCell<{ value: number }>(
+      space,
+      "stagea-union-input",
+      undefined,
+      undefined,
+      "user",
+    );
+    const action = Object.assign(
+      (tx: IExtendedStorageTransaction) => {
+        // Each instance run reads ITS instance of the scoped input.
+        scoped.withTx(tx).get();
+      },
+      {
+        schedulerObservationIdentity: {
+          pieceId: `space:${rootId}`,
+          pieceRootId: rootId,
+        },
+      },
+    );
+    await runtime.scheduler.run(action);
+    await runtime.idle();
+
+    const inputId = scoped.getAsNormalizedFullLink().id;
+    const snapshot = runtime.scheduler.getGraphSnapshot();
+    const node = snapshot.nodes.find((candidate) =>
+      candidate.reads?.some((read) => read.includes(inputId))
+    );
+    expect(node).toBeDefined();
+    const inputReads = node!.reads!.filter((read) => read.includes(inputId));
+    // BOTH instances registered — the union.
+    expect(
+      inputReads.some((read) => read.includes(resolveScopeKey("user", alice))),
+    ).toBe(true);
+    expect(
+      inputReads.some((read) => read.includes(resolveScopeKey("user", bob))),
+    ).toBe(true);
+    // And the graph stays SINGULAR: one node for the action (C11b).
+    expect(
+      snapshot.nodes.filter((candidate) =>
+        candidate.reads?.some((read) => read.includes(inputId))
+      ).length,
+    ).toBe(1);
+  });
+
+  it("two instance-named loads of one doc are two watches, and the pull-kick reservation is per instance", () => {
+    const address = {
+      id: "of:stagea-watch" as never,
+      type: "application/json" as const,
+      scope: "user" as const,
+    };
+    const selector = { path: [], schema: false as const };
+    const plain = watchIdForEntry(address, selector, "");
+    const asAlice = watchIdForEntry(
+      { ...address, scopeKey: resolveScopeKey("user", alice) },
+      selector,
+      "",
+    );
+    const asBob = watchIdForEntry(
+      { ...address, scopeKey: resolveScopeKey("user", bob) },
+      selector,
+      "",
+    );
+    expect(asAlice).not.toBe(asBob);
+    expect(asAlice).not.toBe(plain);
+    // An unnamed entry's id is independent of the field's existence.
+    expect(watchIdForEntry({ ...address, scopeKey: undefined }, selector, ""))
+      .toBe(plain);
+
+    // The manager reserves one kick per (space, instance, id).
+    expect(storageManager.shouldPullDoc(space, address.id, "user", alice))
+      .toBe(true);
+    expect(storageManager.shouldPullDoc(space, address.id, "user", alice))
+      .toBe(false);
+    expect(storageManager.shouldPullDoc(space, address.id, "user", bob))
+      .toBe(true);
+    // The own-identity reservation is a distinct key from either.
+    expect(storageManager.shouldPullDoc(space, address.id, "user")).toBe(true);
+  });
+});

--- a/packages/runner/test/storage-instance-keying.test.ts
+++ b/packages/runner/test/storage-instance-keying.test.ts
@@ -820,7 +820,9 @@ describe("stage A: instance keying — unit pins", () => {
     const readSeed = (tx: IExtendedStorageTransaction) =>
       tx.readValueOrThrow({ ...seedLink, path: [] });
 
-    // Alice's run serializes the cell: her instance is seeded.
+    // Alice's run: her instance is already PRESENT (she wrote it), so the
+    // serialization's presence check finds it and MEMOIZES — under HER
+    // instance key (the memo records presence, never a seed it wrote).
     const aliceTx = runtime.edit();
     stampWaveRunContext(aliceTx, {
       actionId: "stagea-seed-alice",
@@ -828,14 +830,16 @@ describe("stage A: instance keying — unit pins", () => {
       scopeKeyIdentity: alice,
       actionScopeKey: resolveScopeKey("user", alice),
     });
+    seedCell.withTx(aliceTx).set("alice-wrote-this");
     holder.withTx(aliceTx).set({ slot: seedCell });
-    expect(readSeed(aliceTx)).toBe("hello");
+    expect(readSeed(aliceTx)).toBe("alice-wrote-this");
 
     // Bob's run serializes the same cell: HIS instance is absent, so it
-    // must be seeded too. Pre-fix the memo keyed under the runtime's own
-    // identity for every run — Alice's presence check had already
-    // memoized the doc, Bob's check was skipped, and his default never
-    // landed (the panel's Lens 2d hazard).
+    // must be seeded. Pre-fix the memo keyed under the runtime's own
+    // identity for every run — Alice's presence check had memoized the
+    // doc under that one key, Bob's check was skipped, and his default
+    // never landed (the panel's Lens 2d hazard: one user's presence
+    // suppressing another's seed).
     const bobTx = runtime.edit();
     stampWaveRunContext(bobTx, {
       actionId: "stagea-seed-bob",

--- a/packages/runner/test/storage-instance-keying.test.ts
+++ b/packages/runner/test/storage-instance-keying.test.ts
@@ -255,6 +255,107 @@ describe("stage A: instance keying — unit pins", () => {
     runtime.clearSealDestination();
   });
 
+  it("keyed retraction (finding 1's replica half): a KEYED remove of a keyed-delivered foreign instance drops exactly that instance and the replica's OWN instance survives — and an UNKEYED remove names the own instance, which is why the server may never send one for a keyed delivery", async () => {
+    // The serving replica's stage-A steady state: its OWN instance of a
+    // user-scoped doc (from its own commit) plus Alice's instance (from
+    // a KEYED lease-holder frame). Then the memory server retracts
+    // Alice's entry — a former holder's catch-up (protocol.md §3's
+    // filter once the lease lapsed). The wire invariant the memory server
+    // now keeps (`v2-explicit-read.test.ts` "finding 1 (wire half)"): a
+    // keyed delivery is retracted KEYED. This is the replica's side of
+    // that contract — a keyed remove resolves to the named instance, an
+    // unkeyed one to the own instance — so both halves together are what
+    // keeps the own doc intact.
+    const replica = storageManager.open(space).replica as unknown as {
+      getDocument: (
+        id: string,
+        scope?: string,
+        identity?: ScopeKeyIdentity,
+      ) => { value?: unknown } | undefined;
+      applySessionSync: (sync: unknown, type: "pull" | "integrate") => void;
+    };
+    const ownCell = runtime.getCell<{ value: string }>(
+      space,
+      "stagea-keyed-retraction-cell",
+      undefined,
+      undefined,
+      "user",
+    );
+    const ownTx = runtime.edit();
+    ownCell.withTx(ownTx).set({ value: "own" });
+    expect((await ownTx.commit()).error).toBeUndefined();
+    const docId = ownCell.getAsNormalizedFullLink().id;
+    const aliceKey = resolveScopeKey("user", alice);
+    const readAs = (identity: ScopeKeyIdentity | undefined) =>
+      (replica.getDocument(docId, "user", identity)?.value as
+        | { value?: string }
+        | undefined)?.value;
+    expect(readAs(undefined)).toBe("own");
+
+    // A KEYED lease-holder frame delivers Alice's instance.
+    replica.applySessionSync({
+      type: "sync",
+      fromSeq: 0,
+      toSeq: 5,
+      upserts: [{
+        branch: "",
+        id: docId,
+        scope: "user",
+        scopeKey: aliceKey,
+        seq: 5,
+        doc: { value: { value: "alice" } },
+      }],
+      removes: [],
+    }, "integrate");
+    expect(readAs(alice)).toBe("alice");
+    expect(readAs(undefined)).toBe("own");
+
+    // The KEYED retraction: exactly Alice's instance goes; the own
+    // instance is untouched. (Mutation: `applySessionSync` ignoring
+    // `remove.scopeKey` wipes the own instance and keeps Alice's stale
+    // one — the exact inverse.)
+    replica.applySessionSync({
+      type: "sync",
+      fromSeq: 5,
+      toSeq: 6,
+      upserts: [],
+      removes: [{ branch: "", id: docId, scope: "user", scopeKey: aliceKey }],
+    }, "integrate");
+    expect(readAs(alice)).toBeUndefined();
+    expect(readAs(undefined)).toBe("own");
+
+    // Re-delivered keyed (the re-arm after a survived blip), then an
+    // UNKEYED remove: that names the OWN instance — the client cannot
+    // tell it apart from a legitimate retraction of its own watch, which
+    // is exactly why the memory server keys every retraction on a keyed
+    // wire (the pre-fix former-holder catch-up sent this frame for
+    // ALICE's entry and wiped the own doc: `own: undefined, alice: alice`).
+    replica.applySessionSync({
+      type: "sync",
+      fromSeq: 6,
+      toSeq: 7,
+      upserts: [{
+        branch: "",
+        id: docId,
+        scope: "user",
+        scopeKey: aliceKey,
+        seq: 7,
+        doc: { value: { value: "alice-2" } },
+      }],
+      removes: [],
+    }, "integrate");
+    expect(readAs(alice)).toBe("alice-2");
+    replica.applySessionSync({
+      type: "sync",
+      fromSeq: 7,
+      toSeq: 8,
+      upserts: [],
+      removes: [{ branch: "", id: docId, scope: "user" }],
+    }, "integrate");
+    expect(readAs(undefined)).toBeUndefined();
+    expect(readAs(alice)).toBe("alice-2");
+  });
+
   it("the N-run loop resubscribes ONCE to the union of its instance logs: after two instance runs both instances' reads are registered (mutation: per-run replacement keeps only the last)", async () => {
     const rootId = "of:stagea-union-root";
     runtime.installSealDestination(

--- a/tasks/server-execution-on-skips.ts
+++ b/tasks/server-execution-on-skips.ts
@@ -182,7 +182,20 @@ export const SERVER_EXECUTION_ON_SKIPS: Record<
     {
       file: "integration/cfc-group-chat-demo-two-browsers.test.ts",
       phase: "phase-7",
-      reason: TWO_BROWSER_NON_SETTLING_REASON,
+      reason: TWO_BROWSER_NON_SETTLING_REASON +
+        " Fan-out stage A (2026-08-16/17): the client arrival gate treated " +
+        "OW32's symptom (both browsers boot < 3 s, zero non-settling, " +
+        "'Alice save + own status' PASSES — the R7 wall is closed), and " +
+        "this gate's NEXT wall is verification-coverage.md OW34: a " +
+        "CFC-serving POLICY item, UNMASKED by stage A and not caused by " +
+        "it — the served save handler's write to the shared owner-" +
+        "protected `profiles` cell is refused at prepare (`missing " +
+        "trusted-event policy input`), because a per-user served handler " +
+        "run carries no renderer-trusted event mark for its UI-contract " +
+        "write; owning layer: stage B's attribution work or a CFC " +
+        "policy-input rule for actor-stamped served entries (its own spec " +
+        "sentence first). Lifts when OW32's triage AND OW34 land and the " +
+        "gate greens 5/5 fresh-store under the full ON posture.",
     },
     {
       file: "integration/lunch-poll-vote.test.ts",


### PR DESCRIPTION
## Why

The arc's central goal — ALL reactive computation server-side — is unmet: a space-scoped derivation that narrows to a user must run for every user who demands it, and today it cannot even be *correct* at cardinality ≥ 2. The fan-out design (owner-ruled 2026-08-16, panel-amended) names two gaps in dependency order: the demand registry drops WHO demands a space root (stage B), and — the hard prerequisite — the serving replica and the wire are keyed by scope NAME, so any fanned runs read each other's data (OW17: one local doc per (id, scope); frames that cannot carry two instances; the scheduler keying against the runtime identity; "last instance run wins" on resubscribe; over-keyed basis rows). This is stage A: **the serving replica and the wire become INSTANCE-keyed**, so one replica holds the service instance AND per-principal instances of a doc, a per-instance run reads and writes THROUGH ITS INSTANCE, and the R7 wall (a served save handler reading the service instance's empty draft) closes. Panel amendments folded in: instance keys carry the FULL (scope-kind, principal) address because narrowing below the space→user hop is RAGGED per principal (scopes.md §2 amended, RULED 2026-08-16); the A3 seed-memo site is in the audit; and the client ARRIVAL GATE (the OW32 triage's measured prototype) lands early as its own commit — it treats the symptom (a never-served instance flips to nothing); stage B fixes the cause.

## What changed

- **Replica** (`packages/runner/src/storage/v2.ts`): `docKey(id, instance)` at the 16 sites via one resolver (explicit key → run identity → own, memoized; unresolvable → name); seals/verdicts/frames/notifications thread the instance; `getDocument(id, scope, identity?)`, `sealNative(…, {identity})`.
- **Wire** (`packages/memory`): `SessionSyncUpsert/Remove.scopeKey`, `EntitySnapshot.scopeKey` — lease-holder frames only; the collapse guard scoped to non-holders; `WatchView` keys by instance.
- **tx→replica seam**: `IStorageTransaction.scopeKeyIdentity` (set once by the wave stamp), `IMemoryAddress.scopeKey` on logged/loaded/notified addresses (absent everywhere off the serving path); the commit-time claim re-reads the same instance; the runner's explicit-instance loads (`Cell.sync`, `syncCell`/`syncInstance`, the transaction-layer kick, `ensureLinkedDocLoaded`, the served event's presync/preflight as the actor).
- **Scheduler**: per-instance dependency/trigger keys; NAME-keyed writer/materializer indexes (the deliberate fan-in; O(N) recorded); the N-run loop resubscribes once to the union.
- **Wave S4**: basis rows keyed by the run's full instance address; stranded stamp/broader-chain keys cleared both directions.
- **Audit**: the seed memo keys under the run identity; piece registry / shaper buckets deliberately keep the runtime identity (per piece); effect completions seal under the carriage identity (reads flagged).
- **Arrival gate** (own commit): `#sweep` requires arrival; riders supersede-by-newer + own-retirement-is-not-a-trigger; speculation.md §4 amended.
- **Specs/register**: key-vocabulary §3b/§5, scopes §2, protocol §2/§3, serving-loop S4, speculation §4; OW17 IN PROGRESS (leg 1), OW32 triaged/symptom treated (open), NEW OW34, the stage-A delta.

## Test plan

Red-first at the P7 head (via the detached `fanout-panel` worktree): `executor-instance-keyed-replica.test.ts` 4/4 red → green (two demanded runs read their OWN per-user inputs → divergent per-instance rows; **R7**; instance-aware resubscribe; S4 ragged); memory `v2-explicit-read.test.ts` two-instances red → green. Unit pins `storage-instance-keying.test.ts` (OFF neutrality per site, the two-instance replica, the union, per-instance watches/kicks, the writer-index edge — mutation-verified) and `speculation-arrival-gate.test.ts` (OW32 shape with the gate mutation; arrival; own-retirement mechanism with its mutation; supersede-by-newer scripted).

| Gate | Result |
|---|---|
| full runner (4 chunks) | 1202/0 |
| memory | 517/0 |
| toolshed 142 · runtime-client 61 · piece 37 · spec-model 23 · shell 59 · bg-piece-service 14 | green |
| tasks validators | 549 passed, 2 failed — both red at the P7 head too (stale profile lists) |
| check.sh / check-docs / fmt / lint | exit 0 / 548 / clean / one pre-existing lint (wave.ts) |
| soaks | serving-loop 10/10; effect-channel, space-server, run-supply, events-down, instance-keyed-replica 5/5; wedge+queue suites 2/2 |
| sx2 family (fresh store) | ON 5/5 · OFF 5/5 |
| runner integration | ON 13/13 (+1 skip) · OFF 14/14 |
| runtime-client integration | ON 43 steps (+2 ignored, OW33) · OFF 45 |
| shell integration | OFF 8/8 · ON `piece.test.ts` hangs — reproduced at the P7 head (pre-existing) |
| two-browsers gate | OFF green 3.5 s · ON 0/2 (still skip-listed): boot < 2 s, **"Alice save + own status" passes (R7 closed)**, ZERO non-settling, stalls at "Bob sees Alice": served handler's UI-contract write refused by CFC (`missing trusted-event policy input`) → OW34 |
| lunch gate ON | 0/2 (still skip-listed): boot fast, zero non-settling, stalls at "both join lands" — the served `#profile` wish identity-less (OW29, stage B) |

## Audited site list (final)

`data-updating.ts:850/860` seedMemoKey → RUN identity · `runner.ts:3882 getDocKey` (piece registry) → runtime, deliberate · `runner.ts:3960/6195` shaper pieceId buckets → runtime, deliberate · `runner.ts:5815` → per run (already) · `schema.ts` traversal identity → run + tx fallback · `scheduler/facade.ts` thunks (271/349/1684/1689/1708/1937/2126/2298) → `entityKey` prefers the address instance · `facade.ts:902` event shaping → own · `space-server.ts:955` wave-level fallback · `space-server.ts:1213` effect completion → local layer under the carriage identity (writeback reads FLAGGED).

## Flags

OW34 (served handler runs lack the renderer-trusted event mark for UI-contract-gated writes — unmasked by stage A); effect-completion writeback reads under own identity; handler-only writes to a never-written PerUser slot land at the base scope (pre-existing at OFF); the two P2-F basis-key pins moved to the S4 truth; the fallback run's `user:<serviceDID>` garbage instance (B5, stage B); the two red validators + the shell ON hang are pre-existing at the P7 head; the own-retirement rider's E2E loop did not reproduce (mechanism pinned).

Reports: `/Users/berni/labs-worktrees/fanout-a-build-report.md`, `/Users/berni/labs-worktrees/fanout-a-review-report.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

