### PR TITLE
feat(runner): a materialized read describes the instant it was taken

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -394,16 +394,14 @@ probe reads. `Pattern Runner - Lift` pins both halves: the forwarding lift runs
 once instead of twice, while the inner lift still runs and still produces the
 new result.
 
-Reads fall back to eager materialization once the transaction has written, so
-every read describes one instant: a lift that writes into a `Writable` input and
-reads back through it gets what it wrote, and a read taken after a write is
-detached exactly as an eager one is. A lift reads its argument before it writes,
-so the win is untouched.
+A view describes the instant its `.get()` fixed, so a reader iterating a list
+while writing into it walks the list as it stood, and a lift that writes into a
+`Writable` input reads back what it wrote by taking the read again. Both
+readings on a marked transaction pin — the schema view and the schema-less
+proxy; unmarked reads are untouched, so the standing handle long-lived consumers
+rely on keeps tracking current state.
 
-Still unbuilt, and recorded in the plan: handlers materialize eagerly, and a
-view handed out BEFORE a write still tracks that write where an eager read would
-have detached — the fallback cannot recover the pre-write value after the fact,
-which is what the write epoch is for.
+Still unbuilt, and recorded in the plan: handlers materialize eagerly.
 
 ## Category 2: Contextual Flow Control enforcement rollout dials
 

--- a/docs/features/lazy-cell-materialization.md
+++ b/docs/features/lazy-cell-materialization.md
@@ -125,15 +125,45 @@ The view withdraws the record for a refusal it catches itself — the optional
 property above, whose answer is absence rather than a refusal. It clears only
 that exact refusal; another one held on the same transaction is somebody else's.
 
+## A view describes the instant it was taken
+
+`Cell.get()` on a marked transaction fixes an instant, and everything read
+through the value it returns describes that instant — the keys an object
+carried, an array's length and iteration order, and the values below them. A
+reader that writes and then reads back through a value it already holds sees
+what was there when it took that value, which is what an eager read gives, since
+an eager read hands back a value built before the write.
+
+Seeing your own write means taking the read again. A fresh `.get()` fixes a
+fresh instant, and so does `.get()` on a handle the argument carried, so a lift
+that writes into a `Writable` input and reads it back gets what it wrote. Two
+values taken either side of a write describe their own instants and disagree
+with each other, which is the point of them.
+
+That is what carries a reader iterating a list while writing into it: the walk
+runs over the list as it stood, whatever the writes do to it meanwhile.
+
+### How an instant is kept
+
+The transaction counts the roots it replaces, and a read taken now names that
+count. A write keeps the root it displaces only where a reader was handed an
+instant that root answers for — so a transaction nobody reads this way keeps
+nothing, and a run of writes with no read between them keeps one root rather
+than one per write.
+
+Keeping a root means freezing it first. A write thaws a frozen container by
+cloning it and edits an already-mutable one where it stands, so a root left
+behind by an earlier write is mutable and the next write would edit the very
+value a reader is describing. Freezing puts that write on the cloning path.
+Deep-freezing what is already deep-frozen costs nothing, so this is paid only on
+what the transaction has thawed by writing.
+
+Before the first write there is nothing to resolve — every document still stands
+at the root it was loaded with, so every instant names the same state — and
+reads skip the machinery outright on that check.
+
 ## Where a view is not used
 
-- **Once the transaction has written.** A view resolves each path when it is
-  touched, so a view taken before a write would report the value after it, where
-  an eager read hands back one detached at the moment it was taken. Reads fall
-  back to eager materialization once `tx.hasWrites()`, which keeps every read
-  describing one instant — what a reader iterating a list while writing into it
-  depends on. Nothing is lost where the win is: a lift reads its argument before
-  it writes anything.
 - **Handlers.** They stay eager.
 - **An absent or `true` schema.** That is the schema-less query-result proxy's
   job, and `validateAndTransform` dispatches to it before a view is considered.
@@ -142,17 +172,18 @@ that exact refusal; another one held on the same transaction is somebody else's.
 
 Assignment, deletion, `defineProperty` and freezing all throw. Snapshot it with
 `snapshotQueryResult` if you need a value you own. A view also keeps the
-transaction it was created with, so what it describes stays what was there when
-it was taken; reading after that transaction finishes throws rather than quietly
-reading from committed state.
+transaction it was created with, so reading after that transaction finishes
+throws rather than quietly reading from committed state.
 
-That last point is what separates a view from the schema-less proxy in
+That is what separates a view from the standing handle in
 [`query-result-proxy.ts`](../../packages/runner/src/query-result-proxy.ts),
 which re-resolves its transaction on every access so a holder keeps reading
 current state after the transaction it was made against has finished. Long-lived
 consumers depend on that — an LLM tool call dispatched later, a SQLite result
 flushed post-commit, a piece started on demand — so the mark is what selects
-between the two readings rather than one replacing the other.
+between the two readings rather than one replacing the other. A schema-less read
+on a marked transaction is a view like any other, and describes its instant; it
+is the unmarked ones that stand.
 
 ## Related documents
 

--- a/docs/plans/lazy-cell-materialization.md
+++ b/docs/plans/lazy-cell-materialization.md
@@ -1,8 +1,8 @@
 # Lazy, schema-observing cell materialization
 
 Status: built end to end and on by default behind `lazyMaterialization`. What
-remains is removing the flag and the eager path for lift arguments, plus the two
-pieces listed under Stages 3 and 5.
+remains is removing the flag and the eager path for lift arguments, plus the
+handler materialization listed under Stage 5.
 
 `Cell.get()` materializes everything its schema selects, in one pass, before the
 reader touches any of it. A lift declaring a list of a thousand entries gets a
@@ -165,43 +165,43 @@ container-shaped read, not a descent.
 
 A lazy view reads the state as of the `.get()` that created it, not the live
 transaction state. A reader that materializes a list and then writes into it
-iterates what it was handed, which is what eager materialization gives today.
+iterates what it was handed, which is what eager materialization gives.
 
-This is close to free, for a reason that falls out of how writes work. A write
-descends through `cloneForMutation` with `force: false`
-([`mutable-path-write.ts`](../../packages/runner/src/storage/transaction/mutable-path-write.ts),
-[`value-clone.ts`](../../packages/data-model/src/value-clone.ts)), which thaws a
-frozen container by shallow-cloning it and leaves an already-mutable one alone.
-So a **deep-frozen document root is stable against every later write in the
-transaction**: each write rebuilds the spine it descends and never reaches into
-the frozen tree. Pinning a snapshot is therefore one `deepFreeze` of the current
-root — and `deepFreeze` short-circuits on already-deep-frozen values through its
-cache ([`deep-freeze.ts`](../../packages/data-model/src/deep-freeze.ts)), so it
-costs only what this transaction has already thawed by writing. Nothing is
-copied, and there is no per-write cost afterwards.
+Read-your-own-writes is preserved by re-reading rather than by reading live: a
+fresh `.get()` fixes a fresh instant, and `.get()` on a handle the argument
+carried does too, so a lift that writes into a `Writable` input and reads it
+back gets what it wrote.
 
-For the case this plan exists to serve, the cost is zero. The scheduler opens a
-transaction and hands it straight to the action
-([`run.ts`](../../packages/runner/src/scheduler/run.ts)), whose first act is to
-read its argument. No write precedes it, so the snapshot for every document is
-its `initial` attestation — which the transaction already retains, unmodified,
-for the whole of its life.
+The transaction carries a write epoch, bumped each time it replaces a document
+root, and a view records the epoch it was taken at. Reading a document at epoch
+E resolves to the root standing at E: the current one where nothing has
+displaced it, and otherwise the one a write set aside.
 
-The general shape, for a `.get()` that happens after writes:
+A write sets a root aside only where a reader holds an instant that root answers
+for, so a transaction nobody reads this way costs its write path nothing, and a
+run of writes with no read between them keeps one root rather than one per
+write. Setting one aside means deep-freezing it first, because a write thaws a
+frozen container by cloning and edits an already-mutable one in place —
+so without the freeze the next write would edit the value a reader is
+describing. `deepFreeze` short-circuits on what is already deep-frozen, so this
+costs only what the transaction has thawed by writing.
 
-- The transaction carries a write epoch, bumped on each write.
-- A lazy view records the epoch at creation.
-- Reading a document at epoch E resolves to its `initial` attestation when its
-  first write is later than E (the common case — nothing needs pinning), and
-  otherwise to the root pinned for E.
-- Pins are taken at materialization, for the documents the transaction has
-  already written. That set is small and known: it is the transaction's writable
-  document entries.
+Before the first write every document still stands at its `initial` attestation,
+so every epoch names the same state and reads skip epoch resolution on that
+check alone. That is the shape the plan exists to serve: the scheduler opens a
+transaction and hands it straight to the action, whose first act is to read its
+argument.
 
-Reads still register their activity on the live transaction, so reactivity and
-commit preconditions are unchanged; only the _value_ comes from the pin. The
-preconditions describe committed state, which is what the pin holds, so the two
-stay consistent.
+Reads register their activity on the live transaction, so reactivity and commit
+preconditions are unchanged; only the _value_ comes from the epoch. The
+preconditions describe committed state, which is what an untouched root holds,
+so the two stay consistent.
+
+Caches that key on path rather than on instant — the transaction's read-result
+cache, its link-resolution memo, the frozen-reads cache, and the proxy cache —
+are not consulted or filled while a read resolves against an earlier epoch. A
+value kept under one instant and served under another is the failure this
+avoids.
 
 ### The mismatch signal
 
@@ -379,31 +379,36 @@ registers no read for its siblings, nor for array elements never reached.
 
 ### Stage 3 — Snapshot semantics
 
-**Closed for every read, by falling back rather than by pinning.** A view keeps
-the transaction it was created with (Stage 1), so two views taken together
-agree, and a view sees writes made through the handles it was passed — a lift
-that writes into a `Writable` input and reads back through it gets what it
-wrote, in either mode.
+**Done, by the write epoch.** A view describes the instant its `.get()` fixed,
+containers and values alike, and a reader sees its own writes by re-reading.
+"Snapshot semantics" above states the design.
 
-What a view cannot do is describe an instant that has already moved. It resolves
-each path when the reader touches it, so a read taken after a write would report
-the new value where an eager read hands back one detached when it was taken. So
-a read is materialized eagerly once the transaction has written
-(`tx.hasWrites()`). Nothing is lost where the win is: a lift reads its argument
-before it writes anything, so that read is still lazy.
-
-- [x] `hasWrites()` on the transaction, set at the one point every write funnels
-      through.
-- [x] `validateAndTransform` takes the lazy route only on a transaction that has
-      not written.
-- [x] Tested against an eager read, both for a read taken after a write and for
-      a lift writing through a handle and reading back.
-
-- [ ] One case is still open, and it needs the write epoch rather than the
-      fallback: a view handed out BEFORE a write still tracks that write, where
-      an eager read would have detached. The fallback cannot fix it after the
-      fact — recovering the pre-write value is exactly what an epoch buys. The
-      design and its cost analysis are under "Snapshot semantics" above.
+- [x] A write epoch on the transaction, bumped at the one chokepoint every root
+      replacement funnels through.
+- [x] A read resolves against the epoch its view was taken at, decided at the
+      single site where a read chooses its root.
+- [x] A write sets aside the root it displaces, deep-frozen, only where a reader
+      holds an instant that root answers for.
+- [x] Caches keyed on path rather than instant stand aside while a read resolves
+      against an earlier epoch.
+- [x] A nested materialization inherits the instant it is being read at rather
+      than fixing a later one.
+- [x] `validateAndTransform` takes the lazy route on every marked transaction,
+      whether or not it has written.
+- [x] Both readings on a marked transaction pin: the schema view and the
+      schema-less proxy. Unmarked reads are untouched, and the standing handle
+      keeps tracking current state.
+- [x] Benchmarked in `test/lazy-view-epoch.bench.ts`, with one runtime for the
+      file and every iteration aborting, so no iteration pays for a runtime or a
+      seeded document. A single walk of a thousand elements is not slower under
+      an epoch — it comes out ahead, because an epoch read neither fills nor
+      consults the per-path caches, which a walk that touches each path once
+      pays for and never collects on. Fifty writes after one view is taken cost
+      no more than fifty writes after a raw read: one preserve covers the run
+      and deep-freezing an already-frozen root is a cache hit. Fifty
+      write/read rounds, where every write finds an instant to preserve, cost
+      about 1.6x — seven runs spread between 1.5x and 2.0x, which is the figure
+      to quote rather than any single run's.
 
 ### Stage 4 — The transaction mode
 
@@ -483,8 +488,13 @@ Four properties carry most of the confidence:
   refusal, absent key, declared default — registers the read it stands in for.
   The cheapest assertion is on the registered read set; the honest one writes
   the value afterwards and observes the reader run.
-- **Snapshot.** A view taken before a write reads pre-write state; the pin does
-  not disturb later writes.
+- **Snapshot.** A view iterates the list it was handed while the reader writes
+  into that list, whichever side of a write the view was taken on, and a value
+  below the container reads as what stood at the instant the view was taken.
+  Taking the read again reads what the transaction now holds. Test it over a
+  list of primitives: an inline object element is rebased onto a `data:`
+  identity derived from its own value, so a read of one never reaches the
+  document and holds still whether or not the instant does any work.
 
 Mutation-test each new test: break the behavior it claims to guard and confirm
 it fails. A test over a proxy is unusually easy to write in a form that cannot
@@ -525,19 +535,17 @@ One carve-out, and it is deliberate: a finished view answers a `then` probe with
 it receives and a lift's result crosses a promise boundary by construction, so a
 view that refuses the probe cannot be returned at all.
 
-**Handles disagreeing across a write.** Not yet closed, and it needs the write
-epoch Stage 3 leaves unbuilt. Inside a marked transaction every read pins
-together, so two views agree; what they do not yet do is ignore writes the
-reader made after taking them. `getRaw()` is not a party to this — it returns a
-detached value at call time, so it has no lifetime to drift.
+**What an instant costs a transaction that keeps taking them.** A read between
+every write is the shape where every write preserves a root, and it is the one
+to watch: such a run costs around 1.6x the same run reading raw, spread between
+1.5x and 2.0x across runs. A run of writes under a single view costs nothing
+measurable, because one preserve covers it. Neither is the lift path, which reads its argument and writes nothing.
 
-Nothing catches such a disagreement, which is why it wants the epoch rather than
-a test. `StorageTransactionInconsistent` is a different check: `validate()`
-claims each read document's `initial` attestation against the live replica, so
-it fires when the replica moved under the transaction. Commit preconditions do
-not catch it either — `buildReads` emits address, path and version basis, never
-the value read — so a pinned read produces exactly the precondition a live one
-would.
+Retention rides on the same thing. `displaced` grows one root per document per
+read-then-write round and is never pruned, and `documentAtEpoch` scans it
+oldest-first, so a long-lived transaction alternating reads and writes pays in
+both memory and lookup. Deliberately left: the transactions this runs on are one
+action long.
 
 **CFC label timing.** Labels join the flow as paths are touched rather than at
 materialization, so a run's label set can be narrower — more precise, and a

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -83,12 +83,18 @@ const getProxyCache = (
 const proxyCacheKey = (
   link: NormalizedFullLink,
   cfcLabelView: CfcLabelView | undefined,
+  // Two pinned views over the same link describe different instants when they
+  // were taken either side of a write, so the instant is part of what makes
+  // them the same view. An unpinned handle has none and shares as it always
+  // has.
+  epoch: number | undefined,
 ): string =>
   JSON.stringify([
     link.space,
     link.id,
     link.path,
     cfcLabelView ?? null,
+    epoch ?? null,
   ]);
 
 /** Whether a transaction can still answer a read. */
@@ -180,9 +186,10 @@ export function createQueryResultProxy<T>(
   cfcLabelView?: CfcLabelView,
 ): T {
   // The transaction decides which of the two this is. Marked for lazy
-  // materialization, the proxy is a view: it keeps this transaction, so the
-  // value it describes stays the value that was there when it was taken, and
-  // reading after the transaction finishes throws.
+  // materialization, the proxy is a view: it keeps this transaction and
+  // describes the instant it was taken at, so the value it reports stays the
+  // value that was there however the reader writes afterwards, and reading
+  // after the transaction finishes throws.
   //
   // Unmarked — every caller today — it is a standing handle on a cell that
   // resolves the transaction afresh on every access, so a holder keeps reading
@@ -234,6 +241,29 @@ function createViewProxy<T>(
     pinned ? viewTx : runtime.readTx(tx);
   const childViewTx = (): IExtendedStorageTransaction =>
     pinned ? viewTx : runtime.readTx(tx ?? viewTx);
+  // The instant a pinned view describes. A child built inside a parent's trap
+  // inherits that parent's instant rather than taking a later one, which is
+  // what `issueReadEpoch` hands back while a read is already walking. An
+  // unpinned handle tracks current state and takes none.
+  //
+  // The reads this construction makes need no scope around them: no write can
+  // land between the epoch above and them, so current state IS that instant.
+  // The traps below fire later, and those do.
+  const epoch = pinned ? viewTx.issueReadEpoch() : undefined;
+  // Unlike the schema view, which gates its two read chokepoints by hand, the
+  // traps here read from a dozen branches apiece, so they share one wrapper.
+  // The thunk costs an allocation per trap call on a transaction that has
+  // written; this is the schema-LESS path, which a lift's argument does not
+  // take, and the shape of these traps makes the by-hand form a worse trade.
+  const atEpoch = <T>(body: () => T): T => {
+    if (epoch === undefined || !viewTx.hasWrites()) return body();
+    const previous = viewTx.enterReadEpoch(epoch);
+    try {
+      return body();
+    } finally {
+      viewTx.exitReadEpoch(previous);
+    }
+  };
   // Check recursion depth
   if (depth > MAX_RECURSION_DEPTH) {
     throw new Error(
@@ -382,294 +412,314 @@ function createViewProxy<T>(
   // one cache per transaction — which is right, because it describes the instant
   // that transaction saw.
   const txCache = getProxyCache(tx, runtime);
-  const cacheKey = proxyCacheKey(link, cfcLabelView);
+  const cacheKey = proxyCacheKey(link, cfcLabelView, epoch);
 
   // Check if we already have a proxy for this target in the cache.
   // The cache key is the original `value` (not the stub), ensuring that
   // the same frozen object always maps to the same proxy instance.
   const existingProxy = txCache.byLink.get(cacheKey) ??
-    (cfcLabelView === undefined ? txCache.byValue.get(value) : undefined);
+    (cfcLabelView === undefined && epoch === undefined
+      ? txCache.byValue.get(value)
+      : undefined);
   if (existingProxy) return remember(existingProxy);
 
   const proxy = new Proxy(proxyTarget as object, {
-    get: (target, prop, receiver) => {
-      // Promise adoption probes `then` on every value it receives, so a view
-      // that refuses the probe cannot cross a promise boundary at all — and a
-      // lift's result crosses one by construction. A finished view returns
-      // `undefined` for it, which is what a live one returns for a value
-      // with no `then`; every other property still refuses.
-      if (prop === "then" && pinned && !isReadable(viewTx)) return undefined;
-      if (Array.isArray(value) && prop === "length") {
-        const current = readTx().readValueOrThrow(link) as typeof value;
-        return Array.isArray(current) ? current.length : 0;
-      }
+    get: (target, prop, receiver) =>
+      atEpoch(() => {
+        // Promise adoption probes `then` on every value it receives, so a view
+        // that refuses the probe cannot cross a promise boundary at all — and a
+        // lift's result crosses one by construction. A finished view returns
+        // `undefined` for it, which is what a live one returns for a value
+        // with no `then`; every other property still refuses.
+        if (prop === "then" && pinned && !isReadable(viewTx)) return undefined;
+        if (Array.isArray(value) && prop === "length") {
+          const current = readTx().readValueOrThrow(link) as typeof value;
+          return Array.isArray(current) ? current.length : 0;
+        }
 
-      // When encountering a frozen property, we just return the value to
-      // maintain proxy invariants.
-      const descriptor = Object.getOwnPropertyDescriptor(target, prop);
-      if (descriptor?.configurable === false) {
-        return Reflect.get(target, prop, receiver);
-      }
+        // When encountering a frozen property, we just return the value to
+        // maintain proxy invariants.
+        const descriptor = Object.getOwnPropertyDescriptor(target, prop);
+        if (descriptor?.configurable === false) {
+          return Reflect.get(target, prop, receiver);
+        }
 
-      if (typeof prop === "symbol") {
-        if (prop === toCell) {
-          return () =>
-            createCell(runtime, link, tx, false, undefined, cfcLabelView);
-        } else if (prop === Symbol.iterator && Array.isArray(value)) {
-          return function () {
-            let index = 0;
-            return {
-              next() {
+        if (typeof prop === "symbol") {
+          if (prop === toCell) {
+            return () =>
+              createCell(runtime, link, tx, false, undefined, cfcLabelView);
+          } else if (prop === Symbol.iterator && Array.isArray(value)) {
+            return function () {
+              let index = 0;
+              return {
+                // Pulled after the trap returned, so it steps into the
+                // instant itself rather than inheriting the trap's scope.
+                next: () =>
+                  atEpoch(() => {
+                    const length = readTx().readValueOrThrow({
+                      ...link,
+                      path: [...link.path, "length"],
+                    }) as number;
+                    if (index < length) {
+                      const result = {
+                        value: createViewProxy(
+                          runtime,
+                          childViewTx(),
+                          tx,
+                          {
+                            ...link,
+                            path: [...link.path, String(index)],
+                          },
+                          depth + 1,
+                          childLabelView(cfcLabelView, String(index)),
+                          pinned,
+                        ),
+                        done: false,
+                      };
+                      index++;
+                      return result;
+                    }
+                    return { done: true };
+                  }),
+              };
+            };
+          }
+          const current = readTx().readValueOrThrow(link) as typeof value;
+
+          const returnValue = Reflect.get(current, prop, current);
+          if (typeof returnValue === "function") {
+            return returnValue.bind(current);
+          } else return returnValue;
+        }
+
+        if (
+          Array.isArray(value) &&
+          Object.prototype.hasOwnProperty.call(arrayMethods, prop) &&
+          typeof (value[prop as keyof typeof value]) === "function"
+        ) {
+          const method = Array.prototype[prop as keyof typeof Array.prototype];
+          const isReadWrite = arrayMethods[prop as keyof typeof arrayMethods];
+
+          return isReadWrite === ArrayMethodType.ReadOnly
+            // Invoked after the trap returned, so reading the elements steps
+            // into the instant itself; see the iterator above. The caller's
+            // callback runs OUTSIDE it, below — the instant belongs to reading
+            // this array, not to whatever the caller does with what it reads,
+            // and a read the callback takes of anything else (a cell it just
+            // wrote, most of all) describes current state as it would anywhere
+            // else. Mirrors `materialize()` in the schema view.
+            ? (...args: any[]) => {
+              const copy = atEpoch(() => {
+                // This will also mark each element read in the log. Almost all
+                // methods implicitly read all elements. TODO: Deal with
+                // exceptions like at().
                 const length = readTx().readValueOrThrow({
                   ...link,
                   path: [...link.path, "length"],
                 }) as number;
-                if (index < length) {
-                  const result = {
-                    value: createViewProxy(
-                      runtime,
-                      childViewTx(),
-                      tx,
-                      {
-                        ...link,
-                        path: [...link.path, String(index)],
-                      },
-                      depth + 1,
-                      childLabelView(cfcLabelView, String(index)),
-                      pinned,
-                    ),
-                    done: false,
-                  };
-                  index++;
-                  return result;
+
+                if (typeof length !== "number") {
+                  throw new Error(
+                    `Array length is not a number for ${prop} operation`,
+                  );
                 }
-                return { done: true };
-              },
-            };
-          };
-        }
-        const current = readTx().readValueOrThrow(link) as typeof value;
 
-        const returnValue = Reflect.get(current, prop, current);
-        if (typeof returnValue === "function") return returnValue.bind(current);
-        else return returnValue;
-      }
+                const current = readTx().readValueOrThrow(link) as typeof value;
+                const copy = new Array(length);
+                for (let i = 0; i < length; i++) {
+                  if (!(i in current)) {
+                    continue;
+                  }
+                  copy[i] = createViewProxy(
+                    runtime,
+                    childViewTx(),
+                    tx,
+                    { ...link, path: [...link.path, String(i)] },
+                    depth + 1,
+                    childLabelView(cfcLabelView, String(i)),
+                    pinned,
+                  );
+                }
 
-      if (
-        Array.isArray(value) &&
-        Object.prototype.hasOwnProperty.call(arrayMethods, prop) &&
-        typeof (value[prop as keyof typeof value]) === "function"
-      ) {
-        const method = Array.prototype[prop as keyof typeof Array.prototype];
-        const isReadWrite = arrayMethods[prop as keyof typeof arrayMethods];
-
-        return isReadWrite === ArrayMethodType.ReadOnly
-          ? (...args: any[]) => {
-            // This will also mark each element read in the log. Almost all
-            // methods implicitly read all elements. TODO: Deal with
-            // exceptions like at().
-            const length = readTx().readValueOrThrow({
-              ...link,
-              path: [...link.path, "length"],
-            }) as number;
-
-            if (typeof length !== "number") {
+                return copy;
+              });
+              return method.apply(copy, args);
+            }
+            : () => {
+              // A view is read-only, so the in-place mutators have nothing to
+              // route to. Mutate through the `asCell` handle a `Writable<..>`
+              // field mints, whose `Cell.push`/`Cell.set` carry the merge intent
+              // these methods never could.
               throw new Error(
-                `Array length is not a number for ${prop} operation`,
+                "This value is read-only, declare type as Writable<..> instead to get a writable version",
               );
-            }
+            };
+        }
 
-            const current = readTx().readValueOrThrow(link) as typeof value;
-            const copy = new Array(length);
-            for (let i = 0; i < length; i++) {
-              if (!(i in current)) {
-                continue;
-              }
-              copy[i] = createViewProxy(
-                runtime,
-                childViewTx(),
-                tx,
-                { ...link, path: [...link.path, String(i)] },
-                depth + 1,
-                childLabelView(cfcLabelView, String(i)),
-                pinned,
-              );
-            }
+        // Prototype properties are JavaScript behavior, not persisted child
+        // values. Reflect them from the current container instead of issuing a
+        // storage read for an inherited path such as `constructor` or
+        // `toString`. Storage traversal deliberately considers own properties
+        // only; keeping the same boundary here also avoids recording spurious
+        // reactive dependencies for prototype members.
+        //
+        // The receiver is the container, not this proxy: a prototype accessor
+        // has to run against the object that actually holds the state. Every
+        // `FabricInstance` keeps its state in private fields behind accessors,
+        // and a private field is unreachable from a proxy that does not declare
+        // it. (The receiver is immaterial for a data property, which is what
+        // every prototype member of a plain object or array is, so this costs
+        // those nothing.) A `FabricInstance` leafs through storage traversal
+        // whole, so the read of the container already covers what an accessor
+        // returns.
+        if (!Object.hasOwn(value, prop) && prop in value) {
+          return Reflect.get(value, prop);
+        }
 
-            return method.apply(copy, args);
-          }
-          : () => {
-            // A view is read-only, so the in-place mutators have nothing to
-            // route to. Mutate through the `asCell` handle a `Writable<..>`
-            // field mints, whose `Cell.push`/`Cell.set` carry the merge intent
-            // these methods never could.
-            throw new Error(
-              "This value is read-only, declare type as Writable<..> instead to get a writable version",
-            );
-          };
-      }
-
-      // Prototype properties are JavaScript behavior, not persisted child
-      // values. Reflect them from the current container instead of issuing a
-      // storage read for an inherited path such as `constructor` or
-      // `toString`. Storage traversal deliberately considers own properties
-      // only; keeping the same boundary here also avoids recording spurious
-      // reactive dependencies for prototype members.
-      //
-      // The receiver is the container, not this proxy: a prototype accessor
-      // has to run against the object that actually holds the state. Every
-      // `FabricInstance` keeps its state in private fields behind accessors,
-      // and a private field is unreachable from a proxy that does not declare
-      // it. (The receiver is immaterial for a data property, which is what
-      // every prototype member of a plain object or array is, so this costs
-      // those nothing.) A `FabricInstance` leafs through storage traversal
-      // whole, so the read of the container already covers what an accessor
-      // returns.
-      if (!Object.hasOwn(value, prop) && prop in value) {
-        return Reflect.get(value, prop);
-      }
-
-      return createViewProxy(
-        runtime,
-        childViewTx(),
-        tx,
-        { ...link, path: [...link.path, prop] },
-        depth + 1,
-        childLabelView(cfcLabelView, String(prop)),
-        pinned,
-      );
-    },
+        return createViewProxy(
+          runtime,
+          childViewTx(),
+          tx,
+          { ...link, path: [...link.path, prop] },
+          depth + 1,
+          childLabelView(cfcLabelView, String(prop)),
+          pinned,
+        );
+      }),
     set: (_, prop) => {
       if (typeof prop === "symbol") return false;
       throw new Error(
         "This value is read-only, declare type as Writable<..> instead to get a writable version",
       );
     },
-    ownKeys: () => {
-      const current = readTx().readValueOrThrow(link, SHAPE_READ);
-      const keys = isObjectOrArray(current) || Array.isArray(current)
-        ? Reflect.ownKeys(current)
-        : Reflect.ownKeys(value);
-      if (Array.isArray(proxyTarget)) {
-        if (!keys.includes("length")) {
-          // Insert `length` where a real array carries it -- after the index
-          // keys, ahead of any other name -- rather than appending it. Own-key
-          // order is load-bearing: a consumer can tell an index-only array from
-          // one carrying named properties by asking whether `length` comes
-          // last, and appending would make a named property look like an
-          // index-only one. `isInertArray()` reads exactly that, and fabric
-          // membership (`isFabricValue()`) is decided by it for every array,
-          // so the order here is what makes a proxied array carrying a named
-          // property fail membership instead of passing as index-only.
-          const firstNonIndex = keys.findIndex((key) =>
-            !((typeof key === "string") && isArrayIndexPropertyName(key))
-          );
-          keys.splice(
-            (firstNonIndex === -1) ? keys.length : firstNonIndex,
-            0,
-            "length",
-          );
-        }
-        // Enumerating an array's keys (`Object.keys`/`values`/`entries`, a spread,
-        // `for...in`) observes which index keys are present. For a dense array
-        // that is its `length`, but an array here can be sparse (holes below
-        // `length`), and filling or punching a hole changes the present-key set
-        // without changing `length` — a write at `/arr/<i>` with no `/arr/length`
-        // write. The SHAPE_READ above is dropped at commit as the op's incidental
-        // container read, and neither a `length` read nor a nonRecursive shape
-        // read at the array path conflicts with a same-length element-slot write.
-        // Record a recursive (by-value) read of the array — the one read the
-        // mergeable narrowing keeps that a hole edit invalidates — so an
-        // enumeration-derived mergeable write conflicts and retries instead of
-        // merging on a stale key set. It is marked `ignoreReadForScheduling` so it
-        // adds only the conflict dependency; reactivity stays on the SHAPE_READ.
-        readTx().readValueOrThrow(link, { meta: ignoreReadForScheduling });
-      }
-      return keys;
-    },
-    getOwnPropertyDescriptor: (target, prop) => {
-      if (Array.isArray(target) && prop === "length") {
-        // Read the array fully (not SHAPE_READ) so the length descriptor tracks
-        // element add/remove, matching the `length` get trap above. [review: ubik2]
-        const current = readTx().readValueOrThrow(link);
-        return {
-          configurable: false,
-          enumerable: false,
-          writable: true,
-          value: Array.isArray(current) ? current.length : 0,
-        };
-      }
-
-      // For properties that exist on the original target (e.g. array `length`),
-      // delegate to the target to satisfy proxy invariants for non-configurable
-      // properties.
-      const targetDesc = Object.getOwnPropertyDescriptor(target, prop);
-      if (targetDesc && !targetDesc.configurable) {
-        return targetDesc;
-      }
-      if (typeof prop === "symbol") {
-        return Object.getOwnPropertyDescriptor(value, prop);
-      }
-      const current = readTx().readValueOrThrow(
-        link,
-        SHAPE_READ,
-      ) as typeof value;
-      // `Object.hasOwn`, not `in`: this trap reports on OWN properties, and
-      // `in` walks the prototype chain. Because the underlying value is an
-      // ordinary `Object.prototype`-rooted record, `in` reported every member of
-      // `Object.prototype` -- `toString`, `valueOf`, `constructor`, `__proto__`
-      // -- as an own property of the proxy, while `ownKeys` (which uses
-      // `Reflect.ownKeys`) listed none of them. Two traps describing the same
-      // value disagreed by construction, so every consumer that reasons about a
-      // read-back value's shape was being told it carries names it does not.
-      //
-      // That is not academic: `unsafeObjectKeyIn()` refuses a `FabricValue`
-      // carrying own `__proto__`/`constructor` and tests with `Object.hasOwn()`,
-      // so writing a read-back record back to a cell was rejected for a key the
-      // record never had, and every read-modify-write against a cell failed
-      // (loom CT-1949). The `has` trap below keeps `in` -- there it is correct,
-      // being the `in` operator's own trap.
-      if (
-        (isObjectOrArray(current) || Array.isArray(current)) &&
-        Object.hasOwn(current, prop)
-      ) {
-        return {
-          configurable: true,
-          enumerable: true,
-          writable: false,
-          value: createViewProxy(
-            runtime,
-            childViewTx(),
-            tx,
-            { ...link, path: [...link.path, prop as string] },
-            depth + 1,
-            childLabelView(cfcLabelView, String(prop)),
-            pinned,
-          ),
-        };
-      }
-      return undefined;
-    },
-    has: (_target, prop) => {
-      if (typeof prop === "symbol") {
-        return prop in value;
-      }
-      const current = readTx().readValueOrThrow(link, SHAPE_READ);
-      if (isObjectOrArray(current) || Array.isArray(current)) {
-        // Probing whether a numeric index is present (`n in arr`) observes the
-        // array's key set: for a dense array the answer is `n < length`, but a
-        // sparse array has holes, so the answer depends on whether index `n` is
-        // specifically present — which a same-length hole fill or punch changes
-        // with no `length` write. Record a recursive read of the array (marked
-        // conflict-only, like ownKeys above) so an `n in arr`-derived mergeable
-        // write conflicts and retries instead of merging on a stale key set.
-        if (Array.isArray(current) && /^\d+$/.test(prop)) {
+    ownKeys: () =>
+      atEpoch(() => {
+        const current = readTx().readValueOrThrow(link, SHAPE_READ);
+        const keys = isObjectOrArray(current) || Array.isArray(current)
+          ? Reflect.ownKeys(current)
+          : Reflect.ownKeys(value);
+        if (Array.isArray(proxyTarget)) {
+          if (!keys.includes("length")) {
+            // Insert `length` where a real array carries it -- after the index
+            // keys, ahead of any other name -- rather than appending it. Own-key
+            // order is load-bearing: a consumer can tell an index-only array from
+            // one carrying named properties by asking whether `length` comes
+            // last, and appending would make a named property look like an
+            // index-only one. `isInertArray()` reads exactly that, and fabric
+            // membership (`isFabricValue()`) is decided by it for every array,
+            // so the order here is what makes a proxied array carrying a named
+            // property fail membership instead of passing as index-only.
+            const firstNonIndex = keys.findIndex((key) =>
+              !((typeof key === "string") && isArrayIndexPropertyName(key))
+            );
+            keys.splice(
+              (firstNonIndex === -1) ? keys.length : firstNonIndex,
+              0,
+              "length",
+            );
+          }
+          // Enumerating an array's keys (`Object.keys`/`values`/`entries`, a spread,
+          // `for...in`) observes which index keys are present. For a dense array
+          // that is its `length`, but an array here can be sparse (holes below
+          // `length`), and filling or punching a hole changes the present-key set
+          // without changing `length` — a write at `/arr/<i>` with no `/arr/length`
+          // write. The SHAPE_READ above is dropped at commit as the op's incidental
+          // container read, and neither a `length` read nor a nonRecursive shape
+          // read at the array path conflicts with a same-length element-slot write.
+          // Record a recursive (by-value) read of the array — the one read the
+          // mergeable narrowing keeps that a hole edit invalidates — so an
+          // enumeration-derived mergeable write conflicts and retries instead of
+          // merging on a stale key set. It is marked `ignoreReadForScheduling` so it
+          // adds only the conflict dependency; reactivity stays on the SHAPE_READ.
           readTx().readValueOrThrow(link, { meta: ignoreReadForScheduling });
         }
-        return prop in current;
-      }
-      return prop in value;
-    },
+        return keys;
+      }),
+    getOwnPropertyDescriptor: (target, prop) =>
+      atEpoch(() => {
+        if (Array.isArray(target) && prop === "length") {
+          // Read the array fully (not SHAPE_READ) so the length descriptor tracks
+          // element add/remove, matching the `length` get trap above. [review: ubik2]
+          const current = readTx().readValueOrThrow(link);
+          return {
+            configurable: false,
+            enumerable: false,
+            writable: true,
+            value: Array.isArray(current) ? current.length : 0,
+          };
+        }
+
+        // For properties that exist on the original target (e.g. array `length`),
+        // delegate to the target to satisfy proxy invariants for non-configurable
+        // properties.
+        const targetDesc = Object.getOwnPropertyDescriptor(target, prop);
+        if (targetDesc && !targetDesc.configurable) {
+          return targetDesc;
+        }
+        if (typeof prop === "symbol") {
+          return Object.getOwnPropertyDescriptor(value, prop);
+        }
+        const current = readTx().readValueOrThrow(
+          link,
+          SHAPE_READ,
+        ) as typeof value;
+        // `Object.hasOwn`, not `in`: this trap reports on OWN properties, and
+        // `in` walks the prototype chain. Because the underlying value is an
+        // ordinary `Object.prototype`-rooted record, `in` reported every member of
+        // `Object.prototype` -- `toString`, `valueOf`, `constructor`, `__proto__`
+        // -- as an own property of the proxy, while `ownKeys` (which uses
+        // `Reflect.ownKeys`) listed none of them. Two traps describing the same
+        // value disagreed by construction, so every consumer that reasons about a
+        // read-back value's shape was being told it carries names it does not.
+        //
+        // That is not academic: `unsafeObjectKeyIn()` refuses a `FabricValue`
+        // carrying own `__proto__`/`constructor` and tests with `Object.hasOwn()`,
+        // so writing a read-back record back to a cell was rejected for a key the
+        // record never had, and every read-modify-write against a cell failed
+        // (loom CT-1949). The `has` trap below keeps `in` -- there it is correct,
+        // being the `in` operator's own trap.
+        if (
+          (isObjectOrArray(current) || Array.isArray(current)) &&
+          Object.hasOwn(current, prop)
+        ) {
+          return {
+            configurable: true,
+            enumerable: true,
+            writable: false,
+            value: createViewProxy(
+              runtime,
+              childViewTx(),
+              tx,
+              { ...link, path: [...link.path, prop as string] },
+              depth + 1,
+              childLabelView(cfcLabelView, String(prop)),
+              pinned,
+            ),
+          };
+        }
+        return undefined;
+      }),
+    has: (_target, prop) =>
+      atEpoch(() => {
+        if (typeof prop === "symbol") {
+          return prop in value;
+        }
+        const current = readTx().readValueOrThrow(link, SHAPE_READ);
+        if (isObjectOrArray(current) || Array.isArray(current)) {
+          // Probing whether a numeric index is present (`n in arr`) observes the
+          // array's key set: for a dense array the answer is `n < length`, but a
+          // sparse array has holes, so the answer depends on whether index `n` is
+          // specifically present — which a same-length hole fill or punch changes
+          // with no `length` write. Record a recursive read of the array (marked
+          // conflict-only, like ownKeys above) so an `n in arr`-derived mergeable
+          // write conflicts and retries instead of merging on a stale key set.
+          if (Array.isArray(current) && /^\d+$/.test(prop)) {
+            readTx().readValueOrThrow(link, { meta: ignoreReadForScheduling });
+          }
+          return prop in current;
+        }
+        return prop in value;
+      }),
     // A query-result proxy is a live, transaction-backed view: reads resolve
     // through the get trap on every access. Structural mutations (freeze, seal,
     // defineProperty, delete) cannot be honored without either corrupting the
@@ -700,7 +750,10 @@ function createViewProxy<T>(
 
   // Cache the proxy in the appropriate cache before returning
   txCache.byLink.set(cacheKey, proxy);
-  if (cfcLabelView === undefined) {
+  // Not the by-value index for a pinned view: it names a value rather than an
+  // instant, so it would hand a view taken at one epoch to a reader asking at
+  // another.
+  if (cfcLabelView === undefined && epoch === undefined) {
     txCache.byValue.set(value, proxy);
   }
   return remember(proxy);

--- a/packages/runner/src/schema-view.ts
+++ b/packages/runner/src/schema-view.ts
@@ -407,6 +407,11 @@ const defaultForAbsentValue = (
  * the reader's shape and the link's own. `value` is the container read at that
  * link, which the caller has already taken.
  *
+ * The view describes the instant it is built at: the keys `value` carried, an
+ * array's length and iteration order, and every value below, which resolve
+ * against the epoch taken here rather than against whatever the reader writes
+ * afterwards. Taking the read again is what fixes a later instant.
+ *
  * At the root a mismatch is `undefined` — the answer an eager read gives for
  * the same data. Below it, a mismatch throws.
  */
@@ -535,6 +540,11 @@ export function materializeSchemaView(
 
   const viewLink: NormalizedFullLink = { ...link, schema };
 
+  // The instant this view describes. Taken even where the transaction has not
+  // written yet — that is the ordinary case, and it is the asking that puts a
+  // later write on notice to keep the root it displaces.
+  const epoch = tx.issueReadEpoch();
+
   if (Array.isArray(value)) {
     return createArrayView(
       runtime,
@@ -543,6 +553,7 @@ export function materializeSchemaView(
       value,
       cfcLabelView,
       synced,
+      epoch,
     );
   }
 
@@ -566,7 +577,15 @@ export function materializeSchemaView(
     }
   }
 
-  return createObjectView(runtime, tx, viewLink, value, cfcLabelView, synced);
+  return createObjectView(
+    runtime,
+    tx,
+    viewLink,
+    value,
+    cfcLabelView,
+    synced,
+    epoch,
+  );
 }
 
 /** The keys a reader sees: the data's own keys the schema selects, plus any
@@ -662,10 +681,11 @@ function createObjectView(
   value: Record<string, FabricValue>,
   cfcLabelView: CfcLabelView | undefined,
   synced: boolean,
+  epoch: number | undefined,
 ): unknown {
   const schema = link.schema;
   const required = new Set(requiredKeys(schema));
-  const childOrAbsent = (key: string): unknown => {
+  const resolveChild = (key: string): unknown => {
     const narrowed = childSchema(schema, key);
     if (isExcluded(narrowed)) return undefined;
     if (!Object.hasOwn(value, key)) {
@@ -706,6 +726,22 @@ function createObjectView(
       // the reader back when the data arrives.
       tx.clearSchemaRefusal(error);
       return ABSENT;
+    }
+  };
+
+  // Every read this view takes goes through here, so this is where it steps
+  // into the instant it describes. Before the transaction's first write there
+  // is nothing to step into — every epoch names the same root — so the common
+  // case pays one boolean and no more. Entered by hand rather than around a
+  // callback: a reader walking a large value touches this per property, and a
+  // callback would allocate a closure each time.
+  const childOrAbsent = (key: string): unknown => {
+    if (!tx.hasWrites()) return resolveChild(key);
+    const previous = tx.enterReadEpoch(epoch);
+    try {
+      return resolveChild(key);
+    } finally {
+      tx.exitReadEpoch(previous);
     }
   };
 
@@ -766,9 +802,10 @@ function createArrayView(
   value: FabricValue[],
   cfcLabelView: CfcLabelView | undefined,
   synced: boolean,
+  epoch: number | undefined,
 ): unknown {
   const schema = link.schema;
-  const element = (index: number): unknown => {
+  const resolveElement = (index: number): unknown => {
     const key = String(index);
     const itemSchema = childSchema(schema, key);
     const item = value[index];
@@ -810,6 +847,19 @@ function createArrayView(
       );
     }
     return readChildAt(runtime, tx, slotLink, [key], cfcLabelView, synced);
+  };
+
+  // The array's counterpart to the object view's gate: every element read steps
+  // into the instant this view describes, and skips the step entirely until the
+  // transaction has written. See the note there for why it is entered by hand.
+  const element = (index: number): unknown => {
+    if (!tx.hasWrites()) return resolveElement(index);
+    const previous = tx.enterReadEpoch(epoch);
+    try {
+      return resolveElement(index);
+    } finally {
+      tx.exitReadEpoch(previous);
+    }
   };
 
   // A read-only array method runs against element views built on demand. The

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -1320,14 +1320,12 @@ export function validateAndTransform(
   // combination — so a view and an eager read start from the same link and the
   // same schema; only the materialization differs.
   //
-  // Not once the transaction has written, though. A view resolves each path
-  // when the reader touches it, so a view taken before a write reports the
-  // value after it, where an eager read hands back a value detached at the
-  // moment it was taken. Falling back keeps every read describing one instant,
-  // which is what a reader iterating a list while writing into it depends on.
-  // Nothing is lost where the win is: a lift reads its argument before it
-  // writes anything, so that read is still lazy.
-  if (tx.isLazyMaterialize() && !tx.hasWrites()) {
+  // A view describes the instant this read fixes, and goes on describing it
+  // however the reader writes afterwards — which is what a reader iterating a
+  // list while writing into it stands on, and what an eager read gives, since
+  // an eager read hands back a value built before the write. Seeing its own
+  // write means taking the read again.
+  if (tx.isLazyMaterialize()) {
     // Crossing the last link is a hop the eager traverser combines schemas
     // across (`linkHopSelector`), because a link's own schema describes the
     // value at its target while the reader's schema describes what the reader

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -899,6 +899,31 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     return isLazyMaterializationTx(this);
   }
 
+  hasWrites(): boolean {
+    return this.tx.hasWrites?.() ?? false;
+  }
+
+  issueReadEpoch(): number | undefined {
+    return this.tx.issueReadEpoch?.();
+  }
+
+  enterReadEpoch(epoch: number | undefined): number | undefined {
+    const previous = this.#readEpoch;
+    this.#readEpoch = epoch;
+    this.tx.enterReadEpoch?.(epoch);
+    return previous;
+  }
+
+  exitReadEpoch(previous: number | undefined): void {
+    this.#readEpoch = previous;
+    this.tx.exitReadEpoch?.(previous);
+  }
+
+  // Mirrors the epoch pushed down to the storage transaction, so the caches
+  // this class owns can tell whether the value they are about to keep, or
+  // hand out, describes the current state or an earlier one.
+  #readEpoch: number | undefined;
+
   noteSchemaRefusal(refusal: unknown): void {
     noteSchemaRefusalTx(this, refusal);
   }
@@ -929,6 +954,13 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     key: string,
     variant: string,
   ): { value: unknown } | undefined {
+    // Both caches key on path and schema, not on which instant is being read,
+    // and they are dropped on write to stay level with current state. A read
+    // resolving against an earlier epoch is describing a different instant, so
+    // it neither takes from them nor adds to them — serving one across that
+    // boundary would hand a materialized read's value to a current one, or the
+    // reverse.
+    if (this.#readEpoch !== undefined) return undefined;
     const cached = this.readResultCache.get(key)?.get(variant);
     if (cached === undefined) {
       this.readResultCacheMisses++;
@@ -943,6 +975,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     variant: string,
     value: unknown,
   ): void {
+    if (this.#readEpoch !== undefined) return;
     let byVariant = this.readResultCache.get(key);
     if (byVariant === undefined) {
       byVariant = new Map();
@@ -956,6 +989,9 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     // A finished transaction answers no reads, so nothing it memoized earlier
     // may be handed out as if it had.
     if (this.status().status !== "ready") return undefined;
+    // A read resolving against an earlier epoch describes a different instant
+    // than the memo does; see `getCachedReadResult`.
+    if (this.#readEpoch !== undefined) return undefined;
     // Once CFC is prepared, the read path's `read-after-prepare` invalidation
     // is load-bearing: a memoized resolution issues no reads and would leave a
     // prepared digest standing over a read it never made.
@@ -990,25 +1026,6 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
       sets: this.readResultCacheSets,
       entries,
     };
-  }
-
-  hasWrites(): boolean {
-    return this.#hasWrites;
-  }
-
-  #hasWrites = false;
-
-  /**
-   * Record that this transaction has written.
-   *
-   * Called from every write path rather than inferred from one of their side
-   * effects: a mergeable op and a folded SQLite write are both writes, and
-   * neither drops the read-result cache — the value write a mergeable op
-   * annotates has already done that, and a SQLite op changes no cell value
-   * locally. Deriving "has written" from cache invalidation would miss both.
-   */
-  private noteWrite(): void {
-    this.#hasWrites = true;
   }
 
   private invalidateReadResultCache(): void {
@@ -1619,7 +1636,6 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
 
   recordMergeableOp(link: NormalizedFullLink, delta: MergeableOpDelta): void {
     this.assertWritable("recordMergeableOp");
-    this.noteWrite();
     const address = toMemorySpaceAddress(link);
     // Same S18 chokepoint as write()/writeOrThrow(): a mergeable op IS a
     // write. The ["cfc"]-path arm is structurally unreachable here (a
@@ -1646,7 +1662,6 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     // A folded SQLite write is a write — honor the wrapper's read-only mode the
     // same way cell writes do, instead of silently recording it.
     this.assertWritable("recordSqliteWrite");
-    this.noteWrite();
     if (!this.tx.recordSqliteWrite) {
       throw new Error(
         "storage transaction does not support recordSqliteWrite()",
@@ -1745,7 +1760,6 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     options?: IWriteOptions,
   ): Result<IAttestation, WriteError | WriterError> {
     this.assertWritable("write()");
-    this.noteWrite();
     this.noteSystemWrite(address);
     this.noteWriteIdentity();
     if (this.#cfcState.prepare.status === "prepared") {
@@ -1761,7 +1775,6 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     options?: IWriteOptions,
   ): void {
     this.assertWritable("writeOrThrow()");
-    this.noteWrite();
     this.noteSystemWrite(address);
     this.noteWriteIdentity();
     if (this.#cfcState.prepare.status === "prepared") {
@@ -1880,18 +1893,16 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
       // `packages/runner/test/memory-v2-acl-mutation.test.ts`.
       const noteSystemWrite = (address: IMemorySpaceAddress) =>
         this.noteSystemWrite(address);
-      // Note the write per yielded write (not once up front): an empty batch
-      // must not mark the tx as written-to, for the identity or for the
-      // has-written flag lazy materialization reads.
+      // Capture the identity per yielded write, not once up front: an empty
+      // batch authored nothing, so it must not record a write for the
+      // transaction's write-identity summary.
       const noteWriteIdentity = () => this.noteWriteIdentity();
-      const noteWrite = () => this.noteWrite();
       const result = this.tx.writeBatch(
         (function* () {
           for (const write of writes) {
             const address = toMemorySpaceAddress(write.address);
             noteSystemWrite(address);
             noteWriteIdentity();
-            noteWrite();
             yield { address, value: write.value, delete: write.delete };
           }
         })(),
@@ -2324,6 +2335,18 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
 
   hasWrites(): boolean {
     return this.wrapped.hasWrites();
+  }
+
+  issueReadEpoch(): number | undefined {
+    return this.wrapped.issueReadEpoch();
+  }
+
+  enterReadEpoch(epoch: number | undefined): number | undefined {
+    return this.wrapped.enterReadEpoch(epoch);
+  }
+
+  exitReadEpoch(previous: number | undefined): void {
+    this.wrapped.exitReadEpoch(previous);
   }
 
   noteSchemaRefusal(refusal: unknown): void {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -896,6 +896,36 @@ export interface IStorageTransaction {
   recordSqliteWrite?(space: MemorySpace, op: SqliteOperation): void;
 
   /**
+   * Optional: whether this transaction has replaced any document root.
+   *
+   * Read by materialization as a fast path — before the first write every read
+   * epoch describes the same state, so a reader can skip epoch handling
+   * outright rather than resolve one per path it touches.
+   */
+  hasWrites?(): boolean;
+
+  /**
+   * Optional: the epoch a materialized read taken now should describe.
+   *
+   * Asking for one is also what tells later writes that the root they displace
+   * is still being described, so a transaction nobody reads this way costs its
+   * write path nothing.
+   */
+  issueReadEpoch?(): number | undefined;
+
+  /**
+   * Optional: resolve reads against `epoch` until the matching
+   * {@link IStorageTransaction.exitReadEpoch}, returning the epoch that was in
+   * force.
+   *
+   * Paired rather than callback-wrapped so a reader walking a large value
+   * allocates no closure per property it touches.
+   */
+  enterReadEpoch?(epoch: number | undefined): number | undefined;
+
+  exitReadEpoch?(previous: number | undefined): void;
+
+  /**
    * Optional raw read observations recorded by this transaction.
    *
    * V2 transactions can provide these directly instead of requiring callers to
@@ -1224,28 +1254,43 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
    *
    * A marked transaction hands a reader views that resolve each path as it is
    * touched, rather than a value built in one pass before the reader looks at
-   * any of it. A view also keeps the transaction it was created with, so the
-   * value it describes stays the value that was there when it was taken, and
-   * reading after the transaction finishes throws rather than quietly
-   * reading from committed state.
+   * any of it. A view keeps the transaction it was created with and describes
+   * the instant it was taken at — containers and values alike — so a reader
+   * that writes and reads back through a value it already holds still sees what
+   * was there. Taking the read again fixes a later instant, which is how a
+   * reader sees its own writes. Reading after the transaction finishes throws
+   * rather than quietly reading from committed state.
    *
-   * Unmarked, every read behaves exactly as it did before lazy materialization
-   * existed — including the standing-handle semantics that long-lived
-   * consumers rely on, where a query-result proxy keeps tracking current state
+   * Unmarked, a read is built in one pass and the query-result proxy is a
+   * standing handle that long-lived consumers rely on, tracking current state
    * after the transaction it was made against has finished.
    */
   markLazyMaterialize(enabled?: boolean): void;
   isLazyMaterialize(): boolean;
 
   /**
-   * Whether this transaction has written anything yet.
+   * Whether this transaction has replaced any document root.
    *
-   * Lazy materialization reads it to decide whether a view can still describe
-   * one instant: a view resolves each path when it is touched, so once the
-   * transaction has written, a view taken earlier would report the new value
-   * where an eager read hands back a detached one taken before the write.
+   * A materialized read consults it to decide whether epoch resolution can be
+   * skipped: before the first write every document still stands at its
+   * `initial` attestation, so every epoch describes the same state and a read
+   * taken at any of them reads alike.
    */
   hasWrites(): boolean;
+
+  /**
+   * The epoch a materialized read taken now should describe, or undefined
+   * where this transaction cannot answer for an earlier one.
+   */
+  issueReadEpoch(): number | undefined;
+
+  /**
+   * Resolve reads against `epoch` until the matching {@link exitReadEpoch},
+   * returning the epoch that was in force.
+   */
+  enterReadEpoch(epoch: number | undefined): number | undefined;
+
+  exitReadEpoch(previous: number | undefined): void;
 
   /**
    * Record that a reader touched data its schema does not describe.

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -1,6 +1,6 @@
 import type { FabricValue } from "@commonfabric/api";
 import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
-import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
+import { deepFreeze, isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import {
   cloneIfNecessary,
   valueEqual,
@@ -106,6 +106,17 @@ type RootAttestation = IAttestation;
 
 const DOCUMENT_MIME = "application/json" as const;
 
+/**
+ * A root this transaction replaced, and the epoch it stood until.
+ *
+ * `root` is the document's value for every read epoch at or below `until`; the
+ * write that moved the epoch past `until` is the one that displaced it.
+ */
+type DisplacedRoot = {
+  until: number;
+  root: RootAttestation;
+};
+
 type ReadDocumentEntry = {
   initial: RootAttestation;
   validated: boolean;
@@ -113,6 +124,10 @@ type ReadDocumentEntry = {
   frozenReads?: PathKeyMap<FabricValue | undefined>;
   writeDetails?: Map<string, TransactionWriteDetail>;
   patchDetails?: Map<string, TransactionWriteDetail>;
+  // Oldest first, and only for epochs a reader was actually handed. Absent on
+  // the overwhelming majority of documents: one is created the first time a
+  // write displaces a root some materialized read may still describe.
+  displaced?: DisplacedRoot[];
 };
 
 type WritableDocumentEntry = {
@@ -122,6 +137,7 @@ type WritableDocumentEntry = {
   frozenReads: PathKeyMap<FabricValue | undefined>;
   writeDetails: Map<string, TransactionWriteDetail>;
   patchDetails: Map<string, TransactionWriteDetail>;
+  displaced?: DisplacedRoot[];
   // Mergeable-write intents recorded by recordMergeableOp, keyed by document
   // path. The commit emits these as the corresponding mergeable op (which the
   // server resolves against durable state) instead of a value diffed against a
@@ -202,6 +218,27 @@ function withCommitTiming<T>(
 
 const currentDocument = (doc: DocumentEntry): RootAttestation =>
   doc.current ?? doc.initial;
+
+/**
+ * The root a read at `epoch` describes.
+ *
+ * The displaced roots are oldest first and short — one per epoch actually
+ * handed to a reader — so the first one still standing at `epoch` is the
+ * answer. Falling off the end means no write has displaced anything this
+ * reader could still be describing, which is the ordinary case.
+ */
+const documentAtEpoch = (
+  doc: DocumentEntry,
+  epoch: number,
+): RootAttestation => {
+  const displaced = doc.displaced;
+  if (displaced !== undefined) {
+    for (let index = 0; index < displaced.length; index++) {
+      if (displaced[index].until >= epoch) return displaced[index].root;
+    }
+  }
+  return doc.current ?? doc.initial;
+};
 
 const isWritableDocument = (
   doc: DocumentEntry,
@@ -877,6 +914,20 @@ export class V2StorageTransaction implements IStorageTransaction {
   // and recordPatchIntent(). Consumed by CFC write-prefix provenance
   // (docs/specs/cfc-write-prefix-provenance.md §4/§6).
   #activityClock = 0;
+  // How many times this transaction has replaced a document root. A read taken
+  // at epoch E describes the state after E replacements, which is what lets a
+  // materialized read keep answering for the moment it was taken while the
+  // reader goes on writing. Zero writes means every document still stands at
+  // its `initial` attestation, so every epoch describes the same state and
+  // nothing below has to run.
+  #writeEpoch = 0;
+  // The epoch reads resolve against while a materialized read is walking, or
+  // undefined for the transaction's current state.
+  #readEpoch: number | undefined;
+  // The newest epoch handed to a reader, or undefined where none has been. A
+  // replacement keeps the root it displaces only when a reader could still ask
+  // for it, and this is what decides that.
+  #lastIssuedEpoch: number | undefined;
   #writeAttemptLog: IWriteAttempt[] = [];
   #reactivityLogCache?: TransactionReactivityLog;
   #schedulerObservation?: FabricValue;
@@ -1336,7 +1387,14 @@ export class V2StorageTransaction implements IStorageTransaction {
 
     const branch = this.branch(address.space);
     const { doc } = this.document(branch, address);
-    const current = currentDocument(doc);
+    // The one place a read chooses which root it is reading. A materialized
+    // read walking under an epoch describes the state that epoch names; every
+    // other read describes the transaction's current state. The epoch is only
+    // ever set on a transaction that has written, because before that the two
+    // are the same root.
+    const current = this.#readEpoch === undefined
+      ? currentDocument(doc)
+      : documentAtEpoch(doc, this.#readEpoch);
     const readMeta = options?.meta ?? EMPTY_META;
     // In a UI-input blind-leaf-write tx (a scalar `$value` overwrite), every read
     // is recorded for CFC/scheduling but carries no value-equality commit
@@ -1388,7 +1446,11 @@ export class V2StorageTransaction implements IStorageTransaction {
         },
       };
     }
-    const frozenReads = doc.frozenReads;
+    // The frozen-reads cache describes the current root — writes invalidate it
+    // along the chain they touch — so a read resolving against an earlier epoch
+    // neither takes from it nor adds to it.
+    const cacheable = this.#readEpoch === undefined;
+    const frozenReads = cacheable ? doc.frozenReads : undefined;
     if (frozenReads?.has(memoryAddress.path)) {
       return {
         ok: {
@@ -1411,13 +1473,97 @@ export class V2StorageTransaction implements IStorageTransaction {
     }
 
     const frozenValue = freezeReadValue(result.ok.value);
-    (doc.frozenReads ??= new PathKeyMap()).set(memoryAddress.path, frozenValue);
+    if (cacheable) {
+      (doc.frozenReads ??= new PathKeyMap()).set(
+        memoryAddress.path,
+        frozenValue,
+      );
+    }
     return {
       ok: {
         ...result.ok,
         value: frozenValue,
       },
     };
+  }
+
+  hasWrites(): boolean {
+    return this.#writeEpoch > 0;
+  }
+
+  /**
+   * The epoch a materialized read taken now should describe.
+   *
+   * Handing one out is what tells a later write that the root it displaces is
+   * still being described, so a reader that never asks costs the write path
+   * nothing.
+   */
+  issueReadEpoch(): number {
+    // A read taken while another is already walking is part of that walk — a
+    // view building the child a reader just touched — so it describes the same
+    // instant. Handing it a fresh epoch would let a subtree resolved after a
+    // write describe a later moment than the value it hangs off.
+    if (this.#readEpoch !== undefined) return this.#readEpoch;
+    this.#lastIssuedEpoch = this.#writeEpoch;
+    return this.#writeEpoch;
+  }
+
+  /**
+   * Resolve reads against `epoch` until the matching {@link exitReadEpoch}.
+   *
+   * Paired rather than wrapped around a callback so a reader on the hot path
+   * allocates no closure per property it touches. Returns the epoch that was
+   * in force, which the caller hands back to restore it.
+   */
+  enterReadEpoch(epoch: number | undefined): number | undefined {
+    const previous = this.#readEpoch;
+    this.#readEpoch = epoch;
+    return previous;
+  }
+
+  exitReadEpoch(previous: number | undefined): void {
+    this.#readEpoch = previous;
+  }
+
+  /**
+   * Move `doc` to a new root, keeping the one it displaces if a reader may
+   * still be describing it.
+   *
+   * Every write funnels here, so the epoch counts root replacements and
+   * nothing else.
+   *
+   * The root about to be displaced has stood since this document's last
+   * displacement, so it answers for every epoch in between. It is worth keeping
+   * exactly when a reader was handed one of those — which is the newest issued
+   * epoch, since an older one is answered by the same root. A run of writes
+   * with no read taken between them therefore keeps one root, not one per
+   * write, and a document nobody has read against keeps none.
+   *
+   * Keeping one means freezing it, and freezing it before the write starts.
+   * A write descends through `cloneForMutation` with `force: false`, which
+   * thaws a frozen container by shallow-cloning it and leaves an already-
+   * mutable one alone — so the root a first write leaves behind is mutable, and
+   * the next write edits it where it stands rather than replacing it. Freezing
+   * first puts that write on the cloning path, which is what makes the kept
+   * root stay the value it was. `deepFreeze` short-circuits on what is already
+   * deep-frozen, so this costs only what this transaction has thawed by
+   * writing.
+   *
+   * Called before the write reads the root it is about to descend, which is why
+   * this is separate from {@link V2StorageTransaction.#replaceCurrent}.
+   */
+  #preserveForReaders(doc: DocumentEntry): void {
+    const issued = this.#lastIssuedEpoch;
+    if (issued === undefined) return;
+    if (issued <= (doc.displaced?.at(-1)?.until ?? -1)) return;
+    const standing = currentDocument(doc);
+    deepFreeze(standing.value);
+    (doc.displaced ??= []).push({ until: this.#writeEpoch, root: standing });
+  }
+
+  #replaceCurrent(doc: DocumentEntry, next: RootAttestation): void {
+    this.#writeEpoch++;
+    doc.current = next;
   }
 
   trackReadPaths(
@@ -1581,6 +1727,7 @@ export class V2StorageTransaction implements IStorageTransaction {
 
     const { doc: readDoc } = this.document(branch, address);
     const doc = ensureWritableDocument(readDoc);
+    this.#preserveForReaders(doc);
     const current = doc.current;
     const previous = inspectPath(current.value, address.path);
     if (previous.kind === "ok") {
@@ -1655,7 +1802,7 @@ export class V2StorageTransaction implements IStorageTransaction {
       value: collapseEmptyJsonDocumentEnvelope(result.ok.root),
     };
 
-    doc.current = collapsedNext;
+    this.#replaceCurrent(doc, collapsedNext);
     invalidateFrozenReadsOnChain(doc, address.path);
     this.recordPatchIntent(
       space,
@@ -1709,6 +1856,7 @@ export class V2StorageTransaction implements IStorageTransaction {
 
     const { doc: readDoc } = this.document(branch, writes[0]!.address);
     const doc = ensureWritableDocument(readDoc);
+    this.#preserveForReaders(doc);
     const originalRoot = doc.current.value;
     let nextRoot = originalRoot;
     let changed = false;
@@ -1781,12 +1929,12 @@ export class V2StorageTransaction implements IStorageTransaction {
       );
       if (result.error) {
         if (changed) {
-          doc.current = {
+          this.#replaceCurrent(doc, {
             ...doc.current,
             value: collapseEmptyJsonDocumentEnvelope(
               nextRoot,
             ),
-          };
+          });
           for (const written of writtenPaths) {
             invalidateFrozenReadsOnChain(doc, written);
           }
@@ -1825,12 +1973,12 @@ export class V2StorageTransaction implements IStorageTransaction {
       return { ok: {} };
     }
 
-    doc.current = {
+    this.#replaceCurrent(doc, {
       ...doc.current,
       value: collapseEmptyJsonDocumentEnvelope(
         nextRoot,
       ),
-    };
+    });
     for (const written of writtenPaths) {
       invalidateFrozenReadsOnChain(doc, written);
     }

--- a/packages/runner/test/extended-storage-transaction.test.ts
+++ b/packages/runner/test/extended-storage-transaction.test.ts
@@ -1,0 +1,100 @@
+// The transaction's side of a materialized read's instant.
+//
+// A read resolving against an earlier epoch describes a different moment than
+// the transaction's caches do, so those caches stand aside for it. And a
+// wrapper answers for the instant exactly as the transaction it wraps does,
+// which is what keeps a read taken through `Cell.sample()` describing the same
+// moment as one taken directly.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import { createNonReactiveTransaction } from "../src/storage/extended-storage-transaction.ts";
+import { type JSONSchema } from "../src/builder/types.ts";
+
+const signer = await Identity.fromPassphrase("extended-storage-transaction");
+const space = signer.did();
+
+const SCHEMA = {
+  type: "object",
+  properties: { title: { type: "string" } },
+} as const satisfies JSONSchema;
+
+describe("extended-storage-transaction", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({ apiUrl: new URL(import.meta.url), storageManager });
+  });
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  const seeded = async (cause: string) => {
+    const write = runtime.edit();
+    runtime.getCell(space, cause, undefined, write).set({ title: "before" });
+    await write.commit();
+    const tx = runtime.edit();
+    tx.markLazyMaterialize(true);
+    return { tx, cell: runtime.getCell(space, cause, SCHEMA, tx) };
+  };
+
+  describe("the read-result cache under an epoch", () => {
+    it("serves nothing while a read resolves against an earlier epoch", () => {
+      const tx = runtime.edit();
+      // Optional on the interface, and the behavior under test is what it
+      // does, so a transaction without it has nothing to say.
+      expect(typeof tx.getCachedReadResult).toBe("function");
+      tx.setCachedReadResult!("key", "variant", 1);
+      expect(tx.getCachedReadResult!("key", "variant")).toEqual({ value: 1 });
+
+      const previous = tx.enterReadEpoch(0);
+      expect(tx.getCachedReadResult!("key", "variant")).toBeUndefined();
+      tx.exitReadEpoch(previous);
+
+      expect(tx.getCachedReadResult!("key", "variant")).toEqual({ value: 1 });
+      tx.abort("done");
+    });
+
+    it("keeps nothing taken while a read resolves against an earlier epoch", () => {
+      const tx = runtime.edit();
+
+      const previous = tx.enterReadEpoch(0);
+      tx.setCachedReadResult!("key", "variant", 2);
+      tx.exitReadEpoch(previous);
+
+      // Had it been kept, this would answer with the value taken under the
+      // epoch — a materialized read's value served to a current one.
+      expect(tx.getCachedReadResult!("key", "variant")).toBeUndefined();
+      tx.abort("done");
+    });
+  });
+
+  describe("a wrapped transaction", () => {
+    it("answers for the instant as the transaction it wraps does", async () => {
+      const { tx, cell } = await seeded("wrapped-instant");
+      const wrapper = createNonReactiveTransaction(tx);
+      try {
+        expect(wrapper.hasWrites()).toBe(false);
+
+        const view = cell.withTx(wrapper).get() as { title: string };
+        cell.withTx(tx).key("title").set("after");
+
+        expect(wrapper.hasWrites()).toBe(true);
+        // The wrapper carried the epoch down, so the view it handed back keeps
+        // describing the moment it was taken.
+        expect(view.title).toBe("before");
+        expect((cell.withTx(wrapper).get() as { title: string }).title).toBe(
+          "after",
+        );
+      } finally {
+        await tx.commit();
+      }
+    });
+  });
+});

--- a/packages/runner/test/lazy-view-epoch.bench.ts
+++ b/packages/runner/test/lazy-view-epoch.bench.ts
@@ -1,0 +1,180 @@
+/**
+ * What the instant a materialized read describes costs to keep.
+ *
+ * A view resolves each path against the epoch it was taken at, so reads made
+ * after the reader has written have to find the root standing at that epoch
+ * rather than the current one. Three groups measure that:
+ *
+ *   - **read**: walking a list through a view, on a transaction that has not
+ *     written and on one that has. The first is the shape a lift takes — read
+ *     the argument, never write through it — and is where the epoch has to cost
+ *     nothing, because before the first write every epoch names the same root.
+ *   - **write**: a run of writes with and without a reader holding an instant.
+ *     Holding one puts the write path on the preserving branch, which
+ *     deep-freezes the root it displaces so the next write clones instead of
+ *     editing it where it stands.
+ *   - **interleave**: a read taken between every write, which is the shape that
+ *     makes every write preserve. The write group amortises one preserve over
+ *     its whole run and so understates this.
+ *
+ * One runtime is built for the whole file and every iteration aborts its
+ * transaction, so no iteration pays for a runtime, a store or a seeded document,
+ * and none leaves state behind for the next. Each `fn` also runs its body once
+ * untimed, so the timed window is not the one that pays for the transaction's
+ * first document load.
+ *
+ * Environment controls:
+ * - LAZY_VIEW_EPOCH_N: list size, default 1000
+ * - LAZY_VIEW_EPOCH_WRITES: writes per iteration, default 50
+ */
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import { type JSONSchema } from "../src/builder/types.ts";
+
+const signer = await Identity.fromPassphrase("bench lazy view epoch");
+const space = signer.did();
+
+const N = Number(Deno.env.get("LAZY_VIEW_EPOCH_N") ?? "1000");
+const WRITES = Number(Deno.env.get("LAZY_VIEW_EPOCH_WRITES") ?? "50");
+
+const SCHEMA = {
+  type: "object",
+  properties: {
+    title: { type: "string" },
+    xs: { type: "array", items: { type: "number" } },
+  },
+} as const satisfies JSONSchema;
+
+const storageManager = StorageManager.emulate({ as: signer });
+const runtime = new Runtime({
+  apiUrl: new URL(import.meta.url),
+  storageManager,
+});
+
+const CAUSE = "lazy-view-epoch-doc";
+{
+  const tx = runtime.edit();
+  runtime.getCell(space, CAUSE, undefined, tx).set({
+    title: "bench",
+    xs: Array.from({ length: N }, (_, index) => index),
+  });
+  await tx.commit();
+}
+
+/**
+ * Open a marked transaction over the seeded document.
+ *
+ * Every iteration aborts, so the document never moves and one seeded copy
+ * serves the whole file.
+ */
+const open = () => {
+  const tx = runtime.edit();
+  tx.markLazyMaterialize(true);
+  return { tx, cell: runtime.getCell(space, CAUSE, SCHEMA, tx) };
+};
+
+const READ_VARIANTS: [string, boolean][] = [
+  ["no write taken", false],
+  ["past one write", true],
+];
+
+for (const [label, writeFirst] of READ_VARIANTS) {
+  const walk = () => {
+    const { tx, cell } = open();
+    if (writeFirst) cell.withTx(tx).key("title").set("written");
+    const view = cell.get() as { xs: number[] };
+    return { tx, view };
+  };
+  Deno.bench({
+    name: `lazy view epoch - walk ${N} elements - ${label}`,
+    group: "lazy-view-epoch-read",
+    baseline: !writeFirst,
+    fn(b) {
+      // Untimed, so the timed window below is not the one paying for this
+      // transaction's first look at the document.
+      const warm = walk();
+      for (const item of warm.view.xs) if (item < 0) throw new Error("no");
+      warm.tx.abort("bench");
+
+      const { tx, view } = walk();
+      b.start();
+      let total = 0;
+      for (const item of view.xs) total += item;
+      b.end();
+      tx.abort("bench");
+      if (total < 0) throw new Error("unreachable");
+    },
+  });
+}
+
+const WRITE_VARIANTS: [string, boolean][] = [
+  ["no reader holding an instant", false],
+  ["a reader holding an instant", true],
+];
+
+for (const [label, readerFirst] of WRITE_VARIANTS) {
+  const setup = () => {
+    const { tx, cell } = open();
+    // The baseline reads RAW rather than skipping the read: it pulls the same
+    // document into the transaction, so neither variant pays that load inside
+    // the timed window, but it takes no view and so issues no epoch. Taking a
+    // view is what puts the writes below on the preserving branch — and it is
+    // the asking that does it, not the holding, since `get()` issues an epoch
+    // whether or not the caller keeps what it returns.
+    if (readerFirst) cell.get();
+    else cell.getRaw();
+    return { tx, cell };
+  };
+  Deno.bench({
+    name: `lazy view epoch - ${WRITES} writes - ${label}`,
+    group: "lazy-view-epoch-write",
+    baseline: !readerFirst,
+    fn(b) {
+      const warm = setup();
+      warm.cell.withTx(warm.tx).key("title").set("warm");
+      warm.tx.abort("bench");
+
+      const { tx, cell } = setup();
+      b.start();
+      for (let index = 0; index < WRITES; index++) {
+        cell.withTx(tx).key("xs").key(index % N).set(index);
+      }
+      b.end();
+      tx.abort("bench");
+    },
+  });
+}
+
+// A read between every write, so every write finds an instant to preserve.
+// The write group above amortises one preserve over its whole run; this is the
+// shape that pays for one per write.
+const INTERLEAVE_VARIANTS: [string, boolean][] = [
+  ["reading raw", false],
+  ["taking a view", true],
+];
+
+for (const [label, takeView] of INTERLEAVE_VARIANTS) {
+  Deno.bench({
+    name: `lazy view epoch - ${WRITES} write/read rounds - ${label}`,
+    group: "lazy-view-epoch-interleave",
+    baseline: !takeView,
+    fn(b) {
+      const warm = open();
+      if (takeView) warm.cell.get();
+      else warm.cell.getRaw();
+      warm.tx.abort("bench");
+
+      const { tx, cell } = open();
+      b.start();
+      for (let index = 0; index < WRITES; index++) {
+        cell.withTx(tx).key("xs").key(index % N).set(index);
+        if (takeView) cell.get();
+        else cell.getRaw();
+      }
+      b.end();
+      tx.abort("bench");
+    },
+  });
+}

--- a/packages/runner/test/query-result-proxy-transaction-lifetime.test.ts
+++ b/packages/runner/test/query-result-proxy-transaction-lifetime.test.ts
@@ -98,14 +98,92 @@ describe("query-result-proxy transaction lifetime", () => {
       expect(() => middle.leaf).toThrow("Transaction is complete");
     });
 
-    it("reads the state its transaction sees, including its own writes", async () => {
+    // An array method and an iterator hand back work that runs after the trap
+    // returned, so the instant has to travel with them rather than with the
+    // property access that produced them.
+    describe("over an array", () => {
+      const seedList = async (cause: string) => {
+        const tx = runtime.edit();
+        const cell = runtime.getCell<number[]>(space, cause, undefined, tx);
+        cell.set([1, 2, 3]);
+        await tx.commit();
+        return cell;
+      };
+
+      const pinnedList = (
+        cell: Cell<number[]>,
+        tx: IExtendedStorageTransaction,
+      ) => {
+        tx.markLazyMaterialize(true);
+        return createQueryResultProxy<number[]>(
+          runtime,
+          tx,
+          cell.getAsNormalizedFullLink(),
+        );
+      };
+
+      it("spreads the elements it was taken over", async () => {
+        const cell = await seedList("list-spread");
+        const readTx = runtime.edit();
+        const view = pinnedList(cell, readTx);
+
+        cell.withTx(readTx).set([1, 2, 3, 4]);
+
+        expect([...view]).toEqual([1, 2, 3]);
+        await readTx.commit();
+      });
+
+      it("runs the caller's callback outside the instant", async () => {
+        // The instant belongs to reading the elements, not to whatever the
+        // caller does with them. A read the callback takes — of another cell,
+        // or of one it just wrote — describes current state, exactly as it
+        // would outside the method.
+        const cell = await seedList("list-callback-scope");
+        const other = runtime.getCell<number>(space, "callback-other");
+        const setup = runtime.edit();
+        other.withTx(setup).set(10);
+        await setup.commit();
+
+        const readTx = runtime.edit();
+        const view = pinnedList(cell, readTx);
+        other.withTx(readTx).set(100);
+
+        expect(view.map(() => other.withTx(readTx).get())).toEqual([
+          100,
+          100,
+          100,
+        ]);
+        await readTx.commit();
+      });
+
+      it("maps over the elements it was taken over", async () => {
+        const cell = await seedList("list-map");
+        const readTx = runtime.edit();
+        const view = pinnedList(cell, readTx);
+
+        cell.withTx(readTx).set([9, 9, 9]);
+
+        expect(view.map((n) => n)).toEqual([1, 2, 3]);
+        await readTx.commit();
+      });
+    });
+
+    it("keeps the state it was taken over when the reader writes", async () => {
       const cell = await seed("lifetime-own-writes");
 
       const readTx = runtime.edit();
       const view = pinnedView(cell, readTx);
 
       cell.withTx(readTx).key("outer").key("middle").key("leaf").set(2);
-      expect(view.outer.middle.leaf).toBe(2);
+      expect(view.outer.middle.leaf).toBe(1);
+      // Taking the read again is how the reader sees what it wrote.
+      expect(
+        createQueryResultProxy<Nested>(
+          runtime,
+          readTx,
+          cell.getAsNormalizedFullLink(),
+        ).outer.middle.leaf,
+      ).toBe(2);
 
       await readTx.commit();
     });

--- a/packages/runner/test/schema-view.test.ts
+++ b/packages/runner/test/schema-view.test.ts
@@ -531,72 +531,179 @@ describe("schema-view", () => {
     });
   });
 
-  describe("once the transaction has written", () => {
-    it("stays lazy after a write batch that staged nothing", async () => {
-      const read = await seeded(
-        "empty-batch",
-        { a: 1, untouched: { leaf: 2 } },
-        {
-          type: "object",
-          properties: {
-            a: { type: "number" },
-            untouched: {
-              type: "object",
-              properties: { leaf: { type: "number" } },
-            },
-          },
-        } as const,
-      );
+  describe("a transaction that writes under the view", () => {
+    const LIST = {
+      type: "object",
+      properties: {
+        title: { type: "string" },
+        // Primitives on purpose. An inline object element is rebased onto a
+        // `data:` identity derived from its own value, and a read of one never
+        // reaches the document — so a list of them would hold its elements
+        // still whether or not the instant did any work.
+        xs: { type: "array", items: { type: "number" } },
+      },
+    } as const;
 
-      const lazy = read(true);
+    /** Seed `cause`, then hand back a cell on a marked transaction. */
+    const opened = async (cause: string, value: unknown) => {
+      const write = runtime.edit();
+      runtime.getCell(space, cause, undefined, write).set(value);
+      await write.commit();
+
+      const tx = runtime.edit();
+      tx.markLazyMaterialize(true);
+      return { tx, cell: runtime.getCell(space, cause, LIST, tx) };
+    };
+
+    it("keeps the value it was taken over when the reader writes it", async () => {
+      const { tx, cell } = await opened("write-under-view", {
+        title: "before",
+        xs: [1],
+      });
       try {
-        // The batch write is optional on the interface, and the behavior under
-        // test is what it does, so a transaction without it has nothing to say.
-        expect(typeof lazy.tx.writeValuesOrThrow).toBe("function");
-        lazy.tx.writeValuesOrThrow!([]);
-        expect((lazy.get() as { a: number }).a).toBe(1);
-        // Eager materialization would have walked the sibling; a view that is
-        // still lazy never looks at it.
-        expect(pathsRead(lazy.tx).some((path) => path.includes("untouched")))
-          .toBe(false);
+        const value = cell.get() as { title: string };
+        cell.withTx(tx).key("title").set("after");
+        expect(value.title).toBe("before");
+        // Taking the read again is how the reader sees what it wrote.
+        expect((cell.get() as { title: string }).title).toBe("after");
       } finally {
-        await lazy.tx.commit();
+        await tx.commit();
       }
     });
 
-    // A view resolves each path when it is touched, so a read taken after a
-    // write would report the new value where an eager read hands back one
-    // detached at the moment it was taken. A read is materialized eagerly once
-    // the transaction has written, so it describes the same instant either way.
-    //
-    // This covers a read taken AFTER a write. A view handed out BEFORE one
-    // still tracks it, which the write epoch in the plan is what fixes.
-    it("materializes eagerly for a read taken after a write", async () => {
-      const readAfterWrite = async (lazy: boolean) => {
-        const cause = `read-after-write-${lazy}`;
-        const write = runtime.edit();
-        runtime.getCell(space, cause, undefined, write).set({ n: 1 });
-        await write.commit();
-
-        const tx = runtime.edit();
-        if (lazy) tx.markLazyMaterialize(true);
-        const schema = {
-          type: "object",
-          properties: { n: { type: "number" } },
-        } as const;
-        const cell = runtime.getCell(space, cause, schema, tx);
-        cell.key("n").set(99);
-        // Taken after the write, so it is detached at this instant and does
-        // not move when the value is written again.
-        const value = cell.get() as { n: number };
-        const seen = value.n;
-        cell.key("n").set(7);
-        const afterSecondWrite = value.n;
+    it("keeps the value it was taken over when the write came first", async () => {
+      const { tx, cell } = await opened("write-under-later-view", {
+        title: "before",
+        xs: [1],
+      });
+      try {
+        cell.withTx(tx).key("title").set("first");
+        // Taken past a write, so the instant it describes is the one after it.
+        const value = cell.get() as { title: string };
+        cell.withTx(tx).key("title").set("second");
+        expect(value.title).toBe("first");
+        expect((cell.get() as { title: string }).title).toBe("second");
+      } finally {
         await tx.commit();
-        return { seen, afterSecondWrite };
-      };
+      }
+    });
 
-      expect(await readAfterWrite(true)).toEqual(await readAfterWrite(false));
+    it("keeps two views taken at different instants apart", async () => {
+      const { tx, cell } = await opened("two-instants", {
+        title: "before",
+        xs: [1],
+      });
+      try {
+        const first = cell.get() as { title: string };
+        cell.withTx(tx).key("title").set("middle");
+        const second = cell.get() as { title: string };
+        cell.withTx(tx).key("title").set("last");
+        expect(first.title).toBe("before");
+        expect(second.title).toBe("middle");
+      } finally {
+        await tx.commit();
+      }
+    });
+
+    it("keeps an element's value across a write into the list", async () => {
+      const { tx, cell } = await opened("element-under-write", {
+        title: "t",
+        xs: [1, 2],
+      });
+      try {
+        const value = cell.get() as { xs: number[] };
+        cell.withTx(tx).key("xs").key(1).set(99);
+        expect([...value.xs]).toEqual([1, 2]);
+        // The element the write landed on reads as written through a fresh
+        // read, so the pinning above is the instant and not a stale container.
+        expect((cell.get() as { xs: number[] }).xs[1]).toBe(99);
+      } finally {
+        await tx.commit();
+      }
+    });
+
+    it("iterates the length the list had when the view was taken", async () => {
+      // What a reader iterating a list while writing into it stands on. The
+      // view answers for the container it was built over, so appending during
+      // the walk cannot extend the walk.
+      const { tx, cell } = await opened("iterate-while-appending", {
+        title: "t",
+        xs: [1, 2, 3],
+      });
+      try {
+        const value = cell.get() as { xs: number[] };
+        const visited: number[] = [];
+        for (const item of value.xs) {
+          visited.push(item);
+          // Appending only while the walk is within its starting length keeps
+          // a view that re-read the container to a walk that ends and fails
+          // the assertion, rather than one that never ends.
+          if (visited.length > 3) continue;
+          const current = cell.withTx(tx).key("xs").get() as number[];
+          cell.withTx(tx).key("xs").set([...current, 0]);
+        }
+        expect(visited).toEqual([1, 2, 3]);
+      } finally {
+        await tx.commit();
+      }
+    });
+
+    it("iterates the length the list had when the write came first", async () => {
+      const { tx, cell } = await opened("write-first-then-iterate", {
+        title: "t",
+        xs: [1, 2],
+      });
+      try {
+        cell.withTx(tx).key("title").set("written first");
+        const value = cell.get() as { xs: number[] };
+        const visited: number[] = [];
+        for (const item of value.xs) {
+          visited.push(item);
+          if (visited.length > 2) continue;
+          const current = cell.withTx(tx).key("xs").get() as number[];
+          cell.withTx(tx).key("xs").set([...current, 0]);
+        }
+        expect(visited).toEqual([1, 2]);
+      } finally {
+        await tx.commit();
+      }
+    });
+
+    it("holds an array view's length across a write that changes it", async () => {
+      const { tx, cell } = await opened("held-length", {
+        title: "t",
+        xs: [1],
+      });
+      try {
+        const held = (cell.get() as { xs: number[] }).xs;
+        cell.withTx(tx).key("xs").set([7, 8]);
+        expect(held.length).toBe(1);
+        expect(held[0]).toBe(1);
+        // Asking the parent again reads the container afresh, which is how a
+        // reader that wants the new list gets it.
+        const fresh = (cell.get() as { xs: number[] }).xs;
+        expect(fresh.length).toBe(2);
+        expect(fresh[0]).toBe(7);
+      } finally {
+        await tx.commit();
+      }
+    });
+
+    it("reads only the paths the reader touched after a write", async () => {
+      const { tx, cell } = await opened("lazy-after-write", {
+        title: "before",
+        xs: [1, 2, 3],
+      });
+      try {
+        cell.withTx(tx).key("title").set("after");
+        const value = cell.get() as { title: string };
+        expect(value.title).toBe("after");
+        // An eager materialization walks the list to build it; the view never
+        // looks, because the reader never asked.
+        expect(pathsRead(tx).some((path) => path.includes("xs"))).toBe(false);
+      } finally {
+        await tx.commit();
+      }
     });
 
     it("still reads back what a lift wrote through a handle it was passed", async () => {


### PR DESCRIPTION
## What this changes

A lazily materialized view resolved each path when the reader touched it, so a
value read back through a held view reported whatever the reader had written
since. The `hasWrites()` fallback did not fix that — a view handed out before a
write kept tracking that write — while costing laziness for every read past the
transaction's first write.

A view now describes the instant its `.get()` fixed, containers and values alike.
Reading your own write means taking the read again: a fresh `.get()`, or `.get()`
on a handle the argument carried, fixes a fresh instant, so a lift writing into a
`Writable` input still reads back what it wrote.

## How

- The transaction counts the roots it replaces; a view records that count and a
  read resolves against the root standing at it. The decision is one branch at the
  single site where a read picks its root.
- A write sets aside the root it displaces only where a reader holds an instant
  that root answers for. A transaction nobody reads this way costs its write path
  nothing; a run of writes with no read between them keeps one root, not one per
  write.
- Setting a root aside deep-freezes it first. A write thaws a frozen container by
  cloning and edits an already-mutable one where it stands, so without the freeze
  the next write would edit the value a reader is describing.
- Before the first write every document still stands at the root it was loaded
  with, so every instant names the same state and reads skip epoch resolution on
  that check alone — the shape a lift takes, reading its argument before it writes.
- Both readings on a marked transaction pin: the schema view and the schema-less
  proxy. Unmarked reads are untouched, so the standing handle long-lived consumers
  rely on keeps tracking current state.
- Caches that key on path rather than instant — the read-result cache, the
  link-resolution memo, the frozen-reads cache and the proxy cache — stand aside
  while a read resolves against an earlier epoch.
- The instant covers reading an array, not what the caller does with what it
  reads: a read-only array method builds its element views under the instant and
  runs the caller's callback outside it, so a `.get()` inside a `map` or `forEach`
  callback describes current state as it would anywhere else.

## Performance

`packages/runner/test/lazy-view-epoch.bench.ts` builds one runtime for the file
and aborts every iteration, so no iteration pays for a runtime, a store or a
seeded document, and each runs its body once untimed first.

Ratios rather than absolutes: the absolute figures move a lot with machine
state, while the ratio holds.

| | ratio, instant taken vs not |
|---|---|
| walk 1000 elements | not slower |
| 50 writes, one view taken | no measurable cost |
| 50 write/read rounds | **~1.6x** (1.5–2.0x across seven runs) |

The walk comes out ahead because an epoch read neither fills nor consults the
per-path caches, which a walk touching each path once pays for and never collects
on. Fifty writes after one view costs nothing measurable — one preserve covers the
run, and deep-freezing an already-frozen root is a cache hit. The cost is the last
row: a read between every write, so every write finds an instant to preserve.
Neither is the lift path, which reads its argument and writes nothing.

## Reviewing

`packages/runner/src/query-result-proxy.ts` reads as a large diff but much of it
is reindentation from wrapping traps in the epoch scope — review it with
whitespace ignored. The substance is the epoch, the wrapper, and the cache key.

## Not in this change

- Handlers still materialize eagerly.
- Displaced roots are not pruned. They grow one root per document per
  read-then-write round and `documentAtEpoch` scans them oldest-first, so a
  long-lived transaction alternating reads and writes pays in both memory and
  lookup. Deliberate: these transactions are one action long.

## Coverage

The check first reported +8 uncovered lines in `packages/runner`. Collecting a
V8 profile over the whole runner suite and intersecting the uncovered lines
against the lines this branch adds found two real gaps, both the early-return
halves of the read-result cache guards — nothing exercised
`getCachedReadResult`/`setCachedReadResult` while an epoch was active, which is
the same failure class that had to be taught to `frozenReads`.
`test/extended-storage-transaction.test.ts` covers them, and a wrapper's
delegation besides, each test verified by mutation.

One line remains, and the same measurement now finds no uncovered added line in
any changed source file, so it is not a line this branch wrote. Accepting it
rather than writing a test aimed at the number instead of at a behavior:

ACCEPT_COVERAGE_DEBT: packages/runner +1 line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

