### PR TITLE
run_pattern: a pattern with no argument schema is a tool error, not a dead run

### DIFF
--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -674,10 +674,13 @@ export const runPatternTool: HarnessToolDefinition<
     // closed set of names to measure against. `additionalProperties` admits
     // them both when it is `true` and when it is a schema: a schema there is an
     // index signature, which names what an undeclared key is allowed to hold
-    // rather than forbidding one.
-    const additionalArguments =
-      (argumentSchema as { additionalProperties?: unknown })
-        .additionalProperties;
+    // rather than forbidding one. A plain-function pattern compiles with no
+    // argument schema at all — not even a boolean one — so the read is
+    // guarded rather than assumed.
+    const additionalArguments = isObjectNotArray(argumentSchema)
+      ? (argumentSchema as { additionalProperties?: unknown })
+        .additionalProperties
+      : undefined;
     const admitsUndeclaredArguments = additionalArguments === true ||
       isObjectNotArray(additionalArguments);
     if (

--- a/packages/cf-harness/test/run-pattern.test.ts
+++ b/packages/cf-harness/test/run-pattern.test.ts
@@ -278,6 +278,25 @@ describe("run-pattern", () => {
       expect(output.linkedStringCount).toBe(0);
     });
 
+    it("returns a structured error for a plain-function pattern whose compiled argument schema is undefined, rather than throwing out of the run", async () => {
+      const engine = createEngine();
+      // A bare default function compiles to a pattern with no argument
+      // schema at all — not even the boolean schema `pattern()` synthesizes
+      // — so the undeclared-input check must not assume one exists. The
+      // source itself is not a runnable pattern; what this pins is that its
+      // failure comes back as a tool output the model can read and correct.
+      const result = await engine.invokeBuiltinTool("run_pattern", {
+        sourceText: [
+          'export const NAME = "Probe";',
+          "export default function({}: {}) { return { ok: true }; }",
+          "",
+        ].join("\n"),
+      });
+      const output = result.output as { status: string; message?: string };
+      expect(output.status).toBe("error");
+      expect((output.message ?? "").length).toBeGreaterThan(0);
+    });
+
     it("keeps a computed number when the result carries framework keys the schema does not declare", async () => {
       // Every pattern result carries the framework's own keys, and a schema
       // describing only what the pattern computes declares none of them. The


### PR DESCRIPTION
A plain-function default export compiles to a pattern whose `argumentSchema` is `undefined` — not even the boolean schema `pattern()` synthesizes — and `run_pattern`'s undeclared-input check read `.additionalProperties` off it unguarded. The TypeError escaped the tool implementation and failed the whole run: a model's exploratory probe cost the run instead of a turn, which is precisely the failure class the invalid-tool-call contract exists to prevent.

Found live on the first CFC-enforcement-chapter agent run, whose model opened with a minimal plain-function probe — a shape no typed test pattern had ever sent. The pinning test deploys that exact shape and asserts the failure comes back as a structured tool output the model can read and correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

