### PR TITLE
fix: server-execution v2 stage C — served-wish timing (lunch gate) + the arrival-gate revisit

### DIFF
--- a/docs/specs/server-side-execution/speculation.md
+++ b/docs/specs/server-side-execution/speculation.md
@@ -178,6 +178,30 @@ prototype, 2026-08-16): 45–56 k → 55–137 client action runs per
 5-minute two-browser gate, zero non-settling episodes, `runtime:idle`
 resolving, both two-browser gates booting in < 3 s.
 
+Revisited at Stage C (2026-08-17) against fan-out A/B's per-demander
+run supply and the F2 transient-demander preflight — VERDICT KEEP, no
+code change. Those are SERVER-side fixes (they make the per-user
+instance get SERVED and RE-ARMED); this gate is CLIENT-side and treats
+the orthogonal symptom — an echo must not retire on watermark COVERAGE
+before the authoritative value ARRIVES at this client's replica, the
+frame-coupling window stated above as an assumption — so the server
+supply does not subsume it (a serving runtime never speculates and
+never reaches this gate; a server change that guaranteed same-frame
+delivery of value + watermark for every watched instance would shrink
+the window, and is the arrival re-sweep already named above, but none
+of A/B/F2 is that change). The gate remains the client's backstop for
+the design's first-demand transient (§E residual 1) and walk-coverage
+gap (§E residual 4), which persist as fan-out B's own residuals; the
+OW32-shape pin's gate-removed mutation shows the retire-to-nothing loop
+returning without it, and the Stage-C live instrumentation saw the gate
+holding echoes in exactly its window. One EDGE is recorded, not ruled:
+a LATE echo of a non-idempotent handler (a cascade run that sealed after
+the served consequence had already landed at this client) is divergent
+by construction and its written doc's confirmed seq sits below the
+entry's floor for good, so the gate keeps it indefinitely — a rule for
+echoes of already-consequenced intents is owed (verification-coverage.md's
+Stage-C delta).
+
 ## 5. Offline
 
 - Events accumulate locally in fired order (events.md §5), speculation

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -2767,7 +2767,237 @@ Delta 2026-08-15 — Phase 6 independent-review fixes (same PR):
   (or the pattern's `if (!now) return` guard reading a wall clock the
   serving runtime supplies) — plus the pre-existing
   client-instantiate-vs-server-derive race at piece creation (the
-  300 ms demand-wake grace mitigates, does not close it; residual x).**
+  300 ms demand-wake grace mitigates, does not close it; residual x).
+  **STAGE C RE-CHARACTERIZED THE LUNCH RESIDUAL (2026-08-17), REFUTING
+  the served-wish/`nowTick` premise above.** Evidence: 5 instrumented
+  fresh-store runs on the ON binary (the serving loop's dispatch/drain/
+  wave-close, the client overlay's seal/sweep/arrival gate, and a
+  `castVote` probe read from the SERVING runtime's log — the browsers'
+  worker consoles were captured separately) plus store forensics on the
+  2 un-instrumented clean runs and on the fixer's preserved RED store.
+  Established (each item's discriminator named):
+  - `nowTick` is NOT null/stale. The served `#now/300` interval timer
+    arms on the serving runtime and writes valid coarsened ticks (the
+    store's tick doc advances `…600000 → …900000` by derived-class
+    commits), and EVERY served `castVote` run in the probe read a
+    current `nowTick`; every vote doc the served runs wrote carries a
+    valid `castAt` (the fixer's RED store: both votes, `castAt`
+    `1787005500000`). `castVote` does not no-op — it TOGGLES (below).
+    The supply half is now durably pinned by `executor-serving-loop.
+    test.ts` "SERVES an interval #now/1 wish" (a served host on the real
+    clock: the timer arms server-side and a served run reads a current,
+    advancing coarsened instant — the advancing tick's revision is
+    derived-class under the space server's holder). The HANDLER-AT-
+    DISPATCH read (F4's precise hypothesis) is pinned too:
+    `executor-events-down.test.ts` "a SERVED handler bound to an
+    interval-#now derivation reads a CURRENT nowTick at dispatch" — an
+    ON client fires the durable event, the drain dispatches it, and the
+    served handler writes the bound `nowTick` it read (or a `-1`
+    sentinel when null) into the argument doc: a coarsened current
+    instant lands, in a derived commit consequencing the event;
+    mutation (the handler writes `-1`) → RED.
+  - The real residual is a served castVote **DOUBLE DISPATCH of ONE
+    durable event** (never a second event, never a second stream). Per
+    click the store holds exactly ONE castVote sidecar entry (clean run
+    1: `f3f7bd73` Alice green, `5c2d7a90` Bob green, `bcc76f69` Bob red
+    — one sidecar `izXSNtW1rR…`, one entry each; the entry's eventId is
+    minted ONCE at the emitting run's LT1 send, `cell.ts:1718`), and
+    that ONE event id is consequenced by 2–5 derived commits, i.e. the
+    served handler RAN 2–5 times for one click. The runs alternate
+    CAST/TOGGLE-OFF (`main.tsx` `castVote`'s `sameColorToday` arm), so
+    the durable outcome is the INTERLEAVING of the duplicate runs — the
+    parity of the run count in the common case; two duplicates dispatched
+    together can read the same pre-state and toggle the same way.
+    Observed served run counts per click: clean run 2 — Bob 2 (cast, off
+    → LOST), Alice 4 (cast, off, cast, off → LOST) → RED at "option B"
+    (both greens gone; the merge had passed on the transient "2 love
+    it"); clean run 1 — Alice 3 (cast, off, cast → kept), Bob 5 (cast,
+    off, cast, off, off — the last two read the same view → LOST) → RED;
+    the served-runtime probe: Bob 4 / Alice 5 (one run), Alice 3 / Bob 1
+    (another). The review's swatch flip is the same alternation seen
+    through the swatch VDOM.
+    (The `castVote` stream being referenced at two sites — the exported
+    API `main.tsx:2035` and the child-card arg `:1664` — is NOT the
+    mechanism: both are links to the same stream cell, and removing the
+    export in one experiment did not stop the multiple runs — Alice's
+    handler still ran 3×; the merge passed only because 3 is odd.)
+  - MECHANISM (the exact path, `cell.ts`/`space-server.ts` at the tip):
+    a served click handler's `castVote.send()` takes the LT1 same-space
+    arm (`cell.ts:1703-1819`): it writes the durable entry into its own
+    tx (`:1776-1783`) AND queues the event IN-PROCESS for same-wave
+    processing (`:1799-1819` — no `streamEntry` on that queue: "the
+    batch owns the mark"). If that in-process run does not happen
+    before the wave seals (the flush deadline — `wavesBudgetExhausted`
+    ≈ `waves` on this gate, `space-server.ts:2702-2708`), (α) the event
+    STAYS in the scheduler's queue and runs in a LATER wave carrying no
+    `streamEntry`, so its consequences commit UNMARKED (the batch marks
+    only entries APPENDED in that wave, `wave.ts:2137-2239`; the
+    stamper's mark needs `streamEntry`, `space-server.ts:1159-1180`);
+    and (β) the wave that appended the entry re-arms the scan
+    (`:2951-2962`), so the next drain (`#drainStreamEvents`, `:1791`;
+    `selectPendingStreamEventDocs` = the STORE's unconsequenced entries)
+    queues the SAME event id again WITH a `streamEntry` (`:1920-2016`)
+    — the second run. Both are diag-witnessed (DIAG-DISPATCH: the same
+    id once without and once with `streamEntry`; e.g. Bob's `1e731bc9`
+    LT1-queued at 51.1 s, wave sealed 56.08 s, in-process run 56.09 s,
+    drain re-queue 60.10 s, both committed in wave 78 as cast+off). A
+    second variant needs no cascade: an entry the drain queued but the
+    scheduler had not yet run when the cycle ended is queued AGAIN by
+    the next cycle's drain when the scan is re-armed — and the re-arm
+    doors are many: the post-commit re-arm at ANY committing wave close
+    with a drained-but-unrun entry still pending (`:2951-2962`), any new
+    event append (`:1717-1720`), `#armDeferredRescan` (`:1607`), and a
+    feed record while deferrals are outstanding (`:1725-1730`) — where
+    `#eventDeferrals` is cleared only at activation (`:700`), drop
+    (`:1992`) and non-deferred failure (`:2006`), NEVER on a later
+    success, so after one deferral (routine at piece start) EVERY feed
+    record re-arms the scan for the life of the activation (a small leak
+    of its own; why the re-scan is near-continuous on this gate) —
+    witnessed on a directly-bound handler (`9f8b1916` drain-queued twice
+    at 22.28 s and 22.52 s, dispatched twice, one wave). The design
+    comment covers
+    the REQUEUED case ("a requeued run leaves the entry unmarked and the
+    next wave's drain re-runs it (C8b)", `cell.ts:1784-1798`) but
+    nothing removes an UNRUN in-process LT1 event at wave close, and
+    nothing dedupes the drain's dispatch against an event already queued
+    or already run in the still-open wave. `space-server.ts:1182-1188`
+    already names "consequences committing unmarked → re-run on the next
+    drain → double consequences" as the class to prevent — this is that
+    class through two other doors.
+  - OFF-ARM PARITY: under OFF the same pattern is exactly-once BY
+    CONSTRUCTION — a client `send` from a handler takes the plain
+    `queueEvent` (`cell.ts:1918`) into the ONE in-process queue
+    (`scheduler/events.ts:330 queueSchedulerEvent` → one
+    `findEventHandler` registration per stream link, `:347`); there is
+    no durable-entry/drain second path, and two links to one stream
+    resolve to one handler. No dedupe mechanism exists because none is
+    needed. The OFF-arm lunch gate PASSES 9–11 s (the wall triage's OFF
+    runs). So the served path's second producer (durable entry + drain)
+    beside the in-process queue, with no dedupe between them, is a
+    served-execution PARITY GAP — a defect of the serving loop, not a
+    pattern bug.
+  - A SECOND, CLIENT-side mechanism rides the same runs — independent
+    of the double dispatch and enabled by residual x: the client's LATE
+    speculative echo of its own click's cascade. When the client's local
+    dispatch of the click is delayed past the server's round trip (the
+    RED runs' "both cast green concurrently" step took 15–20 s versus
+    0.5–2.5 s in green runs — the browser was mid re-fetch/piece-restart
+    churn; the overlay seal of Alice's castVote echo landed 3–4 s AFTER
+    the server's consequence commit had already been applied to her
+    replica: entry floor 78 vs her vote doc's `confirmedSeq` 77 in the
+    instrumented run), the echo runs against a replica that ALREADY
+    holds its own vote, so the non-idempotent handler computes the
+    TOGGLE-OFF — a DIVERGENT echo whose written vote doc sits at
+    `confirmedSeq` < the entry's floor. The arrival gate (working as
+    specified) then KEEPS it — indefinitely, since the server never
+    rewrites that doc — and the client renders a state the store never
+    held: the fixer's own RED run 1 (`gate/store-lunch1`, preserved) has
+    NO server-side loss at all (Alice 1 run, Bob 3 → both KEPT, store
+    "2 love it") yet its host showed "1 love it" / swatch [Bob] / "1
+    votes today" for 300 s; the instrumented run 1's host showed "0
+    votes today" for 120+ s while the store held Alice's vote. So the
+    gate's bimodality has TWO independent coins: the parity of the
+    served run count (store-side) AND whether the client's echo ran
+    before or after the served consequence (client-side). This is an
+    ARRIVAL-GATE EDGE, recorded in the Part 2 revisit (KEEP, edge
+    flagged for a ruling — not filled here): an intent-origin cascade
+    echo whose parent intent was ALREADY consequenced when the echo
+    sealed is a re-derivation of a served intent; a candidate rule is to
+    not register (or to retire at seal) such an echo, which is a
+    speculation.md §4 semantic the spec does not state.
+  - The `events.processed`/`events.appended` counters are NOT a
+    discriminating signature: `processed` counts drain queueings
+    (`:2024`) and re-drains, `appended` counts feed-notified/activation
+    appends (`:707`, `:1719`) — an LT1 cascade processed in-wave counts
+    in neither, so a gap also arises from ordinary re-drains. (Corrects
+    the earlier Stage-C wording; the run counts above are the evidence.)
+  - Secondary, unchanged: residual x — the pre-existing
+    client-instantiate-vs-server-derive race at piece creation
+    (`piece-start-commit-failed` ×4 + one deferred-start ConflictError +
+    the ~6 s `compile-cache-hit` re-fetch churn per run; the 300 ms
+    demand-wake grace softens, does not close). It does not gate the
+    merge here.
+  - Same class elsewhere: the two-browsers gate's admin-lockdown toggle
+    (`cfc-group-chat-demo/trusted.tsx:667 commitTrustedAdminToggle`,
+    bound DIRECTLY to the checkbox `onClick` at `:947`/`:1022` — the
+    click, not `cf-checkbox`'s `cf-change`, so the event carries no
+    `detail.checked` and `:692`'s fallback takes the toggle branch
+    `!chatAdminEveryoneIsAdmin(adminRegistry)`) flips BACK under a
+    double dispatch — it is exposed to the second (re-drain) variant only
+    (no LT1 cascade), the same class; a ruling on the delivery invariant
+    covers both.
+  - Gate status: the un-instrumented lunch gate is 0/2 green at Stage C
+    (both RED by the run-count interleaving above; the fixer's preserved
+    RED run is RED by the client-side stranded echo alone); the 5
+    instrumented runs reached the vote steps green twice and RED three
+    times (none counted as gate-green). The lifting condition (≥2/2
+    fresh-store green) is not met — the skip STAYS.
+  - DISPOSITION: FLAG, do not fill (owner ruling OWED). NOTE the lift
+    condition (≥2/2 green) needs BOTH coins: this dossier's ruling (the
+    server-side double dispatch) AND the client-side late-echo edge filed
+    under the Part 2 revisit below. Three candidate resolutions for the
+    server-side coin, costs stated, none chosen here:
+    - (i) the serving loop dedupes dispatch per event id across its two
+      queue paths — parity with OFF's single queue: (α) at the wave's
+      DEADLINE decision (`:2702-2708`, synchronously — the scheduler
+      keeps executing through `await commitWave` at `:2925`, so a purge
+      after it can lose the race to the leftover's next turn), purge
+      from the scheduler queue every LT1 in-process cascade event that
+      did not run — the discriminator is `served !== undefined &&
+      served.streamEntry === undefined` (a plain in-process event on the
+      serving runtime carries no `served` and no durable entry and must
+      never be purged); its durable entry is the truth and the next drain
+      re-runs it WITH a `streamEntry`, so the mark lands — the fallback
+      `cell.ts:1784-1798` already intends; (β) the drain skips an entry
+      whose id is already queued, or already ran in the still-open wave,
+      ONLY when that other copy carries a mark path (a `streamEntry`-
+      bearing dispatch) — never on the strength of a `streamEntry`-less
+      LT1 leftover, which cannot mark (skipping for it would leave the
+      entry unmarked and re-drained the NEXT wave: the double one wave
+      later); and "already queued" must include shaper-HELD events
+      (renderer-trusted click events take `holdShapedEvent` and sit
+      outside `eventQueue` until released — a queue-only walk misses
+      them, the pre-existing blind spot `transientEventDemandersFor`
+      shares). Cost: a scheduler queue inspect/remove seam keyed on
+      eventId (`transientEventDemandersFor` already walks `eventQueue`;
+      `dropQueuedEvent` exists) that also sees the shaper's held set, a
+      deadline-time hook, a per-wave dispatched-id set cleared on
+      close/abort. Risk, stated: (α)'s safety holds for EVENT-HANDLER
+      emitters (the append and the emitter's own mark ride one tx; a
+      requeue withdraws whole and the parent's re-run re-emits under a
+      fresh id — C8d) but NOT for DERIVATION-kind LT1 emitters
+      (`cell.ts:1692`/`:1726` admit them): a derivation's sidecar append
+      on a conflicted doc is dropped per-doc as superseded (`wave.ts:
+      1420-1429`, "re-arms nothing"), nothing re-emits, so a purge would
+      lose that event silently — today it runs as an ORPHAN consequence
+      (zero durable entries, one delivery: the same invariant broken
+      from the other side), which (ii)'s sentence must also decide.
+      Contained to `space-server.ts` + a facade helper; OFF byte-identical
+      (both seams behind the serving posture);
+    - (ii) events.md §4 states the invariant — "one durable entry = one
+      COMPLETED delivery to its handler, regardless of dispatch path or
+      reference count (a requeued run is legitimately re-delivered by
+      the drain); an entry not completed in the wave that appended it is
+      dispatched by the drain alone; and a delivery with no durable entry
+      is [refused | tolerated as an orphan] (the derivation-emitter case
+      above, to be decided)" — and the drain enforces it (= (i) with the
+      sentence written down; §4 today states exactly-once only via the
+      consequenced mark on the drain path); cost: (i) + spec sentence +
+      register row;
+    - (iii) patterns must make handlers idempotent (castVote's toggle is
+      the pattern's bug) — the harshest; it contradicts the OFF arm
+      (exactly-once by construction, gate green with this pattern), and
+      would make every non-idempotent handler (append/increment/toggle)
+      wrong under serving, which events.md §4's exactly-once exists to
+      prevent.
+  - RECOMMENDATION (the implementer's, not a decision): (ii) — state the
+    invariant (with the orphan-delivery clause decided) and enforce it
+    via (i)'s two seams as sharpened above; NOT (iii). Evidence: OFF
+    parity; `space-server.ts:1182-1188`'s own statement of the class;
+    the LT1 fallback comment intending the drain as the one re-run path.
+    Papering it in the pattern is refused; a blind dedupe without the
+    stated invariant risks the legitimate same-wave LT1 cascade path.
+    The skip entry names this mechanism.
 - OW34 — a CFC-serving POLICY item: served handler runs carry NO
   renderer-trusted event mark, so a per-user served handler's write to a
   UI-contract-gated (owner-protected) cell is refused by CFC at prepare
@@ -3219,6 +3449,90 @@ supply; OW29/OW32/OW34 closed):
   draft) — a recurrence in CI is evidence about B7 (a keyed cascade
   not dirtying a walk instance) and should be read as such, not
   retried.
+
+Delta 2026-08-17 — Stage C follow-ups (the lunch residual + the
+arrival-gate revisit):
+
+- OW32's lunch residual RE-CHARACTERIZED (the row above carries the
+  full dossier): the served-wish/`nowTick` premise is REFUTED; the
+  residual is a served castVote DOUBLE DISPATCH of one durable event
+  (the LT1 in-process leftover + the drain, and the drain re-scan) whose
+  alternating cast/toggle-off runs make the durable tally a parity
+  question. The skip STAYS (0/2 clean runs green), the mechanism is
+  FLAGGED with three costed resolutions and a recommendation for the
+  owner, and the served `#now` SUPPLY is pinned positively —
+  `executor-serving-loop.test.ts` "SERVES an interval #now/1 wish": a
+  served host on the real clock arms the interval timer server-side and
+  a served run reads a current, advancing `nowTick`, the advancing
+  tick's revision derived-class under the space server's holder — and
+  the HANDLER-at-dispatch read is pinned in `executor-events-down.
+  test.ts` "a SERVED handler bound to an interval-#now derivation reads
+  a CURRENT nowTick at dispatch" (mutation: a `-1` null-sentinel write →
+  RED). No spec sentence (test pins + register correction; no new
+  binding claim).
+- Register STALENESS corrected: OW17's "a reliable MWISH pin is OWED as
+  a served-host wish E2E" — that pin LANDED on the fan-out-B tip as
+  `f5a0cac5c` (`executor-cross-space.test.ts` "a wish sidecar's OWN
+  actions are demanded through the wish's OWNING piece root"); the row
+  text above is left as history, this delta records the landing.
+- **THE CLIENT ARRIVAL GATE (speculation.md §4) — REVISITED ON
+  EVIDENCE, VERDICT: KEEP.** The question the revisit answers: now that
+  fan-out A/B supply per-demander runs and the F2 transient-demander
+  preflight re-arms a served handler's not-current instances, is the
+  client arrival gate redundant or subsumed? It is NOT. The gate is
+  CLIENT-side (it lives in the non-serving overlay's `#sweep`,
+  `overlay-destination.ts:1010-1031`; serving runtimes never speculate,
+  so they never reach it — `runtime.ts:1897-1899`
+  `#speculationDestination` returns undefined under the serving
+  posture); every fan-out fix — the arrival RE-ARM
+  (`scheduler/facade.ts:845 invalidateActionsForDemandRoots`, called
+  from `space-server.ts`), the per-demander run supply, the F2
+  `rearmNotCurrentFanOutForActor` (`facade.ts:940`, wired only under
+  the serving posture) — is SERVER-side. They fix the CAUSE (per-user
+  instances are served / re-armed on the server); the gate treats the
+  CLIENT-side SYMPTOM (an echo must not retire on watermark COVERAGE
+  before the authoritative value ARRIVES at this client's replica), the
+  frame-coupling window §4 already states as an ASSUMPTION. Stated
+  precisely: no server-side SUPPLY change lands the value in the
+  client's replica frame-coupled to the covering watermark; a server
+  change that guaranteed same-frame delivery of value + watermark for
+  every watched instance would SHRINK the window (and is the "arrival
+  re-sweep" follow-up §4 already names), but none of A/B/F2 is that
+  change. Evidence for KEEP: (1) LIVE — under the full ON posture on the
+  lunch gate the Stage-C client-overlay instrumentation showed the gate
+  HOLDING per-user echoes whose written instance had `confirmedSeq` 0
+  (never served yet) or `< floor` (arrived a frame late) — exactly its
+  window; (2) UNIT — the OW32-shape pin in
+  `speculation-arrival-gate.test.ts` carries the gate-removed mutation
+  (`arrived` check dropped → the entry retires to nothing → the
+  retire-to-nothing loop returns); the other two pins (own-retirement
+  source; supersede-by-newer) pin the gate's RIDERS with their own
+  mutations, not the gate's removal; (3) the design's §E residuals the
+  gate backstops — residual 1 (the first-demand transient) and residual
+  4 (a walk-coverage gap) — PERSIST as fan-out B's own documented
+  residuals (OW17 viii/ix + F2's transitive not-current-for-actor gap);
+  post-B the loop the gate prevents is a bounded transient for a served
+  instance and unbounded only for a never-served one — still the case
+  the gate exists for. No SIMPLIFY keeps the OW32-shape pin green.
+  (4) ONE EDGE OBSERVED, FLAGGED, NOT FILLED (it needs a ruling on
+  late-echo semantics, and it is orthogonal to the KEEP question — the
+  loop returns without the gate either way): a LATE speculative echo of
+  a NON-IDEMPOTENT handler — the client's local cascade run of its own
+  click, delayed past the served consequence (residual x's re-fetch
+  churn) — computes a DIVERGENT result against a replica that already
+  holds the authoritative write, and the gate strands it indefinitely
+  (its written doc's `confirmedSeq` is below the entry's floor and the
+  server never rewrites the doc). Evidence: the fixer's RED lunch run 1
+  (store correct, host rendering "1 love it"/[Bob] for 300 s) and the
+  Stage-C instrumented run 1 (floor 78 vs `confirmedSeq` 77 on Alice's
+  vote doc; host "0 votes today" for 120+ s). Candidate rule (an owner
+  call): an intent-origin echo whose parent intent is already
+  consequenced at seal is not registered (or retires at seal) — the
+  served consequence IS the authoritative run of that intent. Recorded
+  in the OW32 row's dossier as the second lunch coin.
+  Verdict recorded; NO code change (KEEP). speculation.md §4 gains the
+  Stage-C revisit sentence (the server supply does not subsume the
+  client gate; the late-echo edge named).
 
 ## 4. Standing rule
 

--- a/packages/runner/test/executor-events-down.test.ts
+++ b/packages/runner/test/executor-events-down.test.ts
@@ -118,6 +118,27 @@ const BUMP_PATTERN = [
   ">(({ value }) => ({ value, bump: bump({ value }) }));",
 ].join("\n");
 
+// Stage C (verification-coverage.md OW32): a served HANDLER bound to an
+// interval-`#now` derivation records what it READ at dispatch. The lunch
+// residual was mis-attributed to "the served handler reads `nowTick` null
+// at dispatch and no-ops"; this pins the read itself: the handler writes
+// the bound `nowTick` (or -1 when null) into the argument doc.
+const NOW_READ_PATTERN = [
+  "import { computed, handler, pattern, Stream, wish, Writable } from 'commonfabric';",
+  "const record = handler<",
+  "  unknown,",
+  "  { nowTick: number | null; value: Writable<number> }",
+  ">((_ev, { nowTick, value }) => { value.set(nowTick ?? -1); });",
+  "export default pattern<",
+  "  { value: Writable<number> },",
+  "  { value: number; nowTick: number | null; record: Stream<unknown> }",
+  ">(({ value }) => {",
+  "  const nowWish = wish<number>({ query: '#now/1' });",
+  "  const nowTick = computed(() => nowWish.result ?? null);",
+  "  return { value, nowTick, record: record({ nowTick, value }) };",
+  "});",
+].join("\n");
+
 const CASCADE_PATTERN = [
   "import { handler, pattern, Stream, Writable } from 'commonfabric';",
   "const secondHandler = handler<unknown, { value: Writable<number> }>(",
@@ -365,6 +386,83 @@ describe("Phase 3 events-down (serving side)", () => {
       "the durable-ack settle callback",
     );
     expect(ackStatus).not.toBe("error");
+    cancelDemand();
+  });
+
+  it("a SERVED handler bound to an interval-#now derivation reads a CURRENT nowTick at dispatch — never null (Stage C, verification-coverage.md OW32: the handler-read half of the refuted served-wish-timing premise)", async () => {
+    // Real clock (this file is in clock-preload.ts `realClockFiles`), so the
+    // interval timer arms for real — on the serving runtime AND on the ON
+    // client, which runs the pattern too and may feed the shared tick doc
+    // with authored ticks; which runtime lands a tick is immaterial here.
+    // The pin is about the served HANDLER's read: the ON client fires the
+    // durable event, the drain dispatches it to the served handler, and the
+    // handler's write of the bound `nowTick` into the ARGUMENT doc (which
+    // only the served run writes durably — the client's echo diverts to
+    // the overlay) is the witness: a coarsened current instant, NOT the -1
+    // sentinel a null read would leave (the F4 hypothesis: "`castVote`
+    // reads `nowTick` null and returns without writing"). It does not
+    // distinguish one dispatch from two (a second run rewrites the same
+    // value) — the served `#now` SUPPLY is pinned in
+    // executor-serving-loop.test.ts.
+    ({ manager: clientManager, runtime: clientRuntime } = openClient());
+    const engine = await server.engineForSpace(space);
+    const { argument, result } = await standUp(
+      clientRuntime,
+      NOW_READ_PATTERN,
+      { arg: "now-read-arg", result: "now-read-result" },
+    );
+    const cancelDemand = result.sink(() => {});
+    await clientRuntime.idle();
+    await clientRuntime.storageManager.synced();
+
+    host = newHost();
+    const before = Engine.serverSeq(engine);
+    result.key("record").send({});
+    await clientRuntime.idle();
+    await clientRuntime.storageManager.synced();
+
+    // The served handler ran and wrote what it READ: a coarsened, current
+    // instant — durably, in a DERIVED commit that consequences the event.
+    const argumentId = argument.getAsNormalizedFullLink().id;
+    const storedValue = (): number | undefined =>
+      (Engine.read(engine, { id: argumentId })?.value as
+        | { value?: number }
+        | undefined)?.value;
+    await waitUntil(
+      () => {
+        const v = storedValue();
+        return typeof v === "number" && v !== 0 && v !== -1;
+      },
+      "the served handler's nowTick write to land durably",
+    );
+    const read = storedValue()!;
+    expect(read).not.toBe(-1);
+    expect(read % 1000).toBe(0);
+    expect(Math.abs(Date.now() - read)).toBeLessThan(5_000);
+
+    await waitUntil(
+      () => sidecarIdsIn(engine).length >= 1,
+      "the event append to land",
+    );
+    const consequenceRows = engine.database.prepare(
+      `SELECT seq, consequence_of FROM "commit"
+       WHERE seq > :from_seq AND class = 'derived'
+         AND consequence_of IS NOT NULL`,
+    ).all({ from_seq: before }) as Array<
+      { seq: number; consequence_of: string }
+    >;
+    // The write rides a derived commit consequencing the fired event.
+    const writers = engine.database.prepare(
+      `SELECT c.seq AS seq, c.class AS class FROM revision r
+       JOIN "commit" c ON c.seq = r.commit_seq
+       WHERE r.id = :id AND r.data LIKE :needle ORDER BY r.seq DESC LIMIT 1`,
+    ).get({ id: argumentId, needle: `%${read}%` }) as
+      | { seq: number; class: string }
+      | undefined;
+    expect(writers?.class).toBe("derived");
+    expect(consequenceRows.some((row) => row.seq === writers?.seq)).toBe(
+      true,
+    );
     cancelDemand();
   });
 

--- a/packages/runner/test/executor-serving-loop.test.ts
+++ b/packages/runner/test/executor-serving-loop.test.ts
@@ -371,6 +371,178 @@ describe("stage F serving loop", () => {
     ).toBeGreaterThanOrEqual(authored2);
   });
 
+  it("SERVES an interval #now/1 wish: the timer ARMS on the serving runtime (real clock) and a served run reads a CURRENT, advancing nowTick — not null/stale (Stage C: nowTick supply, verification-coverage.md OW32)", async () => {
+    // Stage C (verification-coverage.md OW32): the served interval-`#now`
+    // SUPPLY, pinned positively on a served host with a REAL clock. The
+    // runner suite's mandatory fake clock freezes the interval timer, so
+    // this could be witnessed only by the bimodal lunch browser gate — where
+    // it was mis-attributed to a NULL `nowTick`. This file is on the real
+    // clock (clock-preload.ts `realClockFiles`), so the interval `#now/N`
+    // timer's wall-clock `setTimeout` (builtins/wish.ts
+    // `scheduleIntervalNowTick`) fires for real. The pin proves the serving
+    // runtime SUPPLIES a current, ADVANCING tick — the timer armed on the
+    // serving runtime, not a one-shot frozen at boot — refuting the
+    // register's "the served `#now/300` wish resolves null/stale on the
+    // serving loop". (The served HANDLER's read of the bound `nowTick` at
+    // dispatch is pinned separately in executor-events-down.test.ts.)
+    host = newHost({ flushDeadlineMs: 5_000, idleParkMs: 600_000 });
+
+    // A served pattern that wishes the 1-second `#now` grid and re-exposes
+    // its value — the same shape the lunch poll uses for `nowTick`, minus
+    // the vote machinery. The wish node runs SERVER-SIDE at activation, so
+    // the interval timer arms on the serving runtime (never the client).
+    onServingRuntime = async (runtime) => {
+      const compiled = await runtime.patternManager.compilePattern({
+        main: "/main.tsx",
+        files: [{
+          name: "/main.tsx",
+          contents: [
+            "import { computed, pattern, wish } from 'commonfabric';",
+            "export default pattern<{ seed: number }, { nowTick: number | null }>(",
+            "  () => {",
+            "    const nowWish = wish<number>({ query: '#now/1' });",
+            "    return { nowTick: computed(() => nowWish.result ?? null) };",
+            "  },",
+            ");",
+          ].join("\n"),
+        }],
+      }, { space });
+      const argument = runtime.getCell<{ seed: number }>(
+        space,
+        "now-serving-arg",
+        undefined,
+      );
+      const result = runtime.getCell<{ nowTick: number | null }>(
+        space,
+        "now-serving-result",
+        compiled.resultSchema,
+      );
+      for (let attempt = 0;; attempt++) {
+        await argument.sync();
+        await result.sync();
+        const tx = runtime.edit();
+        runtime.run(tx, compiled, argument, result);
+        const committed = await tx.commit();
+        if (committed.error === undefined) break;
+        if (attempt >= 4) {
+          throw new Error(
+            `serving #now pattern run failed: ${committed.error.message}`,
+          );
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      await runtime.idle();
+    };
+
+    openClient();
+    const engine = await server.engineForSpace(space);
+
+    // The client's DEMAND activates the serving loop; an authored write
+    // wakes it so the wish node's structure loads and derives.
+    const clientResult = clientRuntime.getCell<{ nowTick: number | null }>(
+      space,
+      "now-serving-result",
+      undefined,
+    );
+    await clientResult.sync();
+    const clientArg = clientRuntime.getCell<{ seed: number }>(
+      space,
+      "now-serving-arg",
+      undefined,
+    );
+    await clientArg.sync();
+    const tx = clientRuntime.edit();
+    clientArg.withTx(tx).set({ seed: 1 });
+    expect((await tx.commit()).error).toBeUndefined();
+
+    // Wait for the SpaceServer to be ACTIVE first: activation installs the
+    // seal destination and only then flips `active` (space-server.ts, the
+    // `installSealDestination` → `#active = true` order). The interval
+    // timer arms earlier, inside `createRuntime`, so a 1-second boundary
+    // that fires in the pre-install window commits an AUTHORED tick (no
+    // stamper yet); reading `firstTick` only after `active` guarantees the
+    // ADVANCE asserted below fires post-install and rides the wave.
+    await waitUntil(
+      () => host!.spaceServer(space)?.active === true,
+      "the space server to activate",
+      15_000,
+    );
+    // The served run reads a CURRENT tick — a real coarsened wall-clock
+    // instant, never null. This is the property the lunch residual was
+    // (wrongly) blamed on: a served handler reading `nowTick` sees a
+    // current value.
+    await waitUntil(
+      () => {
+        const v = clientResult.key("nowTick").get();
+        return typeof v === "number" && v > 0 && v % 1000 === 0;
+      },
+      "the client to observe a current served nowTick",
+      15_000,
+    );
+    const firstTick = clientResult.key("nowTick").get() as number;
+    expect(typeof firstTick).toBe("number");
+    expect(firstTick % 1000).toBe(0);
+    // CURRENT, not merely a coarsened number: the served instant sits
+    // within a few seconds of the (shared, real) wall clock — a stale or
+    // boot-frozen value would drift away from `Date.now()`.
+    expect(Math.abs(Date.now() - firstTick)).toBeLessThan(5_000);
+
+    // …and it keeps ADVANCING: a wall second later the grid moves to the
+    // next instant on the SERVING runtime (the client reads the pushed
+    // value), so `nowTick` is a live clock, not a one-shot frozen at boot.
+    // Only the serving runtime's interval timer can write this advance —
+    // the client here is a plain OFF runtime that never runs the pattern.
+    await waitUntil(
+      () => {
+        const v = clientResult.key("nowTick").get();
+        return typeof v === "number" && v > firstTick;
+      },
+      () =>
+        `the served nowTick to advance past ${firstTick} (got ${
+          clientResult.key("nowTick").get()
+        })`,
+      15_000,
+    );
+    const advanced = clientResult.key("nowTick").get() as number;
+    expect(advanced).toBeGreaterThan(firstTick);
+    expect(advanced % 1000).toBe(0);
+    expect(Math.abs(Date.now() - advanced)).toBeLessThan(5_000);
+
+    // The timer ARMED ON THE SERVING RUNTIME: the ADVANCED tick's revision
+    // of the shared interval-tick doc (the content-addressed cell
+    // `{wish:{now:true,interval:1000}}` builtins/wish.ts acquires) is a
+    // DERIVED-class commit under THIS space server's holder — the serving
+    // runtime's own `writeIntervalNowTick` (a bookkeeping-stamped
+    // `editWithRetry` riding the wave), never an authored client write.
+    // Asserted on the ADVANCE (post-`installSealDestination`, since
+    // `firstTick` was read only after `active`), not on the initial
+    // acquire-time write.
+    expect(servingRuntime).toBeDefined();
+    const tickDocId = servingRuntime!.getCell<number>(
+      space,
+      { wish: { now: true, interval: 1000 } },
+      undefined,
+    ).getAsNormalizedFullLink().id;
+    const advancedRow = engine.database.prepare(
+      `SELECT c.class AS class, c.holder AS holder FROM revision r
+       JOIN "commit" c ON c.seq = r.commit_seq
+       WHERE r.id = :id AND r.data LIKE :needle
+       ORDER BY r.seq DESC LIMIT 1`,
+    ).get({ id: tickDocId, needle: `%${advanced}%` }) as
+      | { class: string; holder: string | null }
+      | undefined;
+    expect(advancedRow).toBeDefined();
+    expect(advancedRow?.class).toBe("derived");
+    expect(advancedRow?.holder).toBe(host.spaceServer(space)?.holder);
+
+    // The serving loop stayed healthy across the interval ticks (no park,
+    // no lease loss): the tick's bookkeeping commits ride the wave, never
+    // storming it.
+    const stats = host.stats();
+    expect(stats.lease.lost).toBe(0);
+    expect(host.spaceServer(space)?.active).toBe(true);
+  });
+
   it("retries a demanded root the loader could not start YET: demand precedes the instantiation commit (the creation race), the deferred ensure re-attempts on a later cycle, and the piece serves", async () => {
     host = newHost({ flushDeadlineMs: 5_000, idleParkMs: 600_000 });
     // NO onServingRuntime pattern run: unlike the tests above, the

--- a/tasks/server-execution-on-skips.ts
+++ b/tasks/server-execution-on-skips.ts
@@ -172,34 +172,83 @@ export const SERVER_EXECUTION_ON_SKIPS: Record<
         "the wish runs per demander and provisions with its " +
         "`demanded-run:<user>` carriage — 'both join lands' 35–640 ms), " +
         "and OW34 (the renderer-trust attestation on the durable entry). " +
-        "Under the full ON posture on a fresh store this gate is " +
-        "BIMODAL (stage B build `store-lunch4` GREEN 2m28s; the fixer " +
-        "pass on the independent review reproduced 1/2 on binary " +
-        "fadc2efb1b — run 1 RED at 'both browsers see 2 love it (merge)' " +
-        "hanging to the 300 s timeout with '1 love it', run 2 GREEN " +
-        "1m18s). The residual mechanism, triaged (review F4) as " +
-        "SERVED-WISH TIMING and NOT a stage-B B7 dirtiness miss: the " +
-        "served `castVote` handler run as the second voter reads " +
-        "`nowTick` (the `#now/300` interval wish's value) null and " +
-        "returns without writing (`main.tsx` `if (!now) return`), so " +
-        "ONE vote no-ops; `todaysVotes`/`ranked` read only SHARED inputs " +
-        "(they are SPACE-scoped, not fanned out — a `nowTick` change is a " +
-        "space cause that dirties them and any per-user swatch VDOM " +
-        "downstream via `dirtyFanOutAll`, never a missed re-dirty), so " +
-        "the review's swatch flip [Bob,Alice]→[Alice]→[Bob,Alice] is " +
-        "`todaysVotes`' `dayKeyOf(nowTick)` filter flipping as `nowTick` " +
-        "resolves, not a per-instance dirtiness bug. The two-browsers " +
-        "gate (no `#now`/`nowTick` dependency) is GREEN 2/2 under the " +
-        "same binary and load, isolating the failure to the `nowTick` " +
-        "chain. Compounded by the pre-existing client-instantiate-vs-" +
-        "server-derive re-fetch race at piece creation (the ~6 s " +
-        "`compile-cache-hit` churn the 300 ms demand-wake grace only " +
-        "softens). Owed at Stage C (NOT stage-B-owned): the served " +
-        "`#now/300` value for a serving runtime at dispatch, or a wall " +
-        "clock the serving runtime supplies to the `if (!now)` guard. " +
-        "Recorded in verification-coverage.md (OW32's row); lifts when " +
-        "this gate greens ≥2/2 fresh-store under the full ON posture; " +
-        "the flip PR needs this list EMPTY.",
+        "Under the full ON posture on a fresh store this gate is BIMODAL " +
+        "(builder `store-lunch4` GREEN 2m28s; fixer 1/2; Stage C 0/2 " +
+        "clean runs green, both RED — at the merge, or at 'option B' " +
+        "after a transient '2 love it'). STAGE C RE-CHARACTERIZED THE " +
+        "RESIDUAL (2026-08-17), REFUTING the fan-out-B review-F4 " +
+        "SERVED-WISH-TIMING triage: the cause is NOT a null/stale " +
+        "`nowTick`. Instrumented on the ON binary (serving loop + client " +
+        "overlay + a `castVote` probe read from the serving runtime), 5 " +
+        "fresh-store runs show `nowTick` ALWAYS valid — the served " +
+        "`#now/300` interval timer arms on the SERVING runtime and writes " +
+        "valid coarsened ticks (derived-class commits), every served " +
+        "`castVote` run reads a current `nowTick`, and every vote doc the " +
+        "served runs wrote carries a valid `castAt` (pinned: the served " +
+        "`#now` SUPPLY by `executor-serving-loop` 'SERVES an interval " +
+        "#now/1 wish', and the served HANDLER's read at dispatch by " +
+        "`executor-events-down` 'a SERVED handler bound to an interval-#now " +
+        "derivation reads a CURRENT nowTick at dispatch'). The real " +
+        "residual is a served " +
+        "castVote DOUBLE DISPATCH of ONE durable event: per click the " +
+        "store holds exactly ONE castVote sidecar entry (one stream, one " +
+        "eventId minted once at the LT1 send), and that ONE event id is " +
+        "consequenced by 2–5 derived commits — the served handler RAN 2–5 " +
+        "times per click, alternating CAST / TOGGLE-OFF (`main.tsx` " +
+        "`castVote`'s `sameColorToday` arm), so the durable tally is the " +
+        "INTERLEAVING of the duplicate runs — the parity of the count in " +
+        "the common case (clean run 2: Bob 2 runs → lost, Alice 4 → lost → " +
+        "RED at option B; clean run 1: Alice 3 kept, Bob 5 with the last " +
+        "two reading the same view → lost). Mechanism " +
+        "(`cell.ts`/`space-server.ts` at the tip): the " +
+        "served click handler's `castVote.send()` takes the LT1 same-space " +
+        "arm (`cell.ts:1703-1819`) — it writes the durable entry into its " +
+        "tx AND queues the event IN-PROCESS for same-wave processing " +
+        "(`:1799`, no `streamEntry`); when that run misses the wave's " +
+        "flush deadline (`wavesBudgetExhausted` ≈ `waves` here) it stays " +
+        "queued and runs in a LATER wave UNMARKED (the batch marks only " +
+        "same-wave appends, `wave.ts:2137-2239`), while the drain " +
+        "(`space-server.ts:1791`, store-driven) re-queues the still-" +
+        "pending id WITH a `streamEntry` (`:1920`) — a second run; a " +
+        "second variant re-queues an entry the drain queued but the " +
+        "scheduler had not yet run when a cycle ended without a commit " +
+        "and the scan was re-armed (`:1607`, `:1725-1730`) — no cascade " +
+        "needed. Both diag-witnessed (the same id dispatched once without " +
+        "and once with `streamEntry`; one id drain-queued twice). Under " +
+        "OFF the same pattern is exactly-once BY CONSTRUCTION (one " +
+        "in-process queue, `cell.ts:1918` → `scheduler/events.ts:330`; no " +
+        "second path; the OFF lunch gate passes 9–11 s) — a served-" +
+        "execution PARITY GAP, not a pattern bug. (The two references to " +
+        "`boundCastVote` — exported API + child-card arg — are NOT the " +
+        "mechanism: one stream cell; removing the export did not stop the " +
+        "multiple runs.) `events.processed > appended` is NOT a " +
+        "discriminating signature (re-drains inflate it). A SECOND, " +
+        "client-side coin rides the same runs: when the browser's local " +
+        "dispatch of its own click is delayed past the served round trip " +
+        "(15–20 s in the RED runs, during the re-fetch/piece-restart " +
+        "churn), its castVote echo runs against a replica that already " +
+        "holds the vote, computes the TOGGLE-OFF, and the arrival gate " +
+        "strands that divergent echo indefinitely (written doc " +
+        "`confirmedSeq` < the entry's floor; the fixer's preserved RED " +
+        "store had NO server-side loss yet its host showed '1 love it' " +
+        "for 300 s) — an arrival-gate edge flagged in the register's " +
+        "Part 2 revisit, not filled. Same class: the " +
+        "two-browsers admin-lockdown toggle (`trusted.tsx:667`, bound " +
+        "directly to the checkbox click, toggle branch on a plain click) " +
+        "is exposed to the re-drain variant. Compounded (secondary) by the " +
+        "pre-existing client-instantiate-vs-server-derive re-fetch race at " +
+        "piece creation (residual x; the 300 ms demand-wake grace only " +
+        "softens). FLAGGED, not filled — owner ruling OWED on the delivery " +
+        "invariant (verification-coverage.md OW32's row carries the three " +
+        "costed resolutions and the recommendation: state 'one durable " +
+        "entry = one COMPLETED delivery' in events.md §4 and enforce it in " +
+        "the serving loop — a deadline-time purge of unrun LT1 leftovers " +
+        "(`served.streamEntry === undefined`) + a drain dedupe keyed on a " +
+        "mark-bearing `streamEntry` copy, shaper-held events included; NOT " +
+        "handler idempotency, which contradicts OFF). Lifting needs BOTH " +
+        "coins (the server-side ruling and the client-side late-echo " +
+        "edge); lifts when this gate greens ≥2/2 fresh-store under the " +
+        "full ON posture; the flip PR needs this list EMPTY.",
     },
   ],
   runner: [


### PR DESCRIPTION
## Why

Stacked on fan-out stage B (#5924). Two Stage-C follow-ups the fan-out-B
review left owed: the **lunch residual** (the last entry keeping
`lunch-poll-vote` on the ON skip list — the flip PR needs that list
EMPTY) and the **arrival-gate revisit on evidence**.

The register and the skip entry characterized the lunch residual as
**served-wish timing** — the served `#now/300` interval wish (`nowTick`)
resolving null/stale on the serving runtime, so `castVote` "no-ops on
null nowTick" (fan-out-B review F4). **Instrumented investigation on the
ON binary refutes that premise, and store forensics on the un-instrumented
runs establish the real mechanism.** Across 5 instrumented fresh-store runs
(serving loop dispatch/drain/wave-close, the client overlay's seal/sweep,
and a `castVote` probe read from the SERVING runtime) plus 2 clean runs:

- `nowTick` is **always valid**: the served `#now/300` interval timer arms
  on the *serving* runtime and writes valid coarsened ticks (derived-class
  commits); every served `castVote` run reads a current `nowTick`; every
  vote doc the served runs wrote carries a valid `castAt`. `castVote` does
  **not** no-op — it **toggles**.
- The real residual is a served **castVote DOUBLE DISPATCH of ONE durable
  event**: per click the store holds exactly ONE castVote sidecar entry
  (one stream, one eventId), and that ONE event id is consequenced by 2–5
  derived commits — the served handler ran 2–5 times per click,
  alternating CAST / TOGGLE-OFF (`castVote`'s `sameColorToday` arm), so the
  durable tally is the **interleaving of the duplicate runs** — the parity
  of the count in the common case (clean run 2: Bob 2 runs
  → lost, Alice 4 → lost → RED at "option B"; clean run 1: Alice 3 kept,
  Bob 5 lost, the last two runs reading the same view → RED). Under OFF the
  same pattern is exactly-once by
  construction — a served-execution **parity gap**, not a pattern bug.
- A **second, client-side coin** rides the same runs: when the browser's
  local dispatch of its own click is delayed past the served round trip
  (15–20 s in the RED runs, during the re-fetch/piece-restart churn —
  residual x), its castVote **echo** runs against a replica that already
  holds the vote, computes the TOGGLE-OFF, and the **arrival gate strands
  that divergent echo indefinitely** (written doc `confirmedSeq` < the
  entry's floor; the server never rewrites the doc). The fixer's own
  preserved RED store has **no** server-side loss (both votes KEPT, "2 love
  it") yet its host showed "1 love it"/[Bob] for 300 s — this coin alone.
  An arrival-gate EDGE, flagged (Part 2), not filled.

Both are served-execution semantics the spec does not state, so
per **flag-don't-fill** it is **not fixed here** and the gate stays
red — **the skip stays listed** (the flip's skip-list-empty rule is
absolute; papering it is worse than owing it). What this PR lands: the
corrected characterization with a precise mechanism dossier for the owner's
ruling, two positive pins that the served `#now` supply AND the served
handler's read at dispatch work, and the arrival-gate verdict.

## What

- **`tasks/server-execution-on-skips.ts`** — the `lunch-poll-vote` skip
  entry REASON rewritten to the evidenced mechanism (double dispatch of one
  durable event; not `nowTick`), with the flag-don't-fill disposition and a
  pointer to the register dossier. The entry **stays listed** (still in the
  ON `--ignore`).
- **`docs/specs/server-side-execution/verification-coverage.md`** — OW32's
  Stage-C block re-characterized into the mechanism dossier below (exact
  code path with `file:line` at the tip, one-stream/N-dispatch, OFF parity,
  per-click run counts, three costed resolutions + recommendation, the
  two-browsers lockdown toggle as the same class); a Stage-C delta records
  the lunch correction, the F3 MWISH-pin landing (`f5a0cac5c`, the register
  had gone stale saying "OWED"), and the arrival-gate KEEP verdict.
- **`packages/runner/test/executor-serving-loop.test.ts`** — new served-host
  E2E pin "SERVES an interval #now/1 wish": on a served host with a REAL
  clock the interval timer arms server-side and a served run reads a
  current, ADVANCING `nowTick`; the advancing tick's revision is
  derived-class under this space server's holder (queried by the tick doc's
  own id), both instants within 5 s of the wall clock.
- **`packages/runner/test/executor-events-down.test.ts`** — new pin "a SERVED
  handler bound to an interval-#now derivation reads a CURRENT nowTick at
  dispatch": an ON client fires the durable event, the drain dispatches it,
  the served handler writes the bound `nowTick` it read (or a `-1` sentinel
  when null) — a current coarsened instant lands in a derived commit
  consequencing the event. Mutation (handler writes `-1`) → RED. This pins
  F4's precise hypothesis (the handler-at-dispatch read) as false.
- **`docs/specs/server-side-execution/speculation.md`** — §4 gains the
  Stage-C arrival-gate revisit sentence (the server supply does not
  subsume the client gate).

**Arrival-gate revisit — VERDICT: KEEP (no code change).** The gate is
**client-side** (the non-serving overlay's `#sweep`,
`overlay-destination.ts:1010-1031`; serving runtimes never speculate —
`runtime.ts:1897-1899` `#speculationDestination` returns undefined under the
serving posture); every fan-out fix (`invalidateActionsForDemandRoots`
`facade.ts:845`, the per-demander supply, `rearmNotCurrentFanOutForActor`
`facade.ts:940`) is **server-side**. They fix the CAUSE (per-user instances
get served/re-armed); the gate treats the orthogonal client-side SYMPTOM (an
echo must not retire on watermark COVERAGE before the authoritative value
ARRIVES at this client's replica — the frame-coupling window §4 states as an
assumption; no supply change lands the value frame-coupled to the covering
watermark). Evidence for KEEP: (1) LIVE — the Stage-C client-overlay
instrumentation showed the gate holding per-user echoes whose written
instance had `confirmedSeq` 0 or `< floor`, exactly its window; (2) UNIT —
the OW32-shape pin's gate-removed mutation reddens (retire-to-nothing
returns); (3) the §E residuals it backstops (first-demand transient,
walk-coverage gap) persist as fan-out B's own residuals. No SIMPLIFY keeps
that pin green. (4) ONE EDGE observed and FLAGGED, not filled (orthogonal to
KEEP — the loop returns without the gate either way): a LATE echo of a
non-idempotent handler is divergent by construction and the gate strands it
indefinitely; candidate rule (owner call): an intent-origin echo whose parent
intent is already consequenced at seal is not registered / retires at seal.

## Verification

- **lunch-poll-vote gate (harness protocol: fresh store per run, ON binary
  `sha=59b5329ae` verified `/api/meta.shellServerExecutionDefine=true`,
  serving loop present, load recorded): 0/2 clean (un-instrumented) runs
  green — STAYS skip-listed.**
  - clean run 1: RED (hung to the 300 s step timeout); store: Alice's
    castVote event run 3× (cast/off/cast → kept), Bob's 5× (cast/off/cast/
    off/off, the last two reading the same view → lost).
  - clean run 2: RED at "option B vote lands (3 votes)" (6m26s; the merge
    had passed in 125 ms on the transient "2 love it"); store: Bob 2 runs
    (cast/off → lost), Alice 4 (cast/off/cast/off → lost).
  - 5 earlier instrumented runs (2 reached all vote steps green, 3 RED)
    established the mechanisms: `nowTick` valid at every served dispatch;
    the same event id dispatched once without and once with `streamEntry`;
    one id drain-queued twice; run counts Bob 4 / Alice 5 in one run; the
    client's late castVote echo sealed at floor 78 vs its vote doc's
    `confirmedSeq` 77 and stayed (host "0 votes today" 120+ s).
  - the fixer's own preserved stores, re-read: gate run 1 (RED) — no
    server-side loss (Alice 1, Bob 3 → KEPT) → the client-side coin; gate
    run 2 (GREEN) — Bob 3 (kept); rfb runs 1/3 (RED at swatches) — Bob 2
    runs (cast/off → LOST) → the server-side coin.
- **new pins**: `executor-serving-loop` "SERVES an interval #now/1 wish" and
  `executor-events-down` "a SERVED handler … reads a CURRENT nowTick at
  dispatch" — green; the two real-clock files (25 + 12 steps) **soaked 3×
  together (37/37 each)**; the events-down pin's mutation (`-1` write) RED.
- **`speculation-arrival-gate.test.ts`**: 3 steps / 0 failed.
  **executor-fan-out**: 11 steps / 0 failed (neighbor smoke).
- **skip-list validator** (`server-execution-on-skips.test.ts`): 17/17; the
  CLI validator prints the lunch entry and keeps it in `--ignore`.
- **`deno task check-docs`**: 548 blocks. **`deno fmt --check`**, **`deno
  check`** (changed files): clean. **`deno lint`**: only the 2 pre-existing
  `require-await` in `executor-serving-loop.test.ts` (unchanged code).

No production code changed — the diff is two test pins + doc/register/skip
corrections (additive).

## Flags

1. **The lunch residual — served castVote DOUBLE DISPATCH of one durable
   event (the real mechanism; OWNER RULING OWED; flag-don't-fill).**
   Mechanism dossier (verbatim in verification-coverage.md OW32):
   - (a) *Exact path* (`cell.ts` / `space-server.ts` at the tip): the served
     click handler's `castVote.send()` takes the LT1 same-space arm
     (`cell.ts:1703-1819`): it writes the durable entry into its own tx
     (`:1776-1783`) AND queues the event IN-PROCESS for same-wave processing
     (`:1799-1819`, no `streamEntry` — "the batch owns the mark"). If that
     in-process run misses the wave's flush deadline (`wavesBudgetExhausted`
     ≈ `waves` on this gate; `space-server.ts:2702-2708`), (α) the event
     STAYS in the scheduler queue and runs in a LATER wave carrying no
     `streamEntry`, so its consequences commit UNMARKED (the batch marks
     only entries APPENDED in that wave, `wave.ts:2137-2239`; the stamper's
     mark needs `streamEntry`, `space-server.ts:1159-1180`), and (β) the
     wave that appended the entry re-arms the scan (`:2951-2962`), so the
     next drain (`#drainStreamEvents` `:1791`; `selectPendingStreamEventDocs`
     = the STORE's unconsequenced entries) queues the SAME id again WITH a
     `streamEntry` (`:1920-2016`) — the second run. Diag-witnessed: the same
     id dispatched once without and once with `streamEntry` (Bob's
     `1e731bc9`: LT1-queued 51.1 s, wave sealed 56.08 s, in-process run
     56.09 s, drain re-queue 60.10 s, both in wave 78 as cast+off). A second
     variant needs no cascade: an entry the drain queued but the scheduler
     had not yet run when the cycle ended without a commit is queued AGAIN by
     the next cycle's drain when the scan is re-armed (`#armDeferredRescan`
     `:1607`; a feed record while deferrals are outstanding `:1725-1730` —
     near-continuous on this gate) — witnessed on a directly-bound handler
     (`9f8b1916` drain-queued twice, dispatched twice, one wave). The design
     comment covers the REQUEUED case ("a requeued run leaves the entry
     unmarked and the next wave's drain re-runs it (C8b)", `cell.ts:1784-
     1798`) but nothing removes an UNRUN in-process LT1 event at wave close,
     and nothing dedupes the drain against an event already queued or
     already run in the still-open wave. `space-server.ts:1182-1188` already
     names "consequences committing unmarked → re-run on the next drain →
     double consequences" as the class to prevent.
   - (b) *One stream, one event, N dispatches*: `boundCastVote` is ONE stream
     cell; its two references (the exported API `main.tsx:2035`, the
     child-card arg `:1664`) are two links to it and are NOT the mechanism
     (removing the export did not stop the multiple runs). Per click the
     sidecar holds ONE entry with ONE eventId (minted once at the LT1 send,
     `cell.ts:1718`); the duplicates are that same event id run again — not
     a second event under §4's per-attempt minting, not two subscription
     paths, but two DISPATCH paths (in-process queue + drain) and repeated
     drains.
   - (c) *OFF-arm parity*: under OFF a client `send` from a handler takes
     the plain `queueEvent` (`cell.ts:1918`) into the ONE in-process queue
     (`scheduler/events.ts:330` → one `findEventHandler` registration per
     stream link, `:347`); no durable-entry/drain second path exists, and two
     links to one stream resolve to one handler — exactly-once BY
     CONSTRUCTION, no dedupe mechanism needed. The OFF lunch gate passes
     9–11 s. The served path's second producer beside the in-process queue,
     with no dedupe, is a served-execution PARITY GAP.
   - (d) *Resolutions, costed, none chosen*: **(i)** the serving loop dedupes
     dispatch per event id across its two queue paths — (α) at the wave's
     DEADLINE decision (`:2702-2708`, synchronously — the scheduler keeps
     executing through `await commitWave` `:2925`, so a later purge can lose
     the race to the leftover's next turn) purge every unrun LT1 in-process
     cascade event, discriminator `served !== undefined &&
     served.streamEntry === undefined` (a plain in-process event on the
     serving runtime has no `served` and no durable entry — never purge it);
     the durable entry is the truth and the next drain re-runs it WITH
     `streamEntry` so the mark lands (the fallback `cell.ts:1784-1798`
     already intends); (β) the drain skips an id already queued or already
     run in the still-open wave ONLY when that other copy carries a mark path
     (a `streamEntry`-bearing dispatch) — never on the strength of a
     `streamEntry`-less LT1 leftover, which cannot mark (skipping for it
     leaves the entry unmarked and re-drained the next wave: the double one
     wave later); "already queued" must include shaper-HELD events
     (renderer-trusted clicks take `holdShapedEvent`, outside `eventQueue`
     until released — the pre-existing blind spot `transientEventDemandersFor`
     shares). Cost: a scheduler queue inspect/remove seam keyed on eventId
     that also sees the shaper's held set (`transientEventDemandersFor`
     already walks `eventQueue`; `dropQueuedEvent` exists), a deadline-time
     hook, a per-wave dispatched-id set cleared on close/abort. Risk, stated:
     (α)'s safety holds for EVENT-HANDLER emitters (append + own mark ride
     one tx; a requeue withdraws whole and the parent's re-run re-emits under
     a fresh id, C8d) but NOT for DERIVATION-kind LT1 emitters
     (`cell.ts:1692`/`:1726` admit them): a derivation's sidecar append on a
     conflicted doc is dropped per-doc as superseded (`wave.ts:1420-1429`,
     re-arms nothing), nothing re-emits, so a purge would lose that event
     silently — today it runs as an ORPHAN consequence (zero durable
     entries, one delivery: the invariant broken from the other side), which
     (ii)'s sentence must also decide. Contained to `space-server.ts` + a
     facade helper; OFF byte-identical. **(ii)** events.md §4 states the
     invariant — "one durable entry = one COMPLETED delivery to its handler,
     regardless of dispatch path or reference count (a requeued run is
     legitimately re-delivered by the drain); an entry not completed in the
     wave that appended it is dispatched by the drain alone; a delivery with
     no durable entry is [refused | tolerated as an orphan] (to be decided)"
     — and the drain enforces it (= (i) with the sentence written; §4 today
     states exactly-once only via the mark on the drain path); cost: (i) +
     spec sentence + register row. **(iii)** patterns must make handlers
     idempotent (castVote's toggle is the pattern's bug) — harshest;
     contradicts the OFF arm (exactly-once by construction, gate green with
     this pattern) and would make every non-idempotent handler wrong under
     serving, which §4's exactly-once exists to prevent.
   - *Recommendation (mine, not a decision)*: **(ii)** — state the invariant
     (with the orphan-delivery clause decided), enforce via (i)'s two seams
     as sharpened; NOT (iii). Evidence: OFF parity; `space-server.ts:1182-
     1188`'s own statement of the class; the LT1 fallback comment intending
     the drain as the one re-run path. Papering it in the pattern is refused;
     a blind dedupe without the stated invariant risks the legitimate
     same-wave LT1 cascade path.
   - *β's doors are many*: the post-commit re-arm at ANY committing wave close
     with a drained-but-unrun entry pending (`:2951-2962`), any new event
     append (`:1717-1720`), `#armDeferredRescan` (`:1607`), and a feed record
     while deferrals are outstanding (`:1725-1730`) — where `#eventDeferrals`
     is cleared only at activation/drop/non-deferred failure, NEVER on a later
     success, so after one deferral (routine at piece start) every feed
     record re-arms the scan for the life of the activation (a small leak of
     its own; why the re-scan is near-continuous on this gate).
   - *Same class elsewhere*: the two-browsers gate's admin-lockdown toggle
     (`cfc-group-chat-demo/trusted.tsx:667 commitTrustedAdminToggle`, bound
     DIRECTLY to the checkbox `onClick` at `:947`/`:1022` — the click, not
     `cf-checkbox`'s `cf-change`, so no `detail.checked` rides it and `:692`'s
     fallback takes the toggle branch `!chatAdminEveryoneIsAdmin(adminRegistry)`)
     flips BACK under a double dispatch — exposed to the re-drain variant only
     (no LT1 cascade), the same class; a ruling under (ii) covers both.
   - Not a signature: `events.processed > events.appended` (re-drains
     inflate `processed`; in-wave LT1 cascades count in neither) — corrected
     from the earlier Stage-C wording; the per-event run counts are the
     evidence.
2. **The second lunch coin — a LATE divergent echo stranded by the arrival
   gate (CLIENT-side; OWNER RULING OWED; flag-don't-fill).** Mechanism: the
   client's local cascade run of its own click (its castVote echo) is
   delayed past the served round trip (15–20 s in RED runs — the browser's
   ~6 s re-fetch / piece-restart churn, residual x's family); it seals with
   a floor ABOVE the served consequence (instrumented run 1: floor 78 vs the
   vote doc's `confirmedSeq` 77), so the non-idempotent handler computes the
   TOGGLE-OFF against a replica that already holds the vote; the arrival
   gate (`overlay-destination.ts:1010-1031`, working as specified) keeps
   the divergent echo indefinitely because the server never rewrites that
   doc. Evidence: the fixer's preserved RED run 1 (`gate/store-lunch1`):
   store correct (Alice 1 run, Bob 3 → both KEPT), host "1 love it"/[Bob]/"1
   votes today" for 300 s; Stage-C instrumented run 1: host "0 votes today"
   for 120+ s while the store held Alice's vote. Candidate rule (an owner
   call, a speculation.md §4 semantic the spec does not state): an
   intent-origin echo whose parent intent is already consequenced when the
   echo seals is not registered (or retires at seal) — the served
   consequence IS the authoritative run of that intent. KEEP for the gate
   stands regardless (removing it does not fix this and brings OW32 back).
3. **Residual x (secondary, unchanged, but now the ENABLER of coin 2):** the pre-existing
   client-instantiate-vs-server-derive re-fetch race at piece creation
   (`piece-start-commit-failed` + the ~6 s `compile-cache-hit` churn; the
   300 ms demand-wake grace softens, does not close). It does not gate the
   merge here.
4. **Register staleness corrected, not a new item:** OW17's "MWISH pin OWED
   as a served-host wish E2E" had landed on the fan-out-B tip (`f5a0cac5c`,
   `executor-cross-space.test.ts:932`); the Stage-C delta records it.

## Self-review

Two adversarial subagent passes over the full diff. Round 1 (M1–M3, m1–m8)
found the first Stage-C wording over-claimed the mechanism ("a duplicate
derived append to castVote's other stream instance"; "processed >
appended" as a signature) — re-derived from the un-instrumented stores and
rewritten as the dossier above; the `#now` pin now asserts on the ADVANCED
tick's revision by the tick doc's id (class + holder) and pins currency; the
handler-at-dispatch read got its own mutation-killed pin; the F3/MWISH
attribution dropped (that pin had already landed, `f5a0cac5c`); the
arrival-gate evidence wording corrected (only the OW32-shape pin's mutation
is the gate removal). Round 2 (on the rewritten dossier): every cited
`file:line` verified against the tip; no per-eventId dedupe exists anywhere
(the central claim stands); MAJOR — resolution (i)(β) was unsound as first
worded (a skip must key on a mark-bearing `streamEntry` copy and the purge
must run at the deadline decision, before the scheduler's next turn) →
sharpened above; MINORs folded in — the derivation-emitter hole in (α), the
shaper-held blind spot, β's re-arm doors + the never-cleared
`#eventDeferrals` leak, the lift condition needing BOTH coins, the `#now`
pin's `firstTick` now gated on the space server being ACTIVE (closing the
pre-install authored-tick window), the events-down comment corrected (the
ON client's own timer may feed the tick doc; the pin is about the handler's
read). Two review artifacts stayed non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

