### PR TITLE
feat: deploy data files with a pattern and let it read them

### DIFF
--- a/.claude/agents/pattern-user.md
+++ b/.claude/agents/pattern-user.md
@@ -63,6 +63,12 @@ CF_API_URL=<url> deno task cf call --piece <piece_id> --identity <key_path> <han
 same test flags on every `setsrc`, because each update defines the complete
 source package for that revision.
 
+Repeatable `--datafile <path>` attaches a file that is not code — a fixture or
+lookup table the pattern is deployed with. Its bytes are stored verbatim and
+never parsed, compiled, or importable; the pattern reads one with
+`dataFile(path)` from `commonfabric`. The complete-revision rule covers it
+too: repeat every data-file flag on each `setsrc`.
+
 ## Done When
 
 Automated tests pass, every test entry is attached to the deployed source

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -140,6 +140,9 @@
       "packages/static/assets/",
       "packages/ts-transformers/test/fixtures",
       "packages/schema-generator/test/fixtures",
+      // Attached data files travel byte-for-byte and their bytes are asserted
+      // on; formatting them would rewrite the thing under test.
+      "packages/cli/integration/pattern/data/",
       "packages/ui/src/v2/components/cf-chart/cf-chart.ts",
       "packages/ui/src/v2/components/cf-chart/lib/axes.ts",
       "packages/ui/src/v2/components/cf-chart/lib/render.ts",

--- a/docs/common/workflows/development.md
+++ b/docs/common/workflows/development.md
@@ -13,8 +13,11 @@ deno task cf test pattern.test.tsx
 # Deploy with every test entry attached
 deno task cf piece new ... --test pattern.test.tsx pattern.tsx
 
-# Update existing and retain the complete test package
+# Update existing and retain the complete source package
 deno task cf piece setsrc ... --test pattern.test.tsx --piece PIECE_ID pattern.tsx
+
+# Ship a file that is not code alongside the source
+deno task cf piece setsrc ... --test pattern.test.tsx --datafile data/cities.json --piece PIECE_ID pattern.tsx
 
 # Inspect data
 deno task cf piece inspect ... --piece PIECE_ID
@@ -28,6 +31,12 @@ deno task cf piece link ... editor-id/items viewer-id/items
 - Write automated pattern tests for new or changed behavior, run every test
   entry with `cf test`, and repeat `--test` for every entry during deployment.
   Deployment packages and type-checks attached tests but does not run them.
+- Attach a file that is not code with repeatable `--datafile`. Its bytes are
+  stored verbatim — never parsed, compiled, or importable — and recovered by
+  `cf piece getsrc` with the rest of the package. The pattern reads one with
+  `dataFile(path)` from `commonfabric`, naming the path it is stored under.
+  Repeat every flag on each `setsrc`; an update defines the complete source
+  revision.
 - Deploy once, then use `setsrc` for updates
 - Repeat the complete set of `--test` flags on every `setsrc`. Each update
   defines a complete source revision, so omitted test roots are not retained.

--- a/docs/development/space-clone-rehearsal.md
+++ b/docs/development/space-clone-rehearsal.md
@@ -104,8 +104,10 @@ Add one `cf test` command and one `--test` flag for every authored test entry,
 and one `--datafile` flag for every attached data file. Run `setsrc` once per
 piece with the complete flag set: a rehearsal that omits part of the source
 package does not rehearse the update you mean to make against real data.
-Deployment packages and type-checks the tests but does not run them, and stores
-data files verbatim without reading them at all.
+Deployment packages and type-checks the tests but does not run them. It reads
+each data file to store it, and refuses one that is not valid UTF-8 text, but
+never parses or executes it — a data file's bytes are stored exactly as
+authored.
 
 ### Stop the server before resetting
 

--- a/docs/development/space-clone-rehearsal.md
+++ b/docs/development/space-clone-rehearsal.md
@@ -79,13 +79,15 @@ deno task cf space verify $CLONE
 deno task cf inspect churn $DB --bucket 60 --until "$(date -u '+%Y-%m-%d %H:%M:%S')"
 
 # 4. Run every authored test locally. Then update against the CLONE's api-url
-#    once, with one --test flag per entry. Children first, board last, serially
-#    — the parent's result recomputation is what storms.
+#    once, with one --test flag per entry and one --datafile flag per attached
+#    data file. Children first, board last, serially — the parent's result
+#    recomputation is what storms.
 deno task cf test <pattern.test.tsx>
 deno task cf test <pattern.integration.test.tsx>
 deno task cf piece setsrc <pattern.tsx> \
   --test <pattern.test.tsx> \
   --test <pattern.integration.test.tsx> \
+  --datafile <data/fixture.json> \
   --api-url http://localhost:8010 …
 
 # 5. Judge it. --expect-migration gates on removal, not on change.
@@ -98,9 +100,12 @@ deno task cf inspect churn $DB --bucket 60 \
 deno task cf space reset $CLONE
 ```
 
-Add one `cf test` command and one `--test` flag for every authored test entry.
-Run `setsrc` once per piece with the complete flag set. Deployment packages and
-type-checks the tests but does not run them.
+Add one `cf test` command and one `--test` flag for every authored test entry,
+and one `--datafile` flag for every attached data file. Run `setsrc` once per
+piece with the complete flag set: a rehearsal that omits part of the source
+package does not rehearse the update you mean to make against real data.
+Deployment packages and type-checks the tests but does not run them, and stores
+data files verbatim without reading them at all.
 
 ### Stop the server before resetting
 

--- a/docs/specs/module-loading.md
+++ b/docs/specs/module-loading.md
@@ -110,8 +110,17 @@ this work and is out of scope.
 ### Compilation
 
 [`Engine.compileToRecordGraph`][c1] receives a `RuntimeProgram` =
-`{ main, files[] }`, where `files` is the entry file plus its resolved import
-closure, and produces a graph of per-module records. It:
+`{ main, files[], mainExport?, sourceRoots?, dataFiles? }`, where `files` is the
+entry file plus its resolved import closure, plus whatever else the source
+package carries. `sourceRoots` names attached entry points that are resolved and
+compiled but never executed, such as tests. `dataFiles` names members of `files`
+that are not code at all: they are split out before the pipeline below runs, so
+nothing prefixes, parses, transforms, or compiles them, and they rejoin only at
+the identity and persistence steps. Their bytes are carried on the resulting
+graph, keyed by stored path, and bound into the runtime-module namespaces this
+load registers, so a module's `dataFile` read is a lookup against the same
+closure its code came from. The result is a graph of per-module records.
+It:
 
 1. Derives a per-load program id and prefixes every file path with it
    ([`pretransformProgramForModules`][c2]). The prefix is a per-load namespace
@@ -526,7 +535,19 @@ identity. Their link sets are different. A source document stores internal
 authored-import links, including links to authored declarations. It omits fabric
 edges so one program's source closure does not absorb another program.
 Synthetic retention links may keep other source roots alive, but they are
-excluded from the identity hash and executable graph traversal. A compiled
+excluded from the identity hash and executable graph traversal. Separately, an
+entry source document stores one identity-only link per member of its source
+package that no import reaches: [`SOURCE_ROOT_SPECIFIER`][c7]
+(`cf:source-root/`) for an attached source entry point such as a test, and
+[`DATA_FILE_SPECIFIER`][c7] (`cf:data-file/`) for an attached data file. Unlike
+a retention link, these participate in the entry module's identity, so changing
+the package changes the revision. Neither resolves a module record. A data
+document is hashed as a leaf over its own bytes and filename rather than through
+a parse of its contents, which is what lets a data file hold bytes that are not
+TypeScript. Both namespaces are reserved against authored imports. The compiled
+set carries the same data documents under `kind: "data"`, with the authored
+bytes as their `code`, so a warm load has everything the pattern needs without
+reading the source set. A compiled
 document stores runtime edges only between emitted modules. It includes fabric
 edges needed by the self-contained compiled closure. The entry compiled
 document also uses synthetic [`ROOT_LINK_SPECIFIER`][c14] (`cf:cache-root/`)

--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -205,6 +205,62 @@ therefore creates a distinct revision even when the executable source is
 unchanged. Test dependencies remain ordinary source files in that revision, but
 only paths supplied with `--test` are recovered as test entry points.
 
+### Data files
+
+The same three local deployment commands accept a repeatable
+`--datafile <path>` flag, which attaches a file that is stored with the source
+package and never treated as code. A data file is a file the pattern's author
+keeps beside the pattern source and its tests — a fixture, a table, a list of
+names — and wants deployed with them so that every checkout of the piece
+receives the same bytes.
+
+The bytes are stored verbatim. They are never scanned for imports, never
+transformed, never type-checked, and never compiled or executed, so a data file
+may hold anything a source package can carry. A source package holds text, so a
+data file must be valid UTF-8; the CLI refuses one that is not, by name, rather
+than storing replacement characters. Nothing imports a data file: an import
+specifier that would land on one does not resolve, and fails the compile.
+
+When `--root` is omitted, the CLI uses the common directory containing the main
+entry, every test entry, and every data file. An explicit `--root` remains
+authoritative, and a data file outside it is refused — including one reached
+through a symbolic link. A data file's stored name is its path relative to that
+root, so `--datafile ./data/cities.json` deployed from a root of `.` is stored
+as `/data/cities.json`.
+
+Attached data files participate in the deployed source revision's identity, on
+the same footing as attached test entry points and through the same kind of
+identity-only edge from the entry module. Changing, adding, or removing a data
+file therefore creates a distinct revision even when the executable source is
+unchanged, and each revision stays independently recoverable with its own
+bytes. Source recovery and `cf piece getsrc` return the executable source, its
+attached tests, and its data files together, and report which files are data.
+Repeat the complete set of `--datafile` flags on every `setsrc` because each
+update defines a complete source revision. `set-home --reset` rejects
+`--datafile` because a reset deploys no local source package.
+
+A pattern reads an attached data file with `dataFile(path)` from
+`commonfabric`, naming the path the file is stored under. A data file belongs
+to the package rather than to any one module, so that path is absolute within
+the package and does not resolve relative to the caller — every module in the
+package names a given file the same way, and a sub-pattern reads one as readily
+as the entry does. A path naming no attached data file throws.
+
+The read is immediate. A data file's bytes travel with the pattern's code in
+the same content-addressed closure, so they are present before any module
+executes and the read needs no storage access. It therefore returns the same
+bytes on every load of a given source revision, cold or warm. A data file is
+still not importable: an import specifier that would land on one does not
+resolve.
+
+Data files are fixed at deploy time. Data that changes while the pattern runs
+belongs in its cells; a data file changes only by deploying a new source
+revision.
+
+The same bytes are read by whatever reads the source package: `cf piece
+getsrc`, the FUSE `.src/` view, and any tool working from a recovered
+checkout.
+
 ## Specifier syntax
 
 ### One grammar, no type tag
@@ -267,8 +323,8 @@ Parsing rules (each form is disjoint by prefix; no segment counting needed):
   always space-scoped (slug ids are `slugIdForSpace(space, slug)`), with the
   current space as default. A parsed `pattern:` ref with a subpath is rejected
   during resolution because one module identity does not bind an exports map.
-- The emitted-namespace specifiers `cf:module/<hash>` and `cf:cache-root/`
-  remain compiler-internal and are **rejected in authored source**.
+- The compiler-internal specifiers `cf:module/<hash>`, `cf:cache-root/`,
+  `cf:source-root/`, and `cf:data-file/` are **rejected in authored source**.
 
 ### Resolution and target selection
 
@@ -550,7 +606,7 @@ expose arbitrary filenames or infer names from entry-module re-exports.
 | `./ ../ /` | program-relative files | today |
 | bare (`commonfabric`, `turndown`, …) | **reserved for runtime modules only**, allowlist | today; never used for packages |
 | `cf:` (authored reference grammar above) | this spec | today for content-addressed and same-toolshed entry references; host-qualified routing, explicit exports maps, and subpaths planned |
-| `cf:module/`, `cf:cache-root/` | compiled output / cache internals; rejected in authored source | today |
+| `cf:module/`, `cf:cache-root/`, `cf:source-root/`, `cf:data-file/` | compiled output, cache internals, and source-package identity edges; rejected in authored source | today |
 | `npm: jsr: https:` | future external packages | reserved now |
 
 Reserving bare specifiers for runtime modules is the load-bearing rule: future
@@ -597,7 +653,8 @@ with storage and network access, and `ProgramResolver.resolveSource` is async)
   `isSlugAddress`/`validateSlug`.
 - `runtime-module-policy.ts`: `isAllowedAuthoredImportSpecifier` accepts
   specifiers parsing under the `cf:` reference grammar (and continues to
-  reject the emitted namespaces `cf:module/`, `cf:cache-root/`).
+  reject the compiler-internal namespaces `cf:module/`, `cf:cache-root/`,
+  `cf:source-root/`, `cf:data-file/`).
 
 ### 2. Resolution (a `FabricProgramResolver` wrapper)
 
@@ -822,8 +879,8 @@ unchanged.
 
 - **Grammar**: parse/format round-trips; prefix-form table (`cf:ref`,
   `cf:/space/ref`, `cf://host/space/ref`, subpaths, pins, DIDs-as-space,
-  `of:`/`pattern:` refs); rejection of `cf:module/` and `cf:cache-root/` in
-  authored source.
+  `of:`/`pattern:` refs); rejection of `cf:module/`, `cf:cache-root/`,
+  `cf:source-root/`, and `cf:data-file/` in authored source.
 - **Resolution chase**: slug→piece→pattern, slug→pattern (direct
   publication), `of:<patternId>` start, `pattern:<hash>` terminal; "not a
   pattern" failures per chain shape.

--- a/docs/tutorial/06-workflow.md
+++ b/docs/tutorial/06-workflow.md
@@ -105,6 +105,46 @@ infers the common directory that contains the main entry and every test entry.
 An explicit `--root` applies to all of them. A test-only change creates a new
 source revision, so history and recovery keep each test package separate.
 
+Files that hold data rather than code — a fixture, a table, a list of names —
+travel the same way, under a repeatable `--datafile` flag:
+
+```bash
+deno task cf piece setsrc pattern.tsx \
+  --test pattern.test.tsx \
+  --datafile data/cities.json \
+  --piece fid1:abc... -s myspace
+```
+
+A data file is stored verbatim beside the source. Deployment never parses,
+type-checks, or compiles it, and no pattern can import it. It must be UTF-8
+text, and it must sit inside the deployment root, which the CLI infers to cover
+the main entry, every test entry, and every data file. Like a test entry, a data
+file is part of the source revision's identity, so changing one creates a new
+revision, and each revision keeps its own bytes. Repeat the complete set of
+`--datafile` flags on every `setsrc`.
+
+The pattern reads one with `dataFile`, naming the path the file is stored
+under:
+
+```tsx
+// Shown for illustration only.
+import { dataFile, pattern } from "commonfabric";
+
+export default pattern(() => ({
+  cities: JSON.parse(dataFile("/data/cities.json")).cities,
+}));
+```
+
+The bytes travel with the pattern's code, so the read is immediate and returns
+the same text on every load of a given revision. Reading at module scope rather
+than inside a pattern produces a top-level value like any other, so it takes
+the usual `__cf_data` snapshot.
+
+Data files also travel for whoever reads the source next — you on another
+machine, a teammate running `cf piece getsrc`, a tool reading the FUSE `.src/`
+view. They are fixed at deploy time: data that changes while the pattern runs
+belongs in its cells.
+
 ## Drive a deployed piece from the CLI
 
 Everything a pattern exports (Chapter 3) is drivable without a browser:

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2926,6 +2926,22 @@ export type CompileAndRunFunction = <T = any, S = any>(
   params: FactoryInput<BuiltInCompileAndRunParams<T>>,
 ) => Reactive<BuiltInCompileAndRunState<S>>;
 
+/**
+ * Read an attached data file's text.
+ *
+ * `path` is the file's root-relative path within the deployed source package —
+ * the same spelling `cf piece getsrc` writes it at, and the same one passed to
+ * `--datafile`. A data file belongs to the package rather than to any one
+ * module, so the path is absolute within the package and does not resolve
+ * relative to the caller.
+ *
+ * The bytes travel with the pattern's code in the same content-addressed
+ * closure, so this reads memory rather than storage: it is synchronous, it
+ * cannot fail part-way, and it returns the same bytes on every load of a given
+ * source revision. A path naming no attached data file throws.
+ */
+export type DataFileFunction = (path: string) => string;
+
 // --- SQLite builtins (docs/specs/sqlite-builtin) ---
 
 declare const __sqliteDb: unique symbol;
@@ -3500,6 +3516,7 @@ export declare const fetchJsonUnchecked: FetchJsonUncheckedFunction;
 export declare const fetchProgram: FetchProgramFunction;
 export declare const streamData: StreamDataFunction;
 export declare const compileAndRun: CompileAndRunFunction;
+export declare const dataFile: DataFileFunction;
 export declare const sqliteDatabase: SqliteDatabaseFunction;
 export declare const sqliteQuery: SqliteQueryFunction;
 export declare const table: SqliteTableFunction;

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -929,6 +929,7 @@ such as `--log-level` — plus live values read from the fabric:
 | `piece link <source>/<target>`  | `pieceId/path/to/field` endpoints           |
 | `--space`                       | space DIDs of local memory-v2 stores        |
 | `--identity`, pattern arguments | `*.key` / `*.tsx` files, via the shell      |
+| `--datafile`                    | any file, via the shell                     |
 
 Live values need an identity and an api-url. Both are read from the line being
 typed (`-i`, `-a`, `-u`) before falling back to `CF_IDENTITY`/`CF_API_URL`, so

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -272,6 +272,7 @@ export function localPatternEntry(
     repository?: string;
     root?: string;
     test?: string[];
+    datafile?: string[];
   },
 ): EntryConfig {
   return {
@@ -280,6 +281,7 @@ export function localPatternEntry(
     repository: options.repository,
     rootPath: options.root ? absPath(options.root) : undefined,
     testPaths: options.test?.map((path) => absPath(path)),
+    dataFilePaths: options.datafile?.map((path) => absPath(path)),
   };
 }
 
@@ -1722,6 +1724,11 @@ export const piece = targetOptions(
     "Attach a test pattern source file to the deployed source package. Repeatable.",
     { collect: true },
   )
+  .option(
+    "--datafile <path:string>",
+    "Attach a data file to the deployed source package. Repeatable.",
+    { collect: true },
+  )
   .option("--slug <slug:string>", "Slug URL/address for this piece.")
   .option(
     "--dangerously-allow-incompatible-schema",
@@ -1857,6 +1864,11 @@ export const piece = targetOptions(
   .option(
     "--test <path:string>",
     "Attach a test pattern source file to the deployed source package. Repeatable.",
+    { collect: true },
+  )
+  .option(
+    "--datafile <path:string>",
+    "Attach a data file to the deployed source package. Repeatable.",
     { collect: true },
   )
   .option(
@@ -2439,6 +2451,11 @@ updated effective label view.`),
     "Attach a test pattern source file to the deployed source package. Repeatable.",
     { collect: true },
   )
+  .option(
+    "--datafile <path:string>",
+    "Attach a data file to the deployed source package. Repeatable.",
+    { collect: true },
+  )
   .arguments("[main:string]")
   .action(async (options, main?: string) => {
     setQuietMode(!!options.quiet);
@@ -2464,6 +2481,12 @@ updated effective label view.`),
     if (options.reset && options.test !== undefined) {
       throw new ValidationError(
         "Cannot use --test with --reset.",
+        { exitCode: 1 },
+      );
+    }
+    if (options.reset && options.datafile !== undefined) {
+      throw new ValidationError(
+        "Cannot use --datafile with --reset.",
         { exitCode: 1 },
       );
     }
@@ -2494,6 +2517,7 @@ export interface PieceCLIOptions {
   repository?: string;
   root?: string;
   test?: string[];
+  datafile?: string[];
   dangerouslyAllowIncompatibleSchema?: boolean;
   json?: boolean;
 }

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -1128,9 +1128,65 @@ run_wish() {
   echo "Successfully ran CLI wish integration tests for ${API_URL}."
 }
 
+run_piece_data_files() {
+  setup_space
+
+  local data_pattern="$SCRIPT_DIR/pattern/data-reader.tsx"
+  local data_file="$SCRIPT_DIR/pattern/data/cities.json"
+  local data_dir="$WORK_DIR/datafiles"
+  mkdir -p "$data_dir"
+
+  # Deploy with the data file attached. The pattern reads it while it runs, so
+  # a successful read is what puts the bytes in the result cell below.
+  DATA_PIECE_ID=$(cf piece new $SPACE_ARGS \
+    --root "$SCRIPT_DIR/pattern" \
+    --datafile "$data_file" \
+    "$data_pattern")
+  echo "Created data-file piece: $DATA_PIECE_ID"
+
+  CITIES=$(cf get $SPACE_ARGS --piece $DATA_PIECE_ID cities)
+  assert_json_eq "$CITIES" '["Oslo", "Lima"]' \
+    "Pattern should read the attached data file, got: $CITIES"
+
+  # The bytes reaching the runtime must be the authored bytes, not a reserialized
+  # form. The fixture's spacing is deliberately not what a formatter would
+  # produce, so a re-serialization anywhere in the path shows up here.
+  RAW=$(cf get $SPACE_ARGS --piece $DATA_PIECE_ID raw)
+  EXPECTED_RAW=$(jq -Rs . < "$data_file")
+  assert_json_eq "$RAW" "$EXPECTED_RAW" \
+    "Attached data file should reach the pattern verbatim, got: $RAW"
+
+  # The data file comes back with the source package.
+  cf piece getsrc $SPACE_ARGS --piece $DATA_PIECE_ID "$data_dir"
+  if [ ! -f "$data_dir/data/cities.json" ]; then
+    error "Data file was not retrieved with the source from $DATA_PIECE_ID"
+  fi
+  if ! diff -u "$data_file" "$data_dir/data/cities.json" > /dev/null; then
+    error "Retrieved data file does not match the deployed bytes"
+  fi
+
+  # Redeploy from the recovered checkout, which `getsrc` laid out with the same
+  # relative paths the piece was built from. A data-only edit is a complete new
+  # source revision, so the pattern must read the new bytes — that is what shows
+  # the runtime is not serving a stale copy.
+  printf '{"cities":["Oslo","Lima","Accra"]}\n' > "$data_dir/data/cities.json"
+  cf piece setsrc $SPACE_ARGS --piece $DATA_PIECE_ID \
+    --root "$data_dir" \
+    --datafile "$data_dir/data/cities.json" \
+    "$data_dir/data-reader.tsx"
+  cf piece step $SPACE_ARGS --piece $DATA_PIECE_ID
+
+  UPDATED=$(cf get $SPACE_ARGS --piece $DATA_PIECE_ID cities)
+  assert_json_eq "$UPDATED" '["Oslo", "Lima", "Accra"]' \
+    "Pattern should read the updated data file, got: $UPDATED"
+
+  echo "Successfully ran CLI data-file integration tests for ${API_URL}."
+}
+
 case "$SECTION" in
   all)
     run_piece_values
+    run_piece_data_files
     run_piece_links
     run_piece_call
     run_piece_call_retry
@@ -1144,6 +1200,7 @@ case "$SECTION" in
     ;;
   piece-values)
     run_piece_values
+    run_piece_data_files
     run_spelling_parity
     ;;
   spelling-parity)

--- a/packages/cli/integration/pattern/data-reader.tsx
+++ b/packages/cli/integration/pattern/data-reader.tsx
@@ -1,0 +1,18 @@
+import { dataFile, pattern } from "commonfabric";
+
+/**
+ * Reads an attached data file. The deployed piece exposes both the parsed
+ * contents and the raw text, so the integration run can check the bytes that
+ * reached the runtime rather than only that the pattern compiled.
+ *
+ * The optional input exists so a later `setsrc` has an argument schema that
+ * accepts the deployed piece's existing arguments.
+ */
+export default pattern<{ label?: string }>(({ label }) => {
+  const raw = dataFile("/data/cities.json");
+  return {
+    label,
+    cities: JSON.parse(raw).cities,
+    raw,
+  };
+});

--- a/packages/cli/integration/pattern/data/cities.json
+++ b/packages/cli/integration/pattern/data/cities.json
@@ -1,0 +1,2 @@
+{"cities":["Oslo","Lima"],
+  "note":  "spacing here is deliberate: a data file is stored byte-for-byte"}

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -335,6 +335,9 @@ const OPTION_VALUE_PROVIDERS: Readonly<
   identity: () => Promise.resolve(directive({ kind: "files", glob: "*.key" })),
   root: () => Promise.resolve(directive({ kind: "dirs" })),
   test: patternFiles,
+  // A data file has no fixed extension; the shell's own file completion is the
+  // only honest candidate set.
+  datafile: () => Promise.resolve(directive({ kind: "files" })),
   // `cf space clone --to <dir>` builds a clone directory.
   to: () => Promise.resolve(directive({ kind: "dirs" })),
   "log-file": () => Promise.resolve(directive({ kind: "files" })),

--- a/packages/cli/lib/fabric-deps.ts
+++ b/packages/cli/lib/fabric-deps.ts
@@ -26,8 +26,16 @@ export async function pinProgramFabricImports(
 ): Promise<{ program: RuntimeProgram; rewrites: ProgramFabricPinRewrite[] }> {
   const rewrites: ProgramFabricPinRewrite[] = [];
   const files = [];
+  // A data file's bytes are stored exactly as authored and are never read as
+  // code. Parsing one for import specifiers would rewrite text that only
+  // resembles an import, so pinning skips them.
+  const dataFiles = new Set(program.dataFiles ?? []);
 
   for (const file of program.files) {
+    if (dataFiles.has(file.name)) {
+      files.push(file);
+      continue;
+    }
     const resolvedBySpecifier = new Map<string, string>();
     const rewritten = await rewriteFabricPins(
       file.contents,

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -9,7 +9,10 @@ import {
 } from "@commonfabric/data-model/fabric-value";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { createSession, isDID, Session } from "@commonfabric/identity";
-import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import {
+  FileSystemProgramResolver,
+  readDataFileSource,
+} from "@commonfabric/js-compiler";
 import { setLLMUrl } from "@commonfabric/llm";
 import {
   assignSlug,
@@ -106,6 +109,8 @@ export interface EntryConfig {
   rootPath?: string;
   /** Test entry paths whose resolved source closures travel with the piece. */
   testPaths?: string[];
+  /** Data file paths stored with the piece and never compiled. */
+  dataFilePaths?: string[];
 }
 
 export interface SpaceConfig {
@@ -598,8 +603,12 @@ export async function getProgramFromFile(
   entry: EntryConfig,
 ): Promise<RuntimeProgram> {
   const entryPaths = [entry.mainPath, ...(entry.testPaths ?? [])];
+  const dataPaths = entry.dataFilePaths ?? [];
   const rootPath = entry.rootPath ??
-    join(common(entryPaths.map((path) => dirname(path))), ".");
+    join(
+      common([...entryPaths, ...dataPaths].map((path) => dirname(path))),
+      ".",
+    );
   const programs: RuntimeProgram[] = await Promise.all(
     entryPaths.map((path) =>
       pieces.runtime.harness.resolve(
@@ -620,12 +629,29 @@ export async function getProgramFromFile(
       files.set(file.name, file);
     }
   }
+  // Data files are read directly rather than resolved: nothing imports them, so
+  // there is no closure to follow, and their bytes are never parsed.
+  const dataFiles: string[] = [];
+  for (const path of dataPaths) {
+    const source = readDataFileSource(path, rootPath);
+    if (dataFiles.includes(source.name)) continue;
+    // The entry or one of its tests reaches this name through an import, so the
+    // package would have to both compile it and store it uninterpreted.
+    if (files.has(source.name)) {
+      throw new Error(
+        `Data file "${source.name}" is also a source module of this package.`,
+      );
+    }
+    files.set(source.name, source);
+    dataFiles.push(source.name);
+  }
   const program: RuntimeProgram = {
     main: mainProgram.main,
     files: [...files.values()],
     ...(testPrograms.length === 0
       ? {}
       : { sourceRoots: testPrograms.map((test) => test.main) }),
+    ...(dataFiles.length === 0 ? {} : { dataFiles }),
   };
   if (entry.mainExport) {
     program.mainExport = entry.mainExport;

--- a/packages/cli/test/completion-output.test.ts
+++ b/packages/cli/test/completion-output.test.ts
@@ -144,6 +144,12 @@ Deno.test("--test defers to pattern file completion", async () => {
   ]);
 });
 
+Deno.test("--datafile defers to unfiltered file completion", async () => {
+  assertEquals(await completeFor("cf piece new --datafile "), [
+    ":cf:files",
+  ]);
+});
+
 Deno.test("a live slot with no resolvable context yields nothing, not an error", async () => {
   // Mid-keystroke with no identity configured: silence is the correct signal.
   const previous = Deno.env.get("CF_IDENTITY");

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -141,6 +141,7 @@ Deno.test("live candidates: path-shaped slots defer to the shell", async () => {
     ["cf piece ls -i ", "files"],
     ["cf piece new --root ", "dirs"],
     ["cf piece new --test ", "files"],
+    ["cf piece new --datafile ", "files"],
     ["cf check ", "files"],
     ["cf space verify ", "dirs"],
     ["cf space clone --to ", "dirs"],

--- a/packages/cli/test/fabric-deps.test.ts
+++ b/packages/cli/test/fabric-deps.test.ts
@@ -85,6 +85,33 @@ describe("cli fabric deps", () => {
     ]);
   });
 
+  it("leaves an attached data file's bytes alone while pinning", async () => {
+    await writePatternSlug("dep");
+    // The data file's text reads as a mutable fabric import. Storing it
+    // verbatim is the whole point of attaching it, so pinning must not touch
+    // it — a rewrite here would be silent data corruption.
+    const dataContents = `import dep from "cf:dep";\nnot code at all`;
+    const result = await pinProgramFabricImports(runtime, space, {
+      main: "/main.tsx",
+      dataFiles: ["/data/notes.txt"],
+      files: [
+        {
+          name: "/main.tsx",
+          contents: `import dep from "cf:dep";\nexport default dep;`,
+        },
+        { name: "/data/notes.txt", contents: dataContents },
+      ],
+    });
+
+    expect(
+      result.program.files.find((file) => file.name === "/data/notes.txt")
+        ?.contents,
+    ).toBe(dataContents);
+    expect(result.rewrites.map((rewrite) => rewrite.file)).toEqual([
+      "/main.tsx",
+    ]);
+  });
+
   it("pins fabric imports across every file of a program", async () => {
     await writePatternSlug("dep");
     const result = await pinProgramFabricImports(runtime, space, {

--- a/packages/cli/test/piece-source-package.test.ts
+++ b/packages/cli/test/piece-source-package.test.ts
@@ -109,6 +109,262 @@ describe("piece source package", () => {
     }
   });
 
+  it("attaches data files alongside the main entry and its tests", async () => {
+    const root = await Deno.makeTempDir();
+    const dataDirectory = join(root, "data");
+    await Deno.mkdir(dataDirectory);
+    const mainPath = join(root, "main.tsx");
+    const testPath = join(root, "main.test.tsx");
+    const citiesPath = join(dataDirectory, "cities.json");
+    const notesPath = join(root, "notes.txt");
+    await Deno.writeTextFile(mainPath, "export default {};");
+    await Deno.writeTextFile(testPath, "export default {};");
+    await Deno.writeTextFile(citiesPath, '{"cities": ["Oslo"]}');
+    // Text a TypeScript parser would read as an import, if a data file were
+    // ever parsed.
+    await Deno.writeTextFile(notesPath, 'import x from "./absent.ts";');
+
+    const resolve = async (resolver: ProgramResolver): Promise<Program> => ({
+      main: (await resolver.main()).name,
+      files: [await resolver.main()],
+    });
+
+    try {
+      const program = await getProgramFromFile(
+        { runtime: { harness: { resolve } } } as any,
+        {
+          mainPath,
+          rootPath: root,
+          testPaths: [testPath],
+          dataFilePaths: [citiesPath, notesPath],
+        },
+      );
+
+      expect(program.main).toBe("/main.tsx");
+      expect(program.sourceRoots).toEqual(["/main.test.tsx"]);
+      expect(program.dataFiles).toEqual(["/data/cities.json", "/notes.txt"]);
+      expect(
+        program.files.find((file) => file.name === "/data/cities.json")
+          ?.contents,
+      ).toBe('{"cities": ["Oslo"]}');
+      expect(
+        program.files.find((file) => file.name === "/notes.txt")?.contents,
+      ).toBe('import x from "./absent.ts";');
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("infers a shared root covering a data file outside the entry directory", async () => {
+    const root = await Deno.makeTempDir();
+    const patternsDirectory = join(root, "patterns");
+    const dataDirectory = join(root, "data");
+    await Deno.mkdir(patternsDirectory);
+    await Deno.mkdir(dataDirectory);
+    const mainPath = join(patternsDirectory, "main.tsx");
+    const dataPath = join(dataDirectory, "cities.json");
+    await Deno.writeTextFile(mainPath, "export default {};");
+    await Deno.writeTextFile(dataPath, "[]");
+
+    const resolve = async (resolver: ProgramResolver): Promise<Program> => ({
+      main: (await resolver.main()).name,
+      files: [await resolver.main()],
+    });
+
+    try {
+      const program = await getProgramFromFile(
+        { runtime: { harness: { resolve } } } as any,
+        { mainPath, dataFilePaths: [dataPath] },
+      );
+      expect(program.main).toBe("/patterns/main.tsx");
+      expect(program.dataFiles).toEqual(["/data/cities.json"]);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("refuses a data file outside the deployment root", async () => {
+    const root = await Deno.makeTempDir();
+    const inner = join(root, "inner");
+    await Deno.mkdir(inner);
+    const mainPath = join(inner, "main.tsx");
+    const outsidePath = join(root, "outside.json");
+    await Deno.writeTextFile(mainPath, "export default {};");
+    await Deno.writeTextFile(outsidePath, "{}");
+
+    const resolve = async (resolver: ProgramResolver): Promise<Program> => ({
+      main: (await resolver.main()).name,
+      files: [await resolver.main()],
+    });
+
+    try {
+      await expect(getProgramFromFile(
+        { runtime: { harness: { resolve } } } as any,
+        { mainPath, rootPath: inner, dataFilePaths: [outsidePath] },
+      )).rejects.toThrow("must be within root directory");
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("refuses a data file that is not valid UTF-8 text", async () => {
+    const root = await Deno.makeTempDir();
+    const mainPath = join(root, "main.tsx");
+    const binaryPath = join(root, "blob.bin");
+    await Deno.writeTextFile(mainPath, "export default {};");
+    await Deno.writeFile(binaryPath, new Uint8Array([0xff, 0xfe, 0x00]));
+
+    const resolve = async (resolver: ProgramResolver): Promise<Program> => ({
+      main: (await resolver.main()).name,
+      files: [await resolver.main()],
+    });
+
+    try {
+      await expect(getProgramFromFile(
+        { runtime: { harness: { resolve } } } as any,
+        { mainPath, rootPath: root, dataFilePaths: [binaryPath] },
+      )).rejects.toThrow("is not valid UTF-8 text");
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("refuses a data file that is also a source module", async () => {
+    const root = await Deno.makeTempDir();
+    const mainPath = join(root, "main.tsx");
+    const sharedPath = join(root, "shared.ts");
+    await Deno.writeTextFile(
+      mainPath,
+      'import "./shared.ts"; export default {};',
+    );
+    await Deno.writeTextFile(sharedPath, "export const shared = 1;");
+
+    const resolve = async (resolver: ProgramResolver): Promise<Program> => {
+      const main = await resolver.main();
+      const files: Source[] = [main];
+      const shared = await resolver.resolveSource("/shared.ts");
+      if (shared !== undefined) files.push(shared);
+      return { main: main.name, files };
+    };
+
+    try {
+      await expect(getProgramFromFile(
+        { runtime: { harness: { resolve } } } as any,
+        { mainPath, rootPath: root, dataFilePaths: [sharedPath] },
+      )).rejects.toThrow(
+        'Data file "/shared.ts" is also a source module of this package.',
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("accepts a repeated --datafile path once", async () => {
+    const root = await Deno.makeTempDir();
+    const mainPath = join(root, "main.tsx");
+    const dataPath = join(root, "cities.json");
+    await Deno.writeTextFile(mainPath, "export default {};");
+    await Deno.writeTextFile(dataPath, "[]");
+
+    const resolve = async (resolver: ProgramResolver): Promise<Program> => ({
+      main: (await resolver.main()).name,
+      files: [await resolver.main()],
+    });
+
+    try {
+      const program = await getProgramFromFile(
+        { runtime: { harness: { resolve } } } as any,
+        { mainPath, rootPath: root, dataFilePaths: [dataPath, dataPath] },
+      );
+      expect(program.dataFiles).toEqual(["/cities.json"]);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("recovers attached data files from the fabric source package", async () => {
+    const root = await Deno.makeTempDir();
+    const dataDirectory = join(root, "data");
+    await Deno.mkdir(dataDirectory);
+    const mainPath = join(root, "main.tsx");
+    const dataPath = join(dataDirectory, "cities.json");
+    await Deno.writeTextFile(
+      mainPath,
+      `import { pattern } from "commonfabric";
+export default pattern(() => ({ value: 1 }));`,
+    );
+    await Deno.writeTextFile(dataPath, '{"cities": ["Oslo"]}');
+
+    const signer = await Identity.fromPassphrase("attached piece data files");
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+    });
+
+    try {
+      const program = await getProgramFromFile(
+        { runtime } as any,
+        { mainPath, rootPath: root, dataFilePaths: [dataPath] },
+      );
+      const compiled = await runtime.patternManager.compilePattern(program, {
+        space: signer.did(),
+      });
+      const entry = runtime.patternManager.getArtifactEntryRef(compiled);
+      expect(entry).toBeDefined();
+
+      const recovered = await runtime.patternManager
+        .getPatternSourceProgramByIdentity(entry!.identity, signer.did());
+      expect(recovered?.dataFiles).toEqual(["/data/cities.json"]);
+      expect(
+        recovered?.files.find((file) => file.name === "/data/cities.json")
+          ?.contents,
+      ).toBe('{"cities": ["Oslo"]}');
+
+      const recompiled = await runtime.harness.compileResolvedToRecordGraph(
+        recovered!.files,
+        recovered!.main,
+        { dataFiles: recovered!.dataFiles },
+      );
+      expect(recompiled.entryIdentity).toBe(entry!.identity);
+
+      // A data-only edit is a distinct source revision, so the earlier one
+      // stays recoverable with its own bytes.
+      await Deno.writeTextFile(dataPath, '{"cities": ["Lima"]}');
+      const nextProgram = await getProgramFromFile(
+        { runtime } as any,
+        { mainPath, rootPath: root, dataFilePaths: [dataPath] },
+      );
+      const nextCompiled = await runtime.patternManager.compilePattern(
+        nextProgram,
+        { space: signer.did() },
+      );
+      const nextEntry = runtime.patternManager.getArtifactEntryRef(
+        nextCompiled,
+      );
+      expect(nextEntry).toBeDefined();
+      expect(nextEntry!.identity).not.toBe(entry!.identity);
+
+      const firstAgain = await runtime.patternManager
+        .getPatternSourceProgramByIdentity(entry!.identity, signer.did());
+      const second = await runtime.patternManager
+        .getPatternSourceProgramByIdentity(nextEntry!.identity, signer.did());
+      expect(
+        firstAgain?.files.find((file) => file.name === "/data/cities.json")
+          ?.contents,
+      ).toBe('{"cities": ["Oslo"]}');
+      expect(
+        second?.files.find((file) => file.name === "/data/cities.json")
+          ?.contents,
+      ).toBe('{"cities": ["Lima"]}');
+    } finally {
+      await runtime.settled();
+      await runtime.dispose({ closeStorage: false });
+      await storageManager.close();
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
   it("recovers attached tests from the fabric source package", async () => {
     const root = await Deno.makeTempDir();
     const testsDirectory = join(root, "tests");

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -999,6 +999,7 @@ describe("cli piece parsing", () => {
     expect(newFlags).toContain("--root");
     expect(newFlags).toContain("--repository");
     expect(newFlags).toContain("--test");
+    expect(newFlags).toContain("--datafile");
     expect(newFlags).toContain("--dangerously-allow-incompatible-schema");
 
     for (const command of ["setsrc", "set-home"]) {
@@ -1006,6 +1007,7 @@ describe("cli piece parsing", () => {
       expect(flags).toContain("--root");
       expect(flags).toContain("--repository");
       expect(flags).toContain("--test");
+      expect(flags).toContain("--datafile");
     }
     expect(optionFlags("setsrc")).toContain(
       "--dangerously-allow-incompatible-schema",
@@ -1996,18 +1998,33 @@ describe("cli piece parsing", () => {
     ])).rejects.toThrow("Cannot use --test with --reset");
   });
 
+  it("rejects attached data files when resetting the home pattern", async () => {
+    const { piece: command } = await import(
+      "../commands/piece.ts?test-reset-datafile"
+    );
+    command.throwErrors();
+    await expect(command.parse([
+      "set-home",
+      "--reset",
+      "--datafile",
+      "/repo/data/cities.json",
+    ])).rejects.toThrow("Cannot use --datafile with --reset");
+  });
+
   it("builds repository-aware entries from deployment flags", () => {
     expect(localPatternEntry("/repo/pattern.tsx", {
       mainExport: "named",
       repository: "https://github.com/commontoolsinc/labs",
       root: "/repo",
       test: ["/repo/pattern.test.tsx", "/repo/other.test.tsx"],
+      datafile: ["/repo/data/cities.json"],
     })).toEqual({
       mainPath: "/repo/pattern.tsx",
       mainExport: "named",
       repository: "https://github.com/commontoolsinc/labs",
       rootPath: "/repo",
       testPaths: ["/repo/pattern.test.tsx", "/repo/other.test.tsx"],
+      dataFilePaths: ["/repo/data/cities.json"],
     });
   });
 

--- a/packages/fuse/mod.test.ts
+++ b/packages/fuse/mod.test.ts
@@ -173,6 +173,18 @@ Deno.test("source writeback retains attached test roots", async () => {
   );
 });
 
+Deno.test("source writeback retains attached data files", async () => {
+  const source = await Deno.readTextFile(new URL("./mod.ts", import.meta.url));
+  const sourceWriteback = source.slice(
+    source.indexOf('if (writeTarget?.kind === "source")'),
+  );
+
+  assert(
+    sourceWriteback.includes("dataFiles: program.dataFiles"),
+    "source writeback must pass the recovered data files to setPattern",
+  );
+});
+
 Deno.test("no-handle truncate opens only the bounded target prefix", () => {
   const content = new Uint8Array([1, 2, 3, 4, 5]);
   assertEquals([...bufferForNoHandleTruncate(content, 2)], [1, 2]);

--- a/packages/fuse/mod.test.ts
+++ b/packages/fuse/mod.test.ts
@@ -6,6 +6,7 @@ import {
   cfcWritebackXattrResultErrno,
   createSupervisorStatusWriter,
   decodeFuseNamespaceName,
+  decodeSourceWriteText,
   DEFAULT_CFC_XATTR_NAMESPACE,
   defaultCfcWritebackStatePath,
   disconnectedWriteErrno,
@@ -183,6 +184,31 @@ Deno.test("source writeback retains attached data files", async () => {
     sourceWriteback.includes("dataFiles: program.dataFiles"),
     "source writeback must pass the recovered data files to setPattern",
   );
+});
+
+Deno.test("source writes decode as strict UTF-8 text", () => {
+  const encode = (text: string) => new TextEncoder().encode(text);
+  assertEquals(
+    decodeSourceWriteText(encode("export default 1;")),
+    "export default 1;",
+  );
+  assertEquals(decodeSourceWriteText(new Uint8Array(0)), "");
+});
+
+Deno.test("source writes keep a byte order mark", () => {
+  // The mark is content: an attached data file is stored byte-for-byte.
+  const withMark = new Uint8Array([0xef, 0xbb, 0xbf, 0x7b, 0x7d]);
+  assertEquals(decodeSourceWriteText(withMark), "\uFEFF{}");
+});
+
+Deno.test("source writes that are not UTF-8 text decode to undefined", () => {
+  // Storing replacement characters here would deploy something other than what
+  // was written, so the write has to be refused instead.
+  assertEquals(
+    decodeSourceWriteText(new Uint8Array([0xff, 0xfe, 0x00])),
+    undefined,
+  );
+  assertEquals(decodeSourceWriteText(new Uint8Array([0xc3, 0x28])), undefined);
 });
 
 Deno.test("no-handle truncate opens only the bounded target prefix", () => {

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -190,6 +190,27 @@ export function sourceRelPathToTreeSegments(relPath: string): string[] {
   return encodeFusePathSegments(relPath.split("/"));
 }
 
+/**
+ * Decode a write bound for a pattern's source package, or `undefined` when the
+ * bytes are not valid UTF-8 text.
+ *
+ * A source package holds text, so a write that is not text has no faithful
+ * representation in it. Decoding strictly reports that instead of substituting
+ * replacement characters, which would store something other than what was
+ * written. A byte order mark is content and is kept, since an attached data
+ * file is stored byte-for-byte.
+ */
+export function decodeSourceWriteText(
+  buffer: Uint8Array,
+): string | undefined {
+  try {
+    return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true })
+      .decode(buffer);
+  } catch {
+    return undefined;
+  }
+}
+
 export function bufferForNoHandleTruncate(
   content: Uint8Array,
   newSize: number,
@@ -1729,15 +1750,8 @@ export async function main(argv: string[] = Deno.args) {
 
       if (writeTarget?.kind === "source") {
         const { piece, relPath, srcIno } = writeTarget.target;
-        // A source package holds text. Decoding strictly refuses a write that
-        // is not valid UTF-8 rather than storing replacement characters in
-        // place of the bytes, which would silently deploy something other than
-        // what was written — the same refusal `--datafile` makes on the CLI.
-        let text: string;
-        try {
-          text = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true })
-            .decode(buffer);
-        } catch {
+        const text = decodeSourceWriteText(buffer);
+        if (text === undefined) {
           console.error(`[source] Write to ${relPath} is not valid UTF-8 text`);
           markExistingFailed("write is not valid UTF-8 text");
           return EINVAL;

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -1729,7 +1729,19 @@ export async function main(argv: string[] = Deno.args) {
 
       if (writeTarget?.kind === "source") {
         const { piece, relPath, srcIno } = writeTarget.target;
-        const text = new TextDecoder().decode(buffer);
+        // A source package holds text. Decoding strictly refuses a write that
+        // is not valid UTF-8 rather than storing replacement characters in
+        // place of the bytes, which would silently deploy something other than
+        // what was written — the same refusal `--datafile` makes on the CLI.
+        let text: string;
+        try {
+          text = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true })
+            .decode(buffer);
+        } catch {
+          console.error(`[source] Write to ${relPath} is not valid UTF-8 text`);
+          markExistingFailed("write is not valid UTF-8 text");
+          return EINVAL;
+        }
 
         // Optimistically update the file content in the tree
         let fileIno: bigint | undefined = srcIno;

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -1804,6 +1804,7 @@ export async function main(argv: string[] = Deno.args) {
             mainExport: baseMainExport,
             files: updatedFiles,
             sourceRoots: program.sourceRoots,
+            dataFiles: program.dataFiles,
           }, { dangerouslyAllowIncompatibleSchema });
           // Clear error.log on success
           const errorLogIno = tree.lookup(srcIno, "error.log");

--- a/packages/js-compiler/mod.ts
+++ b/packages/js-compiler/mod.ts
@@ -26,6 +26,7 @@ export {
   FileSystemProgramResolver,
   HttpProgramResolver,
   InMemoryProgram,
+  readDataFileSource,
 } from "./program.ts";
 export {
   composeBundleSourceMap,

--- a/packages/js-compiler/program.ts
+++ b/packages/js-compiler/program.ts
@@ -83,7 +83,11 @@ export function readDataFileSource(
   const bytes = Deno.readFileSync(realDataPath);
   let contents: string;
   try {
-    contents = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    // `ignoreBOM` keeps a leading byte order mark in `contents` instead of
+    // consuming it. A data file is stored byte-for-byte, so dropping the mark
+    // would deploy something other than the authored file.
+    contents = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true })
+      .decode(bytes);
   } catch {
     throw new Error(
       `Data file "${dataPath}" is not valid UTF-8 text.`,

--- a/packages/js-compiler/program.ts
+++ b/packages/js-compiler/program.ts
@@ -11,6 +11,16 @@ import { isDeno } from "@commonfabric/utils/env";
 
 import { ProgramResolver, Source } from "./interface.ts";
 
+/**
+ * Guard the Deno-only file system entry points. Each caller names itself, so a
+ * caller reaching this in a browser or worker is told which one it was.
+ */
+function requireDeno(what: string): void {
+  if (!isDeno()) {
+    throw new Error(`${what} is not supported in this environment.`);
+  }
+}
+
 function isOutsideRoot(relativePath: string): boolean {
   return relativePath === ".." || relativePath.startsWith(`..${SEPARATOR}`) ||
     isAbsolute(relativePath);
@@ -63,9 +73,7 @@ export function readDataFileSource(
   dataPath: string,
   rootPath: string,
 ): Source {
-  if (!isDeno()) {
-    throw new Error("readDataFileSource is not supported in this environment.");
-  }
+  requireDeno("readDataFileSource");
   const fsRoot = normalize(rootPath);
   const normalizedDataPath = normalize(dataPath);
   const relativeDataPath = relative(fsRoot, normalizedDataPath);
@@ -156,20 +164,12 @@ export class FileSystemProgramResolver implements ProgramResolver {
   }
 
   #realPath(path: string): string {
-    if (!isDeno()) {
-      throw new Error(
-        "FileSystemProgramResolver is not supported in this environment.",
-      );
-    }
+    requireDeno("FileSystemProgramResolver");
     return Deno.realPathSync(path);
   }
 
   #readFile(path: string): string {
-    if (!isDeno()) {
-      throw new Error(
-        "FileSystemProgramResolver is not supported in this environment.",
-      );
-    }
+    requireDeno("FileSystemProgramResolver");
     return Deno.readTextFileSync(path);
   }
 }

--- a/packages/js-compiler/program.ts
+++ b/packages/js-compiler/program.ts
@@ -46,6 +46,52 @@ export class InMemoryProgram implements ProgramResolver {
   }
 }
 
+/**
+ * Read a data file from the file system as a program source, grounded against
+ * `rootPath` exactly as {@link FileSystemProgramResolver} grounds a module: the
+ * returned `name` is the portable, root-relative path the deployed package
+ * stores it under, and a path that escapes the root — through `..` or through a
+ * symbolic link — is refused.
+ *
+ * A source package holds text, so the bytes are decoded as UTF-8 strictly. A
+ * file that is not valid UTF-8 is reported by name rather than being silently
+ * stored with replacement characters in place of the bytes that were read.
+ *
+ * Deno-only.
+ */
+export function readDataFileSource(
+  dataPath: string,
+  rootPath: string,
+): Source {
+  if (!isDeno()) {
+    throw new Error("readDataFileSource is not supported in this environment.");
+  }
+  const fsRoot = normalize(rootPath);
+  const normalizedDataPath = normalize(dataPath);
+  const relativeDataPath = relative(fsRoot, normalizedDataPath);
+  if (isOutsideRoot(relativeDataPath)) {
+    throw new Error(
+      `Data file "${dataPath}" must be within root directory "${fsRoot}".`,
+    );
+  }
+  const realDataPath = Deno.realPathSync(normalizedDataPath);
+  if (isOutsideRoot(relative(Deno.realPathSync(fsRoot), realDataPath))) {
+    throw new Error(
+      `Data file "${dataPath}" must be within root directory "${fsRoot}".`,
+    );
+  }
+  const bytes = Deno.readFileSync(realDataPath);
+  let contents: string;
+  try {
+    contents = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new Error(
+      `Data file "${dataPath}" is not valid UTF-8 text.`,
+    );
+  }
+  return { name: groundedSourceName(relativeDataPath), contents };
+}
+
 // Resolve a program using the file system.
 // Deno-only.
 export class FileSystemProgramResolver implements ProgramResolver {

--- a/packages/js-compiler/test/program.test.ts
+++ b/packages/js-compiler/test/program.test.ts
@@ -5,6 +5,7 @@ import {
   FileSystemProgramResolver,
   HttpProgramResolver,
   InMemoryProgram,
+  readDataFileSource,
 } from "../program.ts";
 
 describe("InMemoryProgram", () => {
@@ -126,6 +127,84 @@ describe("FileSystemProgramResolver", () => {
         name: "/linked-dependency.ts",
         contents: "export default 2;",
       });
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+});
+
+describe("readDataFileSource", () => {
+  it("grounds a data file under the deployment root", async () => {
+    const root = await Deno.makeTempDir();
+    const dataDirectory = `${root}/data`;
+    await Deno.mkdir(dataDirectory);
+    await Deno.writeTextFile(`${dataDirectory}/cities.json`, '{"a": 1}');
+
+    try {
+      expect(readDataFileSource(`${dataDirectory}/cities.json`, root)).toEqual({
+        name: "/data/cities.json",
+        contents: '{"a": 1}',
+      });
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("reads bytes verbatim without treating them as TypeScript", async () => {
+    const root = await Deno.makeTempDir();
+    const contents = 'import x from "./nowhere.ts";\n\u00e9\t{ not code';
+    await Deno.writeTextFile(`${root}/notes.txt`, contents);
+
+    try {
+      expect(readDataFileSource(`${root}/notes.txt`, root).contents).toBe(
+        contents,
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("rejects a data file outside the root", async () => {
+    const root = await Deno.makeTempDir();
+    const outside = await Deno.makeTempDir();
+    await Deno.writeTextFile(`${outside}/data.json`, "{}");
+
+    try {
+      expect(() => readDataFileSource(`${outside}/data.json`, root)).toThrow(
+        "must be within root directory",
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+      await Deno.remove(outside, { recursive: true });
+    }
+  });
+
+  it("rejects a data file symlinked out of the root", async () => {
+    const root = await Deno.makeTempDir();
+    const outside = await Deno.makeTempDir();
+    await Deno.writeTextFile(`${outside}/data.json`, "{}");
+    await Deno.symlink(`${outside}/data.json`, `${root}/data.json`, {
+      type: "file",
+    });
+
+    try {
+      expect(() => readDataFileSource(`${root}/data.json`, root)).toThrow(
+        "must be within root directory",
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+      await Deno.remove(outside, { recursive: true });
+    }
+  });
+
+  it("rejects bytes that are not valid UTF-8 text", async () => {
+    const root = await Deno.makeTempDir();
+    await Deno.writeFile(`${root}/blob.bin`, new Uint8Array([0xc3, 0x28]));
+
+    try {
+      expect(() => readDataFileSource(`${root}/blob.bin`, root)).toThrow(
+        "is not valid UTF-8 text",
+      );
     } finally {
       await Deno.remove(root, { recursive: true });
     }

--- a/packages/js-compiler/test/program.test.ts
+++ b/packages/js-compiler/test/program.test.ts
@@ -164,6 +164,21 @@ describe("readDataFileSource", () => {
     }
   });
 
+  it("keeps a byte order mark in the contents", async () => {
+    const root = await Deno.makeTempDir();
+    const bytes = new Uint8Array([0xef, 0xbb, 0xbf, 0x7b, 0x7d]);
+    await Deno.writeFile(`${root}/bom.json`, bytes);
+
+    try {
+      // The mark is part of the file, and a data file is stored byte-for-byte.
+      expect(readDataFileSource(`${root}/bom.json`, root).contents).toBe(
+        "\uFEFF{}",
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
   it("rejects a data file outside the root", async () => {
     const root = await Deno.makeTempDir();
     const outside = await Deno.makeTempDir();

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -3271,10 +3271,10 @@ export class PieceController<T = unknown> {
    * The pattern's authored source program, recovered from the content-addressed
    * `pattern:<identity>` source-doc closure in the piece's space. Replaces the
    * deleted meta cell's `program`. `main` is the executable entry filename;
-   * `mainExport` is the pattern pointer's export symbol; and `sourceRoots` names
-   * retained source entry points such as attached tests. Returns undefined when
-   * no verified source closure exists (the source docs are written by every cold
-   * compile).
+   * `mainExport` is the pattern pointer's export symbol; `sourceRoots` names
+   * retained source entry points such as attached tests; and `dataFiles` names
+   * attached data files. Returns undefined when no verified source closure
+   * exists (the source docs are written by every cold compile).
    */
   async getPatternSourceProgram(): Promise<
     | {
@@ -3282,6 +3282,7 @@ export class PieceController<T = unknown> {
       mainExport?: string;
       files: { name: string; contents: string }[];
       sourceRoots?: string[];
+      dataFiles?: string[];
     }
     | undefined
   > {

--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -218,6 +218,16 @@ export const createBuilder = (options: CreateBuilderOptions = {}): {
     fetchProgram,
     streamData,
     compileAndRun,
+    // Placeholder for the per-load binding. Each compiled graph replaces this
+    // with a reader closed over that load's attached data files (see
+    // `Engine.compileToRecordGraph`), so reaching this body means the module is
+    // running outside a graph that carries any.
+    dataFile: (path: string): string => {
+      throw new Error(
+        `No attached data file "${path}": this pattern was loaded without a ` +
+          `data-file closure.`,
+      );
+    },
     sqliteDatabase,
     sqliteQuery,
     table,

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -18,6 +18,7 @@ import type {
   CfSqliteHelpers,
   CompileAndRunFunction,
   ComputedFunction,
+  DataFileFunction,
   EntityRefToStringFunction,
   EqualsFunction,
   FabricExecValue,
@@ -416,6 +417,7 @@ export interface BuilderFunctionsAndConstants {
   fetchProgram: FetchProgramFunction;
   streamData: StreamDataFunction;
   compileAndRun: CompileAndRunFunction;
+  dataFile: DataFileFunction;
   sqliteDatabase: SqliteDatabaseFunction;
   sqliteQuery: SqliteQueryFunction;
   table: SqliteTableFunction;

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -20,6 +20,7 @@ import {
   pinnedIdentity,
 } from "../sandbox/fabric-import-specifier.ts";
 import {
+  DATA_FILE_SPECIFIER,
   deriveModuleRecordFields,
   SOURCE_ROOT_SPECIFIER,
 } from "../sandbox/module-record-compiler.ts";
@@ -106,9 +107,18 @@ export interface SourceDoc extends ModuleDocBase {
   readonly annotations?: Record<string, unknown>;
 }
 
-/** A compiled-set document (`compileCache:<runtimeVersion>/<identity>`). */
+/**
+ * A compiled-set document (`compileCache:<runtimeVersion>/<identity>`).
+ *
+ * `kind` separates the two things this set holds. A `"compiled"` document's
+ * `code` is an emitted module body, built into a record and executed. A
+ * `"data"` document's `code` is the verbatim bytes of an attached data file:
+ * the compiled set carries them so a warm load has everything the pattern
+ * needs without reading the source set, and nothing ever parses, verifies, or
+ * executes them.
+ */
 export interface CompiledDoc extends ModuleDocBase {
-  readonly kind: "compiled";
+  readonly kind: "compiled" | "data";
   /** Per-module source map, if any (registered for fn.src / CFC resolution). */
   readonly sourceMap?: unknown;
   /**
@@ -359,8 +369,9 @@ export function compiledDocKey(
  * warm closure would always be incomplete. These links carry no authored
  * specifier, so they are ignored by the Merkle identity recompute (which
  * resolves a module's edges from its own source, not its stored links).
- * Explicit source-package roots use {@link SOURCE_ROOT_SPECIFIER} instead and
- * participate in the entry module's identity.
+ * Explicit source-package roots use {@link SOURCE_ROOT_SPECIFIER} and attached
+ * data files use {@link DATA_FILE_SPECIFIER} instead; both participate in the
+ * entry module's identity.
  */
 export const ROOT_LINK_SPECIFIER = "cf:cache-root/";
 
@@ -536,6 +547,22 @@ export function verifySourceDocs(
     }
   }
 
+  // Data documents, named by the whole closure rather than by one view. A data
+  // file hashes as a leaf over its own bytes, and reaching that verdict must not
+  // depend on which document a view happens to be rooted at — a data document
+  // rooted in its own view names nothing itself. A forged data edge does not buy
+  // anything: it changes the identity of the document that carries it, and
+  // hashing a real module as a leaf changes that module's identity too, so both
+  // diverge from their keys here.
+  const dataFilenames = new Set<string>();
+  for (const doc of docsByIdentity.values()) {
+    for (const imp of doc.imports) {
+      if (!imp.specifier.startsWith(DATA_FILE_SPECIFIER)) continue;
+      const target = docsByIdentity.get(imp.identity);
+      if (target !== undefined) dataFilenames.add(target.filename);
+    }
+  }
+
   // identity → whether its recomputed hash matches its key. A verdict reached
   // inside one view holds in every view (entry-point independence), so each
   // document is hashed at most once.
@@ -578,18 +605,24 @@ export function verifySourceDocs(
     >();
     for (const id of viewIds) {
       const doc = docsByIdentity.get(id)!;
-      const sourceRoots = doc.imports
-        .filter((imp) => imp.specifier.startsWith(SOURCE_ROOT_SPECIFIER))
+      const packageEdges = doc.imports
+        .filter((imp) =>
+          imp.specifier.startsWith(SOURCE_ROOT_SPECIFIER) ||
+          imp.specifier.startsWith(DATA_FILE_SPECIFIER)
+        )
         .flatMap((imp) => {
           const target = docsByIdentity.get(imp.identity);
           return target === undefined
             ? []
             : [{ specifier: imp.specifier, target: target.filename }];
         });
-      if (sourceRoots.length > 0) {
-        additionalInternalDeps.set(doc.filename, sourceRoots);
+      if (packageEdges.length > 0) {
+        additionalInternalDeps.set(doc.filename, packageEdges);
       }
     }
+    const viewDataFiles = new Set(
+      files.map((file) => file.name).filter((name) => dataFilenames.has(name)),
+    );
     const recomputed = computeModuleHashes(
       { main: rootDoc.filename, files },
       {
@@ -597,6 +630,7 @@ export function verifySourceDocs(
         ...(additionalInternalDeps.size === 0
           ? {}
           : { additionalInternalDeps }),
+        ...(viewDataFiles.size === 0 ? {} : { dataFiles: viewDataFiles }),
       },
     );
     for (const id of viewIds) {
@@ -1145,7 +1179,7 @@ export function compiledDocWriteSchema(): JSONSchema {
 }
 
 interface StoredCompiledDoc {
-  kind: "compiled";
+  kind: "compiled" | "data";
   identity: string;
   code: string;
   filename: string;
@@ -1346,8 +1380,12 @@ export function writeCompiledDocs(
         tx,
       );
       // Fix B: derive the record surface from the compiled body once, here, so
-      // the boot-time record build reads it instead of re-parsing per load.
-      const derived = deriveModuleRecordFields(module.js);
+      // the boot-time record build reads it instead of re-parsing per load. A
+      // data entry has no record surface and its bytes are not JavaScript, so
+      // it is never handed to the extractor.
+      const derived = module.isData
+        ? undefined
+        : deriveModuleRecordFields(module.js);
       const delegatedModuleIdentities = validDelegatedModuleIdentities(
         module.identity,
         [...(effectiveModuleDelegations.get(module.identity) ?? [])],
@@ -1365,13 +1403,15 @@ export function writeCompiledDocs(
         runtime.registerCfcPolicyManifests(undefined, policyManifests);
       }
       cell.set({
-        kind: "compiled",
+        kind: module.isData ? "data" : "compiled",
         identity: module.identity,
         code: module.js,
         filename: module.filename,
-        exportNames: derived.exportNames,
-        starTargetSpecs: derived.starTargetSpecs,
-        importSpecs: derived.importSpecs,
+        ...(derived === undefined ? {} : {
+          exportNames: derived.exportNames,
+          starTargetSpecs: derived.starTargetSpecs,
+          importSpecs: derived.importSpecs,
+        }),
         ...(module.sourceMap !== undefined
           ? { sourceMap: module.sourceMap }
           : {}),
@@ -1658,7 +1698,10 @@ export async function loadCompiledClosure(
       if (!visited.has(child.identity)) queue.push({ doc: child });
     }
     out.set(doc.identity, {
-      kind: "compiled",
+      // A stored `kind` the writer did not produce is read as compiled, the
+      // conservative reading: a data entry is only ever treated as data when
+      // the document says so.
+      kind: doc.kind === "data" ? "data" : "compiled",
       code: doc.code,
       filename: doc.filename,
       ...(doc.sourceMap !== undefined ? { sourceMap: doc.sourceMap } : {}),

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -547,19 +547,20 @@ export function verifySourceDocs(
     }
   }
 
-  // Data documents, named by the whole closure rather than by one view. A data
-  // file hashes as a leaf over its own bytes, and reaching that verdict must not
-  // depend on which document a view happens to be rooted at — a data document
-  // rooted in its own view names nothing itself. A forged data edge does not buy
-  // anything: it changes the identity of the document that carries it, and
-  // hashing a real module as a leaf changes that module's identity too, so both
-  // diverge from their keys here.
-  const dataFilenames = new Set<string>();
+  // Data documents, collected across the whole closure by IDENTITY. Reaching
+  // the verdict "this is data" must not depend on which document a view happens
+  // to be rooted at, since a data document rooted in its own view names nothing
+  // itself. Identity rather than filename is what makes that safe: one closure
+  // may legally hold several generations of a filename, so a filename set would
+  // condemn a code module that merely shares a name with data elsewhere.
+  // A forged data edge buys nothing: it changes the identity of the document
+  // carrying it, and hashing a real module as a leaf changes that module's
+  // identity too, so both diverge from their keys here.
+  const dataIdentities = new Set<string>();
   for (const doc of docsByIdentity.values()) {
     for (const imp of doc.imports) {
       if (!imp.specifier.startsWith(DATA_FILE_SPECIFIER)) continue;
-      const target = docsByIdentity.get(imp.identity);
-      if (target !== undefined) dataFilenames.add(target.filename);
+      if (docsByIdentity.has(imp.identity)) dataIdentities.add(imp.identity);
     }
   }
 
@@ -620,8 +621,12 @@ export function verifySourceDocs(
         additionalInternalDeps.set(doc.filename, packageEdges);
       }
     }
+    // Within one view, filenames are unique by construction, so mapping the
+    // view's data identities to their filenames is unambiguous here.
     const viewDataFiles = new Set(
-      files.map((file) => file.name).filter((name) => dataFilenames.has(name)),
+      viewIds
+        .filter((id) => dataIdentities.has(id))
+        .map((id) => docsByIdentity.get(id)!.filename),
     );
     const recomputed = computeModuleHashes(
       { main: rootDoc.filename, files },

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -763,17 +763,14 @@ export class Engine extends EventTarget {
             });
           }
           for (const dataPath of dataPaths) {
-            const dataIdentity = identityByPath.get(dataPath);
-            if (dataIdentity === undefined) {
-              throw new Error(
-                `Data file '${dataPath}' has no content identity.`,
-              );
-            }
+            // Every data path is in the pristine set the identities were
+            // computed over, the same guarantee the module lookup above relies
+            // on.
             imports.push({
               specifier: dataFileSpecifier(
                 storedFilenameFor(dataPath, id, mounts),
               ),
-              targetIdentity: dataIdentity,
+              targetIdentity: identityByPath.get(dataPath)!,
             });
           }
         }
@@ -1142,15 +1139,11 @@ export class Engine extends EventTarget {
           });
         }
         for (const dataPath of dataPaths) {
-          const dataIdentity = identityByPath.get(dataPath);
-          if (dataIdentity === undefined) {
-            throw new Error(`Data file '${dataPath}' has no content identity.`);
-          }
           imports.push({
             specifier: dataFileSpecifier(
               storedFilenameFor(dataPath, undefined, mounts),
             ),
-            targetIdentity: dataIdentity,
+            targetIdentity: identityByPath.get(dataPath)!,
           });
         }
       }

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -45,6 +45,7 @@ import {
   RuntimeModuleIdentifiers,
   SESRuntime,
 } from "../sandbox/mod.ts";
+import { freezeSandboxValue } from "../sandbox/hardening.ts";
 import {
   buildRecordsFromCompiled,
   type CachedCompiledModule,
@@ -52,6 +53,7 @@ import {
   type CompiledModuleGraph,
   compileSourcesToRecords,
   computeFabricModuleIdentities,
+  dataFileSpecifier,
   FABRIC_MOUNT_ROOT,
   type FabricMount,
   sourceRootSpecifier,
@@ -201,6 +203,52 @@ function canonicalSourceRoots(
   return [...new Set(roots ?? [])]
     .filter((root) => root !== main)
     .sort();
+}
+
+function canonicalDataFiles(
+  main: string,
+  dataFiles: readonly string[] | undefined,
+): string[] {
+  return [...new Set(dataFiles ?? [])]
+    .filter((dataFile) => dataFile !== main)
+    .sort();
+}
+
+/**
+ * Split a program's files into the code the compiler sees and the data files it
+ * must not. A data file named by the program but absent from its files is a
+ * caller error, and stops the compile rather than deploying a package whose
+ * identity claims data that is not there. `idPrefix` names the per-load path
+ * prefix to drop when reporting such a file, so the report spells the path the
+ * caller wrote.
+ */
+function partitionDataFiles(
+  program: RuntimeProgram,
+  idPrefix?: string,
+): { dataPaths: string[]; codeFiles: Source[]; dataSources: Source[] } {
+  const dataPaths = canonicalDataFiles(program.main, program.dataFiles);
+  if (dataPaths.length === 0) {
+    return { dataPaths, codeFiles: [...program.files], dataSources: [] };
+  }
+  const wanted = new Set(dataPaths);
+  const codeFiles: Source[] = [];
+  const dataSources: Source[] = [];
+  for (const file of program.files) {
+    (wanted.has(file.name) ? dataSources : codeFiles).push(file);
+  }
+  if (dataSources.length !== wanted.size) {
+    const present = new Set(dataSources.map((file) => file.name));
+    const absent = dataPaths
+      .filter((path) => !present.has(path))
+      .map((path) =>
+        idPrefix !== undefined && path.startsWith(`${idPrefix}/`)
+          ? path.slice(idPrefix.length)
+          : path
+      )
+      .join(", ");
+    throw new Error(`Program names data files it does not carry: ${absent}`);
+  }
+  return { dataPaths, codeFiles, dataSources };
 }
 
 function persistableSourceFiles(files: readonly Source[]): Source[] {
@@ -354,9 +402,17 @@ export class Engine extends EventTarget {
         mappedProgram.main,
         mappedProgram.sourceRoots,
       );
-      assertFabricImportsHaveSpace(mappedProgram.files, options);
-      const engineResolver = new EngineProgramResolver(
+      // Data files leave the program before anything that reads TypeScript
+      // touches it: they are neither scanned for imports nor offered to the
+      // resolver, so an import can never land on one. They rejoin the pristine
+      // set below, which is what identity and the source store are built from.
+      const { dataPaths, codeFiles, dataSources } = partitionDataFiles(
         mappedProgram,
+        `/${id}`,
+      );
+      assertFabricImportsHaveSpace(codeFiles, options);
+      const engineResolver = new EngineProgramResolver(
+        { ...mappedProgram, files: codeFiles },
         this.ctRuntime.staticCache,
       );
       const fabricResolver = options.fabricImports
@@ -396,24 +452,30 @@ export class Engine extends EventTarget {
       const authoredByStoredName = new Map(
         program.files.map((f) => [f.name, f.contents]),
       );
+      const authoredDataFiles = new Set(program.dataFiles ?? []);
       const patternCoverage = patternCoverageOptionsForCompile(
         options.patternCoverage,
         {
           id,
           mounts,
           sourceFiles: [
-            ...program.files,
+            ...program.files.filter((file) =>
+              !authoredDataFiles.has(file.name)
+            ),
             ...resolvedFiles.filter((file) =>
               file.name.startsWith(FABRIC_MOUNT_ROOT)
             ),
           ],
         },
       );
-      const pristineSourceFiles = pristineModuleSources(
-        persistableSourceFiles(resolvedFiles),
-        authoredByStoredName,
-        (name) => storedFilenameFor(name, id, mounts),
-      );
+      const pristineSourceFiles = [
+        ...pristineModuleSources(
+          persistableSourceFiles(resolvedFiles),
+          authoredByStoredName,
+          (name) => storedFilenameFor(name, id, mounts),
+        ),
+        ...dataSources,
+      ];
 
       // Prefix-free content identity per resolved module path. Computed here
       // (cheap, no TS compile) so the cache-hit check and the write-back
@@ -423,11 +485,12 @@ export class Engine extends EventTarget {
         mounts,
         {
           idPrefix: `/${id}`,
-          ...(sourceRoots.length
+          ...(sourceRoots.length || dataPaths.length
             ? {
               sourcePackage: {
                 entryPath: mappedProgram.main,
                 rootPaths: sourceRoots,
+                dataPaths,
               },
             }
             : {}),
@@ -565,6 +628,11 @@ export class Engine extends EventTarget {
         precompiledSourceMaps,
         runtimeModules: runtimeModulesOption,
         specifierAliases,
+        // Carried onto the graph under their stored (prefix-free) names, the
+        // same spelling the warm path recovers from the compiled set.
+        dataFiles: dataSources.map((file) =>
+          [storedFilenameFor(file.name, id, mounts), file.contents] as const
+        ),
         // Strip the whole-program `/<id>` prefix from per-module identities so
         // `cf:module/<hash>` is entry-point independent and dedupes across
         // programs (the content-addressed cache keys off these identities).
@@ -586,7 +654,9 @@ export class Engine extends EventTarget {
         >;
       }
       for (
-        const [spec, record] of runtimeModuleRecords(runtimeRecordExports)
+        const [spec, record] of runtimeModuleRecords(
+          bindDataFileReader(runtimeRecordExports, graph.dataByPath),
+        )
       ) {
         graph.records.set(spec, record as VirtualModuleRecord);
       }
@@ -651,10 +721,11 @@ export class Engine extends EventTarget {
       // and the internal import edges as specifier → dependency-identity links.
       // On a cache hit these mirror the artifacts just loaded. Built over the
       // pristine module set so `source` and the edges are over authored bytes.
+      const dataFileSet = new Set(dataPaths);
       const importEdges = resolveModuleImports({
         main: "",
         files: pristineSourceFiles,
-      });
+      }, { dataFiles: dataFileSet });
       const modules: CacheableModule[] = pristineSourceFiles.map((file) => {
         const identity = identityByPath.get(file.name)!;
         const sourceMap = precompiledSourceMaps.get(file.name);
@@ -686,6 +757,20 @@ export class Engine extends EventTarget {
               targetIdentity: rootIdentity,
             });
           }
+          for (const dataPath of dataPaths) {
+            const dataIdentity = identityByPath.get(dataPath);
+            if (dataIdentity === undefined) {
+              throw new Error(
+                `Data file '${dataPath}' has no content identity.`,
+              );
+            }
+            imports.push({
+              specifier: dataFileSpecifier(
+                storedFilenameFor(dataPath, id, mounts),
+              ),
+              targetIdentity: dataIdentity,
+            });
+          }
         }
         const policyManifests = emittedBody === undefined
           ? undefined
@@ -693,11 +778,16 @@ export class Engine extends EventTarget {
             identity,
             precompiledPolicyManifests.get(file.name),
           );
+        // A data entry's compiled form is its own bytes: the compiled set is
+        // what a warm load reads, and it must carry everything the runtime
+        // needs to run the pattern.
+        const isData = dataFileSet.has(file.name);
         return {
           identity,
           filename: storedFilenameFor(file.name, id, mounts),
           source: file.contents,
-          js: emittedBody ?? "",
+          js: isData ? file.contents : (emittedBody ?? ""),
+          ...(isData ? { isData: true } : {}),
           ...(sourceMap === undefined ? {} : { sourceMap }),
           ...(patternCoverageSpans === undefined
             ? {}
@@ -766,7 +856,7 @@ export class Engine extends EventTarget {
       batchIds.push(id);
       const mapped = pretransformProgramForModules(program, id);
       const resolver = new EngineProgramResolver(
-        mapped,
+        { ...mapped, files: partitionDataFiles(mapped).codeFiles },
         this.ctRuntime.staticCache,
       );
       const resolved = await this.resolveWithSourceRoots(
@@ -869,11 +959,21 @@ export class Engine extends EventTarget {
       fabricImports?: TypeScriptHarnessProcessOptions["fabricImports"];
       patternCoverage?: PatternCoverageCollector;
       sourceRoots?: readonly string[];
+      dataFiles?: readonly string[];
     } = {},
   ): Promise<{ modules: CacheableModule[]; entryIdentity: string }> {
     const { compiler } = await this.getCompilerInternals();
     assertNoReservedFabricPaths(resolvedFiles);
-    assertFabricImportsHaveSpace(resolvedFiles, options);
+    // Data files carry arbitrary bytes; keep them away from every scan, parse
+    // and compile step, and rejoin them at the pristine set below.
+    const { dataPaths, codeFiles, dataSources } = partitionDataFiles({
+      main: entryFilename,
+      files: resolvedFiles,
+      ...(options.dataFiles === undefined
+        ? {}
+        : { dataFiles: [...options.dataFiles] }),
+    });
+    assertFabricImportsHaveSpace(codeFiles, options);
     // The stored source set holds prefix-free AUTHORED TS (the helper import is
     // NOT baked in — identity is over authored source, module-loading.md).
     // Inject the helper BEFORE resolve so the resolver pulls the `commonfabric`
@@ -890,7 +990,7 @@ export class Engine extends EventTarget {
     // writes back under the current runtimeVersion (self-heal on load).
     const injectedInput = transformInjectHelperModule({
       main: entryFilename,
-      files: resolvedFiles,
+      files: codeFiles,
       ...(options.sourceRoots === undefined
         ? {}
         : { sourceRoots: [...options.sourceRoots] }),
@@ -933,21 +1033,25 @@ export class Engine extends EventTarget {
     // the authored closure — they match the stored identities the source docs
     // were keyed by.
     const authoredByStoredName = new Map(
-      resolvedFiles.map((f) => [f.name, f.contents]),
+      codeFiles.map((f) => [f.name, f.contents]),
     );
-    const pristineSourceFiles = pristineModuleSources(
-      persistableSourceFiles(resolvedProgramFiles),
-      authoredByStoredName,
-      (name) => storedFilenameFor(name, undefined, mounts),
-    );
+    const pristineSourceFiles = [
+      ...pristineModuleSources(
+        persistableSourceFiles(resolvedProgramFiles),
+        authoredByStoredName,
+        (name) => storedFilenameFor(name, undefined, mounts),
+      ),
+      ...dataSources,
+    ];
     const identityByPath = computeFabricModuleIdentities(
       pristineSourceFiles,
       mounts,
-      sourceRoots.length
+      sourceRoots.length || dataPaths.length
         ? {
           sourcePackage: {
             entryPath: entryFilename,
             rootPaths: sourceRoots,
+            dataPaths,
           },
         }
         : {},
@@ -997,10 +1101,11 @@ export class Engine extends EventTarget {
       }
     }
 
+    const dataFileSet = new Set(dataPaths);
     const importEdges = resolveModuleImports({
       main: "",
       files: pristineSourceFiles,
-    });
+    }, { dataFiles: dataFileSet });
     const modules: CacheableModule[] = pristineSourceFiles.map((file) => {
       const out = emitted.get(file.name);
       const identity = identityByPath.get(file.name)!;
@@ -1031,15 +1136,29 @@ export class Engine extends EventTarget {
             targetIdentity: rootIdentity,
           });
         }
+        for (const dataPath of dataPaths) {
+          const dataIdentity = identityByPath.get(dataPath);
+          if (dataIdentity === undefined) {
+            throw new Error(`Data file '${dataPath}' has no content identity.`);
+          }
+          imports.push({
+            specifier: dataFileSpecifier(
+              storedFilenameFor(dataPath, undefined, mounts),
+            ),
+            targetIdentity: dataIdentity,
+          });
+        }
       }
       const policyManifests = out === undefined
         ? undefined
         : validatePolicyManifestsForModule(identity, out.policyManifests);
+      const isData = dataFileSet.has(file.name);
       return {
         identity,
         filename: storedFilenameFor(file.name, undefined, mounts),
         source: file.contents,
-        js: out?.js ?? "",
+        js: isData ? file.contents : (out?.js ?? ""),
+        ...(isData ? { isData: true } : {}),
         ...(out?.sourceMap === undefined ? {} : { sourceMap: out.sourceMap }),
         ...(patternCoverageSpans === undefined ? {} : { patternCoverageSpans }),
         ...(policyManifests === undefined ? {} : { policyManifests }),
@@ -1078,7 +1197,13 @@ export class Engine extends EventTarget {
       program,
       options,
     );
-    return this.evaluateRecordGraph(id, graph, mainSpecifier, program.files);
+    return this.evaluateRecordGraph(
+      id,
+      graph,
+      mainSpecifier,
+      program.files,
+      program.dataFiles,
+    );
   }
 
   /**
@@ -1087,12 +1212,15 @@ export class Engine extends EventTarget {
    * {@link evaluateGraph} with the source-compile registration strategy: module
    * identities are recomputed from `files`, paths carry the `/<id>` prefix, and
    * `files` flow into the export map for sub-pattern re-instantiation.
+   * `dataFiles` names the members of `files` that are data, so a sub-pattern
+   * re-instantiated from the export map keeps the same source package.
    */
   evaluateRecordGraph(
     id: string,
     graph: CompiledModuleGraph,
     mainSpecifier: string,
     files: Source[],
+    dataFiles?: readonly string[],
   ): EvaluateResult {
     const prefix = `/${id}`;
     // Register module hashes up front so the canonical `cf:module/<hash>/<path>`
@@ -1115,6 +1243,9 @@ export class Engine extends EventTarget {
       fileNameForPath: (path) =>
         path.startsWith(prefix) ? path.slice(prefix.length) : path,
       filesForExports: files,
+      ...(dataFiles === undefined
+        ? {}
+        : { dataFilesForExports: [...dataFiles] }),
     });
   }
 
@@ -1138,6 +1269,7 @@ export class Engine extends EventTarget {
       registerHashes(): void;
       fileNameForPath(path: string): string;
       filesForExports: Source[];
+      dataFilesForExports?: string[];
     },
   ): EvaluateResult {
     logger.timeStart("evaluateRecordGraph");
@@ -1339,6 +1471,9 @@ export class Engine extends EventTarget {
             main: fileName,
             mainExport: exportName,
             files: ctx.filesForExports,
+            ...(ctx.dataFilesForExports === undefined
+              ? {}
+              : { dataFiles: ctx.dataFilesForExports }),
           });
         }
       }
@@ -1447,12 +1582,14 @@ export class Engine extends EventTarget {
    * (`cf:module/<entryIdentity>`). Optional `sourceFiles` (the cached source
    * closure) flow into the export map so sub-pattern re-instantiation keeps a
    * program to recompile from; omit them and sub-patterns fall back to identity.
+   * `dataFiles` names the members of `sourceFiles` that are data.
    */
   async evaluateCachedModules(
     modules: readonly CachedCompiledModule[],
     entryIdentity: string,
     options: {
       sourceFiles?: Source[];
+      dataFiles?: readonly string[];
       trustedBodies?: boolean;
       patternCoverage?: PatternCoverageCollector;
     } = {},
@@ -1509,7 +1646,11 @@ export class Engine extends EventTarget {
         unknown
       >;
     }
-    for (const [spec, record] of runtimeModuleRecords(runtimeRecordExports)) {
+    for (
+      const [spec, record] of runtimeModuleRecords(
+        bindDataFileReader(runtimeRecordExports, graph.dataByPath),
+      )
+    ) {
       graph.records.set(spec, record as VirtualModuleRecord);
     }
 
@@ -1578,6 +1719,9 @@ export class Engine extends EventTarget {
       },
       fileNameForPath: (path) => path, // already normalized
       filesForExports: options.sourceFiles ?? [],
+      ...(options.dataFiles === undefined
+        ? {}
+        : { dataFilesForExports: [...options.dataFiles] }),
     });
   }
 
@@ -1757,11 +1901,50 @@ function validatePolicyManifestsForModule(
   });
 }
 
+/**
+ * Bind this load's attached data files into the runtime-module namespaces that
+ * expose `dataFile`.
+ *
+ * The shared namespaces are process-global and carry only a placeholder, since
+ * which data files exist is a property of the program being loaded rather than
+ * of the runtime. Each load therefore hands its own graph's data to the records
+ * it registers, so a module's `dataFile` reads the bytes that travelled in the
+ * same content-addressed closure as its code.
+ *
+ * The read is a plain map lookup: the closure is fully loaded before any module
+ * executes, so this needs no storage access and cannot be asynchronous.
+ */
+function bindDataFileReader(
+  runtimeRecordExports: Record<string, Record<string, unknown>>,
+  dataByPath: ReadonlyMap<string, string>,
+): Record<string, Record<string, unknown>> {
+  const read = (path: string): string => {
+    const bytes = dataByPath.get(path);
+    if (bytes !== undefined) return bytes;
+    const attached = [...dataByPath.keys()].sort();
+    throw new Error(
+      `No attached data file "${path}". ` +
+        (attached.length === 0
+          ? "This pattern has none; attach one with --datafile."
+          : `Attached: ${attached.join(", ")}.`),
+    );
+  };
+  const bound: Record<string, Record<string, unknown>> = {};
+  for (const [name, namespace] of Object.entries(runtimeRecordExports)) {
+    bound[name] = namespace !== undefined && "dataFile" in namespace
+      ? freezeSandboxValue({ ...namespace, dataFile: read })
+      : namespace;
+  }
+  return bound;
+}
+
 function computeId(program: RuntimeProgram): string {
   const sourceRoots = canonicalSourceRoots(program.main, program.sourceRoots);
+  const dataFiles = canonicalDataFiles(program.main, program.dataFiles);
   const source = [
     program.main,
     ...(sourceRoots.length === 0 ? [] : [{ sourceRoots }]),
+    ...(dataFiles.length === 0 ? [] : [{ dataFiles }]),
     ...persistableSourceFiles(program.files),
   ];
   return hashOf(source).toString();

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -209,9 +209,14 @@ function canonicalDataFiles(
   main: string,
   dataFiles: readonly string[] | undefined,
 ): string[] {
-  return [...new Set(dataFiles ?? [])]
-    .filter((dataFile) => dataFile !== main)
-    .sort();
+  const paths = [...new Set(dataFiles ?? [])].sort();
+  // Unlike a source root, which the entry trivially is, an entry named as data
+  // is a contradiction: it is the module the program executes. Dropping it
+  // would silently compile a file the caller asked to store uninterpreted.
+  if (paths.includes(main)) {
+    throw new Error(`The program entry '${main}' cannot be a data file.`);
+  }
+  return paths;
 }
 
 /**
@@ -1611,10 +1616,13 @@ export class Engine extends EventTarget {
     // — load the deferred compiler stack first. The warm-cache boot path
     // always carries the surface (runtimeVersion fingerprints the extractor),
     // so the steady boot stays compiler-free.
+    // A data entry has no record surface and is never parsed, so it must not
+    // drag the compiler onto the warm boot path.
     if (
       modules.some((m) =>
-        m.exportNames === undefined || m.starTargetSpecs === undefined ||
-        m.importSpecs === undefined
+        !m.isData &&
+        (m.exportNames === undefined || m.starTargetSpecs === undefined ||
+          m.importSpecs === undefined)
       )
     ) {
       await ensureCompilerStack();

--- a/packages/runner/src/harness/module-identity.ts
+++ b/packages/runner/src/harness/module-identity.ts
@@ -167,9 +167,13 @@ export function computeModuleHashes(
         );
       }
     }
+    // A data file's bytes are the payload the runtime hands to a pattern, so
+    // line endings are content rather than formatting: two data files differing
+    // only in them are different files and must not share an identity.
+    const isData = options.dataFiles?.has(file.name) === true;
     nodes.set(file.name, {
       path: file.name,
-      src: normalizeSource(file.contents),
+      src: isData ? file.contents : normalizeSource(file.contents),
       internalDeps: [...internalDeps, ...additionalInternalDeps],
       externalDeps,
     });
@@ -245,7 +249,8 @@ export function findInternalTarget(
 
 function normalizeSource(contents: string): string {
   // Identity is over authored source; the only normalization is line endings,
-  // so a CRLF/LF difference does not change a module's hash.
+  // so a CRLF/LF difference does not change a module's hash. Data files are
+  // excluded from this: their bytes are content, not source text.
   return contents.replace(/\r\n/g, "\n");
 }
 

--- a/packages/runner/src/harness/module-identity.ts
+++ b/packages/runner/src/harness/module-identity.ts
@@ -64,6 +64,12 @@ export interface ModuleIdentityOptions {
     string,
     readonly { specifier: string; target: string }[]
   >;
+  /**
+   * Paths carrying data rather than code. A data file hashes as a leaf over its
+   * own bytes and path: it is never scanned for imports, and never the target of
+   * another module's import edge.
+   */
+  dataFiles?: ReadonlySet<string>;
 }
 
 interface ModuleNode {
@@ -88,18 +94,31 @@ export interface ModuleImportEdges {
  * internal (program-file) and external (bare/runtime) deps. Shared by the
  * identity hash and the content-addressed cache's import links so they agree on
  * what counts as an internal edge. Self-imports are dropped.
+ *
+ * `options.dataFiles` names the program's data files. Their bytes are not
+ * TypeScript, so they are not parsed and carry no edges, and an import that
+ * would land on one resolves to nothing instead — such a specifier is reported
+ * as external, and fails to resolve at compile time.
  */
 export function resolveModuleImports(
   program: Program,
+  options: { dataFiles?: ReadonlySet<string> } = {},
 ): Map<string, ModuleImportEdges> {
   // Deferred compiler stack: import scanning parses with the TS parser, so
   // every flow reaching this must have awaited ensureCompilerStack().
   const { collectImportSpecifiers, ts } = compilerStack();
-  const fileNames = new Set(program.files.map((f) => f.name));
+  const dataFiles = options.dataFiles ?? new Set<string>();
+  const fileNames = new Set(
+    program.files.map((f) => f.name).filter((name) => !dataFiles.has(name)),
+  );
   const edges = new Map<string, ModuleImportEdges>();
   for (const file of program.files) {
     const internalDeps: { specifier: string; target: string }[] = [];
     const externalDeps: string[] = [];
+    if (dataFiles.has(file.name)) {
+      edges.set(file.name, { internalDeps, externalDeps });
+      continue;
+    }
     for (
       const specifier of collectImportSpecifiers(
         file,
@@ -129,7 +148,10 @@ export function computeModuleHashes(
   options: ModuleIdentityOptions = {},
 ): Map<string, string> {
   const runtimeFingerprint = options.runtimeFingerprint ?? "";
-  const edges = resolveModuleImports(program);
+  const edges = resolveModuleImports(
+    program,
+    options.dataFiles === undefined ? {} : { dataFiles: options.dataFiles },
+  );
   const nodes = new Map<string, ModuleNode>();
 
   for (const file of program.files) {

--- a/packages/runner/src/harness/pretransform.ts
+++ b/packages/runner/src/harness/pretransform.ts
@@ -41,10 +41,11 @@ export function transformInjectHelperModule(
   // Deferred compiler stack (parses + prints): pretransform only runs on
   // compile flows, which await ensureCompilerStack() at their entry.
   const { isLegacyInjectedEnvelope, transformCfDirective } = compilerStack();
+  const dataFiles = new Set(program.dataFiles ?? []);
   return {
     main: program.main,
     files: program.files.map((source) => {
-      if (source.name.endsWith(".d.ts")) {
+      if (source.name.endsWith(".d.ts") || dataFiles.has(source.name)) {
         return { name: source.name, contents: source.contents };
       }
       // CT-1838 tolerance: an exact legacy-envelope stored doc passes
@@ -77,6 +78,7 @@ export function transformInjectHelperModule(
     }),
     mainExport: program.mainExport,
     sourceRoots: program.sourceRoots,
+    dataFiles: program.dataFiles,
   };
 }
 
@@ -106,6 +108,7 @@ export function transformProgramWithPrefix(
     main: `/index.ts`,
     files,
     sourceRoots: program.sourceRoots?.map((root) => prefix(root, id)),
+    dataFiles: program.dataFiles?.map((data) => prefix(data, id)),
   };
 }
 
@@ -129,6 +132,9 @@ export function pretransformProgramForModules(
       : {}),
     ...(program.sourceRoots !== undefined
       ? { sourceRoots: program.sourceRoots.map((root) => prefix(root, id)) }
+      : {}),
+    ...(program.dataFiles !== undefined
+      ? { dataFiles: program.dataFiles.map((data) => prefix(data, id)) }
       : {}),
   };
 }

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -11,6 +11,12 @@ export type RuntimeProgram = Program & {
   mainExport?: string;
   /** Source entry points retained and compiled without being executed. */
   sourceRoots?: string[];
+  /**
+   * Names of entries in `files` that carry data rather than code. A data file
+   * travels with the source package and binds to the entry module's identity,
+   * and is never transformed, compiled, or executed.
+   */
+  dataFiles?: string[];
 };
 
 export interface TypeScriptHarnessProcessOptions {
@@ -103,6 +109,13 @@ export interface CacheableModule extends CompiledModuleArtifact {
   source: string;
   /** Internal import edges: specifier → the dependency module's identity. */
   imports: { specifier: string; targetIdentity: string }[];
+  /**
+   * This entry carries data rather than code. A data entry's compiled form is
+   * its own bytes, so `js` repeats `source` and the compiled set carries what a
+   * warm load needs without reading the source set. It is never parsed,
+   * verified as a module body, or built into a record.
+   */
+  isData?: boolean;
 }
 
 export type Exports = Record<string, any>;

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -1129,6 +1129,9 @@ export class PatternManager {
         // security boundary — skip redundant SES body re-verification.
         {
           sourceFiles: program.files,
+          ...(program.dataFiles === undefined
+            ? {}
+            : { dataFiles: program.dataFiles }),
           trustedBodies: true,
           ...(patternCoverage ? { patternCoverage } : {}),
         },

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -54,6 +54,7 @@ import {
 } from "./sandbox/fabric-import-specifier.ts";
 import {
   type CachedCompiledModule,
+  DATA_FILE_SPECIFIER,
   SOURCE_ROOT_SPECIFIER,
 } from "./sandbox/module-record-compiler.ts";
 import type {
@@ -229,6 +230,23 @@ function uniqueCacheableImports(
     out.push(imp);
   }
   return out;
+}
+
+/**
+ * The authored filenames an entry document's source-package edges point at, for
+ * one edge kind — {@link SOURCE_ROOT_SPECIFIER} for attached source entry
+ * points, {@link DATA_FILE_SPECIFIER} for attached data files. An edge whose
+ * target is not in the closure contributes nothing.
+ */
+function sourcePackagePaths(
+  entry: { imports: readonly { specifier: string; identity: string }[] },
+  docsByIdentity: ReadonlyMap<string, { filename: string }>,
+  specifierPrefix: string,
+): string[] {
+  return entry.imports
+    .filter((edge) => edge.specifier.startsWith(specifierPrefix))
+    .map((edge) => docsByIdentity.get(edge.identity)?.filename)
+    .filter((filename): filename is string => filename !== undefined);
 }
 
 export class PatternManager {
@@ -666,6 +684,7 @@ export class PatternManager {
       graph,
       mainSpecifier,
       program.files,
+      program.dataFiles,
     );
     return this.patternFromEvaluation(result, program);
   }
@@ -739,6 +758,7 @@ export class PatternManager {
       graph,
       mainSpecifier,
       program.files,
+      program.dataFiles,
     );
     this.registerEvaluatedModules(result);
     return result;
@@ -806,6 +826,7 @@ export class PatternManager {
         graph,
         mainSpecifier,
         program.files,
+        program.dataFiles,
       );
       return this.patternFromEvaluation(result, program, entryIdentity);
     }
@@ -976,6 +997,7 @@ export class PatternManager {
       graph,
       mainSpecifier,
       program.files,
+      program.dataFiles,
     );
     logger.time(evalStart, "compile-cache", "evaluate");
 
@@ -1066,6 +1088,9 @@ export class PatternManager {
         identity,
         filename: doc.filename,
         code: doc.code,
+        // A data entry rides the closure to reach the compartment; the record
+        // builder takes it out before anything reads `code` as a body.
+        ...(doc.kind === "data" ? { isData: true } : {}),
         ...(doc.sourceMap !== undefined
           ? { sourceMap: doc.sourceMap as never }
           : {}),
@@ -1088,7 +1113,8 @@ export class PatternManager {
         imports: doc.imports
           .filter((i) =>
             !i.specifier.startsWith(ROOT_LINK_SPECIFIER) &&
-            !i.specifier.startsWith(SOURCE_ROOT_SPECIFIER)
+            !i.specifier.startsWith(SOURCE_ROOT_SPECIFIER) &&
+            !i.specifier.startsWith(DATA_FILE_SPECIFIER)
           )
           .map((i) => ({ specifier: i.specifier, targetIdentity: i.identity })),
       }),
@@ -1252,6 +1278,9 @@ export class PatternManager {
         identity,
         filename: doc.filename,
         code: doc.code,
+        // A data entry rides the closure to reach the compartment; the record
+        // builder takes it out before anything reads `code` as a body.
+        ...(doc.kind === "data" ? { isData: true } : {}),
         ...(doc.sourceMap !== undefined
           ? { sourceMap: doc.sourceMap as never }
           : {}),
@@ -1272,7 +1301,8 @@ export class PatternManager {
         imports: doc.imports
           .filter((i) =>
             !i.specifier.startsWith(ROOT_LINK_SPECIFIER) &&
-            !i.specifier.startsWith(SOURCE_ROOT_SPECIFIER)
+            !i.specifier.startsWith(SOURCE_ROOT_SPECIFIER) &&
+            !i.specifier.startsWith(DATA_FILE_SPECIFIER)
           )
           .map((i) => ({ specifier: i.specifier, targetIdentity: i.identity })),
       }),
@@ -1340,10 +1370,16 @@ export class PatternManager {
     const entry = sourceDocs.get(entryIdentity);
     if (entry === undefined) return undefined;
     const moduleDelegations = moduleDelegationsFromDocs(sourceDocs);
-    const sourceRoots = entry.imports
-      .filter((edge) => edge.specifier.startsWith(SOURCE_ROOT_SPECIFIER))
-      .map((edge) => sourceDocs.get(edge.identity)?.filename)
-      .filter((filename): filename is string => filename !== undefined);
+    const sourceRoots = sourcePackagePaths(
+      entry,
+      sourceDocs,
+      SOURCE_ROOT_SPECIFIER,
+    );
+    const dataFiles = sourcePackagePaths(
+      entry,
+      sourceDocs,
+      DATA_FILE_SPECIFIER,
+    );
 
     const sourceFiles: Source[] = [...sourceDocs.values()].map((doc) => ({
       name: doc.filename,
@@ -1359,6 +1395,7 @@ export class PatternManager {
           fabricImports: { space },
           ...(patternCoverage ? { patternCoverage } : {}),
           ...(sourceRoots.length === 0 ? {} : { sourceRoots }),
+          ...(dataFiles.length === 0 ? {} : { dataFiles }),
         },
       );
       if (compiled.entryIdentity !== entryIdentity) {
@@ -1371,6 +1408,7 @@ export class PatternManager {
           identity: module.identity,
           filename: module.filename,
           code: module.js,
+          ...(module.isData ? { isData: true } : {}),
           ...(module.sourceMap !== undefined
             ? { sourceMap: module.sourceMap as never }
             : {}),
@@ -1386,6 +1424,7 @@ export class PatternManager {
         entryIdentity,
         {
           sourceFiles,
+          ...(dataFiles.length === 0 ? {} : { dataFiles }),
           ...(patternCoverage ? { patternCoverage } : {}),
         },
       );
@@ -2115,8 +2154,9 @@ export class PatternManager {
    * cell's `program`: the source docs are written (awaited) by every cold
    * compile, so this returns the same bytes that produced the identity. `main`
    * is the executable entry document's authored filename. `sourceRoots` names
-   * retained source entry points such as attached tests. Returns `undefined`
-   * when no verified source closure exists in the space.
+   * retained source entry points such as attached tests, and `dataFiles` names
+   * attached data files. Returns `undefined` when no verified source closure
+   * exists in the space.
    */
   async getPatternSourceProgramByIdentity(
     entryIdentity: string,
@@ -2127,6 +2167,7 @@ export class PatternManager {
       main: string;
       files: { name: string; contents: string }[];
       sourceRoots?: string[];
+      dataFiles?: string[];
     } | undefined
   > {
     const readTx = this.runtime.edit();
@@ -2170,12 +2211,16 @@ export class PatternManager {
     if (sourceDocs === undefined) return undefined;
     const entry = sourceDocs.get(entryIdentity);
     if (entry === undefined) return undefined;
-    const sourceRoots = entry.imports
-      .filter((edge) => edge.specifier.startsWith(SOURCE_ROOT_SPECIFIER))
-      .map((edge) => sourceDocs.get(edge.identity)?.filename)
-      .filter((filename): filename is string =>
-        filename?.startsWith("/") === true
-      );
+    const sourceRoots = sourcePackagePaths(
+      entry,
+      sourceDocs,
+      SOURCE_ROOT_SPECIFIER,
+    ).filter((filename) => filename.startsWith("/"));
+    const dataFiles = sourcePackagePaths(
+      entry,
+      sourceDocs,
+      DATA_FILE_SPECIFIER,
+    ).filter((filename) => filename.startsWith("/"));
     // Return only the AUTHORED files — the faithful replacement for the old
     // meta-cell `program`. The verified source closure also contains
     // runtime-INJECTED helper modules (e.g. `cfc.ts`), which the compiler
@@ -2191,6 +2236,7 @@ export class PatternManager {
           contents: doc.code,
         })),
       ...(sourceRoots.length === 0 ? {} : { sourceRoots }),
+      ...(dataFiles.length === 0 ? {} : { dataFiles }),
     };
   }
 

--- a/packages/runner/src/sandbox/fabric-import-specifier.ts
+++ b/packages/runner/src/sandbox/fabric-import-specifier.ts
@@ -33,10 +33,12 @@ export function parseFabricRef(specifier: string): FabricRef | undefined {
   let rest = specifier.slice("cf:".length);
   if (
     rest.startsWith("module/") || rest.startsWith("cache-root/") ||
-    rest.startsWith("source-root/")
+    rest.startsWith("source-root/") || rest.startsWith("data-file/")
   ) {
     throw new FabricRefError(
-      "'cf:module/...', 'cf:cache-root/...', and 'cf:source-root/...' are compiler-internal namespaces and cannot be imported",
+      "'cf:module/...', 'cf:cache-root/...', 'cf:source-root/...', and " +
+        "'cf:data-file/...' are compiler-internal namespaces and cannot be " +
+        "imported",
       specifier,
     );
   }

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -38,6 +38,13 @@ export function sourceRootSpecifier(path: string): string {
   return `${SOURCE_ROOT_SPECIFIER}${path.replace(/^\/+/, "")}`;
 }
 
+/** Identity-only import edge for an attached data file. */
+export const DATA_FILE_SPECIFIER = "cf:data-file/";
+
+export function dataFileSpecifier(path: string): string {
+  return `${DATA_FILE_SPECIFIER}${path.replace(/^\/+/, "")}`;
+}
+
 /**
  * Memo of the two pure derivations {@link buildRecordsFromCompiled} extracts
  * from a module's compiled body: its direct export surface (names + `export *`
@@ -368,6 +375,12 @@ export interface CompileSourcesOptions {
   runtimeModules?: Record<string, string[]>;
   runtimeFingerprint?: string;
   /**
+   * Attached data files as `[authored path, bytes]`, carried onto the graph for
+   * the modules that read them. They are not sources: nothing here compiles,
+   * parses, or records them.
+   */
+  dataFiles?: Iterable<readonly [string, string]>;
+  /**
    * Pre-compiled CommonJS body per source name. When provided (e.g. from
    * `TypeScriptCompiler.compileToModules`, which runs the full CF transformer
    * pipeline), the adapter uses it instead of the bare `ts.transpileModule`
@@ -431,6 +444,15 @@ export interface CompiledModuleGraph {
    * missed fails closed at runtime instead of registering attacker values.
    */
   registrationApproved: Set<string>;
+  /**
+   * Verbatim bytes of every attached data file in this graph, keyed by the
+   * data entry's authored path. These are carried alongside the records rather
+   * than as records: a data file is never a module, so it has no specifier, no
+   * exports, and nothing to execute. The graph carries them so the bytes a
+   * pattern reads come from the same content-addressed closure its code came
+   * from, on the warm load path as much as the cold one.
+   */
+  dataByPath: Map<string, string>;
 }
 
 /**
@@ -445,6 +467,19 @@ function stripIdentityPrefix(name: string, idPrefix?: string): string {
 }
 
 /**
+ * The parts of a deployed source package that bind to the entry module's
+ * identity without being reachable from it through an import. `rootPaths` are
+ * attached source entry points such as tests; `dataPaths` are attached data
+ * files. Each contributes one identity-only edge from `entryPath`, so adding,
+ * changing, or removing any of them yields a distinct entry identity.
+ */
+export interface SourcePackageIdentity {
+  entryPath: string;
+  rootPaths: readonly string[];
+  dataPaths?: readonly string[];
+}
+
+/**
  * Per-module content-addressed identity (`cf:module/<hash>` minus the `cf:module/`
  * scheme) for every source path, computed prefix-free so identities dedupe
  * across programs. Shared by {@link compileSourcesToRecords} and the Engine's
@@ -456,7 +491,7 @@ export function computeModuleIdentities(
   options: {
     idPrefix?: string;
     runtimeFingerprint?: string;
-    sourcePackage?: { entryPath: string; rootPaths: readonly string[] };
+    sourcePackage?: SourcePackageIdentity;
   } = {},
 ): Map<string, string> {
   const stripPath = (path: string) =>
@@ -465,20 +500,30 @@ export function computeModuleIdentities(
     string,
     { specifier: string; target: string }[]
   >();
+  const dataFiles = new Set<string>();
   if (options.sourcePackage !== undefined) {
     const entryPath = stripPath(options.sourcePackage.entryPath);
     const rootPaths = [
       ...new Set(options.sourcePackage.rootPaths.map(stripPath)),
     ]
       .filter((rootPath) => rootPath !== entryPath);
-    if (rootPaths.length > 0) {
-      additionalInternalDeps.set(
-        entryPath,
-        rootPaths.map((rootPath) => ({
-          specifier: sourceRootSpecifier(rootPath),
-          target: rootPath,
-        })),
-      );
+    const dataPaths = [
+      ...new Set((options.sourcePackage.dataPaths ?? []).map(stripPath)),
+    ]
+      .filter((dataPath) => dataPath !== entryPath);
+    for (const dataPath of dataPaths) dataFiles.add(dataPath);
+    const entryDeps = [
+      ...rootPaths.map((rootPath) => ({
+        specifier: sourceRootSpecifier(rootPath),
+        target: rootPath,
+      })),
+      ...dataPaths.map((dataPath) => ({
+        specifier: dataFileSpecifier(dataPath),
+        target: dataPath,
+      })),
+    ];
+    if (entryDeps.length > 0) {
+      additionalInternalDeps.set(entryPath, entryDeps);
     }
   }
   const hashes = computeModuleHashes(
@@ -494,6 +539,7 @@ export function computeModuleIdentities(
         ? { runtimeFingerprint: options.runtimeFingerprint }
         : {}),
       ...(additionalInternalDeps.size === 0 ? {} : { additionalInternalDeps }),
+      ...(dataFiles.size === 0 ? {} : { dataFiles }),
     },
   );
   const identityByPath = new Map<string, string>();
@@ -528,7 +574,7 @@ export function computeFabricModuleIdentities(
   options: {
     idPrefix?: string;
     runtimeFingerprint?: string;
-    sourcePackage?: { entryPath: string; rootPaths: readonly string[] };
+    sourcePackage?: SourcePackageIdentity;
   } = {},
 ): Map<string, string> {
   const authored: Source[] = [];
@@ -823,6 +869,7 @@ export function compileSourcesToRecords(
     moduleSourceMaps,
     registrationSink,
     registrationApproved,
+    dataByPath: new Map(options.dataFiles ?? []),
   };
 }
 
@@ -832,10 +879,15 @@ export interface CachedCompiledModule {
   identity: string;
   /** Normalized authored path (e.g. `/main.tsx`); used for the eval sourceURL. */
   filename: string;
-  /** Compiled CommonJS body. */
+  /** Compiled CommonJS body, or the verbatim bytes of a data entry. */
   code: string;
   /** Internal import edges: require specifier → dependency module identity. */
   imports: { specifier: string; targetIdentity: string }[];
+  /**
+   * This entry carries data rather than code, so `code` is its authored bytes.
+   * A data entry never becomes a module record and is never parsed as one.
+   */
+  isData?: boolean;
   /** Per-module source map, if cached. */
   sourceMap?: SourceMap;
   /**
@@ -908,8 +960,16 @@ export function buildRecordsFromCompiled(
 ): CompiledModuleGraph {
   const runtimeModules = options.runtimeModules ?? {};
   const specifierOf = (identity: string) => `cf:module/${identity}`;
-  const byIdentity = new Map(modules.map((m) => [m.identity, m]));
-  const sourceNames = cachedModuleSourceNames(modules);
+  // Data entries leave before anything reads `code` as JavaScript. Their bytes
+  // are the payload, not a body, so they never gain a specifier or a record.
+  const dataByPath = new Map<string, string>();
+  const moduleEntries = modules.filter((m) => {
+    if (!m.isData) return true;
+    dataByPath.set(m.filename, m.code);
+    return false;
+  });
+  const byIdentity = new Map(moduleEntries.map((m) => [m.identity, m]));
+  const sourceNames = cachedModuleSourceNames(moduleEntries);
 
   // Fix B: use the record surface persisted on the compiled doc; parse the body
   // only when it wasn't precomputed. A module carries the full surface (a warm
@@ -943,7 +1003,7 @@ export function buildRecordsFromCompiled(
     string,
     { names: Set<string>; starTargets: string[] }
   >();
-  for (const m of modules) {
+  for (const m of moduleEntries) {
     const parsed = persistedSurface(m) ?? parseCompiledExports(m.code);
     const names = new Set<string>(parsed.exportNames);
     const starTargets: string[] = [];
@@ -986,7 +1046,7 @@ export function buildRecordsFromCompiled(
   const registrationSink: HoistRegistrationSink = new Map();
   const registrationApproved = new Set<string>();
 
-  for (const m of modules) {
+  for (const m of moduleEntries) {
     const specifier = specifierOf(m.identity);
     specifierByPath.set(sourceNames.get(m.identity)!, specifier);
     compiledBodies.set(specifier, m.code);
@@ -1061,6 +1121,7 @@ export function buildRecordsFromCompiled(
     moduleSourceMaps,
     registrationSink,
     registrationApproved,
+    dataByPath,
   };
 }
 

--- a/packages/runner/test/builder-data-file.test.ts
+++ b/packages/runner/test/builder-data-file.test.ts
@@ -1,0 +1,37 @@
+/**
+ * `dataFile` is exposed to pattern code through the `commonfabric` builder
+ * surface (declared in `api/index.ts`, bound in `builder/factory.ts`). The
+ * surface carries a placeholder, because which data files exist is a property
+ * of the program being loaded rather than of the runtime: each compiled graph
+ * replaces it with a reader closed over that load's attached files.
+ *
+ * These tests pin the placeholder's behavior. Reaching it means a module is
+ * running outside any graph carrying data files, and the failure has to say so
+ * rather than returning something a pattern would go on to parse.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createBuilder } from "../src/builder/factory.ts";
+
+describe("commonfabric dataFile builtin", () => {
+  const { dataFile } = createBuilder().commonfabric;
+
+  it("is exposed as a function on the pattern surface", () => {
+    expect(typeof dataFile).toBe("function");
+  });
+
+  it("refuses a read when no data-file closure is bound", () => {
+    expect(() => dataFile("/data/cities.json")).toThrow(
+      'No attached data file "/data/cities.json"',
+    );
+  });
+
+  it("says the closure is missing rather than blaming the path", () => {
+    // The distinction matters: a caller whose path is right, on a load that
+    // carried no data, is told the load is the problem.
+    expect(() => dataFile("/data/cities.json")).toThrow(
+      "loaded without a data-file closure",
+    );
+  });
+});

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -34,7 +34,10 @@ import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
 import { buildCfcPolicyArtifactManifest } from "../src/cfc/policy.ts";
 import { PatternCoverageCollector } from "../src/pattern-coverage.ts";
 import { pattern } from "../src/builder/pattern.ts";
-import { sourceRootSpecifier } from "../src/sandbox/module-record-compiler.ts";
+import {
+  dataFileSpecifier,
+  sourceRootSpecifier,
+} from "../src/sandbox/module-record-compiler.ts";
 
 // These tests drive the sync parse internals directly (below the async flow
 // boundaries that normally load the deferred compiler stack), so load it here.
@@ -286,6 +289,109 @@ describe("cell-cache: verifySourceDocs (Merkle self-verification)", () => {
     const verification = verifySourceDocs(entryIdentity, tampered);
     expect(verification.ok).toBe(false);
     expect(verification.mismatches).toContain(entryIdentity);
+  });
+
+  it("rejects removing a source-package data-file edge", () => {
+    // The data file's bytes parse as an import in TypeScript. Verification must
+    // hash it as a leaf, or its identity will not reproduce.
+    const files = [
+      { name: "/main.tsx", contents: "export default 1;" },
+      { name: "/notes.txt", contents: 'import x from "./main.tsx";' },
+    ];
+    const dataSpecifier = dataFileSpecifier("/notes.txt");
+    const identities = computeModuleHashes(
+      { main: "/main.tsx", files },
+      {
+        additionalInternalDeps: new Map([
+          ["/main.tsx", [{ specifier: dataSpecifier, target: "/notes.txt" }]],
+        ]),
+        dataFiles: new Set(["/notes.txt"]),
+      },
+    );
+    const entryIdentity = identities.get("/main.tsx")!;
+    const dataIdentity = identities.get("/notes.txt")!;
+    const docs = buildSourceDocs(
+      [
+        {
+          identity: entryIdentity,
+          filename: "/main.tsx",
+          source: files[0].contents,
+          js: "",
+          imports: [{
+            specifier: dataSpecifier,
+            targetIdentity: dataIdentity,
+          }],
+        },
+        {
+          identity: dataIdentity,
+          filename: "/notes.txt",
+          source: files[1].contents,
+          js: "",
+          imports: [],
+        },
+      ],
+      entryIdentity,
+    );
+    expect(verifySourceDocs(entryIdentity, docs).ok).toBe(true);
+
+    const tampered = new Map(docs);
+    tampered.set(entryIdentity, {
+      ...docs.get(entryIdentity)!,
+      imports: [],
+    });
+    const verification = verifySourceDocs(entryIdentity, tampered);
+    expect(verification.ok).toBe(false);
+    expect(verification.mismatches).toContain(entryIdentity);
+  });
+
+  it("rejects tampering with an attached data file's bytes", () => {
+    const files = [
+      { name: "/main.tsx", contents: "export default 1;" },
+      { name: "/data.json", contents: '{"a": 1}' },
+    ];
+    const dataSpecifier = dataFileSpecifier("/data.json");
+    const identities = computeModuleHashes(
+      { main: "/main.tsx", files },
+      {
+        additionalInternalDeps: new Map([
+          ["/main.tsx", [{ specifier: dataSpecifier, target: "/data.json" }]],
+        ]),
+        dataFiles: new Set(["/data.json"]),
+      },
+    );
+    const entryIdentity = identities.get("/main.tsx")!;
+    const dataIdentity = identities.get("/data.json")!;
+    const docs = buildSourceDocs(
+      [
+        {
+          identity: entryIdentity,
+          filename: "/main.tsx",
+          source: files[0].contents,
+          js: "",
+          imports: [{
+            specifier: dataSpecifier,
+            targetIdentity: dataIdentity,
+          }],
+        },
+        {
+          identity: dataIdentity,
+          filename: "/data.json",
+          source: files[1].contents,
+          js: "",
+          imports: [],
+        },
+      ],
+      entryIdentity,
+    );
+
+    const tampered = new Map(docs);
+    tampered.set(dataIdentity, {
+      ...docs.get(dataIdentity)!,
+      code: '{"a": 2}',
+    });
+    const verification = verifySourceDocs(entryIdentity, tampered);
+    expect(verification.ok).toBe(false);
+    expect(verification.mismatches).toContain(dataIdentity);
   });
 
   it("is entry-point independent (util identity is stable across entries)", () => {

--- a/packages/runner/test/engine-evaluate-record-graph.test.ts
+++ b/packages/runner/test/engine-evaluate-record-graph.test.ts
@@ -203,6 +203,179 @@ describe("Engine.evaluateRecordGraph()", () => {
     expect(graph.registrationSink.size).toBe(0);
   });
 
+  it("retains data files without compiling them", async () => {
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      dataFiles: ["/data/cities.json", "/data/notes.txt"],
+      files: [
+        {
+          name: "/main.tsx",
+          contents: "export default 42;",
+        },
+        {
+          name: "/data/cities.json",
+          contents: '{"cities": ["Oslo", "Lima"]}',
+        },
+        {
+          // Bytes that are not TypeScript, and that a parser would read as an
+          // import edge if a data file were ever scanned.
+          name: "/data/notes.txt",
+          contents: 'import nonsense from "./nowhere.ts";\nnot code at all',
+        },
+      ],
+    };
+
+    const { id, graph, mainSpecifier, modules, entryIdentity } = await engine
+      .compileToRecordGraph(program);
+
+    expect(
+      [...graph.specifierByPath.keys()].some((path) =>
+        path.endsWith("/data/cities.json")
+      ),
+    ).toBe(false);
+
+    const stored = new Map(modules.map((m) => [m.filename, m]));
+    expect(stored.get("/data/cities.json")?.source).toBe(
+      '{"cities": ["Oslo", "Lima"]}',
+    );
+    // A data entry's compiled form is its own bytes, so the compiled set alone
+    // carries what a warm load needs.
+    expect(stored.get("/data/cities.json")?.js).toBe(
+      '{"cities": ["Oslo", "Lima"]}',
+    );
+    expect(stored.get("/data/cities.json")?.isData).toBe(true);
+    expect(stored.get("/main.tsx")?.isData).toBeUndefined();
+    expect(stored.get("/data/notes.txt")?.imports).toEqual([]);
+
+    const entry = modules.find((m) => m.identity === entryIdentity)!;
+    expect(
+      entry.imports.map((edge) => edge.specifier).filter((specifier) =>
+        specifier.startsWith("cf:data-file/")
+      ),
+    ).toEqual(["cf:data-file/data/cities.json", "cf:data-file/data/notes.txt"]);
+
+    const result = engine.evaluateRecordGraph(
+      id,
+      graph,
+      mainSpecifier,
+      program.files,
+      program.dataFiles,
+    );
+    expect(result.main?.default).toBe(42);
+    expect(
+      Object.keys(result.exportMap ?? {}).some((path) =>
+        path.startsWith("/data/")
+      ),
+    ).toBe(false);
+  });
+
+  it("reads an attached data file's bytes from the pattern", async () => {
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      dataFiles: ["/data/cities.json"],
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            'import { __cf_data, dataFile } from "commonfabric";',
+            // A value computed at module scope is a top-level value like any
+            // other, so it takes the same `__cf_data` snapshot the SES verifier
+            // requires of one. Reading inside a pattern body needs no wrapper.
+            "const cities = __cf_data(",
+            '  JSON.parse(dataFile("/data/cities.json")).cities,',
+            ");",
+            "export default cities;",
+          ].join("\n"),
+        },
+        { name: "/data/cities.json", contents: '{"cities": ["Oslo", "Lima"]}' },
+      ],
+    };
+
+    const { main } = await engine.compileAndEvaluateModules(program);
+    expect(main?.default).toEqual(["Oslo", "Lima"]);
+  });
+
+  it("names the attached data files when a path matches none", async () => {
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      dataFiles: ["/data/cities.json"],
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            'import { __cf_data, dataFile } from "commonfabric";',
+            'export default __cf_data(dataFile("/data/absent.json"));',
+          ].join("\n"),
+        },
+        { name: "/data/cities.json", contents: "[]" },
+      ],
+    };
+
+    await expect(engine.compileAndEvaluateModules(program)).rejects.toThrow(
+      'No attached data file "/data/absent.json". Attached: /data/cities.json.',
+    );
+  });
+
+  it("refuses an import that lands on a data file", async () => {
+    await expect(engine.compileToRecordGraph({
+      main: "/main.tsx",
+      dataFiles: ["/data.json"],
+      files: [
+        {
+          name: "/main.tsx",
+          contents: 'import data from "./data.json";\nexport default data;',
+        },
+        { name: "/data.json", contents: "{}" },
+      ],
+    })).rejects.toThrow(/Could not resolve ".*\/data\.json"/);
+  });
+
+  it("refuses a program naming a data file it does not carry", async () => {
+    await expect(engine.compileToRecordGraph({
+      main: "/main.tsx",
+      dataFiles: ["/absent.json"],
+      files: [{ name: "/main.tsx", contents: "export default 42;" }],
+    })).rejects.toThrow(
+      "Program names data files it does not carry: /absent.json",
+    );
+  });
+
+  it("separates load identities for different data-file sets", async () => {
+    const files = [
+      { name: "/main.tsx", contents: "export default 42;" },
+      { name: "/a.json", contents: '{"a": 1}' },
+      { name: "/b.json", contents: '{"b": 2}' },
+    ];
+
+    const aOnly = await engine.compileToRecordGraph({
+      main: "/main.tsx",
+      files,
+      dataFiles: ["/a.json"],
+    });
+    const both = await engine.compileToRecordGraph({
+      main: "/main.tsx",
+      files,
+      dataFiles: ["/a.json", "/b.json"],
+    });
+    const reordered = await engine.compileToRecordGraph({
+      main: "/main.tsx",
+      files,
+      dataFiles: ["/b.json", "/a.json", "/a.json"],
+    });
+    const contentChanged = await engine.compileToRecordGraph({
+      main: "/main.tsx",
+      files: files.map((file) =>
+        file.name === "/a.json" ? { ...file, contents: '{"a": 9}' } : file
+      ),
+      dataFiles: ["/a.json", "/b.json"],
+    });
+
+    expect(aOnly.entryIdentity).not.toBe(both.entryIdentity);
+    expect(reordered.id).toBe(both.id);
+    expect(reordered.entryIdentity).toBe(both.entryIdentity);
+    expect(contentChanged.entryIdentity).not.toBe(both.entryIdentity);
+  });
+
   it("separates load identities for different source-root sets", async () => {
     const files = [
       {

--- a/packages/runner/test/engine-evaluate-record-graph.test.ts
+++ b/packages/runner/test/engine-evaluate-record-graph.test.ts
@@ -244,7 +244,7 @@ describe("Engine.evaluateRecordGraph()", () => {
       '{"cities": ["Oslo", "Lima"]}',
     );
     expect(stored.get("/data/cities.json")?.isData).toBe(true);
-    expect(stored.get("/main.tsx")?.isData).toBeUndefined();
+    expect(stored.get("/main.tsx")).not.toHaveProperty("isData");
     expect(stored.get("/data/notes.txt")?.imports).toEqual([]);
 
     const entry = modules.find((m) => m.identity === entryIdentity)!;
@@ -314,6 +314,36 @@ describe("Engine.evaluateRecordGraph()", () => {
     await expect(engine.compileAndEvaluateModules(program)).rejects.toThrow(
       'No attached data file "/data/absent.json". Attached: /data/cities.json.',
     );
+  });
+
+  it("separates identities for data files differing only in line endings", async () => {
+    // A data file's bytes are the payload a pattern reads, so CRLF and LF are
+    // different content — unlike source text, where they are formatting.
+    const compile = (contents: string) =>
+      engine.compileToRecordGraph({
+        main: "/main.tsx",
+        dataFiles: ["/data/rows.csv"],
+        files: [
+          { name: "/main.tsx", contents: "export default 42;" },
+          { name: "/data/rows.csv", contents },
+        ],
+      });
+
+    const lf = await compile("a,b\nc,d\n");
+    const crlf = await compile("a,b\r\nc,d\r\n");
+
+    expect(lf.entryIdentity).not.toBe(crlf.entryIdentity);
+    const dataIdentity = (r: Awaited<ReturnType<typeof compile>>) =>
+      r.modules.find((m) => m.filename === "/data/rows.csv")!.identity;
+    expect(dataIdentity(lf)).not.toBe(dataIdentity(crlf));
+  });
+
+  it("refuses a program naming its entry as a data file", async () => {
+    await expect(engine.compileToRecordGraph({
+      main: "/main.tsx",
+      dataFiles: ["/main.tsx"],
+      files: [{ name: "/main.tsx", contents: "export default 42;" }],
+    })).rejects.toThrow("cannot be a data file");
   });
 
   it("refuses an import that lands on a data file", async () => {

--- a/packages/runner/test/fabric-import-specifier.test.ts
+++ b/packages/runner/test/fabric-import-specifier.test.ts
@@ -183,6 +183,7 @@ describe("fabric import specifiers", () => {
       `cf:module/${HASH}`,
       "cf:cache-root/x",
       "cf:source-root/tests/main.test.tsx",
+      "cf:data-file/data/cities.json",
       "cf:Has_Upper",
       "cf:",
       "cf:/",

--- a/packages/runner/test/load-by-identity.test.ts
+++ b/packages/runner/test/load-by-identity.test.ts
@@ -21,7 +21,10 @@ import { Engine } from "../src/harness/engine.ts";
 import { computeModuleHashes } from "../src/harness/module-identity.ts";
 import type { CacheableModule, RuntimeProgram } from "../src/harness/types.ts";
 import { Runtime } from "../src/runtime.ts";
-import type { CachedCompiledModule } from "../src/sandbox/module-record-compiler.ts";
+import {
+  buildRecordsFromCompiled,
+  type CachedCompiledModule,
+} from "../src/sandbox/module-record-compiler.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("load-by-identity");
@@ -249,6 +252,201 @@ describe("load by module identity (warm + version-bump recovery)", () => {
       }
     } finally {
       await coldRuntime.dispose({ closeStorage: false });
+    }
+  });
+
+  it("cold-loads an exact attached data-file package", async () => {
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      dataFiles: ["/data/cities.json", "/data/notes.txt"],
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            'import { pattern } from "commonfabric";',
+            "export default pattern(() => ({ value: 1 }));",
+          ].join("\n"),
+        },
+        {
+          name: "/data/cities.json",
+          contents: '{"cities": ["Oslo", "Lima"]}',
+        },
+        {
+          // Not TypeScript, and readable as an import edge by a parser that
+          // should never see it.
+          name: "/data/notes.txt",
+          contents: 'import { pattern } from "commonfabric";\nplain text',
+        },
+      ],
+    };
+    const compiled = await engine.compileToRecordGraph(program);
+    writeSourceDocs(
+      runtime,
+      space,
+      compiled.modules,
+      compiled.entryIdentity,
+      tx,
+    );
+    runtime.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    tx = runtime.edit();
+    await runtime.storageManager.synced();
+
+    const coldRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    try {
+      const loaded = await coldRuntime.patternManager.loadPatternByIdentity(
+        compiled.entryIdentity,
+        "default",
+        space,
+      );
+      expect(typeof loaded).toBe("function");
+      const recovered = await coldRuntime.patternManager
+        .getPatternSourceProgramByIdentity(compiled.entryIdentity, space);
+      expect(recovered?.dataFiles).toEqual([
+        "/data/cities.json",
+        "/data/notes.txt",
+      ]);
+      expect(
+        recovered?.files.find((file) => file.name === "/data/cities.json")
+          ?.contents,
+      ).toBe('{"cities": ["Oslo", "Lima"]}');
+      await coldRuntime.patternManager.flushCompileCacheWrites();
+      await coldRuntime.storageManager.synced();
+
+      const warmRuntime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+      });
+      try {
+        const warm = await warmRuntime.patternManager.loadPatternByIdentity(
+          compiled.entryIdentity,
+          "default",
+          space,
+        );
+        expect(typeof warm).toBe("function");
+        const warmSource = await warmRuntime.patternManager
+          .getPatternSourceProgramByIdentity(compiled.entryIdentity, space);
+        expect(warmSource?.dataFiles).toEqual([
+          "/data/cities.json",
+          "/data/notes.txt",
+        ]);
+      } finally {
+        await warmRuntime.dispose({ closeStorage: false });
+      }
+    } finally {
+      await coldRuntime.dispose({ closeStorage: false });
+    }
+  });
+
+  it("carries attached data-file bytes through the compiled set", async () => {
+    // The warm path never reads the source set, so the compiled closure alone
+    // has to carry everything the pattern needs — including its data.
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      dataFiles: ["/data/cities.json"],
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            'import { pattern } from "commonfabric";',
+            "export default pattern(() => ({ value: 1 }));",
+          ].join("\n"),
+        },
+        { name: "/data/cities.json", contents: '{"cities": ["Oslo"]}' },
+      ],
+    };
+    const compiled = await engine.compileToRecordGraph(program);
+    expect(compiled.graph.dataByPath.get("/data/cities.json")).toBe(
+      '{"cities": ["Oslo"]}',
+    );
+
+    writeSourceDocs(
+      runtime,
+      space,
+      compiled.modules,
+      compiled.entryIdentity,
+      tx,
+    );
+    runtime.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    tx = runtime.edit();
+    await runtime.storageManager.synced();
+
+    // Cold load first, so the compiled set gets written back.
+    const coldRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    try {
+      expect(
+        typeof await coldRuntime.patternManager.loadPatternByIdentity(
+          compiled.entryIdentity,
+          "default",
+          space,
+        ),
+      ).toBe("function");
+      await coldRuntime.patternManager.flushCompileCacheWrites();
+      await coldRuntime.storageManager.synced();
+    } finally {
+      await coldRuntime.dispose({ closeStorage: false });
+    }
+
+    // Warm load: the compiled closure alone must yield the data bytes, and the
+    // data entry must never become a module record.
+    const warmRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    try {
+      const runtimeVersion = await getCompileCacheRuntimeVersion();
+      expect(runtimeVersion).toBeDefined();
+      const readTx = warmRuntime.edit();
+      const closure = await loadCompiledClosure(
+        warmRuntime,
+        space,
+        compiled.entryIdentity,
+        { runtimeVersion: runtimeVersion! },
+        readTx,
+      );
+      readTx.abort?.("warm data-file read complete");
+
+      const dataDoc = [...closure.values()].find((doc) =>
+        doc.filename === "/data/cities.json"
+      );
+      expect(dataDoc?.kind).toBe("data");
+      expect(dataDoc?.code).toBe('{"cities": ["Oslo"]}');
+
+      const graph = buildRecordsFromCompiled(
+        [...closure].map(([identity, doc]) => ({
+          identity,
+          filename: doc.filename,
+          code: doc.code,
+          ...(doc.kind === "data" ? { isData: true } : {}),
+          imports: doc.imports.map((edge) => ({
+            specifier: edge.specifier,
+            targetIdentity: edge.identity,
+          })),
+        })),
+      );
+      expect(graph.dataByPath.get("/data/cities.json")).toBe(
+        '{"cities": ["Oslo"]}',
+      );
+      expect(
+        [...graph.specifierByPath.keys()].includes("/data/cities.json"),
+      ).toBe(false);
+
+      expect(
+        typeof await warmRuntime.patternManager.loadPatternByIdentity(
+          compiled.entryIdentity,
+          "default",
+          space,
+        ),
+      ).toBe("function");
+    } finally {
+      await warmRuntime.dispose({ closeStorage: false });
     }
   });
 

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -135,6 +135,7 @@ See `docs/development/EXPERIMENTAL_OPTIONS.md` for available flags.
 | Type check         | `deno task cf check pattern.tsx --no-run`                                                                                    |
 | Test pattern       | `deno task cf test pattern.test.tsx`                                                                                         |
 | Deploy new         | `deno task cf piece new pattern.tsx --test pattern.test.tsx --root . --repository REPO -i key -a url -s space`               |
+| Attach a data file | `deno task cf piece new pattern.tsx --test pattern.test.tsx --datafile data/cities.json ...`                                 |
 | Update existing    | `deno task cf piece setsrc pattern.tsx --test pattern.test.tsx --root . --repository REPO --piece ID -i key -a url -s space` |
 | Inspect state      | `deno task cf piece inspect --piece ID ...`                                                                                  |
 | Get field          | `deno task cf get --piece ID fieldPath ...`                                                                                  |
@@ -208,6 +209,16 @@ deno task cf piece setsrc pattern.tsx --test pattern.test.tsx --piece bafyreia..
 packages and type-checks a test entry but does not run it. Repeat the flag for
 every authored test entry. Each `setsrc` describes a complete new source
 revision, so omitting the flags drops those test roots from that revision.
+
+`--datafile <path>` attaches a file that is not code — a fixture, a lookup
+table, a list of names — so it ships and is recovered with the source. Its bytes
+are stored verbatim: never parsed, type-checked, compiled, or importable, and
+the pattern reads one with `dataFile("/data/cities.json")` from `commonfabric`.
+It must be UTF-8 text and sit inside the deployment root, which the CLI infers
+to cover the main entry, every test entry, and every data file unless `--root`
+says otherwise. Like `--test`, it is repeatable and defines part of the
+revision, so repeat the complete set on every `setsrc`. Changing a data file
+alone still produces a new source revision.
 
 `setsrc` normally rejects incompatible argument/result schema changes and
 retained links whose durable contracts no longer fit. For an intentional

--- a/skills/fuse-workflow/SKILL.md
+++ b/skills/fuse-workflow/SKILL.md
@@ -377,8 +377,13 @@ understand how a piece works; write to modify it live.
 MOUNT/SPACE/pieces/My Piece/
   .src/
     main.tsx       ← pattern source — readable and writable
+    data/
+      cities.json  ← an attached data file — readable and writable
     error.log      ← synthetic, read-only — pattern execution errors
 ```
+
+Every file of the deployed source package appears here at its stored path: the
+entry, its imports, any attached test entries, and any attached data files.
 
 **Read source:**
 
@@ -397,11 +402,13 @@ open(path, "w").write(modified_src)
 # Write triggers setsrc automatically — no cf piece setsrc needed
 ```
 
-FUSE preserves the existing attached test roots during this write, but it does
-not run them and cannot change which entries are attached. Treat the live edit
-as a diagnostic experiment. Before completing the change, make it in the
-repository checkout, run every test against that changed source, and deploy it
-with explicit `cf piece setsrc` plus the complete set of `--test` flags.
+FUSE preserves the existing attached test roots and data files during this
+write, but it does not run the tests and cannot change which entries are
+attached or which files are data. Editing a data file this way replaces its
+bytes and leaves it a data file. Treat the live edit as a diagnostic experiment.
+Before completing the change, make it in the repository checkout, run every test
+against that changed source, and deploy it with explicit `cf piece setsrc` plus
+the complete set of `--test` and `--datafile` flags.
 
 **Check for errors after modifying:**
 

--- a/skills/pattern-deploy/SKILL.md
+++ b/skills/pattern-deploy/SKILL.md
@@ -73,6 +73,13 @@ which creates a duplicate piece.
 defines the complete source revision, so repeat all test flags on every update
 or the new revision will omit those test roots.
 
+Repeatable `--datafile <path>` attaches a file that is not code — a fixture, a
+lookup table — so it ships and is recovered with the source. Its bytes are
+stored verbatim and never parsed, compiled, or importable; it must be UTF-8 text
+inside the deployment root. A pattern reads one with `dataFile(path)` from
+`commonfabric`, naming the path it is stored under. The same complete-revision
+rule applies, so repeat every data-file flag on each update too.
+
 **Inspect piece state:**
 
 ```bash

--- a/skills/pattern-dev/SKILL.md
+++ b/skills/pattern-dev/SKILL.md
@@ -14,7 +14,10 @@ write automated pattern tests, run every test entry with `cf test`, and attach
 every entry with repeatable `--test` flags on `piece new` and every later
 `piece setsrc`. Manual browser or CLI verification does not replace the
 automated tests. Deployment packages and type-checks attached tests but does not
-run them.
+run them. A file the pattern ships with that is not code — a fixture, a lookup
+table — attaches the same way with repeatable `--datafile` flags, is stored
+verbatim rather than compiled, and is read with `dataFile(path)` from
+`commonfabric`.
 
 Also read the foundational reactivity references before implementing or
 debugging pattern state:


### PR DESCRIPTION
A pattern author often keeps files beside the pattern source and its tests that are not code at all: a fixture, a lookup table, a list of names. There was no way to deploy those with the piece. Only files reachable from an entry point through an import were resolved into the authored program, so a file nothing imports never left the working copy, and a checkout recovered from the space came back missing it.

Add data files to the deployed source package and give patterns a way to read them.

## Attaching

A repeatable `--datafile <path>` joins `--test` on `piece new`, `piece setsrc`, and custom `piece set-home`. Each named file is read directly rather than resolved, since nothing imports it and there is no closure to follow, and its bytes are stored verbatim beside the source.

The deployment root now covers the main entry, every test entry, and every data file when `--root` is omitted; an explicit `--root` stays authoritative, and a data file that escapes it — including through a symbolic link — is refused. A source package holds text, so the bytes are decoded as UTF-8 strictly and a file that is not valid UTF-8 is reported by name instead of being stored with replacement characters in place of what was read.

## Identity

Each data file binds into the entry module's identity through an identity-only `cf:data-file/` edge, the analog of the `cf:source-root/` edge an attached test carries. A data-only change therefore yields a distinct source revision, and each revision stays independently recoverable with its own bytes. That specifier namespace is reserved against authored imports alongside the three that already exist.

The bytes stay away from everything that reads TypeScript. A data file is split out of the program before the helper injection, the import scan, the resolver, and the compiler, and it rejoins only the pristine set that identity and the source store are built from. It hashes as a leaf over its own bytes and path rather than through a parse, so text that merely resembles an import does not become an identity edge, and fabric-import pinning skips it rather than rewriting a specifier it only appears to contain.

## Reaching the runtime

The warm load path never reads the source set — it builds records straight from the compiled closure and is source-free by design — so bytes held only in the source set would be absent on every load after the first. A read built on that would work once and then stop working after a restart.

So the compiled set takes the same job for data that it already has for code: hold everything the runtime needs to run the pattern. A data entry's compiled form is its own bytes, and the document is written with `kind: "data"` beside the existing `kind: "compiled"`. The entry's compiled document already carries the `cf:data-file/` edge and the compiled-document schema is recursive, so one sync brings the data documents along with the module closure and no new fetch appears.

The marker keeps the two kinds apart everywhere it matters. A data entry is never handed to the record-surface extractor, whose parse assumes JavaScript. It is filtered out of the record build, so it gains no specifier, no exports, and nothing to execute. It never enters the compiled-body map, so the SES body verifier never sees it — that verifier classifies code, and there is no code here to classify. A document whose stored `kind` the writer did not produce is read as compiled, so an entry is treated as data only when the document says so.

## Reading

`commonfabric` gains `dataFile(path)`, returning an attached file's text. `path` is the file's root-relative path in the source package — the spelling `--datafile` takes and `cf piece getsrc` writes. A data file belongs to the package rather than to any one module, so the path does not resolve relative to the caller and every module names a given file the same way. That is what lets a sub-pattern read one as readily as the entry: nothing about the call depends on which module runs it.

The read is a lookup against the graph's data, which the closure already carried before any module executed. It is synchronous, needs no storage access, cannot half-fail, and returns identical bytes on every load of a revision. A path naming no attached file throws and lists the ones that are attached, since the mistake is almost always a misspelling of a path that is right there.

Binding is per load rather than per process. The shared runtime namespaces are process-global while which data files exist is a property of the program, so each compiled graph hands its own data to the records it registers, replacing the placeholder the shared namespace carries. Both load paths bind the same way, so a warm load reads what a cold one does.

Reading at module scope produces a top-level value like any other, so it takes the `__cf_data` snapshot the SES verifier requires of one. Reading inside a pattern body needs no wrapper.

A data file remains unimportable: a specifier that would land on one does not resolve, and fails the compile.

## Recovery and tooling

The package travels through cold and warm cache recovery, source-document verification, `piece getsrc`, and the FUSE source writeback, so a recovered program reports which of its files are data. A program that names a data file it does not carry is refused, as is a data file whose path is also a source module of the same package.

Documentation, skills, and agent instructions covering deployment and the source package are updated to match, including the completion table, the space-clone rehearsal procedure, and the module-loading spec's account of where the bytes live.

Add CLI, resolver, identity, compilation, cache-verification, recovery, warm round-trip, and data-read tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

