### PR TITLE
refactor: one shared answer to the object-shape question

### DIFF
--- a/packages/cf-harness/src/contracts/prompt-slot.ts
+++ b/packages/cf-harness/src/contracts/prompt-slot.ts
@@ -1,5 +1,8 @@
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
-import { isObjectNotArray } from "@commonfabric/utils/types";
+import {
+  isObjectNotArray,
+  type ReadonlyRecord,
+} from "@commonfabric/utils/types";
 
 export type PromptSlotRole = "direct-command" | "context" | "quote";
 
@@ -47,9 +50,6 @@ const PROMPT_SLOT_ROLES: readonly PromptSlotRole[] = [
   "quote",
 ];
 
-const isJsonObject = (input: unknown): input is Record<string, unknown> =>
-  isObjectNotArray(input);
-
 const isPromptSlotRole = (input: unknown): input is PromptSlotRole =>
   typeof input === "string" &&
   PROMPT_SLOT_ROLES.includes(input as PromptSlotRole);
@@ -61,10 +61,10 @@ const isPromptSlotReference = (
   input: unknown,
 ): input is PromptSlotReference =>
   isNonEmptyString(input) ||
-  (isJsonObject(input) && Object.keys(input).length > 0);
+  (isObjectNotArray(input) && Object.keys(input).length > 0);
 
 const optionalString = (
-  input: Record<string, unknown>,
+  input: ReadonlyRecord,
   field: keyof PromptSlotBinding,
 ): string | undefined => {
   const value = input[field];
@@ -83,7 +83,7 @@ const normalizePromptSlotRenderRef = (
   if (input === undefined) {
     return undefined;
   }
-  if (!isJsonObject(input)) {
+  if (!isObjectNotArray(input)) {
     throw new Error("prompt slot renderRef must be an object");
   }
   if (typeof input.seq !== "number" || !Number.isSafeInteger(input.seq)) {
@@ -101,7 +101,7 @@ const normalizePromptSlotRenderRef = (
 export const normalizePromptSlotBinding = (
   input: unknown,
 ): PromptSlotBinding => {
-  if (!isJsonObject(input)) {
+  if (!isObjectNotArray(input)) {
     throw new Error("prompt slot binding must be a JSON object");
   }
   if (input.type !== CFC_PROMPT_SLOT_BOUND_ATOM_TYPE) {

--- a/packages/cf-harness/src/contracts/run-manifest.ts
+++ b/packages/cf-harness/src/contracts/run-manifest.ts
@@ -130,9 +130,6 @@ export const bindLoomLocalRunManifest = (
   };
 };
 
-const isJsonObject = (input: unknown): input is Record<string, unknown> =>
-  isObjectNotArray(input);
-
 const isLoomRunManifestType = (input: unknown): boolean =>
   input === undefined || input === LOOM_RUN_MANIFEST_TYPE;
 
@@ -142,7 +139,7 @@ const normalizeLoomRunManifestCfc = (
   if (input === undefined) {
     return undefined;
   }
-  if (!isJsonObject(input)) {
+  if (!isObjectNotArray(input)) {
     throw new Error("run manifest cfc must be a JSON object");
   }
   if (
@@ -177,7 +174,7 @@ const normalizeCredentialOwnerRef = (
   input: unknown,
 ): HarnessCredentialOwnerRef | undefined => {
   if (input === undefined) return undefined;
-  if (!isJsonObject(input)) {
+  if (!isObjectNotArray(input)) {
     throw new Error("run manifest credentialOwner must be a JSON object");
   }
   if (
@@ -201,7 +198,7 @@ const normalizeCredentialOwnerRef = (
 export const normalizeLoomRunManifest = (
   input: unknown,
 ): LoomRunManifest => {
-  if (!isJsonObject(input)) {
+  if (!isObjectNotArray(input)) {
     throw new Error("run manifest must be a JSON object");
   }
   if (!isLoomRunManifestType(input.type)) {

--- a/packages/cf-harness/src/diagnostics.ts
+++ b/packages/cf-harness/src/diagnostics.ts
@@ -1,4 +1,5 @@
 import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 import type { HarnessRunManifest } from "./contracts/run-manifest.ts";
 import { ProcessTimeoutError } from "./sandbox/process-runner.ts";
 import type {
@@ -219,9 +220,6 @@ const createEmptyCapabilitySnapshot = (
   cfc,
 });
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
 const isCfcEnforcementMode = (
   value: unknown,
 ): value is CfcEnforcementMode =>
@@ -232,10 +230,10 @@ const isFailedDelegateTaskOutput = (
   output: unknown,
 ): output is DelegateTaskToolOutput => {
   if (
-    !isRecord(output) ||
+    !isObjectNotArray(output) ||
     output.type !== "cf-harness.delegate-task-output" ||
     typeof output.outputId !== "string" ||
-    !isRecord(output.subagent)
+    !isObjectNotArray(output.subagent)
   ) {
     return false;
   }
@@ -393,8 +391,8 @@ const parseFabricStatusProbeOutput = (
   }
   try {
     const parsed = JSON.parse(payload);
-    const cfc = isRecord(parsed) ? parsed.cfc : undefined;
-    const mode = isRecord(cfc) ? cfc.mode : undefined;
+    const cfc = isObjectNotArray(parsed) ? parsed.cfc : undefined;
+    const mode = isObjectNotArray(cfc) ? cfc.mode : undefined;
     return {
       statusProbe: "present",
       ...(isCfcEnforcementMode(mode) ? { attestedMode: mode } : {}),
@@ -785,11 +783,11 @@ const classifyWebFetchToolFailure = (
 const isFailedSkillResourceOutput = (
   output: unknown,
 ): output is ReadSkillResourceToolOutput =>
-  isRecord(output) &&
+  isObjectNotArray(output) &&
   output.type === "cf-harness.read-skill-resource-output" &&
   output.status === "error" &&
   typeof output.outputId === "string" &&
-  isRecord(output.error) &&
+  isObjectNotArray(output.error) &&
   typeof output.error.message === "string";
 
 const classifySkillResourceToolFailure = (

--- a/packages/cf-harness/src/interactive-chat-service.ts
+++ b/packages/cf-harness/src/interactive-chat-service.ts
@@ -1,4 +1,8 @@
 import {
+  isObjectNotArray,
+  type ReadonlyRecord,
+} from "@commonfabric/utils/types";
+import {
   CfHarnessPromptLoop,
   type CreateHarnessPromptLoopOptions,
   type RunHarnessTranscriptOptions,
@@ -42,9 +46,6 @@ import type {
 } from "./contracts/transcript.ts";
 import type { HarnessChatSessionStore } from "./session-store.ts";
 import { HarnessControlError } from "./control-errors.ts";
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 export type HarnessInteractivePromptLoop = Pick<
   CfHarnessPromptLoop,
@@ -177,7 +178,7 @@ const providerMismatchError = (
 const isLoomLocalHostBinding = (
   value: unknown,
 ): value is LoomLocalHostBinding => {
-  if (!isRecord(value) || value.source !== "loom") {
+  if (!isObjectNotArray(value) || value.source !== "loom") {
     return false;
   }
   if (
@@ -194,7 +195,7 @@ const isLoomLocalHostBinding = (
     return false;
   }
   const owner = value.credentialOwner;
-  return isRecord(owner) &&
+  return isObjectNotArray(owner) &&
     owner.type === "cf-harness.credential-owner-ref" && owner.version === 1 &&
     typeof owner.ownerKey === "string" && owner.ownerKey.length > 0 &&
     (owner.tenantKey === undefined || typeof owner.tenantKey === "string") &&
@@ -353,17 +354,17 @@ const clearActiveTurnStatus = (
 
 const parseToolMessageContent = (
   content: string,
-): Record<string, unknown> | undefined => {
+): ReadonlyRecord | undefined => {
   try {
     const parsed: unknown = JSON.parse(content);
-    return isRecord(parsed) ? parsed : undefined;
+    return isObjectNotArray(parsed) ? parsed : undefined;
   } catch {
     return undefined;
   }
 };
 
 const toolMessageStatus = (
-  parsedContent: Record<string, unknown> | undefined,
+  parsedContent: ReadonlyRecord | undefined,
 ): "completed" | "failed" | "denied" => {
   if (parsedContent?.type === "cf-harness.observation-denied") {
     return "denied";
@@ -376,7 +377,7 @@ const toolMessageStatus = (
 
 const fileChangeFromToolMessage = (
   message: HarnessToolTranscriptMessage,
-  parsedContent: Record<string, unknown> | undefined,
+  parsedContent: ReadonlyRecord | undefined,
 ): HarnessChatStructuredEvent | undefined => {
   if (
     parsedContent === undefined ||

--- a/packages/cf-harness/src/interactive-chat-stdio.ts
+++ b/packages/cf-harness/src/interactive-chat-stdio.ts
@@ -1,5 +1,9 @@
 import { resolve, toFileUrl } from "@std/path";
 import {
+  isObjectNotArray,
+  type ReadonlyRecord,
+} from "@commonfabric/utils/types";
+import {
   createHarnessChatErrorResponse,
   HARNESS_CHAT_PROTOCOL_VERSION,
   HARNESS_CHAT_REQUEST_TYPE,
@@ -215,16 +219,13 @@ const SUPPORTED_CFC_ENFORCEMENT_MODES = new Set([
   "enforce-strict",
 ]);
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
 const hasOptionalString = (
-  value: Record<string, unknown>,
+  value: ReadonlyRecord,
   key: string,
 ): boolean => value[key] === undefined || typeof value[key] === "string";
 
 const hasOptionalStringIn = (
-  value: Record<string, unknown>,
+  value: ReadonlyRecord,
   key: string,
   allowedValues: readonly string[],
 ): boolean =>
@@ -232,14 +233,14 @@ const hasOptionalStringIn = (
   (typeof value[key] === "string" && allowedValues.includes(value[key]));
 
 const hasOptionalNonNegativeInteger = (
-  value: Record<string, unknown>,
+  value: ReadonlyRecord,
   key: string,
 ): boolean =>
   value[key] === undefined ||
   (Number.isInteger(value[key]) && Number(value[key]) >= 0);
 
 const hasOptionalPositiveInteger = (
-  value: Record<string, unknown>,
+  value: ReadonlyRecord,
   key: string,
 ): boolean =>
   value[key] === undefined ||
@@ -249,13 +250,13 @@ const isNonEmptyString = (value: unknown): value is string =>
   typeof value === "string" && value.trim() !== "";
 
 const isValidWorkspaceParam = (value: unknown): boolean =>
-  isRecord(value) &&
+  isObjectNotArray(value) &&
   typeof value.hostPath === "string" &&
   hasOptionalString(value, "cwd") &&
   hasOptionalString(value, "sandboxPath");
 
 const isValidTurnInputParam = (value: unknown): boolean =>
-  isRecord(value) &&
+  isObjectNotArray(value) &&
   typeof value.text === "string" &&
   (value.imageAttachments === undefined ||
     Array.isArray(value.imageAttachments));
@@ -277,7 +278,7 @@ const isValidPromptSlotParam = (value: unknown): boolean => {
 };
 
 const isValidBrowserAccessParam = (value: unknown): boolean =>
-  isRecord(value) &&
+  isObjectNotArray(value) &&
   value.type === HARNESS_BROWSER_ACCESS_LEASE_TYPE &&
   isNonEmptyString(value.leaseId) &&
   isNonEmptyString(value.cdpUrl) &&
@@ -295,7 +296,7 @@ const isValidBrowserAccessParam = (value: unknown): boolean =>
   );
 
 const isValidChatPolicyParam = (value: unknown): boolean =>
-  isRecord(value) &&
+  isObjectNotArray(value) &&
   value.type === "cf-harness.chat-policy" &&
   typeof value.toolMode === "string" &&
   SUPPORTED_POLICY_TOOL_MODES.has(value.toolMode) &&
@@ -312,7 +313,7 @@ const isValidChatPolicyParam = (value: unknown): boolean =>
 
 const isValidRequestParams = (
   method: HarnessChatRequestMethod,
-  params: Record<string, unknown>,
+  params: ReadonlyRecord,
 ): boolean => {
   switch (method) {
     case "start_session":
@@ -320,23 +321,24 @@ const isValidRequestParams = (
         isValidWorkspaceParam(params.workspace) &&
         hasOptionalString(params, "model") &&
         hasOptionalString(params, "artifactRoot") &&
-        (params.context === undefined || isRecord(params.context)) &&
+        (params.context === undefined || isObjectNotArray(params.context)) &&
         (params.policy === undefined ||
           isValidChatPolicyParam(params.policy)) &&
-        (params.capabilities === undefined || isRecord(params.capabilities)) &&
+        (params.capabilities === undefined ||
+          isObjectNotArray(params.capabilities)) &&
         (params.browserAccess === undefined ||
           isValidBrowserAccessParam(params.browserAccess)) &&
-        (params.metadata === undefined || isRecord(params.metadata));
+        (params.metadata === undefined || isObjectNotArray(params.metadata));
     case "start_turn":
       return typeof params.sessionId === "string" &&
         hasOptionalString(params, "turnId") &&
         isValidTurnInputParam(params.input) &&
-        (params.context === undefined || isRecord(params.context)) &&
+        (params.context === undefined || isObjectNotArray(params.context)) &&
         (params.policy === undefined ||
           isValidChatPolicyParam(params.policy)) &&
         (params.browserAccess === undefined ||
           isValidBrowserAccessParam(params.browserAccess)) &&
-        (params.metadata === undefined || isRecord(params.metadata));
+        (params.metadata === undefined || isObjectNotArray(params.metadata));
     case "cancel_turn":
       return typeof params.sessionId === "string" &&
         hasOptionalString(params, "turnId") &&
@@ -362,7 +364,7 @@ const isRequestEnvelope = (
   value: unknown,
 ): value is HarnessChatRequestEnvelope => {
   if (
-    !isRecord(value) ||
+    !isObjectNotArray(value) ||
     !("type" in value) ||
     value.type !== HARNESS_CHAT_REQUEST_TYPE ||
     !("protocolVersion" in value) ||
@@ -373,7 +375,7 @@ const isRequestEnvelope = (
     typeof value.method !== "string" ||
     !SUPPORTED_REQUEST_METHODS.has(value.method as HarnessChatRequestMethod) ||
     !("params" in value) ||
-    !isRecord(value.params)
+    !isObjectNotArray(value.params)
   ) {
     return false;
   }
@@ -384,7 +386,7 @@ const isRequestEnvelope = (
 };
 
 const requestIdFromUnknown = (value: unknown): string =>
-  isRecord(value) &&
+  isObjectNotArray(value) &&
     "requestId" in value &&
     typeof value.requestId === "string"
     ? value.requestId
@@ -469,9 +471,7 @@ export const runHarnessInteractiveChatNdjsonTransport = async (
 const isTransportErrorResponse = (
   value: unknown,
 ): value is HarnessChatResponse =>
-  typeof value === "object" &&
-  value !== null &&
-  !Array.isArray(value) &&
+  isObjectNotArray(value) &&
   "type" in value &&
   value.type === HARNESS_CHAT_RESPONSE_TYPE &&
   "ok" in value &&

--- a/packages/cf-harness/src/model/openai-codex-responses.ts
+++ b/packages/cf-harness/src/model/openai-codex-responses.ts
@@ -11,6 +11,8 @@ import {
   toResponsesTools,
 } from "./responses-protocol.ts";
 import type { OpenAICodexOAuthCredential } from "../auth/types.ts";
+import { isObjectNotArray } from "@commonfabric/utils/types";
+
 import { HarnessControlError } from "../control-errors.ts";
 import type {
   HarnessModelAttemptDiagnostic,
@@ -520,9 +522,8 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
     if (terminalOutputEmpty && streamedItems.length > 0) {
       terminal = { ...terminal, output: streamedItems };
     }
-    const rawUsage = typeof terminal.usage === "object" &&
-        terminal.usage !== null && !Array.isArray(terminal.usage)
-      ? terminal.usage as Record<string, unknown>
+    const rawUsage = isObjectNotArray(terminal.usage)
+      ? terminal.usage
       : undefined;
     const normalizedUsage = normalizeOpenAIUsage(rawUsage);
     const usage = normalizedUsage === undefined ? undefined : {

--- a/packages/cf-harness/src/model/usage.ts
+++ b/packages/cf-harness/src/model/usage.ts
@@ -1,4 +1,9 @@
 import {
+  isObjectNotArray,
+  type ReadonlyRecord,
+} from "@commonfabric/utils/types";
+
+import {
   HARNESS_MODEL_USAGE_NUMERIC_FIELDS,
   type HarnessCostEstimateWithheldReason,
   type HarnessModelUsage,
@@ -9,15 +14,11 @@ const finiteNonNegativeNumber = (value: unknown): number | undefined =>
     ? value
     : undefined;
 
-const recordValue = (
-  value: unknown,
-): Record<string, unknown> | undefined =>
-  typeof value === "object" && value !== null && !Array.isArray(value)
-    ? value as Record<string, unknown>
-    : undefined;
+const recordValue = (value: unknown): ReadonlyRecord | undefined =>
+  isObjectNotArray(value) ? value : undefined;
 
 const firstNumber = (
-  record: Record<string, unknown>,
+  record: ReadonlyRecord,
   names: readonly string[],
 ): number | undefined => {
   for (const name of names) {
@@ -31,7 +32,7 @@ const firstNumber = (
  * Normalizes usage returned by either the Responses API or Chat Completions.
  */
 export const normalizeOpenAIUsage = (
-  usage: Record<string, unknown> | undefined,
+  usage: ReadonlyRecord | undefined,
 ): HarnessModelUsage | undefined => {
   if (usage === undefined) return undefined;
   const inputDetails = recordValue(

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -6,6 +6,10 @@ import {
   type CfcStreamObservation,
   evaluateHarnessWriteFileAuthorization,
 } from "@commonfabric/runner/cfc";
+import {
+  isObjectNotArray,
+  type ReadonlyRecord,
+} from "@commonfabric/utils/types";
 
 import { isHarnessModelProviderId } from "./config.ts";
 import type { HarnessBrowserAccessLease } from "./contracts/browser-access.ts";
@@ -228,7 +232,7 @@ const parseToolArguments = (
       },
     };
   }
-  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+  if (!isObjectNotArray(parsed)) {
     return {
       invalid: {
         reason: "arguments-not-an-object",
@@ -628,7 +632,7 @@ const summarizeToolInput = async (
             sourceTextDigest: sourceTextSummary.digest,
           }
           : {}),
-        ...(isObjectRecord(input.inputs)
+        ...(isObjectNotArray(input.inputs)
           ? { inputCount: Object.keys(input.inputs).length }
           : {}),
         ...(resultSchemaSummary !== undefined
@@ -1079,12 +1083,11 @@ const summarizeSubagentRunState = (
  * sanitizer substitutes for a position it seals.
  */
 const isSealedOpaqueLinkObject = (value: unknown): boolean => {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+  if (!isObjectNotArray(value)) {
     return false;
   }
-  const record = value as Record<string, unknown>;
-  const target = record["@link"];
-  return Object.keys(record).length === 1 &&
+  const target = value["@link"];
+  return Object.keys(value).length === 1 &&
     typeof target === "string" &&
     target.startsWith("opaque:");
 };
@@ -1131,18 +1134,14 @@ const swapSealedAddressStringsForTokens = async (
     }
     return { table, value: items, replaced };
   }
-  if (
-    typeof sanitized === "object" && sanitized !== null &&
-    !Array.isArray(sanitized) &&
-    typeof raw === "object" && raw !== null && !Array.isArray(raw)
-  ) {
+  if (isObjectNotArray(sanitized) && isObjectNotArray(raw)) {
     let replaced = 0;
     const entries: Record<string, unknown> = {};
     for (const [key, child] of Object.entries(sanitized)) {
       const result = await swapSealedAddressStringsForTokens(
         table,
         child,
-        (raw as Record<string, unknown>)[key],
+        raw[key],
       );
       table = result.table;
       replaced += result.replaced;
@@ -1368,21 +1367,18 @@ interface CfcSandboxResultCarrier {
   cfcResult?: CfcSandboxResult;
 }
 
-const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
 const cfcResultFromOutput = (
   output: unknown,
 ): CfcSandboxResult | undefined =>
-  isObjectRecord(output) &&
+  isObjectNotArray(output) &&
     "cfcResult" in output &&
-    isObjectRecord(output.cfcResult) &&
+    isObjectNotArray(output.cfcResult) &&
     output.cfcResult.version === 1
     ? output.cfcResult as CfcSandboxResult
     : undefined;
 
 const stripInternalCfcFields = (output: unknown): unknown => {
-  if (!isObjectRecord(output)) {
+  if (!isObjectNotArray(output)) {
     return output;
   }
   const { cfcResult: _cfcResult, ...publicOutput } = output as
@@ -1546,7 +1542,7 @@ const truncateModelFacingBashOutput = (
   output: unknown,
   resultRef: ToolResultRef,
 ): unknown => {
-  if (!isObjectRecord(output)) {
+  if (!isObjectNotArray(output)) {
     return output;
   }
   const stdout = truncateModelFacingBashStream(
@@ -1582,7 +1578,7 @@ const truncateModelFacingReadFileOutput = (
   output: unknown,
   resultRef: ToolResultRef,
 ): unknown => {
-  if (!isObjectRecord(output)) {
+  if (!isObjectNotArray(output)) {
     return output;
   }
   const content = truncateModelFacingBashStream(
@@ -1728,7 +1724,7 @@ const modelContextObservationForExitCode = (
 };
 
 const renderMediatedBashOutput = (
-  output: Record<string, unknown>,
+  output: ReadonlyRecord,
   cfcResult: CfcSandboxResult,
   resultRef: ToolResultRef,
   toolCallId: string,
@@ -1862,7 +1858,7 @@ const renderMediatedRunSkillScriptOutput = (
 };
 
 const renderMediatedReadFileOutput = (
-  output: Record<string, unknown>,
+  output: ReadonlyRecord,
   cfcResult: CfcSandboxResult,
   resultRef: ToolResultRef,
   toolCallId: string,
@@ -1898,7 +1894,7 @@ const renderMediatedReadFileOutput = (
 };
 
 const renderMediatedEditFileOutput = (
-  output: Record<string, unknown>,
+  output: ReadonlyRecord,
   cfcResult: CfcSandboxResult,
   resultRef: ToolResultRef,
   toolCallId: string,
@@ -3196,7 +3192,7 @@ export class CfHarnessPromptLoop {
         output: toModelFacingWebFetchOutput(output as WebFetchToolOutput),
       };
     }
-    if (toolId === "run_pattern" && isObjectRecord(output)) {
+    if (toolId === "run_pattern" && isObjectNotArray(output)) {
       // The persisted artifact keeps the raw result value and the piece id
       // — a bare fabric identifier the handle boundary never swaps, and
       // redundant with `resultRef` since the piece cell is the result cell.
@@ -3279,7 +3275,7 @@ export class CfHarnessPromptLoop {
       });
       return { output: denial };
     }
-    if (toolId === "bash" && isObjectRecord(output)) {
+    if (toolId === "bash" && isObjectNotArray(output)) {
       return renderMediatedBashOutput(output, cfcResult, resultRef, toolCallId);
     }
     if (
@@ -3292,7 +3288,7 @@ export class CfHarnessPromptLoop {
         toolCallId,
       );
     }
-    if (toolId === "read_file" && isObjectRecord(output)) {
+    if (toolId === "read_file" && isObjectNotArray(output)) {
       return renderMediatedReadFileOutput(
         output,
         cfcResult,
@@ -3300,7 +3296,7 @@ export class CfHarnessPromptLoop {
         toolCallId,
       );
     }
-    if (toolId === "edit_file" && isObjectRecord(output)) {
+    if (toolId === "edit_file" && isObjectNotArray(output)) {
       return renderMediatedEditFileOutput(
         output,
         cfcResult,

--- a/packages/cf-harness/src/sandbox/docker-runsc.ts
+++ b/packages/cf-harness/src/sandbox/docker-runsc.ts
@@ -19,6 +19,7 @@ import {
   CFC_ENFORCING_STRICTNESS,
   cfcEnforcementStrictness,
 } from "@commonfabric/runner/cfc";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 
 import { SandboxPathEscapeError } from "./errors.ts";
 import { DenoProcessRunner, type ProcessRunner } from "./process-runner.ts";
@@ -327,9 +328,6 @@ export const assertDockerRunscCfcTransportForMode = (
   }
 };
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
 const byteLength = (text: string): number => textEncoder.encode(text).length;
 
 const appendStderr = (stderr: string, message: string): string =>
@@ -426,14 +424,14 @@ const hasNonEmptyXattrValue = (value: unknown): boolean => {
   if (Array.isArray(value)) {
     return value.length > 0;
   }
-  if (isRecord(value)) {
+  if (isObjectNotArray(value)) {
     return Object.values(value).some(hasNonEmptyXattrValue);
   }
   return value !== undefined && value !== null;
 };
 
 const runscTaintLabel = (taint: RunscCfcLabelSidecar): IFCLabel => {
-  const xattr = isRecord(taint.xattrJSON) ? taint.xattrJSON : {};
+  const xattr = isObjectNotArray(taint.xattrJSON) ? taint.xattrJSON : {};
   return {
     ...(Array.isArray(xattr.confidentiality)
       ? { confidentiality: xattr.confidentiality }
@@ -443,7 +441,7 @@ const runscTaintLabel = (taint: RunscCfcLabelSidecar): IFCLabel => {
 };
 
 const isPublicRunscTaint = (taint: RunscCfcLabelSidecar): boolean => {
-  if (isRecord(taint.xattrJSON)) {
+  if (isObjectNotArray(taint.xattrJSON)) {
     return !Object.values(taint.xattrJSON).some(hasNonEmptyXattrValue);
   }
   const stringValue = typeof taint.string === "string"
@@ -476,7 +474,7 @@ const cfcResultFromRunscSidecar = (
       },
     );
   }
-  if (!isRecord(parsed.cfcTaint)) {
+  if (!isObjectNotArray(parsed.cfcTaint)) {
     return deniedCfcResult(
       "runsc_cfc_sidecar_missing_taint",
       "runsc CFC result sidecar did not include final CFC taint",

--- a/packages/cf-harness/src/structured-result.ts
+++ b/packages/cf-harness/src/structured-result.ts
@@ -5,6 +5,7 @@ import {
   validateAndSanitizeStructuredResultValue,
   validateStructuredResultValue as validateCfcStructuredResultValue,
 } from "@commonfabric/runner/cfc";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 
 export const DEFAULT_STRUCTURED_RESULT_SCHEMA_MAX_BYTES = 32 * 1024;
 
@@ -44,9 +45,6 @@ const sha256Digest = async (input: Uint8Array): Promise<string> => {
 export const digestJsonValue = async (input: unknown): Promise<string> =>
   await sha256Digest(textBytes(JSON.stringify(input)));
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
 export const parseStructuredResultSchema = (
   input: unknown,
   options: ParseStructuredResultSchemaOptions = {},
@@ -63,10 +61,7 @@ export const parseStructuredResultSchema = (
       throw new Error(`${label} string must be valid JSON`);
     }
   }
-  if (
-    typeof parsed !== "boolean" &&
-    (!isRecord(parsed) || Array.isArray(parsed))
-  ) {
+  if (typeof parsed !== "boolean" && !isObjectNotArray(parsed)) {
     throw new Error(
       `${label} must be a JSON Schema object, boolean, or JSON string`,
     );

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -8,6 +8,7 @@ import {
   parseLLMFriendlyLink,
 } from "@commonfabric/runner/shared";
 import { PieceController } from "@commonfabric/piece/ops";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import { defineOwnEntry } from "../handle-table.ts";
 import {
@@ -187,9 +188,6 @@ const asSerializableValue = (value: unknown): unknown => {
   }
 };
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
 /**
  * Awaits `work` unless `signal` aborts first. Resolution (not rejection)
  * signals the abort so the losing promise never surfaces as an unhandled
@@ -330,8 +328,8 @@ export const runPatternTool: HarnessToolDefinition<
     // A live-cell input's current value must match the compiled pattern's
     // argument schema for its key before any piece exists, so a mismatch is
     // a model-correctable error rather than a persisted broken piece.
-    const argumentProperties = isRecord(pattern.argumentSchema) &&
-        isRecord(pattern.argumentSchema.properties)
+    const argumentProperties = isObjectNotArray(pattern.argumentSchema) &&
+        isObjectNotArray(pattern.argumentSchema.properties)
       ? pattern.argumentSchema.properties
       : undefined;
     if (argumentProperties !== undefined) {

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -15,7 +15,11 @@ import {
   relaxDefaultedRequired,
   validateSchemaValue,
 } from "@commonfabric/runner/cfc/schema-sanitization";
-import { isInstance } from "@commonfabric/utils/types";
+import {
+  isInstance,
+  isObjectNotArray,
+  type ReadonlyRecord,
+} from "@commonfabric/utils/types";
 
 import {
   type CallableKind,
@@ -262,20 +266,17 @@ export interface ExecutedCallable {
   resultRef?: CallableResultRef;
 }
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
 /** Read a tool callable's stored `pattern` slot as the pattern the runner
  * will run. Only the record shape is checked here; a record missing the
  * schemas reaches `runtime.run` the same way any malformed stored pattern
  * does. */
 function asCallablePattern(value: unknown): Pattern | undefined {
-  if (!isRecord(value)) return undefined;
+  if (!isObjectNotArray(value)) return undefined;
   return value as Pattern;
 }
 
 function asExtraParams(value: unknown): Record<string, unknown> {
-  return isRecord(value) ? value : {};
+  return isObjectNotArray(value) ? value : {};
 }
 
 export function runtimeErrorLog(runtime: unknown): CliRuntimeErrorRecord[] {
@@ -311,12 +312,10 @@ function errorMessage(error: unknown): string {
   return String(error);
 }
 
-function isSchemaObject(schema: JSONSchema | undefined): schema is Record<
-  string,
-  unknown
-> {
-  return typeof schema === "object" && schema !== null &&
-    !Array.isArray(schema);
+function isSchemaObject(
+  schema: JSONSchema | undefined,
+): schema is ReadonlyRecord {
+  return isObjectNotArray(schema);
 }
 
 /**
@@ -568,8 +567,7 @@ function isOpaqueReference(value: unknown): boolean {
   // nothing to malform. Every link a PAYLOAD can carry is the envelope form,
   // since the primitive spelling is that same sigil.
   if (payload === undefined) return true;
-  return typeof payload === "object" && payload !== null &&
-    !Array.isArray(payload);
+  return isObjectNotArray(payload);
 }
 
 /** Whether a schema node marks its position as a cell or a stream, which is
@@ -929,10 +927,7 @@ function cloneWithoutBoundToolKeys(
   if (schema.type !== "object" && !schema.properties) return schema;
 
   const rawProperties = schema.properties;
-  if (
-    typeof rawProperties !== "object" || rawProperties === null ||
-    Array.isArray(rawProperties)
-  ) {
+  if (!isObjectNotArray(rawProperties)) {
     return schema;
   }
 
@@ -961,12 +956,11 @@ function mergeToolInput(
   input: unknown,
   extraParams: Record<string, unknown>,
 ): Record<string, unknown> {
-  const base =
-    typeof input === "object" && input !== null && !Array.isArray(input)
-      ? input as Record<string, unknown>
-      : input === undefined
-      ? {}
-      : { value: input };
+  const base = isObjectNotArray(input)
+    ? input
+    : input === undefined
+    ? {}
+    : { value: input };
 
   return {
     ...base,
@@ -1475,7 +1469,7 @@ export async function executeResolvedCallable(
       // link a launched or chained-cell result converts to, an instance's
       // codec form, a keyless raw primitive — is a result.
       const raw = receipt.getRaw();
-      const valueLess = isRecord(raw) && !isInstance(raw) &&
+      const valueLess = isObjectNotArray(raw) && !isInstance(raw) &&
         Object.keys(raw).length === 0;
       if (value !== undefined && !valueLess) {
         result = value;

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -1,6 +1,10 @@
 import type { JSONSchema } from "@commonfabric/api";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { schemaToTypeString } from "@commonfabric/runner";
+import {
+  isObjectNotArray,
+  type ReadonlyRecord,
+} from "@commonfabric/utils/types";
 import { cliCommand } from "./cli-name.ts";
 // A value import back to callable.ts, whose own import of this module is
 // type-only and therefore erased — so this creates no runtime cycle.
@@ -77,9 +81,8 @@ interface ParsedInputMode {
   usedJsonInput: boolean;
 }
 
-function isSchemaObject(schema: JSONSchema): schema is Record<string, unknown> {
-  return typeof schema === "object" && schema !== null &&
-    !Array.isArray(schema);
+function isSchemaObject(schema: JSONSchema): schema is ReadonlyRecord {
+  return isObjectNotArray(schema);
 }
 
 /**

--- a/packages/cli/lib/trusted-test-event.ts
+++ b/packages/cli/lib/trusted-test-event.ts
@@ -15,6 +15,7 @@
  */
 
 import { markRendererTrustedEvent } from "@commonfabric/runner/cfc";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 
 export interface TrustedUiDescriptor {
   /** `data-ui-pattern` / `data-ui-event-integrity` of the trusted surface. */
@@ -29,9 +30,6 @@ export const isTrustedUiDescriptor = (
   typeof value === "object" && value !== null &&
   typeof (value as { surface?: unknown }).surface === "string" &&
   typeof (value as { action?: unknown }).action === "string";
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 /**
  * Resolve the event value to send for an action step: the step's literal
@@ -51,7 +49,7 @@ export function buildActionEvent(
   }
   const eventValue = {
     type: "click",
-    ...(isRecord(event) ? event : {}),
+    ...(isObjectNotArray(event) ? event : {}),
     provenance: {
       origin: "dom",
       trusted: true,

--- a/packages/fuse/annotations.ts
+++ b/packages/fuse/annotations.ts
@@ -3,6 +3,7 @@ import { encodeHex } from "@std/encoding/hex";
 import { CFC_FUSE_ATOM_CLASS, cfcAtom } from "@commonfabric/api/cfc";
 import { sha256 } from "@commonfabric/content-hash";
 import { isLinkRef } from "@commonfabric/runner/shared";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 
 import type { CallableKind } from "./callables.ts";
 
@@ -196,10 +197,6 @@ const emptyDerivedSlots = (): CfcDerivedSlotsAnnotation => ({
 
 function labelKeys(): Array<keyof CfcLabel> {
   return ["confidentiality", "integrity"];
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function canonicalPath(path: readonly CfcPathSegment[]): string[] {
@@ -625,7 +622,7 @@ export class CfcProjectionAnnotator {
       );
     }
 
-    if (isRecord(value) && !isLinkRef(value)) {
+    if (isObjectNotArray(value) && !isLinkRef(value)) {
       const keys = Object.keys(value);
       if (keys.length === 0) return this.labelAt(path);
       return joinLabels(...keys.map((key) => this.labelAt([...path, key])));

--- a/packages/fuse/callables.ts
+++ b/packages/fuse/callables.ts
@@ -1,4 +1,9 @@
 import type { JSONSchema } from "@commonfabric/api";
+import {
+  isObjectNotArray,
+  type ReadonlyRecord,
+} from "@commonfabric/utils/types";
+
 import { ContextualFlowControl } from "../runner/src/cfc.ts";
 
 const encoder = new TextEncoder();
@@ -9,22 +14,19 @@ function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
-function isSchemaRecord(schema: JSONSchema | undefined): schema is Record<
-  string,
-  unknown
-> {
-  return typeof schema === "object" && schema !== null &&
-    !Array.isArray(schema);
+function isSchemaRecord(
+  schema: JSONSchema | undefined,
+): schema is ReadonlyRecord {
+  return isObjectNotArray(schema);
 }
 
 function isPatternSchemaValue(value: unknown): boolean {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+  if (!isObjectNotArray(value)) {
     return false;
   }
 
-  const pattern = value as Record<string, unknown>;
-  return "argumentSchema" in pattern || "resultSchema" in pattern ||
-    "nodes" in pattern;
+  return "argumentSchema" in value || "resultSchema" in value ||
+    "nodes" in value;
 }
 
 function isPatternSchemaSchema(schema: JSONSchema | undefined): boolean {

--- a/packages/fuse/cfc-writeback.ts
+++ b/packages/fuse/cfc-writeback.ts
@@ -9,6 +9,7 @@ import {
   type CfcEnforcementMode as RunnerCfcEnforcementMode,
   DEFAULT_CFC_ENFORCEMENT_MODE,
 } from "@commonfabric/runner/cfc";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 
 import {
   canonicalCfcJsonStringify,
@@ -1211,7 +1212,7 @@ export class CfcWritebackStore {
       return;
     }
     if (
-      !isRecord(parsed) || parsed.version !== 1 ||
+      !isObjectNotArray(parsed) || parsed.version !== 1 ||
       !Array.isArray(parsed.records)
     ) {
       this.recordMalformed(0n, this.storagePath, "unsupported recovery store");
@@ -1248,12 +1249,12 @@ function parsePreparedWriteback(value: string): CfcPreparedWriteback | null {
   } catch {
     return null;
   }
-  if (!isRecord(parsed)) return null;
+  if (!isObjectNotArray(parsed)) return null;
   if (parsed.version !== 1) return null;
   if (!isOperation(parsed.operation)) return null;
   if (typeof parsed.expectedGeneration !== "string") return null;
-  if (!isRecord(parsed.target)) return null;
-  if (!isRecord(parsed.labels)) return null;
+  if (!isObjectNotArray(parsed.target)) return null;
+  if (!isObjectNotArray(parsed.labels)) return null;
   return parsed as CfcPreparedWriteback;
 }
 
@@ -1264,7 +1265,7 @@ function parseFinalizedWriteback(value: string): CfcFinalizedWriteback | null {
   } catch {
     return null;
   }
-  if (!isRecord(parsed)) return null;
+  if (!isObjectNotArray(parsed)) return null;
   if (parsed.version !== 1) return null;
   if (!isOperation(parsed.operation)) return null;
   if (typeof parsed.committedGeneration !== "string") return null;
@@ -1396,7 +1397,7 @@ function cloneRecoveryRecord(
 function isRecoveryRecord(
   value: unknown,
 ): value is CfcWritebackRecoveryRecord {
-  if (!isRecord(value)) return false;
+  if (!isObjectNotArray(value)) return false;
   if (value.version !== 1) return false;
   if (typeof value.key !== "string") return false;
   if (!RECOVERY_STATUSES.includes(value.status as CfcPreparedWritebackStatus)) {
@@ -1420,10 +1421,6 @@ function isOperation(value: unknown): value is CfcWritebackOperation {
     value === "unlink" || value === "rmdir" ||
     value === "rename-source" || value === "rename-destination" ||
     value === "symlink" || value === "setattr-metadata";
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function preparedGeneration(prepared: CfcPreparedWriteback): string {

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -1,5 +1,6 @@
 import { Database } from "@db/sqlite";
 import type { FabricValue } from "@commonfabric/api";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 import { applySqliteCommitWrite } from "./sqlite/commit-eval.ts";
 import {
   applyPatchToDocument,
@@ -975,13 +976,8 @@ type SchedulerWriteAddress = SchedulerObservationAddress & {
   scopeKey?: string;
 };
 
-const isSchedulerRecord = (
-  value: unknown,
-): value is Record<string, unknown> =>
-  value !== null && typeof value === "object" && !Array.isArray(value);
-
 const isSchedulerObservationAddress = (value: unknown): boolean =>
-  isSchedulerRecord(value) &&
+  isObjectNotArray(value) &&
   !("scopeKey" in value) &&
   !("scope_key" in value) &&
   !("readScopeKey" in value) &&
@@ -1001,7 +997,7 @@ const isCompleteActionScopeSummary = (
   implementationFingerprint: unknown,
   runtimeFingerprint: unknown,
 ): boolean =>
-  isSchedulerRecord(value) && value.version === 1 && value.complete === true &&
+  isObjectNotArray(value) && value.version === 1 && value.complete === true &&
   value.implementationFingerprint === implementationFingerprint &&
   value.runtimeFingerprint === runtimeFingerprint &&
   isSchedulerObservationAddress(value.piece) &&
@@ -1014,7 +1010,7 @@ export const schedulerObservationFromValue = (
   value: unknown,
 ): SchedulerActionObservation | undefined => {
   if (
-    !isSchedulerRecord(value) ||
+    !isObjectNotArray(value) ||
     "executionContextKey" in value ||
     "execution_context_key" in value ||
     (value.version !== 1 && value.version !== 2) ||
@@ -1053,7 +1049,7 @@ export const schedulerObservationFromValue = (
     (value.ignoredSchedulingWrites !== undefined &&
       !isSchedulerAddressArray(value.ignoredSchedulingWrites)) ||
     (value.actionOptions !== undefined &&
-      (!isSchedulerRecord(value.actionOptions) ||
+      (!isObjectNotArray(value.actionOptions) ||
         (value.actionOptions.debounceMs !== undefined &&
           (typeof value.actionOptions.debounceMs !== "number" ||
             !Number.isFinite(value.actionOptions.debounceMs) ||

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -2,6 +2,7 @@ import * as FS from "@std/fs";
 import * as Path from "@std/path";
 
 import type { FabricPlainObject } from "@commonfabric/api";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import { SpanStatusCode, trace } from "@opentelemetry/api";
 
 import {
@@ -176,9 +177,6 @@ const recordSlowQueryDuration = (
 
 /** Returns the last N slow query/watch operations (>100ms). */
 export const getSlowQueries = (): readonly SlowQuery[] => slowQueries;
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  value !== null && typeof value === "object" && !Array.isArray(value);
 
 const randomHex = (bytes: number): string => {
   const data = crypto.getRandomValues(new Uint8Array(bytes));
@@ -476,7 +474,9 @@ class Connection {
 
   sessionOpenAuthContext(message: SessionOpenRequest): SessionOpenAuthContext {
     const audience = this.server.sessionOpenAudience();
-    const invocation = isRecord(message.invocation) ? message.invocation : null;
+    const invocation = isObjectNotArray(message.invocation)
+      ? message.invocation
+      : null;
     if (invocation === null || typeof invocation.aud !== "string") {
       throw authorizationError("memory session.open requires audience");
     }
@@ -4138,7 +4138,7 @@ const parseSchedulerSnapshotQuery = (
   let cursor: SchedulerActionSnapshotQuery["cursor"];
   if (value.cursor !== undefined) {
     if (
-      !isRecord(value.cursor) ||
+      !isObjectNotArray(value.cursor) ||
       (value.cursor.ownerSpace !== undefined &&
         typeof value.cursor.ownerSpace !== "string") ||
       typeof value.cursor.pieceId !== "string" ||
@@ -4193,7 +4193,7 @@ export const parseClientMessage = (
     return null;
   }
 
-  if (!isRecord(parsed)) {
+  if (!isObjectNotArray(parsed)) {
     return null;
   }
 
@@ -4215,7 +4215,7 @@ export const parseClientMessage = (
     parsed.type === "session.open" &&
     typeof parsed.requestId === "string" &&
     typeof parsed.space === "string" &&
-    isRecord(parsed.session)
+    isObjectNotArray(parsed.session)
   ) {
     return {
       type: "session.open",
@@ -4232,7 +4232,9 @@ export const parseClientMessage = (
           ? parsed.session.sessionToken
           : undefined,
       },
-      invocation: isRecord(parsed.invocation) ? parsed.invocation : undefined,
+      invocation: isObjectNotArray(parsed.invocation)
+        ? parsed.invocation
+        : undefined,
       authorization: parsed
         .authorization as SessionOpenRequest["authorization"],
     };
@@ -4243,7 +4245,7 @@ export const parseClientMessage = (
     typeof parsed.requestId === "string" &&
     typeof parsed.space === "string" &&
     typeof parsed.sessionId === "string" &&
-    isRecord(parsed.commit)
+    isObjectNotArray(parsed.commit)
   ) {
     return {
       type: "transact",
@@ -4259,7 +4261,7 @@ export const parseClientMessage = (
     typeof parsed.requestId === "string" &&
     typeof parsed.space === "string" &&
     typeof parsed.sessionId === "string" &&
-    isRecord(parsed.query) &&
+    isObjectNotArray(parsed.query) &&
     Array.isArray(parsed.query.roots)
   ) {
     return {
@@ -4320,21 +4322,21 @@ export const parseClientMessage = (
     typeof parsed.sessionId === "string" &&
     typeof parsed.sql === "string" &&
     parsed.sql.length <= 100_000 &&
-    isRecord(parsed.db) &&
+    isObjectNotArray(parsed.db) &&
     typeof parsed.db.id === "string" &&
     parsed.db.id.length > 0 && parsed.db.id.length <= 256 &&
     (parsed.db.tables === undefined ||
-      (isRecord(parsed.db.tables) &&
+      (isObjectNotArray(parsed.db.tables) &&
         Object.keys(parsed.db.tables).length <= 256)) &&
     (parsed.db.scope === undefined || parsed.db.scope === "space" ||
       parsed.db.scope === "user" || parsed.db.scope === "session")
   ) {
     const db = {
       id: parsed.db.id,
-      tables: isRecord(parsed.db.tables) ? parsed.db.tables : undefined,
+      tables: isObjectNotArray(parsed.db.tables) ? parsed.db.tables : undefined,
       scope: parsed.db.scope as CellScope | undefined,
     };
-    const params = Array.isArray(parsed.params) || isRecord(parsed.params)
+    const params = isObjectOrArray(parsed.params)
       ? parsed.params as SqliteParamsWire
       : undefined;
     return {
@@ -4405,7 +4407,7 @@ export const parseClientMessage = (
     typeof parsed.requestId === "string" &&
     typeof parsed.space === "string" &&
     typeof parsed.sessionId === "string" &&
-    isRecord(parsed.query)
+    isObjectNotArray(parsed.query)
   ) {
     const query = parseSchedulerSnapshotQuery(parsed.query);
     if (query === undefined) return null;

--- a/packages/memory/v2/session-open-auth.ts
+++ b/packages/memory/v2/session-open-auth.ts
@@ -23,11 +23,9 @@
 
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 import { fromDID } from "../util.ts";
 import { MEMORY_PROTOCOL, type SessionOpenChallenge } from "../v2.ts";
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  value !== null && typeof value === "object" && !Array.isArray(value);
 
 /**
  * Build an `AuthorizationError`. Pass `retriable: true` for the anti-replay
@@ -88,7 +86,7 @@ export type WireSessionOpenAuthorization = {
 export const wireAuthorizationOf = (
   authorization: unknown,
 ): WireSessionOpenAuthorization | undefined => {
-  if (!isRecord(authorization)) return undefined;
+  if (!isObjectNotArray(authorization)) return undefined;
   const { signature } = authorization;
   return signature instanceof FabricBytes ? { signature } : undefined;
 };
@@ -116,7 +114,7 @@ export const verifySessionOpenAuthorization = async (
 ): Promise<string> => {
   const wireAuthorization = wireAuthorizationOf(message.authorization);
   const signature = wireAuthorization?.signature.slice() ?? null;
-  if (!isRecord(message.invocation) || signature === null) {
+  if (!isObjectNotArray(message.invocation) || signature === null) {
     throw authorizationError("memory session.open requires authorization");
   }
 
@@ -125,9 +123,9 @@ export const verifySessionOpenAuthorization = async (
     typeof invocation.iss !== "string" ||
     invocation.cmd !== "session.open" ||
     invocation.sub !== message.space ||
-    !isRecord(invocation.args) ||
+    !isObjectNotArray(invocation.args) ||
     invocation.args.protocol !== MEMORY_PROTOCOL ||
-    !isRecord(invocation.args.session) ||
+    !isObjectNotArray(invocation.args.session) ||
     !sameSessionDescriptor(invocation.args.session, message.session)
   ) {
     throw authorizationError("memory session.open authorization mismatch");

--- a/packages/memory/v2/sqlite/row-label.ts
+++ b/packages/memory/v2/sqlite/row-label.ts
@@ -20,6 +20,7 @@
 
 import type { FabricPlainObject, FabricValue } from "@commonfabric/api";
 import type { MutableFabricPlainObjectLayer } from "@commonfabric/data-model/fabric-value";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 
 /** A reference to a declared column, handed to the rule as `f.<col>`. */
 export type FieldRef = {
@@ -49,11 +50,9 @@ export type RowLabelRule<C extends Record<string, unknown>> = (
   f: RowFieldHandles<C>,
 ) => { confidentiality?: FabricValue; integrity?: FabricValue };
 
-const isRecord = (x: unknown): x is Record<string, unknown> =>
-  typeof x === "object" && x !== null && !Array.isArray(x);
-
 const isFieldRef = (x: unknown): x is FieldRef =>
-  isRecord(x) && typeof x.field === "string" && Object.keys(x).length === 1;
+  isObjectNotArray(x) && typeof x.field === "string" &&
+  Object.keys(x).length === 1;
 
 // ---------------------------------------------------------------------------
 // Builders — each returns its serialized AST node.
@@ -122,7 +121,7 @@ export function principal(
       `principal(): invalid DID protocol ${JSON.stringify(protocol)}`,
     );
   }
-  if (!isRecord(of) || !isRecord(of.match)) {
+  if (!isObjectNotArray(of) || !isObjectNotArray(of.match)) {
     throw new TypeError("principal() takes a match(...) term");
   }
   return { principal: { protocol, of } };
@@ -189,7 +188,7 @@ function assertRegExp(x: unknown, who: string): asserts x is RegExp {
   if (!(x instanceof RegExp)) throw new TypeError(`${who} takes a RegExp`);
 }
 function assertPrincipal(x: unknown, who: string) {
-  if (!isRecord(x) || !isRecord(x.principal)) {
+  if (!isObjectNotArray(x) || !isObjectNotArray(x.principal)) {
     throw new TypeError(`${who} takes a principal(...) term`);
   }
 }
@@ -281,21 +280,21 @@ function validateAnyOfAlternative(
   node: unknown,
   columns: ReadonlySet<string>,
 ): string | undefined {
-  if (isRecord(node) && ("allOf" in node || "anyOf" in node)) {
+  if (isObjectNotArray(node) && ("allOf" in node || "anyOf" in node)) {
     return "an any() alternative must be a single principal-like term, not " +
       "all()/any() — a conjunction or nested disjunction cannot be an " +
       "OR-clause alternative (CFC spec §3.1.8)";
   }
-  if (isRecord(node)) {
+  if (isObjectNotArray(node)) {
     // Before the `when` branch below follows the gate: a dual-op alternative
     // (e.g. {when, then, principal}) would be validated as a when() here but
     // EVALUATED as a principal (evalConf dispatches on `principal` first).
     const amb = ambiguousOpReason(node, "any()-alternative");
     if (amb) return amb;
   }
-  if (isRecord(node) && "when" in node) {
+  if (isObjectNotArray(node) && "when" in node) {
     const test = (node as { when?: unknown }).when;
-    const gate = isRecord(test) && "match" in test
+    const gate = isObjectNotArray(test) && "match" in test
       ? validateMatchNode(test.match, columns, "when")
       : "malformed when gate (use whenMatches())";
     if (gate) return gate;
@@ -309,7 +308,7 @@ function validateMatchNode(
   columns: ReadonlySet<string>,
   who: string,
 ): string | undefined {
-  if (!isRecord(node)) return `${who}: malformed match node`;
+  if (!isObjectNotArray(node)) return `${who}: malformed match node`;
   const { field, source, flags, group, min } = node;
   if (typeof field !== "string") return `${who}: match without a field`;
   if (!columns.has(field)) {
@@ -341,14 +340,14 @@ function validatePrincipalNode(
   node: unknown,
   columns: ReadonlySet<string>,
 ): string | undefined {
-  if (!isRecord(node) || typeof node.protocol !== "string") {
+  if (!isObjectNotArray(node) || typeof node.protocol !== "string") {
     return "malformed principal node";
   }
   if (!/^[a-z][a-z0-9.+-]*$/.test(node.protocol)) {
     return `invalid DID protocol ${JSON.stringify(node.protocol)}`;
   }
   const of = node.of;
-  if (!isRecord(of) || !("match" in of)) {
+  if (!isObjectNotArray(of) || !("match" in of)) {
     return "principal() takes a match(...) term";
   }
   return validateMatchNode(of.match, columns, "principal");
@@ -396,7 +395,7 @@ function validateConfTerm(
   node: unknown,
   columns: ReadonlySet<string>,
 ): string | undefined {
-  if (!isRecord(node)) return "malformed confidentiality term";
+  if (!isObjectNotArray(node)) return "malformed confidentiality term";
   const amb = ambiguousOpReason(node, "confidentiality");
   if (amb) return amb;
   if ("anyOf" in node) return validateConfAnyOf(node, columns);
@@ -417,7 +416,7 @@ function validateConfTerm(
   if ("constant" in node) return undefined;
   if ("when" in node) {
     const test = (node as { when?: unknown }).when;
-    const r = isRecord(test) && "match" in test
+    const r = isObjectNotArray(test) && "match" in test
       ? validateMatchNode(test.match, columns, "when")
       : "malformed when gate (use whenMatches())";
     if (r) return r;
@@ -430,7 +429,7 @@ function validateConfExpr(
   node: unknown,
   columns: ReadonlySet<string>,
 ): string | undefined {
-  if (!isRecord(node)) return "malformed confidentiality expression";
+  if (!isObjectNotArray(node)) return "malformed confidentiality expression";
   const amb = ambiguousOpReason(node, "confidentiality");
   if (amb) return amb;
   if ("anyOf" in node) return validateConfAnyOf(node, columns);
@@ -452,7 +451,7 @@ function validateIntegTerm(
   node: unknown,
   columns: ReadonlySet<string>,
 ): string | undefined {
-  if (!isRecord(node)) return "malformed integrity term";
+  if (!isObjectNotArray(node)) return "malformed integrity term";
   const amb = ambiguousOpReason(node, "integrity");
   if (amb) return amb;
   if ("anyOf" in node) {
@@ -461,7 +460,7 @@ function validateIntegTerm(
   }
   if ("authoredBy" in node || "endorsedBy" in node) {
     const inner = (node.authoredBy ?? node.endorsedBy) as unknown;
-    if (!isRecord(inner) || !("principal" in inner)) {
+    if (!isObjectNotArray(inner) || !("principal" in inner)) {
       return "authoredBy()/endorsedBy() take a principal(...) term";
     }
     return validatePrincipalNode(inner.principal, columns);
@@ -479,7 +478,7 @@ function validateIntegTerm(
   }
   if ("when" in node) {
     const test = node.when;
-    const r = isRecord(test) && "match" in test
+    const r = isObjectNotArray(test) && "match" in test
       ? validateMatchNode(test.match, columns, "when")
       : "malformed when gate (use whenMatches())";
     if (r) return r;
@@ -499,7 +498,7 @@ export function validateRowLabelSpec(
   spec: unknown,
   columns: readonly string[],
 ): string | undefined {
-  if (!isRecord(spec)) return "rowLabel spec must be an object";
+  if (!isObjectNotArray(spec)) return "rowLabel spec must be an object";
   if (spec.version !== 1) {
     return `unsupported rowLabel version ${JSON.stringify(spec.version)}`;
   }
@@ -528,7 +527,7 @@ export function buildRowLabelSpec<C extends Record<string, unknown>>(
     columns.map((name) => [name, { field: name }]),
   ) as RowFieldHandles<C>;
   const out = rule(handles);
-  if (!isRecord(out)) {
+  if (!isObjectNotArray(out)) {
     throw new TypeError(
       "table(): a rowLabel rule must return { confidentiality?, integrity? }",
     );
@@ -563,7 +562,7 @@ export function atomKey(v: unknown): string {
   if (typeof v === "string") return `s:${v}`;
   return `j:${
     JSON.stringify(v, (_k, val) =>
-      isRecord(val)
+      isObjectNotArray(val)
         ? Object.fromEntries(Object.keys(val).sort().map((k) => [k, val[k]]))
         : val)
   }`;
@@ -643,7 +642,7 @@ function evalTest(
   test: unknown,
   row: Record<string, unknown>,
 ): boolean {
-  if (!isRecord(test) || !isRecord(test.match)) {
+  if (!isObjectNotArray(test) || !isObjectNotArray(test.match)) {
     return fail("malformed when gate (use whenMatches())");
   }
   const { field, source, flags } = test.match as Record<string, unknown>;
@@ -677,7 +676,7 @@ function evalPrincipal(
 // fails closed on the same shape the validator rejects, even for a wire spec
 // that bypassed validation.
 function anyOfAlternativeHasConjunction(node: unknown): boolean {
-  if (!isRecord(node)) return false;
+  if (!isObjectNotArray(node)) return false;
   if ("allOf" in node || "anyOf" in node) return true;
   if ("when" in node) {
     return anyOfAlternativeHasConjunction((node as { then?: unknown }).then);
@@ -690,7 +689,7 @@ function evalConf(
   row: Record<string, unknown>,
   ctx: { dbOwner?: string },
 ): unknown[] {
-  if (!isRecord(node)) return fail("malformed confidentiality term");
+  if (!isObjectNotArray(node)) return fail("malformed confidentiality term");
   // Defense in depth against a wire spec that bypassed validation: a dual-op
   // node must refuse, never be resolved by this dispatch's key precedence
   // (the validator and the static analysis each have their own).
@@ -749,7 +748,7 @@ function evalInteg(
   row: Record<string, unknown>,
   ctx: { dbOwner?: string },
 ): unknown[] {
-  if (!isRecord(node)) return fail("malformed integrity term");
+  if (!isObjectNotArray(node)) return fail("malformed integrity term");
   const amb = ambiguousOpReason(node, "integrity");
   if (amb) return fail(amb);
   if ("anyOf" in node) return fail("disjunctive integrity does not exist");
@@ -812,10 +811,10 @@ export function evaluateRowLabel(
 ):
   | { confidentiality: unknown[]; integrity: unknown[] }
   | { error: string } {
-  if (!isRecord(spec) || spec.version !== 1) {
+  if (!isObjectNotArray(spec) || spec.version !== 1) {
     return {
       error: `unsupported rowLabel version ${
-        JSON.stringify(isRecord(spec) ? spec.version : spec)
+        JSON.stringify(isObjectNotArray(spec) ? spec.version : spec)
       }`,
     };
   }
@@ -842,7 +841,7 @@ function staticUnconditionalAlternatives(
   node: unknown,
   ctx: { dbOwner?: string },
 ): unknown[] {
-  if (!isRecord(node)) return [];
+  if (!isObjectNotArray(node)) return [];
   // A dual-op node is ambiguous (the evaluator dispatches by a DIFFERENT key
   // precedence — e.g. {principal, dbOwner} labels rows with only the
   // principal): it contributes no static reader, so the aggregate refuses.
@@ -873,7 +872,7 @@ function staticUnconditionalAlternatives(
 // {allOf: [], constant} keeps counting as a constraint rather than reading as
 // the degenerate empty conjunction (which would make an aggregate public).
 function flattenConfConjuncts(conf: unknown): unknown[] {
-  return isRecord(conf) && Array.isArray(conf.allOf) &&
+  return isObjectNotArray(conf) && Array.isArray(conf.allOf) &&
       presentOps(conf).length === 1
     ? conf.allOf.flatMap(flattenConfConjuncts)
     : [conf];
@@ -893,7 +892,7 @@ export function ruleCommonAlternatives(
   spec: RowLabelSpec,
   ctx: { dbOwner?: string },
 ): unknown[] {
-  const conf = isRecord(spec) ? spec.confidentiality : undefined;
+  const conf = isObjectNotArray(spec) ? spec.confidentiality : undefined;
   if (conf === undefined) return [];
   const conjuncts = flattenConfConjuncts(conf);
   if (conjuncts.length === 0) return [];
@@ -924,7 +923,7 @@ export function ruleCommonAlternatives(
  * across tables must skip unconstrained rules, not treat them as a refusal.
  */
 export function ruleConstrainsConfidentiality(spec: RowLabelSpec): boolean {
-  const conf = isRecord(spec) ? spec.confidentiality : undefined;
+  const conf = isObjectNotArray(spec) ? spec.confidentiality : undefined;
   if (conf === undefined) return false;
   return flattenConfConjuncts(conf).length > 0;
 }
@@ -932,9 +931,9 @@ export function ruleConstrainsConfidentiality(spec: RowLabelSpec): boolean {
 /** The rule attached to a (possibly wire-supplied) table schema, or undefined.
  *  Presence gates all Phase 3 work, so rule-less tables pay nothing. */
 export function rowLabelSpecOf(tableSchema: unknown): RowLabelSpec | undefined {
-  if (!isRecord(tableSchema)) return undefined;
+  if (!isObjectNotArray(tableSchema)) return undefined;
   const spec = tableSchema.rowLabel;
-  return isRecord(spec) ? spec as unknown as RowLabelSpec : undefined;
+  return isObjectNotArray(spec) ? spec as unknown as RowLabelSpec : undefined;
 }
 
 /**
@@ -951,9 +950,11 @@ export function ruleInputFields(spec: RowLabelSpec): string[] {
       for (const x of n) walk(x);
       return;
     }
-    if (!isRecord(n)) return;
+    if (!isObjectNotArray(n)) return;
     const m = n.match;
-    if (isRecord(m) && typeof m.field === "string" && !seen.has(m.field)) {
+    if (
+      isObjectNotArray(m) && typeof m.field === "string" && !seen.has(m.field)
+    ) {
       seen.add(m.field);
       out.push(m.field);
     }

--- a/packages/memory/v2/sync-schema-ref.ts
+++ b/packages/memory/v2/sync-schema-ref.ts
@@ -4,9 +4,6 @@ import { REQUEST_SCHEMA_CAS_REF_PREFIX } from "./schema-table-links.ts";
 
 export const SYNC_SCHEMA_REF_PREFIX = "schema-ref@2:";
 
-const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
-  isPlainObject(value);
-
 const isReservedSchemaRef = (value: string): boolean =>
   value.startsWith(SYNC_SCHEMA_REF_PREFIX) ||
   value.startsWith(REQUEST_SCHEMA_CAS_REF_PREFIX);
@@ -71,7 +68,7 @@ export const findSyncSchemaRef = (value: unknown): string | undefined => {
 
     if (isLinkRef(current)) {
       const payload = linkRefPayload(current);
-      if (isPlainRecord(payload)) {
+      if (isPlainObject(payload)) {
         const ref = payloadSchemaRef(payload);
         if (ref !== undefined) {
           return ref;
@@ -87,12 +84,12 @@ export const findSyncSchemaRef = (value: unknown): string | undefined => {
       // Fall through to the ordinary record walk, mirroring the mapper.
     }
 
-    if (!isPlainRecord(current)) {
+    if (!isPlainObject(current)) {
       continue;
     }
 
     const legacyAlias = current.$alias;
-    const hasLegacyAlias = isPlainRecord(legacyAlias);
+    const hasLegacyAlias = isPlainObject(legacyAlias);
     if (hasLegacyAlias) {
       const ref = payloadSchemaRef(legacyAlias);
       if (ref !== undefined) {
@@ -149,7 +146,7 @@ export const containsSyncSchemaRefString = (value: unknown): boolean => {
       }
       continue;
     }
-    if (isLinkRef(current) && !isPlainRecord(current)) {
+    if (isLinkRef(current) && !isPlainObject(current)) {
       // A FabricLink's payload is not reachable by plain-record iteration.
       // The legacy envelope IS a plain record and takes the ordinary walk
       // below, which reaches its payload — malformed or not — and any
@@ -157,7 +154,7 @@ export const containsSyncSchemaRefString = (value: unknown): boolean => {
       pending.push(linkRefPayload(current));
       continue;
     }
-    if (!isPlainRecord(current)) {
+    if (!isPlainObject(current)) {
       continue;
     }
     for (const key in current) {

--- a/packages/memory/v2/sync-schema-table.ts
+++ b/packages/memory/v2/sync-schema-table.ts
@@ -26,11 +26,8 @@ type RewriteState = {
   onSchema?: (schema: JSONSchema) => void;
 };
 
-const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
-  isPlainObject(value);
-
 const isCompressibleSchema = (value: unknown): value is JSONSchema =>
-  value === true || value === false || isPlainRecord(value);
+  value === true || value === false || isPlainObject(value);
 
 const schemaRefFor = (
   schema: JSONSchema,
@@ -184,11 +181,11 @@ const compressResponseSync = (
   if (message.type !== "response" || message.ok === undefined) {
     return message;
   }
-  if (!isPlainRecord(message.ok)) {
+  if (!isPlainObject(message.ok)) {
     return message;
   }
   const sync = message.ok.sync;
-  if (!isPlainRecord(sync) || sync.type !== "sync") {
+  if (!isPlainObject(sync) || sync.type !== "sync") {
     return message;
   }
 
@@ -208,14 +205,14 @@ const expandResponseSync = (
   message: unknown,
   onSchema?: (schema: JSONSchema) => void,
 ): unknown => {
-  if (!isPlainRecord(message) || message.type !== "response") {
+  if (!isPlainObject(message) || message.type !== "response") {
     return message;
   }
-  if (!isPlainRecord(message.ok)) {
+  if (!isPlainObject(message.ok)) {
     return message;
   }
   const sync = message.ok.sync;
-  if (!isPlainRecord(sync) || sync.type !== "sync") {
+  if (!isPlainObject(sync) || sync.type !== "sync") {
     return message;
   }
 
@@ -248,7 +245,7 @@ export const expandServerMessageSchemas = (
   message: unknown,
   onSchema?: (schema: JSONSchema) => void,
 ): unknown => {
-  if (isPlainRecord(message) && message.type === "session/effect") {
+  if (isPlainObject(message) && message.type === "session/effect") {
     return {
       ...message,
       effect: expandSessionSyncSchemas(

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -22,6 +22,7 @@ import {
 } from "./pieces-controller.ts";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { getLoggerCountsBreakdown } from "@commonfabric/utils/logger";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 
 export interface WorkerRequest {
   id: number;
@@ -235,7 +236,7 @@ const handlers: Record<
       ),
     );
     const created = await controller().create(program, {
-      input: isRecord(input) ? input : undefined,
+      input: isObjectNotArray(input) ? input : undefined,
       start: true,
     });
     await attachPiece(created);
@@ -258,7 +259,7 @@ const handlers: Record<
       // applies when delivering real DOM events.
       eventValue = {
         type: "click",
-        ...(isRecord(event) ? event : {}),
+        ...(isObjectNotArray(event) ? event : {}),
         provenance: {
           origin: "dom",
           trusted: true,
@@ -469,9 +470,6 @@ const handlers: Record<
     return {};
   },
 };
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  value !== null && typeof value === "object" && !Array.isArray(value);
 
 self.onmessage = (event: MessageEvent<WorkerRequest>) => {
   const { id, cmd, args } = event.data;

--- a/packages/patterns/tools/lunch-poll-diagnose.ts
+++ b/packages/patterns/tools/lunch-poll-diagnose.ts
@@ -1,3 +1,4 @@
+import { isObjectNotArray } from "@commonfabric/utils/types";
 import {
   MultiRuntimeHarness,
   type MultiRuntimeSession,
@@ -229,9 +230,6 @@ const ROOT_PATH = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
 const LUNCH_POLL_DIR = new URL("../lunch-poll/", import.meta.url).pathname
   .replace(/\/$/, "");
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  value !== null && typeof value === "object" && !Array.isArray(value);
-
 const asString = (value: unknown): string =>
   typeof value === "string" ? value : "";
 
@@ -241,7 +239,7 @@ const asNumber = (value: unknown): number =>
 const asBoolean = (value: unknown): boolean => value === true;
 
 const asRecordArray = (value: unknown): readonly Record<string, unknown>[] =>
-  Array.isArray(value) ? value.filter(isRecord) : [];
+  Array.isArray(value) ? value.filter(isObjectNotArray) : [];
 
 const asStringArray = (value: unknown): readonly string[] =>
   Array.isArray(value)
@@ -249,7 +247,7 @@ const asStringArray = (value: unknown): readonly string[] =>
     : [];
 
 function pollSummary(value: unknown): PollOutputSummary {
-  if (!isRecord(value)) {
+  if (!isObjectNotArray(value)) {
     throw new Error(
       `poll output is not an object: ${JSON.stringify(value)}`,
     );
@@ -277,7 +275,7 @@ function pathKey(address: TraceAddressSummary): string {
 }
 
 function traceAddressSummary(value: unknown): TraceAddressSummary {
-  if (!isRecord(value)) return {};
+  if (!isObjectNotArray(value)) return {};
   return {
     space: asString(value.space),
     entityId: asString(value.entityId),
@@ -286,7 +284,7 @@ function traceAddressSummary(value: unknown): TraceAddressSummary {
 }
 
 function traceEntrySummary(value: unknown): ActionRunTraceSummary {
-  if (!isRecord(value)) {
+  if (!isObjectNotArray(value)) {
     return {
       actionId: "",
       actionType: "",
@@ -309,13 +307,15 @@ function traceEntrySummary(value: unknown): ActionRunTraceSummary {
 }
 
 function summarizeSettleEntry(value: unknown) {
-  const stats = isRecord(value) && isRecord(value.stats) ? value.stats : {};
+  const stats = isObjectNotArray(value) && isObjectNotArray(value.stats)
+    ? value.stats
+    : {};
   const iterations = Array.isArray(stats.iterations) ? stats.iterations : [];
   let maxWorkSetSize = 0;
   let maxOrderSize = 0;
   let actionsRun = 0;
   for (const iteration of iterations) {
-    if (!isRecord(iteration)) continue;
+    if (!isObjectNotArray(iteration)) continue;
     maxWorkSetSize = Math.max(maxWorkSetSize, asNumber(iteration.workSetSize));
     maxOrderSize = Math.max(maxOrderSize, asNumber(iteration.orderSize));
     actionsRun += asNumber(iteration.actionsRun);

--- a/packages/runner/src/builtins/sqlite/row-label-read.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-read.ts
@@ -17,6 +17,7 @@ import {
   validateRowLabelSpec,
 } from "@commonfabric/memory/sqlite/row-label";
 import { tableDeclaresRowLabel } from "@commonfabric/memory/v2";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 
 import type { CfcConfClause } from "../../cfc/clause.ts";
 import { clauseAlternatives } from "../../cfc/clause.ts";
@@ -71,9 +72,6 @@ export type RowLabelReadResult =
      *  clearance was requested. */
     withheld?: number;
   };
-
-const isRecord = (x: unknown): x is Record<string, unknown> =>
-  typeof x === "object" && x !== null && !Array.isArray(x);
 
 // The common-alternative outcome for a null-origin (aggregate) projection over
 // the rule-bearing tables. `unconstrained`: no rule imposes any confidentiality
@@ -280,7 +278,7 @@ export function computeRowLabelRead(
         labels = [];
         for (let i = 0; i < rows.length; i++) {
           const row = rows[i];
-          if (!isRecord(row)) {
+          if (!isObjectNotArray(row)) {
             return { error: `sqlite: result row ${i} is not an object` };
           }
           const rowValues: Record<string, unknown> = {};
@@ -415,7 +413,8 @@ export function resolveCeilingPlaceholders(
   const atoms: CfcConfClause[] = [];
   for (const atom of ceiling) {
     if (
-      isRecord(atom) && (atom as CfcAtomObject).__ctCurrentPrincipal === true
+      isObjectNotArray(atom) &&
+      (atom as CfcAtomObject).__ctCurrentPrincipal === true
     ) {
       if (ctx.actingPrincipal === undefined) {
         return {
@@ -426,7 +425,9 @@ export function resolveCeilingPlaceholders(
       atoms.push(ctx.actingPrincipal);
       continue;
     }
-    if (isRecord(atom) && (atom as CfcAtomObject).__ctDbOwner === true) {
+    if (
+      isObjectNotArray(atom) && (atom as CfcAtomObject).__ctDbOwner === true
+    ) {
       if (ctx.owner === undefined) {
         return {
           error: "sqlite: ceiling references the db owner but the db ref " +

--- a/packages/runner/src/cfc/schema-sanitization.ts
+++ b/packages/runner/src/cfc/schema-sanitization.ts
@@ -17,7 +17,11 @@ import {
 } from "@commonfabric/data-model/fabric-value";
 import { deepFrozenCloneAndInternSchema } from "@commonfabric/data-model/schema-hash";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
-import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
+import {
+  isObjectNotArray,
+  isObjectOrArray,
+  type ReadonlyRecord,
+} from "@commonfabric/utils/types";
 
 import { isSubschema } from "../schema-walk.ts";
 import {
@@ -1430,8 +1434,7 @@ const unmarkSchemaValueActive = (
 
 const isSchemaObject = (
   schema: JSONSchema | undefined,
-): schema is Record<string, unknown> =>
-  typeof schema === "object" && schema !== null && !Array.isArray(schema);
+): schema is ReadonlyRecord => isObjectNotArray(schema);
 
 /**
  * Follow `$ref` chains to the schema they name, so a `default` behind one is

--- a/packages/runner/test/bench-write-accounting.ts
+++ b/packages/runner/test/bench-write-accounting.ts
@@ -22,6 +22,7 @@
  * these numbers reads them before it commits.
  */
 
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import type { IAttestation } from "../src/storage/interface.ts";
 
 /** One top-level write: a document, a path in it, and the value written. */
@@ -67,10 +68,6 @@ function emptyNode(): PathNode {
   return { written: false, value: undefined, children: new Map() };
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 /** Builds the container the keys of `children` describe. */
 function containerFor(children: Map<string, PathNode>): unknown {
   for (const key of children.keys()) {
@@ -89,9 +86,7 @@ function containerFor(children: Map<string, PathNode>): unknown {
 function materialize(node: PathNode, inherited: unknown): unknown {
   const base = node.written ? node.value : inherited;
   if (node.children.size === 0) return base;
-  const container = Array.isArray(base) || isRecord(base)
-    ? base
-    : containerFor(node.children);
+  const container = isObjectOrArray(base) ? base : containerFor(node.children);
   if (Array.isArray(container)) {
     const out = [...container];
     for (const [index, child] of node.children) {

--- a/packages/runner/test/cell.bench.ts
+++ b/packages/runner/test/cell.bench.ts
@@ -1,5 +1,6 @@
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 import { Runtime } from "../src/runtime.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { type JSONSchema } from "../src/builder/types.ts";
@@ -1422,12 +1423,9 @@ Deno.bench("Notebook read - 100 notes, 1000 reads", async () => {
 // ============================================================================
 
 Deno.bench(
-  "Overhead - isRecord check (10000x)",
+  "Overhead - isObjectNotArray check (10000x)",
   { group: "overhead" },
   () => {
-    const isRecord = (v: unknown): v is Record<string, unknown> =>
-      typeof v === "object" && v !== null && !Array.isArray(v);
-
     const values = [
       42,
       "string",
@@ -1438,7 +1436,7 @@ Deno.bench(
       { key: "value" },
     ];
     for (let i = 0; i < 10000; i++) {
-      isRecord(values[i % values.length]);
+      isObjectNotArray(values[i % values.length]);
     }
   },
 );

--- a/packages/state-inspector/detail.ts
+++ b/packages/state-inspector/detail.ts
@@ -12,6 +12,11 @@
 // Built in one reconstruction pass over the space (buildAllDetails) so link
 // targets and owner→child names resolve against the whole space.
 
+import {
+  isObjectNotArray,
+  type ReadonlyRecord,
+} from "@commonfabric/utils/types";
+
 import type { SpaceDb } from "./db.ts";
 import {
   annotate,
@@ -112,14 +117,10 @@ export interface EntityDetail {
   code?: string;
 }
 
-function isObj(v: unknown): v is Record<string, unknown> {
-  return typeof v === "object" && v !== null && !Array.isArray(v);
-}
-
 /** A `{ link, specifier }` cell is a module-import entry. */
 function importSpecifier(v: unknown): string | undefined {
   if (
-    isObj(v) && typeof v.specifier === "string" && "link" in v &&
+    isObjectNotArray(v) && typeof v.specifier === "string" && "link" in v &&
     Object.keys(v).length === 2
   ) return v.specifier;
   return undefined;
@@ -132,7 +133,7 @@ function importSpecifier(v: unknown): string | undefined {
  * note at the top of model.ts for the full removal checklist.
  */
 function legacyResultId(v: unknown): string | undefined {
-  if (isObj(v) && "$TYPE" in v && "resultRef" in v) {
+  if (isObjectNotArray(v) && "$TYPE" in v && "resultRef" in v) {
     return parseSigilLink(v.resultRef)?.id;
   }
   return undefined;
@@ -148,13 +149,15 @@ function legacyName(
 ): string | undefined {
   const rid = legacyResultId(v);
   const rv = rid ? docs.get(rid)?.value : undefined;
-  return isObj(rv) && typeof rv.$NAME === "string" ? rv.$NAME : undefined;
+  return isObjectNotArray(rv) && typeof rv.$NAME === "string"
+    ? rv.$NAME
+    : undefined;
 }
 
 /** Render a CFC atom (string sigil, or an object atom) to a short string. */
 function atomLabel(a: unknown): string {
   if (typeof a === "string") return a;
-  if (isObj(a)) {
+  if (isObjectNotArray(a)) {
     const t = typeof a.type === "string" ? a.type.split("/").pop() : "atom";
     const extra = a.name ?? a.subject ?? a.class ?? a.symbol;
     return extra ? `${t}:${extra}` : String(t);
@@ -163,16 +166,18 @@ function atomLabel(a: unknown): string {
 }
 
 function parseCfc(cfc: unknown): CfcSummary | undefined {
-  if (!isObj(cfc)) return undefined;
+  if (!isObjectNotArray(cfc)) return undefined;
   const out: CfcSummary = {
     schemaHash: typeof cfc.schemaHash === "string" ? cfc.schemaHash : undefined,
     entries: [],
   };
   const lm = cfc.labelMap;
-  const entries = isObj(lm) && Array.isArray(lm.entries) ? lm.entries : [];
+  const entries = isObjectNotArray(lm) && Array.isArray(lm.entries)
+    ? lm.entries
+    : [];
   for (const e of entries) {
-    if (!isObj(e)) continue;
-    const label = isObj(e.label) ? e.label : {};
+    if (!isObjectNotArray(e)) continue;
+    const label = isObjectNotArray(e.label) ? e.label : {};
     out.entries.push({
       path: Array.isArray(e.path) ? (e.path as string[]).join("/") : "",
       confidentiality: Array.isArray(label.confidentiality)
@@ -200,14 +205,14 @@ function declaredSchemaFor(
   key: string,
 ): { schema: unknown; keys?: string[]; via: string } | undefined {
   // 1. inline schema carried on the naming link.
-  const linkRaw = isObj(ownerDoc?.value)
+  const linkRaw = isObjectNotArray(ownerDoc?.value)
     ? (ownerDoc!.value as Record<string, unknown>)[key]
     : undefined;
-  if (isObj(linkRaw) && isObj(linkRaw["/"])) {
+  if (isObjectNotArray(linkRaw) && isObjectNotArray(linkRaw["/"])) {
     const slash = linkRaw["/"] as Record<string, unknown>;
     const linkKey = Object.keys(slash).find((k) => k.startsWith("link@"));
     const inner = linkKey ? slash[linkKey] : undefined;
-    if (isObj(inner) && isObj(inner.schema)) {
+    if (isObjectNotArray(inner) && isObjectNotArray(inner.schema)) {
       return {
         schema: annotate(inner.schema),
         keys: Object.keys(inner.schema),
@@ -224,14 +229,14 @@ function declaredSchemaFor(
   // here would pull a heavy live-runtime dep into the offline tool; until that's
   // worth it, a nested/escaped ref simply shows its raw `{ $ref }`.
   const osch = ownerDoc?.schema;
-  if (isObj(osch) && isObj(osch.properties)) {
+  if (isObjectNotArray(osch) && isObjectNotArray(osch.properties)) {
     const prop = osch.properties[key];
-    if (isObj(prop)) {
-      let resolved: Record<string, unknown> = prop;
+    if (isObjectNotArray(prop)) {
+      let resolved: ReadonlyRecord = prop;
       const ref = typeof prop.$ref === "string" ? prop.$ref : undefined;
-      if (ref?.startsWith("#/$defs/") && isObj(osch.$defs)) {
+      if (ref?.startsWith("#/$defs/") && isObjectNotArray(osch.$defs)) {
         const def = osch.$defs[ref.slice("#/$defs/".length)];
-        if (isObj(def)) resolved = def;
+        if (isObjectNotArray(def)) resolved = def;
       }
       return {
         schema: annotate(resolved),
@@ -256,7 +261,7 @@ function linksWithPaths(
     out.push({ link, at: base.join("/") });
     return out;
   }
-  if (isObj(v)) {
+  if (isObjectNotArray(v)) {
     for (const [k, val] of Object.entries(v)) {
       linksWithPaths(val, [...base, k], out, depth - 1);
     }
@@ -323,7 +328,7 @@ function detailFromDoc(
   }
   if (c.lineage.owner) lineage.owner = refTo(c.lineage.owner, ctx);
   // Legacy: surface the result cell + the owned-cell manifest from the value.
-  if (c.kind === "piece" && c.regime === "legacy" && isObj(value)) {
+  if (c.kind === "piece" && c.regime === "legacy" && isObjectNotArray(value)) {
     const rid = legacyResultId(value);
     if (rid) lineage.result = refTo(rid, ctx);
     const internalIds = linksWithPaths(value.internal)
@@ -373,7 +378,9 @@ function detailFromDoc(
 
   // --- schema / ifc / cfc ------------------------------------------------
   let schema = doc.schema !== undefined ? annotate(doc.schema) : undefined;
-  let schemaKeys = isObj(doc.schema) ? Object.keys(doc.schema) : undefined;
+  let schemaKeys = isObjectNotArray(doc.schema)
+    ? Object.keys(doc.schema)
+    : undefined;
   let schemaSource: string | undefined;
   let streamPayload: boolean | undefined;
   // A stream / named owned cell has no own schema — resolve the DECLARED one
@@ -389,7 +396,9 @@ function detailFromDoc(
         : `declared in owner schema · ${named.key}`;
     }
   }
-  const ifc = isObj(value) && "ifc" in value ? annotate(value.ifc) : undefined;
+  const ifc = isObjectNotArray(value) && "ifc" in value
+    ? annotate(value.ifc)
+    : undefined;
   const cfc = parseCfc(doc.cfc);
 
   return {
@@ -494,7 +503,9 @@ export function buildAllDetails(
     // Only MODERN piece result values carry semantic names as keys (createProfile,
     // profiles, …). A legacy PROCESS cell's top-level keys are control-plane
     // ($TYPE/resultRef/internal/argument) — naming children by those is noise.
-    if (c.kind === "piece" && c.regime === "modern" && isObj(doc.value)) {
+    if (
+      c.kind === "piece" && c.regime === "modern" && isObjectNotArray(doc.value)
+    ) {
       for (const [key, val] of Object.entries(doc.value)) {
         const tid = parseSigilLink(val)?.id;
         if (tid && !nameOf.has(tid)) nameOf.set(tid, { owner: id, key });

--- a/packages/state-inspector/grouping.ts
+++ b/packages/state-inspector/grouping.ts
@@ -1,3 +1,5 @@
+import { isObjectNotArray } from "@commonfabric/utils/types";
+
 // Space grouping — "a user's whole world" from a pile of space DBs.
 //
 // A user's state is spread across SEVERAL spaces; understanding it means
@@ -63,7 +65,7 @@ function didFromPath(path: string): string {
 
 /** A home piece's result value carries both `profiles` and `createProfile`. */
 function isHomeResultValue(v: unknown): boolean {
-  return typeof v === "object" && v !== null && !Array.isArray(v) &&
+  return isObjectNotArray(v) &&
     "profiles" in v && "createProfile" in v;
 }
 

--- a/packages/state-inspector/model.ts
+++ b/packages/state-inspector/model.ts
@@ -51,6 +51,8 @@
 //                  (`hasTable`, the scope_key shim). A schema-migration concern.
 // └────────────────────────────────────────────────────────────────────────────┘
 
+import { isObjectNotArray } from "@commonfabric/utils/types";
+
 import type { SpaceDb } from "./db.ts";
 import { countLinks, parseSigilLink, summarize } from "./decode.ts";
 import { reconstructDocument } from "./reconstruct.ts";
@@ -113,10 +115,6 @@ export interface EntityModel {
   links?: number;
 }
 
-function isObj(v: unknown): v is Record<string, unknown> {
-  return typeof v === "object" && v !== null && !Array.isArray(v);
-}
-
 /** The target id of a SigilLink value, if it is one. */
 function linkId(v: unknown): string | undefined {
   return parseSigilLink(v)?.id ?? undefined;
@@ -127,7 +125,7 @@ function internalIds(internal: unknown): string[] {
   if (!Array.isArray(internal)) return [];
   const out: string[] = [];
   for (const el of internal) {
-    if (isObj(el) && "link" in el) {
+    if (isObjectNotArray(el) && "link" in el) {
       const id = linkId(el.link);
       if (id) out.push(id);
     }
@@ -143,26 +141,28 @@ function basename(p: string): string {
 export function isModuleValue(
   v: unknown,
 ): v is { code: string; identity: string; filename?: string; kind?: string } {
-  return isObj(v) && typeof v.code === "string" &&
+  return isObjectNotArray(v) && typeof v.code === "string" &&
     typeof v.identity === "string";
 }
 
 /** A value shaped like a JSONSchema stored as data: `{ type, properties|$defs }`. */
 function isSchemaValue(v: unknown): boolean {
-  if (!isObj(v)) return false;
+  if (!isObjectNotArray(v)) return false;
   if (typeof v.type !== "string") return false;
-  if (!(isObj(v.properties) || isObj(v.$defs))) return false;
+  if (!(isObjectNotArray(v.properties) || isObjectNotArray(v.$defs))) {
+    return false;
+  }
   // Schemas-as-data don't carry render markers.
   return !("$UI" in v) && !("$NAME" in v);
 }
 
 function isStreamValue(v: unknown): boolean {
-  return isObj(v) && v.$stream === true;
+  return isObjectNotArray(v) && v.$stream === true;
 }
 
 /** A piece result value: carries render/name markers. */
 function isPieceResultValue(v: unknown): boolean {
-  return isObj(v) && ("$UI" in v || "$NAME" in v || "$TILE_UI" in v);
+  return isObjectNotArray(v) && ("$UI" in v || "$NAME" in v || "$TILE_UI" in v);
 }
 
 /**
@@ -179,7 +179,7 @@ function isLegacyProcessValue(
   spell?: unknown;
   source?: unknown;
 } {
-  return isObj(v) && typeof v.$TYPE === "string" &&
+  return isObjectNotArray(v) && typeof v.$TYPE === "string" &&
     ("resultRef" in v || "spell" in v || "source" in v);
 }
 
@@ -190,7 +190,7 @@ function valueShapeOf(v: unknown): ValueShape {
   if (isSchemaValue(v)) return "schema";
   if (isPieceResultValue(v)) return "piece-result";
   if (Array.isArray(v)) return "array";
-  if (isObj(v)) return "object";
+  if (isObjectNotArray(v)) return "object";
   return "scalar";
 }
 
@@ -227,7 +227,7 @@ export function classifyDocument(doc: EntityDocument): Classification {
 
   // --- Pieces -------------------------------------------------------------
   // Modern: the durable piece → pattern pointer is `patternIdentity`.
-  if (isObj(doc.patternIdentity)) {
+  if (isObjectNotArray(doc.patternIdentity)) {
     const pi = doc.patternIdentity as { identity?: unknown; symbol?: unknown };
     lineage.argument = linkId(doc.argument);
     lineage.internal = internalIds(doc.internal);
@@ -237,7 +237,7 @@ export function classifyDocument(doc: EntityDocument): Classification {
         symbol: typeof pi.symbol === "string" ? pi.symbol : undefined,
       };
     }
-    const name = isObj(value) && typeof value.$NAME === "string"
+    const name = isObjectNotArray(value) && typeof value.$NAME === "string"
       ? value.$NAME
       : undefined;
     return {
@@ -269,7 +269,7 @@ export function classifyDocument(doc: EntityDocument): Classification {
   // Legacy: a result cell links to its process cell via top-level `source`.
   if ("source" in doc && isPieceResultValue(value)) {
     lineage.source = linkId(doc.source);
-    const name = isObj(value) && typeof value.$NAME === "string"
+    const name = isObjectNotArray(value) && typeof value.$NAME === "string"
       ? value.$NAME
       : undefined;
     return {
@@ -307,7 +307,7 @@ export function classifyDocument(doc: EntityDocument): Classification {
     };
   }
   if (isSchemaValue(value)) {
-    const ifc = isObj(value) && "ifc" in value ? "+ifc" : "";
+    const ifc = isObjectNotArray(value) && "ifc" in value ? "+ifc" : "";
     return {
       kind: "schema",
       regime: "n/a",
@@ -575,7 +575,7 @@ export function describePiece(
   if (c.kind !== "piece") return { error: `not a piece (kind=${c.kind})` };
 
   const value = doc.value;
-  const name = isObj(value) && typeof value.$NAME === "string"
+  const name = isObjectNotArray(value) && typeof value.$NAME === "string"
     ? value.$NAME
     : "(unnamed)";
 
@@ -646,8 +646,8 @@ export function describePiece(
     name,
     pattern,
     input,
-    resultKeys: isObj(value) ? Object.keys(value) : [],
-    schemaKeys: isObj(doc.schema) ? Object.keys(doc.schema) : [],
+    resultKeys: isObjectNotArray(value) ? Object.keys(value) : [],
+    schemaKeys: isObjectNotArray(doc.schema) ? Object.keys(doc.schema) : [],
     ownedCells,
   };
 }

--- a/packages/state-inspector/timetravel.ts
+++ b/packages/state-inspector/timetravel.ts
@@ -15,7 +15,7 @@ import { applyPatch } from "@commonfabric/memory/v2/patch";
 import type { PatchOp } from "@commonfabric/memory/v2";
 import type { FabricValue } from "@commonfabric/api";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
-import { isPlainObject } from "@commonfabric/utils/types";
+import { isObjectOrArray, isPlainObject } from "@commonfabric/utils/types";
 
 import type { SpaceDb } from "./db.ts";
 import {
@@ -75,10 +75,6 @@ export interface ExactValueChange extends ValueChange {
   pathSegments: string[];
 }
 
-function isObj(v: unknown): v is Record<string, unknown> {
-  return isPlainObject(v);
-}
-
 // The data-model hash defines equality for Fabric leaves, including BigInt,
 // symbols, and Fabric instances.
 function canonical(v: unknown): string {
@@ -92,7 +88,7 @@ function storedValueKind(value: unknown): StoredValueKind {
   if (parseEntityRef(value) !== null) return "reference";
   if (Array.isArray(value)) return "array";
   if (typeof value === "object") {
-    return isObj(value) ? "object" : "fabric";
+    return isPlainObject(value) ? "object" : "fabric";
   }
   return typeof value;
 }
@@ -134,8 +130,8 @@ function valuesEqual(a: unknown, b: unknown): boolean {
       }
       continue;
     }
-    const leftIsObject = isObj(left);
-    const rightIsObject = isObj(right);
+    const leftIsObject = isPlainObject(left);
+    const rightIsObject = isPlainObject(right);
     if (leftIsObject || rightIsObject) {
       if (!leftIsObject || !rightIsObject) return false;
       const leftKeys = Object.keys(left);
@@ -242,7 +238,7 @@ function diffSelectedValues(
       });
       return;
     }
-    if (isObj(a) && isObj(b)) {
+    if (isPlainObject(a) && isPlainObject(b)) {
       for (const key of new Set([...Object.keys(a), ...Object.keys(b)])) {
         const aHasKey = Object.hasOwn(a, key);
         const bHasKey = Object.hasOwn(b, key);
@@ -508,7 +504,7 @@ export function entityTimeline(
       }
     }
     const exists = stateKnown && doc !== undefined;
-    const hasValue = exists && typeof doc === "object" && doc !== null &&
+    const hasValue = exists && isObjectOrArray(doc) &&
       Object.hasOwn(doc, "value");
     const docValue = hasValue ? (doc as { value: unknown }).value : undefined;
     const value = { present: hasValue, value: docValue };

--- a/packages/toolshed/routes/ai/llm/schema.ts
+++ b/packages/toolshed/routes/ai/llm/schema.ts
@@ -1,10 +1,6 @@
-const OMIT_SCHEMA = Symbol("omit-schema");
+import { isObjectNotArray } from "@commonfabric/utils/types";
 
-function isObjectRecord(
-  value: unknown,
-): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
+const OMIT_SCHEMA = Symbol("omit-schema");
 
 function normalizeSchemaNode(schema: unknown): unknown {
   if (schema === true || schema === false) return schema;
@@ -13,7 +9,7 @@ function normalizeSchemaNode(schema: unknown): unknown {
       .map((item) => normalizeSchemaNode(item))
       .filter((item) => item !== OMIT_SCHEMA);
   }
-  if (!isObjectRecord(schema)) return schema;
+  if (!isObjectNotArray(schema)) return schema;
   if (schema.type === "undefined") return OMIT_SCHEMA;
 
   const out: Record<string, unknown> = {};
@@ -44,7 +40,7 @@ function normalizeSchemaNode(schema: unknown): unknown {
   }
 
   let droppedPropertyNames = new Set<string>();
-  if (isObjectRecord(schema.properties)) {
+  if (isObjectNotArray(schema.properties)) {
     const properties: Record<string, unknown> = {};
     droppedPropertyNames = new Set<string>();
     for (const [key, value] of Object.entries(schema.properties)) {
@@ -71,7 +67,7 @@ function normalizeSchemaNode(schema: unknown): unknown {
     const anyOf = schema.anyOf
       .map((branch) => normalizeSchemaNode(branch))
       .filter((branch) => branch !== OMIT_SCHEMA);
-    if (anyOf.length === 1 && isObjectRecord(anyOf[0])) {
+    if (anyOf.length === 1 && isObjectNotArray(anyOf[0])) {
       return {
         ...anyOf[0],
         ...out,

--- a/packages/toolshed/routes/blobs/blobs.index.ts
+++ b/packages/toolshed/routes/blobs/blobs.index.ts
@@ -4,6 +4,7 @@ import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { isDID } from "@commonfabric/identity";
 import { decodeMemoryBoundary } from "@commonfabric/memory/v2";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 import type { Context } from "@hono/hono";
 
 // Blob routes are intentionally unauthenticated for the MVP. Anyone can POST a
@@ -49,9 +50,6 @@ class BlobPayloadTooLarge extends Error {
   }
 }
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  value !== null && typeof value === "object" && !Array.isArray(value);
-
 /**
  * Interprets a decoded request body as bytes, or returns `undefined` when it
  * is not byte-shaped. The result is always freshly allocated and unshared, so
@@ -73,7 +71,7 @@ const toByteArray = (value: unknown): Uint8Array | undefined => {
   ) {
     return Uint8Array.from(value);
   }
-  if (!isRecord(value)) {
+  if (!isObjectNotArray(value)) {
     return undefined;
   }
 
@@ -95,7 +93,7 @@ const toByteArray = (value: unknown): Uint8Array | undefined => {
 };
 
 const asBlobContents = (value: unknown): BlobContents | undefined => {
-  if (!isRecord(value) || typeof value.type !== "string") {
+  if (!isObjectNotArray(value) || typeof value.type !== "string") {
     return undefined;
   }
   if (value.body instanceof FabricBytes) {

--- a/packages/ts-transformers/src/transformers/cfc-policy-authoring.ts
+++ b/packages/ts-transformers/src/transformers/cfc-policy-authoring.ts
@@ -1,6 +1,7 @@
 import ts from "typescript";
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 import { TransformationContext, Transformer } from "../core/mod.ts";
 import type { CfcPolicyCompilerManifestV1 } from "../core/runtime-contract.ts";
 
@@ -38,9 +39,6 @@ class StaticAuthoringError extends Error {
     super(message);
   }
 }
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const assertKeys = (
   value: Record<string, unknown>,
@@ -207,7 +205,7 @@ const expressionFromStatic = (
       value.map((entry) => expressionFromStatic(entry, factory)),
     );
   }
-  if (isRecord(value)) {
+  if (isObjectNotArray(value)) {
     return factory.createObjectLiteralExpression(
       Object.entries(value).map(([key, field]) =>
         factory.createPropertyAssignment(
@@ -223,7 +221,7 @@ const expressionFromStatic = (
 const collectVariables = (value: unknown, into: Set<string>): void => {
   if (Array.isArray(value)) {
     value.forEach((entry) => collectVariables(entry, into));
-  } else if (isRecord(value)) {
+  } else if (isObjectNotArray(value)) {
     if (
       Object.keys(value).length === 1 && typeof value.var === "string"
     ) {
@@ -236,7 +234,7 @@ const collectVariables = (value: unknown, into: Set<string>): void => {
 
 const containsThisPolicy = (value: unknown): boolean => {
   if (Array.isArray(value)) return value.some(containsThisPolicy);
-  if (!isRecord(value)) return false;
+  if (!isObjectNotArray(value)) return false;
   if (value.thisPolicy === true) return true;
   return Object.values(value).some(containsThisPolicy);
 };
@@ -246,7 +244,7 @@ const lowerRule = (
   value: unknown,
   node: ts.Node,
 ): AuthoredRule => {
-  if (!isRecord(value)) {
+  if (!isObjectNotArray(value)) {
     throw new StaticAuthoringError(node, "exchangeRule() requires an object");
   }
   assertKeys(
@@ -256,7 +254,7 @@ const lowerRule = (
     "rule",
   );
   if (
-    !isRecord(value.appliesTo) || value.appliesTo.thisPolicy !== true ||
+    !isObjectNotArray(value.appliesTo) || value.appliesTo.thisPolicy !== true ||
     Object.keys(value.appliesTo).length !== 1
   ) {
     throw new StaticAuthoringError(
@@ -266,7 +264,7 @@ const lowerRule = (
   }
 
   const pre = value.pre === undefined ? {} : value.pre;
-  if (!isRecord(pre)) {
+  if (!isObjectNotArray(pre)) {
     throw new StaticAuthoringError(node, "rule pre must be a static object");
   }
   assertKeys(pre, new Set(["confidentiality", "integrity"]), node, "pre");
@@ -287,7 +285,7 @@ const lowerRule = (
 
   let guard: AuthoredRule["guard"];
   if (value.guard !== undefined) {
-    if (!isRecord(value.guard)) {
+    if (!isObjectNotArray(value.guard)) {
       throw new StaticAuthoringError(
         node,
         "rule guard must be a static object",
@@ -305,7 +303,8 @@ const lowerRule = (
     }
     for (const entry of value.guard.policyState) {
       if (
-        !isRecord(entry) || typeof entry.kind !== "string" || entry.kind === ""
+        !isObjectNotArray(entry) || typeof entry.kind !== "string" ||
+        entry.kind === ""
       ) {
         throw new StaticAuthoringError(
           node,
@@ -329,7 +328,7 @@ const lowerRule = (
   ) {
     throw new StaticAuthoringError(node, "invalid preConfScope");
   }
-  if (!isRecord(value.post)) {
+  if (!isObjectNotArray(value.post)) {
     throw new StaticAuthoringError(node, "rule post must be a static object");
   }
   assertKeys(

--- a/tasks/check.sh
+++ b/tasks/check.sh
@@ -124,6 +124,7 @@ DIRS=(
   "packages/patterns/scrabble"
   "packages/patterns/system"
   "packages/patterns/test"
+  "packages/patterns/tools"
   "packages/patterns/weekly-calendar"
   "packages/piece"
   "packages/runner"


### PR DESCRIPTION
ACCEPT_COVERAGE_DEBT: packages/state-inspector +4 lines
ACCEPT_COVERAGE_DEBT: packages/patterns +1 line

`packages/utils/src/types.ts` names its object-shape predicates for the answer they give, because `typeof [] === "object"` and a predicate named only for "object" leaves a reader guessing whether an array passes. `isObjectOrArray()` accepts any non-`null` value whose `typeof` is `"object"`; `isObjectNotArray()` asks the same question with arrays removed; `isPlainObject()` additionally requires the prototype be `Object.prototype` or `null`.

Around thirty files did not use any of them. Each declared its own copy of the test, under a dozen different names, and the names were exactly what the shared module exists to fix. Twenty-four spelled it `isRecord`, and those did not agree with each other: twenty-one excluded arrays and three admitted them, so the same identifier meant two different things about the case a reader most needs to know. The rest called it `isObjectRecord`, `isJsonObject`, `isSchedulerRecord`, `isSchemaObject`, `isSchemaRecord`, `isPlainRecord`, `recordValue` or `isObj`.

Every one of those bodies is now a call to the shared predicate. Where the local name says something the shared one does not -- that the value is a schema node, a transport error, a pattern schema -- the predicate stays and only its duplicated body goes. Where the name was a synonym for the shared question, it is deleted and its callers ask the shared predicate directly. Two composed expressions of the form `Array.isArray(x) || isObjectNotArray(x)` are the whole of what `isObjectOrArray()` asks, and say so in one call now; one of the two had never wanted the non-array question at all.

Candidates were found by their bodies, never by their names, and the state inspector is why. Three of its modules declared a helper called `isObj`, and they did not all mean the same thing: two tested for a non-array object while the third asked the narrower plain-object question. Those two tests disagree on twenty-one of fifty-two sample values -- every `Date`, `Map`, `Set`, `Error`, `RegExp` and class instance goes one way, and an array whose prototype has been repointed goes the other. Converting all three on the strength of a shared name would have changed what the time-travel diff accepts. For the same reason `isPlainRecord` in the runner's policy module stays exactly as it is: it looks like two wrappers deleted here, but it is `isObjectNotArray()` followed by a prototype check, and it differs from `isPlainObject()` on precisely the prototype-repointed array its comment is guarding against.

Nothing changes at runtime. Each removed body was the same test in one of four spellings, and the spellings differ only in the order of two comparisons that cannot throw and cannot both be reached with different answers.

Thirty type annotations change, and they are the point rather than a side effect. `isObjectNotArray()` narrows to a read-only record so that a frozen value keeps its protection, and that claim was being dropped at the first function the value reached: TypeScript does not check `readonly` index-signature modifiers when deciding assignability, so a mutable parameter accepts the narrowed value silently and a clean type-check says nothing about it. Thirteen signatures across five packages were in that position, and every one of them only ever indexes its argument to read; they take `ReadonlyRecord` now, and six `as` casts that stood in for the mismatch are gone.

Two smaller things ride along. A structured-result schema check tested `!isObjectNotArray(parsed) || Array.isArray(parsed)`, whose second half is reachable only when the value is already known not to be an array; that was dead before the rename too, but unreadable as dead while the predicate's name left the array question open. And the runner's shape-check overhead benchmark is renamed, because its body now measures the shared predicate rather than a copy declared inside the timed closure, and a trend chart keyed by title should show that break rather than absorb it.

`packages/patterns/tools` is added to the type-checked path list in `tasks/check.sh`. It was in neither the directory list nor the top-level globs, and nothing imports the diagnostic tools there, so no test task loaded them either. A tripwire confirms it: a deliberate type error in that directory left `deno task check` reporting success, and is reported once the directory is listed.

Five copies remain, all of them pattern source, which may import only `commonfabric`, `commonfabric/cfc`, `commonfabric/schema`, `turndown`, a `cf:` reference or a relative path. Adding the import to one of them and running its test fails to compile, which is the check that settles it rather than a reading of the policy. Three of the five are the array-admitting spelling, so the shared `isObjectOrArray()` gains no call site from them.

Two things are deliberately not done here. The tree still writes these three conjuncts inline where they open a longer structural check, and rewriting those changes how a check reads rather than removing a second definition of a predicate. And several validators would arguably be better asking the plain-object question, since a class instance carrying own properties passes the looser test; on the memory wire path that is a change to what a deployed server accepts, and it belongs with its own justification rather than inside a consolidation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

