### PR TITLE
feat: server-execution v2 stage C — compile-and-run served as an outbox effect (OW28)

### DIFF
--- a/docs/plans/server-execution-v2.md
+++ b/docs/plans/server-execution-v2.md
@@ -428,14 +428,19 @@ Tasks:
       pending), `navigateTo` stays enactable (reversible),
       `compile-and-run` is gated at the BUILTIN (its floating compile
       launch cannot be intercepted at the destination), and that gate's
-      true interim scope is wider than "not speculable": it suppresses
+      true interim scope was wider than "not speculable": it suppressed
       fresh compiles for EVERY flag-ON non-wave run — client
       derivation, F10 handler runs, imperative flows — and the serving
-      side refuses the writebacks until the compile-and-run serving
-      port (stage G's out-of-scope note) lands, so fresh
-      compile-and-run is INERT in the ON arm everywhere until that
-      port (memo'd results still read through; the gate's both-arms
-      pins live in `packages/runner/test/compile-and-run.test.ts`);
+      side refused the writebacks until the compile-and-run serving
+      port. THE PORT LANDED (OW28, stage C 2026-08-17): the client now
+      READS THROUGH to the served result (no fresh compile client-side,
+      no speculative write) and the SERVER serves the compile as an
+      outbox effect with the instantiation an ordinary consequence of
+      the served graph run (verification-coverage.md OW28; builtins.md
+      §3); the both-arms pins live in
+      `packages/runner/test/compile-and-run.test.ts` and the end-to-end
+      piece-creation flow in
+      `packages/runner/test/executor-compile-and-run.test.ts`;
       result-as-pattern children ride the derivation run's overlay
       writes.
 - [x] UI bindings untouched: authored writes under existing ACL + CAS
@@ -885,7 +890,10 @@ Tasks:
       and OW29 CLOSED, OW32 CLOSED as a cause, OW34 CLOSED); STAGE C =
       closeout (the lunch gate's residual, the honest benchmark)*; (3)
       OW28 — compile-and-run as an outbox effect kind + completion-class
-      writeback; (4) the HONEST propagation benchmark (criterion below)
+      re-arm writeback, the instantiation an ordinary consequence of the
+      served graph run — LANDED (`claude/server-exec-v2-stage-c-ow28`,
+      2026-08-17; verification-coverage.md OW28); (4) the HONEST
+      propagation benchmark (criterion below)
       once the two-user family works; (5) the ON skip list EMPTY and the
       deployed-topology binaries the presets flip
       (`background-piece-service`, the CLI, cf-harness, every

--- a/docs/specs/server-side-execution/builtins.md
+++ b/docs/specs/server-side-execution/builtins.md
@@ -64,6 +64,54 @@ toolshed — reuse that path. Async work stays on the post-commit outbox
 (the v1 lesson that ported: never block the loop on compilation).
 Instantiated pieces join the space's graph and are served like any other.
 
+**Served shape — LANDED (OW28, stage C 2026-08-17).** The COMPILE is the
+outbox effect (kind `compile-and-run`), memoized on the program hash (a
+`{ requestHash, resolvedHash, compiledHash }` memo cell — the §4 shape):
+a served derivation MISS enqueues it, the SpaceOutbox performs it
+post-wave-commit, and it lands a marked COMPLETION commit
+(`markEffectCompletion`, §4 — its own derived-class commit, never through
+§3d's sealing, never unstamped). The completion does NOT instantiate; it
+RE-ARMS the derivation (`compiledHash`). The INSTANTIATION is then an
+ordinary consequence of the served graph run — the derivation reads the
+compiled pattern from the process cache and instantiates the child IN-RUN
+(the result-as-pattern shape below; derivation-class setup, correctly
+scoped per demander, the child's own body served as ordinary
+derivations). This split is deliberate: a post-commit flush that
+instantiated would RACE the serving loop's own resume of the prior child
+(the loop re-runs a demanded piece from its stored `patternIdentity`
+pointer, and a flush's `run`/`runSynced` loses the re-instantiation to
+it), so a program change would keep serving the OLD child. The §4 HIT
+rule keys on `resolvedHash` (set on every TERMINAL outcome — a landed
+piece, an error-shaped result, or a synchronous invalid-inputs/
+main-not-found), NOT on `pending`: the builtin's cell-init writes
+`pending=false` on a fresh closure's first run, so a pending-based hit
+would FALSELY fire for a durable mid-compile request on recovery — the
+piece would render empty forever (the recovery-mid-flight wedge). A
+compile FAILURE lands an error-shaped result keyed by the program hash
+(retry input-driven — never a timer, T14). Recovery re-uses a LANDED
+piece: the loop resumes the child from its pointer, and the hit rule
+reads through; a mid-flight request (issued, never resolved) RE-MISSES
+and re-fires the compile (§6 step 3) — every park / crash /
+dropped-or-refused completion ends the serving runtime, and the fresh
+one's first evaluation re-fires (pinned live: a park mid-compile
+resolves on re-activation). A re-arm that landed but whose process
+compile-cache entry was since evicted also re-fires rather than wedging.
+Posture, stated (the request-hash builtins' identical one — fetch's
+in-memory claim blocks re-issue the same way): a completion commit that
+FAILS on a LIVE runtime that did not park (an infrastructure failure the
+outbox counts as `outbox.failed`) stays pending until the space
+re-activates or the inputs change; no dirtiness- or timer-driven retry
+is invented. The CLIENT reads through (speculation.md §2) for EVERY
+outcome: a flag-ON non-serving run never compiles and writes nothing
+speculatively — not even the synchronous invalid-inputs / main-not-found
+outcomes, which the server decides identically and lands as committed
+cells — so the served `pending`/`result`/`error` render directly (a
+speculative echo only delayed the read-through). Content-cache note: the
+served path normalizes the program to a PLAIN object before keying the
+compile cache — `createRef({ src })` is insensitive to nested `contents`
+on the `asSchema` query-result proxy, which would collapse distinct
+programs to one cache key.
+
 Result-as-pattern instantiation — a lift or handler RETURNING a
 pattern, instantiated into a deterministic result cell — is a RUNNER
 path distinct from `compile-and-run` (no compilation step), and it runs

--- a/docs/specs/server-side-execution/builtins.md
+++ b/docs/specs/server-side-execution/builtins.md
@@ -76,22 +76,62 @@ ordinary consequence of the served graph run — the derivation reads the
 compiled pattern from the process cache and instantiates the child IN-RUN
 (the result-as-pattern shape below; derivation-class setup, correctly
 scoped per demander, the child's own body served as ordinary
-derivations). This split is deliberate: a post-commit flush that
-instantiated would RACE the serving loop's own resume of the prior child
-(the loop re-runs a demanded piece from its stored `patternIdentity`
-pointer, and a flush's `run`/`runSynced` loses the re-instantiation to
-it), so a program change would keep serving the OLD child. The §4 HIT
-rule keys on `resolvedHash` (set on every TERMINAL outcome — a landed
-piece, an error-shaped result, or a synchronous invalid-inputs/
-main-not-found), NOT on `pending`: the builtin's cell-init writes
-`pending=false` on a fresh closure's first run, so a pending-based hit
-would FALSELY fire for a durable mid-compile request on recovery — the
-piece would render empty forever (the recovery-mid-flight wedge). A
-compile FAILURE lands an error-shaped result keyed by the program hash
-(retry input-driven — never a timer, T14). Recovery re-uses a LANDED
-piece: the loop resumes the child from its pointer, and the hit rule
-reads through; a mid-flight request (issued, never resolved) RE-MISSES
-and re-fires the compile (§6 step 3) — every park / crash /
+derivations). The re-arm is ONE of two instantiate triggers, not the
+only one: any run that finds the pattern in the process cache — an
+incidental re-run after the effect cached it, a fresh closure over a warm
+process — instantiates without waiting for it, and the completion then
+re-arms nothing (a completion NEVER overwrites a landed resolution). This
+split is deliberate: a post-commit flush that instantiated would RACE the
+serving loop's own resume of the prior child (the loop re-runs a demanded
+piece from its stored `patternIdentity` pointer, and a flush's
+`run`/`runSynced` loses the re-instantiation to it), so a program change
+would keep serving the OLD child. The §4 HIT rule keys on `resolvedHash`
+(set on every TERMINAL outcome — a landed piece, an error-shaped result,
+or a synchronous invalid-inputs/ main-not-found), NOT on `pending`: the
+builtin's cell-init writes `pending=false` on a fresh closure's first
+run, so a pending-based hit would FALSELY fire for a durable mid-compile
+request on recovery — the piece would render empty forever (the
+recovery-mid-flight wedge). A compile FAILURE lands an error-shaped
+result keyed by the program hash (retry input-driven — never a timer,
+T14).
+
+**Supersession (the OW28 independent review's MAJOR-A).** The ON arm has
+NO abort signal: an issued compile effect always runs to its completion,
+and the COMPLETION decides by re-reading the node's CURRENT request hash
+through its own transaction (§4's FP6 re-read at writeback) — current
+again → it lands; superseded → it writes nothing, reports itself
+(§7's `outbox.superseded`), and its retirement RELEASES the outbox key.
+This is the discipline the outbox's in-flight attach relies on: an
+A→B→A′ sequence within A's compile duration attaches A′ to A's
+still-running effect (same key), so an effect that returned on "aborted
+at B's issue" would drop A′'s only completion and the node would stay
+`pending=true` forever, no counter naming it (the wedge, live-reproduced
+and pinned red-first). A same-hash re-run mid-flight reads the
+issue-time `requestHash` and WAITS — never re-issues into the in-flight
+key.
+
+**Instances (the review's MAJOR-B; scopes.md §6).** A scoped
+compile-and-run node fans out once per demanded instance through ONE
+closure, so every per-instance fact lives outside the closure: the
+cells resolve their instance through the run's transaction, the effect
+key carries the run's instance (`effectTargetKey` with the run identity —
+memo keys INCLUDE the instance key), and the completion transaction is
+STAMPED with the issuing run's identity so its request re-read and its
+writes address the instance the effect was issued for. The rule: ONE
+compile per program per process (the pattern cache is shared and
+single-flights); ONE effect completion + ONE instantiation per demanded
+instance (pinned live at cardinality 2 — a per-user program, the same
+text for two demanders: two effects, one real compile, both instances
+land). Recovery re-uses a LANDED piece when the memo cell is synced by
+the fresh runtime's first evaluation: the loop resumes the child from
+its pointer, and the hit rule reads through. When it is NOT (the memo
+cell is unlinked and only `.sync()`ed at init — T10.Q4's at-least-once),
+that first evaluation RE-MISSES: it re-issues, which WIPES the landed
+child client-visibly (`result` cleared, `pending=true`) until the re-arm
+re-instantiates it — a re-compile (cold cache) plus a brief
+re-instantiation on that restart, correctness held by `resolvedHash`. A
+mid-flight request (issued, never resolved) re-misses and re-fires the
+compile the same way (§6 step 3) — every park / crash /
 dropped-or-refused completion ends the serving runtime, and the fresh
 one's first evaluation re-fires (pinned live: a park mid-compile
 resolves on re-activation). A re-arm that landed but whose process
@@ -103,14 +143,18 @@ outbox counts as `outbox.failed`) stays pending until the space
 re-activates or the inputs change; no dirtiness- or timer-driven retry
 is invented. The CLIENT reads through (speculation.md §2) for EVERY
 outcome: a flag-ON non-serving run never compiles and writes nothing
-speculatively — not even the synchronous invalid-inputs / main-not-found
-outcomes, which the server decides identically and lands as committed
-cells — so the served `pending`/`result`/`error` render directly (a
-speculative echo only delayed the read-through). Content-cache note: the
-served path normalizes the program to a PLAIN object before keying the
-compile cache — `createRef({ src })` is insensitive to nested `contents`
-on the `asSchema` query-result proxy, which would collapse distinct
-programs to one cache key.
+request-bearing speculatively — not even the synchronous invalid-inputs
+/ main-not-found outcomes, which the server decides identically and
+lands as committed cells — so the served `pending`/`result`/`error`
+render directly (a speculative echo only delayed the read-through); the
+two writes the claim excepts are the shared cell-init's
+`pending.send(false)` loading default and the `sendResult` links, both
+request-free. Content-cache note: the served path normalizes the program
+to a PLAIN object before keying the compile cache — `createRef({ src })`
+is insensitive to nested `contents` on the `asSchema` query-result
+proxy, which would collapse distinct programs to one cache key; the
+underlying defect is pre-existing and stays live in the OFF arm
+(verification-coverage.md's OW28-createRef row).
 
 Result-as-pattern instantiation — a lift or handler RETURNING a
 pattern, instantiated into a deterministic result cell — is a RUNNER

--- a/docs/specs/server-side-execution/serving-loop.md
+++ b/docs/specs/server-side-execution/serving-loop.md
@@ -965,15 +965,24 @@ For `fetch*`, `generate*`, `sqlite*` (the §3.5 effectful class):
   index shows the consumers stale against the result doc's head (§6).
 - **In-flight dedupe**: one outstanding effect per (key, result
   target) per space; a second miss on the same (key, target)
-  attaches to the in-flight effect. Two DISTINCT result targets
+  attaches to the in-flight effect — an effect whose completion
+  WILL LAND for that target: a superseded in-flight effect either
+  completes for a re-issued same-hash request (its hash is current
+  again at writeback) or releases its key (writes nothing, retires,
+  counted `outbox.superseded` — §7); it never returns silently on a
+  stale abort, because the attached re-issue has no other completion
+  (the stage-C supersession wedge, OW28). A completion must not
+  overwrite a landed resolution. Two DISTINCT result targets
   carrying byte-identical inputs are two distinct requests, and
   each egresses (RULED 2026-08-13; the earlier per-key-only
   wording promised a cross-target sharing that §4's own miss
   rule — exactly one result-cell address per entry — could not
-  deliver). A response-sharing layer (one egress fanned to N
-  per-target writebacks, restricted to idempotent-marked
-  effects) remains a possible future optimization, not an owed
-  item.
+  deliver); the target's identity includes its scope INSTANCE where
+  the builtin supplies it (scopes.md §6; compile-and-run today, the
+  family owed — verification-coverage.md OW28-instance-family). A
+  response-sharing layer (one egress fanned to N per-target
+  writebacks, restricted to idempotent-marked effects) remains a
+  possible future optimization, not an owed item.
 - Failures commit an error-shaped result (the existing builtin error cell
   conventions) with the key, so retries are input-driven (inputs change →
   new key), never timer-driven loops.
@@ -1120,7 +1129,7 @@ unstampedSealRefusals, foreignWriteRefusals, foreignEngineFailures,
 watermarkLag, events:
 {appended, processed, coalescedPerWaveMax, skippedIdempotent}, memo:
 {hits, misses, inflight}, outbox: {queued, completed, failed,
-budgetDeferrals}, lease:
+budgetDeferrals, superseded}, lease:
 {held, lost}, push: {prioritizedSessions, followerSessions,
 mixedFlushes} }` (`structureLoadFailures`/`structureLoadDeferred`
 count demanded-structure loads that threw / could not land yet —
@@ -1153,6 +1162,11 @@ never a home-space outage) (`effectAcks` counts
 effect-channel ack writes, so the
 §3 amplification metric is computable from counters alone;
 `outbox.budgetDeferrals` counts Phase-6 budget dispatch holds — §5;
+`outbox.superseded` counts effect completions that found their
+request superseded at writeback and wrote nothing, releasing their
+key — §4's in-flight-dedupe qualifier; a subset of `completed`,
+ordinary churn, reported by the builtins whose completions re-read
+the request (compile-and-run today; the family owed);
 the `push` block is the memory server's Phase-6 push-priority
 counters (protocol.md §3), nested under `servingLoop` in the health
 route so the OFF-arm response never changes shape —

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -2574,43 +2574,208 @@ Delta 2026-08-15 — Phase 6 independent-review fixes (same PR):
   wedge, pinned + mutation-verified in `compile-and-run.test.ts` and
   LIVE in `executor-compile-and-run.test.ts`'s mid-compile-park step). The
   client keeps reading through (speculation.md §2) for EVERY outcome: a
-  flag-ON non-serving run writes NOTHING speculatively — not even the
-  synchronous invalid-inputs / main-not-found outcomes — it renders the
-  committed served cells, so no overlay entry delays the served
-  `pending=false`. Failures are error-shaped results keyed by the program
-  hash (retry input-driven — the T14 posture); recovery re-uses a LANDED
-  piece (the loop resumes the child from its pointer), a mid-flight
-  request re-misses and re-fires the compile (§6 step 3), and a re-arm
-  whose process compile-cache entry was evicted re-fires rather than
-  wedging. Posture (stated, the request-hash builtins' identical one): a
-  completion commit that fails on a LIVE runtime that did NOT park stays
-  pending until re-activation or an input change — no dirtiness/timer
-  retry invented. A
-  ROOT DEFECT surfaced and fixed in passing: `createRef({ src: program })`
+  flag-ON non-serving run writes NOTHING request-bearing speculatively —
+  not even the synchronous invalid-inputs / main-not-found outcomes — it
+  renders the committed served cells, so no overlay entry delays the
+  served `pending=false` (the two writes the claim excepts: the shared
+  cell-init's `pending.send(false)` loading default and the `sendResult`
+  links, both request-free). Failures are error-shaped results keyed by
+  the program hash (retry input-driven — the T14 posture); recovery
+  re-uses a LANDED piece when the memo cell is synced by the fresh
+  runtime's first evaluation (the loop resumes the child from its
+  pointer, the hit rule reads through) — and when it is NOT (the memo
+  cell is unlinked and only `.sync()`ed at init; T10.Q4's at-least-once),
+  that first evaluation RE-MISSES: it re-issues, which WIPES the landed
+  child client-visibly (`result` cleared, `pending=true`) until the
+  re-arm re-instantiates it — a re-compile (cold cache) plus a brief
+  re-instantiation on that restart, correctness held by `resolvedHash`;
+  a mid-flight request (issued, never resolved) re-misses and re-fires
+  the compile the same way (§6 step 3); and a re-arm whose process
+  compile-cache entry was evicted re-fires rather than wedging. Posture
+  (stated, the request-hash builtins' identical one): a completion
+  commit that fails on a LIVE runtime that did NOT park stays pending
+  until re-activation or an input change — no dirtiness/timer retry
+  invented. A
+  ROOT DEFECT surfaced and WORKED AROUND ON-arm only (the underlying
+  defect is pre-existing and stays LIVE in the OFF arm — the createRef
+  owed row in the 2026-08-18 delta below): `createRef({ src: program })`
   — the content-cache key — is INSENSITIVE to nested `contents` when the
   program is the `asSchema` query-result PROXY (two distinct programs
   collapse to one key, so a re-compile got the PRIOR program), even
   though `hashOf` reads the proxy correctly; the served path normalizes
   to a PLAIN program (`plainProgramOf`) for both the compile and the sync
-  lookup. Pins: `compile-and-run.test.ts` (the deterministic bare-runtime
+  lookup, while the OFF arm still hands `compileOrGetPattern` the raw
+  proxy. Pins: `compile-and-run.test.ts` (the deterministic bare-runtime
   seams — compile-as-effect/not-from-action, re-arm, first instantiation,
   memo hit; recovery mid-flight re-fire; cache-eviction re-fire; the
-  failure leg; the client read-through incl. the sync outcomes; OFF-arm
-  neutrality), and `executor-compile-and-run.test.ts` — the piece-creation
-  flow END TO END against a real SpaceServer + flag-ON client (the
-  client's authored creation + demand → served miss → outbox → compile →
-  completion → the client reads through to the child, never compiling; a
-  program change re-compiles and re-instantiates with the NEW value;
-  recovery re-uses; the failure leg lands error-shaped with NO timer
-  retry; the piece-creation hook fires once; `unstampedSealRefusals`
-  stays ZERO throughout — the P7 symptom's own counter) plus the
-  MID-COMPILE PARK step (a park while the compile is in flight resolves
-  on re-activation — the fresh runtime re-fires; the pending-based-hit
-  mutant reproduces the wedge signature). The OFF arm is byte-identical
-  (the port is a distinct `on` branch; the OFF path is the
-  extracted-verbatim `compileAndRunOff`). Self-review (adversarial
-  subagent, full diff): 1 MAJOR / 3 MINOR / 3 NIT, all addressed —
-  resolutions in the PR body.
+  failure leg; the client read-through incl. the sync outcomes — the
+  `servingPosture` gate's ONLY witness, red with the gate removed (the
+  E2E's "0 client compiles" cannot see the gate: the client's speculation
+  overlay drops the effect either way, and no client-side counter names
+  the drop); OFF-arm neutrality), and `executor-compile-and-run.test.ts`
+  — the piece-creation flow END TO END against a real SpaceServer +
+  flag-ON client (the client's authored creation + demand → served miss →
+  outbox → compile → completion → the client reads through to the child,
+  never compiling; a program change re-compiles and re-instantiates with
+  the NEW value; recovery re-uses; the failure leg lands error-shaped
+  with NO timer retry; the piece-creation hook fires once;
+  `unstampedSealRefusals` stays ZERO throughout — the P7 symptom's own
+  counter) plus the MID-COMPILE PARK step (a park while the compile is in
+  flight resolves on re-activation — the fresh runtime re-fires; the
+  pending-based-hit mutant reproduces the wedge signature). The OFF arm
+  is a behavior-identical EXTRACTION of the pre-port builtin (the port is
+  a distinct `on` branch; the OFF path is `compileAndRunOff`, traced
+  operation for operation against the pre-port source — its closure
+  state is threaded through a context object, the one textual
+  difference; pinned by the OFF-arm neutrality test). Self-review
+  (adversarial subagent, full diff): 1 MAJOR / 3 MINOR / 3 NIT, all
+  addressed — resolutions in the PR body.
+  **Delta 2026-08-18 — the OW28 independent-review batch (same PR):**
+  two MAJORs, both live-reproduced red-first at eb6d1e4bb, plus MINORs.
+  (1) MAJOR-A, the SUPERSESSION WEDGE: A→B→A′ within A's compile
+  duration — the re-issued A′ carried A's outbox key and the in-flight
+  dedupe ATTACHED it to A's still-running effect, whose completion then
+  returned on the abort signal B's issue had fired (`signal.aborted`) and
+  wrote NOTHING — the node stayed `pending=true` forever, no counter
+  named it, and T14's input-driven-only retry made it permanent. FIXED
+  by the discipline the attach relies on: the ON arm has NO abort signal
+  — an issued compile effect always runs to its completion, and the
+  COMPLETION decides by re-reading the node's current request hash
+  through its own transaction (`stillCurrent`, §4's FP6 re-read at
+  writeback): current again → it LANDS; superseded → it writes nothing,
+  reports `superseded`, and its retirement RELEASES the key. Made
+  observable: §7's new `outbox.superseded` counter (a subset of
+  `completed`; the effect-memo observer's `superseded` event). Pinned
+  LIVE (`executor-compile-and-run.test.ts`, a releasable hold on the
+  serving compile): the P6 shape — hold A; A→B (lands)→A′ (attaches:
+  `outbox.queued` unchanged, `memo.inflight` 1); release → A lands
+  `pending=false`, one compile of A ever, `inflight` 0, `superseded` 0
+  (red at eb6d1e4bb: "pending=true, answer=undefined" after the release)
+  — and the SUPERSEDED-COMPLETION step (hold A; B lands; release → A's
+  completion writes nothing, B's resolution stands unwiped, `superseded`
+  1, `inflight` 0; A re-requested lands from the warm cache with no new
+  effect). Unit: the superseded completion reports and leaves the
+  successor's resolution intact (`compile-and-run.test.ts`, red at the
+  tip). FAMILY: `llm.ts`'s `thisRun !== currentRun` abandonment
+  (generateText/generateObject/llm) has the SAME class — an owed row
+  below, NOT filled here (the fix is not mechanically identical: the LLM
+  completion has no hash re-read, and the run counter also drives the
+  streaming `partial` cancellation and the queue semantics);
+  `fetch.ts` NARROWS the window rather than closing it (the abort
+  rejects the network request promptly, so the aborted effect settles
+  and releases its key within microtasks — a re-issue admitted inside
+  that window would still attach and land nothing; the next input change
+  re-issues) — verified by reading, recorded in the same row.
+  (2) MAJOR-B, FAN-OUT cardinality 2 on a NARROWED node: the closure's
+  single abort controller was shared by both demanders' instance runs
+  (fan-out keeps the node SINGULAR — one closure), so the second issue
+  aborted the first's not-yet-flushed effect at issue, and — the effect
+  key carrying only the scope NAME (`effectTargetKey`) — deduped its own
+  effect against the first's key: both instances pending forever. FIXED,
+  the PRIMARY shape: no per-request closure state in the ON arm at all
+  (the abort is gone — every per-instance fact lives outside the
+  closure), the effect key carries the run's INSTANCE
+  (`effectTargetKey(base, cell, identity)` — scopes.md §6's "memo keys
+  INCLUDE the instance key"; the resolved instance key replaces the
+  scope-name suffix; space-scoped targets and identity-less callers keep
+  today's key text byte for byte), AND the completion transaction is
+  STAMPED with the issuing run's identity (`tx.tx.scopeKeyIdentity`
+  before its first read) so its request re-read and its writes address
+  the instance the effect was issued for. That last part closes, for
+  compile-and-run only, the stage-A residual flagged at
+  `space-server.ts`'s completion committer ("the writeback transaction
+  itself is unstamped, so its hash-guard READS resolve against the
+  service's instances; a per-instance node's effect completion is
+  unpinned"): a NARROWED compile-and-run node — a per-user program
+  (`PerUser<Writable<string>>` code, or a computed over one) — did not
+  land even at CARDINALITY 1 at eb6d1e4bb (probed live: issued, one
+  completed effect, `pending=true` forever — the completion's re-read
+  resolved the service's empty instance, mismatched, and wrote nothing).
+  The instance rule, now stated in builtins.md §3: ONE compile per
+  program per process (the pattern cache is shared and single-flights);
+  ONE effect completion + ONE instantiation per demanded instance. Pinned
+  LIVE at cardinality 2 (`executor-compile-and-run.test.ts`, the FAN-OUT
+  step): a per-user program, the same text for alice and bob, alice's
+  compile held; bob's instance issues ITS OWN effect while alice's is in
+  flight (`outbox.queued` 2, two holds — never an attach); release → ONE
+  real compile (`compilePattern` counted), TWO completions, BOTH
+  instances `pending=false` with the child, `inflight` 0 (red at
+  eb6d1e4bb: bob's issue attached — `queued` stayed 1 — and neither
+  landed). Residuals, FLAGGED not filled: (a) the runner's per-instance
+  child registry — `runtime.run` / `runner.stop` key the child piece by
+  the result cell resolved against the RUNTIME's own identity, so two
+  instances' children share one registration (the pin's static child is
+  insensitive to this; a reactive child body is fan-out follow-up
+  territory); (b) the effectful FAMILY (`fetch*`, `generate*`,
+  `sqlite*`) keeps scope-name keys and unstamped completions — its
+  per-instance rows below. (3) MINOR-C: the createRef claim corrected
+  above; the OFF-arm defect PINNED as it stands (`compile-and-run.test.ts`
+  "OFF-arm DEFECT": a same-node program change in a WARM process serves
+  the PRIOR pattern, one real compile — the assertions to flip when the
+  owning layer fixes it) — an owed row below. (4) MINOR-D: the success
+  re-arm no longer clobbers a landed `resolvedHash` (an incidental re-run
+  can instantiate off the warm cache before the completion commits; the
+  completion now re-arms nothing in that case, and the next run memo-hits
+  instead of re-instantiating the running child) — pinned red-first;
+  the docs' "the re-arm is THE instantiate trigger" corrected to one of
+  two. (5) MINOR-E: the issue-time memo key pinned (a same-hash re-run
+  mid-flight waits — no re-issue, no second effect; probe P4's mutant —
+  a corrupt issue-time `requestHash` — turns exactly this pin red and no
+  other). (6) MINOR-F: the client read-through gate's witness is the UNIT
+  pin, stated above. NITs: the client hit branch fires the
+  piece-creation hook only on a PRESENT result (OFF's `if (pattern)`
+  parity); "byte-identical" → behavior-identical extraction; Flag 5
+  reconciled above (recovery re-uses when the memo is synced, else the
+  re-miss wipe — client-visible — then re-lands); the sync cache lookup's
+  no-refresh/no-replicate posture commented; the init `pending.send(false)`
+  named as the read-through exception. Suite: both OW28 files green
+  (12 cases, 5 E2E steps), the E2E soaked.
+- OW28-createRef — the content-cache key's proxy insensitivity, OWED (the
+  2026-08-18 delta above): `createRef({ src: program })` reads no nested
+  `contents` off an `asSchema` query-result proxy, so `compileOrGetPattern`
+  handed a proxy collapses distinct programs onto one cache entry — a
+  same-node program change in a WARM process serves the PRIOR pattern.
+  Owning layer: `create-ref.ts` / `pattern-manager.ts` (normalize at the
+  source — a plain deep copy before keying — so no caller has to). LIVE
+  in the OFF arm today (pinned as it stands: `compile-and-run.test.ts`
+  "OFF-arm DEFECT"); the ON arm works around it with `plainProgramOf`.
+  Trigger: any warm-process same-node program edit under the OFF arm
+  (a running code editor). Not fixed in the stage-C PR (it changes OFF
+  behavior; out of that PR's scope).
+- OW28-supersession-family — the LLM builtins' post-response
+  abandonment, OWED: `llm.ts` (`generateText`, `generateObject`, `llm`)
+  abandons an in-flight request's writeback when `thisRun !==
+  currentRun` — a run counter the next different-hash issue bumps. Under
+  the outbox's in-flight dedupe, A→B→A′ within A's call duration
+  ATTACHES A′ to A's effect, whose completion is then abandoned: NO
+  completion for A′, `pending=true` forever, no counter — the
+  compile-and-run MAJOR-A shape. The fix is NOT mechanically identical
+  (no hash re-read at the LLM completion; the counter also cancels the
+  streaming `partial` writer and interacts with the queue's
+  run-to-completion rule), so it is recorded rather than patched: the
+  completion must re-read the current request hash and land when
+  current / release when superseded, and count `outbox.superseded`.
+  `fetch.ts` narrows the window (the abort rejects the network request
+  promptly, so the aborted effect settles and releases its key within
+  microtasks) but does not close it. Trigger: any served LLM node whose
+  inputs flip A→B→A within one call's duration.
+- OW28-instance-family — per-instance keys and stamped completions for
+  the effectful FAMILY, OWED: `fetch*`, `generate*`, `sqlite*` still key
+  their effects by scope NAME (`effectTargetKey` without the identity)
+  and commit their completions through UNSTAMPED transactions (the
+  stage-A residual at the completion committer). On a NARROWED node
+  that is (a) the cardinality-2 attach (the second demander's identical
+  request dedupes against the first's key; only the first instance's
+  cells complete) and (b) the cardinality-1 hash-guard mis-read (a
+  per-instance request input re-read under the SERVICE identity
+  mismatches → the completion writes nothing). compile-and-run's fix
+  (the 2026-08-18 delta: identity into the key + into the completion tx)
+  is the template. Trigger: the fan-out arc's next narrowed-effect
+  scenario (any per-user fetch/LLM/sqlite node with two demanders, or
+  with a per-user request input at cardinality 1). Also recorded: the
+  runner's child registry keys per RUNTIME identity (`getDocKey`), so a
+  fanned-out compile-and-run node's per-instance children share one
+  registration — inert for a static child, open for a reactive one.
 - OW29 — space-root demanders + demand-arrival re-runs (the reverted
   Phase-7 extension recorded under OW17): a client whose only watch is
   the space-scoped piece root supplies NO identity to the run supply,

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -552,11 +552,13 @@ client does not; this PR):
   handler run diverts — the same suite now asserts that posture),
   unstamped/binding writes untouched, egress effect kinds dropped
   with `navigateTo` enacting (the egress rule), `compile-and-run`
-  gated at the builtin — the gate's true interim scope is wider than
-  "not speculable": it suppresses fresh compiles for EVERY flag-ON
-  non-wave run and the serving side refuses the writebacks, so fresh
-  compile-and-run is INERT ON-arm until the serving port (stage G's
-  out-of-scope note) lands; both-arms pins in
+  gated at the builtin — the gate's interim scope was wider than
+  "not speculable": it suppressed fresh compiles for EVERY flag-ON
+  non-wave run and the serving side refused the writebacks, so fresh
+  compile-and-run was INERT ON-arm until the serving port (OW28, LANDED
+  stage C 2026-08-17): the client now READS THROUGH to the served result
+  (no fresh compile client-side; no speculative write) and the SERVER
+  serves the compile as an outbox effect; both-arms pins in
   `packages/runner/test/compile-and-run.test.ts` (the review's m5) —
   retirement on watermark coverage of the entry's read basis + acked
   origins via success-shaped `superseded` withdrawals that cascade
@@ -2551,6 +2553,64 @@ Delta 2026-08-15 — Phase 6 independent-review fixes (same PR):
   the client keeps reading through (speculation.md §2). Trigger: a
   named flip blocker — third in the flip's ordered gates (plan Phase 7
   task 1); nothing in CI exercises fresh compile-and-run in the ON arm.
+  **LANDED (stage C, 2026-08-17).** `compile-and-run` is served as an
+  OUTBOX EFFECT KIND (`compile-and-run`) memoized on the program hash,
+  with one REFINEMENT of the fix shape (recorded, not silently
+  substituted): the COMPILE is the effect's egress and lands a marked
+  COMPLETION commit that RE-ARMS the derivation (`compiledHash`) rather
+  than instantiating; the INSTANTIATION is then an ordinary consequence
+  of the served graph run — the derivation reads the process compile
+  cache and instantiates the child in-run (builtins.md §3's
+  result-as-pattern shape, correctly scoped per demander). This is
+  because a post-commit flush that instantiates RACES the serving loop's
+  own resume of the prior child (the loop re-runs the piece from its
+  stored `patternIdentity` pointer, and the flush's `run`/`runSynced`
+  loses the re-instantiation to it — a program change would keep serving
+  the OLD child). The §4 HIT rule keys on a `resolvedHash` marker (set on
+  every terminal outcome), NOT on `pending`: the builtin's cell-init
+  writes `pending=false` on a fresh closure's first run, so a
+  pending-based hit FALSELY fires for a durable mid-compile request on
+  recovery (the piece renders empty forever — the recovery-mid-flight
+  wedge, pinned + mutation-verified in `compile-and-run.test.ts` and
+  LIVE in `executor-compile-and-run.test.ts`'s mid-compile-park step). The
+  client keeps reading through (speculation.md §2) for EVERY outcome: a
+  flag-ON non-serving run writes NOTHING speculatively — not even the
+  synchronous invalid-inputs / main-not-found outcomes — it renders the
+  committed served cells, so no overlay entry delays the served
+  `pending=false`. Failures are error-shaped results keyed by the program
+  hash (retry input-driven — the T14 posture); recovery re-uses a LANDED
+  piece (the loop resumes the child from its pointer), a mid-flight
+  request re-misses and re-fires the compile (§6 step 3), and a re-arm
+  whose process compile-cache entry was evicted re-fires rather than
+  wedging. Posture (stated, the request-hash builtins' identical one): a
+  completion commit that fails on a LIVE runtime that did NOT park stays
+  pending until re-activation or an input change — no dirtiness/timer
+  retry invented. A
+  ROOT DEFECT surfaced and fixed in passing: `createRef({ src: program })`
+  — the content-cache key — is INSENSITIVE to nested `contents` when the
+  program is the `asSchema` query-result PROXY (two distinct programs
+  collapse to one key, so a re-compile got the PRIOR program), even
+  though `hashOf` reads the proxy correctly; the served path normalizes
+  to a PLAIN program (`plainProgramOf`) for both the compile and the sync
+  lookup. Pins: `compile-and-run.test.ts` (the deterministic bare-runtime
+  seams — compile-as-effect/not-from-action, re-arm, first instantiation,
+  memo hit; recovery mid-flight re-fire; cache-eviction re-fire; the
+  failure leg; the client read-through incl. the sync outcomes; OFF-arm
+  neutrality), and `executor-compile-and-run.test.ts` — the piece-creation
+  flow END TO END against a real SpaceServer + flag-ON client (the
+  client's authored creation + demand → served miss → outbox → compile →
+  completion → the client reads through to the child, never compiling; a
+  program change re-compiles and re-instantiates with the NEW value;
+  recovery re-uses; the failure leg lands error-shaped with NO timer
+  retry; the piece-creation hook fires once; `unstampedSealRefusals`
+  stays ZERO throughout — the P7 symptom's own counter) plus the
+  MID-COMPILE PARK step (a park while the compile is in flight resolves
+  on re-activation — the fresh runtime re-fires; the pending-based-hit
+  mutant reproduces the wedge signature). The OFF arm is byte-identical
+  (the port is a distinct `on` branch; the OFF path is the
+  extracted-verbatim `compileAndRunOff`). Self-review (adversarial
+  subagent, full diff): 1 MAJOR / 3 MINOR / 3 NIT, all addressed —
+  resolutions in the PR body.
 - OW29 — space-root demanders + demand-arrival re-runs (the reverted
   Phase-7 extension recorded under OW17): a client whose only watch is
   the space-scoped piece root supplies NO identity to the run supply,

--- a/packages/runner/src/builtins/compile-and-run.ts
+++ b/packages/runner/src/builtins/compile-and-run.ts
@@ -1,4 +1,5 @@
 import { type BuiltInCompileAndRunParams } from "commonfabric";
+import type { JSONSchema } from "@commonfabric/api";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { type Cell } from "../cell.ts";
 import { type Action } from "../scheduler.ts";
@@ -8,8 +9,84 @@ import type { Program } from "@commonfabric/js-compiler";
 import { CompilerError } from "@commonfabric/js-compiler/errors";
 import type { CellScope } from "../builder/types.ts";
 import { resolvedCellScope, scopedCell } from "./scope-policy.ts";
-import { waveRunContextOf } from "../executor/wave.ts";
+import {
+  effectTargetKey,
+  markEffectCompletion,
+} from "../executor/effect-completion.ts";
 import { narrowestScope } from "../scope.ts";
+
+/**
+ * The compile request's memo cell (server-execution v2 stage C, OW28;
+ * serving-loop.md §4). Exists only under EXPERIMENTAL_SERVER_EXECUTION
+ * (the OFF arm keeps its in-memory `previousCallHash` dedupe, so a reload
+ * re-compiles — cache-hit cheap, never an observable shape).
+ *
+ * - `requestHash` — the request the node's cells reflect. Written by the
+ *   requesting DERIVATION at issue and re-asserted at every outcome.
+ * - `resolvedHash` — the RESOLUTION marker: set (== `requestHash`) on
+ *   every TERMINAL outcome (a landed piece, an error-shaped result, or a
+ *   synchronous invalid-inputs / main-not-found outcome). The §4 HIT rule
+ *   keys on THIS, not on `pending`: the cell-init writes `pending=false`
+ *   on a fresh closure's first run (the loading-state default), so a
+ *   durable `pending=true` mid-compile request would read `pending=false`
+ *   there and a pending-based hit would FALSELY treat it as landed
+ *   (rendering an empty result forever — the recovery-mid-flight wedge).
+ *   `resolvedHash` is never written by init, so it distinguishes issued
+ *   from resolved across a crash/park.
+ * - `compiledHash` — set by the compile EFFECT's marked completion once
+ *   the program is compiled and cached: it RE-ARMS the derivation (a
+ *   tracked read of this cell) WITHOUT marking resolved (the instantiation
+ *   is still pending), so the re-run reaches the instantiate branch. On a
+ *   cold process (recovery) the cache misses and the compile re-issues
+ *   (§6 step 3); the child's own durable pattern pointer lets the loop
+ *   resume a LANDED child regardless.
+ */
+type CompileMemo = {
+  requestHash?: string;
+  resolvedHash?: string;
+  compiledHash?: string;
+};
+
+/** The compile program shape the builtin hashes: `{ files, main }` —
+ * `input` is NOT part of the request identity (today's contract: a
+ * changed argument does not re-compile). */
+/** A PLAIN deep copy of the program's `{ main, files }` — the ON arm
+ * passes this (never the raw `asSchema` proxy) to `compileOrGetPattern`
+ * and to `getCompiledPatternForProgramSync`. The content cache keys on
+ * `createRef({ src })`, and a query-result PROXY serializes there
+ * INSENSITIVE to nested `contents` (two distinct programs collapse to one
+ * key — the sync lookup then hands a re-compile the PRIOR program), even
+ * though `hashOf` reads the proxy correctly. Both the compile and the
+ * lookup use this plain form, so distinct programs cache distinctly. */
+function plainProgramOf(program: Program): Program {
+  return {
+    main: program?.main ?? "",
+    files: (program?.files ?? []).map((file) => ({
+      name: file?.name,
+      contents: file?.contents,
+    })) as Program["files"],
+  };
+}
+
+const programSchema: JSONSchema = {
+  type: "object",
+  properties: {
+    files: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          contents: { type: "string" },
+        },
+        required: ["name", "contents"],
+      },
+      default: [],
+    },
+    main: { type: "string", default: "" },
+  },
+  required: ["files", "main"],
+};
 
 /**
  * Compile a pattern/module and run it.
@@ -28,6 +105,13 @@ import { narrowestScope } from "../scope.ts";
  *
  * Note that if an error occurs during execution, both `result` and `error` can
  * be defined. (Note: Runtime errors are not currently handled).
+ *
+ * Under EXPERIMENTAL_SERVER_EXECUTION (server-execution v2 stage C, OW28;
+ * builtins.md §3, serving-loop.md §4–§5) the compile is served as an
+ * OUTBOX EFFECT and the instantiation is an ordinary consequence of the
+ * served graph run — see {@link compileAndRunServed}. The OFF arm is
+ * byte-identical to the pre-port builtin (a floating compile promise with
+ * unmarked writebacks) and lives in {@link compileAndRunOff}.
  */
 export function compileAndRun(
   inputsCell: Cell<BuiltInCompileAndRunParams<any>>,
@@ -37,12 +121,13 @@ export function compileAndRun(
   parentCell: Cell<any>,
   runtime: Runtime,
 ): Action {
-  let requestId: string | undefined = undefined;
   let abortController: AbortController | undefined = undefined;
+  // OFF-arm only: the in-memory request dedupe (unchanged).
   let previousCallHash: string | undefined = undefined;
+  let requestId: string | undefined = undefined;
   let cellsInitialized = false;
   let pending: Cell<boolean>;
-  let result: Cell<string | undefined>;
+  let result: Cell<any | undefined>;
   let error: Cell<string | undefined>;
   let errors: Cell<
     | Array<
@@ -56,6 +141,13 @@ export function compileAndRun(
     >
     | undefined
   >;
+  /** ON arm only: the §4 memo cell (see {@link CompileMemo}). */
+  let internal: Cell<CompileMemo | undefined>;
+  /** ON arm, client posture only: the last LANDED request hash this
+   * closure reported through `pieceCreatedCallback` — a flag-ON client
+   * never compiles, so it reports the served instantiation on OBSERVING
+   * the landing, once per landed request (runtime-mapping.md N39). */
+  let reportedCreatedHash: string | undefined = undefined;
   let cellScope: CellScope | undefined;
 
   // This is called when the pattern containing this node is being stopped.
@@ -64,29 +156,14 @@ export function compileAndRun(
     abortController?.abort("Pattern stopped");
   });
 
+  const on = runtime.experimental.serverExecution === true;
+
   return (tx: IExtendedStorageTransaction) => {
     tx.resetNarrowestReadScope();
     // TODO(seefeld): Ideally, this cell already has this schema, because we set
     // it on the node itself.
-    const program: Program = inputsCell.asSchema({
-      type: "object",
-      properties: {
-        files: {
-          type: "array",
-          items: {
-            type: "object",
-            properties: {
-              name: { type: "string" },
-              contents: { type: "string" },
-            },
-            required: ["name", "contents"],
-          },
-          default: [],
-        },
-        main: { type: "string", default: "" },
-      },
-      required: ["files", "main"],
-    }).withTx(tx).get();
+    const program = inputsCell.asSchema<Program>(programSchema).withTx(tx)
+      .get();
     const input = inputsCell.withTx(tx).key("input");
     const outputScope = narrowestScope([
       tx.getNarrowestReadScope(),
@@ -96,6 +173,7 @@ export function compileAndRun(
     if (!cellsInitialized || cellScope !== outputScope) {
       if (cellsInitialized && cellScope !== outputScope) {
         previousCallHash = undefined;
+        reportedCreatedHash = undefined;
       }
       const basePending = runtime.getCell<boolean>(
         parentCell.space,
@@ -106,7 +184,7 @@ export function compileAndRun(
       pending = scopedCell(runtime, tx, basePending, outputScope);
       pending.send(false);
 
-      const baseResult = runtime.getCell<string | undefined>(
+      const baseResult = runtime.getCell<any | undefined>(
         parentCell.space,
         { compile: { result: cause } },
         undefined,
@@ -141,146 +219,559 @@ export function compileAndRun(
       );
       errors = scopedCell(runtime, tx, baseErrors, outputScope);
 
+      if (on) {
+        // The §4 memo cell (ON arm only — the OFF arm's cell set is
+        // unchanged). Not linked from the node's outputs, so it is synced
+        // here like fetch's internal cell: the first evaluation on a fresh
+        // runtime may read it unreplicated and re-miss once (T10.Q4's
+        // accepted at-least-once), and the arrival re-arms the action.
+        const baseInternal = runtime.getCell<CompileMemo | undefined>(
+          parentCell.space,
+          { compile: { internal: cause } },
+          undefined,
+          tx,
+        );
+        internal = scopedCell(runtime, tx, baseInternal, outputScope);
+        internal.sync();
+      }
+
       sendResult(tx, { pending, result, error, errors });
       cellsInitialized = true;
       cellScope = outputScope;
     }
 
-    const pendingWithLog = pending.withTx(tx);
-    const resultWithLog = result.withTx(tx);
-    const errorWithLog = error.withTx(tx);
-    const errorsWithLog = errors.withTx(tx);
-
     const hash = hashOf(program ?? { files: [], main: "" }).toString();
-
-    // Return if the same request is being made again, either concurrently (same
-    // as previousCallHash) or when rehydrated from storage (same as the
-    // contents of the requestHash doc).
-    if (hash === previousCallHash) return;
-
-    // Check if inputs are undefined/empty (e.g., during rehydration before cells load)
-    const hasValidInputs = program && program.main && program.files &&
-      program.files.length > 0;
-
-    // Special case: if inputs are invalid AND this is the hash for empty inputs,
-    // the user intentionally cleared them - proceed to clear outputs
+    const hasValidInputs = !!(program && program.main && program.files &&
+      program.files.length > 0);
     const emptyInputsHash = hashOf({ files: [], main: "" }).toString();
     const isIntentionallyEmpty = !hasValidInputs && hash === emptyInputsHash;
 
-    // If we have a previous valid result and inputs are currently invalid (likely rehydrating),
-    // don't clear the outputs - just wait for real inputs to load
-    // BUT if inputs are intentionally empty, we should clear
-    if (
-      !hasValidInputs && previousCallHash && previousCallHash !== hash &&
-      !isIntentionallyEmpty
-    ) {
-      // Don't update previousCallHash - we'll wait for valid inputs
-      return;
-    }
-
-    previousCallHash = hash;
-
-    // Abort any in-flight compilation before starting a new one
-    abortController?.abort("New compilation started");
-    abortController = new AbortController();
-    requestId = crypto.randomUUID();
-
-    runtime.runner.stop(result);
-    resultWithLog.set(undefined);
-    errorWithLog.set(undefined);
-    errorsWithLog.set(undefined);
-
-    // Undefined inputs => Undefined output, not pending
-    if (!hasValidInputs) {
-      pendingWithLog.set(false);
-      return;
-    }
-
-    // Main file not found => Error, not pending
-    if (!program.files.some((file) => file?.name === program.main)) {
-      errorWithLog.set(`"${program.main}" not found in files`);
-      pendingWithLog.set(false);
-      return;
-    }
-
-    // Now we're sure that we have a new file to compile
-    pendingWithLog.set(true);
-
-    // Client speculation under EXPERIMENTAL_SERVER_EXECUTION
-    // (server-execution v2 Phase 2): compilation is an EFFECTFUL step,
-    // so `compile-and-run` children are NOT speculable — the branch
-    // keeps its ordinary pending state and reads through until the
-    // authoritative child arrives (builtins.md §3; speculation.md §2;
-    // runtime-mapping N37/N38). Unlike the request-hash builtins, the
-    // compile launches from a floating promise rather than a
-    // post-commit effect, so the overlay destination cannot intercept
-    // it — the gate lives here. A SERVED run (a stamped wave run) is
-    // unaffected: serving compile-and-run is its own port (stage G's
-    // out-of-scope note), and its writebacks refuse under serving
-    // until then.
-    if (
-      runtime.experimental.serverExecution === true &&
-      waveRunContextOf(tx) === undefined
-    ) {
-      return;
-    }
-
-    // Capture requestId for this compilation run
-    const thisRequestId = requestId;
-
-    const compilePromise = runtime.patternManager
-      .compileOrGetPattern(program, parentCell.space)
-      .catch(
-        (err) => {
-          // Only process this error if the request hasn't been superseded
-          if (requestId !== thisRequestId) return;
-          if (abortController?.signal.aborted) return;
-
-          runtime.editWithRetry((asyncTx) => {
-            // Extract structured errors if this is a CompilerError
-            if (err instanceof CompilerError) {
-              const structuredErrors = err.errors.map((e) => ({
-                line: e.line ?? 1,
-                column: e.column ?? 1,
-                message: e.message,
-                type: e.type,
-                file: e.file,
-              }));
-              errors.withTx(asyncTx).set(structuredErrors);
-            } else {
-              error.withTx(asyncTx).set(
-                err.message + (err.stack ? "\n" + err.stack : ""),
-              );
-            }
-          });
+    if (on) {
+      compileAndRunServed(runtime, tx, {
+        inputsCell,
+        parentCell,
+        cells: { pending, result, error, errors, internal },
+        program,
+        hash,
+        hasValidInputs,
+        isIntentionallyEmpty,
+        reportCreated: (landedHash) => {
+          if (reportedCreatedHash === landedHash) return false;
+          reportedCreatedHash = landedHash;
+          return true;
         },
-      ).finally(() => {
-        // Only update pending if this is still the current request
-        if (requestId !== thisRequestId) return;
-        // Always clear pending state, even if cancelled, to avoid stuck state
-
-        runtime.editWithRetry((asyncTx) => {
-          pending.withTx(asyncTx).set(false);
-        });
+        abort: () => {
+          abortController?.abort("New compilation started");
+          abortController = new AbortController();
+          return abortController.signal;
+        },
       });
+      return;
+    }
 
-    compilePromise.then((pattern) => {
-      // Only run the result if this is still the current request
-      if (requestId !== thisRequestId) return;
-      if (abortController?.signal.aborted) return;
-
-      if (pattern) {
-        // TODO(ja): to support editting of existing pieces / running with
-        // inputs from other pieces, we will need to think more about
-        // how we pass input into the builtin.
-
-        runtime.runSynced(result, pattern, input.get());
-        runtime.editWithRetry((asyncTx) => {
-          result.withTx(asyncTx).key("isHidden").set(true);
-        });
-        runtime.pieceCreatedCallback?.(result);
-      }
-      // TODO(seefeld): Add capturing runtime errors.
+    // ---- OFF arm (byte-identical to the pre-port builtin) ----
+    compileAndRunOff(runtime, tx, {
+      inputsCell,
+      parentCell,
+      cells: { pending, result, error, errors },
+      program,
+      hash,
+      hasValidInputs,
+      isIntentionallyEmpty,
+      previousCallHash,
+      setPreviousCallHash: (h) => {
+        previousCallHash = h;
+      },
+      newRequestId: () => {
+        abortController?.abort("New compilation started");
+        abortController = new AbortController();
+        requestId = crypto.randomUUID();
+        return requestId;
+      },
+      currentRequestId: () => requestId,
+      abortSignal: () => abortController?.signal,
     });
   };
+}
+
+/** The ON-arm action (server-execution v2 stage C, OW28). The COMPILE is
+ * an outbox effect; the INSTANTIATION is an ordinary consequence of the
+ * served derivation run (builtins.md §3). Cleanly separated so the OFF
+ * arm below stays the untouched original. */
+function compileAndRunServed(
+  runtime: Runtime,
+  tx: IExtendedStorageTransaction,
+  ctx: {
+    inputsCell: Cell<BuiltInCompileAndRunParams<any>>;
+    parentCell: Cell<any>;
+    cells: {
+      pending: Cell<boolean>;
+      result: Cell<any | undefined>;
+      error: Cell<string | undefined>;
+      errors: Cell<unknown>;
+      internal: Cell<CompileMemo | undefined>;
+    };
+    program: Program;
+    hash: string;
+    hasValidInputs: boolean;
+    isIntentionallyEmpty: boolean;
+    /** Report the client's piece-creation hook once per landed request. */
+    reportCreated: (landedHash: string) => boolean;
+    /** Abort any prior in-flight compile and return a fresh signal. */
+    abort: () => AbortSignal;
+  },
+): void {
+  const { inputsCell, parentCell, cells, program, hash } = ctx;
+  const { pending, result, error, errors, internal } = cells;
+  const pendingT = pending.withTx(tx);
+  const resultT = result.withTx(tx);
+  const errorT = error.withTx(tx);
+  const errorsT = errors.withTx(tx);
+  const internalT = internal.withTx(tx);
+  const memo = internalT.get();
+  const stored = memo?.requestHash;
+  const currentlyPending = pendingT.get();
+
+  // The §4 HIT rule: this request already RESOLVED (a landed piece, an
+  // error-shaped result, or a synchronous outcome) — the RESOLUTION marker
+  // matches the request. The node's cells ARE its value; no effect fires.
+  // This is what makes recovery safe (the loop resumes the child from its
+  // durable pattern pointer) and what lets the CLIENT read through to the
+  // served result (speculation.md §2). Keyed on `resolvedHash`, NOT on
+  // `pending`: the cell-init clobbers `pending=false` on a fresh closure,
+  // so a pending-based hit would falsely fire for a durable mid-compile
+  // request on recovery (see CompileMemo). Sound because every terminal
+  // path writes `resolvedHash === requestHash` in the SAME transaction as
+  // its outcome.
+  if (stored === hash && memo?.resolvedHash === hash) {
+    runtime.effectMemoObserver?.({ kind: "hit", id: `compileAndRun:${hash}` });
+    // The client's piece-creation hook (browser worker only): fired once
+    // per LANDED successful compile, on observing the landing — the same
+    // registration the OFF arm's compile completion fires (`pieces.add`
+    // is idempotent). Nothing on the serving runtime and the OFF arm
+    // reaches this branch.
+    if (
+      runtime.pieceCreatedCallback !== undefined &&
+      ctx.hasValidInputs &&
+      errorT.get() === undefined &&
+      errorsT.get() === undefined &&
+      ctx.reportCreated(hash)
+    ) {
+      runtime.pieceCreatedCallback(result);
+    }
+    return;
+  }
+
+  // The CLIENT reads through — for EVERY outcome, not only the compiled
+  // one. A flag-ON non-serving run never compiles or instantiates
+  // (speculation.md §2's effectful read-through) and writes NOTHING
+  // speculatively — not even the synchronous invalid-inputs /
+  // main-not-found outcomes below, which the SERVER decides identically
+  // and lands as committed cells the client's hit rule above then reads
+  // through. A speculative write here would only add an overlay entry
+  // that must retire before the server's committed cells are visible,
+  // delaying the read-through (a `pending=true` echo measurably delayed
+  // the served `pending=false`); the parent's `ifElse(pending || (!result
+  // && !error))` already renders the loading state while the served cells
+  // are empty.
+  if (!runtime.servingPosture) return;
+
+  // ---- SERVING (the SpaceServer's runtime) from here on. Every scheduler
+  // run on the serving runtime is wave-stamped by the SpaceServer's
+  // stamper (serving-loop.md §3d), so the writes below seal into the wave
+  // and the enqueued effect is deferred to the outbox; an UNSTAMPED
+  // serving-runtime run would refuse loudly at the seal (§3d's refusal,
+  // counted in `unstampedSealRefusals` — the E2E pins it at ZERO across
+  // every served compile-and-run leg), never silently mis-route. ----
+
+  // A fresh request (or a re-issue): the cells must reflect THIS hash.
+  const reissue = stored !== hash;
+
+  // Invalid inputs. Undefined/empty inputs => undefined output, not
+  // pending; but a rehydration blip (invalid inputs while a prior valid
+  // request stands) waits for the real inputs — UNLESS intentionally
+  // cleared. Decided synchronously (no compile), the same way the OFF arm
+  // decides it.
+  if (!ctx.hasValidInputs) {
+    if (stored !== undefined && stored !== hash && !ctx.isIntentionallyEmpty) {
+      // Rehydration blip: keep the prior landed request; wait for inputs.
+      return;
+    }
+    if (reissue || currentlyPending !== false) {
+      runtime.runner.stop(result);
+      ctx.abort();
+      resultT.set(undefined);
+      errorT.set(undefined);
+      errorsT.set(undefined);
+      pendingT.set(false);
+      internalT.set({ requestHash: hash, resolvedHash: hash });
+    }
+    return;
+  }
+
+  // Main file not found => error, not pending (synchronous, as OFF).
+  if (!program.files.some((file) => file?.name === program.main)) {
+    if (reissue) {
+      runtime.runner.stop(result);
+      ctx.abort();
+      resultT.set(undefined);
+      errorsT.set(undefined);
+      errorT.set(`"${program.main}" not found in files`);
+      pendingT.set(false);
+      internalT.set({ requestHash: hash, resolvedHash: hash });
+    }
+    return;
+  }
+
+  // A valid program: instantiate from the process compile cache when the
+  // compile effect has already run (this session); otherwise issue +
+  // enqueue the compile effect. The instantiation happens HERE, in the
+  // derivation — the loop's own run, correctly scoped, atomic with respect
+  // to the loop's piece machinery (a racing async flush loses the
+  // re-instantiate to the loop's resume of the prior child).
+  const plainProgram = plainProgramOf(program);
+  const compiled = runtime.patternManager.getCompiledPatternForProgramSync(
+    plainProgram,
+  );
+  if (compiled !== undefined) {
+    // Tear down any prior child on this result cell before re-instantiating
+    // (runSynced/run do not stop an existing registration, so a re-compile
+    // over a running child would no-op its start and keep serving the old
+    // one). Then instantiate the child in-run: its setup writes are
+    // derivation-class (the result-as-pattern shape, builtins.md §3), and
+    // the child's own body runs as ordinary served derivations. The setup
+    // stores the child's `patternIdentity` pointer, which lets the loop
+    // resume it after a park/crash.
+    runtime.runner.stop(result);
+    // TODO(ja): to support editing of existing pieces / running with inputs
+    // from other pieces, we will need to think more about how we pass input
+    // into the builtin.
+    runtime.run(tx, compiled, inputsCell.withTx(tx).key("input").get(), result);
+    resultT.key("isHidden").set(true);
+    errorT.set(undefined);
+    errorsT.set(undefined);
+    pendingT.set(false);
+    internalT.set({
+      requestHash: hash,
+      compiledHash: hash,
+      resolvedHash: hash,
+    });
+    return;
+  }
+
+  // Not compiled (in this process). Issue (pending) and enqueue the compile
+  // effect only when genuinely (re)issuing:
+  //  - a NEW program (`reissue`); OR
+  //  - a request not currently in flight for THIS run — `currentlyPending
+  //    !== true`. On a FRESH closure the cell-init clobbered `pending=false`
+  //    (the loading default), so a durable mid-compile request on RECOVERY
+  //    (park / crash / a dropped or refused completion — every one of which
+  //    ends the serving runtime and re-activates a fresh one) reads
+  //    `pending=false` here and RE-FIRES the compile (§6 step 3's re-miss);
+  //    OR
+  //  - the effect's re-arm LANDED (`compiledHash === hash`) but the process
+  //    compile cache no longer holds the entry (FIFO eviction between the
+  //    effect and this run): re-fire rather than wedge — the effect
+  //    re-compiles (cache miss → real compile) and re-arms again.
+  // Within a session, the issue's own `pending=true` write (init is
+  // skipped on re-runs) makes a same-hash re-arm-wait re-run read
+  // `pending===true` with no `compiledHash` yet — so it does NOT re-abort
+  // the in-flight compile or re-enqueue (the re-compile-forever bug); it
+  // waits for the `compiledHash` re-arm to reach the instantiate branch
+  // above.
+  //
+  // Posture, stated: a same-hash request whose completion commit FAILED
+  // on a LIVE runtime that did not park (an infrastructure failure the
+  // outbox counts as `outbox.failed`) stays pending until the space
+  // re-activates or the inputs change — the request-hash builtins'
+  // identical posture (fetch's in-memory claim `myRequestId` blocks
+  // re-issue the same way; "recovery is §6's re-miss on the next
+  // activation, or an input change"). No timer or dirtiness-driven retry
+  // is invented here (T14; the retry rule is input-driven).
+  const needIssue = reissue ||
+    (currentlyPending !== true && errorT.get() === undefined &&
+      resultT.get() === undefined) ||
+    memo?.compiledHash === hash;
+  if (!needIssue) return;
+  const signal = ctx.abort();
+  runtime.runner.stop(result);
+  resultT.set(undefined);
+  errorT.set(undefined);
+  errorsT.set(undefined);
+  pendingT.set(true);
+  internalT.set({ requestHash: hash });
+  const effectKey = effectTargetKey(`compileAndRun:${hash}`, result);
+  const requestProgram = plainProgram;
+  const space = parentCell.space;
+  tx.enqueuePostCommitEffect({
+    id: `compileAndRun:${hash}`,
+    idempotencyKey: effectKey,
+    kind: "compile-and-run",
+    flush: () => {
+      // Only the SERVING loop reaches here: a flag-ON client returned
+      // above (`!servingPosture`) without enqueuing, so this effect exists
+      // only on the serving runtime. `signal.aborted` skips a superseded
+      // request (the program changed before the post-commit flush ran).
+      if (signal.aborted) return;
+      const work = performServedCompile(
+        runtime,
+        inputsCell,
+        space,
+        { pending, error, errors, internal },
+        requestProgram,
+        hash,
+        effectKey,
+        signal,
+      );
+      // Tracked as async builtin work owned by this run: the outbox
+      // captures it during the flush's synchronous prefix (its settlement
+      // is the effect's completion; a rejection counts outbox.failed).
+      runtime.trackAsyncWork(work, parentCell);
+    },
+  });
+}
+
+/**
+ * The served compile effect's work (ON arm; see {@link compileAndRunServed}):
+ * compile the program (caching + persisting it), then land a marked
+ * COMPLETION commit that either RE-ARMS the instantiating derivation
+ * (`compiledHash`) on success, or writes the error-shaped result on a
+ * compile failure. The instantiation itself is NOT done here — it is the
+ * derivation's job (the loop's own run) — because a post-commit flush's
+ * instantiation races the loop's resume of the prior child and loses.
+ *
+ * Rejects only when the completion itself cannot commit (the outbox counts
+ * `outbox.failed`; recovery is §6's re-miss). An effect-level failure (the
+ * compile rejecting) is an error-shaped RESULT, never a rejection.
+ */
+async function performServedCompile(
+  runtime: Runtime,
+  inputsCell: Cell<BuiltInCompileAndRunParams<any>>,
+  space: string,
+  cells: {
+    pending: Cell<boolean>;
+    error: Cell<string | undefined>;
+    errors: Cell<unknown>;
+    internal: Cell<CompileMemo | undefined>;
+  },
+  program: Program,
+  hash: string,
+  effectKey: string,
+  signal: AbortSignal,
+): Promise<void> {
+  /** The request the cells reflect NOW (re-read through the completion
+   * transaction, so a superseded request writes nothing — the new
+   * request's own effect owns the cells; serving-loop.md §4's failure/
+   * retry rule and the FP6 structural basis re-read). */
+  const stillCurrent = (tx: IExtendedStorageTransaction): boolean => {
+    if (signal.aborted) return false;
+    const current = inputsCell.asSchema<Program>(programSchema).withTx(tx)
+      .get();
+    return hashOf(current ?? { files: [], main: "" }).toString() === hash;
+  };
+  let pattern: Awaited<
+    ReturnType<typeof runtime.patternManager.compileOrGetPattern>
+  >;
+  try {
+    pattern = await runtime.patternManager.compileOrGetPattern(
+      program,
+      space as never,
+    );
+  } catch (err) {
+    if (signal.aborted) return;
+    // The compile failed: an error-shaped result, keyed, in one completion
+    // commit — retries are input-driven (a new hash), never timers (T14).
+    const written = await runtime.editWithRetry((tx) => {
+      markEffectCompletion(tx, effectKey);
+      if (!stillCurrent(tx)) return;
+      if (err instanceof CompilerError) {
+        const structuredErrors = err.errors.map((e) => ({
+          line: e.line ?? 1,
+          column: e.column ?? 1,
+          message: e.message,
+          type: e.type,
+          file: e.file,
+        }));
+        cells.errors.withTx(tx).set(structuredErrors);
+      } else {
+        const message = err instanceof Error
+          ? err.message + (err.stack ? "\n" + err.stack : "")
+          : String(err);
+        cells.error.withTx(tx).set(message);
+      }
+      cells.pending.withTx(tx).set(false);
+      cells.internal.withTx(tx).set({ requestHash: hash, resolvedHash: hash });
+    });
+    if (written.error !== undefined) {
+      throw new Error(
+        `compileAndRun error writeback failed to commit: ${written.error.message}`,
+        { cause: err },
+      );
+    }
+    return;
+  }
+  if (signal.aborted) return;
+  if (!pattern) {
+    // No pattern (a module without a default entry): today's OFF-arm
+    // outcome is "not pending, no result, no error"; land the same, keyed,
+    // so the request memo-hits instead of re-firing.
+    const written = await runtime.editWithRetry((tx) => {
+      markEffectCompletion(tx, effectKey);
+      if (!stillCurrent(tx)) return;
+      cells.pending.withTx(tx).set(false);
+      cells.internal.withTx(tx).set({ requestHash: hash, resolvedHash: hash });
+    });
+    if (written.error !== undefined) {
+      throw new Error(
+        `compileAndRun completion failed to commit: ${written.error.message}`,
+      );
+    }
+    return;
+  }
+  // Success: the pattern is now in the process compile cache. RE-ARM the
+  // instantiating derivation — `compiledHash` is a tracked read, so this
+  // marked completion dirties the action, which then sync-hits the cache
+  // and instantiates the child (correctly scoped, no race). `pending`
+  // stays true until that instantiation lands `pending=false`.
+  const written = await runtime.editWithRetry((tx) => {
+    markEffectCompletion(tx, effectKey);
+    if (!stillCurrent(tx)) return;
+    cells.internal.withTx(tx).set({ requestHash: hash, compiledHash: hash });
+  });
+  if (written.error !== undefined) {
+    throw new Error(
+      `compileAndRun re-arm completion failed to commit: ${written.error.message}`,
+    );
+  }
+  // TODO(seefeld): Add capturing runtime errors.
+}
+
+/** The OFF arm — byte-identical to the pre-port builtin: a floating
+ * compile promise with unmarked writebacks, the in-memory
+ * `previousCallHash` dedupe, and `pieceCreatedCallback` at compile
+ * completion. Extracted verbatim so the ON arm above cannot perturb it. */
+function compileAndRunOff(
+  runtime: Runtime,
+  tx: IExtendedStorageTransaction,
+  ctx: {
+    inputsCell: Cell<BuiltInCompileAndRunParams<any>>;
+    parentCell: Cell<any>;
+    cells: {
+      pending: Cell<boolean>;
+      result: Cell<any | undefined>;
+      error: Cell<string | undefined>;
+      errors: Cell<unknown>;
+    };
+    program: Program;
+    hash: string;
+    hasValidInputs: boolean;
+    isIntentionallyEmpty: boolean;
+    previousCallHash: string | undefined;
+    setPreviousCallHash: (hash: string) => void;
+    newRequestId: () => string;
+    currentRequestId: () => string | undefined;
+    abortSignal: () => AbortSignal | undefined;
+  },
+): void {
+  const { inputsCell, parentCell, cells, program, hash } = ctx;
+  const { pending, result, error, errors } = cells;
+  const input = inputsCell.withTx(tx).key("input");
+  const pendingWithLog = pending.withTx(tx);
+  const resultWithLog = result.withTx(tx);
+  const errorWithLog = error.withTx(tx);
+  const errorsWithLog = errors.withTx(tx);
+
+  // Return if the same request is being made again, either concurrently (same
+  // as previousCallHash) or when rehydrated from storage.
+  if (hash === ctx.previousCallHash) return;
+
+  // If we have a previous valid result and inputs are currently invalid
+  // (likely rehydrating), don't clear the outputs — wait for real inputs.
+  // BUT if inputs are intentionally empty, we should clear.
+  if (
+    !ctx.hasValidInputs && ctx.previousCallHash &&
+    ctx.previousCallHash !== hash && !ctx.isIntentionallyEmpty
+  ) {
+    return;
+  }
+
+  ctx.setPreviousCallHash(hash);
+
+  const thisRequestId = ctx.newRequestId();
+
+  runtime.runner.stop(result);
+  resultWithLog.set(undefined);
+  errorWithLog.set(undefined);
+  errorsWithLog.set(undefined);
+
+  // Undefined inputs => Undefined output, not pending
+  if (!ctx.hasValidInputs) {
+    pendingWithLog.set(false);
+    return;
+  }
+
+  // Main file not found => Error, not pending
+  if (!program.files.some((file) => file?.name === program.main)) {
+    errorWithLog.set(`"${program.main}" not found in files`);
+    pendingWithLog.set(false);
+    return;
+  }
+
+  // Now we're sure that we have a new file to compile
+  pendingWithLog.set(true);
+
+  const compilePromise = runtime.patternManager
+    .compileOrGetPattern(program, parentCell.space)
+    .catch(
+      (err) => {
+        // Only process this error if the request hasn't been superseded
+        if (ctx.currentRequestId() !== thisRequestId) return;
+        if (ctx.abortSignal()?.aborted) return;
+
+        runtime.editWithRetry((asyncTx) => {
+          // Extract structured errors if this is a CompilerError
+          if (err instanceof CompilerError) {
+            const structuredErrors = err.errors.map((e) => ({
+              line: e.line ?? 1,
+              column: e.column ?? 1,
+              message: e.message,
+              type: e.type,
+              file: e.file,
+            }));
+            errors.withTx(asyncTx).set(structuredErrors);
+          } else {
+            error.withTx(asyncTx).set(
+              err.message + (err.stack ? "\n" + err.stack : ""),
+            );
+          }
+        });
+      },
+    ).finally(() => {
+      // Only update pending if this is still the current request
+      if (ctx.currentRequestId() !== thisRequestId) return;
+      // Always clear pending state, even if cancelled, to avoid stuck state
+
+      runtime.editWithRetry((asyncTx) => {
+        pending.withTx(asyncTx).set(false);
+      });
+    });
+
+  compilePromise.then((pattern) => {
+    // Only run the result if this is still the current request
+    if (ctx.currentRequestId() !== thisRequestId) return;
+    if (ctx.abortSignal()?.aborted) return;
+
+    if (pattern) {
+      // TODO(ja): to support editting of existing pieces / running with
+      // inputs from other pieces, we will need to think more about
+      // how we pass input into the builtin.
+
+      runtime.runSynced(result, pattern, input.get());
+      runtime.editWithRetry((asyncTx) => {
+        result.withTx(asyncTx).key("isHidden").set(true);
+      });
+      runtime.pieceCreatedCallback?.(result);
+    }
+    // TODO(seefeld): Add capturing runtime errors.
+  });
 }

--- a/packages/runner/src/builtins/compile-and-run.ts
+++ b/packages/runner/src/builtins/compile-and-run.ts
@@ -1,6 +1,7 @@
 import { type BuiltInCompileAndRunParams } from "commonfabric";
 import type { JSONSchema } from "@commonfabric/api";
 import { hashOf } from "@commonfabric/data-model/value-hash";
+import type { ScopeKeyIdentity } from "@commonfabric/memory/v2";
 import { type Cell } from "../cell.ts";
 import { type Action } from "../scheduler.ts";
 import type { Runtime } from "../runtime.ts";
@@ -22,7 +23,12 @@ import { narrowestScope } from "../scope.ts";
  * re-compiles — cache-hit cheap, never an observable shape).
  *
  * - `requestHash` — the request the node's cells reflect. Written by the
- *   requesting DERIVATION at issue and re-asserted at every outcome.
+ *   requesting DERIVATION at issue and re-asserted at every outcome. The
+ *   issue-time write is load-bearing on its own: a same-hash re-run while
+ *   the effect is in flight reads `stored === hash` + issued and WAITS
+ *   for the re-arm; a corrupt or missing issue-time key would read as a
+ *   new request and re-issue into the in-flight effect's dedupe key —
+ *   the supersession wedge's shape (pinned: the issue-time-key test).
  * - `resolvedHash` — the RESOLUTION marker: set (== `requestHash`) on
  *   every TERMINAL outcome (a landed piece, an error-shaped result, or a
  *   synchronous invalid-inputs / main-not-found outcome). The §4 HIT rule
@@ -32,14 +38,46 @@ import { narrowestScope } from "../scope.ts";
  *   there and a pending-based hit would FALSELY treat it as landed
  *   (rendering an empty result forever — the recovery-mid-flight wedge).
  *   `resolvedHash` is never written by init, so it distinguishes issued
- *   from resolved across a crash/park.
+ *   from resolved across a crash/park. A completion NEVER overwrites a
+ *   landed resolution (an incidental re-run may instantiate off the warm
+ *   cache before the completion commits; the completion then re-arms
+ *   nothing rather than clearing the marker and forcing a second
+ *   instantiation of the running child).
  * - `compiledHash` — set by the compile EFFECT's marked completion once
  *   the program is compiled and cached: it RE-ARMS the derivation (a
  *   tracked read of this cell) WITHOUT marking resolved (the instantiation
  *   is still pending), so the re-run reaches the instantiate branch. On a
  *   cold process (recovery) the cache misses and the compile re-issues
  *   (§6 step 3); the child's own durable pattern pointer lets the loop
- *   resume a LANDED child regardless.
+ *   resume a LANDED child regardless. The re-arm is ONE of the two
+ *   instantiate triggers, not THE trigger: any run that finds the pattern
+ *   in the process cache (an incidental re-run after the compile cached
+ *   it, a fresh closure over a warm process) instantiates without waiting
+ *   for it.
+ *
+ * SUPERSESSION (the independent review's MAJOR-A): the ON arm has NO
+ * abort signal — an issued compile effect always runs to its completion,
+ * and the COMPLETION decides by re-reading the node's current request
+ * hash through its own transaction (`stillCurrent`, serving-loop.md §4's
+ * FP6 re-read at writeback): current again → it lands; superseded → it
+ * writes nothing, reports `superseded` (§7's `outbox.superseded`), and
+ * its retirement releases the outbox key. Why no signal: the outbox
+ * dedupes in flight per key, so an A→B→A′ sequence within A's compile
+ * duration ATTACHES A′ to A's still-running effect — an effect that
+ * returned on "aborted at B's issue" would drop A′'s only completion and
+ * the node would stay `pending=true` forever, no counter naming it.
+ * Completing-or-releasing is the discipline the attach relies on.
+ *
+ * INSTANCES (the review's MAJOR-B; scopes.md §6): a scoped node fans out
+ * once per demanded instance through ONE closure. Every per-instance
+ * fact lives outside the closure — the cells resolve their instance
+ * through the run's transaction, the effect key carries the run's
+ * instance (`effectTargetKey` with the run identity), and the
+ * completion transaction is stamped with that identity so its request
+ * re-read and its writes address the SAME instance the effect was
+ * issued for. One compile per program per process (the pattern cache is
+ * shared); one effect completion + one instantiation per demanded
+ * instance.
  */
 type CompileMemo = {
   requestHash?: string;
@@ -109,9 +147,12 @@ const programSchema: JSONSchema = {
  * Under EXPERIMENTAL_SERVER_EXECUTION (server-execution v2 stage C, OW28;
  * builtins.md §3, serving-loop.md §4–§5) the compile is served as an
  * OUTBOX EFFECT and the instantiation is an ordinary consequence of the
- * served graph run — see {@link compileAndRunServed}. The OFF arm is
- * byte-identical to the pre-port builtin (a floating compile promise with
- * unmarked writebacks) and lives in {@link compileAndRunOff}.
+ * served graph run — see {@link compileAndRunServed}. The OFF arm is a
+ * behavior-identical extraction of the pre-port builtin (a floating
+ * compile promise with unmarked writebacks; the same operations in the
+ * same order, traced against the pre-port source — the closure state it
+ * needs is threaded through a context object) and lives in
+ * {@link compileAndRunOff}.
  */
 export function compileAndRun(
   inputsCell: Cell<BuiltInCompileAndRunParams<any>>,
@@ -121,6 +162,10 @@ export function compileAndRun(
   parentCell: Cell<any>,
   runtime: Runtime,
 ): Action {
+  // OFF-arm only: the in-flight compile's abort controller and request
+  // id (the ON arm's effect has no abort — see CompileMemo's SUPERSESSION
+  // note — and keeps no per-request closure state at all, which is what
+  // lets one closure serve every demanded instance of a fanned-out node).
   let abortController: AbortController | undefined = undefined;
   // OFF-arm only: the in-memory request dedupe (unchanged).
   let previousCallHash: string | undefined = undefined;
@@ -146,13 +191,18 @@ export function compileAndRun(
   /** ON arm, client posture only: the last LANDED request hash this
    * closure reported through `pieceCreatedCallback` — a flag-ON client
    * never compiles, so it reports the served instantiation on OBSERVING
-   * the landing, once per landed request (runtime-mapping.md N39). */
+   * the landing, once per landed request (runtime-mapping.md N39). A
+   * client is cardinality 1 (its own instance), so one slot suffices;
+   * the serving runtime installs no hook and never reads this. */
   let reportedCreatedHash: string | undefined = undefined;
   let cellScope: CellScope | undefined;
 
   // This is called when the pattern containing this node is being stopped.
   addCancel(() => {
-    // Abort any in-flight compilation if it's still pending.
+    // OFF arm: abort any in-flight compilation if it's still pending. (The
+    // ON arm's effect has nothing to abort: a compile is content-cached
+    // local work, and its completion is hash-guarded — a stopped node's
+    // completion lands at most a memo re-arm nobody re-runs on.)
     abortController?.abort("Pattern stopped");
   });
 
@@ -182,6 +232,13 @@ export function compileAndRun(
         tx,
       );
       pending = scopedCell(runtime, tx, basePending, outputScope);
+      // The loading-state default, written by BOTH arms at cell-init —
+      // including a flag-ON CLIENT's first run: the one write the ON
+      // client's "reads through, writes nothing speculatively" claim
+      // excepts (with the `sendResult` links below). It carries no
+      // request state (the §4 hit keys on `resolvedHash`, never on
+      // `pending`), so it decides nothing; it only renders the loading
+      // state until the served cells arrive.
       pending.send(false);
 
       const baseResult = runtime.getCell<any | undefined>(
@@ -260,16 +317,12 @@ export function compileAndRun(
           reportedCreatedHash = landedHash;
           return true;
         },
-        abort: () => {
-          abortController?.abort("New compilation started");
-          abortController = new AbortController();
-          return abortController.signal;
-        },
       });
       return;
     }
 
-    // ---- OFF arm (byte-identical to the pre-port builtin) ----
+    // ---- OFF arm (a behavior-identical extraction of the pre-port
+    // builtin) ----
     compileAndRunOff(runtime, tx, {
       inputsCell,
       parentCell,
@@ -317,8 +370,6 @@ function compileAndRunServed(
     isIntentionallyEmpty: boolean;
     /** Report the client's piece-creation hook once per landed request. */
     reportCreated: (landedHash: string) => boolean;
-    /** Abort any prior in-flight compile and return a fresh signal. */
-    abort: () => AbortSignal;
   },
 ): void {
   const { inputsCell, parentCell, cells, program, hash } = ctx;
@@ -349,12 +400,16 @@ function compileAndRunServed(
     // per LANDED successful compile, on observing the landing — the same
     // registration the OFF arm's compile completion fires (`pieces.add`
     // is idempotent). Nothing on the serving runtime and the OFF arm
-    // reaches this branch.
+    // reaches this branch. Guarded on a PRESENT result (parity with the
+    // OFF arm's `if (pattern)`): a resolved no-pattern outcome (a module
+    // without a default entry: `pending=false`, no result) never reports
+    // a piece.
     if (
       runtime.pieceCreatedCallback !== undefined &&
       ctx.hasValidInputs &&
       errorT.get() === undefined &&
       errorsT.get() === undefined &&
+      resultT.get() !== undefined &&
       ctx.reportCreated(hash)
     ) {
       runtime.pieceCreatedCallback(result);
@@ -368,12 +423,18 @@ function compileAndRunServed(
   // speculatively — not even the synchronous invalid-inputs /
   // main-not-found outcomes below, which the SERVER decides identically
   // and lands as committed cells the client's hit rule above then reads
-  // through. A speculative write here would only add an overlay entry
-  // that must retire before the server's committed cells are visible,
-  // delaying the read-through (a `pending=true` echo measurably delayed
-  // the served `pending=false`); the parent's `ifElse(pending || (!result
-  // && !error))` already renders the loading state while the served cells
-  // are empty.
+  // through. (The two writes the claim excepts are the shared cell-init's
+  // `pending.send(false)` loading default and the `sendResult` links —
+  // both request-free.) A speculative write here would only add an
+  // overlay entry that must retire before the server's committed cells
+  // are visible, delaying the read-through (a `pending=true` echo
+  // measurably delayed the served `pending=false`); the parent's
+  // `ifElse(pending || (!result && !error))` already renders the loading
+  // state while the served cells are empty. This gate's witness is the
+  // unit read-through pin (a bare flag-ON client runtime: no compile, no
+  // memo/pending/error write for any outcome — red with the gate
+  // removed); the E2E's "0 client compiles" cannot see it, because the
+  // client's speculation overlay drops the effect either way.
   if (!runtime.servingPosture) return;
 
   // ---- SERVING (the SpaceServer's runtime) from here on. Every scheduler
@@ -383,6 +444,12 @@ function compileAndRunServed(
   // serving-runtime run would refuse loudly at the seal (§3d's refusal,
   // counted in `unstampedSealRefusals` — the E2E pins it at ZERO across
   // every served compile-and-run leg), never silently mis-route. ----
+
+  // The run's instance identity (server-execution v2 stage A's tx→replica
+  // seam, stamped per demanded instance by the wave run stamp; absent on
+  // the wave-level fallback and on every bare runtime) keys this run's
+  // effect and rides into its completion — CompileMemo's INSTANCES note.
+  const identity: ScopeKeyIdentity | undefined = tx.tx.scopeKeyIdentity;
 
   // A fresh request (or a re-issue): the cells must reflect THIS hash.
   const reissue = stored !== hash;
@@ -399,7 +466,6 @@ function compileAndRunServed(
     }
     if (reissue || currentlyPending !== false) {
       runtime.runner.stop(result);
-      ctx.abort();
       resultT.set(undefined);
       errorT.set(undefined);
       errorsT.set(undefined);
@@ -413,7 +479,6 @@ function compileAndRunServed(
   if (!program.files.some((file) => file?.name === program.main)) {
     if (reissue) {
       runtime.runner.stop(result);
-      ctx.abort();
       resultT.set(undefined);
       errorsT.set(undefined);
       errorT.set(`"${program.main}" not found in files`);
@@ -473,12 +538,15 @@ function compileAndRunServed(
   //    compile cache no longer holds the entry (FIFO eviction between the
   //    effect and this run): re-fire rather than wedge — the effect
   //    re-compiles (cache miss → real compile) and re-arms again.
-  // Within a session, the issue's own `pending=true` write (init is
-  // skipped on re-runs) makes a same-hash re-arm-wait re-run read
-  // `pending===true` with no `compiledHash` yet — so it does NOT re-abort
-  // the in-flight compile or re-enqueue (the re-compile-forever bug); it
-  // waits for the `compiledHash` re-arm to reach the instantiate branch
-  // above.
+  // Within a session, the issue's own `pending=true` + `requestHash`
+  // writes (init is skipped on re-runs) make a same-hash re-arm-wait
+  // re-run read `stored === hash` + `pending===true` with no
+  // `compiledHash` yet — so it does NOT re-issue (the re-compile-forever
+  // bug); it waits for the `compiledHash` re-arm to reach the instantiate
+  // branch above. A DIFFERENT-hash run re-issues without aborting
+  // anything: the superseded effect runs to its hash-guarded completion
+  // and writes nothing (or lands, if its hash is current again by then —
+  // CompileMemo's SUPERSESSION note).
   //
   // Posture, stated: a same-hash request whose completion commit FAILED
   // on a LIVE runtime that did not park (an infrastructure failure the
@@ -493,14 +561,20 @@ function compileAndRunServed(
       resultT.get() === undefined) ||
     memo?.compiledHash === hash;
   if (!needIssue) return;
-  const signal = ctx.abort();
   runtime.runner.stop(result);
   resultT.set(undefined);
   errorT.set(undefined);
   errorsT.set(undefined);
   pendingT.set(true);
   internalT.set({ requestHash: hash });
-  const effectKey = effectTargetKey(`compileAndRun:${hash}`, result);
+  // The effect key carries this run's INSTANCE (scopes.md §6): a scoped
+  // node's demanded instances each own their effect, its carriage, and
+  // its completion; a space-scoped node's key is unchanged.
+  const effectKey = effectTargetKey(
+    `compileAndRun:${hash}`,
+    result,
+    identity ?? runtime.scopeKeyIdentity,
+  );
   const requestProgram = plainProgram;
   const space = parentCell.space;
   tx.enqueuePostCommitEffect({
@@ -510,9 +584,11 @@ function compileAndRunServed(
     flush: () => {
       // Only the SERVING loop reaches here: a flag-ON client returned
       // above (`!servingPosture`) without enqueuing, so this effect exists
-      // only on the serving runtime. `signal.aborted` skips a superseded
-      // request (the program changed before the post-commit flush ran).
-      if (signal.aborted) return;
+      // only on the serving runtime. No abort short-circuit: an effect
+      // superseded before its flush still runs to its hash-guarded
+      // completion (a re-issue of the same key may have ATTACHED to it —
+      // outbox.ts admitSealedEffects — and this effect is that request's
+      // only completion). The compile is content-cached local work.
       const work = performServedCompile(
         runtime,
         inputsCell,
@@ -521,7 +597,7 @@ function compileAndRunServed(
         requestProgram,
         hash,
         effectKey,
-        signal,
+        identity,
       );
       // Tracked as async builtin work owned by this run: the outbox
       // captures it during the flush's synchronous prefix (its settlement
@@ -540,6 +616,16 @@ function compileAndRunServed(
  * derivation's job (the loop's own run) — because a post-commit flush's
  * instantiation races the loop's resume of the prior child and loses.
  *
+ * Every completion is HASH-GUARDED (`stillCurrent`) and INSTANCE-STAMPED:
+ * the completion transaction carries the issuing run's identity, so its
+ * request re-read and its writes address the instance the effect was
+ * issued for (a per-instance node's request inputs are that instance's;
+ * an unstamped re-read would resolve the SERVICE's instance, mismatch,
+ * and land nothing — the wedge a per-user program hit at cardinality 1
+ * before this). A superseded completion writes nothing, reports
+ * `superseded`, and returns — its tracked work settles and the outbox
+ * releases the key (CompileMemo's SUPERSESSION note).
+ *
  * Rejects only when the completion itself cannot commit (the outbox counts
  * `outbox.failed`; recovery is §6's re-miss). An effect-level failure (the
  * compile rejecting) is an error-shaped RESULT, never a rejection.
@@ -557,17 +643,36 @@ async function performServedCompile(
   program: Program,
   hash: string,
   effectKey: string,
-  signal: AbortSignal,
+  identity: ScopeKeyIdentity | undefined,
 ): Promise<void> {
   /** The request the cells reflect NOW (re-read through the completion
    * transaction, so a superseded request writes nothing — the new
    * request's own effect owns the cells; serving-loop.md §4's failure/
    * retry rule and the FP6 structural basis re-read). */
   const stillCurrent = (tx: IExtendedStorageTransaction): boolean => {
-    if (signal.aborted) return false;
     const current = inputsCell.asSchema<Program>(programSchema).withTx(tx)
       .get();
     return hashOf(current ?? { files: [], main: "" }).toString() === hash;
+  };
+  /** Open a completion writeback: stamp the issuing run's instance
+   * identity FIRST (before the transaction's first read — the storage
+   * transaction enforces the order), mark it as this effect's completion,
+   * then re-read the request. Returns false when the request was
+   * superseded (write nothing). */
+  let superseded = false;
+  const beginCompletion = (tx: IExtendedStorageTransaction): boolean => {
+    if (identity !== undefined) tx.tx.scopeKeyIdentity = identity;
+    markEffectCompletion(tx, effectKey);
+    if (stillCurrent(tx)) return true;
+    superseded = true;
+    return false;
+  };
+  const reportIfSuperseded = () => {
+    if (!superseded) return;
+    runtime.effectMemoObserver?.({
+      kind: "superseded",
+      id: `compileAndRun:${hash}`,
+    });
   };
   let pattern: Awaited<
     ReturnType<typeof runtime.patternManager.compileOrGetPattern>
@@ -578,12 +683,10 @@ async function performServedCompile(
       space as never,
     );
   } catch (err) {
-    if (signal.aborted) return;
     // The compile failed: an error-shaped result, keyed, in one completion
     // commit — retries are input-driven (a new hash), never timers (T14).
     const written = await runtime.editWithRetry((tx) => {
-      markEffectCompletion(tx, effectKey);
-      if (!stillCurrent(tx)) return;
+      if (!beginCompletion(tx)) return;
       if (err instanceof CompilerError) {
         const structuredErrors = err.errors.map((e) => ({
           line: e.line ?? 1,
@@ -608,16 +711,15 @@ async function performServedCompile(
         { cause: err },
       );
     }
+    reportIfSuperseded();
     return;
   }
-  if (signal.aborted) return;
   if (!pattern) {
     // No pattern (a module without a default entry): today's OFF-arm
     // outcome is "not pending, no result, no error"; land the same, keyed,
     // so the request memo-hits instead of re-firing.
     const written = await runtime.editWithRetry((tx) => {
-      markEffectCompletion(tx, effectKey);
-      if (!stillCurrent(tx)) return;
+      if (!beginCompletion(tx)) return;
       cells.pending.withTx(tx).set(false);
       cells.internal.withTx(tx).set({ requestHash: hash, resolvedHash: hash });
     });
@@ -626,16 +728,22 @@ async function performServedCompile(
         `compileAndRun completion failed to commit: ${written.error.message}`,
       );
     }
+    reportIfSuperseded();
     return;
   }
   // Success: the pattern is now in the process compile cache. RE-ARM the
   // instantiating derivation — `compiledHash` is a tracked read, so this
   // marked completion dirties the action, which then sync-hits the cache
   // and instantiates the child (correctly scoped, no race). `pending`
-  // stays true until that instantiation lands `pending=false`.
+  // stays true until that instantiation lands `pending=false`. Unless the
+  // request already RESOLVED — an incidental re-run instantiated off the
+  // warm cache between the compile and this commit — in which case the
+  // landed resolution stands and this completion re-arms nothing (a
+  // whole-object `set` here would clear `resolvedHash` and the next run
+  // would re-instantiate the running child once more).
   const written = await runtime.editWithRetry((tx) => {
-    markEffectCompletion(tx, effectKey);
-    if (!stillCurrent(tx)) return;
+    if (!beginCompletion(tx)) return;
+    if (cells.internal.withTx(tx).get()?.resolvedHash === hash) return;
     cells.internal.withTx(tx).set({ requestHash: hash, compiledHash: hash });
   });
   if (written.error !== undefined) {
@@ -643,13 +751,18 @@ async function performServedCompile(
       `compileAndRun re-arm completion failed to commit: ${written.error.message}`,
     );
   }
+  reportIfSuperseded();
   // TODO(seefeld): Add capturing runtime errors.
 }
 
-/** The OFF arm — byte-identical to the pre-port builtin: a floating
- * compile promise with unmarked writebacks, the in-memory
- * `previousCallHash` dedupe, and `pieceCreatedCallback` at compile
- * completion. Extracted verbatim so the ON arm above cannot perturb it. */
+/** The OFF arm — a behavior-identical extraction of the pre-port builtin
+ * (traced operation for operation against the pre-port source; the
+ * closure state it reads and writes — the previous-call hash, the request
+ * id, the abort controller — is threaded through `ctx` rather than
+ * captured, which is the only textual difference): a floating compile
+ * promise with unmarked writebacks, the in-memory `previousCallHash`
+ * dedupe, and `pieceCreatedCallback` at compile completion. Kept apart so
+ * the ON arm above cannot perturb it. */
 function compileAndRunOff(
   runtime: Runtime,
   tx: IExtendedStorageTransaction,

--- a/packages/runner/src/executor/effect-completion.ts
+++ b/packages/runner/src/executor/effect-completion.ts
@@ -36,15 +36,38 @@
 
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import type { Cell } from "../cell.ts";
+import {
+  resolveScopeKey,
+  type ScopeKeyIdentity,
+} from "@commonfabric/memory/v2";
 
 const effectCompletionKeys = new WeakMap<object, string>();
 
 /**
  * The per-target effect key: `<builtin>:<inputHash>` widened by the
- * requesting node's result-cell identity (entity id + scope). This is
- * the OUTBOX in-flight/dedupe key and the completion-routing key — the
- * `idempotencyKey` the builtins enqueue with, and the key every
- * `markEffectCompletion` of that request must use.
+ * requesting node's result-cell identity (entity id + scope — or, when
+ * the caller passes the run's `identity`, entity id + scope INSTANCE
+ * key). This is the OUTBOX in-flight/dedupe key and the
+ * completion-routing key — the `idempotencyKey` the builtins enqueue
+ * with, and the key every `markEffectCompletion` of that request must
+ * use.
+ *
+ * The INSTANCE widening (server-execution v2 stage C, OW28's
+ * independent-review MAJOR-B; scopes.md §6: memo keys INCLUDE the
+ * instance key): a scoped node fans out once per demanded instance
+ * (one closure, per-instance stamped transactions), and each instance
+ * run writes ITS instance of the node's cells. With the scope NAME
+ * alone in the key, two demanders' identical requests collide — the
+ * second dedupes against the first's in-flight effect, whose completion
+ * lands (via the carriage captured at admission) on the FIRST
+ * demander's instance only, so the second stays pending forever. With
+ * the identity, the suffix is the resolved instance key
+ * (`user:<principal>` / `session:<principal>:<session>`), so each
+ * demanded instance owns its own effect, carriage, and completion; a
+ * space-scoped target carries no suffix either way, and a caller that
+ * passes no identity keeps the scope-name text byte for byte
+ * (`fetch*`, `generate*`, `sqlite*` today — their per-instance keying
+ * is an owed row in verification-coverage.md).
  *
  * Why the target rides in the key (the stage-G round-2 headline): two
  * DISTINCT recipe nodes can issue byte-identical inputs, colliding on
@@ -72,12 +95,23 @@ const effectCompletionKeys = new WeakMap<object, string>();
 export function effectTargetKey(
   base: string,
   targetCell: Cell<unknown>,
+  identity?: ScopeKeyIdentity,
 ): string {
   const link = targetCell.getAsNormalizedFullLink();
-  const scope = link.scope !== undefined && link.scope !== "space"
-    ? `:${String(link.scope)}`
-    : "";
-  return `${base}@${link.id}${scope}`;
+  if (link.scope === undefined || link.scope === "space") {
+    return `${base}@${link.id}`;
+  }
+  let suffix = String(link.scope);
+  if (identity !== undefined) {
+    try {
+      suffix = resolveScopeKey(link.scope, identity);
+    } catch {
+      // An identity that cannot resolve this scope (a sessionless pair
+      // at session depth): fall back to the scope name — the same key
+      // text an identity-less caller produces.
+    }
+  }
+  return `${base}@${link.id}:${suffix}`;
 }
 
 /**

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -595,7 +595,11 @@ export class SpaceServer implements TransactionSealDestination {
     });
     this.#outbox = outbox;
     runtime.asyncWorkObserver = (work) => outbox.observeAsyncWork(work);
-    runtime.effectMemoObserver = () => {
+    runtime.effectMemoObserver = (event) => {
+      if (event.kind === "superseded") {
+        this.#options.stats.outbox.superseded += 1;
+        return;
+      }
       this.#options.stats.memo.hits += 1;
     };
     // Stage P2-F (the F1 fold-in, RULED 2026-08-13): a piece-start

--- a/packages/runner/src/executor/stats.ts
+++ b/packages/runner/src/executor/stats.ts
@@ -162,6 +162,20 @@ export type ServingLoopStats = {
      * cap or an egress-rate token. Growth under load is the budget
      * WORKING (the runaway degrades its own space), not a failure. */
     budgetDeferrals: number;
+    /** Effect completions that found their request SUPERSEDED at
+     * writeback (serving-loop.md §4's hash re-read: the node's current
+     * request no longer matches the effect's) — the completion wrote
+     * nothing (the successor's own effect owns the cells) and the
+     * effect retired, RELEASING its dedupe key (stage C, OW28's
+     * independent-review MAJOR-A: a superseded effect must complete or
+     * release, never silently return — a re-issued same-key request
+     * that attached to it in flight would wedge pending forever, and
+     * no counter would name it). A subset of `completed`; growth is
+     * ordinary churn (an input changed while its effect ran), never a
+     * failure. Reported by the builtins whose completions re-read the
+     * request through the effect-memo observer (compile-and-run
+     * today). */
+    superseded: number;
   };
   lease: { held: number; lost: number };
 };
@@ -196,7 +210,13 @@ export const emptyServingLoopStats = (): ServingLoopStats => ({
     skippedIdempotent: 0,
   },
   memo: { hits: 0, misses: 0, inflight: 0 },
-  outbox: { queued: 0, completed: 0, failed: 0, budgetDeferrals: 0 },
+  outbox: {
+    queued: 0,
+    completed: 0,
+    failed: 0,
+    budgetDeferrals: 0,
+    superseded: 0,
+  },
   lease: { held: 0, lost: 0 },
 });
 

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -2062,6 +2062,15 @@ export class PatternManager {
    * flush. A cold process (recovery) misses here and re-issues the
    * compile effect (§6 step 3; the child's durable pattern pointer also
    * lets the loop resume it independently).
+   *
+   * Deliberately a PEEK, unlike the async path: it does NOT refresh the
+   * entry's FIFO recency (a peek must not reorder eviction behind the
+   * effect that populated the entry) and does NOT replicate the pattern's
+   * source closure to another space (`replicatePatternToSpace`) — the
+   * served builtin runs on the SpaceServer's runtime, one runtime per
+   * served space, so the entry was compiled INTO this space by the effect
+   * that cached it. A caller on a runtime spanning several spaces would
+   * need the async path for the cross-space replicate.
    */
   getCompiledPatternForProgramSync(
     input: string | RuntimeProgram,

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -2051,6 +2051,29 @@ export class PatternManager {
   }
 
   /**
+   * The SYNCHRONOUS side of {@link compileOrGetPattern}'s content cache:
+   * the already-compiled pattern for `input`, or undefined when it has
+   * not been compiled in THIS process (never triggers a compile, never
+   * touches the space cell cache). Used by the served `compile-and-run`
+   * builtin (server-execution v2 stage C, OW28): the compile is an
+   * outbox EFFECT, and once it has run and cached the pattern, the
+   * builtin's derivation instantiates the child in-run from this sync
+   * hit — the loop's own run, correctly scoped, never a racing async
+   * flush. A cold process (recovery) misses here and re-issues the
+   * compile effect (§6 step 3; the child's durable pattern pointer also
+   * lets the loop resume it independently).
+   */
+  getCompiledPatternForProgramSync(
+    input: string | RuntimeProgram,
+  ): Pattern | undefined {
+    const program: RuntimeProgram = typeof input === "string"
+      ? { main: "/main.tsx", files: [{ name: "/main.tsx", contents: input }] }
+      : input;
+    const dedupeKey = toURI(createRef({ src: program }, "pattern source"));
+    return this.compiledByContent.get(dedupeKey)?.pattern;
+  }
+
+  /**
    * Compile a pattern from source, or return a cached/in-flight result.
    * Provides single-flight deduplication based on program content.
    *

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1427,15 +1427,18 @@ export class Runtime {
   asyncWorkObserver: ((work: Promise<unknown>) => void) | undefined;
 
   /**
-   * Serving-loop observer of effect-memo hits (server-execution v2
-   * stage G, serving-loop.md §4's hit rule / §7's `memo.hits`): the
-   * effectful builtins report an evaluation that resolved from the
-   * stored request hash — no effect fired. Installed by the
-   * SpaceServer on the serving runtime; undefined everywhere else (the
-   * OFF arm pays one optional call).
+   * Serving-loop observer of effect-memo events (server-execution v2
+   * stage G, serving-loop.md §4 / §7): the effectful builtins report
+   * `hit` — an evaluation that resolved from the stored request hash,
+   * no effect fired (`memo.hits`) — and `superseded` — an effect
+   * completion that found its request superseded at writeback and
+   * wrote nothing, releasing its key (`outbox.superseded`; stage C,
+   * OW28's supersession discipline). Installed by the SpaceServer on
+   * the serving runtime; undefined everywhere else (the OFF arm pays
+   * one optional call).
    */
   effectMemoObserver:
-    | ((event: { kind: "hit"; id: string }) => void)
+    | ((event: { kind: "hit" | "superseded"; id: string }) => void)
     | undefined;
 
   /**

--- a/packages/runner/test/clock-preload.ts
+++ b/packages/runner/test/clock-preload.ts
@@ -87,5 +87,10 @@ installFakeClock({
     // virtual timers diverge from the bucket's time source (Date.now) —
     // the rate gate would regenerate its refill sleep unboundedly.
     "executor-outbox-budget",
+    // The stage-C compile-and-run suite (OW28) drives a live ExecutorHost
+    // + a flag-ON client under the same wall-clock policies (renew
+    // cadence, flush deadline, park/re-activate), waiting on store/replica
+    // edges with bounded timeouts.
+    "executor-compile-and-run",
   ],
 });

--- a/packages/runner/test/compile-and-run.test.ts
+++ b/packages/runner/test/compile-and-run.test.ts
@@ -1,10 +1,12 @@
 import { assertEquals } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
+import { hashOf } from "@commonfabric/data-model/value-hash";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
 import { compileAndRun } from "../src/builtins/compile-and-run.ts";
-import { stampWaveRunContext } from "../src/executor/wave.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import type { Cell } from "../src/cell.ts";
+import type { MemorySpace } from "../src/storage/interface.ts";
 
 Deno.test("compileAndRun initializes outputs and handles invalid programs", async () => {
   const identity = await Identity.fromPassphrase("compile and run coverage");
@@ -76,127 +78,409 @@ Deno.test("compileAndRun initializes outputs and handles invalid programs", asyn
   }
 });
 
-// Server-execution v2 Phase 2's compile gate (the builtin's flag-ON
-// posture, stated truthfully): compilation is an EFFECTFUL step whose
-// launch is a floating promise the overlay destination cannot
-// intercept, so the gate lives in the builtin and suppresses fresh
-// compiles for EVERY flag-ON non-wave run — client derivation runs,
-// F10 handler runs, imperative flows alike. Until the serving port
-// lands (stage G's out-of-scope note; the serving side refuses the
-// writebacks), fresh compile-and-run is INERT in the ON arm everywhere:
-// memo'd results still read through, `pending` renders the ordinary
-// loading state. A WAVE-STAMPED run passes the gate (the seam the
-// serving port will drive), and the OFF arm is untouched.
-Deno.test("compileAndRun's Phase-2 gate: flag-ON non-wave runs launch NO fresh compile (pending stands), a wave-stamped run passes, and the OFF arm is unaffected", async () => {
-  const identity = await Identity.fromPassphrase("compile and run gate");
-  const space = identity.did();
+// ---------------------------------------------------------------------------
+// Server-execution v2 stage C (OW28): compile-and-run SERVED as an outbox
+// effect. These pins run the builtin's action + its post-commit effect
+// INLINE over a bare runtime — no SpaceServer — with REAL compiles (so
+// the process content cache the instantiate branch reads is genuinely
+// populated). The full route through a live SpaceServer + client (the
+// piece-creation flow end to end, recovery, counters, unstamped=0) is in
+// executor-compile-and-run.test.ts. What is pinned here:
+//
+// - a WAVE-STAMPED serving run compiles the program via the OUTBOX EFFECT
+//   (not client-side, not from the action), RE-ARMS (`compiledHash`), then
+//   INSTANTIATES the child in a later run from the process cache
+//   (`pending=false`, the request memoized, the child's value served); a
+//   re-evaluation MEMO-HITS instead of re-compiling;
+// - a flag-ON CLIENT (non-serving) NEVER compiles and writes nothing
+//   speculatively — it reads through to the served cells (speculation.md
+//   §2);
+// - a failing compile lands an ERROR-SHAPED result, keyed — no infinite
+//   pending, and no re-fire on re-evaluation (input-driven retry, T14);
+// - the OFF arm compiles from the action, exactly as today, and has no
+//   memo cell.
+//
+// The re-instantiation on a PROGRAM change, the piece-creation hook, the
+// client read-through end to end, recovery (memo reuse across park), and
+// the §7 counters are pinned LIVE against a real SpaceServer + client in
+// executor-compile-and-run.test.ts (a bare runtime has no wave cycle to
+// serialize a re-instantiated child's async body against).
+// ---------------------------------------------------------------------------
 
-  const PROGRAM_A = {
-    main: "/main.tsx",
-    files: [{ name: "/main.tsx", contents: "export default 1;" }],
-  };
-  const PROGRAM_B = {
-    main: "/other.tsx",
-    files: [{ name: "/other.tsx", contents: "export default 2;" }],
-  };
+type ProgramInput = {
+  main: string;
+  files: Array<{ name: string; contents: string }>;
+};
 
-  /** One builtin instance over `runtime`, with the compile launch
-   * DETECTED (never performed): the stub never resolves, so no
-   * writeback races teardown — the launch COUNT is the observable. */
-  const armed = (
-    runtime: Runtime,
-    tx: IExtendedStorageTransaction,
-    name: string,
-    program: { main: string; files: Array<{ name: string; contents: string }> },
-  ) => {
-    let launches = 0;
-    (runtime.patternManager as unknown as {
-      compileOrGetPattern: () => Promise<unknown>;
-    }).compileOrGetPattern = () => {
-      launches += 1;
-      return new Promise<never>(() => {});
-    };
-    const inputs = runtime.getCell<{
-      main: string;
-      files: Array<{ name: string; contents: string }>;
-    }>(space, `${name}-inputs`, undefined, tx);
-    const parent = runtime.getCell(space, `${name}-parent`, undefined, tx);
-    let outputs: any;
-    const action = compileAndRun(
-      inputs as never,
-      (_tx, result) => {
-        outputs = result;
-      },
-      () => {},
-      { test: name },
-      parent,
-      runtime,
-    );
-    inputs.set(program);
+const childProgram = (answer: number): ProgramInput => ({
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { pattern } from 'commonfabric';",
+      "export default pattern<Record<string, never>, { answer: number }>(",
+      `  () => ({ answer: ${answer} }),`,
+      ");",
+    ].join("\n"),
+  }],
+});
+const PROGRAM_A = childProgram(42);
+const BROKEN: ProgramInput = {
+  main: "/main.tsx",
+  files: [{ name: "/main.tsx", contents: "this is not valid (((" }],
+};
+const hashOfProgram = (program: ProgramInput) => hashOf(program).toString();
+
+/** A builtin instance over `runtime` whose compiles are COUNTED (the real
+ * compileOrGetPattern is wrapped, never replaced — the instantiate branch
+ * reads the genuine content cache). */
+const armed = (
+  runtime: Runtime,
+  space: MemorySpace,
+  name: string,
+) => {
+  const launched: ProgramInput[] = [];
+  const pm = runtime.patternManager as unknown as {
+    compileOrGetPattern: (
+      input: ProgramInput | string,
+      space?: string,
+    ) => Promise<unknown>;
+  };
+  const real = pm.compileOrGetPattern.bind(pm);
+  pm.compileOrGetPattern = (input, targetSpace) => {
+    launched.push(input as ProgramInput);
+    return real(input, targetSpace);
+  };
+  const inputs = runtime.getCell<ProgramInput>(
+    space,
+    `${name}-inputs`,
+    undefined,
+  );
+  const parent = runtime.getCell(space, `${name}-parent`, undefined);
+  let outputs:
+    | {
+      pending: Cell<boolean>;
+      result: Cell<any>;
+      error: Cell<string | undefined>;
+      errors: Cell<unknown>;
+    }
+    | undefined;
+  const cause = { test: name };
+  const action = compileAndRun(
+    inputs as never,
+    (_tx, result) => {
+      outputs = result;
+    },
+    () => {},
+    cause,
+    parent,
+    runtime,
+  );
+  /** Run the action inside a fresh transaction, commit it (on this bare
+   * runtime the commit runs the effect flush inline), and settle so the
+   * compile + its re-arm complete. The SERVED/CLIENT posture is the
+   * RUNTIME's (`servingPosture`), not a per-tx stamp: on the real serving
+   * runtime every scheduler run is wave-stamped by the SpaceServer, and an
+   * unstamped one refuses loudly at the seal (the E2E pins
+   * `unstampedSealRefusals === 0`). */
+  const run = async (program: ProgramInput) => {
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    const tx: IExtendedStorageTransaction = runtime.edit();
+    inputs.withTx(tx).set(program);
     action(tx);
-    return {
-      launches: () => launches,
-      pending: () => outputs.pending.withTx(tx).get(),
-    };
+    const launchesAtAction = launched.length;
+    const committed = await tx.commit();
+    await runtime.settled();
+    return { launchesAtAction, error: committed.error };
   };
+  /** Re-run the action (the loop's re-arm re-run) to reach the instantiate
+   * branch after the compile effect cached the pattern. Settles first so
+   * the prior run's instantiated child body has landed (a bare runtime has
+   * no wave cycle to serialize against; a real SpaceServer does). */
+  const rerun = async (program: ProgramInput) => {
+    const { error } = await run(program);
+    return error;
+  };
+  /** Seed the DURABLE state of a request issued but never resolved (a
+   * process that crashed/parked mid-compile): `pending=true` +
+   * `internal={requestHash}` committed, with NO `resolvedHash` and an
+   * empty compile cache. A FRESH closure over this store must RE-FIRE the
+   * compile — not falsely memo-hit on the init-clobbered `pending`. */
+  const seedMidFlight = async (program: ProgramInput) => {
+    const h = hashOfProgram(program);
+    const tx: IExtendedStorageTransaction = runtime.edit();
+    runtime.getCell<boolean>(
+      space,
+      { compile: { pending: cause } },
+      undefined,
+      tx,
+    ).set(true);
+    runtime.getCell(space, { compile: { internal: cause } }, undefined, tx)
+      .set({ requestHash: h });
+    inputs.withTx(tx).set(program);
+    await tx.commit();
+  };
+  return {
+    inputs,
+    seedMidFlight,
+    launches: () => launched.length,
+    launchesOf: (program: ProgramInput) =>
+      launched.filter((p) => JSON.stringify(p) === JSON.stringify(program))
+        .length,
+    run,
+    rerun,
+    outputs: () => outputs!,
+    memo: () =>
+      runtime.getCell<
+        | { requestHash?: string; compiledHash?: string; resolvedHash?: string }
+        | undefined
+      >(
+        space,
+        { compile: { internal: cause } },
+        undefined,
+      ).get(),
+  };
+};
 
-  // ON arm, NON-wave run (the client posture — derivation, F10
-  // handler, imperative flows all reach the builtin unstamped): the
-  // gate suppresses the fresh compile; pending stays the ordinary
-  // loading state.
-  {
-    const storageManager = StorageManager.emulate({ as: identity });
-    const runtime = new Runtime({
-      apiUrl: new URL(import.meta.url),
-      storageManager,
-      experimental: { serverExecution: true },
-    });
-    try {
-      const tx: IExtendedStorageTransaction = runtime.edit();
-      const nonWave = armed(runtime, tx, "gate-on-non-wave", PROGRAM_A);
-      assertEquals(
-        nonWave.launches(),
-        0,
-        "the flag-ON non-wave run must not launch a fresh compile",
-      );
-      assertEquals(nonWave.pending(), true);
+const newOnRuntime = async (
+  passphrase: string,
+  extra: {
+    servingPosture?: boolean;
+    pieceCreatedCallback?: (piece: Cell<any>) => void;
+  } = {},
+) => {
+  const identity = await Identity.fromPassphrase(passphrase);
+  const storageManager = StorageManager.emulate({ as: identity });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+    experimental: { serverExecution: true },
+    ...(extra.servingPosture ? { servingPosture: true } : {}),
+    ...(extra.pieceCreatedCallback
+      ? { pieceCreatedCallback: extra.pieceCreatedCallback }
+      : {}),
+  });
+  return { runtime, storageManager, space: identity.did() as MemorySpace };
+};
 
-      // ON arm, WAVE-STAMPED run (the serving seam): the gate passes.
-      const waveTx: IExtendedStorageTransaction = runtime.edit();
-      stampWaveRunContext(waveTx, {
-        actionId: "test/compile-gate-wave",
-        kind: "derivation",
-      });
-      const wave = armed(runtime, waveTx, "gate-on-wave", PROGRAM_B);
-      assertEquals(
-        wave.launches(),
-        1,
-        "a wave-stamped run must pass the gate (the serving port's seam)",
-      );
-    } finally {
-      await runtime.dispose();
-      await storageManager.close();
-    }
+Deno.test("OW28 — a served run compiles via the OUTBOX EFFECT (not from the action), re-arms, then instantiates the child in a later run; a re-evaluation MEMO-HITS instead of re-compiling", async () => {
+  const hits: string[] = [];
+  const { runtime, storageManager, space } = await newOnRuntime(
+    "compile and run served instantiate",
+    { servingPosture: true },
+  );
+  runtime.effectMemoObserver = (event) => {
+    if (event.kind === "hit") hits.push(event.id);
+  };
+  try {
+    const node = armed(runtime, space, "served");
+
+    // First run: the compile is an EFFECT (0 launches at action time); the
+    // effect compiles once and RE-ARMS the derivation (`compiledHash`);
+    // `pending` stays issued (the instantiation is the re-arm run below).
+    const first = await node.run(PROGRAM_A);
+    assertEquals(first.error, undefined);
+    assertEquals(first.launchesAtAction, 0, "the action launches no compile");
+    assertEquals(node.launchesOf(PROGRAM_A), 1, "the effect compiled once");
+    assertEquals(node.outputs().pending.get(), true);
+    assertEquals(node.memo()?.requestHash, hashOfProgram(PROGRAM_A));
+    assertEquals(node.memo()?.compiledHash, hashOfProgram(PROGRAM_A));
+
+    // The re-arm run: the cached pattern instantiates the child in-run
+    // (`pending=false`, the request memoized, the child's value served).
+    assertEquals(await node.rerun(PROGRAM_A), undefined);
+    assertEquals(node.outputs().pending.get(), false);
+    assertEquals(node.outputs().error.get(), undefined);
+    assertEquals(
+      node.outputs().result.key("isHidden").get() as unknown as boolean,
+      true,
+    );
+    assertEquals(
+      node.outputs().result.key("answer").get() as unknown as number,
+      42,
+    );
+    assertEquals(node.memo()?.requestHash, hashOfProgram(PROGRAM_A));
+
+    // A re-evaluation of the landed request: the §4 hit — no re-compile,
+    // the hit reported. (Re-instantiation on a PROGRAM change, recovery,
+    // and the full lifecycle are pinned live in
+    // executor-compile-and-run.test.ts against a real SpaceServer.)
+    assertEquals(await node.rerun(PROGRAM_A), undefined);
+    assertEquals(node.launchesOf(PROGRAM_A), 1);
+    assertEquals(
+      hits.includes(`compileAndRun:${hashOfProgram(PROGRAM_A)}`),
+      true,
+    );
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
   }
+});
 
-  // OFF arm: unaffected — the compile launches exactly as today.
-  {
-    const storageManager = StorageManager.emulate({ as: identity });
-    const runtime = new Runtime({
-      apiUrl: new URL(import.meta.url),
-      storageManager,
-    });
-    try {
-      const tx: IExtendedStorageTransaction = runtime.edit();
-      const off = armed(runtime, tx, "gate-off", PROGRAM_A);
-      assertEquals(
-        off.launches(),
-        1,
-        "the OFF arm must launch the fresh compile exactly as today",
-      );
-    } finally {
-      await runtime.dispose();
-      await storageManager.close();
+Deno.test("OW28 — recovery mid-flight: a durable `pending` request that NEVER resolved (crash/park between issue and completion) RE-FIRES the compile instead of wedging as a false memo-hit", async () => {
+  const { runtime, storageManager, space } = await newOnRuntime(
+    "compile and run mid-flight recovery",
+    { servingPosture: true },
+  );
+  try {
+    const node = armed(runtime, space, "recov");
+    // The "dead process" left `pending=true` + an ISSUED memo (no
+    // resolvedHash) durably, and the compile cache is empty (fresh
+    // process). The hit rule keys on `resolvedHash`, so this is NOT a hit
+    // even though the cell-init reads `pending=false`.
+    await node.seedMidFlight(PROGRAM_A);
+    assertEquals(node.memo()?.requestHash, hashOfProgram(PROGRAM_A));
+    assertEquals(node.memo()?.resolvedHash, undefined);
+
+    // The fresh closure re-fires the compile (the §6 re-miss) rather than
+    // reading through an empty result forever.
+    const first = await node.run(PROGRAM_A);
+    assertEquals(first.error, undefined);
+    assertEquals(node.launchesOf(PROGRAM_A), 1, "the compile re-fired");
+    // Re-arm run instantiates and RESOLVES.
+    assertEquals(await node.rerun(PROGRAM_A), undefined);
+    assertEquals(node.outputs().pending.get(), false);
+    assertEquals(
+      node.outputs().result.key("answer").get() as unknown as number,
+      42,
+    );
+    assertEquals(node.memo()?.resolvedHash, hashOfProgram(PROGRAM_A));
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("OW28 — compile-cache EVICTION between the effect's re-arm and the instantiate run RE-FIRES the compile instead of wedging (the re-arm landed, the process cache lost the entry)", async () => {
+  const { runtime, storageManager, space } = await newOnRuntime(
+    "compile and run cache eviction",
+    { servingPosture: true },
+  );
+  try {
+    const node = armed(runtime, space, "evict");
+    // Issue: the effect compiles, caches, and RE-ARMS (compiledHash).
+    assertEquals((await node.run(PROGRAM_A)).error, undefined);
+    assertEquals(node.launchesOf(PROGRAM_A), 1);
+    assertEquals(node.memo()?.compiledHash, hashOfProgram(PROGRAM_A));
+    assertEquals(node.outputs().pending.get(), true);
+
+    // The FIFO content cache evicts the entry before the re-arm run reaches
+    // the instantiate branch (white-box: the >1000-distinct-programs window
+    // compressed to a delete).
+    const cache = (runtime.patternManager as unknown as {
+      compiledByContent: Map<string, unknown>;
+    }).compiledByContent;
+    assertEquals(cache.size >= 1, true);
+    cache.clear();
+
+    // The re-arm run finds no cached pattern for a request whose re-arm
+    // LANDED: it re-fires (a second real compile), re-arms, and the next
+    // run instantiates — never a wedge on `pending=true`.
+    assertEquals(await node.rerun(PROGRAM_A), undefined);
+    assertEquals(node.launchesOf(PROGRAM_A), 2, "re-fired after eviction");
+    assertEquals(await node.rerun(PROGRAM_A), undefined);
+    assertEquals(node.outputs().pending.get(), false);
+    assertEquals(
+      node.outputs().result.key("answer").get() as unknown as number,
+      42,
+    );
+    assertEquals(node.memo()?.resolvedHash, hashOfProgram(PROGRAM_A));
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("OW28 — a flag-ON CLIENT (non-serving) never compiles and writes nothing speculatively: it reads through to the served cells", async () => {
+  const { runtime, storageManager, space } = await newOnRuntime(
+    "compile and run client read-through",
+  );
+  try {
+    const node = armed(runtime, space, "client");
+    const { launchesAtAction, error } = await node.run(PROGRAM_A);
+    assertEquals(error, undefined);
+    assertEquals(launchesAtAction, 0);
+    assertEquals(node.launches(), 0, "the client must never compile");
+    // Read-through: no speculative pending write, no result, no memo issue —
+    // the cells reflect the (empty) served state.
+    assertEquals(node.outputs().pending.get(), false);
+    assertEquals(node.outputs().result.get(), undefined);
+    assertEquals(node.memo(), undefined);
+
+    // The SYNCHRONOUS outcomes too (the review's MINOR-2): the client
+    // decides nothing for invalid inputs or a missing main — the SERVER
+    // lands those as committed cells the hit rule reads through. No
+    // error/memo/pending write from the client, ever.
+    assertEquals(
+      (await node.run({
+        main: "/missing.tsx",
+        files: [{ name: "/other.tsx", contents: "export default 1;" }],
+      })).error,
+      undefined,
+    );
+    assertEquals(node.outputs().error.get(), undefined);
+    assertEquals(node.outputs().pending.get(), false);
+    assertEquals(node.memo(), undefined);
+    assertEquals((await node.run({ main: "", files: [] })).error, undefined);
+    assertEquals(node.outputs().error.get(), undefined);
+    assertEquals(node.memo(), undefined);
+    assertEquals(node.launches(), 0);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("OW28 — a failing compile lands an ERROR-SHAPED result, keyed: pending clears, no re-fire on re-evaluation (no timer), the retry is input-driven", async () => {
+  const { runtime, storageManager, space } = await newOnRuntime(
+    "compile and run served failure",
+    { servingPosture: true },
+  );
+  try {
+    const node = armed(runtime, space, "fail");
+    assertEquals((await node.run(BROKEN)).error, undefined);
+    // The compile failed in the effect: an error-shaped result, keyed.
+    assertEquals(node.outputs().pending.get(), false, "no infinite pending");
+    const hasError = node.outputs().error.get() !== undefined ||
+      node.outputs().errors.get() !== undefined;
+    assertEquals(hasError, true);
+    assertEquals(node.outputs().result.get(), undefined);
+    assertEquals(node.memo()?.requestHash, hashOfProgram(BROKEN));
+    const compilesAfterFail = node.launchesOf(BROKEN);
+
+    // Re-evaluations of the same failing program: the §4 hit — no re-fire
+    // (the T14 posture, retries never timer-driven). The input-driven
+    // retry to SUCCESS is pinned live in executor-compile-and-run.test.ts.
+    for (let i = 0; i < 3; i++) {
+      assertEquals(await node.rerun(BROKEN), undefined);
     }
+    assertEquals(node.launchesOf(BROKEN), compilesAfterFail);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("OW28 — the OFF arm is unaffected: the compile launches from the action, and there is no memo cell", async () => {
+  const identity = await Identity.fromPassphrase("compile and run off");
+  const storageManager = StorageManager.emulate({ as: identity });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  try {
+    const node = armed(runtime, identity.did() as MemorySpace, "off");
+    const { launchesAtAction } = await node.run(PROGRAM_A);
+    assertEquals(
+      launchesAtAction,
+      1,
+      "the OFF arm launches the compile from the action, as today",
+    );
+    // No memo cell exists in the OFF arm.
+    assertEquals(node.memo(), undefined);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
   }
 });

--- a/packages/runner/test/compile-and-run.test.ts
+++ b/packages/runner/test/compile-and-run.test.ts
@@ -97,12 +97,22 @@ Deno.test("compileAndRun initializes outputs and handles invalid programs", asyn
 //   §2);
 // - a failing compile lands an ERROR-SHAPED result, keyed — no infinite
 //   pending, and no re-fire on re-evaluation (input-driven retry, T14);
+// - the ISSUE-TIME memo key: a same-hash re-run mid-flight WAITS (no
+//   re-issue into the in-flight effect's key — probe P4's mutant turns
+//   exactly this pin red);
+// - a SUPERSEDED completion writes nothing, leaves the successor's landed
+//   resolution intact, and reports itself (`outbox.superseded`'s source);
+// - the success RE-ARM never clobbers a landed `resolvedHash` (an
+//   incidental warm-cache instantiation before the completion commits);
 // - the OFF arm compiles from the action, exactly as today, and has no
-//   memo cell.
+//   memo cell — and its pre-existing createRef-on-proxy program-change
+//   defect is pinned AS IT STANDS (an owed row; not fixed here).
 //
 // The re-instantiation on a PROGRAM change, the piece-creation hook, the
-// client read-through end to end, recovery (memo reuse across park), and
-// the §7 counters are pinned LIVE against a real SpaceServer + client in
+// client read-through end to end, recovery (memo reuse across park), the
+// supersession journeys (A→B→A within A's compile; the superseded
+// completion's release), fan-out at cardinality 2, and the §7 counters are
+// pinned LIVE against a real SpaceServer + client in
 // executor-compile-and-run.test.ts (a bare runtime has no wave cycle to
 // serialize a re-instantiated child's async body against).
 // ---------------------------------------------------------------------------
@@ -131,6 +141,18 @@ const BROKEN: ProgramInput = {
 };
 const hashOfProgram = (program: ProgramInput) => hashOf(program).toString();
 
+/** A hold on one program's compile: the wrapped compileOrGetPattern
+ * enters, reports `held`, and RESUMES the real compile once `release`
+ * resolves; `afterCompiled` (optional) runs after the real compile
+ * resolved and BEFORE the pattern is handed back to the effect — the
+ * window between "cached in the process" and "the completion commit". */
+type CompileHold = {
+  program: ProgramInput;
+  held: () => void;
+  release: Promise<void>;
+  afterCompiled?: () => Promise<void>;
+};
+
 /** A builtin instance over `runtime` whose compiles are COUNTED (the real
  * compileOrGetPattern is wrapped, never replaced — the instantiate branch
  * reads the genuine content cache). */
@@ -138,6 +160,7 @@ const armed = (
   runtime: Runtime,
   space: MemorySpace,
   name: string,
+  options: { hold?: CompileHold } = {},
 ) => {
   const launched: ProgramInput[] = [];
   const pm = runtime.patternManager as unknown as {
@@ -149,6 +172,18 @@ const armed = (
   const real = pm.compileOrGetPattern.bind(pm);
   pm.compileOrGetPattern = (input, targetSpace) => {
     launched.push(input as ProgramInput);
+    const hold = options.hold;
+    if (
+      hold !== undefined &&
+      JSON.stringify(input) === JSON.stringify(hold.program)
+    ) {
+      hold.held();
+      return hold.release.then(async () => {
+        const pattern = await real(input, targetSpace);
+        await hold.afterCompiled?.();
+        return pattern;
+      });
+    }
     return real(input, targetSpace);
   };
   const inputs = runtime.getCell<ProgramInput>(
@@ -194,6 +229,21 @@ const armed = (
     await runtime.settled();
     return { launchesAtAction, error: committed.error };
   };
+  /** Like `run`, but WITHOUT settling: the action runs and commits (the
+   * effect flush runs inline at commit and its compile may be HELD), and
+   * control returns while the effect is in flight — the mid-flight
+   * journeys. */
+  const issue = async (program: ProgramInput) => {
+    await runtime.idle();
+    const tx: IExtendedStorageTransaction = runtime.edit();
+    inputs.withTx(tx).set(program);
+    action(tx);
+    const committed = await tx.commit();
+    // The flush ran (its synchronous prefix started the compile — held or
+    // not — and tracked the work); the work itself may still be in flight.
+    await tx.postCommitEffectsSettled();
+    return { error: committed.error };
+  };
   /** Re-run the action (the loop's re-arm re-run) to reach the instantiate
    * branch after the compile effect cached the pattern. Settles first so
    * the prior run's instantiated child body has landed (a bare runtime has
@@ -230,6 +280,9 @@ const armed = (
         .length,
     run,
     rerun,
+    issue,
+    /** The raw action, for a test that drives it inside its own tx. */
+    action,
     outputs: () => outputs!,
     memo: () =>
       runtime.getCell<
@@ -456,6 +509,262 @@ Deno.test("OW28 — a failing compile lands an ERROR-SHAPED result, keyed: pendi
       assertEquals(await node.rerun(BROKEN), undefined);
     }
     assertEquals(node.launchesOf(BROKEN), compilesAfterFail);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("OW28 — the ISSUE-TIME memo key (the review's MINOR-E): an issued request writes `requestHash` at issue, so a same-hash re-run MID-FLIGHT waits — no re-issue, no second effect, the memo untouched (the guard whose failure mode is the supersession wedge)", async () => {
+  const { runtime, storageManager, space } = await newOnRuntime(
+    "compile and run issue-time key",
+    { servingPosture: true },
+  );
+  try {
+    let heldCount = 0;
+    const release = Promise.withResolvers<void>();
+    const node = armed(runtime, space, "issue-key", {
+      hold: {
+        program: PROGRAM_A,
+        held: () => {
+          heldCount++;
+        },
+        release: release.promise,
+      },
+    });
+    assertEquals((await node.issue(PROGRAM_A)).error, undefined);
+    assertEquals(heldCount, 1, "the effect entered the (held) compile");
+    // The issue's OWN memo write, observed mid-flight — before any
+    // completion could re-assert it: `requestHash` names the request,
+    // nothing is resolved, the request is pending.
+    assertEquals(node.memo()?.requestHash, hashOfProgram(PROGRAM_A));
+    assertEquals(node.memo()?.resolvedHash, undefined);
+    assertEquals(node.memo()?.compiledHash, undefined);
+    assertEquals(node.outputs().pending.get(), true);
+
+    // Same-hash re-runs mid-flight: `stored === hash` and issued → the
+    // run WAITS for the re-arm — no re-issue (one launch, one hold), the
+    // memo untouched. A corrupt or missing issue-time key (probe P4's
+    // mutant) reads as a NEW request here and re-issues: a second effect
+    // that dedupes against the first's key — the wedge shape.
+    assertEquals((await node.issue(PROGRAM_A)).error, undefined);
+    assertEquals((await node.issue(PROGRAM_A)).error, undefined);
+    assertEquals(node.launchesOf(PROGRAM_A), 1, "no re-issue mid-flight");
+    assertEquals(heldCount, 1);
+    assertEquals(node.memo()?.requestHash, hashOfProgram(PROGRAM_A));
+    assertEquals(node.memo()?.resolvedHash, undefined);
+    assertEquals(node.outputs().pending.get(), true);
+
+    // Release: the compile completes, re-arms; the next run instantiates.
+    release.resolve();
+    await runtime.settled();
+    assertEquals(node.memo()?.compiledHash, hashOfProgram(PROGRAM_A));
+    assertEquals(await node.rerun(PROGRAM_A), undefined);
+    assertEquals(node.outputs().pending.get(), false);
+    assertEquals(
+      node.outputs().result.key("answer").get() as unknown as number,
+      42,
+    );
+    assertEquals(node.launchesOf(PROGRAM_A), 1);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("OW28 — a SUPERSEDED completion (the review's MAJOR-A family): an effect whose request was superseded before it completed writes NOTHING — the successor's landed resolution stands (no wipe, no clobber) — and reports itself superseded; the successor's key and cells are its own", async () => {
+  const events: Array<{ kind: string; id: string }> = [];
+  const { runtime, storageManager, space } = await newOnRuntime(
+    "compile and run superseded completion",
+    { servingPosture: true },
+  );
+  runtime.effectMemoObserver = (event) => {
+    events.push(event);
+  };
+  try {
+    let heldCount = 0;
+    const release = Promise.withResolvers<void>();
+    const node = armed(runtime, space, "superseded", {
+      hold: {
+        program: PROGRAM_A,
+        held: () => {
+          heldCount++;
+        },
+        release: release.promise,
+      },
+    });
+    const B = childProgram(7);
+    // A issued, its compile held; B supersedes it and LANDS (compile,
+    // re-arm, instantiate) while A's effect is still in flight.
+    assertEquals((await node.issue(PROGRAM_A)).error, undefined);
+    assertEquals(heldCount, 1);
+    assertEquals((await node.issue(B)).error, undefined);
+    // Settle B: its (real) compile completes and re-arms; the re-arm run
+    // instantiates B. `settled()` waits for ALL tracked work — A's held
+    // compile included — so release A first, and let it complete AFTER B
+    // was issued: A's completion re-reads the current request (B) and
+    // must write nothing.
+    release.resolve();
+    await runtime.settled();
+    assertEquals(node.memo()?.requestHash, hashOfProgram(B));
+    assertEquals(node.memo()?.compiledHash, hashOfProgram(B));
+    assertEquals(await node.rerun(B), undefined);
+    assertEquals(node.outputs().pending.get(), false);
+    assertEquals(
+      node.outputs().result.key("answer").get() as unknown as number,
+      7,
+    );
+    assertEquals(node.memo()?.resolvedHash, hashOfProgram(B));
+    // A's completion was SUPERSEDED: reported as such (the counter's
+    // source), and B's landed resolution untouched by it. A re-issue of
+    // the superseded program running a FRESH effect (its key released) is
+    // pinned live in executor-compile-and-run.test.ts (a bare runtime has
+    // no wave cycle to serialize a re-instantiated child's async body
+    // against, so program changes are not chained here).
+    assertEquals(
+      events.filter((e) => e.kind === "superseded").map((e) => e.id),
+      [`compileAndRun:${hashOfProgram(PROGRAM_A)}`],
+    );
+    assertEquals(node.launchesOf(PROGRAM_A), 1);
+    assertEquals(node.launchesOf(B), 1);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("OW28 — the success RE-ARM must not clobber a LANDED resolution (the review's MINOR-D): an incidental re-run that instantiated off the warm cache before the completion committed keeps `resolvedHash`; the completion re-arms nothing and the next run memo-HITS instead of re-instantiating the running child", async () => {
+  const { runtime, storageManager, space } = await newOnRuntime(
+    "compile and run re-arm no clobber",
+    { servingPosture: true },
+  );
+  try {
+    const release = Promise.withResolvers<void>();
+    // The interposition: after the real compile resolved (the process
+    // cache is warm) and BEFORE the effect's completion commit, an
+    // incidental re-run of the derivation instantiates from the cache and
+    // RESOLVES the request.
+    let incidentalRuns = 0;
+    const node: ReturnType<typeof armed> = armed(
+      runtime,
+      space,
+      "rearm-clobber",
+      {
+        hold: {
+          program: PROGRAM_A,
+          held: () => {},
+          release: release.promise,
+          afterCompiled: async () => {
+            incidentalRuns++;
+            const tx: IExtendedStorageTransaction = runtime.edit();
+            node.inputs.withTx(tx).set(PROGRAM_A);
+            // The derivation's own run: the sync cache hits → instantiate +
+            // resolve, committed before the effect's completion.
+            node.action(tx);
+            assertEquals((await tx.commit()).error, undefined);
+          },
+        },
+      },
+    );
+    let instantiations = 0;
+    const realRun = runtime.run.bind(runtime);
+    (runtime as unknown as { run: typeof runtime.run }).run = (
+      ...args: Parameters<typeof runtime.run>
+    ) => {
+      instantiations++;
+      return realRun(...args);
+    };
+    assertEquals((await node.issue(PROGRAM_A)).error, undefined);
+    release.resolve();
+    await runtime.settled();
+    assertEquals(incidentalRuns, 1);
+    // The incidental run instantiated (once) and RESOLVED; the completion
+    // that followed must not have cleared that resolution.
+    assertEquals(instantiations, 1);
+    assertEquals(node.outputs().pending.get(), false);
+    assertEquals(node.memo()?.resolvedHash, hashOfProgram(PROGRAM_A));
+    assertEquals(node.memo()?.requestHash, hashOfProgram(PROGRAM_A));
+    // The next run is a memo HIT: no second instantiation of the running
+    // child (at eb6d1e4bb the completion's `set` dropped `resolvedHash`,
+    // so this run re-instantiated — stop + run — once more).
+    assertEquals(await node.rerun(PROGRAM_A), undefined);
+    assertEquals(instantiations, 1, "no re-instantiation after the re-arm");
+    assertEquals(node.outputs().pending.get(), false);
+    assertEquals(
+      node.outputs().result.key("answer").get() as unknown as number,
+      42,
+    );
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("OFF-arm DEFECT, pre-existing (the review's MINOR-C; owed — verification-coverage.md OW28's createRef row): a same-node PROGRAM CHANGE in a WARM process serves the PRIOR pattern — `compileOrGetPattern(proxy)` keys the content cache by `createRef` of the asSchema proxy, which is insensitive to nested `contents`. Pinned AS IT STANDS so the fix flips this test; not fixed here (OFF behavior is out of this PR's scope)", async () => {
+  const identity = await Identity.fromPassphrase("compile and run off defect");
+  const storageManager = StorageManager.emulate({ as: identity });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  try {
+    const node = armed(runtime, identity.did() as MemorySpace, "off-defect");
+    const realCompiles: ProgramInput[] = [];
+    const pm = runtime.patternManager as unknown as {
+      compilePattern: (
+        input: ProgramInput,
+        options?: unknown,
+      ) => Promise<unknown>;
+    };
+    const realCompile = pm.compilePattern.bind(pm);
+    pm.compilePattern = (input, options) => {
+      realCompiles.push(input);
+      return realCompile(input, options);
+    };
+    const settledOff = async () => {
+      // The OFF arm's compile promise floats (untracked): drain reactive
+      // work and step the fake clock until `pending` clears.
+      for (let i = 0; i < 500 && node.outputs().pending.get() !== false; i++) {
+        await runtime.idle();
+        await clock.tick(20);
+      }
+      await runtime.settled();
+      await runtime.idle();
+    };
+    const B = childProgram(7);
+    assertEquals((await node.run(PROGRAM_A)).error, undefined);
+    await settledOff();
+    assertEquals(
+      node.outputs().result.key("answer").get() as unknown as number,
+      42,
+    );
+    assertEquals(realCompiles.length, 1);
+
+    // The program CHANGES on the same node, in the same (warm) process.
+    assertEquals((await node.run(B)).error, undefined);
+    await settledOff();
+    assertEquals(node.outputs().pending.get(), false);
+    // THE DEFECT: the child still serves the PRIOR program's value, and no
+    // second real compile ran — the proxy's content-cache key collapsed
+    // both programs onto one entry (`createRef({ src: proxy })` reads no
+    // nested `contents`), so the change was handed program A's pattern.
+    // The correct outcome is `answer === 7` and a second real compile;
+    // when the owning layer (create-ref.ts / pattern-manager.ts —
+    // normalize at the source) fixes this, flip these two assertions.
+    assertEquals(
+      node.outputs().result.key("answer").get() as unknown as number,
+      42,
+      "DEFECT pinned as it stands: the prior program's pattern is served",
+    );
+    assertEquals(
+      realCompiles.length,
+      1,
+      "DEFECT pinned as it stands: no real compile of the changed program",
+    );
+    // The ON arm keys the cache by a PLAIN program (`plainProgramOf`) —
+    // both the compile and the sync lookup — so it does not share this;
+    // its program-change re-compile is pinned live in
+    // executor-compile-and-run.test.ts (answer 42→7→99).
   } finally {
     await runtime.dispose();
     await storageManager.close();

--- a/packages/runner/test/executor-compile-and-run.test.ts
+++ b/packages/runner/test/executor-compile-and-run.test.ts
@@ -1,0 +1,563 @@
+// Server-execution v2 stage C (OW28): `compile-and-run` SERVED as an
+// outbox effect, end to end against a real memory server, a live
+// ExecutorHost, and a flag-ON client (builtins.md §3; serving-loop.md
+// §4–§6; speculation.md §2). What the P7 independent review characterized
+// — fresh compile-and-run INERT everywhere under the flag (the client gate
+// suppressing every non-wave compile; the serving side's writebacks
+// refused unstamped at the wave seal, `pending` never clearing) — is
+// pinned CLOSED here on both postures:
+//
+// - the IMPERATIVE piece-creation flow (protocol.md §1's scheduler tell):
+//   the client's authored creation write (`runtime.run` of a pattern that
+//   uses `compileAndRun`, from a flag-ON client — the `cf piece new` /
+//   `fetchAndRunPattern` shape) + its watch as demand → the SpaceServer
+//   runs the piece → the served compile-and-run node MISSES → the compile
+//   rides the outbox post-wave-commit → the completion lands the child
+//   piece + `pending=false` + the key as its OWN derived commit → the
+//   client, reading through, sees `pending` clear and the child's served
+//   output; the client itself NEVER compiles; the child's creation reaches
+//   the client's `pieceCreatedCallback` once;
+// - the SERVED DERIVATION re-invoking compile-and-run: an authored program
+//   change (a new key) re-compiles exactly once; a re-evaluation memo-hits;
+// - recovery: park/re-activate re-uses the landed piece (T10.Q4's bounded
+//   at-least-once, never unbounded);
+// - failure: a broken program lands an error-shaped result — `pending`
+//   clears, NO re-fire across further waves (input-driven retry, never a
+//   timer: the T14 posture), and a fixed program recovers;
+// - counters: misses/queued/completed and hits live; and the P7 symptom's
+//   own counter — `unstampedSealRefusals` — stays ZERO throughout.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import * as Engine from "@commonfabric/memory/v2/engine";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { MemorySpace } from "../src/storage/interface.ts";
+import type { Cell } from "../src/cell.ts";
+import { ExecutorHost } from "../src/executor/host.ts";
+import { readWatermarkSeq } from "../src/executor/watermark.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
+
+const spaceSigner = await Identity.fromPassphrase("compile and run space");
+const space = spaceSigner.did() as MemorySpace;
+const serviceSigner = await Identity.fromPassphrase("compile and run service");
+const aliceSigner = await Identity.fromPassphrase("compile and run alice");
+
+const waitUntil = async (
+  predicate: () => boolean,
+  label: string | (() => string),
+  timeoutMs = 30_000,
+): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      const rendered = typeof label === "function" ? label() : label;
+      throw new Error(`timed out waiting for ${rendered}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+};
+
+/** The parent: a pattern whose compile-and-run node compiles the
+ * AUTHORED `code` — the compiler.tsx / write-and-run.tsx shape. */
+const PARENT_PATTERN = [
+  "import { compileAndRun, pattern } from 'commonfabric';",
+  "export default pattern<{ code: string }, { compiled: any; code: string }>(",
+  "  ({ code }) => {",
+  "    const compiled = compileAndRun({",
+  "      files: [{ name: '/main.tsx', contents: code }],",
+  "      main: '/main.tsx',",
+  "    });",
+  "    return { compiled, code };",
+  "  },",
+  ");",
+].join("\n");
+
+const childProgram = (answer: number) =>
+  [
+    "import { pattern } from 'commonfabric';",
+    "export default pattern<Record<string, never>, { answer: number }>(",
+    `  () => ({ answer: ${answer} }),`,
+    ");",
+  ].join("\n");
+
+const BROKEN_PROGRAM = "this is not a program (((";
+
+type CompiledView = {
+  pending?: boolean;
+  result?: { answer?: number; isHidden?: boolean };
+  error?: unknown;
+  errors?: unknown;
+};
+
+describe("stage C (OW28): compile-and-run served as an outbox effect", () => {
+  let server: MemoryV2Server.Server;
+  let host: ExecutorHost | undefined;
+  let clientManager: EmulatedStorageManager;
+  let clientRuntime: Runtime;
+  /** Compiles the SERVING runtime performed, per program main-file
+   * contents (a counting wrapper over the real compile — never a stub:
+   * the child must really instantiate). */
+  let servingCompiles: string[];
+  /** Compiles the CLIENT runtime's builtin path performed: must stay
+   * empty (the client reads through, speculation.md §2). */
+  let clientCompiles: string[];
+  let created: Cell<any>[];
+  /** Serving-runtime creations, in order (activation #1, #2, ...). */
+  let servingRuntimes: Runtime[];
+  /** A HOLD on the serving side's compile (the mid-compile-park journey):
+   * when set, the serving runtime whose activation index matches holds
+   * its compile of the matching program on a promise the test never
+   * releases — the process-death stand-in (a real park disposes the
+   * runtime and its outbox work with it). */
+  let holdCompile:
+    | { activation: number; contents: string; held: () => void }
+    | undefined;
+
+  const countCompiles = (
+    runtime: Runtime,
+    into: string[],
+    activation: number,
+  ) => {
+    const manager = runtime.patternManager as unknown as {
+      compileOrGetPattern: (
+        input: unknown,
+        space?: MemorySpace,
+      ) => Promise<unknown>;
+    };
+    const real = manager.compileOrGetPattern.bind(manager);
+    manager.compileOrGetPattern = (input, targetSpace) => {
+      const program = input as {
+        files?: Array<{ contents?: string }>;
+      };
+      const contents = program.files?.[0]?.contents ?? String(input);
+      into.push(contents);
+      if (
+        holdCompile !== undefined && holdCompile.activation === activation &&
+        holdCompile.contents === contents
+      ) {
+        holdCompile.held();
+        return new Promise<never>(() => {});
+      }
+      return real(input, targetSpace);
+    };
+  };
+
+  const newHost = (
+    policy?: ConstructorParameters<typeof ExecutorHost>[0]["policy"],
+  ): ExecutorHost =>
+    new ExecutorHost({
+      server,
+      serviceIdentity: serviceSigner.did(),
+      // deno-lint-ignore require-await
+      createRuntime: async () => {
+        const manager = EmulatedStorageManager.connectTo(server, {
+          as: serviceSigner,
+        });
+        const runtime = new Runtime({
+          apiUrl: new URL(import.meta.url),
+          storageManager: manager,
+          servingPosture: true,
+          experimental: {
+            serverExecution: true,
+            systemPatternAutoUpdate: false,
+          },
+        });
+        servingRuntimes.push(runtime);
+        countCompiles(runtime, servingCompiles, servingRuntimes.length);
+        return {
+          runtime,
+          dispose: async () => {
+            await runtime.dispose();
+            await manager.close();
+          },
+        };
+      },
+      policy: policy ?? { flushDeadlineMs: 5_000, idleParkMs: 600_000 },
+    });
+
+  beforeEach(() => {
+    server = newSharedServer({ subscriptionRefreshDelayMs: 0 });
+    servingCompiles = [];
+    clientCompiles = [];
+    created = [];
+    servingRuntimes = [];
+    holdCompile = undefined;
+  });
+
+  afterEach(async () => {
+    await host?.close();
+    host = undefined;
+    await clientRuntime?.dispose();
+    await clientManager?.close();
+    await server.close();
+  });
+
+  const openClient = () => {
+    clientManager = EmulatedStorageManager.connectTo(server, {
+      as: aliceSigner,
+    });
+    clientRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: clientManager,
+      experimental: { serverExecution: true },
+      // The browser worker's hook: the client observes the served
+      // instantiation and registers the piece (runtime-mapping N39).
+      pieceCreatedCallback: (piece) => {
+        created.push(piece);
+      },
+    });
+    // The client is never a serving activation (activation 0 matches no
+    // hold): its compiles are only counted — and must stay at the parent's.
+    countCompiles(clientRuntime, clientCompiles, 0);
+  };
+
+  const compilesOf = (into: string[], contents: string) =>
+    into.filter((entry) => entry === contents).length;
+
+  it("the piece-creation flow END TO END: client authored creation + demand → served miss → outbox → compile → completion commit → the client reads through to the child (never compiling); a program change re-compiles once; recovery re-uses; a broken program lands error-shaped with no timer retry; unstampedSealRefusals stays 0", async () => {
+    // The host is up BEFORE the client's session opens: activation rides
+    // the admission-side observer (serving-loop.md §1 plane (b)).
+    host = newHost();
+    openClient();
+    const engine = await server.engineForSpace(space);
+
+    // The IMPERATIVE creation (protocol.md §1's scheduler tell): the
+    // client compiles the PARENT locally (its own authored act — the
+    // `cf piece new` shape) and writes the result doc + metadata with
+    // `runtime.run`, an unstamped client transaction → an AUTHORED
+    // commit. Its watch is the demand that has the server run round one.
+    const parent = await clientRuntime.patternManager.compilePattern({
+      main: "/main.tsx",
+      files: [{ name: "/main.tsx", contents: PARENT_PATTERN }],
+    }, { space });
+    const argument = clientRuntime.getCell<{ code: string }>(
+      space,
+      "compile-arg",
+      undefined,
+    );
+    const result = clientRuntime.getCell<{ compiled: CompiledView }>(
+      space,
+      "compile-result",
+      parent.resultSchema,
+    );
+    await argument.sync();
+    await result.sync();
+    {
+      const seed = clientRuntime.edit();
+      argument.withTx(seed).set({ code: childProgram(42) });
+      expect((await seed.commit()).error).toBeUndefined();
+    }
+    {
+      const tx = clientRuntime.edit();
+      clientRuntime.run(tx, parent, argument, result);
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    const cancelDemand = result.sink(() => {});
+    await clientRuntime.idle();
+    await clientRuntime.storageManager.synced();
+
+    // The parent's own compile happened on the client (the creation act);
+    // its compile-and-run NODE compiled nothing client-side — the client
+    // speculative run's effect was owned and dropped by the overlay.
+    const parentCompiles = clientCompiles.length;
+    expect(compilesOf(clientCompiles, childProgram(42))).toBe(0);
+
+    const compiled = () => result.key("compiled");
+    const answerOf = () =>
+      compiled().key("result").key("answer").get() as unknown as
+        | number
+        | undefined;
+
+    // The served round: the SpaceServer runs the piece; the node misses;
+    // the compile rides the outbox and lands as a completion commit; the
+    // client observes `pending` clear AND the child's served output.
+    await waitUntil(
+      () => compiled().key("pending").get() === false && answerOf() === 42,
+      () =>
+        `the client to observe the served child (pending=${
+          compiled().key("pending").get()
+        }, answer=${answerOf()}, error=${
+          JSON.stringify(compiled().key("error").get())
+        })`,
+    );
+    expect(compiled().key("error").get()).toBeUndefined();
+    expect(compiled().key("errors").get()).toBeUndefined();
+    expect(compiled().key("result").key("isHidden").get()).toBe(true);
+    // Exactly ONE served compile of the child; the client compiled none.
+    expect(compilesOf(servingCompiles, childProgram(42))).toBe(1);
+    expect(clientCompiles.length).toBe(parentCompiles);
+    // The client's piece-creation hook fired for the child, once.
+    await waitUntil(
+      () => created.length >= 1,
+      "the client's pieceCreatedCallback for the served child",
+    );
+    expect(created.length).toBe(1);
+    // The hook received the CHILD's result cell (the link target, not
+    // the parent's path).
+    expect(created[0].getAsNormalizedFullLink().id).toBe(
+      compiled().key("result").resolveAsCell().getAsNormalizedFullLink().id,
+    );
+    // Counters: the miss rode the outbox and completed; the post-completion
+    // re-evaluation memo-hits; and the P7 symptom's counter is ZERO — no
+    // compile-and-run writeback was refused as unstamped.
+    let stats = host.stats();
+    expect(stats.memo.misses).toBeGreaterThanOrEqual(1);
+    expect(stats.outbox.queued).toBeGreaterThanOrEqual(1);
+    expect(stats.outbox.completed).toBeGreaterThanOrEqual(1);
+    // memo.hits fire when a served run re-evaluates a LANDED request
+    // (stored hash matches, not pending) — e.g. the parent re-deriving
+    // when the child's value lands. It is a counter sanity check, not the
+    // core contract; read it without blocking (a quiet graph may not
+    // re-run the node at all after it settles).
+    expect(host.stats().memo.hits).toBeGreaterThanOrEqual(0);
+    expect(host.stats().unstampedSealRefusals).toBe(0);
+    // The completion commit is a derived-class commit of the loop's own
+    // (its holder is the service session), not an authored client commit:
+    // no client-side commit ever carried the child's setup.
+    const derivedRows = engine.database.prepare(
+      `SELECT COUNT(*) AS n FROM "commit" WHERE class = 'derived'`,
+    ).get() as { n: number };
+    expect(derivedRows.n).toBeGreaterThanOrEqual(1);
+
+    // The SERVED DERIVATION re-invoking compile-and-run: an authored
+    // program change is a NEW key — exactly one more served compile; the
+    // client sees the new child.
+    {
+      const tx = clientRuntime.edit();
+      argument.withTx(tx).set({ code: childProgram(7) });
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    await waitUntil(
+      () => compiled().key("pending").get() === false && answerOf() === 7,
+      () =>
+        `the client to observe the re-compiled child (pending=${
+          compiled().key("pending").get()
+        }, answer=${answerOf()})`,
+    );
+    expect(compilesOf(servingCompiles, childProgram(7))).toBe(1);
+    expect(compilesOf(servingCompiles, childProgram(42))).toBe(1);
+    expect(clientCompiles.length).toBe(parentCompiles);
+    await waitUntil(
+      () => created.length >= 2,
+      "the client's pieceCreatedCallback for the re-compiled child",
+    );
+    expect(created.length).toBe(2);
+
+    // RECOVERY (T10.Q4, §6 step 3): park, then re-activate on fresh input.
+    // The recovered runtime re-evaluates against COMMITTED state: the
+    // stored key + landed piece memo-hit and nothing re-compiles — with
+    // the RULED at-least-once allowance for a first evaluation that raced
+    // its memo-cell sync (bounded, never unbounded growth).
+    await host.spaceServer(space)!.park("test-recovery");
+    await waitUntil(
+      () => host!.spaceServer(space)?.active !== true,
+      "space to park for the recovery leg",
+    );
+    const poke = clientRuntime.getCell<{ n: number }>(
+      space,
+      "compile-poke",
+      undefined,
+    );
+    {
+      const pokeTx = clientRuntime.edit();
+      poke.withTx(pokeTx).set({ n: 1 });
+      expect((await pokeTx.commit()).error).toBeUndefined();
+    }
+    const pokeSeq = Engine.serverSeq(engine);
+    await waitUntil(
+      () => host!.spaceServer(space)?.active === true,
+      "space to re-activate",
+    );
+    await waitUntil(
+      () => readWatermarkSeq(engine) >= pokeSeq,
+      "the recovered loop to claim the poke input",
+    );
+    expect(compilesOf(servingCompiles, childProgram(7))).toBeLessThanOrEqual(
+      2,
+    );
+    expect(compiled().key("pending").get()).toBe(false);
+    expect(answerOf()).toBe(7);
+
+    // FAILURE (T14): a broken program lands an ERROR-SHAPED result, keyed —
+    // `pending` clears, and the retry is input-driven, never a timer.
+    {
+      const tx = clientRuntime.edit();
+      argument.withTx(tx).set({ code: BROKEN_PROGRAM });
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    await waitUntil(
+      () =>
+        compiled().key("pending").get() === false &&
+        (compiled().key("error").get() !== undefined ||
+          compiled().key("errors").get() !== undefined),
+      () =>
+        `the client to observe the error-shaped result (pending=${
+          compiled().key("pending").get()
+        })`,
+    );
+    expect(compilesOf(servingCompiles, BROKEN_PROGRAM)).toBe(1);
+    // No timer retry, pinned deterministically: drive the loop through
+    // several full waves on an UNRELATED doc (each claimed by the
+    // watermark) and assert the failed key never re-fired.
+    const retryProbe = clientRuntime.getCell<{ n: number }>(
+      space,
+      "no-timer-retry-probe",
+      undefined,
+    );
+    for (let i = 1; i <= 3; i++) {
+      const seqBefore = Engine.serverSeq(engine);
+      const probeTx = clientRuntime.edit();
+      retryProbe.withTx(probeTx).set({ n: i });
+      expect((await probeTx.commit()).error).toBeUndefined();
+      await waitUntil(
+        () => readWatermarkSeq(engine) > seqBefore,
+        `the loop to claim no-timer-retry probe ${i}`,
+      );
+    }
+    expect(compilesOf(servingCompiles, BROKEN_PROGRAM)).toBe(1);
+    // A failed compile creates no piece: the hook did not fire again.
+    expect(created.length).toBe(2);
+
+    // The input-driven retry: a fixed program re-fires (fresh key) and the
+    // node recovers.
+    {
+      const tx = clientRuntime.edit();
+      argument.withTx(tx).set({ code: childProgram(99) });
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    await waitUntil(
+      () => compiled().key("pending").get() === false && answerOf() === 99,
+      () =>
+        `the client to observe the recovered child (pending=${
+          compiled().key("pending").get()
+        }, answer=${answerOf()})`,
+    );
+    expect(compiled().key("error").get()).toBeUndefined();
+    expect(compiled().key("errors").get()).toBeUndefined();
+    expect(compilesOf(servingCompiles, childProgram(99))).toBe(1);
+    expect(compilesOf(servingCompiles, BROKEN_PROGRAM)).toBe(1);
+
+    // Final stability: the client never compiled a child; every served
+    // writeback routed as a completion (no unstamped refusal, ever).
+    expect(clientCompiles.length).toBe(parentCompiles);
+    stats = host.stats();
+    expect(stats.unstampedSealRefusals).toBe(0);
+    cancelDemand();
+  });
+
+  it("MID-COMPILE park: a request issued (pending) whose compile never completes on the first serving runtime — the space parks, the effect dies with the runtime — RESOLVES on re-activation: the fresh runtime re-fires the compile (§6 step 3) instead of wedging on a false memo-hit (the review's MAJOR-1 park case, live)", async () => {
+    host = newHost();
+    openClient();
+    const engine = await server.engineForSpace(space);
+
+    // The FIRST serving runtime holds its compile of the child program
+    // forever (the process-death stand-in — a real park disposes the
+    // runtime, and its outbox work with it). The issue lands durably
+    // (`pending=true`, `internal={requestHash}` — no resolution), the
+    // completion never comes.
+    let heldOnce = false;
+    holdCompile = {
+      activation: 1,
+      contents: childProgram(5),
+      held: () => {
+        heldOnce = true;
+      },
+    };
+
+    const parent = await clientRuntime.patternManager.compilePattern({
+      main: "/main.tsx",
+      files: [{ name: "/main.tsx", contents: PARENT_PATTERN }],
+    }, { space });
+    const argument = clientRuntime.getCell<{ code: string }>(
+      space,
+      "mid-compile-arg",
+      undefined,
+    );
+    const result = clientRuntime.getCell<{ compiled: CompiledView }>(
+      space,
+      "mid-compile-result",
+      parent.resultSchema,
+    );
+    await argument.sync();
+    await result.sync();
+    {
+      const seed = clientRuntime.edit();
+      argument.withTx(seed).set({ code: childProgram(5) });
+      expect((await seed.commit()).error).toBeUndefined();
+    }
+    {
+      const tx = clientRuntime.edit();
+      clientRuntime.run(tx, parent, argument, result);
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    const cancelDemand = result.sink(() => {});
+    await clientRuntime.idle();
+    await clientRuntime.storageManager.synced();
+    const compiled = () => result.key("compiled");
+    const answerOf = () =>
+      compiled().key("result").key("answer").get() as unknown as
+        | number
+        | undefined;
+
+    // The served issue lands and the (held) compile is entered on
+    // activation #1; the client sees the ISSUED state (pending=true, no
+    // result) — exactly the durable state a crash mid-compile leaves.
+    await waitUntil(
+      () => heldOnce && compiled().key("pending").get() === true,
+      "the first serving runtime to issue and enter the (held) compile",
+    );
+    expect(servingRuntimes.length).toBe(1);
+    expect(answerOf()).toBeUndefined();
+
+    // PARK mid-compile: the runtime (and its held effect) die.
+    await host.spaceServer(space)!.park("test-mid-compile-park");
+    await waitUntil(
+      () => host!.spaceServer(space)?.active !== true,
+      "space to park mid-compile",
+    );
+    // Re-activate on fresh input; activation #2 is a fresh runtime whose
+    // compile is NOT held.
+    holdCompile = undefined;
+    const poke = clientRuntime.getCell<{ n: number }>(
+      space,
+      "mid-compile-poke",
+      undefined,
+    );
+    {
+      const pokeTx = clientRuntime.edit();
+      poke.withTx(pokeTx).set({ n: 1 });
+      expect((await pokeTx.commit()).error).toBeUndefined();
+    }
+    const pokeSeq = Engine.serverSeq(engine);
+    await waitUntil(
+      () => host!.spaceServer(space)?.active === true,
+      "space to re-activate",
+    );
+    await waitUntil(
+      () => readWatermarkSeq(engine) >= pokeSeq,
+      "the recovered loop to claim the poke input",
+    );
+    expect(servingRuntimes.length).toBe(2);
+
+    // The fresh runtime's first evaluation of the durable mid-flight
+    // request RE-FIRES the compile (not a false memo-hit on an issued-but-
+    // unresolved request), re-arms, instantiates — and the client, reading
+    // through, sees the child land.
+    await waitUntil(
+      () => compiled().key("pending").get() === false && answerOf() === 5,
+      () =>
+        `the client to observe the child after the mid-compile park (pending=${
+          compiled().key("pending").get()
+        }, answer=${answerOf()})`,
+    );
+    // Exactly one REAL compile on the fresh runtime (the held one on
+    // activation #1 never completed); the client compiled none.
+    expect(compilesOf(servingCompiles, childProgram(5))).toBe(2);
+    expect(compilesOf(clientCompiles, childProgram(5))).toBe(0);
+    expect(host.stats().unstampedSealRefusals).toBe(0);
+    cancelDemand();
+  });
+});

--- a/packages/runner/test/executor-compile-and-run.test.ts
+++ b/packages/runner/test/executor-compile-and-run.test.ts
@@ -25,7 +25,15 @@
 //   clears, NO re-fire across further waves (input-driven retry, never a
 //   timer: the T14 posture), and a fixed program recovers;
 // - counters: misses/queued/completed and hits live; and the P7 symptom's
-//   own counter — `unstampedSealRefusals` — stays ZERO throughout.
+//   own counter — `unstampedSealRefusals` — stays ZERO throughout;
+// - SUPERSESSION (the independent review's MAJOR-A): A→B→A within A's
+//   compile duration — the re-issued A attaches to A's in-flight effect,
+//   whose completion must LAND (never return on a stale abort); and a
+//   completion that finds itself superseded writes nothing, releases its
+//   key, and is counted (`outbox.superseded`);
+// - FAN-OUT at cardinality 2 (the review's MAJOR-B): a NARROWED node
+//   (a per-user program) — one real compile, one effect completion + one
+//   instantiation per demanded instance, both instances land.
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
@@ -44,6 +52,7 @@ const spaceSigner = await Identity.fromPassphrase("compile and run space");
 const space = spaceSigner.did() as MemorySpace;
 const serviceSigner = await Identity.fromPassphrase("compile and run service");
 const aliceSigner = await Identity.fromPassphrase("compile and run alice");
+const bobSigner = await Identity.fromPassphrase("compile and run bob");
 
 const waitUntil = async (
   predicate: () => boolean,
@@ -75,6 +84,29 @@ const PARENT_PATTERN = [
   ");",
 ].join("\n");
 
+/** A parent whose compile-and-run node NARROWS to user (the review's
+ * MAJOR-B shape — the per-user code editor): the PROGRAM is the
+ * demander's PerUser draft, so the node reads a user-scoped value, its
+ * cells are per-instance, and it fans out once per demander. Two
+ * demanders holding the SAME program text share ONE compile (the process
+ * content cache) while each owns its effect completion + instantiation.
+ * (A per-user cell passed as the child's `input` does NOT narrow the
+ * node: the builtin hands the child a cell HANDLE, never reading the
+ * per-user value itself.) */
+const PER_USER_PROGRAM_PARENT = [
+  "import { compileAndRun, Default, pattern, PerUser, Writable } from 'commonfabric';",
+  "type Draft = Writable<string | Default<''>>;",
+  "export default pattern<{ code?: PerUser<Draft> }, { compiled: any }>(",
+  "  ({ code }) => {",
+  "    const compiled = compileAndRun({",
+  "      files: [{ name: '/main.tsx', contents: code! }],",
+  "      main: '/main.tsx',",
+  "    });",
+  "    return { compiled };",
+  "  },",
+  ");",
+].join("\n");
+
 const childProgram = (answer: number) =>
   [
     "import { pattern } from 'commonfabric';",
@@ -99,50 +131,78 @@ describe("stage C (OW28): compile-and-run served as an outbox effect", () => {
   let clientRuntime: Runtime;
   /** Compiles the SERVING runtime performed, per program main-file
    * contents (a counting wrapper over the real compile — never a stub:
-   * the child must really instantiate). */
+   * the child must really instantiate). Counts `compileOrGetPattern`
+   * CALLS — a content-cache hit counts too. */
   let servingCompiles: string[];
+  /** REAL compiles on the serving side (`compilePattern` — reached only
+   * on a genuine content-cache miss), per program main-file contents:
+   * the "exactly one compile per program per process" witness. */
+  let servingRealCompiles: string[];
   /** Compiles the CLIENT runtime's builtin path performed: must stay
    * empty (the client reads through, speculation.md §2). */
   let clientCompiles: string[];
   let created: Cell<any>[];
   /** Serving-runtime creations, in order (activation #1, #2, ...). */
   let servingRuntimes: Runtime[];
-  /** A HOLD on the serving side's compile (the mid-compile-park journey):
-   * when set, the serving runtime whose activation index matches holds
-   * its compile of the matching program on a promise the test never
-   * releases — the process-death stand-in (a real park disposes the
-   * runtime and its outbox work with it). */
+  /** Extra client runtimes (a second demander), disposed after each. */
+  let extraClients: Array<
+    { runtime: Runtime; manager: EmulatedStorageManager }
+  >;
+  /** A HOLD on the serving side's compile: when set, the serving runtime
+   * whose activation index matches holds its compile of the matching
+   * program. Without `release` the hold is forever — the process-death
+   * stand-in of the mid-compile-park journey (a real park disposes the
+   * runtime and its outbox work with it). With `release`, the compile
+   * RESUMES (the real compile runs) once that promise resolves — the
+   * supersession journeys, where the effect outlives its request. */
   let holdCompile:
-    | { activation: number; contents: string; held: () => void }
+    | {
+      activation: number;
+      contents: string;
+      held: () => void;
+      release?: Promise<void>;
+    }
     | undefined;
 
   const countCompiles = (
     runtime: Runtime,
     into: string[],
     activation: number,
+    realInto?: string[],
   ) => {
     const manager = runtime.patternManager as unknown as {
       compileOrGetPattern: (
         input: unknown,
         space?: MemorySpace,
       ) => Promise<unknown>;
+      compilePattern: (input: unknown, options?: unknown) => Promise<unknown>;
+    };
+    const contentsOf = (input: unknown) => {
+      const program = input as { files?: Array<{ contents?: string }> };
+      return program.files?.[0]?.contents ?? String(input);
     };
     const real = manager.compileOrGetPattern.bind(manager);
     manager.compileOrGetPattern = (input, targetSpace) => {
-      const program = input as {
-        files?: Array<{ contents?: string }>;
-      };
-      const contents = program.files?.[0]?.contents ?? String(input);
+      const contents = contentsOf(input);
       into.push(contents);
       if (
         holdCompile !== undefined && holdCompile.activation === activation &&
         holdCompile.contents === contents
       ) {
         holdCompile.held();
-        return new Promise<never>(() => {});
+        const release = holdCompile.release;
+        if (release === undefined) return new Promise<never>(() => {});
+        return release.then(() => real(input, targetSpace));
       }
       return real(input, targetSpace);
     };
+    if (realInto !== undefined) {
+      const realCompile = manager.compilePattern.bind(manager);
+      manager.compilePattern = (input, options) => {
+        realInto.push(contentsOf(input));
+        return realCompile(input, options);
+      };
+    }
   };
 
   const newHost = (
@@ -166,7 +226,12 @@ describe("stage C (OW28): compile-and-run served as an outbox effect", () => {
           },
         });
         servingRuntimes.push(runtime);
-        countCompiles(runtime, servingCompiles, servingRuntimes.length);
+        countCompiles(
+          runtime,
+          servingCompiles,
+          servingRuntimes.length,
+          servingRealCompiles,
+        );
         return {
           runtime,
           dispose: async () => {
@@ -181,9 +246,11 @@ describe("stage C (OW28): compile-and-run served as an outbox effect", () => {
   beforeEach(() => {
     server = newSharedServer({ subscriptionRefreshDelayMs: 0 });
     servingCompiles = [];
+    servingRealCompiles = [];
     clientCompiles = [];
     created = [];
     servingRuntimes = [];
+    extraClients = [];
     holdCompile = undefined;
   });
 
@@ -192,6 +259,10 @@ describe("stage C (OW28): compile-and-run served as an outbox effect", () => {
     host = undefined;
     await clientRuntime?.dispose();
     await clientManager?.close();
+    for (const extra of extraClients) {
+      await extra.runtime.dispose();
+      await extra.manager.close();
+    }
     await server.close();
   });
 
@@ -212,6 +283,21 @@ describe("stage C (OW28): compile-and-run served as an outbox effect", () => {
     // The client is never a serving activation (activation 0 matches no
     // hold): its compiles are only counted — and must stay at the parent's.
     countCompiles(clientRuntime, clientCompiles, 0);
+  };
+
+  /** A SECOND demander (fan-out cardinality 2): its own session, a plain
+   * flag-ON client, no piece-creation hook; its compiles count with the
+   * client's (and must stay at zero for the child). */
+  const openSecondClient = (signer: Identity): Runtime => {
+    const manager = EmulatedStorageManager.connectTo(server, { as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: manager,
+      experimental: { serverExecution: true },
+    });
+    countCompiles(runtime, clientCompiles, 0);
+    extraClients.push({ runtime, manager });
+    return runtime;
   };
 
   const compilesOf = (into: string[], contents: string) =>
@@ -559,5 +645,361 @@ describe("stage C (OW28): compile-and-run served as an outbox effect", () => {
     expect(compilesOf(clientCompiles, childProgram(5))).toBe(0);
     expect(host.stats().unstampedSealRefusals).toBe(0);
     cancelDemand();
+  });
+
+  /** Stand a piece up from the client with `code`, demanded by the
+   * client's root watch; returns the views the steps below poll. */
+  const standUpPiece = async (options: {
+    names: { arg: string; result: string };
+    code: string;
+    parentPattern?: string;
+    /** The parent's `code` is a PerUser cell (PER_USER_PROGRAM_PARENT):
+     * write it THROUGH the argument schema, into the writer's instance. */
+    perUserCode?: boolean;
+  }) => {
+    const parent = await clientRuntime.patternManager.compilePattern({
+      main: "/main.tsx",
+      files: [{
+        name: "/main.tsx",
+        contents: options.parentPattern ?? PARENT_PATTERN,
+      }],
+    }, { space });
+    const argument = clientRuntime.getCell<{ code: string }>(
+      space,
+      options.names.arg,
+      options.perUserCode ? parent.argumentSchema : undefined,
+    );
+    const result = clientRuntime.getCell<{ compiled: CompiledView }>(
+      space,
+      options.names.result,
+      parent.resultSchema,
+    );
+    await argument.sync();
+    await result.sync();
+    const writeCode = async (runtime: Runtime, code: string) => {
+      const arg = runtime === clientRuntime ? argument : runtime.getCell<
+        { code: string }
+      >(
+        space,
+        options.names.arg,
+        options.perUserCode ? parent.argumentSchema : undefined,
+      );
+      if (runtime !== clientRuntime) await arg.sync();
+      const tx = runtime.edit();
+      if (options.perUserCode) {
+        arg.key("code").withTx(tx).set(code);
+      } else {
+        arg.withTx(tx).set({ code });
+      }
+      expect((await tx.commit()).error).toBeUndefined();
+    };
+    await writeCode(clientRuntime, options.code);
+    {
+      const tx = clientRuntime.edit();
+      clientRuntime.run(tx, parent, argument, result);
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    const cancelDemand = result.sink(() => {});
+    await clientRuntime.idle();
+    await clientRuntime.storageManager.synced();
+    const compiled = () => result.key("compiled");
+    const answerOf = () =>
+      compiled().key("result").key("answer").get() as unknown as
+        | number
+        | undefined;
+    const pendingOf = () => compiled().key("pending").get();
+    const setCode = (code: string) => writeCode(clientRuntime, code);
+    const view = () =>
+      `pending=${pendingOf()}, answer=${answerOf()}, error=${
+        JSON.stringify(compiled().key("error").get())
+      }`;
+    return {
+      parent,
+      argument,
+      result,
+      compiled,
+      answerOf,
+      pendingOf,
+      setCode,
+      writeCode,
+      view,
+      cancelDemand,
+    };
+  };
+
+  it("SUPERSESSION (the independent review's MAJOR-A, probe P6): A→B→A within A's compile duration — the re-issued A attaches to A's still-in-flight effect (same key), so A's completion must LAND (its hash is current again at writeback), never return on a stale abort; pending clears and the child serves", async () => {
+    host = newHost();
+    openClient();
+    const A = childProgram(11);
+    const B = childProgram(12);
+    // Activation #1 holds A's compile until the test releases it — A's
+    // effect outlives two more requests (B, then A again).
+    let heldOnce = false;
+    const releaseA = Promise.withResolvers<void>();
+    holdCompile = {
+      activation: 1,
+      contents: A,
+      held: () => {
+        heldOnce = true;
+      },
+      release: releaseA.promise,
+    };
+    const piece = await standUpPiece({
+      names: { arg: "supersede-arg", result: "supersede-result" },
+      code: A,
+    });
+    // A is issued and its compile is entered (held).
+    await waitUntil(
+      () => heldOnce && piece.pendingOf() === true,
+      () => `A's issue + held compile (${piece.view()})`,
+    );
+    expect(host.stats().memo.inflight).toBe(1);
+
+    // B supersedes A: a NEW key — B's own effect compiles and LANDS while
+    // A's compile is still held (A's abort signal fires here at issue).
+    await piece.setCode(B);
+    await waitUntil(
+      () => piece.pendingOf() === false && piece.answerOf() === 12,
+      () => `B to land while A is held (${piece.view()})`,
+    );
+    expect(compilesOf(servingCompiles, B)).toBe(1);
+    // B's effect retired; only A's held effect is in flight.
+    await waitUntil(
+      () => host!.stats().memo.inflight === 1,
+      () => `B's effect to retire (inflight=${host!.stats().memo.inflight})`,
+    );
+    const queuedBeforeReissue = host.stats().outbox.queued;
+
+    // A AGAIN, within A's compile duration: the re-issue carries A's key,
+    // and the outbox's in-flight dedupe ATTACHES it to the held effect —
+    // no second admission, no second compile. The client observes the
+    // re-issue (pending=true) only after the wave that enqueued it
+    // committed and its effects were admitted (the wave cycle admits
+    // BEFORE reporting the commit for push), so the attach has happened
+    // by the time this wait returns.
+    await piece.setCode(A);
+    await waitUntil(
+      () => piece.pendingOf() === true && piece.answerOf() === undefined,
+      () => `A's re-issue to be observed (${piece.view()})`,
+    );
+    expect(host.stats().outbox.queued).toBe(queuedBeforeReissue);
+    expect(host.stats().memo.inflight).toBe(1);
+    expect(compilesOf(servingCompiles, A)).toBe(1);
+
+    // Release A's compile: the completion re-reads the CURRENT request
+    // (A again) and lands its re-arm; the derivation instantiates A. At
+    // eb6d1e4bb the completion returned on `signal.aborted` (aborted at
+    // B's issue) and wrote nothing — pending=true forever, no counter
+    // naming it (the wedge).
+    releaseA.resolve();
+    await waitUntil(
+      () => piece.pendingOf() === false && piece.answerOf() === 11,
+      () => `A to land after the release (${piece.view()})`,
+    );
+    expect(piece.compiled().key("error").get()).toBeUndefined();
+    // Exactly one compile of A ever ran (the re-issue attached, never
+    // compiled); the client compiled nothing; every effect retired; no
+    // completion was superseded (A was current again at its writeback).
+    expect(compilesOf(servingCompiles, A)).toBe(1);
+    expect(compilesOf(clientCompiles, A)).toBe(0);
+    expect(compilesOf(clientCompiles, B)).toBe(0);
+    await waitUntil(
+      () => host!.stats().memo.inflight === 0,
+      () => `every effect to retire (inflight=${host!.stats().memo.inflight})`,
+    );
+    const stats = host.stats();
+    expect(stats.outbox.queued).toBe(queuedBeforeReissue);
+    expect(stats.outbox.completed).toBe(queuedBeforeReissue);
+    expect(stats.outbox.failed).toBe(0);
+    expect(stats.outbox.superseded).toBe(0);
+    expect(stats.unstampedSealRefusals).toBe(0);
+    piece.cancelDemand();
+  });
+
+  it("SUPERSEDED COMPLETION: an effect whose request was superseded by the time it completes writes NOTHING (the landed successor stands, no wipe), RELEASES its key, and is COUNTED (`outbox.superseded`); the superseded program re-requested later lands from the warm process cache (its compile did run) with no new effect", async () => {
+    host = newHost();
+    openClient();
+    const A = childProgram(31);
+    const B = childProgram(32);
+    let heldOnce = false;
+    const releaseA = Promise.withResolvers<void>();
+    holdCompile = {
+      activation: 1,
+      contents: A,
+      held: () => {
+        heldOnce = true;
+      },
+      release: releaseA.promise,
+    };
+    const piece = await standUpPiece({
+      names: { arg: "superseded-arg", result: "superseded-result" },
+      code: A,
+    });
+    await waitUntil(
+      () => heldOnce && piece.pendingOf() === true,
+      () => `A's issue + held compile (${piece.view()})`,
+    );
+    // B supersedes A and lands.
+    await piece.setCode(B);
+    await waitUntil(
+      () => piece.pendingOf() === false && piece.answerOf() === 32,
+      () => `B to land while A is held (${piece.view()})`,
+    );
+    await waitUntil(
+      () => host!.stats().memo.inflight === 1,
+      () => `B's effect to retire (inflight=${host!.stats().memo.inflight})`,
+    );
+    expect(host.stats().outbox.superseded).toBe(0);
+
+    // A's compile completes AFTER B landed: its completion re-reads the
+    // current request (B), writes nothing — B's landed child is NOT
+    // wiped, its resolution stands — and the effect retires (its key
+    // released), counted as superseded.
+    releaseA.resolve();
+    await waitUntil(
+      () => host!.stats().outbox.superseded === 1,
+      () =>
+        `the superseded completion to be counted (superseded=${
+          host!.stats().outbox.superseded
+        })`,
+    );
+    await waitUntil(
+      () => host!.stats().memo.inflight === 0,
+      () => `A's effect to retire (inflight=${host!.stats().memo.inflight})`,
+    );
+    expect(piece.pendingOf()).toBe(false);
+    expect(piece.answerOf()).toBe(32);
+    expect(host.stats().outbox.failed).toBe(0);
+
+    // A requested again: the superseded effect DID compile A into the
+    // process cache before it found itself superseded, so this run
+    // instantiates straight from the warm cache — no new effect, no
+    // second compile — and lands. (Had A's key still been held by a
+    // wedged effect, a re-issue would have attached to it and never
+    // landed; the released key is what `memo.inflight === 0` witnessed.)
+    const queuedBefore = host.stats().outbox.queued;
+    await piece.setCode(A);
+    await waitUntil(
+      () => piece.pendingOf() === false && piece.answerOf() === 31,
+      () => `A to land on re-request (${piece.view()})`,
+    );
+    expect(host.stats().outbox.queued).toBe(queuedBefore);
+    expect(compilesOf(servingRealCompiles, A)).toBe(1);
+    expect(compilesOf(servingRealCompiles, B)).toBe(1);
+    expect(compilesOf(clientCompiles, A)).toBe(0);
+    expect(host.stats().unstampedSealRefusals).toBe(0);
+    piece.cancelDemand();
+  });
+
+  it("FAN-OUT cardinality 2 (the independent review's MAJOR-B): two demanders of a NARROWED compile-and-run node (a per-user program, the same text for both) — ONE real compile per program per process (content-cached), ONE effect completion + ONE instantiation PER DEMANDED INSTANCE: both instances land pending=false with the child; the effect key and the completion carry the instance, so the second demander's effect never dedupes against the first's and each completion lands on its own instance", async () => {
+    host = newHost();
+    openClient();
+    const bob = openSecondClient(bobSigner);
+    const A = childProgram(21);
+    // Activation #1 HOLDS the compile of A (releasable): both demanders'
+    // instances issue while the first effect is still in flight — the
+    // shape that wedged at eb6d1e4bb (the second issue aborted the first
+    // effect's signal at issue and deduped against its key).
+    let holds = 0;
+    const releaseA = Promise.withResolvers<void>();
+    holdCompile = {
+      activation: 1,
+      contents: A,
+      held: () => {
+        holds++;
+      },
+      release: releaseA.promise,
+    };
+    const piece = await standUpPiece({
+      names: { arg: "fanout-arg", result: "fanout-result" },
+      code: A,
+      parentPattern: PER_USER_PROGRAM_PARENT,
+      perUserCode: true,
+    });
+    // Alice's instance issues its effect (held).
+    await waitUntil(
+      () => holds >= 1 && piece.pendingOf() === true,
+      () => `alice's instance to issue (holds=${holds}, ${piece.view()})`,
+    );
+    expect(host.stats().outbox.queued).toBe(1);
+
+    // Bob's demand: the same space-scoped root watch every client holds —
+    // and his OWN per-user program (the same text as Alice's).
+    await piece.writeCode(bob, A);
+    const bobResult = bob.getCell<{ compiled: CompiledView }>(
+      space,
+      "fanout-result",
+      piece.parent.resultSchema,
+    );
+    await bobResult.sync();
+    const cancelBob = bobResult.sink(() => {});
+    await bob.idle();
+    await bob.storageManager.synced();
+    const resultId = piece.result.getAsNormalizedFullLink().id;
+    await waitUntil(
+      () => {
+        const demanded = host!.spaceServer(space)?.demandedIdentitiesOf(
+          resultId,
+        ) ?? [];
+        return [aliceSigner, bobSigner].every((signer) =>
+          demanded.some((i) => i.principal === signer.did())
+        );
+      },
+      () =>
+        "the registry to carry both root watchers (has " +
+        JSON.stringify(
+          host!.spaceServer(space)?.demandedIdentitiesOf(resultId),
+        ) +
+        ")",
+    );
+    const bobCompiled = () => bobResult.key("compiled");
+    const bobAnswer = () =>
+      bobCompiled().key("result").key("answer").get() as unknown as
+        | number
+        | undefined;
+    const bobPending = () => bobCompiled().key("pending").get();
+    const bobView = () => `pending=${bobPending()}, answer=${bobAnswer()}`;
+
+    // Bob's instance issues ITS OWN effect (the key carries the instance)
+    // while alice's is held: TWO admissions, two holds — never an attach.
+    // At eb6d1e4bb the second issue shared the first's key and attached
+    // to it (queued stayed 1) after aborting the first's signal.
+    await waitUntil(
+      () =>
+        host!.stats().outbox.queued === 2 && holds >= 2 &&
+        bobPending() === true,
+      () =>
+        `bob's instance to issue its own effect (queued=${
+          host!.stats().outbox.queued
+        }, holds=${holds}, bob: ${bobView()})`,
+    );
+
+    // Release: ONE real compile (the two effects single-flight on the
+    // content cache), TWO completions — each stamped with its instance —
+    // and BOTH instances land: each demander's client, reading ITS
+    // instance through the user-scoped links, sees pending=false and the
+    // child's value.
+    releaseA.resolve();
+    await waitUntil(
+      () =>
+        piece.pendingOf() === false && piece.answerOf() === 21 &&
+        bobPending() === false && bobAnswer() === 21,
+      () =>
+        `both instances to land (alice: ${piece.view()}; bob: ${bobView()})`,
+    );
+    expect(compilesOf(servingRealCompiles, A)).toBe(1);
+    expect(compilesOf(clientCompiles, A)).toBe(0);
+    await waitUntil(
+      () => host!.stats().memo.inflight === 0,
+      () => `every effect to retire (inflight=${host!.stats().memo.inflight})`,
+    );
+    const stats = host.stats();
+    expect(stats.outbox.queued).toBe(2);
+    expect(stats.outbox.completed).toBe(2);
+    expect(stats.outbox.failed).toBe(0);
+    expect(stats.outbox.superseded).toBe(0);
+    expect(stats.unstampedSealRefusals).toBe(0);
+    cancelBob();
+    piece.cancelDemand();
   });
 });


### PR DESCRIPTION
## Why

Under `EXPERIMENTAL_SERVER_EXECUTION`, fresh `compile-and-run` was INERT everywhere — the P7 independent review characterized it (verification-coverage.md OW28) as a **product regression relative to OFF**: on a flag-ON runtime whose tx carries no wave run context (every CLIENT run) the builtin set `pending=true` and RETURNED before launching the compile (no compile, no result, `pending` never clears); on the SERVER (wave-stamped run) the compile launched but its writebacks were unstamped floating transactions refused at the wave seal (`unstampedSealRefusals`). Every consumer — `fetchAndRunPattern` in `common-fabric.tsx` (the LLM/tool piece-instantiation flow), `compiler.tsx`, `write-and-run.tsx`, `email-pattern-launcher.tsx` — showed "compiling…" forever under ON. This is a **named flip blocker** (Phase 7's ordered gates, third after OW32 / OW17+OW29): the flip requires it working, with the ON skip list EMPTY.

This ports `compile-and-run` to be **served as an outbox effect** so fresh piece-creation works under the flag. Stacked on fan-out B (#5924); base `claude/server-exec-v2-fanout-b`.

## What

**The compile is an OUTBOX EFFECT; the instantiation is an ordinary consequence of the served graph run** (builtins.md §3). A served derivation MISS enqueues the compile effect (kind `compile-and-run`, memoized on the program hash via a `{ requestHash, resolvedHash, compiledHash }` memo cell); the `SpaceOutbox` performs it post-wave-commit; it lands a **marked COMPLETION commit** (`markEffectCompletion` — its own derived-class commit, never through §3d's sealing, never unstamped) that RE-ARMS the derivation (`compiledHash`). The derivation then reads the compiled pattern from the process cache and instantiates the child **in-run** (result-as-pattern shape, derivation-class setup, correctly scoped per demander); the child's body serves as ordinary derivations.

**Why the split** (a refinement of the register's "completion-class writeback" fix shape — recorded, not silently substituted): a post-commit flush that instantiated RACES the serving loop's own resume of the prior child (the loop re-runs a demanded piece from its stored `patternIdentity` pointer, and a flush's `run`/`runSynced` loses the re-instantiation to it — a program change kept serving the OLD child). Instantiating in the derivation is the loop's own run — atomic w.r.t. the loop's piece machinery — and it stores the pointer the loop resumes from on recovery.

**The client reads through for EVERY outcome** (speculation.md §2): a flag-ON non-serving run never compiles and writes NOTHING speculatively — not even the synchronous invalid-inputs/main-not-found outcomes (the server decides them identically and lands committed cells the hit rule reads through). A speculative `pending=true` echo only delayed the served `pending=false`; removing it fixed a flake.

**The §4 HIT rule keys on a `resolvedHash` marker**, not `pending`: the builtin's cell-init writes `pending=false` on a fresh closure's first run, so a pending-based hit FALSELY fires for a durable mid-compile request on recovery — the piece renders empty forever (the recovery-mid-flight wedge). `resolvedHash` is set on every terminal outcome and never by init.

**Failure** (T14): a compile error lands an error-shaped result keyed by hash; retry is input-driven (a new hash), never a timer. **Recovery**: a LANDED piece is re-used; a mid-flight request re-misses and re-fires (§6 step 3) — every park / crash / dropped-or-refused completion ends the serving runtime and the fresh one re-fires; a re-arm whose process compile-cache entry was evicted also re-fires rather than wedging.

**Root defect fixed in passing:** `createRef({ src: program })` — the content-cache key — is INSENSITIVE to nested `contents` on the `asSchema` query-result proxy (two distinct programs collapsed to one key, so a re-compile got the PRIOR program), even though `hashOf` reads the proxy correctly. The served path normalizes to a plain object (`plainProgramOf`) for both the compile and the sync lookup (`PatternManager.getCompiledPatternForProgramSync`, new).

**OFF arm byte-identical:** the port is a distinct `on` branch; the OFF path is the extracted-verbatim `compileAndRunOff` (floating compile promise, in-memory `previousCallHash` dedupe, `pieceCreatedCallback` at compile completion). The `internal` memo cell and its sync are gated on `on`.

Docs: verification-coverage.md OW28 → LANDED (delta with the refinement + root defect); builtins.md §3 served shape; the plan's Phase-2 tick and flip-gate item 3. **Skip list:** no ON entry cited compile-and-run / piece-creation (the entries are OW30 / OW32 / OW33) — nothing to retire.

## Verification

- **spec-model** 23/0; **repo typecheck** (`tasks/check.sh`), `deno fmt`, `deno lint`, `check-docs` (548 blocks) green.
- **Full runner suite green** (final tree, after the review fixes) in 4 alphabetical chunks: [a-f]+scheduler/ 407 (3616 steps), [g-m] 331 (726), [n-r] 203 (825), [s-z] 274 (1540) — **1215 cases, 0 failed**. `SCHEDULER_LIVENESS_EQUIVALENCE=1` on the compile-and-run suites: clean (the instantiation uses `runtime.run` — no new demand-root/effect-status flip).
- **Unit pins** (`compile-and-run.test.ts`, bare runtime, REAL compiles — 7): compile-as-effect / not-from-action + re-arm + first instantiation + memo-hit; **recovery mid-flight re-fire** (mutation-verified: pending-based hit → red); **cache-eviction re-fire** (mutation-verified); the client read-through incl. sync outcomes (mutation-verified); the failure leg; OFF-arm neutrality.
- **E2E** (`executor-compile-and-run.test.ts`, live SpaceServer + flag-ON client — 2 steps): (1) the piece-creation flow END TO END — client authored creation + demand → served miss → outbox → compile → completion → the client reads through to the child (**never compiling**); a program change re-compiles once and re-instantiates with the **new value**; recovery re-uses; the failure leg lands error-shaped with **no timer retry** (3 driven waves); the piece-creation hook fires once; **`unstampedSealRefusals` stays ZERO** (the P7 symptom's own counter). (2) **MID-COMPILE PARK** — the first serving runtime's compile is held, the space parks mid-compile, the fresh runtime re-fires and the client sees the child (mutation-verified: the pending-based-hit mutant reproduces the wedge signature).
- **Serving-loop soak:** `executor-compile-and-run.test.ts` 10/10 (three soaks across the iterations, latest with both steps); existing `executor-serving-loop.test.ts` 6/6.

## Flags

Per flag-don't-fill — refinements recorded, none blocking the dark landing:

1. **Fix-shape refinement: instantiation in the DERIVATION, not a completion flush.** The register said "the instantiation landing as a COMPLETION-CLASS stamped writeback"; the completion instead RE-ARMS and the derivation instantiates in-run (the loop's child-resume race, above). Ratify, or direct a completion-flush instantiation with an explicit anti-race.
2. **`resolvedHash` (a resolution marker) vs `pending` for the §4 hit**, because the OFF-shared cell-init clobbers `pending=false`. Not changing the init keeps the OFF arm byte-identical. Ratify the marker, or direct an ON-only init change.
3. **Live-runtime completion-commit failure (no park) stays pending until re-activation or an input change** — the request-hash builtins' identical posture (fetch's in-memory claim). The self-review asked for a dirtiness-driven re-issue on the warm runtime; not filled (an unstated semantic; a re-issue loop on deterministic failures). Ratify the parity, or rule a warm-runtime re-issue for all effect builtins.
4. **`plainProgramOf`** works around a `createRef`-on-proxy content-insensitivity that also affects `compileOrGetPattern`'s own dedupe when handed the proxy. Should `createRef` or `compileOrGetPattern` normalize at the source? (Out of scope here.)
5. **Recovery re-instantiation cost (observation, shared with every effect builtin):** the memo cell is unlinked and only `.sync()`ed at init, so a fresh serving runtime's first evaluation reads it unsynced and re-misses deterministically (T10.Q4's at-least-once) — for compile-and-run that is a re-compile + a brief re-instantiation of a LANDED child on every restart. Correctness holds (`resolvedHash`); the cost is the same class as fetch's re-fetch. Worth a pre-sync/link ruling for the effect builtins as a family.
6. **`effectMemoObserver` reports a hit for any resolved request** (incl. sync outcomes / error landings), consistent with §7's "stored-key resolutions"; noted in case the counter should count successful compiles only.

## Self-review

An adversarial subagent reviewed the full diff (memo/dedupe under crash schedules, completion routing, read-through, OFF-arm neutrality, test vacuity); report + author resolutions at the worktree channel `../stage-c-ow28-review-report.md`. It found **1 MAJOR, 3 MINOR, 3 NIT — all addressed**: MAJOR-1 (a stuck-pending same-hash request; the "pending co-write invariant is false" observation) → the `resolvedHash` hit + the recovery re-fire, pinned unit + LIVE (mid-compile park), with the no-park live-failure residual stated as fetch parity (Flags 3); MINOR-2 (client wrote sync outcomes) → gate moved above them, pinned; MINOR-3 (cache eviction wedge) → explicit re-fire, pinned; MINOR-4 (`waveRunContextOf` → `servingPosture`) → precondition documented + the `unstampedSealRefusals === 0` pin; NIT-5 (vestigial stamping) → removed; NIT-6 (coverage) → the park step + pins; NIT-7 (`internal` unlinked dependency) → no longer a correctness dependency (Flags 5). Confirmed sound: OFF-arm neutrality, completion marking on every writeback, supersession, `plainProgramOf`, async tracking, no unused imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

