### PR TITLE
Reduce CI shard count within runner capacity

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -16,8 +16,10 @@ concurrency:
 # aliases at each job and each work step, so the numbers live here and nowhere
 # else. Most jobs take the first pair. The CLI integration suites take the
 # `cli-` ones, which are tighter because a wedged suite there is what they were
-# sized against. The environment variables holding the numbers are how a
-# workflow declares a value an anchor can name; nothing reads them.
+# sized against. See "Step And Job Timeouts" in
+# docs/development/CI_PERFORMANCE.md for the sizing rule. The environment
+# variables holding the numbers are how a workflow declares a value an anchor
+# can name; nothing reads them.
 env:
   WORK_TIMEOUT_MINUTES: &work-timeout 30
   JOB_TIMEOUT_MINUTES: &job-timeout 40
@@ -31,20 +33,22 @@ env:
 # vocabulary and which emoji belongs to which phase.
 #
 # Every work step carries a bound of its own, and the bound on the job around it
-# is the longer of the two by ten minutes. GitHub ends a job that runs past the
-# bound on the job by cancelling it, and the job's conclusion is then
-# `cancelled`, which is the conclusion a run stopped by hand or by a newer push
-# also gets. A step that runs past the bound on the step fails, and its job
-# fails with it. So the bound that a wedged test hits first is the one on the
-# step, and a wedge is reported as a failure. tasks/ci-workflow.test.ts holds
-# every work step here to that shape, and refuses a bound written as anything
-# but an alias.
+# is at least ten minutes longer. GitHub ends a job that runs past its bound by
+# cancelling it, while a step that reaches its own bound fails. An individual
+# wedged step normally reaches its bound first; the job bound remains the final
+# limit when several sequential steps take unusually long.
+# tasks/ci-workflow.test.ts holds every work step here to that shape, and
+# refuses a bound written as anything but an alias.
 #
 # The deploy jobs at the end carry no bound. Each hands the work to a script
 # that lives elsewhere, and how long that takes is not this workflow's to say.
 jobs:
   # ---------------------------------------------------------------------------
   # Tier 0 – These jobs all start immediately with no dependencies
+  # GitHub allows this organization 60 parallel hosted runners. Keep this
+  # dependency-free wave below that shared limit so overlapping runs leave
+  # capacity for one another and for jobs whose dependencies have completed.
+  # See "Current Posture" in docs/development/CI_PERFORMANCE.md.
   # ---------------------------------------------------------------------------
   check:
     name: "Check"
@@ -127,14 +131,9 @@ jobs:
         run: deno task check-withheld-globals
 
   cfcheck:
-    name: "CFC Pattern Check (${{ matrix.shard }}/${{ matrix.total }})"
+    name: "CFC Pattern Check"
     runs-on: ubuntu-latest
     timeout-minutes: *job-timeout
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2]
-        total: [2]
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v7
@@ -147,8 +146,6 @@ jobs:
 
       - name: 🔎 Check Common Fabric patterns
         timeout-minutes: *work-timeout
-        env:
-          CFCHECK_SHARD: "${{ matrix.shard }}/${{ matrix.total }}"
         run: deno task cfcheck
 
   pattern-compat:
@@ -181,12 +178,16 @@ jobs:
         run: deno task pattern-compat
 
   pattern-vintage:
-    name: "Pattern Update State Continuity"
+    name: "Pattern Update State and Baseline Integrity"
     runs-on: ubuntu-latest
     timeout-minutes: *job-timeout
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v7
+        # The baseline check diffs against the merge base and needs real
+        # history. The replay step reads the same full checkout.
+        with:
+          fetch-depth: 0
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -228,29 +229,12 @@ jobs:
         timeout-minutes: *work-timeout
         run: deno task pattern-vintage
 
-  baselines-append-only:
-    name: "Pattern Baselines Append-Only"
-    runs-on: ubuntu-latest
-    timeout-minutes: *job-timeout
-    steps:
-      # Needs real history: the check diffs against the merge base, and the
-      # default shallow checkout has none.
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - name: 🦕 Setup Deno
-        uses: ./.github/actions/deno-setup
-
-      - name: 🔍 Verify lock file & install dependencies
-        uses: ./.github/actions/deno-install
-
       # The gate's safety argument is that `--update` can only ADD a baseline.
       # `rm` is not `--update`, and one deleted file hides easily in a diff full
       # of recorded JSON — so deleting a baseline without retiring its pattern
       # is refused here.
       - name: 🔎 Check pattern baselines are append-only
+        if: ${{ !cancelled() }}
         timeout-minutes: *work-timeout
         run: deno task check-baselines-append-only origin/${{ github.base_ref || 'main' }}
 
@@ -459,8 +443,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
-        total: [3]
+        shard: [1, 2]
+        total: [2]
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v7
@@ -648,30 +632,26 @@ jobs:
       matrix:
         include:
           - suite_name: core-piece-values
-            script: integration.sh
-            section: piece-values
+            core_section: piece-values
+            timing_name: core-piece-values
             toolshed_port: 8000
             install_fuse_deps: false
-          - suite_name: core-piece-links
-            script: integration.sh
-            section: piece-links
-            toolshed_port: 8001
-            install_fuse_deps: false
+            run_acl: false
+            run_fuse: false
           - suite_name: core-piece-call
-            script: integration.sh
-            section: piece-call
+            core_section: piece-call
+            timing_name: core-piece-call
             toolshed_port: 8002
             install_fuse_deps: false
-          - suite_name: acl
-            script: acl.sh
-            section: ""
-            toolshed_port: 8004
-            install_fuse_deps: false
-          - suite_name: fuse
-            script: fuse-exec.sh
-            section: ""
-            toolshed_port: 8003
+            run_acl: false
+            run_fuse: false
+          - suite_name: core-piece-links-acl-fuse
+            core_section: piece-links
+            timing_name: core-piece-links
+            toolshed_port: 8001
             install_fuse_deps: true
+            run_acl: true
+            run_fuse: true
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v7
@@ -716,34 +696,33 @@ jobs:
           packages: ${{ matrix.install_fuse_deps && 'jq fuse3 libfuse3-dev' || 'jq' }}
           cache-key: cli-integration
 
-      - name: 🔧 Enable FUSE device access
-        if: ${{ matrix.suite_name == 'fuse' }}
-        run: sudo chmod 666 /dev/fuse
-
       - name: 🧪 Run CLI integration suite
-        if: ${{ startsWith(matrix.suite_name, 'core-') }}
         timeout-minutes: *cli-work-timeout
         working-directory: packages/cli
         env:
           TOOLSHED_PORT: ${{ matrix.toolshed_port }}
-          CF_CLI_INTEGRATION_SECTION: ${{ matrix.section }}
+          CF_CLI_INTEGRATION_SECTION: ${{ matrix.core_section }}
           CF_CLI_INTEGRATION_TIMINGS: "1"
-          CF_CLI_INTEGRATION_TIMINGS_FILE: "../../test-results/cli-${{ matrix.suite_name }}-cf-timings.log"
+          CF_CLI_INTEGRATION_TIMINGS_FILE: "../../test-results/cli-${{ matrix.timing_name }}-cf-timings.log"
         run: |
           mkdir -p ../../test-results
           : > "$CF_CLI_INTEGRATION_TIMINGS_FILE"
-          API_URL="http://localhost:${TOOLSHED_PORT}" ./integration/${{ matrix.script }}
+          API_URL="http://localhost:${TOOLSHED_PORT}" ./integration/integration.sh
 
       # Space ACL grant/revoke against a real server. Needs the toolshed's
       # default MEMORY_ACL_MODE=enforce, so it deliberately sets no override.
       - name: 🧪 Run CLI ACL integration suite
-        if: ${{ matrix.suite_name == 'acl' }}
+        if: ${{ !cancelled() && matrix.run_acl }}
         timeout-minutes: *cli-work-timeout
         working-directory: packages/cli
         env:
           TOOLSHED_PORT: ${{ matrix.toolshed_port }}
         run: |
-          API_URL="http://localhost:${TOOLSHED_PORT}" ./integration/${{ matrix.script }}
+          API_URL="http://localhost:${TOOLSHED_PORT}" ./integration/acl.sh
+
+      - name: 🔧 Enable FUSE device access
+        if: ${{ !cancelled() && matrix.run_fuse }}
+        run: sudo chmod 666 /dev/fuse
 
       # Deno-based integration tests against the same toolshed. Type checking
       # of the CLI package is done by `deno task check`, so this run skips it.
@@ -761,7 +740,8 @@ jobs:
             --allow-run test/piece-integration.test.ts
 
       - name: 🧪 Run CLI FUSE integration suite
-        if: ${{ matrix.suite_name == 'fuse' }}
+        id: fuse-suite
+        if: ${{ !cancelled() && matrix.run_fuse }}
         timeout-minutes: *cli-fuse-work-timeout
         working-directory: packages/cli
         env:
@@ -776,7 +756,7 @@ jobs:
           set +e
           API_URL="http://localhost:${TOOLSHED_PORT}" \
             FUSE_EXEC_OVERALL_TIMEOUT_SECONDS="${FUSE_STEP_TIMEOUT_SECONDS}" \
-            timeout "${FUSE_STEP_TIMEOUT_SECONDS}" ./integration/${{ matrix.script }}
+            timeout "${FUSE_STEP_TIMEOUT_SECONDS}" ./integration/fuse-exec.sh
           rc=$?
           set -e
           if [ "$rc" -eq 124 ]; then
@@ -785,7 +765,7 @@ jobs:
           exit "$rc"
 
       - name: 📋 FUSE daemon log (on failure)
-        if: ${{ failure() && matrix.suite_name == 'fuse' }}
+        if: ${{ failure() && steps.fuse-suite.outcome == 'failure' }}
         # `cf fuse mount --background` writes its log to /tmp/cf-fuse-<mountpoint>.log
         # (see packages/cli/commands/fuse.ts), not ~/.cf/fuse — the old path always
         # printed "No daemon log found", hiding the real daemon error. The mountpoint
@@ -803,11 +783,11 @@ jobs:
           fi
 
       - name: 📤 Upload CLI integration timing data
-        if: ${{ always() && startsWith(matrix.suite_name, 'core-') }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: test-timing-cli-${{ matrix.suite_name }}
-          path: test-results/cli-${{ matrix.suite_name }}-cf-timings.log
+          name: test-timing-cli-${{ matrix.timing_name }}
+          path: test-results/cli-${{ matrix.timing_name }}-cf-timings.log
           retention-days: 90
           if-no-files-found: ignore
 
@@ -1015,8 +995,8 @@ jobs:
     needs: ["build-cf"]
     strategy:
       matrix:
-        chunk: [1, 2, 3, 4, 5]
-        total: [5]
+        chunk: [1, 2, 3, 4]
+        total: [4]
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v7
@@ -1032,9 +1012,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.compile-cache/pattern-unit-coverage-${{ matrix.chunk }}.json
-          key: cc-pattern-unit-coverage-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.chunk }}-${{ hashFiles('packages/patterns/**/*.ts', 'packages/patterns/**/*.tsx', 'tasks/integration.ts') }}
+          key: cc-pattern-unit-coverage-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.total }}-${{ matrix.chunk }}-${{ hashFiles('packages/patterns/**/*.ts', 'packages/patterns/**/*.tsx', 'tasks/integration.ts') }}
           restore-keys: |
-            cc-pattern-unit-coverage-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.chunk }}-
+            cc-pattern-unit-coverage-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.total }}-${{ matrix.chunk }}-
 
       - name: 🧾 Record compile cache state for the Coverage Check
         uses: ./.github/actions/record-compile-cache-state
@@ -1170,7 +1150,6 @@ jobs:
       - cfcheck
       - pattern-compat
       - pattern-vintage
-      - baselines-append-only
       - test
       - runner-test
       - build-toolshed
@@ -1216,7 +1195,6 @@ jobs:
         "check",
         "pattern-compat",
         "pattern-vintage",
-        "baselines-append-only",
         "build-toolshed",
         "build-bg-piece-service",
         "build-cf",

--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -6,6 +6,14 @@ split, rebalance, or otherwise optimize CI jobs.
 
 ## Current Posture
 
+GitHub's Team plan allows the organization
+[60 parallel hosted runners](https://docs.github.com/en/actions/reference/limits#job-concurrency-limits-for-github-hosted-runners).
+That capacity is shared by every workflow and repository in the organization.
+Keep the first dependency-free wave of this workflow below half the limit so
+two overlapping runs do not queue behind one another and later jobs can start
+as soon as their dependencies finish. Prefer combining short jobs when their
+combined work stays below the existing critical path.
+
 Stop active CI-splitting work when the required test jobs are already in the
 same rough band. As a default, stop when:
 
@@ -208,15 +216,16 @@ missing marker is easy to find and fix.
 ## Step And Job Timeouts
 
 Every work step in `.github/workflows/deno.yml` carries its own
-`timeout-minutes`, and the `timeout-minutes` on the job around it is ten minutes
-larger. The two bounds do different things when they are reached. GitHub ends a
-job that runs past the bound on the job by cancelling it, so the job's
-conclusion is `cancelled` — the conclusion that a run stopped by hand or
+`timeout-minutes`, and the `timeout-minutes` on the job around it is at least ten
+minutes larger. The two bounds do different things when they are reached.
+GitHub ends a job that runs past the bound on the job by cancelling it, so the
+job's conclusion is `cancelled` — the conclusion that a run stopped by hand or
 superseded by a newer push also carries, and one that reads as nobody's fault. A
 step that runs past the bound on the step fails, and its job fails with it. The
-ten minutes between the two bounds are what the setup and upload steps around
-the work need, and they mean a wedged test reaches the bound on its step first
-and is reported as a failure.
+headroom between the bounds is what the setup and upload steps around the work
+normally need. An individual wedged step can therefore reach its step bound and
+report a failure before the outer job bound. The outer bound remains the final
+limit when several steps in one job consume unusual amounts of time.
 
 The minutes are written once. The top of the workflow declares them as YAML
 anchors, which GitHub Actions has accepted since September 2025:
@@ -235,10 +244,10 @@ cannot carry a block that a job then overrides.
 
 The CLI integration suites take a second set of anchors, `cli-work-timeout` at
 ten minutes, `cli-fuse-work-timeout` at fifteen, and `cli-job-timeout` at
-twenty-five. Those suites were bounded against a wedge in the FUSE work when
-they were first split up, and the tighter numbers are what that sizing produced.
-A job needing its own bound adds a pair of anchors alongside these rather than a
-number next to the step.
+twenty-five. The combined suite's observed runtime remains comfortably inside
+that outer bound, while the individual work bounds identify an isolated wedged
+suite before the outer bound in normal runs. A job needing its own bound adds a
+pair of anchors alongside these rather than a number next to the step.
 
 The deploy jobs carry no bound at all. A deploy hands the work to a script that
 lives outside this repository, and a bound here would cancel a deploy this

--- a/docs/specs/pattern-update-testing.md
+++ b/docs/specs/pattern-update-testing.md
@@ -18,7 +18,7 @@ The two gates guard different halves of the same risk:
 | | Gate | CI job | What it proves |
 | --- | --- | --- | --- |
 | Tier 1 | `deno task pattern-compat` | Pattern Update Compatibility | The **contract** a pattern declares can still be applied over every contract it has declared before |
-| Tier 2 | `deno task pattern-vintage` | Pattern Update State Continuity | A real **document** written by an older version is still readable, and its data survives |
+| Tier 2 | `deno task pattern-vintage` | Pattern Update State and Baseline Integrity | A real **document** written by an older version is still readable, and its data survives |
 
 Tier 1 is a statement about schemas. Tier 2 proves the stronger thing schemas
 cannot say. Neither subsumes the other: a contract can stay compatible while
@@ -33,8 +33,8 @@ over every contract recorded for it under `packages/patterns/baselines/`.
 There is no opt-in: a pattern is covered by existing.
 
 Baselines are **append-only**, enforced mechanically by
-`tasks/check-baselines-append-only.ts` (CI job: Pattern Baselines
-Append-Only). An author-run `--update` that could remove a baseline could
+`tasks/check-baselines-append-only.ts` in the Pattern Update State and Baseline
+Integrity job. An author-run `--update` that could remove a baseline could
 remove the very one that would have caught a break.
 
 ### Findings and their remedies

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -29,6 +29,19 @@ function jobIds(workflow: string): string[] {
   ].map((match) => match[1]);
 }
 
+function expandedJobCount(job: string): number {
+  const includeRows = [...job.matchAll(/^ {10}- [A-Za-z_][A-Za-z0-9_-]*:/gm)];
+  if (includeRows.length > 0) return includeRows.length;
+
+  const dimensions = [
+    ...job.matchAll(/^ {8}[A-Za-z_][A-Za-z0-9_-]*: \[([^\]]+)\]$/gm),
+  ];
+  return dimensions.reduce(
+    (count, dimension) => count * dimension[1].split(",").length,
+    1,
+  );
+}
+
 function stepBlock(job: string, stepName: string): string {
   const header = `      - name: ${stepName}\n`;
   const start = job.indexOf(header);
@@ -175,6 +188,25 @@ Deno.test("Status waits for every pull request validation job", async () => {
   assertEquals(triggers.includes("\n    paths:"), false);
 });
 
+Deno.test("the first CI wave leaves runner capacity for another run", async () => {
+  const contents = await workflow("deno.yml");
+  const githubParallelRunnerLimit = 60;
+  const firstWaveJobs = jobIds(contents)
+    .map((jobId) => jobBlock(contents, jobId))
+    .filter((job) => !/^ {4}needs:/m.test(job));
+  const firstWaveRunnerCount = firstWaveJobs.reduce(
+    (count, job) => count + expandedJobCount(job),
+    0,
+  );
+
+  assert(
+    firstWaveRunnerCount < githubParallelRunnerLimit / 2,
+    `the dependency-free wave expands to ${firstWaveRunnerCount} jobs; ` +
+      `two overlapping runs must fit within GitHub's ` +
+      `${githubParallelRunnerLimit}-runner limit`,
+  );
+});
+
 Deno.test("every step we name carries a phase marker", async () => {
   // A step whose name starts with no marker in `PHASE_MARKERS` is charted as
   // "other", which is how a job's setup time goes missing from the timings
@@ -203,11 +235,11 @@ Deno.test("every work step is bounded before its job is", async () => {
   // cancelling it, so the job's conclusion is `cancelled` — the same conclusion
   // a run stopped by hand or superseded by a newer push carries, and one that
   // reads as nobody's fault. A step that runs past the step's own bound fails
-  // instead, and its job fails with it. So each work step carries a bound of
-  // its own, below the bound on the job by the headroom the setup and upload
-  // steps around it need, and a wedged test is reported as a failure. Both
-  // bounds are aliases to an anchor, so each is a name here rather than a
-  // number, and the minutes behind the names are written once.
+  // instead, and its job fails with it. Each work step therefore carries a
+  // bound of its own, below the bound on the job by the headroom the setup and
+  // upload steps around it normally need. Both bounds are aliases to an anchor,
+  // so each is a name here rather than a number, and the minutes behind the
+  // names are written once.
   const headroom = 10;
   const contents = await workflow("deno.yml");
   const anchors = anchoredMinutes(contents);
@@ -247,7 +279,7 @@ Deno.test("every work step is bounded before its job is", async () => {
         jobBound - stepBound >= headroom,
         `${jobId}: "${step.name}" is bounded at ${stepBound} minutes within a ` +
           `job bounded at ${jobBound}, leaving under ${headroom} minutes ` +
-          `between them, so the job's bound can be the one a wedge hits first`,
+          `between that step bound and the outer job bound`,
       );
     }
   }
@@ -265,20 +297,28 @@ Deno.test("Coverage Comment follows the CI workflow by name", async () => {
 Deno.test("coverage requirements follow sharded test matrices", async () => {
   const contents = await workflow("deno.yml");
   const jobs = [
-    ["test", "coverage-profile-workspace-"],
-    ["runner-test", "coverage-profile-runner-"],
+    ["test", "coverage-profile-workspace-", "shard"],
+    ["runner-test", "coverage-profile-runner-", "shard"],
     [
       "generated-patterns-integration-test",
       "coverage-profile-generated-patterns-",
+      "shard",
     ],
-    ["pattern-integration-test", "coverage-profile-pattern-integration-"],
+    [
+      "pattern-integration-test",
+      "coverage-profile-pattern-integration-",
+      "shard",
+    ],
+    ["pattern-unit-test", "coverage-profile-pattern-unit-", "chunk"],
   ] as const;
 
-  for (const [jobId, artifactPrefix] of jobs) {
+  for (const [jobId, artifactPrefix, dimension] of jobs) {
     const job = jobBlock(contents, jobId);
-    const shardMatch = job.match(/^ {8}shard: \[([0-9, ]+)\]$/m);
+    const shardMatch = job.match(
+      new RegExp(`^ {8}${dimension}: \\[([0-9, ]+)\\]$`, "m"),
+    );
     const totalMatch = job.match(/^ {8}total: \[(\d+)\]$/m);
-    assert(shardMatch, `${jobId} shard matrix not found`);
+    assert(shardMatch, `${jobId} ${dimension} matrix not found`);
     assert(totalMatch, `${jobId} total matrix not found`);
 
     const shards = shardMatch[1].split(",").map((value) =>
@@ -295,11 +335,11 @@ Deno.test("coverage requirements follow sharded test matrices", async () => {
     assertEquals(
       shards,
       Array.from({ length: total }, (_, index) => index + 1),
-      `${jobId} must list every shard exactly once`,
+      `${jobId} must list every ${dimension} exactly once`,
     );
     assertStringIncludes(
       job,
-      `name: ${artifactPrefix}\${{ matrix.shard }}`,
+      `name: ${artifactPrefix}\${{ matrix.${dimension} }}`,
     );
     assertEquals(
       EXPECTED_COVERAGE_ARTIFACT_NAMES.filter((name) =>
@@ -313,20 +353,23 @@ Deno.test("coverage requirements follow sharded test matrices", async () => {
 
 Deno.test("sharded pattern caches follow their shard topology", async () => {
   const contents = await workflow("deno.yml");
-  const topology = "-${{ matrix.total }}-${{ matrix.shard }}-";
   for (
-    const [jobId, selector] of [
+    const [jobId, selector, dimension] of [
       [
         "generated-patterns-integration-test",
         "'tasks/select-generated-pattern-files.ts'",
+        "shard",
       ],
       [
         "pattern-integration-test",
         "'tasks/select-pattern-integration-files.ts'",
+        "shard",
       ],
+      ["pattern-unit-test", "'tasks/integration.ts'", "chunk"],
     ] as const
   ) {
     const job = jobBlock(contents, jobId);
+    const topology = `-\${{ matrix.total }}-\${{ matrix.${dimension} }}-`;
     assertEquals(job.split(topology).length - 1, 2);
     const key = job.match(/^ {10}key: (.+)$/m);
     assert(key, `${jobId} cache key not found`);

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -960,7 +960,7 @@ export const EXPECTED_COVERAGE_ARTIFACT_NAMES = [
   ...[1, 2, 3, 4, 5, 6, 7, 8].map((shard) =>
     `coverage-profile-runner-${shard}`
   ),
-  ...[1, 2, 3].map((shard) => `coverage-profile-generated-patterns-${shard}`),
+  ...[1, 2].map((shard) => `coverage-profile-generated-patterns-${shard}`),
   "coverage-profile-package-runner",
   "coverage-profile-package-runtime-client",
   "coverage-profile-package-shell",
@@ -968,7 +968,7 @@ export const EXPECTED_COVERAGE_ARTIFACT_NAMES = [
     `coverage-profile-pattern-integration-${shard}`
   ),
   "coverage-profile-pattern-reload",
-  ...[1, 2, 3, 4, 5].map((chunk) => `coverage-profile-pattern-unit-${chunk}`),
+  ...[1, 2, 3, 4].map((chunk) => `coverage-profile-pattern-unit-${chunk}`),
 ];
 
 function sampleForRun(

--- a/tasks/integration.test.ts
+++ b/tasks/integration.test.ts
@@ -20,13 +20,13 @@ Deno.test("selectPatternTestFiles assigns every file by stable FNV-1a hash", () 
   ];
 
   const expected = [
-    ["packages/patterns/lunch-poll/multi-user.test.tsx"],
     [
-      "packages/patterns/lunch-poll/main.test.tsx",
+      "packages/patterns/lunch-poll/multi-user.test.tsx",
       "packages/patterns/notes/note.test.tsx",
+      "packages/patterns/record-module-fields.test.tsx",
     ],
-    ["packages/patterns/record-module-fields.test.tsx"],
     ["packages/patterns/record.test.tsx"],
+    ["packages/patterns/lunch-poll/main.test.tsx"],
     ["packages/patterns/notes/notebook.test.tsx"],
   ];
 
@@ -38,9 +38,9 @@ Deno.test("selectPatternTestFiles assigns every file by stable FNV-1a hash", () 
   ) {
     assertEquals(
       Array.from(
-        { length: 5 },
+        { length: 4 },
         (_, index) =>
-          selectPatternTestFiles(paths, { index: index + 1, total: 5 }),
+          selectPatternTestFiles(paths, { index: index + 1, total: 4 }),
       ),
       expected,
     );

--- a/tasks/select-generated-pattern-files.test.ts
+++ b/tasks/select-generated-pattern-files.test.ts
@@ -5,7 +5,7 @@ import {
   selectGeneratedPatternFiles,
 } from "./select-generated-pattern-files.ts";
 
-const TOTAL_SHARDS = 3;
+const TOTAL_SHARDS = 2;
 
 Deno.test("parseShard parses shard notation", () => {
   assertEquals(parseShard("2/4"), { index: 2, total: 4 });


### PR DESCRIPTION
GitHub Team limits the organization to 60 parallel hosted runners. The dependency-free CI wave had grown large enough that two overlapping runs could consume that capacity and queue jobs that were ready to start.

Reduce generated-pattern integration tests from three shards to two, pattern unit tests from five shards to four, and the Common Fabric pattern check from two shards to one. Combine the short ACL, FUSE, and core piece-links CLI suites, and combine pattern vintage replay with the append-only baseline check. Measured and modeled runtimes keep the resulting jobs below the current test-suite long pole.

Keep independent checks running after an earlier check fails and preserve FUSE diagnostics after a suite failure. Retain the existing forty-minute general job bound and twenty-five-minute CLI job bound, which comfortably cover observed runtimes. Clarify that individual step bounds normally identify an isolated wedge while the outer job bound remains the final limit.

Update coverage artifact requirements and include shard topology in pattern unit compile-cache keys. Test that coverage artifacts follow their matrices and that two dependency-free waves fit below the runner limit.

Record the capacity and timeout rules in the CI performance policy. Link the relevant workflow comments directly to those policy sections.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

