### PR TITLE
Refresh the cf-harness profile past CT-2003's delegation handles

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -33,6 +33,10 @@ decision is reversed or superseded).
 - [Hosted pattern authoring](hosted-pattern-authoring.md)
 - [Scoped cell instances](scoped-cell-instances.md)
 
+### Agent execution
+
+- [Agent harness](agent-harness/README.md)
+
 ### Data, storage, and execution
 
 - [JSON Schema](json_schema.md)

--- a/docs/specs/agent-harness/01-runtime-contract.md
+++ b/docs/specs/agent-harness/01-runtime-contract.md
@@ -1,0 +1,327 @@
+# Agent Harness Runtime Contract
+
+Status: draft 0.1
+
+This document specifies the caller-visible behavior of a Common Fabric agent
+harness. The contract is transport-neutral: a batch CLI, long-lived stdio
+service, or another protocol may conform if it preserves the same lifecycle,
+authority, containment, and evidence semantics.
+
+## 1. Roles and trust boundaries
+
+- The **caller** selects the task, prompt-slot roles, capabilities, mounts,
+  policy profile, and resource bounds.
+- The **harness** runs the model/tool loop and records authoritative run
+  lifecycle evidence. It does not invent authority on the model's behalf.
+- The **model gateway** produces model messages and tool requests. Its output is
+  untrusted proposal data unless another trusted component supplies evidence to
+  the contrary.
+- The **execution substrate** executes tools inside the configured containment
+  boundary.
+- A **mediator** supplies trusted observation or policy evidence. It may be the
+  execution substrate, the Common Fabric runner, or another declared trusted
+  component.
+- An **integration adapter** maps a product's concepts onto the harness
+  contract. Adapter routing and product policy are not implicit harness powers.
+
+An implementation profile MUST name which components occupy these roles and
+which boundaries are trusted.
+
+## 2. Invocation contract
+
+**AH-INV-1.** Every run MUST have a stable run identifier and a run-start
+configuration snapshot.
+
+**AH-INV-2.** The snapshot MUST identify the selected model and provider
+adapter, provider-affecting controls, credential-owner and authentication-source
+binding, workspace and initial working directory, enabled tools and child
+profiles, resource bounds, policy profile, prompt slots, and caller-supplied
+mounts. Secret values MAY be represented by opaque references or digests rather
+than copied into artifacts.
+
+**AH-INV-3.** Prompt inputs MUST retain their declared roles. At minimum an
+implementation MUST distinguish direct commands from context and quoted or
+retrieved material. Text that sounds command-like MUST NOT acquire a stronger
+role merely because of its content.
+
+**AH-INV-4.** Invalid configuration, unavailable required capabilities, or paths
+outside declared boundaries MUST fail before the first model request.
+
+**AH-INV-5.** A provider failure MUST NOT silently move a run to a different
+credential, billing, retention, or data-processing route. Any allowed fallback
+MUST be explicit in the run snapshot and preserve the caller's authority and
+disclosure constraints.
+
+## 3. Capability negotiation
+
+**AH-CAP-1.** A harness MUST expose a machine-readable capability description
+without starting a model run.
+
+**AH-CAP-2.** The description MUST distinguish parent tools, child profiles,
+native model tools, repeatable configuration fields, and optional protocol
+features. A caller MUST NOT infer capability from a binary's presence alone.
+
+**AH-CAP-3.** Integrations SHOULD gate optional arguments and workflows from the
+capability description so that version skew fails explicitly or degrades through
+a documented path.
+
+**AH-CAP-4.** Advertised capability means the harness understands and can
+validate the feature. It does not by itself prove that an external dependency,
+such as a sandbox daemon or browser lease, is healthy. Required dependency
+health MUST be checked before accepting a run that needs it.
+
+## 4. Run and turn lifecycle
+
+**AH-LIFE-1.** A run moves from created to running and then to exactly one
+terminal state: completed, failed, or cancelled.
+
+**AH-LIFE-2.** The harness MUST durably record the terminal state and the last
+accepted event before reporting terminal completion to the caller.
+
+**AH-LIFE-3.** Cancellation MUST stop further model and tool work. An
+implementation that launches child processes MUST reap or terminalize the owned
+process tree; returning while owned executors continue side effects is
+non-conforming.
+
+**AH-LIFE-4.** Resource limits such as model turns, child turns, wall time, and
+output size MUST be caller-visible and terminal failures MUST identify the limit
+that was reached.
+
+**AH-LIFE-5.** Automatic retries MUST be bounded, visible in run evidence, and
+limited to operations whose replay semantics are declared safe.
+
+The following clauses apply when context compaction, pruning, or another
+provider continuation mechanism is advertised.
+
+**AH-LIFE-6.** Context replacement MUST be represented in ordered run evidence.
+It MUST preserve the active instructions, prompt-role distinctions, authority
+evidence, and valid tool-call/tool-result relationships required by the selected
+provider protocol.
+
+**AH-LIFE-7.** The activation threshold, disabled state, and provider/model
+compatibility of context replacement MUST be caller-visible. Discovery or
+compaction failure MUST remain eligible for a later safe attempt or fail
+explicitly; it MUST NOT permanently disable a required context guard through a
+transient cached failure.
+
+## 5. Tools and side effects
+
+**AH-TOOL-1.** The parent tool surface MUST be derived from an explicit
+allowlist or an implementation-profile default published in the conformance
+statement.
+
+**AH-TOOL-2.** A skill, retrieved document, model message, or child result MUST
+NOT expand the allowed tool surface.
+
+**AH-TOOL-3.** Every tool call MUST record the tool identity, bounded input
+summary, outcome, timing, and policy/mediation disposition. Sensitive raw inputs
+MAY be retained only inside the declared artifact boundary.
+
+**AH-TOOL-4.** A side-effecting tool call MUST be attributable to an authorized
+prompt slot or another explicit authority grant. Model intent alone is not an
+authority grant.
+
+**AH-TOOL-5.** Recoverable tool failures MUST return typed failure information
+rather than masquerading as successful observations.
+
+**AH-TOOL-6.** A harness MUST distinguish model-correctable tool failures from
+failures in tool setup, containment, mediation, persistence, or harness
+invariants. Only the former MAY be returned to the model as recoverable tool
+outcomes. The latter MUST fail the run and keep operator-only diagnostic detail
+out of the model-facing channel.
+
+**AH-TOOL-7.** A tool that executes in a trusted host or external runtime MUST
+be advertised separately from sandbox execution. Its configuration snapshot
+MUST identify the bounded authority it uses, and its credentials MUST NOT enter
+the model context or an untrusted execution substrate.
+
+**AH-TOOL-8.** Before such a tool creates an external side effect, referenced
+inputs MUST be resolved and authorized against the tool's configured authority.
+A cross-authority or schema-incompatible reference MUST fail before the side
+effect is created.
+
+**AH-TOOL-9.** A tool that creates a durable external resource MUST publish its
+cancellation, cleanup, enumeration, and retention semantics. The terminal run
+evidence MUST retain enough provenance to find resources that ordinary product
+listing surfaces do not enumerate.
+
+**AH-TOOL-10.** Raw tool results MAY contain operator-only identifiers and
+diagnostics, but every model-facing success and failure channel MUST apply the
+declared sanitization and opaque-reference boundary before exposure.
+
+## 6. Filesystem, host, and network containment
+
+**AH-CONT-1.** The harness MUST resolve filesystem operations against an
+explicit workspace or mount table and reject traversal through paths or symlinks
+outside it.
+
+**AH-CONT-2.** Read-only and writable mounts MUST remain distinguishable in the
+run snapshot and enforcement path.
+
+**AH-CONT-3.** Host execution MUST be a named capability with a narrower policy
+than general sandbox execution. It MUST NOT appear in the parent surface merely
+because a child profile uses it.
+
+**AH-CONT-4.** Network posture MUST be explicit per profile. A caller MUST be
+able to distinguish disabled, destination-constrained, and general network
+access.
+
+**AH-CONT-5.** Raw operator artifacts SHOULD be outside ordinary model-readable
+workspace mounts. When they are not, artifact paths MUST be reserved from model
+file and discovery tools.
+
+**AH-CONT-6.** Each executor's working directory MUST resolve inside its own
+mount table. A child MUST NOT inherit a parent working directory that is absent
+from, or broader than, the child's authority; the harness MUST select an
+explicit profile root instead.
+
+## 7. Delegation
+
+These clauses apply when delegation is advertised.
+
+**AH-DEL-1.** A child run MUST begin with a fresh model context and an explicit
+profile. Parent context, skills, tools, mounts, and credentials MUST NOT
+transfer implicitly.
+
+**AH-DEL-2.** A child profile MUST publish its tools, host powers, network
+posture, skills, resource limits, and return policy.
+
+**AH-DEL-3.** Raw child transcripts, tool outputs, and failure detail MUST
+remain inside the child artifact boundary unless a declared release step
+authorizes them for the parent.
+
+**AH-DEL-4.** The ordinary parent return channel MUST be bounded and sanitized.
+If a structured return schema is supplied, the harness MUST validate it before
+exposure to the parent and fail closed on invalid values.
+
+**AH-DEL-5.** The parent run MUST retain references to child identity, profile,
+terminal state, and operator-visible artifacts.
+
+## 8. Interactive sessions
+
+These clauses apply when interactive sessions are advertised.
+
+**AH-INT-1.** Sessions, turns, requests, responses, and events MUST have stable
+identifiers sufficient for idempotent correlation and replay.
+
+**AH-INT-2.** A session MUST define whether turns are serial or concurrent and
+MUST reject unsupported overlap rather than silently interleave model context.
+
+**AH-INT-3.** Event replay MUST have an explicit cursor or sequence contract.
+Bounded in-memory retention MUST NOT erase events promised as durable.
+
+**AH-INT-4.** Restoring a session MUST validate its workspace, policy, model,
+mounts, and other authority-bearing configuration. A caller MUST NOT attach a
+persisted session to a different authority context by changing metadata alone.
+
+**AH-INT-5.** Turn cancellation and session closure MUST follow the terminality
+and child-reaping requirements in section 4.
+
+## 9. Model-bound references and immutable observations
+
+The reference clauses apply when a harness advertises opaque handles for
+structured resources. The observation clauses apply when file or binary
+content is placed in model context.
+
+**AH-REF-1.** The harness MUST mint handles only for positively identified,
+structured referents. It MUST NOT infer a capability from an ambiguous bare
+identifier or arbitrary free-form text.
+
+**AH-REF-2.** A model-authored handle MUST resolve only when the current run's
+table holds it. Resolution MUST occur before policy evaluation and dispatch.
+Unknown, malformed, child-originated, or otherwise unheld tokens MUST remain
+inert and MUST NOT become authority through their spelling alone.
+
+**AH-REF-3.** A handle MUST remain stable for the same referent within its
+declared lifetime, including supported resume paths. Handle tables and canonical
+referents are sensitive run state. They MUST NOT transfer to another run or
+child implicitly.
+
+**AH-REF-4.** Substitution MUST preserve raw operator evidence while preventing
+canonical identifiers from leaking through any model-facing success, denial,
+or recoverable-error channel. A handle is an opaque presentation token, not an
+authority grant or release decision.
+
+**AH-OBS-1.** The byte identity of content exposed to the model MUST remain
+stable for the observation's lifetime. An implementation MAY create an
+immutable snapshot or integrity-lock the source, but a later source mutation,
+deletion, or replacement MUST NOT silently change an earlier observation.
+
+**AH-OBS-2.** Attachment media types and sizes MUST be bounded before model
+exposure. Retained snapshots MUST be confined to the declared artifact boundary
+and protected by the same integrity and model-disclosure rules as the
+observation they preserve.
+
+## 10. Artifacts and resume
+
+**AH-ART-1.** A run MUST retain a configuration/capability snapshot, ordered
+transcript or event log, terminal run state, policy events, and references to
+tool and child outputs.
+
+**AH-ART-2.** Artifact writes that represent accepted lifecycle state MUST be
+atomic with respect to readers. A crash MUST produce either the prior complete
+state or the next complete state, not a silently accepted partial document.
+
+**AH-ART-3.** Artifact paths and run identifiers MUST be confined beneath the
+declared artifact root.
+
+**AH-ART-4.** Resume MUST preserve the original authority-bearing run
+configuration. Any allowed override MUST be explicit, recorded, and unable to
+silently broaden tools, mounts, policy, prompt authority, provider route,
+credential owner, or authentication source.
+
+**AH-ART-5.** Resume MUST detect incompatible or missing state and fail closed
+rather than synthesizing a plausible transcript.
+
+## 11. Model usage and cost evidence
+
+These clauses apply when the selected provider reports usage or the harness
+publishes usage or cost metadata.
+
+**AH-USAGE-1.** Usage evidence MUST preserve which counters the provider
+reported for each model attempt and MUST associate them with the selected model,
+provider adapter, and attempt identity. An absent counter MUST remain absent; a
+harness MUST NOT silently replace it with zero.
+
+**AH-USAGE-2.** Direct-run usage and usage inclusive of completed descendants
+MUST remain distinguishable. Every aggregate MUST define its coverage and MUST
+avoid counting descendant usage both through a parent total and again as a
+separate entry.
+
+**AH-USAGE-3.** Cache-read, cache-write, reasoning, input, and output counters
+MUST retain the selected provider's documented semantics. In particular, a
+harness MUST NOT assume that cache counters are additive to input tokens, or
+subsets of input tokens, without a provider contract that says so.
+
+**AH-USAGE-4.** Provider-reported monetary cost and harness-estimated cost MUST
+be separate fields with explicit provenance. An estimate MUST identify its
+currency and rate-card source or version and MUST NOT be described as an
+invoice, provider-reported charge, or subscription-quota conversion.
+
+**AH-USAGE-5.** An aggregate monetary cost MUST be omitted when any included
+record lacks compatible cost evidence. The result SHOULD include a typed reason
+that distinguishes incomplete coverage from unsupported pricing, missing
+provider detail, and invalid counters.
+
+**AH-USAGE-6.** Terminal run artifacts MUST retain the usage and cost evidence
+exposed to the caller. A transport with a structured terminal result SHOULD
+include the same aggregate or an unambiguous reference to it.
+
+## 12. Diagnostics and disclosure
+
+**AH-DIAG-1.** Operator diagnostics SHOULD identify the failing boundary—model
+gateway, configuration, sandbox, mediator, tool, child, artifact store, or
+integration—without exposing secrets to the model-facing channel.
+
+**AH-DIAG-2.** Reduced-assurance operation MUST be explicit in both the run
+snapshot and terminal report. A warning in a transient log is insufficient.
+
+**AH-DIAG-3.** Implementation profiles MUST list known deviations, provisional
+host or network paths, and product adapters that deliberately select a weaker
+profile.
+
+**AH-DIAG-4.** If a harness attaches attribution metadata to provider requests,
+the field set and coverage MUST be published. Values MUST be bounded and MUST
+NOT include prompt text, tool arguments or results, personal identifiers, or
+secrets. Inferred and caller-supplied attribution MUST remain distinguishable in
+operator documentation.

--- a/docs/specs/agent-harness/02-cfc-integration.md
+++ b/docs/specs/agent-harness/02-cfc-integration.md
@@ -1,0 +1,125 @@
+# CFC Integration Profile for Agent Harnesses
+
+Status: draft 0.1
+
+This profile defines how an agent harness participates in Contextual Flow
+Control without becoming the source of authoritative CFC meaning. The
+[deployment mode matrix](../cfc-enforcement-matrix.md) defines the public
+enforcement-mode vocabulary. The clauses below are the complete harness-facing
+obligations; the runner owns broader label, policy, and release semantics.
+
+The public transport types include the
+[prompt-slot binding](../../../packages/cf-harness/src/contracts/prompt-slot.ts),
+[invocation context](../../../packages/cf-harness/src/contracts/cfc-invocation-context.ts),
+[mediated observation](../../../packages/cf-harness/src/contracts/observation.ts),
+and [policy trace](../../../packages/cf-harness/src/contracts/policy-trace.ts)
+contracts.
+
+## 1. Architectural split
+
+**AH-CFC-1.** The runner or another declared trusted CFC component owns
+authoritative labels, policy decisions, and release/write authorization. A
+harness transports and enforces supplied evidence; it MUST NOT ask the model to
+decide whether CFC permits an action.
+
+**AH-CFC-2.** The execution substrate or mediator MUST bind observations and
+side effects to the invocation that produced them. Untrusted stdout, tool JSON,
+or model text MUST NOT be relabeled as trusted mediation evidence by parsing its
+contents.
+
+## 2. Prompt authority
+
+**AH-CFC-3.** Direct-command authority MUST depend on trusted `PromptSlotBound`
+evidence for the relevant kernel, subject, slot role, and value or snapshot
+digest.
+
+**AH-CFC-4.** Context, quoted text, retrieved documents, skills, browser
+observations, child summaries, and previous model output MUST NOT mint
+direct-command authority.
+
+**AH-CFC-5.** Re-rendering, copying, summarizing, or resuming text MUST NOT
+preserve prompt-slot authority unless a trusted component creates fresh binding
+evidence for the new value and role.
+
+## 3. Observation mediation and model context
+
+**AH-CFC-6.** Before an observation is exposed to a model in an enforcing
+profile, the harness MUST receive trusted mediation metadata or return a typed
+opaque/denied observation. Absence of metadata MUST NOT be interpreted as an
+unlabeled successful observation.
+
+**AH-CFC-7.** Labels on observations exposed to the model MUST be accumulated as
+influence on subsequent model-authored invocation inputs. Opaque or denied
+observations MUST NOT be accumulated as if their content were visible.
+
+**AH-CFC-8.** Explicit trusted input labels and derived prompt-influence labels
+MUST remain distinguishable. Influence is not integrity and does not authorize a
+side effect.
+
+## 4. Side effects
+
+**AH-CFC-9.** A side-effect request MUST carry the direct-command evidence and
+input influence labels required by the selected CFC runtime profile.
+
+**AH-CFC-10.** Tools that internally read before writing MUST include the
+internal observation labels in the write decision. An implementation MUST NOT
+discard labels merely because the read and write occur inside one convenience
+tool.
+
+**AH-CFC-11.** Policy denial MUST be recorded as a policy event and exposed to
+the model only through the profile's typed deny/recovery channel.
+
+## 5. Delegation
+
+**AH-CFC-12.** Delegation is a policy transition. A child receives only the
+authority, labels, skills, and capabilities explicitly bound to the child
+profile.
+
+**AH-CFC-13.** Child artifacts and raw browser/network observations remain under
+the child boundary. A structured or summarized return is a new observation and
+MUST pass the configured validation and mediation step before entering parent
+model context.
+
+## 6. Enforcement modes
+
+An implementation MAY publish the following common modes:
+
+- `disabled`: no CFC enforcement claim; normal harness containment may remain.
+- `observe`: policy and mediation gaps are recorded, but otherwise available
+  observations may be exposed. This is a diagnostic mode and MUST NOT be
+  described as CFC enforcement.
+- `enforce-explicit`: trusted metadata is required when the selected policy
+  surface calls for it; explicitly unprotected operations may continue.
+- `enforce-strict`: every modeled observation and side effect requires the
+  evidence defined by the strict runtime profile.
+
+**AH-CFC-14.** The selected mode and any fallback MUST be present in the run
+snapshot and report.
+
+**AH-CFC-15.** An integration that forces `observe` because trusted mediation is
+not wired end to end MUST publish that as a reduced-assurance deviation with an
+owner and retirement condition. It MUST NOT silently fall back from an enforcing
+mode.
+
+## 7. Evidence and retention
+
+**AH-CFC-16.** The artifact boundary MUST retain prompt-slot evidence,
+invocation-context references, mediation dispositions, policy events,
+model-context influence state, and side-effect decisions sufficient to explain
+why a tool result was exposed or denied.
+
+**AH-CFC-17.** CFC evidence may itself reveal sensitive provenance. Its access
+and retention boundary MUST be at least as strict as the transcript and raw tool
+artifacts it explains.
+
+## 8. Opaque reference presentation
+
+**AH-CFC-18.** Resolving a model-bound opaque handle to a canonical reference
+MUST occur before invocation policy evaluation. Possession or successful
+resolution of a handle supplies neither prompt-slot authority nor a CFC release;
+the resulting invocation remains subject to the same label, authority, and
+side-effect checks as a directly supplied reference.
+
+**AH-CFC-19.** Handle mappings are sensitive provenance evidence. Their access,
+retention, child-transfer, and model-disclosure boundaries MUST be at least as
+strict as those of the canonical references they contain.

--- a/docs/specs/agent-harness/03-conformance.md
+++ b/docs/specs/agent-harness/03-conformance.md
@@ -1,0 +1,73 @@
+# Agent Harness Conformance
+
+Status: draft 0.1
+
+Conformance is an evidence-backed claim about a named implementation version,
+not a synonym for “supports similar features.” Because these specifications are
+draft, current profiles are expected to contain explicit deviations.
+
+## Conformance classes
+
+| Class         | Required clauses                                                                                                             |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Core batch    | `AH-INV-*`, `AH-CAP-*`, `AH-LIFE-*`, `AH-TOOL-*`, `AH-CONT-*`, `AH-REF-*`, `AH-OBS-*`, `AH-ART-*`, `AH-USAGE-*`, `AH-DIAG-*` |
+| Delegation    | Core batch plus `AH-DEL-*`                                                                                                   |
+| Interactive   | Core batch plus `AH-INT-*`                                                                                                   |
+| CFC transport | Core batch plus `AH-CFC-*`                                                                                                   |
+
+An implementation MAY claim multiple classes. It MUST NOT claim an optional
+class merely because it parses related configuration.
+
+## Implementation profile
+
+A conformance statement MUST include:
+
+1. implementation name, version or commit, and profile date;
+2. claimed conformance classes;
+3. machine-readable capability-probe command and schema version;
+4. model gateway, execution substrate, mediator, and adapter trust boundaries;
+5. provider, model, credential-owner, authentication-source, billing-route, and
+   request-attribution behavior;
+6. parent tools and child profiles, including host/network powers and durable
+   external-resource semantics;
+7. lifecycle, cancellation, context management, and retry behavior;
+8. attachment-integrity and model-bound opaque-reference behavior;
+9. artifact and resume behavior, including authority-binding validation;
+10. usage counters, aggregate coverage, cache semantics, and cost provenance;
+11. supported CFC modes and the default selected by each product integration;
+12. known deviations and reduced-assurance paths;
+13. test or operational evidence for each claimed class; and
+14. an owner and retirement condition for every temporary deviation.
+
+## Evidence rules
+
+- Unit tests are appropriate evidence for parsing, policy transitions,
+  containment, lifecycle, replay, and artifact invariants.
+- Integration tests are required for claims that depend on a real sandbox,
+  mediator, browser, network boundary, or process tree.
+- A machine-readable capability probe is evidence of interface availability, not
+  dependency health or security enforcement.
+- Product adapters must state when they narrow, broaden, or select a weaker
+  profile than the package default.
+- Usage and cost tests must cover missing counters, descendant aggregation,
+  provider-specific cache semantics, and incomplete cost evidence rather than
+  only the fully populated success case.
+- Context-management tests must cover provider compatibility, transcript
+  pruning boundaries, tool-call/tool-result pairing, explicit disablement, and
+  retry after transient discovery or compaction failure.
+- Opaque-reference tests must cover deterministic resume, collisions, malformed
+  and unknown tokens, child isolation, and separation of model-facing values
+  from raw operator evidence.
+- Attachment tests must prove byte stability after source mutation and fail
+  closed on missing or tampered retained content.
+- Resume tests must reject incomplete, inconsistent, or changed provider and
+  credential-owner bindings before provider traffic.
+- Historical plans and migration notes are not conformance evidence.
+
+## Current first profile
+
+The first implementation profile is maintained beside `@commonfabric/cf-harness`
+in the `labs` repository. It currently characterizes Core batch, Delegation,
+Interactive, and CFC transport separately so that experimental interactive
+support or reduced-assurance CFC integrations do not overstate the mature batch
+runtime.

--- a/docs/specs/agent-harness/README.md
+++ b/docs/specs/agent-harness/README.md
@@ -1,0 +1,66 @@
+# Agent Harness Specifications
+
+Status: draft 0.1
+
+This directory defines implementation-independent contracts for agent harnesses
+used by Common Fabric products. They live with the `cf-harness` implementation
+so changes to behavior, tests, and the governing contract can land together.
+The package documents what one implementation does; these specifications state
+the behavior on which callers, policy runtimes, and other harness
+implementations may rely.
+
+Package-specific CLI flags, file layouts, experimental defaults, and deployment
+recipes remain with their owning implementation. Product-specific routing,
+mounts, brokers, and rollout choices remain with their adapters.
+
+## Status and interpretation
+
+These documents are an initial draft extracted from the behavior already used by
+Loom, Pattern Factory, `cf-harness`, and the CFC runtime profile. They are not
+yet a claim that every implementation conforms.
+
+The key words **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY**
+are normative. A conforming implementation publishes a conformance statement as
+described in [03-conformance.md](03-conformance.md), including every known
+deviation and reduced-assurance mode.
+
+## Reading order
+
+1. [01-runtime-contract.md](01-runtime-contract.md) — invocation, lifecycle,
+   capabilities, context management, tools, delegation, interactive sessions,
+   opaque references, immutable observations, artifacts, and resource
+   accounting.
+2. [02-cfc-integration.md](02-cfc-integration.md) — the CFC transport and
+   enforcement profile for agent harnesses.
+3. [03-conformance.md](03-conformance.md) — conformance classes, evidence, and
+   implementation-profile requirements.
+
+## Ownership boundary
+
+The specification owns:
+
+- caller-visible lifecycle and capability meaning;
+- authority and containment invariants;
+- durable evidence required for audit, replay, and resume;
+- model-bound reference and immutable-observation semantics;
+- provider-neutral model-usage and cost-evidence semantics;
+- the contract between a harness and an authoritative CFC runtime.
+
+An implementation profile owns:
+
+- exact commands, flags, schemas, defaults, and artifact filenames;
+- supported tools, model gateways, sandboxes, and product adapters;
+- experimental features and documented deviations;
+- test evidence for its conformance claims.
+
+The first [implementation profile](../../../packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md)
+is maintained with `@commonfabric/cf-harness`. Loom and Pattern Factory
+maintain separate adapter documents because their routing, mounts, brokers, and
+product rollout choices are not universal harness behavior.
+
+## Non-goals
+
+This draft does not standardize a model-provider API, a universal tool catalog,
+a UI protocol, a sandbox technology, or a product's agent-routing policy. It
+also does not elevate an implementation's temporary bridge into a platform
+guarantee.

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -1029,5 +1029,5 @@ export CF_HARNESS_RUNSC_CFC_INVOCATION_CONTEXT_DIR="$HOME/.local/share/runsc-cfc
 - [roadmap](docs/ROADMAP.md)
 - [skills support design and contract](docs/SKILLS_SUPPORT_SPEC.md)
 - [runner README](../runner/README.md)
-- `specs/agent-harness/` in the sibling `specs` repo
+- [Agent Harness specifications](../../docs/specs/agent-harness/README.md)
 - `specs/cfc/18-runtime-implementation-profiles.md` in the sibling `specs` repo

--- a/packages/cf-harness/docs/CURRENT_STATE.md
+++ b/packages/cf-harness/docs/CURRENT_STATE.md
@@ -1,7 +1,7 @@
 # cf-harness Current State
 
 Status: current implementation reference\
-Last verified: 2026-07-30
+Last verified: 2026-08-14
 
 `cf-harness` is an experimental but product-integrated Common Fabric agent
 runtime. Loom is its first product adapter and Pattern Factory is its first
@@ -14,11 +14,14 @@ The runtime has four main boundaries:
 1. The caller supplies prompt-slot roles, model and gateway configuration,
    tools, child profiles, mounts, resource bounds, skills, policy mode, and
    optional structured-result schemas.
-2. The prompt loop performs bounded OpenAI-compatible model turns and invokes
-   only the configured tool/profile surface.
-3. Tool execution uses Docker with a configurable runtime, normally `runsc-cfc`.
-   The browser child is the exceptional host-adjacent profile and is constrained
-   to a leased local CDP endpoint and a narrow command policy.
+2. The prompt loop performs bounded turns through the selected model provider
+   and invokes only the configured tool/profile surface.
+3. Most tool execution uses Docker with a configurable runtime, normally
+   `runsc-cfc`. The browser child is a constrained host-adjacent profile bound
+   to a leased local CDP endpoint and narrow command policy. The optional
+   `run_pattern` tool is a distinct trusted-host path whose Fabric identity
+   stays outside Docker and whose authority is constrained to one configured
+   space.
 4. The artifact store records run state, transcript, reports, capability and
    policy snapshots, tool outputs, child references, skills provenance, and
    optional product run manifests.
@@ -47,6 +50,9 @@ The current package provides:
 - explicit skill preload, indexed supporting-resource reads, and exact
   allowlisted Deno/Bash skill scripts;
 - transcript-based resume and durable run artifacts;
+- server-side Responses context compaction with a default threshold derived from
+  the model's input budget, an explicit override/disable control, retained
+  compaction evidence, and tool-call/result-safe transcript pruning;
 - per-turn and aggregate token/cache usage in run reports, operator output,
   batch metadata, and interactive turn-completion events;
 - stable interactive prompt-cache affinity, configurable reasoning effort, and
@@ -62,6 +68,11 @@ The current package provides:
   resume; the prompt loop swaps addresses to tokens in model-bound tool output
   and resolves tokens in model-authored tool arguments before policy evaluation
   and dispatch, `delegate_task` arguments excepted;
+- bounded request-attribution headers on OpenAI-compatible gateway traffic,
+  using persisted operational provenance rather than request content or personal
+  identifiers;
+- content-addressed snapshots for in-run `view_image` observations, while
+  run-start images remain source-integrity-locked;
 - an opt-in `run_pattern` tool (`--fabric-api-url`, `--fabric-identity`, and
   `--fabric-space` configured together, or their `CF_HARNESS_FABRIC_*`
   environment fallbacks): compiles and runs an inline `sourceText` pattern
@@ -93,6 +104,14 @@ creates a narrow temporary workspace, supplies explicit mounts and skills,
 requests structured capture results, and retains reviewable run artifacts.
 Autonomous wish dispatch currently routes through `cf-harness` when Loom's Page
 authority prerequisites are considered available.
+
+Local batch and interactive entrypoints use a dedicated single-user host
+binding. It resolves the persisted provider from a canonical `CF_HARNESS_HOME`,
+binds Codex credentials to the fixed local owner, records the provider, model,
+authentication source, owner, and home identity, and requires that exact
+snapshot on resume before any provider traffic. Hosted multi-user integrations
+must supply an owner-bound credential resolver rather than reuse this local
+host.
 
 Loom also has an opt-in adapter for the interactive NDJSON protocol. It is not
 the default interactive harness, and browser automation is not yet wired into
@@ -134,7 +153,8 @@ mode.
 - Raw operator artifacts use filesystem paths. Parent-visible child returns are
   sanitized, and the prompt loop swaps model-bound tool output and
   model-authored tool arguments through the address handle table; denial-path
-  tool messages are not swapped.
+  tool messages are not swapped, and interactive restore does not persist the
+  handle table.
 - The session-local handle table covers cell addresses only. Value handles
   (`cfh:v:`) are reserved in the token grammar but not implemented, and there is
   no explicit dereference/release mechanism.

--- a/packages/cf-harness/docs/CURRENT_STATE.md
+++ b/packages/cf-harness/docs/CURRENT_STATE.md
@@ -1,7 +1,7 @@
 # cf-harness Current State
 
 Status: current implementation reference\
-Last verified: 2026-08-14
+Last verified: 2026-08-18
 
 `cf-harness` is an experimental but product-integrated Common Fabric agent
 runtime. Loom is its first product adapter and Pattern Factory is its first
@@ -42,8 +42,10 @@ The current package provides:
 - workspace, Fabric, and explicit host mounts with path containment;
 - sandboxed shell, file, image, web-fetch, skills, edit/write, and delegation
   tools;
-- one child at a time through `default`, `browser`, `web_fetch`, and
-  `web_search` profiles;
+- one child at a time through `default`, `browser`, `web_fetch`, `web_search`,
+  and `pattern-author` profiles, the last with its own turn budget, no
+  file-write tools, and a discriminated-union return contract whose failure arm
+  is a fixed inert vocabulary;
 - schema-validated, sanitized child returns with raw child evidence retained
   outside the ordinary parent return channel;
 - image inputs and structured top-level batch results;
@@ -67,7 +69,13 @@ The current package provides:
   run for cell addresses, recorded in `run-state.json`, and carried across
   resume; the prompt loop swaps addresses to tokens in model-bound tool output
   and resolves tokens in model-authored tool arguments before policy evaluation
-  and dispatch, `delegate_task` arguments excepted;
+  and dispatch, `delegate_task` and `describe_handle` arguments excepted;
+- delegation-scoped cross-agent references: tokens the parent names in a
+  delegation's goal or context seed the child's handle table with exactly those
+  entries, a child-discovered reference returns as a parent-minted token, and
+  unheld token-shaped text in a child return is scrubbed; a `describe_handle`
+  parent tool reports a held token's harness-derived schema and piece path
+  without reading its value;
 - bounded request-attribution headers on OpenAI-compatible gateway traffic,
   using persisted operational provenance rather than request content or personal
   identifiers;
@@ -156,8 +164,10 @@ mode.
   tool messages are not swapped, and interactive restore does not persist the
   handle table.
 - The session-local handle table covers cell addresses only. Value handles
-  (`cfh:v:`) are reserved in the token grammar but not implemented, and there is
-  no explicit dereference/release mechanism.
+  (`cfh:v:`) are reserved in the token grammar but not implemented.
+  `describe_handle` discloses a held token's shape, never its value; there is
+  still no value dereference or release mechanism, and cross-agent transfer
+  exists only as delegation-scoped seeding.
 - `estimatedCostUsd` is available only for known GPT-5.6 gateway models when the
   response includes cache reads and writes. It uses public OpenAI pricing;
   gateway markup, subscription quota accounting, and provider invoices remain

--- a/packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md
+++ b/packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md
@@ -1,8 +1,8 @@
 # cf-harness Implementation Profile
 
 Status: draft conformance statement\
-Profile date: 2026-08-14\
-Implementation revision: Labs `114f8af286d16203a0fa7356fa6f1da1af6d57d2`
+Profile date: 2026-08-18\
+Implementation revision: Labs `093006b5a72c0235c9c9b4a76aac985fc4ce1f41`
 
 This document describes `@commonfabric/cf-harness` against the draft Common
 Fabric
@@ -76,12 +76,17 @@ readiness.
 
 Current selectable parent tools are `bash`, `read_file`, `view_image`,
 `web_fetch`, `read_skill_resource`, `run_skill_script`, `edit_file`,
-`write_file`, `delegate_task`, and the conditional `run_pattern`. Individual
-runs receive only their configured subset; `web_fetch` and `run_skill_script`
-are not in the ordinary default surface. `run_pattern` is absent unless its API
-URL, identity, and space are all configured. `bash-no-sandbox` exists only as a
-built-in used by authorized child profiles and cannot be selected as a parent
-CLI tool.
+`write_file`, `delegate_task`, `describe_handle`, and the conditional
+`run_pattern`. Individual runs receive only their configured subset; `web_fetch`
+and `run_skill_script` are not in the ordinary default surface. `run_pattern` is
+absent unless its API URL, identity, and space are all configured.
+`bash-no-sandbox` exists only as a built-in used by authorized child profiles
+and cannot be selected as a parent CLI tool.
+
+`describe_handle` reports the shape of a held handle token — the harness-derived
+schema and the referent's path within its piece — without dereferencing the cell
+or reading a value. An unknown or unheld token gets a typed not-known answer,
+not an error and not authority.
 
 `run_pattern` accepts at most 256 KiB of inline source. It resolves whole-string
 LLM-friendly link inputs to live cells only within the configured space and
@@ -92,12 +97,21 @@ artifact. The shared Common Fabric CLI parser accepts the same LLM-friendly
 reference grammar at piece-intake seams, including validated embedded paths for
 commands that operate on paths.
 
-Current child profiles are `default`, `browser`, `web_fetch`, and `web_search`.
-Each profile supplies an exact tool/network/skill policy. Parent skills and
-authority do not transfer implicitly. Sandboxed children inherit the parent's
-working directory within their host-backed mounts; host-command children begin
-at the engine workspace rather than inheriting a parent directory they cannot
-resolve.
+Current child profiles are `default`, `browser`, `web_fetch`, `web_search`, and
+`pattern-author`. Each profile supplies an exact tool/network/skill policy.
+Parent skills and authority do not transfer implicitly. Sandboxed children
+inherit the parent's working directory within their host-backed mounts;
+host-command children begin at the engine workspace rather than inheriting a
+parent directory they cannot resolve.
+
+The `pattern-author` profile moves pattern authoring out of the orchestrating
+parent: it carries its own larger turn budget, receives `bash`, `read_file`,
+`read_skill_resource`, `describe_handle`, and the fabric-gated `run_pattern` —
+no file-write tools, because its deliverable is a result reference rather than a
+file — and returns through a discriminated-union contract whose failure arm uses
+a fixed inert vocabulary, so a failure cannot pass as a success and carries
+nothing read out of a space. Authoring-guide skills are preloaded best-effort
+when the run has a skill registry.
 
 ## Lifecycle and evidence
 
@@ -121,9 +135,18 @@ compaction disablement is the exception.
 The session-local address handle table maps positively identified cell addresses
 to deterministic per-run `cfh:a:` tokens. Model-bound tool output and
 model-authored tool arguments pass through the table before policy evaluation
-and dispatch. Bare Fabric IDs are not converted, delegation arguments carry
-tokens only as inert text, raw artifacts retain canonical references, and the
-table is persisted across batch resume.
+and dispatch. Bare Fabric IDs are not converted, raw artifacts retain canonical
+references, and the table is persisted across batch resume.
+
+Delegation is the cross-agent handle boundary. Tokens the parent wrote into a
+delegation's goal or context reach the child verbatim and seed the child's own
+table with exactly those entries — a token the parent did not name is absent
+from the child's table and cannot resolve there. A reference the child
+discovered for itself returns to the parent as a freshly minted parent token; a
+seeded address mints back to the token the parent already holds; and
+token-shaped text the child's own table cannot resolve is irreversibly scrubbed
+rather than passed through, so a child cannot name a parent entry the delegation
+withheld.
 
 Resume preserves recorded transcript/run configuration and rejects unsupported
 new inputs such as image or skill changes. The local Loom host additionally
@@ -154,12 +177,13 @@ in-flight external side effect.
    web tools.
 4. **Incomplete opaque-reference boundary.** Address handles cover cell
    addresses but not the reserved value-handle form. Denial-path messages are
-   not swapped, interactive restore does not persist the table, and there is no
-   cross-agent transfer, dereference, release, or garbage-collection contract.
-   Raw operator reports may expose artifact paths and canonical references.
-   Owner: `cf-harness`. Retirement: every model-facing path uses held opaque
-   handles with explicit lifetime and release/readback semantics while operator
-   tooling retains resolvable provenance.
+   not swapped, and interactive restore does not persist the table. Cross-agent
+   transfer exists only as delegation-scoped seeding, and `describe_handle`
+   discloses only shape; there is still no value dereference, release, or
+   garbage-collection contract. Raw operator reports may expose artifact paths
+   and canonical references. Owner: `cf-harness`. Retirement: every model-facing
+   path uses held opaque handles with explicit lifetime and release/readback
+   semantics while operator tooling retains resolvable provenance.
 5. **Durable trusted-host pattern execution.** Each `run_pattern` call creates
    an unlisted, detached Fabric piece whose source revision remains a retention
    root. Abort stops the piece, but there is no deadline, resource ceiling,
@@ -172,10 +196,11 @@ in-flight external side effect.
 
 - `deno task test` — package contract suite.
 - `deno task test:integration` — environment-gated real `runsc-cfc` paths.
-- Handle-table, prompt-loop-handle, image-attachment, compaction, provenance,
-  provider/auth, `run_pattern`, and local-Loom-host suites — model boundary,
-  observation integrity, context continuity, request attribution, external side
-  effects, and exact resume binding.
+- Handle-table, prompt-loop-handle, subagent-handle, `describe_handle`,
+  image-attachment, compaction, provenance, provider/auth, `run_pattern`, and
+  local-Loom-host suites — model boundary, delegation-scoped handle seeding and
+  scrubbing, observation integrity, context continuity, request attribution,
+  external side effects, and exact resume binding.
 - Loom `tests/harness/` and dispatch tests — capability skew, commands,
   cancellation, mounts, structured results, interactive translation, and run
   review.

--- a/packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md
+++ b/packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md
@@ -1,22 +1,23 @@
 # cf-harness Implementation Profile
 
 Status: draft conformance statement\
-Profile date: 2026-07-22
+Profile date: 2026-08-14\
+Implementation revision: Labs `114f8af286d16203a0fa7356fa6f1da1af6d57d2`
 
 This document describes `@commonfabric/cf-harness` against the draft Common
 Fabric
-[Agent Harness specifications](https://github.com/commontoolsinc/specs/tree/main/agent-harness).
-It is deliberately more conservative than the feature list: protocol presence
-does not imply full conformance or external dependency health.
+[Agent Harness specifications](../../../docs/specs/agent-harness/README.md). It
+is deliberately more conservative than the feature list: protocol presence does
+not imply full conformance or external dependency health.
 
 ## Claimed classes
 
-| Class         | Status                                                     | Evidence boundary                                                                                                                                                                                      |
-| ------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Core batch    | implemented; provisional conformance                       | Package unit tests cover configuration, lifecycle, tools, containment, artifacts, resume, and diagnostics. Real Docker/runtime behavior requires integration tests.                                    |
-| Delegation    | implemented; experimental                                  | Unit tests cover profiles, fresh child context, retained child artifacts, and sanitized/structured return handling. Only serial single-child orchestration is supported.                               |
-| Interactive   | implemented; experimental                                  | NDJSON v1 and SQLite-backed sessions/turns/events/replay are covered by package and Loom adapter tests. The protocol is not yet declared stable.                                                       |
-| CFC transport | partial; reduced assurance in current product integrations | Prompt-slot, invocation-context, model-influence, mediation, and deny/recovery behavior are tested. Loom and Pattern Factory still select `observe` because trusted mediation is not wired end to end. |
+| Class         | Status                                                     | Evidence boundary                                                                                                                                                                                                                     |
+| ------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Core batch    | implemented; provisional conformance                       | Package unit tests cover configuration, lifecycle, context management, tools, handles, attachment integrity, artifacts, resume, and diagnostics. Real Docker, Fabric, and other external-runtime behavior requires integration tests. |
+| Delegation    | implemented; experimental                                  | Unit tests cover profiles, fresh child context, retained child artifacts, and sanitized/structured return handling. Only serial single-child orchestration is supported.                                                              |
+| Interactive   | implemented; experimental                                  | NDJSON v1 and SQLite-backed sessions/turns/events/replay are covered by package and Loom adapter tests. The protocol is not yet declared stable.                                                                                      |
+| CFC transport | partial; reduced assurance in current product integrations | Prompt-slot, invocation-context, model-influence, mediation, and deny/recovery behavior are tested. Loom and Pattern Factory still select `observe` because trusted mediation is not wired end to end.                                |
 
 ## Capability discovery
 
@@ -31,44 +32,72 @@ profiles, native model tools, and optional features. Adapters should use this
 probe to handle vendor skew.
 
 The probe does not health-check Docker, the selected Docker runtime, Browser
-Access, a model gateway, or configured mount sources. This is a known deviation
-from `AH-CAP-4` when a caller treats advertised capability as readiness. The
-retirement condition is a caller-visible dependency preflight contract that
-checks every dependency required by the selected run profile before the first
-model turn.
+Access, a model gateway, configured mount sources, or the Fabric session used by
+`run_pattern`. Callers must not treat advertised capability as dependency
+readiness.
 
 ## Trust and execution profile
 
-- Model gateway: OpenAI-compatible. `gpt-*` turns use the Responses API, which
-  accepts function tools together with reasoning; provider-native tools and
-  non-OpenAI models use chat completions, which cannot serve that combination.
-  Native model tools are declared separately in either case.
+- Model gateway: either an OpenAI-compatible gateway or the authenticated OpenAI
+  Codex subscription transport. Gateway `gpt-*` turns use the Responses API,
+  which accepts function tools together with reasoning; provider-native tools
+  and non-OpenAI models use chat completions, which cannot serve that
+  combination. Native model tools are declared separately in either case.
+- Provider and credentials: versioned private provider configuration and Codex
+  credentials live beneath `CF_HARNESS_HOME`. Provider resolution is explicit; a
+  broken Codex binding does not fall back to gateway billing or retention. The
+  dedicated local Loom host uses the fixed credential owner `local`, a canonical
+  home identity, and the persisted provider/authentication source.
 - Execution substrate: Docker; normally the sibling gVisor `runsc-cfc` runtime,
   with configurable image and runtime.
 - CFC authority: Common Fabric runner/runtime evidence and trusted sandbox
   sidecars. Harness-local policy logic is conservative transport/enforcement,
   not the source of label meaning.
-- Host execution: unavailable to parent runs. The browser child profile exposes
-  only a constrained host command/script policy bound to an explicit local CDP
-  lease.
+- Host execution: general parent host command execution is unavailable. The
+  conditionally advertised `run_pattern` parent tool is a separate trusted-host
+  capability: it holds the Fabric identity outside Docker and uses a lazy,
+  authorized session constrained to one configured space. The browser child
+  exposes only a constrained host command/script policy bound to an explicit
+  local CDP lease.
 - Network: explicit in configuration but still provisional. Sandboxed `bash`
   applies a direct-`curl` destination guard; `web_fetch` and web child profiles
   have their own bounded request policies.
-- Artifacts: retained under an explicit artifact root and reserved from normal
-  workspace discovery when the roots overlap.
+- Gateway attribution: OpenAI-compatible requests carry bounded `x-cf-harness-*`
+  and `User-Agent` provenance fields. These contain operational origin labels,
+  not prompts, tool content, secrets, or personal identifiers. The Codex
+  subscription transport does not use these gateway headers.
+- Artifacts and observations: artifacts are retained under an explicit root and
+  reserved from normal workspace discovery when the roots overlap. Run-start
+  image inputs are integrity-locked. In-run `view_image` observations use
+  content-addressed snapshots when an artifact store is present, so regenerating
+  the source file does not change an earlier observation.
 
 ## Parent and child surfaces
 
 Current selectable parent tools are `bash`, `read_file`, `view_image`,
 `web_fetch`, `read_skill_resource`, `run_skill_script`, `edit_file`,
-`write_file`, and `delegate_task`. Individual runs receive only their configured
-subset; `web_fetch` and `run_skill_script` are not in the ordinary default
-surface. `bash-no-sandbox` exists only as a built-in used by authorized child
-profiles and cannot be selected as a parent CLI tool.
+`write_file`, `delegate_task`, and the conditional `run_pattern`. Individual
+runs receive only their configured subset; `web_fetch` and `run_skill_script`
+are not in the ordinary default surface. `run_pattern` is absent unless its API
+URL, identity, and space are all configured. `bash-no-sandbox` exists only as a
+built-in used by authorized child profiles and cannot be selected as a parent
+CLI tool.
+
+`run_pattern` accepts at most 256 KiB of inline source. It resolves whole-string
+LLM-friendly link inputs to live cells only within the configured space and
+checks their current values against the compiled argument schema before piece
+creation. Success returns a result reference and an optional schema-sanitized
+value to the model while retaining raw identifiers and values only in the
+artifact. The shared Common Fabric CLI parser accepts the same LLM-friendly
+reference grammar at piece-intake seams, including validated embedded paths for
+commands that operate on paths.
 
 Current child profiles are `default`, `browser`, `web_fetch`, and `web_search`.
 Each profile supplies an exact tool/network/skill policy. Parent skills and
-authority do not transfer implicitly.
+authority do not transfer implicitly. Sandboxed children inherit the parent's
+working directory within their host-backed mounts; host-command children begin
+at the engine workspace rather than inheriting a parent directory they cannot
+resolve.
 
 ## Lifecycle and evidence
 
@@ -79,34 +108,74 @@ groups are responsible for forwarding cancellation and reaping the complete
 owned group; Loom's batch wrapper implements and tests that integration
 boundary.
 
+Gateway Responses turns support server-side context compaction. The default
+threshold is 75% of the input budget derived from the model's context window and
+maximum output; `--compact-threshold` overrides it and `0` disables compaction.
+Lazy budget discovery is bounded by a text-bearing input-size guard. Compaction
+items remain transcript evidence, replay starts at the newest compatible
+boundary, and function-call/output pairs remain intact. Transient discovery,
+compaction, and abort failures are not permanently cached. A child that
+overrides its model does not inherit parent provider controls; explicit run-wide
+compaction disablement is the exception.
+
+The session-local address handle table maps positively identified cell addresses
+to deterministic per-run `cfh:a:` tokens. Model-bound tool output and
+model-authored tool arguments pass through the table before policy evaluation
+and dispatch. Bare Fabric IDs are not converted, delegation arguments carry
+tokens only as inert text, raw artifacts retain canonical references, and the
+table is persisted across batch resume.
+
 Resume preserves recorded transcript/run configuration and rejects unsupported
-new inputs such as image or skill changes. It is not a general recovery system
-for an in-flight external side effect.
+new inputs such as image or skill changes. The local Loom host additionally
+requires an exact recorded provider, model, authentication source,
+credential-owner, and canonical-home binding before provider traffic; legacy,
+incomplete, inconsistent, or switched bindings fail closed. This fixed-owner
+host is for local single-user Loom. A hosted multi-user adapter must inject an
+owner-bound credential resolver. Resume is not a general recovery system for an
+in-flight external side effect.
 
-## CFC deviations and retirement conditions
+## Known deviations and retirement conditions
 
-1. **Product `observe` bridges.** Loom and Pattern Factory select `observe` for
+1. **Dependency readiness.** The capability probe does not establish health for
+   Docker, `runsc-cfc`, Browser Access, mounts, gateways, or Fabric sessions.
+   Owner: `cf-harness` and each product adapter. Retirement: the selected run
+   profile has a caller-visible preflight that checks every required dependency
+   before the first model turn.
+2. **Product `observe` bridges.** Loom and Pattern Factory select `observe` for
    workflows whose sandbox output does not yet carry trusted mediation metadata
    end to end. Owners: the respective product adapters plus the cf-harness/CFC
    integration. Retirement: real sidecar evidence is present for every exposed
    observation and enforcing-mode adapter suites pass without opaque-output
    regressions.
-2. **Provisional network policy.** Package-default bridge networking and the
+3. **Provisional network policy.** Package-default bridge networking and the
    shell `curl` guard are integration mechanisms, not a complete destination
-   capability system. Retirement: network authority is represented and enforced
-   as an explicit profile across sandbox and dedicated web tools.
-3. **Filesystem artifact references.** Operator reports may expose raw artifact
-   paths. The session-local address handle table supplies deterministic per-run
-   tokens for cell addresses, persisted in run state and carried across resume,
-   and the prompt loop swaps model-bound tool output and model-authored tool
-   arguments through it, but no release/readback step exists. Retirement:
-   parent/model channels use opaque handles with an explicit release/readback
-   step while operator tooling retains resolvable provenance.
+   capability system. Owner: `cf-harness`. Retirement: network authority is
+   represented and enforced as an explicit profile across sandbox and dedicated
+   web tools.
+4. **Incomplete opaque-reference boundary.** Address handles cover cell
+   addresses but not the reserved value-handle form. Denial-path messages are
+   not swapped, interactive restore does not persist the table, and there is no
+   cross-agent transfer, dereference, release, or garbage-collection contract.
+   Raw operator reports may expose artifact paths and canonical references.
+   Owner: `cf-harness`. Retirement: every model-facing path uses held opaque
+   handles with explicit lifetime and release/readback semantics while operator
+   tooling retains resolvable provenance.
+5. **Durable trusted-host pattern execution.** Each `run_pattern` call creates
+   an unlisted, detached Fabric piece whose source revision remains a retention
+   root. Abort stops the piece, but there is no deadline, resource ceiling,
+   deletion, garbage collection, or outbound CFC flow check over the compiled
+   source. Owner: `cf-harness` and Fabric runtime tooling. Retirement: callers
+   can bound, enumerate, retain, and delete tool-created resources, and trusted
+   CFC evidence covers the external read/write path.
 
 ## Test evidence
 
 - `deno task test` — package contract suite.
 - `deno task test:integration` — environment-gated real `runsc-cfc` paths.
+- Handle-table, prompt-loop-handle, image-attachment, compaction, provenance,
+  provider/auth, `run_pattern`, and local-Loom-host suites — model boundary,
+  observation integrity, context continuity, request attribution, external side
+  effects, and exact resume binding.
 - Loom `tests/harness/` and dispatch tests — capability skew, commands,
   cancellation, mounts, structured results, interactive translation, and run
   review.

--- a/packages/cf-harness/docs/README.md
+++ b/packages/cf-harness/docs/README.md
@@ -13,7 +13,7 @@ migration notes live under `docs/history/` at the repository root.
 - [CURRENT_STATE.md](CURRENT_STATE.md) — concise current architecture,
   integrations, and known gaps.
 - [IMPLEMENTATION_PROFILE.md](IMPLEMENTATION_PROFILE.md) — conformance statement
-  against the cross-repository Agent Harness specification.
+  against the Agent Harness specification.
 - [ROADMAP.md](ROADMAP.md) — remaining work only; shipped milestones are not
   repeated as a plan.
 - [SKILLS_SUPPORT_SPEC.md](SKILLS_SUPPORT_SPEC.md) — live
@@ -21,10 +21,10 @@ migration notes live under `docs/history/` at the repository root.
 
 ## Normative boundary
 
-The implementation-independent runtime and CFC contracts live in the sibling
-`specs` repository under `agent-harness/`. This package owns exact CLI flags,
-tools, profiles, schemas, defaults, artifacts, and deviations. Loom and Pattern
-Factory own their adapter and rollout behavior.
+The implementation-independent runtime and CFC contracts live in
+[`docs/specs/agent-harness/`](../../../docs/specs/agent-harness/README.md). This
+package owns exact CLI flags, tools, profiles, schemas, defaults, artifacts, and
+deviations. Loom and Pattern Factory own their adapter and rollout behavior.
 
 ## Historical records
 


### PR DESCRIPTION
## Why

Stacked on #5412. The profile and current-state reference in that PR are accurate at their pinned revision (`114f8af2`, verified 2026-08-14), but CT-2003 (#5781, merged 2026-08-17) changed the seams they document. Rather than asking for a re-roll of the base PR, this stacks the refresh so #5412 can merge as written and this lands the delta on top.

## What Changed

Re-verified both documents at current main (`093006b5a`) and updated the statements CT-2003 invalidated:

- **Parent tools** now include `describe_handle`, with a paragraph on its shape-only disclosure (harness-derived schema and piece path, never a value; unheld tokens get a typed not-known answer).
- **Child profiles** now include `pattern-author`: own turn budget, no file-write tools, discriminated-union return contract with an inert failure vocabulary, best-effort skill preload.
- **Delegation handle boundary** rewritten: tokens the parent names in a delegation's goal/context seed the child's table with exactly those entries, child-discovered references return as parent-minted tokens, and unheld token-shaped text in child returns is scrubbed. Replaces "delegation arguments carry tokens only as inert text".
- **Deviation 4** no longer claims "no cross-agent transfer, dereference" — transfer exists as delegation-scoped seeding and `describe_handle` is shape-only; the remaining gaps (value handles, release/GC, denial-path swap, interactive-restore persistence) stay listed.
- Test-evidence line picks up the subagent-handle and describe-handle suites; profile date and `Last verified` bumped to 2026-08-18.

The spec clauses in #5412 need no change — AH-REF-3 forbids *implicit* transfer, and CT-2003's parent-selected seeding is the explicit mechanism it anticipated.

## Test plan

- `deno fmt --check` on both files
- Claims spot-checked against main: `describe_handle` in the selectable tool list and `tools/describe-handle.ts` (schema/path only), `PATTERN_AUTHOR_SUBAGENT_*` in `contracts/subagent.ts` (turn budget, tool surface, return contract), `seedSubagentHandleTable` and the child-return scrub in `prompt-loop.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

