### PR TITLE
fix(ts-transformers): read inline callback arguments through parentheses at every extraction seam

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -599,7 +599,8 @@ Diagnostics emitted in all modes:
     `computed(() => ...)`, module-scope `lift()`, or a helper.
 - **Error** `pattern-context:patterntool-requires-pattern`
   - `patternTool(fn, ...)` where the first argument is a bare callback (arrow /
-    function expression) rather than a `pattern(...)`. The runtime/transformer
+    function expression, read through transparent parentheses) rather than a
+    `pattern(...)`. The runtime/transformer
     auto-wrapping (`pattern(fn)`) and auto-capture were removed in CT-1655;
     authors now wrap explicitly: `patternTool(pattern(fn), extraParams?)`. The
     diagnostic is reported on the bare-callback argument.
@@ -1015,6 +1016,10 @@ Transform eligibility:
   the read itself is the thing being lowered, and the expression-site
   machinery owns it (§6.5); inside standalone hardened functions the eager
   `<cell>.get().filter(...)` spelling stays untouched plain JavaScript
+- the inline callback argument is read through transparent parentheses:
+  `receiver.map(((r) => ...))` lowers exactly like the bare spelling
+  (target-language spec §5.7 paren-invariance; fixture
+  `map-paren-wrapped-callback` pins the emission)
 - transformed callbacks are marked in `mapCallbackRegistry` and become
   pattern-callback contexts for downstream classification
 - synthetic compute-owned array-method nodes assert that stale pattern ownership

--- a/packages/ts-transformers/src/closures/strategies/array-method-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/array-method-strategy.ts
@@ -5,6 +5,7 @@ import {
   isFunctionLikeExpression,
   type ReactiveContextInfo,
 } from "../../ast/mod.ts";
+import { unwrapExpression } from "../../utils/expression.ts";
 import { shouldTransformArrayMethod } from "./array-method-policy.ts";
 import { transformArrayMethodCallback } from "./array-method-transform.ts";
 import { rewriteArrayMethodCallbackExpressionSites } from "../../transformers/expression-site-lowering.ts";
@@ -30,7 +31,9 @@ export function transformArrayMethodCall(
     return undefined;
   }
 
-  const callback = node.arguments[0];
+  // Read the callback through paren spelling — a blind read here skips the
+  // lowering and a raw reactive method call reaches the runtime.
+  const callback = node.arguments[0] && unwrapExpression(node.arguments[0]);
   if (callback && isFunctionLikeExpression(callback)) {
     assertValidSyntheticComputeOwnedArrayMethodContext(
       node,

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -2625,7 +2625,8 @@ export function analyzeFunctionCapabilities(
         return;
       }
 
-      const callbackArg = call.arguments[0];
+      const callbackArg = call.arguments[0] &&
+        unwrapExpression(call.arguments[0]);
       if (!callbackArg || !isCapabilityAnalyzableFunction(callbackArg)) {
         return;
       }

--- a/packages/ts-transformers/src/transformers/assert-diagnostics.ts
+++ b/packages/ts-transformers/src/transformers/assert-diagnostics.ts
@@ -125,7 +125,7 @@ function rewriteAssertCall(
   node: ts.CallExpression,
   context: TransformationContext,
 ): ts.Node | undefined {
-  const callback = node.arguments[0];
+  const callback = node.arguments[0] && unwrapExpression(node.arguments[0]);
   if (
     !callback ||
     (!ts.isArrowFunction(callback) && !ts.isFunctionExpression(callback))

--- a/packages/ts-transformers/src/transformers/expression-site-lowering.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-lowering.ts
@@ -7,6 +7,7 @@ import {
   visitEachChildWithJsx,
 } from "../ast/mod.ts";
 import type { TransformationContext } from "../core/mod.ts";
+import { unwrapExpression } from "../utils/expression.ts";
 import { shouldTransformArrayMethod } from "../closures/strategies/array-method-policy.ts";
 import { transformArrayMethodCallback } from "../closures/strategies/array-method-transform.ts";
 import {
@@ -232,7 +233,9 @@ function rewriteLateArrayMethodCallbackCall(
   context: TransformationContext,
   visit: ts.Visitor,
 ): ts.CallExpression | undefined {
-  const callback = node.arguments[0];
+  // Read the callback through paren spelling — a blind read here skips the
+  // lowering and a raw reactive method call reaches the runtime.
+  const callback = node.arguments[0] && unwrapExpression(node.arguments[0]);
   if (!callback || !isFunctionLikeExpression(callback)) {
     return undefined;
   }

--- a/packages/ts-transformers/src/transformers/pattern-context-validation.ts
+++ b/packages/ts-transformers/src/transformers/pattern-context-validation.ts
@@ -42,6 +42,7 @@
 import ts from "typescript";
 import { COMMONFABRIC_REACTIVE_ORIGIN_BUILDER_NAMES } from "../core/commonfabric-runtime-registry.ts";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
+import { unwrapExpression } from "../utils/expression.ts";
 import {
   classifyArrayMethodCallSite,
   detectCallKind,
@@ -941,7 +942,7 @@ export class PatternContextValidationTransformer
     if (detectCallKind(node, checker)?.kind !== "pattern-tool") {
       return;
     }
-    const firstArg = node.arguments[0];
+    const firstArg = node.arguments[0] && unwrapExpression(node.arguments[0]);
     if (
       !firstArg ||
       !(ts.isArrowFunction(firstArg) || ts.isFunctionExpression(firstArg))

--- a/packages/ts-transformers/src/transformers/schema-generator.ts
+++ b/packages/ts-transformers/src/transformers/schema-generator.ts
@@ -15,6 +15,7 @@ import {
   HelpersOnlyTransformer,
   TransformationContext,
 } from "../core/mod.ts";
+import { unwrapExpression } from "../utils/expression.ts";
 import { createPropertyName } from "../utils/identifiers.ts";
 import { normalizeWriterIdentityFile } from "../utils/writer-identity-file.ts";
 import { compileCfcPolicyManifestsForSource } from "./cfc-policy-authoring.ts";
@@ -87,7 +88,7 @@ export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
           );
         }
 
-        const arg0 = node.arguments[0];
+        const arg0 = node.arguments[0] && unwrapExpression(node.arguments[0]);
         let optionsObj: Record<string, unknown> = {};
         let widenLiterals: boolean | undefined;
         if (arg0 && ts.isObjectLiteralExpression(arg0)) {

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -3751,7 +3751,8 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
       if (callKind?.kind === "builder" && callKind.builderName === "lift") {
         const factory = transformation.factory;
 
-        const firstArgument = node.arguments[0];
+        const firstArgument = node.arguments[0] &&
+          unwrapExpression(node.arguments[0]);
         if (firstArgument && isToSchemaCall(firstArgument)) {
           const argumentType = firstArgument.typeArguments?.[0];
           const liftCallback = resolveFunctionLikeExpression(

--- a/packages/ts-transformers/test/assert-diagnostics.test.ts
+++ b/packages/ts-transformers/test/assert-diagnostics.test.ts
@@ -68,6 +68,18 @@ Deno.test("assert records the operands of a comparison", async () => {
   assertEquals(recordSource(root), "a.get() + b.get() <= c.get()");
 });
 
+Deno.test("assert records through a parenthesized callback", async () => {
+  const root = await transformed(patternSource(`
+  const check = assert((() => a.get() + b.get() <= c.get()));
+  return { check };`));
+
+  assertEquals(assertCaptures(root), [
+    { src: "a.get() + b.get()", value: "a.get() + b.get()" },
+    { src: "c.get()", value: "c.get()" },
+  ]);
+  assertEquals(recordSource(root), "a.get() + b.get() <= c.get()");
+});
+
 Deno.test("assert records the arguments of a call", async () => {
   const root = await transformed(patternSource(`
   const check = assert(() => Object.is(a.get(), b.get()));

--- a/packages/ts-transformers/test/fixtures/closures/map-paren-wrapped-callback.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-paren-wrapped-callback.expected.jsx
@@ -1,0 +1,91 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { pattern } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+interface Row {
+    label: string;
+}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const r = __cf_pattern_input.key("element");
+    return r.key("label");
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Row"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                }
+            },
+            required: ["label"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
+// FIXTURE: map-paren-wrapped-callback
+// Verifies: a parenthesized inline map callback lowers exactly like its bare
+//   spelling — rows.map(((r) => r.label)) → rows.mapWithPattern(pattern(...))
+// Context: paren-invariance (target spec §5.7) at the extraction seam; a blind
+//   arguments[0] read here once skipped the lowering entirely, emitting a raw
+//   reactive .map that throws at runtime
+export default pattern((__cf_pattern_input) => {
+    const rows = __cf_pattern_input.key("rows");
+    const out = rows.mapWithPattern(__cfPattern_1, {}).for("out", true);
+    return { out };
+}, {
+    type: "object",
+    properties: {
+        rows: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Row"
+            }
+        }
+    },
+    required: ["rows"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                }
+            },
+            required: ["label"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        out: {
+            type: "array",
+            items: {
+                type: "string"
+            }
+        }
+    },
+    required: ["out"]
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-paren-wrapped-callback.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-paren-wrapped-callback.input.tsx
@@ -1,0 +1,16 @@
+import { pattern } from "commonfabric";
+
+interface Row {
+  label: string;
+}
+
+// FIXTURE: map-paren-wrapped-callback
+// Verifies: a parenthesized inline map callback lowers exactly like its bare
+//   spelling — rows.map(((r) => r.label)) → rows.mapWithPattern(pattern(...))
+// Context: paren-invariance (target spec §5.7) at the extraction seam; a blind
+//   arguments[0] read here once skipped the lowering entirely, emitting a raw
+//   reactive .map that throws at runtime
+export default pattern<{ rows: Row[] }>(({ rows }) => {
+  const out = rows.map(((r) => r.label));
+  return { out };
+});

--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -4414,6 +4414,29 @@ Deno.test("Standalone Function Validation", async (t) => {
   );
 
   await t.step(
+    "errors when patternTool's first argument is a parenthesized bare callback",
+    async () => {
+      const source =
+        `      import { patternTool, computed, Cell } from "commonfabric";
+
+      declare const multiplier: Cell<number>;
+
+      const tool = patternTool((({ query }: { query: string }) => {
+        return computed(() => query.length * multiplier.get());
+      }));
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertHasErrorType(
+        errors,
+        "pattern-context:patterntool-requires-pattern",
+      );
+    },
+  );
+
+  await t.step(
     "keeps unresolved patternTool callbacks in compute context",
     async () => {
       const source = `      const helpers: Record<string, unknown> = {};


### PR DESCRIPTION
Completes the audit #5919 started, one axis of it: everywhere the package answers "which node is this call's argument" now agrees with the boundary/site classifiers about parenthesized spellings. The sweep classified every bare `arguments[N]` read (62) and every `isParenthesizedExpression` site (~35) in the package — and found one real bug that #5919 itself had newly exposed.

## Problem

The boundary classifiers (post-#5919) read a callback's argument position through transparent parentheses, but several extraction seams still read `arguments[0]` blind. Where the two layers disagree, the paren spelling slips between them. The worst case miscompiled:

```tsx
const out = rows.map(((r) => r.label));   // rows: reactive collection
```

passed validation clean — the callback-boundary classifier sees the callback — while the array-method lowering skipped it — its extraction does not — so the emitted pattern kept a raw reactive `.map`, which throws at runtime ("Reactive.map(fn) is no longer supported"). Before #5919 the spurious `pattern-context:function-creation` rejection masked the hole; #5919 removed the rejection without the extraction seams learning to see through the spelling.

## Fix

The paren-wrapped spelling of an inline callback now extracts like its bare spelling at every seam (via `unwrapExpression`, matching the cast-inclusive vocabulary the package's callback resolvers already use):

- **Array-method lowering entries** (`transformArrayMethodCall`, `rewriteLateArrayMethodCallbackCall`) — closes the miscompile. Fixture `map-paren-wrapped-callback` pins the emission; body and JSX positions probe-verified byte-identical to the bare twin.
- **`validatePatternToolFirstArgument`** — the CT-1655 bare-callback diagnostic is no longer dodged by parentheses (pinned).
- **`rewriteAssertCall`** — a parenthesized assert thunk keeps its parts-capture rewrite (pinned).
- **The eager array-callback capability walk** — a parenthesized comparator no longer silently skips capability analysis.
- **Authored `lift(toSchema<T>(), …)` recognition** and **`toSchema(options)`** — schema derivation sees through the spelling.

## Audit: sites classified and left alone

- `isMapWithPatternCallbackPatternCall` (schema-injection) and the pattern-callback-lowering position test recognize shapes **this package itself emits**; a parenthesized argument there would mean a broken emitter, so the strict test is the invariant — left strict deliberately.
- Index-based change-detection loops (assert-diagnostics, rewrite-expression) compare a mapped list against itself — not position tests.
- Every remaining `isParenthesizedExpression` site is a downward unwrapper or an upward wrapper-walk that already includes parentheses; the `arguments[N]` extraction reads not listed above feed resolvers that already strip wrappers (`resolveCallbackFunctionExpression`, `resolveFunctionLikeExpression`, `unwrapExpr`, `evaluateStatic`).

## Verification

- Emission twins verified: `rows.map(((r) => r.label))` now lowers to `mapWithPattern(__cfPattern_1, {})` identically to the bare spelling, in a body binding and inside a JSX expression; golden fixture added
- New pins: parenthesized patternTool bare-callback still draws `pattern-context:patterntool-requires-pattern`; parenthesized assert thunk keeps operand capture
- Full package suite 1141/0; repo-wide `deno fmt --check`, `deno lint`, `deno task check`, `check-docs` 554/554 (mise, deno 2.9.4)
- Current-behavior spec updated in step: §9.4 gains the extraction paren-invariance bullet; §6 patternTool entry names the paren-transparent read

A sibling PR stacked on this one closes the remaining semantic hole (`isStandaloneFunctionDefinition`) and adds a systematic paren-twin battery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

