### PR TITLE
test(cli): the spelling parity net completes an operation per spelling

### DIFF
--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -1049,6 +1049,57 @@ run_verb_session_gaps() {
   echo "Successfully ran the verb-session gap harness for ${API_URL}."
 }
 
+# The top-level spellings are the same commands as their `cf piece`
+# counterparts (docs/plans/cli-surface-shape.md, step 5). The unit guard
+# (test/piece-data-spellings.test.ts) proves the two mounts share one
+# surface and refuse identically; what it cannot do is complete an
+# operation. This section is the successful-path half: each spelling
+# performs a real write, read, and dispatch against a live space, and every
+# assertion crosses spellings, so "identical surface" is backed by
+# "identical outcome" rather than by two green paths that never met.
+run_spelling_parity() {
+  setup_space
+
+  # Reads and writes: the stepped counter fixture, whose result cell exists
+  # and accepts a value write.
+  create_stepped_counter_piece 7
+
+  # Write through the new spelling, read back through the old.
+  echo '5' | cf set $SPACE_ARGS --piece $PIECE_ID value
+  RESULT=$(cf piece get $SPACE_ARGS --piece $PIECE_ID value)
+  [ "$RESULT" = '5' ] ||
+    error "cf piece get should read what cf set wrote, got: $RESULT"
+
+  # Write through the old spelling, read back through the new — once by
+  # flag, once through the positional canonical address, the composed form
+  # the surface arc exists for.
+  echo '9' | cf piece set $SPACE_ARGS --piece $PIECE_ID value
+  RESULT=$(cf get $SPACE_ARGS --piece $PIECE_ID value)
+  [ "$RESULT" = '9' ] ||
+    error "cf get should read what cf piece set wrote, got: $RESULT"
+  RESULT=$(cf get $SPACE_ARGS "/of:$PIECE_ID/value")
+  [ "$RESULT" = '9' ] ||
+    error "cf get with a positional address should read the same cell, got: $RESULT"
+
+  # Dispatch: the callable fixture. The same tool through both spellings
+  # answers identically.
+  PARITY_CALLABLE_ID=$(cf piece new --main-export $CUSTOM_EXPORT $SPACE_ARGS "$SCRIPT_DIR/pattern/fuse-exec.tsx")
+  echo "Created parity callable piece: $PARITY_CALLABLE_ID"
+  OLD_CALL=$(cf piece call $SPACE_ARGS --piece $PARITY_CALLABLE_ID search -- --query parity)
+  NEW_CALL=$(cf call $SPACE_ARGS --piece $PARITY_CALLABLE_ID search -- --query parity)
+  assert_json_eq "$NEW_CALL" "$OLD_CALL" \
+    "cf call and cf piece call should return the same tool result"
+
+  # A handler dispatched through the new spelling commits like the old one.
+  LEGACY_BEFORE=$(read_piece_value_or_default "$PARITY_CALLABLE_ID" "legacyCount" "0")
+  cf call $SPACE_ARGS --piece $PARITY_CALLABLE_ID legacyWrite
+  RESULT=$(cf piece get $SPACE_ARGS --piece $PARITY_CALLABLE_ID legacyCount)
+  [ "$RESULT" = "$((LEGACY_BEFORE + 1))" ] ||
+    error "A handler dispatched via cf call should commit once, got legacyCount=$RESULT"
+
+  echo "Successfully ran CLI spelling parity tests for ${API_URL}/${SPACE}."
+}
+
 run_wish() {
   setup_space
 
@@ -1084,6 +1135,7 @@ case "$SECTION" in
     run_piece_call
     run_piece_call_retry
     run_three_topic_fixture
+    run_spelling_parity
     run_wish
     ;;
   piece-basics)
@@ -1092,6 +1144,10 @@ case "$SECTION" in
     ;;
   piece-values)
     run_piece_values
+    run_spelling_parity
+    ;;
+  spelling-parity)
+    run_spelling_parity
     ;;
   piece-links)
     run_piece_links


### PR DESCRIPTION
## Why

Follow-up to the surface-shape stack (#5894/#5896/#5899), and the gate for migrating the integration scripts to the new spellings: until something completes an operation through `cf get`/`cf set`/`cf call`, the whole evidence that they WORK is that they look identical to the `piece` spellings and fail identically. Verified before writing: no test or integration script exercised a successful path through the top-level spellings anywhere.

## What changed

A `run_spelling_parity` section in `packages/cli/integration/integration.sh`, wired into the `piece-values` section (so the core-piece-values CI suite runs it) and invocable alone as `spelling-parity`. Against a live space: a write through `cf set` read back through `cf piece get`; the reverse pair, read once by flag and once through the positional canonical address; the same tool dispatched through `cf call` and `cf piece call` with results compared as JSON; and a handler committed through `cf call` observed through `cf piece get`. Every assertion crosses spellings — the reads/writes use the stepped counter fixture (a result write on an unstepped piece fails its schema, which is correct and not what this net is for), dispatch uses the callable fixture.

## Test plan

Run locally against a local toolshed, both the section alone and the full `piece-values` section it rides in: all assertions pass (`Successfully ran CLI spelling parity tests`). CI runs it in core-piece-values on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

