### PR TITLE
docs: the data commands teach their top-level spellings

### DIFF
--- a/docs/common/concepts/handler.md
+++ b/docs/common/concepts/handler.md
@@ -6,7 +6,7 @@ Use `handler()` when you need to define event-handling logic once and bind it to
 
 1. **Same logic, different state** - You want to reuse identical handler logic with different state
 2. **Exported streams** - Other patterns need to call your handler via linking
-3. **CLI testing** - You want to test handlers via `cf piece call` before building UI
+3. **CLI testing** - You want to test handlers via `cf call` before building UI
 
 ## Basic Structure
 
@@ -175,8 +175,8 @@ clearAll({ items }).send();
 Export handlers to test them via CLI during development:
 
 ```bash
-# Call a handler with JSON payload
-deno task cf piece call addItem '{"title": "Test"}' --piece <ID>
+# Call a handler with JSON payload (flags go before the callable name)
+deno task cf call --piece <ID> addItem '{"title": "Test"}'
 
 # Step to process
 deno task cf piece step --piece <ID>

--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -1,8 +1,8 @@
 # Verbs over the CLI
 
 A **verb** is a pattern's callable surface: a `Stream` property a caller invokes
-with `cf piece call` — or `cf call`, the same command mounted at top level, so
-every `cf piece call` in this document works as `cf call` too. This document is
+with `cf call` — or `cf piece call`, the same command mounted under `piece`, so
+every `cf call` in this document works as `cf piece call` too. This document is
 about what a caller gets *back*.
 
 A verb can declare a result, and the caller reads it off the call. That turns a
@@ -111,9 +111,9 @@ data field is never offered as callable, whatever the pattern hangs at that
 name.
 
 Every row is real, and says where it lives: a name in the listing is a name
-`cf piece call` resolves, and the row's `on` names the cell the dispatcher
+`cf call` resolves, and the row's `on` names the cell the dispatcher
 will reach it on. Result shadows input there exactly as it does in
-`cf piece call`, so a verb stored on both cells is listed — and called — on
+`cf call`, so a verb stored on both cells is listed — and called — on
 the result cell, carrying that cell's schema. Build a payload from the row and
 it is the payload the verb you reach expects.
 
@@ -124,7 +124,7 @@ an answer:
   listed**. Nothing stored distinguishes it from a data field, and the one
   probe that finds it accepts every name it is given, so listing on that probe
   would offer the whole piece as callable. Given such a verb's name,
-  `cf piece call` still reaches it.
+  `cf call` still reaches it.
 - When the compiled pattern cannot be read, a verb the declared result type
   omits has no other source of its name and is missing. The listing says so
   rather than passing the short list off as the surface: `incomplete` carries
@@ -139,7 +139,7 @@ One verb at a time, `--help` answers the same question from the callable
 itself:
 
 ```bash
-cf piece call --piece <piece> <verb> --help
+cf call --piece <piece> <verb> --help
 ```
 
 ```text
@@ -157,10 +157,10 @@ all, for a client that wants the schema rather than the summary.
 
 ### Call a verb and read its result
 
-`cf piece call` prints one settled **Invocation JSON** object on stdout:
+`cf call` prints one settled **Invocation JSON** object on stdout:
 
 ```bash
-cf piece call --piece <board> addTopic \
+cf call --piece <board> addTopic \
   '{"title":"Ship the thing","body":"the initial document","agentName":"Sol"}'
 ```
 
@@ -188,7 +188,7 @@ handling wrote it to, written as one string in the canonical reference syntax
 again —
 
 ```bash
-cf piece get --piece "$(echo "$RESULT" | jq -r .receipt)"
+cf get --piece "$(echo "$RESULT" | jq -r .receipt)"
 ```
 
 — which is an ordinary read, so the verb's body does not run a second time.
@@ -199,12 +199,12 @@ receipt to name.
 ### Asking for a smaller result
 
 A verb decides what it returns; the caller decides how much of it to look at.
-`--filter`, `--select`, and `--schema` — the same three flags `cf piece get`,
+`--filter`, `--select`, and `--schema` — the same three flags `cf get`,
 `cf wish` and `cf exec` take, with the same grammar — shape the `result` before
 it reaches stdout, and go before the callable name:
 
 ```bash
-cf piece call --piece <topic> --select comment.writtenAt addComment \
+cf call --piece <topic> --select comment.writtenAt addComment \
   '{"body":"first","agentName":"Sol"}'
 ```
 
@@ -242,8 +242,9 @@ address on stderr. The line spells out the whole command that reads it back,
 and the address is one token that carries all three parts — space, id, and
 scope — as the canonical `/@did:.../of:...` reference `--piece` takes whole.
 Naming the space inside the token is what makes the command portable: `cf exec`
-gets its space from the mount it ran through, while `cf piece get` falls back
-to whichever space the caller has configured, so an address that named only id
+gets its space from the mount it ran through, while the suggested read falls
+back to whichever space the caller has configured, so an address that named
+only id
 and scope would read the right cell only for a reader configured for the same
 space.
 
@@ -263,7 +264,7 @@ the circle, so that position renders its address and the rest reads as it
 always did:
 
 ```bash
-cf piece call --piece "$EPIC" addChild -- --title "Session cookie handling"
+cf call --piece "$EPIC" addChild -- --title "Session cookie handling"
 ```
 
 ```json
@@ -322,12 +323,12 @@ that chose it** hands back the **original** result, and nothing is written a
 second time:
 
 ```bash
-cf piece call --piece <topic> --invocation add-comment-1 \
+cf call --piece <topic> --invocation add-comment-1 \
   addComment '{"body":"first","agentName":"Sol"}'
 
 # Same id, same session, different payload: the original result comes back,
 # and no second comment is recorded.
-cf piece call --piece <topic> --invocation add-comment-1 \
+cf call --piece <topic> --invocation add-comment-1 \
   addComment '{"body":"different","agentName":"Sol"}'
 ```
 
@@ -362,12 +363,12 @@ a verb refuses the payload, correct it and retry under the same id.
 ```bash
 # Refused: nonzero exit, nothing written — and `add-1` is NOT spent, because
 # the payload never became an event.
-cf piece call --piece <board> --invocation add-1 \
+cf call --piece <board> --invocation add-1 \
   addTopic '{"title":"","agentName":"Sol"}'
 
 # The same id, corrected. This one executes; a settled id would have replayed
 # instead.
-cf piece call --piece <board> --invocation add-1 \
+cf call --piece <board> --invocation add-1 \
   addTopic '{"title":"Corrected","agentName":"Sol"}'
 ```
 
@@ -384,7 +385,7 @@ settled. The refusal names the field, the position it sat at, the vocabulary
 that position takes, and the declared name it is one edit from:
 
 ```bash
-cf piece call --piece <board> addTopic '{"titel":"Ship it","agentName":"Sol"}'
+cf call --piece <board> addTopic '{"titel":"Ship it","agentName":"Sol"}'
 ```
 
 ```
@@ -408,7 +409,7 @@ payload need satisfy only one branch, so a field missing from one branch may be
 named by another. And a position marked as a cell or a stream may hold a link
 rather than a value, whose `"/"` is nothing anybody declared.
 
-The declared vocabulary is what `cf piece call --piece <id> <verb> --help`
+The declared vocabulary is what `cf call --piece <id> <verb> --help`
 prints, and it names the fields the verb's handler **reads**. That can be fewer
 than the TypeScript event type declares: a field the body never touches is one
 the runtime would have dropped, so the call is refused rather than accepted and
@@ -420,8 +421,8 @@ never spent, and the corrected retry can reuse it.
 
 ### Reading is not calling
 
-`cf piece get` reads data. A path that lands on a verb is refused and redirected
-to `cf piece call`, because reading a verb would return the stream's
+`cf get` reads data. A path that lands on a verb is refused and redirected
+to `cf call`, because reading a verb would return the stream's
 serialization — never what a caller wanted.
 
 ### Watching where the time goes
@@ -453,7 +454,7 @@ durable, and only the readback is skipped. The envelope still carries the
 }
 ```
 
-— and collecting the outcome later is `cf piece get --piece <that string>`.
+— and collecting the outcome later is `cf get --piece <that string>`.
 Replaying the same id and session recovers it too, but that re-runs the handler
 body: a verb that sends mail or spends a model call does it again. Reading the
 address does not.
@@ -520,7 +521,7 @@ Each step demonstrates one use case:
 | 8 | A piece result survives `plainResultReceipts=false`; a plain record does not — and the write lands either way |
 | 9 | A value-less verb settles with the empty witness |
 | 10 | A refused call does not spend its invocation id |
-| 11 | Reading a verb redirects to `cf piece call` |
+| 11 | Reading a verb redirects to `cf call` |
 | 12 | Timings on stderr, Invocation JSON still clean on stdout |
 | 13 | An invocation id without a session is refused, and the refusal says how to mint one |
 | 14 | A detached (`--no-wait`) call's `receipt` address reads back the outcome, and a settled call's receipt reads back exactly its `result` |
@@ -532,7 +533,7 @@ that piece needs its address, and `--show-links` supplies it: a dictionary of
 RFC 6901 pointers into the result, each naming the document behind that path.
 
 ```bash
-cf piece call --show-links --piece <board> createNote '{"title":"Notes"}'
+cf call --show-links --piece <board> createNote '{"title":"Notes"}'
 ```
 
 ```json
@@ -551,7 +552,7 @@ canonical reference syntax `--piece` reads — taken exactly as emitted, `of:`
 prefix included — so it addresses directly:
 
 ```bash
-cf piece call --piece "$(echo "$RESULT" | jq -r '.links["/note"]')" \
+cf call --piece "$(echo "$RESULT" | jq -r '.links["/note"]')" \
   append '{"text":"second line"}'
 ```
 
@@ -588,7 +589,7 @@ its contents. A field list marks with a trailing `@`, and a JSON Schema marks
 with `{"$link": true}`.
 
 ```bash
-cf piece get --piece <board> notes \
+cf get --piece <board> notes \
   --schema '{"type":"array","items":{"$link":true}}'
 ```
 
@@ -615,7 +616,7 @@ collection is reordered.
 identity.** Addresses are many-to-one over cells: a holder of one cannot tell a
 canonical id from an alias, and normal use does not require it. Two positions
 holding one piece can render two different addresses, and a marker and
-`cf piece call --show-links` can disagree about the same piece, because a piece
+`cf call --show-links` can disagree about the same piece, because a piece
 created inside a handler and pushed into a collection is held through a link
 that redirects to it and the two stop at different points along that redirect.
 
@@ -629,7 +630,7 @@ The marker sits beside a projection when both are wanted, and the answer
 carries both:
 
 ```bash
-cf piece get --piece <board> notes --schema \
+cf get --piece <board> notes --schema \
   '{"type":"array","items":{"$link":true,"type":"object","properties":{"title":true}}}'
 ```
 
@@ -641,7 +642,7 @@ A field list unions the same way, and its two paths meet at the one position.
 `noteCount` is computed, so the read steps the piece to bring it up to date:
 
 ```bash
-cf piece get --piece <board> --step --select 'notes@,noteCount'
+cf get --piece <board> --step --select 'notes@,noteCount'
 ```
 
 ```json
@@ -670,5 +671,5 @@ or below it: a position that asks for nothing but addresses is not read either,
 so `notes.title@` reads what holds the collection and none of the notes. Where
 the marker is the whole selection, nothing behind it is read at all.
 
-The address a marked read returns is one `cf piece call` accepts exactly as
+The address a marked read returns is one `cf call` accepts exactly as
 emitted, `of:` prefix included — which is the reason to ask for it.

--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -422,8 +422,9 @@ never spent, and the corrected retry can reuse it.
 ### Reading is not calling
 
 `cf get` reads data. A path that lands on a verb is refused and redirected
-to `cf call`, because reading a verb would return the stream's
-serialization — never what a caller wanted.
+to `cf piece call` — the spelling the diagnostic literally prints — because
+reading a verb would return the stream's serialization — never what a
+caller wanted.
 
 ### Watching where the time goes
 
@@ -521,7 +522,7 @@ Each step demonstrates one use case:
 | 8 | A piece result survives `plainResultReceipts=false`; a plain record does not — and the write lands either way |
 | 9 | A value-less verb settles with the empty witness |
 | 10 | A refused call does not spend its invocation id |
-| 11 | Reading a verb redirects to `cf call` |
+| 11 | Reading a verb redirects to `cf piece call` |
 | 12 | Timings on stderr, Invocation JSON still clean on stdout |
 | 13 | An invocation id without a session is refused, and the refusal says how to mint one |
 | 14 | A detached (`--no-wait`) call's `receipt` address reads back the outcome, and a settled call's receipt reads back exactly its `result` |

--- a/docs/common/workflows/handlers-cli-testing.md
+++ b/docs/common/workflows/handlers-cli-testing.md
@@ -65,7 +65,7 @@ deno task cf piece new ... --test pattern.test.tsx pattern.tsx
 deno task cf piece setsrc ... --test pattern.test.tsx pattern.tsx
 
 # Call a handler directly with JSON payload
-deno task cf piece call ... addItem '{"title": "Test Item", "category": "demo"}'
+deno task cf call ... addItem '{"title": "Test Item", "category": "demo"}'
 
 # Run a step to process the handler
 deno task cf piece step ...
@@ -97,10 +97,10 @@ Handler calls below are runtime checks, not replacements for automated coverage.
 1. Write or update automated tests for changed behavior
 2. Run every test entry with `cf test`
 3. Deploy with every test attached using repeatable `--test`
-4. Either call the handler directly with `cf piece call` or mount the space with `cf fuse mount`
+4. Either call the handler directly with `cf call` or mount the space with `cf fuse mount`
 5. Use `cf exec <mounted-callable-file> --help` to inspect the mounted schema-derived interface without invoking it
 6. Execute `*.handler` or `*.tool` via `cf exec`; after the verb, schema-derived flags own the namespace, so a tool input field named `help` is parsed normally
 7. Legacy `echo ... > file.handler` still works for handlers
-8. Inspect state with `cf piece inspect` or `cf piece get`
+8. Inspect state with `cf piece inspect` or `cf get`
 9. Iterate until the callable works correctly, running tests and retaining every
    `--test` flag on `setsrc`, then build UI on top

--- a/docs/common/workflows/pattern-testing.md
+++ b/docs/common/workflows/pattern-testing.md
@@ -363,7 +363,7 @@ deno task cf get subject/items --piece <PIECE_ID>
 
 # Step through manually (the reserved key is the literal `$TESTS`, quoted so
 # the shell does not expand it)
-deno task cf call '$TESTS/0/action' --piece <PIECE_ID>
+deno task cf call --piece <PIECE_ID> '$TESTS/0/action'
 deno task cf piece step --piece <PIECE_ID>
 deno task cf get '$TESTS/1/assertion' --piece <PIECE_ID>
 ```

--- a/docs/common/workflows/pattern-testing.md
+++ b/docs/common/workflows/pattern-testing.md
@@ -359,13 +359,13 @@ deno task cf piece new ./main.test.tsx
 deno task cf piece inspect --piece <PIECE_ID>
 
 # Get specific values
-deno task cf piece get subject/items --piece <PIECE_ID>
+deno task cf get subject/items --piece <PIECE_ID>
 
 # Step through manually (the reserved key is the literal `$TESTS`, quoted so
 # the shell does not expand it)
-deno task cf piece call '$TESTS/0/action' --piece <PIECE_ID>
+deno task cf call '$TESTS/0/action' --piece <PIECE_ID>
 deno task cf piece step --piece <PIECE_ID>
-deno task cf piece get '$TESTS/1/assertion' --piece <PIECE_ID>
+deno task cf get '$TESTS/1/assertion' --piece <PIECE_ID>
 ```
 
 This diagnostic command deliberately deploys the test pattern as the executable

--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -301,7 +301,7 @@ the labs checkout and dispatches to `packages/cli/mod.ts`.
 |---|---|---|
 | `CF_IDENTITY` | _(none)_ | Path to identity keyfile. Required for `piece`, `acl`, `exec` against a remote toolshed. |
 | `CF_API_URL` | _(none)_ | Toolshed URL. Required for the same commands as above. |
-| `CF_INVOCATION_SESSION` | _(none)_ | Invocation session `cf piece call` scopes an invocation id to. Mint one per agent run with `cf invocation-session new`. Carried here rather than as `--invocation-session <id>` because the session is what makes a call's outcome unguessable, and an argument is readable in a process listing. |
+| `CF_INVOCATION_SESSION` | _(none)_ | Invocation session `cf call` scopes an invocation id to. Mint one per agent run with `cf invocation-session new`. Carried here rather than as `--invocation-session <id>` because the session is what makes a call's outcome unguessable, and an argument is readable in a process listing. |
 | `CF_LOG_LEVEL` | `error` | `debug` \| `info` \| `warn` \| `error` \| `silent`. Also settable per-invocation with `--log-level`. |
 | `CF_CLI_NAME` | `cf` | Override the displayed CLI name (for branded builds). |
 | `CF_CLI_TRACE_TIMINGS` | `0` | Set to `1` for detailed timing traces. |

--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -299,7 +299,7 @@ the labs checkout and dispatches to `packages/cli/mod.ts`.
 
 | Var | Default | Notes |
 |---|---|---|
-| `CF_IDENTITY` | _(none)_ | Path to identity keyfile. Required for `piece`, `acl`, `exec` against a remote toolshed. |
+| `CF_IDENTITY` | _(none)_ | Path to identity keyfile. Required for the server-touching commands — `piece`, the top-level `get`/`set`/`call`, `wish`, `acl`, `exec` — against a remote toolshed. |
 | `CF_API_URL` | _(none)_ | Toolshed URL. Required for the same commands as above. |
 | `CF_INVOCATION_SESSION` | _(none)_ | Invocation session `cf call` scopes an invocation id to. Mint one per agent run with `cf invocation-session new`. Carried here rather than as `--invocation-session <id>` because the session is what makes a call's outcome unguessable, and an argument is readable in a process listing. |
 | `CF_LOG_LEVEL` | `error` | `debug` \| `info` \| `warn` \| `error` \| `silent`. Also settable per-invocation with `--log-level`. |

--- a/docs/development/DEPENDENCIES.md
+++ b/docs/development/DEPENDENCIES.md
@@ -361,7 +361,7 @@ The CLI uses three declarations that have to remain compatible:
 The two Cliffy packages share internal packages and resolve as a set. They are
 held at the release candidate because Cliffy 1.2.1 changes how a required
 argument followed by a variadic argument is parsed. With that release,
-`cf piece call` stops receiving its first argument.
+`cf call` stops receiving its first argument.
 
 The `@std/fmt/colors` pin has a separate single-copy requirement.
 `setColorEnabled()` stores state in its module instance. If the CLI imports a

--- a/docs/development/debugging/cli-debugging.md
+++ b/docs/development/debugging/cli-debugging.md
@@ -113,15 +113,17 @@ deno task cf check \
 # 1. What's the full state?
 deno task cf piece inspect --piece <piece-id> -i "$CF_IDENTITY" -a URL -s space
 
-# 2. What are the inputs?
-deno task cf get --piece <piece-id> /input -i "$CF_IDENTITY" -a URL -s space
+# 2. What are the inputs? (--input selects the arguments cell; a positional
+# /input would read a result field of that name)
+deno task cf get --piece <piece-id> --input -i "$CF_IDENTITY" -a URL -s space
 
 # 3. What's a specific computed value?
 deno task cf get --piece <piece-id> myComputedField -i "$CF_IDENTITY" -a URL -s space
 
-# 4. Set known input, trigger recompute, verify output
+# 4. Set known input, trigger recompute, verify output ("" writes the whole
+# input cell; --input selects it)
 echo '{"items":[{"title":"test","done":false}]}' | \
-  deno task cf set --piece <piece-id> /input -i "$CF_IDENTITY" -a URL -s space
+  deno task cf set --piece <piece-id> "" --input -i "$CF_IDENTITY" -a URL -s space
 deno task cf piece step --piece <piece-id> -i "$CF_IDENTITY" -a URL -s space
 deno task cf get --piece <piece-id> itemCount -i "$CF_IDENTITY" -a URL -s space
 ```

--- a/docs/development/debugging/cli-debugging.md
+++ b/docs/development/debugging/cli-debugging.md
@@ -44,7 +44,7 @@ deno task cf piece new -i "$CF_IDENTITY" --api-url URL --space SPACE \
 
 # Set test data
 echo '{"title": "Test", "done": false}' | \
-  deno task cf piece set -i "$CF_IDENTITY" --api-url URL --space SPACE --piece ID testItem
+  deno task cf set -i "$CF_IDENTITY" --api-url URL --space SPACE --piece ID testItem
 ```
 
 Write automated tests for new or changed pattern behavior and run every entry
@@ -73,13 +73,13 @@ packages and type-checks attached tests but does not run them.
 
 ```bash
 # WRONG: Returns stale computed values
-echo '[...]' | deno task cf piece set --piece ID expenses ...
-deno task cf piece get --piece ID totalSpent ...  # May return old value!
+echo '[...]' | deno task cf set --piece ID expenses ...
+deno task cf get --piece ID totalSpent ...  # May return old value!
 
 # CORRECT: Run piece step to trigger recompute
-echo '[...]' | deno task cf piece set --piece ID expenses ...
+echo '[...]' | deno task cf set --piece ID expenses ...
 deno task cf piece step --piece ID ...  # Runs scheduling step, triggers recompute
-deno task cf piece get --piece ID totalSpent ...  # Now correct
+deno task cf get --piece ID totalSpent ...  # Now correct
 ```
 
 ## Inspect Transformed Output
@@ -114,16 +114,16 @@ deno task cf check \
 deno task cf piece inspect --piece <piece-id> -i "$CF_IDENTITY" -a URL -s space
 
 # 2. What are the inputs?
-deno task cf piece get --piece <piece-id> /input -i "$CF_IDENTITY" -a URL -s space
+deno task cf get --piece <piece-id> /input -i "$CF_IDENTITY" -a URL -s space
 
 # 3. What's a specific computed value?
-deno task cf piece get --piece <piece-id> myComputedField -i "$CF_IDENTITY" -a URL -s space
+deno task cf get --piece <piece-id> myComputedField -i "$CF_IDENTITY" -a URL -s space
 
 # 4. Set known input, trigger recompute, verify output
 echo '{"items":[{"title":"test","done":false}]}' | \
-  deno task cf piece set --piece <piece-id> /input -i "$CF_IDENTITY" -a URL -s space
+  deno task cf set --piece <piece-id> /input -i "$CF_IDENTITY" -a URL -s space
 deno task cf piece step --piece <piece-id> -i "$CF_IDENTITY" -a URL -s space
-deno task cf piece get --piece <piece-id> itemCount -i "$CF_IDENTITY" -a URL -s space
+deno task cf get --piece <piece-id> itemCount -i "$CF_IDENTITY" -a URL -s space
 ```
 
 ## Common CLI Debugging Patterns
@@ -162,7 +162,7 @@ deno task cf piece setsrc --piece <piece-id> pattern.tsx \
   --test pattern.test.tsx -i "$CF_IDENTITY" -a URL -s space
 
 # Test again
-deno task cf piece get --piece <piece-id> brokenField -i "$CF_IDENTITY" -a URL -s space
+deno task cf get --piece <piece-id> brokenField -i "$CF_IDENTITY" -a URL -s space
 ```
 
 This keeps you working with the same piece instance, preserving any test data you've set up.

--- a/docs/development/debugging/gotchas/persisting-images-in-cells.md
+++ b/docs/development/debugging/gotchas/persisting-images-in-cells.md
@@ -2,10 +2,10 @@
 
 **Symptom:** A pattern captures photos with `<cf-image-input>` and stores the
 resulting `ImageData` in a persisted cell (e.g. a `PerSpace` array of records).
-The data appears to save (CLI `cf piece get …/0/someField` works), but in the
+The data appears to save (CLI `cf get …/0/someField` works), but in the
 browser the list **renders intermittently or not at all** — the same cell reads
 as a populated array in one `computed()` and as `undefined`/`nil` in another
-during the same render, with no console error. A full `cf piece get <cell>` may
+during the same render, with no console error. A full `cf get <cell>` may
 return nothing (the payload is enormous).
 
 **Cause:** `ImageData.data` is the full image as an inline base64 **data-URL**
@@ -58,6 +58,6 @@ sightings.set([...sightings.get(), { image: light, /* … */ }]);
   into the durable record.
 
 **Verify with:** after saving, reload the piece and confirm the list still
-renders. Reading a tiny field via `cf piece get <cell>/0/<field>` confirms the
+renders. Reading a tiny field via `cf get <cell>/0/<field>` confirms the
 record persisted; an enormous/empty full-cell read is the tell that you inlined
 a blob.

--- a/docs/features/host-embedding.md
+++ b/docs/features/host-embedding.md
@@ -349,7 +349,7 @@ principal, with **no `uiContract`**. Creating a profile, by contrast,
 *is* gesture-gated: `profile-create.tsx` carries the only `uiContract`
 (the `ProfileCreateSurface` trusted pattern).
 
-**Consequence.** Headless pinning (`cf piece call` into the `addPiece`
+**Consequence.** Headless pinning (`cf call` into the `addPiece`
 stream) and cross-pattern pin flows are **sanctioned** use cases.
 Future guards must keep supporting them — do not "harden" pinning with
 a `uiContract`; that conflates the create seam (correctly

--- a/docs/specs/PATTERN_TESTING_SPEC.md
+++ b/docs/specs/PATTERN_TESTING_SPEC.md
@@ -18,7 +18,7 @@ primitive), and are run via `cf test`.
 
 1. **Patterns all the way down** - Tests are patterns, proving the system works
 2. **Fast feedback loops** - Tests run with emulated storage (~10ms setup)
-3. **Debuggability** - Inspect test patterns via CLI (`cf piece inspect`, `cf piece get`)
+3. **Debuggability** - Inspect test patterns via CLI (`cf piece inspect`, `cf get`)
 4. **Minimal infrastructure** - Reuse existing `piece step` machinery
 5. **Self-contained tests** - Test logic lives inside actions, not external scripts
 

--- a/docs/specs/json_schema.md
+++ b/docs/specs/json_schema.md
@@ -37,7 +37,7 @@ The authoritative field inventory is the `JSONSchema` type in
   a UI affordance outside the headless contract, inferred at compile time
   from session-scoped handler bindings plus a void event
   (ts-transformers current-behavior spec §12.1). `cf piece verbs` hides
-  marked verbs by default; everything stays callable, and `cf piece call`
+  marked verbs by default; everything stays callable, and `cf call`
   never consults the mark. Annotation-class in the piece compat checker
   (adds and removes freely). Standard `deprecated: true` is the companion
   mark on the other axis, produced from `@deprecated` JSDoc.

--- a/docs/specs/scheduler-v2/README.md
+++ b/docs/specs/scheduler-v2/README.md
@@ -867,7 +867,7 @@ only value that document ever holds. A verb's *declared* result type is a
 separate question: lowered onto `module.resultSchema`, it reaches the runtime —
 a launched result pattern carries it as its result schema, which `setupInternal`
 records as that receipt's stored schema, and the CLI serves it from the
-compiled graph (`cf piece verbs`, `cf piece call <verb> --help`). What it never
+compiled graph (`cf piece verbs`, `cf call <verb> --help`). What it never
 enters is the pattern's own durable schema — the shape the update gate compares
 across versions — and whichever source a receipt's stored schema came from, it
 describes one handling and constrains nothing written later.

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -1523,7 +1523,7 @@ not yet `.for(...)`-wrapped.
 For each `pattern(cb, argumentSchema, resultSchema)` call it marks
 result-schema stream properties `tier: "wrapper"` — the verb-listing mark
 `cf piece verbs` hides by default (verb contract WS-F; everything stays
-callable, `cf piece call` never consults marks). A property is marked when its
+callable, `cf call` never consults marks). A property is marked when its
 returned value resolves (identifier → nearest const initializer, callback body
 first then module scope) to an applied handler factory that:
 

--- a/docs/tutorial/06-workflow.md
+++ b/docs/tutorial/06-workflow.md
@@ -113,9 +113,9 @@ Everything a pattern exports (Chapter 3) is drivable without a browser:
 deno task cf piece ls -s myspace                       # list registered pieces
 deno task cf piece search -s myspace "invoice"         # search registered pieces
 deno task cf piece inspect --piece <ID>                # dump structure/state
-deno task cf piece get --piece <ID> items              # read one exported field
-deno task cf piece call addItem '{"title": "Test"}' --piece <ID>   # send to a stream
-echo '"hello"' | deno task cf piece set --piece <ID> title          # write a field
+deno task cf get --piece <ID> items                    # read one exported field
+deno task cf call --piece <ID> addItem '{"title": "Test"}'   # send to a stream
+echo '"hello"' | deno task cf set --piece <ID> title   # write a field
 deno task cf piece step --piece <ID>                   # force recompute
 deno task cf piece view --piece <ID>                   # render the UI in the terminal
 deno task cf piece link <srcID>/items <dstID>/items    # wire two pieces
@@ -131,13 +131,14 @@ drives the next command unchanged, even from a shell configured for a
 different space.
 
 On `get`, `set`, and `call`, the canonical reference can also sit in the
-first positional instead of the flag — `cf piece get /of:fid1:.../items`. On
+first positional instead of the flag — `cf get /of:fid1:.../items`. On
 the commands that take `--input` (`get` and `set` here), a trailing
 `#argument` selects the piece's arguments cell the way that flag does;
-`call` takes no `--input` and refuses the suffix. These three are also
-mounted at top level, so `cf get /of:fid1:.../items` is the same command
-with a shorter name: reading and writing cells is not really a
-piece-management concern, and the spelling says so.
+`call` takes no `--input` and refuses the suffix. The three are the piece
+data commands mounted at top level — reading and writing cells is not
+really a piece-management concern, and the spelling says so. `cf piece
+get`, `cf piece set`, and `cf piece call` are the same commands and keep
+working.
 
 One subtlety: neither `piece set` nor `piece call` refreshes *computed*
 outputs. `set` writes the cell without running anything; `call` runs the

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -225,7 +225,7 @@ at, the vocabulary that position takes, and the declared name it is one edit
 from:
 
 ```console
-$ cf piece call --piece ID addItem '{"titel":"Milk","done":false}'
+$ cf call --piece ID addItem '{"titel":"Milk","done":false}'
 Invalid input for "addItem": "titel" at <event> is not a field this verb
 declares. Did you mean "title"? <event> takes "title", "done"
 ```
@@ -258,9 +258,9 @@ passed over — a payload need satisfy only one branch — and so is a position
 marked as a cell or a stream, which may hold a link rather than a value. A call
 reaching either goes out rather than being refused on a guess.
 
-The declared vocabulary is what `cf piece call --piece ID <verb> --help` prints,
-which is the list to check when a field comes back refused. It names the fields
-the verb's handler READS, which can be fewer than its TypeScript event type
+The declared vocabulary is what `cf call --piece ID <verb> --help` prints, which
+is the list to check when a field comes back refused. It names the fields the
+verb's handler READS, which can be fewer than its TypeScript event type
 declares: a field the body never touches is one the runtime would have dropped,
 and the refusal says so rather than accepting it and losing it.
 
@@ -281,8 +281,8 @@ vocabulary is learned once and written wherever you arrived from.
 a smaller shape:
 
 ```bash
-cf piece get --piece ID items --filter '.status == "open"'
-cf piece get --piece ID items \
+cf get --piece ID items --filter '.status == "open"'
+cf get --piece ID items \
   --filter '.status == "open" and .score >= 10' \
   --select id,title,author.name
 ```
@@ -290,8 +290,8 @@ cf piece get --piece ID items \
 `piece call` writes them before the callable name:
 
 ```bash
-cf piece call --piece ID --select topic.title addTopic '{"title":"Ship it"}'
-cf piece call --piece ID --filter '.status == "open"' listTopics
+cf call --piece ID --select topic.title addTopic '{"title":"Ship it"}'
+cf call --piece ID --filter '.status == "open"' listTopics
 ```
 
 `wish` writes them beside the target it resolves:
@@ -446,7 +446,7 @@ A projection marks a position to get that position's address rather than what is
 behind it. A JSON `--schema` marks with `"$link": true`:
 
 ```bash
-cf piece get --piece ID notes --schema '{"type":"array","items":{"$link":true}}'
+cf get --piece ID notes --schema '{"type":"array","items":{"$link":true}}'
 ```
 
 ```json
@@ -454,12 +454,12 @@ cf piece get --piece ID notes --schema '{"type":"array","items":{"$link":true}}'
 ```
 
 The address is one string in the fabric's canonical reference syntax —
-`/[@did/]<id>[@scope][/path]` — which is exactly what `cf piece call --piece`
-and `cf piece get --piece` accept, scheme included, so an address emitted by one
-command composes into the next unchanged, without being reassembled. The space
-rides in front as `@did:key:…` only when it differs from the space the command
-targeted, the scope follows the id as `@user`/`@session` only when it is not the
-default, and the path follows as ordinary segments. No schema is inlined and no
+`/[@did/]<id>[@scope][/path]` — which is exactly what `cf call --piece` and
+`cf get --piece` accept, scheme included, so an address emitted by one command
+composes into the next unchanged, without being reassembled. The space rides in
+front as `@did:key:…` only when it differs from the space the command targeted,
+the scope follows the id as `@user`/`@session` only when it is not the default,
+and the path follows as ordinary segments. No schema is inlined and no
 write-redirect flag rides along.
 
 **Every address this CLI publishes is that one string** — a `$link` marker's
@@ -491,7 +491,7 @@ A field list marks with a trailing `@`, which is that same marker at the
 position the segment names:
 
 ```bash
-cf piece get --piece ID --select 'topic@,topic.title'
+cf get --piece ID --select 'topic@,topic.title'
 ```
 
 ```json
@@ -510,7 +510,7 @@ array the answer is one address per element, so `notes@` is the concise spelling
 of `{"type":"array","items":{"$link":true}}`:
 
 ```bash
-cf piece get --piece ID --select 'notes@'
+cf get --piece ID --select 'notes@'
 ```
 
 ```json
@@ -528,7 +528,7 @@ A path that is only `@` names the position the read is already at, which no
 field path reaches because it sits above every field:
 
 ```bash
-cf piece get --piece ID topic --select '@,title'
+cf get --piece ID topic --select '@,title'
 ```
 
 ```json
@@ -559,13 +559,13 @@ result is read off the cell the tool wrote. Use a selection to control what
 reaches stdout, not to control what travels.
 
 A selection also couples the call to graph quiescence. The shaped readback runs
-through the same shared read step as `cf piece get`, and that step awaits the
-CLI runtime's global idle plus storage sync before answering — while the plain
-call acknowledges at its own handling's commit. On a piece with heavy derived
-state, a shaped call can therefore wait on unrelated recomputation the handler
+through the same shared read step as `cf get`, and that step awaits the CLI
+runtime's global idle plus storage sync before answering — while the plain call
+acknowledges at its own handling's commit. On a piece with heavy derived state,
+a shaped call can therefore wait on unrelated recomputation the handler
 triggered elsewhere in the graph. When that wait matters, shape the collect
 instead: call plain (or `--no-wait`), then
-`cf piece get --piece <receipt id> --select …`.
+`cf get --piece <receipt id> --select …`.
 
 Three cases follow from that:
 
@@ -580,7 +580,7 @@ Three cases follow from that:
   The refusal names the flags that need the readback, alongside `--show-links`
   for the same reason. What it still returns is the envelope's `receipt` — the
   address of the cell holding the outcome, known at commit — so the shaping
-  flags apply to the `cf piece get` that collects it.
+  flags apply to the `cf get` that collects it.
 - **`--show-links` composes with a projection, not with `--filter`.** Links are
   collected after the selection, over exactly the value the caller is holding: a
   projection leaves every surviving path where it was, so each address still
@@ -727,7 +727,7 @@ errors go to stderr. If a command does not support `--json`, it rejects the
 option without printing command help to stdout. Static `--help` and `--json`
 cannot be combined. Callable schema help is the exception because it is JSON:
 use `cf exec <mounted-file> --help --json` or
-`cf piece call ... <callable> --help --json`.
+`cf call ... <callable> --help --json`.
 
 The supported output switches are:
 
@@ -744,7 +744,7 @@ The supported output switches are:
   writes only JSON render records to stdout; watch status goes to stderr.
   Rendering a piece without a UI fails instead of returning an empty successful
   JSON stream.
-- `cf piece get` and `cf wish` always return JSON. Their `--json` options are
+- `cf get` and `cf wish` always return JSON. Their `--json` options are
   accepted, documented no-ops for callers that select JSON explicitly.
 - `cf check --json` compiles without evaluating and prints one object with a
   `files` array. Each entry has the input `path` and the compiled module bodies
@@ -755,25 +755,24 @@ exclusive stdout modes. The command buffers all three modes until every input
 succeeds. A failure therefore leaves stdout empty instead of mixing successful
 output with later errors.
 
-For `cf exec`, `--json` belongs after the mounted callable path. For
-`cf piece call`, it belongs after the callable name. In both commands, it
-selects complete JSON input — and in both, that is the opposite side of the
-callable from where the read options go, which shape what comes back rather than
-what goes in:
+For `cf exec`, `--json` belongs after the mounted callable path. For `cf call`,
+it belongs after the callable name. In both commands, it selects complete JSON
+input — and in both, that is the opposite side of the callable from where the
+read options go, which shape what comes back rather than what goes in:
 
 ```bash
 cf exec /tmp/cf/home/pieces/notes/result/search.tool --json '{"query":"milk"}'
 printf '%s' '{"query":"milk"}' |
   cf exec /tmp/cf/home/pieces/notes/result/search.tool --json
 
-cf piece call ... search --json '{"query":"milk"}'
-printf '%s' '{"query":"milk"}' | cf piece call ... search --json
+cf call ... search --json '{"query":"milk"}'
+printf '%s' '{"query":"milk"}' | cf call ... search --json
 ```
 
 Bare `--json` reads stdin. An inline value immediately after it is parsed as the
 complete input. `piece call` also accepts a single positional JSON value. Put
 schema-derived piece-call flags after `--`, for example
-`cf piece call ... search -- --query milk`. Use `-- --json-file <path>` for a
+`cf call ... search -- --query milk`. Use `-- --json-file <path>` for a
 piece-call JSON file. These rules keep the options before the callable name for
 `piece call` itself and the arguments after the name for the invoked callable.
 
@@ -929,11 +928,11 @@ such as `--log-level` — plus live values read from the fabric:
 
 Live values need an identity and an api-url. Both are read from the line being
 typed (`-i`, `-a`, `-u`) before falling back to `CF_IDENTITY`/`CF_API_URL`, so
-`cf piece call -s other-space --piece <TAB>` lists that space's pieces rather
-than the environment's. When neither is resolvable, or the server is
-unreachable, completion yields nothing — it never prints an error into the
-command line. Each request costs one CLI invocation plus one round trip, so
-value completion is as fast as the fabric it queries.
+`cf call -s other-space --piece <TAB>` lists that space's pieces rather than the
+environment's. When neither is resolvable, or the server is unreachable,
+completion yields nothing — it never prints an error into the command line. Each
+request costs one CLI invocation plus one round trip, so value completion is as
+fast as the fabric it queries.
 
 ### `deno task cf` and other invocations
 

--- a/packages/patterns/cozy-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/cozy-poll/DEPLOY-AND-SHARE.md
@@ -90,8 +90,8 @@ MINE=$(deno task cf piece new packages/patterns/cozy-poll/main.tsx \
 # 2. Copy each PerSpace field from the canonical piece into yours.
 #    `--input` reads/writes the input cell where these live.
 for field in question users options votes adminName; do
-  deno task cf piece get --piece "$PIECE" -s "$SPACE" "$field" --input -q \
-    | deno task cf piece set --piece "$MINE" -s "$SPACE" "$field" --input -q
+  deno task cf get --piece "$PIECE" -s "$SPACE" "$field" --input -q \
+    | deno task cf set --piece "$MINE" -s "$SPACE" "$field" --input -q
 done
 
 # 3. Recompute so derived values (counts, ranking, nudges) refresh.
@@ -135,10 +135,10 @@ or seed the shared cells directly, write the input cells. **This mutates shared
 state — coordinate before running against the canonical piece.**
 
 ```bash
-echo '[]' | deno task cf piece set --piece "$PIECE" -s "$SPACE" users     --input -q
-echo '""' | deno task cf piece set --piece "$PIECE" -s "$SPACE" adminName --input -q
-echo '[]' | deno task cf piece set --piece "$PIECE" -s "$SPACE" options   --input -q
-echo '[]' | deno task cf piece set --piece "$PIECE" -s "$SPACE" votes     --input -q
+echo '[]' | deno task cf set --piece "$PIECE" -s "$SPACE" users     --input -q
+echo '""' | deno task cf set --piece "$PIECE" -s "$SPACE" adminName --input -q
+echo '[]' | deno task cf set --piece "$PIECE" -s "$SPACE" options   --input -q
+echo '[]' | deno task cf set --piece "$PIECE" -s "$SPACE" votes     --input -q
 deno task cf piece step --piece "$PIECE" -s "$SPACE"
 ```
 

--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -199,9 +199,8 @@ interface casually against a piece you care about.
 
 ## Option B — copy the state into your own piece
 
-> **Note:** the copy loop below writes with `cf piece set --input`, which
-> validates the whole input object on every write. Every field fails on this
-> pattern with
+> **Note:** the copy loop below writes with `cf set --input`, which validates
+> the whole input object on every write. Every field fails on this pattern with
 > `updated input does not match its schema: myName: value does not
 > match type string`,
 > including a write to `myName` itself. The pattern's `myName` is `PerUser`, and
@@ -223,8 +222,8 @@ MINE=$(deno task cf piece new packages/patterns/lunch-poll/main.tsx \
 # 2. Copy each PerSpace field from the shared piece into yours.
 #    `--input` reads/writes the input cell where these live.
 for field in question users options votes participantProfiles adminName visits; do
-  deno task cf piece get --piece "$PIECE" -s "$SPACE" "$field" --input -q \
-    | deno task cf piece set --piece "$MINE" -s "$SPACE" "$field" --input -q
+  deno task cf get --piece "$PIECE" -s "$SPACE" "$field" --input -q \
+    | deno task cf set --piece "$MINE" -s "$SPACE" "$field" --input -q
 done
 
 # 3. Recompute so derived values (counts, ranking) refresh.
@@ -248,7 +247,7 @@ gotcha and no SQLite files to inspect.
 - **Read the `visits` input directly** to confirm a write landed (no browser
   needed):
   ```bash
-  deno task cf piece get --piece "$PIECE" -s "$SPACE" visits --input -q
+  deno task cf get --piece "$PIECE" -s "$SPACE" visits --input -q
   ```
   The derived outputs (`recentVisits`, `placeStats`, `historyCount`,
   `mostRecentTitle`, `voteHistoryCount`) recompute on `step` and read back the
@@ -257,14 +256,14 @@ gotcha and no SQLite files to inspect.
 **Smoke test after deploy** (host-gated handlers need a join first):
 
 ```bash
-deno task cf piece call --piece "$PIECE" -s "$SPACE" joinAs '{"name":"Host"}'
+deno task cf call --piece "$PIECE" -s "$SPACE" joinAs '{"name":"Host"}'
 deno task cf piece step --piece "$PIECE" -s "$SPACE"
-deno task cf piece call --piece "$PIECE" -s "$SPACE" addOption '{"title":"Test Cafe"}'
+deno task cf call --piece "$PIECE" -s "$SPACE" addOption '{"title":"Test Cafe"}'
 deno task cf piece step --piece "$PIECE" -s "$SPACE"
-deno task cf piece call --piece "$PIECE" -s "$SPACE" logVisit '{"title":"Test Cafe"}'
+deno task cf call --piece "$PIECE" -s "$SPACE" logVisit '{"title":"Test Cafe"}'
 deno task cf piece step --piece "$PIECE" -s "$SPACE"
 # Confirm the entry landed (no browser needed):
-deno task cf piece get --piece "$PIECE" -s "$SPACE" visits --input -q
+deno task cf get --piece "$PIECE" -s "$SPACE" visits --input -q
 ```
 
 ## Identity & joining
@@ -305,17 +304,17 @@ everyone sees, and direct `set` races anyone's live browser session.**
 - **History:** use the **`clearHistory` handler** (host-gated) — it empties the
   `visits` log (and its embedded vote snapshots):
   ```bash
-  deno task cf piece call --piece "$PIECE" -s "$SPACE" clearHistory '{}'
+  deno task cf call --piece "$PIECE" -s "$SPACE" clearHistory '{}'
   deno task cf piece step --piece "$PIECE" -s "$SPACE"
   ```
   Or, since `visits` is an ordinary `PerSpace` cell, write it directly (below).
 - **PerSpace cells:** write the input cells directly:
   ```bash
-  echo '[]' | deno task cf piece set --piece "$PIECE" -s "$SPACE" users     --input -q
-  echo '""' | deno task cf piece set --piece "$PIECE" -s "$SPACE" adminName --input -q
-  echo '[]' | deno task cf piece set --piece "$PIECE" -s "$SPACE" options   --input -q
-  echo '[]' | deno task cf piece set --piece "$PIECE" -s "$SPACE" votes     --input -q
-  echo '[]' | deno task cf piece set --piece "$PIECE" -s "$SPACE" visits    --input -q
+  echo '[]' | deno task cf set --piece "$PIECE" -s "$SPACE" users     --input -q
+  echo '""' | deno task cf set --piece "$PIECE" -s "$SPACE" adminName --input -q
+  echo '[]' | deno task cf set --piece "$PIECE" -s "$SPACE" options   --input -q
+  echo '[]' | deno task cf set --piece "$PIECE" -s "$SPACE" votes     --input -q
+  echo '[]' | deno task cf set --piece "$PIECE" -s "$SPACE" visits    --input -q
   deno task cf piece step --piece "$PIECE" -s "$SPACE"
   ```
   After this, the first person to join in the browser becomes host as their own

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -83,16 +83,16 @@ pattern's source identity, before relying on either. Against a deployed board
 piece:
 
 ```bash
-cf piece call --piece <board> addTopic \
+cf call --piece <board> addTopic \
   '{"title":"...","body":"the initial living document","agentName":"Sol"}'
 # -> { "result": { "topic": … } }: the topic this call created
-cf piece get --piece <board> topics --input \
+cf get --piece <board> topics --input \
   --select title,createdAt,lastActivityAt,commentCount
-cf piece call --piece <topic> addComment \
+cf call --piece <topic> addComment \
   '{"body":"point-in-time progress update","agentName":"Sol"}'
-cf piece call --piece <topic> setBody \
+cf call --piece <topic> setBody \
   '{"body":"latest state plus the topic narrative","agentName":"Sol"}'
-cf piece call --piece <topic> addLink \
+cf call --piece <topic> addLink \
   '{"kind":"pr","url":"https://github.com/org/repo/pull/123","label":"PR #123","agentName":"Sol"}'
 ```
 
@@ -103,7 +103,7 @@ references — every reference declared through a title-only schema, so the read
 cannot expand a topic's body, thread, or verbs no matter how it is projected:
 
 ```bash
-cf piece get --piece <board> index --step
+cf get --piece <board> index --step
 ```
 
 The board input links to complete Topic objects, including bodies, threads,
@@ -112,19 +112,19 @@ should therefore combine an exact/range `--filter` with a concise `--select`
 instead of materializing the whole corpus:
 
 ```bash
-cf piece get --piece <board> topics --input \
+cf get --piece <board> topics --input \
   --filter '.title == "<exact title>"' \
   --select title,lastActivityAt,commentCount
-cf piece get --piece <board> topics --input \
+cf get --piece <board> topics --input \
   --filter '.lastActivityAt >= <epoch-milliseconds>' \
   --select title,lastActivityAt,commentCount,createdBy.kind,createdBy.name
-cf piece get --piece <board> crossrefs --step \
+cf get --piece <board> crossrefs --step \
   --filter '.topic.title == "<exact title>"' \
   --select fid,topic.title,topic.lastActivityAt,topic.commentCount
-cf piece get --piece <topic> comments --input \
+cf get --piece <topic> comments --input \
   --filter '.author.name == "Sol" or .authorName == "Sol"' \
   --select sentAt,author.kind,author.name,authorName,body
-cf piece get --piece <topic> links --input \
+cf get --piece <topic> links --input \
   --filter '.kind == "pr"' --select kind,url,label,addedAt
 ```
 


### PR DESCRIPTION
## Why

Precondition for step 6a (the dated deprecation warning), and task 2 of the post-stack follow-ups. Step 6a makes every `cf piece get/set/call` invocation print a warning naming the date the spelling stops working — and a warning that fires on examples this repository still teaches trains agents to generate warnings. The live docs held ~660 old-spelling occurrences against ~25 new ones the day step 5 landed, so the sweep has to precede the warning: after this PR, the teaching surface and the warning agree about which spelling is current.

## What changed

18 live teaching documents (tutorial, `docs/common`, debugging guides, dev/spec references, the CLI README, and three pattern deploy guides) now write the top-level spellings where they teach reading, writing, and dispatching — 115 sites, converted with a guard that leaves `get-label`/`set-label`/`setsrc`/`getsrc`/`set-slug`/`set-home` alone, then reviewed per file. Where a document deliberately explains the two-spelling equivalence (the CLI README's reference section, the tutorial's drive chapter, the verbs doc's opening), the piece-mounted spellings stay named; `docs/history` is untouched per its charter, `docs/plans` keeps its own prose, and `verb-session-walkthrough.md` is left to its maintainer (b3, whose #5905 pass owns it).

Riding along, two latent example bugs found by the review pass: `cf piece call addItem '{…}' --piece <ID>` in the tutorial and handler concept doc put the flags after the callable name, where `.stopEarly()` hands them to the callable's own parser — that spelling never parsed `--piece` as the piece flag. Both now lead with the flags.

One prose fix in `verbs-over-the-cli.md`: the paragraph describing `cf exec`'s printed readback line no longer names a spelling at all, since the line's literal text says `cf piece get` and the sweep must not make docs misquote real output.

## Test plan

`deno task check-docs` (549 blocks pass), repo-wide `deno fmt --check`, `deno task docs-links --orphan` (no orphans), and a targeted grep confirming no doc quotes the exec hint's literal text. Shell blocks in Markdown have no mechanical check in this repo, and per Mike's ruling none is being added — the per-file review pass is the whole of the verification, which is why it was a review pass rather than a bare sed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)