### PR TITLE
fix(ts-transformers): a parenthesized standalone function is standalone, plus a paren-twin battery

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -501,7 +501,9 @@ Diagnostics emitted in all modes:
     spelling of the read (`layout["get"]()`) do not change the decision, and
     neither does optionality — `layout?.get()` and `layout?.get?.()` on a cell
     lower like their non-optional spellings, per the 2026-07-23
-    optionality-orthogonality resolution. Each lift's input schema shrinks to
+    optionality-orthogonality resolution. The bare/parenthesized spelling
+    pairs across site kinds are pinned by the `test/validation.test.ts`
+    "Paren-Invariance Twins" battery. Each lift's input schema shrinks to
     what its body reads (`test/validation.test.ts:3179`; goldens
     `cell-get-binding-autowrap`, `cell-get-terminal-binding-autowrap`,
     `with-reactive`). This is the ratified has-a-lowerable-site rule —
@@ -542,6 +544,9 @@ Diagnostics emitted in all modes:
   - in standalone functions (except inline first arg to `patternTool`):
     `computed(...)`, `lift(...)`, or reactive collection methods on reactive
     receivers
+  - what counts as a standalone definition is read through transparent
+    parentheses: `const helper = (() => ...)` is validated (and context-
+    classified) like its bare spelling
   - collection-method diagnostics currently use `.map(...)`-style guidance and
     suggest eager `<cell>.get().map(...)` when explicit eager mapping is
     acceptable

--- a/docs/specs/ts-transformer/ts_transformers_target_pattern_language_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_target_pattern_language_spec.md
@@ -555,9 +555,10 @@ The intended split is:
      - `const sorted = rows.get().toSorted(byDate)`
      - JSX expression sites like `{input.key("foo").get()}`
      - `ifElse(show, count.get(), 0)`
-   - the spelling of the read does not change the classification: parentheses
-     around the site, the computed-key form `cell["get"]()`, and the optional
-     forms `cell?.get()` and `cell.get?.()` all follow the same rule (§5.6)
+   - the spelling of the read does not change the classification
+     (paren-invariance): parentheses around the site, the computed-key form
+     `cell["get"]()`, and the optional forms `cell?.get()` and `cell.get?.()`
+     all follow the same rule (§5.6)
 4. **eager read with no lowerable expression site**
    - not part of the target language, even for true cells — there is no site
      to lower into a lift, so the read cannot be kept live

--- a/packages/ts-transformers/src/ast/reactive-context.ts
+++ b/packages/ts-transformers/src/ast/reactive-context.ts
@@ -131,13 +131,18 @@ export function isStandaloneFunctionDefinition(
     return true;
   }
 
-  const parent = func.parent;
+  // Parentheses around the function are spelling: `const f = ((x) => x)`
+  // defines the same standalone function as the bare initializer, and must
+  // reach the same standalone validation and context classification.
+  let parent: ts.Node | undefined = func.parent;
+  while (parent && ts.isParenthesizedExpression(parent)) {
+    parent = parent.parent;
+  }
+  if (!parent) return false;
   if (ts.isVariableDeclaration(parent)) return true;
   if (ts.isPropertyAssignment(parent)) return true;
-  if (ts.isCallExpression(parent) && parent.arguments.includes(func)) {
-    return false;
-  }
-  if (ts.isJsxExpression(parent)) return false;
+  // Everything else — call arguments, JSX expressions, operands — is an
+  // inline use, owned by whatever consumes it.
   return false;
 }
 

--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -4287,6 +4287,26 @@ Deno.test("Standalone Function Validation", async (t) => {
     },
   );
 
+  await t.step(
+    "errors on computed() inside a parenthesized standalone function",
+    async () => {
+      const source = `      import { computed, Cell } from "commonfabric";
+
+      declare const count: Cell<number>;
+
+      const helper = (() => {
+        return computed(() => count.get() * 2);
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertGreater(errors.length, 0, "Expected at least one error");
+      assertHasErrorType(errors, "standalone-function:reactive-operation");
+    },
+  );
+
   const builderFactoryCases = [
     {
       name: "action()",
@@ -4945,4 +4965,237 @@ Deno.test("Module-extracted reactive callback bodies (CT-1587)", async (t) => {
       assert(hasKeyPathRead(root, "0", "foo"));
     },
   );
+});
+
+Deno.test("Paren-Invariance Twins", async (t) => {
+  // Target-language spec §5.7: parentheses around a site are spelling and do
+  // not change its classification. Each step validates a bare/parenthesized
+  // source pair: the bare spelling must match the expected diagnostic types
+  // (so a twin can never pass because both sides broke the same way), and the
+  // parenthesized spelling must reproduce the bare spelling exactly.
+  const assertTwins = async (
+    bare: string,
+    paren: string,
+    expectedBareErrorTypes: string[],
+  ) => {
+    const bareResult = await validateSource(bare, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const parenResult = await validateSource(paren, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const typesOf = (diagnostics: typeof bareResult.diagnostics) =>
+      getErrors(diagnostics).map((error) => error.type).sort();
+    assertEquals(
+      typesOf(bareResult.diagnostics),
+      expectedBareErrorTypes.slice().sort(),
+      "bare spelling expectation",
+    );
+    assertEquals(
+      typesOf(parenResult.diagnostics),
+      typesOf(bareResult.diagnostics),
+      "parenthesized spelling matches its bare twin",
+    );
+  };
+
+  const countPattern = (body: string) =>
+    `      import { pattern, Writable } from "commonfabric";
+
+      export default pattern<{ count: Writable<number> }>(({ count }) => {
+        ${body}
+      });
+    `;
+
+  const rowsPattern = (body: string) =>
+    `      import { pattern, Writable } from "commonfabric";
+
+      interface Row {
+        sentAt?: number;
+        label: string;
+      }
+
+      export default pattern<{ rows: Writable<Row[]> }>(({ rows }) => {
+        ${body}
+      });
+    `;
+
+  await t.step("variable-initializer site", async () => {
+    await assertTwins(
+      countPattern(`const v = count.get();
+        return { v };`),
+      countPattern(`const v = (count.get());
+        return { v };`),
+      [],
+    );
+  });
+
+  await t.step("object-property site", async () => {
+    await assertTwins(
+      countPattern(`return { value: count.get() };`),
+      countPattern(`return { value: (count.get()) };`),
+      [],
+    );
+  });
+
+  await t.step("array-element site", async () => {
+    await assertTwins(
+      countPattern(`return { list: [count.get()] };`),
+      countPattern(`return { list: [(count.get())] };`),
+      [],
+    );
+  });
+
+  await t.step("call-argument site", async () => {
+    const bare =
+      `      import { ifElse, pattern, Writable } from "commonfabric";
+
+      export default pattern<{ count: Writable<number>; show: boolean }>(
+        ({ count, show }) => {
+          return { v: ifElse(show, count.get(), 0) };
+        },
+      );
+    `;
+    const paren =
+      `      import { ifElse, pattern, Writable } from "commonfabric";
+
+      export default pattern<{ count: Writable<number>; show: boolean }>(
+        ({ count, show }) => {
+          return { v: ifElse(show, (count.get()), 0) };
+        },
+      );
+    `;
+    await assertTwins(bare, paren, []);
+  });
+
+  await t.step("computation-over-read site", async () => {
+    await assertTwins(
+      countPattern(`const v = count.get() * 2;
+        return { v };`),
+      countPattern(`const v = (count.get()) * 2;
+        return { v };`),
+      [],
+    );
+  });
+
+  await t.step("receiver-chain site", async () => {
+    await assertTwins(
+      rowsPattern(`const s = rows.get().map((r) => r.label).join(",");
+        return { s };`),
+      rowsPattern(`const s = (rows.get()).map((r) => r.label).join(",");
+        return { s };`),
+      [],
+    );
+  });
+
+  await t.step("JSX expression site", async () => {
+    const bare = `      import { h, pattern, Writable } from "commonfabric";
+
+      export default pattern<{ count: Writable<number> }>(({ count }) => {
+        return { ui: <div>{count.get()}</div> };
+      });
+    `;
+    const paren = `      import { h, pattern, Writable } from "commonfabric";
+
+      export default pattern<{ count: Writable<number> }>(({ count }) => {
+        return { ui: <div>{(count.get())}</div> };
+      });
+    `;
+    await assertTwins(bare, paren, []);
+  });
+
+  await t.step("statement-position read stays rejected", async () => {
+    await assertTwins(
+      countPattern(`count.get();
+        return { done: true };`),
+      countPattern(`(count.get());
+        return { done: true };`),
+      ["pattern-context:get-call"],
+    );
+  });
+
+  await t.step("inline comparator with optional access", async () => {
+    await assertTwins(
+      rowsPattern(
+        `const sorted = rows.get().toSorted((a, b) =>
+          (a?.sentAt ?? 0) - (b?.sentAt ?? 0)
+        );
+        return { sorted };`,
+      ),
+      rowsPattern(
+        `const sorted = rows.get().toSorted(((a, b) =>
+          (a?.sentAt ?? 0) - (b?.sentAt ?? 0)
+        ));
+        return { sorted };`,
+      ),
+      [],
+    );
+  });
+
+  await t.step("parenthesized reactive map callback", async () => {
+    await assertTwins(
+      rowsPattern(`const out = rows.map((r) => r.label);
+        return { out };`),
+      rowsPattern(`const out = rows.map(((r) => r.label));
+        return { out };`),
+      [],
+    );
+  });
+
+  await t.step("parenthesized builder callback", async () => {
+    const bare =
+      `      import { computed, pattern, Writable } from "commonfabric";
+
+      export default pattern<{ count: Writable<number> }>(({ count }) => {
+        const doubled = computed(() => count.get() * 2);
+        return { doubled };
+      });
+    `;
+    const paren =
+      `      import { computed, pattern, Writable } from "commonfabric";
+
+      export default pattern<{ count: Writable<number> }>(({ count }) => {
+        const doubled = computed((() => count.get() * 2));
+        return { doubled };
+      });
+    `;
+    await assertTwins(bare, paren, []);
+  });
+
+  await t.step("standalone helper with reactive operation", async () => {
+    const bare = `      import { computed, Cell } from "commonfabric";
+
+      declare const count: Cell<number>;
+
+      const helper = () => {
+        return computed(() => count.get() * 2);
+      };
+    `;
+    const paren = `      import { computed, Cell } from "commonfabric";
+
+      declare const count: Cell<number>;
+
+      const helper = (() => {
+        return computed(() => count.get() * 2);
+      });
+    `;
+    await assertTwins(bare, paren, [
+      "standalone-function:reactive-operation",
+    ]);
+  });
+
+  await t.step("parenthesized JSX event handler", async () => {
+    const bare = `      import { h, pattern, Writable } from "commonfabric";
+
+      export default pattern<{ count: Writable<number> }>(({ count }) => {
+        return { ui: <button onClick={() => count.set(1)}>x</button> };
+      });
+    `;
+    const paren = `      import { h, pattern, Writable } from "commonfabric";
+
+      export default pattern<{ count: Writable<number> }>(({ count }) => {
+        return { ui: <button onClick={(() => count.set(1))}>x</button> };
+      });
+    `;
+    await assertTwins(bare, paren, []);
+  });
 });


### PR DESCRIPTION
Follow-up to #5939 (landed; this branch is rebased onto main with it in). Several battery steps pin behavior that PR fixed, which is why the two shipped as a stack.

## Problem

`isStandaloneFunctionDefinition` read the function's literal parent, so a parenthesized initializer spelling was not recognized as a standalone definition:

```ts
const helper = (() => {
  return computed(() => count.get() * 2);
});
```

Two consequences, both twin-divergent. `validateStandaloneFunction` never ran on it — a `standalone-function:reactive-operation` violation could hide behind the parentheses (a leniency hole: the spelling dodges a validator). And `classifyReactiveContext` denied its body the compute/standalone classification the bare spelling gets, so diagnostics inside such a function could cascade differently.

## Fix

The standalone determination walks up transparent parentheses before testing the parent, for the initializer and property-assignment positions. Call arguments, JSX expressions, and operands remain inline uses owned by their consumer — parens or not.

## The battery

`test/validation.test.ts` gains a **"Paren-Invariance Twins"** group: the systematic pin for the target-language spec's §5.7 clause. Each step validates a bare/parenthesized source pair and asserts two things — the bare spelling produces exactly the expected diagnostic types (so a twin can never pass because both sides broke identically), and the parenthesized spelling reproduces the bare spelling's diagnostics exactly. Coverage:

- the eight lowerable site kinds: variable initializer, object property, array element, call argument (`ifElse`), computation-over-read, receiver chain, JSX expression — all accepting in both spellings — plus the statement-position read rejecting identically in both
- the inline-callback surfaces: optional-access comparator (#5797/#5919's shape), reactive `map` callback (#5939's shape), builder callback (`computed`), and a JSX event handler
- the standalone-helper rejection this PR closes

Instrument-validated: with this PR's fix stashed, exactly the standalone step fails and everything else passes — the battery is load-bearing, not decorative.

## Verification

- Full package suite 1142/0; repo-wide `deno fmt --check`, `deno lint`, `deno task check`, `check-docs` 554/554 (mise, deno 2.9.4)
- New pin in the Standalone Function Validation group: the parenthesized helper draws `standalone-function:reactive-operation` like its bare twin
- Current-behavior spec: §6 standalone entry states the paren-transparent determination; the get-call entry cites the battery as the spelling-pair pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


