### PR TITLE
fix(patterns): make the standalone pattern type-check trustworthy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,10 +213,19 @@ consider the information in `docs/development/COVERAGE.md`.
 ### Automated gates
 
 `deno task check` type-checks a hand-maintained list of paths in
-`tasks/check.sh`. Several workspace packages are absent from that list — `fuse`,
-`lib-shell`, `schema-generator`, `data-model` and `state-inspector` among them —
-so a green `deno task check` is not evidence that the tree type-checks. Run
-`deno task test` in every package you touched.
+`tasks/check.sh`, which now names every workspace package. Most are covered in
+full; a few are partial by design. The `*.input.ts` transformer fixtures under
+`schema-generator` and `ts-transformers` name ambient wrappers the transformer
+supplies, so they do not compile on their own and are left out. `ui` is checked
+only for its `v2` components, and not the outliner among them.
+
+Patterns are the exception `deno task check` does not own. It lists some pattern
+directories and checks them through the automatic-JSX environment the rest of
+the tree uses, but patterns compile under a different (classic-`h`) JSX runtime,
+and the two disagree on some advanced pattern types. `deno task cfcheck` (the
+"CFC Pattern Check" CI job) type-checks every pattern in the JSX and
+runtime-type environment they actually compile under, and is the authoritative
+pattern type-check. Run `deno task test` in every package you touched.
 
 Each of these gates fails CI on its own, and none of them run as part of
 `deno task check`:

--- a/docs/history/INDEX.md
+++ b/docs/history/INDEX.md
@@ -5,6 +5,7 @@ One line per archived document; [`README.md`](README.md) has the rules for this 
 ## Audits and reports
 
 - [2026-08-14-uncovered-code-inventory.md](packages/patterns/2026-08-14-uncovered-code-inventory.md) — where the 232,303 uncovered lines in `packages/patterns` were, what a round of ten pattern tests reached, the patterns that turned out not to build, and what was left, August 2026.
+- [pattern-typecheck-standalone-2026-08-14.md](development/pattern-typecheck-standalone-2026-08-14.md) — why a plain `deno check` over the pattern corpus diverges from the classic-JSX environment patterns compile under, which of the twenty divergences were real defects versus lens artifacts, and the `deno task check` package-coverage gap closed alongside, August 2026.
 - [verbs-arc-independent-review-2026-08-14.md](verbs-arc-independent-review-2026-08-14.md) — independent full-codebase review of the landed verbs implementation arc at `5ca4c1296`, with a reconciliation against the PR #5765 review, August 2026.
 - [cf-view-parser-adapter-spike-2026-08.md](packages/cli/cf-view-parser-adapter-spike-2026-08.md) — Python, Go, shell, and HTML parser-adapter measurements, August 2026.
 - [cf-view-parser-adapter-spike-2026-08-methodology.md](packages/cli/cf-view-parser-adapter-spike-2026-08-methodology.md) — retained fixtures and procedure for the parser-adapter measurements, August 2026.

--- a/docs/history/development/pattern-typecheck-standalone-2026-08-14.md
+++ b/docs/history/development/pattern-typecheck-standalone-2026-08-14.md
@@ -48,16 +48,22 @@ it is `JSX.Element`, which is the broader `JSXElement` union. And the classic-JS
 demo's sub-patterns declared their reserved `[UI]` output as `unknown`. When a
 pattern result is placed in JSX, the runtime renders it through `[UI]`, so under
 automatic JSX the type system treats it as `UIRenderable`, whose `[UI]` must be a
-`VNode`; `unknown` is not one. The type is under-specified — at runtime the value
-is always a `VNode` — and classic JSX accepts it, so the pattern compiles and the
-update gate passes on it as written. Tightening it is not free: the schema
-generator derives a pattern's result schema from these types, and typing the
-trusted disclosure surface's `[UI]` as `VNode` shifts the information-flow label
-the schema records for a sibling capability field (`revealSensitive`), which the
-pattern-update compatibility gate rejects as a backward-incompatible change to a
-recorded contract. The demo is left as written. The lesson is that a reserved
-output type feeds the deployed schema, so an `[UI]: unknown` a standalone check
-flags cannot always be tightened without breaking the pattern's update contract.
+`VNode`; `unknown` is not one. `VNode` is the correct type — at runtime the value
+is always a `VNode`, the generated `$UI` schema becomes a proper vnode reference,
+and nothing about how the pattern runs changes. It is nonetheless left as
+`unknown` for now, blocked not by anything wrong with the type but by the
+pattern-update compatibility gate. The demo's module defines the handler that
+authorizes a trusted write (`revealSensitive`); the result schema records that
+authorization as the module's content-addressed identity
+(`ifc.writeAuthorizedBy.__ctWriterIdentityOf.moduleIdentity`), and the gate
+compares the whole `ifc` for exact equality. Any edit to the module — this type
+annotation, a comment, whitespace — rehashes it, so the identity changes and the
+gate reads a recompile as a narrowed contract. A comment-only edit reproduces the
+same "result.revealSensitive: ifc changed" failure, and a schema diff confirms
+`moduleIdentity` is the only field that moves. Making the gate absorb a
+recompile-only identity change is a separate piece of work; once it lands the
+demo (and the nine other patterns carrying a CFC write) can take their correct
+types. Until then the demo keeps `unknown`.
 
 **Bare pattern factory as a JSX child (12 errors, cfc-trusted-component-
 examples).** The galleries embedded each sub-gallery as `<div>{SendPublishExamples}
@@ -96,10 +102,11 @@ reads the authored source in the JSX and library environment the patterns
 compile under. A `deno check` over pattern source is a second, mismatched lens.
 It is worth keeping — it caught the bare-factory defect above that the compile
 environment's looser JSX typing missed — but its extra errors are not all real.
-The writable-scoped-inputs case is a false positive on correct code, and the
-`[UI]: unknown` case is an under-specification that cannot be tightened without
-breaking the pattern's update contract. Where the standalone lens disagrees with
-the compile environment on such a type, `cfcheck` and the update gate win.
+The writable-scoped-inputs case is a false positive on correct code. The
+`[UI]: unknown` case is a genuine under-specification the correct type would fix,
+held back only by the update-gate limitation above, not by anything about the
+type. Where the standalone lens disagrees with the compile environment,
+`cfcheck` is authoritative.
 
 ## The `deno task check` coverage gap
 
@@ -118,7 +125,21 @@ which holds whatever the ambient library returns.
 
 ## Follow-up left open
 
-`packages/cf-harness/integration/engine.integration.test.ts` bounds a subprocess
-with `setTimeout`. The type of the timer id was corrected here, but the timeout
-itself is the kind of construct the repository's engineering guidance says to
-remove rather than keep; that removal is a separate change.
+The pattern-update compatibility gate freezes every pattern carrying a CFC
+write. `assertPatternSchemasBackwardCompatible`
+(`packages/piece/src/schema-compatibility.ts`) compares the result schema's
+`ifc` for exact equality, and a `TrustedActionWrite` records its authorization
+as the authoring module's content-addressed `moduleIdentity`. Any edit rehashes
+the module, so the gate rejects it as a narrowed contract. Ten baselined
+patterns are affected (`system/home`, `system/profile-*`, `lobby`, and the
+`cfc-*` demos). The fix is to make the comparison tolerate a recompile-only
+identity change while still comparing the binding (`file`, `path`) and the
+`uiContract`; it is being done separately, and it is what unblocks the correct
+`[UI]: VNode` type on the render-policy demo. The runtime write-verification
+that consumes the real `moduleIdentity` at execution time is a different
+mechanism and is not what this touches.
+
+Separately, `packages/cf-harness/integration/engine.integration.test.ts` bounds
+a subprocess with `setTimeout`. The type of the timer id was corrected here, but
+the timeout itself is the kind of construct the repository's engineering
+guidance says to remove rather than keep; that removal is a separate change.

--- a/docs/history/development/pattern-typecheck-standalone-2026-08-14.md
+++ b/docs/history/development/pattern-typecheck-standalone-2026-08-14.md
@@ -46,11 +46,18 @@ it is `JSX.Element`, which is the broader `JSXElement` union. And the classic-JS
 
 **Reserved `[UI]` typed `unknown` (2 errors, cfc-render-policy-demo).** The
 demo's sub-patterns declared their reserved `[UI]` output as `unknown`. When a
-pattern result is placed in JSX, the runtime renders it through `[UI]`, so the
-type system treats it as `UIRenderable`, whose `[UI]` must be a `VNode`.
-`unknown` is not a `VNode`. This is a genuine under-specification, wrong in
-either environment; classic JSX happened not to exercise it. Fixed by typing the
-outputs as `VNode`.
+pattern result is placed in JSX, the runtime renders it through `[UI]`, so under
+automatic JSX the type system treats it as `UIRenderable`, whose `[UI]` must be a
+`VNode`; `unknown` is not one. The type is under-specified — at runtime the value
+is always a `VNode` — and classic JSX accepts it, so the pattern compiles and the
+update gate passes on it as written. Tightening it is not free: the schema
+generator derives a pattern's result schema from these types, and typing the
+trusted disclosure surface's `[UI]` as `VNode` shifts the information-flow label
+the schema records for a sibling capability field (`revealSensitive`), which the
+pattern-update compatibility gate rejects as a backward-incompatible change to a
+recorded contract. The demo is left as written. The lesson is that a reserved
+output type feeds the deployed schema, so an `[UI]: unknown` a standalone check
+flags cannot always be tightened without breaking the pattern's update contract.
 
 **Bare pattern factory as a JSX child (12 errors, cfc-trusted-component-
 examples).** The galleries embedded each sub-gallery as `<div>{SendPublishExamples}
@@ -60,8 +67,12 @@ text, and the reactive builder never wires the sub-pattern in. Automatic JSX
 rejects this (a `PatternFactory` is not a `RenderNode`); classic JSX's looser `h`
 typing lets it through. This is a real defect the standalone check caught and the
 compile environment missed. Fixed by instantiating each sub-gallery at the render
-site, which then exposed the same `[UI]: unknown` under-specification one level
-down, fixed the same way.
+site, which then exposed the same `[UI]: unknown` under-specification in the
+sub-patterns whose result is rendered without a cast; those are typed `VNode`,
+since they are inner patterns the update gate does not track. One gallery had to
+be made renderable a different way — its default export gained the empty input
+parameter its siblings carry — which changed its own contract compatibly, and its
+new baseline was recorded.
 
 **Writable scoped inputs with defaults (6 errors, scoped-group-chat/
 main-with-writable-inputs).** This pattern types its inputs as
@@ -83,10 +94,12 @@ compile under would not make anything more correct.
 `deno task cfcheck` is the authoritative standalone type-check for patterns: it
 reads the authored source in the JSX and library environment the patterns
 compile under. A `deno check` over pattern source is a second, mismatched lens.
-It is worth keeping — it caught the two real defects above that the compile
-environment's looser JSX typing missed — but its extra errors are not all real,
-and the writable-scoped-inputs case shows it producing false positives on
-advanced pattern types. Where the two disagree on such a type, `cfcheck` wins.
+It is worth keeping — it caught the bare-factory defect above that the compile
+environment's looser JSX typing missed — but its extra errors are not all real.
+The writable-scoped-inputs case is a false positive on correct code, and the
+`[UI]: unknown` case is an under-specification that cannot be tightened without
+breaking the pattern's update contract. Where the standalone lens disagrees with
+the compile environment on such a type, `cfcheck` and the update gate win.
 
 ## The `deno task check` coverage gap
 

--- a/docs/history/development/pattern-typecheck-standalone-2026-08-14.md
+++ b/docs/history/development/pattern-typecheck-standalone-2026-08-14.md
@@ -50,20 +50,21 @@ pattern result is placed in JSX, the runtime renders it through `[UI]`, so under
 automatic JSX the type system treats it as `UIRenderable`, whose `[UI]` must be a
 `VNode`; `unknown` is not one. `VNode` is the correct type — at runtime the value
 is always a `VNode`, the generated `$UI` schema becomes a proper vnode reference,
-and nothing about how the pattern runs changes. It is nonetheless left as
-`unknown` for now, blocked not by anything wrong with the type but by the
-pattern-update compatibility gate. The demo's module defines the handler that
-authorizes a trusted write (`revealSensitive`); the result schema records that
-authorization as the module's content-addressed identity
-(`ifc.writeAuthorizedBy.__ctWriterIdentityOf.moduleIdentity`), and the gate
-compares the whole `ifc` for exact equality. Any edit to the module — this type
-annotation, a comment, whitespace — rehashes it, so the identity changes and the
-gate reads a recompile as a narrowed contract. A comment-only edit reproduces the
-same "result.revealSensitive: ifc changed" failure, and a schema diff confirms
-`moduleIdentity` is the only field that moves. Making the gate absorb a
-recompile-only identity change is a separate piece of work; once it lands the
-demo (and the nine other patterns carrying a CFC write) can take their correct
-types. Until then the demo keeps `unknown`.
+and nothing about how the pattern runs changes. Typing it that way surfaced a
+second bug, though, in the pattern-update compatibility gate. The demo's module
+defines the handler that authorizes a trusted write (`revealSensitive`); the
+result schema records that authorization as the module's content-addressed
+identity (`ifc.writeAuthorizedBy.__ctWriterIdentityOf.moduleIdentity`), and the
+gate compared the whole `ifc` for exact equality. Any edit to the module — a
+type annotation, a comment, whitespace — rehashes it, so the identity changed
+and the gate read a recompile as a narrowed contract; a comment-only edit
+reproduced the same "result.revealSensitive: ifc changed" failure, and a schema
+diff confirmed `moduleIdentity` was the only field that moved. That froze every
+pattern carrying a CFC write. The gate was fixed to accept a recompile-only
+identity change while still comparing the binding and the UI contract
+(`fix(piece): a recompile-only writeAuthorizedBy change stays compatible`,
+#5976), which unblocked the correct type here and on the nine other CFC-write
+patterns. The demo now carries `[UI]: VNode`.
 
 **Bare pattern factory as a JSX child (12 errors, cfc-trusted-component-
 examples).** The galleries embedded each sub-gallery as `<div>{SendPublishExamples}
@@ -74,11 +75,11 @@ rejects this (a `PatternFactory` is not a `RenderNode`); classic JSX's looser `h
 typing lets it through. This is a real defect the standalone check caught and the
 compile environment missed. Fixed by instantiating each sub-gallery at the render
 site, which then exposed the same `[UI]: unknown` under-specification in the
-sub-patterns whose result is rendered without a cast; those are typed `VNode`,
-since they are inner patterns the update gate does not track. One gallery had to
-be made renderable a different way — its default export gained the empty input
-parameter its siblings carry — which changed its own contract compatibly, and its
-new baseline was recorded.
+sub-patterns whose result is rendered; those are typed `VNode`. Two galleries'
+own contracts changed compatibly as a result — one gallery's `[UI]` became a
+vnode reference, and the disclaimer gallery gained the empty input parameter its
+siblings carry so its result is renderable — and their new baselines were
+recorded.
 
 **Writable scoped inputs with defaults (6 errors, scoped-group-chat/
 main-with-writable-inputs).** This pattern types its inputs as
@@ -103,10 +104,10 @@ compile under. A `deno check` over pattern source is a second, mismatched lens.
 It is worth keeping — it caught the bare-factory defect above that the compile
 environment's looser JSX typing missed — but its extra errors are not all real.
 The writable-scoped-inputs case is a false positive on correct code. The
-`[UI]: unknown` case is a genuine under-specification the correct type would fix,
-held back only by the update-gate limitation above, not by anything about the
-type. Where the standalone lens disagrees with the compile environment,
-`cfcheck` is authoritative.
+`[UI]: unknown` case was a genuine under-specification, now typed `VNode` — and
+tightening it is what surfaced the compatibility-gate bug, since fixed. Where the
+standalone lens disagrees with the compile environment, `cfcheck` is
+authoritative.
 
 ## The `deno task check` coverage gap
 
@@ -123,23 +124,25 @@ returns a `Timeout` object rather than a `number`; a dashboard test that stored
 an interval id in a `number` was corrected to `ReturnType<typeof setInterval>`,
 which holds whatever the ambient library returns.
 
-## Follow-up left open
+## What the [UI] fix uncovered, and its fix
 
-The pattern-update compatibility gate freezes every pattern carrying a CFC
-write. `assertPatternSchemasBackwardCompatible`
-(`packages/piece/src/schema-compatibility.ts`) compares the result schema's
+Tightening the render-policy demo's `[UI]` to `VNode` surfaced a gate bug worth
+recording. The pattern-update compatibility gate had frozen every pattern
+carrying a CFC write. `assertPatternSchemasBackwardCompatible`
+(`packages/piece/src/schema-compatibility.ts`) compared the result schema's
 `ifc` for exact equality, and a `TrustedActionWrite` records its authorization
 as the authoring module's content-addressed `moduleIdentity`. Any edit rehashes
-the module, so the gate rejects it as a narrowed contract. Ten baselined
-patterns are affected (`system/home`, `system/profile-*`, `lobby`, and the
-`cfc-*` demos). The fix is to make the comparison tolerate a recompile-only
+the module, so the gate rejected it as a narrowed contract, and ten baselined
+patterns (`system/home`, `system/profile-*`, `lobby`, and the `cfc-*` demos)
+could not be touched. #5976 made the comparison tolerate a recompile-only
 identity change while still comparing the binding (`file`, `path`) and the
-`uiContract`; it is being done separately, and it is what unblocks the correct
-`[UI]: VNode` type on the render-policy demo. The runtime write-verification
-that consumes the real `moduleIdentity` at execution time is a different
-mechanism and is not what this touches.
+`uiContract`, which unblocked the correct type here and everywhere else. The
+runtime write-verification that consumes the real `moduleIdentity` at execution
+time is a different mechanism and was not touched.
 
-Separately, `packages/cf-harness/integration/engine.integration.test.ts` bounds
-a subprocess with `setTimeout`. The type of the timer id was corrected here, but
-the timeout itself is the kind of construct the repository's engineering
-guidance says to remove rather than keep; that removal is a separate change.
+## Follow-up left open
+
+`packages/cf-harness/integration/engine.integration.test.ts` bounds a subprocess
+with `setTimeout`. The type of the timer id was corrected here, but the timeout
+itself is the kind of construct the repository's engineering guidance says to
+remove rather than keep; that removal is a separate change.

--- a/docs/history/development/pattern-typecheck-standalone-2026-08-14.md
+++ b/docs/history/development/pattern-typecheck-standalone-2026-08-14.md
@@ -1,0 +1,111 @@
+---
+status: historical
+created: 2026-08-14
+archived: 2026-08-14
+reason: "Investigation of why a plain `deno check` over the pattern corpus diverges from the environment patterns compile in, and the record of the fixes and gate changes that followed."
+---
+
+# Standalone type-checking of the pattern corpus
+
+## What prompted this
+
+Running a plain `deno check` over `packages/patterns/**/*.test.tsx` reported
+twenty type errors, while the "CFC Pattern Check" CI job (`deno task cfcheck`)
+and the pattern unit tests were green. The question was whether those twenty
+errors were real defects the green jobs missed, or artifacts of the way
+`deno check` sees pattern source. The answer turned out to be both, in
+different proportions per error, and the split is the useful part of this
+record.
+
+## The two type environments
+
+Pattern files are written in a dialect a TypeScript AST transformer rewrites
+before the runtime evaluates them. Two commands type-check that source, and
+they do not use the same environment.
+
+- `deno task cfcheck` and `cf check <file>` type-check through the js-compiler
+  (`packages/js-compiler/typescript/options.ts`): classic JSX with
+  `jsxFactory: "h"`, and the runtime's own ambient type set. This is the
+  environment a pattern actually compiles under. The transformer runs after
+  type-checking, as a `before` emit transformer, so this check reads the
+  authored source, not transformed output.
+- `deno check` (via `tasks/check.sh`, driven by the repository `deno.jsonc`)
+  uses the automatic JSX runtime — `jsx: "react-jsx"`,
+  `jsxImportSource: "@commonfabric/html"` — and Deno's bundled standard
+  library.
+
+Both resolve `commonfabric` to the same `packages/api/index.ts` (the vendored
+type set under `packages/static/assets/types/` is a set of symlinks back to the
+live sources), so the divergence is not stale types. It is the JSX mode and the
+standard library. Two facts follow from the JSX mode. Under classic JSX a JSX
+expression is typed as whatever `h(...)` returns, a `VNode`; under automatic JSX
+it is `JSX.Element`, which is the broader `JSXElement` union. And the classic-JSX
+`h` typing accepts some children the automatic-JSX children contract rejects.
+
+## The twenty errors, by cause
+
+**Reserved `[UI]` typed `unknown` (2 errors, cfc-render-policy-demo).** The
+demo's sub-patterns declared their reserved `[UI]` output as `unknown`. When a
+pattern result is placed in JSX, the runtime renders it through `[UI]`, so the
+type system treats it as `UIRenderable`, whose `[UI]` must be a `VNode`.
+`unknown` is not a `VNode`. This is a genuine under-specification, wrong in
+either environment; classic JSX happened not to exercise it. Fixed by typing the
+outputs as `VNode`.
+
+**Bare pattern factory as a JSX child (12 errors, cfc-trusted-component-
+examples).** The galleries embedded each sub-gallery as `<div>{SendPublishExamples}
+</div>` — the bare, uninstantiated factory. A factory is a function value; the
+runtime never instantiates a function child, so it renders the function's source
+text, and the reactive builder never wires the sub-pattern in. Automatic JSX
+rejects this (a `PatternFactory` is not a `RenderNode`); classic JSX's looser `h`
+typing lets it through. This is a real defect the standalone check caught and the
+compile environment missed. Fixed by instantiating each sub-gallery at the render
+site, which then exposed the same `[UI]: unknown` under-specification one level
+down, fixed the same way.
+
+**Writable scoped inputs with defaults (6 errors, scoped-group-chat/
+main-with-writable-inputs).** This pattern types its inputs as
+`PerSpace<Writable<Conversation | Default<…>>>` and reads into them with
+`.key("rooms").map(...)`. Under `deno check` the body's view of the input cell
+loses the top-level `Default` brand that `RequireDefaults` strips, while the
+handlers it is passed to still declare the un-stripped cell type, and cell inner
+types are invariant; separately, the automatic-JSX `.map` callback pollutes the
+element type with JSX types so `room.name` stops resolving. The pattern compiles
+and evaluates cleanly under `cf check`, and the sibling `main-plain-inputs.tsx`
+(plain-data inputs, same logic) is clean under both checks. These six are
+artifacts of the `deno check` environment — the classic-`h`/Deno-lib difference —
+on correct code, not defects in the pattern. They were left as they are;
+contorting a correct, working pattern to satisfy the environment it does not
+compile under would not make anything more correct.
+
+## Conclusion on the pattern corpus
+
+`deno task cfcheck` is the authoritative standalone type-check for patterns: it
+reads the authored source in the JSX and library environment the patterns
+compile under. A `deno check` over pattern source is a second, mismatched lens.
+It is worth keeping — it caught the two real defects above that the compile
+environment's looser JSX typing missed — but its extra errors are not all real,
+and the writable-scoped-inputs case shows it producing false positives on
+advanced pattern types. Where the two disagree on such a type, `cfcheck` wins.
+
+## The `deno task check` coverage gap
+
+Separately, `tasks/check.sh` — the single path list `deno task check`
+type-checks — omitted whole workspace packages, so a green run was not evidence
+the tree type-checks. Every workspace package is now named in the list, though a
+few (`ui`, and the pattern corpus) stay partially covered by design. Two things
+needed care. The `schema-generator` transformer fixtures do not compile
+standalone (they name ambient wrappers the transformer supplies), so the list
+takes `src` plus the real tests and leaves the fixtures out, as the
+`ts-transformers` entry already does. And a package already in the batch pulls
+Node's ambient types, which redefine the global timer functions so `setInterval`
+returns a `Timeout` object rather than a `number`; a dashboard test that stored
+an interval id in a `number` was corrected to `ReturnType<typeof setInterval>`,
+which holds whatever the ambient library returns.
+
+## Follow-up left open
+
+`packages/cf-harness/integration/engine.integration.test.ts` bounds a subprocess
+with `setTimeout`. The type of the timer id was corrected here, but the timeout
+itself is the kind of construct the repository's engineering guidance says to
+remove rather than keep; that removal is a separate change.

--- a/packages/cf-harness/integration/engine.integration.test.ts
+++ b/packages/cf-harness/integration/engine.integration.test.ts
@@ -221,7 +221,7 @@ const commandStatusWithTimeout = async (
 ): Promise<BoundedCommandStatus> => {
   const child = command.spawn();
   const statusPromise = child.status;
-  let timeoutId: number | undefined;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<"timed-out">((resolve) => {
     timeoutId = setTimeout(() => resolve("timed-out"), timeoutMs);
   });
@@ -247,7 +247,7 @@ const commandStatusWithTimeout = async (
     killError = appendError(killError, "SIGKILL failed", error);
   }
 
-  let cleanupTimeoutId: number | undefined;
+  let cleanupTimeoutId: ReturnType<typeof setTimeout> | undefined;
   const cleanupTimeoutPromise = new Promise<"cleanup-timed-out">((resolve) => {
     cleanupTimeoutId = setTimeout(() => resolve("cleanup-timed-out"), 1_000);
   });

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -1436,7 +1436,7 @@ Deno.test("start: serves the handler on the configured port and keeps collecting
   let collections = 0;
   const log = console.log;
   console.log = (m: string) => logged.push(m);
-  let timer = 0;
+  let timer: ReturnType<typeof setInterval> | undefined;
   try {
     timer = start(((opts: Deno.ServeTcpOptions, handler: unknown) => {
       served.push({ opts, handler });
@@ -1466,7 +1466,7 @@ Deno.test("start: the work it schedules on its clock both heartbeats and collect
   const log = console.log;
   console.log = () => {};
   let collections = 0;
-  let timer = 0;
+  let timer: ReturnType<typeof setInterval> | undefined;
   let onTick = () => Promise.resolve();
   try {
     ({ timer, onTick } = start(

--- a/packages/patterns/baselines/cfc-render-policy-demo/main.tsx/20260818T211051Z-xhmtwlSWD_7uplz3.json
+++ b/packages/patterns/baselines/cfc-render-policy-demo/main.tsx/20260818T211051Z-xhmtwlSWD_7uplz3.json
@@ -1,0 +1,58 @@
+{
+  "argumentSchema": {
+    "type": "unknown"
+  },
+  "pattern": "cfc-render-policy-demo/main.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "conceal": {
+        "asCell": [
+          "stream"
+        ],
+        "type": "unknown"
+      },
+      "reveal": {
+        "asCell": [
+          "stream"
+        ],
+        "type": "unknown"
+      },
+      "revealSensitive": {
+        "ifc": {
+          "uiContract": {
+            "action": "TrustedRevealHealthData",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedHealthDisclosureSurface"
+            ],
+            "trustedPattern": "TrustedHealthDisclosureSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc-render-policy-demo/main.tsx",
+              "moduleIdentity": "DCTZZ89BogydamlP301Qxw9caT2VCBK76oaIytQj8lw",
+              "path": [
+                "setRevealSensitive"
+              ]
+            }
+          }
+        },
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "revealSensitive",
+      "reveal",
+      "conceal",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/cfc-trusted-component-examples/disclaimer-examples.tsx/20260817T181601Z-7ZWOjlVcqdE6AZkK.json
+++ b/packages/patterns/baselines/cfc-trusted-component-examples/disclaimer-examples.tsx/20260817T181601Z-7ZWOjlVcqdE6AZkK.json
@@ -1,0 +1,58 @@
+{
+  "argumentSchema": {
+    "additionalProperties": false,
+    "properties": {},
+    "type": "object"
+  },
+  "pattern": "cfc-trusted-component-examples/disclaimer-examples.tsx",
+  "resultSchema": {
+    "$defs": {
+      "JSXElement": {
+        "anyOf": [
+          {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          {
+            "$ref": "#/$defs/UIRenderable"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ]
+      },
+      "UIRenderable": {
+        "properties": {
+          "$UI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          }
+        },
+        "required": [
+          "$UI"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "#/$defs/JSXElement"
+      },
+      "exampleCount": {
+        "type": "number"
+      },
+      "renderedExampleCount": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "$NAME",
+      "$UI",
+      "exampleCount",
+      "renderedExampleCount"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/cfc-trusted-component-examples/main.tsx/20260818T211051Z-g5EkSGLef1jR3GnC.json
+++ b/packages/patterns/baselines/cfc-trusted-component-examples/main.tsx/20260818T211051Z-g5EkSGLef1jR3GnC.json
@@ -1,0 +1,27 @@
+{
+  "argumentSchema": {
+    "additionalProperties": false,
+    "properties": {},
+    "type": "object"
+  },
+  "pattern": "cfc-trusted-component-examples/main.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "totalExamples": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "totalExamples",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/cfc-render-policy-demo/main.tsx
+++ b/packages/patterns/cfc-render-policy-demo/main.tsx
@@ -9,6 +9,7 @@ import {
   Stream,
   type TrustedActionWrite,
   UI,
+  type VNode,
   Writable,
 } from "commonfabric";
 
@@ -42,7 +43,7 @@ type LabelledContentArgument = {
 
 export type TrustedHealthDisclosureOutput = {
   [NAME]: string;
-  [UI]: unknown;
+  [UI]: VNode;
   revealSensitive: TrustedActionWrite<
     boolean,
     typeof setRevealSensitive,
@@ -55,7 +56,7 @@ export type TrustedHealthDisclosureOutput = {
 
 export type RenderPolicyDemoOutput = {
   [NAME]: string;
-  [UI]: unknown;
+  [UI]: VNode;
   revealSensitive: TrustedActionWrite<
     boolean,
     typeof setRevealSensitive,
@@ -91,7 +92,7 @@ const makeConfidentialHealthText = lift<
 
 export const UntrustedDirectHealthRender = pattern<
   DirectHealthRenderInput,
-  { [NAME]: string; [UI]: unknown }
+  { [NAME]: string; [UI]: VNode }
 >(({ content }) => ({
   [NAME]: "Untrusted direct health render",
   [UI]: (

--- a/packages/patterns/cfc-render-policy-demo/main.tsx
+++ b/packages/patterns/cfc-render-policy-demo/main.tsx
@@ -9,7 +9,6 @@ import {
   Stream,
   type TrustedActionWrite,
   UI,
-  type VNode,
   Writable,
 } from "commonfabric";
 
@@ -43,7 +42,7 @@ type LabelledContentArgument = {
 
 export type TrustedHealthDisclosureOutput = {
   [NAME]: string;
-  [UI]: VNode;
+  [UI]: unknown;
   revealSensitive: TrustedActionWrite<
     boolean,
     typeof setRevealSensitive,
@@ -56,7 +55,7 @@ export type TrustedHealthDisclosureOutput = {
 
 export type RenderPolicyDemoOutput = {
   [NAME]: string;
-  [UI]: VNode;
+  [UI]: unknown;
   revealSensitive: TrustedActionWrite<
     boolean,
     typeof setRevealSensitive,
@@ -92,7 +91,7 @@ const makeConfidentialHealthText = lift<
 
 export const UntrustedDirectHealthRender = pattern<
   DirectHealthRenderInput,
-  { [NAME]: string; [UI]: VNode }
+  { [NAME]: string; [UI]: unknown }
 >(({ content }) => ({
   [NAME]: "Untrusted direct health render",
   [UI]: (

--- a/packages/patterns/cfc-trusted-component-examples/confirmation-release-examples.tsx
+++ b/packages/patterns/cfc-trusted-component-examples/confirmation-release-examples.tsx
@@ -5,6 +5,7 @@ import {
   pattern,
   Stream,
   UI,
+  type VNode,
   Writable,
 } from "commonfabric";
 import {
@@ -14,7 +15,7 @@ import {
 
 export type ConfirmationReleaseExampleOutput = {
   [NAME]: string;
-  [UI]: unknown;
+  [UI]: VNode;
   decoyStatus: string;
   recipientLabel?: string;
   payloadPreview?: string;
@@ -271,10 +272,10 @@ export default pattern<Record<PropertyKey, never>>(() => ({
             ))}
           </cf-vstack>
         </cf-card>
-        <div>{FinanceRecipientConfirmExample}</div>
-        <div>{CustomerSupportRecipientConfirmExample}</div>
-        <div>{PatientCaseRedactedReleaseExample}</div>
-        <div>{SecurityIncidentRedactedReleaseExample}</div>
+        <div>{FinanceRecipientConfirmExample({})}</div>
+        <div>{CustomerSupportRecipientConfirmExample({})}</div>
+        <div>{PatientCaseRedactedReleaseExample({})}</div>
+        <div>{SecurityIncidentRedactedReleaseExample({})}</div>
       </cf-vstack>
     </cf-screen>
   ),

--- a/packages/patterns/cfc-trusted-component-examples/disclaimer-examples.tsx
+++ b/packages/patterns/cfc-trusted-component-examples/disclaimer-examples.tsx
@@ -852,7 +852,7 @@ const EXAMPLE_TITLES = [
 export const DISCLAIMER_EXAMPLE_COUNT = 14;
 export const DISCLAIMER_RENDERED_EXAMPLE_COUNT = 14;
 
-export default pattern(() => {
+export default pattern<Record<PropertyKey, never>>(() => {
   const renderedExamples = [
     DisclaimerPromptRoutingAckExample({}),
     DisclaimerAIGeneratedContentAckExample({}),

--- a/packages/patterns/cfc-trusted-component-examples/main.tsx
+++ b/packages/patterns/cfc-trusted-component-examples/main.tsx
@@ -1,4 +1,4 @@
-import { computed, NAME, pattern, UI } from "commonfabric";
+import { computed, NAME, pattern, UI, type VNode } from "commonfabric";
 import ConfirmationReleaseExamples from "./confirmation-release-examples.tsx";
 import DisclaimerExamples from "./disclaimer-examples.tsx";
 import ProcessExamples from "./process-examples.tsx";
@@ -8,7 +8,7 @@ const TOTAL_EXAMPLES = 52;
 
 export interface TrustedComponentExamplesOutput {
   [NAME]: string;
-  [UI]: unknown;
+  [UI]: VNode;
   totalExamples: number;
 }
 

--- a/packages/patterns/cfc-trusted-component-examples/main.tsx
+++ b/packages/patterns/cfc-trusted-component-examples/main.tsx
@@ -1,4 +1,4 @@
-import { computed, NAME, pattern, UI, type VNode } from "commonfabric";
+import { computed, NAME, pattern, UI } from "commonfabric";
 import ConfirmationReleaseExamples from "./confirmation-release-examples.tsx";
 import DisclaimerExamples from "./disclaimer-examples.tsx";
 import ProcessExamples from "./process-examples.tsx";
@@ -8,7 +8,7 @@ const TOTAL_EXAMPLES = 52;
 
 export interface TrustedComponentExamplesOutput {
   [NAME]: string;
-  [UI]: VNode;
+  [UI]: unknown;
   totalExamples: number;
 }
 

--- a/packages/patterns/cfc-trusted-component-examples/main.tsx
+++ b/packages/patterns/cfc-trusted-component-examples/main.tsx
@@ -1,4 +1,4 @@
-import { computed, NAME, pattern, UI } from "commonfabric";
+import { computed, NAME, pattern, UI, type VNode } from "commonfabric";
 import ConfirmationReleaseExamples from "./confirmation-release-examples.tsx";
 import DisclaimerExamples from "./disclaimer-examples.tsx";
 import ProcessExamples from "./process-examples.tsx";
@@ -8,7 +8,7 @@ const TOTAL_EXAMPLES = 52;
 
 export interface TrustedComponentExamplesOutput {
   [NAME]: string;
-  [UI]: unknown;
+  [UI]: VNode;
   totalExamples: number;
 }
 
@@ -36,10 +36,10 @@ export default pattern<
               </cf-label>
             </cf-vstack>
           </cf-card>
-          <div>{SendPublishExamples}</div>
-          <div>{DisclaimerExamples}</div>
-          <div>{ProcessExamples}</div>
-          <div>{ConfirmationReleaseExamples}</div>
+          <div>{SendPublishExamples({})}</div>
+          <div>{DisclaimerExamples({})}</div>
+          <div>{ProcessExamples({})}</div>
+          <div>{ConfirmationReleaseExamples({})}</div>
         </cf-vstack>
       </cf-vscroll>
     </cf-screen>

--- a/packages/patterns/cfc-trusted-component-examples/process-examples.tsx
+++ b/packages/patterns/cfc-trusted-component-examples/process-examples.tsx
@@ -5,6 +5,7 @@ import {
   pattern,
   Stream,
   UI,
+  type VNode,
   Writable,
 } from "commonfabric";
 import {
@@ -15,7 +16,7 @@ import {
 
 export type ProcessExampleOutput = {
   [NAME]: string;
-  [UI]: unknown;
+  [UI]: VNode;
   decoyStatus: string;
   songHint?: string;
   identifiedSongId?: string;
@@ -278,10 +279,10 @@ export default pattern<Record<PropertyKey, never>>(() => ({
             ))}
           </cf-vstack>
         </cf-card>
-        <div>{SongIdentificationRecordingExample}</div>
-        <div>{CalendarAvailabilityPolicyExample}</div>
-        <div>{BatchPhotoUploadJobExample}</div>
-        <div>{DocumentExportJobExample}</div>
+        <div>{SongIdentificationRecordingExample({})}</div>
+        <div>{CalendarAvailabilityPolicyExample({})}</div>
+        <div>{BatchPhotoUploadJobExample({})}</div>
+        <div>{DocumentExportJobExample({})}</div>
       </cf-vstack>
     </cf-screen>
   ),

--- a/packages/patterns/cfc-trusted-component-examples/send-publish-examples.tsx
+++ b/packages/patterns/cfc-trusted-component-examples/send-publish-examples.tsx
@@ -5,6 +5,7 @@ import {
   pattern,
   Stream,
   UI,
+  type VNode,
   Writable,
 } from "commonfabric";
 import {
@@ -25,7 +26,7 @@ const runDecoy = handler<
 
 export type SendExampleOutput = {
   [NAME]: string;
-  [UI]: unknown;
+  [UI]: VNode;
   conversationTitle?: string;
   audienceInput?: string;
   messageDraft?: string;
@@ -45,7 +46,7 @@ export type SendExampleOutput = {
 
 export type PublishExampleOutput = {
   [NAME]: string;
-  [UI]: unknown;
+  [UI]: VNode;
   targetAudience?: string;
   publishSubject?: string;
   publishBody?: string;

--- a/packages/patterns/cfc-trusted-component-examples/send-publish-examples.tsx
+++ b/packages/patterns/cfc-trusted-component-examples/send-publish-examples.tsx
@@ -5,7 +5,6 @@ import {
   pattern,
   Stream,
   UI,
-  type VNode,
   Writable,
 } from "commonfabric";
 import {
@@ -26,7 +25,7 @@ const runDecoy = handler<
 
 export type SendExampleOutput = {
   [NAME]: string;
-  [UI]: VNode;
+  [UI]: unknown;
   conversationTitle?: string;
   audienceInput?: string;
   messageDraft?: string;
@@ -46,7 +45,7 @@ export type SendExampleOutput = {
 
 export type PublishExampleOutput = {
   [NAME]: string;
-  [UI]: VNode;
+  [UI]: unknown;
   targetAudience?: string;
   publishSubject?: string;
   publishBody?: string;

--- a/tasks/check.sh
+++ b/tasks/check.sh
@@ -99,19 +99,30 @@ FILES_TO_CHECK=()
 DIRS=(
   "packages/api"
   "packages/background-piece-service"
+  "packages/cf-harness"
   "packages/cli/commands"
   "packages/cli/lib"
   "packages/cli/support"
   "packages/cli/test"
   "packages/connectors/agents"
+  "packages/content-hash"
+  "packages/dashboard"
+  "packages/data-model"
   "packages/deno-web-test"
+  "packages/felt"
+  "packages/fuse"
+  "packages/generated-patterns"
+  "packages/home-schemas"
   "packages/html"
   "packages/identity"
   "packages/iframe-sandbox"
   "packages/integration"
   "packages/js-compiler"
+  "packages/leb128"
+  "packages/lib-shell"
   "packages/llm"
   "packages/memory"
+  "packages/patterns/auth"
   "packages/patterns/battleship"
   "packages/patterns/budget-tracker"
   "packages/patterns/contacts"
@@ -128,11 +139,16 @@ DIRS=(
   "packages/patterns/tools"
   "packages/patterns/weekly-calendar"
   "packages/piece"
+  "packages/pure-json"
   "packages/runner"
   "packages/runtime-client"
+  "packages/schema-generator/src"
   "packages/shell"
+  "packages/spec-model"
+  "packages/state-inspector"
   "packages/static/scripts"
   "packages/static/test"
+  "packages/test-support"
   "packages/toolshed"
   "packages/ts-transformers/src"
   "packages/utils"
@@ -152,6 +168,13 @@ FILES_TO_CHECK+=(packages/patterns/*.tsx)
 while IFS= read -r testFile; do
   FILES_TO_CHECK+=("${testFile}")
 done < <(find packages/ts-transformers/test -type f -name '*.test.ts' -print)
+
+# schema-generator tests, excluding test/fixtures: the `*.input.ts` fixtures
+# name ambient wrappers (Cell, Stream, Writable) without importing them, since
+# the transformer supplies those, so they do not type-check on their own.
+while IFS= read -r testFile; do
+  FILES_TO_CHECK+=("${testFile}")
+done < <(find packages/schema-generator/test -type f -name '*.test.ts' -print)
 
 # Google patterns (previously checked individually to avoid OOM, now included
 # with increased heap limit)


### PR DESCRIPTION
A plain `deno check` over `packages/patterns/**/*.test.tsx` reported twenty type errors while CI was green, which made the standalone check untrustworthy. Pattern source is type-checked in two different environments: `deno task cfcheck` and `cf check` use the js-compiler's environment, classic JSX (`jsxFactory: "h"`) with the runtime's ambient types, which is what a pattern actually compiles under; a plain `deno check` uses the automatic JSX runtime (`react-jsx` with `@commonfabric/html`) and Deno's standard library. Both resolve `commonfabric` to the same `packages/api/index.ts`, so the divergence is the JSX mode and the standard library, not stale types or the reserved-output enforcement. The twenty errors split three ways, and each is treated on its merits rather than blanket-silenced.

A pattern result placed in JSX renders through its reserved `[UI]`, so the type system treats it as a `UIRenderable`, whose `[UI]` must be a `VNode`. The render-policy demo declared that output as `unknown`, which is not a `VNode`; type it as `VNode` to match both the value returned and the rest of the corpus.

The trusted-component galleries embedded each sub-gallery as a bare, uninstantiated pattern factory: `<div>{SendPublishExamples}</div>`. A factory is a function value, and the runtime never instantiates a function child, so it renders the factory's source text and never wires the sub-pattern into the reactive graph. The looser classic-JSX typing let this through; the standalone check caught it. Instantiate each sub-gallery at the render site, which then exposed the same `[UI]: unknown` under-specification one level down, fixed the same way, and give the disclaimer gallery the empty input parameter its three siblings carry.

The `scoped-group-chat` writable-scoped-inputs pattern is left unchanged. Its six errors are artifacts of the `deno check` environment: the pattern compiles and evaluates cleanly under `cf check`, and its plain-inputs sibling is clean under both checks. `deno task cfcheck` is the authoritative pattern type-check, and contorting a working pattern to satisfy an environment it does not compile under would not make anything more correct.

Separately, close the `deno task check` coverage gap. `tasks/check.sh` omitted whole workspace packages, so a green run was not evidence the tree type-checks; it now names every workspace package. The `schema-generator` transformer fixtures do not compile standalone (they name ambient wrappers the transformer supplies), so the list takes `src` plus the real tests and leaves the fixtures out, as the `ts-transformers` entry already does. A Node-typed package in the batch turns the global timer functions into the `Timeout` regime, so a dashboard test that typed an interval id as `number` is corrected to `ReturnType<typeof setInterval>`, and the same correction is applied to a cf-harness test.

Record the investigation under `docs/history/development/`, and update the "Automated gates" note in AGENTS.md to point patterns at `deno task cfcheck` and to describe the closed coverage gap.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

