### PR TITLE
The old spellings expire on a date the warning names

### DIFF
--- a/docs/plans/cli-surface-implementation.md
+++ b/docs/plans/cli-surface-implementation.md
@@ -23,9 +23,10 @@ quickly.
 
 ## Governing decisions
 
-**Additive until step 6.** Steps 4 and 5 only add. Every spelling that works
-today still works, and nothing is deprecated until the replacement carries real
-traffic.
+**Additive until 6b.** Steps 4 through 6a only add: 6a adds a warning, not a
+removal. Every spelling that works today still works, and the old ones keep
+working until the date those warnings name — two weeks after 6a reaches main,
+written into the warning as a literal so it reads the same on any day.
 
 **A deprecated spelling keeps working.** It costs a line of aliasing to leave a
 redirect in place, and it costs every script and skill file that used it to
@@ -123,11 +124,12 @@ and say what replaced them.
 teach `--piece` or `--input` today. They move to the new spellings in one pass,
 because a skill teaching a warned spelling teaches an agent to generate warnings.
 
-*The decision this needs.* **What "carries traffic" means.** The shape document
-defers deprecation until the new spellings carry traffic, and nothing in the CLI
-measures that. Either a signal is added, or the condition is replaced with one
-that can actually be evaluated — a release count, the skills being migrated, or
-a date. Deprecating on an unmeasurable condition means deprecating on a guess.
+*Decided: a date, not a traffic threshold.* Each warning names the day its
+spelling stops working, two weeks after D1 reaches main, written in as a literal
+so the warning reads the same whenever it is read. Traffic was never measurable
+here — both spellings mount the same builder and emit identical requests, and
+the CLI sends nothing that would let a server attribute one to either, so the
+condition could only ever have been estimated.
 
 *Exit:* no file in this repository teaches a deprecated spelling, and every
 deprecated spelling still works.
@@ -183,7 +185,7 @@ outside the accretion this addresses.
 | N1 | P1, P2 | a new name should be born with the new address forms, not gain them later |
 | N2 | — | nothing to do |
 | D1 | N1 | cannot deprecate before the replacement exists |
-| D2 | D1 | and before the traffic question is answered |
+| D2 | — | and BEFORE D1: a warning that fires on examples this repository still teaches trains agents to generate warnings |
 | M1–M5 | — | each independent of the others and of everything above |
 
 The merges do not depend on the renames. They are ordered last because they are
@@ -227,9 +229,11 @@ commands that agree by coincidence.
 behaviors, and merging keeps one. Without characterization tests first, the
 survivor is whichever was easier to keep.
 
-**Deprecating on an unmeasurable condition.** Named above as the decision D1
-needs. Left unresolved, "once it carries traffic" becomes "whenever someone feels
-ready", which is how a deprecation stalls indefinitely or lands too early.
+**Deprecating on an unmeasurable condition.** Retired: the condition is a date
+the warning itself carries, so "whenever someone feels ready" is not available
+as an answer. What the date cannot cover is consumers outside this repository,
+who are unreachable by any sweep here and unmeasurable by any signal the CLI
+could add — which is what the two weeks are for.
 
 ## Documentation owed
 

--- a/docs/plans/cli-surface-implementation.md
+++ b/docs/plans/cli-surface-implementation.md
@@ -184,8 +184,8 @@ outside the accretion this addresses.
 | P2 | P1 | the suffix attaches to the positional |
 | N1 | P1, P2 | a new name should be born with the new address forms, not gain them later |
 | N2 | — | nothing to do |
-| D1 | N1 | cannot deprecate before the replacement exists |
-| D2 | — | and BEFORE D1: a warning that fires on examples this repository still teaches trains agents to generate warnings |
+| D2 | P1, P2, N1 | it teaches what those three add, so it cannot precede them |
+| D1 | N1, D2 | cannot deprecate before the replacement exists, nor before the sweep: a warning that fires on examples this repository still teaches trains agents to generate warnings |
 | M1–M5 | — | each independent of the others and of everything above |
 
 The merges do not depend on the renames. They are ordered last because they are

--- a/docs/plans/cli-surface-shape.md
+++ b/docs/plans/cli-surface-shape.md
@@ -175,8 +175,9 @@ their own is a step-7-class decision this document leaves open.
 
 ## How to get there
 
-Additive, in dependency order. Nothing before step 6 removes or renames anything
-a caller depends on — steps 1–5 only add.
+Additive, in dependency order. Nothing before 6b removes or renames anything a
+caller depends on — steps 1 through 6a only add, and 6a adds a warning rather
+than taking anything away.
 
 1. **Factor out the shared read step** so a single implementation turns a cell
    and a shape into structured output.
@@ -189,7 +190,12 @@ a caller depends on — steps 1–5 only add.
    flags, keeping both.
 5. **Add `cf get`/`set`/`call`** as aliases of the existing
    implementations. Same code, honest names, both spellings working.
-6. **Deprecate the old spellings** once the new ones carry traffic.
+6a. **Warn on the old spellings**, each warning naming the date its spelling
+   stops working — two weeks after this step reaches main. The date is a
+   literal, fixed when this step merges, not a window recomputed per run: a
+   caller who reads the warning today and acts on it next week must be told
+   the same date both times.
+6b. **Remove the old spellings** on the date the warnings named.
 7. **Merge the duplicated nouns** — the two `inspect`s, the two `view`s, `piece
    map` against `inspect graph`, and `apply` against `set`.
 
@@ -208,13 +214,27 @@ intermediate state wrong. What each step owes:
 | 3 | Address forms wherever `--piece` is taught: the CLI README and the tutorial's workflow chapter |
 | 4 | `#argument` beside every `--input` example, in the same places |
 | 5 | The new spellings alongside the old ones everywhere both work |
-| 6 | Removal of the old spellings, once redirects have carried traffic |
+| 6a | The old spellings marked deprecated wherever they are taught, each carrying the removal date |
+| 6b | Removal of the old spellings, and of the deprecation notes 6a added |
 | 7 | Whatever the merges decide |
 
-**Old spellings stay as redirects, not errors, until step 6 has traffic behind
-it.** A deprecated spelling that still works costs a line of aliasing; one that
-fails costs every script and skill file that used it, including ones outside
-this repository.
+**Old spellings stay as redirects, not errors, until the date 6a names.** A
+deprecated spelling that still works costs a line of aliasing; one that fails
+costs every script and skill file that used it, including ones outside this
+repository.
+
+A DATE rather than a traffic threshold, because the traffic is not observable.
+Both spellings mount the same builder and emit identical requests, and the CLI
+sends nothing that would let a server attribute one to either — so measuring
+adoption means adding a marker to the wire, somewhere to collect it, and a
+privacy decision about a tool that runs on other people's machines. The
+condition that wording implied could not be checked, only estimated.
+
+What IS checkable is this repository, and it is a precondition rather than a
+gate: the sweep in step 5's documentation row should land before 6a, so the
+warning does not fire on examples we ourselves still teach. Consumers outside
+this repository are unmeasurable by any means available here, which is an
+argument for a generous interval rather than for instrumenting one.
 
 ## Decisions this document does not make
 

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -684,9 +684,9 @@ this document stops being read.
 [The CLI surface](cli-surface-implementation.md), already sequenced. Its first
 two stages add positional addresses and the top-level names, and they can start
 as soon as the read layer has merged; they touch the same commands, so starting
-earlier means resolving the same files twice. Its deprecation stage carries an
-unanswered question of its own — what "carries traffic" means, given nothing
-measures it — and that wants an answer before the stage rather than during it.
+earlier means resolving the same files twice. Its deprecation stage is now
+dated rather than conditional: each warning names the day its spelling stops
+working, two weeks after the warnings land.
 
 **Retention and CFC execution provenance** —
 [its own plan](retention-and-provenance.md). Gated on a CFC review that has not


### PR DESCRIPTION
## Why

Step 6 said two different things in one document. Its step list said
**"Deprecate the old spellings"**; its documentation-owed table said
**"Removal of the old spellings"**. Those differ by everything a caller cares
about, and the document supported both readings — so the first person to pick
it up would have guessed.

It also deferred to a condition nobody could evaluate. Three plans said the
deprecation waits until the new spellings **"carry traffic"**, and
`cli-surface-implementation.md` had already flagged that as the open decision
the stage needed, with `verbs-implementation.md` noting it wanted an answer
before the stage rather than during it.

## The decision

**6a warns; 6b removes; the warning names the date.** Two weeks after 6a
reaches main, written into the warning as a literal rather than computed per
run — a caller who reads it today and acts on it next week has to be told the
same date both times.

A date rather than a traffic threshold because **the traffic is not
observable**. Both spellings mount the same builder — `main.ts` mounts
`.command("get", pieceDataCommand("get"))` and the `piece` chain mounts the
identical thing — so they emit byte-identical requests, and the CLI sends
nothing that would let a server attribute one to either. Measuring adoption
would mean adding a marker to the wire, somewhere to collect it, and a privacy
decision about a tool that runs on other people's machines. The condition could
only ever have been estimated.

What remains genuinely unmeasurable is consumers outside this repository. No
signal we could add would see them, which is an argument for a generous
interval rather than for instrumenting one — and it is what the two weeks are
for.

## What Changed

Three plans carried the old condition, and all three now agree:

- `cli-surface-shape.md` — step 6 splits into 6a and 6b; the documentation-owed
  table gains a row for each; the redirects paragraph states the date and why a
  date replaced the threshold.
- `cli-surface-implementation.md` — the open decision D1 named becomes the
  answer; the "unmeasurable condition" risk is retired, keeping only the part
  that survives (external consumers); "additive until step 6" becomes "additive
  until 6b", since 6a adds a warning rather than taking anything away.
- `verbs-implementation.md` — its downstream note no longer describes the stage
  as carrying an unanswered question.

**One dependency inverts.** `D2` (the documentation sweep) was listed as
depending on `D1` (the warning) *"and before the traffic question is answered"*.
Neither clause holds now: the question is answered, and the sweep should
**precede** the warning rather than follow it. A warning that fires on examples
this repository still teaches trains agents to generate warnings — which is the
implementation document's own stated reason for moving the docs, applied to its
own ordering.

## Test plan

Documentation only; no code changes. `deno fmt --check`, `deno lint`,
`deno task check-docs` (549 blocks), and `deno task check-docs-history-index`
all pass. Nothing under `docs/history/` was touched.

A sweep for the retired language across `docs/plans/` leaves one hit, which is
the retired-risk entry naming itself as retired.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

