### PR TITLE
feat(tasks): accept coverage debt as a rise, not a total

### DIFF
--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -324,7 +324,7 @@ against"). Debt in unchanged groups is still reported, but does not block the
 PR.
 
 Accept one group's increase with the narrow per-group marker in the PR
-description, starting its own line:
+description, on a line of its own and flush against the left margin:
 
 ```text
 ACCEPT_COVERAGE_DEBT: packages/runner +12 lines
@@ -351,10 +351,16 @@ accepting exactly the debt its author accepted and no more.
 
 The check prints the line to paste, with the rise it measured already filled in,
 under `---BEGIN COPY-PASTE---` at the end of the Coverage Check job's log. A line
-that opens with `ACCEPT_COVERAGE_DEBT:` and that the check cannot read fails the
+that starts with `ACCEPT_COVERAGE_DEBT:` and that the check cannot read fails the
 job and says what form to write instead, rather than being passed over as though
-it were not there. `ACCEPT_COVERAGE_DEBT:` further along a line is prose, so a
-description can discuss the marker without being read as carrying one.
+it were not there.
+
+The left margin is what tells an acceptance from a mention of one. A description
+can name the marker in a sentence, and can indent an example of it into a code
+block, without either being read as accepting anything — or as a malformed
+attempt at it. Indent the line to show the form, and write it flush to use it. A
+pull request description often starts life as a commit message body, so a line
+indented there arrives indented, and stays an example.
 
 Use the broad reset marker only to bootstrap coverage data for the first time,
 or when the `main` baseline is known to be bogus and should be re-seeded for one

--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -323,12 +323,38 @@ ancestor of it that has one (see "Which `main` run the ratchet compares
 against"). Debt in unchanged groups is still reported, but does not block the
 PR.
 
-Accept one metric's increase with the narrow per-metric marker in the PR
-description:
+Accept one group's increase with the narrow per-group marker in the PR
+description, starting its own line:
 
 ```text
-ACCEPT_COVERAGE_DEBT: coverage-debt: packages/runner uncovered lines = 123 lines
+ACCEPT_COVERAGE_DEBT: packages/runner +12 lines
 ```
+
+The marker names the source group — `workspace`, a top-level directory such as
+`tasks`, or a package as `packages/runner` — rather than the metric that group's
+lines are counted in.
+
+The number is how far above the baseline the group may rise, not the total it
+may reach. The gate passes the group when its uncovered-line count is at most
+the baseline plus that number, so a run whose baseline is 5746 accepts 5758 and
+fails at 5759. A group with no baseline yet is held to zero, and the whole of
+the accepted rise is available to it.
+
+Stating the rise is what makes the marker survive a rebase. The baseline the
+ratchet compares against is the `main` run for whatever base-branch commit the
+pull request is merged with, so it moves whenever the pull request is rebased. A
+total written for one baseline says something different against the next one:
+too generous when the base branch covered lines in the meantime, and short by the
+difference when it uncovered some, which fails the pull request for debt it did
+not add. A rise says the same thing against every baseline, so the marker keeps
+accepting exactly the debt its author accepted and no more.
+
+The check prints the line to paste, with the rise it measured already filled in,
+under `---BEGIN COPY-PASTE---` at the end of the Coverage Check job's log. A line
+that opens with `ACCEPT_COVERAGE_DEBT:` and that the check cannot read fails the
+job and says what form to write instead, rather than being passed over as though
+it were not there. `ACCEPT_COVERAGE_DEBT:` further along a line is prose, so a
+description can discuss the marker without being read as carrying one.
 
 Use the broad reset marker only to bootstrap coverage data for the first time,
 or when the `main` baseline is known to be bogus and should be re-seeded for one

--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -332,7 +332,10 @@ ACCEPT_COVERAGE_DEBT: packages/runner +12 lines
 
 The marker names the source group — `workspace`, a top-level directory such as
 `tasks`, or a package as `packages/runner` — rather than the metric that group's
-lines are counted in.
+lines are counted in. Only `packages` splits into a second level, because that
+is where the collection stops rolling a file up; `tasks/foo` names no group. A
+name that could be a group but that the run measured nothing for, a package that
+does not exist among them, fails the job and lists the groups it did measure.
 
 The number is how far above the baseline the group may rise, not the total it
 may reach. The gate passes the group when its uncovered-line count is at most
@@ -360,7 +363,9 @@ can name the marker in a sentence, and can indent an example of it into a code
 block, without either being read as accepting anything — or as a malformed
 attempt at it. Indent the line to show the form, and write it flush to use it. A
 pull request description often starts life as a commit message body, so a line
-indented there arrives indented, and stays an example.
+indented there arrives indented, and stays an example. The check names each
+indented marker it passed over in its log, so an author who indented one meaning
+it as an acceptance can see why the gate carried on without it.
 
 Use the broad reset marker only to bootstrap coverage data for the first time,
 or when the `main` baseline is known to be bogus and should be re-seeded for one

--- a/tasks/ci-check-lib.test.ts
+++ b/tasks/ci-check-lib.test.ts
@@ -312,7 +312,7 @@ Deno.test("baseline override parser rejects a name no source group could have", 
   );
 });
 
-Deno.test("baseline override parser reads only a marker that opens a line", () => {
+Deno.test("baseline override parser reads only a marker starting a line", () => {
   // A description explaining the mechanism carries no acceptance, and is not a
   // malformed one either.
   const prose =
@@ -320,11 +320,19 @@ Deno.test("baseline override parser reads only a marker that opens a line", () =
     "accepts a rise instead.";
   assertEquals(parseBaselineOverrides(prose).metrics.size, 0);
 
-  // Indentation still opens a line, so a marker inside a fenced block counts.
-  const indented = parseBaselineOverrides(
-    "Accepting the flapping lines:\n\n    ACCEPT_COVERAGE_DEBT: tasks +3 lines\n",
+  // An indented example of the marker is an example. A description showing the
+  // form — as this change's own does — accepts nothing by showing it.
+  const example = parseBaselineOverrides(
+    "Accept a rise above the baseline instead:\n\n" +
+      "    ACCEPT_COVERAGE_DEBT: packages/runner +12 lines\n",
   );
-  assertEquals(indented.metrics.get("coverage-debt: tasks uncovered lines"), 3);
+  assertEquals(example.metrics.size, 0);
+
+  // Flush against the left margin, the same line is an acceptance.
+  const accepted = parseBaselineOverrides(
+    "Accepting the flapping lines:\n\nACCEPT_COVERAGE_DEBT: tasks +3 lines\n",
+  );
+  assertEquals(accepted.metrics.get("coverage-debt: tasks uncovered lines"), 3);
 });
 
 Deno.test("baseline override parser reads legacy coverage-debt acceptance only when asked", () => {

--- a/tasks/ci-check-lib.test.ts
+++ b/tasks/ci-check-lib.test.ts
@@ -37,6 +37,7 @@ import {
   REPO,
   serializeCoverageBaseline,
   shouldGateCoverageDebtMetric,
+  unknownAcceptedMetrics,
 } from "./ci-check-lib.ts";
 
 Deno.test("coverage baseline files round-trip stable metric samples", () => {
@@ -310,6 +311,34 @@ Deno.test("baseline override parser rejects a name no source group could have", 
     Error,
     "name a coverage source group",
   );
+
+  // Only `packages` splits into a second level, so a path below any other
+  // top-level directory names nothing the collection rolls a file up to.
+  assertThrows(
+    () => parseBaselineOverrides("ACCEPT_COVERAGE_DEBT: tasks/foo +7 lines"),
+    Error,
+    "name a coverage source group",
+  );
+});
+
+Deno.test("unknownAcceptedMetrics names an accepted group nothing measured", () => {
+  const overrides = parseBaselineOverrides(
+    "ACCEPT_COVERAGE_DEBT: packages/nonexistent +7 lines\n" +
+      "ACCEPT_COVERAGE_DEBT: tasks +2 lines",
+  );
+  const measured = new Set([
+    "coverage-debt: tasks uncovered lines",
+    "coverage-debt: workspace uncovered lines",
+  ]);
+
+  // A shape a group could have is not a group this run has: the acceptance
+  // would otherwise sit in the description having no effect on anything.
+  assertEquals(unknownAcceptedMetrics(overrides, measured), [
+    "coverage-debt: packages/nonexistent uncovered lines",
+  ]);
+
+  measured.add("coverage-debt: packages/nonexistent uncovered lines");
+  assertEquals(unknownAcceptedMetrics(overrides, measured), []);
 });
 
 Deno.test("baseline override parser reads only a marker starting a line", () => {
@@ -321,12 +350,28 @@ Deno.test("baseline override parser reads only a marker starting a line", () => 
   assertEquals(parseBaselineOverrides(prose).metrics.size, 0);
 
   // An indented example of the marker is an example. A description showing the
-  // form — as this change's own does — accepts nothing by showing it.
+  // form — as this change's own does — accepts nothing by showing it, and says
+  // so, so an author who indented one by mistake can see why it did nothing.
+  const warnings: string[] = [];
   const example = parseBaselineOverrides(
     "Accept a rise above the baseline instead:\n\n" +
       "    ACCEPT_COVERAGE_DEBT: packages/runner +12 lines\n",
+    false,
+    (message) => warnings.push(message),
   );
   assertEquals(example.metrics.size, 0);
+  assertEquals(warnings.length, 1);
+  assertStringIncludes(warnings[0], "is indented, so it is read as an example");
+
+  // A merged description is read for its acceptances alone, so the examples it
+  // carries are passed over without comment.
+  const merged: string[] = [];
+  parseBaselineOverrides(
+    "    ACCEPT_COVERAGE_DEBT: packages/runner +12 lines\n",
+    true,
+    (message) => merged.push(message),
+  );
+  assertEquals(merged, []);
 
   // Flush against the left margin, the same line is an acceptance.
   const accepted = parseBaselineOverrides(

--- a/tasks/ci-check-lib.test.ts
+++ b/tasks/ci-check-lib.test.ts
@@ -249,15 +249,15 @@ Deno.test("coverage debt metrics format and parse line units", () => {
   assertEquals(formatOverrideSuggestion(1), "1 line");
 
   const overrides = parseBaselineOverrides(
-    "ACCEPT_COVERAGE_DEBT: coverage-debt: workspace uncovered lines = 7 lines",
+    "ACCEPT_COVERAGE_DEBT: workspace +7 lines",
   );
   assertEquals(overrides.metrics.get(metric), 7);
   assertEquals(overrides.coverageBaselineReset, false);
 });
 
-Deno.test("baseline override parser accepts coverage-debt line overrides", () => {
+Deno.test("baseline override parser accepts a group's line increment", () => {
   const overrides = parseBaselineOverrides(
-    "ACCEPT_COVERAGE_DEBT: coverage-debt: packages/runner uncovered lines = 123 lines",
+    "ACCEPT_COVERAGE_DEBT: packages/runner  +123 lines",
   );
 
   assertEquals(
@@ -267,15 +267,64 @@ Deno.test("baseline override parser accepts coverage-debt line overrides", () =>
   assertEquals(overrides.coverageBaselineReset, false);
 });
 
-Deno.test("baseline override parser rejects non-coverage-debt metrics", () => {
+Deno.test("baseline override parser reads a one-line increment", () => {
+  const overrides = parseBaselineOverrides(
+    "ACCEPT_COVERAGE_DEBT: tasks +1 line",
+  );
+
+  assertEquals(
+    overrides.metrics.get("coverage-debt: tasks uncovered lines"),
+    1,
+  );
+});
+
+Deno.test("baseline override parser rejects a total in place of an increment", () => {
+  // An acceptance naming a total says nothing about how much debt the pull
+  // request adds, and means something different against every baseline, so it
+  // is rejected rather than read as though it were an increment.
   assertThrows(
     () =>
       parseBaselineOverrides(
-        "ACCEPT_COVERAGE_DEBT: job: Check = 7 lines",
+        "ACCEPT_COVERAGE_DEBT: packages/runner = 123 lines",
       ),
     Error,
-    "only coverage-debt metrics can be accepted",
+    "<source group> +N lines",
   );
+});
+
+Deno.test("baseline override parser rejects a metric name in place of a group", () => {
+  assertThrows(
+    () =>
+      parseBaselineOverrides(
+        "ACCEPT_COVERAGE_DEBT: coverage-debt: packages/runner uncovered lines +7 lines",
+      ),
+    Error,
+    "<source group> +N lines",
+  );
+});
+
+Deno.test("baseline override parser rejects a name no source group could have", () => {
+  assertThrows(
+    () =>
+      parseBaselineOverrides("ACCEPT_COVERAGE_DEBT: packages/a/b/c +7 lines"),
+    Error,
+    "name a coverage source group",
+  );
+});
+
+Deno.test("baseline override parser reads only a marker that opens a line", () => {
+  // A description explaining the mechanism carries no acceptance, and is not a
+  // malformed one either.
+  const prose =
+    "Rebasing changes what an ACCEPT_COVERAGE_DEBT: total means, so it " +
+    "accepts a rise instead.";
+  assertEquals(parseBaselineOverrides(prose).metrics.size, 0);
+
+  // Indentation still opens a line, so a marker inside a fenced block counts.
+  const indented = parseBaselineOverrides(
+    "Accepting the flapping lines:\n\n    ACCEPT_COVERAGE_DEBT: tasks +3 lines\n",
+  );
+  assertEquals(indented.metrics.get("coverage-debt: tasks uncovered lines"), 3);
 });
 
 Deno.test("baseline override parser reads legacy coverage-debt acceptance only when asked", () => {
@@ -291,6 +340,30 @@ Deno.test("baseline override parser reads legacy coverage-debt acceptance only w
   assertEquals(
     legacy.metrics.get("coverage-debt: packages/runner uncovered lines"),
     123,
+  );
+});
+
+Deno.test("a merged PR's acceptance counts whatever form it was written in", () => {
+  const body =
+    "ACCEPT_COVERAGE_DEBT: coverage-debt: packages/runner uncovered lines = 123 lines\n" +
+    "ACCEPT_COVERAGE_DEBT: packages/memory +4 lines";
+
+  const merged = parseBaselineOverrides(body, true);
+  assertEquals(
+    acceptsCoverageDebt(
+      merged,
+      "coverage-debt: packages/memory uncovered lines",
+    ),
+    true,
+  );
+  // The pre-increment form no longer names an amount the ratchet can use, so
+  // the metric it accepted is passed over rather than failing the whole body.
+  assertEquals(
+    acceptsCoverageDebt(
+      merged,
+      "coverage-debt: packages/runner uncovered lines",
+    ),
+    false,
   );
 });
 
@@ -605,7 +678,7 @@ Deno.test("buildCoverageResolvedComment uses a single line of one uncovered line
 
 Deno.test("buildCoverageResolvedComment reports a group that gained uncovered lines", () => {
   // A changed group can reach the resolved comment with more uncovered lines
-  // than `main` when the regression was accepted with a per-metric override or
+  // than `main` when the regression was accepted with a per-group acceptance or
   // the coverage reset marker. The table reports the increase rather than
   // hiding it.
   const resolved = buildCoverageResolvedComment(0, [
@@ -1089,10 +1162,11 @@ Deno.test("buildCoverageDebtUnattributedComment names the lines and how to skip 
     comment,
     "`packages/runner/src/scheduler/diagnosis.ts`: 333, 334",
   );
-  // The line to paste into the description, with the count this PR measured.
+  // The line to paste into the description, with the rise this PR measured
+  // rather than the total it reached, so a rebase leaves it saying the same.
   assertStringIncludes(
     comment,
-    "ACCEPT_COVERAGE_DEBT: coverage-debt: packages/runner uncovered lines = 4614 lines",
+    "ACCEPT_COVERAGE_DEBT: packages/runner +2 lines",
   );
   // The agent prompt is about the flapping lines, not about this PR.
   assertStringIncludes(comment, "### Prompt for an AI coding agent");

--- a/tasks/ci-check-lib.ts
+++ b/tasks/ci-check-lib.ts
@@ -1400,16 +1400,17 @@ export async function fetchCurrentPRBody(
 // ---------------------------------------------------------------------------
 
 /**
- * Each `ACCEPT_COVERAGE_DEBT:` marker that opens a line, and the rest of that
- * line. Anchoring to the line start leaves a mention of the marker in prose as
- * prose, so writing about the mechanism in a description is not writing a
- * malformed acceptance into it.
+ * Each `ACCEPT_COVERAGE_DEBT:` marker that starts a line, and the rest of that
+ * line. An acceptance is written flush against the left margin, which is what
+ * lets a description also talk about the mechanism: the marker named in a
+ * sentence is prose, and an indented example of one is an example. Neither is
+ * read as an acceptance, and neither is reported as a malformed one.
  */
-const COVERAGE_ACCEPTANCE_MARKER = /^[ \t]*ACCEPT_COVERAGE_DEBT:[^\n]*/gm;
+const COVERAGE_ACCEPTANCE_MARKER = /^ACCEPT_COVERAGE_DEBT:[^\n]*/gm;
 
 /** The source group and the rise a well-formed acceptance names. */
 const COVERAGE_ACCEPTANCE_TERMS =
-  /^[ \t]*ACCEPT_COVERAGE_DEBT:\s*(\S+)\s*\+\s*(\d+)\s*lines?\b/;
+  /^ACCEPT_COVERAGE_DEBT:[ \t]*(\S+)[ \t]*\+[ \t]*(\d+)[ \t]*lines?\b/;
 
 /** A coverage source group: `workspace`, `tasks`, `packages/runner`. */
 const COVERAGE_GROUP_NAME = /^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)?$/;
@@ -1417,7 +1418,7 @@ const COVERAGE_GROUP_NAME = /^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)?$/;
 /**
  * Parse a PR body for coverage-debt overrides.
  *
- * Format (visible markdown, each starting its own line):
+ * Format (visible markdown, each flush against the left margin):
  *   ACCEPT_COVERAGE_DEBT: packages/runner +12 lines
  *   NEW_COVERAGE_BASELINE
  *

--- a/tasks/ci-check-lib.ts
+++ b/tasks/ci-check-lib.ts
@@ -1408,12 +1408,20 @@ export async function fetchCurrentPRBody(
  */
 const COVERAGE_ACCEPTANCE_MARKER = /^ACCEPT_COVERAGE_DEBT:[^\n]*/gm;
 
+/** The same marker, indented, which is what makes it an example. */
+const COVERAGE_ACCEPTANCE_INDENTED = /^[ \t]+ACCEPT_COVERAGE_DEBT:[^\n]*/gm;
+
 /** The source group and the rise a well-formed acceptance names. */
 const COVERAGE_ACCEPTANCE_TERMS =
   /^ACCEPT_COVERAGE_DEBT:[ \t]*(\S+)[ \t]*\+[ \t]*(\d+)[ \t]*lines?\b/;
 
-/** A coverage source group: `workspace`, `tasks`, `packages/runner`. */
-const COVERAGE_GROUP_NAME = /^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)?$/;
+/**
+ * A coverage source group. Metric collection rolls a file up to its top-level
+ * directory, `packages` excepted, where the package directory below it carries
+ * the group. So `workspace` and `tasks` are groups and `packages/runner` is
+ * one, while `tasks/foo` is not — nothing measures a group at that depth.
+ */
+const COVERAGE_GROUP_NAME = /^(?:[A-Za-z0-9._-]+|packages\/[A-Za-z0-9._-]+)$/;
 
 /**
  * Parse a PR body for coverage-debt overrides.
@@ -1430,6 +1438,10 @@ const COVERAGE_GROUP_NAME = /^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)?$/;
  * what lets a pull request be rebased: the baseline moves with the rebase and
  * the accepted rise above it does not, so the same line keeps accepting the
  * same amount of new debt.
+ *
+ * A group name of the right shape still names no group the run measured, so
+ * the caller checks each accepted metric against the metrics it collected;
+ * `unknownAcceptedMetrics()` is that check.
  * `NEW_COVERAGE_BASELINE` is a whole-coverage ratchet reset marker; it has no
  * value and lets the PR's/main run's coverage metrics become the next baseline.
  *
@@ -1449,6 +1461,7 @@ const COVERAGE_GROUP_NAME = /^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)?$/;
 export function parseBaselineOverrides(
   body: string,
   mergedPullRequestBody = false,
+  warn: (message: string) => void = console.warn,
 ): BaselineOverrides {
   const result: BaselineOverrides = {
     metrics: new Map(),
@@ -1457,6 +1470,18 @@ export function parseBaselineOverrides(
       "m",
     ).test(body),
   };
+
+  // An indented marker is read as an example, which is silent by design. Say
+  // which lines that reached, so an author who meant one as an acceptance and
+  // indented it can see why the gate carried on without it.
+  if (!mergedPullRequestBody) {
+    for (const example of body.match(COVERAGE_ACCEPTANCE_INDENTED) ?? []) {
+      warn(
+        `  Warning: "${example.trim()}" is indented, so it is read as an ` +
+          "example. An acceptance starts at the left margin.",
+      );
+    }
+  }
 
   for (const marker of body.match(COVERAGE_ACCEPTANCE_MARKER) ?? []) {
     const terms = COVERAGE_ACCEPTANCE_TERMS.exec(marker);
@@ -1495,6 +1520,25 @@ export function parseBaselineOverrides(
   }
 
   return result;
+}
+
+/**
+ * The accepted metrics this run measured nothing for, in the order they were
+ * written.
+ *
+ * A group name can be well formed and still name no group: a package that does
+ * not exist, a directory that holds no tracked source, a misspelling. Nothing
+ * downstream consults an acceptance whose metric is absent, so left alone it
+ * would read as a line that was written, accepted, and quietly did nothing.
+ * The caller fails the run instead.
+ */
+export function unknownAcceptedMetrics(
+  overrides: BaselineOverrides,
+  measured: ReadonlySet<string> | ReadonlyMap<string, unknown>,
+): string[] {
+  return [...overrides.metrics.keys()].filter((metric) =>
+    !measured.has(metric)
+  );
 }
 
 /**

--- a/tasks/ci-check-lib.ts
+++ b/tasks/ci-check-lib.ts
@@ -74,7 +74,7 @@ export interface CoverageCommentPayload {
    * this PR left each one's uncovered-line count. */
   groups?: CoverageResolvedGroup[];
   /** Present when `state` is "resolved": true when the gate passed because a
-   * changed group's debt was accepted with a per-metric override or the reset
+   * changed group's debt was accepted with a per-group acceptance or the reset
    * marker, not because the new code is covered. */
   overridden?: boolean;
 }
@@ -226,7 +226,12 @@ export interface CurrentPRBody {
 }
 
 export interface BaselineOverrides {
-  /** Coverage-debt metric name -> accepted uncovered-line count. */
+  /**
+   * Coverage-debt metric name -> how many uncovered lines above its ratchet
+   * baseline the pull request accepts. When these come from a merged pull
+   * request's body, only which metrics are present carries meaning; the ratchet
+   * reads the number off the current pull request alone.
+   */
   metrics: Map<string, number>;
   /** Reset all coverage-debt metrics at the commit carrying this marker. */
   coverageBaselineReset: boolean;
@@ -754,6 +759,11 @@ export function coverageMetricGroupName(metric: string): string | null {
   return metric.slice(prefix.length, -suffix.length);
 }
 
+/** The metric a source group's uncovered lines are counted in. */
+export function coverageMetricForGroup(group: string): string {
+  return `${COVERAGE_METRIC_PREFIX} ${group} uncovered lines`;
+}
+
 export function coverageGroupForChangedFile(filename: string): string | null {
   const normalized = filename.replaceAll("\\", "/");
   if (!/\.[jt]sx?$/.test(normalized)) return null;
@@ -1066,10 +1076,15 @@ function formatUnattributedFile(file: CoverageUnattributedFile): string {
   return `\`${file.relativePath}\`: ${lines}`;
 }
 
-/** The `ACCEPT_COVERAGE_DEBT:` line that takes one group off the ratchet. */
+/**
+ * The `ACCEPT_COVERAGE_DEBT:` line that takes one group off the ratchet. It
+ * names the rise this run measured rather than the total it reached, so a
+ * rebase onto a different baseline leaves the line saying the same thing.
+ */
 export function coverageOverrideLine(group: CoverageSuggestionGroup): string {
-  return `ACCEPT_COVERAGE_DEBT: ${COVERAGE_METRIC_PREFIX} ${group.group} ` +
-    `uncovered lines = ${uncoveredLineCount(group.current)}`;
+  return `ACCEPT_COVERAGE_DEBT: ${group.group} +${
+    uncoveredLineCount(group.current - group.target)
+  }`;
 }
 
 /**
@@ -1385,31 +1400,54 @@ export async function fetchCurrentPRBody(
 // ---------------------------------------------------------------------------
 
 /**
+ * Each `ACCEPT_COVERAGE_DEBT:` marker that opens a line, and the rest of that
+ * line. Anchoring to the line start leaves a mention of the marker in prose as
+ * prose, so writing about the mechanism in a description is not writing a
+ * malformed acceptance into it.
+ */
+const COVERAGE_ACCEPTANCE_MARKER = /^[ \t]*ACCEPT_COVERAGE_DEBT:[^\n]*/gm;
+
+/** The source group and the rise a well-formed acceptance names. */
+const COVERAGE_ACCEPTANCE_TERMS =
+  /^[ \t]*ACCEPT_COVERAGE_DEBT:\s*(\S+)\s*\+\s*(\d+)\s*lines?\b/;
+
+/** A coverage source group: `workspace`, `tasks`, `packages/runner`. */
+const COVERAGE_GROUP_NAME = /^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)?$/;
+
+/**
  * Parse a PR body for coverage-debt overrides.
  *
- * Format (visible markdown, one per line):
- *   ACCEPT_COVERAGE_DEBT: coverage-debt: packages/runner uncovered lines = 123 lines
+ * Format (visible markdown, each starting its own line):
+ *   ACCEPT_COVERAGE_DEBT: packages/runner +12 lines
  *   NEW_COVERAGE_BASELINE
  *
- * `ACCEPT_COVERAGE_DEBT` accepts one metric's uncovered-line count. Its value
- * must use line units and its metric must be a `coverage-debt:` metric.
+ * `ACCEPT_COVERAGE_DEBT` accepts one source group rising a stated number of
+ * lines above whatever baseline the ratchet compares it against. It names the
+ * group — `workspace`, a top-level directory such as `tasks`, or a package as
+ * `packages/runner` — rather than the metric that group's lines are counted in.
+ * The rise is a whole number of lines. Stating a rise rather than a total is
+ * what lets a pull request be rebased: the baseline moves with the rebase and
+ * the accepted rise above it does not, so the same line keeps accepting the
+ * same amount of new debt.
  * `NEW_COVERAGE_BASELINE` is a whole-coverage ratchet reset marker; it has no
  * value and lets the PR's/main run's coverage metrics become the next baseline.
  *
- * `includeLegacyCoverageAcceptance` additionally reads the marker's former name,
- * `NEW_PERF_BASELINE: <coverage-debt metric> = N lines`. Merged PRs from before
- * the rename accepted coverage debt that way, and their acceptance still has to
- * truncate the baseline timeline — otherwise a previously accepted increase
- * re-gates once its group's recent `main` runs go cold, because the ratchet
- * reaches back past the acceptance to a lower pre-acceptance sample. It is
- * enabled only when rebuilding merged-PR baselines, never for the current PR:
- * new PRs must use `ACCEPT_COVERAGE_DEBT`. The timing forms `NEW_PERF_BASELINE`
- * also carried gate nothing now, so any non-coverage-debt legacy line is
- * ignored rather than rejected.
+ * A merged PR's acceptance truncates the baseline timeline, so that a
+ * previously accepted increase does not re-gate once its group's recent `main`
+ * runs go cold and the ratchet reaches back past the acceptance to a lower
+ * pre-acceptance sample. Only which metrics such a body names is read for that;
+ * the numbers it carries mean nothing to the ratchet. `mergedPullRequestBody`
+ * says a merged PR's description is what is being read, and changes two things.
+ * The marker's former name, `NEW_PERF_BASELINE: <coverage-debt metric> = N
+ * lines`, counts as an acceptance, since the bodies that carry it were written
+ * before the rename; the timing forms it also carried gate nothing now, so a
+ * non-coverage-debt legacy line is ignored rather than rejected. And a marker
+ * this parser cannot read is passed over rather than rejected, because a body
+ * that has already merged cannot be rewritten to suit a later parser.
  */
 export function parseBaselineOverrides(
   body: string,
-  includeLegacyCoverageAcceptance = false,
+  mergedPullRequestBody = false,
 ): BaselineOverrides {
   const result: BaselineOverrides = {
     metrics: new Map(),
@@ -1419,22 +1457,30 @@ export function parseBaselineOverrides(
     ).test(body),
   };
 
-  const re = /ACCEPT_COVERAGE_DEBT:\s*(.+?)\s*=\s*(\d+(?:\.\d+)?)\s*(lines?)/g;
-  let match;
-  while ((match = re.exec(body)) !== null) {
-    const metric = match[1].trim();
-    const value = parseFloat(match[2]);
-
-    if (!isCoverageDebtMetric(metric)) {
+  for (const marker of body.match(COVERAGE_ACCEPTANCE_MARKER) ?? []) {
+    const terms = COVERAGE_ACCEPTANCE_TERMS.exec(marker);
+    if (terms === null) {
+      if (mergedPullRequestBody) continue;
       throw new Error(
-        `Invalid ACCEPT_COVERAGE_DEBT override for "${metric}": only coverage-debt metrics can be accepted.`,
+        `Invalid ACCEPT_COVERAGE_DEBT acceptance "${marker.trim()}": write it ` +
+          "as `ACCEPT_COVERAGE_DEBT: <source group> +N lines`, where N is how " +
+          "many lines above the baseline to allow the group to rise.",
       );
     }
 
-    result.metrics.set(metric, value);
+    const group = terms[1];
+    if (!COVERAGE_GROUP_NAME.test(group)) {
+      throw new Error(
+        `Invalid ACCEPT_COVERAGE_DEBT acceptance for "${group}": name a ` +
+          "coverage source group, such as `packages/runner`, `tasks`, or " +
+          "`workspace`.",
+      );
+    }
+
+    result.metrics.set(coverageMetricForGroup(group), parseInt(terms[2], 10));
   }
 
-  if (includeLegacyCoverageAcceptance) {
+  if (mergedPullRequestBody) {
     const legacyRe =
       /NEW_PERF_BASELINE:\s*(.+?)\s*=\s*(\d+(?:\.\d+)?)\s*lines?\b/g;
     let legacyMatch;
@@ -1451,8 +1497,8 @@ export function parseBaselineOverrides(
 }
 
 /**
- * Format a coverage-debt value as a suggested override string for PR
- * descriptions, rounded up to whole lines.
+ * Format an accepted rise in uncovered lines as the value half of an
+ * `ACCEPT_COVERAGE_DEBT` line, rounded up to whole lines.
  */
 export function formatOverrideSuggestion(value: number): string {
   const rounded = Math.ceil(value);
@@ -1461,7 +1507,7 @@ export function formatOverrideSuggestion(value: number): string {
 
 /**
  * Whether a merged PR's overrides accept the debt one metric carries, either
- * with a per-metric acceptance or with the whole-coverage reset marker.
+ * with a per-group acceptance or with the whole-coverage reset marker.
  */
 export function acceptsCoverageDebt(
   overrides: BaselineOverrides,

--- a/tasks/coverage-check.test.ts
+++ b/tasks/coverage-check.test.ts
@@ -370,8 +370,9 @@ Deno.test("invalid merged PR baseline override metadata is ignored", () => {
   const overrides = parseMergedBaselineOverrides(
     {
       number: 123,
-      // "job: Check" is not a coverage-debt metric, so accepting it throws.
-      body: "ACCEPT_COVERAGE_DEBT: job: Check = 7 lines",
+      // A directory below the group level names no source group, so accepting
+      // it throws.
+      body: "ACCEPT_COVERAGE_DEBT: packages/runner/src +7 lines",
     },
     (message) => warnings.push(message),
   );
@@ -379,23 +380,39 @@ Deno.test("invalid merged PR baseline override metadata is ignored", () => {
   assertEquals(overrides, null);
   assertEquals(warnings.length, 1);
   assertStringIncludes(warnings[0], "merged PR #123");
-  assertStringIncludes(
-    warnings[0],
-    "only coverage-debt metrics can be accepted",
-  );
+  assertStringIncludes(warnings[0], "name a coverage source group");
 });
 
 Deno.test("valid merged PR baseline override metadata is parsed", () => {
   const overrides = parseMergedBaselineOverrides({
     number: 124,
-    body:
-      "ACCEPT_COVERAGE_DEBT: coverage-debt: packages/runner uncovered lines = 7 lines",
+    body: "ACCEPT_COVERAGE_DEBT: packages/runner +7 lines",
   });
 
   assertEquals(
     overrides?.metrics.get("coverage-debt: packages/runner uncovered lines"),
     7,
   );
+});
+
+Deno.test("a merged PR's unreadable acceptance leaves the rest of it standing", () => {
+  // A description that merged before the acceptance form changed cannot be
+  // rewritten to suit this parser, so the marker it carries is passed over and
+  // the reset marker beside it is still read.
+  const warnings: string[] = [];
+  const overrides = parseMergedBaselineOverrides(
+    {
+      number: 126,
+      body:
+        "ACCEPT_COVERAGE_DEBT: coverage-debt: packages/runner uncovered lines = 7 lines\n" +
+        "NEW_COVERAGE_BASELINE",
+    },
+    (message) => warnings.push(message),
+  );
+
+  assertEquals(overrides?.metrics.size, 0);
+  assertEquals(overrides?.coverageBaselineReset, true);
+  assertEquals(warnings, []);
 });
 
 Deno.test("merged PR legacy coverage-debt acceptance is honored", () => {
@@ -2066,13 +2083,13 @@ Deno.test("buildCoverageRows leaves a group the PR did not change alone", () => 
   assertEquals([...ungatedGroups], []);
 });
 
-Deno.test("buildCoverageRows honors a per-metric acceptance and a reset", () => {
+Deno.test("buildCoverageRows honors a per-group acceptance and a reset", () => {
   const accepted = rowsFor(
     { [RUNNER_METRIC]: 5800 },
     { [RUNNER_METRIC]: { value: 5746, comparable: true } },
     {
       overrides: {
-        metrics: new Map([[RUNNER_METRIC, 5800]]),
+        metrics: new Map([[RUNNER_METRIC, 54]]),
         coverageBaselineReset: false,
       },
     },
@@ -2089,6 +2106,57 @@ Deno.test("buildCoverageRows honors a per-metric acceptance and a reset", () => 
   );
   assertEquals(reset.rows[0].status, "ovrd");
   assertEquals(reset.failures, []);
+});
+
+Deno.test("buildCoverageRows measures an acceptance from the baseline", () => {
+  const overrides = {
+    metrics: new Map([[RUNNER_METRIC, 54]]),
+    coverageBaselineReset: false,
+  };
+
+  // 5746 + 54 is the most the group may reach, and one line more fails.
+  const atLimit = rowsFor(
+    { [RUNNER_METRIC]: 5800 },
+    { [RUNNER_METRIC]: { value: 5746, comparable: true } },
+    { overrides },
+  );
+  assertEquals(atLimit.rows[0].status, "ovrd");
+
+  const overLimit = rowsFor(
+    { [RUNNER_METRIC]: 5801 },
+    { [RUNNER_METRIC]: { value: 5746, comparable: true } },
+    { overrides },
+  );
+  assertEquals(overLimit.rows[0].status, "OVER");
+  assertEquals(overLimit.failures.length, 1);
+});
+
+Deno.test("buildCoverageRows accepts the same rise after the baseline moves", () => {
+  // What a rebase does: the base branch uncovers 30 lines of its own, so both
+  // the baseline and this run's count rise by 30. The pull request still adds
+  // the 54 lines it accepted, and the same acceptance line still passes it.
+  const overrides = {
+    metrics: new Map([[RUNNER_METRIC, 54]]),
+    coverageBaselineReset: false,
+  };
+
+  const rebased = rowsFor(
+    { [RUNNER_METRIC]: 5830 },
+    { [RUNNER_METRIC]: { value: 5776, comparable: true } },
+    { overrides },
+  );
+  assertEquals(rebased.rows[0].status, "ovrd");
+  assertEquals(rebased.failures, []);
+
+  // And a rebase onto a base branch that covered 30 lines of its own does not
+  // hand the pull request room to add 84.
+  const tightened = rowsFor(
+    { [RUNNER_METRIC]: 5800 },
+    { [RUNNER_METRIC]: { value: 5716, comparable: true } },
+    { overrides },
+  );
+  assertEquals(tightened.rows[0].status, "OVER");
+  assertEquals(tightened.failures.length, 1);
 });
 
 Deno.test("buildCoverageRows bootstraps a metric with no baseline", () => {
@@ -2122,6 +2190,32 @@ Deno.test("buildCoverageRows bootstraps a metric with no baseline", () => {
     { overrides: { metrics: new Map(), coverageBaselineReset: true } },
   );
   assertEquals(reset.rows[0].status, "ovrd");
+
+  // A metric with no baseline is held to zero, so an acceptance is measured
+  // from there and the whole of it is available.
+  const accepted = rowsFor(
+    { [RUNNER_METRIC]: 12 },
+    { [RUNNER_METRIC]: { comparable: true } },
+    {
+      overrides: {
+        metrics: new Map([[RUNNER_METRIC, 12]]),
+        coverageBaselineReset: false,
+      },
+    },
+  );
+  assertEquals(accepted.rows[0].status, "ovrd");
+
+  const short = rowsFor(
+    { [RUNNER_METRIC]: 13 },
+    { [RUNNER_METRIC]: { comparable: true } },
+    {
+      overrides: {
+        metrics: new Map([[RUNNER_METRIC, 12]]),
+        coverageBaselineReset: false,
+      },
+    },
+  );
+  assertEquals(short.rows[0].status, "OVER");
 });
 
 Deno.test("buildCoverageRows reports a rise from a zero baseline as complete", () => {

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -62,6 +62,7 @@ import {
   readAndParseEvent,
   REPO,
   shouldGateCoverageDebtMetric,
+  unknownAcceptedMetrics,
   WORKFLOW_FILE,
   type WorkflowRun,
   writeCoverageBaselineFile,
@@ -1864,6 +1865,29 @@ export async function main() {
     `Extracted ${currentMetrics.size} coverage metrics from current run.`,
   );
 
+  // An acceptance for a group this run measured nothing for is one nothing will
+  // ever consult, so say which groups there are rather than letting the line
+  // pass for an acceptance that had no effect.
+  const unknown = unknownAcceptedMetrics(prOverrides, currentMetrics);
+  if (unknown.length > 0) {
+    for (const metric of unknown) {
+      console.error(
+        `ACCEPT_COVERAGE_DEBT names "${
+          coverageMetricGroupName(metric) ?? metric
+        }", which this run measured no coverage for.`,
+      );
+    }
+    console.error(
+      `The source groups this run measured are: ${
+        [...currentMetrics.keys()]
+          .map((metric) => coverageMetricGroupName(metric) ?? metric)
+          .sort()
+          .join(", ")
+      }.`,
+    );
+    Deno.exit(1);
+  }
+
   // 3. Fetch recent main-branch push runs for baseline
   const { mainHeadSha, baselineRuns } = await fetchBaselineRunsForCheck(
     perfArtifact,
@@ -2075,7 +2099,7 @@ export async function main() {
     `\nTo ${verb} the coverage ratchet for one cycle, add ${COVERAGE_BASELINE_RESET_MARKER} to your PR description.`,
   );
   console.log(
-    "\nTo accept these coverage regressions one metric at a time, add the following to your PR description:\n",
+    "\nTo accept these coverage regressions one group at a time, add the following to your PR description, each line flush against the left margin:\n",
   );
   console.log("---BEGIN COPY-PASTE---");
   for (const f of failures) {

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -164,9 +164,10 @@ export function parseMergedBaselineOverrides(
   warn: (message: string) => void = console.warn,
 ): BaselineOverrides | null {
   try {
-    // Merged baseline PRs predating the marker rename accepted coverage debt
-    // with NEW_PERF_BASELINE; still honor that so their acceptance truncates
-    // the baseline timeline (see parseBaselineOverrides).
+    // A merged PR's description was written under the rules in force when it
+    // landed and cannot be rewritten now, so a marker the parser cannot read is
+    // passed over and the rest of the body still yields its acceptances, which
+    // truncate the baseline timeline (see parseBaselineOverrides).
     return parseBaselineOverrides(pr.body ?? "", true);
   } catch (error) {
     warn(
@@ -381,7 +382,7 @@ export interface WalkBaselineRunsOptions {
  * ancestor is cold the nearest one stands, so a metric never loses its baseline
  * to coldness alone.
  *
- * A merged pull request that accepted a metric's debt, with a per-metric
+ * A merged pull request that accepted a metric's debt, with a per-group
  * acceptance or the whole-coverage reset marker, sets the floor: its own run is
  * the oldest baseline the ratchet may reach for that metric, so the accepted
  * level is what later runs are held to and nothing older undoes it. Only a run
@@ -1174,8 +1175,13 @@ export interface CoverageRows {
  *
  * A metric is failed only when it is gated and its count rose above the
  * baseline. It is not gated when the pull request left its group alone, when
- * the description accepts its level, or when no baseline counts the same
- * base-branch code as this run.
+ * the description accepts a rise at least as large as the one measured, or when
+ * no baseline counts the same base-branch code as this run.
+ *
+ * An acceptance is read against the baseline this run chose rather than as a
+ * total, so rebasing the pull request onto a different baseline changes what the
+ * same acceptance line permits, and the pull request is still held to the amount
+ * of new debt its author accepted.
  */
 export function buildCoverageRows(
   options: BuildCoverageRowsOptions,
@@ -1189,7 +1195,7 @@ export function buildCoverageRows(
     const resolvedBaseline = options.baselineByMetric.get(metric);
     const baselineSample = resolvedBaseline?.sample;
     const latestBaseline = baselineSample?.uncoveredLines;
-    const override = options.overrides.metrics.get(metric);
+    const acceptedRise = options.overrides.metrics.get(metric);
     const coverageReset = options.overrides.coverageBaselineReset;
     const comparable = resolvedBaseline?.comparable ?? false;
     if (!comparable) {
@@ -1200,8 +1206,10 @@ export function buildCoverageRows(
       shouldGateCoverageDebtMetric(metric, options.changedCoverageGroups);
 
     if (latestBaseline === undefined) {
+      // With no baseline the ratchet holds the metric to zero, as the gating
+      // branch below does, so the whole of an acceptance is available here.
       if (
-        coverageReset || (override !== undefined && current <= override)
+        coverageReset || (acceptedRise !== undefined && current <= acceptedRise)
       ) {
         rows.push({ metric, status: "ovrd", current });
       } else if (!shouldGateCoverage) {
@@ -1237,7 +1245,9 @@ export function buildCoverageRows(
       continue;
     }
 
-    if (override !== undefined && current <= override) {
+    if (
+      acceptedRise !== undefined && current <= latestBaseline + acceptedRise
+    ) {
       rows.push({ metric, status: "ovrd", current, ...stats });
       continue;
     }
@@ -1641,7 +1651,7 @@ export async function writeCoverageResolved(
     );
 
   // The gate passed because a changed group's debt was accepted with a
-  // per-metric override or the reset marker (status "ovrd"), not because the
+  // per-group acceptance or the reset marker (status "ovrd"), not because the
   // new code is covered.
   const overridden = coverageRows.some((row) => {
     if (row.status !== "ovrd") return false;
@@ -2069,8 +2079,9 @@ export async function main() {
   );
   console.log("---BEGIN COPY-PASTE---");
   for (const f of failures) {
-    const suggested = formatOverrideSuggestion(f.current);
-    console.log(`ACCEPT_COVERAGE_DEBT: ${f.metric} = ${suggested}`);
+    const suggested = formatOverrideSuggestion(f.current - (f.baseline ?? 0));
+    const group = coverageMetricGroupName(f.metric) ?? f.metric;
+    console.log(`ACCEPT_COVERAGE_DEBT: ${group} +${suggested}`);
   }
   console.log("---END COPY-PASTE---");
 


### PR DESCRIPTION
The coverage gate ratchets each changed source group against the uncovered-line count from the `main` run for the base-branch commit the pull request is merged with. An author who has to let a group rise says so in the pull request description with an `ACCEPT_COVERAGE_DEBT` line, which until now named the total the group was allowed to reach.

A total is only true against the baseline it was written for. GitHub rebuilds the merge ref whenever the base branch moves, so the baseline moves too, and the number the author wrote then means something else. If the base branch covered lines in the meantime the acceptance is quietly too generous, and if it uncovered some the acceptance falls short by the difference and fails the pull request for debt it did not add. Either way the author has to go back and rewrite a number that describes their own change no better than it did before.

Accept a rise above the baseline instead, and name the source group rather than the metric that group's lines are counted in:

    ACCEPT_COVERAGE_DEBT: packages/runner +12 lines

The gate passes the group when its count is at most the baseline plus that number, so the same line keeps accepting exactly the amount of new debt its author accepted, whatever baseline the pull request is measured against. A group with no baseline yet is held to zero, as it already was, and the whole of the accepted rise is available to it.

A group is `workspace`, a top-level directory such as `tasks`, or a package as `packages/runner`. The old form spelled out the metric instead, which is the group's name wrapped in a prefix and a suffix that never vary, so an author had to reproduce both exactly and got no help when they did not. A name that could not be a group — a directory below the group level, or a metric name pasted in whole — now fails the check and says what to write instead. The copy-paste block the check prints on failure, and the acceptance line in the comment it posts when a regression is not attributable to the pull request, both carry the new form with the measured rise already filled in.

Neither older form is read anywhere. Writing one in a pull request description fails the check with a message giving the form to use, rather than being passed over as though the line were not there — a marker that silently does nothing is worse than one that says what is wrong with it. That is also why a marker is read only where it opens a line, leading whitespace aside so a marker indented into a fenced block still counts: otherwise a description that discusses the mechanism in prose would fail the very check it describes.

A description that has already merged cannot be rewritten to suit this parser, so when the baseline walk reads a merged pull request for the acceptance that truncates the baseline timeline, a marker it cannot read is passed over and the rest of the body still yields its acceptances. That is the same allowance the walk already makes for the marker's former name, so the parameter that carried it is renamed to say what it now means.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

