### PR TITLE
refactor(data-model): the base class owns an act from end to end

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -2518,12 +2518,10 @@ export type JsonCodecValue =
 Every engine exposes `encode()` and `decode()`, parameterized by the boundary
 type — `string` for JSON, `Uint8Array` for a binary format — and an engine may
 add a pair for a second boundary type, as `JsonCodecEngine` does for bytes.
-The machinery beneath (tag wrapping, tree walking, codec dispatch) is not
-public. Much of it is `protected` rather than private, that being the surface
-a second engine extends — including the two factories below.
-
-Each act of encoding or decoding carries a context, minted per call by a
-factory the engine's subclass supplies:
+Both are supplied by the base class and are not overridden: they mint the
+act's context, run the walk, and hand off to the format at each end. What a
+format supplies is those two ends and the context factories, all `protected`
+— the surface a second engine extends rather than one a caller reaches.
 
 ```typescript
 // Shown at module scope.
@@ -2535,9 +2533,33 @@ abstract class ExampleEngine {
   ): EncodeContext;
   protected abstract newDecodeContext(
     env: LiveEnvironment,
+    data: string,
   ): DecodeContext;
+
+  protected abstract serializedFromEncoded(
+    encoded: JsonCodecValue,
+    ctx: EncodeContext,
+  ): string;
+  protected abstract encodedFromSerializedForm(
+    data: string,
+    ctx: DecodeContext,
+  ): JsonCodecValue;
 }
 ```
+
+Minting the context in the base rather than in each engine is what makes
+*per act* structural: an engine cannot hold one across calls, because it
+never gets to decide when one is made.
+
+`encodedFromSerializedForm()` is where a format checks that what it was
+handed is its own. What arrives there is data off a channel like anything
+else, so a form that is not this format's is refused by throwing, and
+`decode()` settles that against the engine's `lenient` setting — a lenient
+decode answers a syntactic fault with a `ProblematicValue`, exactly as it
+does a fault found further in. `newDecodeContext()` sees the same form and
+may read something out of it for the act, but it *sniffs rather than
+validates*: it runs before anything has established that the form is this
+format's at all.
 
 The context is what the walk threads from node to node: the caller's
 `LiveEnvironment`, and the values whose encoding or decoding is in

--- a/packages/data-model/src/codec-common/BaseCodecEngine.ts
+++ b/packages/data-model/src/codec-common/BaseCodecEngine.ts
@@ -151,25 +151,12 @@ export abstract class BaseCodecEngine<
     env: LiveEnvironment = NULL_LIVE_ENVIRONMENT,
   ): FabricValue {
     const ctx = this.newDecodeContext(env, data);
-    let encoded: Encoded;
 
     try {
-      encoded = this.encodedFromSerializedForm(data, ctx);
+      return this.decodeValue(this.encodedFromSerializedForm(data), ctx);
     } catch (e) {
-      // A serialized form is data off a channel like any other, so being the
-      // wrong shape for this format settles against `lenient` exactly as a
-      // malformation inside a well-formed one does. Only this class's own
-      // refusal is caught: anything else a format's conversion throws is its
-      // own business and is left alone.
-      if (this.lenient && (e instanceof ProblematicStateError)) {
-        return deepFreeze(
-          new ProblematicValue(e.wireTypeTag, e.state, e.message),
-        );
-      }
-      throw e;
+      return this.settleSyntacticRefusal(e);
     }
-
-    return this.decodeValue(encoded, ctx);
   }
 
   /**
@@ -196,13 +183,12 @@ export abstract class BaseCodecEngine<
    * {@link #lenient} -- so a lenient decode answers a syntactic fault with a
    * `ProblematicValue`, exactly as it does a fault found further in.
    *
-   * `ctx` is the act being decoded, already built from this same data, so a
-   * format that reads something out of the form for its context has it there
-   * rather than reading it twice.
+   * Takes no context. What a format needs out of the form for the act it is
+   * about to run, it takes in {@link #newDecodeContext}, which sees the same
+   * form; this step is the conversion and nothing else.
    */
   protected abstract encodedFromSerializedForm(
     data: SerializedForm,
-    ctx: DecCtx,
   ): Encoded;
 
   /**
@@ -360,6 +346,35 @@ export abstract class BaseCodecEngine<
         }: no applicable codec.`,
       );
     }
+  }
+
+  /**
+   * Settles a refusal of the serialized form itself against {@link #lenient}:
+   * strictly it raises, and leniently it becomes a `ProblematicValue`.
+   *
+   * A serialized form is data off a channel like any other, so being the wrong
+   * shape for this format -- or the right shape around a payload that will not
+   * parse -- is a malformation of the same kind as a bad state inside a
+   * well-formed one, and settles the same way.
+   *
+   * Only this class's own refusal is settled. Anything else thrown while
+   * converting a form is the format's own business and is re-raised untouched,
+   * so a bug in a conversion does not come back as a `ProblematicValue`.
+   *
+   * Available to a format's own entry points, which reach a conversion without
+   * passing through {@link #decode} -- `JsonCodecEngine`'s byte pair, for one.
+   *
+   * @throws Whatever it was given, if this engine is not lenient or the throw
+   *   was not a refusal.
+   */
+  protected settleSyntacticRefusal(e: unknown): FabricValue {
+    if (this.lenient && (e instanceof ProblematicStateError)) {
+      return deepFreeze(
+        new ProblematicValue(e.wireTypeTag, e.state, e.message),
+      );
+    }
+
+    throw e;
   }
 
   /**

--- a/packages/data-model/src/codec-common/BaseCodecEngine.ts
+++ b/packages/data-model/src/codec-common/BaseCodecEngine.ts
@@ -369,11 +369,11 @@ export abstract class BaseCodecEngine<
    */
   protected settleSyntacticRefusal(e: unknown): FabricValue {
     if (this.lenient && (e instanceof ProblematicStateError)) {
-      return deepFreeze(
-        new ProblematicValue(e.wireTypeTag, e.state, e.message),
-      );
+      return this.reportMalformed(e.wireTypeTag, e.state, e.message);
     }
 
+    // Rethrown rather than rebuilt, strictly: the refusal already names its
+    // tag and state, and re-raising it keeps whatever `cause` it carries.
     throw e;
   }
 
@@ -511,12 +511,10 @@ export abstract class BaseCodecEngine<
 
       // Report over the state the codec was actually handed, so that it says
       // what the codec choked on.
-      return deepFreeze(
-        new ProblematicValue(
-          tag,
-          state as FabricValue,
-          e instanceof Error ? e.message : String(e),
-        ),
+      return this.reportMalformed(
+        tag,
+        state,
+        e instanceof Error ? e.message : String(e),
       );
     }
 

--- a/packages/data-model/src/codec-common/BaseCodecEngine.ts
+++ b/packages/data-model/src/codec-common/BaseCodecEngine.ts
@@ -18,6 +18,7 @@ import { isCodecTypeTag } from "./isCodecTypeTag.ts";
 import { ProblematicStateError } from "./ProblematicStateError.ts";
 import { ProblematicValue } from "./ProblematicValue.ts";
 import { UnknownValue } from "./UnknownValue.ts";
+import { NULL_LIVE_ENVIRONMENT } from "@/codec-interface/NullLiveEnvironment.ts";
 
 /**
  * Base class for a whole-value codec: the object that walks a fabric value
@@ -114,7 +115,14 @@ export abstract class BaseCodecEngine<
    *   `FabricSpecialObject` whose class no codec in the registry claims, a
    *   cycle, or an object that is no kind of `FabricValue` at all.
    */
-  abstract encode(value: FabricValue, env?: LiveEnvironment): SerializedForm;
+  encode(
+    value: FabricValue,
+    env: LiveEnvironment = NULL_LIVE_ENVIRONMENT,
+  ): SerializedForm {
+    const ctx = this.newEncodeContext(env);
+
+    return this.serializedFromEncoded(this.encodeValue(value, ctx), ctx);
+  }
 
   /**
    * Decodes this format's serialized form back into a fabric value.
@@ -138,10 +146,64 @@ export abstract class BaseCodecEngine<
    *   only tell from finding something it never emits -- or if a codec rejects
    *   a state and this instance is not lenient.
    */
-  abstract decode(
+  decode(
     data: SerializedForm,
-    env: LiveEnvironment,
-  ): FabricValue;
+    env: LiveEnvironment = NULL_LIVE_ENVIRONMENT,
+  ): FabricValue {
+    const ctx = this.newDecodeContext(env, data);
+    let encoded: Encoded;
+
+    try {
+      encoded = this.encodedFromSerializedForm(data, ctx);
+    } catch (e) {
+      // A serialized form is data off a channel like any other, so being the
+      // wrong shape for this format settles against `lenient` exactly as a
+      // malformation inside a well-formed one does. Only this class's own
+      // refusal is caught: anything else a format's conversion throws is its
+      // own business and is left alone.
+      if (this.lenient && (e instanceof ProblematicStateError)) {
+        return deepFreeze(
+          new ProblematicValue(e.wireTypeTag, e.state, e.message),
+        );
+      }
+      throw e;
+    }
+
+    return this.decodeValue(encoded, ctx);
+  }
+
+  /**
+   * Converts the walk's finished tree into this format's serialized form --
+   * a stringify step, an envelope, or nothing at all for a format whose tree
+   * is what crosses.
+   *
+   * `ctx` is the act the tree was built by, for a format whose serialized form
+   * carries something minted per call.
+   */
+  protected abstract serializedFromEncoded(
+    encoded: Encoded,
+    ctx: EncCtx,
+  ): SerializedForm;
+
+  /**
+   * Converts this format's serialized form into the tree the walk decodes,
+   * which is where a format checks that what it was handed is its own: a parse
+   * step, an envelope check, or nothing at all.
+   *
+   * What arrives is data off a channel and is not to be assumed well-formed. A
+   * form that is not this format's is refused by throwing
+   * `ProblematicStateError`, which {@link #decode} settles against
+   * {@link #lenient} -- so a lenient decode answers a syntactic fault with a
+   * `ProblematicValue`, exactly as it does a fault found further in.
+   *
+   * `ctx` is the act being decoded, already built from this same data, so a
+   * format that reads something out of the form for its context has it there
+   * rather than reading it twice.
+   */
+  protected abstract encodedFromSerializedForm(
+    data: SerializedForm,
+    ctx: DecCtx,
+  ): Encoded;
 
   /**
    * Encodes an array, which is this format's business entirely.
@@ -214,10 +276,20 @@ export abstract class BaseCodecEngine<
 
   /**
    * Constructs the context for one act of decoding, around the live
-   * environment the caller gave. Called once per `decode()`, and where a
-   * format says whether its walk guards against cycles.
+   * environment the caller gave and the form about to be decoded. Called
+   * once per `decode()`.
+   *
+   * `data` is here so that a format whose walk needs something carried in
+   * the form itself -- a marker read off an envelope, say -- can take it
+   * now. It **sniffs rather than validates**: this runs before anything
+   * has checked that `data` is this format's at all, so an implementation
+   * reads defensively and leaves the refusing to
+   * {@link #encodedFromSerializedForm}.
    */
-  protected abstract newDecodeContext(env: LiveEnvironment): DecCtx;
+  protected abstract newDecodeContext(
+    env: LiveEnvironment,
+    data: SerializedForm,
+  ): DecCtx;
 
   //
   // Instance members

--- a/packages/data-model/src/codec-json/JsonCodecEngine.ts
+++ b/packages/data-model/src/codec-json/JsonCodecEngine.ts
@@ -4,6 +4,7 @@ import { utf8SortedKeysOf } from "@commonfabric/utils/utf8";
 
 import type { FabricValue } from "@/interface.ts";
 import { BaseCodecEngine } from "@/codec-common/BaseCodecEngine.ts";
+import { ProblematicStateError } from "@/codec-common/ProblematicStateError.ts";
 import { DecodeContext } from "@/codec-common/DecodeContext.ts";
 import { EncodeContext } from "@/codec-common/EncodeContext.ts";
 import { NULL_LIVE_ENVIRONMENT } from "@/codec-interface/NullLiveEnvironment.ts";
@@ -65,7 +66,10 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
    * {@link #decode} gives, so the context's in-progress set is never
    * allocated.
    */
-  protected override newDecodeContext(env: LiveEnvironment): DecodeContext {
+  protected override newDecodeContext(
+    env: LiveEnvironment,
+    _data: string,
+  ): DecodeContext {
     return new DecodeContext(env);
   }
 
@@ -75,36 +79,42 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
    * Walks the value into the `/<Type>@<Version>` tagged tree, stringifies it,
    * and prefixes the format tag.
    */
-  override encode(
-    value: FabricValue,
-    env: LiveEnvironment = NULL_LIVE_ENVIRONMENT,
+  /**
+   * @inheritDoc
+   *
+   * Stringifies the walked tree and prefixes the format tag.
+   */
+  protected override serializedFromEncoded(
+    encoded: JsonCodecValue,
+    _ctx: EncodeContext,
   ): string {
-    return ENCODING_PREFIX_TAG +
-      JSON.stringify(this.encodeValue(value, this.newEncodeContext(env)));
+    return ENCODING_PREFIX_TAG + JSON.stringify(encoded);
   }
 
   /**
    * @inheritDoc
    *
-   * Checks the format tag, parses what follows it, and walks the resulting
-   * tree back into fabric values.
-   *
-   * The walk carries no cycle guard, and needs none: what it walks is the
-   * product of `JSON.parse()`, and a parse of text yields a tree. This format
-   * never receives a tree it did not build itself, which is the condition
-   * under which a decode can be handed a cycle at all.
+   * Checks the format tag and parses what follows it. A string without the tag
+   * is not this format's serialized form at all, which is refused here rather
+   * than walked -- and settles against `lenient` like any other malformation
+   * off a channel.
    */
-  override decode(data: string, env: LiveEnvironment): FabricValue {
+  protected override encodedFromSerializedForm(
+    data: string,
+    _ctx: DecodeContext,
+  ): JsonCodecValue {
     if (!JsonCodecEngine.seemsLikeEncoded(data)) {
       const excerpt = (data.length <= 50) ? data : `${data.slice(0, 50)}...`;
-      throw new Error(
+      throw new ProblematicStateError(
+        "",
+        excerpt,
         `Not a JSON-encoded \`FabricValue\` string: ${backtickQuote(excerpt)}`,
       );
     }
 
-    const json = data.slice(ENCODING_PREFIX_TAG.length);
-    const parsed = JsonCodecEngine.#parseWireText(json);
-    return this.decodeValue(parsed, this.newDecodeContext(env));
+    return JsonCodecEngine.#parseWireText(
+      data.slice(ENCODING_PREFIX_TAG.length),
+    );
   }
 
   /** Encodes a fabric value to UTF-8 JSON bytes. */
@@ -124,10 +134,12 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
    */
   decodeFromBytes(
     bytes: Uint8Array,
-    env: LiveEnvironment,
+    env: LiveEnvironment = NULL_LIVE_ENVIRONMENT,
   ): FabricValue {
-    const tree = JsonCodecEngine.#fromBytes(bytes);
-    return this.decodeValue(tree, this.newDecodeContext(env));
+    const text = JsonCodecEngine.#textDecoder.decode(bytes);
+    const ctx = this.newDecodeContext(env, text);
+
+    return this.decodeValue(JsonCodecEngine.#parseWireText(text), ctx);
   }
 
   /**

--- a/packages/data-model/src/codec-json/JsonCodecEngine.ts
+++ b/packages/data-model/src/codec-json/JsonCodecEngine.ts
@@ -76,12 +76,6 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
   /**
    * @inheritDoc
    *
-   * Walks the value into the `/<Type>@<Version>` tagged tree, stringifies it,
-   * and prefixes the format tag.
-   */
-  /**
-   * @inheritDoc
-   *
    * Stringifies the walked tree and prefixes the format tag.
    */
   protected override serializedFromEncoded(
@@ -99,10 +93,7 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
    * than walked -- and settles against `lenient` like any other malformation
    * off a channel.
    */
-  protected override encodedFromSerializedForm(
-    data: string,
-    _ctx: DecodeContext,
-  ): JsonCodecValue {
+  protected override encodedFromSerializedForm(data: string): JsonCodecValue {
     if (!JsonCodecEngine.seemsLikeEncoded(data)) {
       const excerpt = (data.length <= 50) ? data : `${data.slice(0, 50)}...`;
       throw new ProblematicStateError(
@@ -138,8 +129,15 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
   ): FabricValue {
     const text = JsonCodecEngine.#textDecoder.decode(bytes);
     const ctx = this.newDecodeContext(env, text);
+    let tree: JsonCodecValue;
 
-    return this.decodeValue(JsonCodecEngine.#parseWireText(text), ctx);
+    try {
+      tree = JsonCodecEngine.#parseWireText(text);
+    } catch (e) {
+      return this.settleSyntacticRefusal(e);
+    }
+
+    return this.decodeValue(tree, ctx);
   }
 
   /**
@@ -685,6 +683,25 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
 
   /** Parses the JSON-text wire form, _without_ a tag prefix. */
   static #parseWireText(jsonText: string): JsonCodecValue {
-    return deepFreeze(JSON.parse(jsonText) as JsonCodecValue);
+    try {
+      return deepFreeze(JSON.parse(jsonText) as JsonCodecValue);
+    } catch (e) {
+      // The tag said this was ours and the text under it is not JSON, which
+      // is a refusal of the serialized form and settles against `lenient`
+      // like the tag check above it. Raised as this class's own refusal
+      // rather than passing `JSON.parse()`'s `SyntaxError` along, which
+      // nothing downstream recognizes.
+      const excerpt = (jsonText.length <= 50)
+        ? jsonText
+        : `${jsonText.slice(0, 50)}...`;
+      throw new ProblematicStateError(
+        "",
+        excerpt,
+        `Malformed JSON in an encoded \`FabricValue\` string: ${
+          backtickQuote(excerpt)
+        }`,
+        { cause: e },
+      );
+    }
   }
 }

--- a/packages/data-model/src/codec-json/JsonCodecEngine.ts
+++ b/packages/data-model/src/codec-json/JsonCodecEngine.ts
@@ -608,12 +608,6 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
     return JsonCodecEngine.#textEncoder.encode(JSON.stringify(data));
   }
 
-  /** Parses UTF-8-encoded JSON bytes back into a codec-value tree. */
-  static #fromBytes(bytes: Uint8Array): JsonCodecValue {
-    const json = JsonCodecEngine.#textDecoder.decode(bytes);
-    return JsonCodecEngine.#parseWireText(json);
-  }
-
   /**
    * Indicates whether `count` is usable as a `/hole` run length: a safe
    * integer of at least one. A run always stands for at least one absent

--- a/packages/data-model/test/codec-common/probe-engine.ts
+++ b/packages/data-model/test/codec-common/probe-engine.ts
@@ -310,10 +310,7 @@ export class ProbeEngine extends BaseCodecEngine<ProbeValue> {
    * The tree is what arrives, so there is nothing to convert and nothing this
    * format can tell is not its own: any value at all is a candidate.
    */
-  protected override encodedFromSerializedForm(
-    data: ProbeValue,
-    _ctx: DecodeContext,
-  ): ProbeValue {
+  protected override encodedFromSerializedForm(data: ProbeValue): ProbeValue {
     return data;
   }
 

--- a/packages/data-model/test/codec-common/probe-engine.ts
+++ b/packages/data-model/test/codec-common/probe-engine.ts
@@ -21,7 +21,6 @@ import type {
 import { CodecRegistry } from "@/codec-common/CodecRegistry.ts";
 import { DecodeContext } from "@/codec-common/DecodeContext.ts";
 import { EncodeContext } from "@/codec-common/EncodeContext.ts";
-import { NULL_LIVE_ENVIRONMENT } from "@/codec-interface/NullLiveEnvironment.ts";
 import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
 
 /**
@@ -293,18 +292,29 @@ export class ProbeEngine extends BaseCodecEngine<ProbeValue> {
   // Instance members
   //
 
-  override encode(
-    value: FabricValue,
-    env: LiveEnvironment = NULL_LIVE_ENVIRONMENT,
+  /**
+   * @inheritDoc
+   *
+   * The tree is what crosses, so there is nothing to convert.
+   */
+  protected override serializedFromEncoded(
+    encoded: ProbeValue,
+    _ctx: EncodeContext,
   ): ProbeValue {
-    return this.encodeValue(value, this.newEncodeContext(env));
+    return encoded;
   }
 
-  override decode(
+  /**
+   * @inheritDoc
+   *
+   * The tree is what arrives, so there is nothing to convert and nothing this
+   * format can tell is not its own: any value at all is a candidate.
+   */
+  protected override encodedFromSerializedForm(
     data: ProbeValue,
-    env: LiveEnvironment,
-  ): FabricValue {
-    return this.decodeValue(data, this.newDecodeContext(env));
+    _ctx: DecodeContext,
+  ): ProbeValue {
+    return data;
   }
 
   /** @inheritDoc */
@@ -319,7 +329,10 @@ export class ProbeEngine extends BaseCodecEngine<ProbeValue> {
    * the tree itself, so a caller can hand `decode()` a graph with a cycle in
    * it, and the base's guard is what refuses one.
    */
-  protected override newDecodeContext(env: LiveEnvironment): DecodeContext {
+  protected override newDecodeContext(
+    env: LiveEnvironment,
+    _data: ProbeValue,
+  ): DecodeContext {
     return new DecodeContext(env);
   }
 

--- a/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
@@ -396,6 +396,30 @@ describe("JsonCodecEngine", () => {
     });
   });
 
+  describe("a string that is not this format's serialized form", () => {
+    const NOT_OURS = '{"a":1}';
+
+    it("throws when strict", () => {
+      expect(() =>
+        newDefaultJsonCodecEngine().decode(NOT_OURS, new TestLiveEnvironment())
+      )
+        .toThrow(/Not a JSON-encoded `FabricValue` string/);
+    });
+
+    it("returns a `ProblematicValue` when lenient", () => {
+      // A serialized form is data off a channel like any other, so being the
+      // wrong shape for this format settles against `lenient` exactly as a
+      // malformation inside a well-formed one does. Anything else would make
+      // the outermost check the one refusal `lenient` could not contain.
+      const decoded = newDefaultJsonCodecEngine({ lenient: true })
+        .decode(NOT_OURS, new TestLiveEnvironment());
+
+      expect(decoded).toBeInstanceOf(ProblematicValue);
+      expect((decoded as ProblematicValue).error)
+        .toMatch(/Not a JSON-encoded `FabricValue` string/);
+    });
+  });
+
   describe("`encodeToBytes()` / `decodeFromBytes()` (bytes entry points)", () => {
     it("returns `Uint8Array` from `encodeToBytes()`", () => {
       const { jsonCodecEngine } = makeTestCodec();

--- a/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
@@ -418,6 +418,27 @@ describe("JsonCodecEngine", () => {
       expect((decoded as ProblematicValue).error)
         .toMatch(/Not a JSON-encoded `FabricValue` string/);
     });
+    it("throws for a well-tagged but unparseable payload when strict", () => {
+      const bad = "fvj1:{not json";
+
+      expect(() =>
+        newDefaultJsonCodecEngine().decode(bad, new TestLiveEnvironment())
+      )
+        .toThrow(/Malformed JSON in an encoded `FabricValue` string/);
+    });
+
+    it("returns a `ProblematicValue` for an unparseable payload when lenient", () => {
+      // The tag says the form is ours and the text under it is not JSON. That
+      // is a refusal of the serialized form just as an absent tag is, so it
+      // settles the same way -- otherwise `lenient` would contain one half of
+      // "is this well-formed?" and not the other.
+      const decoded = newDefaultJsonCodecEngine({ lenient: true })
+        .decode("fvj1:{not json", new TestLiveEnvironment());
+
+      expect(decoded).toBeInstanceOf(ProblematicValue);
+      expect((decoded as ProblematicValue).error)
+        .toMatch(/Malformed JSON in an encoded `FabricValue` string/);
+    });
   });
 
   describe("`encodeToBytes()` / `decodeFromBytes()` (bytes entry points)", () => {

--- a/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
@@ -442,6 +442,31 @@ describe("JsonCodecEngine", () => {
   });
 
   describe("`encodeToBytes()` / `decodeFromBytes()` (bytes entry points)", () => {
+    it("throws for unparseable bytes when strict", () => {
+      const bytes = new TextEncoder().encode("{not json");
+
+      expect(() =>
+        newDefaultJsonCodecEngine().decodeFromBytes(
+          bytes,
+          new TestLiveEnvironment(),
+        )
+      ).toThrow(/Malformed JSON in an encoded `FabricValue` string/);
+    });
+
+    it("returns a `ProblematicValue` for unparseable bytes when lenient", () => {
+      // This entry point reaches a conversion without passing through
+      // `decode()`, so it settles the refusal itself. Were it not to, the
+      // byte boundary would answer a malformed payload differently from the
+      // string boundary for no reason a caller could name.
+      const bytes = new TextEncoder().encode("{not json");
+      const decoded = newDefaultJsonCodecEngine({ lenient: true })
+        .decodeFromBytes(bytes, new TestLiveEnvironment());
+
+      expect(decoded).toBeInstanceOf(ProblematicValue);
+      expect((decoded as ProblematicValue).error)
+        .toMatch(/Malformed JSON in an encoded `FabricValue` string/);
+    });
+
     it("returns `Uint8Array` from `encodeToBytes()`", () => {
       const { jsonCodecEngine } = makeTestCodec();
       const result = jsonCodecEngine.encodeToBytes(42);


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

`newEncodeContext()` and `newDecodeContext()` were `abstract` on
`BaseCodecEngine` and called only by its subclasses. **An abstract method the
base never calls is not a hook — it is a naming convention the base cannot
enforce.** And what it failed to enforce here is the invariant the whole per-act
design rests on: an engine was free to mint one context and reuse it across
calls, which is precisely the ablation used to prove those tests have teeth.

## What changes

`encode()` and `decode()` become concrete. They mint the act's context, run the
walk, and hand off to the format at each end:

```
encode(value, env?)  ->  newEncodeContext  ->  encodeValue  ->  serializedFromEncoded
decode(data,  env?)  ->  newDecodeContext  ->  encodedFromSerializedForm  ->  decodeValue
```

`decode()`'s `catch` covers the whole act, not just the conversion, so anything
escaping the walk settles rather than propagating raw.
`encodedFromSerializedForm()` takes no context: what a format needs out of the
form, it takes in `newDecodeContext()`, which sees the same form.

**The outer `catch` does not subsume the two in-place conversions, and is not
meant to.** They differ in granularity rather than kind — an in-place report
degrades the faulty node and keeps the document around it, where the outer one
answers for the whole act. Removing them collapses `{keep: "me", bad: <report>}`
to a bare report and turns ten steps red, among them the nested reserved key and
both circular-reference cases.

**One place decides what `lenient` means.** `reportMalformed()` was already the
primitive; the codec-throw arm and the syntactic settling now go through it
rather than each writing its own `deepFreeze(new ProblematicValue(...))`. What
stays at each site is only what is particular to it — normalizing an arbitrary
codec throw when strict, and re-raising the original refusal so it keeps its
`cause`.

What a format supplies is the two ends and the two factories, all `protected`.
Minting in the base is what makes *per act* **structural**: an engine cannot
hold a context across calls, because it never decides when one is made. The
`NULL_LIVE_ENVIRONMENT` default collapses into one place with it, having been
repeated in every engine.

`newDecodeContext()` gains the serialized form, so a format whose walk needs
something carried in it — a marker off an envelope — can take it now rather
than reading the form twice. It **sniffs rather than validates**: it runs
before anything has established that the form is this format's at all.

## A serialized form is untrusted input in its own right

That establishing is `encodedFromSerializedForm()`'s job, and it now settles
against `lenient` like everything else off a channel.

Being the wrong shape for this format is a malformation of the same kind as a
bad state inside a well-formed one, so it is refused by throwing
`ProblematicStateError`, which `decode()` turns into a `ProblematicValue` when
lenient. `JsonCodecEngine`'s `fvj1:` prefix check moves onto that path, and so does a
payload that will not parse — a `SyntaxError` from `JSON.parse()` is not this
class's refusal, so it used to propagate whatever the setting, leaving
`lenient` containing one half of "is this well-formed?" and not the other.
`decodeFromBytes()` had the same gap, reaching a conversion without passing
through `decode()`; both now share `settleSyntacticRefusal()`. The prefix check
had also thrown whatever the setting — which had made the outermost check the
one refusal `lenient` could not contain, and had left the two formats
disagreeing about their own boundary.

## Audit: no production caller is affected

Every `lenient: true` in the repository is in a test — 20 sites, all
`*.test.ts`. Production has five engine constructions and all take the strict
default:

| site | direction |
| --- | --- |
| `codecs.ts` — the shared `jsonCodecEngine` / `realmCodecEngine` singletons | both |
| `toolshed/routes/blobs/blobs.index.ts` | decode |
| `runtime-client/backends/runtime-processor.ts` | encode only |
| `connectors/agents/src/chunking.ts` | encode only |

So the change alters what a *lenient* engine does, and no production engine is
lenient. The audit did turn up something at the one production decode site,
which is #5952 and independent of this.

## Verification

Ablations, each confirmed to **type-check** first, so the failure is behavioral
rather than a compile error:

| ablation | result |
| --- | --- |
| `decode()` rethrows instead of settling against `lenient` | red — the new JSON leniency test |
| per-act minting replaced by a memoized context (on the prior head) | red — all four per-act tests |

New tests cover both halves of the boundary rule: a string that is not this
format's serialized form throws when strict, and returns a `ProblematicValue`
carrying the same message when lenient.

Gates, each on its exit code: `deno lint`, `deno task check`, `check-docs`,
`check-skill-facts`, `check-conflict-markers`, `check-no-waitfor`,
`check-docs-history-index`, `deno fmt --check`. Tests pass in `data-model`,
`memory`, `runner` and `toolshed`.

Section 4.3 of the formal spec is updated: the entry points are described as
the base's, the factory block carries all four hooks, and the sniff-versus-
validate split and the leniency rule are stated.

## Why this is a prep PR

`codec-realm` (#5823) is the change these keep falling out of. Its
`RealmDecodeContext` currently takes the marker through an `adoptMarker()`
setter, because the factory had no way to see the envelope; with
`newDecodeContext(env, data)` the marker arrives in the constructor and that
setter disappears.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


