### PR TITLE
fix(cli): cf's own output stops teaching the spelling that is going away

### DIFF
--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -365,7 +365,7 @@ compilation:
 | a comment on an **event field** (what `title` means) | `$defs.<Event>.properties.<field>.description` |
 | a comment on the **event interface** | nowhere — this one does not compile ([#5937](https://github.com/commontoolsinc/labs/issues/5937)) |
 
-`cf piece verbs` and `cf piece call <verb> --help` already load that pattern to
+`cf piece verbs` and `cf call <verb> --help` already load that pattern to
 report what a verb hands back, so both read the prose from the same load. The
 verb's own comment becomes the listing row's `description` and the help page's
 summary line. The event fields' comments are folded into the input schema the

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -307,9 +307,9 @@ cf call --piece board addItem -- --help
 
 ```text
 Usage:
-  cf piece call --piece board addItem -- --help
-  cf piece call --piece board addItem <json>
-  cf piece call --piece board addItem -- --title <string>
+  cf call --piece board addItem -- --help
+  cf call --piece board addItem <json>
+  cf call --piece board addItem -- --title <string>
 
 File a new root item on the board.
 

--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -422,7 +422,7 @@ never spent, and the corrected retry can reuse it.
 ### Reading is not calling
 
 `cf get` reads data. A path that lands on a verb is refused and redirected
-to `cf piece call` — the spelling the diagnostic literally prints — because
+to `cf call` — the spelling the diagnostic literally prints — because
 reading a verb would return the stream's serialization — never what a
 caller wanted.
 
@@ -522,7 +522,7 @@ Each step demonstrates one use case:
 | 8 | A piece result survives `plainResultReceipts=false`; a plain record does not — and the write lands either way |
 | 9 | A value-less verb settles with the empty witness |
 | 10 | A refused call does not spend its invocation id |
-| 11 | Reading a verb redirects to `cf piece call` |
+| 11 | Reading a verb redirects to `cf call` |
 | 12 | Timings on stderr, Invocation JSON still clean on stdout |
 | 13 | An invocation id without a session is refused, and the refusal says how to mint one |
 | 14 | A detached (`--no-wait`) call's `receipt` address reads back the outcome, and a settled call's receipt reads back exactly its `result` |

--- a/packages/cli/commands/exec.ts
+++ b/packages/cli/commands/exec.ts
@@ -71,7 +71,7 @@ export function renderExecOutcome(
     if (result.resultRef) {
       const address = canonicalAddress(result.resultRef);
       writeError(
-        `Tool result cell: ${address} (read it back with \`cf piece get ` +
+        `Tool result cell: ${address} (read it back with \`cf get ` +
           `--piece ${address}\`)`,
       );
     }

--- a/packages/cli/commands/exec.ts
+++ b/packages/cli/commands/exec.ts
@@ -36,9 +36,9 @@ export interface ExecCommandOptions {
  * What `cf exec` writes, and where.
  *
  * **stdout carries the machine surface, and only it.** A tool's is its result
- * — the same bytes `cf piece call` prints for the same tool, now shaped by
+ * — the same bytes `cf call` prints for the same tool, now shaped by
  * whatever the caller selected. A handler's is the Invocation JSON its
- * handling settled to, which is the envelope `cf piece call` already declares:
+ * handling settled to, which is the envelope `cf call` already declares:
  * `cf exec` reaches a verb through a filesystem mount rather than through a
  * piece address, and that is the whole of the difference between them.
  *
@@ -46,7 +46,7 @@ export interface ExecCommandOptions {
  * takes it.** An address has three parts, and `canonicalAddress` renders all
  * three as the one token `--piece` parses, the space embedded as its
  * `/@did:.../` prefix. Naming the space is not decoration — `cf exec` takes
- * its space from the mount, while `cf piece get` falls back to whatever space
+ * its space from the mount, while `cf get` falls back to whatever space
  * the caller has configured, so a token that omitted it would suggest a
  * command that reads a different cell.
  *

--- a/packages/cli/commands/invocation-session.ts
+++ b/packages/cli/commands/invocation-session.ts
@@ -20,7 +20,7 @@ export const invocationSession = new Command()
   .name("invocation-session")
   .description(
     "Mint an invocation session: the caller identity that an invocation id " +
-      "passed to `cf piece call` is chosen within. One per agent run.",
+      "passed to `cf call` is chosen within. One per agent run.",
   )
   .default("help")
   /* invocation-session new */

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1274,7 +1274,7 @@ const pieceDescription = cliText(`Interact with pieces running on a server.
 COMMON WORKFLOWS:
   Deploy:    cf piece new ./pattern.tsx -i ./claude.key -a http://localhost:${ports.toolshed} -s my-space
   Update:    cf piece setsrc --piece <ID> ./pattern.tsx -i ./claude.key -a http://localhost:${ports.toolshed} -s my-space
-  Test:      cf call --piece <ID> callableName -i ./claude.key -a http://localhost:${ports.toolshed} -s my-space
+  Test:      cf call --piece <ID> -i ./claude.key -a http://localhost:${ports.toolshed} -s my-space callableName
   Inspect:   cf piece inspect --piece <ID> -i ./claude.key -a http://localhost:${ports.toolshed} -s my-space
 ${pieceEnvStatus()}
 TIPS:

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -24,7 +24,7 @@ import {
   CellSelectionError,
   parseCellSelectionOptions,
 } from "../lib/cell-selection.ts";
-import { cliText } from "../lib/cli-name.ts";
+import { cliCommand, cliText } from "../lib/cli-name.ts";
 import { reservesStdoutForCommandOutput } from "../lib/json-output.ts";
 import { normalizeLLMFriendlyRef } from "../lib/llm-friendly-ref.ts";
 import { renderPiece } from "../lib/piece-render.ts";
@@ -937,7 +937,7 @@ export function renderPieceCallOutcome(
       const ref = addressArgument(result.resultRef);
       hintOut(
         `Tool result cell: ${ref} (read it back with ` +
-          `\`cf piece get --piece ${ref}\`)`,
+          `\`cf get --piece ${ref}\`)`,
         false,
       );
     }
@@ -969,20 +969,20 @@ export function renderPieceCallOutcome(
             // the replay as a recovery would be offering a duplicate.
             ? `NEXT STEPS:
   → Nothing to collect: this handling wrote no receipt, so the outcome has no address and a call naming the same pair executes and commits AGAIN rather than deduplicating.
-  → Verify state:     cf piece get --piece ${piece} <path> ...`
+  → Verify state:     cf get --piece ${piece} <path> ...`
             // The replay names its session through the environment rather
             // than `--invocation-session`, because a session is what keeps an
             // outcome's address out of reach of anyone who can guess a piece,
             // a verb and an id — and an argument is readable in a process
             // listing where an environment variable is not.
             : `NEXT STEPS:
-  → Read the outcome: cf piece get --piece ${receiptId} (this call's receipt, an ordinary read — the handler does not run again)
+  → Read the outcome: cf get --piece ${receiptId} (this call's receipt, an ordinary read — the handler does not run again)
   → Or replay it:     CF_INVOCATION_SESSION=${
               opts.invocation?.session ?? "<session>"
             } cf piece call --piece ${piece} --invocation ${
               opts.invocation?.id ?? "<id>"
             } ${callableName} ... (the commit is durable and the replay loses the race for the receipt, so nothing commits twice — but the handler body RUNS AGAIN, repeating effects outside its transaction, and any write it made into another space)
-  → Verify state:     cf piece get --piece ${piece} <path> ...`,
+  → Verify state:     cf get --piece ${piece} <path> ...`,
         )
         : nextSteps,
     );
@@ -1281,7 +1281,7 @@ TIPS:
   • Use 'setsrc' for iteration, not repeated 'new' (avoids clutter)
   • After 'set', run 'step' to trigger computed value updates
   • Path format: forward slashes only (items/0/name, not items[0].name)
-  • JSON values: strings need quotes: echo '"hello"' | cf piece set ...`);
+  • JSON values: strings need quotes: echo '"hello"' | cf set ...`);
 
 /**
  * The target-selection surface every piece data command carries: quiet, the
@@ -1671,7 +1671,7 @@ cf ${spelling} /of:fid1:... addItem '{"title":"Milk"}'.`,
       "--no-wait",
       "Exit once this handling's commit is acknowledged (before the callable " +
         "name), skipping only the receipt readback: stdout reports status " +
-        '"committed" plus the receipt address, so `cf piece get --piece <that ' +
+        '"committed" plus the receipt address, so `cf get --piece <that ' +
         "address>` collects the outcome later without re-running the handler; " +
         "a call naming the same session and --invocation recovers it too, but " +
         "runs the handler body again. The handler still executes here and its " +
@@ -1778,6 +1778,13 @@ cf ${spelling} /of:fid1:... addItem '{"title":"Milk"}'.`,
             invocation.rawArgs,
             {
               invocation: identity,
+              // The verb help page names the mount that was invoked, so the
+              // blessed spelling never renders usage lines teaching the
+              // deprecated one — and the deprecated mount names itself,
+              // beside its own notice.
+              helpCommandPrefix: cliCommand(
+                [...spelling.split(" "), "...", callableName],
+              ),
               skipReadback: waitControl.mode === "commit",
               showLinks: !!options.showLinks,
               ...(selection === undefined ? {} : { selection }),
@@ -2569,7 +2576,7 @@ updated effective label view.`),
     if (shown.length === 0) return;
     hint(
       cliText(
-        `TIP: --json includes each verb's input schema; 'cf piece call --piece ${pieceConfig.piece} <verb> --help --json' has the full command spec.`,
+        `TIP: --json includes each verb's input schema; 'cf call --piece ${pieceConfig.piece} <verb> --help --json' has the full command spec.`,
       ),
     );
   })
@@ -2963,7 +2970,7 @@ export async function describePieceFromCommand(
   }
   hint(
     cliText(
-      `TIP: 'cf piece verbs --piece ${pieceConfig.piece} --json' has each verb's schemas; 'cf piece call --piece ${pieceConfig.piece} <verb> -- --help' documents one verb.`,
+      `TIP: 'cf piece verbs --piece ${pieceConfig.piece} --json' has each verb's schemas; 'cf call --piece ${pieceConfig.piece} <verb> -- --help' documents one verb.`,
     ),
   );
 }

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -944,7 +944,7 @@ export function renderPieceCallOutcome(
     return;
   }
   const nextSteps = cliText(`NEXT STEPS:
-  → Verify state:  cf piece get --piece ${piece} <path> ...
+  → Verify state:  cf get --piece ${piece} <path> ...
   → Full inspect:  cf piece inspect --piece ${piece} ...`);
   if (result.invocation) {
     // The machine surface for a handler invocation: stdout carries the
@@ -979,7 +979,7 @@ export function renderPieceCallOutcome(
   → Read the outcome: cf get --piece ${receiptId} (this call's receipt, an ordinary read — the handler does not run again)
   → Or replay it:     CF_INVOCATION_SESSION=${
               opts.invocation?.session ?? "<session>"
-            } cf piece call --piece ${piece} --invocation ${
+            } cf call --piece ${piece} --invocation ${
               opts.invocation?.id ?? "<id>"
             } ${callableName} ... (the commit is durable and the replay loses the race for the receipt, so nothing commits twice — but the handler body RUNS AGAIN, repeating effects outside its transaction, and any write it made into another space)
   → Verify state:     cf get --piece ${piece} <path> ...`,
@@ -1274,7 +1274,7 @@ const pieceDescription = cliText(`Interact with pieces running on a server.
 COMMON WORKFLOWS:
   Deploy:    cf piece new ./pattern.tsx -i ./claude.key -a http://localhost:${ports.toolshed} -s my-space
   Update:    cf piece setsrc --piece <ID> ./pattern.tsx -i ./claude.key -a http://localhost:${ports.toolshed} -s my-space
-  Test:      cf piece call --piece <ID> callableName -i ./claude.key -a http://localhost:${ports.toolshed} -s my-space
+  Test:      cf call --piece <ID> callableName -i ./claude.key -a http://localhost:${ports.toolshed} -s my-space
   Inspect:   cf piece inspect --piece <ID> -i ./claude.key -a http://localhost:${ports.toolshed} -s my-space
 ${pieceEnvStatus()}
 TIPS:
@@ -1955,7 +1955,7 @@ export const piece = targetOptions(
     hint(cliText(`NEXT STEPS:
   → Open in browser: ${spaceConfig.apiUrl}/${spaceConfig.space}/${browserPieceRef}
   → Update code:     cf piece setsrc --piece ${pieceId} ${main} ...
-  → Test a callable: cf piece call --piece ${pieceId} <callableName> ...
+  → Test a callable: cf call --piece ${pieceId} <callableName> ...
   → Inspect state:   cf piece inspect --piece ${pieceId} ...`));
   })
   /* piece set-slug */
@@ -2104,7 +2104,7 @@ export const piece = targetOptions(
     render(`Updated source for piece ${pieceConfig.piece}`);
     hint(cliText(`NEXT STEPS:
   → Test in browser: ${pieceConfig.apiUrl}/${pieceConfig.space}/${pieceConfig.piece}
-  → Test a callable: cf piece call --piece ${pieceConfig.piece} <callableName> ...
+  → Test a callable: cf call --piece ${pieceConfig.piece} <callableName> ...
   → Check state:     cf piece inspect --piece ${pieceConfig.piece} ...`));
   })
   /* piece inspect */

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -1110,6 +1110,17 @@ run_spelling_parity() {
   [ "$RESULT" = "$((LEGACY_BEFORE + 1))" ] ||
     error "A handler dispatched via cf call should commit once, got legacyCount=$RESULT"
 
+  # The one place the two mounts deliberately differ: each verb help page
+  # names the mount that was invoked. Asserted from both ends here, in the
+  # section that dies with the piece-mounted spellings, so "the page names
+  # what you typed" cannot regress on either branch while both exist.
+  cf call $SPACE_ARGS --piece $PARITY_CALLABLE_ID search --help |
+    grep -q "cf call ... search --help" ||
+    error "cf call's verb help should name the top-level mount"
+  cf piece call $SPACE_ARGS --piece $PARITY_CALLABLE_ID search --help |
+    grep -q "cf piece call ... search --help" ||
+    error "cf piece call's verb help should name the piece mount"
+
   echo "Successfully ran CLI spelling parity tests for ${API_URL}/${SPACE}."
 }
 

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -549,14 +549,13 @@ run_piece_call() {
   echo "Created callable piece: $CALLABLE_PIECE_ID"
 
   CALL_HELP=$(cf call $SPACE_ARGS --piece $CALLABLE_PIECE_ID search --help)
-  # The expected strings keep the `piece call` spelling: the help page names
-  # it in its usage lines whichever mount was invoked — these greps assert
-  # cf's output, not this script's own spelling.
-  echo "$CALL_HELP" | grep -q "cf piece call ... search --help" ||
+  # These greps assert cf's output: the help page names the mount that was
+  # invoked, and the invocation above is the top-level spelling.
+  echo "$CALL_HELP" | grep -q "cf call ... search --help" ||
     error "Top-level callable help should work without the delimiter"
-  echo "$CALL_HELP" | grep -q "cf piece call ... search <json>" ||
+  echo "$CALL_HELP" | grep -q "cf call ... search <json>" ||
     error "Piece-call help should describe JSON input without --json"
-  echo "$CALL_HELP" | grep -q "cf piece call ... search --json \[<json>\]" ||
+  echo "$CALL_HELP" | grep -q "cf call ... search --json \[<json>\]" ||
     error "Piece-call help should describe explicit --json input"
 
   CALL_HELP_JSON=$(cf call $SPACE_ARGS --piece $CALLABLE_PIECE_ID search --help --json)

--- a/packages/cli/integration/verbs-over-the-cli.sh
+++ b/packages/cli/integration/verbs-over-the-cli.sh
@@ -257,12 +257,12 @@ C=$($CF call --quiet --piece "$BOARD" $ARGS --invocation reuse-1 \
 check "Corrected" "$(echo "$C" | jq -r '.result.note["$NAME"] // empty')" \
   "the SAME id then executes, because the refusal never consumed it"
 
-step "11. Reading a verb redirects to cf piece call"
+step "11. Reading a verb redirects to cf call"
 OUT=$($CF get --piece "$BOARD" $ARGS createNote 2>&1)
 rc=$?
 check "1" "$([ "$rc" -ne 0 ] && echo 1 || echo 0)" "a verb read exits nonzero"
-echo "$OUT" | grep -qi "piece call" &&
-  ok "the refusal names cf piece call" ||
+echo "$OUT" | grep -qi "cf call" &&
+  ok "the refusal names cf call" ||
   bad "the refusal does not name the right command"
 
 step "12. --verbose times the phases on stderr; stdout stays JSON"

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -181,7 +181,7 @@ export interface InvocationOutcome {
    * callback carries, so the address is known BEFORE the outcome is read.
    * That is what makes it available under `--no-wait`: a caller that chose
    * not to wait still holds the address to collect from, and reads it back
-   * with `cf piece get --piece <receipt>` rather than re-invoking the verb.
+   * with `cf get --piece <receipt>` rather than re-invoking the verb.
    * The receipt is a COMMIT witness, not an execution witness — a same-id
    * replay
    * runs the handler body again and then loses the race, so effects outside

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -1344,7 +1344,7 @@ async function boundCyclicResult(
       " Collect the outcome with a shape that bounds it: " +
       (receiptId === undefined
         ? "read the receipt with --select or --schema."
-        : `cf piece get --piece ${receiptId} ` +
+        : `cf get --piece ${receiptId} ` +
           `--schema '{"properties":{"<field>":{"$link":true}}}'.`) +
       " Calling the verb again under --select or --schema shapes it at the " +
       "call, but runs the handler body a second time.",

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -279,7 +279,7 @@ export class PieceVerbReadError extends Error {
   constructor(verb: string, piece: string, callable: boolean) {
     super(
       callable
-        ? `Path resolves to a verb; use 'cf piece call --piece ${piece} ${verb}' instead.`
+        ? `Path resolves to a verb; use 'cf call --piece ${piece} ${verb}' instead.`
         : `Path resolves to a verb that is not directly callable: verbs are ` +
           `invoked at the piece's root surface. Read the parent object ` +
           `instead, or list the callable verbs with ` +
@@ -3143,8 +3143,12 @@ export async function executePieceCallable(
       return parsed.showHelpJson
         ? renderExecHelpJson(spec)
         : renderPieceCallHelp(
+          // Each mount passes its own spelling, so the page names the
+          // command that was typed. The fallback is the canonical top-level
+          // spelling: a page minted with no mount to name must not teach
+          // the deprecated one.
           deps.helpCommandPrefix ??
-            cliCommand(["piece", "call", "...", callableName]),
+            cliCommand(["call", "...", callableName]),
           spec,
         );
     },

--- a/packages/cli/test/exec-read-options.test.ts
+++ b/packages/cli/test/exec-read-options.test.ts
@@ -378,7 +378,7 @@ describe("cf exec read options", () => {
     // command name no `--space` at all.
     expect(err[0]).not.toContain("--space");
     expect(err[0]).toContain(
-      "cf piece get --piece /@did:key:test-home/of:tool-result@user",
+      "cf get --piece /@did:key:test-home/of:tool-result@user",
     );
   });
 
@@ -398,7 +398,7 @@ describe("cf exec read options", () => {
     );
 
     expect(err[0]).toContain(
-      "cf piece get --piece /@did:key:test-home/of:tool-result`)",
+      "cf get --piece /@did:key:test-home/of:tool-result`)",
     );
     expect(err[0]).not.toContain("@space");
   });

--- a/packages/cli/test/piece-call-cyclic-result-live.test.ts
+++ b/packages/cli/test/piece-call-cyclic-result-live.test.ts
@@ -494,7 +494,7 @@ describe("cf piece call on a piece that points back at its container", () => {
       // mutation, and the message says so rather than leaving a stack trace to
       // read as "the call failed".
       expect(message).toContain("COMMITTED");
-      expect(message).toContain("cf piece get --piece of:");
+      expect(message).toContain("cf get --piece of:");
       expect(message).toContain("declared result leaves the closing position");
 
       // And the write did land.
@@ -525,7 +525,7 @@ describe("cf piece call on a piece that points back at its container", () => {
           'closes a circle at "/item/parent/children/0"',
         );
         expect(message).toContain("COMMITTED");
-        expect(message).toContain("cf piece get --piece of:");
+        expect(message).toContain("cf get --piece of:");
         expect(message).not.toContain("leaves the closing position");
         // No pattern was loaded to look for a declaration, because this
         // resolution attaches no thunk to reach one through.

--- a/packages/cli/test/piece-call-help-live.test.ts
+++ b/packages/cli/test/piece-call-help-live.test.ts
@@ -193,7 +193,7 @@ describe("cf piece call --help against a live piece", () => {
 
     expect(patternLoads).toBe(1);
     expect(outputSection(helpText)).toBeUndefined();
-    expect(helpText).toContain("cf piece call ... add --help");
+    expect(helpText).toContain("cf call ... add --help");
     expect(helpText).toContain("--title <string>");
   });
 

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -934,7 +934,7 @@ describe("executePieceCallable", () => {
     expect(harness.tracker.handlerWrites).toEqual([]);
   });
 
-  it("renders piece-call help with the piece-call command prefix", async () => {
+  it("renders help under the canonical spelling when no mount names itself", async () => {
     const harness = createPieceCallableHarness({
       callableKind: "tool",
       cellKey: "search",
@@ -971,18 +971,21 @@ describe("executePieceCallable", () => {
       },
     );
 
+    // The default prefix is the top-level spelling: a page minted with no
+    // mount to name must not teach the deprecated one. Each mount passes its
+    // own spelling as helpCommandPrefix.
     expect(result.helpText).toContain(
-      "cf piece call ... search --help",
+      "cf call ... search --help",
     );
     expect(result.helpText).toContain(
-      "cf piece call ... search -- [run] --query <string>",
+      "cf call ... search -- [run] --query <string>",
     );
     expect(result.helpText).toContain("JSON input:");
     expect(result.helpText).toContain(
       "Pass inline JSON as one positional argument or after `--json`",
     );
     expect(result.helpText).toContain(
-      "cf piece call ... search --json [<json>]",
+      "cf call ... search --json [<json>]",
     );
     expect(result.helpText).toContain("query: string");
     expect(result.helpText).toContain("Flags after `--`:");
@@ -990,7 +993,7 @@ describe("executePieceCallable", () => {
       "Read the full input object from stdin.",
     );
     expect(result.helpText).not.toContain(
-      "cf piece call ... search -- [run] --help",
+      "cf call ... search -- [run] --help",
     );
     expect(result.helpText).not.toContain("cf exec");
   });
@@ -4224,7 +4227,7 @@ describe("piece get data errors", () => {
     // "Path resolves to a handler; use invoke() instead." — so no extra hint
     // rides along (the --input tip would be a wrong remedy for a verb).
     expect(report?.message).toBe(
-      "Path resolves to a verb; use 'cf piece call --piece fid1:piece-123 addTopic' instead.",
+      "Path resolves to a verb; use 'cf call --piece fid1:piece-123 addTopic' instead.",
     );
     expect(report?.hint).toBeUndefined();
 
@@ -4239,7 +4242,7 @@ describe("piece get data errors", () => {
     expect(nestedReport?.message).toMatch(
       /cf piece verbs --piece fid1:piece-123/,
     );
-    expect(nestedReport?.message).not.toContain("cf piece call");
+    expect(nestedReport?.message).not.toContain("cf call");
     expect(nestedReport?.hint).toBeUndefined();
 
     // Threaded through the shared data-error exit: stderr message, exit 1.
@@ -4256,7 +4259,7 @@ describe("piece get data errors", () => {
       })
     ).toThrow("exit-sentinel");
     expect(printed).toEqual([
-      "Path resolves to a verb; use 'cf piece call --piece fid1:piece-123 addTopic' instead.",
+      "Path resolves to a verb; use 'cf call --piece fid1:piece-123 addTopic' instead.",
     ]);
     expect(exited).toEqual([1]);
   });
@@ -4776,7 +4779,7 @@ describe("renderPieceCallOutcome", () => {
     // bare because the readback runs under the same configured space as the
     // call; `cf exec`, whose space comes from the mount instead, prints the
     // space-carrying canonical form for the same cell.
-    assertStringIncludes(hinted[0], "cf piece get --piece of:x");
+    assertStringIncludes(hinted[0], "cf get --piece of:x");
     expect(hinted[0]).not.toContain("(space did:key:s");
   });
 
@@ -4798,7 +4801,7 @@ describe("renderPieceCallOutcome", () => {
     // space-scoped instance, which is a different cell — so the suffix rides
     // the address rather than sitting in a parenthetical the way the prose
     // form's did.
-    assertStringIncludes(hinted[0], "cf piece get --piece of:x@user");
+    assertStringIncludes(hinted[0], "cf get --piece of:x@user");
   });
 
   it("handler invocations render the Invocation JSON with next steps", () => {
@@ -4875,7 +4878,7 @@ describe("renderPieceCallOutcome", () => {
     assertStringIncludes(hinted[0], "executes and commits AGAIN");
     // And no dangling alternative: there is nothing for an "Or" to be or to.
     expect(hinted[0]).not.toContain("Or replay");
-    assertStringIncludes(hinted[0], "cf piece get --piece fid1:piece");
+    assertStringIncludes(hinted[0], "cf get --piece fid1:piece");
   });
 
   it("leads the detached next steps with the address it published", () => {
@@ -4899,12 +4902,12 @@ describe("renderPieceCallOutcome", () => {
     // Collecting the outcome is a read of the address this call published,
     // and it comes first because it does not run the verb again. The replay
     // stays on offer below it, for a caller that lost the address.
-    assertStringIncludes(hinted[0], "cf piece get --piece /of:receipt-1");
+    assertStringIncludes(hinted[0], "cf get --piece /of:receipt-1");
     assertStringIncludes(
       hinted[0],
       "CF_INVOCATION_SESSION=ses-7 cf piece call",
     );
-    expect(hinted[0].indexOf("cf piece get --piece /of:receipt-1"))
+    expect(hinted[0].indexOf("cf get --piece /of:receipt-1"))
       .toBeLessThan(hinted[0].indexOf("CF_INVOCATION_SESSION"));
   });
 
@@ -4933,7 +4936,7 @@ describe("renderPieceCallOutcome", () => {
     );
     assertStringIncludes(
       hinted[0],
-      "cf piece get --piece /of:receipt-1@session",
+      "cf get --piece /of:receipt-1@session",
     );
   });
 

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -4847,7 +4847,7 @@ describe("renderPieceCallOutcome", () => {
     // address unguessable, and an argument is readable in a process listing.
     assertStringIncludes(
       hinted[0],
-      "CF_INVOCATION_SESSION=ses-7 cf piece call",
+      "CF_INVOCATION_SESSION=ses-7 cf call",
     );
     assertStringIncludes(hinted[0], "--invocation inv-1");
     // And it says what the replay costs: the receipt witnesses the commit,
@@ -4905,7 +4905,7 @@ describe("renderPieceCallOutcome", () => {
     assertStringIncludes(hinted[0], "cf get --piece /of:receipt-1");
     assertStringIncludes(
       hinted[0],
-      "CF_INVOCATION_SESSION=ses-7 cf piece call",
+      "CF_INVOCATION_SESSION=ses-7 cf call",
     );
     expect(hinted[0].indexOf("cf get --piece /of:receipt-1"))
       .toBeLessThan(hinted[0].indexOf("CF_INVOCATION_SESSION"));

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -1696,13 +1696,13 @@ describe("cli piece parsing", () => {
       piece: PIECE,
     };
 
-    it("refuses a root verb path, pointing at cf piece call", async () => {
+    it("refuses a root verb path, pointing at cf call", async () => {
       const deps = guardDeps(guardPiece(RESULT_VALUE));
       const error = await getCellValue(config, ["addItem"], {}, deps)
         .catch((error) => error);
       expect(error).toBeInstanceOf(PieceVerbReadError);
       expect((error as Error).message).toBe(
-        `Path resolves to a verb; use 'cf piece call --piece ${PIECE} addItem' instead.`,
+        `Path resolves to a verb; use 'cf call --piece ${PIECE} addItem' instead.`,
       );
 
       // A root verb on the input cell redirects the same way: the dispatcher
@@ -1712,7 +1712,7 @@ describe("cli piece parsing", () => {
       );
       await expect(
         getCellValue(config, ["setup"], { input: true }, inputDeps),
-      ).rejects.toThrow(/use 'cf piece call/);
+      ).rejects.toThrow(/use 'cf call/);
     });
 
     it("refuses on the stored schema marker even when the value reads empty", async () => {
@@ -1736,7 +1736,7 @@ describe("cli piece parsing", () => {
         },
       };
       await expect(getCellValue(config, ["notify"], {}, guardDeps(piece)))
-        .rejects.toThrow(/use 'cf piece call/);
+        .rejects.toThrow(/use 'cf call/);
     });
 
     it("refuses a nested verb path without suggesting an uncallable command", async () => {
@@ -1757,7 +1757,7 @@ describe("cli piece parsing", () => {
           "instead, or list the callable verbs with " +
           `'cf piece verbs --piece ${PIECE}'.`,
       );
-      expect((error as Error).message).not.toContain("cf piece call");
+      expect((error as Error).message).not.toContain("cf call");
     });
 
     it("reads a probe-classifiable but marker-less output (fails open)", async () => {
@@ -1817,7 +1817,7 @@ describe("cli piece parsing", () => {
       )
         .catch((error) => error);
       expect(error).toBeInstanceOf(PieceVerbReadError);
-      expect((error as Error).message).toContain("cf piece call");
+      expect((error as Error).message).toContain("cf call");
       expect((error as Error).message).not.toContain("--step");
     });
 
@@ -1860,7 +1860,7 @@ describe("cli piece parsing", () => {
           ),
       }).catch((error) => error);
       expect(thrown).toBeInstanceOf(PieceVerbReadError);
-      expect((thrown as Error).message).toContain("cf piece call");
+      expect((thrown as Error).message).toContain("cf call");
 
       // And the same when the selection simply yields nothing.
       const empty = await getCellValue(config, ["addTopic"], options, {


### PR DESCRIPTION
## Why

Invoked through the blessed `cf call`, the verb help page still printed `cf piece call ...` in every usage line — the spelling that warns today and dies on 2026-08-31. The prefix was a literal default at the render site (`executePieceCallable`'s `renderHelp`, `packages/cli/lib/piece.ts`), with a `helpCommandPrefix` seam that only `cf exec` used; neither call mount passed it, so cf taught the dying spelling to everyone, including callers who had already migrated. The same defect shape lived everywhere cf composes a command for a person to copy: TIP hints, refusal remedies, NEXT-STEPS blocks, and help epilogs. Surfaced while migrating the harness in #5961; requested as the follow-up.

## What Changed

- **The help page names the mount that was typed**: `buildCallCommand`'s action passes its own `spelling` as `helpCommandPrefix`, so `cf call <verb> -- --help` renders `cf call ...` usage lines and the deprecated mount shows its own name beside its own deprecation notice. The render-site fallback becomes the canonical spelling — a page minted with no mount to name must not teach the one that is going away.
- **The composed-output sweep** (one defect shape, fixed everywhere it lived): the `verbs` and `describe` TIP hints, the read-a-verb refusal's remedy (`use 'cf call ...'`), the call outcome's NEXT-STEPS `cf get` hints, `exec`'s tool-result read-back hint, `invocation-session`'s command description, and the `cf piece` group's help epilog. The deprecation notice itself still names both spellings — that is its job.
- **Everything bound to the literal output moves with it**: `verbs-over-the-cli.md`'s "the spelling the diagnostic literally prints" passage and its step table; the walkthrough's illustrated help block now speaks the spelling the demo types; `verbs-over-the-cli.sh` step 11 asserts the new remedy; `integration.sh`'s three `CALL_HELP` needles flip to `cf call ...` — the very needles #5961 deliberately kept old-spelled while the page ignored the mount, with the comment rewritten to say what they now assert; and eleven pinned strings across six test files, including tightening two negative guards so they keep refusing the remedy under the new spelling.

## Test plan

- Full `packages/cli` suite: **175 passed, 0 failed**; repo `deno fmt --check` and `deno lint` clean on the touched files.
- Live against a freshly built toolshed: demo exit 0 with act 3's transcript now reading `cf call ... addItem --help`; gaps harness 35 passed / 0 failed / 1 known gap; `verbs-over-the-cli.sh` 48 passed / 0 failed including the step-11 remedy assertion.
- `deno task check-verb-session-sync` and `deno task check-docs` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

