### PR TITLE
fix(ui): build markdown and SVG as nodes, never as markup

### DIFF
--- a/docs/common/components/COMPONENTS.md
+++ b/docs/common/components/COMPONENTS.md
@@ -151,7 +151,7 @@ cell means none confirmed — check the component source before assuming.
 | `cf-loader` | Inline spinner for pending async operations | |
 | `cf-location` | Geolocation capture (single or continuous) | `$location` |
 | `cf-map` | Interactive Leaflet/OpenStreetMap map (see [cf-map](#cf-map)) | `$value`, `$center`, `$zoom`, `$bounds` |
-| `cf-markdown` | Renders markdown with syntax highlighting and copy buttons | `$content` |
+| `cf-markdown` | Renders markdown with syntax highlighting and copy buttons; safe for untrusted content, and raw HTML written into the markdown is not rendered | `$content` |
 | `cf-message-beads` | Compact bead visualization of a message history | `$messages` |
 | `cf-message-input` | Input + send button combo for chat-style item entry; emits a synthetic (untrusted) `cf-send` event, so use `cf-submit-input` when the submit must authorize an owner-protected write | |
 | `cf-modal` | Accessible modal dialog with bottom-sheet presentation mode | `$open` |
@@ -179,7 +179,7 @@ cell means none confirmed — check the component source before assuming.
 | `cf-slider` | Range input slider | |
 | `cf-space-link` | Renders a space as a clickable navigation pill | |
 | `cf-submit-input` | Text field + submit button whose real (trusted) click carries the typed text as `event.target.value` with the surface's UI integrity, so it can authorize an owner-protected runtime write; prefer over `cf-message-input` when the submit gesture must be trusted | |
-| `cf-svg` | Renders SVG content from a string | |
+| `cf-svg` | Renders SVG content from a string; safe for untrusted content, and anything that would run script is dropped | |
 | `cf-switch` | Toggle switch for binary on/off state | `$checked` |
 | `cf-tab` | Individual tab button used within `cf-tab-list` | |
 | `cf-tab-bar` | Fixed navigation bar for app-like UIs (with `cf-tab-bar-item`) | `$value` |

--- a/packages/ui/deno.jsonc
+++ b/packages/ui/deno.jsonc
@@ -5,7 +5,7 @@
   },
   "tasks": {
     "bundle": "../../scripts/bundle.ts src/index.ts",
-    "test": "deno test --allow-env --allow-ffi --allow-read --allow-write --allow-run --ignore=src/v2/components/cf-svg/sanitize-svg.test.ts --ignore=src/v2/components/cf-pointer-accessibility.browser.test.ts --ignore=src/v2/components/cf-modal/cf-modal-layout.browser.test.ts && deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts src/v2/components/cf-svg/sanitize-svg.test.ts src/v2/components/cf-pointer-accessibility.browser.test.ts src/v2/components/cf-modal/cf-modal-layout.browser.test.ts"
+    "test": "deno test --allow-env --allow-ffi --allow-read --allow-write --allow-run --ignore=src/v2/components/cf-svg/sanitize-svg.test.ts --ignore=src/v2/components/cf-markdown/cf-markdown.browser.test.ts --ignore=src/v2/components/cf-pointer-accessibility.browser.test.ts --ignore=src/v2/components/cf-modal/cf-modal-layout.browser.test.ts && deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts src/v2/components/cf-svg/sanitize-svg.test.ts src/v2/components/cf-markdown/cf-markdown.browser.test.ts src/v2/components/cf-pointer-accessibility.browser.test.ts src/v2/components/cf-modal/cf-modal-layout.browser.test.ts"
   },
   "imports": {
     // Dependency guide: ../../docs/development/DEPENDENCIES.md

--- a/packages/ui/src/v2/components/cf-markdown/cf-markdown.browser.test.ts
+++ b/packages/ui/src/v2/components/cf-markdown/cf-markdown.browser.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Tests for the DOM cf-markdown builds from a markdown document.
+ *
+ * These need a browser, and run under deno-web-test rather than `deno test`.
+ * The harness registers tests through `Deno.test` and calls each one with no
+ * arguments, so the BDD functions the rest of the repository uses are not
+ * available here.
+ */
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+
+import { CFMarkdown } from "./index.ts";
+
+interface Rendered {
+  content: HTMLElement;
+  element: CFMarkdown;
+  done(): void;
+}
+
+async function render(markdown: string): Promise<Rendered> {
+  const element = new CFMarkdown();
+  element.content = markdown;
+  document.body.appendChild(element);
+  await element.updateComplete;
+  const content = element.shadowRoot?.querySelector(
+    ".markdown-content",
+  ) as HTMLElement;
+  assert(content, "the component renders a .markdown-content wrapper");
+  return { content, element, done: () => element.remove() };
+}
+
+/** Every element the component put in the document, the wrapper aside. */
+function elementsOf(content: HTMLElement): Element[] {
+  return Array.from(content.querySelectorAll("*"));
+}
+
+/**
+ * A document collecting the ways markdown can carry markup, a URL that runs
+ * script, or an event handler.
+ */
+const HOSTILE = [
+  "<script>globalThis.__markdownXss = true;</script>",
+  '<img src="x" onerror="globalThis.__markdownXss = true;">',
+  '<div onmouseover="globalThis.__markdownXss = true;">hover me</div>',
+  '<iframe src="javascript:alert(1)"></iframe>',
+  '<a href="javascript:alert(1)">an anchor</a>',
+  '<svg><animate attributeName="href" to="javascript:alert(1)"></svg>',
+  "[a link](javascript:alert(1))",
+  "[a link](JaVaScRiPt:alert(1))",
+  "![an image](javascript:alert(1))",
+  "[a link](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)",
+  "[a link](vbscript:msgbox(1))",
+  "<style>@import url(https://example.invalid/x.css);</style>",
+].join("\n\n");
+
+Deno.test("cf-markdown renders no element that can run script", async () => {
+  const { content, done } = await render(HOSTILE);
+  try {
+    for (const forbidden of ["script", "iframe", "img", "svg", "style"]) {
+      assertEquals(
+        content.querySelectorAll(forbidden).length,
+        0,
+        `renders no <${forbidden}>`,
+      );
+    }
+  } finally {
+    done();
+  }
+});
+
+Deno.test("cf-markdown renders no event-handler attribute", async () => {
+  const { content, done } = await render(HOSTILE);
+  try {
+    for (const element of elementsOf(content)) {
+      for (const attribute of Array.from(element.attributes)) {
+        assert(
+          !attribute.name.toLowerCase().startsWith("on"),
+          `<${element.localName}> carries ${attribute.name}`,
+        );
+      }
+    }
+  } finally {
+    done();
+  }
+});
+
+Deno.test("cf-markdown renders no URL that runs script", async () => {
+  const { content, done } = await render(HOSTILE);
+  try {
+    for (const element of elementsOf(content)) {
+      for (const attribute of Array.from(element.attributes)) {
+        const value = attribute.value.replace(/[\s]/g, "").toLowerCase();
+        assert(
+          !value.startsWith("javascript:") && !value.startsWith("vbscript:") &&
+            !value.startsWith("data:text/html"),
+          `<${element.localName}> carries ${attribute.name}="${attribute.value}"`,
+        );
+      }
+    }
+  } finally {
+    done();
+  }
+});
+
+Deno.test("cf-markdown renders a hostile document's text as text", async () => {
+  const { content, done } = await render("A <b>bold</b> word and <script>");
+  try {
+    assertEquals(content.querySelectorAll("b").length, 0);
+    assertStringIncludes(content.textContent ?? "", "A bold word and");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("cf-markdown drops a block of raw HTML along with its text", async () => {
+  const { content, done } = await render(
+    "<div>text inside the block</div>\n\nA paragraph after it.",
+  );
+  try {
+    // marked reads a block of HTML as one token holding its content, so the
+    // text inside goes when the block does. Inline HTML is one token per tag,
+    // and the text between a pair of tags survives on its own — the test
+    // above pins that half.
+    assertEquals(content.textContent?.includes("text inside the block"), false);
+    assertStringIncludes(content.textContent ?? "", "A paragraph after it.");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("cf-markdown keeps a link whose target it cannot follow as text", async () => {
+  const { content, done } = await render("[the label](javascript:alert(1))");
+  try {
+    assertEquals(content.querySelectorAll("a").length, 0);
+    assertStringIncludes(content.textContent ?? "", "the label");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("cf-markdown renders emphasis, strong text and a code span", async () => {
+  const { content, done } = await render(
+    "Hello **world**, *now* with `code`",
+  );
+  try {
+    assertEquals(content.querySelector("strong")?.textContent, "world");
+    assertEquals(content.querySelector("em")?.textContent, "now");
+    assertEquals(content.querySelector("code")?.textContent, "code");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("cf-markdown renders an ordinary link", async () => {
+  const { content, done } = await render(
+    '[example](https://example.com/a "the title")',
+  );
+  try {
+    const anchor = content.querySelector("a");
+    assertEquals(anchor?.getAttribute("href"), "https://example.com/a");
+    assertEquals(anchor?.getAttribute("title"), "the title");
+    assertEquals(anchor?.textContent, "example");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("cf-markdown renders an image with an allowed source", async () => {
+  const { content, done } = await render(
+    "![the alt](https://example.com/a.png)",
+  );
+  try {
+    const image = content.querySelector("img");
+    assertEquals(image?.getAttribute("src"), "https://example.com/a.png");
+    assertEquals(image?.getAttribute("alt"), "the alt");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("cf-markdown renders a code block with a copy button holding the code", async () => {
+  const { content, done } = await render(
+    "```js\nconst a = 1 < 2 && 3 > 2;\n```",
+  );
+  try {
+    const code = content.querySelector(".code-block-container pre code");
+    assertEquals(code?.getAttribute("class"), "language-js");
+    assertEquals(code?.textContent, "const a = 1 < 2 && 3 > 2;\n");
+    const copy = content.querySelector("cf-copy-button") as
+      | (Element & { text: string })
+      | null;
+    assertEquals(copy?.text, "const a = 1 < 2 && 3 > 2;\n");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("cf-markdown wraps each table in its own scroll container", async () => {
+  const { content, done } = await render([
+    "| A | B |",
+    "| --- | ---: |",
+    "| 1 | 2 |",
+    "",
+    "Prose between the tables.",
+    "",
+    "| C | D |",
+    "| --- | --- |",
+    "| 3 | 4 |",
+  ].join("\n"));
+  try {
+    const wrappers = content.querySelectorAll(".table-scroll");
+    assertEquals(wrappers.length, 2);
+    for (const wrapper of Array.from(wrappers)) {
+      assertEquals(wrapper.querySelectorAll("table").length, 1);
+    }
+    // The prose between the tables is outside both wrappers.
+    assertEquals(
+      content.querySelector(".table-scroll")?.textContent?.includes("Prose"),
+      false,
+    );
+    assertEquals(
+      content.querySelectorAll("td")[1]?.getAttribute("align"),
+      "right",
+    );
+  } finally {
+    done();
+  }
+});
+
+Deno.test("cf-markdown renders a cell link as a cf-cell-link", async () => {
+  const { content, done } = await render("Check this [Link](/of:bafyabc/path)");
+  try {
+    const link = content.querySelector("cf-cell-link") as
+      | (Element & { link: string; label: string })
+      | null;
+    assertEquals(link?.link, "/of:bafyabc/path");
+    assertEquals(link?.label, "Link");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("cf-markdown gives a fragment link a heading to land on", async () => {
+  const { content, done } = await render(
+    "# Section One\n\n[Jump](#section-one)",
+  );
+  try {
+    assertEquals(content.querySelector("h1")?.id, "section-one");
+    assertEquals(
+      content.querySelector("a")?.getAttribute("href"),
+      "#section-one",
+    );
+  } finally {
+    done();
+  }
+});
+
+Deno.test("cf-markdown reports which task-list checkbox was toggled", async () => {
+  const { content, element, done } = await render(
+    "- [ ] first\n- [ ] second\n- [x] third",
+  );
+  try {
+    const boxes = content.querySelectorAll('input[type="checkbox"]');
+    assertEquals(boxes.length, 3);
+    assertEquals((boxes[2] as HTMLInputElement).checked, true);
+    assertEquals((boxes[1] as HTMLInputElement).disabled, false);
+
+    const reported: unknown[] = [];
+    element.addEventListener("cf-checkbox-change", (event) => {
+      reported.push((event as CustomEvent).detail);
+    });
+    (boxes[1] as HTMLInputElement).click();
+
+    assertEquals(reported, [{ index: 1, checked: true }]);
+  } finally {
+    done();
+  }
+});
+
+Deno.test("cf-markdown puts a toggled checkbox back to what the document says", async () => {
+  const { content, element, done } = await render("- [ ] first");
+  try {
+    const box = content.querySelector("input") as HTMLInputElement;
+    box.click();
+    assertEquals(box.checked, true);
+
+    // Any re-render. The document still says the task is not done, and a
+    // consumer that did not record the toggle should see that again.
+    element.variant = "inverse";
+    await element.updateComplete;
+
+    assertEquals(
+      (content.querySelector("input") as HTMLInputElement).checked,
+      false,
+    );
+  } finally {
+    done();
+  }
+});
+
+Deno.test("cf-markdown resolves character references in text", async () => {
+  const { content, done } = await render("Tips &amp; tricks &copy; AT&T");
+  try {
+    assertEquals(
+      content.querySelector("p")?.textContent,
+      "Tips & tricks © AT&T",
+    );
+  } finally {
+    done();
+  }
+});
+
+Deno.test("cf-markdown leaves character references in a code span as written", async () => {
+  const { content, done } = await render("Write `&amp;` for an ampersand");
+  try {
+    assertEquals(content.querySelector("code")?.textContent, "&amp;");
+  } finally {
+    done();
+  }
+});

--- a/packages/ui/src/v2/components/cf-markdown/cf-markdown.test.ts
+++ b/packages/ui/src/v2/components/cf-markdown/cf-markdown.test.ts
@@ -1,279 +1,59 @@
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { CFMarkdown } from "./index.ts";
+import { describe, it } from "@std/testing/bdd";
+
 import {
   createMockCellHandle,
   pushUpdate,
 } from "../../test-utils/mock-cell-handle.ts";
+import { CFMarkdown } from "./index.ts";
 
+// What the component renders is covered by cf-markdown.browser.test.ts, which
+// runs in a browser and asserts against the DOM the component built.
 describe("cf-markdown", () => {
-  it("should be defined", () => {
+  it("is defined", () => {
     expect(CFMarkdown).toBeDefined();
   });
 
-  it("should create element instance", () => {
+  it("creates an element instance", () => {
+    expect(new CFMarkdown()).toBeInstanceOf(CFMarkdown);
+  });
+
+  it("starts with empty content", () => {
+    expect(new CFMarkdown().content).toBe("");
+  });
+
+  it("starts in the default variant", () => {
+    expect(new CFMarkdown().variant).toBe("default");
+  });
+
+  it("starts with streaming off", () => {
+    expect(new CFMarkdown().streaming).toBe(false);
+  });
+
+  it("accepts the inverse variant", () => {
     const element = new CFMarkdown();
-    expect(element).toBeInstanceOf(CFMarkdown);
+    element.variant = "inverse";
+    expect(element.variant).toBe("inverse");
   });
 
-  it("should have default empty content", () => {
+  it("accepts streaming", () => {
     const element = new CFMarkdown();
-    expect(element.content).toBe("");
+    element.streaming = true;
+    expect(element.streaming).toBe(true);
   });
 
-  it("should have default variant", () => {
+  it("reads content from a string", () => {
     const element = new CFMarkdown();
-    expect(element.variant).toBe("default");
+    element.content = "test content";
+
+    expect((element as any)._getContentValue()).toBe("test content");
   });
 
-  it("should have streaming disabled by default", () => {
+  it("reads empty content from a null content property", () => {
     const element = new CFMarkdown();
-    expect(element.streaming).toBe(false);
-  });
+    element.content = null as any;
 
-  it("should render basic markdown", () => {
-    const el = new CFMarkdown();
-    const markdown = "Hello **world**";
-
-    const rendered = (el as any)._renderMarkdown(markdown);
-
-    expect(rendered).toContain("<strong>world</strong>");
-  });
-
-  it("should replace LLM-friendly links with cf-cell-link", () => {
-    const el = new CFMarkdown();
-    const link = "/of:bafyabc123/path";
-    const markdown = `Check this [Link](${link})`;
-
-    const rendered = (el as any)._renderMarkdown(markdown);
-
-    expect(rendered).toContain(
-      `<cf-cell-link link="${link}" label="Link"></cf-cell-link>`,
-    );
-  });
-
-  it("should replace a cross-space LLM-friendly link with cf-cell-link", () => {
-    const el = new CFMarkdown();
-    // What `createLLMFriendlyLink` writes when the destination's space differs
-    // from the reader's: the space leads, prefixed with `@`.
-    const link = "/@did:key:z6MkpXpe/of:bafyabc123/path";
-    const markdown = `Check this [Link](${link})`;
-
-    const rendered = (el as any)._renderMarkdown(markdown);
-
-    expect(rendered).toContain(
-      `<cf-cell-link link="${link}" label="Link"></cf-cell-link>`,
-    );
-  });
-
-  it("should wrap code blocks with copy buttons", () => {
-    const el = new CFMarkdown();
-    const markdown = "```js\nconsole.log('hello');\n```";
-
-    const rendered = (el as any)._renderMarkdown(markdown);
-
-    expect(rendered).toContain("code-block-container");
-    expect(rendered).toContain("cf-copy-button");
-  });
-
-  it("should wrap tables in a horizontal scroll container", () => {
-    const el = new CFMarkdown();
-    const markdown = [
-      "| Airport | Flights | Notes |",
-      "| --- | --- | --- |",
-      "| Haneda | Terminal 1 North Wing | Arrive early |",
-    ].join("\n");
-
-    const rendered = (el as any)._renderMarkdown(markdown);
-
-    // The table is rendered...
-    expect(rendered).toContain("<table");
-    // ...and wrapped so it can scroll horizontally on narrow screens
-    // instead of cramming its columns.
-    expect(rendered).toContain('<div class="table-scroll">');
-    // The wrapper opens before the table and closes after it.
-    expect(rendered).toMatch(
-      /<div class="table-scroll"><table[\s\S]*?<\/table><\/div>/,
-    );
-  });
-
-  it("wraps multiple tables independently, not as one span", () => {
-    const el = new CFMarkdown();
-    // Two tables with prose between them. _wrapTablesForScroll uses a
-    // non-greedy match so each table gets its own .table-scroll; a greedy
-    // match would swallow the first table, the prose, AND the second table
-    // into a single wrapper.
-    const markdown = [
-      "| A | B |",
-      "| --- | --- |",
-      "| 1 | 2 |",
-      "",
-      "Prose between the tables.",
-      "",
-      "| C | D |",
-      "| --- | --- |",
-      "| 3 | 4 |",
-    ].join("\n");
-
-    const rendered = (el as any)._renderMarkdown(markdown);
-
-    // Exactly two independent wrappers, each closing right after its table.
-    // (A greedy match would produce a single wrapper and a single
-    // </table></div>.)
-    expect((rendered.match(/<div class="table-scroll">/g) ?? []).length).toBe(
-      2,
-    );
-    expect((rendered.match(/<\/table><\/div>/g) ?? []).length).toBe(2);
-    // The prose between the tables is not swallowed into a wrapper.
-    expect(rendered).toContain("Prose between the tables.");
-  });
-
-  // marked generated these ids itself until version 5, under a `headerIds`
-  // option that defaulted to on, and dropped them in a later major. The
-  // expected ids below are the ones marked 4 produced, because fragment links
-  // written against the old output point at them.
-  describe("heading ids", () => {
-    const idsOf = (markdown: string): string[] => {
-      const el = new CFMarkdown();
-      const rendered = (el as any)._renderMarkdown(markdown);
-      return [...rendered.matchAll(/<h\d id="([^"]*)"/g)].map((m: string[]) =>
-        m[1]
-      );
-    };
-
-    it("gives a heading an id", () => {
-      expect(idsOf("# Section")).toEqual(["section"]);
-    });
-
-    it("suffixes repeated headings so each id stays unique", () => {
-      expect(idsOf("# Section\n\n# Section\n\n# Section")).toEqual([
-        "section",
-        "section-1",
-        "section-2",
-      ]);
-    });
-
-    it("counts headings that differ only by case as repeats", () => {
-      expect(idsOf("# Section\n\n# section\n\n# SECTION")).toEqual([
-        "section",
-        "section-1",
-        "section-2",
-      ]);
-    });
-
-    it("skips a suffix that a later heading already claims", () => {
-      // "Section 1" slugs to "section-1", which the second "Section" took, so
-      // the suffix search moves past it rather than emitting a duplicate id.
-      expect(idsOf("# Section\n\n# Section\n\n# Section 1")).toEqual([
-        "section",
-        "section-1",
-        "section-1-1",
-      ]);
-    });
-
-    it("restarts the suffixes on each render", () => {
-      // The slugger is per-parse, so re-rendering the same content gives the
-      // same ids instead of continuing to count up.
-      const markdown = "# Section\n\n# Section";
-      expect(idsOf(markdown)).toEqual(["section", "section-1"]);
-      expect(idsOf(markdown)).toEqual(["section", "section-1"]);
-    });
-
-    it("drops punctuation", () => {
-      expect(idsOf("# What's New? (v2.0)")).toEqual(["whats-new-v20"]);
-    });
-
-    it("keeps non-ASCII letters", () => {
-      expect(idsOf("# Café Münster")).toEqual(["café-münster"]);
-      expect(idsOf("# 中文标题")).toEqual(["中文标题"]);
-      expect(idsOf("# 🚀 Quick Start")).toEqual(["🚀-quick-start"]);
-    });
-
-    it("drops an ampersand and any entity around it", () => {
-      expect(idsOf("# Q&A")).toEqual(["qa"]);
-      expect(idsOf("# AT&T Integration")).toEqual(["att-integration"]);
-      // An escaped ampersand slugs the same way a bare one does.
-      expect(idsOf("# Tips &amp; Tricks")).toEqual(["tips--tricks"]);
-    });
-
-    it("drops an ampersand nested inside inline markup", () => {
-      // The slug is built from the heading's tokens, so the text inside
-      // emphasis, strikethrough, a link or an image has to be walked into and
-      // escaped exactly as the text around it is. Reading a container token's
-      // own text instead leaves the ampersand unescaped, and unescaping it
-      // then eats the letter after it: `att-integration` becomes
-      // `at-integration`.
-      expect(idsOf("# **AT&T** Integration")).toEqual(["att-integration"]);
-      expect(idsOf("# **Q&A**")).toEqual(["qa"]);
-      expect(idsOf("# *Tips & Tricks*")).toEqual(["tips--tricks"]);
-      expect(idsOf("# ~~R&D~~")).toEqual(["rd"]);
-      expect(idsOf("# [Q&A](/faq)")).toEqual(["qa"]);
-      expect(idsOf("# ![Q&A](/i.png)")).toEqual(["qa"]);
-      expect(idsOf("# `a & b`")).toEqual(["a--b"]);
-    });
-
-    it("resolves a numeric entity but leaves an over-long one alone", () => {
-      expect(idsOf("# &#65; letter")).toEqual(["a-letter"]);
-      // Past marked's limits (7 decimal digits, 6 hex) the run is not an
-      // entity, so the `&` and `;` are dropped and the digits stay.
-      expect(idsOf("# &#12345678; tail")).toEqual(["12345678-tail"]);
-      expect(idsOf("# &#x1234567; tail")).toEqual(["x1234567-tail"]);
-    });
-
-    it("resolves the named colon entity, then strips the colon", () => {
-      // `&colon;` is the one named entity marked resolves — to `:` — instead of
-      // dropping it whole the way it drops every other named entity. The colon
-      // it produces is punctuation, so the slug then removes it: `a:b` becomes
-      // `ab`, matching marked 4. Were `&colon;` left as literal text the slug
-      // would keep the letters and read `acolonb` instead.
-      expect(idsOf("# a&colon;b")).toEqual(["ab"]);
-      expect(idsOf("# time&colon; now")).toEqual(["time-now"]);
-    });
-
-    it("slugs the heading's text, not its markup", () => {
-      const rendered = (new CFMarkdown() as any)._renderMarkdown(
-        "# Using **bold** and `code`",
-      );
-      expect(rendered).toContain('id="using-bold-and-code"');
-      expect(rendered).toContain("<strong>bold</strong>");
-    });
-
-    it("gives every heading level an id", () => {
-      expect(idsOf("## Sub Section\n\n### Deep Section")).toEqual([
-        "sub-section",
-        "deep-section",
-      ]);
-    });
-
-    it("gives a fragment link a heading to land on", () => {
-      // The regression this guards: the link rendered but the id did not, so
-      // the anchor pointed at nothing.
-      const rendered = (new CFMarkdown() as any)._renderMarkdown(
-        "# Section One\n\n[Jump](#section-one)",
-      );
-      const id = rendered.match(/<h1 id="([^"]*)"/)?.[1];
-      const href = rendered.match(/<a href="#([^"]*)"/)?.[1];
-      expect(id).toBe("section-one");
-      expect(href).toBe(id);
-    });
-  });
-
-  it("should get content value from string", () => {
-    const el = new CFMarkdown();
-    el.content = "test content";
-
-    const value = (el as any)._getContentValue();
-
-    expect(value).toBe("test content");
-  });
-
-  it("should handle null/undefined content gracefully", () => {
-    const el = new CFMarkdown();
-    el.content = null as any;
-
-    const value = (el as any)._getContentValue();
-
-    expect(value).toBe("");
+    expect((element as any)._getContentValue()).toBe("");
   });
 
   describe("Cell integration", () => {
@@ -281,48 +61,44 @@ describe("cf-markdown", () => {
     // which are complex to mock. These tests verify the component's
     // subscription management logic with manual _unsubscribe manipulation.
 
-    it("should have null _unsubscribe by default", () => {
-      const el = new CFMarkdown();
-      expect((el as any)._unsubscribe).toBeNull();
+    it("has no subscription before content is bound", () => {
+      expect((new CFMarkdown() as any)._unsubscribe).toBeNull();
     });
 
-    it("should cleanup subscription on disconnect", () => {
-      const el = new CFMarkdown();
+    it("drops its subscription on disconnect", () => {
+      const element = new CFMarkdown();
 
       // Simulate having a subscription
       let cleaned = false;
-      (el as any)._unsubscribe = () => {
+      (element as any)._unsubscribe = () => {
         cleaned = true;
       };
 
-      // Trigger disconnect
-      el.disconnectedCallback();
+      element.disconnectedCallback();
 
       expect(cleaned).toBe(true);
-      expect((el as any)._unsubscribe).toBeNull();
+      expect((element as any)._unsubscribe).toBeNull();
     });
 
-    it("should cleanup old subscription when willUpdate is called with changed content", () => {
-      const el = new CFMarkdown();
+    it("drops the old subscription when the content property changes", () => {
+      const element = new CFMarkdown();
 
       // Simulate having an old subscription
       let oldCleaned = false;
-      (el as any)._unsubscribe = () => {
+      (element as any)._unsubscribe = () => {
         oldCleaned = true;
       };
 
-      // Trigger willUpdate with content change (string content, not Cell)
-      el.content = "new content";
-      (el as any).willUpdate(new Map([["content", "old content"]]));
+      element.content = "new content";
+      (element as any).willUpdate(new Map([["content", "old content"]]));
 
-      // Old subscription should have been cleaned up
       expect(oldCleaned).toBe(true);
       // No new subscription for string content
-      expect((el as any)._unsubscribe).toBeNull();
+      expect((element as any)._unsubscribe).toBeNull();
     });
 
     it("syncs uncached cell content on first bind", async () => {
-      const el = new CFMarkdown();
+      const element = new CFMarkdown();
       const cell = createMockCellHandle<string>(undefined as any);
       let syncCalls = 0;
       let requestUpdates = 0;
@@ -332,60 +108,17 @@ describe("cf-markdown", () => {
         pushUpdate(cell, "loaded from sync");
         return Promise.resolve("loaded from sync");
       };
-      el.requestUpdate = (() => {
+      element.requestUpdate = (() => {
         requestUpdates++;
-      }) as typeof el.requestUpdate;
+      }) as typeof element.requestUpdate;
 
-      el.content = cell;
-      (el as any).willUpdate(new Map([["content", "old content"]]));
+      element.content = cell;
+      (element as any).willUpdate(new Map([["content", "old content"]]));
       await Promise.resolve();
 
       expect(syncCalls).toBe(1);
-      expect((el as any)._getContentValue()).toBe("loaded from sync");
+      expect((element as any)._getContentValue()).toBe("loaded from sync");
       expect(requestUpdates).toBeGreaterThan(0);
-    });
-  });
-
-  describe("variant", () => {
-    it("should accept inverse variant", () => {
-      const el = new CFMarkdown();
-      el.variant = "inverse";
-      expect(el.variant).toBe("inverse");
-    });
-  });
-
-  describe("streaming", () => {
-    it("should accept streaming prop", () => {
-      const el = new CFMarkdown();
-      el.streaming = true;
-      expect(el.streaming).toBe(true);
-    });
-  });
-
-  describe("entity decoding", () => {
-    it("should decode basic HTML entities", () => {
-      const el = new CFMarkdown();
-
-      const decoded = (el as any)._decodeHtmlEntities("&lt;div&gt;&amp;&quot;");
-
-      expect(decoded).toBe('<div>&"');
-    });
-
-    it("should decode numeric entities in fallback mode", () => {
-      const el = new CFMarkdown();
-
-      // Force fallback mode (test environment has no document)
-      const decoded = (el as any)._decodeHtmlEntities("&#60;&#62;");
-
-      expect(decoded).toBe("<>");
-    });
-
-    it("should decode hex entities in fallback mode", () => {
-      const el = new CFMarkdown();
-
-      const decoded = (el as any)._decodeHtmlEntities("&#x3C;&#x3E;");
-
-      expect(decoded).toBe("<>");
     });
   });
 });

--- a/packages/ui/src/v2/components/cf-markdown/cf-markdown.ts
+++ b/packages/ui/src/v2/components/cf-markdown/cf-markdown.ts
@@ -1,29 +1,30 @@
+import { type CellHandle, isCellHandle } from "@commonfabric/runtime-client";
 import { consume } from "@lit/context";
 import { css, html } from "lit";
 import { property } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
-import { unsafeHTML } from "lit/directives/unsafe-html.js";
-import { marked } from "marked";
 
 import { BaseElement } from "../../core/base-element.ts";
-import { HeadingIdRenderer } from "./heading-id.ts";
-
-import "../cf-copy-button/index.ts";
-import "../cf-cell-link/index.ts";
-
-import { type CellHandle, isCellHandle } from "@commonfabric/runtime-client";
-
 import {
   applyThemeToElement,
   type CFTheme,
   cfThemeContext,
   defaultTheme,
 } from "../theme-context.ts";
+import {
+  type MarkdownCallbacks,
+  markdownTemplate,
+} from "./markdown-template.ts";
 
 export type MarkdownVariant = "default" | "inverse";
 
 /**
  * CFMarkdown - Renders markdown content with syntax highlighting and copy buttons
+ *
+ * The content is rendered as markdown only. Raw HTML written into it is not
+ * rendered, and a link or an image whose URL names a scheme outside the
+ * allowlist in `safe-url.ts` loses its URL, so untrusted content is safe to
+ * pass in. `markdown-template.ts` describes how that holds.
  *
  * @element cf-markdown
  *
@@ -336,8 +337,8 @@ export class CFMarkdown extends BaseElement {
 
       /* Tables */
       /* Scroll container so a wide table scrolls horizontally instead of
-      * cramming its columns on narrow (mobile) screens. Injected around every
-      * <table> by _wrapTablesForScroll. */
+      * cramming its columns on narrow (mobile) screens. Wrapped around every
+      * <table> by markdown-template.ts. */
       .markdown-content .table-scroll {
         overflow-x: auto;
         max-width: 100%;
@@ -444,135 +445,6 @@ export class CFMarkdown extends BaseElement {
     return this.content ?? "";
   }
 
-  private _renderMarkdown(content: string): string {
-    if (!content) return "";
-
-    // Use marked.parse with options to avoid mutating global state
-    // A fresh HeadingIdRenderer per parse restarts the duplicate-heading
-    // suffixes, so the same content always renders the same ids.
-    let renderedHtml = marked.parse(content, {
-      breaks: true,
-      gfm: true,
-      async: false,
-      renderer: new HeadingIdRenderer(),
-    });
-
-    // Wrap code blocks with copy buttons
-    renderedHtml = this._wrapCodeBlocksWithCopyButtons(renderedHtml);
-
-    // Wrap tables so wide tables scroll horizontally instead of cramming
-    renderedHtml = this._wrapTablesForScroll(renderedHtml);
-
-    // Replace cell links with cf-cell-link
-    renderedHtml = this._replaceCellLinks(renderedHtml);
-
-    // TODO(CT-1088): XSS VULNERABILITY - This component uses unsafeHTML without sanitization!
-    //
-    // We need to sanitize the HTML to prevent XSS attacks. Originally we used DOMPurify
-    // but it added a dependency (isomorphic-dompurify) that caused lockfile issues.
-    //
-    // Options to fix this:
-    // 1. Add DOMPurify back with proper lockfile management
-    // 2. Implement our own sanitizer that allows our custom elements (cf-cell-link, cf-copy-button)
-    // 3. Find an alternative sanitization library
-    //
-    // For now, only use this component with trusted markdown content!
-    //
-    // Security note: The _escapeForAttribute() method helps prevent attribute injection,
-    // but this doesn't protect against <script> tags or other HTML-based XSS vectors.
-
-    return renderedHtml;
-  }
-
-  private _replaceCellLinks(html: string): string {
-    // Matches <a href="/of:...">Name</a>, and the cross-space form the
-    // LLM-friendly link writes as /@did:key:.../of:... — a link whose space
-    // differs from the reader's leads with `@space`, and a matcher requiring
-    // an alphanumeric first character would leave it an ordinary relative
-    // anchor pointing at a path the shell does not serve.
-    return html.replace(
-      /<a href="(\/@?[a-zA-Z0-9]+:[^"]+)">([^<]*)<\/a>/g,
-      (_match, link, text) => {
-        return `<cf-cell-link link="${link}" label="${
-          this._escapeForAttribute(text)
-        }"></cf-cell-link>`;
-      },
-    );
-  }
-
-  private _wrapCodeBlocksWithCopyButtons(html: string): string {
-    return html.replace(
-      /<pre><code([^>]*)>([\s\S]*?)<\/code><\/pre>/g,
-      (_match, codeAttrs, codeContent) => {
-        const decodedContent = this._decodeHtmlEntities(codeContent);
-
-        return `<div class="code-block-container">
-          <pre><code${codeAttrs}>${codeContent}</code></pre>
-          <cf-copy-button
-            class="code-copy-button"
-            text="${this._escapeForAttribute(decodedContent)}"
-            variant="ghost"
-            size="sm"
-            icon-only
-          ></cf-copy-button>
-        </div>`;
-      },
-    );
-  }
-
-  /**
-   * Wrap each rendered <table> in a horizontally scrollable container.
-   *
-   * marked emits a bare <table> with no wrapper, and the table CSS keeps
-   * columns at a readable minimum width. On a narrow screen (mobile) a wide
-   * table therefore overflows; the wrapper's `overflow-x: auto` gives it its
-   * own horizontal scroll so the overflow is handled inside the markdown block
-   * rather than being clipped by an ancestor (cf-screen sets
-   * `overflow-x: hidden`) or cramming the columns. Mirrors the code-block
-   * wrapper approach above. GFM tables cannot nest, so a non-greedy match is
-   * sufficient.
-   */
-  private _wrapTablesForScroll(html: string): string {
-    return html.replace(
-      /<table[\s\S]*?<\/table>/g,
-      (table) => `<div class="table-scroll">${table}</div>`,
-    );
-  }
-
-  private _decodeHtmlEntities(text: string): string {
-    // Use browser API when available for complete entity decoding
-    if (typeof document !== "undefined") {
-      const textarea = document.createElement("textarea");
-      textarea.innerHTML = text;
-      return textarea.value;
-    }
-
-    // Fallback for SSR/test environments - decode common entities
-    return text
-      .replace(/&amp;/g, "&")
-      .replace(/&lt;/g, "<")
-      .replace(/&gt;/g, ">")
-      .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'")
-      .replace(/&#x27;/g, "'")
-      .replace(/&#x2F;/g, "/")
-      .replace(/&nbsp;/g, " ")
-      .replace(/&#(\d+);/g, (_, dec) => String.fromCharCode(Number(dec)))
-      .replace(
-        /&#x([0-9a-fA-F]+);/g,
-        (_, hex) => String.fromCharCode(parseInt(hex, 16)),
-      );
-  }
-
-  private _escapeForAttribute(text: string): string {
-    return text
-      .replace(/&/g, "&amp;")
-      .replace(/"/g, "&quot;")
-      .replace(/'/g, "&#39;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;");
-  }
-
   override willUpdate(
     changedProperties: Map<string | number | symbol, unknown>,
   ) {
@@ -618,45 +490,12 @@ export class CFMarkdown extends BaseElement {
     if (changedProperties.has("theme") && this.theme) {
       this._updateThemeProperties();
     }
-
-    // Attach click handlers to checkboxes after content is rendered
-    this._attachCheckboxHandlers();
   }
 
-  private _attachCheckboxHandlers() {
-    const container = this.shadowRoot?.querySelector(".markdown-content");
-    if (!container) return;
-
-    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
-    checkboxes.forEach((checkbox, index) => {
-      const inputEl = checkbox as HTMLInputElement;
-
-      // Remove the disabled attribute that marked adds by default
-      inputEl.removeAttribute("disabled");
-
-      // Remove existing handler to prevent duplicates
-      inputEl.removeEventListener("change", this._handleCheckboxChange);
-
-      // Store index as data attribute for retrieval in handler
-      inputEl.dataset.checkboxIndex = String(index);
-
-      // Add new handler
-      inputEl.addEventListener("change", this._handleCheckboxChange);
-    });
-  }
-
-  private _handleCheckboxChange = (event: Event) => {
-    const checkbox = event.target as HTMLInputElement;
-    const index = parseInt(checkbox.dataset.checkboxIndex ?? "0", 10);
-    const checked = checkbox.checked;
-
-    this.dispatchEvent(
-      new CustomEvent("cf-checkbox-change", {
-        detail: { index, checked },
-        bubbles: true,
-        composed: true,
-      }),
-    );
+  private _markdownCallbacks: MarkdownCallbacks = {
+    checkboxToggled: (index: number, checked: boolean) => {
+      this.emit("cf-checkbox-change", { index, checked });
+    },
   };
 
   override disconnectedCallback() {
@@ -673,9 +512,6 @@ export class CFMarkdown extends BaseElement {
   }
 
   override render() {
-    const contentValue = this._getContentValue();
-    const renderedContent = this._renderMarkdown(contentValue);
-
     const classes = {
       "markdown-content": true,
       inverse: this.variant === "inverse",
@@ -685,7 +521,7 @@ export class CFMarkdown extends BaseElement {
 
     return html`
       <div class="${classMap(classes)}" part="content">
-        ${unsafeHTML(renderedContent)}
+        ${markdownTemplate(this._getContentValue(), this._markdownCallbacks)}
       </div>
     `;
   }

--- a/packages/ui/src/v2/components/cf-markdown/heading-id.test.ts
+++ b/packages/ui/src/v2/components/cf-markdown/heading-id.test.ts
@@ -1,0 +1,121 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { Lexer, type Tokens } from "marked";
+
+import { HeadingIds } from "./heading-id.ts";
+
+// marked generated these ids itself until version 5, under a `headerIds`
+// option that defaulted to on, and dropped them in a later major. The expected
+// ids below are the ones marked 4 produced, because fragment links written
+// against the old output point at them.
+describe("heading-id", () => {
+  const idsOf = (markdown: string): string[] => {
+    const ids = new HeadingIds();
+    return Lexer.lex(markdown, { breaks: true, gfm: true })
+      .filter((token): token is Tokens.Heading => token.type === "heading")
+      .map((token) => ids.idFor(token.tokens));
+  };
+
+  it("gives a heading an id", () => {
+    expect(idsOf("# Section")).toEqual(["section"]);
+  });
+
+  it("suffixes repeated headings so each id stays unique", () => {
+    expect(idsOf("# Section\n\n# Section\n\n# Section")).toEqual([
+      "section",
+      "section-1",
+      "section-2",
+    ]);
+  });
+
+  it("counts headings that differ only by case as repeats", () => {
+    expect(idsOf("# Section\n\n# section\n\n# SECTION")).toEqual([
+      "section",
+      "section-1",
+      "section-2",
+    ]);
+  });
+
+  it("skips a suffix that a later heading already claims", () => {
+    // "Section 1" slugs to "section-1", which the second "Section" took, so
+    // the suffix search moves past it rather than emitting a duplicate id.
+    expect(idsOf("# Section\n\n# Section\n\n# Section 1")).toEqual([
+      "section",
+      "section-1",
+      "section-1-1",
+    ]);
+  });
+
+  it("restarts the suffixes on each render", () => {
+    // The slugger is per-render, so re-rendering the same content gives the
+    // same ids instead of continuing to count up.
+    const markdown = "# Section\n\n# Section";
+    expect(idsOf(markdown)).toEqual(["section", "section-1"]);
+    expect(idsOf(markdown)).toEqual(["section", "section-1"]);
+  });
+
+  it("drops punctuation", () => {
+    expect(idsOf("# What's New? (v2.0)")).toEqual(["whats-new-v20"]);
+  });
+
+  it("keeps non-ASCII letters", () => {
+    expect(idsOf("# Café Münster")).toEqual(["café-münster"]);
+    expect(idsOf("# 中文标题")).toEqual(["中文标题"]);
+    expect(idsOf("# 🚀 Quick Start")).toEqual(["🚀-quick-start"]);
+  });
+
+  it("drops an ampersand and any entity around it", () => {
+    expect(idsOf("# Q&A")).toEqual(["qa"]);
+    expect(idsOf("# AT&T Integration")).toEqual(["att-integration"]);
+    // An escaped ampersand slugs the same way a bare one does.
+    expect(idsOf("# Tips &amp; Tricks")).toEqual(["tips--tricks"]);
+  });
+
+  it("drops an ampersand nested inside inline markup", () => {
+    // The slug is built from the heading's tokens, so the text inside
+    // emphasis, strikethrough, a link or an image has to be walked into and
+    // escaped exactly as the text around it is. Reading a container token's
+    // own text instead leaves the ampersand unescaped, and unescaping it
+    // then eats the letter after it: `att-integration` becomes
+    // `at-integration`.
+    expect(idsOf("# **AT&T** Integration")).toEqual(["att-integration"]);
+    expect(idsOf("# **Q&A**")).toEqual(["qa"]);
+    expect(idsOf("# *Tips & Tricks*")).toEqual(["tips--tricks"]);
+    expect(idsOf("# ~~R&D~~")).toEqual(["rd"]);
+    expect(idsOf("# [Q&A](/faq)")).toEqual(["qa"]);
+    expect(idsOf("# ![Q&A](/i.png)")).toEqual(["qa"]);
+    expect(idsOf("# `a & b`")).toEqual(["a--b"]);
+  });
+
+  it("resolves a numeric entity but leaves an over-long one alone", () => {
+    expect(idsOf("# &#65; letter")).toEqual(["a-letter"]);
+    // Past marked's limits (7 decimal digits, 6 hex) the run is not an
+    // entity, so the `&` and `;` are dropped and the digits stay.
+    expect(idsOf("# &#12345678; tail")).toEqual(["12345678-tail"]);
+    expect(idsOf("# &#x1234567; tail")).toEqual(["x1234567-tail"]);
+  });
+
+  it("resolves the named colon entity, then strips the colon", () => {
+    // `&colon;` is the one named entity marked resolves — to `:` — instead of
+    // dropping it whole the way it drops every other named entity. The colon
+    // it produces is punctuation, so the slug then removes it: `a:b` becomes
+    // `ab`, matching marked 4. Were `&colon;` left as literal text the slug
+    // would keep the letters and read `acolonb` instead.
+    expect(idsOf("# a&colon;b")).toEqual(["ab"]);
+    expect(idsOf("# time&colon; now")).toEqual(["time-now"]);
+  });
+
+  it("slugs the heading's text, not its markup", () => {
+    expect(idsOf("# Using **bold** and `code`")).toEqual([
+      "using-bold-and-code",
+    ]);
+  });
+
+  it("gives every heading level an id", () => {
+    expect(idsOf("## Sub Section\n\n### Deep Section")).toEqual([
+      "sub-section",
+      "deep-section",
+    ]);
+  });
+});

--- a/packages/ui/src/v2/components/cf-markdown/heading-id.ts
+++ b/packages/ui/src/v2/components/cf-markdown/heading-id.ts
@@ -1,4 +1,10 @@
-import { Renderer, TextRenderer, type Token, type Tokens } from "marked";
+import {
+  Parser,
+  type Renderer,
+  TextRenderer,
+  type Token,
+  type Tokens,
+} from "marked";
 
 // marked emitted an id on every heading until version 5, under a `headerIds`
 // option that defaulted to on. Version 5 deprecated the option and a later
@@ -143,19 +149,21 @@ class HeadingSlugger {
 }
 
 /**
- * A marked renderer that gives every heading an id.
+ * The ids for the headings of one rendered document.
  *
  * Each instance slugs against its own set of seen headings, so one is created
- * per parse and the suffixes restart at each render.
+ * per render and the suffixes restart each time.
  */
-export class HeadingIdRenderer extends Renderer {
+export class HeadingIds {
   #slugger = new HeadingSlugger();
+  #parser = new Parser();
 
-  override heading({ tokens, depth }: Tokens.Heading): string {
-    const text = this.parser.parseInline(tokens);
-    const raw = unescape(
-      this.parser.parseInline(tokens, new SlugTextRenderer(this.parser)),
+  /** The id for a heading, given the tokens of its text. */
+  idFor(tokens: Token[]): string {
+    return this.#slugger.slug(
+      unescape(
+        this.#parser.parseInline(tokens, new SlugTextRenderer(this.#parser)),
+      ),
     );
-    return `<h${depth} id="${this.#slugger.slug(raw)}">${text}</h${depth}>\n`;
   }
 }

--- a/packages/ui/src/v2/components/cf-markdown/markdown-template.test.ts
+++ b/packages/ui/src/v2/components/cf-markdown/markdown-template.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Tests for the template a markdown document builds.
+ *
+ * A Lit template is two things: static strings, which Lit parses as markup,
+ * and values, which it puts in a text node or an attribute value without
+ * parsing. The document is safe to render exactly when none of it reaches the
+ * first, so the tests here read both halves apart and say which one each piece
+ * of a document landed in. That is a stronger statement than any list of
+ * payloads, and it needs no DOM: a template is inert data until something
+ * renders it, which `cf-markdown.browser.test.ts` does.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { nothing } from "lit";
+
+import { markdownTemplate } from "./markdown-template.ts";
+
+/** A Lit template, as the tag function returns it. */
+interface Template {
+  strings: readonly string[];
+  values: readonly unknown[];
+}
+
+/** A directive, which stands in for a value until Lit commits it. */
+interface Directive {
+  values: readonly unknown[];
+}
+
+function isTemplate(value: unknown): value is Template {
+  return typeof value === "object" && value !== null && "_$litType$" in value;
+}
+
+function isDirective(value: unknown): value is Directive {
+  return typeof value === "object" && value !== null &&
+    "_$litDirective$" in value;
+}
+
+/** Renders a document, discarding what its checkboxes report. */
+function templateFor(source: string): unknown {
+  return markdownTemplate(source, { checkboxToggled: () => {} });
+}
+
+/** Everything Lit parses as markup when it renders `value`. */
+function markupOf(value: unknown): string {
+  if (Array.isArray(value)) return value.map(markupOf).join("");
+  if (isTemplate(value)) {
+    return value.strings.join("") + value.values.map(markupOf).join("");
+  }
+  return "";
+}
+
+/** Everything Lit binds without parsing when it renders `value`. */
+function boundValues(value: unknown, into: unknown[] = []): unknown[] {
+  if (Array.isArray(value)) {
+    for (const item of value) boundValues(item, into);
+  } else if (isTemplate(value)) {
+    for (const item of value.values) boundValues(item, into);
+  } else if (isDirective(value)) {
+    for (const item of value.values) boundValues(item, into);
+  } else {
+    into.push(value);
+  }
+  return into;
+}
+
+/** The bound values that are text, which is what a reader ends up seeing. */
+function boundText(source: string): string[] {
+  return boundValues(templateFor(source)).filter((value) =>
+    typeof value === "string"
+  ) as string[];
+}
+
+/**
+ * A document that reaches every kind of token, used where a test needs the
+ * builder to have been down each branch rather than any one result.
+ */
+const KITCHEN_SINK = [
+  "# One",
+  "## Two",
+  "### Three",
+  "#### Four",
+  "##### Five",
+  "###### Six",
+  "",
+  "A paragraph with **bold**, *italic*, ~~struck~~ and `code`.",
+  "",
+  "> A quote.",
+  "",
+  "- a",
+  "- b",
+  "",
+  "1. first",
+  "",
+  "- [ ] undone",
+  "- [x] done",
+  "",
+  "| A | B |",
+  "| :-- | --: |",
+  "| 1 | 2 |",
+  "",
+  "```js",
+  "const a = 1;",
+  "```",
+  "",
+  "---",
+  "",
+  "[label](https://example.test/a) and ![alt](https://example.test/a.png)",
+  "",
+  "[Name](/of:bafyabc/field)",
+].join("\n");
+
+describe("markdown-template", () => {
+  describe("markdownTemplate()", () => {
+    // Each of these is a way a markdown document can carry markup, a URL that
+    // runs script, or an event handler.
+    const HOSTILE = [
+      "<script>steal()</script>",
+      '<img src="x" onerror="steal()">',
+      '<div onmouseover="steal()">hover me</div>',
+      '<iframe src="javascript:steal()"></iframe>',
+      '<a href="javascript:steal()">an anchor</a>',
+      "[a link](javascript:steal())",
+      "[a link](JaVaScRiPt:steal())",
+      "![an image](javascript:steal())",
+      "[a link](data:text/html;base64,c3RlYWwoKQ==)",
+      "[a link](vbscript:steal())",
+      "<style>@import url(https://example.invalid/x.css);</style>",
+      "# <script>steal()</script>",
+      "| <script>steal()</script> |\n| --- |\n| `<script>` |",
+    ].join("\n\n");
+
+    it("puts no part of a hostile document in the markup it builds", () => {
+      const markup = markupOf(templateFor(HOSTILE)).toLowerCase();
+
+      for (
+        const fragment of [
+          "script",
+          "onerror",
+          "onmouseover",
+          "iframe",
+          "javascript:",
+          "vbscript:",
+          "data:text/html",
+          "steal",
+        ]
+      ) {
+        expect(markup).not.toContain(fragment);
+      }
+    });
+
+    it("builds its markup out of tags this module names", () => {
+      // Every `<` in the markup opens a tag this module wrote. A document that
+      // reached the markup would put one here that is not on this list.
+      const allowed = new Set([
+        "a",
+        "blockquote",
+        "br",
+        "cf-cell-link",
+        "cf-copy-button",
+        "code",
+        "del",
+        "div",
+        "em",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "hr",
+        "img",
+        "input",
+        "li",
+        "ol",
+        "p",
+        "pre",
+        "strong",
+        "table",
+        "tbody",
+        "td",
+        "th",
+        "thead",
+        "tr",
+        "ul",
+      ]);
+      const markup = markupOf(templateFor(`${HOSTILE}\n\n${KITCHEN_SINK}`));
+      const tags = [...markup.matchAll(/<\/?([a-zA-Z][^\s/>]*)/g)].map((
+        match,
+      ) => match[1].toLowerCase());
+
+      expect(tags.length).toBeGreaterThan(0);
+      expect([...new Set(tags)].filter((tag) => !allowed.has(tag))).toEqual([]);
+    });
+
+    it("keeps a hostile document's text, as text", () => {
+      // Dropping the markup does not drop what a person wrote around it.
+      expect(boundText("A <b>bold</b> word").join("")).toContain("A bold word");
+    });
+
+    it("renders emphasis, strong text, strikethrough and a code span", () => {
+      const markup = markupOf(templateFor("**a** *b* ~~c~~ `d`"));
+
+      expect(markup).toContain("<strong>");
+      expect(markup).toContain("<em>");
+      expect(markup).toContain("<del>");
+      expect(markup).toContain("<code>");
+      // The spaces between them are text of their own.
+      expect(boundText("**a** *b* ~~c~~ `d`")).toEqual([
+        "a",
+        " ",
+        "b",
+        " ",
+        "c",
+        " ",
+        "d",
+      ]);
+    });
+
+    it("gives each heading level its own tag, and an id", () => {
+      for (let depth = 1; depth <= 6; depth++) {
+        const source = `${"#".repeat(depth)} A Heading`;
+
+        expect(markupOf(templateFor(source))).toContain(`<h${depth} id=`);
+        expect(boundText(source)).toEqual(["a-heading", "A Heading"]);
+      }
+    });
+
+    it("renders a code block with its language and a copy button", () => {
+      const source = "```js\nconst a = 1;\n```";
+
+      expect(markupOf(templateFor(source))).toContain("cf-copy-button");
+      // The language, then the code, then the same code for the copy button.
+      expect(boundText(source)).toEqual([
+        "language-js",
+        "const a = 1;\n",
+        "const a = 1;\n",
+      ]);
+    });
+
+    it("renders a code block with no language", () => {
+      expect(boundText("```\nplain\n```")).toEqual(["plain\n", "plain\n"]);
+    });
+
+    it("renders a list, and numbers an ordered one from its start", () => {
+      expect(markupOf(templateFor("- a\n- b"))).toContain("<ul>");
+      expect(markupOf(templateFor("1. a\n2. b"))).toContain("<ol start=");
+      // A list starting at 1 needs no `start`, so the binding removes it.
+      expect(boundValues(templateFor("1. a"))[0]).toBe(nothing);
+      expect(boundValues(templateFor("3. a"))[0]).toBe(3);
+    });
+
+    it("renders a task list checkbox per item", () => {
+      const markup = markupOf(templateFor("- [ ] one\n- [x] two"));
+
+      expect([...markup.matchAll(/<input/g)].length).toBe(2);
+      expect(boundValues(templateFor("- [ ] one\n- [x] two"))).toContain(false);
+      expect(boundValues(templateFor("- [ ] one\n- [x] two"))).toContain(true);
+    });
+
+    it("renders a table, its header, and each cell's alignment", () => {
+      const source = "| A | B |\n| :-- | --: |\n| 1 | 2 |";
+      const markup = markupOf(templateFor(source));
+
+      expect(markup).toContain('<div class="table-scroll">');
+      expect(markup).toContain("<thead>");
+      expect(markup).toContain("<tbody>");
+      expect(markup).toContain("<th align=");
+      expect(markup).toContain("<td align=");
+      // Every cell binds its own alignment, header and body alike.
+      expect(boundText(source)).toEqual([
+        "left",
+        "A",
+        "right",
+        "B",
+        "left",
+        "1",
+        "right",
+        "2",
+      ]);
+    });
+
+    it("renders a table with a header and no rows", () => {
+      const markup = markupOf(templateFor("| A |\n| --- |"));
+
+      expect(markup).toContain("<thead>");
+      expect(markup).not.toContain("<tbody>");
+    });
+
+    it("renders a blockquote, a rule and a line break", () => {
+      expect(markupOf(templateFor("> quoted"))).toContain("<blockquote>");
+      expect(markupOf(templateFor("---"))).toContain("<hr>");
+      expect(markupOf(templateFor("a\nb"))).toContain("<br>");
+    });
+
+    it("renders a link the browser may follow, with its title", () => {
+      const source = '[label](https://example.test/a "the title")';
+
+      expect(markupOf(templateFor(source))).toContain("<a href=");
+      expect(boundText(source)).toEqual([
+        "https://example.test/a",
+        "the title",
+        "label",
+      ]);
+    });
+
+    it("renders a link with no title", () => {
+      expect(boundText("[label](https://example.test/a)")).toEqual([
+        "https://example.test/a",
+        "label",
+      ]);
+    });
+
+    it("renders a link the browser must not follow as its text alone", () => {
+      const source = "[label](javascript:steal())";
+
+      expect(markupOf(templateFor(source))).not.toContain("<a href=");
+      expect(boundText(source)).toEqual(["label"]);
+    });
+
+    it("renders a cell link as a cf-cell-link", () => {
+      const source = "[Name](/of:bafyabc/field)";
+
+      expect(markupOf(templateFor(source))).toContain("<cf-cell-link");
+      expect(boundText(source)).toEqual(["/of:bafyabc/field", "Name"]);
+    });
+
+    it("renders an image the browser may load, with its title", () => {
+      const source = '![alt](https://example.test/a.png "the title")';
+
+      expect(markupOf(templateFor(source))).toContain("<img src=");
+      expect(boundText(source)).toEqual([
+        "https://example.test/a.png",
+        "alt",
+        "the title",
+      ]);
+    });
+
+    it("renders an image carrying its own bytes", () => {
+      const source = "![alt](data:image/png;base64,AAAA)";
+
+      expect(markupOf(templateFor(source))).toContain("<img src=");
+      expect(boundText(source)).toEqual(["data:image/png;base64,AAAA", "alt"]);
+    });
+
+    it("renders an image the browser must not load as its alt text alone", () => {
+      const source = "![alt](javascript:steal())";
+
+      expect(markupOf(templateFor(source))).not.toContain("<img src=");
+      expect(boundText(source)).toEqual(["alt"]);
+    });
+
+    it("resolves a backslash escape to the character it escaped", () => {
+      expect(boundText("a \\* b")).toEqual(["a ", "*", " b"]);
+    });
+
+    it("renders nothing for an empty document", () => {
+      expect(markupOf(templateFor(""))).toBe("");
+    });
+
+    it("renders nothing for a link reference definition", () => {
+      // The definition draws nothing; the link that uses it draws an anchor.
+      expect(markupOf(templateFor("[ref]: https://example.test/a")))
+        .toBe("");
+    });
+
+    it("numbers checkboxes across the whole document, in order", () => {
+      const reported: Array<[number, boolean]> = [];
+      const template = markdownTemplate("- [ ] one\n- [ ] two\n\n- [ ] three", {
+        checkboxToggled: (index, checked) => reported.push([index, checked]),
+      });
+      const handlers = boundValues(template).filter((value) =>
+        typeof value === "function"
+      ) as Array<(event: Event) => void>;
+
+      expect(handlers.length).toBe(3);
+      for (const handler of handlers) {
+        handler({ target: { checked: true } } as unknown as Event);
+      }
+
+      expect(reported).toEqual([[0, true], [1, true], [2, true]]);
+    });
+  });
+});

--- a/packages/ui/src/v2/components/cf-markdown/markdown-template.test.ts
+++ b/packages/ui/src/v2/components/cf-markdown/markdown-template.test.ts
@@ -326,6 +326,17 @@ describe("markdown-template", () => {
       expect(boundText(source)).toEqual(["/of:bafyabc/field", "Name"]);
     });
 
+    it("renders a cell link that names its space as a cf-cell-link", () => {
+      // The cross-space form opens with the space rather than the piece. The
+      // runner's own matcher decides what a cell link looks like, so both
+      // forms reach the pill.
+      const target = "/@did:key:z6MkABC/of:bafyabc/field";
+      const source = `[Name](${target})`;
+
+      expect(markupOf(templateFor(source))).toContain("<cf-cell-link");
+      expect(boundText(source)).toEqual([target, "Name"]);
+    });
+
     it("renders an image the browser may load, with its title", () => {
       const source = '![alt](https://example.test/a.png "the title")';
 

--- a/packages/ui/src/v2/components/cf-markdown/markdown-template.ts
+++ b/packages/ui/src/v2/components/cf-markdown/markdown-template.ts
@@ -1,0 +1,280 @@
+/**
+ * Builds the Lit template for a markdown document.
+ *
+ * The document never becomes markup. marked reads it into tokens, and this
+ * module turns those tokens into a template whose tags and attribute names it
+ * writes itself; every piece of the document reaches the page through a
+ * binding, which Lit puts in a text node or an attribute value rather than
+ * parsing. Markup in the source is therefore text, and no combination of
+ * characters in it can add an element, an attribute, or an event handler.
+ *
+ * Two things the source can still reach are handled here. A URL is checked
+ * against the scheme allowlist in `safe-url.ts` before it goes into an `href`
+ * or a `src`. Raw HTML, which markdown allows and marked reports as an `html`
+ * token, is dropped. What that costs depends on where it was written: inline
+ * HTML is one token per tag, so `<b>bold</b>` loses the tags and keeps the
+ * word between them, while a block of HTML is a single token holding the whole
+ * block, so its text goes with it.
+ */
+
+import { html, nothing } from "lit";
+import { live } from "lit/directives/live.js";
+import { Lexer, type Token, type Tokens } from "marked";
+
+import { safeImageUrl, safeUrl } from "../../core/safe-url.ts";
+import { HeadingIds } from "./heading-id.ts";
+
+import "../cf-cell-link/index.ts";
+import "../cf-copy-button/index.ts";
+
+/** What a rendered document reports back to the component that owns it. */
+export interface MarkdownCallbacks {
+  /**
+   * A task-list checkbox was toggled. `index` counts checkboxes across the
+   * whole document, in the order they appear.
+   */
+  checkboxToggled(index: number, checked: boolean): void;
+}
+
+/**
+ * A link whose target is a cell rather than a document, written as a path that
+ * opens with a scheme-like segment: `/of:bafy.../field`. These render as a
+ * pill that resolves the cell, not as an anchor.
+ */
+const CELL_LINK = /^\/[a-zA-Z0-9]+:/;
+
+/**
+ * Resolves the HTML character references in a run of markdown text.
+ *
+ * marked leaves them as written, because the renderer it ships hands its
+ * output to an HTML parser that resolves them. This one does not, so `&amp;`
+ * would otherwise reach the page as four characters rather than one.
+ *
+ * The assignment below cannot produce an element: `<` and `>` are replaced by
+ * their own references first, and every markup construct needs a `<`. What
+ * comes back is the single text node the parser built.
+ */
+let scratch: HTMLElement | undefined;
+function decodeEntities(text: string): string {
+  if (!text.includes("&")) return text;
+  scratch ??= document.createElement("div");
+  scratch.innerHTML = text.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return scratch.textContent ?? "";
+}
+
+class MarkdownTemplate {
+  #callbacks: MarkdownCallbacks;
+  #headingIds = new HeadingIds();
+  #checkboxes = 0;
+
+  constructor(callbacks: MarkdownCallbacks) {
+    this.#callbacks = callbacks;
+  }
+
+  blocks(tokens: Token[]): unknown {
+    return tokens.map((token) => this.#block(token));
+  }
+
+  #block(token: Token): unknown {
+    switch (token.type) {
+      case "heading":
+        return this.#heading(token as Tokens.Heading);
+      case "paragraph":
+        return html`<p>${this.#inline((token as Tokens.Paragraph).tokens)}</p>`;
+      case "code":
+        return this.#code(token as Tokens.Code);
+      case "blockquote":
+        return html`<blockquote>
+          ${this.blocks((token as Tokens.Blockquote).tokens)}
+        </blockquote>`;
+      case "list":
+        return this.#list(token as Tokens.List);
+      case "table":
+        return this.#table(token as Tokens.Table);
+      case "hr":
+        return html`<hr>`;
+      case "text":
+        return this.#text(token as Tokens.Text);
+      case "checkbox":
+        return this.#checkbox(token as Tokens.Checkbox);
+      // Raw markup in the source is not rendered. What remains — a blank line
+      // between blocks, a link reference definition — draws nothing.
+      case "html":
+      default:
+        return nothing;
+    }
+  }
+
+  #inline(tokens: Token[]): unknown {
+    return tokens.map((token) => this.#inlineToken(token));
+  }
+
+  #inlineToken(token: Token): unknown {
+    switch (token.type) {
+      case "text":
+        return this.#text(token as Tokens.Text);
+      // A backslash escape carries the character it escaped, already resolved.
+      case "escape":
+        return (token as Tokens.Escape).text;
+      case "strong":
+        return html`<strong>${
+          this.#inline((token as Tokens.Strong).tokens)
+        }</strong>`;
+      case "em":
+        return html`<em>${this.#inline((token as Tokens.Em).tokens)}</em>`;
+      case "del":
+        return html`<del>${this.#inline((token as Tokens.Del).tokens)}</del>`;
+      case "codespan":
+        return html`<code>${(token as Tokens.Codespan).text}</code>`;
+      case "br":
+        return html`<br>`;
+      case "link":
+        return this.#link(token as Tokens.Link);
+      case "image":
+        return this.#image(token as Tokens.Image);
+      case "checkbox":
+        return this.#checkbox(token as Tokens.Checkbox);
+      // Raw markup in the source is not rendered.
+      case "html":
+      default:
+        return nothing;
+    }
+  }
+
+  #text(token: Tokens.Text): unknown {
+    if (token.tokens) return this.#inline(token.tokens);
+    return decodeEntities(token.text);
+  }
+
+  #heading(token: Tokens.Heading): unknown {
+    const id = this.#headingIds.idFor(token.tokens);
+    const content = this.#inline(token.tokens);
+    // A tag name cannot be bound, so each level names its own tag.
+    switch (token.depth) {
+      case 1:
+        return html`<h1 id=${id}>${content}</h1>`;
+      case 2:
+        return html`<h2 id=${id}>${content}</h2>`;
+      case 3:
+        return html`<h3 id=${id}>${content}</h3>`;
+      case 4:
+        return html`<h4 id=${id}>${content}</h4>`;
+      case 5:
+        return html`<h5 id=${id}>${content}</h5>`;
+      default:
+        return html`<h6 id=${id}>${content}</h6>`;
+    }
+  }
+
+  #code(token: Tokens.Code): unknown {
+    const language = (token.lang ?? "").match(/^\S*/)?.[0] ?? "";
+    const text = `${token.text.replace(/\n$/, "")}\n`;
+    return html`
+      <div class="code-block-container">
+        <pre><code
+              class=${language ? `language-${language}` : nothing}
+            >${text}</code></pre>
+        <cf-copy-button
+          class="code-copy-button"
+          .text=${text}
+          variant="ghost"
+          size="sm"
+          icon-only
+        ></cf-copy-button>
+      </div>
+    `;
+  }
+
+  #list(token: Tokens.List): unknown {
+    const items = token.items.map((item) =>
+      html`<li>${this.blocks(item.tokens)}</li>`
+    );
+    if (!token.ordered) return html`<ul>${items}</ul>`;
+    const start = typeof token.start === "number" && token.start !== 1
+      ? token.start
+      : nothing;
+    return html`<ol start=${start}>${items}</ol>`;
+  }
+
+  #checkbox(token: Tokens.Checkbox): unknown {
+    const index = this.#checkboxes++;
+    // A reader can toggle the box, which leaves the DOM disagreeing with the
+    // document. `live` compares the binding against what the box currently
+    // holds rather than against what was last rendered, so the next render
+    // puts the box back to what the document says.
+    return html`
+      <input
+        type="checkbox"
+        .checked=${live(token.checked)}
+        @change=${(event: Event) =>
+          this.#callbacks.checkboxToggled(
+            index,
+            (event.target as HTMLInputElement).checked,
+          )}
+      >
+    `;
+  }
+
+  #table(token: Tokens.Table): unknown {
+    const header = token.header.map((cell) => this.#cell(cell));
+    const rows = token.rows.map((row) =>
+      html`<tr>${row.map((cell) => this.#cell(cell))}</tr>`
+    );
+    const body = rows.length === 0 ? nothing : html`<tbody>${rows}</tbody>`;
+    // The wrapper scrolls a table wider than the screen instead of letting it
+    // overflow the markdown block; the column widths in the component's CSS
+    // keep a table from cramming its columns to fit.
+    return html`
+      <div class="table-scroll">
+        <table><thead><tr>${header}</tr></thead>${body}</table>
+      </div>
+    `;
+  }
+
+  #cell(cell: Tokens.TableCell): unknown {
+    const align = cell.align ?? nothing;
+    const content = this.#inline(cell.tokens);
+    return cell.header
+      ? html`<th align=${align}>${content}</th>`
+      : html`<td align=${align}>${content}</td>`;
+  }
+
+  // The templates below sit inline in a run of text, so each one stays on a
+  // single line: a line break inside it would put a space beside the element.
+  #link(token: Tokens.Link): unknown {
+    const label = decodeEntities(token.text);
+    const link = token.href;
+    if (CELL_LINK.test(link)) {
+      return html`<cf-cell-link .link=${link} .label=${label}></cf-cell-link>`;
+    }
+    const content = this.#inline(token.tokens);
+    const href = safeUrl(link);
+    if (href === null) return content;
+    const title = token.title ? decodeEntities(token.title) : nothing;
+    return html`<a href=${href} title=${title}>${content}</a>`;
+  }
+
+  #image(token: Tokens.Image): unknown {
+    const src = safeImageUrl(token.href);
+    const alt = decodeEntities(token.text);
+    if (src === null) return alt;
+    const title = token.title ? decodeEntities(token.title) : nothing;
+    return html`<img src=${src} alt=${alt} title=${title}>`;
+  }
+}
+
+/**
+ * Renders a markdown document as a Lit template.
+ *
+ * A fresh builder per call restarts the duplicate-heading suffixes and the
+ * checkbox numbering, so the same document always renders the same ids and
+ * reports the same checkbox indices.
+ */
+export function markdownTemplate(
+  source: string,
+  callbacks: MarkdownCallbacks,
+): unknown {
+  if (!source) return nothing;
+  const tokens = Lexer.lex(source, { breaks: true, gfm: true });
+  return new MarkdownTemplate(callbacks).blocks(tokens);
+}

--- a/packages/ui/src/v2/components/cf-markdown/markdown-template.ts
+++ b/packages/ui/src/v2/components/cf-markdown/markdown-template.ts
@@ -15,8 +15,12 @@
  * HTML is one token per tag, so `<b>bold</b>` loses the tags and keeps the
  * word between them, while a block of HTML is a single token holding the whole
  * block, so its text goes with it.
+ *
+ * Building a template touches no DOM, but resolving the character references
+ * in a run of text does, so this module runs in a browser.
  */
 
+import { matchLLMFriendlyLink } from "@commonfabric/runtime-client";
 import { html, nothing } from "lit";
 import { live } from "lit/directives/live.js";
 import { Lexer, type Token, type Tokens } from "marked";
@@ -35,13 +39,6 @@ export interface MarkdownCallbacks {
    */
   checkboxToggled(index: number, checked: boolean): void;
 }
-
-/**
- * A link whose target is a cell rather than a document, written as a path that
- * opens with a scheme-like segment: `/of:bafy.../field`. These render as a
- * pill that resolves the cell, not as an anchor.
- */
-const CELL_LINK = /^\/[a-zA-Z0-9]+:/;
 
 /**
  * Resolves the HTML character references in a run of markdown text.
@@ -244,7 +241,11 @@ class MarkdownTemplate {
   #link(token: Tokens.Link): unknown {
     const label = decodeEntities(token.text);
     const link = token.href;
-    if (CELL_LINK.test(link)) {
+    // A link whose target is a cell rather than a document renders as a pill
+    // that resolves the cell. The runner decides what one looks like, in both
+    // the plain `/of:bafy.../field` form and the cross-space
+    // `/@did:key:.../of:bafy.../field` one.
+    if (matchLLMFriendlyLink.test(link)) {
       return html`<cf-cell-link .link=${link} .label=${label}></cf-cell-link>`;
     }
     const content = this.#inline(token.tokens);

--- a/packages/ui/src/v2/components/cf-render/cf-render.test.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.test.ts
@@ -7,6 +7,10 @@ import { defer } from "@commonfabric/utils/defer";
 import { providePieceBoundary } from "../../../../../html/src/main/space-context.ts";
 import { createMockCellHandle } from "../../test-utils/mock-cell-handle.ts";
 import {
+  createMockElement,
+  installMockDocument,
+} from "../../test-utils/mock-document.ts";
+import {
   CFRender,
   hasVariantValue,
   normalizeVariant,
@@ -110,29 +114,71 @@ describe("CFRender render concurrency", () => {
   });
 
   it("cleans up an error render when its cell is cleared", async () => {
-    const element = new CFRender();
-    const container = { innerHTML: "" } as HTMLDivElement;
-    const internals = element as unknown as {
-      _cleanup?: () => void;
-      _containerRef: { value?: HTMLDivElement };
-      _handleRenderError(error: unknown): void;
-      _renderCell(): Promise<void>;
-    };
-    internals._containerRef = { value: container };
-    element.cell = {
-      runtime: () => ({ signal: { aborted: false } }),
-    } as unknown as CellHandle;
+    const mockDocument = installMockDocument();
+    try {
+      const element = new CFRender();
+      const container = createMockElement("div");
+      const internals = element as unknown as {
+        _cleanup?: () => void;
+        _containerRef: { value?: HTMLDivElement };
+        _handleRenderError(error: unknown): void;
+        _renderCell(): Promise<void>;
+      };
+      internals._containerRef = {
+        value: container as unknown as HTMLDivElement,
+      };
+      element.cell = {
+        runtime: () => ({ signal: { aborted: false } }),
+      } as unknown as CellHandle;
 
-    captureConsoleError(() => {
-      internals._handleRenderError(new Error("boom"));
-    });
-    expect(container.innerHTML).toContain("Error rendering content: boom");
+      captureConsoleError(() => {
+        internals._handleRenderError(new Error("boom"));
+      });
+      expect(container.children.map((child) => child.textContent)).toEqual([
+        "Error rendering content: boom",
+      ]);
 
-    element.cell = undefined;
-    await internals._renderCell();
+      element.cell = undefined;
+      await internals._renderCell();
 
-    expect(container.innerHTML).toBe("");
-    expect(internals._cleanup).toBeUndefined();
+      expect(container.children).toEqual([]);
+      expect(internals._cleanup).toBeUndefined();
+    } finally {
+      mockDocument.restore();
+    }
+  });
+
+  it("renders a failure message as text rather than as markup", () => {
+    const mockDocument = installMockDocument();
+    try {
+      const element = new CFRender();
+      const container = createMockElement("div");
+      const internals = element as unknown as {
+        _containerRef: { value?: HTMLDivElement };
+        _handleRenderError(error: unknown): void;
+      };
+      internals._containerRef = {
+        value: container as unknown as HTMLDivElement,
+      };
+      element.cell = {
+        runtime: () => ({ signal: { aborted: false } }),
+      } as unknown as CellHandle;
+
+      captureConsoleError(() => {
+        internals._handleRenderError(
+          new Error('<img src="x" onerror="alert(1)">'),
+        );
+      });
+
+      // The message reaches the page whole, as the text of one element, so
+      // markup in it describes nothing for the browser to build.
+      expect(container.children.length).toBe(1);
+      expect(container.children[0].textContent).toBe(
+        'Error rendering content: <img src="x" onerror="alert(1)">',
+      );
+    } finally {
+      mockDocument.restore();
+    }
   });
 
   it("accepts a retarget delivered before subscribe returns", async () => {

--- a/packages/ui/src/v2/components/cf-render/cf-render.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.ts
@@ -716,12 +716,17 @@ export class CFRender extends BaseElement {
 
     const container = this._containerRef.value;
     if (container) {
-      container.innerHTML =
-        `<div style="color: var(--cf-theme-color-error, var(--cf-colors-error, #ff6057))">Error rendering content: ${
-          error instanceof Error ? error.message : "Unknown error"
-        }</div>`;
+      // The message can carry anything a failing pattern put in it, so it goes
+      // in as text rather than as markup.
+      const message = document.createElement("div");
+      message.style.color =
+        "var(--cf-theme-color-error, var(--cf-colors-error, #ff6057))";
+      message.textContent = `Error rendering content: ${
+        error instanceof Error ? error.message : "Unknown error"
+      }`;
+      container.replaceChildren(message);
       this._cleanup = () => {
-        container.innerHTML = "";
+        container.replaceChildren();
       };
     }
   }

--- a/packages/ui/src/v2/components/cf-svg/cf-svg.ts
+++ b/packages/ui/src/v2/components/cf-svg/cf-svg.ts
@@ -1,7 +1,6 @@
 import { type CellHandle, isCellHandle } from "@commonfabric/runtime-client";
 import { css, html } from "lit";
 import { property } from "lit/decorators.js";
-import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
 import { BaseElement } from "../../core/base-element.ts";
 import { sanitizeSvg } from "./sanitize-svg.ts";
@@ -11,6 +10,9 @@ import { sanitizeSvg } from "./sanitize-svg.ts";
 
 /**
  * CFSvg - Renders SVG content from a string
+ *
+ * The source is sanitized before it is drawn, so untrusted content is safe to
+ * pass in. `sanitize-svg.ts` describes what survives and what does not.
  *
  * @element cf-svg
  *
@@ -107,7 +109,7 @@ export class CFSvg extends BaseElement {
 
     return html`
       <div class="svg-content" part="content">
-        ${unsafeHTML(sanitizeSvg(contentValue))}
+        ${sanitizeSvg(contentValue)}
       </div>
     `;
   }

--- a/packages/ui/src/v2/components/cf-svg/sanitize-svg.test.ts
+++ b/packages/ui/src/v2/components/cf-svg/sanitize-svg.test.ts
@@ -228,6 +228,14 @@ Deno.test("sanitizeSvg returns null for source that holds no drawing", function 
   assertEquals(sanitizeSvg("<div>not svg</div>"), null);
 });
 
+Deno.test("sanitizeSvg returns null for a fragment with no svg element", function () {
+  // A bare shape is not a drawing. Nothing paints it: an element by that name
+  // outside the SVG namespace has no geometry, and the HTML parser puts one
+  // there unless an `<svg>` encloses it.
+  assertEquals(sanitizeSvg('<circle cx="50" cy="50" r="40"/>'), null);
+  assertEquals(sanitizeSvg("<g><rect width='10' height='10'/></g>"), null);
+});
+
 Deno.test("sanitizeSvg recovers from an unclosed element", function () {
   const root = sanitized("<svg><circle cx='5' cy='5' r='4'></svg>");
 

--- a/packages/ui/src/v2/components/cf-svg/sanitize-svg.test.ts
+++ b/packages/ui/src/v2/components/cf-svg/sanitize-svg.test.ts
@@ -1,447 +1,244 @@
 /**
- * Tests for SVG sanitization
+ * Tests for SVG sanitization.
  *
- * NOTE: These tests require browser APIs (DOMParser, XMLSerializer) and must be run
- * in a browser environment. To run these tests:
- *
- * 1. Using deno-web-test:
- *    deno run -A packages/deno-web-test/cli.ts packages/ui/src/v2/components/cf-svg/sanitize-svg.test.ts
- *
- * 2. Or run them manually in a browser console
- *
- * These tests will fail in a standard Deno test environment because DOMParser
- * is not available outside of a browser context.
+ * These need a browser for `DOMParser`, and run under deno-web-test rather
+ * than `deno test`. The harness registers tests through `Deno.test` and calls
+ * each one with no arguments, so the BDD functions the rest of the repository
+ * uses are not available here.
  */
 
-import { assert } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import { sanitizeSvg } from "./sanitize-svg.ts";
 
-// Helper to check if string contains substring
-function contains(str: string, substring: string): boolean {
-  return str.indexOf(substring) !== -1;
+/** The sanitized drawing, which each test here expects to exist. */
+function sanitized(svg: string): Element {
+  const result = sanitizeSvg(svg);
+  assert(result !== null, "expected the source to survive sanitizing");
+  return result;
 }
 
-// Helper to check if string does NOT contain substring
-function notContains(str: string, substring: string): boolean {
-  return str.indexOf(substring) === -1;
+/** The local names of every element in the sanitized drawing, root included. */
+function elementNames(root: Element): string[] {
+  return [root, ...Array.from(root.querySelectorAll("*"))].map((element) =>
+    element.localName
+  );
 }
 
-// Valid SVG tests
-Deno.test("sanitizeSvg: should pass through simple valid SVG", function () {
-  const svg = '<svg><circle cx="50" cy="50" r="40"/></svg>';
-  const result = sanitizeSvg(svg);
-
-  assert(contains(result, "<circle"), "Should contain <circle");
-  assert(contains(result, 'cx="50"'), 'Should contain cx="50"');
-  assert(contains(result, 'cy="50"'), 'Should contain cy="50"');
-  assert(contains(result, 'r="40"'), 'Should contain r="40"');
-});
-
-Deno.test("sanitizeSvg: should preserve SVG attributes", function () {
-  const svg =
-    '<svg viewBox="0 0 100 100" width="100" height="100"><rect x="10" y="10" width="80" height="80" fill="blue"/></svg>';
-  const result = sanitizeSvg(svg);
-
-  assert(contains(result, "viewBox"), "Should contain viewBox");
-  assert(contains(result, "width"), "Should contain width");
-  assert(contains(result, "height"), "Should contain height");
-  assert(contains(result, "<rect"), "Should contain <rect");
-  assert(contains(result, 'fill="blue"'), 'Should contain fill="blue"');
-});
-
-Deno.test("sanitizeSvg: should preserve nested groups and elements", function () {
-  const svg =
-    '<svg><g id="layer1"><circle cx="50" cy="50" r="40"/><rect x="10" y="10" width="20" height="20"/></g></svg>';
-  const result = sanitizeSvg(svg);
-
-  assert(contains(result, "<g"), "Should contain <g");
-  assert(contains(result, 'id="layer1"'), 'Should contain id="layer1"');
-  assert(contains(result, "<circle"), "Should contain <circle");
-  assert(contains(result, "<rect"), "Should contain <rect");
-});
-
-// Script removal tests
-Deno.test("sanitizeSvg: should remove script tags", function () {
-  const svg =
-    "<svg><script>alert('xss')</script><circle cx='50' cy='50' r='40'/></svg>";
-  const result = sanitizeSvg(svg);
-
-  assert(notContains(result, "<script"), "Should not contain <script");
-  assert(notContains(result, "alert"), "Should not contain alert");
-  assert(contains(result, "<circle"), "Should contain <circle");
-});
-
-Deno.test("sanitizeSvg: should remove multiple script tags", function () {
-  const svg =
-    "<svg><script>alert('xss1')</script><circle cx='50' cy='50' r='40'/><script>alert('xss2')</script></svg>";
-  const result = sanitizeSvg(svg);
-
-  assert(notContains(result, "<script"), "Should not contain <script");
-  assert(notContains(result, "alert"), "Should not contain alert");
-  assert(notContains(result, "xss1"), "Should not contain xss1");
-  assert(notContains(result, "xss2"), "Should not contain xss2");
-  assert(contains(result, "<circle"), "Should contain <circle");
-});
-
-Deno.test("sanitizeSvg: should remove nested script tags inside groups", function () {
-  const svg =
-    "<svg><g><script>alert('xss')</script><circle cx='50' cy='50' r='40'/></g></svg>";
-  const result = sanitizeSvg(svg);
-
-  assert(notContains(result, "<script"), "Should not contain <script");
-  assert(notContains(result, "alert"), "Should not contain alert");
-  assert(contains(result, "<circle"), "Should contain <circle");
-  assert(contains(result, "<g"), "Should contain <g");
-});
-
-// Event handler removal tests
-Deno.test("sanitizeSvg: should remove onclick attribute", function () {
-  const svg =
-    '<svg><circle onclick="alert(\'xss\')" cx="50" cy="50" r="40"/></svg>';
-  const result = sanitizeSvg(svg);
-
-  assert(notContains(result, "onclick"), "Should not contain onclick");
-  assert(notContains(result, "alert"), "Should not contain alert");
-  assert(contains(result, "<circle"), "Should contain <circle");
-  assert(contains(result, 'cx="50"'), 'Should contain cx="50"');
-});
-
-Deno.test("sanitizeSvg: should remove onload attribute from SVG element", function () {
-  const svg =
-    '<svg onload="alert(\'xss\')"><circle cx="50" cy="50" r="40"/></svg>';
-  const result = sanitizeSvg(svg);
-
-  assert(notContains(result, "onload"), "Should not contain onload");
-  assert(notContains(result, "alert"), "Should not contain alert");
-  assert(contains(result, "<circle"), "Should contain <circle");
-});
-
-Deno.test("sanitizeSvg: should remove onerror attribute", function () {
-  const svg = '<svg><image onerror="alert(\'xss\')" href="test.png"/></svg>';
-  const result = sanitizeSvg(svg);
-
-  assert(notContains(result, "onerror"), "Should not contain onerror");
-  assert(notContains(result, "alert"), "Should not contain alert");
-  assert(contains(result, "<image"), "Should contain <image");
-});
-
-Deno.test("sanitizeSvg: should remove multiple event handlers from same element", function () {
-  const svg =
-    '<svg><circle onclick="alert(1)" onload="alert(2)" onmouseover="alert(3)" cx="50" cy="50" r="40"/></svg>';
-  const result = sanitizeSvg(svg);
-
-  assert(notContains(result, "onclick"), "Should not contain onclick");
-  assert(notContains(result, "onload"), "Should not contain onload");
-  assert(notContains(result, "onmouseover"), "Should not contain onmouseover");
-  assert(notContains(result, "alert"), "Should not contain alert");
-  assert(contains(result, "<circle"), "Should contain <circle");
-  assert(contains(result, 'cx="50"'), 'Should contain cx="50"');
-});
-
-Deno.test("sanitizeSvg: should remove event handlers with mixed case", function () {
-  const svg =
-    '<svg><circle onClick="alert(\'xss\')" onLoad="alert(\'xss\')" cx="50" cy="50" r="40"/></svg>';
-  const result = sanitizeSvg(svg);
-
-  // Event handlers should be removed regardless of case
-  assert(
-    notContains(result.toLowerCase(), "onclick"),
-    "Should not contain onclick",
+/** Every attribute in the sanitized drawing, as `name=value` pairs. */
+function attributes(root: Element): string[] {
+  return [root, ...Array.from(root.querySelectorAll("*"))].flatMap((element) =>
+    Array.from(element.attributes).map((attribute) =>
+      `${attribute.name}=${attribute.value}`
+    )
   );
-  assert(
-    notContains(result.toLowerCase(), "onload"),
-    "Should not contain onload",
+}
+
+Deno.test("sanitizeSvg keeps a plain drawing", function () {
+  const root = sanitized(
+    '<svg viewBox="0 0 100 100"><circle cx="50" cy="50" r="40" fill="blue"/></svg>',
   );
-  assert(notContains(result, "alert"), "Should not contain alert");
+
+  assertEquals(root.getAttribute("viewBox"), "0 0 100 100");
+  const circle = root.querySelector("circle");
+  assertEquals(circle?.getAttribute("cx"), "50");
+  assertEquals(circle?.getAttribute("fill"), "blue");
 });
 
-// URL sanitization tests
-Deno.test("sanitizeSvg: should remove javascript: URL in href", function () {
-  const svg =
-    '<svg><a href="javascript:alert(\'xss\')"><text x="10" y="20">click</text></a></svg>';
-  const result = sanitizeSvg(svg);
-
-  assert(notContains(result, "javascript:"), "Should not contain javascript:");
-  assert(notContains(result, "alert"), "Should not contain alert");
-  assert(contains(result, "<text"), "Should contain <text");
-  assert(contains(result, "click"), "Should contain click");
-});
-
-Deno.test("sanitizeSvg: should remove javascript: URL in xlink:href", function () {
-  const svg =
-    '<svg xmlns:xlink="http://www.w3.org/1999/xlink"><a xlink:href="javascript:alert(\'xss\')"><text x="10" y="20">click</text></a></svg>';
-  const result = sanitizeSvg(svg);
-
-  assert(notContains(result, "javascript:"), "Should not contain javascript:");
-  assert(notContains(result, "alert"), "Should not contain alert");
-  assert(contains(result, "<text"), "Should contain <text");
-});
-
-Deno.test("sanitizeSvg: should remove vbscript: URL", function () {
-  const svg =
-    "<svg><a href=\"vbscript:msgbox('xss')\"><text>click</text></a></svg>";
-  const result = sanitizeSvg(svg);
-
-  assert(notContains(result, "vbscript:"), "Should not contain vbscript:");
-  assert(notContains(result, "msgbox"), "Should not contain msgbox");
-  assert(contains(result, "<text"), "Should contain <text");
-});
-
-Deno.test("sanitizeSvg: should remove data:text/html URL", function () {
-  const svg =
-    "<svg><a href=\"data:text/html,<script>alert('xss')</script>\"><text>click</text></a></svg>";
-  const result = sanitizeSvg(svg);
-
-  // The key security requirement: dangerous URL protocol is removed
-  assert(
-    notContains(result, "data:text/html"),
-    "Should not contain data:text/html",
+Deno.test("sanitizeSvg keeps nested groups, gradients and filters", function () {
+  const root = sanitized(
+    '<svg><defs><linearGradient id="grad"><stop offset="0%" stop-color="red"/>' +
+      '</linearGradient><filter id="blur"><feGaussianBlur stdDeviation="2"/>' +
+      '</filter></defs><g id="layer1"><rect width="10" height="10"/></g></svg>',
   );
-  // Also verify the XSS payload doesn't get through
-  assert(notContains(result, "alert"), "Should not contain alert");
+
+  assertEquals(elementNames(root), [
+    "svg",
+    "defs",
+    "linearGradient",
+    "stop",
+    "filter",
+    "feGaussianBlur",
+    "g",
+    "rect",
+  ]);
 });
 
-Deno.test("sanitizeSvg: should preserve safe URLs", function () {
-  const svg =
-    '<svg><a href="https://example.com"><text x="10" y="20">click</text></a></svg>';
-  const result = sanitizeSvg(svg);
-
-  assert(
-    contains(result, "https://example.com"),
-    "Should contain https://example.com",
+Deno.test("sanitizeSvg keeps a style element and a style attribute", function () {
+  const root = sanitized(
+    "<svg><style>.cls { fill: red; }</style>" +
+      '<circle class="cls" style="stroke: blue;" cx="5" cy="5" r="4"/></svg>',
   );
-  assert(contains(result, "<text"), "Should contain <text");
-});
 
-Deno.test("sanitizeSvg: should preserve relative URLs", function () {
-  const svg =
-    '<svg><image href="./image.png" x="0" y="0" width="100" height="100"/></svg>';
-  const result = sanitizeSvg(svg);
-
-  assert(contains(result, "./image.png"), "Should contain ./image.png");
-  assert(contains(result, "<image"), "Should contain <image");
-});
-
-Deno.test("sanitizeSvg: should handle javascript: with mixed case", function () {
-  const svg =
-    "<svg><a href=\"JavaScript:alert('xss')\"><text>click</text></a></svg>";
-  const result = sanitizeSvg(svg);
-
-  assert(
-    notContains(result.toLowerCase(), "javascript:"),
-    "Should not contain javascript:",
-  );
-  assert(notContains(result, "alert"), "Should not contain alert");
-});
-
-// Dangerous element removal tests
-Deno.test("sanitizeSvg: should remove foreignObject element", function () {
-  const svg =
-    '<svg><foreignObject width="100" height="100"><div xmlns="http://www.w3.org/1999/xhtml">html content</div></foreignObject><circle cx="50" cy="50" r="40"/></svg>';
-  const result = sanitizeSvg(svg);
-
-  assert(
-    notContains(result, "foreignObject"),
-    "Should not contain foreignObject",
-  );
-  assert(notContains(result, "<div"), "Should not contain <div");
-  assert(
-    notContains(result, "html content"),
-    "Should not contain html content",
-  );
-  assert(contains(result, "<circle"), "Should contain <circle");
-});
-
-Deno.test("sanitizeSvg: should remove set element", function () {
-  const svg =
-    '<svg><set attributeName="onclick" to="alert(\'xss\')"/><circle cx="50" cy="50" r="40"/></svg>';
-  const result = sanitizeSvg(svg);
-
-  assert(notContains(result, "<set"), "Should not contain <set");
-  assert(
-    notContains(result, "attributeName"),
-    "Should not contain attributeName",
-  );
-  assert(contains(result, "<circle"), "Should contain <circle");
-});
-
-Deno.test("sanitizeSvg: should remove iframe element", function () {
-  const svg =
-    '<svg><iframe src="evil.html"/><circle cx="50" cy="50" r="40"/></svg>';
-  const result = sanitizeSvg(svg);
-
-  assert(notContains(result, "<iframe"), "Should not contain <iframe");
-  assert(contains(result, "<circle"), "Should contain <circle");
-});
-
-Deno.test("sanitizeSvg: should remove embed element", function () {
-  const svg =
-    '<svg><embed src="evil.swf"/><circle cx="50" cy="50" r="40"/></svg>';
-  const result = sanitizeSvg(svg);
-
-  assert(notContains(result, "<embed"), "Should not contain <embed");
-  assert(contains(result, "<circle"), "Should contain <circle");
-});
-
-Deno.test("sanitizeSvg: should remove object element", function () {
-  const svg =
-    '<svg><object data="evil.html"/><circle cx="50" cy="50" r="40"/></svg>';
-  const result = sanitizeSvg(svg);
-
-  assert(notContains(result, "<object"), "Should not contain <object");
-  assert(contains(result, "<circle"), "Should contain <circle");
-});
-
-// Nested dangerous content tests
-Deno.test("sanitizeSvg: should remove dangerous elements inside defs", function () {
-  const svg =
-    '<svg><defs><script>alert(\'xss\')</script><linearGradient id="grad1"><stop offset="0%" stop-color="red"/></linearGradient></defs></svg>';
-  const result = sanitizeSvg(svg);
-
-  assert(notContains(result, "<script"), "Should not contain <script");
-  assert(notContains(result, "alert"), "Should not contain alert");
-  assert(contains(result, "<defs"), "Should contain <defs");
-  assert(contains(result, "linearGradient"), "Should contain linearGradient");
-});
-
-Deno.test("sanitizeSvg: should remove event handlers in nested elements", function () {
-  const svg =
-    '<svg><g><g><circle onclick="alert(\'xss\')" cx="50" cy="50" r="40"/></g></g></svg>';
-  const result = sanitizeSvg(svg);
-
-  assert(notContains(result, "onclick"), "Should not contain onclick");
-  assert(notContains(result, "alert"), "Should not contain alert");
-  assert(contains(result, "<circle"), "Should contain <circle");
-});
-
-Deno.test("sanitizeSvg: should handle complex nested structure with multiple threats", function () {
-  const svg =
-    '<svg><g id="layer1"><script>alert(1)</script><a href="javascript:alert(2)"><text onclick="alert(3)">text</text></a><foreignObject><div>html</div></foreignObject></g></svg>';
-  const result = sanitizeSvg(svg);
-
-  assert(notContains(result, "<script"), "Should not contain <script");
-  assert(notContains(result, "javascript:"), "Should not contain javascript:");
-  assert(notContains(result, "onclick"), "Should not contain onclick");
-  assert(
-    notContains(result, "foreignObject"),
-    "Should not contain foreignObject",
-  );
-  assert(notContains(result, "<div"), "Should not contain <div");
-  assert(notContains(result, "alert"), "Should not contain alert");
-  assert(contains(result, "<g"), "Should contain <g");
-  assert(contains(result, "<text"), "Should contain <text");
-  assert(contains(result, "text"), "Should contain text");
-});
-
-// Edge case tests
-Deno.test("sanitizeSvg: should return empty string for empty input", function () {
-  const result = sanitizeSvg("");
-  assert(result === "", "Should return empty string");
-});
-
-Deno.test("sanitizeSvg: should return empty string for whitespace-only input", function () {
-  const result = sanitizeSvg("   \n\t  ");
-  assert(result === "", "Should return empty string");
-});
-
-Deno.test("sanitizeSvg: should return empty string for null input", function () {
-  const result = sanitizeSvg(null as any);
-  assert(result === "", "Should return empty string");
-});
-
-Deno.test("sanitizeSvg: should return empty string for undefined input", function () {
-  const result = sanitizeSvg(undefined as any);
-  assert(result === "", "Should return empty string");
-});
-
-Deno.test("sanitizeSvg: should return empty string for non-string input", function () {
-  const result = sanitizeSvg(123 as any);
-  assert(result === "", "Should return empty string");
-});
-
-Deno.test("sanitizeSvg: should return empty string for malformed XML", function () {
-  const result = sanitizeSvg("<svg><circle></svg>");
-  assert(result === "", "Should return empty string");
-});
-
-Deno.test("sanitizeSvg: should handle non-SVG content", function () {
-  const result = sanitizeSvg("<div>not svg</div>");
-  // Note: DOMParser with "image/svg+xml" may parse non-SVG elements differently depending on the browser
-  // The important thing is that the result is safe (no scripts, no event handlers)
-  // and non-SVG elements like <div> are either removed or made safe
-  // The current implementation allows <div> since it's not in the dangerous elements list
-  // This is acceptable since <div> without event handlers is not a security risk
-  assert(
-    typeof result === "string" && result.length >= 0,
-    "Should return a string",
+  assertEquals(root.querySelector("style")?.textContent, ".cls { fill: red; }");
+  assertEquals(
+    root.querySelector("circle")?.getAttribute("style"),
+    "stroke: blue;",
   );
 });
 
-// Style element tests
-Deno.test("sanitizeSvg: should preserve style elements", function () {
-  const svg =
-    '<svg><style>.cls { fill: red; }</style><circle class="cls" cx="50" cy="50" r="40"/></svg>';
-  const result = sanitizeSvg(svg);
+Deno.test("sanitizeSvg drops a script element", function () {
+  const root = sanitized(
+    "<svg><script>alert('xss')</script><circle cx='5' cy='5' r='4'/></svg>",
+  );
 
-  // Note: The implementation does NOT remove <style> elements from the dangerous list
-  // Style elements are allowed, which is fine for SVG since they are scoped
-  assert(contains(result, "<style"), "Should contain <style");
-  assert(contains(result, "<circle"), "Should contain <circle");
+  assertEquals(elementNames(root), ["svg", "circle"]);
 });
 
-Deno.test("sanitizeSvg: should preserve inline style attributes", function () {
-  const svg =
-    '<svg><circle style="fill: red; stroke: blue;" cx="50" cy="50" r="40"/></svg>';
-  const result = sanitizeSvg(svg);
+Deno.test("sanitizeSvg drops a script element nested in a group or in defs", function () {
+  const root = sanitized(
+    "<svg><g><script>alert(1)</script><circle cx='5' cy='5' r='4'/></g>" +
+      "<defs><script>alert(2)</script></defs></svg>",
+  );
 
-  assert(contains(result, "style"), "Should contain style");
-  assert(contains(result, "fill: red"), "Should contain fill: red");
-  assert(contains(result, "<circle"), "Should contain <circle");
+  assertEquals(elementNames(root), ["svg", "g", "circle", "defs"]);
 });
 
-// Comprehensive XSS vector test
-Deno.test("sanitizeSvg: should sanitize multiple attack vectors in single SVG", function () {
-  const svg = `<svg onload="alert(1)">
-    <script>alert(2)</script>
-    <a href="javascript:alert(3)"><text onclick="alert(4)">click</text></a>
-    <foreignObject><body onload="alert(5)">test</body></foreignObject>
-    <set attributeName="onload" to="alert(6)"/>
-    <circle onerror="alert(7)" cx="50" cy="50" r="40"/>
-  </svg>`;
-  const result = sanitizeSvg(svg);
-
-  // Ensure no alert() calls remain
-  assert(notContains(result, "alert(1)"), "Should not contain alert(1)");
-  assert(notContains(result, "alert(2)"), "Should not contain alert(2)");
-  assert(notContains(result, "alert(3)"), "Should not contain alert(3)");
-  assert(notContains(result, "alert(4)"), "Should not contain alert(4)");
-  assert(notContains(result, "alert(5)"), "Should not contain alert(5)");
-  assert(notContains(result, "alert(6)"), "Should not contain alert(6)");
-  assert(notContains(result, "alert(7)"), "Should not contain alert(7)");
-
-  // Ensure dangerous elements/attributes removed
-  assert(notContains(result, "<script"), "Should not contain <script");
-  assert(notContains(result, "javascript:"), "Should not contain javascript:");
-  assert(
-    notContains(result, "foreignObject"),
-    "Should not contain foreignObject",
-  );
-  assert(notContains(result, "<set"), "Should not contain <set");
-  assert(
-    notContains(result.toLowerCase(), "onload"),
-    "Should not contain onload",
-  );
-  assert(
-    notContains(result.toLowerCase(), "onclick"),
-    "Should not contain onclick",
-  );
-  assert(
-    notContains(result.toLowerCase(), "onerror"),
-    "Should not contain onerror",
+Deno.test("sanitizeSvg drops an element that would embed foreign content", function () {
+  const root = sanitized(
+    '<svg><foreignObject width="100" height="100">' +
+      '<div xmlns="http://www.w3.org/1999/xhtml">html content</div>' +
+      "</foreignObject><circle cx='5' cy='5' r='4'/></svg>",
   );
 
-  // Ensure safe content preserved
-  assert(contains(result, "<text"), "Should contain <text");
-  assert(contains(result, "click"), "Should contain click");
-  assert(contains(result, "<circle"), "Should contain <circle");
+  assertEquals(elementNames(root), ["svg", "circle"]);
+});
+
+Deno.test("sanitizeSvg drops an animation element that can retarget an attribute", function () {
+  // `<animate>` writes a new value into an attribute while the drawing plays,
+  // which would put a URL into an `href` after it had been checked.
+  const root = sanitized(
+    '<svg><a href="https://example.com">' +
+      '<animate attributeName="href" to="javascript:alert(1)"/>' +
+      "<text>click</text></a></svg>",
+  );
+
+  assertEquals(elementNames(root), ["svg", "a", "text"]);
+});
+
+Deno.test("sanitizeSvg drops an element from outside the SVG namespace", function () {
+  // `desc` and `title` are the two places a drawing may hold HTML, and an
+  // element that arrives there shares a local name with a drawing element it
+  // is not.
+  const root = sanitized(
+    '<svg><desc><a href="javascript:alert(1)">x</a></desc>' +
+      "<circle cx='5' cy='5' r='4'/></svg>",
+  );
+
+  assertEquals(elementNames(root), ["svg", "desc", "circle"]);
+});
+
+Deno.test("sanitizeSvg drops an element it does not recognize", function () {
+  const root = sanitized(
+    "<svg><iframe src='evil.html'/><object data='evil.html'/>" +
+      "<set attributeName='onclick' to='alert(1)'/>" +
+      "<animateTransform attributeName='transform'/>" +
+      "<circle cx='5' cy='5' r='4'/></svg>",
+  );
+
+  assertEquals(elementNames(root), ["svg", "circle"]);
+});
+
+Deno.test("sanitizeSvg drops an event-handler attribute", function () {
+  const root = sanitized(
+    '<svg onload="alert(1)"><circle onclick="alert(2)" onMouseOver="alert(3)"' +
+      ' cx="50" cy="50" r="40"/></svg>',
+  );
+
+  assertEquals(attributes(root), ["cx=50", "cy=50", "r=40"]);
+});
+
+Deno.test("sanitizeSvg drops a URL that runs script", function () {
+  for (
+    const url of [
+      "javascript:alert(1)",
+      "JavaScript:alert(1)",
+      "java\tscript:alert(1)",
+      "java\nscript:alert(1)",
+      "vbscript:msgbox(1)",
+      "data:text/html,<script>alert(1)</script>",
+    ]
+  ) {
+    const root = sanitized(
+      `<svg><a href="${url}"><text>click</text></a></svg>`,
+    );
+
+    assertEquals(root.querySelector("a")?.hasAttribute("href"), false, url);
+    assertEquals(root.querySelector("text")?.textContent, "click");
+  }
+});
+
+Deno.test("sanitizeSvg drops a script URL in xlink:href", function () {
+  const root = sanitized(
+    '<svg xmlns:xlink="http://www.w3.org/1999/xlink">' +
+      '<a xlink:href="javascript:alert(1)"><text>click</text></a></svg>',
+  );
+
+  assertEquals(
+    root.querySelector("a")?.hasAttributeNS(
+      "http://www.w3.org/1999/xlink",
+      "href",
+    ),
+    false,
+  );
+});
+
+Deno.test("sanitizeSvg keeps a URL the browser may follow", function () {
+  const root = sanitized(
+    '<svg><a href="https://example.com"><text>click</text></a>' +
+      '<image href="./picture.png" width="10" height="10"/>' +
+      '<use href="#shape"/></svg>',
+  );
+
+  assertEquals(
+    root.querySelector("a")?.getAttribute("href"),
+    "https://example.com",
+  );
+  assertEquals(
+    root.querySelector("image")?.getAttribute("href"),
+    "./picture.png",
+  );
+  assertEquals(root.querySelector("use")?.getAttribute("href"), "#shape");
+});
+
+Deno.test("sanitizeSvg keeps an image carrying its own bytes", function () {
+  const root = sanitized(
+    '<svg><image href="data:image/png;base64,AAAA" width="10" height="10"/></svg>',
+  );
+
+  assertEquals(
+    root.querySelector("image")?.getAttribute("href"),
+    "data:image/png;base64,AAAA",
+  );
+});
+
+Deno.test("sanitizeSvg drops a data URL from a link, which navigates", function () {
+  const root = sanitized(
+    '<svg><a href="data:image/png;base64,AAAA"><text>click</text></a></svg>',
+  );
+
+  assertEquals(root.querySelector("a")?.hasAttribute("href"), false);
+});
+
+Deno.test("sanitizeSvg returns null for source that holds no drawing", function () {
+  assertEquals(sanitizeSvg(""), null);
+  assertEquals(sanitizeSvg("   \n\t  "), null);
+  assertEquals(sanitizeSvg(null as any), null);
+  assertEquals(sanitizeSvg(undefined as any), null);
+  assertEquals(sanitizeSvg(123 as any), null);
+  assertEquals(sanitizeSvg("<div>not svg</div>"), null);
+});
+
+Deno.test("sanitizeSvg recovers from an unclosed element", function () {
+  const root = sanitized("<svg><circle cx='5' cy='5' r='4'></svg>");
+
+  assertEquals(elementNames(root), ["svg", "circle"]);
+});
+
+Deno.test("sanitizeSvg puts a drawing that declares no namespace in the SVG namespace", function () {
+  // The source a drawing arrives in often omits the declaration, and an
+  // element outside the SVG namespace draws nothing.
+  const root = sanitized("<svg viewBox='0 0 10 10'><rect width='5'/></svg>");
+
+  assertEquals(root.namespaceURI, "http://www.w3.org/2000/svg");
+  assertEquals(root.querySelector("rect")?.namespaceURI, root.namespaceURI);
 });

--- a/packages/ui/src/v2/components/cf-svg/sanitize-svg.ts
+++ b/packages/ui/src/v2/components/cf-svg/sanitize-svg.ts
@@ -1,113 +1,137 @@
 /**
- * Sanitizes SVG strings to prevent XSS attacks.
+ * Turns SVG source into an element that is safe to put in a document.
  *
- * Uses browser-native DOMParser to parse and walk the SVG DOM tree,
- * removing dangerous elements and attributes.
+ * The guarantee is that nothing in the source runs script. An element survives
+ * only if it appears in the allowlist below, so an element nobody anticipated
+ * is dropped rather than kept; an attribute whose name begins with `on` is
+ * removed; and a URL-valued attribute keeps its value only when the scheme
+ * allowlist in `safe-url.ts` accepts it.
  *
- * @param svgString - The SVG string to sanitize
- * @returns Sanitized SVG string, or empty string if parsing fails
+ * The element that comes back is inserted as a node. Nothing serializes it
+ * back to a string, so no second parse can read the sanitized tree differently
+ * from the way this function left it.
+ *
+ * The guarantee does not extend to the network: a drawing may reference an
+ * image or a font, and displaying it fetches what it references.
  */
-export function sanitizeSvg(svgString: string): string {
-  // Handle empty input
-  if (!svgString || typeof svgString !== "string") {
-    return "";
-  }
 
-  const trimmed = svgString.trim();
-  if (trimmed === "") {
-    return "";
-  }
+import { safeImageUrl, safeUrl } from "../../core/safe-url.ts";
 
-  // Parse the SVG string
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(trimmed, "image/svg+xml");
+/**
+ * The elements a drawing is built from.
+ *
+ * The list leaves out three groups on purpose. `script` runs code. `animate`,
+ * `animateMotion`, `animateTransform` and `set` retarget an attribute while the
+ * drawing plays, which would let a drawing write a `javascript:` URL into an
+ * attribute this function had already checked. `foreignObject` opens a window
+ * back into HTML, where everything the list excludes becomes available again.
+ */
+const ALLOWED_ELEMENTS = new Set([
+  "a",
+  "circle",
+  "clippath",
+  "defs",
+  "desc",
+  "ellipse",
+  "feblend",
+  "fecolormatrix",
+  "fecomponenttransfer",
+  "fecomposite",
+  "feconvolvematrix",
+  "fediffuselighting",
+  "fedisplacementmap",
+  "fedistantlight",
+  "fedropshadow",
+  "feflood",
+  "fefunca",
+  "fefuncb",
+  "fefuncg",
+  "fefuncr",
+  "fegaussianblur",
+  "feimage",
+  "femerge",
+  "femergenode",
+  "femorphology",
+  "feoffset",
+  "fepointlight",
+  "fespecularlighting",
+  "fespotlight",
+  "fetile",
+  "feturbulence",
+  "filter",
+  "g",
+  "image",
+  "line",
+  "lineargradient",
+  "marker",
+  "mask",
+  "metadata",
+  "path",
+  "pattern",
+  "polygon",
+  "polyline",
+  "radialgradient",
+  "rect",
+  "stop",
+  "style",
+  "svg",
+  "switch",
+  "symbol",
+  "text",
+  "textpath",
+  "title",
+  "tspan",
+  "use",
+]);
 
-  // Check for parser errors
-  const parserError = doc.querySelector("parsererror");
-  if (parserError) {
-    return "";
-  }
+/** The attributes that name something for the browser to fetch or follow. */
+const URL_ATTRIBUTES = new Set(["href", "xlink:href", "src"]);
 
-  // Dangerous elements to remove (case-insensitive)
-  const DANGEROUS_ELEMENTS = new Set([
-    "script",
-    "foreignobject",
-    "iframe",
-    "embed",
-    "object",
-    "applet",
-    "meta",
-    "link",
-    "set", // SVG <set> can target event handler attributes
-  ]);
+const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
 
-  // URL attributes that need sanitization
-  const URL_ATTRIBUTES = new Set([
-    "href",
-    "xlink:href",
-    "src",
-    "action",
-    "formaction",
-  ]);
-
-  // Dangerous URL protocols (case-insensitive)
-  const DANGEROUS_PROTOCOLS = ["javascript:", "vbscript:", "data:text/html"];
-
-  /**
-   * Recursively walks the DOM tree and sanitizes nodes
-   */
-  function sanitizeNode(node: Node): void {
-    if (node.nodeType === Node.ELEMENT_NODE) {
-      const element = node as Element;
-      const tagName = element.tagName.toLowerCase();
-
-      // Remove dangerous elements
-      if (DANGEROUS_ELEMENTS.has(tagName)) {
-        element.remove();
-        return;
-      }
-
-      // Remove event handler attributes (onclick, onload, onerror, etc.)
-      const attributesToRemove: string[] = [];
-      for (let i = 0; i < element.attributes.length; i++) {
-        const attr = element.attributes[i];
-        const attrName = attr.name.toLowerCase();
-
-        // Remove event handlers
-        if (attrName.startsWith("on")) {
-          attributesToRemove.push(attr.name);
-          continue;
-        }
-
-        // Sanitize URL attributes
-        if (URL_ATTRIBUTES.has(attrName)) {
-          const attrValue = attr.value.trim().toLowerCase();
-          for (const protocol of DANGEROUS_PROTOCOLS) {
-            if (attrValue.startsWith(protocol)) {
-              attributesToRemove.push(attr.name);
-              break;
-            }
-          }
-        }
-      }
-
-      // Remove dangerous attributes
-      for (const attrName of attributesToRemove) {
-        element.removeAttribute(attrName);
-      }
-
-      // Recursively sanitize children
-      const children = Array.from(element.childNodes);
-      for (const child of children) {
-        sanitizeNode(child);
-      }
+function sanitizeElement(element: Element): void {
+  for (const child of Array.from(element.children)) {
+    if (
+      child.namespaceURI !== SVG_NAMESPACE ||
+      !ALLOWED_ELEMENTS.has(child.localName.toLowerCase())
+    ) {
+      child.remove();
+      continue;
     }
+    sanitizeElement(child);
   }
 
-  // Sanitize the document
-  sanitizeNode(doc.documentElement);
+  // A link navigates, so it is held to the schemes a document may point at.
+  // Everything else with a URL loads a drawing, which may carry its own bytes.
+  const checkUrl = element.localName.toLowerCase() === "a"
+    ? safeUrl
+    : safeImageUrl;
+  for (const attribute of Array.from(element.attributes)) {
+    const name = attribute.name.toLowerCase();
+    const dangerous = name.startsWith("on") ||
+      (URL_ATTRIBUTES.has(name) && checkUrl(attribute.value) === null);
+    if (dangerous) element.removeAttributeNode(attribute);
+  }
+}
 
-  // Serialize back to string
-  const serializer = new XMLSerializer();
-  return serializer.serializeToString(doc);
+/**
+ * Parses and sanitizes SVG source, returning the drawing it describes.
+ *
+ * Returns `null` when the source holds no drawing.
+ *
+ * The source is read by the HTML parser, which puts a drawing in the SVG
+ * namespace whether or not the source declares one, and which recovers from
+ * markup that an XML parser would reject. The document it builds has no
+ * browsing context: nothing in it runs, and nothing in it loads, before this
+ * function has finished with it.
+ */
+export function sanitizeSvg(svgString: string): Element | null {
+  if (typeof svgString !== "string" || svgString.trim() === "") return null;
+
+  const doc = new DOMParser().parseFromString(svgString, "text/html");
+  const root = doc.body.querySelector("svg");
+  if (root === null || root.namespaceURI !== SVG_NAMESPACE) return null;
+
+  sanitizeElement(root);
+  return root;
 }

--- a/packages/ui/src/v2/components/cf-svg/sanitize-svg.ts
+++ b/packages/ui/src/v2/components/cf-svg/sanitize-svg.ts
@@ -25,6 +25,13 @@ import { safeImageUrl, safeUrl } from "../../core/safe-url.ts";
  * drawing plays, which would let a drawing write a `javascript:` URL into an
  * attribute this function had already checked. `foreignObject` opens a window
  * back into HTML, where everything the list excludes becomes available again.
+ *
+ * `style` is the one entry that paints nothing, and it is here because a
+ * drawing exported from a design tool routinely carries its fills in a
+ * stylesheet rather than on each shape, and drops to black without it. CSS
+ * runs no script, so it does not cost the guarantee above. It can name a URL,
+ * which the network caveat above already covers and which this function does
+ * not read: a `url()` inside a stylesheet is not an attribute value.
  */
 const ALLOWED_ELEMENTS = new Set([
   "a",

--- a/packages/ui/src/v2/core/safe-url.test.ts
+++ b/packages/ui/src/v2/core/safe-url.test.ts
@@ -1,0 +1,96 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { safeImageUrl, safeUrl } from "./safe-url.ts";
+
+describe("safe-url", () => {
+  describe("safeUrl()", () => {
+    it("returns an `https` URL unchanged", () => {
+      expect(safeUrl("https://example.com/a?b=c#d")).toBe(
+        "https://example.com/a?b=c#d",
+      );
+    });
+
+    it("returns a `mailto` URL unchanged", () => {
+      expect(safeUrl("mailto:someone@example.com")).toBe(
+        "mailto:someone@example.com",
+      );
+    });
+
+    it("returns a relative URL unchanged", () => {
+      expect(safeUrl("/docs/guide.md")).toBe("/docs/guide.md");
+      expect(safeUrl("../sibling.png")).toBe("../sibling.png");
+    });
+
+    it("returns a fragment unchanged", () => {
+      expect(safeUrl("#section-one")).toBe("#section-one");
+    });
+
+    it("returns a relative path whose later segment contains a colon", () => {
+      // The colon is not a scheme separator here, because what precedes it is
+      // not a scheme: a path segment intervenes.
+      expect(safeUrl("path/to:file")).toBe("path/to:file");
+      expect(safeUrl("/of:bafy123/field")).toBe("/of:bafy123/field");
+    });
+
+    it("returns `null` for a `javascript` URL", () => {
+      expect(safeUrl("javascript:alert(1)")).toBeNull();
+    });
+
+    it("returns `null` for a `javascript` URL in any casing", () => {
+      expect(safeUrl("JaVaScRiPt:alert(1)")).toBeNull();
+    });
+
+    it("returns `null` for a scheme split or padded by whitespace", () => {
+      // The URL parser discards these before it reads the scheme, so each of
+      // these names the `javascript` scheme to a browser.
+      expect(safeUrl("java\tscript:alert(1)")).toBeNull();
+      expect(safeUrl("java\nscript:alert(1)")).toBeNull();
+      expect(safeUrl("java\rscript:alert(1)")).toBeNull();
+      expect(safeUrl("  javascript:alert(1)")).toBeNull();
+    });
+
+    it("returns `null` for a `data` URL", () => {
+      expect(safeUrl("data:text/html,<script>alert(1)</script>")).toBeNull();
+      expect(safeUrl("data:image/png;base64,AAAA")).toBeNull();
+    });
+
+    it("returns `null` for a scheme outside the allowlist", () => {
+      expect(safeUrl("vbscript:msgbox(1)")).toBeNull();
+      expect(safeUrl("file:///etc/passwd")).toBeNull();
+      expect(safeUrl("blob:https://example.com/abc")).toBeNull();
+    });
+  });
+
+  describe("safeImageUrl()", () => {
+    it("returns an `https` URL unchanged", () => {
+      expect(safeImageUrl("https://example.com/a.png")).toBe(
+        "https://example.com/a.png",
+      );
+    });
+
+    it("returns a `data:image` URL unchanged", () => {
+      expect(safeImageUrl("data:image/png;base64,AAAA")).toBe(
+        "data:image/png;base64,AAAA",
+      );
+      expect(safeImageUrl("DATA:IMAGE/SVG+XML,%3Csvg%3E")).toBe(
+        "DATA:IMAGE/SVG+XML,%3Csvg%3E",
+      );
+    });
+
+    it("returns `null` for a `data` URL that is not an image", () => {
+      expect(safeImageUrl("data:text/html,<script>alert(1)</script>"))
+        .toBeNull();
+    });
+
+    it("returns `null` for a `javascript` URL", () => {
+      expect(safeImageUrl("javascript:alert(1)")).toBeNull();
+    });
+
+    it("reads the scheme past a control character in a `data:image` URL", () => {
+      expect(safeImageUrl("data\t:image/png;base64,AAAA")).toBe(
+        "data\t:image/png;base64,AAAA",
+      );
+    });
+  });
+});

--- a/packages/ui/src/v2/core/safe-url.ts
+++ b/packages/ui/src/v2/core/safe-url.ts
@@ -1,0 +1,67 @@
+/**
+ * Whether a URL taken from untrusted content is safe to put in a document.
+ *
+ * A component that renders content it did not author decides, for every URL in
+ * that content, whether the browser may follow it. The decision is an
+ * allowlist: a URL passes only when its scheme is one this module names, so a
+ * scheme nobody anticipated is refused rather than permitted.
+ */
+
+/**
+ * The schemes a link, an image, or any other URL-valued attribute may name.
+ *
+ * `javascript:` and `data:text/html` run script and are absent for that
+ * reason, but so is every other scheme, including ones that are harmless
+ * today. A URL with no scheme at all is relative to the document, cannot name
+ * a protocol handler, and is allowed without appearing here.
+ */
+const ALLOWED_SCHEMES = new Set(["http", "https", "mailto", "tel"]);
+
+/**
+ * The prefix an image URL may carry in place of a scheme from the set above.
+ *
+ * A browser renders `data:image/...` as a still image: an SVG delivered this
+ * way is drawn without running the script it contains and without loading the
+ * resources it references.
+ */
+const DATA_IMAGE = "data:image/";
+
+const SCHEME = /^([a-zA-Z][a-zA-Z0-9+.-]*):/;
+
+/**
+ * Drops the characters a URL parser discards before it reads a scheme: ASCII
+ * whitespace and the C0 controls. `java\tscript:alert(1)` names the
+ * `javascript` scheme, and reading it from the string as written misses that.
+ *
+ * Dropping every character in that range rather than the exact set the parser
+ * drops can only widen the scheme this finds, never narrow it, so a URL the
+ * browser would treat as script cannot slip past the check below.
+ */
+function withoutIgnoredCharacters(url: string): string {
+  let kept = "";
+  for (const character of url) {
+    if (character.codePointAt(0)! > 0x20) kept += character;
+  }
+  return kept;
+}
+
+/**
+ * The URL a link may point at, or `null` when the browser must not follow it.
+ *
+ * The URL is returned as written; only its scheme is read.
+ */
+export function safeUrl(url: string): string | null {
+  const scheme = SCHEME.exec(withoutIgnoredCharacters(url))?.[1].toLowerCase();
+  if (scheme === undefined) return url;
+  return ALLOWED_SCHEMES.has(scheme) ? url : null;
+}
+
+/**
+ * The URL an image may load, or `null` when the browser must not fetch it.
+ *
+ * An image may also carry its own bytes in a `data:image/` URL.
+ */
+export function safeImageUrl(url: string): string | null {
+  const normalized = withoutIgnoredCharacters(url).toLowerCase();
+  return normalized.startsWith(DATA_IMAGE) ? url : safeUrl(url);
+}

--- a/packages/ui/src/v2/test-utils/mock-document.ts
+++ b/packages/ui/src/v2/test-utils/mock-document.ts
@@ -11,10 +11,12 @@
 export interface MockElement {
   tagName: string;
   style: { cssText: string };
+  textContent: string;
   children: MockElement[];
   parentNode: MockElement | null;
   appendChild(child: MockElement): MockElement;
   removeChild(child: MockElement): MockElement;
+  replaceChildren(...replacements: MockElement[]): void;
   // Components assign their own properties, `cell` and `isStatic` among them.
   [key: string]: unknown;
 }
@@ -29,6 +31,7 @@ export function createMockElement(tagName: string): MockElement {
   const element: MockElement = {
     tagName,
     style: { cssText: "" },
+    textContent: "",
     children,
     parentNode: null,
     appendChild(child: MockElement) {
@@ -41,6 +44,11 @@ export function createMockElement(tagName: string): MockElement {
       if (index >= 0) children.splice(index, 1);
       child.parentNode = null;
       return child;
+    },
+    replaceChildren(...replacements: MockElement[]) {
+      for (const child of children) child.parentNode = null;
+      children.length = 0;
+      for (const child of replacements) element.appendChild(child);
     },
   };
   return element;


### PR DESCRIPTION
cf-markdown rendered a markdown document by asking marked for an HTML string, rewriting that string with four regular expressions, and handing the result to Lit's unsafeHTML. Anything the document's author wrote went into the page as markup, so a document containing a script tag, an image with an onerror handler, or a link with a javascript: URL got exactly what it asked for. The component carried a TODO saying so and asking callers to pass only trusted markdown, which is not a property the callers have: the documents it renders come from language models, from other people's spaces, and from note and topic bodies.

The fix removes the string stage rather than sanitizing it. marked already reads a document into tokens, so this walks the tokens and builds a Lit template whose tags and attribute names come from this repository's own source. Every piece of the document reaches the page through a binding, which Lit puts in a text node or an attribute value without parsing it. Markup in the source is therefore text, and no arrangement of characters in it can add an element, an attribute, or an event handler. Two things the source still reaches are handled explicitly: a URL is checked against a scheme allowlist before it goes in an href or a src, and raw HTML, which markdown permits and marked reports as its own kind of token, is dropped.

What dropping raw HTML costs depends on where it was written, and the module comment says so. Inline HTML is one token per tag, unmatched and flat among the text tokens around it, so `<b>bold</b>` loses the tags and keeps the word. A block of HTML is a single token whose text is the whole block, so its content goes with it. A browser test pins each half.

Working from tokens also retires the machinery that existed to patch up the string: the regular expressions that wrapped code blocks and tables and swapped cell links, the two hand-written escapers, and the pass that walked the shadow root after each render to attach checkbox handlers and strip the disabled attribute marked adds. Checkboxes now bind their handler directly, and bind their state through Lit's live directive so a toggled box returns to what the document says on the next render.

The SVG component had the same shape of problem one step further along. It sanitized, but against a list of elements known to be dangerous, so an element nobody had thought of survived: an animate element retargets an href after the sanitizer has checked it, and a scheme split by a tab reads as javascript to a URL parser but not to a prefix comparison. That list is now an allowlist of the elements a drawing is built from, the URL check is the shared one, and the sanitized drawing is returned as an element rather than serialized back to a string for unsafeHTML to reparse - a round trip through two different parsers is its own source of surprises. Reading the source with the HTML parser rather than the XML one also puts a drawing that omits its namespace declaration where it will actually draw, and recovers from an unclosed tag instead of rendering nothing.

The render component built its failure message by interpolating an error's text into an HTML string, which the message is not guaranteed to be safe for; it now sets that text on an element.

No unsafeHTML remains in the package, and no dependency was added.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

