### PR TITLE
run_pattern: a result that settles to nothing names its cause

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -832,23 +832,13 @@ A link that resolves into a space other than the configured session space is
 refused with a structured error before anything is created, and an input whose
 value does not match the compiled pattern's argument schema for its key is
 refused the same way — named after the offending key, with no piece persisted.
-
-A result that settles to nothing is an error, not a success: when the settled
-result fails the declared `resultSchema` or holds no fields of its own beyond
-the framework keys, the tool consults what the session's runtime reported during
-that invocation's settle window and names the cause. An action error attributed
-to the created piece names the failing computation; a non-settling episode — the
-scheduler deferring actions past its convergence budget — names the other
-observed shape, which a reactive cycle, a non-idempotent computation, and a
-policy-refused commit all produce. The refusal reason itself has no channel yet
-(CT-2037), so the message names the shapes rather than claiming to know which
-one happened. What supplies the value does not change that question: a live cell
-is measured by what it currently holds, and a plain JSON value by itself. So is
-an input the pattern's argument schema does not declare at all, listing the
-names the pattern does declare: a misnamed input is the mismatch a shape check
-cannot see, since the pattern then runs with that argument undefined and renders
-a complete page holding no values. Only a pattern whose argument schema names
-its properties, and does not admit further ones, is measured that way — an
+What supplies the value does not change that question: a live cell is measured
+by what it currently holds, and a plain JSON value by itself. So is an input the
+pattern's argument schema does not declare at all, listing the names the pattern
+does declare: a misnamed input is the mismatch a shape check cannot see, since
+the pattern then runs with that argument undefined and renders a complete page
+holding no values. Only a pattern whose argument schema names its properties,
+and does not admit further ones, is measured that way — an
 `additionalProperties` that is `true`, or that is a schema describing what an
 undeclared key may hold, admits undeclared inputs by name. What such an input's
 value is measured against is whatever that `additionalProperties` states:
@@ -956,6 +946,18 @@ swap resolves such a token passed back through `inputs`; the tool itself carries
 no handle code. The persisted tool-output artifact keeps the raw reference, the
 raw result value, and the `pieceId` — a bare fabric identifier the handle
 boundary never swaps, so it stays out of the model-facing rendering.
+
+A result that settles to nothing names its cause when one was observed: when the
+settled result fails the declared `resultSchema` or holds no fields of its own
+beyond the framework keys, the tool consults what the session's runtime reported
+during that invocation's settle window. An action error attributed to the
+created piece names the failing computation; a convergence-budget episode whose
+deferred-action labels name this pattern's module identity names the other
+observed shape, which a reactive cycle, a non-idempotent computation, and a
+policy-refused commit all produce. The refusal reason itself has no channel yet
+(CT-2037), so the message names the shapes rather than claiming to know which
+one happened — and an empty result with no observed cause still reports ok,
+since silence is not evidence of failure.
 
 A registered run adds `registration` to that output: `{ slug }`, plus `url` when
 the harness can compose one honestly. The URL is the session's API URL, the

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -832,13 +832,23 @@ A link that resolves into a space other than the configured session space is
 refused with a structured error before anything is created, and an input whose
 value does not match the compiled pattern's argument schema for its key is
 refused the same way — named after the offending key, with no piece persisted.
-What supplies the value does not change that question: a live cell is measured
-by what it currently holds, and a plain JSON value by itself. So is an input the
-pattern's argument schema does not declare at all, listing the names the pattern
-does declare: a misnamed input is the mismatch a shape check cannot see, since
-the pattern then runs with that argument undefined and renders a complete page
-holding no values. Only a pattern whose argument schema names its properties,
-and does not admit further ones, is measured that way — an
+
+A result that settles to nothing is an error, not a success: when the settled
+result fails the declared `resultSchema` or holds no fields of its own beyond
+the framework keys, the tool consults what the session's runtime reported during
+that invocation's settle window and names the cause. An action error attributed
+to the created piece names the failing computation; a non-settling episode — the
+scheduler deferring actions past its convergence budget — names the other
+observed shape, which a reactive cycle, a non-idempotent computation, and a
+policy-refused commit all produce. The refusal reason itself has no channel yet
+(CT-2037), so the message names the shapes rather than claiming to know which
+one happened. What supplies the value does not change that question: a live cell
+is measured by what it currently holds, and a plain JSON value by itself. So is
+an input the pattern's argument schema does not declare at all, listing the
+names the pattern does declare: a misnamed input is the mismatch a shape check
+cannot see, since the pattern then runs with that argument undefined and renders
+a complete page holding no values. Only a pattern whose argument schema names
+its properties, and does not admit further ones, is measured that way — an
 `additionalProperties` that is `true`, or that is a schema describing what an
 undeclared key may hold, admits undeclared inputs by name. What such an input's
 value is measured against is whatever that `additionalProperties` states:

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -954,10 +954,12 @@ during that invocation's settle window. An action error attributed to the
 created piece names the failing computation; a convergence-budget episode whose
 deferred-action labels name this pattern's module identity names the other
 observed shape, which a reactive cycle, a non-idempotent computation, and a
-policy-refused commit all produce. The refusal reason itself has no channel yet
-(CT-2037), so the message names the shapes rather than claiming to know which
-one happened — and an empty result with no observed cause still reports ok,
-since silence is not evidence of failure.
+policy-refused commit all produce. The refusal reason itself has no channel of
+its own, so the message names the shapes rather than claiming to know which one
+happened, and the failing computation's own text is withheld from model context
+— a computation over data the model cannot read may carry that data in what it
+throws — while the run artifact keeps it. An empty result with no observed cause
+still reports ok, since silence is not evidence of failure.
 
 A registered run adds `registration` to that output: `{ slug }`, plus `url` when
 the harness can compose one honestly. The URL is the session's API URL, the

--- a/packages/cf-harness/docs/CURRENT_STATE.md
+++ b/packages/cf-harness/docs/CURRENT_STATE.md
@@ -120,23 +120,25 @@ The current package provides:
   match, so the message says the name may still resolve to the created piece and
   reports the piece list as that path left it; scrubs bare fabric identifiers
   from model-facing diagnostics; reports a result that settles to empty or
-  schema-failing as an error naming its observed cause — an action error
-  attributed to the piece, or actions deferred past the scheduler's convergence
-  budget — instead of an ok over nothing; returns the result cell's canonical
-  reference plus an optionally schema-sanitized value, and leaves the piece
-  detached (no recorded origin) and, unless `register` asked for a named
-  address, out of the space's registered piece list, with run→piece provenance
-  carried by the run's persisted artifacts; without the session configuration
-  the tool is absent from the tool surface, for a `default`- or
-  `pattern-author`-profile subagent as much as for the parent — a child shares
-  the one session the parent built; `--fabric-cfc-enforcement-mode` (raise-only:
-  `enforce-explicit` or `enforce-strict`) and `--fabric-cfc-flow-labels`
-  (`off`/`observe`/`persist`) set the session runtime's CFC dials, so with
-  labels persisted a confidentiality-tainted pattern write is refused at commit
-  under strict — these are the fabric session's dials, independent of the
-  harness's own `--cfc-enforcement-mode`, and the resolved posture (each dial's
-  value and source) is recorded as `fabricSessionCfc` in run state and printed
-  in the operator summary;
+  schema-failing as an error when the invocation's settle window observed a
+  cause — an action error attributed to the piece, or a convergence-budget
+  episode whose deferred actions name this pattern — and otherwise still reports
+  ok, since an empty result with no observed cause is not evidence of failure;
+  returns the result cell's canonical reference plus an optionally
+  schema-sanitized value, and leaves the piece detached (no recorded origin)
+  and, unless `register` asked for a named address, out of the space's
+  registered piece list, with run→piece provenance carried by the run's
+  persisted artifacts; without the session configuration the tool is absent from
+  the tool surface, for a `default`- or `pattern-author`-profile subagent as
+  much as for the parent — a child shares the one session the parent built;
+  `--fabric-cfc-enforcement-mode` (raise-only: `enforce-explicit` or
+  `enforce-strict`) and `--fabric-cfc-flow-labels` (`off`/`observe`/`persist`)
+  set the session runtime's CFC dials, so with labels persisted a
+  confidentiality-tainted pattern write is refused at commit under strict —
+  these are the fabric session's dials, independent of the harness's own
+  `--cfc-enforcement-mode`, and the resolved posture (each dial's value and
+  source) is recorded as `fabricSessionCfc` in run state and printed in the
+  operator summary;
 - a `pattern-author` child profile that authors and runs Common Fabric pattern
   source: `run_pattern` under the same fabric-session gate, plus `read_file`,
   `bash`, and `read_skill_resource`, and no workspace writes, so its deliverable

--- a/packages/cf-harness/docs/CURRENT_STATE.md
+++ b/packages/cf-harness/docs/CURRENT_STATE.md
@@ -119,21 +119,24 @@ The current package provides:
   because its redirect carries no per-assignment identity a withdrawal could
   match, so the message says the name may still resolve to the created piece and
   reports the piece list as that path left it; scrubs bare fabric identifiers
-  from model-facing diagnostics; returns the result cell's canonical reference
-  plus an optionally schema-sanitized value, and leaves the piece detached (no
-  recorded origin) and, unless `register` asked for a named address, out of the
-  space's registered piece list, with run→piece provenance carried by the run's
-  persisted artifacts; without the session configuration the tool is absent from
-  the tool surface, for a `default`- or `pattern-author`-profile subagent as
-  much as for the parent — a child shares the one session the parent built;
-  `--fabric-cfc-enforcement-mode` (raise-only: `enforce-explicit` or
-  `enforce-strict`) and `--fabric-cfc-flow-labels` (`off`/`observe`/`persist`)
-  set the session runtime's CFC dials, so with labels persisted a
-  confidentiality-tainted pattern write is refused at commit under strict —
-  these are the fabric session's dials, independent of the harness's own
-  `--cfc-enforcement-mode`, and the resolved posture (each dial's value and
-  source) is recorded as `fabricSessionCfc` in run state and printed in the
-  operator summary;
+  from model-facing diagnostics; reports a result that settles to empty or
+  schema-failing as an error naming its observed cause — an action error
+  attributed to the piece, or actions deferred past the scheduler's convergence
+  budget — instead of an ok over nothing; returns the result cell's canonical
+  reference plus an optionally schema-sanitized value, and leaves the piece
+  detached (no recorded origin) and, unless `register` asked for a named
+  address, out of the space's registered piece list, with run→piece provenance
+  carried by the run's persisted artifacts; without the session configuration
+  the tool is absent from the tool surface, for a `default`- or
+  `pattern-author`-profile subagent as much as for the parent — a child shares
+  the one session the parent built; `--fabric-cfc-enforcement-mode` (raise-only:
+  `enforce-explicit` or `enforce-strict`) and `--fabric-cfc-flow-labels`
+  (`off`/`observe`/`persist`) set the session runtime's CFC dials, so with
+  labels persisted a confidentiality-tainted pattern write is refused at commit
+  under strict — these are the fabric session's dials, independent of the
+  harness's own `--cfc-enforcement-mode`, and the resolved posture (each dial's
+  value and source) is recorded as `fabricSessionCfc` in run state and printed
+  in the operator summary;
 - a `pattern-author` child profile that authors and runs Common Fabric pattern
   source: `run_pattern` under the same fabric-session gate, plus `read_file`,
   `bash`, and `read_skill_resource`, and no workspace writes, so its deliverable

--- a/packages/cf-harness/src/fabric-observations.ts
+++ b/packages/cf-harness/src/fabric-observations.ts
@@ -1,0 +1,108 @@
+/**
+ * What the fabric session's runtime reported while a `run_pattern`
+ * invocation settled: action errors attributed to a piece, and non-settling
+ * episodes in which the scheduler deferred actions after exhausting a pass's
+ * convergence budget. `run_pattern` reads these to name the cause when a
+ * piece it created settles to an empty or schema-failing result — the two
+ * silent shapes observed live were a computation that throws on every rerun,
+ * and a commit the CFC boundary refuses, which the scheduler retries and
+ * which surfaces nowhere else (CT-2037 tracks giving the refusal a reason
+ * channel of its own).
+ *
+ * One observer is installed per runtime, memoized, because the scheduler's
+ * `onError` registry has no removal — a per-invocation subscription would
+ * leak a handler per call. Invocations scope their reads by sequence number
+ * instead: `sequence()` before the piece starts, `errorsSince`/
+ * `episodesSince` after the settle barrier. Both buffers are bounded and drop
+ * oldest first; an invocation that reads after heavy churn may therefore
+ * miss records, which under-reports causes rather than misattributing them.
+ */
+
+import type { Runtime } from "@commonfabric/runner";
+import { RuntimeTelemetryEvent } from "@commonfabric/runner";
+
+export interface FabricActionErrorRecord {
+  sequence: number;
+  pieceId: string;
+  patternId: string;
+  message: string;
+}
+
+export interface FabricDeferredEpisodeRecord {
+  sequence: number;
+  deferredActions: readonly string[];
+  deferredActionCount: number;
+}
+
+export interface FabricRuntimeObservations {
+  /** Monotonic position; capture before starting a piece. */
+  sequence(): number;
+  /** Action errors recorded after `since` for the given piece. */
+  errorsSince(
+    since: number,
+    pieceId: string,
+  ): readonly FabricActionErrorRecord[];
+  /** Non-settling episodes recorded after `since`. */
+  episodesSince(since: number): readonly FabricDeferredEpisodeRecord[];
+}
+
+const BUFFER_LIMIT = 128;
+
+/** `of:fid1:…` and `fid1:…` name the same entity at different seams. */
+const normalizedPieceId = (id: string): string =>
+  id.startsWith("of:") ? id.slice("of:".length) : id;
+
+const observers = new WeakMap<Runtime, FabricRuntimeObservations>();
+
+export const fabricRuntimeObservations = (
+  runtime: Runtime,
+): FabricRuntimeObservations => {
+  const existing = observers.get(runtime);
+  if (existing !== undefined) {
+    return existing;
+  }
+  let sequence = 0;
+  const errors: FabricActionErrorRecord[] = [];
+  const episodes: FabricDeferredEpisodeRecord[] = [];
+  const push = <T>(buffer: T[], record: T): void => {
+    buffer.push(record);
+    if (buffer.length > BUFFER_LIMIT) {
+      buffer.shift();
+    }
+  };
+  runtime.scheduler.onError((error) => {
+    push(errors, {
+      sequence: ++sequence,
+      pieceId: normalizedPieceId(error.pieceId),
+      patternId: error.patternId,
+      message: error.message,
+    });
+  });
+  runtime.telemetry.addEventListener("telemetry", (event) => {
+    if (!(event instanceof RuntimeTelemetryEvent)) {
+      return;
+    }
+    const marker = event.marker;
+    if (marker.type !== "scheduler.non-settling") {
+      return;
+    }
+    push(episodes, {
+      sequence: ++sequence,
+      deferredActions: marker.deferredActions ?? [],
+      deferredActionCount: marker.deferredActionCount ?? 0,
+    });
+  });
+  const observations: FabricRuntimeObservations = {
+    sequence: () => sequence,
+    errorsSince: (since, pieceId) => {
+      const wanted = normalizedPieceId(pieceId);
+      return errors.filter((record) =>
+        record.sequence > since && record.pieceId === wanted
+      );
+    },
+    episodesSince: (since) =>
+      episodes.filter((record) => record.sequence > since),
+  };
+  observers.set(runtime, observations);
+  return observations;
+};

--- a/packages/cf-harness/src/fabric-observations.ts
+++ b/packages/cf-harness/src/fabric-observations.ts
@@ -6,8 +6,8 @@
  * when a piece it created settles to an empty or schema-failing result — the
  * two silent shapes observed live were a computation that throws on every
  * rerun, and a commit the CFC boundary refuses, which the scheduler retries
- * and which surfaces nowhere else (CT-2037 tracks giving the refusal a
- * reason channel of its own).
+ * and which surfaces nowhere else — the refusal reason has no channel of
+ * its own yet.
  *
  * One observer is installed per runtime, memoized, because the scheduler's
  * `onError` registry has no removal — a per-invocation subscription would

--- a/packages/cf-harness/src/fabric-observations.ts
+++ b/packages/cf-harness/src/fabric-observations.ts
@@ -1,13 +1,13 @@
 /**
  * What the fabric session's runtime reported while a `run_pattern`
- * invocation settled: action errors attributed to a piece, and non-settling
- * episodes in which the scheduler deferred actions after exhausting a pass's
- * convergence budget. `run_pattern` reads these to name the cause when a
- * piece it created settles to an empty or schema-failing result — the two
- * silent shapes observed live were a computation that throws on every rerun,
- * and a commit the CFC boundary refuses, which the scheduler retries and
- * which surfaces nowhere else (CT-2037 tracks giving the refusal a reason
- * channel of its own).
+ * invocation settled: action errors attributed to a piece, and
+ * convergence-budget episodes in which the scheduler deferred actions after
+ * exhausting a pass's budget. `run_pattern` reads these to name the cause
+ * when a piece it created settles to an empty or schema-failing result — the
+ * two silent shapes observed live were a computation that throws on every
+ * rerun, and a commit the CFC boundary refuses, which the scheduler retries
+ * and which surfaces nowhere else (CT-2037 tracks giving the refusal a
+ * reason channel of its own).
  *
  * One observer is installed per runtime, memoized, because the scheduler's
  * `onError` registry has no removal — a per-invocation subscription would
@@ -20,6 +20,7 @@
 
 import type { Runtime } from "@commonfabric/runner";
 import { RuntimeTelemetryEvent } from "@commonfabric/runner";
+import { hashStringForEntityAddress } from "@commonfabric/runner/entity-kind";
 
 export interface FabricActionErrorRecord {
   sequence: number;
@@ -42,15 +43,32 @@ export interface FabricRuntimeObservations {
     since: number,
     pieceId: string,
   ): readonly FabricActionErrorRecord[];
-  /** Non-settling episodes recorded after `since`. */
+  /** Convergence-budget episodes recorded after `since`. */
   episodesSince(since: number): readonly FabricDeferredEpisodeRecord[];
 }
 
 const BUFFER_LIMIT = 128;
 
-/** `of:fid1:…` and `fid1:…` name the same entity at different seams. */
-const normalizedPieceId = (id: string): string =>
-  id.startsWith("of:") ? id.slice("of:".length) : id;
+/**
+ * The hash both sides of an attribution compare by, through the canonical
+ * entity-id seam: `of:` ids reduce to their hash, a bare hash passes
+ * through, and a kinded id — which the canonical helper refuses rather than
+ * silently aliasing to its `of:` sibling — or an absent id yields
+ * `undefined`, so the record never matches instead of matching wrongly. An
+ * error without a pattern frame reaches the handler with no `pieceId`
+ * despite the declared type, which is why absence is handled rather than
+ * assumed away.
+ */
+const comparableEntityHash = (id: unknown): string | undefined => {
+  if (typeof id !== "string" || id.length === 0) {
+    return undefined;
+  }
+  try {
+    return hashStringForEntityAddress(id);
+  } catch {
+    return undefined;
+  }
+};
 
 const observers = new WeakMap<Runtime, FabricRuntimeObservations>();
 
@@ -71,10 +89,17 @@ export const fabricRuntimeObservations = (
     }
   };
   runtime.scheduler.onError((error) => {
+    // A record that cannot be attributed can never be surfaced, so it is
+    // not recorded — and nothing here may throw, because the scheduler
+    // walks its error handlers without a guard.
+    const pieceHash = comparableEntityHash(error.pieceId);
+    if (pieceHash === undefined) {
+      return;
+    }
     push(errors, {
       sequence: ++sequence,
-      pieceId: normalizedPieceId(error.pieceId),
-      patternId: error.patternId,
+      pieceId: pieceHash,
+      patternId: typeof error.patternId === "string" ? error.patternId : "",
       message: error.message,
     });
   });
@@ -83,19 +108,30 @@ export const fabricRuntimeObservations = (
       return;
     }
     const marker = event.marker;
-    if (marker.type !== "scheduler.non-settling") {
+    // The `scheduler.non-settling` marker carries two kinds of episode: a
+    // convergence-budget pass that deferred named actions, and a busy-window
+    // heuristic crossing that defers nothing. Only the first says anything
+    // about a specific pattern's writes, so only it is recorded.
+    if (
+      marker.type !== "scheduler.non-settling" ||
+      typeof marker.deferredActionCount !== "number" ||
+      marker.deferredActionCount <= 0
+    ) {
       return;
     }
     push(episodes, {
       sequence: ++sequence,
       deferredActions: marker.deferredActions ?? [],
-      deferredActionCount: marker.deferredActionCount ?? 0,
+      deferredActionCount: marker.deferredActionCount,
     });
   });
   const observations: FabricRuntimeObservations = {
     sequence: () => sequence,
     errorsSince: (since, pieceId) => {
-      const wanted = normalizedPieceId(pieceId);
+      const wanted = comparableEntityHash(pieceId);
+      if (wanted === undefined) {
+        return [];
+      }
       return errors.filter((record) =>
         record.sequence > since && record.pieceId === wanted
       );

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -3234,6 +3234,7 @@ export class CfHarnessPromptLoop {
       // are scrubbed here; the artifact keeps the raw text.
       const {
         rawValue: _rawValue,
+        rawCauseMessage: _rawCauseMessage,
         pieceId: _pieceId,
         resultRefSchema: _resultRefSchema,
         ...publicOutput

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -2,6 +2,7 @@ import type { JSONSchema } from "@commonfabric/api";
 import {
   type Cell,
   compileAndSavePattern,
+  getPatternIdentityRef,
   validateSlug,
 } from "@commonfabric/runner";
 import { validateAgainstSchema } from "@commonfabric/runner/cfc";
@@ -955,12 +956,25 @@ export const runPatternTool: HarnessToolDefinition<
           }${registrationNote}`,
         );
       }
-      const episodes = observations.episodesSince(observationStart);
-      if (episodes.length > 0) {
+      // A convergence-budget episode is claimed only when its deferred-action
+      // labels name this pattern's module identity — another piece churning
+      // during this invocation's settle window is not evidence about this
+      // one. An episode lists at most its first ten deferred actions, so a
+      // wide episode can omit this pattern and under-report, which falls
+      // back to the plain ok-with-valueError rather than misattributing.
+      const patternIdentity = getPatternIdentityRef(resultCell)?.identity;
+      const ownEpisodes = patternIdentity === undefined
+        ? []
+        : observations.episodesSince(observationStart).filter((episode) =>
+          episode.deferredActions.some((label) =>
+            label.includes(patternIdentity)
+          )
+        );
+      if (ownEpisodes.length > 0) {
         return errorOutput(
           "error",
           `the pattern ran but its writes never landed: the scheduler deferred ${
-            episodes[episodes.length - 1].deferredActionCount
+            ownEpisodes[ownEpisodes.length - 1].deferredActionCount
           } action(s) past its convergence budget while settling. A reactive cycle, a non-idempotent computation, or a write the space's policy refuses all produce this shape${registrationNote}`,
         );
       }

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -122,6 +122,18 @@ export interface RunPatternToolErrorOutput {
   outputId: string;
   status: "compile-error" | "error" | "cancelled";
   message: string;
+  /**
+   * The durable piece a post-persistence failure leaves behind, for the
+   * persisted artifact's run-to-piece provenance. Stripped from the
+   * model-facing rendering like the success output's `pieceId`.
+   */
+  pieceId?: string;
+  /**
+   * The failing computation's own message, retained for the persisted
+   * artifact and stripped from the model-facing rendering: a computation
+   * over data the model cannot read may carry that data in its thrown text.
+   */
+  rawCauseMessage?: string;
 }
 
 export type RunPatternToolOutput =
@@ -936,8 +948,8 @@ export const runPatternTool: HarnessToolDefinition<
     // computation, and a non-settling episode names the other observed shape
     // — actions deferred past the convergence budget, which is what both a
     // reactive cycle and a policy-refused commit look like from here. The
-    // refusal reason itself has no channel yet (CT-2037), so the message
-    // names the shapes rather than claiming to know which one happened.
+    // refusal reason itself has no channel of its own, so the message names
+    // the shapes rather than claiming to know which one happened.
     const inertResultKeys = isObjectNotArray(rawValue)
       ? Object.keys(rawValue).filter((key) => !key.startsWith("$"))
       : undefined;
@@ -949,19 +961,29 @@ export const runPatternTool: HarnessToolDefinition<
         ? `; the piece was registered at slug "${registration.slug}" and resolves to this broken result`
         : "";
       if (pieceErrors.length > 0) {
-        return errorOutput(
-          "error",
-          `the pattern ran but its computation failed while settling: ${
-            pieceErrors[0].message
-          }${registrationNote}`,
-        );
+        // The thrown text stays out of the model-facing message: a
+        // computation over data the model cannot read may carry that data in
+        // what it throws, so the artifact keeps the diagnostic and the model
+        // gets the fact of the failure.
+        return {
+          ...errorOutput(
+            "error",
+            `the pattern ran but a computation attributed to the created piece failed on every rerun while settling, so the result never landed; the failure text is retained in the run artifact and withheld here, since a computation's thrown message can carry the data it read${registrationNote}`,
+          ),
+          pieceId: piece.id,
+          rawCauseMessage: pieceErrors[0].message,
+        };
       }
       // A convergence-budget episode is claimed only when its deferred-action
-      // labels name this pattern's module identity — another piece churning
-      // during this invocation's settle window is not evidence about this
-      // one. An episode lists at most its first ten deferred actions, so a
-      // wide episode can omit this pattern and under-report, which falls
-      // back to the plain ok-with-valueError rather than misattributing.
+      // labels name this pattern's module identity — an unrelated piece
+      // churning during this invocation's settle window is not evidence
+      // about this one. Module identity is as fine as the labels resolve:
+      // another live piece created from the same source shares it, so the
+      // message says "this pattern's module" rather than claiming the
+      // episode as this piece's own. An episode lists at most its first ten
+      // deferred actions, so a wide episode can omit this pattern and
+      // under-report, which falls back to the plain ok-with-valueError
+      // rather than misattributing.
       const patternIdentity = getPatternIdentityRef(resultCell)?.identity;
       const ownEpisodes = patternIdentity === undefined
         ? []
@@ -971,12 +993,15 @@ export const runPatternTool: HarnessToolDefinition<
           )
         );
       if (ownEpisodes.length > 0) {
-        return errorOutput(
-          "error",
-          `the pattern ran but its writes never landed: the scheduler deferred ${
-            ownEpisodes[ownEpisodes.length - 1].deferredActionCount
-          } action(s) past its convergence budget while settling. A reactive cycle, a non-idempotent computation, or a write the space's policy refuses all produce this shape${registrationNote}`,
-        );
+        return {
+          ...errorOutput(
+            "error",
+            `the pattern ran but its result never landed: while it settled, the scheduler deferred ${
+              ownEpisodes[ownEpisodes.length - 1].deferredActionCount
+            } action(s) of this pattern's module past its convergence budget — this piece's own, or another live piece created from the same source in an earlier attempt. A reactive cycle, a non-idempotent computation, or a write the space's policy refuses all produce this shape${registrationNote}`,
+          ),
+          pieceId: piece.id,
+        };
       }
     }
     return {

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -22,6 +22,7 @@ import {
 } from "@commonfabric/piece/ops";
 import { isObjectNotArray } from "@commonfabric/utils/types";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
+import { fabricRuntimeObservations } from "../fabric-observations.ts";
 import { defineOwnEntry } from "../handle-table.ts";
 import {
   isSealedOpaqueLinkObject,
@@ -753,6 +754,10 @@ export const runPatternTool: HarnessToolDefinition<
         return mismatch;
       }
     }
+    // Position in the runtime's observation stream before the piece exists,
+    // so the post-settle read covers exactly this invocation's window.
+    const observations = fabricRuntimeObservations(pieces.runtime);
+    const observationStart = observations.sequence();
     let piece: PieceController<unknown>;
     try {
       // Deliberately unregistered: no `pieces.add()` and no default-pattern
@@ -921,6 +926,43 @@ export const runPatternTool: HarnessToolDefinition<
         linkedStringCount = sanitized.linkedStringCount;
       } catch (error) {
         valueError = errorMessage(error);
+      }
+    }
+    // A result that settled to nothing is not a success to report. When the
+    // sanitized value failed its schema, or the raw result holds no fields of
+    // its own beyond the framework keys, the runtime's observation window
+    // says why: an action error attributed to this piece names the failing
+    // computation, and a non-settling episode names the other observed shape
+    // — actions deferred past the convergence budget, which is what both a
+    // reactive cycle and a policy-refused commit look like from here. The
+    // refusal reason itself has no channel yet (CT-2037), so the message
+    // names the shapes rather than claiming to know which one happened.
+    const inertResultKeys = isObjectNotArray(rawValue)
+      ? Object.keys(rawValue).filter((key) => !key.startsWith("$"))
+      : undefined;
+    const resultAbsent = rawValue === undefined || rawValue === null ||
+      (inertResultKeys !== undefined && inertResultKeys.length === 0);
+    if (valueError !== undefined || resultAbsent) {
+      const pieceErrors = observations.errorsSince(observationStart, piece.id);
+      const registrationNote = registration !== undefined
+        ? `; the piece was registered at slug "${registration.slug}" and resolves to this broken result`
+        : "";
+      if (pieceErrors.length > 0) {
+        return errorOutput(
+          "error",
+          `the pattern ran but its computation failed while settling: ${
+            pieceErrors[0].message
+          }${registrationNote}`,
+        );
+      }
+      const episodes = observations.episodesSince(observationStart);
+      if (episodes.length > 0) {
+        return errorOutput(
+          "error",
+          `the pattern ran but its writes never landed: the scheduler deferred ${
+            episodes[episodes.length - 1].deferredActionCount
+          } action(s) past its convergence budget while settling. A reactive cycle, a non-idempotent computation, or a write the space's policy refuses all produce this shape${registrationNote}`,
+        );
       }
     }
     return {

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -215,6 +215,7 @@ export const runPatternToolDescriptor: HarnessToolDescriptor = {
         value: {},
         linkedStringCount: { type: "integer", minimum: 0 },
         valueError: { type: "string" },
+        rawValue: {},
       },
       required: [
         "outputId",
@@ -233,6 +234,8 @@ export const runPatternToolDescriptor: HarnessToolDescriptor = {
           enum: ["compile-error", "error", "cancelled"],
         },
         message: { type: "string" },
+        pieceId: { type: "string" },
+        rawCauseMessage: { type: "string" },
       },
       required: ["outputId", "status", "message"],
       additionalProperties: false,
@@ -968,7 +971,7 @@ export const runPatternTool: HarnessToolDefinition<
         return {
           ...errorOutput(
             "error",
-            `the pattern ran but a computation attributed to the created piece failed on every rerun while settling, so the result never landed; the failure text is retained in the run artifact and withheld here, since a computation's thrown message can carry the data it read${registrationNote}`,
+            `the pattern ran but a computation attributed to the created piece failed while settling and the result never landed; the failure text is retained in the run artifact and withheld here, since a computation's thrown message can carry the data it read${registrationNote}`,
           ),
           pieceId: piece.id,
           rawCauseMessage: pieceErrors[0].message,

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -987,12 +987,17 @@ export const runPatternTool: HarnessToolDefinition<
       // deferred actions, so a wide episode can omit this pattern and
       // under-report, which falls back to the plain ok-with-valueError
       // rather than misattributing.
+      // The scheduler composes deferred-action ids as
+      // `cf:module/<identity>:<symbol>:<instanceKey>` from the same entry
+      // ref this meta stamp stores, so the match is on that composed prefix
+      // rather than a bare substring — a representation drift on either
+      // side fails the settle-cause test that drives this path, loudly.
       const patternIdentity = getPatternIdentityRef(resultCell)?.identity;
       const ownEpisodes = patternIdentity === undefined
         ? []
         : observations.episodesSince(observationStart).filter((episode) =>
           episode.deferredActions.some((label) =>
-            label.includes(patternIdentity)
+            label.includes(`cf:module/${patternIdentity}:`)
           )
         );
       if (ownEpisodes.length > 0) {

--- a/packages/cf-harness/test/fabric-observations.test.ts
+++ b/packages/cf-harness/test/fabric-observations.test.ts
@@ -1,3 +1,9 @@
+/**
+ * The per-runtime observer behind run_pattern's settle-window reads: piece
+ * attribution through the canonical entity hash, the guard against errors
+ * that arrive without a pattern frame, the exclusion of busy-window markers
+ * that defer nothing, and sequence-scoped windows.
+ */
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { type Runtime, RuntimeTelemetry } from "@commonfabric/runner";

--- a/packages/cf-harness/test/fabric-observations.test.ts
+++ b/packages/cf-harness/test/fabric-observations.test.ts
@@ -1,0 +1,109 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { type Runtime, RuntimeTelemetry } from "@commonfabric/runner";
+import { fabricRuntimeObservations } from "../src/fabric-observations.ts";
+
+type ErrorListener = (error: {
+  pieceId?: string;
+  patternId?: string;
+  message: string;
+}) => void;
+
+// A stand-in carrying exactly the two surfaces the observer subscribes to.
+const stubRuntime = (): {
+  runtime: Runtime;
+  emitError: ErrorListener;
+  telemetry: RuntimeTelemetry;
+} => {
+  let listener: ErrorListener | undefined;
+  const telemetry = new RuntimeTelemetry();
+  const runtime = {
+    scheduler: {
+      onError: (fn: ErrorListener) => {
+        listener = fn;
+      },
+    },
+    telemetry,
+  } as unknown as Runtime;
+  return {
+    runtime,
+    telemetry,
+    emitError: (error) => listener?.(error as Parameters<ErrorListener>[0]),
+  };
+};
+
+describe("fabric-observations", () => {
+  it("attributes errors through the canonical entity hash across the `of:` seam", () => {
+    const { runtime, emitError } = stubRuntime();
+    const observations = fabricRuntimeObservations(runtime);
+    const start = observations.sequence();
+    emitError({
+      pieceId: "of:fid1:abc",
+      patternId: "mod1",
+      message: "boom",
+    });
+    expect(observations.errorsSince(start, "fid1:abc").map((e) => e.message))
+      .toEqual(["boom"]);
+    expect(observations.errorsSince(start, "fid1:other")).toEqual([]);
+  });
+
+  it("drops an error without a piece id rather than throwing in the handler", () => {
+    const { runtime, emitError } = stubRuntime();
+    const observations = fabricRuntimeObservations(runtime);
+    const start = observations.sequence();
+    emitError({ message: "frameless" });
+    emitError({ pieceId: "of:fid1:abc", message: "attributed" });
+    expect(observations.errorsSince(start, "fid1:abc").map((e) => e.message))
+      .toEqual(["attributed"]);
+  });
+
+  it("never matches a kinded piece id against its `of:` sibling", () => {
+    const { runtime, emitError } = stubRuntime();
+    const observations = fabricRuntimeObservations(runtime);
+    const start = observations.sequence();
+    emitError({ pieceId: "computed:fid1:abc", message: "kinded" });
+    expect(observations.errorsSince(start, "fid1:abc")).toEqual([]);
+    expect(observations.errorsSince(start, "computed:fid1:abc")).toEqual([]);
+  });
+
+  it("records only convergence-budget episodes, not busy-window markers", () => {
+    const { runtime, telemetry } = stubRuntime();
+    const observations = fabricRuntimeObservations(runtime);
+    const start = observations.sequence();
+    telemetry.submit({
+      type: "scheduler.non-settling",
+      busyTime: 0,
+      windowDuration: 1,
+      busyRatio: 0,
+    });
+    telemetry.submit({
+      type: "scheduler.non-settling",
+      busyTime: 0,
+      windowDuration: 1,
+      busyRatio: 0,
+      deferredActionCount: 0,
+      deferredActions: [],
+    });
+    telemetry.submit({
+      type: "scheduler.non-settling",
+      busyTime: 0,
+      windowDuration: 1,
+      busyRatio: 0,
+      deferredActions: ["cf:module/mod1:__cfLift_1:x"],
+      deferredActionCount: 2,
+    });
+    const episodes = observations.episodesSince(start);
+    expect(episodes.length).toBe(1);
+    expect(episodes[0]!.deferredActionCount).toBe(2);
+  });
+
+  it("scopes reads to the window after the captured sequence", () => {
+    const { runtime, emitError } = stubRuntime();
+    const observations = fabricRuntimeObservations(runtime);
+    emitError({ pieceId: "of:fid1:abc", message: "before" });
+    const start = observations.sequence();
+    emitError({ pieceId: "of:fid1:abc", message: "after" });
+    expect(observations.errorsSince(start, "fid1:abc").map((e) => e.message))
+      .toEqual(["after"]);
+  });
+});

--- a/packages/cf-harness/test/fabric-observations.test.ts
+++ b/packages/cf-harness/test/fabric-observations.test.ts
@@ -112,4 +112,33 @@ describe("fabric-observations", () => {
     expect(observations.errorsSince(start, "fid1:abc").map((e) => e.message))
       .toEqual(["after"]);
   });
+
+  it("returns the same observer for the same runtime", () => {
+    const { runtime } = stubRuntime();
+    expect(fabricRuntimeObservations(runtime)).toBe(
+      fabricRuntimeObservations(runtime),
+    );
+  });
+
+  it("drops oldest records once the ring buffer is full", () => {
+    const { runtime, emitError } = stubRuntime();
+    const observations = fabricRuntimeObservations(runtime);
+    const start = observations.sequence();
+    // One past the 128-record bound: the first record falls off the ring.
+    for (let i = 0; i < 129; i++) {
+      emitError({ pieceId: "of:fid1:abc", message: `error-${i}` });
+    }
+    const seen = observations.errorsSince(start, "fid1:abc");
+    expect(seen.length).toBe(128);
+    expect(seen[0]!.message).toBe("error-1");
+    expect(seen.at(-1)!.message).toBe("error-128");
+  });
+
+  it("ignores a telemetry event that is not a runtime telemetry event", () => {
+    const { runtime, telemetry } = stubRuntime();
+    const observations = fabricRuntimeObservations(runtime);
+    const start = observations.sequence();
+    telemetry.dispatchEvent(new Event("telemetry"));
+    expect(observations.episodesSince(start)).toEqual([]);
+  });
 });

--- a/packages/cf-harness/test/run-pattern.test.ts
+++ b/packages/cf-harness/test/run-pattern.test.ts
@@ -443,7 +443,7 @@ describe("run-pattern", () => {
       });
       const output = result.output as RunPatternToolErrorOutput;
       expect(output.status).toBe("error");
-      expect(output.message).toContain("failed on every rerun while settling");
+      expect(output.message).toContain("failed while settling");
       // The thrown text is a data channel: it stays in the artifact field the
       // prompt loop strips from model context, never in the message.
       expect(output.message).not.toContain("boom in lift");

--- a/packages/cf-harness/test/run-pattern.test.ts
+++ b/packages/cf-harness/test/run-pattern.test.ts
@@ -443,8 +443,12 @@ describe("run-pattern", () => {
       });
       const output = result.output as RunPatternToolErrorOutput;
       expect(output.status).toBe("error");
-      expect(output.message).toContain("computation failed while settling");
-      expect(output.message).toContain("boom in lift");
+      expect(output.message).toContain("failed on every rerun while settling");
+      // The thrown text is a data channel: it stays in the artifact field the
+      // prompt loop strips from model context, never in the message.
+      expect(output.message).not.toContain("boom in lift");
+      expect(output.rawCauseMessage).toContain("boom in lift");
+      expect(output.pieceId).toBeDefined();
       expect(result.runState.status).toBe("completed");
     });
 
@@ -526,8 +530,9 @@ describe("run-pattern", () => {
         });
         const output = result.output as RunPatternToolErrorOutput;
         expect(output.status).toBe("error");
-        expect(output.message).toContain("writes never landed");
+        expect(output.message).toContain("result never landed");
         expect(output.message).toContain("convergence budget");
+        expect(output.pieceId).toBeDefined();
       } finally {
         await strictRuntime.dispose();
         await strictStorage.close();

--- a/packages/cf-harness/test/run-pattern.test.ts
+++ b/packages/cf-harness/test/run-pattern.test.ts
@@ -429,6 +429,111 @@ describe("run-pattern", () => {
       expect(await piece.result.get(["doubled"])).toBe(20);
     });
 
+    it("returns an error naming the failing computation when the result settles to nothing", async () => {
+      const engine = createEngine();
+      const result = await engine.invokeBuiltinTool("run_pattern", {
+        sourceText: [
+          "import { computed, pattern } from 'commonfabric';",
+          "interface Output { boom: number; }",
+          "export default pattern<Record<string, never>, Output>(() => ({",
+          "  boom: computed(() => { throw new Error('boom in lift'); }),",
+          "}));",
+          "",
+        ].join("\n"),
+      });
+      const output = result.output as RunPatternToolErrorOutput;
+      expect(output.status).toBe("error");
+      expect(output.message).toContain("computation failed while settling");
+      expect(output.message).toContain("boom in lift");
+      expect(result.runState.status).toBe("completed");
+    });
+
+    it("returns an error naming deferred writes when a policy-refused commit keeps the result from landing", async () => {
+      // A strict flow-label runtime over a labelled source: the pattern's
+      // description-derived write is refused at the commit boundary, the
+      // scheduler retries it past the convergence budget, and the result
+      // settles to nothing. The tool reports that as an error naming the
+      // deferred-writes shape rather than an ok over an empty value.
+      const strictStorage = StorageManager.emulate({ as: signer });
+      const strictRuntime = new Runtime({
+        apiUrl: new URL("http://toolshed.test"),
+        storageManager: strictStorage,
+        cfcEnforcementMode: "enforce-strict",
+        cfcFlowLabels: "persist",
+      });
+      const strictPieces = new PiecesController(
+        await createSession({
+          identity: signer,
+          spaceName: `run-pattern-strict-${crypto.randomUUID()}`,
+        }),
+        strictRuntime,
+      );
+      try {
+        await strictPieces.synced();
+        const space = strictPieces.getSpace();
+        const seed = strictRuntime.edit();
+        const sourceCell = strictRuntime.getCell(
+          space,
+          "labelled-source",
+          {
+            type: "object",
+            properties: {
+              secret: { type: "string" },
+              amount: { type: "number" },
+            },
+          },
+          seed,
+        );
+        const sourceId = sourceCell.getAsNormalizedFullLink().id;
+        seed.writeOrThrow({ space, scope: "space", id: sourceId, path: [] }, {
+          value: { secret: "s3cr3t", amount: 2 },
+          cfc: {
+            version: 1,
+            schemaHash: "seed-schema",
+            labelMap: {
+              version: 1,
+              entries: [{
+                path: ["secret"],
+                label: { confidentiality: ["secret"] },
+              }],
+            },
+          },
+        });
+        expect((await seed.commit()).ok).toBeDefined();
+        const sourceRef = createLLMFriendlyLink(
+          sourceCell.getAsNormalizedFullLink(),
+          space,
+        );
+
+        const engine = new CfHarnessEngine({
+          sandboxRuntime: new FakeSandboxRuntime(),
+          runId: `run-pattern-strict-${crypto.randomUUID()}`,
+          cfcEnforcementMode: "disabled",
+          fabricSessionFactory: () => Promise.resolve({ pieces: strictPieces }),
+        });
+        const result = await engine.invokeBuiltinTool("run_pattern", {
+          sourceText: [
+            "import { computed, pattern, Reactive } from 'commonfabric';",
+            "interface Source { secret: string; amount: number; }",
+            "interface Input { source: Reactive<Source>; }",
+            "interface Output { copied: string; }",
+            "export default pattern<Input, Output>(({ source }) => ({",
+            "  copied: computed(() => `${source.secret}!`),",
+            "}));",
+            "",
+          ].join("\n"),
+          inputs: { source: sourceRef },
+        });
+        const output = result.output as RunPatternToolErrorOutput;
+        expect(output.status).toBe("error");
+        expect(output.message).toContain("writes never landed");
+        expect(output.message).toContain("convergence budget");
+      } finally {
+        await strictRuntime.dispose();
+        await strictStorage.close();
+      }
+    });
+
     it("returns a `compile-error` output carrying the raw diagnostics without failing the run", async () => {
       const engine = createEngine();
       const result = await engine.invokeBuiltinTool("run_pattern", {


### PR DESCRIPTION
One idea: **`run_pattern` no longer reports ok over a result that never materialized.** The follow-through on the CT-2003 enforcement chapter's most practical finding, and the rebuild of the non-settling consumer on a correct signal (the old roadmap item that was split out of #5885 when its premise — reading the episode marker as proof of a stuck graph — was shown wrong).

## The failure this closes

Two live shapes produced `status: "ok"` over nothing, and an agent read one of them as success and reported a working artifact that was empty:

- a computation that throws on every rerun (a `.filter(fn)` runtime trap, in the live case);
- a commit the CFC boundary refuses under `enforce-strict`, which the scheduler retries until the convergence budget gives up — the refusal reaches no error channel at all (CT-2037).

## The consumer

One observer per session runtime — memoized, because the scheduler's `onError` registry has no removal, so per-invocation subscriptions would leak a handler per call — collects two streams into bounded ring buffers: action errors, attributed by `pieceId`/`patternId` from `ErrorWithContext`, and `scheduler.non-settling` telemetry episodes with their deferred-action labels. Invocations scope their reads by sequence number: position captured before the piece starts, read after the settle barrier, so each call sees exactly its own window. Zero runner changes — both channels already existed.

When the settled result fails its declared `resultSchema` or holds no fields of its own beyond framework keys:

- an action error attributed to the created piece → `status: "error"` naming the failing computation (raw message; the prompt loop scrubs identifiers model-side as usual);
- otherwise a non-settling episode in the window → `status: "error"` naming the deferred-writes shape, which a reactive cycle, a non-idempotent computation, and a policy-refused commit all produce. The refusal *reason* still has no channel — CT-2037 stays open for that — so the message names the shapes rather than claiming to know which happened.

A registration that already succeeded is named in the message, since the slug now resolves to the broken piece.

## Tests

Both drive the real paths against a real runtime: a throwing lift, and a strict flow-label runtime (`enforce-strict` + `persist`) over a labelled source whose derived write is refused at the commit boundary — the exact machinery from the enforcement chapter, in emulate storage. Mechanically falsified: disabling the consult fails both on their assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

