### PR TITLE
feat(cli): the demo speaks cf get and cf call, and the walkthrough only quotes

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -100,6 +100,10 @@ jobs:
         timeout-minutes: *work-timeout
         run: deno task check-conflict-markers
 
+      - name: 🎭 Check the verb-session walkthrough against its demo
+        timeout-minutes: *work-timeout
+        run: deno task check-verb-session-sync
+
       - name: 🔎 Check for unused import map dependencies
         timeout-minutes: *work-timeout
         run: deno task check-unused-deps

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -100,7 +100,7 @@ jobs:
         timeout-minutes: *work-timeout
         run: deno task check-conflict-markers
 
-      - name: 🎭 Check the verb-session walkthrough against its demo
+      - name: 🚧 Guard the verb-session walkthrough against its demo
         timeout-minutes: *work-timeout
         run: deno task check-verb-session-sync
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,9 @@ Each of these gates fails CI on its own, and none of them run as part of
   in a file, which `docs/` has no other mechanical gate against
 - `deno task check-skill-facts` — a path or import cited by a skill, an
   `AGENTS.md`, or a rule that stopped resolving
+- `deno task check-verb-session-sync` — a `cf` command or act reference in
+  `docs/common/verb-session-walkthrough.md` that its demo script does not back;
+  the walkthrough quotes commands, never composes them
 - `deno task check-single-copy-deps`, `check-unused-deps`, `check-deno-pins` —
   dependency declarations across the workspace
 - `deno task check-baselines-append-only` — a pattern baseline that was deleted

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -54,6 +54,7 @@
     "pattern-vintage": "deno run -A ./tasks/pattern-vintage.ts",
     "check-baselines-append-only": "deno run --allow-read --allow-run=git ./tasks/check-baselines-append-only.ts",
     "check-skill-facts": "deno run --allow-read --allow-run=git ./tasks/check-skill-facts.ts",
+    "check-verb-session-sync": "deno run --allow-read ./tasks/check-verb-session-sync.ts",
     "check-tripwires": "deno run --allow-read ./tasks/check-tripwires.ts",
     // Reports the docs/ link graph; --allow-write serves its --out flag.
     "docs-links": "deno run --allow-read --allow-write ./scripts/docs-links.ts",

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -71,6 +71,13 @@ failing loudly the day it does. A verb added to the fixture wants a row above, a
 act in the demo, and a step in the harness; a shape demonstrated in none of the
 three is a claim this document is making alone.
 
+This document quotes commands and never composes them: every `cf` line in a
+bash block below is a line the demo runs — or carries a `# not in the demo`
+comment saying why it cannot be — and every act number names an act the demo
+has. `deno task check-verb-session-sync` enforces both, so a command here
+cannot be wrong in a way the demo would have caught, and an act reference
+cannot go stale under renumbering.
+
 ## What you are driving
 
 Two patterns. A **board** holds root items; an **item** holds its own subtree,
@@ -170,7 +177,8 @@ measured at 3183 bytes for a single child on this pattern. Naming what you want
 brings it to 51:
 
 ```bash
-cf piece get <item-address> children --select 'title,status'
+# not in the demo — the byte measurement's own illustration
+cf get <item-address> children --select 'title,status'
 ```
 
 That is not a workaround; it is the read model working. A schema is a query,
@@ -190,8 +198,9 @@ of the verb's own help page. Step 2 has the measurement.
 An address a person can type, rather than a fid from a previous command.
 
 ```bash
+# not in the demo — the demo deploys straight against a live toolshed
 cf test tracker.test.tsx
-cf piece new tracker.tsx --test tracker.test.tsx --slug board
+cf piece new packages/cli/integration/pattern/tracker.tsx --slug board
 cf piece verbs --piece board
 ```
 
@@ -221,7 +230,7 @@ same words are the summary line.
 ## 2. Ask what a verb wants **[today]**
 
 ```bash
-cf piece call --piece board addItem -- --help
+cf call --piece board addItem -- --help
 ```
 
 ```text
@@ -359,7 +368,8 @@ author to write it, since it sits beside the type it describes.
 ## 3. Complete against the live piece **[today]**
 
 ```bash
-cf piece call --piece board <TAB>
+# not in the demo — completion needs a terminal
+cf call --piece board <TAB>
 addItem
 ```
 
@@ -378,12 +388,12 @@ needs.
 ## 4. Create, and carry the address forward **[today]**
 
 ```bash
-EPIC=$(cf piece call --piece board --select 'item@' addItem -- \
+EPIC=$(cf call --piece board --select 'item@' addItem -- \
        --title "Login rewrite" | jq -r '.result.item."$link"')
 
-cf piece call "$EPIC" addChild -- --title "Session cookie handling"
-cf piece call "$EPIC" recordNote -- --body "Blocked on the cookie spec"
-cf piece get "$EPIC/status"
+cf call "$EPIC" addChild -- --title "Session cookies"
+cf call "$EPIC" recordNote -- --body "blocked on the cookie spec"
+cf get "$EPIC/status"
 ```
 
 **This is the composition the surface exists for.** A create hands back the
@@ -444,10 +454,9 @@ shows the full exchange.
 ## 5. Read the tree back, bounded **[today]**
 
 ```bash
-cf piece get --piece board items --select 'title,status,children@'
+cf get --piece board items --select 'title,status,children@'
 
-cf piece get --piece board items --select 'title,status' \
-  --filter '.status != "done"'
+cf get "$EPIC" children --select title --filter '.status == "open"'
 ```
 
 Two commands rather than one, because **an `@` suffix and `--filter` are
@@ -477,24 +486,31 @@ board first, then only what is open, then the refusal.
 ## 6. Relate two items **[blocked]**
 
 ```bash
-cf piece call "$EPIC" blockOn -- --on "$OTHER"
+cf call "$EPIC" blockOn -- --on "$OTHER"
 ```
 
-This is where the session stops.
+This is where the session stops — on the spelling, no longer on the
+capability.
 
 ## The composition axis
 
 Steps 4 and 6 are the same move — take an address out of one command and put it
-into the next — and only one of them works.
+into the next — and the receiver half works in full while the argument half
+works only under a spelling no read emits.
 
 | Direction | State |
 | --- | --- |
 | address → the receiver (first positional, or `--piece`) | works |
-| address → an argument field | refused |
+| a link envelope → an argument field | works (#5880) — the edge that lands is the target, not a copy |
+| the address a read emits → an argument field | refused |
 
-A call payload is plain JSON. `normalizeCallableInputForExecution`
-(`packages/cli/lib/exec-schema.ts`) does nothing with links, so `--on "$OTHER"`
-arrives as a string the pattern cannot resolve into a reference.
+The pre-dispatch gate now passes a link envelope opaquely where a verb
+declares a reference (#5880), matching the ruling the runtime's own dispatch
+gate had already made. What it still refuses is the canonical string a read
+prints — the one spelling a caller is actually holding, since every `$link`
+and `receipt` in this session emits exactly that form. A caller who wants the
+edge today must assemble the envelope from the string by hand, which is the
+round-trip property failing one level in.
 
 A tree mostly hides this, because the natural shape is to call the verb *on* the
 parent — the receiver carries the relationship, so no address needs to be an
@@ -520,7 +536,7 @@ Declared results make an **output** self-describing; this is about what an
 | An event interface's own comment absent everywhere | The one prose level that does not compile ([#5559](https://github.com/commontoolsinc/labs/issues/5559)). Nothing downstream can serve what was never emitted |
 | A declared event field the handler body never reads is absent from the served input schema | A decision, not a patch: the served schema is the handler's read and the declared type is the contract, and which one a caller is owed is open |
 | `--select` completion, and refusal before the call | A provider reading the declared result the help page already resolves |
-| An address accepted as an argument | The round-trip property above |
+| The address a read emits accepted as an argument | The string form beside the envelope #5880 accepts — the round-trip property above. And beside it the protective refusal: a shape-matching payload still stores a detached copy and reports success |
 
 Five rows and five distinct gaps, and the first three are worth reading
 together because they look like one. They are not: the first is a renderer that

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -186,11 +186,11 @@ run cf piece verbs -s "$SPACE" --piece board
 
 act "3 · Ask what a verb wants"
 say "Flags, types, required-ness and result all come from the author's TypeScript."
-run cf piece call -s "$SPACE" --piece board addItem -- --help
+run cf call -s "$SPACE" --piece board addItem -- --help
 
 act "4 · Create, and act on what you were handed"
 say "The create returns the piece it made. Its address is the next command's target."
-run cf piece call -s "$SPACE" --piece board --select item@ addItem -- --title "Login rewrite"
+run cf call -s "$SPACE" --piece board --select item@ addItem -- --title "Login rewrite"
 # The address the reader can see in the output above, carried whole. Taken
 # from that run, not from a second one: `run` leaves the output it displayed
 # in $OUT. It is one reference string, used exactly as printed: `get` and
@@ -209,22 +209,22 @@ say "from the piece in front of you, so an address is enough to discover a"
 say "surface you were never told about."
 say "On get and call the address needs no flag at all: it begins with '/' and"
 say "a path never does, so it stands bare in the first position."
-run cf piece call -s "$SPACE" "$EPIC" addChild -- --title "Session cookies"
+run cf call -s "$SPACE" "$EPIC" addChild -- --title "Session cookies"
 say "The item it hands back can be reached from inside itself: its parent holds"
 say "it, and it holds its parent. The position where the author's own type"
 say "re-enters answers with an address, so the whole result is still one value."
 # Read options come before the address: the first positional starts the
 # callable's own command line, so a flag after it belongs to the verb.
-run cf piece call -s "$SPACE" --select item.title "$EPIC" addChild -- --title "CSRF tokens"
+run cf call -s "$SPACE" --select item.title "$EPIC" addChild -- --title "CSRF tokens"
 say "And a caller who names one field is given one field, circle or no circle."
 
 act "5 · Read addresses instead of contents"
 say "An unshaped read follows every link. A bare @ stops at the address."
-run cf piece get -s "$SPACE" "$EPIC" children --select @,title
+run cf get -s "$SPACE" "$EPIC" children --select @,title
 
 act "6 · Ask the same question twice"
 say "The first thing anyone watching says is 'show me that again'."
-run cf piece get -s "$SPACE" "$EPIC" children --select @,title
+run cf get -s "$SPACE" "$EPIC" children --select @,title
 say "The same answer. A projection is a question you may ask twice, which is"
 say "what makes any of the reads above safe to put in a script — as here: the"
 say "child the next acts drive is taken from the answer just shown."
@@ -235,37 +235,37 @@ KID=$(printf '%s' "$OUT" | jq -r '.[] | select(.title=="Session cookies")."$link
 
 act "7 · A verb returns what only the pattern could compute"
 say "The note's timestamp is the pattern's; the caller never supplied one."
-run cf piece call -s "$SPACE" "$EPIC" recordNote -- --body "blocked on the cookie spec"
+run cf call -s "$SPACE" "$EPIC" recordNote -- --body "blocked on the cookie spec"
 
 act "8 · Finishing reports what the caller could not know"
 say "openBelow walks the whole subtree — a caller would need N reads to learn it."
 say "A grandchild is filed first, under the child act 6 handed back, so there"
 say "is a subtree to walk."
-run cf piece call -s "$SPACE" --select item.title "$KID" addChild -- --title "Rotate signing key"
-run cf piece call -s "$SPACE" "$EPIC" finish -- --body "shipping behind a flag"
+run cf call -s "$SPACE" --select item.title "$KID" addChild -- --title "Rotate signing key"
+run cf call -s "$SPACE" "$EPIC" finish -- --body "shipping behind a flag"
 
 act "9 · A verb that declares no result"
 say "archive is Stream<void>: nothing to supply, nothing handed back. The call"
 say "is the verb's name alone, and the invocation settles carrying no result"
 say "at all."
-run cf piece call -s "$SPACE" "$KID" archive
+run cf call -s "$SPACE" "$KID" archive
 say "What it changed is a read away, on the one field the caller never sets —"
 say "and the address may carry the path, so one word names the piece and the"
 say "field in it."
-run cf piece get -s "$SPACE" "$KID/status"
+run cf get -s "$SPACE" "$KID/status"
 
 act "10 · Step back and read the board"
 say "Every change so far was seen one call at a time. One read from the name"
 say "the session started with shows the tree they add up to."
-run cf piece get -s "$SPACE" --piece board items --select title,status,children@
+run cf get -s "$SPACE" --piece board items --select title,status,children@
 say "Act 8 paid one verb call for depth — openBelow walked the subtree. Breadth"
 say "is a read: a filter decides membership before projection, so status picks"
 say "the elements and only title comes back."
-run cf piece get -s "$SPACE" "$EPIC" children --select title --filter '.status == "open"'
+run cf get -s "$SPACE" "$EPIC" children --select title --filter '.status == "open"'
 # The two halves of that question do not combine, and the refusal's own message
 # carries the reason, so nothing restates it here.
 refused "an address suffix under a filter" \
-  cf piece get -s "$SPACE" "$EPIC" children \
+  cf get -s "$SPACE" "$EPIC" children \
   --select @,title --filter '.status == "open"'
 
 act "11 · Ask for something that is not there"
@@ -277,10 +277,10 @@ say "the other half of a surface knowing its own vocabulary."
 # reason, and an act that cannot tell those apart would read the same before and
 # after this capability arrived.
 refused "a field the verb does not declare" \
-  cf piece call -s "$SPACE" --piece board addItem \
+  cf call -s "$SPACE" --piece board addItem \
   '{"title":"Ship it","titel":"typo"}'
 refused "a keyword the projection reader does not recognize" \
-  cf piece get -s "$SPACE" "$EPIC" children \
+  cf get -s "$SPACE" "$EPIC" children \
   --schema '{"type":"array","items":{"type":"object","propertes":{"title":true}}}'
 say "One shape of answer from both ends: what was wrong, the position it sat at,"
 say "what that position accepts, and the nearest thing you probably meant. The"
@@ -288,8 +288,13 @@ say "call was turned down before an invocation was spent."
 
 act "12 · Relate two items — PENDING"
 say "The tracker is a graph, not just a tree: an item can wait on any other."
-pending "cf piece call -s $SPACE <cookies-address> blockOn -- --on <csrf-address>" \
-  "an address cannot yet be a verb argument (references-as-arguments.md)" \
+# The capability landed (#5880): a hand-assembled link envelope dispatches, and
+# the edge that comes back is the target rather than a copy. What this act
+# waits for is the spelling it teaches everywhere else — the address exactly as
+# a read printed it. That string is still refused in an argument position, and
+# a demo that assembled the envelope would be teaching assembly, not carrying.
+pending "cf call -s $SPACE <cookies-address> blockOn -- --on <csrf-address>" \
+  "the address a read emits cannot yet be a verb argument (references-as-arguments.md)" \
   '{
   "status": "settled",
   "result": {
@@ -302,7 +307,7 @@ pending "cf piece call -s $SPACE <cookies-address> blockOn -- --on <csrf-address
 act "13 · One item, two paths, one address — PENDING"
 say "This is what addresses are for: the same item under a parent AND as a blocker,"
 say "and a caller can tell it is one item rather than two copies."
-pending "cf piece get -s $SPACE --piece board items --select title,children@,blockedOn@" \
+pending "cf get -s $SPACE --piece board items --select title,children@,blockedOn@" \
   "needs the edge from act 12" \
   'the same of:fid1:… appears under one item'"'"'s children and another'"'"'s blockedOn'
 

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -254,28 +254,43 @@ V=$($CF piece call --quiet --piece "$KID" $ARGS archive '{}' 2>/dev/null)
 check "settled" "$(echo "$V" | jq -r '.status')" "archive settled"
 check "{}" "$(echo "$V" | jq -c '.result // {}')" "its result is the empty witness"
 
-step "10. GAP: an address cannot be a verb argument"
-# blockOn declares `on: Writable<ItemOutput>` — a reference. `send()` already
-# resolves a native sigil (measured), so the pre-dispatch gate is the only
-# thing refusing this. docs/plans/references-as-arguments.md closes it — that
-# work carries no step number in the verbs plan, which numbers only the read
-# and result layers.
+step "10. A reference argument dispatches; the emitted spelling is the GAP"
+# blockOn declares `on: Writable<ItemOutput>` — a reference. The capability
+# landed with #5880: a link ENVELOPE in that position passes the gate and the
+# edge that comes back is the target, not a copy. What has not landed is the
+# round-trip spelling docs/plans/references-as-arguments.md holds out for —
+# the address exactly as a read emits it. The two halves are asserted apart,
+# so neither can hide behind the other.
 OTHER=$($CF piece get --quiet --piece board items $ARGS \
   --schema '{"type":"array","items":{"$link":true}}' 2>/dev/null |
   jq -r '.[0]["$link"] // empty')
-# Guarded, and matched against the SPECIFIC refusal: an empty address, a
-# renamed verb, or a server hiccup would also exit nonzero, and a probe that
-# reads any failure as "gap still open" is a probe that cannot fail.
 if [ -z "$OTHER" ] || [ -z "${KID:-}" ]; then
   bad "no address to probe blockOn with (item=$OTHER target=${KID:-})"
 else
+  # The capability half: the envelope is assembled from the very address the
+  # read above emitted, so the target is one the session was handed.
+  SIGIL="{\"on\":{\"/\":{\"link@1\":{\"id\":\"${OTHER#/}\"}}}}"
+  BLOCKED=$($CF piece call --quiet --piece "$KID" $ARGS \
+    blockOn "$SIGIL" 2>/dev/null)
+  check "1" "$(echo "$BLOCKED" | jq -r '.result.blockedOnCount // empty')" \
+    "a link envelope names an existing item, and the edge lands"
+  # And the edge is the target rather than a copy: the address under
+  # blockedOn is the address the envelope named.
+  EDGE=$($CF piece get --quiet --piece "$KID" blockedOn $ARGS \
+    --schema '{"type":"array","items":{"$link":true}}' 2>/dev/null |
+    jq -r '.[0]["$link"] // empty')
+  check "$OTHER" "$EDGE" "the edge reads back as the address that was named"
+  # The gap half. Guarded, and matched against the SPECIFIC refusal: an empty
+  # address, a renamed verb, or a server hiccup would also exit nonzero, and a
+  # probe that reads any failure as "gap still open" is a probe that cannot
+  # fail.
   BLOCK_ERR=$($CF piece call --quiet --piece "$KID" $ARGS \
     blockOn "{\"on\":\"$OTHER\"}" 2>&1 >/dev/null)
   BLOCK_RC=$?
   if [ "$BLOCK_RC" = "0" ]; then
-    gap 0 "blockOn with a bare address"
+    gap 0 "blockOn with the address a read emits"
   elif printf '%s' "$BLOCK_ERR" | grep -q "does not match type object"; then
-    gap 1 "blockOn with a bare address (the pre-dispatch gate refuses it)"
+    gap 1 "blockOn with the address a read emits (the gate still refuses the string)"
   else
     bad "blockOn failed for a reason that is not the known refusal: $BLOCK_ERR"
   fi

--- a/tasks/check-verb-session-sync.test.ts
+++ b/tasks/check-verb-session-sync.test.ts
@@ -23,6 +23,7 @@ import {
   demoCommands,
   findViolations,
   joinContinuations,
+  main,
   tokenize,
   WALKTHROUGH_PATH,
   walkthroughCommands,
@@ -59,6 +60,17 @@ describe("check-verb-session-sync", () => {
   describe("joinContinuations", () => {
     it("folds a backslash-continued line into its successor", () => {
       expect(joinContinuations("a \\\nb\nc")).toEqual(["a  b", "c"]);
+    });
+
+    it("keeps a continuation the text ends on", () => {
+      expect(joinContinuations("a \\")).toEqual(["a  "]);
+    });
+  });
+
+  describe("demoCommands", () => {
+    it("extracts a command out of an assignment's substitution", () => {
+      expect(demoCommands(`X=$(cf piece get --piece a title | jq -r .)`))
+        .toEqual([["cf", "piece", "get", "--piece", "a", "title"]]);
     });
   });
 
@@ -144,6 +156,27 @@ describe("check-verb-session-sync", () => {
         "```",
       ].join("\n");
       expect(findViolations(sh, block)).toEqual([]);
+    });
+
+    it("returns 0 through main() for the repository's own files", async () => {
+      const lines: string[] = [];
+      expect(await main({ log: (l) => lines.push(l) })).toBe(0);
+      expect(lines.length).toBe(1);
+    });
+
+    it("returns 1 through main() when the walkthrough composes", async () => {
+      const mdPath = await Deno.makeTempFile({ suffix: ".md" });
+      try {
+        await Deno.writeTextFile(
+          mdPath,
+          "```bash\ncf frobnicate --nothing-like-this\n```\n",
+        );
+        const errors: string[] = [];
+        expect(await main({ mdPath, error: (l) => errors.push(l) })).toBe(1);
+        expect(errors.length).toBeGreaterThanOrEqual(2);
+      } finally {
+        await Deno.remove(mdPath);
+      }
     });
 
     it("still flags the line after an exemption is spent", () => {

--- a/tasks/check-verb-session-sync.test.ts
+++ b/tasks/check-verb-session-sync.test.ts
@@ -1,0 +1,160 @@
+/**
+ * These pin the walkthrough↔demo sync check to the three drift classes it
+ * exists to catch, each of which shipped at least once: a composed command
+ * the demo never runs (one was wrong from the day it was written and
+ * survived four editing passes), an act reference gone stale under
+ * renumbering (twice), and a shape-table row pairing a verb with an act that
+ * no longer shows it.
+ *
+ * The real files are checked too, so the gate's green on this repository is
+ * itself a pinned fact — and so is the check's grip: each class is asserted
+ * by injecting one violation into the real walkthrough and watching it
+ * surface.
+ */
+
+import { beforeAll, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { dirname, fromFileUrl, join } from "@std/path";
+import {
+  actReferences,
+  commandMatches,
+  DEMO_PATH,
+  demoActs,
+  demoCommands,
+  findViolations,
+  joinContinuations,
+  tokenize,
+  WALKTHROUGH_PATH,
+  walkthroughCommands,
+} from "./check-verb-session-sync.ts";
+
+const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
+
+describe("check-verb-session-sync", () => {
+  let sh = "";
+  let md = "";
+  beforeAll(async () => {
+    sh = await Deno.readTextFile(join(REPO_ROOT, DEMO_PATH));
+    md = await Deno.readTextFile(join(REPO_ROOT, WALKTHROUGH_PATH));
+  });
+
+  describe("tokenize", () => {
+    it("keeps a quoted span as one token without its quotes", () => {
+      expect(
+        tokenize(`cf call --select 'item@' addItem -- --title "Login rewrite"`),
+      )
+        .toEqual([
+          "cf",
+          "call",
+          "--select",
+          "item@",
+          "addItem",
+          "--",
+          "--title",
+          "Login rewrite",
+        ]);
+    });
+  });
+
+  describe("joinContinuations", () => {
+    it("folds a backslash-continued line into its successor", () => {
+      expect(joinContinuations("a \\\nb\nc")).toEqual(["a  b", "c"]);
+    });
+  });
+
+  describe("commandMatches", () => {
+    it("returns true across variable and placeholder tokens", () => {
+      expect(commandMatches(
+        tokenize(`cf call "$EPIC" blockOn -- --on "$OTHER"`),
+        tokenize(`cf call <cookies-address> blockOn -- --on <csrf-address>`),
+      )).toBe(true);
+    });
+
+    it("returns false for a differing literal token", () => {
+      expect(commandMatches(
+        tokenize("cf get --piece board items"),
+        tokenize("cf get --piece board title"),
+      )).toBe(false);
+    });
+
+    it("returns false when the token counts differ", () => {
+      expect(commandMatches(
+        tokenize("cf get --piece board"),
+        tokenize("cf get --piece board items"),
+      )).toBe(false);
+    });
+  });
+
+  describe("extraction from the real files", () => {
+    it("collects a double-digit command count from the demo", () => {
+      expect(demoCommands(sh).length).toBeGreaterThanOrEqual(10);
+    });
+
+    it("collects walkthrough commands and act references", () => {
+      expect(walkthroughCommands(md).length).toBeGreaterThanOrEqual(5);
+      expect(actReferences(md).length).toBeGreaterThanOrEqual(5);
+    });
+
+    it("maps every demo act number to a nonempty section", () => {
+      const acts = demoActs(sh);
+      expect(acts.size).toBeGreaterThanOrEqual(13);
+      for (const body of acts.values()) expect(body.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("findViolations", () => {
+    it("returns nothing for the repository's own files", () => {
+      expect(findViolations(sh, md)).toEqual([]);
+    });
+
+    it("catches a composed command the demo does not run", () => {
+      // The historical case: read options drifting behind the `--`, where
+      // they become the verb's arguments and the command stops working.
+      const broken = md.replace(
+        "cf call --piece board --select 'item@' addItem -- \\",
+        "cf call --piece board addItem -- --select 'item@' \\",
+      );
+      expect(broken).not.toEqual(md);
+      const found = findViolations(sh, broken);
+      expect(found.length).toBeGreaterThanOrEqual(1);
+      expect(found[0]).toContain("a command the demo does not run");
+    });
+
+    it("catches an act reference the demo does not have", () => {
+      const stale = md.replace(
+        "act 12, **[blocked]**",
+        "act 99, **[blocked]**",
+      );
+      expect(stale).not.toEqual(md);
+      const found = findViolations(sh, stale);
+      expect(found.some((v) => v.includes("act 99"))).toBe(true);
+    });
+
+    it("catches a shape-table row paired with the wrong act", () => {
+      const mispaired = md.replace("| act 9 |", "| act 3 |");
+      expect(mispaired).not.toEqual(md);
+      expect(findViolations(sh, mispaired).length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("lets an exempted line differ from every demo command", () => {
+      const block = [
+        "```bash",
+        "# not in the demo — synthetic case for this test",
+        "cf frobnicate --nothing-like-this",
+        "```",
+      ].join("\n");
+      expect(findViolations(sh, block)).toEqual([]);
+    });
+
+    it("still flags the line after an exemption is spent", () => {
+      const block = [
+        "```bash",
+        "# not in the demo — covers only the next line",
+        "cf frobnicate --nothing-like-this",
+        "cf also-not-a-command",
+        "```",
+      ].join("\n");
+      expect(findViolations(sh, block).length).toBe(1);
+    });
+  });
+});

--- a/tasks/check-verb-session-sync.ts
+++ b/tasks/check-verb-session-sync.ts
@@ -293,16 +293,31 @@ export function findViolations(shText: string, mdText: string): string[] {
   return violations;
 }
 
-if (import.meta.main) {
-  const shText = await Deno.readTextFile(join(REPO_ROOT, DEMO_PATH));
-  const mdText = await Deno.readTextFile(join(REPO_ROOT, WALKTHROUGH_PATH));
+/** Runs the check and returns the process exit code. The file paths and the
+ * printers are injectable so a test can drive both verdicts; the defaults are
+ * the repository's own files and the console. */
+export async function main(deps: {
+  shPath?: string;
+  mdPath?: string;
+  log?: (line: string) => void;
+  error?: (line: string) => void;
+} = {}): Promise<number> {
+  const log = deps.log ?? console.log;
+  const error = deps.error ?? console.error;
+  const shText = await Deno.readTextFile(
+    deps.shPath ?? join(REPO_ROOT, DEMO_PATH),
+  );
+  const mdText = await Deno.readTextFile(
+    deps.mdPath ?? join(REPO_ROOT, WALKTHROUGH_PATH),
+  );
   const violations = findViolations(shText, mdText);
   if (violations.length > 0) {
-    console.error(`verb-session sync: ${violations.length} violation(s)\n`);
-    for (const violation of violations) console.error(`  ${violation}`);
-    Deno.exit(1);
+    error(`verb-session sync: ${violations.length} violation(s)\n`);
+    for (const violation of violations) error(`  ${violation}`);
+    return 1;
   }
-  console.log(
-    "Walkthrough commands and act references all match the demo.",
-  );
+  log("Walkthrough commands and act references all match the demo.");
+  return 0;
 }
+
+if (import.meta.main) Deno.exit(await main());

--- a/tasks/check-verb-session-sync.ts
+++ b/tasks/check-verb-session-sync.ts
@@ -1,0 +1,308 @@
+#!/usr/bin/env -S deno run --allow-read
+/**
+ * Fails when the verb-session walkthrough drifts from the demo that runs it.
+ *
+ * The walkthrough (`docs/common/verb-session-walkthrough.md`) may QUOTE
+ * commands but never compose them: every `cf` line in one of its bash blocks
+ * must be a command `packages/cli/integration/verb-session-demo.sh` actually
+ * runs, or sit under a `# not in the demo` comment saying why it cannot be.
+ * Nothing executes a bash block in a document, so a composed example can be
+ * wrong from the day it is written and stay wrong through every editing pass
+ * — one shipped that way and survived four of them. The same document names
+ * demo acts by number, and those references have gone stale twice as acts
+ * were inserted. Both failure classes are mechanical to detect, and this is
+ * where they are detected.
+ *
+ * Three checks:
+ * - Every walkthrough `cf` command matches a demo command, token for token,
+ *   after normalization: the demo's `-s "$SPACE"` pair is dropped (the
+ *   walkthrough's examples run in a configured shell), quotes are stripped,
+ *   and a token holding a `$variable` or a `<placeholder>` matches anything.
+ * - Every "act N" reference names an act the demo has.
+ * - Every row of the verb shape table pairs its verbs with acts whose demo
+ *   text actually mentions them.
+ *
+ * Usage: deno run --allow-read ./tasks/check-verb-session-sync.ts
+ */
+
+import { dirname, fromFileUrl, join } from "@std/path";
+
+const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
+export const DEMO_PATH = "packages/cli/integration/verb-session-demo.sh";
+export const WALKTHROUGH_PATH = "docs/common/verb-session-walkthrough.md";
+
+/** The comment that exempts the next `cf` line in a walkthrough bash block. */
+const EXEMPTION = /^#.*not in the demo/;
+
+/** Joins backslash-continued lines into one logical line each. */
+export function joinContinuations(text: string): string[] {
+  const out: string[] = [];
+  let held = "";
+  for (const raw of text.split("\n")) {
+    if (raw.endsWith("\\")) {
+      held += raw.slice(0, -1) + " ";
+      continue;
+    }
+    out.push(held + raw);
+    held = "";
+  }
+  if (held !== "") out.push(held);
+  return out;
+}
+
+/** Splits a shell-ish line into tokens, stripping the quotes that grouped
+ * them. A quoted span keeps its spaces; nothing else shell does is modeled,
+ * because the two files under check use nothing else. */
+export function tokenize(line: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let started = false;
+  let quote: string | null = null;
+  for (const ch of line) {
+    if (quote !== null) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (ch === " " || ch === "\t") {
+      if (started) tokens.push(current);
+      current = "";
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (started) tokens.push(current);
+  return tokens;
+}
+
+/** A token that stands for "whatever the session had here": a shell variable
+ * on the demo side, an angle-bracket placeholder on the walkthrough side. */
+function isWildcard(token: string): boolean {
+  return token.includes("$") || (token.startsWith("<") && token.endsWith(">"));
+}
+
+/** Drops the demo's per-command space flag; the walkthrough's examples run in
+ * a shell where the space is already configured. */
+function dropSpaceFlag(tokens: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    if (tokens[i] === "-s") {
+      i++;
+      continue;
+    }
+    out.push(tokens[i]!);
+  }
+  return out;
+}
+
+/** Extracts the `cf …` span from a logical line, stopping where the command
+ * does: a pipe or the closing of a substitution. Returns null when the line
+ * carries no command. */
+function extractCf(line: string): string | null {
+  const match = line.match(/(?:^|[\s(])((?:cf) .*)$/);
+  if (!match) return null;
+  let span = match[1]!;
+  for (const stop of ["|", ")"]) {
+    const at = span.indexOf(stop);
+    if (at !== -1) span = span.slice(0, at);
+  }
+  return span.trim();
+}
+
+/** Every command the demo runs, as normalized token lists: `run`, `refused`,
+ * and `broken` lines execute theirs, and a `pending` line's first argument is
+ * the command it promises. */
+export function demoCommands(shText: string): string[][] {
+  const commands: string[][] = [];
+  for (const line of joinContinuations(shText)) {
+    const trimmed = line.trim();
+    const tokens = tokenize(trimmed);
+    if (tokens.length === 0) continue;
+    const head = tokens[0]!;
+    if (head === "run" || head === "refused" || head === "broken") {
+      const at = tokens.indexOf("cf");
+      if (at !== -1) commands.push(dropSpaceFlag(tokens.slice(at)));
+      continue;
+    }
+    if (head === "pending" && tokens.length > 1) {
+      commands.push(dropSpaceFlag(tokenize(tokens[1]!)));
+      continue;
+    }
+    if (/=\$\(\s*cf /.test(trimmed)) {
+      const span = extractCf(trimmed);
+      if (span) commands.push(dropSpaceFlag(tokenize(span)));
+    }
+  }
+  return commands;
+}
+
+/** Every `cf` command a walkthrough bash block shows, with its 1-indexed
+ * line, minus the ones a `# not in the demo` comment exempts. */
+export function walkthroughCommands(
+  mdText: string,
+): Array<{ tokens: string[]; line: number }> {
+  const out: Array<{ tokens: string[]; line: number }> = [];
+  const lines = mdText.split("\n");
+  let inBash = false;
+  let exempt = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (!inBash) {
+      if (line.startsWith("```bash")) inBash = true;
+      continue;
+    }
+    if (line.startsWith("```")) {
+      inBash = false;
+      exempt = false;
+      continue;
+    }
+    if (EXEMPTION.test(line.trim())) {
+      exempt = true;
+      continue;
+    }
+    let logical = line;
+    while (logical.endsWith("\\") && i + 1 < lines.length) {
+      logical = logical.slice(0, -1) + " " + lines[++i]!;
+    }
+    const span = extractCf(logical);
+    if (!span) continue;
+    if (exempt) {
+      exempt = false;
+      continue;
+    }
+    out.push({ tokens: tokenize(span), line: i + 1 });
+  }
+  return out;
+}
+
+/** Whether one walkthrough command is one of the demo's, token for token,
+ * with a wildcard on either side matching anything. */
+export function commandMatches(walk: string[], demo: string[]): boolean {
+  if (walk.length !== demo.length) return false;
+  return walk.every((token, i) =>
+    isWildcard(token) || isWildcard(demo[i]!) || token === demo[i]
+  );
+}
+
+/** The demo's acts: number → the text of that act's section. */
+export function demoActs(shText: string): Map<number, string> {
+  const acts = new Map<number, string>();
+  let current: number | null = null;
+  let held: string[] = [];
+  const flush = () => {
+    if (current !== null) acts.set(current, held.join("\n"));
+    held = [];
+  };
+  for (const line of shText.split("\n")) {
+    const match = line.match(/^act "(\d+) ·/);
+    if (match) {
+      flush();
+      current = Number(match[1]);
+    }
+    if (current !== null) held.push(line);
+  }
+  flush();
+  return acts;
+}
+
+/** Every "act N" / "acts N and M" reference in the walkthrough. */
+export function actReferences(
+  mdText: string,
+): Array<{ act: number; line: number }> {
+  const out: Array<{ act: number; line: number }> = [];
+  const lines = mdText.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    for (const match of lines[i]!.matchAll(/\bacts? (\d+)(?: and (\d+))?/g)) {
+      out.push({ act: Number(match[1]), line: i + 1 });
+      if (match[2]) out.push({ act: Number(match[2]), line: i + 1 });
+    }
+  }
+  return out;
+}
+
+/** The verb shape table's rows: the backticked verbs in the first cell and
+ * the act numbers in the last. */
+export function shapeTableRows(
+  mdText: string,
+): Array<{ verbs: string[]; acts: number[]; line: number }> {
+  const out: Array<{ verbs: string[]; acts: number[]; line: number }> = [];
+  const lines = mdText.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (!line.startsWith("| `")) continue;
+    const cells = line.split("|").map((cell) => cell.trim());
+    const last = cells[cells.length - 2] ?? "";
+    const acts = [...last.matchAll(/\bact[s]? (\d+)(?: and (\d+))?/g)]
+      .flatMap((m) => m[2] ? [Number(m[1]), Number(m[2])] : [Number(m[1])]);
+    if (acts.length === 0) continue;
+    const verbs = [...(cells[1] ?? "").matchAll(/`(\w+)`/g)].map((m) => m[1]!);
+    if (verbs.length > 0) out.push({ verbs, acts, line: i + 1 });
+  }
+  return out;
+}
+
+/** Every way the two files disagree, as printable findings. */
+export function findViolations(shText: string, mdText: string): string[] {
+  const violations: string[] = [];
+  const demo = demoCommands(shText);
+  for (const { tokens, line } of walkthroughCommands(mdText)) {
+    if (!demo.some((cmd) => commandMatches(tokens, cmd))) {
+      violations.push(
+        `${WALKTHROUGH_PATH}:${line} shows a command the demo does not run: ` +
+          `\`${tokens.join(" ")}\` — quote a demo line, or mark the line ` +
+          `with \`# not in the demo\` and a reason`,
+      );
+    }
+  }
+  const acts = demoActs(shText);
+  for (const { act, line } of actReferences(mdText)) {
+    if (!acts.has(act)) {
+      violations.push(
+        `${WALKTHROUGH_PATH}:${line} names act ${act}, which the demo does ` +
+          `not have`,
+      );
+    }
+  }
+  for (const { verbs, acts: rowActs, line } of shapeTableRows(mdText)) {
+    for (const act of rowActs) {
+      const body = acts.get(act);
+      if (body === undefined) continue; // already reported above
+      if (!verbs.some((verb) => body.includes(verb))) {
+        violations.push(
+          `${WALKTHROUGH_PATH}:${line} pairs ${verbs.join("/")} with act ` +
+            `${act}, whose demo text mentions none of them`,
+        );
+      }
+    }
+    for (const verb of verbs) {
+      if (!rowActs.some((act) => (acts.get(act) ?? "").includes(verb))) {
+        violations.push(
+          `${WALKTHROUGH_PATH}:${line} lists \`${verb}\` under acts ` +
+            `${rowActs.join(", ")}, and none of those acts mentions it`,
+        );
+      }
+    }
+  }
+  return violations;
+}
+
+if (import.meta.main) {
+  const shText = await Deno.readTextFile(join(REPO_ROOT, DEMO_PATH));
+  const mdText = await Deno.readTextFile(join(REPO_ROOT, WALKTHROUGH_PATH));
+  const violations = findViolations(shText, mdText);
+  if (violations.length > 0) {
+    console.error(`verb-session sync: ${violations.length} violation(s)\n`);
+    for (const violation of violations) console.error(`  ${violation}`);
+    Deno.exit(1);
+  }
+  console.log(
+    "Walkthrough commands and act references all match the demo.",
+  );
+}


### PR DESCRIPTION
## Why

Three threads, one file family. Follow-up to #5905; the spellings are #5899's,
the capability witness is #5880's.

**The demo taught the alias where the honest names now exist.** #5899 mounted
`cf get`/`cf set`/`cf call`; the demo still spelled every read and call
`cf piece …`. It now speaks the top-level names, with `piece` keeping what is
genuinely about pieces (`new`, `verbs`) and slugs keeping `--piece`. The full
session against a live toolshed is the first completed-operation evidence the
new mounts work — until now nothing exercised them past surface comparison.
The gaps harness deliberately stays on the `piece` spellings, so the two
scripts exercise both mounts every run, and a regression in one mount diffs
against the other instead of masquerading as a gap event.

**The harness's blockOn probe was half-stale.** #5880 landed the capability it
named as a gap — under the envelope spelling. Step 10 splits: the envelope
dispatch and the edge-is-the-target readback are asserted as capabilities
(the envelope assembled from the very address the read emitted), and the gap
narrows to its true remainder — the address a read emits, fed back as
written, is still refused. Nothing in the arc's honesty checks witnessed
#5880 before this. The demo's pending act 12 carries the same distinction.

**The walkthrough becomes a quoting document, mechanically enforced.** A
composed example shipped broken and survived four editing passes; act
references went stale twice. Every `cf` line in a walkthrough bash block is
now a line the demo runs — or carries a `# not in the demo` reason — and
every act reference names a real act, enforced by the new
`deno task check-verb-session-sync` CI gate. Its tests inject each historical
drift class into the real walkthrough and watch it surface.

## What Changed

- Demo: `cf get`/`cf call` throughout; pending act 12's comment names the
  narrowed gap.
- Harness: step 10 splits into two capability checks plus the narrowed gap
  probe (28 passed / 0 failed / 1 gap open).
- Walkthrough: quotes-only contract stated and applied; composed examples
  rewritten to demo lines or exempted with reasons.
- New gate: `tasks/check-verb-session-sync.ts` (+ tests), `deno.jsonc` task,
  `deno.yml` step, AGENTS.md gate-list entry.

## Test plan

Demo exits 0 against a local toolshed with stdin held open for the whole run,
zero claim-counter failures, every line in the new spelling. Harness green
with the new step-10 assertions passing and the narrowed gap open. Checker
green on the real files and red on all three injected drift classes (born-
broken command, stale act number, mispaired shape row). Repo-wide
`deno fmt --check`, `deno lint` on the new files, `check-docs`,
`check-skill-facts`, `check-conflict-markers` all pass, re-verified after
rebasing over #5806's walkthrough changes — the checker's first encounter
with a third party's edits to the file it guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

