### PR TITLE
feat(cli): the graph acts run — the refusal is the only thing still pending

### DIFF
--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -60,7 +60,7 @@ verbs, and they differ in nothing but what the new item is filed under:
 | `recordNote` | returns what only the pattern could compute: the clock is a handler capability, so the stamp cannot come from the caller | act 7 |
 | `finish` | returns a derived fact — `openBelow` takes a walk of the whole subtree, which a caller would pay N reads for | act 8 |
 | `archive` | declares no result: the invocation settles carrying no `result` at all, and what it changed is a separate read | act 9 |
-| `blockOn` | takes an address as an **argument** rather than as the receiver | act 12, **[blocked]** |
+| `blockOn` | takes an address as an **argument** rather than as the receiver | act 12 — the envelope spelling works, the printed-address spelling is refused |
 
 Those act numbers are `packages/cli/integration/verb-session-demo.sh`, which
 drives the session and prints each command before running it — the transcript is
@@ -483,14 +483,27 @@ their own options go.
 The demo's act 10 is this step run against the session's own tree: the whole
 board first, then only what is open, then the refusal.
 
-## 6. Relate two items **[blocked]**
+## 6. Relate two items **[today]**, minus one spelling
 
 ```bash
-cf call "$EPIC" blockOn -- --on "$OTHER"
+cf call "$KID" blockOn -- --on "$CSRF"
 ```
 
-This is where the session stops — on the spelling, no longer on the
-capability.
+That spelling — the address exactly as a read printed it — is the one still
+refused (#5880 landed the capability, not the round trip). Wrap the same
+address in the link envelope by hand and the call dispatches, the edge that
+lands is the target rather than a copy, and the graph read below shows one
+item under two paths:
+
+```bash
+cf call --select blocked@,on@,blockedOnCount "$KID" blockOn '{"on":{"/":{"link@1":{"id":"of:fid1:…"}}}}'
+
+cf get "$EPIC" children --select @,title,blockedOn@
+```
+
+The demo's acts 12 and 13 run all three: the refusal as a claim that
+self-reports the day the printed address is accepted, the envelope as the
+workaround it is, and the two-paths read as the payoff addresses exist for.
 
 ## The composition axis
 

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -16,11 +16,11 @@
 # line that ran cannot drift apart. What a reader sees is what they can retype,
 # given the two environment variables the header names.
 #
-# Two acts are marked PENDING. They print the command and the result they will
-# produce, without running it, because the capability is sequenced and not yet
-# built (docs/plans/references-as-arguments.md). They are deliberately visible —
-# a demo that quietly omits what does not work teaches a surface that does not
-# exist.
+# No act is marked PENDING today. `pending` stays for the next capability
+# that is sequenced but unbuilt: it prints the command and the result it will
+# produce, without running it, so what does not work yet stays deliberately
+# visible — a demo that quietly omits what does not work teaches a surface
+# that does not exist.
 #
 # No act is marked BROKEN today. `broken` stays for the next one that is: it
 # checks that the defect an act claims still answers to its own signature, so
@@ -229,9 +229,10 @@ say "The same answer. A projection is a question you may ask twice, which is"
 say "what makes any of the reads above safe to put in a script — as here: the"
 say "child the next acts drive is taken from the answer just shown."
 # From the run the reader watched, not from a hidden second read: acts 8 and 9
-# drive this child, and its address sits in $OUT under the title it was filed
-# with.
+# drive the first child, act 12 relates it to the second, and both addresses
+# sit in $OUT under the titles they were filed with.
 KID=$(printf '%s' "$OUT" | jq -r '.[] | select(.title=="Session cookies")."$link"')
+CSRF=$(printf '%s' "$OUT" | jq -r '.[] | select(.title=="CSRF tokens")."$link"')
 
 act "7 · A verb returns what only the pattern could compute"
 say "The note's timestamp is the pattern's; the caller never supplied one."
@@ -286,30 +287,24 @@ say "One shape of answer from both ends: what was wrong, the position it sat at,
 say "what that position accepts, and the nearest thing you probably meant. The"
 say "call was turned down before an invocation was spent."
 
-act "12 · Relate two items — PENDING"
+act "12 · Relate two items"
 say "The tracker is a graph, not just a tree: an item can wait on any other."
-# The capability landed (#5880): a hand-assembled link envelope dispatches, and
-# the edge that comes back is the target rather than a copy. What this act
-# waits for is the spelling it teaches everywhere else — the address exactly as
-# a read printed it. That string is still refused in an argument position, and
-# a demo that assembled the envelope would be teaching assembly, not carrying.
-pending "cf call -s $SPACE <cookies-address> blockOn -- --on <csrf-address>" \
-  "the address a read emits cannot yet be a verb argument (references-as-arguments.md)" \
-  '{
-  "status": "settled",
-  "result": {
-    "blocked":         { "$link": "/of:fid1:…", "title": "Session cookies" },
-    "on":              { "$link": "/of:fid1:…", "title": "CSRF tokens" },
-    "blockedOnCount":  1
-  }
-}'
+say "The spelling this session taught throughout — the address as printed — is"
+say "the one thing still refused here (references-as-arguments.md)."
+refused "the address a read emits, as a verb argument" \
+  cf call -s "$SPACE" "$KID" blockOn -- --on "$CSRF"
+say "The capability itself landed: wrap the same address in the link envelope"
+say "by hand, and the edge that lands is the target rather than a copy. The"
+say "assembly is the workaround; the refusal above is this act's claim that it"
+say "is still needed, and the day it stops being refused, this act says so."
+run cf call -s "$SPACE" --select blocked@,on@,blockedOnCount "$KID" blockOn "{\"on\":{\"/\":{\"link@1\":{\"id\":\"${CSRF#/}\"}}}}"
 
-act "13 · One item, two paths, one address — PENDING"
-say "This is what addresses are for: the same item under a parent AND as a blocker,"
-say "and a caller can tell it is one item rather than two copies."
-pending "cf get -s $SPACE --piece board items --select title,children@,blockedOn@" \
-  "needs the edge from act 12" \
-  'the same of:fid1:… appears under one item'"'"'s children and another'"'"'s blockedOn'
+act "13 · One item, two paths, one address"
+say "This is what addresses are for: the same item under a parent AND as a"
+say "blocker, and a caller can tell it is one item rather than two copies."
+run cf get -s "$SPACE" "$EPIC" children --select @,title,blockedOn@
+say "One address, two positions: the same string sits in the row that holds"
+say "the item and in the blockedOn of the item that waits on it."
 
 printf '\n%s━━ %s %s\n' "$B" "What just happened" "$N"
 say "No tool was written for this tracker. Every flag, type, listing and result"
@@ -321,9 +316,11 @@ say "is the composition the verb surface exists for. On those lines the flags"
 say "that remain name the space and shape the answer; the slug keeps --piece,"
 say "and a verb's own flags stay the verb's."
 say ""
-say "Acts 12 and 13 are the graph half, sequenced as references-as-arguments."
-say "verb-session-gaps.sh asserts both, and fails the day either one starts"
-say "working — so this demo cannot quietly go stale."
+say "Acts 12 and 13 are the graph half, live minus one spelling: the printed"
+say "address is still refused as an argument, and the envelope assembly beside"
+say "that refusal retires the day it stops being refused — act 12 and"
+say "verb-session-gaps.sh both report that day, so this demo cannot quietly"
+say "go stale."
 
 if [ "$UNEXPECTED" != "0" ]; then
   printf '\n%s━━ %d act(s) failed that this demo says work%s\n' \

--- a/tasks/check-verb-session-sync.test.ts
+++ b/tasks/check-verb-session-sync.test.ts
@@ -133,10 +133,9 @@ describe("check-verb-session-sync", () => {
     });
 
     it("catches an act reference the demo does not have", () => {
-      const stale = md.replace(
-        "act 12, **[blocked]**",
-        "act 99, **[blocked]**",
-      );
+      // The first "act 12" in the walkthrough, wherever it sits, renumbered
+      // past the demo's range.
+      const stale = md.replace("act 12", "act 99");
       expect(stale).not.toEqual(md);
       const found = findViolations(sh, stale);
       expect(found.some((v) => v.includes("act 99"))).toBe(true);
@@ -177,6 +176,16 @@ describe("check-verb-session-sync", () => {
       } finally {
         await Deno.remove(mdPath);
       }
+    });
+
+    it("does not let a reasonless marker exempt anything", () => {
+      const block = [
+        "```bash",
+        "# not in the demo",
+        "cf frobnicate --nothing-like-this",
+        "```",
+      ].join("\n");
+      expect(findViolations(sh, block).length).toBe(1);
     });
 
     it("still flags the line after an exemption is spent", () => {

--- a/tasks/check-verb-session-sync.ts
+++ b/tasks/check-verb-session-sync.ts
@@ -31,8 +31,10 @@ const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
 export const DEMO_PATH = "packages/cli/integration/verb-session-demo.sh";
 export const WALKTHROUGH_PATH = "docs/common/verb-session-walkthrough.md";
 
-/** The comment that exempts the next `cf` line in a walkthrough bash block. */
-const EXEMPTION = /^#.*not in the demo/;
+/** The comment that exempts the next `cf` line in a walkthrough bash block.
+ * The marker alone is not enough: an exemption without a reason is one
+ * nobody can review, so a word has to follow the phrase. */
+const EXEMPTION = /^#.*not in the demo\W*\w/;
 
 /** Joins backslash-continued lines into one logical line each. */
 export function joinContinuations(text: string): string[] {


### PR DESCRIPTION
## Why

Follow-up to #5915, closing the loop on #5880: the demo's two graph acts were
still PENDING while the capability they demonstrate had landed. Acts 12 and 13
now run. What stays deliberately unresolved — and is the only thing left of
the references-as-arguments gap in this session — is the spelling: the address
a read emits, fed back as written, is still refused.

Act 12 runs both halves in order. First the spelling the session teaches
throughout — the printed address — as a REFUSED claim, so the act reports
itself the day the string form is accepted. Then the hand-assembled link
envelope as the narrated workaround it is, its result shaped to `blocked@`,
`on@`, and the count. Act 13 is the payoff addresses exist for, live: the same
string under the children row that holds the item and under the `blockedOn` of
the item that waits on it.

Also carries the two cubic findings from #5915's review: the header/act-12
contradiction (resolved by the header rewrite — no act is PENDING now), and
the sync gate's exemption regex hardened so a `# not in the demo` marker
without a reason exempts nothing.

## What Changed

- Demo: acts 12 and 13 converted from `pending` to `refused` + `run`; header
  and epilogue updated; act 6 hands act 12 its second address from the same
  displayed output that feeds acts 8 and 9.
- Walkthrough: step 6 is **[today]** minus one spelling, quoting the demo's
  three commands under the sync gate; the shape table's blockOn row says the
  same.
- Sync gate: exemptions require a reason; the stale-act test's mutation
  needle retargeted (its own not-equal guard caught the orphaning).

## Test plan

Measured against a local toolshed: demo exits 0 with stdin held open for the
whole run; the refusal fires with the gate's own message; the envelope call
settles with `blockedOnCount: 1`; the two-paths read shows the same address in
both positions. Harness 28 passed / 0 failed / 1 gap open. Checker green on
the real files; its test suite covers both verdicts of `main()` and reds under
the injected drift classes. Repo-wide `deno fmt --check` and
`deno task check-docs` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

