### PR TITLE
fix(cli): the harness rides the slug wiring the demo rides, and MARKS says when it shows

### DIFF
--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -209,9 +209,10 @@ run cf piece describe -s "$SPACE" --piece board
 say "And the callable rows again as a table, the shape a client matches"
 say "against. Both are derived from the deployed pattern, not from a manifest."
 run cf piece verbs -s "$SPACE" --piece board
-say "In the table, ON names the cell a verb lives on and MARKS flags wrapper"
-say "or deprecated rows. The listings all take --json for tooling — the tables"
-say "are for the room; reads and calls already answer in JSON."
+say "In the table, ON names the cell a verb lives on. MARKS flags wrapper or"
+say "deprecated rows — hidden by default and listed under --all, so the column"
+say "is blank on a board that declares none. The listings all take --json for"
+say "tooling; reads and calls already answer in JSON."
 
 act "3 · Ask what a verb wants"
 say "Flags, types, required-ness and result all come from the author's TypeScript."

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -65,18 +65,19 @@ step "1. Arrive by name, not by fid"
 # --quiet makes the piece id stdout's only line; stderr is dropped and the
 # grep anchored so a compile warning carrying a fid1: token cannot be taken
 # for the deploy's id.
-BOARD=$($CF piece new --quiet "$FIXTURE" $ARGS 2>/dev/null |
+BOARD=$($CF piece new --quiet --slug board "$FIXTURE" $ARGS 2>/dev/null |
   grep -oE '^fid1:[A-Za-z0-9_-]+' | head -1)
 if [ -n "$BOARD" ]; then ok "deployed $BOARD"; else
   bad "deploy failed"
   exit 1
 fi
-$CF piece set-slug board "$BOARD" $ARGS >/dev/null 2>&1
 SLUG_NAME=$($CF get --quiet --piece board $ARGS '$NAME' 2>/dev/null | tr -d '"')
 check "Work tracker" "$SLUG_NAME" "the slug resolves everywhere --piece is taken"
 # The arrival name is discoverable as well as resolvable: the slug index
-# lists what set-slug wrote, which is what lets a session in a space someone
-# else populated start from a listing rather than from folklore.
+# lists what the deploy's --slug wrote — the same wiring the demo's act 1
+# rides, which a separate set-slug here would quietly stop covering: a
+# regression in the deploy's slug path would pass this harness while act 1's
+# listing came up empty. set-slug keeps its own coverage in integration.sh.
 $CF piece slugs $ARGS --json 2>/dev/null |
   jq -e '[.[].slug] | index("board")' >/dev/null 2>&1 &&
   ok "the slug index lists the arrival name" ||


### PR DESCRIPTION
## Why

Two review findings on #5963, both verified. The gap harness deployed bare and assigned `board` with a separate `set-slug`, so its slug-index assertion covered a write path the demo never takes — a regression in `piece new --slug`'s wiring would have passed the harness while act 1's listing came up empty, which is precisely the drift the harness exists to prevent. And act 2's new MARKS narration explained a column this transcript can never show non-empty: marked rows hide from the default listing and appear only under `--all`, and the tracker declares none besides.

## What Changed

- `verb-session-gaps.sh` deploys with `--slug board` and drops the separate `set-slug`, so the index assertion rides the exact wiring the demo's act 1 rides; the comment records why a separate `set-slug` here would quietly stop covering it. `set-slug` keeps its own coverage in `integration.sh`'s `piece-links` section.
- The demo's MARKS say-line now carries the condition: hidden by default, listed under `--all`, and blank here because the board declares none.

## Test plan

Demo and gaps harness ran green end to end against a freshly started toolshed built from this tree: demo exit 0; gaps **35 passed, 0 failed, 1 gap open**, with "the slug index lists the arrival name" now passing through the `--slug` deploy path. `deno task check-verb-session-sync` and `bash -n` on both scripts pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

