### PR TITLE
The prepared digest binds which links were dereferenced, not how often

### DIFF
--- a/packages/runner/src/cfc/canonical.ts
+++ b/packages/runner/src/cfc/canonical.ts
@@ -75,6 +75,36 @@ const compareAddress = (left: CfcAddress, right: CfcAddress): number => {
   return leftPointer < rightPointer ? -1 : leftPointer > rightPointer ? 1 : 0;
 };
 
+/**
+ * Drops runs of equal entries from an already-sorted array, where `compare`
+ * is the total order it was sorted by and returning 0 means the two entries
+ * are equal rather than merely tied.
+ */
+const dedupeSorted = <T>(
+  sorted: readonly T[],
+  compare: (left: T, right: T) => number,
+): T[] =>
+  sorted.filter((entry, index) =>
+    index === 0 || compare(sorted[index - 1], entry) !== 0
+  );
+
+/**
+ * Total order over dereference traces, comparing every field a trace has.
+ * Comparing equal therefore means the two records ARE equal, which is what
+ * lets `canonicalizePreparedDigestInput` drop duplicates in one adjacent pass
+ * after the sort.
+ */
+const compareDereferenceTrace = (
+  left: CfcDereferenceTrace,
+  right: CfcDereferenceTrace,
+): number => {
+  const sourceCompare = compareAddress(left.source, right.source);
+  if (sourceCompare !== 0) return sourceCompare;
+  const targetCompare = compareAddress(left.target, right.target);
+  if (targetCompare !== 0) return targetCompare;
+  return left.kind < right.kind ? -1 : left.kind > right.kind ? 1 : 0;
+};
+
 const compareConsultedGrant = (
   left: ConsultedGrant,
   right: ConsultedGrant,
@@ -315,17 +345,34 @@ export const canonicalizePreparedDigestInput = (
   ),
   triggerReads: [...(input.triggerReads ?? [])].map(canonicalizeAttemptedWrite)
     .sort(compareAddress),
-  dereferenceTraces: [...input.dereferenceTraces].map(
-    canonicalizeDereferenceTrace,
-  ).sort((left, right) => {
-    const sourceCompare = compareAddress(left.source, right.source);
-    if (sourceCompare !== 0) {
-      return sourceCompare;
-    }
-    const targetCompare = compareAddress(left.target, right.target);
-    if (targetCompare !== 0) return targetCompare;
-    return left.kind < right.kind ? -1 : left.kind > right.kind ? 1 : 0;
-  }),
+  // A SET, not a multiset: the digest binds WHICH dereferences the
+  // transaction performed, never how many times a link was read. Reading one
+  // link twice observes exactly what reading it once observes, so counting
+  // re-reads would let a change in read frequency — a cache, a batch, a loop
+  // rewritten — move the digest without changing what was observed. The two
+  // other consumers already read these as a set: `prepare.ts` indexes trace
+  // sources to classify probes, and `cfcLabelViewForDereferenceTraces` joins
+  // them into a lattice where a repeat merges to the same view.
+  //
+  // Deduplicated HERE rather than at `recordCfcDereferenceTrace`, which must
+  // keep appending: callers bracket a resolution with the trace-array length
+  // and slice off what it appended to derive that hop's label view
+  // (`Cell.resolveAsCell`, `deriveDereferenceLabelView`, the query-result
+  // proxy). Suppressing a repeat's append leaves those slices empty, and the
+  // hop's label view collapses to the resolved document's own labels — the
+  // link slot's contribution, which only the trace's `source` address
+  // reaches, is silently dropped from the second read onward.
+  //
+  // Duplicates land adjacent because `compareDereferenceTrace` orders on
+  // every field, so comparing equal means equal. Dedupe follows the sort, and
+  // the sort follows canonicalization: two traces differing only in a leading
+  // `"value"` path element are the same record, but only once canonicalized.
+  dereferenceTraces: dedupeSorted(
+    [...input.dereferenceTraces].map(canonicalizeDereferenceTrace).sort(
+      compareDereferenceTrace,
+    ),
+    compareDereferenceTrace,
+  ),
   writePolicyInputs: [...input.writePolicyInputs].map(
     canonicalizeWritePolicyInput,
   ).sort(compareWritePolicyInput),

--- a/packages/runner/src/cfc/canonical.ts
+++ b/packages/runner/src/cfc/canonical.ts
@@ -105,6 +105,18 @@ const compareDereferenceTrace = (
   return left.kind < right.kind ? -1 : left.kind > right.kind ? 1 : 0;
 };
 
+/**
+ * Whether two dereference traces are the same record, comparing paths in
+ * canonical form — `compareAddress` reaches each path through
+ * `logicalPathToPointer`, which strips a leading `"value"` on the way. So a
+ * raw trace and its canonicalized twin compare equal without either being
+ * canonicalized first.
+ */
+export const cfcDereferenceTracesEqual = (
+  left: CfcDereferenceTrace,
+  right: CfcDereferenceTrace,
+): boolean => compareDereferenceTrace(left, right) === 0;
+
 const compareConsultedGrant = (
   left: ConsultedGrant,
   right: ConsultedGrant,

--- a/packages/runner/src/cfc/canonical.ts
+++ b/packages/runner/src/cfc/canonical.ts
@@ -76,6 +76,49 @@ const compareAddress = (left: CfcAddress, right: CfcAddress): number => {
 };
 
 /**
+ * Pointer cache for paths that are ALREADY canonical, kept separate from
+ * `pathPointerCache` because the two disagree on exactly the paths this
+ * distinction exists for: they key on the same array identity but encode it
+ * with and without a `"value"` strip.
+ */
+const canonicalPathPointerCache = new WeakMap<readonly string[], string>();
+
+const canonicalPathToPointer = (path: readonly string[]): string => {
+  const cached = canonicalPathPointerCache.get(path);
+  if (cached !== undefined) return cached;
+  const pointer = encodePointer(path);
+  if (Object.isFrozen(path)) canonicalPathPointerCache.set(path, pointer);
+  return pointer;
+};
+
+/**
+ * Orders addresses whose paths are already in canonical form, encoding them
+ * as they stand.
+ *
+ * `compareAddress` cannot serve here. It reaches paths through
+ * `logicalPathToPointer`, which canonicalizes on the way — harmless for a
+ * raw path, but a second strip for one already canonicalized. A payload field
+ * named `value` is what that loses: envelope `["value","value","x"]` is the
+ * payload path `value.x`, canonicalizes to `["value","x"]`, and a second
+ * strip flattens it onto payload `x`. Two distinct addresses then compare
+ * equal, which merely ties their order in a plain sort but silently merges
+ * them under a comparator that also decides identity.
+ */
+const compareCanonicalAddress = (
+  left: CfcAddress,
+  right: CfcAddress,
+): number => {
+  if (left.space !== right.space) {
+    return left.space < right.space ? -1 : 1;
+  }
+  if (left.id !== right.id) return left.id < right.id ? -1 : 1;
+  if (left.scope !== right.scope) return left.scope < right.scope ? -1 : 1;
+  const leftPointer = canonicalPathToPointer(left.path);
+  const rightPointer = canonicalPathToPointer(right.path);
+  return leftPointer < rightPointer ? -1 : leftPointer > rightPointer ? 1 : 0;
+};
+
+/**
  * Drops runs of equal entries from an already-sorted array, where `compare`
  * is the total order it was sorted by and returning 0 means the two entries
  * are equal rather than merely tied.
@@ -89,33 +132,35 @@ const dedupeSorted = <T>(
   );
 
 /**
- * Total order over dereference traces, comparing every field a trace has.
- * Comparing equal therefore means the two records ARE equal, which is what
- * lets `canonicalizePreparedDigestInput` drop duplicates in one adjacent pass
- * after the sort.
+ * Total order over dereference traces whose addresses are already canonical,
+ * comparing every field a trace has. Comparing equal therefore means the two
+ * records ARE equal, which is what lets `canonicalizePreparedDigestInput`
+ * drop duplicates in one adjacent pass after the sort.
  */
 const compareDereferenceTrace = (
   left: CfcDereferenceTrace,
   right: CfcDereferenceTrace,
 ): number => {
-  const sourceCompare = compareAddress(left.source, right.source);
+  const sourceCompare = compareCanonicalAddress(left.source, right.source);
   if (sourceCompare !== 0) return sourceCompare;
-  const targetCompare = compareAddress(left.target, right.target);
+  const targetCompare = compareCanonicalAddress(left.target, right.target);
   if (targetCompare !== 0) return targetCompare;
   return left.kind < right.kind ? -1 : left.kind > right.kind ? 1 : 0;
 };
 
 /**
- * Whether two dereference traces are the same record, comparing paths in
- * canonical form — `compareAddress` reaches each path through
- * `logicalPathToPointer`, which strips a leading `"value"` on the way. So a
- * raw trace and its canonicalized twin compare equal without either being
- * canonicalized first.
+ * Whether two dereference traces name the same dereference. Canonicalizes
+ * both sides, so a caller may pass raw traces — a hop recorded off a raw link
+ * path and the same hop already canonicalized are one dereference, not two.
  */
 export const cfcDereferenceTracesEqual = (
   left: CfcDereferenceTrace,
   right: CfcDereferenceTrace,
-): boolean => compareDereferenceTrace(left, right) === 0;
+): boolean =>
+  compareDereferenceTrace(
+    canonicalizeDereferenceTrace(left),
+    canonicalizeDereferenceTrace(right),
+  ) === 0;
 
 const compareConsultedGrant = (
   left: ConsultedGrant,

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -119,6 +119,7 @@ export {
   canonicalizeLogicalPath,
   canonicalizePreparedDigestInput,
   canonicalizeWritePolicyInput,
+  cfcDereferenceTracesEqual,
   logicalPathToPointer,
   preparedDigestFor,
 } from "./canonical.ts";

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -25,6 +25,7 @@ import {
   type CfcDeclaredMonotonicityMode,
   type CfcDeclaredWideningExemption,
   type CfcDereferenceTrace,
+  cfcDereferenceTracesEqual,
   type CfcEnforcementMode,
   cfcEnforcementStrictness,
   type CfcFlowLabelsMode,
@@ -987,12 +988,24 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   }
 
   recordCfcDereferenceTrace(trace: CfcDereferenceTrace): void {
+    const traces = this.#cfcState.dereferenceTraces;
+    // Only a dereference the transaction had not already performed can move
+    // the digest, which binds the trace SET
+    // (`canonicalizePreparedDigestInput`). Invalidating on a repeat would
+    // reject a commit the recheck in `commit()` goes on to accept, so this
+    // guard answers the same question that recheck does.
+    //
+    // The scan is the rare path, not the hot one: it runs only once prepared,
+    // and every resolution that reaches here has already probed its way down
+    // the link — a probe invalidates on its own, before the hop is recorded.
+    const changesDigest = this.#cfcState.prepare.status === "prepared" &&
+      !traces.some((recorded) => cfcDereferenceTracesEqual(recorded, trace));
     // Freeze on entry: from this point on the record is owned by the tx and
     // identity-stable. Mirrors the chokepoint pattern on
     // `recordCfcWritePolicyInput()`; together they ensure every CfcAddress
     // that flows into the digest input lives behind a deep-frozen wrapper.
-    this.#cfcState.dereferenceTraces.push(deepFreeze(trace));
-    if (this.#cfcState.prepare.status === "prepared") {
+    traces.push(deepFreeze(trace));
+    if (changesDigest) {
       this.invalidateCfc("dereference-trace-added");
     }
   }

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -1065,6 +1065,92 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     }
   });
 
+  it("invalidates prepared state on a dereference the transaction had not performed", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-explicit");
+      tx.markCfcRelevant("test");
+      tx.writeValueOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: "of:cfc-new-dereference",
+        path: [],
+      }, { count: 1 });
+
+      tx.prepareCfc();
+      tx.recordCfcDereferenceTrace({
+        source: {
+          space: signer.did(),
+          id: "of:cfc-new-dereference",
+          scope: "space",
+          path: ["slot"],
+        },
+        target: {
+          space: signer.did(),
+          id: "of:cfc-new-target",
+          scope: "space",
+          path: [],
+        },
+        kind: "value",
+      });
+
+      expect(tx.getCfcState().prepare.status).toBe("invalidated");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("holds prepared state when a recorded dereference repeats", async () => {
+    // The digest binds the dereference SET, so a repeat leaves it untouched
+    // and the commit recheck would accept. Invalidating here would reject a
+    // transaction on the strength of a re-read alone.
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-explicit");
+      tx.markCfcRelevant("test");
+      tx.writeValueOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: "of:cfc-repeat-dereference",
+        path: [],
+      }, { count: 1 });
+
+      const hop = {
+        source: {
+          space: signer.did(),
+          id: "of:cfc-repeat-dereference",
+          scope: "space" as const,
+          // Recorded raw; the repeat below arrives already canonicalized, and
+          // the two are the same dereference.
+          path: ["value", "slot"],
+        },
+        target: {
+          space: signer.did(),
+          id: "of:cfc-repeat-target",
+          scope: "space" as const,
+          path: [],
+        },
+        kind: "value" as const,
+      };
+      tx.recordCfcDereferenceTrace(hop);
+      tx.prepareCfc();
+      expect(tx.getCfcState().prepare.status).toBe("prepared");
+
+      tx.recordCfcDereferenceTrace({
+        ...hop,
+        source: { ...hop.source, path: ["slot"] },
+      });
+
+      expect(tx.getCfcState().prepare.status).toBe("prepared");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   it("invalidates prepared state when the trust snapshot changes", async () => {
     const { runtime, storageManager } = createRuntime();
     try {

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -1151,6 +1151,60 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     }
   });
 
+  it("invalidates prepared state on a dereference under a payload field named `value`", async () => {
+    // `["value","value","slot"]` is the payload path `value.slot`, a
+    // different dereference from `["value","slot"]`'s payload `slot`. Reading
+    // the second must still invalidate, or the guard would mistake it for a
+    // repeat of the first and hold a decision the digest no longer covers.
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-explicit");
+      tx.markCfcRelevant("test");
+      tx.writeValueOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: "of:cfc-payload-value-field",
+        path: [],
+      }, { count: 1 });
+
+      const target = {
+        space: signer.did(),
+        id: "of:cfc-payload-value-target",
+        scope: "space" as const,
+        path: [],
+      };
+      tx.recordCfcDereferenceTrace({
+        source: {
+          space: signer.did(),
+          id: "of:cfc-payload-value-field",
+          scope: "space",
+          path: ["value", "slot"],
+        },
+        target,
+        kind: "value",
+      });
+      tx.prepareCfc();
+      expect(tx.getCfcState().prepare.status).toBe("prepared");
+
+      tx.recordCfcDereferenceTrace({
+        source: {
+          space: signer.did(),
+          id: "of:cfc-payload-value-field",
+          scope: "space",
+          path: ["value", "value", "slot"],
+        },
+        target,
+        kind: "value",
+      });
+
+      expect(tx.getCfcState().prepare.status).toBe("invalidated");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   it("invalidates prepared state when the trust snapshot changes", async () => {
     const { runtime, storageManager } = createRuntime();
     try {

--- a/packages/runner/test/cfc-canonical.test.ts
+++ b/packages/runner/test/cfc-canonical.test.ts
@@ -1,0 +1,117 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+
+import {
+  canonicalizePreparedDigestInput,
+  type CfcDereferenceTrace,
+  preparedDigestFor,
+  type PreparedDigestInput,
+} from "../src/cfc/mod.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-canonical");
+
+describe("canonical", () => {
+  const address = (id: string, ...path: string[]) => ({
+    space: signer.did(),
+    scope: "space" as const,
+    id: `of:${id}`,
+    path,
+  });
+
+  const trace = (
+    source: CfcDereferenceTrace["source"],
+    target: CfcDereferenceTrace["target"],
+    kind: CfcDereferenceTrace["kind"] = "value",
+  ): CfcDereferenceTrace => ({ source, target, kind });
+
+  const baseInput = (
+    overrides: Partial<PreparedDigestInput>,
+  ): PreparedDigestInput => ({
+    consumedReads: [],
+    attemptedWrites: [],
+    writes: [],
+    writeAttemptLog: [],
+    dereferenceTraces: [],
+    triggerReads: [],
+    writePolicyInputs: [],
+    implementationIdentity: undefined,
+    trustSnapshot: undefined,
+    ...overrides,
+  });
+
+  const digestOf = (traces: CfcDereferenceTrace[]) =>
+    preparedDigestFor(baseInput({ dereferenceTraces: traces }));
+
+  describe("dereference traces in the prepared digest", () => {
+    const hop = trace(address("board"), address("row"));
+
+    it("digests a repeated dereference the same as a single one", () => {
+      // The digest binds WHICH dereferences ran, not how many times a link
+      // was read: a quadratic scan over a list resolves each element's link
+      // once per pass, and those passes observe nothing the first did not.
+      expect(digestOf([hop, hop, hop])).toBe(digestOf([hop]));
+    });
+
+    it("digests a structurally equal repeat the same as a single one", () => {
+      // Equality is by content, not object identity — the traces a walk
+      // records are freshly built per hop.
+      const equal = trace(address("board"), address("row"));
+      expect(digestOf([hop, equal])).toBe(digestOf([hop]));
+    });
+
+    it("collapses a repeat that differs only by a leading `value` element", () => {
+      // Dedupe runs after canonicalization, which strips the leading `value`
+      // element. Before it, these two are unequal records.
+      const raw = trace(
+        address("board", "value", "items"),
+        address("row", "value", "cells"),
+      );
+      const canonical = trace(
+        address("board", "items"),
+        address("row", "cells"),
+      );
+      expect(digestOf([raw, canonical])).toBe(digestOf([canonical]));
+    });
+
+    it("distinguishes two different dereferences from one repeated twice", () => {
+      // The guard against a dedupe that collapses too much: two distinct
+      // hops must not digest as one hop read twice.
+      const other = trace(address("board"), address("other-row"));
+      expect(digestOf([hop, other])).not.toBe(digestOf([hop, hop]));
+    });
+
+    it("distinguishes traces that differ only in their source", () => {
+      const elsewhere = trace(address("other-board"), address("row"));
+      expect(digestOf([hop, elsewhere])).not.toBe(digestOf([hop]));
+    });
+
+    it("distinguishes traces that differ only in their kind", () => {
+      const redirect = trace(
+        address("board"),
+        address("row"),
+        "write-redirect",
+      );
+      expect(digestOf([hop, redirect])).not.toBe(digestOf([hop]));
+    });
+
+    it("distinguishes traces that differ only in their target path", () => {
+      const deeper = trace(address("board"), address("row", "cells"));
+      expect(digestOf([hop, deeper])).not.toBe(digestOf([hop]));
+    });
+
+    it("digests the same set regardless of the order it is presented in", () => {
+      const other = trace(address("board"), address("other-row"));
+      expect(digestOf([hop, other])).toBe(digestOf([other, hop]));
+    });
+
+    it("canonicalizes interleaved repeats to one entry per distinct trace", () => {
+      const other = trace(address("board"), address("other-row"));
+      const canonical = canonicalizePreparedDigestInput(
+        baseInput({ dereferenceTraces: [hop, other, hop, other, hop] }),
+      );
+      expect(canonical.dereferenceTraces).toHaveLength(2);
+    });
+  });
+});

--- a/packages/runner/test/cfc-canonical.test.ts
+++ b/packages/runner/test/cfc-canonical.test.ts
@@ -75,6 +75,51 @@ describe("canonical", () => {
       expect(digestOf([raw, canonical])).toBe(digestOf([canonical]));
     });
 
+    it("distinguishes a payload field named `value` from the field it sits over", () => {
+      // Envelope `["value","value","x"]` is the payload path `value.x`; a
+      // payload field may legitimately be named `value`. It canonicalizes to
+      // `["value","x"]`, which a comparator that strips again would flatten
+      // onto payload `x` — two distinct dereferences merging into one, and
+      // the digest binding only the survivor.
+      const overValue = trace(
+        address("board", "value", "value", "x"),
+        address("row"),
+      );
+      const overRoot = trace(address("board", "value", "x"), address("row"));
+      expect(digestOf([overValue, overRoot])).not.toBe(digestOf([overRoot]));
+      expect(
+        canonicalizePreparedDigestInput(
+          baseInput({ dereferenceTraces: [overValue, overRoot] }),
+        ).dereferenceTraces,
+      ).toHaveLength(2);
+    });
+
+    it("distinguishes a payload field named `value` on the target side", () => {
+      const overValue = trace(
+        address("board"),
+        address("row", "value", "value", "x"),
+      );
+      const overRoot = trace(address("board"), address("row", "value", "x"));
+      // Asserted on the canonical length, not on the digest: a merge leaves
+      // whichever trace sorted first, whose content differs from `overRoot`
+      // anyway, so comparing digests would pass without the two surviving.
+      expect(
+        canonicalizePreparedDigestInput(
+          baseInput({ dereferenceTraces: [overValue, overRoot] }),
+        ).dereferenceTraces,
+      ).toHaveLength(2);
+    });
+
+    it("collapses a repeat under a payload field named `value`", () => {
+      // The other side of the same distinction: re-reading `value.x` is one
+      // dereference, exactly as re-reading any other path is.
+      const overValue = trace(
+        address("board", "value", "value", "x"),
+        address("row"),
+      );
+      expect(digestOf([overValue, overValue])).toBe(digestOf([overValue]));
+    });
+
     it("distinguishes two different dereferences from one repeated twice", () => {
       // The guard against a dedupe that collapses too much: two distinct
       // hops must not digest as one hop read twice.

--- a/packages/runner/test/cfc-canonical.test.ts
+++ b/packages/runner/test/cfc-canonical.test.ts
@@ -1,3 +1,16 @@
+/**
+ * The prepared digest binds the SET of dereferences a transaction performed,
+ * never the number of times it read each link. Both halves of that rule are
+ * pinned here: a repeat collapses, and dereferences differing in any field
+ * stay apart — including the pair that a payload field named `value` produces,
+ * whose canonical path still opens with the element canonicalization strips.
+ *
+ * Only `canonicalizePreparedDigestInput`'s handling of `dereferenceTraces` is
+ * in scope. Each other field of the digest input is covered alongside the gate
+ * that depends on it, the write-attempt log's ordering in
+ * `cfc-write-prefix-provenance.test.ts` among them.
+ */
+
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 

--- a/packages/runner/test/cfc-canonicalize.bench.ts
+++ b/packages/runner/test/cfc-canonicalize.bench.ts
@@ -173,6 +173,39 @@ const LARGE_INPUT: PreparedDigestInput = {
   trustSnapshot: undefined,
 };
 
+// A duplicate-heavy fixture, and the one that reflects the trace volume a
+// real commit reaches. A list read through the reactive proxy resolves each
+// element's link once per access, so a quadratic scan — `sources.filter(...)`
+// inside a loop over `sources` — records one trace per element per pass: an
+// 80-entry board produces ~6.5k traces over 80 distinct dereferences. The
+// other fixtures carry six traces, which is the shape of a commit that
+// touched a handful of links rather than walked a list.
+//
+// `canonicalizePreparedDigestInput` reduces these to the distinct set, so
+// what this measures is the sort over the raw list plus the one adjacent
+// pass that collapses it. Both scale with what was RECORDED, which is why
+// the fixture is sized by reads rather than by dereferences.
+const DUPLICATE_BOARD_ENTRIES = 80;
+const DUPLICATE_SCAN_PASSES = 81;
+const DUPLICATE_HEAVY_INPUT: PreparedDigestInput = {
+  consumedReads: [],
+  attemptedWrites: [],
+  writes: [],
+  writeAttemptLog: [],
+  dereferenceTraces: Array.from(
+    { length: DUPLICATE_BOARD_ENTRIES * DUPLICATE_SCAN_PASSES },
+    (_, i) => ({
+      source: makeAddress("board", String(i % DUPLICATE_BOARD_ENTRIES)),
+      target: makeAddress(`row-${i % DUPLICATE_BOARD_ENTRIES}`),
+      kind: "value" as const,
+    }),
+  ),
+  triggerReads: [],
+  writePolicyInputs: [],
+  implementationIdentity: { kind: "builtin", builtinId: "test-builtin" },
+  trustSnapshot: undefined,
+};
+
 // A tiebreak-heavy fixture: many `custom` policies that share `kind` AND
 // `name`, forcing every pairwise sort comparison through the
 // `hashStringOf()` tiebreaker. With the chokepoint freeze in place each
@@ -279,6 +312,14 @@ Deno.bench(
   { group: "preparedDigestFor" },
   () => {
     canonicalizePreparedDigestInput(LARGE_INPUT);
+  },
+);
+
+Deno.bench(
+  "preparedDigestFor — duplicate-heavy (80-entry board scanned quadratically)",
+  { group: "preparedDigestFor" },
+  () => {
+    preparedDigestFor(DUPLICATE_HEAVY_INPUT);
   },
 );
 

--- a/packages/runner/test/cfc-label-view.test.ts
+++ b/packages/runner/test/cfc-label-view.test.ts
@@ -373,6 +373,88 @@ describe("CFC label view helpers", () => {
     }
   });
 
+  it("carries the link slot's label on a second resolution of the same link", async () => {
+    // Every caller that derives a hop's label view brackets the resolution
+    // with the trace-array length and slices off what it appended
+    // (`Cell.resolveAsCell` here; `deriveDereferenceLabelView` and the
+    // query-result proxy identically). So a resolution MUST append its traces
+    // even when it repeats one the transaction already recorded — suppressing
+    // the repeat empties the slice, and the label view falls back to the
+    // resolved document's own labels.
+    //
+    // The link slot's label is what that loses: it lives on the CONTAINER,
+    // reachable only through the trace's `source` address, so the resolved
+    // document cannot supply it. Deduplication belongs in
+    // `canonicalizePreparedDigestInput`, which reads the finished list.
+    const signer = await Identity.fromPassphrase("cfc label view repeat hop");
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "disabled",
+    });
+    try {
+      const tx = runtime.edit();
+      const source = runtime.getCell(
+        signer.did(),
+        "cfc-label-view-repeat-source",
+        undefined,
+        tx,
+      );
+      source.set({ detail: "linked content" } as never);
+      const target = runtime.getCell(
+        signer.did(),
+        "cfc-label-view-repeat-target",
+        undefined,
+        tx,
+      );
+      target.set({ inner: source } as never);
+      const targetLink = parseLink(target.getAsLink());
+      tx.writeOrThrow({
+        space: signer.did(),
+        id: targetLink.id!,
+        type: "application/json",
+        path: ["cfc"],
+      }, {
+        version: 1,
+        schemaHash: "target-schema",
+        labelMap: {
+          version: 1,
+          entries: [{
+            path: ["inner"],
+            label: { confidentiality: ["link-slot-only"] },
+          }],
+        },
+      });
+      await tx.commit();
+
+      // Both resolutions run on ONE transaction, so the second is the repeat.
+      const readTx = runtime.edit();
+      const handle = runtime.getCell(
+        signer.did(),
+        "cfc-label-view-repeat-target",
+        undefined,
+        readTx,
+      );
+      const first = handle.key("inner").withTx(readTx).resolveAsCell();
+      const second = handle.key("inner").withTx(readTx).resolveAsCell();
+      expect(cfcLabelViewForCell(first)).toEqual({
+        version: 1,
+        entries: [{
+          path: [],
+          label: {
+            confidentiality: expect.arrayContaining(["link-slot-only"]),
+          },
+        }],
+      });
+      expect(cfcLabelViewForCell(second)).toEqual(cfcLabelViewForCell(first));
+      readTx.abort();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   it("preserves ref-carried label views when creating cells from sigil links", async () => {
     const signer = await Identity.fromPassphrase(
       "cfc label view sigil carried state",


### PR DESCRIPTION
`canonicalizePreparedDigestInput` sorted the dereference traces without deduplicating them, so the CFC prepared digest counted every *read* of a link rather than every link read. Two transactions that observed exactly the same data digested differently when one happened to touch a link more times, and a change in read frequency alone — a cache, a batch, a loop rewritten — moved the digest. An 80-entry board scanned quadratically through the reactive proxy records 6,480 traces over 80 distinct dereferences.

## Nothing depended on the multiplicity

The other two consumers already read these as a set. `prepare.ts` indexes trace sources to classify probe reads, where duplicates are inert. `cfcLabelViewForDereferenceTraces` joins them into a lattice via `mergeCfcLabelViews`, which keys by `(class, path)` — so a repeat merges to the same view. No verifier, policy check, or peer reads the count, and every other reference to the array is a cursor, a copy, an iteration, or a reset.

The digest also never leaves its transaction: `preparedDigestFor` has exactly two call sites, both in `extended-storage-transaction.ts` — prepare, and the commit recheck comparing against the digest that same transaction produced. It is never persisted or transmitted, and `packages/memory`, `packages/toolshed`, and `packages/api` contain zero references to it. So the rule changes on one side only; this is not a compatibility question.

The sort arrived with #3374 carrying no claim about order or count, unlike the write-attempt log directly above it, which announces itself as order-preserving on purpose.

## Why the dedupe is in the canonicalizer and not at record time

Record-time dedupe is not a cheaper equivalent — it is a label-correctness regression. Three call sites (`Cell.resolveAsCell`, `schema.ts`'s `deriveDereferenceLabelView` ×2, the query-result proxy) bracket a resolution with the trace array's length and slice off what it appended to derive that hop's label view. Suppressing a repeat's append leaves those slices empty. Measured on a repeat resolution with record-time dedupe patched in:

```
SLICE for 1st resolution: 1     FIRST : ["prompt-influence", "container-only"]
SLICE for 2nd resolution: 0     SECOND: ["prompt-influence"]
```

`container-only` lives on the link slot and is reachable only through the trace's `source` address — the resolved document cannot supply it. It disappears from the second read onward. That patch passed every existing CFC suite, so nothing guarded this; a test now does.

Recording therefore still appends unconditionally. Duplicates land adjacent after the sort because the comparator orders on every field a trace has, so comparing equal means equal and one pass collapses them. Deduplicating *after* canonicalization is what collapses two traces differing only in a leading `value` path element.

## Second commit: two consequences of the new rule

**A repeat can no longer move the digest, so it must not invalidate.** `recordCfcDereferenceTrace` invalidated a prepared decision on any post-prepare trace, including a repeat — rejecting a commit the recheck in `commit()` goes on to accept. The guard now asks whether the dereference is new, so both places answer the same question. The scan is guarded on the prepared status, costing nothing on the recording hot path, and it holds if a resolution ever records without probing first.

**The benchmark could not see this workload.** `cfc-canonicalize.bench.ts` states it models what `preparedDigestFor` sees in production, but its largest fixture carried six traces. The new duplicate-heavy fixture measures 8.9ms against 99.8µs for the previous largest — an 89× range the suite was blind to.

## Performance

On the 6,480-trace input, `preparedDigestFor` drops from 19.6ms to 7.0ms, and it runs twice per commit.

## Note on #5909

That PR is still open, so nothing here touches it. Worth flagging for whoever lands it: its description proposes that the trace replay could be dropped once the digest stops counting re-reads. It cannot. #5909 converts only the query-result proxy to returned traces; `cell.ts` and `schema.ts` keep slicing, so removing the replay would reintroduce exactly the label loss shown above. Converting those two sites is the prerequisite, and it is a separate change. Bounding the array's growth with read count depends on the same conversion.

## Testing

- `deno task test` in `packages/runner` (1219 passed) and `packages/piece` (37 passed)
- `deno task check`, `deno fmt --check`, `deno lint`, `check-no-waitfor`, `check-conflict-markers` — all clean
- `deno task integration pattern-tests` (120 passed)

New tests: `cfc-canonical.test.ts` (9 cases — collapse, plus guards against over-collapsing on source, kind, and target path) and guards in `cfc-label-view.test.ts` and `cfc-boundary.test.ts`. Every one was mutation-tested: removing the dedupe fails 4 of 9; a comparator ignoring `kind` or `source` fails exactly that guard; record-time dedupe fails the label guard; restoring unconditional invalidation fails only the repeat test, and never invalidating fails only the new-dereference test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

