### PR TITLE
fix(dashboard): ignore stale CPUs in benchmark headline

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -300,7 +300,7 @@ surveillance tool.
 | prod errors | SigNoz trace error rate for one service (errored spans / all spans): last-12h headline, with a per-hour sparkline over the retained trace history (~2 weeks) and the last-12h slice that feeds the headline highlighted. Scoped to `PROD_SERVICE` — the same SigNoz holds staging and one-off perf runs, whose rates are not production's. Gray (not red) when SigNoz is unreachable. Pops out to the SigNoz logs explorer | `SIGNOZ_URL`, `SIGNOZ_API_KEY`; optional `PROD_SERVICE`, `SIGNOZ_UI_URL` for the pop-out |
 | cloud spend | BigQuery billing export, after credits, projected to month-end from the available part of a 14-day daily-cost window early in the month. The header shows actual MTD spend. The highlighted part of the 45-day chart shows the days used for the estimate | `GCP_BILLING_TABLE` (+ Workload Identity, or `GCP_SA_KEY` locally), optional `GCP_DAILY_BUDGET` |
 | ci spend | GitHub Actions and Blacksmith billing, projected to month-end in USD. Each configured source gets a line in the shared 45-day chart and an MTD label. The header shows combined MTD spend. A source that cannot be read shows `$???`, while the headline remains a lower bound from the sources that did respond. A source whose feed stopped being written more than four days ago counts as one that cannot be read, rather than charting the days since as $0. A month whose usage report cannot be read breaks that source's line across those days rather than charting them as $0 | either or both of `GH_TOKEN` (with org billing read) and `BLACKSMITH_API_TOKEN`; optional `GH_BILLING_ORG`, `BLACKSMITH_ORG`, `CI_MONTHLY_BUDGET` |
-| benchmarks | a scale-invariant index of benchmark performance on `benchmarks.yml` main runs, trended over ~45 days (each run vs the last, geometric mean of per-benchmark changes, so every benchmark weighs the same, divided by the same run's machine calibration so a busy host does not read as a code change): red when the most recent run failed or produced no valid data (the main signal), orange only on a broad across-the-board rise. Adding or removing a benchmark is a non-event. Drills through to the per-benchmark history | `GH_TOKEN` |
+| benchmarks | a scale-invariant index of benchmark performance on `benchmarks.yml` main runs, trended over ~45 days (each run vs the last, geometric mean of per-benchmark changes, so every benchmark weighs the same, divided by the same run's machine calibration so a busy host does not read as a code change): red when the most recent run failed or produced no valid data (the main signal), orange only on a broad across-the-board rise from a CPU measured in the preceding twelve hours. Adding or removing a benchmark is a non-event. Drills through to the per-benchmark history | `GH_TOKEN` |
 | performance history → `/bench?view=runtime` | runtime benchmark trends, labs or loom CI duration history, and a detailed CI run Gantt. Historical views support windows from 1 through 45 days, date axes, and duration sorting. CI includes end-to-end workflow time, every job, and slowest-shard group lines | `GH_TOKEN` |
 | model spend | OpenAI + Anthropic + OpenRouter usage APIs. Headline is the projected full-month spend (extrapolated from the recent daily rate, spilling into last month when this month is under two weeks old), summed across providers. OpenAI and Anthropic (which expose per-day cost) are charted as one line each over ~45 days, with a recent daily-rate slice highlighted and each line's MTD in the right gutter; OpenRouter (monthly total only, abbreviated "OR") is folded into the totals. The subtitle is the bullet-separated key (`OpenAI • Anthropic • OR $0`); the combined MTD sits in the header (the `aside` slot); the span the chart covers is in its bottom-left corner (the `duration` slot). A provider we can't read shows `$???` and drops the tile to gray, but the rest still chart and total; a provider whose cost report stopped being written more than four days ago is one of those | any of `OPENAI_ADMIN_KEY`, `ANTHROPIC_ADMIN_KEY`, `OPENROUTER_KEY`; optional `MODEL_MONTHLY_BUDGET` |
 | discord online | Discord gateway presence, team vs visitors over time | `DISCORD_BOT_TOKEN`, `DISCORD_GUILD_ID` (Server Members + Presence intents) |
@@ -643,8 +643,9 @@ Notes:
   benchmark barely registers, however slow that benchmark is. The drill-down
   covers individual benchmarks. A summed total would instead be dominated by
   the few slowest benchmarks. Each CPU has its own colored line. The headline
-  shows the largest established CPU trend. A second line names how many
-  benchmarks the latest run measured and the highlighted window when applicable.
+  shows the largest established trend among CPUs measured in the preceding
+  twelve hours. A second line names how many benchmarks the latest run measured
+  and the highlighted window when applicable.
   **Red** marks the **most recent run failing outright, or finishing green on CI
   with no readable benchmark data**. A successful run with no usable output is
   treated as failed. Either failure takes over that second line, in place of the
@@ -664,14 +665,17 @@ Notes:
   color may be about to move; the runs that have finished still set it. The red
   state reads the workflow-run list and the latest run's cached result. It
   therefore fires when the artifacts cannot be read. **Orange** means at least
-  one CPU index is **trending up** past 5%. Each CPU trend uses the runs in the
-  last `BENCH_TREND_MAX_AGE_DAYS` or the newest `BENCH_TREND_MIN_RUNS`,
-  whichever set is larger. This matches the window rule used for the CI
-  duration median. The corresponding line still spans the full ~45 days. Its
-  trend window is brighter. Green means every established CPU is flat or
-  falling. A benchmark runs either to a fixed time budget or for a fixed number
-  of iterations, and neither is a measurement. The run's wall clock therefore
-  barely moves with performance. The per-operation times do move, so the tile
+  one CPU measured in the preceding twelve hours has an index **trending up**
+  past 5%. Each CPU trend uses the runs in the last
+  `BENCH_TREND_MAX_AGE_DAYS` or the newest `BENCH_TREND_MIN_RUNS`, whichever set
+  is larger. This matches the window rule used for the CI duration median. The
+  corresponding line still spans the full ~45 days. Its trend window is
+  brighter. Green means every eligible established CPU is flat or falling. If
+  no CPU has been measured in the preceding twelve hours, the tile reports
+  **no recent benchmark data**. A benchmark runs either to a fixed time budget
+  or for a fixed number of iterations, and neither is a measurement. The run's
+  wall clock therefore barely moves with performance. The per-operation times
+  do move, so the tile
   trends those values instead. Because the index
   comes from artifacts, the tile turns gray when no in-window run has readable
   data and the latest run is neither failed nor empty. A collection leaves its

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -671,14 +671,14 @@ Notes:
   is larger. This matches the window rule used for the CI duration median. The
   corresponding line still spans the full ~45 days. Its trend window is
   brighter. Green means every eligible established CPU is flat or falling. If
-  no CPU has been measured in the preceding twelve hours, the tile reports
-  **no recent benchmark data**. A benchmark runs either to a fixed time budget
-  or for a fixed number of iterations, and neither is a measurement. The run's
-  wall clock therefore barely moves with performance. The per-operation times
-  do move, so the tile
-  trends those values instead. Because the index
-  comes from artifacts, the tile turns gray when no in-window run has readable
-  data and the latest run is neither failed nor empty. A collection leaves its
+  no CPU has been measured in the preceding twelve hours, the tile turns gray
+  and reports **no recent benchmark data**. A benchmark runs either to a fixed
+  time budget or for a fixed number of iterations, and neither is a
+  measurement. The run's wall clock therefore barely moves with performance.
+  The per-operation times do move, so the tile trends those values instead.
+  Because the index comes from artifacts, the tile also turns gray when no
+  in-window run has readable data and the latest run is neither failed nor
+  empty. A collection leaves its
   last completed color and values in place until the workflow status and
   artifact refresh have both settled. A collection that takes more than a
   minute says **refresh still pending** without changing that color. A newly

--- a/packages/dashboard/config.ts
+++ b/packages/dashboard/config.ts
@@ -38,6 +38,10 @@ export const DUR_MAX_AGE_HOURS = 6;
 // several distinct days, so the recent slice is measured in days, not hours.
 export const BENCH_TREND_MIN_RUNS = 20;
 export const BENCH_TREND_MAX_AGE_DAYS = 14;
+// A processor contributes to the benchmark headline only while the collection
+// has measured it recently. This keeps an old processor-specific regression
+// from setting the tile after the runner group has moved to other processors.
+export const BENCH_HEADLINE_MAX_AGE_HOURS = 12;
 // The trend reads one run per bucket of this length, matching the
 // benchmarks.yml cron. The collection keeps every run, for the drill-down's
 // shortest view; the trend does not want that resolution, because runs closer

--- a/packages/dashboard/tiles/benchmark.test.ts
+++ b/packages/dashboard/tiles/benchmark.test.ts
@@ -25,6 +25,7 @@ import {
   availableGeneratedCpuColor,
   benchmark,
   type BenchmarkFetchProgress,
+  benchmarkHeadlineCandidates,
   benchmarkHistoryCheckResponse,
   benchmarkFailureLabel,
   benchmarkHistoryProgressResponse,
@@ -62,8 +63,9 @@ if (Deno.env.get("DASHBOARD_CACHE_DIR") === undefined) {
 
 const DAY = 86_400_000;
 const HOUR = 3_600_000;
-// Midnight UTC yesterday plus two hours keeps test data inside the live window.
-const BASE = Math.floor(Date.now() / DAY) * DAY - DAY + 2 * HOUR;
+// One full hour before the current hour keeps each common newest successful
+// fixture inside the headline window.
+const BASE = Math.floor(Date.now() / HOUR) * HOUR - HOUR;
 const COLLECTION_BUCKET = ciHistoryBucketMs(CI_HISTORY_MIN_DAYS);
 const SAMPLED_BASE = Math.floor(BASE / COLLECTION_BUCKET) *
     COLLECTION_BUCKET +
@@ -1231,6 +1233,39 @@ Deno.test("benchmark: runs inside one trend bucket are one sample, newest kept",
   );
 });
 
+Deno.test("benchmark: the headline considers CPUs measured in the last 12 hours", () => {
+  const now = Date.UTC(2026, 7, 17, 12);
+  const hours = (count: number) => count * HOUR;
+  const stale = { name: "stale", points: [{ at: now - hours(12) - 1 }] };
+  const boundary = { name: "boundary", points: [{ at: now - hours(12) }] };
+  const recent = {
+    name: "recent",
+    points: [{ at: now - hours(20) }, { at: now - hours(1) }],
+  };
+  const future = { name: "future", points: [{ at: now + 1 }] };
+
+  assertEquals(
+    benchmarkHeadlineCandidates([stale, boundary, recent, future], now),
+    [boundary, recent],
+  );
+});
+
+Deno.test("benchmark: the tile reports when every CPU measurement is stale", async () => {
+  await withTotals(
+    Array.from({ length: 8 }, (_, day) => ({
+      id: 95_000 + day,
+      at: BASE - (8 - day) * DAY,
+      total: (5 + day) * 1e6,
+    })),
+    async () => {
+      const tile = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+      assertEquals(tile.status, "unknown");
+      assertEquals(tile.value, "—");
+      assertEquals(tile.sub, "no recent benchmark data");
+    },
+  );
+});
+
 Deno.test("benchmark: a red run's measurements still reach the trend", async () => {
   // Eight daily runs whose one benchmark climbs. Three of them are red, because
   // `deno bench` exits non-zero when any single benchmark throws — having
@@ -1477,7 +1512,7 @@ Deno.test("benchmark: returns a failed rising view after the run list settles", 
 });
 
 Deno.test("benchmark: a failed most-recent run turns the tile red over its last good total", async () => {
-  const at = (d: number) => SAMPLED_BASE - (7 - d) * DAY;
+  const at = (d: number) => SAMPLED_BASE - (6 - d) * DAY;
   // The last successful run totals 7ms; the failed head has no artifact to headline.
   await withTotals([
     ...Array.from({ length: 7 }, (_, d) => ({ id: 9_200 + d, at: at(d), total: d === 6 ? 7e6 : 5e6 })),
@@ -1492,7 +1527,7 @@ Deno.test("benchmark: a failed most-recent run turns the tile red over its last 
 });
 
 Deno.test("benchmark: consecutive failures are counted on the tile", async () => {
-  const at = (d: number) => SAMPLED_BASE - (7 - d) * DAY;
+  const at = (d: number) => SAMPLED_BASE - (6 - d) * DAY;
   // Seven good days, then three failures in a row.
   await withTotals([
     ...Array.from({ length: 7 }, (_, d) => ({ id: 9_310 + d, at: at(d), total: 5e6 })),
@@ -1513,7 +1548,7 @@ Deno.test("benchmark: consecutive failures are counted on the tile", async () =>
 Deno.test("benchmark: a failure outranks a rising trend", async () => {
   // Eight days whose one benchmark climbs from 5 to 12 ms, which alone reads orange,
   // and then a failed run.
-  const at = (d: number) => SAMPLED_BASE - (8 - d) * DAY;
+  const at = (d: number) => SAMPLED_BASE - (7 - d) * DAY;
   await withTotals([
     ...Array.from({ length: 8 }, (_, d) => ({ id: 9_330 + d, at: at(d), total: (5 + d) * 1e6 })),
     { id: 9_398, at: SAMPLED_BASE + HOUR, conclusion: "failure" },
@@ -1721,7 +1756,7 @@ Deno.test("benchmark: a run under way is a badge, not a verdict", async () => {
 });
 
 Deno.test("benchmark: a cancelled most-recent run is not a failure", async () => {
-  const at = (d: number) => SAMPLED_BASE - (7 - d) * DAY;
+  const at = (d: number) => SAMPLED_BASE - (6 - d) * DAY;
   await withTotals([
     ...Array.from({ length: 7 }, (_, d) => ({ id: 9_400 + d, at: at(d), total: d === 6 ? 7e6 : 5e6 })),
     { id: 9_499, at: SAMPLED_BASE + HOUR, conclusion: "cancelled" },
@@ -1770,7 +1805,9 @@ Deno.test("benchmark: a run that finished green but produced no valid data reads
   // Seven good days, then a run that passes CI but whose artifact carries no usable
   // measurement. It ran and made nothing, so it is as good as failed: red, over the
   // last run whose total could be read.
-  const at = (d: number) => SAMPLED_BASE - (7 - d) * DAY;
+  const at = (d: number) => d === 7
+    ? SAMPLED_BASE + HOUR
+    : SAMPLED_BASE - (6 - d) * DAY;
   const artifacts: Api["artifacts"] = {};
   const zips: Api["zips"] = {};
   const runs: GhRun[] = [];
@@ -2227,7 +2264,7 @@ Deno.test("benchmark: the tile indexes every benchmark equally; the drill-down k
   });
 });
 
-Deno.test("benchmark: CPU lines split across large gaps and use distinct colors", async () => {
+Deno.test("benchmark: stale CPU trends stay out of the headline while their lines remain", async () => {
   const directory = await Deno.makeTempDir({ prefix: "benchmark-cpus-" });
   const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
   Deno.env.set("DASHBOARD_CACHE_DIR", directory);
@@ -2327,8 +2364,11 @@ Deno.test("benchmark: CPU lines split across large gaps and use distinct colors"
         `./benchmark.ts?cpus=${crypto.randomUUID()}`
       );
       const tile = await isolated.benchmark.collect(ctx({ GH_TOKEN: "t" }));
-      assertEquals(tile.status, "warn");
-      assertStringIncludes(tile.value ?? "", "▲");
+      // The Apple line rises, but its last point is a day old. The recent
+      // one-point CPU lines set the headline and verdict while every line stays
+      // in the chart.
+      assertEquals(tile.status, "good");
+      assertStringIncludes(tile.value ?? "", "new");
       assertStringIncludes(tile.extra ?? "", ">1 benchmark</div>");
       assert(!/\bCPUs?\b/.test(tile.extra ?? ""));
       assert(!(tile.extra ?? "").includes('class="swatch"'));

--- a/packages/dashboard/tiles/benchmark.test.ts
+++ b/packages/dashboard/tiles/benchmark.test.ts
@@ -3140,10 +3140,9 @@ Deno.test("benchmark: a rejected token grays out as an auth failure", async () =
   });
 });
 
-Deno.test("benchmark: a failed fetch keeps the last-known trend grayed instead of blanking", async () => {
-  // Was online and cached two runs, then the source goes unreachable. The tile keeps
-  // its last-known trend — grayed, with the reason — rather than dropping to a bare
-  // dash, and would recover on the next collection once the source is back.
+Deno.test("benchmark: a failed fetch keeps a stale cached trend grayed", async () => {
+  // Cache two runs older than the headline window, then make the source unreachable.
+  // The tile keeps the cached trend and chart gray with the reason.
   const directory = await Deno.makeTempDir({ prefix: "benchmark-offline-" });
   const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
   const originalFetch = globalThis.fetch;
@@ -3151,7 +3150,7 @@ Deno.test("benchmark: a failed fetch keeps the last-known trend grayed instead o
   Deno.env.set("DASHBOARD_CACHE_DIR", directory);
   const key = "packages/a/x.bench.ts";
   const healthy = serve({
-    pages: { 1: [ghRun(7_701, BASE - DAY), ghRun(7_702, BASE)] },
+    pages: { 1: [ghRun(7_701, BASE - 2 * DAY), ghRun(7_702, BASE - DAY)] },
     artifacts: {
       7_701: [{ id: 77_010, name: "bench-results", expired: false }],
       7_702: [{ id: 77_020, name: "bench-results", expired: false }],
@@ -3169,8 +3168,9 @@ Deno.test("benchmark: a failed fetch keeps the last-known trend grayed instead o
       return Promise.resolve(healthy(url));
     }) as typeof fetch;
     const online = await isolated.benchmark.collect(ctx({ GH_TOKEN: token }));
-    assertEquals(online.status, "good");
-    assertStringIncludes(online.value ?? "", "new"); // two runs, under a week -> "new"
+    assertEquals(online.status, "unknown");
+    assertEquals(online.value, "—");
+    assertEquals(online.sub, "no recent benchmark data");
 
     // The source becomes unreachable on the next collection.
     globalThis.fetch = (() =>
@@ -3178,10 +3178,10 @@ Deno.test("benchmark: a failed fetch keeps the last-known trend grayed instead o
         new TypeError("error sending request for url (https://api.github.com/...)"),
       )) as typeof fetch;
     const offline = await isolated.benchmark.collect(ctx({ GH_TOKEN: token }));
-    assertEquals(offline.status, "unknown"); // grayed — never a stale red or green
+    assertEquals(offline.status, "unknown");
     assertEquals(offline.sub, "source unreachable");
-    assertStringIncludes(offline.value ?? "", "new"); // kept the last-known trend
-    assert((offline.value ?? "") !== "—"); // not blanked to a bare dash
+    assertStringIncludes(offline.value ?? "", "new");
+    assertStringIncludes(offline.extra ?? "", "<svg");
   } finally {
     globalThis.fetch = originalFetch;
     if (previousCacheDirectory === undefined) {

--- a/packages/dashboard/tiles/benchmark.ts
+++ b/packages/dashboard/tiles/benchmark.ts
@@ -1151,8 +1151,7 @@ function benchmarkIndexView(
     );
   }
   const headlineCandidates = benchmarkHeadlineCandidates(indices, now);
-  if (!headlineCandidates.length) {
-    if (offline) return benchmarkUnavailable(offline, aside);
+  if (!headlineCandidates.length && !offline) {
     if (failed) {
       return {
         ...benchmarkDrill,
@@ -1165,10 +1164,13 @@ function benchmarkIndexView(
     }
     return benchmarkUnavailable("no recent benchmark data", aside);
   }
-  const established = headlineCandidates.filter((series) =>
+  const displayCandidates = headlineCandidates.length
+    ? headlineCandidates
+    : indices;
+  const established = displayCandidates.filter((series) =>
     series.trend.label !== "new"
   );
-  const headlinePool = established.length ? established : headlineCandidates;
+  const headlinePool = established.length ? established : displayCandidates;
   const headline = headlinePool.reduce((
     worst,
     series,

--- a/packages/dashboard/tiles/benchmark.ts
+++ b/packages/dashboard/tiles/benchmark.ts
@@ -8,9 +8,10 @@
  * materially changing the run's wall-clock time.
  *
  * Each processor has its own colored line, and the headline shows the largest
- * established trend. Orange means at least one processor trends up. Green
- * means every established processor stays flat or falls. Red means the most
- * recent run failed, or finished successfully without readable benchmark data.
+ * established trend among processors measured in the last twelve hours.
+ * Orange means at least one of those processors trends up. Green means every
+ * eligible established processor stays flat or falls. Red means the most recent
+ * run failed, or finished successfully without readable benchmark data.
  * A tile in the failed state drops its benchmark count and window span and
  * names the failure in their place: how long ago the benchmarks last worked,
  * and how many runs have failed since. A run under way puts a "running" badge
@@ -92,6 +93,7 @@ import {
   SPARK_FADE,
 } from "../lib.ts";
 import {
+  BENCH_HEADLINE_MAX_AGE_HOURS,
   BENCH_TREND_BUCKET_MS,
   BENCH_TREND_MAX_AGE_DAYS,
   BENCH_TREND_MIN_RUNS,
@@ -923,6 +925,15 @@ interface BenchmarkCpuIndex {
   trend: ReturnType<typeof benchmarkTrend>;
 }
 
+export function benchmarkHeadlineCandidates<
+  T extends { points: { at: number }[] },
+>(indices: T[], now: number): T[] {
+  const cutoff = now - BENCH_HEADLINE_MAX_AGE_HOURS * 60 * 60_000;
+  return indices.filter((series) =>
+    series.points.some((point) => point.at >= cutoff && point.at <= now)
+  );
+}
+
 type CpuBenchmarkRun = CachedBenchmarkRun & { cpu: string };
 
 // One run per trend bucket on one processor, newest kept, oldest first. The
@@ -1080,11 +1091,12 @@ const RUNNING_BADGE =
 // Each processor has its own index and line. Every index starts at one and
 // changes only between runs on that processor. Hardware changes therefore
 // never become benchmark changes. The headline shows the largest established
-// trend. Orange means any processor trends up. Red means the most recent run
-// failed or produced no readable data. The line under the headline then dates
-// the outage instead of counting the benchmarks measured. `offline` names a
-// fetch failure. The tile then keeps its last-known trends gray, or shows a
-// gray dash when no history is cached.
+// trend among processors measured in the last twelve hours. Orange means any
+// eligible processor trends up. Red means the most recent run failed or
+// produced no readable data. The line under the headline then dates the outage
+// instead of counting the benchmarks measured. `offline` names a fetch failure.
+// The tile then keeps its last-known trends gray, or shows a gray dash when no
+// history is cached.
 function benchmarkIndexView(
   runs: Run[],
   now: number,
@@ -1138,12 +1150,30 @@ function benchmarkIndexView(
       aside,
     );
   }
-  const established = indices.filter((series) => series.trend.label !== "new");
-  const headline = (established.length ? established : indices).reduce((
+  const headlineCandidates = benchmarkHeadlineCandidates(indices, now);
+  if (!headlineCandidates.length) {
+    if (offline) return benchmarkUnavailable(offline, aside);
+    if (failed) {
+      return {
+        ...benchmarkDrill,
+        label: "benchmarks",
+        status: "bad",
+        value: "—",
+        sub: failSub,
+        aside,
+      };
+    }
+    return benchmarkUnavailable("no recent benchmark data", aside);
+  }
+  const established = headlineCandidates.filter((series) =>
+    series.trend.label !== "new"
+  );
+  const headlinePool = established.length ? established : headlineCandidates;
+  const headline = headlinePool.reduce((
     worst,
     series,
   ) => series.trend.pct > worst.trend.pct ? series : worst);
-  const rising = indices.some((series) =>
+  const rising = headlineCandidates.some((series) =>
     series.trend.status === "warn" || series.trend.status === "bad"
   );
   // An offline collection keeps the trend but grays it: the run list it would need


### PR DESCRIPTION
The benchmark tile chose the largest processor-specific trend across the full retained chart. A processor that had stopped appearing could therefore keep the tile orange after current runner processors were flat.

Limit headline and status candidates to processors with a data point in the preceding twelve hours. Keep every processor line in the chart, and report missing recent benchmark data when no candidate remains.

Anchor benchmark fixtures near the current time and cover the freshness boundary, future timestamps, an entirely stale data set, and a stale rising line that remains visible without controlling the tile.

Verified with the dashboard package test suite, repository-wide Deno format checks, and repository-wide Deno lint.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

