### PR TITLE
feat(cli): the piece data spellings warn, naming the day they stop

### DIFF
--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -1,9 +1,9 @@
 # Verbs over the CLI
 
 A **verb** is a pattern's callable surface: a `Stream` property a caller invokes
-with `cf call` — or `cf piece call`, the same command mounted under `piece`, so
-every `cf call` in this document works as `cf piece call` too. This document is
-about what a caller gets *back*.
+with `cf call` — or `cf piece call`, the same command mounted under `piece`,
+which still works and warns as a deprecated spelling. This document is about
+what a caller gets *back*.
 
 A verb can declare a result, and the caller reads it off the call. That turns a
 sequence of "mutate, then go looking for what happened" into a single

--- a/docs/tutorial/06-workflow.md
+++ b/docs/tutorial/06-workflow.md
@@ -137,7 +137,8 @@ the commands that take `--input` (`get` and `set` here), a trailing
 `call` takes no `--input` and refuses the suffix. The three are the piece
 data commands mounted at top level — reading and writing cells is not
 really a piece-management concern, and the spelling says so. `cf piece
-get`, `cf piece set`, and `cf piece call` are the same commands and keep
+get`, `cf piece set`, and `cf piece call` are the same commands, deprecated
+as spellings: each still works and warns on stderr with the date it stops
 working.
 
 One subtlety: neither `piece set` nor `piece call` refreshes *computed*

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -100,8 +100,12 @@ rather than resolved.
 Those three commands are also mounted at top level as `cf get`, `cf set`, and
 `cf call`: reading and writing cells is not a piece-management concern, and the
 spelling says so. Each pair is one definition mounted twice, so the two
-spellings take the same flags, behave identically, and complete identically;
-both keep working.
+spellings take the same flags, behave identically, and complete identically. The
+piece-mounted spellings are deprecated: each invocation prints a stderr notice
+naming the top-level spelling and the literal date the old spelling stops
+working (`PIECE_DATA_SPELLING_END_DATE` in `commands/piece.ts`, the one source
+of that date). Until then both keep working, and the notice never touches stdout
+— `get` and `call` reserve it for machine output.
 
 A canonical reference may also end in `#argument`, which selects the piece's
 arguments cell the way `--input` does. Only commands that take `--input` accept

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1629,9 +1629,11 @@ cf ${spelling} /of:fid1:... addItem '{"title":"Milk"}'.`,
  * A top-level instance of a piece data command: the same builder the
  * `piece` chain mounts under the same name, carrying the target options
  * itself. `cf get`, `cf set`, and `cf call` are these — one definition per
- * command, two spellings that parse and behave identically
- * (docs/plans/cli-surface-shape.md, step 5). Deprecating the `cf piece`
- * spellings later means touching the piece-mounted instances only.
+ * command, two spellings that parse and behave identically in every
+ * respect but one: the piece-mounted spelling is deprecated (step 6a) and
+ * its invocations print the dated stderr notice `dataCommandAction`
+ * attaches, until {@link PIECE_DATA_SPELLING_END_DATE} removes it with the
+ * spelling (docs/plans/cli-surface-shape.md, steps 5–6).
  */
 // deno-lint-ignore no-explicit-any
 export function pieceDataCommand(name: "get" | "set" | "call"): Command<any> {

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1132,10 +1132,11 @@ export function targetOptions(
 
 /**
  * The day the `cf piece get`, `cf piece set`, and `cf piece call` spellings
- * stop working: two weeks after step 6a reaches main
+ * stop working: two weeks after step 6a reached main
  * (docs/plans/cli-surface-shape.md). A literal rather than a window computed
  * at runtime, because a caller who reads the warning today and acts on it
- * next week must be told the same date both times. Set when 6a merges.
+ * next week must be told the same date both times. Step 6b removes the
+ * spellings and their notices on this day.
  */
 export const PIECE_DATA_SPELLING_END_DATE = "2026-08-31";
 

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1131,9 +1131,71 @@ export function targetOptions(
 }
 
 /**
+ * The day the `cf piece get`, `cf piece set`, and `cf piece call` spellings
+ * stop working: two weeks after step 6a reaches main
+ * (docs/plans/cli-surface-shape.md). A literal rather than a window computed
+ * at runtime, because a caller who reads the warning today and acts on it
+ * next week must be told the same date both times. Set when 6a merges.
+ */
+export const PIECE_DATA_SPELLING_END_DATE = "2026-08-31";
+
+/**
+ * The 6a deprecation notice for a piece-mounted data spelling. stderr and
+ * never stdout: `get` and `call` reserve stdout for machine-readable
+ * output, and a notice on stdout would corrupt exactly the piping scripts
+ * this notice exists to migrate. Unconditional rather than behind
+ * `--quiet`, because a quiet script is the caller most in need of the date.
+ */
+export function warnDeprecatedPieceSpelling(
+  spelling: string,
+  deps: { writeError?: (text: string) => void } = {},
+): void {
+  const writeError = deps.writeError ?? console.error;
+  const short = spelling.replace(/^piece /, "");
+  writeError(
+    `'cf ${spelling}' is deprecated; spell it 'cf ${short}'. The ` +
+      `'cf ${spelling}' spelling stops working on ` +
+      `${PIECE_DATA_SPELLING_END_DATE}.`,
+  );
+}
+
+/**
+ * An action wrapped with the 6a notice. The `this` binding passes through
+ * untouched because `call`'s action reads `this.getLiteralArgs()`.
+ */
+export function withDeprecatedSpellingWarning<
+  // deno-lint-ignore no-explicit-any
+  F extends (this: any, ...args: any[]) => unknown,
+>(spelling: string, action: F): F {
+  // deno-lint-ignore no-explicit-any
+  return function (this: any, ...args: any[]) {
+    warnDeprecatedPieceSpelling(spelling);
+    return action.apply(this, args);
+  } as F;
+}
+
+/**
+ * The action a data-command builder mounts: the piece-mounted spelling
+ * warns (step 6a), the top-level spelling does not. Decided here, on the
+ * one definition both mounts share, because a per-mount implementation is
+ * how the two surfaces drift — and this is the single respect in which
+ * they are allowed to differ (test/piece-data-spellings.test.ts pins
+ * exactly that).
+ */
+export function dataCommandAction<
+  // deno-lint-ignore no-explicit-any
+  F extends (this: any, ...args: any[]) => unknown,
+>(spelling: string, action: F): F {
+  return spelling.startsWith("piece ")
+    ? withDeprecatedSpellingWarning(spelling, action)
+    : action;
+}
+
+/**
  * The one definition of `get`, mounted under `cf piece` and, through
  * {@link pieceDataCommand}, at top level as `cf get`. `spelling` is only
- * how the command names itself in its own help.
+ * how the command names itself in its own help — and, since 6a, whether
+ * its action carries the deprecation notice.
  */
 // deno-lint-ignore no-explicit-any
 function buildGetCommand(spelling = "piece get"): Command<any> {
@@ -1245,7 +1307,7 @@ the way --input does.`,
       { conflicts: ["select"] },
     )
     .arguments("[addressOrPath:string] [path:string]")
-    .action(getCellValueFromCommand);
+    .action(dataCommandAction(spelling, getCellValueFromCommand));
 }
 
 /**
@@ -1295,7 +1357,7 @@ counts, so cf ${spelling} /of:fid1:.../title needs no path argument. A trailing
         '"#argument" reference suffix spells the same selection)',
     )
     .arguments("[addressOrPath:string] [path:string]")
-    .action(setCellValueFromCommand);
+    .action(dataCommandAction(spelling, setCellValueFromCommand));
 }
 
 /**
@@ -1457,7 +1519,7 @@ cf ${spelling} /of:fid1:... addItem '{"title":"Milk"}'.`,
     )
     .stopEarly()
     .arguments("<callable:string> [tail...:string]")
-    .action(async function (
+    .action(dataCommandAction(spelling, async function (
       // Spelled out because this builder stands alone: the target options
       // arrive as `piece` globals on one mount and as own options on the
       // other, so neither inference sees the whole surface.
@@ -1560,7 +1622,7 @@ cf ${spelling} /of:fid1:... addItem '{"title":"Milk"}'.`,
       } catch (error) {
         exitPieceCallFailure(observer, error, invocationId, phase);
       }
-    });
+    }));
 }
 
 /**

--- a/packages/cli/test/piece-data-spellings.test.ts
+++ b/packages/cli/test/piece-data-spellings.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { warnDeprecatedPieceSpelling } from "../commands/piece.ts";
 import { cf, stripAnsi } from "./utils.ts";
 
 /**
@@ -58,25 +59,45 @@ describe("piece-data-spellings", () => {
     }
   });
 
-  it("refuses a configuration-free run identically under both spellings", async () => {
+  it("refuses a configuration-free run identically, except the 6a notice", async () => {
     // End to end through real Cliffy parsing in a subprocess with no fabric
     // configuration: the refusal text and exit code are the behavior a
-    // script sees first, and the two spellings must not diverge in it. The
+    // script sees first. Since step 6a the piece-mounted spelling warns and
+    // the top-level spelling does not — the ONE respect in which the two
+    // mounts may differ. The comparison stays exact by naming that line and
+    // removing exactly it, so every other divergence still fails here. The
     // deno task banner echoes the argv and so differs by construction.
-    const refusal = (stderr: string[]) =>
+    const notice = (name: string) => {
+      let line = "";
+      warnDeprecatedPieceSpelling(`piece ${name}`, {
+        writeError: (text) => line = text,
+      });
+      return line;
+    };
+    const stderrLines = (stderr: string[]) =>
       stderr.map((line) => stripAnsi(line))
-        .filter((line) => !line.startsWith("Task "))
-        .join("\n");
+        .filter((line) => !line.startsWith("Task "));
     for (const name of SPELLINGS) {
-      const top = await cf(name);
-      const nested = await cf(`piece ${name}`);
+      // `call` gets a callable name so the refusal happens inside the
+      // action: the 6a notice attaches to invocations, and a grammar error
+      // (missing argument) is refused by Cliffy before any action — and so
+      // before any notice — under both spellings alike.
+      const tail = name === "call" ? " someCallable" : "";
+      const top = await cf(`${name}${tail}`);
+      const nested = await cf(`piece ${name}${tail}`);
       expect(top.code).toBe(nested.code);
-      expect(refusal(top.stderr)).toBe(refusal(nested.stderr));
+      const topLines = stderrLines(top.stderr);
+      const nestedLines = stderrLines(nested.stderr);
+      expect(nestedLines).toContain(notice(name));
+      expect(topLines).not.toContain(notice(name));
+      expect(topLines).toEqual(
+        nestedLines.filter((line) => line !== notice(name)),
+      );
       // `get` and `set` refuse on the missing identity, `call` on the
       // missing callable argument — either way a refusal happened, which is
       // what keeps the equality above from passing vacuously on two silent
       // successes.
-      expect(refusal(top.stderr)).toContain("Missing");
+      expect(topLines.join("\n")).toContain("Missing");
     }
   });
 });

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -24,6 +24,7 @@ import { toCell } from "../../runner/src/back-to-cell.ts";
 import { setResultCell } from "../../runner/src/result-utils.ts";
 import {
   checkPieceSourceFromCommand,
+  dataCommandAction,
   formatPatternIdentity,
   formatPatternRef,
   getCellValueFromCommand,
@@ -34,10 +35,13 @@ import {
   parsePieceOptions,
   parseSpaceOptions,
   piece,
+  PIECE_DATA_SPELLING_END_DATE,
   readCallTarget,
   readTargetPositionals,
   setCellValueFromCommand,
   setPieceSourceFromCommand,
+  warnDeprecatedPieceSpelling,
+  withDeprecatedSpellingWarning,
 } from "../commands/piece.ts";
 import {
   CellSelectionError,
@@ -478,6 +482,54 @@ describe("cli piece parsing", () => {
   it('parseLink() rejects the "#argument" suffix on a link endpoint', () => {
     expect(() => parseLink(`/${LLM_HANDLE}#argument`))
       .toThrow(/does not apply to a link endpoint/);
+  });
+
+  it("warnDeprecatedPieceSpelling() names the short spelling and the end date", () => {
+    const lines: string[] = [];
+    warnDeprecatedPieceSpelling("piece get", {
+      writeError: (text) => lines.push(text),
+    });
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("'cf piece get' is deprecated");
+    expect(lines[0]).toContain("spell it 'cf get'");
+    expect(lines[0]).toContain(
+      `stops working on ${PIECE_DATA_SPELLING_END_DATE}`,
+    );
+  });
+
+  it("withDeprecatedSpellingWarning() warns once, then delegates with `this` intact", () => {
+    const calls: Array<{ self: unknown; args: unknown[] }> = [];
+    const warned: string[] = [];
+    const original = console.error;
+    console.error = (...parts: unknown[]) => {
+      warned.push(parts.join(" "));
+    };
+    try {
+      const wrapped = withDeprecatedSpellingWarning(
+        "piece call",
+        function (this: unknown, ...args: unknown[]) {
+          calls.push({ self: this, args });
+          return "delegated";
+        },
+      );
+      const self = { marker: true };
+      expect(wrapped.call(self, "a", 1)).toBe("delegated");
+    } finally {
+      console.error = original;
+    }
+    // `this` passes through untouched: `call`'s action reads
+    // `this.getLiteralArgs()` off the Cliffy command it runs under.
+    expect(calls).toEqual([{ self: { marker: true }, args: ["a", 1] }]);
+    expect(warned).toHaveLength(1);
+    expect(warned[0]).toContain("'cf piece call' is deprecated");
+  });
+
+  it("dataCommandAction() wraps only the piece-mounted spellings", () => {
+    const action = () => "ran";
+    // The top-level spelling mounts the action untouched — identity, not a
+    // silent wrapper — so the two mounts differ in nothing but the notice.
+    expect(dataCommandAction("get", action)).toBe(action);
+    expect(dataCommandAction("piece get", action)).not.toBe(action);
   });
 
   it("parseSpaceOptions() refuses a piece reference beside a URL that names a piece", () => {


### PR DESCRIPTION
## Why

Step 6a of `docs/plans/cli-surface-shape.md` (as split by the plan updates in #5914): `cf piece get`, `cf piece set`, and `cf piece call` keep working and each warns, naming the literal day the spelling stops working — two weeks after this PR reaches main. A literal rather than a runtime-computed window, because a caller who reads the warning today and acts on it next week must be told the same date both times. 6b, a calendar item, removes the spellings and these notices on that day.

**Merge order**: after #5918 (the agent-surface sweep) — a warning that fires on examples this repository's own agents are still taught is the failure mode the sweeps exist to prevent. #5912 (its docs counterpart) is already on main.

**The date literal is set at merge time.** `PIECE_DATA_SPELLING_END_DATE` in `commands/piece.ts` carries a provisional value and is the single source — no call site, doc, or test copies the date. When this merges, one amend sets it to merge-day-plus-fourteen.

## What changed

- One implementation on the shared builders: `dataCommandAction(spelling, action)` wraps the action with the notice only for `piece `-prefixed spellings, so the decision lives on the one definition both mounts share and cannot drift per-mount. The wrapper preserves `this` (`call`'s action reads `this.getLiteralArgs()`).
- The notice goes to stderr, never stdout — `get` and `call` reserve stdout for machine output, and the piping scripts are exactly the population being migrated. It is unconditional (not behind `--quiet`): a quiet script is the caller most in need of the date.
- It attaches to invocations: a grammar error Cliffy refuses before any action runs warns under neither spelling, and `--help` stays clean.
- The `piece-data-spellings` guard is narrowed exactly once: it reconstructs the notice line through the same function that emits it, asserts it present on the piece mount and absent on the top-level mount, strips exactly that line, and then requires byte-identical stderr — so the one permitted divergence is pinned and every other divergence still fails.
- Docs: the three teaching sites that said the spellings "keep working" now say they keep working and warn, pointing at the constant rather than copying the date.

## Test plan

- Unit: the notice text (spelling, replacement, date), the wrapper's warn-once/delegate/`this`-intact behavior, and `dataCommandAction` returning the top-level action untouched (identity, not a silent wrapper).
- The narrowed cross-spelling guard, end to end through subprocesses.
- Full `packages/cli` suite green; repo-wide fmt, lint, `check-docs` green.
- Live against a local toolshed: piece spelling warns on stderr with the dated notice while stdout carries exactly the machine output; top-level spelling silent; `--help` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

