### PR TITLE
fix(schema-generator): a scope wrapper inside a union is refused, never silently shared

### DIFF
--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -564,6 +564,26 @@ both survive: `PerUser<Cell<PerSession<string>>>` → `{ asCell: [{ kind:
 "cell", scope: "user" }], scope: "session", type: "string" }` (fixture
 `scoped-wrappers`).
 
+A scope wrapper **as a union member throws** (`A scope wrapper cannot be a
+member of a union.`; tested, scope-wrappers.test.ts). The runtime reads a
+slot's scope from the top level of that slot's own schema
+(`ContextualFlowControl.getSchemaScopeCap`), so a declaration that lands in an
+`anyOf` branch is invisible to the write path: no narrowing redirect is
+written, the value lands on the shared space row, and every principal reads
+the same instance. Write the union inside the wrapper
+(`PerUser<string | undefined>` → `{ type: ["string", "undefined"], scope:
+"user" }`) or make the property optional (`draft?: PerUser<string>` →
+`{ type: "string", scope: "user" }`) — both keep the scope at the top level.
+
+Two detection points enforce this, because a wrapper around a cell loses its
+scope before the schema is built. `formatWrapperUnion`
+(`common-fabric-formatter.ts`) catches a scope-wrapped union member while the
+wrapper is still visible; `assertScopeDeclarationsAreReachable`
+(`scope-placement.ts`), run on every finished schema, catches a scope that
+reached an `anyOf`/`oneOf`/`allOf` branch by any route. A scope nested deeper
+— on a property of an object that is itself a union member — is that
+property's own top-level declaration and is accepted.
+
 ## 11. CFC Alias Lowering (`ifc` Metadata)
 
 The canonical authoring surface contains 18 names. The inventory is
@@ -747,6 +767,7 @@ Everything that throws, with source (test-pinned unless noted):
 | `DeepDefault` without object target/default | `DeepDefault must be unioned with an object type …` | `union-formatter.ts` |
 | `DeepDefault` unknown key | `DeepDefault key "…" does not exist on the target object type.` | `union-formatter.ts` |
 | Nested scope wrappers | `Nested scope wrappers require a cell boundary between scopes.` | `common-fabric-formatter.ts` |
+| Scope wrapper as a union member | `A scope wrapper cannot be a member of a union.` | `common-fabric-formatter.ts`, `scope-placement.ts` |
 | Circular type alias (wrapper chain) | `Circular type alias detected: A -> B -> …` | `type-utils.ts` |
 | Circular type alias (union alias) | `Circular type alias detected: <name>` | `union-formatter.ts` |
 | Wrapper/scope/CFC alias without type argument | `<Kind><T> requires type argument` | `common-fabric-formatter.ts` (untested) |

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -31,6 +31,7 @@ import {
 import { numberFromExpression } from "../typescript/numeric-expression.ts";
 import { isDefaultAliasSymbol } from "../typescript/property-optionality.ts";
 import { dedupeByValueEqual } from "../value-equality.ts";
+import { scopeInsideUnionError } from "../scope-placement.ts";
 
 type WrapperKind = CellWrapperKind;
 const CFC_ALIAS_NAMES: ReadonlySet<string> = new Set(CFC_CANONICAL_ALIAS_NAMES);
@@ -2148,6 +2149,18 @@ export class CommonFabricFormatter implements TypeFormatter {
     for (let i = 0; i < members.length; i++) {
       const memberType = members[i]!;
       const memberNode = unionNode?.types[i];
+
+      // A scope wrapper around a cell formats as the cell alone, dropping the
+      // scope before it reaches the schema — so the structural check on the
+      // finished schema would have nothing left to reject. Catch it here,
+      // where the wrapper is still visible.
+      const memberScope = resolveScopeWrapperNode(memberNode)?.scope ??
+        scopeForWrapperName(
+          (memberType as TypeWithInternals).aliasSymbol?.name,
+        );
+      if (memberScope !== undefined) {
+        throw scopeInsideUnionError(memberScope);
+      }
 
       // Include undefined as an explicit type in the schema
       if (this.isUndefinedType(memberType)) {

--- a/packages/schema-generator/src/schema-generator.ts
+++ b/packages/schema-generator/src/schema-generator.ts
@@ -29,6 +29,7 @@ import {
   safeGetTypeOfSymbolAtLocation,
 } from "./type-utils.ts";
 import { attachDocTags, extractDocFromType } from "./doc-utils.ts";
+import { assertScopeDeclarationsAreReachable } from "./scope-placement.ts";
 
 /**
  * Main schema generator that uses a chain of formatters
@@ -148,6 +149,7 @@ export class SchemaGenerator {
 
     // Auto-detect: Should we use node-based or type-based analysis?
     let schema: MutableJSONSchema;
+    let result: MutableJSONSchema;
     if (this.shouldUseNodeBasedAnalysis(type, typeNode, checker)) {
       // Use node-based analysis (for synthetic nodes or when type is unreliable)
       schema = this.analyzeTypeNodeStructure(
@@ -157,18 +159,21 @@ export class SchemaGenerator {
       );
       schema = this.applyNodeSchemaHints(schema, context);
       // Build final schema with $schema and $defs
-      return this.buildFinalSchemaForSynthetic(schema, context);
+      result = this.buildFinalSchemaForSynthetic(schema, context);
+    } else {
+      // Use type-based analysis (normal path)
+      schema = this.formatType(type, context, true);
+      schema = this.applyNodeSchemaHints(schema, context);
+
+      // Attach root-level description from JSDoc if available
+      schema = this.attachRootDescription(schema, type, context);
+
+      // Build final schema with definitions if needed
+      result = this.buildFinalSchema(schema, type, context, typeNode);
     }
 
-    // Use type-based analysis (normal path)
-    schema = this.formatType(type, context, true);
-    schema = this.applyNodeSchemaHints(schema, context);
-
-    // Attach root-level description from JSDoc if available
-    schema = this.attachRootDescription(schema, type, context);
-
-    // Build final schema with definitions if needed
-    return this.buildFinalSchema(schema, type, context, typeNode);
+    assertScopeDeclarationsAreReachable(result);
+    return result;
   }
 
   /**

--- a/packages/schema-generator/src/scope-placement.ts
+++ b/packages/schema-generator/src/scope-placement.ts
@@ -1,3 +1,20 @@
+/**
+ * Validates where a scope declaration sits in a generated schema, so a slot an
+ * author marked `PerUser`/`PerSession` cannot reach storage as shared
+ * space-scoped data.
+ *
+ * The runtime reads a slot's scope from the top level of that slot's own
+ * schema (`ContextualFlowControl.getSchemaScopeCap`). A declaration anywhere
+ * else is not a weaker declaration, it is no declaration: no narrowing
+ * redirect is written, the value lands on the space row, and every principal
+ * reads one instance. Refusing the schema at generation time is what keeps
+ * that from being a silent outcome.
+ *
+ * The subject here is PLACEMENT. Which scope a slot should carry, and which
+ * instance the runtime addresses once it has one, are the write path's
+ * questions.
+ */
+
 import { isObjectOrArray } from "@commonfabric/utils/types";
 import type { MutableJSONSchema } from "@commonfabric/api";
 

--- a/packages/schema-generator/src/scope-placement.ts
+++ b/packages/schema-generator/src/scope-placement.ts
@@ -1,0 +1,140 @@
+import { isObjectOrArray } from "@commonfabric/utils/types";
+import type { MutableJSONSchema } from "@commonfabric/api";
+
+/**
+ * Keywords whose values are schemas for a DIFFERENT slot than the one being
+ * walked. A scope declared at the top level of one of these is that slot's own
+ * declaration, and the write path reads it there.
+ */
+const CHILD_SLOT_KEYWORDS = [
+  "properties",
+  "patternProperties",
+  "$defs",
+  "definitions",
+] as const;
+
+/**
+ * Keywords whose values are a single schema for a different slot.
+ */
+const CHILD_SLOT_SINGLE_KEYWORDS = [
+  "additionalProperties",
+  "items",
+  "contains",
+  "propertyNames",
+] as const;
+
+/**
+ * Keywords that compose alternatives for the SAME slot. A scope declared at the
+ * top level of one of these branches is invisible to the write path, which
+ * reads only the slot schema's own top level.
+ */
+const SAME_SLOT_COMPOUND_KEYWORDS = ["anyOf", "oneOf", "allOf"] as const;
+
+/**
+ * The scope a slot declares at its own top level: the outermost `asCell`
+ * entry's scope if present, otherwise the top-level `scope`. Mirrors
+ * `ContextualFlowControl.getSchemaScopeCap`, which is what the runtime's write
+ * path consults to decide whether a write narrows into a scoped instance.
+ */
+const topLevelScope = (schema: MutableJSONSchema): string | undefined => {
+  if (!isObjectOrArray(schema)) return undefined;
+  const entry = Array.isArray(schema.asCell) ? schema.asCell[0] : undefined;
+  if (typeof entry === "string") return undefined;
+  if (isObjectOrArray(entry) && typeof entry.scope === "string") {
+    return entry.scope;
+  }
+  return typeof schema.scope === "string" ? schema.scope : undefined;
+};
+
+/**
+ * The error raised when a scope wrapper lands inside a union. Shared with the
+ * formatter so the two detection points speak with one voice.
+ */
+export const scopeInsideUnionError = (scope: string): Error =>
+  new Error(
+    `A scope wrapper cannot be a member of a union. ` +
+      `\`PerUser<T> | undefined\` puts \`scope: "${scope}"\` inside an ` +
+      `\`anyOf\` branch, where the write path does not look for it, so the ` +
+      `slot stores one shared space-scoped value instead of one per ` +
+      `principal. Put the union inside the wrapper ` +
+      `(\`PerUser<T | undefined>\`) or make the property optional ` +
+      `(\`prop?: PerUser<T>\`).`,
+  );
+
+const walkSlot = (schema: MutableJSONSchema): void => {
+  if (!isObjectOrArray(schema)) return;
+
+  for (const keyword of SAME_SLOT_COMPOUND_KEYWORDS) {
+    const branches = schema[keyword];
+    if (!Array.isArray(branches)) continue;
+    for (const branch of branches) checkBranch(branch as MutableJSONSchema);
+  }
+
+  descendIntoChildSlots(schema);
+};
+
+/**
+ * A branch of the slot currently being walked. Its top-level scope belongs to
+ * the containing slot, so declaring one here is the defect.
+ */
+const checkBranch = (schema: MutableJSONSchema): void => {
+  if (!isObjectOrArray(schema)) return;
+
+  const scope = topLevelScope(schema);
+  if (scope !== undefined) throw scopeInsideUnionError(scope);
+
+  // A nested compound is still the same slot's alternatives.
+  for (const keyword of SAME_SLOT_COMPOUND_KEYWORDS) {
+    const branches = schema[keyword];
+    if (!Array.isArray(branches)) continue;
+    for (const branch of branches) checkBranch(branch as MutableJSONSchema);
+  }
+
+  descendIntoChildSlots(schema);
+};
+
+const descendIntoChildSlots = (schema: MutableJSONSchema): void => {
+  if (!isObjectOrArray(schema)) return;
+
+  for (const keyword of CHILD_SLOT_KEYWORDS) {
+    const group = schema[keyword];
+    if (!isObjectOrArray(group) || Array.isArray(group)) continue;
+    // `Object.keys`, not `for...in`: these are the schema's own declared
+    // names, and the prototype chain holds none of them.
+    for (const key of Object.keys(group)) {
+      walkSlot((group as Record<string, MutableJSONSchema>)[key]!);
+    }
+  }
+
+  for (const keyword of CHILD_SLOT_SINGLE_KEYWORDS) {
+    const child = schema[keyword];
+    if (child === undefined) continue;
+    if (Array.isArray(child)) {
+      for (const entry of child) walkSlot(entry as MutableJSONSchema);
+    } else {
+      walkSlot(child as MutableJSONSchema);
+    }
+  }
+
+  const prefixItems = schema.prefixItems;
+  if (Array.isArray(prefixItems)) {
+    for (const entry of prefixItems) walkSlot(entry as MutableJSONSchema);
+  }
+};
+
+/**
+ * Throws when a generated schema declares a scope somewhere the runtime's write
+ * path cannot see it.
+ *
+ * A slot's scope is read from the top level of that slot's schema
+ * (`ContextualFlowControl.getSchemaScopeCap`). A declaration buried in an
+ * `anyOf`/`oneOf`/`allOf` branch is therefore inert on the write side: no
+ * narrowing redirect is written, the value lands on the shared space row, and
+ * every principal reads the same instance. Failing at generation time is what
+ * keeps that from reaching storage.
+ */
+export const assertScopeDeclarationsAreReachable = (
+  schema: MutableJSONSchema,
+): void => {
+  walkSlot(schema);
+};

--- a/packages/schema-generator/src/scope-placement.ts
+++ b/packages/schema-generator/src/scope-placement.ts
@@ -39,7 +39,9 @@ const SAME_SLOT_COMPOUND_KEYWORDS = ["anyOf", "oneOf", "allOf"] as const;
 const topLevelScope = (schema: MutableJSONSchema): string | undefined => {
   if (!isObjectOrArray(schema)) return undefined;
   const entry = Array.isArray(schema.asCell) ? schema.asCell[0] : undefined;
-  if (typeof entry === "string") return undefined;
+  // A string entry (`asCell: ["cell"]`) carries no scope of its own and does
+  // not stand in for one: `Cell<PerSession<T>>` puts the scope on the sibling
+  // key, so the fallback below is the only thing that finds it.
   if (isObjectOrArray(entry) && typeof entry.scope === "string") {
     return entry.scope;
   }

--- a/packages/schema-generator/test/scope-wrappers.test.ts
+++ b/packages/schema-generator/test/scope-wrappers.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
+import type { JSONSchemaObj } from "@commonfabric/api";
 import { SchemaGenerator } from "../src/schema-generator.ts";
 import { getTypeFromCode } from "./utils.ts";
 
@@ -17,5 +18,118 @@ interface SchemaRoot {
 
     expect(() => new SchemaGenerator().generateSchema(type, checker, typeNode))
       .toThrow("Nested scope wrappers require a cell boundary between scopes.");
+  });
+
+  it("throws for a scope wrapper that is a union member", async () => {
+    const { type, checker, typeNode } = await getTypeFromCode(
+      `
+interface SchemaRoot {
+  draft: PerUser<string> | undefined;
+}
+`,
+      "SchemaRoot",
+    );
+
+    expect(() => new SchemaGenerator().generateSchema(type, checker, typeNode))
+      .toThrow("A scope wrapper cannot be a member of a union.");
+  });
+
+  it("throws for a scope wrapper around a cell that is a union member", async () => {
+    const { type, checker, typeNode } = await getTypeFromCode(
+      `
+interface SchemaRoot {
+  draft: PerUser<Cell<string>> | undefined;
+}
+`,
+      "SchemaRoot",
+    );
+
+    expect(() => new SchemaGenerator().generateSchema(type, checker, typeNode))
+      .toThrow("A scope wrapper cannot be a member of a union.");
+  });
+
+  it("throws for a scope wrapper unioned with a value type", async () => {
+    const { type, checker, typeNode } = await getTypeFromCode(
+      `
+interface SchemaRoot {
+  draft: PerUser<string> | null;
+}
+`,
+      "SchemaRoot",
+    );
+
+    expect(() => new SchemaGenerator().generateSchema(type, checker, typeNode))
+      .toThrow("A scope wrapper cannot be a member of a union.");
+  });
+
+  it("emits a top-level scope for an optional scoped property", async () => {
+    const { type, checker, typeNode } = await getTypeFromCode(
+      `
+interface SchemaRoot {
+  draft?: PerUser<string>;
+}
+`,
+      "SchemaRoot",
+    );
+
+    const schema = new SchemaGenerator().generateSchema(
+      type,
+      checker,
+      typeNode,
+    );
+    expect((schema as JSONSchemaObj).properties?.draft).toEqual({
+      type: "string",
+      scope: "user",
+    });
+  });
+
+  it("emits a top-level scope when the union is inside the wrapper", async () => {
+    const { type, checker, typeNode } = await getTypeFromCode(
+      `
+interface SchemaRoot {
+  draft: PerUser<string | undefined>;
+}
+`,
+      "SchemaRoot",
+    );
+
+    const schema = new SchemaGenerator().generateSchema(
+      type,
+      checker,
+      typeNode,
+    );
+    expect((schema as JSONSchemaObj).properties?.draft).toEqual({
+      type: ["string", "undefined"],
+      scope: "user",
+    });
+  });
+
+  it("emits a scoped property nested in an object that is a union member", async () => {
+    const { type, checker, typeNode } = await getTypeFromCode(
+      `
+interface SchemaRoot {
+  holder: { draft: PerUser<string> } | undefined;
+}
+`,
+      "SchemaRoot",
+    );
+
+    const schema = new SchemaGenerator().generateSchema(
+      type,
+      checker,
+      typeNode,
+    );
+    const branches =
+      ((schema as JSONSchemaObj).properties?.holder as JSONSchemaObj).anyOf as
+        | JSONSchemaObj[]
+        | undefined;
+    // The scope sits at the top level of `draft`'s own schema, which is where
+    // the write path reads it, so nesting under a union branch is fine.
+    expect(
+      branches?.some((branch) =>
+        (branch.properties?.draft as JSONSchemaObj | undefined)?.scope ===
+          "user"
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/schema-generator/test/scope-wrappers.test.ts
+++ b/packages/schema-generator/test/scope-wrappers.test.ts
@@ -62,6 +62,44 @@ interface SchemaRoot {
       .toThrow("A scope wrapper cannot be a member of a union.");
   });
 
+  it("throws for a scope inside a cell that is a union member", async () => {
+    // `Cell<PerSession<T>>` puts the scope on the sibling key next to a string
+    // `asCell` entry, so the branch carries `{asCell: ["cell"], scope: ...}`.
+    const { type, checker, typeNode } = await getTypeFromCode(
+      `
+interface SchemaRoot {
+  draft: Cell<PerSession<string>> | undefined;
+}
+`,
+      "SchemaRoot",
+    );
+
+    expect(() => new SchemaGenerator().generateSchema(type, checker, typeNode))
+      .toThrow("A scope wrapper cannot be a member of a union.");
+  });
+
+  it("emits a scope beside a string asCell entry outside a union", async () => {
+    const { type, checker, typeNode } = await getTypeFromCode(
+      `
+interface SchemaRoot {
+  draft: Cell<PerSession<string>>;
+}
+`,
+      "SchemaRoot",
+    );
+
+    const schema = new SchemaGenerator().generateSchema(
+      type,
+      checker,
+      typeNode,
+    );
+    expect((schema as JSONSchemaObj).properties?.draft).toEqual({
+      type: "string",
+      scope: "session",
+      asCell: ["cell"],
+    });
+  });
+
   it("emits a top-level scope for an optional scoped property", async () => {
     const { type, checker, typeNode } = await getTypeFromCode(
       `


### PR DESCRIPTION
## What

A `PerUser`/`PerSession`/`PerSpace` wrapper written as a **union member** produces a schema whose scope the runtime's write path cannot see. Refuse it at generation time.

## Why

The runtime reads a slot's scope from the top level of that slot's own schema (`ContextualFlowControl.getSchemaScopeCap`). A declaration that lands inside an `anyOf` branch is therefore inert on the write side: no narrowing redirect is written, the value lands on the shared `space` row, and every principal reads the same instance.

Reproduced against `main` with runner-level tests reading the raw scope rows. Same pattern, same handler, only the slot's schema shape differs:

| slot schema | space row after Alice's handler write | user row |
|---|---|---|
| `{type:"string", scope:"user"}` | redirect → `scope:"user"` | `"ALICE SECRET"` |
| `{anyOf:[{type:"undefined"},{type:"string",scope:"user"}]}` | `"ALICE SECRET"` | *(none)* |

The read side is already hardened for compound shapes — `link-resolution.ts:132` and `schema.ts:1603` both fold in `getAsCellFollowScopeCap`, with comments naming the case. The write side reads the top level alone, while `data-updating.ts:331` documents the two as sharing one precedence.

Three spellings produce the bad shape, and the third is worse than the other two:

| spelling | generated | write path sees |
|---|---|---|
| `PerUser<string> \| undefined` | `anyOf:[{type:"undefined"},{type:"string",scope:"user"}]` | nothing |
| `PerUser<string> \| null` | `anyOf:[{type:"string",scope:"user"},{type:"null"}]` | nothing |
| `PerUser<Cell<string>> \| undefined` | `anyOf:[{type:"undefined"},{type:"string",asCell:["cell"]}]` | nothing — **scope erased** |

That last row is `formatWrapperUnion` seeing through the intersection to the `Cell` wrapper and formatting it without consulting the scope wrapper.

## How

Two detection points, because a wrapper around a cell loses its scope before a schema exists to inspect:

- `formatWrapperUnion` (`common-fabric-formatter.ts`) — catches a scope-wrapped union member while the wrapper is still visible.
- `assertScopeDeclarationsAreReachable` (`scope-placement.ts`, new) — runs on every finished schema and catches a scope that reached an `anyOf`/`oneOf`/`allOf` branch by any other route.

A scope on a property of an object that is *itself* a union member is that property's own top-level declaration, and stays accepted.

This is the same move at the same layer as the existing `Nested scope wrappers require a cell boundary between scopes.` rule. Widening `getSchemaScopeCap` to descend into compounds was the alternative and is not taken: it fixes the first two rows, leaves the erasure row, and merges a precedence the read side keeps separate on purpose.

## Impact: latent, not live

All **165** `PerUser`/`PerSession`/`PerSpace` declarations in `packages/patterns` and `packages/home-schemas` put the union *inside* the wrapper (`PerUser<T | Default<…>>`) or use an optional property (`prop?: PerUser<T>`). Every one of those spellings puts the scope where the write path finds it, including `?: PerUser<Cell<T>>` — the optional path strips `undefined` before formatting, so it never builds a union. Nothing in the corpus is currently sharing per-user data.

## Testing

- `packages/schema-generator` — 56 passed / 303 steps. Six new cases in `scope-wrappers.test.ts`: three rejections, three acceptances (optional property, union-inside-wrapper, scope nested under a union branch).
- Mutation-tested. With both guards disabled the three rejection tests fail and the three acceptance tests pass. With only the structural guard restored, the `PerUser<Cell<string>> | undefined` case survives — the formatter check is not redundant with the walk.
- `packages/ts-transformers` — 1140 passed; its `schema-transform`/`schema-injection` goldens pin this emission end to end.
- `deno task cfcheck` — all 415 pattern files compile clean.
- `deno task check-docs` — 554 blocks. `deno lint` and `deno fmt --check` clean.

Mapping spec §10 and the fail-loud inventory updated in the same change, per the package's `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

