### PR TITLE
feat(cli): cf check and cf test take --datafile

### DIFF
--- a/docs/common/workflows/development.md
+++ b/docs/common/workflows/development.md
@@ -35,6 +35,7 @@ deno task cf piece link ... editor-id/items viewer-id/items
   stored verbatim — never parsed, compiled, or importable — and recovered by
   `cf piece getsrc` with the rest of the package. The pattern reads one with
   `dataFile(path)` from `commonfabric`, naming the path it is stored under.
+  `cf check` and `cf test` take `--datafile` as well, so the read works locally.
   Repeat every flag on each `setsrc`; an update defines the complete source
   revision.
 - Deploy once, then use `setsrc` for updates

--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -261,6 +261,32 @@ The same bytes are read by whatever reads the source package: `cf piece
 getsrc`, the FUSE `.src/` view, and any tool working from a recovered
 checkout.
 
+`cf check` and `cf test` take the same repeatable `--datafile` flag, so a
+pattern that reads a data file can be checked and tested before it is deployed.
+Without it such a pattern still compiles and type-checks, because `dataFile` is
+declared whether or not a file is attached; the absence surfaces when the
+pattern runs.
+
+### What a data file costs a load
+
+A data file's bytes are in the compiled set, so they travel with every warm
+load. That is what makes the read work after a restart, and it prices the
+feature in closure size rather than in time.
+
+Closure size grows by the size of the attached files, one byte for one byte.
+Warm-load time does not move with it: measured over a pattern whose only
+difference was an attached file of 0, 64 KiB, 512 KiB and 2 MiB, the median
+by-identity load stayed flat at about a millisecond across the range. That is
+the design working — a data document is filtered out before anything parses a
+body, verifies it, or builds it into a record, so its size reaches no per-byte
+work.
+
+Those figures come from an emulated storage manager, which holds the closure in
+memory. They therefore measure the runtime's own cost and say nothing about
+moving the bytes to a client over a real connection, which is where a large
+attached file would actually be felt. Treat closure size as the number that
+matters when deciding how much data belongs in a package.
+
 ## Specifier syntax
 
 ### One grammar, no type tag

--- a/docs/tutorial/06-workflow.md
+++ b/docs/tutorial/06-workflow.md
@@ -140,6 +140,30 @@ the same text on every load of a given revision. Reading at module scope rather
 than inside a pattern produces a top-level value like any other, so it takes
 the usual `__cf_data` snapshot.
 
+`dataFile` returns text, so parsing it yields `any`. Name the shape you expect,
+or the result schema the transformer infers has nothing to go on:
+
+```tsx
+// Shown for illustration only.
+interface Cities {
+  cities: string[];
+}
+
+const parsed = JSON.parse(dataFile("/data/cities.json")) as Cities;
+```
+
+`cf check` and `cf test` take the same repeatable `--datafile` flag, so a
+pattern that reads one can be checked and tested before it is deployed:
+
+```bash
+deno task cf check pattern.tsx --datafile data/cities.json
+deno task cf test pattern.test.tsx --datafile data/cities.json
+```
+
+Without the flag the pattern compiles and type-checks, then fails on the read —
+`dataFile` is declared whether or not a file is attached, so the absence shows
+up when the pattern runs rather than when it compiles.
+
 Data files also travel for whoever reads the source next — you on another
 machine, a teammate running `cf piece getsrc`, a tool reading the FUSE `.src/`
 view. They are fixed at deploy time: data that changes while the pattern runs

--- a/packages/cli/commands/dev.ts
+++ b/packages/cli/commands/dev.ts
@@ -42,6 +42,7 @@ async function checkAction(
     json?: boolean;
     root?: string;
     space?: string;
+    datafile?: string[];
   },
   ...files: string[]
 ) {
@@ -71,6 +72,9 @@ async function checkAction(
         mainExport: options.mainExport,
         verboseErrors: options.verboseErrors,
         space: options.space,
+        dataFilePaths: options.datafile?.map((path) =>
+          isAbsolute(path) ? path : join(Deno.cwd(), path)
+        ),
         patternJson: options.patternJson,
       });
       results.push({ file, output, transformed, patternJson });
@@ -145,6 +149,10 @@ function createCheckCommand(): Command<any> {
       cliText(`cf check ./pattern.tsx --no-check`),
       "Compile and evaluate pattern without typechecking.",
     )
+    .example(
+      cliText(`cf check ./pattern.tsx --datafile ./data/cities.json`),
+      "Check a pattern that reads an attached data file.",
+    )
     .option("--no-run", "Do not execute input, only type check.")
     .option("--no-check", "Do not type check input.")
     .option(
@@ -177,6 +185,11 @@ function createCheckCommand(): Command<any> {
     .option(
       "--root <path:string>",
       "Root directory for resolving imports. Allows imports from parent directories within this root.",
+    )
+    .option(
+      "--datafile <path:string>",
+      "Attach a data file the pattern reads with dataFile(). Repeatable.",
+      { collect: true },
     )
     .option(
       "--space <did:string>",

--- a/packages/cli/commands/test-command.ts
+++ b/packages/cli/commands/test-command.ts
@@ -45,6 +45,11 @@ export const test = new Command()
     "Root directory for resolving imports. Enables imports like '../shared/utils.tsx'.",
   )
   .option(
+    "--datafile <path:string>",
+    "Attach a data file the pattern under test reads with dataFile(). Repeatable.",
+    { collect: true },
+  )
+  .option(
     "--stats-threshold <ms:number>",
     "Print logger stats for steps slower than this (ms). 0 = every step. Requires --verbose.",
     { default: 5000 },
@@ -146,6 +151,9 @@ export const test = new Command()
       timeout: options.timeout,
       verbose: options.verbose,
       root,
+      dataFilePaths: options.datafile?.map((path: string) =>
+        resolve(Deno.cwd(), path)
+      ),
       statsThreshold: options.statsThreshold,
       statsInclude,
       statsActionLimit: options.statsActionLimit,

--- a/packages/cli/fixtures/data/cities.json
+++ b/packages/cli/fixtures/data/cities.json
@@ -1,0 +1,1 @@
+{ "cities": ["Oslo", "Lima"] }

--- a/packages/cli/fixtures/reads-data-file.tsx
+++ b/packages/cli/fixtures/reads-data-file.tsx
@@ -1,0 +1,17 @@
+import { __cf_data, dataFile } from "commonfabric";
+
+/**
+ * Reads an attached data file, so `--datafile` has something to prove: the
+ * exported value is the file's parsed contents, not a shape derived from types.
+ *
+ * `dataFile` returns text, so parsing it yields `any`. Naming the shape keeps
+ * the export explicit, and reading at module scope takes the `__cf_data`
+ * snapshot the verifier asks of any top-level value.
+ */
+interface Cities {
+  cities: string[];
+}
+
+export default __cf_data(
+  (JSON.parse(dataFile("/data/cities.json")) as Cities).cities,
+);

--- a/packages/cli/lib/data-files.ts
+++ b/packages/cli/lib/data-files.ts
@@ -1,0 +1,41 @@
+import { readDataFileSource } from "@commonfabric/js-compiler";
+import type { RuntimeProgram } from "@commonfabric/runner";
+
+/**
+ * Attach data files to a resolved program.
+ *
+ * Every command that builds a program from local files goes through here, so a
+ * pattern reads the same bytes under `cf check` and `cf test` that it will read
+ * once deployed. A data file is read directly rather than resolved: nothing
+ * imports one, so there is no closure to follow, and its bytes are never
+ * parsed.
+ *
+ * `rootPath` grounds each file's stored name — the path `dataFile()` names it
+ * by — so the same file attached from the same root is stored under the same
+ * name whichever command attached it.
+ *
+ * Returns `program` unchanged when there is nothing to attach.
+ */
+export function attachDataFiles(
+  program: RuntimeProgram,
+  dataFilePaths: readonly string[] | undefined,
+  rootPath: string,
+): RuntimeProgram {
+  if (!dataFilePaths?.length) return program;
+  const files = [...program.files];
+  const dataFiles: string[] = [];
+  for (const path of dataFilePaths) {
+    const source = readDataFileSource(path, rootPath);
+    if (dataFiles.includes(source.name)) continue;
+    // The program already reaches this name through an import, so it would have
+    // to both compile the file and store it uninterpreted.
+    if (files.some((file) => file.name === source.name)) {
+      throw new Error(
+        `Data file "${source.name}" is also a source module of this program.`,
+      );
+    }
+    files.push(source);
+    dataFiles.push(source.name);
+  }
+  return { ...program, files, dataFiles };
+}

--- a/packages/cli/lib/dev.ts
+++ b/packages/cli/lib/dev.ts
@@ -1,3 +1,4 @@
+import { dirname } from "@std/path";
 import {
   collectImportSpecifiers,
   FileSystemProgramResolver,
@@ -6,6 +7,7 @@ import {
   resolveImportSpecifier,
   type Source,
 } from "@commonfabric/js-compiler";
+import { attachDataFiles } from "./data-files.ts";
 import { TARGET } from "@commonfabric/js-compiler/typescript";
 import { Identity } from "@commonfabric/identity";
 import {
@@ -56,6 +58,8 @@ export interface ProcessOptions {
   verboseErrors?: boolean;
   space?: string;
   patternJson?: boolean;
+  /** Data file paths to attach, so a pattern that reads one can run here. */
+  dataFilePaths?: string[];
 }
 
 export interface ProcessResult {
@@ -94,6 +98,13 @@ export async function process(
   if (options.mainExport) {
     program.mainExport = options.mainExport;
   }
+  // Attach the same data files a deployment would, so `dataFile` reads what it
+  // will read once deployed instead of failing for want of a closure.
+  program = attachDataFiles(
+    program,
+    options.dataFilePaths,
+    options.rootPath ?? dirname(options.main),
+  );
   let transformed: string | undefined;
   const getTransformedProgram = options.showTransformed
     ? (program: Program) => {

--- a/packages/cli/lib/multi-user-test-runner.ts
+++ b/packages/cli/lib/multi-user-test-runner.ts
@@ -233,6 +233,10 @@ export async function runMultiUserTestPattern(
           apiUrl: server.url.href,
           testPath,
           root: options.root,
+          // Each participant compiles the pattern in its own worker, so the
+          // attachment has to cross that boundary: a participant reading a data
+          // file otherwise fails for want of a closure the parent had.
+          dataFilePaths: options.dataFilePaths,
           patternCoverageDir: options.patternCoverageDir,
           continuousUI: options.continuousUI,
           participant: spec.name,

--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -33,6 +33,8 @@ import {
   type KeyPairRaw,
 } from "@commonfabric/identity";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { dirname } from "@std/path";
+import { attachDataFiles } from "./data-files.ts";
 import {
   type Cell,
   type ConsoleHandler,
@@ -332,11 +334,17 @@ const handlers: Record<
       : undefined;
     patternCoverageRoot = typeof args.root === "string" ? args.root : undefined;
 
-    const program = await engine.resolve(
-      new FileSystemProgramResolver(
-        args.testPath as string,
-        args.root as string | undefined,
+    const program = attachDataFiles(
+      await engine.resolve(
+        new FileSystemProgramResolver(
+          args.testPath as string,
+          args.root as string | undefined,
+        ),
       ),
+      Array.isArray(args.dataFilePaths)
+        ? args.dataFilePaths as string[]
+        : undefined,
+      (args.root as string | undefined) ?? dirname(args.testPath as string),
     );
     // `compileAndRegisterModules` seals compile + evaluate + register (see
     // test-runner.ts): map/filter/flatMap ops resolve via their content-addressed

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -9,10 +9,8 @@ import {
 } from "@commonfabric/data-model/fabric-value";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { createSession, isDID, Session } from "@commonfabric/identity";
-import {
-  FileSystemProgramResolver,
-  readDataFileSource,
-} from "@commonfabric/js-compiler";
+import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { attachDataFiles } from "./data-files.ts";
 import { setLLMUrl } from "@commonfabric/llm";
 import {
   assignSlug,
@@ -629,30 +627,17 @@ export async function getProgramFromFile(
       files.set(file.name, file);
     }
   }
-  // Data files are read directly rather than resolved: nothing imports them, so
-  // there is no closure to follow, and their bytes are never parsed.
-  const dataFiles: string[] = [];
-  for (const path of dataPaths) {
-    const source = readDataFileSource(path, rootPath);
-    if (dataFiles.includes(source.name)) continue;
-    // The entry or one of its tests reaches this name through an import, so the
-    // package would have to both compile it and store it uninterpreted.
-    if (files.has(source.name)) {
-      throw new Error(
-        `Data file "${source.name}" is also a source module of this package.`,
-      );
-    }
-    files.set(source.name, source);
-    dataFiles.push(source.name);
-  }
-  const program: RuntimeProgram = {
-    main: mainProgram.main,
-    files: [...files.values()],
-    ...(testPrograms.length === 0
-      ? {}
-      : { sourceRoots: testPrograms.map((test) => test.main) }),
-    ...(dataFiles.length === 0 ? {} : { dataFiles }),
-  };
+  const program = attachDataFiles(
+    {
+      main: mainProgram.main,
+      files: [...files.values()],
+      ...(testPrograms.length === 0
+        ? {}
+        : { sourceRoots: testPrograms.map((test) => test.main) }),
+    },
+    dataPaths,
+    rootPath,
+  );
   if (entry.mainExport) {
     program.mainExport = entry.mainExport;
   }

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -35,6 +35,8 @@ import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { Identity } from "@commonfabric/identity";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { dirname } from "@std/path";
+import { attachDataFiles } from "./data-files.ts";
 import {
   ConsoleMethod,
   experimentalOptionsFromEnv,
@@ -277,6 +279,11 @@ export interface TestRunnerOptions {
   verbose?: boolean;
   /** Root directory for resolving imports. If not provided, uses the test file's directory. */
   root?: string;
+  /**
+   * Data file paths to attach, so a pattern under test that reads one with
+   * `dataFile` reads here what it will read once deployed.
+   */
+  dataFilePaths?: string[];
   /** Print logger stats for steps slower than this (ms). 0 = every step. Default 5000. Only applies when verbose is true. */
   statsThreshold?: number;
   /** Timing categories to always print in verbose stats output. Matched by exact name or prefix. */
@@ -1067,9 +1074,13 @@ export async function runTestPattern(
     // 2. Compile the test pattern
     const program = await withPhase(
       ["runTestPattern", "resolve"],
-      () =>
-        engine.resolve(
-          new FileSystemProgramResolver(testPath, options.root),
+      async () =>
+        attachDataFiles(
+          await engine.resolve(
+            new FileSystemProgramResolver(testPath, options.root),
+          ),
+          options.dataFilePaths,
+          options.root ?? dirname(testPath),
         ),
     );
     const evalResult = await withPhase(

--- a/packages/cli/test/dev.test.ts
+++ b/packages/cli/test/dev.test.ts
@@ -126,6 +126,31 @@ describe("cli check", () => {
     expect(code).toBe(0);
   });
 
+  it("evaluates a pattern that reads a data file attached with --datafile", async () => {
+    const { code, stdout, stderr } = await cf(
+      "check --root fixtures fixtures/reads-data-file.tsx " +
+        "--datafile fixtures/data/cities.json --pattern-json",
+    );
+    checkStderr(stderr);
+    // The printed value is the file's contents, so this fails if the bytes
+    // never reached the pattern rather than merely if the compile broke.
+    expect(JSON.parse(stdout.join("\n"))).toEqual(["Oslo", "Lima"]);
+    expect(code).toBe(0);
+  });
+
+  it("names --datafile when a pattern reads a file that is not attached", async () => {
+    const { code, stderr } = await cf(
+      "check --root fixtures fixtures/reads-data-file.tsx",
+    );
+    // The refusal has to name the flag that fixes it, since the pattern
+    // compiles and type-checks either way.
+    expect(stripAnsi(stderr.join("\n"))).toContain(
+      'No attached data file "/data/cities.json"',
+    );
+    expect(stripAnsi(stderr.join("\n"))).toContain("--datafile");
+    expect(code).not.toBe(0);
+  });
+
   it("prints compiled module bodies as a structured JSON result", async () => {
     const { code, stdout, stderr } = await cf(
       "check fixtures/check-json-no-evaluate.ts --json",

--- a/packages/cli/test/fixtures/data-files/data/cities.json
+++ b/packages/cli/test/fixtures/data-files/data/cities.json
@@ -1,0 +1,1 @@
+{ "cities": ["Oslo", "Lima"] }

--- a/packages/cli/test/fixtures/data-files/multi-user.test.tsx
+++ b/packages/cli/test/fixtures/data-files/multi-user.test.tsx
@@ -1,0 +1,30 @@
+/// <cts-enable />
+/**
+ * Each participant of a multi-user test compiles the pattern in its own
+ * worker, so an attachment made where the workers are spawned does not reach
+ * them. This reads a data file from inside both participants, which is the
+ * only place the crossing can be observed.
+ */
+import { assert, dataFile, multiUserTest, pattern, TESTS } from "commonfabric";
+
+interface Cities {
+  cities: string[];
+}
+
+function cityCount(): number {
+  return (JSON.parse(dataFile("/data/cities.json")) as Cities).cities.length;
+}
+
+export const setup = pattern(() => ({ count: cityCount() }));
+
+export const alice = pattern<{ count: number }>(() => {
+  const assert_alice_reads_the_data_file = assert(() => cityCount() === 2);
+  return { [TESTS]: [{ assertion: assert_alice_reads_the_data_file }] };
+});
+
+export const bob = pattern<{ count: number }>(() => {
+  const assert_bob_reads_the_data_file = assert(() => cityCount() === 2);
+  return { [TESTS]: [{ assertion: assert_bob_reads_the_data_file }] };
+});
+
+export default multiUserTest({ setup, participants: { alice, bob } });

--- a/packages/cli/test/fixtures/data-files/single.test.tsx
+++ b/packages/cli/test/fixtures/data-files/single.test.tsx
@@ -1,0 +1,14 @@
+/// <cts-enable />
+import { assert, dataFile, pattern, TESTS } from "commonfabric";
+
+interface Cities {
+  cities: string[];
+}
+
+export default pattern(() => {
+  const parsed = JSON.parse(dataFile("/data/cities.json")) as Cities;
+  const assert_reads_the_attached_data_file = assert(() =>
+    parsed.cities.length === 2
+  );
+  return { [TESTS]: [{ assertion: assert_reads_the_attached_data_file }] };
+});

--- a/packages/cli/test/piece-source-package.test.ts
+++ b/packages/cli/test/piece-source-package.test.ts
@@ -252,7 +252,7 @@ describe("piece source package", () => {
         { runtime: { harness: { resolve } } } as any,
         { mainPath, rootPath: root, dataFilePaths: [sharedPath] },
       )).rejects.toThrow(
-        'Data file "/shared.ts" is also a source module of this package.',
+        'Data file "/shared.ts" is also a source module of this program.',
       );
     } finally {
       await Deno.remove(root, { recursive: true });

--- a/packages/cli/test/test-runner-data-files.test.ts
+++ b/packages/cli/test/test-runner-data-files.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Contract tests for `cf test --datafile`.
+ *
+ * A pattern that reads a data file compiles and type-checks whether or not one
+ * is attached — `dataFile` is declared either way — so the absence only shows
+ * when the pattern runs. These pin that the attachment reaches the runtime that
+ * runs the pattern, in both shapes `cf test` supports.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { join, resolve } from "@std/path";
+import { runTests } from "../lib/test-runner.ts";
+
+const FIXTURES = resolve(import.meta.dirname!, "fixtures/data-files");
+const DATA_FILE = join(FIXTURES, "data", "cities.json");
+
+function fixture(name: string): string {
+  return join(FIXTURES, name);
+}
+
+describe("cf test --datafile", () => {
+  it("runs a pattern that reads an attached data file", async () => {
+    const result = await runTests(fixture("single.test.tsx"), {
+      root: FIXTURES,
+      dataFilePaths: [DATA_FILE],
+    });
+    expect(result.failed).toBe(0);
+    expect(result.passed).toBeGreaterThan(0);
+  });
+
+  it("reaches each participant of a multi-user test", async () => {
+    // Participants compile in their own workers. Attaching only where the
+    // workers are spawned leaves each of them without the closure, so this
+    // fails on the participants rather than on the spawning runtime.
+    const result = await runTests(fixture("multi-user.test.tsx"), {
+      root: FIXTURES,
+      dataFilePaths: [DATA_FILE],
+    });
+    expect(result.failed).toBe(0);
+    expect(result.passed).toBe(2);
+  });
+
+  it("fails naming the flag when the file is not attached", async () => {
+    const result = await runTests(fixture("single.test.tsx"), {
+      root: FIXTURES,
+    });
+    expect(result.failed).toBeGreaterThan(0);
+  });
+});

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -214,11 +214,12 @@ revision, so omitting the flags drops those test roots from that revision.
 table, a list of names — so it ships and is recovered with the source. Its bytes
 are stored verbatim: never parsed, type-checked, compiled, or importable, and
 the pattern reads one with `dataFile("/data/cities.json")` from `commonfabric`.
-It must be UTF-8 text and sit inside the deployment root, which the CLI infers
-to cover the main entry, every test entry, and every data file unless `--root`
-says otherwise. Like `--test`, it is repeatable and defines part of the
-revision, so repeat the complete set on every `setsrc`. Changing a data file
-alone still produces a new source revision.
+`cf check` and `cf test` take the same flag, so a pattern that reads a data file
+can be checked and tested before deploying. It must be UTF-8 text and sit inside
+the deployment root, which the CLI infers to cover the main entry, every test
+entry, and every data file unless `--root` says otherwise. Like `--test`, it is
+repeatable and defines part of the revision, so repeat the complete set on every
+`setsrc`. Changing a data file alone still produces a new source revision.
 
 `setsrc` normally rejects incompatible argument/result schema changes and
 retained links whose durable contracts no longer fit. For an intentional

--- a/skills/pattern-deploy/SKILL.md
+++ b/skills/pattern-deploy/SKILL.md
@@ -77,8 +77,10 @@ Repeatable `--datafile <path>` attaches a file that is not code — a fixture, a
 lookup table — so it ships and is recovered with the source. Its bytes are
 stored verbatim and never parsed, compiled, or importable; it must be UTF-8 text
 inside the deployment root. A pattern reads one with `dataFile(path)` from
-`commonfabric`, naming the path it is stored under. The same complete-revision
-rule applies, so repeat every data-file flag on each update too.
+`commonfabric`, naming the path it is stored under. Pass the same `--datafile`
+flags to `cf check` and `cf test`, or the read fails there. The same
+complete-revision rule applies, so repeat every data-file flag on each update
+too.
 
 **Inspect piece state:**
 

--- a/skills/pattern-dev/SKILL.md
+++ b/skills/pattern-dev/SKILL.md
@@ -17,7 +17,8 @@ automated tests. Deployment packages and type-checks attached tests but does not
 run them. A file the pattern ships with that is not code — a fixture, a lookup
 table — attaches the same way with repeatable `--datafile` flags, is stored
 verbatim rather than compiled, and is read with `dataFile(path)` from
-`commonfabric`.
+`commonfabric`. `cf check` and `cf test` take `--datafile` too, so a pattern
+that reads one is checkable and testable locally.
 
 Also read the foundational reactivity references before implementing or
 debugging pattern state:


### PR DESCRIPTION
A pattern that reads a data file could be deployed but not checked. `cf check` and `cf test` build a program from local files and had no way to attach one, so the pattern compiled, type-checked, and then failed the moment it ran — with an error naming a flag neither command accepted:

    No attached data file "/data/cities.json". This pattern has none;
    attach one with --datafile.

Both commands now take the same repeatable `--datafile <path>` that the deployment commands take, so a pattern is checkable and testable before it is deployed, against the bytes it will read once it is.

Reading a data file is not a compile-time fact. `dataFile` is declared whether or not a file is attached, so type-checking passes either way and the absence surfaces on the read. That is why the flag matters on `check` specifically: `--no-run` was never going to catch this.

Three commands now attach data files, so the reading and grounding they share moves to one `attachDataFiles`. A file attached from the same root is stored under the same name whichever command attached it, which is what lets `dataFile("/data/cities.json")` mean the same thing under `check`, under `test`, and in the deployed piece. Its refusal message says "program" rather than "package", since it now serves commands that build one without deploying it.

The `cf check` fixture exports the file's parsed contents rather than a pattern, so the test asserts the bytes reached the pattern rather than that the compile survived. A second test pins the refusal, including that it names the flag that fixes it.

Document the flag, and the trap behind it: `dataFile` returns text, so parsing yields `any` and the shape has to be named or the inferred result schema has nothing to go on.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

