### PR TITLE
feat(cli): the demo carries a mixed room — three words up front, and the name is not folklore

### DIFF
--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -204,6 +204,7 @@ An address a person can type, rather than a fid from a previous command.
 # not in the demo — the demo deploys straight against a live toolshed
 cf test tracker.test.tsx
 cf piece new packages/cli/integration/pattern/tracker.tsx --slug board
+cf piece slugs
 cf piece verbs --piece board
 ```
 
@@ -219,7 +220,11 @@ of root items and `$NAME` is its display name; both are data, and data is not
 callable, so neither is offered to a caller as something to call.
 
 Slug resolution sits on the shared path (`resolvePieceConfigWithPieces`,
-`packages/cli/lib/piece.ts`), so every command below takes `board` too.
+`packages/cli/lib/piece.ts`), so every command below takes `board` too. And
+the name is discoverable as well as resolvable: `cf piece slugs` lists the
+space's slug index, so a session in a space someone else populated starts
+from a listing rather than from folklore. The demo's act 1 runs it beside the
+deploy.
 
 The listing carries the deployed pattern's source identity, which is how a
 client tells it is talking to a newer pattern than it was written against.

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -185,6 +185,10 @@ pending() {
 }
 
 printf '%s\n' "${B}A work tracker, driven entirely through cf${N}"
+say "Three words carry the session. A pattern is TypeScript declaring state"
+say "and verbs. Deploying one makes a piece — a running instance. Both live in"
+say "a space, the shared durable place every command below names with -s."
+say ""
 say "space $SPACE · nothing here was written for this pattern"
 say "CF_API_URL=$CF_API_URL and CF_IDENTITY are exported; everything else you see"
 say "is the whole command."
@@ -193,6 +197,9 @@ act "1 · Arrive by name"
 say "A slug is a name in the space: the board is 'board' from here on, and the"
 say "fid this command prints is never typed again."
 run cf piece new "$FIXTURE" -s "$SPACE" --slug board
+say "The name is discoverable, not folklore: the space lists its slugs, so a"
+say "session in a space someone else populated starts from this same command."
+run cf piece slugs -s "$SPACE"
 
 act "2 · Ask what it is, and what it can do"
 say "One command is the piece's man page: name, purpose, state, inputs, and"
@@ -202,6 +209,9 @@ run cf piece describe -s "$SPACE" --piece board
 say "And the callable rows again as a table, the shape a client matches"
 say "against. Both are derived from the deployed pattern, not from a manifest."
 run cf piece verbs -s "$SPACE" --piece board
+say "In the table, ON names the cell a verb lives on and MARKS flags wrapper"
+say "or deprecated rows. The listings all take --json for tooling — the tables"
+say "are for the room; reads and calls already answer in JSON."
 
 act "3 · Ask what a verb wants"
 say "Flags, types, required-ness and result all come from the author's TypeScript."

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -74,6 +74,13 @@ fi
 $CF piece set-slug board "$BOARD" $ARGS >/dev/null 2>&1
 SLUG_NAME=$($CF get --quiet --piece board $ARGS '$NAME' 2>/dev/null | tr -d '"')
 check "Work tracker" "$SLUG_NAME" "the slug resolves everywhere --piece is taken"
+# The arrival name is discoverable as well as resolvable: the slug index
+# lists what set-slug wrote, which is what lets a session in a space someone
+# else populated start from a listing rather than from folklore.
+$CF piece slugs $ARGS --json 2>/dev/null |
+  jq -e '[.[].slug] | index("board")' >/dev/null 2>&1 &&
+  ok "the slug index lists the arrival name" ||
+  bad "the slug index does not list 'board'"
 
 step "2. Ask what it is, and what it can do"
 VERBS=$($CF piece verbs --piece board $ARGS --json 2>/dev/null)


### PR DESCRIPTION
## Why

The verb-session demo is shown to rooms where not everyone knows Common Fabric, and its transcript assumed otherwise: *space*, *pattern*, *piece*, and *slug* all landed undefined before act 1 finished; "arrive by name" quietly assumed someone had already told you the name; and the verbs table's ON and MARKS columns went unexplained while the narration pointed at them. The mixed-audience findings from the review behind #5933, plus the beat #5943 made possible: the slug index means the arrival name is now discoverable, and the demo can show it. Follows #5915/#5925/#5928 on the same script.

## What Changed

- **A three-line on-ramp** in the prologue: pattern (TypeScript declaring state and verbs), piece (a running instance), space (the shared durable place `-s` names) — the vocabulary the session spends, defined before it is spent.
- **Act 1 gains the arrival's other half:** `cf piece slugs` runs beside the deploy, so the transcript shows the name being listed, not just resolved — the day-2 story of arriving in a space someone else populated. The walkthrough quotes the command in step 1 with a sentence on discoverable-versus-resolvable, and `verb-session-gaps.sh` asserts the slug index lists the arrival name.
- **Act 2 explains its own table:** one beat naming what ON and MARKS mean, and where the machine spellings live (`--json` on the listings; reads and calls already answer in JSON) — for the half of a mixed room that will script against this tomorrow.

No act renumbering — every cross-reference in the demo, walkthrough, and harness stands.

## Test plan

- Demo and gaps harness ran green end to end against a freshly started toolshed built from this tree (the long-running local one predates #5954's breaking runner refactor and can no longer initialize a space): demo exit 0 with the new beats in the transcript; gaps **35 passed, 0 failed, 1 gap open** (the known blockOn spelling), including the new slug-index assertion.
- `deno task check-verb-session-sync` (walkthrough commands and act references match the demo), `deno task check-docs`, `bash -n` on both scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

