### PR TITLE
fix(patterns): isolate workspace-backed provenance test

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -2576,6 +2576,7 @@
       },
       "packages/patterns": {
         "dependencies": [
+          "jsr:@db/sqlite@0.13.0",
           "npm:@opentelemetry/api@^1.9.1"
         ]
       },

--- a/docs/development/DEPENDENCIES.md
+++ b/docs/development/DEPENDENCIES.md
@@ -380,9 +380,9 @@ run the complete CLI test task:
 
 ### SQLite
 
-Six workspace members pin `@db/sqlite` exactly: `memory`, `toolshed`,
-`state-inspector`, `cf-harness`, `cli`, and `piece`. They must resolve one
-version. The memory package also repeats that version in
+Seven workspace members pin `@db/sqlite` exactly: `memory`, `toolshed`,
+`state-inspector`, `cf-harness`, `cli`, `piece`, and `patterns`. They must
+resolve one version. The memory package also repeats that version in
 `SQLITE3_RELEASE_VERSION` in
 `packages/memory/v2/sqlite/column-origin.ts`.
 
@@ -393,7 +393,7 @@ the column-origin binding derives the same URL from
 both files creates two independent libsqlite3 images, and passing a prepared
 statement between them can crash the process.
 
-To roll SQLite, update all six import maps and
+To roll SQLite, update all seven import maps and
 `SQLITE3_RELEASE_VERSION` in one change, run `deno install`, and verify:
 
 ```bash

--- a/packages/patterns/deno.jsonc
+++ b/packages/patterns/deno.jsonc
@@ -46,11 +46,12 @@
     "integration": "LOG_LEVEL=warn deno test --v8-flags=--max-old-space-size=4096 --trace-leaks -A $INTEGRATION_TEST_FLAGS ./integration/*.test.ts",
     "integration:reload": "LOG_LEVEL=warn deno test --v8-flags=--max-old-space-size=4096 --trace-leaks -A $INTEGRATION_TEST_FLAGS ./integration/reload/*.test.ts",
     "integration:all": "TEST_HTTP=1 TEST_LLM=1 LOG_LEVEL=warn deno test --v8-flags=--max-old-space-size=4096 --trace-leaks -A ./integration/*.test.ts",
-    // `test/source-coverage/` runs in a second pass under workspace resolution,
-    // not `test-import-map.json`: its `commonfabric` shim re-exports real
-    // `data-model` helpers, whose internal `@/` graph the flat test import map
-    // can't resolve. See test/source-coverage/pattern-source-coverage.test.ts.
-    "test": "deno test -A --import-map ./test-import-map.json --ignore='**/*.test.tsx' --ignore='integration' --ignore='google/core/integration' --ignore='auth' --ignore='test/source-coverage' . && deno test -A test/source-coverage/"
+    // These tests run in a second pass under workspace resolution:
+    // `agent-sessions-debug/provenance.test.ts` imports `state-inspector`, and
+    // the source-coverage shim re-exports real `data-model` helpers. The first
+    // pass's flat import map replaces `commonfabric` throughout every imported
+    // workspace package.
+    "test": "deno test -A --import-map ./test-import-map.json --ignore='**/*.test.tsx' --ignore='integration' --ignore='google/core/integration' --ignore='auth' --ignore='agent-sessions-debug/provenance.test.ts' --ignore='test/source-coverage' . && deno test -A agent-sessions-debug/provenance.test.ts test/source-coverage/"
   },
   // File discovery for the `test` task (lane 1). `include` keeps only
   // `.test.ts`, so pattern tests (`.test.tsx`, lane 2) are never collected;
@@ -72,6 +73,7 @@
   // process runs under Deno's native OpenTelemetry.
   "imports": {
     // Dependency guide: ../../docs/development/DEPENDENCIES.md
+    "@db/sqlite": "jsr:@db/sqlite@0.13.0",
     "@opentelemetry/api": "npm:@opentelemetry/api@^1.9.1"
   }
 }

--- a/packages/patterns/test-import-map.json
+++ b/packages/patterns/test-import-map.json
@@ -1,17 +1,11 @@
 {
   "imports": {
-    "@db/sqlite": "jsr:@db/sqlite@0.13.0",
-    "@noble/hashes": "npm:@noble/hashes@^2.2.0",
-    "@noble/hashes/": "npm:/@noble/hashes@^2.2.0/",
     "@std/assert": "jsr:@std/assert@^1",
     "@std/expect": "jsr:@std/expect@^1",
     "@std/jsonc": "jsr:@std/jsonc@^1",
     "@std/path": "jsr:@std/path@^1",
     "@std/testing/bdd": "jsr:@std/testing@^1/bdd",
     "@commonfabric/test-support/isolated-deno": "../test-support/src/isolated-deno.ts",
-    "commonfabric": "./tools/test-support/commonfabric.ts",
-    "hash-wasm": "npm:hash-wasm@^4.12.0",
-    "multiformats": "npm:multiformats@^14.0.4",
-    "multiformats/": "npm:/multiformats@^14.0.4/"
+    "commonfabric": "./tools/test-support/commonfabric.ts"
   }
 }


### PR DESCRIPTION
The agent sessions provenance test imports the real state-inspector package. The patterns unit-test import map replaces commonfabric with a narrow shim for every module in the graph. Checking state-inspector under that map therefore sends real runtime modules through the shim and produces 73 type errors.

Run provenance in the existing workspace-resolution pass beside source coverage. Declare SQLite at patterns package scope and remove the transitive packages added to the flat test map. Keep the lockfile and SQLite dependency guide aligned with the seventh direct consumer.

Verified with the patterns test task, the repository type check, formatting, lint, dependency checks, package-cycle checking, and frozen installation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

