### PR TITLE
feat(piece): the space names its slugs — an index setSlugLink maintains, and cf piece slugs reads

### DIFF
--- a/docs/common/concepts/piece-discovery.md
+++ b/docs/common/concepts/piece-discovery.md
@@ -27,6 +27,19 @@ These are not storage-wide piece listings. In particular, `cf piece search`
 does not return an unregistered piece just because a registered piece links to
 data owned by it.
 
+## The Slug Index Is the Namespace Root
+
+Slugs have their own discovery boundary, beside the registry's. A slug document
+lives at an ID derived from its name, so nothing can enumerate slugs it was
+never told the names of. The space's **slug index** — one document naming every
+slug assigned through `--slug` or `set-slug` — is what makes the namespace
+enumerable: `cf piece slugs` lists it, resolving each name to the piece it
+addresses. The index records the names only; where a name points remains the
+slug document's own answer. It records assignments made since it existed, so a
+slug written by an older client still resolves but is not listed. A slug may
+also name an unregistered piece, which makes the slug listing a discovery path
+the registry does not have.
+
 ## Finding Pieces Outside the Registry
 
 The ordinary piece-discovery surfaces can find a piece outside the registry

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -118,6 +118,12 @@ positional path spelling.
 the default pattern and starts each registered piece to obtain its name and
 pattern metadata. It does not enumerate every stored piece root.
 
+`cf piece slugs` lists the space's slug index: every name assigned through
+`--slug` or `set-slug`, each resolved to the piece it names. The index records
+assignments made since it existed, so a slug written by an older client still
+resolves but is not listed — a slug document's id is derived from its name, and
+nothing can enumerate names it was never told.
+
 `cf piece search` also starts from the registry. It searches readable input and
 result data, but returns registered pieces only. `cf piece map` likewise shows
 connections among registered pieces rather than walking the complete stored

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -44,6 +44,7 @@ import {
   LinkValidationError,
   listPieceCallables,
   listPieces,
+  listSpaceSlugs,
   MapFormat,
   newPiece,
   partitionVerbListing,
@@ -260,6 +261,36 @@ export function renderPieceSummaries(
       piece.id,
       piece.error ? `<error: ${piece.error}>` : (piece.name ?? "<unnamed>"),
       piece.error ? "" : formatPatternRef(piece.patternRef),
+    ]),
+  ];
+  if (rows.length > 1) render(Table.from(rows).toString());
+}
+
+/** `cf piece slugs` output: one row per indexed name, the piece it resolves
+ * to where it resolves to one, and the resolution's own error where it does
+ * not. The error rides the JSON too — a machine reader has no table to read
+ * a `<error: …>` marker off. */
+export function renderSlugSummaries(
+  slugs: Array<{ slug: string; piece?: string; error?: string }>,
+  json: boolean,
+): void {
+  if (json) {
+    render(
+      slugs.map((entry) => ({
+        slug: entry.slug,
+        piece: entry.piece ?? null,
+        ...(entry.error !== undefined ? { error: entry.error } : {}),
+      })),
+      { json: true },
+    );
+    return;
+  }
+
+  const rows = [
+    ["SLUG", "PIECE"],
+    ...slugs.map((entry) => [
+      entry.slug,
+      entry.error !== undefined ? `<error: ${entry.error}>` : entry.piece!,
     ]),
   ];
   if (rows.length > 1) render(Table.from(rows).toString());
@@ -1672,6 +1703,20 @@ export const piece = targetOptions(
   )
   .option("--json", "Output machine-readable JSON.")
   .action(listPiecesFromCommand)
+  /* piece slugs */
+  .command(
+    "slugs",
+    "List the space's slugs and the piece each resolves to. The index " +
+      "covers slugs assigned since it existed; an older slug still " +
+      "resolves but is not listed.",
+  )
+  .usage(spaceUsage)
+  .example(
+    cliText(`cf piece slugs ${EX_ID} ${EX_COMP}`),
+    `List the slugs of "${RAW_EX_COMP.space}".`,
+  )
+  .option("--json", "Output machine-readable JSON.")
+  .action(listSlugsFromCommand)
   /* piece search */
   .command("search", "Search input and result data in registered pieces.")
   .usage(`${spaceUsage} <query>`)
@@ -2676,6 +2721,21 @@ export async function listPiecesFromCommand(
     parseSpaceOptions(options),
   );
   (deps.renderPieceSummaries ?? renderPieceSummaries)(pieces, !!options.json);
+}
+
+export interface SlugListCommandDependencies {
+  listSpaceSlugs?: typeof listSpaceSlugs;
+  renderSlugSummaries?: typeof renderSlugSummaries;
+}
+
+export async function listSlugsFromCommand(
+  options: PieceSummaryCLIOptions,
+  deps: SlugListCommandDependencies = {},
+): Promise<void> {
+  const slugs = await (deps.listSpaceSlugs ?? listSpaceSlugs)(
+    parseSpaceOptions(options),
+  );
+  (deps.renderSlugSummaries ?? renderSlugSummaries)(slugs, !!options.json);
 }
 
 export interface PieceSearchCommandDependencies {

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -409,6 +409,18 @@ run_piece_links() {
 
   cf piece get $SPACE_ARGS --piece resolved-counter value > /dev/null
 
+  # The slug index: both names just assigned are enumerable, and each resolves
+  # to a piece. Names are compared exactly; the resolved ids are only checked
+  # non-null, because an address is something to read next, not an identifier
+  # to compare (docs/common/verb-session-walkthrough.md, "An address is not an
+  # identifier to compare").
+  SLUGS_JSON=$(cf piece slugs $SPACE_ARGS --json)
+  echo "$SLUGS_JSON" | jq -e '[.[].slug] == ["counter-alias", "resolved-counter"]' > /dev/null ||
+    error "The slug listing should name both assigned slugs, got: $SLUGS_JSON"
+  echo "$SLUGS_JSON" | jq -e 'all(.[]; .piece != null)' > /dev/null ||
+    error "Every listed slug should resolve to a piece, got: $SLUGS_JSON"
+  echo "Successfully listed the slug index."
+
   # Create a second piece from the same pattern
   PIECE_ID2=$(cf piece new --main-export $CUSTOM_EXPORT $SPACE_ARGS $PATTERN_SRC)
   echo "Created second piece: $PIECE_ID2"

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -13,6 +13,7 @@ import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { setLLMUrl } from "@commonfabric/llm";
 import {
   assignSlug,
+  listSlugs,
   pieceId,
   resolvePieceAddress as resolveStoredPieceAddress,
   resolveSlugTargetCell,
@@ -674,6 +675,41 @@ export async function listPieces(
       } catch (err) {
         return {
           id: piece.id,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+    }),
+  );
+}
+
+/** One `cf piece slugs` row: a name the space's slug index records, and the
+ * piece it resolves to. A row carries `error` instead of `piece` when the
+ * name does not resolve to one — a slug pointing at a plain cell path, or at
+ * a document that no longer loads, is still a name the space has, and a
+ * listing that dropped it would misreport the namespace. */
+export interface SlugSummary {
+  slug: string;
+  piece?: string;
+  error?: string;
+}
+
+/** Every slug the space's index records, each resolved to the piece id
+ * `--piece` would resolve it to. The index bounds the listing: it names
+ * slugs assigned since it existed, so an older slug still resolves but is
+ * not listed — nothing can enumerate what it was never told the name of. */
+export async function listSpaceSlugs(
+  config: SpaceConfig,
+  deps: PieceOperationDependencies = {},
+): Promise<SlugSummary[]> {
+  const pieces = await (deps.loadPieces ?? loadPieces)(config);
+  const slugs = await listSlugs(pieces);
+  return Promise.all(
+    slugs.map(async (slug) => {
+      try {
+        return { slug, piece: await resolveStoredPieceAddress(pieces, slug) };
+      } catch (err) {
+        return {
+          slug,
           error: err instanceof Error ? err.message : String(err),
         };
       }

--- a/packages/cli/test/piece-slugs.test.ts
+++ b/packages/cli/test/piece-slugs.test.ts
@@ -1,3 +1,10 @@
+/**
+ * `cf piece slugs` at its three seams: the lib listing over an index-cell
+ * double (name filtering and per-row error isolation — the happy resolution
+ * path runs against a real runtime in `packages/piece/test/slug.test.ts`),
+ * the renderer's JSON and table shapes, and the command wiring.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { decode } from "@commonfabric/utils/encoding";

--- a/packages/cli/test/piece-slugs.test.ts
+++ b/packages/cli/test/piece-slugs.test.ts
@@ -1,0 +1,150 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { decode } from "@commonfabric/utils/encoding";
+import { listSpaceSlugs } from "../lib/piece.ts";
+import {
+  listSlugsFromCommand,
+  renderSlugSummaries,
+} from "../commands/piece.ts";
+
+function captureStdout(fn: () => void): string {
+  let captured = "";
+  const original = Deno.stdout.writeSync;
+  Deno.stdout.writeSync = (data: Uint8Array): number => {
+    captured += decode(data);
+    return data.length;
+  };
+  try {
+    fn();
+  } finally {
+    Deno.stdout.writeSync = original;
+  }
+  return captured;
+}
+
+const CONFIG = {
+  apiUrl: "http://localhost:8000",
+  identity: "/tmp/test-identity.pem",
+  space: "did:key:zSlugTest",
+};
+
+describe("piece-slugs", () => {
+  describe("listSpaceSlugs", () => {
+    it("lists the index's names sorted, and isolates a resolution failure to its row", async () => {
+      // The index cell double answers the map; everything past it is the real
+      // resolution path, which this bare double cannot satisfy — so every
+      // row must come back as an error row rather than the listing throwing.
+      // The happy path resolves against a real runtime in
+      // packages/piece/test/slug.test.ts, where resolution is real too.
+      const pieces = {
+        getSpace: () => CONFIG.space,
+        runtime: {
+          getCellFromEntityId: () => ({
+            asSchema: () => ({
+              pull: () =>
+                Promise.resolve({ tracker: true, board: true, ghost: false }),
+            }),
+          }),
+        },
+      };
+
+      const rows = await listSpaceSlugs(CONFIG, {
+        loadPieces: () => Promise.resolve(pieces as never),
+      });
+
+      // `ghost` holds false, which is not an assignment — only `true` keys
+      // are names.
+      expect(rows.map((row) => row.slug)).toEqual(["board", "tracker"]);
+      for (const row of rows) {
+        expect(Object.hasOwn(row, "piece")).toBe(false);
+        expect(typeof row.error).toBe("string");
+        expect(row.error!.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("lists nothing for a space whose index does not exist", async () => {
+      const pieces = {
+        getSpace: () => CONFIG.space,
+        runtime: {
+          getCellFromEntityId: () => ({
+            asSchema: () => ({ pull: () => Promise.resolve(undefined) }),
+          }),
+        },
+      };
+
+      expect(
+        await listSpaceSlugs(CONFIG, {
+          loadPieces: () => Promise.resolve(pieces as never),
+        }),
+      ).toEqual([]);
+    });
+  });
+
+  describe("renderSlugSummaries", () => {
+    it("renders rows as JSON with a null piece and the error carried through", () => {
+      const json = captureStdout(() =>
+        renderSlugSummaries([
+          { slug: "board", piece: "fid1:abc" },
+          {
+            slug: "broken",
+            error: "redirects to a document that is not a piece",
+          },
+        ], true)
+      );
+      expect(JSON.parse(json)).toEqual([
+        { slug: "board", piece: "fid1:abc" },
+        {
+          slug: "broken",
+          piece: null,
+          error: "redirects to a document that is not a piece",
+        },
+      ]);
+    });
+
+    it("renders a SLUG/PIECE table with an error marker, and nothing when empty", () => {
+      const table = captureStdout(() =>
+        renderSlugSummaries([
+          { slug: "board", piece: "fid1:abc" },
+          { slug: "broken", error: "no longer loads" },
+        ], false)
+      );
+      expect(table).toContain("SLUG");
+      expect(table).toContain("PIECE");
+      expect(table).toContain("board");
+      expect(table).toContain("fid1:abc");
+      expect(table).toContain("<error: no longer loads>");
+
+      expect(captureStdout(() => renderSlugSummaries([], false))).toBe("");
+    });
+  });
+
+  describe("listSlugsFromCommand", () => {
+    it("hands the parsed space config to the lister and the json flag to the renderer", async () => {
+      const seen: { config?: unknown; rows?: unknown; json?: boolean } = {};
+      const rows = [{ slug: "board", piece: "fid1:abc" }];
+
+      await listSlugsFromCommand(
+        {
+          apiUrl: CONFIG.apiUrl,
+          identity: CONFIG.identity,
+          space: CONFIG.space,
+          json: true,
+        } as never,
+        {
+          listSpaceSlugs: (config) => {
+            seen.config = config;
+            return Promise.resolve(rows);
+          },
+          renderSlugSummaries: (given, json) => {
+            seen.rows = given;
+            seen.json = json;
+          },
+        },
+      );
+
+      expect((seen.config as { space: string }).space).toBe(CONFIG.space);
+      expect(seen.rows).toBe(rows);
+      expect(seen.json).toBe(true);
+    });
+  });
+});

--- a/packages/piece/src/index.ts
+++ b/packages/piece/src/index.ts
@@ -1,6 +1,7 @@
 export { pieceId } from "./piece-id.ts";
 export {
   assignSlug,
+  listSlugs,
   resolvePieceAddress,
   resolveSlugTargetCell,
   setSlugLink,

--- a/packages/piece/src/slugs.ts
+++ b/packages/piece/src/slugs.ts
@@ -1,5 +1,6 @@
 import type { JSONSchema } from "@commonfabric/api";
 import type { Cell } from "@commonfabric/runner";
+import { utf8Compare } from "@commonfabric/utils/utf8";
 import {
   entityIdFrom,
   getPatternIdentityRef,
@@ -33,8 +34,8 @@ function slugIndexCell(pieces: PiecesController) {
 }
 
 /**
- * Every slug name the space's index records, in sorted order — the slug
- * alphabet is lowercase ASCII, so lexicographic and byte order agree.
+ * Every slug name the space's index records, in byte order (utf8Compare is
+ * the repo comparator).
  *
  * A lower bound with one boundary it cannot detect: the index lists slugs
  * assigned since it existed, so a slug written by an older client still
@@ -45,7 +46,8 @@ function slugIndexCell(pieces: PiecesController) {
 export async function listSlugs(pieces: PiecesController): Promise<string[]> {
   const index = await slugIndexCell(pieces).pull();
   if (index === undefined) return [];
-  return Object.keys(index).filter((slug) => index[slug] === true).sort();
+  return Object.keys(index).filter((slug) => index[slug] === true)
+    .sort(utf8Compare);
 }
 
 export async function assignSlug(

--- a/packages/piece/src/slugs.ts
+++ b/packages/piece/src/slugs.ts
@@ -1,3 +1,4 @@
+import type { JSONSchema } from "@commonfabric/api";
 import type { Cell } from "@commonfabric/runner";
 import {
   entityIdFrom,
@@ -5,6 +6,7 @@ import {
   isSlugAddress,
   resolveSlugTargetCell as resolveRuntimeSlugTargetCell,
   slugIdForSpace,
+  slugIndexIdForSpace,
   SlugResolutionError,
   validateSlug,
 } from "@commonfabric/runner";
@@ -12,6 +14,39 @@ import { pieceId } from "./piece-id.ts";
 import type { PiecesController } from "./ops/pieces-controller.ts";
 
 export { SlugResolutionError };
+
+/** The slug index's shape: names to `true`. Written one key at a time, so
+ * two clients assigning different slugs merge as two keys rather than two
+ * whole maps racing. The names are the whole content — where a name points
+ * stays the slug cell's own answer, because a copy of the target here would
+ * be a second answer able to disagree with it. */
+const SLUG_INDEX_SCHEMA = {
+  type: "object",
+  additionalProperties: { type: "boolean" },
+} as const satisfies JSONSchema;
+
+function slugIndexCell(pieces: PiecesController) {
+  return pieces.runtime.getCellFromEntityId(
+    pieces.getSpace(),
+    entityIdFrom(slugIndexIdForSpace(pieces.getSpace())),
+  ).asSchema(SLUG_INDEX_SCHEMA);
+}
+
+/**
+ * Every slug name the space's index records, in sorted order — the slug
+ * alphabet is lowercase ASCII, so lexicographic and byte order agree.
+ *
+ * A lower bound with one boundary it cannot detect: the index lists slugs
+ * assigned since it existed, so a slug written by an older client still
+ * resolves but is not named here. Nothing can find such a slug to report it —
+ * a slug cell's id is derived from its name, and that unenumerability is the
+ * reason the index exists at all.
+ */
+export async function listSlugs(pieces: PiecesController): Promise<string[]> {
+  const index = await slugIndexCell(pieces).pull();
+  if (index === undefined) return [];
+  return Object.keys(index).filter((slug) => index[slug] === true).sort();
+}
 
 export async function assignSlug(
   pieces: PiecesController,
@@ -46,6 +81,9 @@ export async function setSlugLink(
     entityIdFrom(slugIdForSpace(pieces.getSpace(), validSlug)),
   );
 
+  const indexCell = slugIndexCell(pieces);
+  await indexCell.sync();
+
   await pieces.runtime.editWithRetry((tx) => {
     const targetWithTx = target.withTx(tx);
     const slugWithTx = slugCell.withTx(tx);
@@ -63,6 +101,9 @@ export async function setSlugLink(
     slugWithTx.setRawUntyped(
       targetWithTx.getAsWriteRedirectLink({ base: slugWithTx }),
     );
+    // The index entry rides the slug's own transaction, so a listing can
+    // never see a name without its slug or a slug without its name.
+    indexCell.withTx(tx).key(validSlug).set(true);
   });
 
   await pieces.runtime.idle();

--- a/packages/piece/test/slug.test.ts
+++ b/packages/piece/test/slug.test.ts
@@ -10,6 +10,7 @@ import { pieceId } from "../src/piece-id.ts";
 import { PiecesController } from "../src/ops/pieces-controller.ts";
 import {
   assignSlug,
+  listSlugs,
   resolvePieceAddress,
   resolveSlugTargetCell,
   setSlugLink,
@@ -68,6 +69,23 @@ describe("piece slugs", () => {
     expect(readRootMeta(id, "slug")).toBe("demo");
     expect(readRootMeta(slugId, "slug")).toBe("demo");
     expect(await resolvePieceAddress(pieces, "demo")).toBe(id);
+  });
+
+  it("lists every assigned slug, once, however many times a name is set", async () => {
+    const piece = await createPiece("index-target");
+    const other = await createPiece("index-other");
+
+    await assignSlug(pieces, piece, "board");
+    await setSlugLink(pieces, "tracker", other);
+    // Repointing a name changes where it resolves, never how it is listed.
+    await setSlugLink(pieces, "board", other);
+
+    expect(await listSlugs(pieces)).toEqual(["board", "tracker"]);
+    expect(await resolvePieceAddress(pieces, "board")).toBe(pieceId(other)!);
+  });
+
+  it("lists no slugs for a space that assigned none", async () => {
+    expect(await listSlugs(pieces)).toEqual([]);
   });
 
   it("sets slug redirects to arbitrary cell links", async () => {

--- a/packages/piece/test/slug.test.ts
+++ b/packages/piece/test/slug.test.ts
@@ -104,6 +104,9 @@ describe("piece slugs", () => {
     expect(link?.id).toBe(piece.getAsNormalizedFullLink().id);
     expect(link?.path).toEqual(["value"]);
     expect(readRootMeta(slugId, "slug")).toBe("value-link");
+    // The index write is unconditional: a slug to a cell path is as much a
+    // name the space has as one to a piece root.
+    expect(await listSlugs(pieces)).toEqual(["value-link"]);
   });
 
   it("resolves slug redirects to arbitrary cells without treating them as pieces", async () => {

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -287,6 +287,7 @@ export {
   isSlugAddress,
   slugCause,
   slugIdForSpace,
+  slugIndexIdForSpace,
   validateSlug,
 } from "./slugs.ts";
 export {

--- a/packages/runner/src/slugs.ts
+++ b/packages/runner/src/slugs.ts
@@ -54,3 +54,22 @@ export function slugCause(space: MemorySpace, slug: string): SlugCause {
 export function slugIdForSpace(space: MemorySpace, slug: string): string {
   return hashOf({ causal: slugCause(space, slug) }).taggedHashString;
 }
+
+/**
+ * The one cell in a space that names its slugs: a map keyed by slug name,
+ * `true` at every key. It exists because slug cells are unenumerable by
+ * construction — each lives at an id derived from its name, so nothing can
+ * find a name it was never told — and "arrive by name" needs names a caller
+ * can discover.
+ *
+ * The index holds names and nothing else. The slug cell stays the one
+ * authority on where a name points; a copy of the target here would be a
+ * second answer that could disagree with it.
+ *
+ * The cause is shaped unlike any slug's — `{space, slugIndex: true}` against
+ * `{space, slug}` — so the index can never collide with a slug cell however
+ * a name is chosen.
+ */
+export function slugIndexIdForSpace(space: MemorySpace): string {
+  return hashOf({ causal: { space, slugIndex: true } }).taggedHashString;
+}


### PR DESCRIPTION
## Why

"Arrive by name" — the verb session's own opening move — assumed someone had already told you the name. A slug document lives at an id derived from its name (`slugIdForSpace` hashes `{space, slug}`), so a space's slugs were unenumerable by construction: `set-slug` wrote one, `--piece` resolved one, and nothing could list them. A caller landing in a space they didn't populate had no way to learn the names it answers to. (Proposal C from the piece-documentation review behind #5933; independent of that PR.)

## What Changed

- **A slug index per space** — one document at `slugIndexIdForSpace(space)`, whose cause (`{space, slugIndex: true}`) is shaped unlike any slug's, so no name can collide with it. `setSlugLink` writes the entry **in the same transaction as the slug it names**, one key at a time (`{[slug]: true}`), so a listing can never see a name without its slug, and two clients assigning different slugs merge as two keys rather than two maps racing. The index holds names only: where a name points stays the slug document's own answer — a copy of the target here would be a second answer able to disagree with it. Both existing writers (`piece new --slug` via `assignSlug`, and `set-slug`) already route through `setSlugLink`, so the index is complete from here on.
- **`cf piece slugs [--json]`** — lists the index, resolving each name through the same path `--piece` uses. A name that stops resolving (a slug to a plain cell path, or a document that no longer loads) keeps its row and carries the resolution's own error — it is still a name the space has. The resolved ids are addresses to read next, not identifiers to compare, so the integration assertion checks names exactly and ids only for presence.
- **The honest boundary, stated where it binds** — the index records assignments made since it existed; a slug written by an older client still resolves but is not listed, there being nothing to find it by. The command description, `packages/cli/README.md` (Piece discovery), and `docs/common/concepts/piece-discovery.md` (new "The Slug Index Is the Namespace Root" section) all carry it. The concepts doc also notes the new asymmetry worth having: a slug may name an *unregistered* piece, which makes the slug listing a discovery path the registry does not have.

### Design notes for review

Two calls worth a second pair of eyes from whoever owns the slug machinery: the index's shape (a keyed map written per-key under `editWithRetry`, leaning on key-level merge for concurrent assignments of different names; same-name races keep the existing last-writer redirect semantics and agree on the index entry), and the decision to store names only rather than name→target pairs.

## Test plan

- `packages/piece/test/slug.test.ts`: real-runtime tests — every assigned slug listed once however many times a name is set, repointing changes resolution but not the listing, empty space lists empty. Suite: 37 passed (454 steps).
- `packages/cli/test/piece-slugs.test.ts`: index filtering/sorting and per-row error isolation through the lib seam, renderer JSON/table/empty cases (the error rides the JSON, unlike `ls`'s known quirk), command wiring. Suite: 174 passed.
- `packages/runner`: 1221 passed (6599 steps).
- Live against a local toolshed: `piece new --slug board` + `set-slug tracker` → `cf piece slugs` lists both, text and JSON, resolving to the board.
- Integration: `run_piece_links` now asserts the listing after its two `set-slug` calls (runs in the `core-piece-links` CI section).
- `check-docs`, `check-skill-facts`, repo-relevant `deno fmt --check` and `deno lint` clean; `bash -n` on `integration.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

