### PR TITLE
fix(runner): the proxy value cache answers for the writability asked for

### DIFF
--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -38,10 +38,19 @@ const MAX_RECURSION_DEPTH = 100;
 // stays recursive.
 const SHAPE_READ: IReadOptions = { nonRecursive: true };
 
-// Cache of target objects to their proxies, scoped by ReactivityLog
+// Cache of target objects to their proxies, scoped by ReactivityLog.
+//
+// `byValue` is split by writability rather than holding one proxy per value.
+// A writable proxy carries write traps a read-only one refuses, so the two are
+// different objects and a lookup that cannot tell them apart hands whichever
+// was built first to both — a read-only view that permits writes, or a
+// writable one that refuses them, decided by nothing but creation order.
+// Within one writability the sharing is unchanged: the reason this index sits
+// behind `byLink` at all is that two values reached by different routes are
+// one object to a consumer comparing by identity.
 type ProxyCache = {
   byLink: Map<string, any>;
-  byValue: WeakMap<object, any>;
+  byValue: WeakMap<object, { readOnly?: any; writable?: any }>;
 };
 
 const proxyCacheByTx = new WeakMap<
@@ -77,7 +86,7 @@ const getProxyCache = (
   if (!txCache) {
     txCache = {
       byLink: new Map<string, any>(),
-      byValue: new WeakMap<object, any>(),
+      byValue: new WeakMap<object, { readOnly?: any; writable?: any }>(),
     };
     proxyCacheByTx.set(cacheIndex, txCache);
   }
@@ -169,6 +178,18 @@ const arrayMethods: { [key: string]: ArrayMethodType } = {
  * normalized (and frozen) level by level inside the write's diff; the caller's
  * input objects are never mutated, and already-deep-frozen valid `FabricValue`
  * inputs are accepted identity-preservingly.
+ *
+ * **Writability is a capability, not authoring guidance.** The refusal a
+ * read-only view gives — "declare type as `Writable<..>`" — names the way to
+ * ask for write access, but the refusal itself is enforcement that the builder
+ * depends on: `collectWritablyBoundRoots` in `builder/pattern.ts` takes a plain
+ * (non-`asCell`) binding in a schema-carrying handler to be unwritable, and a
+ * cell written only through such a binding would be classified `computed` —
+ * replayable from its inputs — if that held and the refusal did not. So a view
+ * built for one writability must never answer a request for the other. Write
+ * capability reaches a pattern two ways: an `asCell` handle minted from a
+ * `Writable<..>` field, or the whole argument of a handler declaring
+ * `{ proxy: true }`, which is the one construction site passing `writable` true.
  */
 export function createQueryResultProxy<T>(
   runtime: Runtime,
@@ -391,9 +412,14 @@ function createViewProxy<T>(
 
   // Check if we already have a proxy for this target in the cache.
   // The cache key is the original `value` (not the stub), ensuring that
-  // the same frozen object always maps to the same proxy instance.
-  const existingProxy = txCache.byLink.get(cacheKey) ??
-    (cfcLabelView === undefined ? txCache.byValue.get(value) : undefined);
+  // the same frozen object always maps to the same proxy instance -- and the
+  // value index is consulted for the writability actually asked for, so a view
+  // built for one never answers a request for the other.
+  let existingProxy = txCache.byLink.get(cacheKey);
+  if (existingProxy === undefined && cfcLabelView === undefined) {
+    const entry = txCache.byValue.get(value);
+    existingProxy = writable ? entry?.writable : entry?.readOnly;
+  }
   if (existingProxy) return remember(existingProxy);
 
   const proxy = new Proxy(proxyTarget as object, {
@@ -881,7 +907,10 @@ function createViewProxy<T>(
   // Cache the proxy in the appropriate cache before returning
   txCache.byLink.set(cacheKey, proxy);
   if (cfcLabelView === undefined) {
-    txCache.byValue.set(value, proxy);
+    const entry = txCache.byValue.get(value) ?? {};
+    if (writable) entry.writable = proxy;
+    else entry.readOnly = proxy;
+    txCache.byValue.set(value, entry);
   }
   return remember(proxy);
 }

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -40,14 +40,13 @@ const SHAPE_READ: IReadOptions = { nonRecursive: true };
 
 // Cache of target objects to their proxies, scoped by ReactivityLog.
 //
-// `byValue` is split by writability rather than holding one proxy per value.
-// A writable proxy carries write traps a read-only one refuses, so the two are
-// different objects and a lookup that cannot tell them apart hands whichever
-// was built first to both — a read-only view that permits writes, or a
-// writable one that refuses them, decided by nothing but creation order.
-// Within one writability the sharing is unchanged: the reason this index sits
-// behind `byLink` at all is that two values reached by different routes are
-// one object to a consumer comparing by identity.
+// `byValue` holds one proxy per value per writability. A writable proxy
+// carries write traps a read-only one refuses, so the two are different
+// objects and each gets its own slot; a view built for one writability is
+// never handed to a caller asking for the other. Within a writability the two
+// share, which is what this index sits behind `byLink` for: two links that
+// resolve to one stored object are one object to a consumer comparing by
+// identity.
 type ProxyCache = {
   byLink: Map<string, any>;
   byValue: WeakMap<object, { readOnly?: any; writable?: any }>;

--- a/packages/runner/test/query-result-proxy-writability.test.ts
+++ b/packages/runner/test/query-result-proxy-writability.test.ts
@@ -40,9 +40,9 @@ describe("query-result-proxy", () => {
 
   describe("writability of a cached view", () => {
     // Both views are taken over one cell in one transaction, so they name the
-    // same value object. Each test builds them in a stated order, because the
-    // defect being pinned is one where the order decides the outcome: a single
-    // ordering passes on its own.
+    // same value object -- the case where the two share a cache entry. Each
+    // test names the order they are built in, and both orders are exercised,
+    // because a view behaves the same whichever of the two was built first.
     const views = (id: string, order: "read-only first" | "writable first") => {
       const cell = runtime.getCell<{ a: number }>(space, id, undefined, tx);
       cell.set({ a: 1 });

--- a/packages/runner/test/query-result-proxy-writability.test.ts
+++ b/packages/runner/test/query-result-proxy-writability.test.ts
@@ -1,0 +1,118 @@
+/**
+ * A query-result proxy is built either read-only or writable, and the two
+ * carry different write traps. Both are cached per transaction, and the value
+ * index that backs that cache is consulted for the writability actually asked
+ * for -- so which of the two a caller receives is decided by what they asked
+ * for, never by which one happened to be built first.
+ */
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("test proxy writability");
+const space = signer.did();
+
+const READ_ONLY_REFUSAL = "This value is read-only";
+
+describe("query-result-proxy", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  describe("writability of a cached view", () => {
+    // Both views are taken over one cell in one transaction, so they name the
+    // same value object. Each test builds them in a stated order, because the
+    // defect being pinned is one where the order decides the outcome: a single
+    // ordering passes on its own.
+    const views = (id: string, order: "read-only first" | "writable first") => {
+      const cell = runtime.getCell<{ a: number }>(space, id, undefined, tx);
+      cell.set({ a: 1 });
+      const readOnlyFirst = order === "read-only first";
+      const first = cell.getAsQueryResult([], tx, !readOnlyFirst) as {
+        a: number;
+      };
+      const second = cell.getAsQueryResult([], tx, readOnlyFirst) as {
+        a: number;
+      };
+      return readOnlyFirst
+        ? { readOnly: first, writable: second, cell }
+        : { writable: first, readOnly: second, cell };
+    };
+
+    it("throws on a write through a read-only view built before a writable one", () => {
+      const { readOnly } = views("ro-then-rw", "read-only first");
+      expect(() => {
+        readOnly.a = 2;
+      }).toThrow(READ_ONLY_REFUSAL);
+    });
+
+    it("throws on a write through a read-only view built after a writable one", () => {
+      const { readOnly } = views("rw-then-ro", "writable first");
+      expect(() => {
+        readOnly.a = 2;
+      }).toThrow(READ_ONLY_REFUSAL);
+    });
+
+    it("stores a write through a writable view built before a read-only one", () => {
+      const { writable, cell } = views("rw-then-ro-write", "writable first");
+      writable.a = 3;
+      expect(cell.get().a).toBe(3);
+    });
+
+    it("stores a write through a writable view built after a read-only one", () => {
+      const { writable, cell } = views("ro-then-rw-write", "read-only first");
+      writable.a = 3;
+      expect(cell.get().a).toBe(3);
+    });
+
+    it("returns distinct views for the two writabilities over one value", () => {
+      const { readOnly, writable } = views("distinct", "read-only first");
+      expect(readOnly as object).not.toBe(writable as object);
+    });
+
+    it("returns the same view for two read-only reads of one value", () => {
+      const cell = runtime.getCell<{ a: number }>(
+        space,
+        "shared-read-only",
+        undefined,
+        tx,
+      );
+      cell.set({ a: 1 });
+      const first = cell.getAsQueryResult([], tx, false) as object;
+      const second = cell.getAsQueryResult([], tx, false) as object;
+      expect(first).toBe(second);
+    });
+
+    it("returns the same view for two writable reads of one value", () => {
+      const cell = runtime.getCell<{ a: number }>(
+        space,
+        "shared-writable",
+        undefined,
+        tx,
+      );
+      cell.set({ a: 1 });
+      const first = cell.getAsQueryResult([], tx, true) as object;
+      const second = cell.getAsQueryResult([], tx, true) as object;
+      expect(first).toBe(second);
+    });
+  });
+});


### PR DESCRIPTION
## What

The query-result proxy cache keeps two indices. `byLink` carries `writable` in its key; `byValue` — a `WeakMap` on the raw stored value object — did not, and it answers whenever `byLink` misses, which is exactly when a caller asks for a writability that has not been built yet. A read-only and a writable view of one value therefore shared a proxy, and creation order decided what both of them did:

| order | read-only write | writable write |
|---|---|---|
| read-only first | throws | **throws** |
| writable first | **succeeds** | succeeds |

Both directions are wrong. The one that matters is the second: a caller who asked for a read-only view could mutate through it, because a writable view of the same value was built earlier in the transaction, and the refusal never fired.

This splits the value index by writability (`{ readOnly?, writable? }`), so it answers for the writability actually asked for. The lookup still consults it only on a `byLink` miss.

## Why `byValue` was kept rather than deleted

`byValue` is not a deliberate secondary index — `96d9c33a5` shows it is the *original* cache, a bare `WeakMap<object, proxy>` with no writability in its key at all. `byLink` was layered on top in that commit, introducing `writable` into a key for the first time; keeping the old map as a fallback is what stopped the new key from ever taking effect.

It is still load-bearing, though not for the reason it looks. Instrumenting the lookup across the runner suite, every `byLink`-miss hit was **cross-address**: two different `$alias` paths in one document resolving to the same shared frozen value.

```
had: [false,…,["search","pattern","result","help","$alias","path"]]
want:[false,…,["search","pattern","nodes","0","outputs","$alias","path"]]
```

All read-only on both sides, so they land in the same slot and are untouched by the split. Deleting the index would have changed identity for real cases. Worth noting the circular-reference identity tests (`proxy.z === proxy`) are satisfied by `byLink`, not by this.

## The refusal is a capability, not authoring guidance

Nothing in the code said which it was, so the doc comment on `createQueryResultProxy` now records it: `collectWritablyBoundRoots` in `builder/pattern.ts` takes a plain non-`asCell` binding in a schema-carrying handler to be unwritable, and that feeds `disqualified`, which gates whether a cell's `kind` becomes `computed` — treated as replayable from its inputs.

**One honest limit.** `writable: true` arises only from the legacy `handler(fn, { proxy: true })` form, and handlers do not share a transaction, so I did not find a path where this hole breaches the computed-kind analysis specifically. The plainly reachable harm is the other direction — a legacy proxy handler's writable view refusing writes because a read-only view of the same value was built first. The read-only-becomes-writable direction is real and worth closing, but I would stop short of calling it a demonstrated capability escape today.

That said, this is cheap insurance for the case where #5502 is fixed rather than deleted: `{ proxy: true }` currently never reaches `module.writableProxy` for a transformed pattern (measured: 0 hits across 120 transformed pattern tests, against 6 in untransformed builder tests as a control). If that were fixed, writable proxies would become reachable from every pattern at once, and this conflation would turn from a latent ordering quirk into a live hole on that boundary.

## Tests

`packages/runner/test/query-result-proxy-writability.test.ts`, mutation-tested against the unfixed code:

| test | unfixed | fixed |
|---|---|---|
| read-only **before** writable refuses | ok (control) | ok |
| read-only **after** writable refuses | **FAILED** | ok |
| writable **before** read-only stores | ok (control) | ok |
| writable **after** read-only stores | **FAILED** | ok |
| the two views are distinct | **FAILED** | ok |
| sharing within one writability | ok | ok |

Each direction is paired with its opposite-order control, because a single ordering passes today by accident and would otherwise carry the test.

## Verification

| Check | Result |
|---|---|
| `packages/runner` `deno task test` | 1221 passed, 0 failed |
| `packages/piece` `deno task test` | 37 passed, 0 failed |
| `deno task integration pattern-tests` | 120 passed |
| `deno task check` | pass |
| repo-wide `deno fmt --check` / `deno lint` | pass |

## Follow-up not in this change

`byValue` can still hand one **writable** view to two different addresses sharing a stored value, so a write through it would target the first link's path. Structural rather than measured — the observed cross-address hits were all read-only, and writable proxies need a legacy `{ proxy: true }` handler. Filed separately; narrowing it changes identity semantics that want their own measurement.

Context: found while reviewing #5909, which added a third index over the same views and put `writable` in its key deliberately. That change is not the cause and does not fix `byValue`; confirmed present before it and unchanged by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

