### PR TITLE
refactor(toolshed): decode a blob upload once

### DIFF
--- a/packages/toolshed/routes/blobs/blobs.index.ts
+++ b/packages/toolshed/routes/blobs/blobs.index.ts
@@ -1,5 +1,3 @@
-import { NullLiveEnvironment } from "@commonfabric/data-model/codec-common";
-import { newDefaultJsonCodecEngine } from "@commonfabric/data-model/codecs";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { isDID } from "@commonfabric/identity";
@@ -15,11 +13,6 @@ import { createRouter } from "@/lib/create-app.ts";
 import { memoryServer } from "@/routes/storage/memory.ts";
 
 const router = createRouter();
-const blobUploadCodec = newDefaultJsonCodecEngine();
-const blobLiveEnvironment = new NullLiveEnvironment(
-  true,
-  "blob upload payloads cannot contain cell references",
-);
 
 type BlobContents = {
   type: string;
@@ -171,13 +164,7 @@ const readRequestContents = async (request: Request) => {
   if (!source) {
     return undefined;
   }
-  try {
-    return asBlobContents(
-      blobUploadCodec.decode(source, blobLiveEnvironment),
-    );
-  } catch {
-    return asBlobContents(decodeMemoryBoundary(source));
-  }
+  return asBlobContents(decodeMemoryBoundary(source));
 };
 
 const loadBlobContents = async (


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

`readRequestContents()` decoded a blob upload one way and, on any throw,
decoded it again the other way:

```ts
try {
  return asBlobContents(blobUploadCodec.decode(source, blobLiveEnvironment));
} catch {
  return asBlobContents(decodeMemoryBoundary(source));
}
```

The two ways were the same way.

## Why the fallback could never fall back

`decodeMemoryBoundary()` calls `fabricFromJsonValue()`, which is the shared
`JsonCodecEngine`. Peel that layer off and the two branches line up exactly:

| | `try` | `catch` |
| --- | --- | --- |
| engine | `newDefaultJsonCodecEngine()` | the same, via `fabricFromJsonValue()` |
| registry | default | default |
| leniency | strict | strict |
| environment | `NullLiveEnvironment(true, "blob upload payloads cannot contain cell references")` | `NullLiveEnvironment(true, "no cell decoding at the memory boundary")` |

Same format, same codecs, same strictness. A body that failed the first decode
failed the second for the identical reason, one layer further down. The shape
of the code suggests format detection — try ours, fall back to theirs — and
there is only one format here.

The single thing the fallback could change is which message a cell reference
produces, and both environments are a `NullLiveEnvironment` differing in
wording alone. Nothing asserts either message; the blob-specific one appears
in the repository exactly once, at its own declaration.

## What is left

The second call, which was already the one that ran whenever the first did not.
`blobUploadCodec`, `blobLiveEnvironment` and their two imports die with the
`try`, as does the bare `catch` — which was discarding the reason for a failure
it had no way to act on.

## Behavior

Unchanged for every body that decoded before, both branches having produced the
same value. A body that decodes to neither form now raises from
`decodeMemoryBoundary()` rather than from the `blobUploadCodec` call, carrying
the memory boundary's wording instead of the blob route's; the route reports
the same failure to the caller either way.

## Verification

The path is covered rather than assumed: ablating the surviving call to a throw
turns five blob-route steps red, and restoring it turns them green. `toolshed`
passes at 137, and `deno lint`, `deno task check`, `deno fmt --check` are each
clean on their exit codes.

Found while auditing where lenient JSON decoding happens in the codebase, ahead
of a change that makes a codec engine's syntactic refusal settle against
`lenient` like any other malformation. This site was the only production
JSON-decode caller, and looking at it closely was how the redundancy surfaced.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

