### PR TITLE
fix(piece): a recompile-only writeAuthorizedBy change stays compatible

### DIFF
--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -646,6 +646,12 @@ Mechanics:
   `normalizeWriterIdentityFile`). The transformer also handles the direct-root
   `toSchema<WriteAuthorizedBy<T, typeof b>>` form specially so the wrapper's
   value schema remains the root while the same identity marker is attached.
+  The content-addressed identity (`moduleIdentity`, and the legacy `bundleId`)
+  is update-volatile in the piece compat checker: it rehashes on any edit to
+  the authoring module, so `assertPatternSchemasBackwardCompatible` normalizes
+  it out of the `ifc` comparison and compares only the binding `file`/`path`
+  and the `uiContract`. The runner still verifies the live writer's
+  `moduleIdentity` against the claim at write time, so this narrows nothing.
 - `SchemaGeneratorTransformer.resolvePolicyOfMarkers` replaces a valid policy
   marker with the compiled module identity, exported symbol, and policy digest.
   If it cannot match a compiler-verified exported `exchangeRules()` binding,

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -153,6 +153,71 @@ const fabricAwareEqual = (left: unknown, right: unknown): boolean => {
 };
 
 /**
+ * The keys inside a `writeAuthorizedBy` writer claim's `__ctWriterIdentityOf`
+ * that record the content hash of the authoring module rather than the
+ * authorization's consumer-facing contract.
+ */
+const WRITER_IDENTITY_HASH_KEYS: ReadonlySet<string> = new Set([
+  "bundleId",
+  "moduleIdentity",
+]);
+
+/**
+ * Return an `ifc` extension with the content-addressed identity of a
+ * `writeAuthorizedBy` writer claim removed, so a recompile of the authorizing
+ * module does not read as a contract change in the semantic-extension
+ * comparison below.
+ *
+ * A CFC write authorization (`TrustedActionWrite`) lowers to
+ * `ifc.writeAuthorizedBy.__ctWriterIdentityOf`, whose `moduleIdentity` (and the
+ * legacy `bundleId`) is the content hash of the module that defines the
+ * authorizing handler. When that handler lives in the pattern's own module —
+ * the common case — any edit to the pattern rehashes the module, so
+ * `moduleIdentity` changes while the binding `file` and `path` and the sibling
+ * `uiContract` stay identical. That is the same authorization recompiled, not a
+ * narrowed contract. The runtime still re-verifies the live writer's
+ * `moduleIdentity` against the claim at write time (`writeAuthorizedByReason`,
+ * `packages/runner/src/cfc/prepare.ts`), so dropping it here only stops the
+ * schema diff from reading "the code was edited" as "the contract changed"; it
+ * does not weaken that enforcement.
+ *
+ * Everything a caller can depend on is kept and still compared: the binding
+ * `file` and `path` — a handler moving files or being renamed is a real change
+ * — and the entire `uiContract` (helper/action/surface/role/kind/
+ * trustedPattern/requiredEventIntegrity). The builtin `readonly string[]` form
+ * of `writeAuthorizedBy` names trusted builtins rather than a compiled module,
+ * so it carries no content hash and is returned unchanged.
+ *
+ * This runs where the `ifc` extension is compared as a semantic-extension key,
+ * which the per-node recursion reaches for a claim placed directly on a
+ * property, behind a `$defs` reference, or in an `anyOf` branch. A claim
+ * reached only through a composite keyword (`allOf`, `oneOf`, `if`/`then`,
+ * `not`) is compared by whole-value equality instead, so its content hash still
+ * participates and a recompile there is reported as a change.
+ */
+const ifcWithoutWriterContentHash = (ifc: unknown): unknown => {
+  if (typeof ifc !== "object" || ifc === null) return ifc;
+  const claim = (ifc as Record<string, unknown>).writeAuthorizedBy;
+  if (typeof claim !== "object" || claim === null || Array.isArray(claim)) {
+    return ifc;
+  }
+  const identity = (claim as Record<string, unknown>).__ctWriterIdentityOf;
+  if (typeof identity !== "object" || identity === null) return ifc;
+  const strippedIdentity: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(identity)) {
+    if (WRITER_IDENTITY_HASH_KEYS.has(key)) continue;
+    strippedIdentity[key] = value;
+  }
+  return {
+    ...(ifc as Record<string, unknown>),
+    writeAuthorizedBy: {
+      ...(claim as Record<string, unknown>),
+      __ctWriterIdentityOf: strippedIdentity,
+    },
+  };
+};
+
+/**
  * Reject a piece update unless its argument and result schemas preserve the
  * contracts of the currently running pattern.
  *
@@ -188,6 +253,16 @@ const fabricAwareEqual = (left: unknown, right: unknown): boolean => {
  * current runner and are therefore always marked. Both are pinned as decisions
  * in `packages/runner/test/pattern-update-argument-validation.test.ts` rather
  * than left to be rediscovered.
+ *
+ * The semantic-extension keys (`asCell`, `ifc`, `readOnly`, `scope`,
+ * `writeOnly`) are compared for exact equality, with one exception: a
+ * `writeAuthorizedBy` writer claim's content-addressed module identity
+ * (`moduleIdentity`, and the legacy `bundleId`) is treated as update-volatile
+ * and normalized out before the `ifc` comparison, because it rehashes on any
+ * edit to the authoring module while the authorization it names is unchanged
+ * (see `ifcWithoutWriterContentHash`). The binding `file` and `path` and the
+ * whole `uiContract` are still compared, and the runtime re-verifies the live
+ * writer's identity at write time, so this narrows nothing.
  */
 export function assertPatternSchemasBackwardCompatible(
   previous: Pattern,
@@ -418,7 +493,17 @@ function schemaSubsetIssue(
     if (constraintIssue) return constraintIssue;
 
     for (const key of SEMANTIC_EXTENSION_KEYS) {
-      if (!fabricAwareEqual(source[key], target[key])) {
+      // The `ifc` extension is compared for exact equality except for a
+      // `writeAuthorizedBy` writer claim's content-addressed module identity,
+      // which is volatile across a recompile of the same authorization (see
+      // ifcWithoutWriterContentHash).
+      const sourceValue = key === "ifc"
+        ? ifcWithoutWriterContentHash(source[key])
+        : source[key];
+      const targetValue = key === "ifc"
+        ? ifcWithoutWriterContentHash(target[key])
+        : target[key];
+      if (!fabricAwareEqual(sourceValue, targetValue)) {
         return `${path}: ${key} changed`;
       }
     }

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -46,12 +46,11 @@ describe("piece schema compatibility", () => {
   // content-addressed hash of the authoring module. Editing that module at all
   // — a type annotation, a comment, whitespace — rehashes it, so `moduleIdentity`
   // changes while `file`, `path`, and the `uiContract` stay identical. That is a
-  // recompile of the same authorization, not a narrowed contract, so a pattern
-  // update must be allowed to carry it. Today the whole `ifc` is compared for
-  // exact equality, so every edit to a pattern with a CFC write is rejected as
-  // "ifc changed" and the pattern is effectively frozen; ten baselined patterns
-  // (system/home, system/profile-*, lobby, and the cfc-* demos) are in that
-  // state. This test states the required behavior and currently fails.
+  // recompile of the same authorization, not a narrowed contract, so the
+  // backward-compatibility check accepts it: the content-addressed identity is
+  // normalized out of the `ifc` comparison. The ten baselined patterns that
+  // carry a CFC write (system/home, system/profile-*, lobby, and the cfc-*
+  // demos) depend on this to stay editable.
   it("accepts a recompile that only changes writeAuthorizedBy moduleIdentity", () => {
     const resultSchema = (moduleIdentity: string): JSONSchema => ({
       type: "object",

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -41,6 +41,174 @@ const oldPattern = pattern(
 );
 
 describe("piece schema compatibility", () => {
+  // A CFC write authorization (`TrustedActionWrite`) lowers to an
+  // `ifc.writeAuthorizedBy.__ctWriterIdentityOf` whose `moduleIdentity` is the
+  // content-addressed hash of the authoring module. Editing that module at all
+  // — a type annotation, a comment, whitespace — rehashes it, so `moduleIdentity`
+  // changes while `file`, `path`, and the `uiContract` stay identical. That is a
+  // recompile of the same authorization, not a narrowed contract, so a pattern
+  // update must be allowed to carry it. Today the whole `ifc` is compared for
+  // exact equality, so every edit to a pattern with a CFC write is rejected as
+  // "ifc changed" and the pattern is effectively frozen; ten baselined patterns
+  // (system/home, system/profile-*, lobby, and the cfc-* demos) are in that
+  // state. This test states the required behavior and currently fails.
+  it("accepts a recompile that only changes writeAuthorizedBy moduleIdentity", () => {
+    const resultSchema = (moduleIdentity: string): JSONSchema => ({
+      type: "object",
+      properties: {
+        flag: {
+          type: "boolean",
+          ifc: {
+            writeAuthorizedBy: {
+              __ctWriterIdentityOf: {
+                file: "/packages/patterns/demo/main.tsx",
+                path: ["setFlag"],
+                moduleIdentity,
+              },
+            },
+            uiContract: {
+              helper: "UiAction",
+              action: "SetFlag",
+              trustedPattern: "DemoSurface",
+              requiredEventIntegrity: ["DemoSurface"],
+            },
+          },
+        },
+      },
+    });
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern({ type: "object" }, resultSchema("UVJh2ChHuLkknYrVet0Iu")),
+        pattern({ type: "object" }, resultSchema("DCTZZ89BogydamlP301Qx")),
+      )
+    ).not.toThrow();
+  });
+
+  // The identity fields excluded from the comparison are only the content
+  // hashes. The rest of the writer claim and the whole uiContract still name
+  // the real consumer-facing contract, so a change to any of them must still be
+  // rejected. These build two result schemas that differ in exactly one such
+  // field and assert the update is refused.
+  const trustedWriteResult = (
+    identity: Record<string, unknown>,
+    uiContract: Record<string, unknown>,
+  ): JSONSchema => ({
+    type: "object",
+    properties: {
+      flag: {
+        type: "boolean",
+        ifc: {
+          writeAuthorizedBy: { __ctWriterIdentityOf: identity },
+          uiContract,
+        },
+      },
+    },
+  });
+
+  const baselineIdentity = {
+    file: "/packages/patterns/demo/main.tsx",
+    path: ["setFlag"],
+    moduleIdentity: "UVJh2ChHuLkknYrVet0Iu",
+  };
+  const baselineUiContract = {
+    helper: "UiAction",
+    action: "SetFlag",
+    trustedPattern: "DemoSurface",
+    requiredEventIntegrity: ["DemoSurface"],
+  };
+
+  it("also treats the legacy bundleId as recompile-volatile", () => {
+    const withBundleId = (bundleId: string): JSONSchema =>
+      trustedWriteResult(
+        { file: baselineIdentity.file, path: baselineIdentity.path, bundleId },
+        baselineUiContract,
+      );
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern({ type: "object" }, withBundleId("bundle-old")),
+        pattern({ type: "object" }, withBundleId("bundle-new")),
+      )
+    ).not.toThrow();
+  });
+
+  it("still rejects a writeAuthorizedBy binding file change", () => {
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(
+          { type: "object" },
+          trustedWriteResult(baselineIdentity, baselineUiContract),
+        ),
+        pattern(
+          { type: "object" },
+          trustedWriteResult(
+            { ...baselineIdentity, file: "/packages/patterns/other/main.tsx" },
+            baselineUiContract,
+          ),
+        ),
+      )
+    ).toThrow(/flag: ifc changed/);
+  });
+
+  it("still rejects a writeAuthorizedBy binding path change", () => {
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(
+          { type: "object" },
+          trustedWriteResult(baselineIdentity, baselineUiContract),
+        ),
+        pattern(
+          { type: "object" },
+          trustedWriteResult(
+            { ...baselineIdentity, path: ["setOtherFlag"] },
+            baselineUiContract,
+          ),
+        ),
+      )
+    ).toThrow(/flag: ifc changed/);
+  });
+
+  it("still rejects a uiContract change", () => {
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(
+          { type: "object" },
+          trustedWriteResult(baselineIdentity, baselineUiContract),
+        ),
+        pattern(
+          { type: "object" },
+          trustedWriteResult(baselineIdentity, {
+            ...baselineUiContract,
+            action: "ClearFlag",
+          }),
+        ),
+      )
+    ).toThrow(/flag: ifc changed/);
+  });
+
+  it("still rejects a change to the builtin writeAuthorizedBy list", () => {
+    const withBuiltins = (builtins: readonly string[]): JSONSchema => ({
+      type: "object",
+      properties: {
+        flag: {
+          type: "boolean",
+          ifc: { writeAuthorizedBy: builtins },
+        },
+      },
+    });
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern({ type: "object" }, withBuiltins(["trustedBuiltin"])),
+        pattern({ type: "object" }, withBuiltins(["trustedBuiltin"])),
+      )
+    ).not.toThrow();
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern({ type: "object" }, withBuiltins(["otherBuiltin"])),
+        pattern({ type: "object" }, withBuiltins(["trustedBuiltin"])),
+      )
+    ).toThrow(/flag: ifc changed/);
+  });
+
   it("accepts named Fabric projection fields through an open link target", () => {
     const source: JSONSchema = {
       type: "object",


### PR DESCRIPTION
A pattern can restrict who may write a field to one specific handler: a CFC write authorization (`TrustedActionWrite`). The schema generator lowers it onto the field's schema as an `ifc.writeAuthorizedBy` claim whose `moduleIdentity` is the content-addressed hash of the module that defines the authorizing handler. A field guarded this way carries:

    revealSensitive: {
      type: "boolean",
      ifc: {
        writeAuthorizedBy: {
          __ctWriterIdentityOf: {
            file: "/patterns/.../main.tsx",  // the binding
            path: ["setRevealSensitive"],     // the handler
            moduleIdentity: "<hash of the module bytes>",
          },
        },
        uiContract: { helper: "UiAction", action: "SetReveal" },
      },
    }

When the handler lives in the pattern's own module — the common case — `moduleIdentity` is that module's hash, so any edit to the pattern rehashes it. Add one comment and recompile: `file`, `path`, and `uiContract` are byte-for-byte identical, and only `moduleIdentity` flips to a new hash.

`assertPatternSchemasBackwardCompatible` — the rule `cf piece setsrc` enforces and the pattern-update CI gate re-runs — refuses an update whose result schema narrows the contract, and it compared the whole `ifc` semantic-extension key for exact equality. So the recompile above reported `result.revealSensitive: ifc changed` and the update was refused, though nothing a caller can observe had changed.

That froze every pattern carrying a CFC write, and the freeze was total. The gate records a new contract with `--update`, but only when the sole finding is "not recorded"; here the spurious incompatibility finding stood alongside it, so `--update` declined to record and the run still failed. A type annotation, a comment, or whitespace was enough. Ten baselined patterns were stuck — `system/home`, `system/profile-*`, `lobby`, and the `cfc-*` demos.

Normalize the content-addressed writer identity — `moduleIdentity` and the legacy `bundleId` — out of both sides before the `ifc` comparison, handling both the object claim form and the builtin `string[]` form. The binding `file` and `path` and the entire `uiContract` are still compared, so a handler moving files, being renamed, or a changed trusted surface is still refused as a real contract change. This touches only the schema diff: the runtime independently re-verifies the live writer's `moduleIdentity` against the claim at write time in `writeAuthorizedByReason`, so no enforcement is weakened.

Cover the accept case and the negative cases with tests: a recompile that changes only `moduleIdentity` (or the legacy `bundleId`) is accepted, while a change to the binding `file`, the binding `path`, the `uiContract`, or the builtin `writeAuthorizedBy` list is still rejected. The normalization runs at the semantic-extension `ifc` comparison; a claim reached only through a composite keyword (`allOf`, `oneOf`, `if`/`then`, `not`) is compared by whole-value equality, and the function's doc comment records that boundary. The schema-generator mapping spec notes that the writer identity is update-volatile in the piece compat checker.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

