### PR TITLE
test(runner): the demand test's second round is back, on a boxed slot

### DIFF
--- a/packages/runner/test/patterns-handlers.test.ts
+++ b/packages/runner/test/patterns-handlers.test.ts
@@ -302,12 +302,22 @@ describe("Pattern Runner - Handlers", () => {
       return tuple;
     });
 
+    // `latest` boxes the node's output, and the handler writes it through
+    // `.key("output")`, because the second event has to RE-POINT that slot at
+    // a second node. An unboxed `latest` cannot be re-pointed: an `asCell`
+    // handle resolves the write-redirect chain and then one step past the
+    // first non-redirect link (`schema-links.test.ts`, "returns Cell pointing
+    // one step past first non-redirect"), so once `latest` holds a reference
+    // to the first node's output document the handle addresses THAT document
+    // and a second `.set()` writes into it. Boxing, and naming the slot with
+    // `.key()`, is the documented shape for a stored reference —
+    // `docs/development/debugging/gotchas/cell-reference-overwrite.md`.
     const incHandler = handler<
       { amount: number },
       {
         counter: Cell<{ value: number }>;
         nested: { a: { b: { c: number } } };
-        latest: Cell<number[] | undefined>;
+        latest: Cell<{ output?: number[] }>;
       }
     >(
       true,
@@ -316,13 +326,17 @@ describe("Pattern Runner - Handlers", () => {
         properties: {
           counter: { type: "object", asCell: ["cell"] },
           nested: true,
-          latest: { type: "array", asCell: ["cell"] },
+          latest: {
+            type: "object",
+            properties: { output: { type: "array" } },
+            asCell: ["cell"],
+          },
         },
       },
       (event, state) => {
         const value = state.counter.key("value");
         value.set(value.get() + event.amount);
-        state.latest.set(incLogger({
+        state.latest.key("output").set(incLogger({
           counter: state.counter,
           amount: event.amount,
           nested: state.nested.a.b,
@@ -334,12 +348,14 @@ describe("Pattern Runner - Handlers", () => {
       counter: { value: number };
       nested: { a: { b: { c: number } } };
     }>(({ counter, nested }) => {
-      const latest = Writable.of<number[] | undefined>(undefined);
+      const latest = Writable.of<{ output?: number[] }>({});
       const stream = incHandler({ counter, nested, latest });
       return { stream, latest };
     });
 
-    const resultCell = runtime.getCell<{ stream: any; latest?: number[] }>(
+    const resultCell = runtime.getCell<
+      { stream: any; latest: { output?: number[] } }
+    >(
       space,
       "demand handler-written pattern results",
       undefined,
@@ -350,19 +366,27 @@ describe("Pattern Runner - Handlers", () => {
 
     await result.pull();
 
+    const output = result.key("latest").key("output");
+
+    // The node the handler built is reached by pulling its cell: dispatching
+    // the event and letting the scheduler settle runs nothing, and the pull is
+    // what evaluates it.
     result.key("stream").send({ amount: 1 });
     await runtime.idle();
     expect(values).toEqual([]);
-    expect(await result.key("latest").pull()).toEqual([1, 1, 0]);
+    expect(await output.pull()).toEqual([1, 1, 0]);
     expect(values).toEqual([[1, 1, 0]]);
 
-    // The node the handler built is reached by pulling its cell, not by a
-    // scheduler node minted for the handler's result.
-    const graph = runtime.scheduler.getGraphSnapshot();
-    expect(graph.nodes.some((node) => node.id.startsWith("readResult:")))
-      .toBe(false);
-    expect(graph.nodes.some((node) => node.id.startsWith("handlerResult:")))
-      .toBe(false);
+    // A second event builds a second node and re-points `latest.output` at it.
+    // The first node's output document is no longer reachable from anything
+    // pulled, so it loses demand: it must not re-run against the newer counter
+    // and must not be what `latest.output` resolves to.
+    result.key("stream").send({ amount: 2 });
+    await runtime.idle();
+    expect(await output.pull()).toEqual([3, 2, 0]);
+    expect(values).toContainEqual([1, 1, 0]);
+    expect(values).toContainEqual([3, 2, 0]);
+    expect(values.some((tuple) => tuple.join(",") === "3,1,0")).toBe(false);
   });
 
   it("should execute handlers with schemas", async () => {


### PR DESCRIPTION
## What

`patterns-handlers.test.ts`'s "evaluates a handler-written pattern result only when it is pulled" lost its second round in the writable-proxy removal (#5954), and with it the only coverage of the ordering guarantee it carried: **after a cell is re-pointed at a second node, a stale node's value must not win.** This restores it, and drops two assertions that could not fail.

## Why the second round did not reproduce

Not a defect in `Cell.set` or `diffAndUpdate` — both wrote faithfully to the address they were handed. The address moved between rounds. Traced by dumping every `diffAndUpdate` target plus the handler's own handle:

```
round 1  state.latest handle -> TAmHw (the Writable's backing doc, empty)
         set writes link->EQ at TAmHw                       re-points
round 2  state.latest handle -> EQ    (the FIRST node's output doc)
         set writes link->n_zK *into EQ*
         node 1, still demanded via the unchanged TAmHw->EQ chain,
         re-runs against the newer counter and clobbers it with [3,1,0]
         node 2 writes [3,2,0] into the now-orphaned n_zK
```

An `asCell` handle resolves the write-redirect chain and then **one step past the first non-redirect link** — pinned in `schema-links.test.ts` as *"returns Cell pointing one step past first non-redirect"*. So once `latest` held a reference to node 1's output document, `state.latest` stopped denoting `latest` and started denoting that document. The same source line meant "re-point" the first time and "write through" every time after.

That is the already-documented stored-reference hazard, [`docs/development/debugging/gotchas/cell-reference-overwrite.md`](../blob/main/docs/development/debugging/gotchas/cell-reference-overwrite.md) — *"Never store Cell references directly — always box them in an object"*, plus its `.key()` alternative. The old writable-proxy assignment wrote at the argument's `latest` path and stopped at the first plain link, so it sidestepped the gotcha; converting to `Cell.set` walked straight into it.

I did try moving the handle instead — stopping the extra follow once the write-redirect walk had moved. It fixes this and it also stops the collateral write into the previous referent, but it breaks the `schema-links.test.ts` invariant above plus five tests across `.inSpace()` and the receipt paths. That rule is load-bearing, so the handle stays where it is.

## What changed

`latest` boxes the output and the handler names the slot with `.key("output")` — an address that does not move. The assertions come back as they stood:

```ts
expect(await output.pull()).toEqual([3, 2, 0]);
expect(values).toContainEqual([1, 1, 0]);
expect(values).toContainEqual([3, 2, 0]);
expect(values.some((tuple) => tuple.join(",") === "3,1,0")).toBe(false);
```

`values` settles at `[[1,1,0],[3,2,0]]`: node 1 loses demand when the slot is re-pointed and never re-runs against the newer counter.

The two graph-snapshot assertions go. Nothing in the tree mints a `readResult:` or `handlerResult:` action id — ids come from `getSchedulerActionId`, which yields `cf:module/...`, an `action.name`, or `anon-N`, and a repo-wide grep for those two literals finds only the assertions themselves — so both `.some(...)` calls returned `false` whatever the runtime did. What they meant to say (the built node is reached by pulling its cell, not by an eagerly registered scheduler node) is what `expect(values).toEqual([])` before the first pull already asserts, and the comment moves there.

## Testing

- `packages/runner` full suite: **1234 passed, 0 failed**
- Repo-wide `deno fmt --check`, `deno lint`, `check-no-waitfor`, `check-skill-facts`, `check-conflict-markers`: clean
- Mutation-tested all five surviving assertions in this test — each mutation fails, including reverting the box to the unboxed shape (the shape that regressed) and expecting a non-empty `values` before the first pull

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

