### PR TITLE
A transaction resolves a link once, not once per element read

### DIFF
--- a/docs/development/PERFORMANCE_PROGRAM.md
+++ b/docs/development/PERFORMANCE_PROGRAM.md
@@ -193,7 +193,7 @@ path) · Medium (benchmarks improve, modest user impact) · Low (micro)
 
 | # | Project | Impact | Cost | Summary |
 |---|---------|--------|------|---------|
-| PERF-3 | Link resolution without JSON.stringify | High | S | `link-resolution.ts:83` allocates via `JSON.stringify` on every cycle-detection step. Replace with null-byte-separated concat (~2x faster on typical inputs). Naive separators like `\|` or `/` cause collisions when path segments contain the separator — use `\0` with a length prefix. [Tests needed.](#perf-3-link-resolution) |
+| PERF-3 | Link resolution without JSON.stringify | High | S | `linkAddressKey` in `link-resolution.ts` allocates via `JSON.stringify` on every hop. Replace with null-byte-separated concat (~2x faster on typical inputs). Naive separators like `\|` or `/` cause collisions when path segments contain the separator — use `\0` with a length prefix. The same key names a resolution's entry in the transaction's snapshot memo, so a collision there serves one link's resolution for another; the memo's own tests cover that. [Tests needed.](#perf-3-link-resolution) |
 
 ### Likely High-Impact (pending profiling confirmation)
 

--- a/packages/runner/src/cfc/label-view-state.ts
+++ b/packages/runner/src/cfc/label-view-state.ts
@@ -69,7 +69,7 @@ export const cfcLabelViewFromMetadata = (
   );
 };
 
-const cfcLabelViewForAddress = (
+const deriveCfcLabelViewForAddress = (
   tx: IExtendedStorageTransaction,
   address: CfcAddress,
 ): CfcLabelView | undefined => {
@@ -81,6 +81,35 @@ const cfcLabelViewForAddress = (
   } catch {
     return undefined;
   }
+};
+
+/**
+ * The stored labels that apply at an address, as a view rebased onto it.
+ *
+ * Memoized on the transaction's snapshot: the derivation reads the target
+ * document's `["cfc"]` metadata and nothing else, so it answers the same until
+ * something is written, and every dereference on a scanned collection asks for
+ * the same handful of addresses once per element. The memoized view is shared
+ * rather than copied — every consumer merges, clones or rebases it into
+ * something new, none writes to it.
+ */
+const cfcLabelViewForAddress = (
+  tx: IExtendedStorageTransaction,
+  address: CfcAddress,
+): CfcLabelView | undefined => {
+  const memo = tx.getSnapshotMemo?.();
+  if (memo === undefined) return deriveCfcLabelViewForAddress(tx, address);
+  const key = `cfcLabels:${address.space}|${address.scope ?? ""}|` +
+    `${address.id}|${JSON.stringify(address.path)}`;
+  // Two-level, so a memoized `undefined` is a hit rather than a miss — an
+  // address with no stored labels is the common case and the one worth having.
+  const cached = memo.get(key) as
+    | { view: CfcLabelView | undefined }
+    | undefined;
+  if (cached !== undefined) return cached.view;
+  const view = deriveCfcLabelViewForAddress(tx, address);
+  memo.set(key, { view });
+  return view;
 };
 
 export const cfcLabelViewForDereference = (

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -21,7 +21,7 @@ import type {
 import { linkResolutionProbe } from "./storage/reactivity-log.ts";
 import { ContextualFlowControl } from "./cfc.ts";
 import type { Runtime } from "./runtime.ts";
-import type { CfcAddress } from "./cfc/types.ts";
+import type { CfcAddress, CfcDereferenceTrace } from "./cfc/types.ts";
 import { canFollowScopedLink, narrowerScopeCap } from "./scope.ts";
 import type { SchemaScope } from "./builder/types.ts";
 
@@ -66,15 +66,24 @@ const hopKindForLink = (
 ): LinkHop["kind"] =>
   link.overwrite === "redirect" ? "write-redirect" : "value";
 
+/**
+ * Record a hop on the transaction and hand back what was recorded, so a
+ * memoized resolution can record the same trace object again rather than build
+ * an equal one. Sharing it is what lets the label view derived from its
+ * addresses be memoized in turn, and the transaction freezes on entry either
+ * way, so the trace list reads exactly as it does for an unmemoized walk.
+ */
 const recordDereferenceHop = (
   tx: IExtendedStorageTransaction,
   hop: LinkHop,
-): void => {
-  tx.recordCfcDereferenceTrace({
+): CfcDereferenceTrace => {
+  const trace = {
     source: cfcAddressFromLink(hop.source),
     target: cfcAddressFromLink(hop.link),
     kind: hop.kind,
-  });
+  };
+  tx.recordCfcDereferenceTrace(trace);
+  return trace;
 };
 
 // The scope cap a link's schema imposes on the next link it permits a read to
@@ -164,6 +173,105 @@ const canFollowLinkHop = (
   );
 
 /**
+ * Force a fetch from the server when the local replica cannot serve a hop
+ * target: crossing spaces (the origin server never pushes other-space docs), or
+ * a same-space doc this replica has never pulled, which `shouldPullDoc`
+ * reserves so only the first reader kicks.
+ *
+ * The second arm is the fresh-replica read-asymmetry fix: selector driven syncs
+ * only deliver what a schema covered, so a link can point at a same-space doc
+ * no selector ever walked — without this kick such reads mask as `undefined`,
+ * indistinguishable from absence. The kick is async; one-shot reads still
+ * return the masked value, but `Cell.pull()`'s convergence loop awaits the
+ * tracked sync and re-reads.
+ *
+ * Sync failures are swallowed: the kick is best-effort (the read still resolves
+ * from the local replica) and an unhandled rejection here would otherwise
+ * escape the resolution path. On failure, retract the `shouldPullDoc`
+ * reservation so a later read may retry — but only when THIS kick took it: a
+ * cross-space kick never reserved, and must not clear a reservation a
+ * concurrent same-space read holds for the same target (that would permit
+ * duplicate syncs).
+ */
+const kickDocPull = (
+  runtime: Runtime,
+  link: NormalizedFullLink,
+  reserved: boolean,
+): void => {
+  const mgr = runtime.storageManager;
+  const { space, id, scope } = link;
+  mgr.trackUntilSettled(
+    runtime.getCellFromLink(link).sync().catch(() => {
+      if (reserved) mgr.retractDocPullKick?.(space, id, scope);
+    }),
+  );
+};
+
+/**
+ * What a resolution leaves on the transaction besides the link it returns, so
+ * a memoized one can reproduce it. See {@link resolveLink}'s cache notes.
+ */
+type LinkResolutionRecord = {
+  /** The resolved link. Handed out as a copy, never this object. */
+  readonly result: NormalizedFullLink;
+  /** Every hop the walk recorded, in order, ready to be recorded again. */
+  readonly traces: readonly CfcDereferenceTrace[];
+  /**
+   * Hop targets in another space. Their sync kick is unreserved, so it fires on
+   * every resolution and a memoized one has to fire it too. A same-space kick
+   * is taken against a reservation and fires once whatever happens, so it is
+   * not recorded here.
+   */
+  readonly crossSpaceTargets: readonly NormalizedFullLink[];
+};
+
+// Identity tags for the link fields a cache key cannot cheaply serialize.
+// Schemas are interned at every resolution exit and `scopeCaps` arrays travel
+// by reference, so within one transaction the hot path presents the same
+// object each time. A structurally-equal object under a different identity
+// simply misses, which costs a resolution rather than serving a wrong one.
+let nextIdentityTag = 0;
+const identityTags = new WeakMap<object, number>();
+
+const identityTag = (value: object): number => {
+  let tag = identityTags.get(value);
+  if (tag === undefined) {
+    tag = ++nextIdentityTag;
+    identityTags.set(value, tag);
+  }
+  return tag;
+};
+
+/**
+ * The address a link names, which is both the walk's cycle-detection key and
+ * the tail of its memo key. Computed once and reused for both, so a resolution
+ * that misses the memo pays for exactly the one the walk needed anyway.
+ */
+const linkAddressKey = (link: NormalizedFullLink): string =>
+  JSON.stringify([link.space, link.id, link.scope, link.path]);
+
+/**
+ * What distinguishes two resolutions of the same address. `schema` and
+ * `scopeCaps` decide which hops may be followed and what the result carries,
+ * `overwrite` survives into the result under `preserveOverwrite`, and both
+ * arguments change the answer for the same link.
+ */
+const resolutionMemoVariant = (
+  link: NormalizedFullLink,
+  lastNode: LastNode,
+  preserveOverwrite: boolean,
+): string => {
+  const schema = typeof link.schema === "object" && link.schema !== null
+    ? `#${identityTag(link.schema)}`
+    : String(link.schema);
+  const caps = link.scopeCaps === undefined
+    ? ""
+    : `#${identityTag(link.scopeCaps)}`;
+  return `link:${lastNode}|${preserveOverwrite ? 1 : 0}|` +
+    `${link.overwrite ?? ""}|${schema}|${caps}|`;
+};
+
+/**
  * Resolves a document path with support for links inside documents.
  *
  * It returns a `ResolvedFullLink` that points to a document that no longer has
@@ -195,6 +303,22 @@ const canFollowLinkHop = (
  * same link to be followed several times, so they are bounded by an upper
  * limit of `MAX_PATH_RESOLUTION_LENGTH` iterations, which throws.
  *
+ * A transaction is a consistent snapshot, so resolving the same link twice
+ * against one has to give the same answer, and the second walk is redundant.
+ * The transaction memoizes them: it hands out a cache while it may be used, and
+ * replaces it on every write, so an entry is only ever served when nothing has
+ * been written since it was made. It withholds the cache entirely where a
+ * resolution is not a pure function of the snapshot — once CFC is prepared,
+ * where the read-after-prepare invalidation is load-bearing, and inside an
+ * ambient-read-meta scope, where the same read carries different metadata.
+ *
+ * A hit still has to leave behind what the walk would have: the dereference
+ * traces, which the transaction accumulates for the commit's digest, and the
+ * sync kicks that fire on every resolution. What it does skip is the probe
+ * reads, which the first resolution already journaled on this transaction —
+ * the reactivity log is a set of addresses, and the second walk adds nothing
+ * to it.
+ *
  * @param tx - The storage transaction to read from.
  * @param link - The link to read.
  * @param lastNode - The last node in the path.
@@ -212,7 +336,59 @@ export function resolveLink(
   lastNode: LastNode = "value",
   options: { preserveOverwrite?: boolean; onScopeBlocked?: () => void } = {},
 ): ResolvedFullLink {
+  return resolveLinkTracingDereferences(runtime, tx, link, lastNode, options)
+    .link;
+}
+
+/**
+ * {@link resolveLink}, with the dereference traces this resolution recorded.
+ *
+ * A caller that derives a CFC label view from those traces would otherwise
+ * bracket the call and slice them back off the transaction, which reads the
+ * CFC state through its read-only proxy twice per resolution — the dominant
+ * cost of an element read once the resolution itself is memoized. Taking them
+ * from here reads nothing.
+ *
+ * The traces are recorded on the transaction either way; this is the same list,
+ * not an alternative to recording it.
+ */
+export function resolveLinkTracingDereferences(
+  runtime: Runtime,
+  tx: IExtendedStorageTransaction,
+  link: NormalizedFullLink,
+  lastNode: LastNode = "value",
+  options: { preserveOverwrite?: boolean; onScopeBlocked?: () => void } = {},
+): { link: ResolvedFullLink; traces: readonly CfcDereferenceTrace[] } {
+  // The walk needs this to detect cycles; the memo needs it to name the entry.
+  let addressKey = linkAddressKey(link);
+  const memo = tx.getSnapshotMemo?.();
+  const memoKey = memo &&
+    resolutionMemoVariant(link, lastNode, options.preserveOverwrite === true) +
+      addressKey;
+  if (memoKey !== undefined) {
+    const cached = memo!.get(memoKey) as LinkResolutionRecord | undefined;
+    if (cached !== undefined) {
+      for (const trace of cached.traces) tx.recordCfcDereferenceTrace(trace);
+      for (const target of cached.crossSpaceTargets) {
+        kickDocPull(runtime, target, false);
+      }
+      return {
+        // A copy, so a caller that mutates what it got back cannot reach into
+        // the entry the next resolution will serve.
+        link: { ...cached.result } as unknown as ResolvedFullLink,
+        traces: cached.traces,
+      };
+    }
+  }
+
   const seen = new Set<string>();
+  const traces: CfcDereferenceTrace[] = [];
+  const crossSpaceTargets: NormalizedFullLink[] = [];
+  // A resolution is memoized only when replaying `traces` and
+  // `crossSpaceTargets` reproduces everything it left behind. A blocked follow
+  // does not: its `onScopeBlocked` and its warning belong to every resolution
+  // that reaches the cut, not just the first.
+  let memoizable = true;
 
   let iteration = 0;
 
@@ -222,8 +398,9 @@ export function resolveLink(
       throw new Error(`Link resolution iteration limit reached`);
     }
 
-    // Detect cycles.
-    const key = JSON.stringify([link.space, link.id, link.scope, link.path]);
+    // Detect cycles. `addressKey` always names the link this iteration starts
+    // from: computed for the first before the loop, refreshed by each hop.
+    const key = addressKey;
     if (seen.has(key)) {
       logger.error(
         "link-res-error",
@@ -351,6 +528,7 @@ export function resolveLink(
           },
         ]);
         options.onScopeBlocked?.();
+        memoizable = false;
         link = undefinedDataLink(link);
         break;
       }
@@ -372,7 +550,7 @@ export function resolveLink(
         logger.error("link-res-error", `Link cycle detected: ${detail}`);
         throw new Error(`Link cycle detected at ${key}: ${detail}`);
       }
-      recordDereferenceHop(tx, nextHop);
+      traces.push(recordDereferenceHop(tx, nextHop));
       const nextLink = nextHop.link;
       const crossSpace = nextLink.space !== link.space;
       // The hop consumed `nextHop.depth` of our path and re-rooted the rest
@@ -401,33 +579,18 @@ export function resolveLink(
           ? nextLink
           : { ...nextLink, scopeCaps: carriedCaps };
       }
-      // Force fetching data from the server when the local replica cannot
-      // serve the hop target: crossing spaces (the origin server never pushes
-      // other-space docs), or a same-space doc this replica has never pulled.
-      // The second arm is the fresh-replica read-asymmetry fix: selector
-      // driven syncs only deliver what a schema covered, so a link can point
-      // at a same-space doc no selector ever walked — without this kick such
-      // reads mask as `undefined`, indistinguishable from absence. The kick
-      // is async; one-shot reads still return the masked value, but
-      // `Cell.pull()`'s convergence loop awaits the tracked sync and re-reads.
       const mgr = runtime.storageManager;
-      const { space, id, scope } = link;
       const reserved = !crossSpace &&
-        mgr.shouldPullDoc?.(space, id, scope) === true;
+        mgr.shouldPullDoc?.(link.space, link.id, link.scope) === true;
       if (crossSpace || reserved) {
-        // Swallow sync failures: this kick is best-effort (the read still
-        // resolves from the local replica) and an unhandled rejection here
-        // would otherwise escape the resolution path. On failure, retract
-        // the shouldPullDoc reservation so a later read may retry — but only
-        // when THIS kick took it: a failed cross-space kick never reserved,
-        // and must not clear a reservation a concurrent same-space read
-        // holds for the same target (that would permit duplicate syncs).
-        mgr.trackUntilSettled(
-          runtime.getCellFromLink(link).sync().catch(() => {
-            if (reserved) mgr.retractDocPullKick?.(space, id, scope);
-          }),
-        );
+        // Only the cross-space kick is replayed. A same-space one is taken
+        // against a reservation, so a second resolution of this link would not
+        // kick it either — and if the sync fails and retracts the reservation,
+        // the read that retries is in a later transaction with its own memo.
+        if (crossSpace) crossSpaceTargets.push(link);
+        kickDocPull(runtime, link, reserved);
       }
+      addressKey = linkAddressKey(link);
     } else {
       break;
     }
@@ -450,9 +613,22 @@ export function resolveLink(
     delete result.overwrite;
   }
 
+  if (memoKey !== undefined && memoizable) {
+    // The entry keeps its own copy, for the same reason a hit hands one out:
+    // this caller owns what it is about to be returned.
+    memo!.set(
+      memoKey,
+      {
+        result: { ...result },
+        traces,
+        crossSpaceTargets,
+      } satisfies LinkResolutionRecord,
+    );
+  }
+
   // The casting is a workaround for the branding, we don't actually want to add
   // the symbol to the result.
-  return result as unknown as ResolvedFullLink;
+  return { link: result as unknown as ResolvedFullLink, traces };
 }
 
 /**

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -372,24 +372,24 @@ export function resolveLinkTracingDereferences(
   // The walk needs this to detect cycles; the memo needs it to name the entry.
   let addressKey = linkAddressKey(link);
   const memo = tx.getSnapshotMemo?.();
-  const memoKey = memo &&
-    resolutionMemoVariant(link, lastNode, options.preserveOverwrite === true) +
-      addressKey;
-  if (memoKey !== undefined) {
-    const cached = memo!.get(memoKey) as LinkResolutionRecord | undefined;
-    if (cached !== undefined) {
-      for (const trace of cached.traces) tx.recordCfcDereferenceTrace(trace);
-      for (const target of cached.crossSpaceTargets) {
-        kickDocPull(runtime, target, false);
-      }
-      return {
-        // A copy, so a caller that mutates what it got back cannot reach into
-        // the entry the next resolution will serve.
-        link: { ...cached.result } as unknown as ResolvedFullLink,
-        traces: cached.traces,
-        memoKey,
-      };
+  const memoKey = memo === undefined ? "" : resolutionMemoVariant(
+    link,
+    lastNode,
+    options.preserveOverwrite === true,
+  ) + addressKey;
+  const cached = memo?.get(memoKey) as LinkResolutionRecord | undefined;
+  if (cached !== undefined) {
+    for (const trace of cached.traces) tx.recordCfcDereferenceTrace(trace);
+    for (const target of cached.crossSpaceTargets) {
+      kickDocPull(runtime, target, false);
     }
+    return {
+      // A copy, so a caller that mutates what it got back cannot reach into
+      // the entry the next resolution will serve.
+      link: { ...cached.result } as unknown as ResolvedFullLink,
+      traces: cached.traces,
+      memoKey,
+    };
   }
 
   const seen = new Set<string>();
@@ -624,10 +624,10 @@ export function resolveLinkTracingDereferences(
     delete result.overwrite;
   }
 
-  if (memoKey !== undefined && memoizable) {
+  if (memoizable) {
     // The entry keeps its own copy, for the same reason a hit hands one out:
     // this caller owns what it is about to be returned.
-    memo!.set(
+    memo?.set(
       memoKey,
       {
         result: { ...result },
@@ -642,7 +642,7 @@ export function resolveLinkTracingDereferences(
   return {
     link: result as unknown as ResolvedFullLink,
     traces,
-    memoKey: memoizable ? memoKey : undefined,
+    memoKey: memo !== undefined && memoizable ? memoKey : undefined,
   };
 }
 

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -351,6 +351,12 @@ export function resolveLink(
  *
  * The traces are recorded on the transaction either way; this is the same list,
  * not an alternative to recording it.
+ *
+ * `memoKey` is the key this resolution was memoized under, or `undefined` where
+ * the transaction memoized nothing. A caller memoizing something of its own
+ * derived from the same link against the same transaction can extend it rather
+ * than build a second key over the same fields — and gets the transaction's
+ * "may I memoize at all" answer with it.
  */
 export function resolveLinkTracingDereferences(
   runtime: Runtime,
@@ -358,7 +364,11 @@ export function resolveLinkTracingDereferences(
   link: NormalizedFullLink,
   lastNode: LastNode = "value",
   options: { preserveOverwrite?: boolean; onScopeBlocked?: () => void } = {},
-): { link: ResolvedFullLink; traces: readonly CfcDereferenceTrace[] } {
+): {
+  link: ResolvedFullLink;
+  traces: readonly CfcDereferenceTrace[];
+  memoKey: string | undefined;
+} {
   // The walk needs this to detect cycles; the memo needs it to name the entry.
   let addressKey = linkAddressKey(link);
   const memo = tx.getSnapshotMemo?.();
@@ -377,6 +387,7 @@ export function resolveLinkTracingDereferences(
         // the entry the next resolution will serve.
         link: { ...cached.result } as unknown as ResolvedFullLink,
         traces: cached.traces,
+        memoKey,
       };
     }
   }
@@ -628,7 +639,11 @@ export function resolveLinkTracingDereferences(
 
   // The casting is a workaround for the branding, we don't actually want to add
   // the symbol to the result.
-  return { link: result as unknown as ResolvedFullLink, traces };
+  return {
+    link: result as unknown as ResolvedFullLink,
+    traces,
+    memoKey: memoizable ? memoKey : undefined,
+  };
 }
 
 /**

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -247,6 +247,43 @@ function createViewProxy<T>(
   // the dereference traces it recorded, so the label view below costs no read
   // of the transaction's CFC state.
   const resolved = resolveLinkTracingDereferences(runtime, viewTx, link);
+
+  // Everything from here down — the label view, the value read, the stream and
+  // primitive dispatch, the proxy — is a function of this transaction's
+  // snapshot and the link the caller ASKED for. The cache below is keyed on
+  // that link rather than the resolved one, which is the difference between
+  // consulting it and having to resolve and read a value first just to name
+  // the entry. A scan that touches each element more than once pays the walk
+  // and the read once.
+  //
+  // The resolution above still runs on every access: it is what records this
+  // read's dereference traces and fires the sync kicks that belong to it, and
+  // being memoized itself, that is all it does on a repeat.
+  //
+  // The key names no more than the caches below it already distinguish, so
+  // this index can never be the reason two things that differ share a view.
+  // `writable` is there because a writable proxy carries write traps a
+  // read-only one refuses; `depth` and `pinned` are not, because `byLink`
+  // conflates the first and the second changes nothing about what a view of
+  // this link against this transaction is.
+  const viewMemo = viewTx.getSnapshotMemo?.();
+  const viewKey = viewMemo !== undefined && resolved.memoKey !== undefined &&
+      cfcLabelView === undefined
+    // A caller-supplied label view would have to be part of the key, and
+    // serializing one costs more than the read it saves. Those reads take the
+    // long way; a label view arrives only where a document carries stored CFC
+    // labels.
+    ? `view:${writable ? 1 : 0}|${resolved.memoKey}`
+    : undefined;
+  if (viewKey !== undefined) {
+    const cached = viewMemo!.get(viewKey) as { view: unknown } | undefined;
+    if (cached !== undefined) return cached.view as T;
+  }
+  const remember = <V>(view: V): V => {
+    if (viewKey !== undefined) viewMemo!.set(viewKey, { view });
+    return view;
+  };
+
   link = resolved.link;
   cfcLabelView = mergeCfcLabelViews([
     cloneCfcLabelView(cfcLabelView),
@@ -267,7 +304,9 @@ function createViewProxy<T>(
   // pattern's Output type wasn't explicitly specified, causing the capture
   // schema to lose the asCell stream information.
   if (isStreamValue(value)) {
-    return createCell(runtime, link, tx, false, "stream", cfcLabelView) as T;
+    return remember(
+      createCell(runtime, link, tx, false, "stream", cfcLabelView) as T,
+    );
   }
 
   // `FabricPrimitive`s (byte sequences, temporal values, hashes, ...) are
@@ -286,7 +325,7 @@ function createViewProxy<T>(
     if (value instanceof FabricPrimitive) {
       viewTx.readValueOrThrow(link);
     }
-    return value;
+    return remember(value);
   }
 
   // A `FabricInstance` is _not_ exempted here the way a `FabricPrimitive` is
@@ -355,7 +394,7 @@ function createViewProxy<T>(
   // the same frozen object always maps to the same proxy instance.
   const existingProxy = txCache.byLink.get(cacheKey) ??
     (cfcLabelView === undefined ? txCache.byValue.get(value) : undefined);
-  if (existingProxy) return existingProxy;
+  if (existingProxy) return remember(existingProxy);
 
   const proxy = new Proxy(proxyTarget as object, {
     get: (target, prop, receiver) => {
@@ -844,7 +883,7 @@ function createViewProxy<T>(
   if (cfcLabelView === undefined) {
     txCache.byValue.set(value, proxy);
   }
-  return proxy;
+  return remember(proxy);
 }
 
 // Wraps a value on an array so that it can be read as literal or object,

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -6,7 +6,7 @@ import { getTopFrame } from "./builder/pattern.ts";
 import { isStreamValue } from "./builder/types.ts";
 import { type BackToCellInternals, toCell } from "./back-to-cell.ts";
 import { diffAndUpdate } from "./data-updating.ts";
-import { resolveLink } from "./link-resolution.ts";
+import { resolveLinkTracingDereferences } from "./link-resolution.ts";
 import { type NormalizedFullLink } from "./link-utils.ts";
 import { type Cell, createCell, frameAnchorIds } from "./cell.ts";
 import { type Runtime } from "./runtime.ts";
@@ -243,15 +243,14 @@ function createViewProxy<T>(
     );
   }
 
-  // Resolve path and follow links to actual value.
-  const traceStart = viewTx.getCfcState().dereferenceTraces.length;
-  link = resolveLink(runtime, viewTx, link);
+  // Resolve path and follow links to actual value. The resolution hands back
+  // the dereference traces it recorded, so the label view below costs no read
+  // of the transaction's CFC state.
+  const resolved = resolveLinkTracingDereferences(runtime, viewTx, link);
+  link = resolved.link;
   cfcLabelView = mergeCfcLabelViews([
     cloneCfcLabelView(cfcLabelView),
-    cfcLabelViewForDereferenceTraces(
-      viewTx,
-      viewTx.getCfcState().dereferenceTraces.slice(traceStart),
-    ),
+    cfcLabelViewForDereferenceTraces(viewTx, resolved.traces),
   ]);
   const value = viewTx.readValueOrThrow(link, SHAPE_READ) as any;
 

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -266,21 +266,21 @@ function createViewProxy<T>(
   // read-only one refuses; `depth` and `pinned` are not, because `byLink`
   // conflates the first and the second changes nothing about what a view of
   // this link against this transaction is.
-  const viewMemo = viewTx.getSnapshotMemo?.();
-  const viewKey = viewMemo !== undefined && resolved.memoKey !== undefined &&
-      cfcLabelView === undefined
-    // A caller-supplied label view would have to be part of the key, and
-    // serializing one costs more than the read it saves. Those reads take the
-    // long way; a label view arrives only where a document carries stored CFC
-    // labels.
-    ? `view:${writable ? 1 : 0}|${resolved.memoKey}`
+  //
+  // A caller-supplied label view would have to be part of the key, and
+  // serializing one costs more than the read it saves. Those reads take the
+  // long way; a label view arrives only where a document carries stored CFC
+  // labels.
+  const viewMemo = cfcLabelView === undefined && resolved.memoKey !== undefined
+    ? viewTx.getSnapshotMemo?.()
     : undefined;
-  if (viewKey !== undefined) {
-    const cached = viewMemo!.get(viewKey) as { view: unknown } | undefined;
-    if (cached !== undefined) return cached.view as T;
-  }
+  const viewKey = viewMemo === undefined
+    ? ""
+    : `view:${writable ? 1 : 0}|${resolved.memoKey}`;
+  const cached = viewMemo?.get(viewKey) as { view: unknown } | undefined;
+  if (cached !== undefined) return cached.view as T;
   const remember = <V>(view: V): V => {
-    if (viewKey !== undefined) viewMemo!.set(viewKey, { view });
+    viewMemo?.set(viewKey, { view });
     return view;
   };
 

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -101,6 +101,7 @@ import {
   clearSchemaRefusalTx,
   isInternalVerifierRead,
   isLazyMaterializationTx,
+  isUiInputBlindWriteTx,
   markLazyMaterializationTx,
   noteSchemaRefusalTx,
   reactivityLogFromActivities,
@@ -380,6 +381,11 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   private readResultCacheHits = 0;
   private readResultCacheMisses = 0;
   private readResultCacheSets = 0;
+  // Per-transaction memo for derivations that read only this snapshot -- link
+  // resolution and CFC label views, each under its own key prefix. Dropped on
+  // any write alongside the read cache above, and bounded the same way: it
+  // retains only what was derived since this transaction's last write.
+  private snapshotMemo = new Map<string, unknown>();
 
   constructor(
     public tx: IStorageTransaction,
@@ -877,6 +883,10 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
 
   resetNarrowestReadScope(scope: CellScope = "space"): void {
     this.narrowestReadScope = scope;
+    // The caller is about to re-read to learn the scope of what it reads. A
+    // memoized link resolution issues no reads, so it would contribute nothing
+    // to the scope taken afterwards and the answer would come out too wide.
+    this.snapshotMemo = new Map();
   }
 
   markLazyMaterialize(enabled = true): void {
@@ -941,6 +951,28 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     this.readResultCacheSets++;
   }
 
+  getSnapshotMemo(): Map<string, unknown> | undefined {
+    // A finished transaction answers no reads, so nothing it memoized earlier
+    // may be handed out as if it had.
+    if (this.status().status !== "ready") return undefined;
+    // Once CFC is prepared, the read path's `read-after-prepare` invalidation
+    // is load-bearing: a memoized resolution issues no reads and would leave a
+    // prepared digest standing over a read it never made.
+    if (this.#cfcState.prepare.status === "prepared") return undefined;
+    // Inside an ambient-read-meta scope the reads a derivation issues carry
+    // metadata that flow-label derivation reads. Serving one across the scope
+    // boundary — either way — would journal the wrong ones, so the scope
+    // neither reads the memo nor writes to it.
+    if (this.#ambientReadMeta !== undefined) return undefined;
+    // Same for the UI-input blind-write mode, which tags every read it sees
+    // `ignoreReadForCommit`. An entry made under it, served after it is
+    // cleared, would stand in for reads that are supposed to carry a
+    // value-equality commit precondition — and the precondition would simply
+    // not be there.
+    if (isUiInputBlindWriteTx(this)) return undefined;
+    return this.snapshotMemo;
+  }
+
   getReadResultCacheStats(): {
     hits: number;
     misses: number;
@@ -979,11 +1011,13 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   }
 
   private invalidateReadResultCache(): void {
-    // A write may have changed any value a cached read depends on. Drop the
-    // whole cache by replacing the map; this enforces
-    // the "no writes between the last read and this one" invariant the cache
-    // relies on.
+    // A write may have changed any value a cached read depends on — including
+    // the links a resolution walked, which a write can add, retarget or
+    // replace with a plain value. Drop both caches by replacing the maps; this
+    // enforces the "no writes between the last read and this one" invariant
+    // they rely on.
     this.readResultCache = new Map();
+    this.snapshotMemo = new Map();
   }
 
   recordCfcDereferenceTrace(trace: CfcDereferenceTrace): void {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -1626,6 +1626,38 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
     sets: number;
     entries: number;
   };
+
+  /**
+   * Answers this transaction's snapshot has already computed, or `undefined`
+   * while it must not serve any.
+   *
+   * A transaction is a consistent snapshot, so a derivation that reads only
+   * through it gives the same answer every time until something is written.
+   * Link resolution and CFC label-view derivation both do exactly that, and
+   * both are driven per element of a collection, so a scan recomputes them
+   * once per element per pass. Each user owns its own key prefix and entry
+   * shape; the transaction owns when the map may be used and when it is
+   * dropped. It is replaced wholesale on any write — same rule as the
+   * `Cell.get()` cache above — so an entry is only ever served when nothing
+   * has been written since it was made.
+   *
+   * A user must be a derivation whose only observable effect is its result, or
+   * must reproduce the rest itself: the reads a memoized derivation skips were
+   * journaled by the one that filled the entry, so the transaction's read set
+   * is unchanged, but anything consumed positionally (CFC dereference traces)
+   * still has to be recorded on every call.
+   *
+   * `undefined` is returned where a derivation is not a pure function of the
+   * snapshot: once CFC is prepared, where the read path's read-after-prepare
+   * invalidation is load-bearing, and inside a `runWithAmbientReadMeta()`
+   * scope, where the reads carry metadata that a call outside the scope would
+   * not.
+   *
+   * Optional: transactions that must not memoize (the non-reactive `sample()`
+   * wrapper, whose reads are excluded from scheduling) leave it undefined, and
+   * their callers derive for real.
+   */
+  getSnapshotMemo?(): Map<string, unknown> | undefined;
 }
 
 /**

--- a/packages/runner/test/link-resolution.bench.ts
+++ b/packages/runner/test/link-resolution.bench.ts
@@ -225,6 +225,69 @@ Deno.bench("array element resolution in circular structures", () => {
   storageManager.close();
 });
 
+// A list scanned through the reactive proxy: what a lift does when it reads a
+// collection of linked entries, and the shape the transaction-scoped memo
+// exists for. `elements per pass` is the per-element cost; `whole array` is
+// one pass over the whole thing. The unmemoized cost of both is linear in the
+// number of resolutions, so a scan that touches each element more than once
+// pays it again per touch.
+const LIST_LENGTH = 50;
+
+const listBoardSetup = () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const tx = runtime.edit();
+  const entries = [];
+  for (let index = 0; index < LIST_LENGTH; index++) {
+    const entry = runtime.getCell<{ title: string }>(
+      space,
+      `bench-list-entry-${index}`,
+      undefined,
+      tx,
+    );
+    entry.set({ title: `Entry ${index}` });
+    entries.push(entry);
+  }
+  const board = runtime.getCell<unknown[]>(
+    space,
+    "bench-list-board",
+    undefined,
+    tx,
+  );
+  board.set(entries as never);
+  return { storageManager, runtime, tx, board };
+};
+
+Deno.bench("reactive list: one element read", () => {
+  const { storageManager, runtime, tx, board } = listBoardSetup();
+  const list = board.get() as unknown[];
+
+  for (let index = 0; index < LIST_LENGTH; index++) void list[index];
+
+  tx.commit();
+  runtime.dispose();
+  storageManager.close();
+});
+
+Deno.bench("reactive list: whole array read per element", () => {
+  const { storageManager, runtime, tx, board } = listBoardSetup();
+  const list = board.get() as unknown[];
+
+  // Every `filter` materializes every element, so this touches each element
+  // once per element -- the scan an author writes when a row needs to know
+  // about the other rows.
+  for (let index = 0; index < LIST_LENGTH; index++) {
+    void list.filter((_entry, other) => other !== index);
+  }
+
+  tx.commit();
+  runtime.dispose();
+  storageManager.close();
+});
+
 Deno.bench("resolveLink with infinitely growing path (A->A/foo)", () => {
   const storageManager = StorageManager.emulate({
     as: signer,

--- a/packages/runner/test/snapshot-memo.test.ts
+++ b/packages/runner/test/snapshot-memo.test.ts
@@ -273,7 +273,12 @@ describe("snapshot memo", () => {
     const dropped = resolveLink(runtime, tx, link, "writeRedirect");
 
     expect(preserved.overwrite).toBe("redirect");
-    expect(dropped.overwrite).toBeUndefined();
+    // The key is deleted, not set to `undefined`, and a result carrying
+    // `overwrite: undefined` is a shape a reader spreading it into a link
+    // would carry along. `Object.hasOwn` is what decides that: reading the
+    // property answers `undefined` either way, and `toHaveProperty` counts a
+    // present-but-undefined key as absent.
+    expect(Object.hasOwn(dropped, "overwrite")).toBe(false);
   });
 
   it("hands back the traces the transaction recorded for this resolution", () => {

--- a/packages/runner/test/snapshot-memo.test.ts
+++ b/packages/runner/test/snapshot-memo.test.ts
@@ -13,6 +13,7 @@ import {
   resolveLink,
   resolveLinkTracingDereferences,
 } from "../src/link-resolution.ts";
+import { createQueryResultProxy } from "../src/query-result-proxy.ts";
 import { Runtime } from "../src/runtime.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { createNonReactiveTransaction } from "../src/storage/extended-storage-transaction.ts";
@@ -490,5 +491,102 @@ describe("snapshot memo", () => {
     expect(afterCommit.path).toEqual(["target"]);
 
     tx = runtime.edit();
+  });
+
+  describe("proxy views", () => {
+    /** A list of links to one-field documents -- the shape a lift scans. */
+    const linkedList = (cause: string, length: number) => {
+      const entries = [];
+      for (let index = 0; index < length; index++) {
+        const entry = runtime.getCell<{ title: string }>(
+          space,
+          `${cause}-entry-${index}`,
+          undefined,
+          tx,
+        );
+        entry.set({ title: `Entry ${index}` });
+        entries.push(entry);
+      }
+      const list = runtime.getCell<unknown[]>(space, cause, undefined, tx);
+      list.set(entries as never);
+      return list;
+    };
+
+    it("issues no further reads for an element already read in the transaction", () => {
+      const list = linkedList("read-once", 3);
+      const view = list.get() as unknown[];
+
+      void view[0];
+      const afterFirst = readCount();
+      void view[0];
+
+      expect(afterFirst).toBeGreaterThan(0);
+      expect(readCount()).toBe(afterFirst);
+    });
+
+    it("returns the same element view on a repeated read", () => {
+      const list = linkedList("same-view", 3);
+      const view = list.get() as unknown[];
+
+      expect(view[1]).toBe(view[1]);
+    });
+
+    it("reads a leaf value once per element in the transaction", () => {
+      const list = linkedList("leaf-once", 3);
+      const view = list.get() as { title: string }[];
+
+      expect(view[2].title).toBe("Entry 2");
+      const afterFirst = readCount();
+
+      expect(view[2].title).toBe("Entry 2");
+      expect(readCount()).toBe(afterFirst);
+    });
+
+    it("reads the new value after a write in the same transaction", () => {
+      const list = linkedList("rewrite", 2);
+      const view = list.get() as { title: string }[];
+      expect(view[0].title).toBe("Entry 0");
+
+      runtime.getCell<{ title: string }>(
+        space,
+        "rewrite-entry-0",
+        undefined,
+        tx,
+      )
+        .key("title").set("Edited");
+
+      expect(view[0].title).toBe("Edited");
+    });
+
+    it("hands two readers of one element the same view", () => {
+      const list = linkedList("shared", 2);
+      const link = list.getAsNormalizedFullLink();
+      const first = createQueryResultProxy<unknown[]>(runtime, tx, link);
+      const second = createQueryResultProxy<unknown[]>(runtime, tx, link);
+
+      // Consumers compare element views by identity -- FUSE matching a
+      // callable against its own entry, a value whose element points back at
+      // the array holding it. The index must hand back what the proxy cache
+      // under it would, not a second object for the same element.
+      expect(second[0]).toBe(first[0]);
+    });
+
+    it("reads the new value through a later transaction", async () => {
+      linkedList("later", 2);
+      const read = (of: IExtendedStorageTransaction) =>
+        (runtime.getCell<{ title: string }[]>(space, "later", undefined, of)
+          .get())[0].title;
+
+      expect(read(tx)).toBe("Entry 0");
+      await tx.commit();
+
+      // Each transaction memoizes for itself. A view taken in one is not an
+      // answer any later one may give.
+      tx = runtime.edit();
+      runtime.getCell<{ title: string }>(space, "later-entry-0", undefined, tx)
+        .key("title").set("Edited");
+
+      expect(read(tx)).toBe("Edited");
+    });
   });
 });

--- a/packages/runner/test/snapshot-memo.test.ts
+++ b/packages/runner/test/snapshot-memo.test.ts
@@ -1,0 +1,494 @@
+// The memo a transaction keeps for derivations that read only its snapshot --
+// link resolution and CFC label views. What it collapses, what a memoized call
+// must still leave behind, and where it has to stand aside.
+
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { type JSONSchema } from "../src/builder/types.ts";
+import {
+  resolveLink,
+  resolveLinkTracingDereferences,
+} from "../src/link-resolution.ts";
+import { Runtime } from "../src/runtime.ts";
+import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { createNonReactiveTransaction } from "../src/storage/extended-storage-transaction.ts";
+import {
+  machineryRead,
+  markUiInputBlindWriteTx,
+  unmarkUiInputBlindWriteTx,
+} from "../src/storage/reactivity-log.ts";
+import {
+  cfcLabelViewForDereference,
+  cfcLabelViewForDereferenceTraces,
+} from "../src/cfc/label-view-state.ts";
+
+const signer = await Identity.fromPassphrase("snapshot memo test");
+const space = signer.did();
+const otherSpace = (await Identity.fromPassphrase("snapshot memo other")).did();
+
+const STRING_SCHEMA = { type: "string" } as const satisfies JSONSchema;
+const NUMBER_SCHEMA = { type: "number" } as const satisfies JSONSchema;
+
+describe("snapshot memo", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  const readCount = (of: IExtendedStorageTransaction = tx): number =>
+    [...(of.getReadActivities?.() ?? [])].length;
+
+  const traceCount = (of: IExtendedStorageTransaction = tx): number =>
+    of.getCfcState().dereferenceTraces.length;
+
+  /** Reads of a document's stored CFC metadata, which sits at `["cfc"]`. */
+  const cfcMetadataReadCount = (): number =>
+    [...(tx.getReadActivities?.() ?? [])]
+      .filter((read) => read.path.length === 1 && read.path[0] === "cfc")
+      .length;
+
+  /** A cell holding `{ target: <link to another cell's value> }`. */
+  const linkingCell = (cause: string, targetCause: string) => {
+    const target = runtime.getCell<{ value: string }>(
+      space,
+      targetCause,
+      undefined,
+      tx,
+    );
+    target.set({ value: targetCause });
+    const holder = runtime.getCell<{ target: unknown }>(
+      space,
+      cause,
+      undefined,
+      tx,
+    );
+    holder.setRaw({ target: target.key("value").getAsLink() });
+    return { holder, target };
+  };
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("issues no further reads for a link already resolved in the transaction", () => {
+    const { holder } = linkingCell("repeat-holder", "repeat-target");
+    const link = holder.key("target").getAsNormalizedFullLink();
+
+    resolveLink(runtime, tx, link);
+    const afterFirst = readCount();
+    resolveLink(runtime, tx, link);
+
+    expect(readCount()).toBe(afterFirst);
+  });
+
+  it("returns the same resolved link for a repeated resolution", () => {
+    const { holder, target } = linkingCell("same-holder", "same-target");
+    const link = holder.key("target").getAsNormalizedFullLink();
+
+    const first = resolveLink(runtime, tx, link);
+    const second = resolveLink(runtime, tx, link);
+
+    expect(second).toEqual(first);
+    expect(second.id).toBe(target.getAsNormalizedFullLink().id);
+  });
+
+  it("does not carry an edit of one resolution's result into the next", () => {
+    const { holder } = linkingCell("copy-holder", "copy-target");
+    const link = holder.key("target").getAsNormalizedFullLink();
+
+    resolveLink(runtime, tx, link);
+    const edited = resolveLink(runtime, tx, link);
+    (edited as { id: string }).id = "of:tampered";
+
+    expect(resolveLink(runtime, tx, link).id).not.toBe("of:tampered");
+  });
+
+  it("records the dereference trace on every resolution, memoized or not", () => {
+    const { holder } = linkingCell("trace-holder", "trace-target");
+    const link = holder.key("target").getAsNormalizedFullLink();
+
+    const before = traceCount();
+    resolveLink(runtime, tx, link);
+    const afterFirst = traceCount();
+    resolveLink(runtime, tx, link);
+
+    expect(afterFirst - before).toBe(1);
+    expect(traceCount() - afterFirst).toBe(1);
+  });
+
+  it("resolves to the new target after a write retargets the link", () => {
+    const first = runtime.getCell<{ value: string }>(
+      space,
+      "retarget-first",
+      undefined,
+      tx,
+    );
+    first.set({ value: "first" });
+    const second = runtime.getCell<{ value: string }>(
+      space,
+      "retarget-second",
+      undefined,
+      tx,
+    );
+    second.set({ value: "second" });
+    const holder = runtime.getCell<{ target: unknown }>(
+      space,
+      "retarget-holder",
+      undefined,
+      tx,
+    );
+    holder.setRaw({ target: first.key("value").getAsLink() });
+    const link = holder.key("target").getAsNormalizedFullLink();
+
+    expect(resolveLink(runtime, tx, link).id).toBe(
+      first.getAsNormalizedFullLink().id,
+    );
+    holder.setRaw({ target: second.key("value").getAsLink() });
+
+    expect(resolveLink(runtime, tx, link).id).toBe(
+      second.getAsNormalizedFullLink().id,
+    );
+  });
+
+  it("resolves to the value in place after a write replaces the link", () => {
+    const { holder } = linkingCell("replaced-holder", "replaced-target");
+    const link = holder.key("target").getAsNormalizedFullLink();
+
+    const followed = resolveLink(runtime, tx, link);
+    expect(followed.id).not.toBe(holder.getAsNormalizedFullLink().id);
+    holder.setRaw({ target: "a plain string, no longer a link" });
+
+    const inPlace = resolveLink(runtime, tx, link);
+    expect(inPlace.id).toBe(holder.getAsNormalizedFullLink().id);
+    expect(inPlace.path).toEqual(["target"]);
+  });
+
+  it("keeps resolutions of two paths in one document apart", () => {
+    const first = runtime.getCell<{ value: string }>(
+      space,
+      "two-paths-first",
+      undefined,
+      tx,
+    );
+    first.set({ value: "first" });
+    const second = runtime.getCell<{ value: string }>(
+      space,
+      "two-paths-second",
+      undefined,
+      tx,
+    );
+    second.set({ value: "second" });
+    const holder = runtime.getCell<{ a: unknown; b: unknown }>(
+      space,
+      "two-paths-holder",
+      undefined,
+      tx,
+    );
+    holder.setRaw({
+      a: first.key("value").getAsLink(),
+      b: second.key("value").getAsLink(),
+    });
+
+    const viaA = resolveLink(
+      runtime,
+      tx,
+      holder.key("a").getAsNormalizedFullLink(),
+    );
+    const viaB = resolveLink(
+      runtime,
+      tx,
+      holder.key("b").getAsNormalizedFullLink(),
+    );
+
+    expect(viaA.id).toBe(first.getAsNormalizedFullLink().id);
+    expect(viaB.id).toBe(second.getAsNormalizedFullLink().id);
+  });
+
+  it("keeps resolutions of the same link under different schemas apart", () => {
+    const { holder } = linkingCell("schema-holder", "schema-target");
+    const base = holder.key("target").getAsNormalizedFullLink();
+
+    const asString = resolveLink(runtime, tx, {
+      ...base,
+      schema: STRING_SCHEMA,
+    });
+    const asNumber = resolveLink(runtime, tx, {
+      ...base,
+      schema: NUMBER_SCHEMA,
+    });
+
+    expect(asString.schema).toEqual(STRING_SCHEMA);
+    expect(asNumber.schema).toEqual(NUMBER_SCHEMA);
+  });
+
+  it("keeps resolutions of the same link under different lastNode apart", () => {
+    const { holder, target } = linkingCell("last-node-holder", "last-node-t");
+    const link = holder.key("target").getAsNormalizedFullLink();
+
+    // The stored link is a value link, so `writeRedirect` stops at the holder
+    // while `value` follows through to the target.
+    const stoppedAtHolder = resolveLink(runtime, tx, link, "writeRedirect");
+    const followed = resolveLink(runtime, tx, link, "value");
+
+    expect(stoppedAtHolder.id).toBe(holder.getAsNormalizedFullLink().id);
+    expect(followed.id).toBe(target.getAsNormalizedFullLink().id);
+  });
+
+  it("keeps resolutions of the same link under different preserveOverwrite apart", () => {
+    const target = runtime.getCell<{ value: string }>(
+      space,
+      "overwrite-target",
+      undefined,
+      tx,
+    );
+    target.set({ value: "kept" });
+    const redirect = target.key("value").getAsWriteRedirectLink();
+    const holder = runtime.getCell<{ target: unknown }>(
+      space,
+      "overwrite-holder",
+      undefined,
+      tx,
+    );
+    holder.setRaw({ target: redirect });
+    const link = holder.key("target").getAsNormalizedFullLink();
+
+    const preserved = resolveLink(runtime, tx, link, "writeRedirect", {
+      preserveOverwrite: true,
+    });
+    const dropped = resolveLink(runtime, tx, link, "writeRedirect");
+
+    expect(preserved.overwrite).toBe("redirect");
+    expect(dropped.overwrite).toBeUndefined();
+  });
+
+  it("hands back the traces the transaction recorded for this resolution", () => {
+    const { holder } = linkingCell("returned-holder", "returned-target");
+    const link = holder.key("target").getAsNormalizedFullLink();
+
+    const before = traceCount();
+    const { traces } = resolveLinkTracingDereferences(runtime, tx, link);
+    const recorded = tx.getCfcState().dereferenceTraces.slice(before);
+
+    expect(traces.length).toBe(1);
+    expect(traces).toEqual(recorded);
+  });
+
+  it("hands back the same traces on a memoized resolution", () => {
+    const { holder } = linkingCell("returned2-holder", "returned2-target");
+    const link = holder.key("target").getAsNormalizedFullLink();
+
+    const first = resolveLinkTracingDereferences(runtime, tx, link);
+    const before = traceCount();
+    const second = resolveLinkTracingDereferences(runtime, tx, link);
+
+    expect(second.traces).toEqual(first.traces);
+    expect(tx.getCfcState().dereferenceTraces.slice(before)).toEqual(
+      second.traces,
+    );
+  });
+
+  it("kicks the cross-space pull again for a memoized resolution", async () => {
+    // A transaction opens a writer for one space at a time, so the other
+    // space's document is written in its own.
+    const otherTx = runtime.edit();
+    const target = runtime.getCell<{ value: string }>(
+      otherSpace,
+      "cross-space-target",
+      undefined,
+      otherTx,
+    );
+    target.set({ value: "over there" });
+    await otherTx.commit();
+    const holder = runtime.getCell<{ target: unknown }>(
+      space,
+      "cross-space-holder",
+      undefined,
+      tx,
+    );
+    holder.setRaw({ target: target.key("value").getAsLink() });
+    const link = holder.key("target").getAsNormalizedFullLink();
+    // The origin server never pushes other-space documents, so the kick is
+    // unreserved and fires on every resolution. A memoized one has to fire it
+    // too, or a reader whose first resolution predates the arrival never asks
+    // again.
+    const kicks: unknown[] = [];
+    const manager = runtime.storageManager as {
+      trackUntilSettled: (work: Promise<unknown>) => void;
+    };
+    const tracked = manager.trackUntilSettled.bind(manager);
+    manager.trackUntilSettled = (work) => {
+      kicks.push(work);
+      tracked(work);
+    };
+    try {
+      resolveLink(runtime, tx, link);
+      const afterFirst = kicks.length;
+      resolveLink(runtime, tx, link);
+
+      expect(afterFirst).toBeGreaterThan(0);
+      expect(kicks.length).toBeGreaterThan(afterFirst);
+    } finally {
+      manager.trackUntilSettled = tracked;
+    }
+  });
+
+  it("reads a document's stored labels once per dereference target", () => {
+    const { holder } = linkingCell("labels-holder", "labels-target");
+    const link = holder.key("target").getAsNormalizedFullLink();
+    const { traces } = resolveLinkTracingDereferences(runtime, tx, link);
+
+    cfcLabelViewForDereferenceTraces(tx, traces);
+    const afterFirst = cfcMetadataReadCount();
+    cfcLabelViewForDereferenceTraces(tx, traces);
+
+    // One dereference names two addresses, and the first derivation read both.
+    expect(afterFirst).toBeGreaterThan(0);
+    expect(cfcMetadataReadCount()).toBe(afterFirst);
+  });
+
+  it("keeps the label views of two paths in one document apart", () => {
+    const labeled = runtime.getCell(space, "labeled-doc", undefined, tx);
+    const link = labeled.getAsNormalizedFullLink();
+    tx.writeOrThrow({
+      space,
+      id: link.id,
+      type: "application/json",
+      path: [],
+    }, {
+      value: { a: "under a", b: "under b" },
+      cfc: {
+        version: 1,
+        schemaHash: "test-schema",
+        labelMap: {
+          version: 1,
+          entries: [
+            { path: ["a"], label: { confidentiality: ["secret-a"] } },
+            { path: ["b"], label: { confidentiality: ["secret-b"] } },
+          ],
+        },
+      },
+    });
+    const at = (path: string[]) => ({
+      space,
+      id: link.id,
+      scope: link.scope,
+      path,
+    });
+
+    // A view is rebased onto the address it was asked for, so the same
+    // document answers differently at each path.
+    const viaA = cfcLabelViewForDereference(tx, at(["a"]), at(["a"]));
+    const viaB = cfcLabelViewForDereference(tx, at(["b"]), at(["b"]));
+
+    expect(viaA?.entries[0].label.confidentiality).toEqual(["secret-a"]);
+    expect(viaB?.entries[0].label.confidentiality).toEqual(["secret-b"]);
+  });
+
+  it("re-reads a document's stored labels after a write", () => {
+    const { holder } = linkingCell("labels2-holder", "labels2-target");
+    const link = holder.key("target").getAsNormalizedFullLink();
+    const { traces } = resolveLinkTracingDereferences(runtime, tx, link);
+
+    cfcLabelViewForDereferenceTraces(tx, traces);
+    const afterFirst = cfcMetadataReadCount();
+    holder.setRaw({ target: "no longer a link" });
+    cfcLabelViewForDereferenceTraces(tx, traces);
+
+    expect(cfcMetadataReadCount()).toBeGreaterThan(afterFirst);
+  });
+
+  it("reads for real inside an ambient-read-meta scope", () => {
+    const { holder } = linkingCell("ambient-holder", "ambient-target");
+    const link = holder.key("target").getAsNormalizedFullLink();
+
+    resolveLink(runtime, tx, link);
+    const afterFirst = readCount();
+    // The scope tags the reads it issues, and label derivation reads those
+    // tags, so a resolution inside it cannot be served from an entry made
+    // outside it.
+    tx.runWithAmbientReadMeta(machineryRead, () => {
+      resolveLink(runtime, tx, link);
+    });
+
+    expect(readCount()).toBeGreaterThan(afterFirst);
+  });
+
+  it("reads for real again after a blind UI-input write mode ends", () => {
+    const { holder } = linkingCell("blind-holder", "blind-target");
+    const link = holder.key("target").getAsNormalizedFullLink();
+
+    // While marked, every read is journaled without a value-equality commit
+    // precondition. An entry made under the mark must not stand in for the
+    // reads a resolution after it is supposed to make.
+    markUiInputBlindWriteTx(tx);
+    resolveLink(runtime, tx, link);
+    unmarkUiInputBlindWriteTx(tx);
+    const afterBlind = readCount();
+    resolveLink(runtime, tx, link);
+
+    expect(readCount()).toBeGreaterThan(afterBlind);
+  });
+
+  it("reads for real after the narrowest read scope is reset", () => {
+    const { holder } = linkingCell("reset-holder", "reset-target");
+    const link = holder.key("target").getAsNormalizedFullLink();
+
+    resolveLink(runtime, tx, link);
+    const afterFirst = readCount();
+    // The caller is about to take the scope of what it reads next; a
+    // resolution that issued no reads would leave that answer too wide.
+    tx.resetNarrowestReadScope();
+    resolveLink(runtime, tx, link);
+
+    expect(readCount()).toBeGreaterThan(afterFirst);
+  });
+
+  it("reads for real through a non-reactive transaction wrapper", () => {
+    const { holder } = linkingCell("sample-holder", "sample-target");
+    const link = holder.key("target").getAsNormalizedFullLink();
+
+    // The wrapper marks its reads as ignored for scheduling. Serving them from
+    // an entry a reactive resolution made would journal the reactive ones in
+    // their place, and serving a reactive read from the wrapper's entry would
+    // lose the dependency.
+    resolveLink(runtime, tx, link);
+    const afterFirst = readCount();
+    const nonReactive = createNonReactiveTransaction(tx);
+    resolveLink(runtime, nonReactive, link);
+
+    expect(readCount()).toBeGreaterThan(afterFirst);
+  });
+
+  it("stops serving what it resolved once the transaction has finished", async () => {
+    const { holder, target } = linkingCell("closed-holder", "closed-target");
+    const link = holder.key("target").getAsNormalizedFullLink();
+
+    expect(resolveLink(runtime, tx, link).id).toBe(
+      target.getAsNormalizedFullLink().id,
+    );
+    await tx.commit();
+
+    // A finished transaction answers no reads, so it must not answer with what
+    // it saw while it was open. Resolution falls through to a walk that finds
+    // no link and leaves the address where it started.
+    const afterCommit = resolveLink(runtime, tx, link);
+    expect(afterCommit.id).toBe(holder.getAsNormalizedFullLink().id);
+    expect(afterCommit.path).toEqual(["target"]);
+
+    tx = runtime.edit();
+  });
+});


### PR DESCRIPTION
`resolveLink` walked the link graph on every call, and the proxy cache that was
meant to save that walk is keyed on the *resolved* link — so consulting it meant
first resolving and reading a value, the two things it exists to save. Every
element access through a reactive array paid both. A lift that scans a list once
per element paid them N times over: on a 40-entry board, 1640 resolutions where
40 will do.

Two commits, each standing on its own.

## 1. A transaction resolves a link once

A transaction is a consistent snapshot, so a second walk cannot reach a
different answer. The transaction now keeps a memo for derivations that read
only its snapshot, keyed per user, replaced on any write — the same rule the
`Cell.get()` cache next to it already follows. Link resolution is one user;
deriving a CFC label view from a document's stored labels is the other, which
was reading `["cfc"]` twice per hop per element.

A memoized resolution still leaves behind what the walk would have: the
dereference traces the commit's digest accumulates, and the cross-space sync
kicks, which are unreserved and fire every time. What it skips is the probe
reads — and only because the resolution that filled the entry already journaled
them on this transaction, so the reactivity log's set of addresses is unchanged.

That argument fails wherever the same read would be journaled *differently*, so
the transaction withholds the memo entirely:

- once CFC is prepared, where the read-after-prepare invalidation is load-bearing
- inside a `runWithAmbientReadMeta()` scope
- under the UI-input blind-write mode, which tags reads `ignoreReadForCommit`
- across `resetNarrowestReadScope()`, where a caller is about to measure what its
  next reads touch
- on a finished transaction, and through the non-reactive `sample()` wrapper

Resolution also hands its traces back now. The caller deriving a label view from
them was bracketing the call and slicing them off the transaction, which reads
the CFC state through its read-only proxy twice per element — the dominant cost
of an element read once the walk itself is memoized.

## 2. An element read finds its view without resolving first

`resolveLink` returns the key it memoized under, and a second index on that key
holds the finished view. A repeat access finds it without resolving, without the
value read, and without building the resolved-link key. The resolution still
runs — it is what records the read's traces and fires its kicks — and being
memoized, on a repeat that is all it does.

The view key distinguishes no less than the caches under it: `writable`, and the
link. Not `depth` (`byLink` already conflates it) and not `pinned` (it changes
nothing about what a view of one link against one transaction is).

## Measured

On a 50-entry list read through the proxy, against `main`:

| benchmark | main | after (1) | after (2) |
|---|---|---|---|
| one element read | 9.1 ms | 8.3 ms | **4.9 ms** |
| whole array read per element | 72.8 ms | 19.6 ms | **6.4 ms** |

Both are new benchmarks in `link-resolution.bench.ts`, so the gain is defended
per the performance program's "protect what you've gained".

On an 80-entry board the quadratic scan is now 9.4 ms against 2.1 ms for the
same scan over a plain `Array.from` copy; before these changes it was 49.8 ms
against 1.0 ms. What remains per access is the memo key — one `JSON.stringify`,
which PERF-3 already tracks — and the dereference trace the digest wants
recorded on every read.

Counted on the same shape: `resolveLink` walks 1640 → 40, `["cfc"]` metadata
reads 3280 → 80.

## Two pre-existing things this surfaced

Neither is changed here; both are worth their own look.

- **A lazily materialized ("pinned") view does not hold its instant.** Measured
  across a `.set` in the same transaction, both proxy paths report the *new*
  value; it is the eager read that holds the original, because it hands back a
  detached copy. That is why `validateAndTransform` falls back to eager once
  `tx.hasWrites()`. Making the pinned view hold its instant is a semantics
  change, not a caching one, so the memo here reproduces today's behavior
  exactly.
- **`byValue` conflates `writable`.** It is keyed on the value object alone, so
  a read-only and a writable proxy over the same value share whichever was
  created first. Confirmed on the pre-change tree. `writable` is in the new key
  so this index does not become the reason that stays true.

## Verification

`packages/runner` 1205 passed / 0 failed, `packages/piece` 37 / 0,
`deno task integration pattern-tests --filter topics` 53 assertions,
`deno task check`, `check-docs`, `check-no-waitfor`, `check-skill-facts`,
`deno fmt --check`, `deno lint` — all green, re-run after rebasing onto current
`main`.

The 28 test steps in `test/snapshot-memo.test.ts` are mutation-tested: **21
mutations of the guards, the key components and the store sites, all caught**,
with no-op detection in the harness so a stale pattern cannot masquerade as a
pass. Mutations include a module-global pool (leaks across writes), a shared
pool (leaks across transactions), each guard removed individually, and each key
component dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

