### PR TITLE
fix(ts-transformers): array methods over a site-lifted local lower coherently at every stage

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -242,6 +242,17 @@ Remaining fallback behavior is intentionally narrow:
   classify as builders in type-only environments
 - shadowed local helpers and object methods with Common Fabric-like names are not
   classified
+- a property call spelled `mapWithPattern` / `filterWithPattern` /
+  `flatMapWithPattern` whose method resolves to **no symbol** classifies as
+  the array-method family by spelling alone. The transformer emits these
+  calls against receivers whose static type is still the plain array type
+  (a site-lifted collection local, for example), so the method never
+  resolves and the spelling is the only remaining evidence of the family —
+  this is what keeps post-closure stages from wrapping an already-rewritten
+  call in a second lift. A `*WithPattern` method that **does** resolve is an
+  author's own declaration and keeps its author's semantics; authored
+  spellings (`.map` et al.) that fail symbol resolution still require a
+  reactive receiver to classify
 
 Builder-placement validation uses `detectDirectBuilderCall()`, so calls to
 functions returned by builders are not reclassified as direct `lift()` or
@@ -864,6 +875,12 @@ Key rewrite rules:
 - `a || b`: lowers to `unless(condition, fallback)` only in pattern context
 - ternary `cond ? x : y`:
   - becomes `ifElse(cond, x, y)` with branch/predicate processing
+- array-method family calls are never wrapped as a unit: the analysis marks
+  them `skip-call-rewrite`, so only the receiver chain before the method is
+  processed. Via §5's spelling fallback this equally covers an
+  already-rewritten symbol-less `*WithPattern` call encountered inside a
+  processed branch — it stays in place rather than acquiring a lift around
+  the rewritten call
 - non-compute contexts:
   - complex reactive expressions are wrapped via `computed(() => expr)` (later
     lowered to the lift-applied form)
@@ -974,6 +991,15 @@ Transform eligibility:
 
 - decision is context/receiver-policy driven:
   - pattern context + reactive receiver origin -> transform
+  - pattern context + receiver identifier bound, directly in a `pattern` /
+    `render` builder callback body, to an initializer the shared
+    expression-site policy classifies as a lowerable `variable-initializer`
+    site (`const view = rows.get().filter(...)`, which §6.5's autowrap turns
+    into a lift) -> transform, and the receiver symbol is registered in
+    `syntheticReactiveCollectionRegistry` so post-closure consumers of the
+    provenance walk agree with the decision. A local inside a JSX IIFE or any
+    other callback is not admitted here — it belongs to that callback's own
+    lowering
   - compute context + `celllike_requires_rewrite` receiver kind -> transform
   - compute context + `opaque_autounwrapped` receiver kind -> do not transform
   - compute context + local alias in the same callback whose initializer
@@ -981,6 +1007,11 @@ Transform eligibility:
     `wish`, already-rewritten collection calls, or other reactive cell-like
     receivers) -> transform
 - plain array `.map()` is not transformed
+- an inline cell-read receiver (`rows.get().filter(...)` used directly as a
+  `.map` receiver, or standing alone) is NOT transformed by this strategy —
+  the read itself is the thing being lowered, and the expression-site
+  machinery owns it (§6.5); inside standalone hardened functions the eager
+  `<cell>.get().filter(...)` spelling stays untouched plain JavaScript
 - transformed callbacks are marked in `mapCallbackRegistry` and become
   pattern-callback contexts for downstream classification
 - synthetic compute-owned array-method nodes assert that stale pattern ownership

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -242,17 +242,20 @@ Remaining fallback behavior is intentionally narrow:
   classify as builders in type-only environments
 - shadowed local helpers and object methods with Common Fabric-like names are not
   classified
-- a property call spelled `mapWithPattern` / `filterWithPattern` /
-  `flatMapWithPattern` whose method resolves to **no symbol** classifies as
-  the array-method family by spelling alone. The transformer emits these
-  calls against receivers whose static type is still the plain array type
-  (a site-lifted collection local, for example), so the method never
-  resolves and the spelling is the only remaining evidence of the family —
-  this is what keeps post-closure stages from wrapping an already-rewritten
-  call in a second lift. A `*WithPattern` method that **does** resolve is an
-  author's own declaration and keeps its author's semantics; authored
-  spellings (`.map` et al.) that fail symbol resolution still require a
-  reactive receiver to classify
+- a **synthetic** property call spelled `mapWithPattern` /
+  `filterWithPattern` / `flatMapWithPattern` whose method resolves to **no
+  symbol** classifies as the array-method family by spelling alone. The
+  closure stage emits these calls against receivers whose static type is
+  still the plain array type (a site-lifted collection local, for example),
+  so the method never resolves and the emitted spelling is the only
+  remaining evidence of the family — this is what keeps post-closure stages
+  from wrapping an already-rewritten call in a second lift. The
+  synthetic-node requirement scopes that testimony to calls the transformer
+  actually produced: an **authored** `*WithPattern` spelling keeps its
+  author's semantics whether its method resolves (their own declaration) or
+  not (an untyped receiver classifies as no call kind). Authored spellings
+  of every family that fail symbol resolution still require a reactive
+  receiver to classify
 
 Builder-placement validation uses `detectDirectBuilderCall()`, so calls to
 functions returned by builders are not reclassified as direct `lift()` or

--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -50,6 +50,7 @@ import { classifyOpaquePathTerminalCall } from "../transformers/opaque-roots.ts"
 import {
   getTypeAtLocationWithFallback,
   getVariableInitializer,
+  isSyntheticNode,
 } from "./utils.ts";
 import { isCollectionType } from "./type-inference.ts";
 
@@ -1387,18 +1388,24 @@ function resolveExpressionKind(
     const name = target.name.text;
     if (isKnownArrayMethodName(name)) {
       // Fallback path: when symbol resolution doesn't already identify the
-      // array-method family. A symbol-less `*WithPattern` spelling needs no
-      // receiver check: the transformer emits these calls against receivers
-      // whose static type is still the plain array type, so the method never
-      // resolves to a symbol and provenance walks see a plain binding — the
-      // spelling itself testifies to the provenance the rewritten tree can
-      // no longer show structurally. A `*WithPattern` method that DOES
-      // resolve is an author's own declaration and keeps its author's
-      // semantics; the authored spellings stay gated on reactive receivers —
-      // a `.map`-named call whose symbol did not resolve is otherwise not
+      // array-method family. A synthetic, symbol-less `*WithPattern`
+      // spelling needs no receiver check: the closure stage emits these
+      // calls against receivers whose static type is still the plain array
+      // type, so the method never resolves to a symbol and provenance walks
+      // see a plain binding — the emitted spelling itself testifies to the
+      // provenance the rewritten tree can no longer show structurally. The
+      // synthetic-node requirement is what scopes that testimony to calls
+      // the transformer actually produced: an AUTHORED `*WithPattern`
+      // spelling keeps its author's semantics whether its method resolves
+      // (their own declaration) or not (an untyped receiver). Authored
+      // spellings of every family stay gated on reactive receivers — a
+      // `.map`-named call whose symbol did not resolve is otherwise not
       // evidence of the family.
       if (
-        (!symbol && getArrayMethodAccessKindByName(name)?.lowered) ||
+        (
+          !symbol && isSyntheticNode(target) &&
+          getArrayMethodAccessKindByName(name)?.lowered
+        ) ||
         isReactiveArrayMethodReceiverExpression(target.expression, checker)
       ) {
         const result = { kind: "array-method" } as const;

--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -757,9 +757,21 @@ export function getLoweredArrayMethodName(
   return `${family}WithPattern`;
 }
 
+/**
+ * The `options` reach the receiver's provenance walk. Passing
+ * `syntheticReactiveCollectionRegistry` is how a stage that runs after the
+ * closure stage sees the collections that stage created rather than derived —
+ * a local whose initializer is site-lifted has no structural provenance to
+ * walk, so without the registry its ownership reads "plain" and the caller
+ * re-lowers a call the closure stage already rewrote. Callers that must NOT
+ * see those registrations — standalone-function validation, where the eager
+ * `<cell>.get().filter(...)` idiom is the supported spelling — stay on the
+ * bare form deliberately.
+ */
 export function classifyArrayMethodCallSite(
   call: ts.CallExpression,
   checker: ts.TypeChecker,
+  options: ReactiveCollectionProvenanceOptions = {},
 ): ArrayMethodCallSiteInfo | undefined {
   const access = classifyArrayMethodCall(call);
   if (!access) {
@@ -779,6 +791,7 @@ export function classifyArrayMethodCallSite(
     ownership: hasReactiveCollectionProvenance(
         target.expression,
         checker,
+        options,
       )
       ? "reactive"
       : "plain",
@@ -1374,8 +1387,20 @@ function resolveExpressionKind(
     const name = target.name.text;
     if (isKnownArrayMethodName(name)) {
       // Fallback path: when symbol resolution doesn't already identify the
-      // array-method family, only treat it as such for reactive receivers.
-      if (isReactiveArrayMethodReceiverExpression(target.expression, checker)) {
+      // array-method family. A symbol-less `*WithPattern` spelling needs no
+      // receiver check: the transformer emits these calls against receivers
+      // whose static type is still the plain array type, so the method never
+      // resolves to a symbol and provenance walks see a plain binding — the
+      // spelling itself testifies to the provenance the rewritten tree can
+      // no longer show structurally. A `*WithPattern` method that DOES
+      // resolve is an author's own declaration and keeps its author's
+      // semantics; the authored spellings stay gated on reactive receivers —
+      // a `.map`-named call whose symbol did not resolve is otherwise not
+      // evidence of the family.
+      if (
+        (!symbol && getArrayMethodAccessKindByName(name)?.lowered) ||
+        isReactiveArrayMethodReceiverExpression(target.expression, checker)
+      ) {
         const result = { kind: "array-method" } as const;
         cache.set(expression, result);
         return result;

--- a/packages/ts-transformers/src/closures/strategies/array-method-policy.ts
+++ b/packages/ts-transformers/src/closures/strategies/array-method-policy.ts
@@ -3,6 +3,7 @@ import ts from "typescript";
 import {
   classifyArrayMethodCall,
   detectCallKind,
+  getCallArgumentPosition,
   getEnclosingFunctionLikeDeclaration,
   getTypeAtLocationWithFallback,
   hasReactiveCollectionProvenance,
@@ -150,14 +151,11 @@ function getSiteLiftedCollectionLocalSymbol(
   ) {
     return undefined;
   }
-  const builderCall = enclosing.parent;
-  if (
-    !builderCall || !ts.isCallExpression(builderCall) ||
-    !builderCall.arguments.includes(enclosing)
-  ) {
+  const builderPosition = getCallArgumentPosition(enclosing);
+  if (!builderPosition) {
     return undefined;
   }
-  const builderKind = detectCallKind(builderCall, context.checker);
+  const builderKind = detectCallKind(builderPosition.call, context.checker);
   if (
     builderKind?.kind !== "builder" ||
     (builderKind.builderName !== "pattern" &&

--- a/packages/ts-transformers/src/closures/strategies/array-method-policy.ts
+++ b/packages/ts-transformers/src/closures/strategies/array-method-policy.ts
@@ -17,6 +17,7 @@ import {
 import { unwrapExpression } from "../../utils/expression.ts";
 import { isFallbackOperator } from "../../utils/reactive-keys.ts";
 import { classifyOpaquePathTerminalCall } from "../../transformers/opaque-roots.ts";
+import { classifyExpressionSiteHandling } from "../../transformers/expression-site-policy.ts";
 
 /**
  * Detects a fallback-guarded reactive receiver: `(<reactive> ?? fallback)` or
@@ -93,6 +94,89 @@ function hasSharedReactiveCollectionProvenance(
 }
 
 /**
+ * Whether the receiver is a pattern-scope variable whose initializer the
+ * expression-site machinery lifts — `const view = rows.get().filter(...)`,
+ * `const linksView = asArray(links.get()).filter((l) => l)`. The lift is
+ * created by PatternOwnedExpressionSiteLowering, which runs AFTER the closure
+ * stage (C-002), so at decision time the binding still reads as its authored
+ * initializer and no registry entry can exist yet — the same decision-time
+ * race CT-1778 records for helper-call results. The cure is the same: decide
+ * from the shape that will exist, by asking the site machinery itself whether
+ * the initializer classifies as a lowerable site. A binding whose initializer
+ * is site-lifted holds a Reactive at runtime, so an array method over it must
+ * take the WithPattern form or the runtime rejects it.
+ */
+function getSiteLiftedCollectionLocalSymbol(
+  mapTarget: ts.Expression,
+  context: TransformationContext,
+): ts.Symbol | undefined {
+  const target = unwrapExpression(mapTarget);
+  if (!ts.isIdentifier(target)) {
+    return undefined;
+  }
+
+  const originalTarget = ts.getOriginalNode(target);
+  const symbol = context.checker.getSymbolAtLocation(target) ??
+    (
+      originalTarget !== target && ts.isIdentifier(originalTarget)
+        ? context.checker.getSymbolAtLocation(originalTarget)
+        : undefined
+    );
+  const declaration = symbol?.valueDeclaration;
+  if (
+    !declaration || !ts.isVariableDeclaration(declaration) ||
+    !declaration.initializer
+  ) {
+    return undefined;
+  }
+
+  const initializer = declaration.initializer;
+  if (context.getReactiveContext(initializer).kind !== "pattern") {
+    return undefined;
+  }
+
+  // Only bindings in the pattern-builder callback body itself are
+  // site-lifted. A local inside a JSX IIFE is owned by the IIFE
+  // decomposition, and a local inside any other callback by that callback's
+  // own lowering — treating either as already-reactive here would misroute
+  // it.
+  let enclosing: ts.Node | undefined = declaration.parent;
+  while (enclosing && !ts.isFunctionLike(enclosing)) {
+    enclosing = enclosing.parent;
+  }
+  if (
+    !enclosing ||
+    !(ts.isArrowFunction(enclosing) || ts.isFunctionExpression(enclosing))
+  ) {
+    return undefined;
+  }
+  const builderCall = enclosing.parent;
+  if (
+    !builderCall || !ts.isCallExpression(builderCall) ||
+    !builderCall.arguments.includes(enclosing)
+  ) {
+    return undefined;
+  }
+  const builderKind = detectCallKind(builderCall, context.checker);
+  if (
+    builderKind?.kind !== "builder" ||
+    (builderKind.builderName !== "pattern" &&
+      builderKind.builderName !== "render")
+  ) {
+    return undefined;
+  }
+
+  const analyze = context.getDataFlowAnalyzer();
+  const decision = classifyExpressionSiteHandling(
+    initializer,
+    "variable-initializer",
+    context,
+    analyze,
+  );
+  return decision.kind !== "skip" && decision.lowerable ? symbol : undefined;
+}
+
+/**
  * Check if an array method call should be transformed to its WithPattern variant.
  *
  * Type-based approach with context awareness (CT-1186 fix):
@@ -139,6 +223,23 @@ export function shouldTransformArrayMethod(
     hasSharedReactiveCollectionProvenance(mapTarget, context)
   ) {
     return true;
+  }
+
+  if (contextInfo.kind === "pattern") {
+    const siteLiftedLocal = getSiteLiftedCollectionLocalSymbol(
+      mapTarget,
+      context,
+    );
+    if (siteLiftedLocal) {
+      // Registering here is what keeps the later stages coherent with this
+      // decision: the site-lowering stages run after the closure stage and
+      // consult the same provenance walk, which without the registry entry
+      // still reads the binding as plain — and would wrap the already
+      // rewritten `*WithPattern` call in a lift. The registry is the same
+      // channel ReactiveVariableFor uses for the CT-1778 shapes.
+      context.state.syntheticReactiveCollectionRegistry.add(siteLiftedLocal);
+      return true;
+    }
   }
 
   const enclosingFunction = getEnclosingFunctionLikeDeclaration(methodCall);

--- a/packages/ts-transformers/src/transformers/expression-site-policy.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-policy.ts
@@ -770,9 +770,21 @@ function isDeferredJsxArrayMethodExpression(
     }
   }
 
+  // The registry is what lets this stage agree with the closure stage about
+  // a local it rewrote an array method over (`const view =
+  // rows.get().filter(...)` — site-lifted, so structurally invisible to the
+  // provenance walk). Without it the rewritten `*WithPattern` call reads as
+  // plain, misses the deferral, and gets wrapped in a second, incoherent
+  // lift. The typeRegistry keeps the walk's type rooting working on the
+  // synthetic nodes that rewrite produced.
   const arrayMethodCallSite = classifyArrayMethodCallSite(
     current,
     context.checker,
+    {
+      typeRegistry: context.state.typeRegistry,
+      syntheticReactiveCollectionRegistry: context.state
+        .syntheticReactiveCollectionRegistry,
+    },
   );
   return !!arrayMethodCallSite &&
     arrayMethodCallSite.ownership === "reactive";

--- a/packages/ts-transformers/test/ast/call-kind.test.ts
+++ b/packages/ts-transformers/test/ast/call-kind.test.ts
@@ -216,6 +216,29 @@ Deno.test("classifyArrayMethodCallSite does not mark custom lowered *WithPattern
   );
 });
 
+Deno.test("an authored *WithPattern call on an untyped receiver keeps no call kind", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare const collection: any;
+
+    const value = collection.mapWithPattern((n: number) => n + 1);
+  `);
+
+  const expression = findInitializer(sourceFile, "value");
+  if (!ts.isCallExpression(expression)) {
+    throw new Error("Expected call expression initializer");
+  }
+
+  // The method resolves to no symbol on \`any\`, but the node is authored
+  // (parser-ranged), so the synthetic-spelling fallback must not claim it —
+  // only calls the transformer itself emitted classify by spelling alone.
+  assertEquals(detectCallKind(expression, checker), undefined);
+  assertEquals(classifyArrayMethodCallSite(expression, checker), {
+    family: "map",
+    lowered: true,
+    ownership: "plain",
+  });
+});
+
 Deno.test("array method classification ignores prototype-key names", () => {
   const { sourceFile, checker } = createProgram(`
     declare function derive<T>(value: T): T;

--- a/packages/ts-transformers/test/closures/array-method-policy-coverage.test.ts
+++ b/packages/ts-transformers/test/closures/array-method-policy-coverage.test.ts
@@ -1,0 +1,128 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import ts from "typescript";
+
+import type { TransformationContext } from "../../src/core/mod.ts";
+import { shouldTransformArrayMethod } from "../../src/closures/strategies/array-method-policy.ts";
+
+function createProgram(source: string): {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+} {
+  const fileName = "/test.ts";
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    strict: true,
+    skipLibCheck: true,
+  };
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    compilerOptions.target!,
+    true,
+  );
+  const host = ts.createCompilerHost(compilerOptions, true);
+  const baseGetSourceFile = host.getSourceFile.bind(host);
+  const baseReadFile = host.readFile.bind(host);
+  const baseFileExists = host.fileExists.bind(host);
+
+  host.getSourceFile = (name, languageVersion, onError, shouldCreate) =>
+    name === fileName
+      ? sourceFile
+      : baseGetSourceFile(name, languageVersion, onError, shouldCreate);
+  host.readFile = (name) => name === fileName ? source : baseReadFile(name);
+  host.fileExists = (name) => name === fileName || baseFileExists(name);
+
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  return { sourceFile, checker: program.getTypeChecker() };
+}
+
+/** Finds the `.map(...)` call over the local named `view`. */
+function findViewMapCall(sourceFile: ts.SourceFile): ts.CallExpression {
+  let found: ts.CallExpression | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      !found &&
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === "map" &&
+      ts.isIdentifier(node.expression.expression) &&
+      node.expression.expression.text === "view"
+    ) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error("Expected a view.map(...) call in the source");
+  return found;
+}
+
+/**
+ * The slice of TransformationContext the pre-admission checks and the
+ * site-lifted-local admission's guards consume. `reactiveKindFor` stands in
+ * for the reactive-context classifier so a test can place the map call in
+ * pattern context while placing the declaration's initializer wherever the
+ * guard under test needs it.
+ */
+function testContext(
+  checker: ts.TypeChecker,
+  reactiveKindFor: (node: ts.Node) => "pattern" | "compute",
+): TransformationContext {
+  return {
+    checker,
+    state: {
+      typeRegistry: new WeakMap<ts.Node, ts.Type>(),
+      syntheticReactiveCollectionRegistry: new WeakSet<ts.Symbol>(),
+    },
+    getReactiveContext: (node: ts.Node) => ({ kind: reactiveKindFor(node) }),
+  } as unknown as TransformationContext;
+}
+
+describe("array-method-policy", () => {
+  it("declines a site-lifted admission when the initializer sits outside pattern context", () => {
+    const { sourceFile, checker } = createProgram(`
+      declare const rows: { get(): { keep: boolean }[] };
+      const view = rows.get().filter((r) => r.keep);
+      const mapped = view.map((v) => v);
+    `);
+    const mapCall = findViewMapCall(sourceFile);
+    const context = testContext(
+      checker,
+      (node) => node === mapCall ? "pattern" : "compute",
+    );
+
+    expect(shouldTransformArrayMethod(mapCall, context)).toBe(false);
+  });
+
+  it("declines a site-lifted admission for a local declared inside a function declaration", () => {
+    const { sourceFile, checker } = createProgram(`
+      declare const rows: { get(): { keep: boolean }[] };
+      function build() {
+        const view = rows.get().filter((r) => r.keep);
+        return view.map((v) => v);
+      }
+    `);
+    const mapCall = findViewMapCall(sourceFile);
+    const context = testContext(checker, () => "pattern");
+
+    expect(shouldTransformArrayMethod(mapCall, context)).toBe(false);
+  });
+
+  it("declines a site-lifted admission when the enclosing callback belongs to a non-builder call", () => {
+    const { sourceFile, checker } = createProgram(`
+      declare const rows: { get(): { keep: boolean }[] };
+      declare function helper(cb: () => unknown): unknown;
+      helper(() => {
+        const view = rows.get().filter((r) => r.keep);
+        return view.map((v) => v);
+      });
+    `);
+    const mapCall = findViewMapCall(sourceFile);
+    const context = testContext(checker, () => "pattern");
+
+    expect(shouldTransformArrayMethod(mapCall, context)).toBe(false);
+  });
+});

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-get-derived-collection-map-paren-builder.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-get-derived-collection-map-paren-builder.expected.jsx
@@ -1,0 +1,238 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { pattern, UI, Writable } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+interface Row {
+    label: string;
+    keep: boolean;
+}
+const __cfLift_1 = __cfHelpers.lift<{
+    rows: __cfHelpers.Writable<Row[]>;
+}, readonly Row[]>(({ rows }) => rows.get(), {
+    type: "object",
+    properties: {
+        rows: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Row"
+            },
+            asCell: ["readonly"]
+        }
+    },
+    required: ["rows"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                },
+                keep: {
+                    type: "boolean"
+                }
+            },
+            required: ["label", "keep"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "array",
+    items: {
+        $ref: "#/$defs/Row"
+    },
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                },
+                keep: {
+                    type: "boolean"
+                }
+            },
+            required: ["label", "keep"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const r = __cf_pattern_input.key("element");
+    return r.key("keep");
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Row"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                },
+                keep: {
+                    type: "boolean"
+                }
+            },
+            required: ["label", "keep"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const v = __cf_pattern_input.key("element");
+    return <li>{v.key("label")}</li>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Row"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                },
+                keep: {
+                    type: "boolean"
+                }
+            },
+            required: ["label", "keep"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+// FIXTURE: cell-get-derived-collection-map-paren-builder
+// Verifies: parentheses around the pattern builder callback do not change the
+//   site-lifted-collection admission — the derived local still registers, and
+//   a JSX map over it still lowers to `.mapWithPattern`, exactly as in the
+//   unparenthesized spelling (cell-get-derived-collection-map).
+// Context: the admission locates the builder call through
+//   getCallArgumentPosition, which reads argument positions through
+//   transparent parens (§5.7 paren-invariance).
+export default pattern((__cf_pattern_input) => {
+    const rows = __cf_pattern_input.key("rows");
+    const view = __cfLift_1({ rows: rows }).filterWithPattern(__cfPattern_1, {}).for("view", true);
+    return {
+        [UI]: (<ul>
+        {view.mapWithPattern(__cfPattern_2, {})}
+      </ul>),
+        view,
+    };
+}, {
+    type: "object",
+    properties: {
+        rows: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Row"
+            },
+            asCell: ["cell"]
+        }
+    },
+    required: ["rows"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                },
+                keep: {
+                    type: "boolean"
+                }
+            },
+            required: ["label", "keep"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        $UI: {
+            $ref: "#/$defs/JSXElement"
+        },
+        view: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Row"
+            }
+        }
+    },
+    required: ["$UI", "view"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                },
+                keep: {
+                    type: "boolean"
+                }
+            },
+            required: ["label", "keep"]
+        },
+        JSXElement: {
+            anyOf: [{
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }, {
+                    $ref: "#/$defs/UIRenderable"
+                }, {
+                    type: "object",
+                    properties: {}
+                }]
+        },
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-get-derived-collection-map-paren-builder.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-get-derived-collection-map-paren-builder.input.tsx
@@ -1,0 +1,26 @@
+import { pattern, UI, Writable } from "commonfabric";
+
+interface Row {
+  label: string;
+  keep: boolean;
+}
+
+// FIXTURE: cell-get-derived-collection-map-paren-builder
+// Verifies: parentheses around the pattern builder callback do not change the
+//   site-lifted-collection admission — the derived local still registers, and
+//   a JSX map over it still lowers to `.mapWithPattern`, exactly as in the
+//   unparenthesized spelling (cell-get-derived-collection-map).
+// Context: the admission locates the builder call through
+//   getCallArgumentPosition, which reads argument positions through
+//   transparent parens (§5.7 paren-invariance).
+export default pattern<{ rows: Writable<Row[]> }>((({ rows }) => {
+  const view = rows.get().filter((r) => r.keep);
+  return {
+    [UI]: (
+      <ul>
+        {view.map((v) => <li>{v.label}</li>)}
+      </ul>
+    ),
+    view,
+  };
+}));

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-get-derived-collection-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-get-derived-collection-map.expected.jsx
@@ -1,0 +1,347 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { pattern, UI, Writable } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+interface Row {
+    label: string;
+    keep: boolean;
+}
+const __cfLift_1 = __cfHelpers.lift<{
+    rows: __cfHelpers.Writable<Row[]>;
+}, readonly Row[]>(({ rows }) => rows.get(), {
+    type: "object",
+    properties: {
+        rows: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Row"
+            },
+            asCell: ["readonly"]
+        }
+    },
+    required: ["rows"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                },
+                keep: {
+                    type: "boolean"
+                }
+            },
+            required: ["label", "keep"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "array",
+    items: {
+        $ref: "#/$defs/Row"
+    },
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                },
+                keep: {
+                    type: "boolean"
+                }
+            },
+            required: ["label", "keep"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const r = __cf_pattern_input.key("element");
+    return r.key("keep");
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Row"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                },
+                keep: {
+                    type: "boolean"
+                }
+            },
+            required: ["label", "keep"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_2 = __cfHelpers.lift<{
+    view: Row[];
+}, boolean>(({ view }) => view.length > 0, {
+    type: "object",
+    properties: {
+        view: {
+            type: "array",
+            items: {
+                type: "unknown"
+            }
+        }
+    },
+    required: ["view"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const v = __cf_pattern_input.key("element");
+    return v.key("label");
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Row"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                },
+                keep: {
+                    type: "boolean"
+                }
+            },
+            required: ["label", "keep"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+    const v = __cf_pattern_input.key("element");
+    return <li>{v.key("label")}</li>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Row"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                },
+                keep: {
+                    type: "boolean"
+                }
+            },
+            required: ["label", "keep"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
+    const v = __cf_pattern_input.key("element");
+    return <em>{v.key("label")}</em>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Row"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                },
+                keep: {
+                    type: "boolean"
+                }
+            },
+            required: ["label", "keep"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+// FIXTURE: cell-get-derived-collection-map
+// Verifies: a local bound to a cell-read chain (`rows.get().filter(...)`) is a
+//   site-lifted reactive collection, and every array-method consumer of it
+//   lowers coherently — a JSX map at the expression root, a JSX map nested in
+//   a ternary branch, and a value-position map each rewrite to
+//   `.mapWithPattern` with no second lift wrapped around the rewritten call
+//   and no callback parameter appearing among any lift's inputs.
+// Context: the root map lowers through the deferred-JSX route, which reads
+//   the closure stage's registry; the nested map lowers through the
+//   control-flow rewrite, whose wrap decision recognizes the symbol-less
+//   `*WithPattern` spelling structurally; the value-position map keeps its
+//   `.for()` naming on the rewritten chain. `hasAny` pins the
+//   boolean-consumer lift over the same local.
+export default pattern((__cf_pattern_input) => {
+    const rows = __cf_pattern_input.key("rows");
+    const view = __cfLift_1({ rows: rows }).filterWithPattern(__cfPattern_1, {}).for("view", true);
+    const hasAny = __cfLift_2({ view: view }).for("hasAny", true);
+    const labels = view.mapWithPattern(__cfPattern_2, {}).for("labels", true);
+    return {
+        [UI]: (<section>
+        <ul>
+          {view.mapWithPattern(__cfPattern_3, {})}
+        </ul>
+        {__cfHelpers.ifElse({
+            type: "boolean"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            anyOf: [{}, {
+                    type: "object",
+                    properties: {}
+                }]
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "null"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            anyOf: [{
+                    type: "null"
+                }, {}, {
+                    type: "object",
+                    properties: {}
+                }]
+        } as const satisfies __cfHelpers.JSONSchema, hasAny, <div>
+              {view.mapWithPattern(__cfPattern_4, {})}
+            </div>, null)}
+      </section>),
+        labels,
+    };
+}, {
+    type: "object",
+    properties: {
+        rows: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Row"
+            },
+            asCell: ["cell"]
+        }
+    },
+    required: ["rows"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                },
+                keep: {
+                    type: "boolean"
+                }
+            },
+            required: ["label", "keep"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        $UI: {
+            $ref: "#/$defs/JSXElement"
+        },
+        labels: {
+            type: "array",
+            items: {
+                type: "string"
+            }
+        }
+    },
+    required: ["$UI", "labels"],
+    $defs: {
+        JSXElement: {
+            anyOf: [{
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }, {
+                    $ref: "#/$defs/UIRenderable"
+                }, {
+                    type: "object",
+                    properties: {}
+                }]
+        },
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1,
+    __cfLift_2,
+    __cfPattern_2,
+    __cfPattern_3,
+    __cfPattern_4
+});

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-get-derived-collection-map.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-get-derived-collection-map.input.tsx
@@ -1,0 +1,42 @@
+import { pattern, UI, Writable } from "commonfabric";
+
+interface Row {
+  label: string;
+  keep: boolean;
+}
+
+// FIXTURE: cell-get-derived-collection-map
+// Verifies: a local bound to a cell-read chain (`rows.get().filter(...)`) is a
+//   site-lifted reactive collection, and every array-method consumer of it
+//   lowers coherently — a JSX map at the expression root, a JSX map nested in
+//   a ternary branch, and a value-position map each rewrite to
+//   `.mapWithPattern` with no second lift wrapped around the rewritten call
+//   and no callback parameter appearing among any lift's inputs.
+// Context: the root map lowers through the deferred-JSX route, which reads
+//   the closure stage's registry; the nested map lowers through the
+//   control-flow rewrite, whose wrap decision recognizes the symbol-less
+//   `*WithPattern` spelling structurally; the value-position map keeps its
+//   `.for()` naming on the rewritten chain. `hasAny` pins the
+//   boolean-consumer lift over the same local.
+export default pattern<{ rows: Writable<Row[]> }>(({ rows }) => {
+  const view = rows.get().filter((r) => r.keep);
+  const hasAny = view.length > 0;
+  const labels = view.map((v) => v.label);
+  return {
+    [UI]: (
+      <section>
+        <ul>
+          {view.map((v) => <li>{v.label}</li>)}
+        </ul>
+        {hasAny
+          ? (
+            <div>
+              {view.map((v) => <em>{v.label}</em>)}
+            </div>
+          )
+          : null}
+      </section>
+    ),
+    labels,
+  };
+});


### PR DESCRIPTION
## The bug

`topic.tsx` keeps `computed()` wrappers on its links path because the direct spellings crash: a pattern-scope local bound to a cell-read chain —

```tsx
const linksView = asArray(links.get()).filter((l) => l);
```

— is a lift + `filterWithPattern` reactive collection once the #5454 expression-site autowrap lowers the initializer, but the stages that decide array-method routing consulted provenance that cannot see that lift:

- The closure stage runs before the lift exists (stage order is behavior, C-002), so `{linksView.map(...)}` in JSX was accepted but emitted **raw** — runtime-fatal `Reactive.map(fn) is no longer supported`.
- Once the closure stage learns to rewrite it, the post-closure site stages still read the binding as plain, and a rewritten call nested in a **ternary branch** got wrapped in a second lift whose inputs carried the map callback's own parameter, unbound at pattern scope: `lift(({ linksView, link }) => linksView.mapWithPattern(...))` applied with `link: { kind: link.kind, ... }` — `Cannot read properties of undefined (reading 'kind')` the moment the branch rendered.

This is the third transformer gap mapped out of topic.tsx's computed() cascade (after the get-call sites, #5454 + gate fix, and the optional-chaining carrier, #5797), and the worst class: accept-but-miscompile.

## The fix — three coordinated pieces

1. **Closures admission + registration** (`closures/strategies/array-method-policy.ts`): `shouldTransformArrayMethod` admits a receiver bound directly in a `pattern`/`render` builder body whose initializer the expression-site policy itself classifies as a lowerable variable-initializer site, and registers the symbol in `syntheticReactiveCollectionRegistry` (the CT-1778 channel) at decision time. Inline cell-read receivers, IIFE-internal locals, and standalone hardened functions stay outside the admission (all pinned by existing fixtures). The admission locates its owning builder call through `getCallArgumentPosition` (#5919), so parentheses around the builder callback don't hide it — the second commit, with its own fixture pinning the parenthesized spelling.

2. **Registry-aware deferral** (`ast/call-kind.ts`, `transformers/expression-site-policy.ts`): `classifyArrayMethodCallSite` gains an optional `ReactiveCollectionProvenanceOptions` parameter (default `{}`, so existing callers and the memoized default path are unchanged), and `isDeferredJsxArrayMethodExpression` passes the registry + typeRegistry — a root-level JSX map over the local now defers to the JSX array-method machinery instead of being re-lowered.

3. **Structural recognition of the lowered spelling** (`ast/call-kind.ts`): `detectCallKind`'s array-method fallback classifies a **synthetic, symbol-less** `*WithPattern` property call as the array-method family by its emitted spelling alone. The closure stage emits these calls against receivers whose static type is still the plain array type, so the method never resolves to a symbol — the emitted spelling is the only remaining evidence of the family, and the synthetic-node requirement scopes that testimony to calls the transformer actually produced (tightened per cubic's review: an authored `*WithPattern` spelling on an untyped receiver keeps no call kind — pinned). That feeds the dataflow `skip-call-rewrite` hint, which keeps the control-flow branch rewriter from wrapping already-rewritten calls nested under ternaries. A `*WithPattern` method that DOES resolve is an author's own declaration and keeps its author's semantics (pinned by the existing call-kind test).

**Deliberately not in this PR:** the topic.tsx computed()-ectomy itself. #5921 rewrites that file wholesale, so the unwrap ships as its own small PR against the rewritten file after #5921 lands — this PR only makes those direct spellings compile correctly (verified against the real file as an acceptance vehicle before being split back out).

## Architecture note (Berni — a judgment call to ratify)

Cross-stage provenance now travels by two mechanisms, chosen by decision point: **before** the rewrite exists, a consulting stage can only know through shared state (the registry); **after** the rewrite, the emitted spelling itself is evidence (structural recognition, no state needed).

Deliberately NOT plumbed, each with a reason: standalone-function validation (the eager `<cell>.get().filter(...)` idiom must stay legal, and validation runs pre-registration anyway); `normalize.ts` / callback-boundary / capability-analysis (pre-closure consumers of authored spellings — audited, empirically clean); the memoized `isReactiveValueExpression` path (options would poison shared caches; known-remaining blind spot, no observed consequence). If we want one mechanism long-term, the candidates are registry-everywhere (heavier plumbing + cache complexity) or spelling/structure-everywhere post-closure (this PR moves one step that way).

## Verification

- ts-transformers suite 1140/0, goldens byte-identical; fixture `schema-transform/cell-get-derived-collection-map` pins the three consumer shapes over one site-lifted local (root JSX map, ternary-nested JSX map, value-position map with `.for()` naming), and `cell-get-derived-collection-map-paren-builder` pins the parenthesized-builder spelling lowering identically
- current-behavior spec §5, §7.2, §9.4 record the contract
- topics lane-2 (`deno task integration pattern-tests topics`): 3/3 on this tree (transformer exercised against the real patterns; `topic.tsx` itself unchanged here)
- the modernized-topic.tsx acceptance (direct spellings live, links card through the real reconciler, pattern coverage 0 uncovered) was verified on this branch before the topics commit was split out for #5921
- repo fmt / lint / check / check-docs green (mise deno 2.9.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
