### PR TITLE
docs: the agent surfaces teach the top-level data spellings

### DIFF
--- a/.claude/agents/manual-tester.md
+++ b/.claude/agents/manual-tester.md
@@ -83,7 +83,7 @@ without it, computed values remain stale.
 
 ```bash
 # Example: test addCard handler
-deno task cf piece call --piece {ID} addCard '{"columnIndex": 0, "title": "Test"}' \
+deno task cf call --piece {ID} addCard '{"columnIndex": 0, "title": "Test"}' \
   --identity claude.key --api-url {api-url} --space {space-name}
 deno task cf piece step --piece {ID} \
   --identity claude.key --api-url {api-url} --space {space-name}

--- a/.claude/agents/manual-tester.md
+++ b/.claude/agents/manual-tester.md
@@ -82,9 +82,11 @@ Test each handler via the CLI. **Always run `piece step` after `piece call`** â€
 without it, computed values remain stale.
 
 ```bash
-# Example: test addCard handler
-deno task cf call --piece {ID} addCard '{"columnIndex": 0, "title": "Test"}' \
-  --identity claude.key --api-url {api-url} --space {space-name}
+# Example: test addCard handler (every target flag before the callable name â€”
+# after it, flags belong to the callable's own parser)
+deno task cf call --piece {ID} \
+  --identity claude.key --api-url {api-url} --space {space-name} \
+  addCard '{"columnIndex": 0, "title": "Test"}'
 deno task cf piece step --piece {ID} \
   --identity claude.key --api-url {api-url} --space {space-name}
 deno task cf piece inspect --piece {ID} \

--- a/.claude/agents/pattern-user.md
+++ b/.claude/agents/pattern-user.md
@@ -39,14 +39,14 @@ deno task cf check main.tsx --no-run
 deno task cf test main.test.tsx
 
 # Deploy to toolshed (this is how you "run" it)
-API_URL=<url> deno task cf piece new main.tsx --test main.test.tsx --identity <key_path>
+CF_API_URL=<url> deno task cf piece new main.tsx --test main.test.tsx --identity <key_path>
 
 # Update existing piece
-API_URL=<url> deno task cf piece setsrc main.tsx --test main.test.tsx --piece <piece_id> --identity <key_path>
+CF_API_URL=<url> deno task cf piece setsrc main.tsx --test main.test.tsx --piece <piece_id> --identity <key_path>
 
 # Inspect state / call handler
-API_URL=<url> deno task cf piece inspect --piece <piece_id> --identity <key_path>
-API_URL=<url> deno task cf call --piece <piece_id> --identity <key_path> <handler>
+CF_API_URL=<url> deno task cf piece inspect --piece <piece_id> --identity <key_path>
+CF_API_URL=<url> deno task cf call --piece <piece_id> --identity <key_path> <handler>
 ```
 
 ## Deploy Flow

--- a/.claude/agents/pattern-user.md
+++ b/.claude/agents/pattern-user.md
@@ -46,7 +46,7 @@ API_URL=<url> deno task cf piece setsrc main.tsx --test main.test.tsx --piece <p
 
 # Inspect state / call handler
 API_URL=<url> deno task cf piece inspect --piece <piece_id> --identity <key_path>
-API_URL=<url> deno task cf piece call <handler> --piece <piece_id> --identity <key_path>
+API_URL=<url> deno task cf call --piece <piece_id> --identity <key_path> <handler>
 ```
 
 ## Deploy Flow

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -60,16 +60,16 @@ what this looks like when it bites.
   blocks on stderr. To also drop runtime warnings, add `--log-level error` (`-q`
   deliberately leaves the log floor alone — scripts parse those warnings).
 - `piece call` payloads: inline JSON argument, `-` to read stdin
-  (`echo '{...}' | cf piece call ... handler -`), a bare pipe with no payload
+  (`echo '{...}' | cf call ... handler -`), a bare pipe with no payload
   argument, or schema-derived flags after `--`. Empty stdin fails loudly.
 - A `piece get` path that doesn't resolve is a data error: one-line message on
   stderr, exit 1 (no usage screen). A `piece link` that fails validation
   (missing source/target piece or path) reports the same way. So does a
   `piece get` path that lands on a handler verb: reading a stream refuses — read
-  data, call verbs. A root verb's refusal points at `cf piece call`; a nested
-  verb is not directly callable, so it points at reading the parent object or
-  `cf piece verbs`. The verb's parent object still reads, and tool bindings read
-  as data.
+  data, call verbs. A root verb's refusal points at `cf piece call` (its literal
+  spelling); a nested verb is not directly callable, so it points at reading the
+  parent object or `cf piece verbs`. The verb's parent object still reads, and
+  tool bindings read as data.
 
 ## Environment Setup
 
@@ -137,21 +137,21 @@ See `docs/development/EXPERIMENTAL_OPTIONS.md` for available flags.
 | Deploy new         | `deno task cf piece new pattern.tsx --test pattern.test.tsx --root . --repository REPO -i key -a url -s space`               |
 | Update existing    | `deno task cf piece setsrc pattern.tsx --test pattern.test.tsx --root . --repository REPO --piece ID -i key -a url -s space` |
 | Inspect state      | `deno task cf piece inspect --piece ID ...`                                                                                  |
-| Get field          | `deno task cf piece get --piece ID fieldPath ...`                                                                            |
-| Filter array       | `deno task cf piece get --piece ID items --filter '.active == true' ...`                                                     |
-| Project fields     | `deno task cf piece get --piece ID items --select id,title ...`                                                              |
-| Read an address    | `deno task cf piece get --piece ID --select 'topic@,topic.title' ...`                                                        |
-| Read addresses     | `deno task cf piece get --piece ID items --schema '{"type":"array","items":{"$link":true}}' ...`                             |
-| Step + get         | `deno task cf piece get --piece ID fieldPath --step ...`                                                                     |
-| Set field          | `echo '{"data":...}' \| deno task cf piece set --piece ID path ...`                                                          |
-| Call handler       | `deno task cf piece call --piece ID handlerName ...`                                                                         |
-| Shape a result     | `deno task cf piece call --piece ID --select topic.title addTopic ...`                                                       |
+| Get field          | `deno task cf get --piece ID fieldPath ...`                                                                                  |
+| Filter array       | `deno task cf get --piece ID items --filter '.active == true' ...`                                                           |
+| Project fields     | `deno task cf get --piece ID items --select id,title ...`                                                                    |
+| Read an address    | `deno task cf get --piece ID --select 'topic@,topic.title' ...`                                                              |
+| Read addresses     | `deno task cf get --piece ID items --schema '{"type":"array","items":{"$link":true}}' ...`                                   |
+| Step + get         | `deno task cf get --piece ID fieldPath --step ...`                                                                           |
+| Set field          | `echo '{"data":...}' \| deno task cf set --piece ID path ...`                                                                |
+| Call handler       | `deno task cf call --piece ID handlerName ...`                                                                               |
+| Shape a result     | `deno task cf call --piece ID --select topic.title addTopic ...`                                                             |
 | List verbs         | `deno task cf piece verbs --piece ID --json ...`                                                                             |
 | Trigger recompute  | `deno task cf piece step --piece ID ...`                                                                                     |
 | Mint a session     | `export CF_INVOCATION_SESSION="$(deno task cf invocation-session new)"` (once per run; ids deduplicate only within it)       |
-| Replayable call    | `deno task cf piece call --piece ID --invocation my-id-1 handlerName ...` (same pair retries settle on the original outcome) |
-| Detached call      | `deno task cf piece call --piece ID --no-wait --invocation my-id-1 handlerName ...` (exits at commit with `receipt` address) |
-| Collect a receipt  | `deno task cf piece get --piece <receipt> ...` (the envelope's `receipt` string, later, from any process)                    |
+| Replayable call    | `deno task cf call --piece ID --invocation my-id-1 handlerName ...` (same pair retries settle on the original outcome)       |
+| Detached call      | `deno task cf call --piece ID --no-wait --invocation my-id-1 handlerName ...` (exits at commit with `receipt` address)       |
+| Collect a receipt  | `deno task cf get --piece <receipt> ...` (the envelope's `receipt` string, later, from any process)                          |
 | List pieces        | `deno task cf piece ls -i key -a url -s space`                                                                               |
 | Visualize          | `deno task cf piece map ...`                                                                                                 |
 | Rehearse an update | `deno task cf space clone <did> --from <snapshot> --to <dir>` (then `verify` / `reset`)                                      |
@@ -238,13 +238,13 @@ All values to `set` and `call` must be valid JSON:
 
 ```bash
 # Strings need nested quotes
-echo '"hello world"' | deno task cf piece set ... title
+echo '"hello world"' | deno task cf set ... title
 
 # Numbers are bare
-echo '42' | deno task cf piece set ... count
+echo '42' | deno task cf set ... count
 
 # Objects
-echo '{"name": "John"}' | deno task cf piece set ... user
+echo '{"name": "John"}' | deno task cf set ... user
 ```
 
 `piece get` and `wish` always print JSON. Both accept a redundant `--json` so
@@ -310,7 +310,7 @@ They shape the result of the call — a handler's `result` inside the Invocation
 JSON, or a tool's JSON on stdout:
 
 ```bash
-deno task cf piece call --piece ID --select topic.title addTopic '{"title":"Ship it"}'
+deno task cf call --piece ID --select topic.title addTopic '{"title":"Ship it"}'
 ```
 
 A selection shapes a result that already exists; it does not narrow what the
@@ -321,12 +321,11 @@ reactive one carries none). A value-less verb therefore still reports no
 result that does exist is refused, so the two stay distinguishable. A shaped
 call also waits on the CLI runtime's global idle, not just its own handling's
 commit, so on a piece with heavy derived state prefer calling plain (or
-`--no-wait`) and shaping the collect:
-`cf piece get --piece <receipt id> --select …`. `--no-wait` refuses all three
-flags, since it skips the receipt readback they are answered from.
-`--show-links` composes with a projection — links are collected after the
-selection, so each address names a position in the value you were handed — but
-not with `--filter`, which moves the positions a link names.
+`--no-wait`) and shaping the collect: `cf get --piece <receipt id> --select …`.
+`--no-wait` refuses all three flags, since it skips the receipt readback they
+are answered from. `--show-links` composes with a projection — links are
+collected after the selection, so each address names a position in the value you
+were handed — but not with `--filter`, which moves the positions a link names.
 
 `wish` and `exec` take the same three flags too, so all four arrivals shape
 their output the one way. `wish` writes them beside its target and shapes the
@@ -350,17 +349,17 @@ JSON forms match `cf exec`:
 
 ```bash
 # Complete input as an inline JSON value
-deno task cf piece call --piece ID search --json '{"query":"milk"}'
+deno task cf call --piece ID search --json '{"query":"milk"}'
 
 # Complete input from stdin
 printf '%s' '{"query":"milk"}' |
-  deno task cf piece call --piece ID search --json
+  deno task cf call --piece ID search --json
 
 # Machine-readable callable schema
-deno task cf piece call --piece ID search --help --json
+deno task cf call --piece ID search --help --json
 
 # Schema-derived input flags
-deno task cf piece call --piece ID search -- --query milk
+deno task cf call --piece ID search -- --query milk
 ```
 
 A single positional JSON value after the callable is also accepted. Use
@@ -378,12 +377,12 @@ carry session-local materialization into the following `piece get` process.
 
 ```bash
 # After setting data:
-echo '[...]' | deno task cf piece set --piece ID expenses ...
+echo '[...]' | deno task cf set --piece ID expenses ...
 deno task cf piece step --piece ID ...  # Required!
-deno task cf piece get --piece ID totalSpent ...
+deno task cf get --piece ID totalSpent ...
 
 # Equivalent one-session read (required for session-scoped computed output):
-deno task cf piece get --piece ID totalSpent --step ...
+deno task cf get --piece ID totalSpent --step ...
 ```
 
 A path-less `piece get` (whole result) degrades outputs it cannot reach — values
@@ -393,7 +392,7 @@ members materialized in your own session.
 
 ```bash
 # After calling a handler:
-deno task cf piece call --piece ID addItem '{"title": "Test"}'
+deno task cf call --piece ID addItem '{"title": "Test"}'
 deno task cf piece step --piece ID ...  # Required!
 deno task cf piece inspect --piece ID ...
 ```
@@ -406,7 +405,7 @@ deno task cf test pattern.test.tsx
 # 2. Deploy with the test attached
 deno task cf piece new pattern.tsx --test pattern.test.tsx -i key -a url -s space
 # 3. Call a handler
-deno task cf piece call --piece ID handlerName '{"arg": "value"}' ...
+deno task cf call --piece ID handlerName '{"arg": "value"}' ...
 # 4. Step to process
 deno task cf piece step --piece ID ...
 # 5. Inspect result

--- a/skills/fuse-agent/SKILL.md
+++ b/skills/fuse-agent/SKILL.md
@@ -30,7 +30,7 @@ ID=$(cf piece new packages/patterns/<path>.tsx \
   --space SPACE --root packages/patterns 2>/dev/null | head -1)
 
 # 3. Set title
-cf piece call --quiet --piece $ID --space SPACE setTitle -- --value "My Title"
+cf call --quiet --piece $ID --space SPACE setTitle -- --value "My Title"
 
 # 4. Step to materialize
 cf piece step --piece $ID --space SPACE
@@ -100,8 +100,8 @@ cat "MOUNT/SPACE/pieces/pieces.json" | python3 -c \
 
 | Operation                     | Step needed?                               |
 | ----------------------------- | ------------------------------------------ |
-| `cf piece call` (CLI)         | Always                                     |
-| `cf piece set` (CLI)          | Always                                     |
+| `cf call` (CLI)               | Always                                     |
+| `cf set` (CLI)                | Always                                     |
 | FUSE handler invocation       | Sometimes — if count suffix doesn't update |
 | Read/Write/Edit on `index.md` | Never                                      |
 
@@ -265,8 +265,8 @@ repeatable `--test` flags here and on every later `setsrc` update.
 ID=$(cf piece new packages/patterns/annotation.tsx \
   --space SPACE --root packages/patterns 2>/dev/null | head -1)
 echo '"Standup notes mention 5 people with no structured contact list"' \
-  | cf piece set --piece $ID content --space SPACE
-echo '"wish"' | cf piece set --piece $ID kind --space SPACE
+  | cf set --piece $ID content --space SPACE
+echo '"wish"' | cf set --piece $ID kind --space SPACE
 cf piece step --piece $ID --space SPACE
 # Re-read pieces.json — name now reflects content: "Standup notes mention..."
 ```
@@ -287,7 +287,7 @@ cf piece step --piece $ID --space SPACE
 **Mark a wish resolved** (when fulfilling another agent's annotation):
 
 ```bash
-echo '"resolved"' | cf piece set --piece $WISH_ID status --space SPACE
+echo '"resolved"' | cf set --piece $WISH_ID status --space SPACE
 cf piece step --piece $WISH_ID --space SPACE
 ```
 

--- a/skills/fuse-workflow/SKILL.md
+++ b/skills/fuse-workflow/SKILL.md
@@ -201,7 +201,7 @@ deno task cf piece new packages/patterns/my-pattern/main.tsx \
   --test packages/patterns/my-pattern/main.test.tsx -s dev-space
 # 5. Mount
 deno task cf fuse mount /tmp/cf
-# 6. Set input via filesystem (faster than cf piece set for complex data)
+# 6. Set input via filesystem (faster than cf set for complex data)
 cat test-data.json > /tmp/cf/dev-space/pieces/my-pattern/input.json
 # 7. Read result
 cat /tmp/cf/dev-space/pieces/my-pattern/result.json | jq '.'
@@ -225,8 +225,8 @@ ls /tmp/cf/2026-03-09-ben/pieces/   # connects on demand
 
 ### No `step` Needed via FUSE
 
-Unlike `cf piece set` which requires `cf piece step` to trigger recomputation,
-FUSE writes go through `cell.set()` directly, which triggers reactive updates
+Unlike `cf set` which requires `cf piece step` to trigger recomputation, FUSE
+writes go through `cell.set()` directly, which triggers reactive updates
 automatically.
 
 ### Writes Are Fire-and-Forget

--- a/skills/pattern-deploy/SKILL.md
+++ b/skills/pattern-deploy/SKILL.md
@@ -82,7 +82,7 @@ deno task cf piece inspect --piece <ID> --identity cf.key --api-url $CF_API_URL 
 **Test handler via CLI:**
 
 ```bash
-deno task cf piece call handlerName --piece PIECE_ID
+deno task cf call --piece PIECE_ID handlerName
 deno task cf piece step --piece PIECE_ID    # Required! Triggers recomputation
 deno task cf piece inspect --piece PIECE_ID  # Now shows updated state
 ```

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -53,7 +53,7 @@ carry scalar summaries plus title-only sibling references, so one read surveys
 the whole board without expanding any topic:
 
 ```bash
-deno task cf piece get --url "$TOPICS_BOARD_URL" index --step
+deno task cf get --url "$TOPICS_BOARD_URL" index --step
 ```
 
 A deployed board can run an older pattern without `index` — the read above
@@ -62,7 +62,7 @@ erroring on an unknown path is the tell. Survey such a board through the durable
 linked Topic and can include its body, comments, handlers, and reference graph.
 
 ```bash
-deno task cf piece get --url "$TOPICS_BOARD_URL" topics --input \
+deno task cf get --url "$TOPICS_BOARD_URL" topics --input \
   --filter '.title != null' \
   --select title,createdAt,lastActivityAt,commentCount,createdBy.kind,createdBy.name
 ```
@@ -76,17 +76,17 @@ declared nested arrays without exposing sibling fields.
 
 ```bash
 # Find one Topic by exact title.
-deno task cf piece get --url "$TOPICS_BOARD_URL" topics --input \
+deno task cf get --url "$TOPICS_BOARD_URL" topics --input \
   --filter '.title == "<exact title>"' \
   --select title,lastActivityAt,commentCount
 
 # Find Topics active at or after an epoch-millisecond threshold.
-deno task cf piece get --url "$TOPICS_BOARD_URL" topics --input \
+deno task cf get --url "$TOPICS_BOARD_URL" topics --input \
   --filter '.lastActivityAt >= 1785074400000' \
   --select title,lastActivityAt,commentCount,createdBy.kind,createdBy.name
 
 # Combine predicates for a narrower field search.
-deno task cf piece get --url "$TOPICS_BOARD_URL" topics --input \
+deno task cf get --url "$TOPICS_BOARD_URL" topics --input \
   --filter '.createdBy.name == "<name>" and .commentCount > 0' \
   --select title,lastActivityAt,commentCount
 ```
@@ -102,22 +102,22 @@ Address a selected Topic by the canonical fid published in the board's
 `crossrefs` result. Filter and project that computed index too:
 
 ```bash
-deno task cf piece get --url "$TOPICS_BOARD_URL" crossrefs --step \
+deno task cf get --url "$TOPICS_BOARD_URL" crossrefs --step \
   --filter '.topic.title == "<exact title>"' \
   --select fid,topic.title,topic.lastActivityAt,topic.commentCount
 export TOPIC_URL='https://estuary.saga-castor.ts.net/topics-dev-476ea34f/<topic-fid>'
-deno task cf piece get --url "$TOPIC_URL" title --input
-deno task cf piece get --url "$TOPIC_URL" body --input
-deno task cf piece get --url "$TOPIC_URL" comments --input \
+deno task cf get --url "$TOPIC_URL" title --input
+deno task cf get --url "$TOPIC_URL" body --input
+deno task cf get --url "$TOPIC_URL" comments --input \
   --select sentAt,author.kind,author.name,authorName,body
-deno task cf piece get --url "$TOPIC_URL" links --input \
+deno task cf get --url "$TOPIC_URL" links --input \
   --select kind,url,label,addedAt,addedBy.kind,addedBy.name
 
 # Search within a selected Topic's arrays.
-deno task cf piece get --url "$TOPIC_URL" comments --input \
+deno task cf get --url "$TOPIC_URL" comments --input \
   --filter '.author.name == "<agent>" or .authorName == "<legacy name>"' \
   --select sentAt,author.kind,author.name,authorName,body
-deno task cf piece get --url "$TOPIC_URL" links --input \
+deno task cf get --url "$TOPIC_URL" links --input \
   --filter '.kind == "pr"' --select kind,url,label,addedAt
 ```
 
@@ -127,7 +127,7 @@ not compose with `--filter` — a filtered array's survivors no longer say which
 positions they came from — so ask for an address in its own unfiltered read:
 
 ```bash
-deno task cf piece get --url "$TOPICS_BOARD_URL" crossrefs --step \
+deno task cf get --url "$TOPICS_BOARD_URL" crossrefs --step \
   --select fid,topic@
 ```
 
@@ -147,9 +147,9 @@ Create a topic through the board rather than deploying the Topic pattern
 directly:
 
 ```bash
-deno task cf piece call --url "$TOPICS_BOARD_URL" addTopic \
+deno task cf call --url "$TOPICS_BOARD_URL" addTopic \
   '{"title":"<title>","agentName":"<agent name>"}'
-deno task cf piece get --url "$TOPICS_BOARD_URL" crossrefs --step \
+deno task cf get --url "$TOPICS_BOARD_URL" crossrefs --step \
   --filter '.topic.title == "<exact title>"' --select fid,topic.title
 ```
 
@@ -163,13 +163,13 @@ handler arguments are JSON; encode multiline Markdown rather than passing an
 unescaped string.
 
 ```bash
-deno task cf piece call --url "$TOPIC_URL" setBody \
+deno task cf call --url "$TOPIC_URL" setBody \
   '{"body":"<complete revised body>","agentName":"<agent name>"}'
-deno task cf piece call --url "$TOPIC_URL" addComment \
+deno task cf call --url "$TOPIC_URL" addComment \
   '{"body":"<point-in-time update>","agentName":"<agent name>"}'
-deno task cf piece call --url "$TOPIC_URL" addLink \
+deno task cf call --url "$TOPIC_URL" addLink \
   '{"kind":"pr","url":"<PR URL>","label":"<PR label>","agentName":"<agent name>"}'
-deno task cf piece get --url "$TOPIC_URL" commentCount --step
+deno task cf get --url "$TOPIC_URL" commentCount --step
 ```
 
 Each of these three returns the record it wrote — the appended comment or link,
@@ -185,8 +185,8 @@ session per run
 pass `--invocation <your-key>` on mutating calls. A retry with the same pair
 settles on the original outcome instead of posting twice — the handler body
 re-runs, but nothing commits twice. The settled envelope also carries `receipt`,
-the address of the outcome, which `deno task cf piece get --piece <receipt id>`
-reads back later without re-invoking.
+the address of the outcome, which `deno task cf get --piece <receipt id>` reads
+back later without re-invoking.
 
 The body is the living big-picture document. Replace it in place with the full
 revised body so a reader sees the current state without replaying the thread,


### PR DESCRIPTION
## Why

The follow-up flagged on #5912's review: `skills/**` and `.claude/agents/**` held 59 operational old-spelling examples, and unlike prose docs these generate real agent traffic — every session that loads the cf or topics skill is trained into the spelling the examples use. Step 6a's warning cannot ship while the repository's own agents are taught to trigger it, so this migrates the agent surfaces with the teaching docs (#5912), before the warning exists.

## What changed

59 sites across `skills/cf`, `skills/topics`, `skills/fuse-agent`, `skills/fuse-workflow`, `skills/pattern-deploy`, and the two agent definitions (`pattern-user`, `manual-tester`), with the same discipline as #5912: guarded conversion (label/src/slug/home subcommands untouched), then a per-file review pass. `skills/` is the authored source; the `.claude/skills` and `.agents/skills` mirrors are symlinks and follow automatically.

The review pass caught the same two classes the docs review caught:

- The cf skill describes the verb-read refusal, whose literal text says `use 'cf piece call --piece …'` — that description keeps the old spelling and now says it is literal.
- Two more examples spelled flags after the callable name (`cf call handlerName --piece ID`), where `.stopEarly()` hands them to the callable's parser — a spelling that has never parsed. Both fixed flags-first. That makes four such sites found across the two sweeps; the class predates the sweep and only the sweep's review passes have been finding them.

## Test plan

`deno task check-skill-facts` (45 documents OK), repo-wide `deno fmt --check`. The examples' spellings are the ones #5910's parity net and the merged stack's CI exercise against a live space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

