### PR TITLE
fix(ts-transformers): read a callback's argument position through parentheses

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -458,6 +458,13 @@ Diagnostics emitted in all modes:
 - **Error** `pattern-context:function-creation`
   - function creation in pattern context unless inside compute
     wrappers/JSX/allowed callbacks
+  - the allowed-callback determination reads the callback's call-argument
+    position through parentheses, so `toSorted(((a, b) => ...))` classifies
+    like `toSorted((a, b) => ...)` — target-language spec §5.7
+    paren-invariance (`test/validation.test.ts` "allows a parenthesized
+    inline callback argument"); parentheses grant nothing outside argument
+    position ("still errors on a parenthesized arrow function in pattern
+    body")
   - class expression or declaration in pattern context unless inside compute
     wrappers; the whole class is flagged once with a class-specific message
 - **Error** `pattern-context:object-member`
@@ -504,7 +511,11 @@ Diagnostics emitted in all modes:
     callback's owning call when that call is outside the lowered array-method
     families and itself sits at a lowerable expression site: the site's lift
     absorbs the callback, so the access runs on resolved values
-    (`rows.get().toSorted((a, b) => (a?.sentAt ?? 0) - (b?.sentAt ?? 0))`)
+    (`rows.get().toSorted((a, b) => (a?.sentAt ?? 0) - (b?.sentAt ?? 0))`);
+    parentheses around the inline callback change neither the carrier nor
+    the callback allowance (`test/validation.test.ts` "allows optional
+    access inside a parenthesized inline comparator" pins the spelling at
+    zero diagnostics)
   - optional calls do not receive this diagnostic merely because they are
     optional: their underlying call root is classified by the same policy as a
     non-optional call

--- a/packages/ts-transformers/src/ast/call-arguments.ts
+++ b/packages/ts-transformers/src/ast/call-arguments.ts
@@ -1,0 +1,48 @@
+import ts from "typescript";
+
+/**
+ * A node's position as a direct call argument: the call that lists it, the
+ * argument node as listed, and its index in the argument list.
+ */
+export interface CallArgumentPosition {
+  /** The call whose argument list carries the node. */
+  readonly call: ts.CallExpression;
+  /** The node `call.arguments` lists — the queried node itself, or the
+   *  outermost parenthesized wrapper around it. Identity comparisons against
+   *  entries of `call.arguments` must use this node, never the queried one. */
+  readonly argument: ts.Expression;
+  /** Index of `argument` within `call.arguments`. */
+  readonly index: number;
+}
+
+/**
+ * Locates the call that lists `node` as a direct argument, treating
+ * parentheses as spelling: `f(((x) => 0))` occupies the same argument
+ * position as `f((x) => 0)`, per the paren-invariance the target-language
+ * spec holds across site classification (§5.7). Argument-position decisions —
+ * membership, index, owning call — go through here so no classifier can tell
+ * the two spellings apart. Parentheses only: type-level wrappers (`as`,
+ * `satisfies`) change what the checker sees and stay visible to callers.
+ *
+ * Returns undefined when `node` (paren wrappers included) is not a direct
+ * argument of a call — including when it is the callee, or an argument of a
+ * `new` expression.
+ */
+export function getCallArgumentPosition(
+  node: ts.Node,
+): CallArgumentPosition | undefined {
+  let argument: ts.Node = node;
+  let parent: ts.Node | undefined = node.parent;
+  while (parent && ts.isParenthesizedExpression(parent)) {
+    argument = parent;
+    parent = parent.parent;
+  }
+  if (!parent || !ts.isCallExpression(parent) || !ts.isExpression(argument)) {
+    return undefined;
+  }
+  const index = parent.arguments.indexOf(argument);
+  if (index < 0) {
+    return undefined;
+  }
+  return { call: parent, argument, index };
+}

--- a/packages/ts-transformers/src/ast/mod.ts
+++ b/packages/ts-transformers/src/ast/mod.ts
@@ -1,4 +1,8 @@
 export {
+  type CallArgumentPosition,
+  getCallArgumentPosition,
+} from "./call-arguments.ts";
+export {
   type ArrayCallbackContainerCallKind,
   type ArrayMethodAccessKind,
   type ArrayMethodCallSiteInfo,

--- a/packages/ts-transformers/src/ast/reactive-context.ts
+++ b/packages/ts-transformers/src/ast/reactive-context.ts
@@ -1,4 +1,5 @@
 import ts from "typescript";
+import { getCallArgumentPosition } from "./call-arguments.ts";
 import { detectCallKind } from "./call-kind.ts";
 import { getCallbackBoundarySemantics } from "../policy/callback-boundary.ts";
 
@@ -84,13 +85,9 @@ function getMarkedSyntheticCallbackContext(
       }
 
       if (lookup?.isSyntheticComputeCallback?.(current)) {
-        const callParent = current.parent;
-        if (
-          callParent &&
-          ts.isCallExpression(callParent) &&
-          callParent.arguments.includes(current)
-        ) {
-          const callKind = detectCallKind(callParent, checker);
+        const position = getCallArgumentPosition(current);
+        if (position) {
+          const callKind = detectCallKind(position.call, checker);
           if (callKind?.kind === "lift-applied") {
             return { kind: "compute", owner: "lift-applied", inJsxExpression };
           }
@@ -117,11 +114,9 @@ export function findEnclosingCallbackContext(
   let current: ts.Node | undefined = resolveContextAnchor(node).parent;
   while (current) {
     if (ts.isArrowFunction(current) || ts.isFunctionExpression(current)) {
-      const parent: ts.Node | undefined = current.parent;
-      if (parent && ts.isCallExpression(parent)) {
-        if (parent.arguments.includes(current as ts.Expression)) {
-          return { callback: current, call: parent };
-        }
+      const position = getCallArgumentPosition(current);
+      if (position) {
+        return { callback: current, call: position.call };
       }
     }
     current = current.parent;

--- a/packages/ts-transformers/src/policy/callback-boundary.ts
+++ b/packages/ts-transformers/src/policy/callback-boundary.ts
@@ -1,5 +1,6 @@
 import ts from "typescript";
 
+import { getCallArgumentPosition } from "../ast/call-arguments.ts";
 import {
   classifyArrayCallbackContainerCall,
   detectCallKind,
@@ -125,14 +126,11 @@ function isPatternToolPatternArgument(
   patternCall: ts.CallExpression,
   checker: ts.TypeChecker,
 ): boolean {
-  const grandparent = patternCall.parent;
-  if (!grandparent || !ts.isCallExpression(grandparent)) {
+  const position = getCallArgumentPosition(patternCall);
+  if (!position || position.index !== 0) {
     return false;
   }
-  if (grandparent.arguments[0] !== patternCall) {
-    return false;
-  }
-  return detectCallKind(grandparent, checker)?.kind === "pattern-tool";
+  return detectCallKind(position.call, checker)?.kind === "pattern-tool";
 }
 
 export function classifyCallbackBoundary(
@@ -157,13 +155,11 @@ export function classifyCallbackBoundary(
     };
   }
 
-  const parent = callback.parent;
-  if (
-    !parent || !ts.isCallExpression(parent) ||
-    !parent.arguments.includes(callback)
-  ) {
+  const position = getCallArgumentPosition(callback);
+  if (!position) {
     return { kind: "none" };
   }
+  const parent = position.call;
 
   if (lookup?.isArrayMethodCallback(callback)) {
     return {
@@ -208,7 +204,7 @@ export function classifyCallbackBoundary(
   // callback is a compute-owned boundary like lift-applied: legitimate inside
   // a pattern body, never a reactive closure.
   if (
-    parent.arguments.length >= 2 && parent.arguments[1] === callback &&
+    position.index === 1 &&
     isSqliteTableCallee(parent.expression, checker)
   ) {
     return {

--- a/packages/ts-transformers/src/transformers/expression-site-policy.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-policy.ts
@@ -3,6 +3,7 @@ import {
   classifyArrayMethodCall,
   classifyArrayMethodCallSite,
   detectCallKind,
+  getCallArgumentPosition,
   getTypeAtLocationWithFallback,
   hasAuthoredSourceSite,
   isCollectionType,
@@ -464,12 +465,9 @@ function hasEnclosingComputeLikeCallback(
   let current: ts.Node | undefined = callbackContext.call.parent;
   while (current) {
     if (ts.isArrowFunction(current) || ts.isFunctionExpression(current)) {
-      const parent: ts.Node | undefined = current.parent;
-      if (
-        parent && ts.isCallExpression(parent) &&
-        parent.arguments.includes(current)
-      ) {
-        const callKind = detectCallKind(parent, context.checker);
+      const position = getCallArgumentPosition(current);
+      if (position) {
+        const callKind = detectCallKind(position.call, context.checker);
         if (callKind?.kind === "lift-applied") {
           return true;
         }
@@ -618,6 +616,12 @@ function isReactiveRuntimeCallTaggedTemplateSpan(
   return isReactiveOriginTaggedTemplate(tagged, context.checker);
 }
 
+/**
+ * Deliberately parent-literal, unlike `getCallArgumentPosition`: visitors
+ * classify a parenthesized expression at its paren node (the inner expression
+ * reports no container), so looking through parens here would classify the
+ * same site at two nesting levels and lower it twice.
+ */
 export function getExpressionContainerKind(
   expression: ts.Expression,
 ): ExpressionContainerKind | undefined {
@@ -1394,32 +1398,21 @@ export function findInlineCallbackCarrierSite(
 
   while (current) {
     if (ts.isFunctionLike(current)) {
-      // Parentheses around the callback are transparent, here as everywhere
-      // in the site rules: `toSorted(((a, b) => ...))` carries like
-      // `toSorted((a, b) => ...)`.
-      let argument: ts.Node = current;
-      let parent: ts.Node | undefined = current.parent;
-      while (parent && ts.isParenthesizedExpression(parent)) {
-        argument = parent;
-        parent = parent.parent;
-      }
-      if (
-        !parent || !ts.isCallExpression(parent) ||
-        !ts.isExpression(argument) || !parent.arguments.includes(argument)
-      ) {
+      const position = getCallArgumentPosition(current);
+      if (!position) {
         return undefined;
       }
 
-      if (classifyArrayMethodCall(parent)) {
+      if (classifyArrayMethodCall(position.call)) {
         return undefined;
       }
 
-      const site = findLowerableExpressionSite(parent, context, analyze);
+      const site = findLowerableExpressionSite(position.call, context, analyze);
       if (site) {
         return site;
       }
 
-      current = parent.parent;
+      current = position.call.parent;
       continue;
     }
 

--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -2328,6 +2328,57 @@ Deno.test("Pattern Context Validation - Function Creation", async (t) => {
   });
 
   await t.step(
+    "allows a parenthesized inline callback argument",
+    async () => {
+      const source = `      import { pattern, Writable } from "commonfabric";
+
+      interface Row {
+        sentAt: number;
+      }
+
+      export default pattern<{ rows: Writable<Row[]> }>(({ rows }) => {
+        const sorted = rows.get().toSorted(((a, b) => a.sentAt - b.sentAt));
+        return { sorted };
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      const creationErrors = errors.filter((error) =>
+        error.type === "pattern-context:function-creation"
+      );
+      assertEquals(
+        creationErrors.length,
+        0,
+        "a parenthesized inline callback occupies the same argument " +
+          "position as its bare spelling",
+      );
+    },
+  );
+
+  await t.step(
+    "still errors on a parenthesized arrow function in pattern body",
+    async () => {
+      const source = `      import { pattern, h } from "commonfabric";
+
+      interface Item { price: number; }
+
+      export default pattern<{ item: Item }>(({ item }) => {
+        const helper = (() => item.price * 2);
+        return <div>{helper()}</div>;
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertGreater(errors.length, 0, "Expected at least one error");
+      assertHasErrorType(errors, "pattern-context:function-creation");
+    },
+  );
+
+  await t.step(
     "allows arithmetic computation inside authored ifElse branches",
     async () => {
       const source = `      import { ifElse, pattern } from "commonfabric";
@@ -3359,17 +3410,11 @@ Deno.test("Reactive .get() Validation", async (t) => {
         types: COMMONFABRIC_TYPES,
       });
       const errors = getErrors(diagnostics);
-      // The parenthesized spelling still draws the (pre-existing)
-      // function-creation rejection — parentheses hide the callback from
-      // that validation's inline-argument allowance, a separate gap. This
-      // step pins the carrier decision alone: optionality is carried
-      // through the parentheses, so no optional-chaining error joins it.
       assertEquals(
-        errors.some((error) =>
-          error.type === "pattern-context:optional-chaining"
-        ),
-        false,
-        "parentheses around the callback do not change the carrier decision",
+        errors.length,
+        0,
+        "parentheses around the comparator change neither the carrier " +
+          "decision nor the inline-argument allowance",
       );
     },
   );


### PR DESCRIPTION
Follow-up to #5797 (landed; this branch is rebased onto main with it in): the two fixes are siblings — #5797 made the parenthesized spelling's optional accesses **carry**, this PR makes the parenthesized spelling's callback **classify**. The motivating probe needs both to compile.

## Problem

The allowed-inline-callback determination tested the callback's own node for call-argument membership, so wrapping an inline callback in parentheses hid it from every classification its bare spelling receives:

```tsx
const sorted = rows.get().toSorted(((a, b) => (a?.sentAt ?? 0) - (b?.sentAt ?? 0)));
// pattern-context:function-creation — while toSorted((a, b) => ...) compiles
```

Two consumers fail independently: `classifyCallbackBoundary` returns no boundary (drawing `pattern-context:function-creation`), and `findEnclosingCallbackContext` skips past the comparator, so its body is judged in pattern context (on a base without #5797 that adds two `pattern-context:optional-chaining` errors; on this stack the carrier rescues those, leaving the function-creation error this PR removes). This violates the target-language spec's §5.7 paren-invariance clause, and it is the third instance of the same idiom-bug — `arguments.includes` against the callback's literal parent — after the #5454 review paren fix and c10bf894.

## Fix

One shared helper instead of a third spot fix: `getCallArgumentPosition` (`src/ast/call-arguments.ts`) walks up transparent parentheses and answers with the owning call, the listed argument node, and its index. Returning the index matters: the boundary function's sqlite second-argument and patternTool first-argument tests compare against `call.arguments[N]` by identity, which parentheses also break — a membership-only fix would have left them wrong.

Six sites now route through it:

- `classifyCallbackBoundary`: the membership gate, the sqlite `table(columns, rule)` second-argument test, and `isPatternToolPatternArgument` (`policy/callback-boundary.ts`)
- `findEnclosingCallbackContext` and `getMarkedSyntheticCallbackContext` (`ast/reactive-context.ts`)
- `hasEnclosingComputeLikeCallback`, and `findInlineCallbackCarrierSite`'s local paren unwrap from c10bf894, consolidated (`transformers/expression-site-policy.ts`)

Parentheses only, deliberately: `as`/`satisfies` change what the checker sees and stay visible to callers (cast-validation owns those).

## Audit

Every remaining `arguments.includes` in the package, classified:

- `getExpressionContainerKind` — deliberately parent-literal: visitors classify a parenthesized expression at its paren node, so a walk-up here would classify one site at two nesting levels and lower it twice. Now stated on the function so the helper is not applied to it later.
- `getHelperBoundaryKind` — ascending walk that tests every ancestor level; paren-transparent by construction.
- `capability-analysis.ts` (×4) — usage sites are pre-normalized by `unwrapIdentifierUsageSite` / `unwrapExpressionUsageSite`, which walk up parens and casts before any parent test; transparent by construction.
- JSX event-handler attributes probed for completeness: both spellings behave identically today — attribute surface, outside this clause's scope.

## Verification

- The probe compiles clean on this stack (was: one function-creation error on the #5797 base; three errors without the stack)
- Negative control pinned: a paren-wrapped arrow as a variable initializer in pattern context still draws `pattern-context:function-creation` — parentheses grant nothing outside argument position
- "allows optional access inside a parenthesized inline comparator" tightened to assert **zero** diagnostics (its residual-gap comment is gone); two new pins in the Function Creation group (paren-argument allowance, paren-initializer rejection)
- Full package suite 1140/0 on the rebased tree (includes spec-sync); repo-wide `deno fmt --check`, `deno lint`, `deno task check`, `check-docs` 549/549 — all under the pinned toolchain (mise, deno 2.9.4)
- Current-behavior spec §6: the function-creation and optional-chaining entries now state the paren-invariance of the allowance, citing the pinning steps by name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


