### PR TITLE
refactor(patterns): drop the dead ?? fallbacks on Default-typed cell inputs

### DIFF
--- a/packages/patterns/factory-outputs/lot-watch/main.tsx
+++ b/packages/patterns/factory-outputs/lot-watch/main.tsx
@@ -429,52 +429,18 @@ const prepareLotWatchAdminToggle = (
 };
 
 // ============================================================
-// Default seed data
-// ============================================================
-
-const DEFAULT_SPOTS: ParkingSpot[] = [
-  { spotNumber: "1", label: "Near entrance", active: true },
-  { spotNumber: "5", label: "", active: true },
-  { spotNumber: "12", label: "Compact only", active: true },
-  { spotNumber: "13", label: "", active: true },
-];
-
-// ============================================================
 // Pattern
 // ============================================================
 
 export default pattern<LotWatchInput, LotWatchOutput>(
-  ({
-    spots: inputSpots,
-    sightings: inputSightings,
-    people: inputPeople,
-    knownVehicles: inputKnownVehicles,
-    adminRegistry: inputAdminRegistry,
-  }) => {
+  ({ spots, sightings, people, knownVehicles, adminRegistry }) => {
     // ---- Cells (DESIGN §5) ----
+    //
+    // Each optional cell input materializes seeded from its type's `Default<>`
+    // when the caller wires nothing; a parent that owns the cells (e.g.
+    // lot-with-coordinator-demo) shares them by passing them in.
 
-    const spots = inputSpots ?? Writable.perSpace.of(DEFAULT_SPOTS);
-    const sightings = inputSightings ??
-      Writable.perSpace.of<Sighting[]>([]);
-
-    // Phase 3b: known-vehicle registry (guests + offenders). When wired from a
-    // parent space we share the same cell; standalone we own it.
-    const knownVehicles = inputKnownVehicles ??
-      Writable.perSpace.of<KnownVehicle[]>([]);
-
-    // Phase 3b: people cell — read-only for deriving the "ours" vehicle set.
-    // When absent (standalone) the "ours" bucket is empty.
-    const people = inputPeople ??
-      Writable.perSpace.of<PersonWithVehicles[]>([]);
-
-    // DESIGN §6: admin registry + manager credential (mirror coordinator)
-    const defaultAdminRegistry = new Writable.perSpace<
-      LotWatchAdminRegistryValue
-    >(
-      {} as LotWatchAdminRegistryValue,
-    );
-    const adminRegistry: LotWatchAdminRegistryCell = inputAdminRegistry ??
-      defaultAdminRegistry;
+    // DESIGN §6: admin manager credential (mirror coordinator)
     const adminManagerCredential = new Writable.perUser<
       LotWatchAdminManagerCredential | null
     >(null);

--- a/packages/patterns/factory-outputs/parking-coordinator/main.tsx
+++ b/packages/patterns/factory-outputs/parking-coordinator/main.tsx
@@ -407,24 +407,10 @@ export const DEFAULT_SPOTS: ParkingSpot[] = [
 // ============================================================
 
 export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
-  (
-    {
-      spots: inputSpots,
-      people: inputPeople,
-      requests: inputRequests,
-      adminRegistry: inputAdminRegistry,
-    },
-  ) => {
-    const spots = inputSpots ?? Writable.perSpace.of(DEFAULT_SPOTS);
-    const people = inputPeople ?? Writable.perSpace.of<Person[]>([]);
-    const requests = inputRequests ?? Writable.perSpace.of<SpotRequest[]>([]);
-    const defaultAdminRegistry = new Writable.perSpace<
-      ParkingAdminRegistryValue
-    >(
-      {} as ParkingAdminRegistryValue,
-    );
-    const adminRegistry: ParkingAdminRegistryCell = inputAdminRegistry ??
-      defaultAdminRegistry;
+  ({ spots, people, requests, adminRegistry }) => {
+    // Each optional cell input materializes seeded from its type's `Default<>`
+    // when the caller wires nothing; a parent that owns the cells (e.g.
+    // lot-with-coordinator-demo) shares them by passing them in.
     const adminManagerCredential = new Writable.perUser<
       ParkingAdminManagerCredential | null
     >(null);

--- a/packages/patterns/google/core/experimental/gmail-agentic-search.tsx
+++ b/packages/patterns/google/core/experimental/gmail-agentic-search.tsx
@@ -1018,9 +1018,11 @@ const GmailAgenticSearch = pattern<
     // AUTH HANDLING
     // ========================================================================
 
-    // Check if we have direct auth input.
-    const directAuth = inputAuth ?? null;
-    const hasDirectAuth = directAuth !== null;
+    // Direct auth is detected by value: the optional input materializes as a
+    // present cell whether or not a parent wired it, so a token in the cell —
+    // not the cell itself — is the signal that direct auth was provided.
+    const directAuthValue = computed(() => inputAuth?.get());
+    const hasDirectAuth = !!directAuthValue?.token;
 
     // Local writable cell for account type selection
     // Input `accountType` may be read-only (Default cells are read-only when using default value)
@@ -1128,7 +1130,7 @@ const GmailAgenticSearch = pattern<
     // When hasDirectAuth is false, we use wishedAuth from the utility.
     // This means inputAuth must be passed as a live cell reference, not derived.
     // See: community-docs/superstitions/2025-12-03-derive-creates-readonly-cells-use-property-access.md
-    const auth = hasDirectAuth ? directAuth : wishedAuth;
+    const auth = inputAuth && hasDirectAuth ? inputAuth : wishedAuth;
 
     // ========================================================================
     // CROSS-PIECE TOKEN REFRESH


### PR DESCRIPTION
## Problem

An unset optional cell input materializes as a present (empty-valued) cell, so in

```tsx
const spots = inputSpots ?? Writable.perSpace.of(DEFAULT_SPOTS);
```

the `??` always keeps `inputSpots` and the right-hand branch has never run. lot-watch and parking-coordinator carried nine of these seams ("wired from a parent → share; standalone → own"): the share half worked; the own half was dead code, with standalone writes landing in the input slot rather than the intended owned cell. gmail-agentic-search had the same bug one level up: `inputAuth ?? null` made `hasDirectAuth` always true, so its wish-based auth fallback was unreachable.

## Fix

**factory-outputs (behavior-preserving):** delete the seams and bind the inputs directly. The inputs' own `Default<>` declarations already seed what the dead branches meant to provide, at creation and on pattern update:

- `[]` for the list cells (sightings, knownVehicles, people, requests)
- `{}` (`EmptyAdminRegistryValue`) for both admin registries
- the spots seed via each `SpotsCell`'s `Default<[...]>` literal — parking-coordinator's matches its `DEFAULT_SPOTS` field-for-field; lot-watch's omits `active`, which both consumers read as active (`isActive === undefined || isActive === true`)

lot-watch's local `DEFAULT_SPOTS` becomes dead and goes with the seams. parking-coordinator's stays exported for lot-with-coordinator-demo and the tests.

**gmail-agentic-search (behavior change on the unset path):** detect direct auth by value — a token in the cell, not the cell's presence — the same detection gmail-importer already uses. Standalone pieces now fall through to `createGoogleAuthUtil` as intended; wish-based auth discovery becomes reachable for the first time.

Same class as CT-1669 (self.tsx), where `Default<>` is already the established idiom. A transformer rule to reject the bare optional-cell spelling outright is in discussion; this clears the known in-tree seams ahead of it (two handler-state candidates in lobby are excluded pending a separate question about handler-state materialization).

## Verification

- `cf check` on all three patterns
- `cf test --root packages/patterns` — lot-watch 31/0, parking-coordinator 63/0 (including the bare `LotWatch({})` standalone instantiations that exercise the migrated path), gmail-agentic-search 15/0
- `deno fmt --check`, `deno lint`, `deno task check`
- `packages/patterns` `deno task test`
- `deno task pattern-compat` over both commits (input schemas are unchanged — body-only diffs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)