### PR TITLE
docs,cli: a test assertion example shows the form that compiles

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -36,8 +36,8 @@ First check which kind of file you are in. A `*.test.tsx` under
 driving another with `action()` and asserting with `assert()` from
 `commonfabric`, run by `deno task cf test`. Nothing in this section applies
 to one.
-`docs/common/workflows/pattern-testing.md` governs those; its "Prefer
-`assert()` over `computed()`" and "Use `assert()` only for assertions"
+`docs/common/workflows/pattern-testing.md` governs those; its "Write
+assertions with `assert()`" and "Use `assert()` only for assertions"
 sections carry the two rules easiest to get wrong.
 
 For everything else, `docs/development/unit-test-coding-style.md` is the

--- a/docs/check.vocabulary.json
+++ b/docs/check.vocabulary.json
@@ -18,6 +18,7 @@
     "Writable",
     "__cfHelpers",
     "action",
+    "assert",
     "cell",
     "cfSqlite",
     "compileAndRun",

--- a/docs/common/ai/pattern-testing-guide.md
+++ b/docs/common/ai/pattern-testing-guide.md
@@ -310,7 +310,7 @@ Key points:
   (`trimmedName(name.get())`, `cell.get() ?? EMPTY_LIST` with a module-level
   constant).
 - Read another runtime's arrays with INLINE literal indexing in the assertion
-  computed (`users?.[0]?.name === "Alice"`). `.map()`, loop-variable
+  body (`users?.[0]?.name === "Alice"`). `.map()`, loop-variable
   indexing, and module-level helper calls over the array resolve in the
   runtime that wrote it but NOT cross-runtime before a local write.
 - A participant cannot read their own never-written `PerUser` array (e.g. an
@@ -331,8 +331,8 @@ with `Math.random()` (allowed inside a handler, coarsened to one-second
 resolution for the clock), keep the assertions deterministic:
 
 - prefer asserting that a value was set, changed, or has the expected shape
-- avoid calling `Date.now()` or `Math.random()` inside a test `computed()`
-  assertion — those built-ins throw a `TimeCapabilityError` in a computed
+- avoid calling `Date.now()` or `Math.random()` inside a test `assert()`
+  assertion — those built-ins throw a `TimeCapabilityError` in a computation
 - if you need an exact value, capture it in the action under test and assert
   against the captured result rather than recomputing it in the assertion
 

--- a/docs/common/workflows/pattern-testing.md
+++ b/docs/common/workflows/pattern-testing.md
@@ -51,7 +51,7 @@ export default pattern(() => {
     counter.increment.send();
   });
 
-  // 3. Define assertions (reactive booleans that report their operands)
+  // 3. Define assertions (reactive conditions that report their operands)
   const assert_is_zero = assert(() => counter.value === 0);
   const assert_is_one = assert(() => counter.value === 1);
 
@@ -197,7 +197,7 @@ and exporting it would only serve the test.
 
 ## Writing Assertions
 
-Use `assert()` to create reactive boolean assertions:
+Use `assert()` to state each condition a test checks:
 
 ```tsx
 // Shown for illustration only.

--- a/docs/specs/PATTERN_TESTING_SPEC.md
+++ b/docs/specs/PATTERN_TESTING_SPEC.md
@@ -448,16 +448,16 @@ const action_add_expense = action(() => {
 
 ### Do: Meaningful Assertion Names
 
-Use descriptive computed cell names:
+Use descriptive assertion names:
 
 ```tsx
 // Shown inside a pattern body.
 // ✅ Good - name describes what's being tested
-const assert_total_equals_45 = computed(() => subject.result.total === 45);
-const assert_items_sorted_by_date = computed(() => isSorted(subject.items));
+const assert_total_equals_45 = assert(() => subject.result.total === 45);
+const assert_items_sorted_by_date = assert(() => isSorted(subject.items));
 
 // ❌ Bad - generic names
-const test1 = computed(() => subject.result.total === 45);
+const test1 = assert(() => subject.result.total === 45);
 ```
 
 ### Do: Use Discriminated Union Format

--- a/packages/cli/fixtures/test-memory-version.test.tsx
+++ b/packages/cli/fixtures/test-memory-version.test.tsx
@@ -1,7 +1,0 @@
-import { computed, pattern, TESTS } from "commonfabric";
-
-export default pattern(() => ({
-  [TESTS]: [
-    { assertion: computed(() => true) },
-  ],
-}));

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -7,7 +7,7 @@
  * 3. Return { [TESTS]: TestStep[] } under the reserved `[TESTS]` output key
  *
  * TestStep is a discriminated union:
- * - { assertion: Reactive<boolean> } from computed(() => condition)
+ * - { assertion: Reactive<AssertRecord> } from assert(() => condition)
  * - { action: Stream<void> } from action(() => sideEffect)
  *
  * The discriminated union avoids TypeScript declaration emit issues
@@ -15,9 +15,9 @@
  *
  * Example:
  * [TESTS]: [
- *   { assertion: computed(() => game.phase === "playing") },
+ *   { assertion: assert(() => game.phase === "playing") },
  *   { action: action(() => game.start.send(undefined)) },
- *   { assertion: computed(() => game.phase === "started") },
+ *   { assertion: assert(() => game.phase === "started") },
  * ]
  *
  * Note: By default, test patterns can only import from their own directory or

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -8,7 +8,11 @@
  *
  * TestStep is a discriminated union:
  * - { assertion: Reactive<AssertRecord> } from assert(() => condition)
- * - { action: Stream<void> } from action(() => sideEffect)
+ * - { action: Stream<unknown> } from action(() => sideEffect)
+ * - { render: unknown } naming a UI target to materialize
+ * - { settle: true } settling fully at a point the author names
+ * - { label: string } and { await: string } coordinating participants
+ *   in a multi-user test
  *
  * The discriminated union avoids TypeScript declaration emit issues
  * that occur when mixing Cell and Stream types in the same array.

--- a/packages/patterns/battleship/multiplayer/room.test.tsx
+++ b/packages/patterns/battleship/multiplayer/room.test.tsx
@@ -11,14 +11,7 @@
  *
  * Run: deno task cf test packages/patterns/battleship/multiplayer/room.test.tsx --root packages/patterns/battleship --verbose
  */
-import {
-  action,
-  assert,
-  computed,
-  pattern,
-  TESTS,
-  Writable,
-} from "commonfabric";
+import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 import BattleshipRoom from "./room.tsx";
 import {
   createInitialShots,
@@ -181,13 +174,13 @@ export default pattern(() => {
   // Assertions - After Hit
   // ==========================================================================
 
-  const _assert_hit_recorded = computed(() => {
+  const _assert_hit_recorded = assert(() => {
     const shots = shotsCell.get();
     // Player 1 fired at player 2's board at 0,0 where destroyer is
     return shots[2][0][0] === "hit";
   });
 
-  const _assert_message_contains_hit = computed(() =>
+  const _assert_message_contains_hit = assert(() =>
     gameStateCell.get().lastMessage.includes("Hit")
   );
 

--- a/packages/patterns/counter/counter.test.tsx
+++ b/packages/patterns/counter/counter.test.tsx
@@ -55,7 +55,7 @@ export default pattern(() => {
   });
 
   // ==========================================================================
-  // Assertions - computed booleans
+  // Assertions - assert() over pattern state
   // ==========================================================================
 
   // Initial state assertions

--- a/packages/patterns/todo-list/todo-list.test.tsx
+++ b/packages/patterns/todo-list/todo-list.test.tsx
@@ -75,7 +75,7 @@ export default pattern(() => {
   });
 
   // ==========================================================================
-  // Assertions - computed booleans
+  // Assertions - assert() over pattern state
   // ==========================================================================
 
   // Initial state

--- a/skills/pattern-test-to-integration/SKILL.md
+++ b/skills/pattern-test-to-integration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pattern-test-to-integration
-description: Convert Common Fabric pattern unit tests (`*.test.tsx` driven by actions and computed assertions) into browser integration tests (`packages/patterns/integration/*.test.ts`) that exercise the rendered UI and can be recorded with `deno task demo`. Use when asked to promote, mirror, spot-check, browser-test, or make a video demo from an existing pattern test, including multi-user pattern tests.
+description: Convert Common Fabric pattern unit tests (`*.test.tsx` driven by actions and assertions) into browser integration tests (`packages/patterns/integration/*.test.ts`) that exercise the rendered UI and can be recorded with `deno task demo`. Use when asked to promote, mirror, spot-check, browser-test, or make a video demo from an existing pattern test, including multi-user pattern tests.
 ---
 
 # Pattern Test to Integration
@@ -69,7 +69,7 @@ Use this map as a starting point, then follow the actual UI:
 | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `Pattern({ inputs })`                        | Compile the source with `FileSystemProgramResolver`, then create a piece with `PiecesController.create(..., { input, start: true })` |
 | `instance.action.send(value)`                | Fill, select, or click the rendered control that a user uses to cause that action                                                    |
-| `computed(() => instance.field === value)`   | Wait for the corresponding rendered text, control state, list contents, or other observable DOM effect                               |
+| `assert(() => instance.field === value)`     | Wait for the corresponding rendered text, control state, list contents, or other observable DOM effect                               |
 | `{ label }` / `{ await }` in `multiUserTest` | Coordinate real participant pages with event-driven waits on shared visible state                                                    |
 | participant runtime                          | A `ShellIntegration` connected to the shared piece, with identity reuse or separation matching the unit test's user/session topology |
 


### PR DESCRIPTION
A pattern test states each check as a step's `{ assertion: X }`. That arm is typed `Reactive<AssertRecord>`, so `assert(() => ...)` is the only way to write one, and a `computed(() => ...)` boolean is a compile error at the pattern's return.

Three places still described the older form. The test runner's own module comment named the arm `Reactive<boolean>` and built both of its example steps with `computed()`. The pattern testing spec's section on naming assertions built all three of its examples the same way. A reader who followed either got a type error at the step, with nothing in the text to say why.

State the current form in both. The runner's comment names the arm `Reactive<AssertRecord>` and builds its example steps with `assert()`, and the spec's naming examples do the same. That section asked for "descriptive computed cell names"; what it is naming is the assertion, so it asks for that instead.

Delete `packages/cli/fixtures/test-memory-version.test.tsx`. It asserts with `computed(() => true)`, so it no longer compiles: `cf check` rejects the step. Nothing in the repository refers to the file, it predates the current test-step type, and the only change it has seen since is the mechanical move to the reserved `[TESTS]` key. It sits in `packages/cli/fixtures/`, a directory no test walks, which is why nothing reported the breakage.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

