### PR TITLE
test(patterns): cover the bulk of the package, and fix what that found

### DIFF
--- a/docs/history/INDEX.md
+++ b/docs/history/INDEX.md
@@ -4,6 +4,7 @@ One line per archived document; [`README.md`](README.md) has the rules for this 
 
 ## Audits and reports
 
+- [2026-08-14-uncovered-code-inventory.md](packages/patterns/2026-08-14-uncovered-code-inventory.md) — where the 232,303 uncovered lines in `packages/patterns` were, what a round of ten pattern tests reached, the patterns that turned out not to build, and what was left, August 2026.
 - [verbs-arc-independent-review-2026-08-14.md](verbs-arc-independent-review-2026-08-14.md) — independent full-codebase review of the landed verbs implementation arc at `5ca4c1296`, with a reconciliation against the PR #5765 review, August 2026.
 - [cf-view-parser-adapter-spike-2026-08.md](packages/cli/cf-view-parser-adapter-spike-2026-08.md) — Python, Go, shell, and HTML parser-adapter measurements, August 2026.
 - [cf-view-parser-adapter-spike-2026-08-methodology.md](packages/cli/cf-view-parser-adapter-spike-2026-08-methodology.md) — retained fixtures and procedure for the parser-adapter measurements, August 2026.

--- a/docs/history/packages/patterns/2026-08-14-uncovered-code-inventory.md
+++ b/docs/history/packages/patterns/2026-08-14-uncovered-code-inventory.md
@@ -1,0 +1,153 @@
+---
+status: historical
+created: 2026-08-14
+archived: 2026-08-14
+reason: "Inventory: where the uncovered lines in packages/patterns were, what a round of high-ratio pattern tests reached, and what was left."
+---
+
+# What was uncovered in `packages/patterns`, and what a round of tests reached
+
+`packages/patterns` carried 232,303 uncovered lines. This is where they were,
+what a round of pattern tests written against them reached, and what remains.
+
+The measurement is the coverage-debt metric the gate uses, described in
+[COVERAGE.md](../../../development/COVERAGE.md): the whole pattern unit test
+lane run with `CF_PATTERN_COVERAGE_DIR` set, its per-test LCOV files joined,
+and the result handed to the same accounting that
+[`tasks/coverage-metrics.ts`](../../../../tasks/coverage-metrics.ts) applies in
+CI. Two numbers matter throughout. A file with no coverage record is charged
+every one of its tracked lines, so it reads as entirely uncovered whether it is
+a thousand-line program nothing loads or a file one test barely touches. A file
+with a record is charged only the lines within it that no test ran.
+
+## Where the lines were
+
+One file held 77% of the total.
+`packages/patterns/scrabble/scrabble-words.ts` is the TWL06 Scrabble
+dictionary: 178,696 lines, one `Set` literal, and nothing in the repository
+imports it. `scrabble.tsx` validates words against its own 300-word
+`EXAMPLE_WORDS` set instead. So the largest single item in the package's
+coverage debt is a file no code reads, and a test that imported it would cover
+178,696 lines while proving nothing about any pattern. It is left alone here
+and wants a decision of its own: either wire the game to the real dictionary,
+or delete the file.
+
+Setting that file aside, 53,607 lines were uncovered, and they split cleanly.
+39,113 of them sat in 208 files with no coverage record at all — patterns
+nothing had ever built. The other 14,494 sat in 162 files that a test loaded
+but only partly ran, mostly the branches behind a signed-in account or a
+language-model response.
+
+By directory, before and after this round:
+
+| Directory | Before | After |
+| --- | ---: | ---: |
+| `google/` | 18,529 | 11,132 |
+| `catalog/` | 7,360 | 86 |
+| top level | 6,626 | 3,922 |
+| `gideon-tests/` | 3,269 | 3,269 |
+| `examples/` | 1,960 | 876 |
+| `experimental/` | 1,697 | 545 |
+| `system/` | 1,665 | 1,020 |
+| `base/` | 1,392 | 416 |
+| everything else | 11,109 | 8,116 |
+| **total, excluding the word list** | **53,607** | **29,382** |
+
+## What the tests did
+
+Ten pattern tests, 1,568 lines between them, closed 24,225 lines: a 45% cut in
+everything but the word list. The ratio comes from a property of the
+measurement rather than from anything clever. Pattern coverage counts
+statements, and most of a pattern's lines are one statement each — a module's
+schema table, its type declarations, the pattern body, the rendered tree.
+Building a pattern runs all of them. So a test that instantiates a pattern with
+plausible inputs and reads what it publishes covers the bulk of it, and a test
+that also reads the rendered tree covers the derived expressions inside it,
+which only run when something reads the node they build.
+
+The tests are not bare smoke tests. Each checks what the pattern claims: the
+name it goes under, the collections it derives, the text its tree carries, and,
+where the pattern turns on one, the state a headline action moves. The Gmail
+extractors are checked for coming up empty rather than failing when no account
+is linked. The catalog is driven through picking a story, collapsing its
+sidebar, reopening it, and picking another. The contacts list is driven through
+both its add buttons. The folksonomy demo is checked for a tag landing on the
+item it was written to and nowhere else.
+
+The largest single result was `catalog/`, which went from 7,360 uncovered to
+86. Sixty stories, each about 120 lines of component example, are covered by
+two test files of about 215 lines each: build the story, check the name the
+catalog lists it under, check it built an example.
+
+## What building the patterns found
+
+Nothing had ever instantiated most of these patterns, so the tests found
+patterns that do not build at all. Six were fixed alongside the tests:
+
+- `usps-informed-delivery.tsx` annotated its pattern-body parameter `: any` and
+  cast the body back with `as any`. That hides from the transformer which
+  values are reactive, so `.map(...)` over a reactive array in the rendered
+  tree was left un-lowered and threw on instantiation. The `any` was also
+  masking an `error` field typed `unknown`, which the runner reads back as
+  `undefined` rather than materializing.
+- `hotel-membership-gmail-agent.tsx` built its multi-account summary as a
+  record keyed by brand and walked it with `Object.entries(...)` inside the
+  rendered tree. Entries taken off a reactive record yield reactive values, and
+  `.map` on one throws the same way.
+- `person.tsx` and `family-member.tsx` wrote every collapsible section header
+  as a helper call inside a JSX expression slot with the toggle handler bound
+  inline: `{header(label, toggle({ section }))}`. The whole expression compiles
+  as one unit and the binding is not available inside it, so all nine headers
+  across the two forms failed at render with "toggle is not a function".
+
+Four more were left for their own change, because each needs more than a test
+around it:
+
+- `google/core/imported-calendar.tsx` (1,211 lines) throws "Cell.of() only
+  accepts static data, but found a reactive value".
+- `google/WIP/google-docs-importer.tsx` is rejected by the compiler over a
+  string in `google/core/util/google-docs-markdown.ts` that reads as an HTML
+  comment. That util is 477 uncovered lines and is under `core/`, so it is
+  worth reaching whatever happens to the importer.
+- `examples/cf-picker.tsx` throws "Bidirectionally bound property $items is not
+  reactive".
+- `suggestable/budget-planner.tsx` opens a language-model request as it builds.
+
+`record-icon.tsx` was left out for a different reason. It builds in under a
+second on its own, takes about thirty seconds when any second pattern shares
+the runtime, and takes over two minutes for two copies of itself. That cost is
+superlinear, so it is not the price of the emoji list it embeds.
+
+Two patterns are untestable as they stand, by design or by dependency.
+`scope-bug-computed-vnode-blank/main.tsx` is a harness whose enabled section
+exists to produce a runtime error on purpose. `examples/llm.tsx` and
+`examples/write-and-run.tsx` each open a language-model request as they build.
+
+## What is left
+
+29,382 lines outside the word list. 10,709 of them are in 74 files with no
+record; 18,673 are in 226 files that a test reaches but does not run through.
+
+The three largest groups:
+
+- **`google/`, 11,132 lines.** Most of what remains here is behind a signed-in
+  Google account: the fetch paths, the response handling, and the branches that
+  run once an email or a calendar event has arrived. Reaching them means a
+  fixture that stands in for the account rather than another instantiation
+  test. `google/core/util/gmail-client.ts` (601), `calendar-write-client.ts`
+  (436), and `gmail-send-client.ts` (302) are plain modules and the easiest
+  starting point, since a plain unit test can drive them directly.
+- **`gideon-tests/`, 3,269 lines, untouched.** Twenty-five regression fixtures,
+  each pinning down one runtime behavior. They are tiered "fixture — never
+  imitate" in [index.md](../../../../packages/patterns/index.md), and several
+  are written to fail. Whether they should be covered at all is a question
+  worth answering before covering them.
+- **The partly-run large patterns.** `record/extraction/extractor-module.tsx`
+  (1,348 of 2,723), `gmail-agentic-search.tsx` (1,102 of 2,302),
+  `self-improving-classifier.tsx` (787 of 2,318), and `store-mapper.tsx` (659
+  of 2,092) are each loaded by a test that exercises one path. What is left is
+  the rest of the paths, which is ordinary test writing rather than a new
+  technique.
+
+`tools/lunch-poll-diagnose.ts` (760) is a diagnostic script rather than a
+pattern; it is charged as tracked source because it sits under `packages/`.

--- a/packages/patterns/base/contacts.test.tsx
+++ b/packages/patterns/base/contacts.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Test Pattern: contacts, and the two record patterns it creates
+ *
+ * Contacts is a list of contact pieces with two buttons above it: one adds a
+ * person, the other adds a family member. Each button instantiates the
+ * matching record pattern and pushes the new piece onto the list. Person and
+ * family member both title themselves from the name they hold.
+ *
+ * This drives the list through both buttons and checks the count and title
+ * that come back. Person and family member are also instantiated on their own,
+ * so their forms are built and read, and a person's name is edited through the
+ * same cell the form writes to, to see the title follow.
+ */
+import {
+  action,
+  assert,
+  NAME,
+  pattern,
+  TESTS,
+  UI,
+  Writable,
+} from "commonfabric";
+import {
+  findElementByText,
+  hasText,
+  propsOf,
+  textContent,
+} from "../test/vnode-helpers.ts";
+import type { ContactPiece } from "./contact-types.tsx";
+import Contacts from "./contacts.tsx";
+import FamilyMember from "./family-member.tsx";
+import Person from "./person.tsx";
+
+type ClickStream = { send: (event: Record<string, never>) => void };
+
+// The add buttons are bound in the list's own JSX rather than exported, so a
+// test reaches them by walking to the button carrying the label.
+function clickButton(root: unknown, label: string): void {
+  const button = findElementByText(root, "cf-button", label);
+  const onClick = propsOf(button)?.onClick;
+  if (typeof onClick === "object" && onClick !== null && "send" in onClick) {
+    (onClick as ClickStream).send({});
+  }
+}
+
+export default pattern(() => {
+  const contactList = new Writable<ContactPiece[]>([]);
+  const groups = new Writable<[]>([]);
+  const contacts = Contacts({ contacts: contactList, groups });
+
+  // Two records instantiated on their own, so their forms are built and read
+  // outside the list's add path.
+  const personCell = new Writable({
+    firstName: "Ada",
+    lastName: "Lovelace",
+    middleName: "",
+    nickname: "",
+    prefix: "",
+    suffix: "",
+    pronouns: "",
+    birthday: { month: 12, day: 10, year: 1815 },
+    photo: "",
+    email: "ada@example.com",
+    phone: "",
+    notes: "",
+    tags: [],
+    addresses: [],
+    socialProfiles: [],
+  });
+  const person = Person({ person: personCell });
+
+  const memberCell = new Writable({
+    firstName: "Bo",
+    lastName: "Kim",
+    relationship: "cousin",
+    birthday: "",
+    dietaryRestrictions: [],
+    notes: "",
+    tags: [],
+    allergies: [],
+    giftIdeas: [],
+  });
+  const member = FamilyMember({ member: memberCell });
+
+  // ==========================================================================
+  // Actions
+  // ==========================================================================
+
+  const action_add_person = action(() => {
+    clickButton(contacts[UI], "+ Person");
+  });
+
+  const action_add_family_member = action(() => {
+    clickButton(contacts[UI], "+ Family");
+  });
+
+  const action_rename_person = action(() => {
+    personCell.key("firstName").set("Grace");
+    personCell.key("lastName").set("Hopper");
+  });
+
+  // ==========================================================================
+  // Assertions
+  // ==========================================================================
+
+  const assert_starts_empty = assert(() =>
+    contacts.count === 0 && contacts.contacts.length === 0 &&
+    contacts[NAME] === "Contacts (0)"
+  );
+
+  const assert_has_one_contact = assert(() =>
+    contacts.count === 1 && contacts[NAME] === "Contacts (1)"
+  );
+
+  const assert_has_two_contacts = assert(() =>
+    contacts.count === 2 && contacts[NAME] === "Contacts (2)"
+  );
+
+  // A record titles itself from the name it holds.
+  const assert_person_named = assert(() =>
+    person[NAME] === "Ada Lovelace" && person.person.email === "ada@example.com"
+  );
+
+  const assert_person_renamed = assert(() =>
+    person[NAME] === "Grace Hopper" &&
+    person.person.firstName === "Grace"
+  );
+
+  const assert_member_named = assert(() =>
+    member[NAME] === "Bo Kim (cousin)" &&
+    member.member.relationship === "cousin"
+  );
+
+  // Each record builds a form with the fields it holds.
+  const assert_forms_render = assert(() =>
+    hasText(person[UI], "First Name") &&
+    hasText(member[UI], "First Name") &&
+    textContent(contacts[UI]).length > 0
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_starts_empty },
+      { assertion: assert_person_named },
+      { assertion: assert_member_named },
+      { assertion: assert_forms_render },
+
+      { action: action_add_person },
+      { assertion: assert_has_one_contact },
+
+      { action: action_add_family_member },
+      { assertion: assert_has_two_contacts },
+
+      { action: action_rename_person },
+      { assertion: assert_person_renamed },
+    ],
+    contacts,
+    person,
+    member,
+  };
+});

--- a/packages/patterns/base/family-member.tsx
+++ b/packages/patterns/base/family-member.tsx
@@ -13,6 +13,7 @@ import {
   handler,
   NAME,
   pattern,
+  type Stream,
   UI,
   type VNode,
   Writable,
@@ -143,7 +144,7 @@ const togglePicker = handler<unknown, { showPicker: Writable<boolean> }>(
   },
 );
 
-const toggle = handler<unknown, { section: Writable<boolean> }>(
+const toggle = handler<Record<string, never>, { section: Writable<boolean> }>(
   (_event, { section }) => {
     section.set(!section.get());
   },
@@ -164,7 +165,10 @@ function buildSectionHeaderLabel(
   return `${arrow} ${label}${suffix}`;
 }
 
-function header(labelContent: any, onClick: any) {
+function header(
+  labelContent: string,
+  onClick: Stream<Record<string, never>>,
+) {
   return (
     <cf-hstack
       style={{
@@ -249,6 +253,15 @@ export default pattern<Input, Output>(({ member, sameAs }) => {
     buildSectionHeaderLabel("Notes", showNotes.get())
   );
 
+  // Each section's toggle is bound here rather than inside the rendered tree.
+  // A handler bound inside a JSX expression that also calls a helper is
+  // compiled as part of that expression, and the binding is not available
+  // there.
+  const toggleFamilyInfo = toggle({ section: showFamilyInfo });
+  const toggleHealth = toggle({ section: showHealth });
+  const toggleGifts = toggle({ section: showGifts });
+  const toggleNotes = toggle({ section: showNotes });
+
   // Computed: autocomplete items from reactive sibling source, filtering self
   const sameAsItems = computed(() => {
     if (!sameAs) return [];
@@ -326,7 +339,7 @@ export default pattern<Input, Output>(({ member, sameAs }) => {
            */
           }
           <div>
-            {header(familyHeader, toggle({ section: showFamilyInfo }))}
+            {header(familyHeader, toggleFamilyInfo)}
             {computed(() => {
               if (!showFamilyInfo.get()) return null;
               return (
@@ -353,7 +366,7 @@ export default pattern<Input, Output>(({ member, sameAs }) => {
 
           {/* Health & Diet Section */}
           <div>
-            {header(healthHeader, toggle({ section: showHealth }))}
+            {header(healthHeader, toggleHealth)}
             {computed(() => {
               if (!showHealth.get()) return null;
               return (
@@ -383,7 +396,7 @@ export default pattern<Input, Output>(({ member, sameAs }) => {
 
           {/* Gift Ideas Section */}
           <div>
-            {header(giftIdeasHeader, toggle({ section: showGifts }))}
+            {header(giftIdeasHeader, toggleGifts)}
             {computed(() => {
               if (!showGifts.get()) return null;
               return (
@@ -399,7 +412,7 @@ export default pattern<Input, Output>(({ member, sameAs }) => {
 
           {/* Notes Section */}
           <div>
-            {header(notesHeader, toggle({ section: showNotes }))}
+            {header(notesHeader, toggleNotes)}
             {computed(() => {
               if (!showNotes.get()) return null;
               return (

--- a/packages/patterns/base/person.tsx
+++ b/packages/patterns/base/person.tsx
@@ -17,6 +17,7 @@ import {
   handler,
   NAME,
   pattern,
+  type Stream,
   UI,
   type VNode,
   Writable,
@@ -117,7 +118,7 @@ const togglePicker = handler<unknown, { showPicker: Writable<boolean> }>(
   },
 );
 
-const toggle = handler<unknown, { section: Writable<boolean> }>(
+const toggle = handler<Record<string, never>, { section: Writable<boolean> }>(
   (_event, { section }) => {
     section.set(!section.get());
   },
@@ -226,7 +227,10 @@ function buildSectionHeaderLabel(
   return `${arrow} ${label}${suffix}`;
 }
 
-function header(labelContent: any, onClick: any) {
+function header(
+  labelContent: string,
+  onClick: Stream<Record<string, never>>,
+) {
   return (
     <cf-hstack
       style={{
@@ -307,6 +311,16 @@ export default pattern<Input, Output>(({ person, sameAs }) => {
   const notesHeader = computed(() =>
     buildSectionHeaderLabel("Notes", showNotes.get())
   );
+
+  // Each section's toggle is bound here rather than inside the rendered tree.
+  // A handler bound inside a JSX expression that also calls a helper is
+  // compiled as part of that expression, and the binding is not available
+  // there.
+  const toggleNameDetails = toggle({ section: showNameDetails });
+  const toggleContactInfo = toggle({ section: showContactInfo });
+  const toggleAddresses = toggle({ section: showAddresses });
+  const toggleSocial = toggle({ section: showSocial });
+  const toggleNotes = toggle({ section: showNotes });
 
   // Computed: autocomplete items from reactive sibling source, filtering self
   const sameAsItems = computed(() => {
@@ -390,7 +404,7 @@ export default pattern<Input, Output>(({ person, sameAs }) => {
 
           {/* Name Details Section */}
           <div>
-            {header(nameHeader, toggle({ section: showNameDetails }))}
+            {header(nameHeader, toggleNameDetails)}
             {computed(() => {
               if (!showNameDetails.get()) return null;
               return (
@@ -495,7 +509,7 @@ export default pattern<Input, Output>(({ person, sameAs }) => {
            */
           }
           <div>
-            {header(contactHeader, toggle({ section: showContactInfo }))}
+            {header(contactHeader, toggleContactInfo)}
             {computed(() => {
               if (!showContactInfo.get()) return null;
               return (
@@ -527,7 +541,7 @@ export default pattern<Input, Output>(({ person, sameAs }) => {
 
           {/* Addresses Section */}
           <div>
-            {header(addressesHeader, toggle({ section: showAddresses }))}
+            {header(addressesHeader, toggleAddresses)}
             {computed(() => {
               if (!showAddresses.get()) return null;
               const addresses = person.key("addresses").get() || [];
@@ -611,7 +625,7 @@ export default pattern<Input, Output>(({ person, sameAs }) => {
 
           {/* Social Profiles Section */}
           <div>
-            {header(socialHeader, toggle({ section: showSocial }))}
+            {header(socialHeader, toggleSocial)}
             {computed(() => {
               if (!showSocial.get()) return null;
               const profiles = person.key("socialProfiles").get() || [];
@@ -657,7 +671,7 @@ export default pattern<Input, Output>(({ person, sameAs }) => {
 
           {/* Notes Section */}
           <div>
-            {header(notesHeader, toggle({ section: showNotes }))}
+            {header(notesHeader, toggleNotes)}
             {computed(() => {
               if (!showNotes.get()) return null;
               return (

--- a/packages/patterns/baselines/chatbot.tsx/20260818T183826Z-ibsxlvix5LQH7bfY.json
+++ b/packages/patterns/baselines/chatbot.tsx/20260818T183826Z-ibsxlvix5LQH7bfY.json
@@ -1,0 +1,522 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "BuiltInLLMContent": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/BuiltInLLMContentPart"
+            },
+            "type": "array"
+          }
+        ]
+      },
+      "BuiltInLLMContentPart": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/BuiltInLLMTextPart"
+          },
+          {
+            "$ref": "#/$defs/BuiltInLLMImagePart"
+          },
+          {
+            "$ref": "#/$defs/BuiltInLLMToolCallPart"
+          },
+          {
+            "$ref": "#/$defs/BuiltInLLMToolResultPart"
+          }
+        ]
+      },
+      "BuiltInLLMImagePart": {
+        "properties": {
+          "image": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "image"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "image"
+        ],
+        "type": "object"
+      },
+      "BuiltInLLMMessage": {
+        "properties": {
+          "content": {
+            "$ref": "#/$defs/BuiltInLLMContent"
+          },
+          "role": {
+            "enum": [
+              "user",
+              "system",
+              "assistant",
+              "tool"
+            ]
+          }
+        },
+        "required": [
+          "role",
+          "content"
+        ],
+        "type": "object"
+      },
+      "BuiltInLLMTextPart": {
+        "properties": {
+          "text": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ],
+        "type": "object"
+      },
+      "BuiltInLLMToolCallPart": {
+        "properties": {
+          "input": {
+            "additionalProperties": true,
+            "properties": {},
+            "type": "object"
+          },
+          "toolCallId": {
+            "type": "string"
+          },
+          "toolName": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "tool-call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "toolCallId",
+          "toolName",
+          "input"
+        ],
+        "type": "object"
+      },
+      "BuiltInLLMToolResultPart": {
+        "properties": {
+          "output": {
+            "anyOf": [
+              {
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "text"
+                    ],
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "json"
+                    ],
+                    "type": "string"
+                  },
+                  "value": true
+                },
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "toolCallId": {
+            "type": "string"
+          },
+          "toolName": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "tool-result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "toolCallId",
+          "toolName",
+          "output"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "messages": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/BuiltInLLMMessage"
+        },
+        "type": "array"
+      },
+      "system": {
+        "type": "string"
+      },
+      "theme": true,
+      "tools": true
+    },
+    "type": "object"
+  },
+  "pattern": "chatbot.tsx",
+  "resultSchema": {
+    "$defs": {
+      "BuiltInLLMContent": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/BuiltInLLMContentPart"
+            },
+            "type": "array"
+          }
+        ]
+      },
+      "BuiltInLLMContentPart": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/BuiltInLLMTextPart"
+          },
+          {
+            "$ref": "#/$defs/BuiltInLLMImagePart"
+          },
+          {
+            "$ref": "#/$defs/BuiltInLLMToolCallPart"
+          },
+          {
+            "$ref": "#/$defs/BuiltInLLMToolResultPart"
+          }
+        ]
+      },
+      "BuiltInLLMImagePart": {
+        "properties": {
+          "image": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "image"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "image"
+        ],
+        "type": "object"
+      },
+      "BuiltInLLMMessage": {
+        "properties": {
+          "content": {
+            "$ref": "#/$defs/BuiltInLLMContent"
+          },
+          "role": {
+            "enum": [
+              "user",
+              "system",
+              "assistant",
+              "tool"
+            ]
+          }
+        },
+        "required": [
+          "role",
+          "content"
+        ],
+        "type": "object"
+      },
+      "BuiltInLLMTextPart": {
+        "properties": {
+          "text": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ],
+        "type": "object"
+      },
+      "BuiltInLLMToolCallPart": {
+        "properties": {
+          "input": {
+            "additionalProperties": true,
+            "properties": {},
+            "type": "object"
+          },
+          "toolCallId": {
+            "type": "string"
+          },
+          "toolName": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "tool-call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "toolCallId",
+          "toolName",
+          "input"
+        ],
+        "type": "object"
+      },
+      "BuiltInLLMToolResultPart": {
+        "properties": {
+          "output": {
+            "anyOf": [
+              {
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "text"
+                    ],
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "json"
+                    ],
+                    "type": "string"
+                  },
+                  "value": true
+                },
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "toolCallId": {
+            "type": "string"
+          },
+          "toolName": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "tool-result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "toolCallId",
+          "toolName",
+          "output"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addMessage": {
+        "$ref": "#/$defs/BuiltInLLMMessage",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "cancelGeneration": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "clearChat": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "messages": {
+        "items": {
+          "$ref": "#/$defs/BuiltInLLMMessage"
+        },
+        "type": "array"
+      },
+      "pending": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "boolean"
+          }
+        ]
+      },
+      "pinCell": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "name"
+        ],
+        "type": "object"
+      },
+      "pinToChat": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "accumulate": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "name",
+          "accumulate"
+        ],
+        "type": "object"
+      },
+      "pinnedCells": {
+        "items": {
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "name"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "title": {
+        "type": "string"
+      },
+      "tools": true,
+      "ui": {
+        "properties": {
+          "attachmentsAndTools": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          "chatLog": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          "promptInput": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          }
+        },
+        "required": [
+          "chatLog",
+          "promptInput",
+          "attachmentsAndTools"
+        ],
+        "type": "object"
+      },
+      "unpinAllCells": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      }
+    },
+    "required": [
+      "messages",
+      "pending",
+      "addMessage",
+      "clearChat",
+      "cancelGeneration",
+      "pinnedCells",
+      "pinCell",
+      "unpinAllCells",
+      "pinToChat",
+      "tools",
+      "ui",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/examples/cf-checkbox-cell.tsx/20260818T183826Z-oSFMXW0cjm74WXRQ.json
+++ b/packages/patterns/baselines/examples/cf-checkbox-cell.tsx/20260818T183826Z-oSFMXW0cjm74WXRQ.json
@@ -1,0 +1,51 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "simpleEnabled": {
+        "asCell": [
+          "cell"
+        ],
+        "default": false,
+        "type": "boolean"
+      },
+      "trackedEnabled": {
+        "asCell": [
+          "cell"
+        ],
+        "default": false,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "simpleEnabled",
+      "trackedEnabled"
+    ],
+    "type": "object"
+  },
+  "pattern": "examples/cf-checkbox-cell.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "simpleEnabled": {
+        "default": false,
+        "type": "boolean"
+      },
+      "trackedEnabled": {
+        "default": false,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "$NAME",
+      "$UI",
+      "simpleEnabled",
+      "trackedEnabled"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/examples/cf-tags.tsx/20260818T183826Z-NAcJ6wIKNUmvgqc8.json
+++ b/packages/patterns/baselines/examples/cf-tags.tsx/20260818T183826Z-NAcJ6wIKNUmvgqc8.json
@@ -1,0 +1,40 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "tags": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "tags"
+    ],
+    "type": "object"
+  },
+  "pattern": "examples/cf-tags.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "tags": {
+        "default": [],
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "tags",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/examples/drag-drop-demo.tsx/20260818T183826Z-CM1_aKYD-g08go3i.json
+++ b/packages/patterns/baselines/examples/drag-drop-demo.tsx/20260818T183826Z-CM1_aKYD-g08go3i.json
@@ -1,0 +1,137 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Item": {
+        "properties": {
+          "$UI": {
+            "$ref": "#/$defs/JSXElement"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "JSXElement": {
+        "anyOf": [
+          {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          {
+            "$ref": "#/$defs/UIRenderable"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ]
+      },
+      "UIRenderable": {
+        "properties": {
+          "$UI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          }
+        },
+        "required": [
+          "$UI"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "availableItems": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Item"
+        },
+        "type": "array"
+      },
+      "droppedItems": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Item"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "availableItems",
+      "droppedItems"
+    ],
+    "type": "object"
+  },
+  "pattern": "examples/drag-drop-demo.tsx",
+  "resultSchema": {
+    "$defs": {
+      "Item": {
+        "properties": {
+          "$UI": {
+            "$ref": "#/$defs/JSXElement"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "JSXElement": {
+        "anyOf": [
+          {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          {
+            "$ref": "#/$defs/UIRenderable"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ]
+      },
+      "UIRenderable": {
+        "properties": {
+          "$UI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          }
+        },
+        "required": [
+          "$UI"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "availableItems": {
+        "items": {
+          "$ref": "#/$defs/Item"
+        },
+        "type": "array"
+      },
+      "droppedItems": {
+        "items": {
+          "$ref": "#/$defs/Item"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "availableItems",
+      "droppedItems",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/examples/multi-option-selection.tsx/20260818T183826Z-e5RQGNb04fNtz0g6.json
+++ b/packages/patterns/baselines/examples/multi-option-selection.tsx/20260818T183826Z-e5RQGNb04fNtz0g6.json
@@ -1,0 +1,73 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "activeTab": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "tab1",
+        "type": "string"
+      },
+      "category": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "Other",
+        "type": "string"
+      },
+      "numericChoice": {
+        "asCell": [
+          "cell"
+        ],
+        "default": 1,
+        "type": "number"
+      },
+      "selected": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "opt_1",
+        "type": "string"
+      }
+    },
+    "required": [
+      "selected",
+      "numericChoice",
+      "category",
+      "activeTab"
+    ],
+    "type": "object"
+  },
+  "pattern": "examples/multi-option-selection.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "activeTab": {
+        "type": "string"
+      },
+      "category": {
+        "type": "string"
+      },
+      "numericChoice": {
+        "type": "number"
+      },
+      "selected": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "selected",
+      "numericChoice",
+      "category",
+      "activeTab",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/examples/write-and-run.tsx/20260818T183826Z-dlKYeLxQAk_YtaMA.json
+++ b/packages/patterns/baselines/examples/write-and-run.tsx/20260818T183826Z-dlKYeLxQAk_YtaMA.json
@@ -1,0 +1,34 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "prompt": {
+        "default": "Create a simple counter",
+        "type": "string"
+      }
+    },
+    "required": [
+      "prompt"
+    ],
+    "type": "object"
+  },
+  "pattern": "examples/write-and-run.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "prompt": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "prompt",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/experimental/folksonomy-demo.tsx/20260818T183826Z-i9_o27JnMsscSKUv.json
+++ b/packages/patterns/baselines/experimental/folksonomy-demo.tsx/20260818T183826Z-i9_o27JnMsscSKUv.json
@@ -1,0 +1,79 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "customScope": {
+        "default": "demo-shared",
+        "description": "Custom scope name",
+        "type": "string"
+      },
+      "itemATags": {
+        "default": [],
+        "description": "Tags for item A (scope: demo-shared)",
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "itemBTags": {
+        "default": [],
+        "description": "Tags for item B (scope: demo-shared - same as A)",
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "itemCTags": {
+        "default": [],
+        "description": "Tags for item C (scope: demo-isolated - different scope)",
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "itemATags",
+      "itemBTags",
+      "itemCTags",
+      "customScope"
+    ],
+    "type": "object"
+  },
+  "pattern": "experimental/folksonomy-demo.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "itemATags": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "itemBTags": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "itemCTags": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "itemATags",
+      "itemBTags",
+      "itemCTags",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/google/extractors/bam-school-dashboard.tsx/20260818T183826Z-xsgopW005bKdgccv.json
+++ b/packages/patterns/baselines/google/extractors/bam-school-dashboard.tsx/20260818T183826Z-xsgopW005bKdgccv.json
@@ -1,0 +1,319 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Auth": {
+        "properties": {
+          "expiresAt": {
+            "default": 0,
+            "type": "number"
+          },
+          "expiresIn": {
+            "default": 0,
+            "type": "number"
+          },
+          "refreshToken": {
+            "default": "",
+            "type": "string"
+          },
+          "scope": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "token": {
+            "default": "",
+            "type": "string"
+          },
+          "tokenType": {
+            "default": "",
+            "type": "string"
+          },
+          "user": {
+            "default": {
+              "email": "",
+              "name": "",
+              "picture": ""
+            },
+            "properties": {
+              "email": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "picture": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "email",
+              "name",
+              "picture"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "token",
+          "tokenType",
+          "scope",
+          "expiresIn",
+          "expiresAt",
+          "refreshToken",
+          "user"
+        ],
+        "type": "object"
+      },
+      "SchoolSettings": {
+        "properties": {
+          "childName": {
+            "default": "Adeline Komoroske",
+            "type": "string"
+          },
+          "grade": {
+            "default": "Kindergarten",
+            "type": "string"
+          },
+          "schoolName": {
+            "default": "Berkeley Arts Magnet",
+            "type": "string"
+          },
+          "teacher": {
+            "default": "Mr. Zaragoza",
+            "type": "string"
+          }
+        },
+        "required": [
+          "childName",
+          "schoolName",
+          "grade",
+          "teacher"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "dismissedIds": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "overrideAuth": {
+        "$ref": "#/$defs/Auth",
+        "asCell": [
+          "cell"
+        ]
+      },
+      "settings": {
+        "$ref": "#/$defs/SchoolSettings",
+        "default": {
+          "childName": "Adeline Komoroske",
+          "grade": "Kindergarten",
+          "schoolName": "Berkeley Arts Magnet",
+          "teacher": "Mr. Zaragoza"
+        }
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "google/extractors/bam-school-dashboard.tsx",
+  "resultSchema": {
+    "$defs": {
+      "Email": {
+        "properties": {
+          "date": {
+            "type": "string"
+          },
+          "from": {
+            "type": "string"
+          },
+          "htmlContent": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "labelIds": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "markdownContent": {
+            "type": "string"
+          },
+          "plainText": {
+            "type": "string"
+          },
+          "snippet": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "summary": {
+            "default": "",
+            "type": "string"
+          },
+          "threadId": {
+            "type": "string"
+          },
+          "to": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "threadId",
+          "labelIds",
+          "snippet",
+          "subject",
+          "from",
+          "date",
+          "to",
+          "plainText",
+          "htmlContent",
+          "markdownContent",
+          "summary"
+        ],
+        "type": "object"
+      },
+      "EventCategory": {
+        "enum": [
+          "field_trip",
+          "award",
+          "deadline",
+          "no_school",
+          "event",
+          "announcement",
+          "attendance",
+          "other"
+        ]
+      },
+      "SchoolEvent": {
+        "properties": {
+          "actionRequired": {
+            "type": "string"
+          },
+          "category": {
+            "$ref": "#/$defs/EventCategory"
+          },
+          "date": {
+            "type": "string"
+          },
+          "emailDate": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "isUrgent": {
+            "type": "boolean"
+          },
+          "originalSubject": {
+            "type": "string"
+          },
+          "sourceEmail": {
+            "type": "string"
+          },
+          "sourceType": {
+            "$ref": "#/$defs/SourceType"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "time": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "category",
+          "title",
+          "isUrgent",
+          "summary",
+          "sourceType",
+          "sourceEmail",
+          "emailDate",
+          "originalSubject"
+        ],
+        "type": "object"
+      },
+      "SourceType": {
+        "enum": [
+          "teacher",
+          "school",
+          "district",
+          "coordinator"
+        ]
+      }
+    },
+    "description": "BAM School Dashboard - At-a-glance view of school events and announcements. #bamSchool",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$TILE_UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "emails": {
+        "items": {
+          "$ref": "#/$defs/Email"
+        },
+        "type": "array"
+      },
+      "events": {
+        "items": {
+          "$ref": "#/$defs/SchoolEvent"
+        },
+        "type": "array"
+      },
+      "teacherMessages": {
+        "items": {
+          "$ref": "#/$defs/SchoolEvent"
+        },
+        "type": "array"
+      },
+      "upcomingEvents": {
+        "items": {
+          "$ref": "#/$defs/SchoolEvent"
+        },
+        "type": "array"
+      },
+      "urgentEvents": {
+        "items": {
+          "$ref": "#/$defs/SchoolEvent"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "emails",
+      "events",
+      "urgentEvents",
+      "upcomingEvents",
+      "teacherMessages",
+      "$NAME",
+      "$UI",
+      "$TILE_UI"
+    ],
+    "tags": [
+      "bamschool"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/google/extractors/berkeley-library.tsx/20260818T183826Z-b_J--vrFaj8AJzsk.json
+++ b/packages/patterns/baselines/google/extractors/berkeley-library.tsx/20260818T183826Z-b_J--vrFaj8AJzsk.json
@@ -1,0 +1,280 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Auth": {
+        "properties": {
+          "expiresAt": {
+            "default": 0,
+            "type": "number"
+          },
+          "expiresIn": {
+            "default": 0,
+            "type": "number"
+          },
+          "refreshToken": {
+            "default": "",
+            "type": "string"
+          },
+          "scope": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "token": {
+            "default": "",
+            "type": "string"
+          },
+          "tokenType": {
+            "default": "",
+            "type": "string"
+          },
+          "user": {
+            "default": {
+              "email": "",
+              "name": "",
+              "picture": ""
+            },
+            "properties": {
+              "email": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "picture": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "email",
+              "name",
+              "picture"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "token",
+          "tokenType",
+          "scope",
+          "expiresIn",
+          "expiresAt",
+          "refreshToken",
+          "user"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "dismissedHolds": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "dueDateOverrides": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "asCell": [
+          "cell"
+        ],
+        "properties": {},
+        "type": "object"
+      },
+      "manuallyReturned": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "overrideAuth": {
+        "$ref": "#/$defs/Auth",
+        "asCell": [
+          "cell"
+        ]
+      },
+      "selectedItems": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "google/extractors/berkeley-library.tsx",
+  "resultSchema": {
+    "$defs": {
+      "ItemStatus": {
+        "enum": [
+          "hold_ready",
+          "checked_out",
+          "overdue",
+          "renewed",
+          "returned"
+        ]
+      },
+      "ItemType": {
+        "enum": [
+          "other",
+          "book",
+          "audiobook",
+          "dvd",
+          "magazine",
+          "ebook"
+        ]
+      },
+      "TrackedItem": {
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "daysUntilDue": {
+            "type": "number"
+          },
+          "dueDate": {
+            "type": "string"
+          },
+          "emailDate": {
+            "type": "string"
+          },
+          "fineAmount": {
+            "type": "number"
+          },
+          "isManuallyReturned": {
+            "type": "boolean"
+          },
+          "itemType": {
+            "$ref": "#/$defs/ItemType"
+          },
+          "key": {
+            "type": "string"
+          },
+          "renewalsRemaining": {
+            "type": "number"
+          },
+          "status": {
+            "$ref": "#/$defs/ItemStatus"
+          },
+          "title": {
+            "type": "string"
+          },
+          "urgency": {
+            "$ref": "#/$defs/UrgencyLevel"
+          }
+        },
+        "required": [
+          "key",
+          "title",
+          "status",
+          "urgency",
+          "daysUntilDue",
+          "emailDate",
+          "isManuallyReturned"
+        ],
+        "type": "object"
+      },
+      "UrgencyLevel": {
+        "enum": [
+          "overdue",
+          "urgent_1day",
+          "warning_3days",
+          "notice_7days",
+          "ok"
+        ]
+      }
+    },
+    "description": "Berkeley Public Library book tracker. #berkeleyLibrary",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$TILE_UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "checkedOutCount": {
+        "type": "number"
+      },
+      "dismissHold": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "holdsReady": {
+        "items": {
+          "$ref": "#/$defs/TrackedItem"
+        },
+        "type": "array"
+      },
+      "holdsReadyCount": {
+        "type": "number"
+      },
+      "markAsReturned": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "overdueCount": {
+        "type": "number"
+      },
+      "trackedItems": {
+        "items": {
+          "$ref": "#/$defs/TrackedItem"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "trackedItems",
+      "holdsReady",
+      "overdueCount",
+      "checkedOutCount",
+      "holdsReadyCount",
+      "markAsReturned",
+      "dismissHold",
+      "$NAME",
+      "$UI",
+      "$TILE_UI"
+    ],
+    "tags": [
+      "berkeleylibrary"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/google/extractors/calendar-change-detector.tsx/20260818T183826Z-ruJxBI-78pH3IAWU.json
+++ b/packages/patterns/baselines/google/extractors/calendar-change-detector.tsx/20260818T183826Z-ruJxBI-78pH3IAWU.json
@@ -1,0 +1,199 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Auth": {
+        "properties": {
+          "expiresAt": {
+            "default": 0,
+            "type": "number"
+          },
+          "expiresIn": {
+            "default": 0,
+            "type": "number"
+          },
+          "refreshToken": {
+            "default": "",
+            "type": "string"
+          },
+          "scope": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "token": {
+            "default": "",
+            "type": "string"
+          },
+          "tokenType": {
+            "default": "",
+            "type": "string"
+          },
+          "user": {
+            "default": {
+              "email": "",
+              "name": "",
+              "picture": ""
+            },
+            "properties": {
+              "email": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "picture": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "email",
+              "name",
+              "picture"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "token",
+          "tokenType",
+          "scope",
+          "expiresIn",
+          "expiresAt",
+          "refreshToken",
+          "user"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "overrideAuth": {
+        "$ref": "#/$defs/Auth",
+        "asCell": [
+          "cell"
+        ]
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "google/extractors/calendar-change-detector.tsx",
+  "resultSchema": {
+    "$defs": {
+      "ChangeType": {
+        "enum": [
+          "cancelled",
+          "rescheduled",
+          "delayed",
+          "time_changed",
+          "other"
+        ]
+      },
+      "ScheduleChange": {
+        "properties": {
+          "changeType": {
+            "$ref": "#/$defs/ChangeType"
+          },
+          "emailDate": {
+            "type": "string"
+          },
+          "emailId": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "newDate": {
+            "type": "string"
+          },
+          "originalDate": {
+            "type": "string"
+          },
+          "originalEvent": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "urgency": {
+            "$ref": "#/$defs/Urgency"
+          }
+        },
+        "required": [
+          "id",
+          "emailId",
+          "emailDate",
+          "changeType",
+          "originalEvent",
+          "source",
+          "urgency",
+          "summary"
+        ],
+        "type": "object"
+      },
+      "Urgency": {
+        "enum": [
+          "critical",
+          "urgent",
+          "normal"
+        ]
+      }
+    },
+    "description": "Calendar change detector for tracking schedule changes. #calendarChanges",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$TILE_UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "changes": {
+        "items": {
+          "$ref": "#/$defs/ScheduleChange"
+        },
+        "type": "array"
+      },
+      "criticalChanges": {
+        "items": {
+          "$ref": "#/$defs/ScheduleChange"
+        },
+        "type": "array"
+      },
+      "hasChanges": {
+        "type": "boolean"
+      },
+      "normalChanges": {
+        "items": {
+          "$ref": "#/$defs/ScheduleChange"
+        },
+        "type": "array"
+      },
+      "urgentChanges": {
+        "items": {
+          "$ref": "#/$defs/ScheduleChange"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "changes",
+      "criticalChanges",
+      "urgentChanges",
+      "normalChanges",
+      "hasChanges",
+      "$NAME",
+      "$UI",
+      "$TILE_UI"
+    ],
+    "tags": [
+      "calendarchanges"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/google/extractors/email-pattern-dreamer.tsx/20260818T183826Z-WbIAEz87MSfUvaQM.json
+++ b/packages/patterns/baselines/google/extractors/email-pattern-dreamer.tsx/20260818T183826Z-WbIAEz87MSfUvaQM.json
@@ -1,0 +1,114 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Auth": {
+        "properties": {
+          "expiresAt": {
+            "default": 0,
+            "type": "number"
+          },
+          "expiresIn": {
+            "default": 0,
+            "type": "number"
+          },
+          "refreshToken": {
+            "default": "",
+            "type": "string"
+          },
+          "scope": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "token": {
+            "default": "",
+            "type": "string"
+          },
+          "tokenType": {
+            "default": "",
+            "type": "string"
+          },
+          "user": {
+            "default": {
+              "email": "",
+              "name": "",
+              "picture": ""
+            },
+            "properties": {
+              "email": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "picture": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "email",
+              "name",
+              "picture"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "token",
+          "tokenType",
+          "scope",
+          "expiresIn",
+          "expiresAt",
+          "refreshToken",
+          "user"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "overrideAuth": {
+        "$ref": "#/$defs/Auth",
+        "asCell": [
+          "cell"
+        ]
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "google/extractors/email-pattern-dreamer.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$TILE_UI": true,
+      "$UI": true,
+      "bam": true,
+      "bofa": true,
+      "calendar": true,
+      "chase": true,
+      "library": true,
+      "notes": true,
+      "tickets": true,
+      "united": true,
+      "usps": true
+    },
+    "required": [
+      "$NAME",
+      "usps",
+      "library",
+      "chase",
+      "bam",
+      "bofa",
+      "tickets",
+      "calendar",
+      "notes",
+      "united",
+      "$TILE_UI",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/google/extractors/email-pattern-launcher.tsx/20260818T183826Z-ijZc7qsu-9ukyEJE.json
+++ b/packages/patterns/baselines/google/extractors/email-pattern-launcher.tsx/20260818T183826Z-ijZc7qsu-9ukyEJE.json
@@ -1,0 +1,188 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Auth": {
+        "properties": {
+          "expiresAt": {
+            "default": 0,
+            "type": "number"
+          },
+          "expiresIn": {
+            "default": 0,
+            "type": "number"
+          },
+          "refreshToken": {
+            "default": "",
+            "type": "string"
+          },
+          "scope": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "token": {
+            "default": "",
+            "type": "string"
+          },
+          "tokenType": {
+            "default": "",
+            "type": "string"
+          },
+          "user": {
+            "default": {
+              "email": "",
+              "name": "",
+              "picture": ""
+            },
+            "properties": {
+              "email": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "picture": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "email",
+              "name",
+              "picture"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "token",
+          "tokenType",
+          "scope",
+          "expiresIn",
+          "expiresAt",
+          "refreshToken",
+          "user"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "overrideAuth": {
+        "$ref": "#/$defs/Auth",
+        "asCell": [
+          "cell"
+        ]
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "google/extractors/email-pattern-launcher.tsx",
+  "resultSchema": {
+    "$defs": {
+      "LaunchedPatternInfo": {
+        "properties": {
+          "entry": {
+            "$ref": "#/$defs/RegistryEntry",
+            "description": "The full registry entry"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "matchedEmails": {
+            "description": "Email addresses that triggered this pattern",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "patternUri": {
+            "description": "Path to the pattern file",
+            "type": "string"
+          },
+          "pending": {
+            "type": "boolean"
+          },
+          "result": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "unknown"
+                },
+                "properties": {},
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "pending",
+          "error",
+          "result",
+          "patternUri",
+          "entry",
+          "matchedEmails"
+        ],
+        "type": "object"
+      },
+      "RegistryEntry": {
+        "properties": {
+          "emailPatterns": {
+            "description": "Glob-style email patterns (e.g., \"*@usps.com\")",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "patternUri": {
+            "description": "Path to the pattern file (relative to /api/patterns/)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "patternUri",
+          "emailPatterns"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Email pattern launcher that discovers and runs relevant patterns. #emailPatternLauncher",
+    "properties": {
+      "$TILE_UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "emailCount": {
+        "type": "number"
+      },
+      "matchCount": {
+        "type": "number"
+      },
+      "matchedPatterns": {
+        "items": {
+          "$ref": "#/$defs/LaunchedPatternInfo"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "matchedPatterns",
+      "emailCount",
+      "matchCount",
+      "$TILE_UI"
+    ],
+    "tags": [
+      "emailpatternlauncher"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/google/extractors/email-ticket-finder.tsx/20260818T183826Z-yB50Vrb04WsRySlN.json
+++ b/packages/patterns/baselines/google/extractors/email-ticket-finder.tsx/20260818T183826Z-yB50Vrb04WsRySlN.json
@@ -1,0 +1,232 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Auth": {
+        "properties": {
+          "expiresAt": {
+            "default": 0,
+            "type": "number"
+          },
+          "expiresIn": {
+            "default": 0,
+            "type": "number"
+          },
+          "refreshToken": {
+            "default": "",
+            "type": "string"
+          },
+          "scope": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "token": {
+            "default": "",
+            "type": "string"
+          },
+          "tokenType": {
+            "default": "",
+            "type": "string"
+          },
+          "user": {
+            "default": {
+              "email": "",
+              "name": "",
+              "picture": ""
+            },
+            "properties": {
+              "email": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "picture": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "email",
+              "name",
+              "picture"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "token",
+          "tokenType",
+          "scope",
+          "expiresIn",
+          "expiresAt",
+          "refreshToken",
+          "user"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "overrideAuth": {
+        "$ref": "#/$defs/Auth",
+        "asCell": [
+          "cell"
+        ]
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "google/extractors/email-ticket-finder.tsx",
+  "resultSchema": {
+    "$defs": {
+      "TicketSource": {
+        "enum": [
+          "airline",
+          "train",
+          "bus",
+          "concert",
+          "sports",
+          "theater",
+          "movie",
+          "hotel",
+          "rental_car",
+          "conference",
+          "workshop",
+          "restaurant",
+          "tour",
+          "other",
+          "not_a_ticket"
+        ]
+      },
+      "TicketStatus": {
+        "enum": [
+          "upcoming",
+          "today",
+          "past",
+          "action_needed"
+        ]
+      },
+      "TrackedTicket": {
+        "properties": {
+          "confirmationCode": {
+            "type": "string"
+          },
+          "daysUntil": {
+            "type": "number"
+          },
+          "emailDate": {
+            "type": "string"
+          },
+          "emailId": {
+            "type": "string"
+          },
+          "emailSubject": {
+            "type": "string"
+          },
+          "endDate": {
+            "type": "string"
+          },
+          "eventDate": {
+            "type": "string"
+          },
+          "eventName": {
+            "type": "string"
+          },
+          "eventTime": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "location": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "seatInfo": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/$defs/TicketStatus"
+          },
+          "ticketSource": {
+            "$ref": "#/$defs/TicketSource"
+          },
+          "venue": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "eventName",
+          "ticketSource",
+          "status",
+          "daysUntil",
+          "emailId",
+          "emailDate",
+          "emailSubject"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Email ticket finder for tracking upcoming events. #emailTickets",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$TILE_UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "pastTickets": {
+        "items": {
+          "$ref": "#/$defs/TrackedTicket"
+        },
+        "type": "array"
+      },
+      "tickets": {
+        "items": {
+          "$ref": "#/$defs/TrackedTicket"
+        },
+        "type": "array"
+      },
+      "todayCount": {
+        "type": "number"
+      },
+      "todayTickets": {
+        "items": {
+          "$ref": "#/$defs/TrackedTicket"
+        },
+        "type": "array"
+      },
+      "upcomingCount": {
+        "type": "number"
+      },
+      "upcomingTickets": {
+        "items": {
+          "$ref": "#/$defs/TrackedTicket"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "tickets",
+      "todayTickets",
+      "upcomingTickets",
+      "pastTickets",
+      "todayCount",
+      "upcomingCount",
+      "$NAME",
+      "$UI",
+      "$TILE_UI"
+    ],
+    "tags": [
+      "emailtickets"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/google/extractors/favorite-foods-gmail-agent.tsx/20260818T183826Z-PHoE9Vi0wM5H48Cj.json
+++ b/packages/patterns/baselines/google/extractors/favorite-foods-gmail-agent.tsx/20260818T183826Z-PHoE9Vi0wM5H48Cj.json
@@ -1,0 +1,123 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "FoodPreference": {
+        "properties": {
+          "category": true,
+          "confidence": true,
+          "extractedAt": {
+            "type": "number"
+          },
+          "foodName": true,
+          "id": {
+            "type": "string"
+          },
+          "notes": true,
+          "sourceEmailDate": true,
+          "sourceEmailId": true,
+          "sourceEmailSubject": true
+        },
+        "required": [
+          "foodName",
+          "category",
+          "confidence",
+          "sourceEmailId",
+          "sourceEmailSubject",
+          "sourceEmailDate",
+          "notes",
+          "id",
+          "extractedAt"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "foods": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/FoodPreference"
+        },
+        "type": "array"
+      },
+      "isScanning": {
+        "default": false,
+        "type": "boolean"
+      },
+      "lastScanAt": {
+        "default": 0,
+        "type": "number"
+      },
+      "maxSearches": {
+        "default": 5,
+        "type": "number"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "google/extractors/favorite-foods-gmail-agent.tsx",
+  "resultSchema": {
+    "$defs": {
+      "FoodPreference": {
+        "properties": {
+          "category": true,
+          "confidence": true,
+          "extractedAt": {
+            "type": "number"
+          },
+          "foodName": true,
+          "id": {
+            "type": "string"
+          },
+          "notes": true,
+          "sourceEmailDate": true,
+          "sourceEmailId": true,
+          "sourceEmailSubject": true
+        },
+        "required": [
+          "foodName",
+          "category",
+          "confidence",
+          "sourceEmailId",
+          "sourceEmailSubject",
+          "sourceEmailDate",
+          "notes",
+          "id",
+          "extractedAt"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Favorite foods extractor from Gmail. #favoriteFoods",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "count": {
+        "type": "number"
+      },
+      "foods": {
+        "items": {
+          "$ref": "#/$defs/FoodPreference"
+        },
+        "type": "array"
+      },
+      "lastScanAt": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "foods",
+      "lastScanAt",
+      "count",
+      "$NAME",
+      "$UI"
+    ],
+    "tags": [
+      "favoritefoods"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/google/extractors/flight-calendar-bridge.tsx/20260818T183826Z-4NM7MEq9ewc7kWCx.json
+++ b/packages/patterns/baselines/google/extractors/flight-calendar-bridge.tsx/20260818T183826Z-4NM7MEq9ewc7kWCx.json
@@ -1,0 +1,149 @@
+{
+  "argumentSchema": {
+    "properties": {},
+    "type": "object"
+  },
+  "pattern": "google/extractors/flight-calendar-bridge.tsx",
+  "resultSchema": {
+    "$defs": {
+      "CalendarEvent": {
+        "properties": {
+          "color": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string"
+          },
+          "endTime": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "eventType": {
+            "enum": [
+              "flight",
+              "travel-to",
+              "travel-from"
+            ]
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "linkedFlightKey": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "date",
+          "startTime",
+          "endTime",
+          "color",
+          "notes",
+          "isHidden",
+          "eventId"
+        ],
+        "type": "object"
+      },
+      "FlightEventGroup": {
+        "properties": {
+          "color": {
+            "type": "string"
+          },
+          "flight": {
+            "$ref": "#/$defs/CalendarEvent"
+          },
+          "flightKey": {
+            "type": "string"
+          },
+          "travelFrom": {
+            "$ref": "#/$defs/CalendarEvent"
+          },
+          "travelTo": {
+            "$ref": "#/$defs/CalendarEvent"
+          }
+        },
+        "required": [
+          "flightKey",
+          "color",
+          "flight"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Flight calendar bridge - generates travel events from flights. #flightCalendar",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "eventGroups": {
+        "items": {
+          "$ref": "#/$defs/FlightEventGroup"
+        },
+        "type": "array"
+      },
+      "events": {
+        "items": {
+          "$ref": "#/$defs/CalendarEvent"
+        },
+        "type": "array"
+      },
+      "flightCount": {
+        "type": "number"
+      },
+      "flightEvents": {
+        "items": {
+          "$ref": "#/$defs/CalendarEvent"
+        },
+        "type": "array"
+      },
+      "homeAddress": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "isConnected": {
+        "type": "boolean"
+      },
+      "travelEvents": {
+        "items": {
+          "$ref": "#/$defs/CalendarEvent"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "flightCount",
+      "events",
+      "flightEvents",
+      "travelEvents",
+      "eventGroups",
+      "homeAddress",
+      "isConnected",
+      "$NAME",
+      "$UI"
+    ],
+    "tags": [
+      "flightcalendar"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/google/extractors/hotel-membership-gmail-agent.tsx/20260818T183826Z-JGYzOkAVm4NNKdhC.json
+++ b/packages/patterns/baselines/google/extractors/hotel-membership-gmail-agent.tsx/20260818T183826Z-JGYzOkAVm4NNKdhC.json
@@ -1,0 +1,212 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "MembershipRecord": {
+        "properties": {
+          "_fromWish": {
+            "type": "boolean"
+          },
+          "confidence": true,
+          "extractedAt": {
+            "type": "number"
+          },
+          "hotelBrand": true,
+          "id": {
+            "type": "string"
+          },
+          "membershipNumber": true,
+          "programName": true,
+          "sourceEmailDate": true,
+          "sourceEmailId": true,
+          "sourceEmailSubject": true,
+          "tier": true
+        },
+        "required": [
+          "hotelBrand",
+          "programName",
+          "membershipNumber",
+          "tier",
+          "sourceEmailId",
+          "sourceEmailSubject",
+          "sourceEmailDate",
+          "confidence",
+          "id",
+          "extractedAt"
+        ],
+        "type": "object"
+      },
+      "ScanMode": {
+        "enum": [
+          "full",
+          "recent"
+        ]
+      },
+      "SearchProgress": {
+        "properties": {
+          "authError": {
+            "type": "string"
+          },
+          "completedQueries": {
+            "items": {
+              "properties": {
+                "emailCount": {
+                  "type": "number"
+                },
+                "query": {
+                  "type": "string"
+                },
+                "timestamp": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "query",
+                "emailCount",
+                "timestamp"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "currentQuery": {
+            "type": "string"
+          },
+          "searchCount": {
+            "type": "number"
+          },
+          "status": {
+            "enum": [
+              "idle",
+              "searching",
+              "analyzing",
+              "limit_reached",
+              "auth_error"
+            ]
+          }
+        },
+        "required": [
+          "currentQuery",
+          "completedQueries",
+          "status",
+          "searchCount"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "accountType": {
+        "default": "default",
+        "enum": [
+          "default",
+          "personal",
+          "work"
+        ],
+        "type": "string"
+      },
+      "currentScanMode": {
+        "$ref": "#/$defs/ScanMode",
+        "default": "full"
+      },
+      "isScanning": {
+        "default": false,
+        "type": "boolean"
+      },
+      "lastScanAt": {
+        "default": 0,
+        "type": "number"
+      },
+      "maxSearches": {
+        "default": 0,
+        "type": "number"
+      },
+      "memberships": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/MembershipRecord"
+        },
+        "type": "array"
+      },
+      "searchProgress": {
+        "$ref": "#/$defs/SearchProgress",
+        "default": {
+          "completedQueries": [],
+          "currentQuery": "",
+          "searchCount": 0,
+          "status": "idle"
+        }
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "google/extractors/hotel-membership-gmail-agent.tsx",
+  "resultSchema": {
+    "$defs": {
+      "MembershipRecord": {
+        "properties": {
+          "_fromWish": {
+            "type": "boolean"
+          },
+          "confidence": true,
+          "extractedAt": {
+            "type": "number"
+          },
+          "hotelBrand": true,
+          "id": {
+            "type": "string"
+          },
+          "membershipNumber": true,
+          "programName": true,
+          "sourceEmailDate": true,
+          "sourceEmailId": true,
+          "sourceEmailSubject": true,
+          "tier": true
+        },
+        "required": [
+          "hotelBrand",
+          "programName",
+          "membershipNumber",
+          "tier",
+          "sourceEmailId",
+          "sourceEmailSubject",
+          "sourceEmailDate",
+          "confidence",
+          "id",
+          "extractedAt"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Hotel loyalty membership extractor from Gmail. #hotelMemberships",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "count": {
+        "type": "number"
+      },
+      "lastScanAt": {
+        "type": "number"
+      },
+      "memberships": {
+        "items": {
+          "$ref": "#/$defs/MembershipRecord"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "memberships",
+      "lastScanAt",
+      "count",
+      "$NAME",
+      "$UI"
+    ],
+    "tags": [
+      "hotelmemberships"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/google/extractors/united-flight-tracker.tsx/20260818T183826Z-yfyxcX8FFD6nGDNu.json
+++ b/packages/patterns/baselines/google/extractors/united-flight-tracker.tsx/20260818T183826Z-yfyxcX8FFD6nGDNu.json
@@ -1,0 +1,279 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Auth": {
+        "properties": {
+          "expiresAt": {
+            "default": 0,
+            "type": "number"
+          },
+          "expiresIn": {
+            "default": 0,
+            "type": "number"
+          },
+          "refreshToken": {
+            "default": "",
+            "type": "string"
+          },
+          "scope": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "token": {
+            "default": "",
+            "type": "string"
+          },
+          "tokenType": {
+            "default": "",
+            "type": "string"
+          },
+          "user": {
+            "default": {
+              "email": "",
+              "name": "",
+              "picture": ""
+            },
+            "properties": {
+              "email": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "picture": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "email",
+              "name",
+              "picture"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "token",
+          "tokenType",
+          "scope",
+          "expiresIn",
+          "expiresAt",
+          "refreshToken",
+          "user"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "overrideAuth": {
+        "$ref": "#/$defs/Auth",
+        "asCell": [
+          "cell"
+        ]
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "google/extractors/united-flight-tracker.tsx",
+  "resultSchema": {
+    "$defs": {
+      "FlightStatus": {
+        "enum": [
+          "scheduled",
+          "delayed",
+          "cancelled",
+          "completed"
+        ]
+      },
+      "TrackedFlight": {
+        "properties": {
+          "arrivalAirport": {
+            "type": "string"
+          },
+          "arrivalCity": {
+            "type": "string"
+          },
+          "arrivalTime": {
+            "type": "string"
+          },
+          "checkInAvailable": {
+            "type": "boolean"
+          },
+          "checkInDeadline": {
+            "type": "string"
+          },
+          "confirmationNumber": {
+            "type": "string"
+          },
+          "daysUntilFlight": {
+            "type": "number"
+          },
+          "delayMinutes": {
+            "type": "number"
+          },
+          "departureAirport": {
+            "type": "string"
+          },
+          "departureCity": {
+            "type": "string"
+          },
+          "departureDate": {
+            "type": "string"
+          },
+          "departureTime": {
+            "type": "string"
+          },
+          "emailIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "flightNumber": {
+            "type": "string"
+          },
+          "gate": {
+            "type": "string"
+          },
+          "isUpcoming": {
+            "type": "boolean"
+          },
+          "key": {
+            "type": "string"
+          },
+          "newDepartureTime": {
+            "type": "string"
+          },
+          "passengerName": {
+            "type": "string"
+          },
+          "seat": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/$defs/FlightStatus"
+          },
+          "terminal": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "confirmationNumber",
+          "flightNumber",
+          "departureCity",
+          "departureAirport",
+          "arrivalCity",
+          "arrivalAirport",
+          "departureDate",
+          "departureTime",
+          "arrivalTime",
+          "status",
+          "checkInAvailable",
+          "isUpcoming",
+          "daysUntilFlight",
+          "emailIds"
+        ],
+        "type": "object"
+      },
+      "TrackedTrip": {
+        "properties": {
+          "confirmationNumber": {
+            "type": "string"
+          },
+          "flights": {
+            "items": {
+              "$ref": "#/$defs/TrackedFlight"
+            },
+            "type": "array"
+          },
+          "hasUpcomingFlights": {
+            "type": "boolean"
+          },
+          "nextFlight": {
+            "$ref": "#/$defs/TrackedFlight"
+          },
+          "passengerName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "confirmationNumber",
+          "flights",
+          "hasUpcomingFlights"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "United Airlines flight tracker. #unitedFlights",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$TILE_UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "activeAlerts": {
+        "items": {
+          "$ref": "#/$defs/TrackedFlight"
+        },
+        "type": "array"
+      },
+      "checkInAvailable": {
+        "items": {
+          "$ref": "#/$defs/TrackedFlight"
+        },
+        "type": "array"
+      },
+      "emailCount": {
+        "type": "number"
+      },
+      "flights": {
+        "items": {
+          "$ref": "#/$defs/TrackedFlight"
+        },
+        "type": "array"
+      },
+      "pastFlights": {
+        "items": {
+          "$ref": "#/$defs/TrackedFlight"
+        },
+        "type": "array"
+      },
+      "trips": {
+        "items": {
+          "$ref": "#/$defs/TrackedTrip"
+        },
+        "type": "array"
+      },
+      "upcomingFlights": {
+        "items": {
+          "$ref": "#/$defs/TrackedFlight"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "emailCount",
+      "flights",
+      "upcomingFlights",
+      "checkInAvailable",
+      "activeAlerts",
+      "pastFlights",
+      "trips",
+      "$NAME",
+      "$UI",
+      "$TILE_UI"
+    ],
+    "tags": [
+      "unitedflights"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/google/extractors/usps-informed-delivery.tsx/20260818T183826Z-C-LYzT-nLyUMHP5d.json
+++ b/packages/patterns/baselines/google/extractors/usps-informed-delivery.tsx/20260818T183826Z-C-LYzT-nLyUMHP5d.json
@@ -1,0 +1,285 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Auth": {
+        "properties": {
+          "expiresAt": {
+            "default": 0,
+            "type": "number"
+          },
+          "expiresIn": {
+            "default": 0,
+            "type": "number"
+          },
+          "refreshToken": {
+            "default": "",
+            "type": "string"
+          },
+          "scope": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "token": {
+            "default": "",
+            "type": "string"
+          },
+          "tokenType": {
+            "default": "",
+            "type": "string"
+          },
+          "user": {
+            "default": {
+              "email": "",
+              "name": "",
+              "picture": ""
+            },
+            "properties": {
+              "email": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "picture": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "email",
+              "name",
+              "picture"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "token",
+          "tokenType",
+          "scope",
+          "expiresIn",
+          "expiresAt",
+          "refreshToken",
+          "user"
+        ],
+        "type": "object"
+      },
+      "HouseholdMember": {
+        "properties": {
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "firstSeen": {
+            "type": "number"
+          },
+          "isConfirmed": {
+            "type": "boolean"
+          },
+          "mailCount": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "aliases",
+          "mailCount",
+          "firstSeen",
+          "isConfirmed"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "householdMembers": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/HouseholdMember"
+        },
+        "type": "array"
+      },
+      "overrideAuth": {
+        "$ref": "#/$defs/Auth",
+        "asCell": [
+          "cell"
+        ]
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "google/extractors/usps-informed-delivery.tsx",
+  "resultSchema": {
+    "$defs": {
+      "HouseholdMember": {
+        "properties": {
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "firstSeen": {
+            "type": "number"
+          },
+          "isConfirmed": {
+            "type": "boolean"
+          },
+          "mailCount": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "aliases",
+          "mailCount",
+          "firstSeen",
+          "isConfirmed"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "USPS Informed Delivery mail analyzer. #uspsInformedDelivery",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$TILE_UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "advertisementCount": {
+        "type": "number"
+      },
+      "billCount": {
+        "type": "number"
+      },
+      "charityCount": {
+        "type": "number"
+      },
+      "financialCount": {
+        "type": "number"
+      },
+      "governmentCount": {
+        "type": "number"
+      },
+      "householdMembers": {
+        "items": {
+          "$ref": "#/$defs/HouseholdMember"
+        },
+        "type": "array"
+      },
+      "mailCount": {
+        "type": "number"
+      },
+      "mailPieces": {
+        "items": {
+          "anyOf": [
+            {
+              "type": "undefined"
+            },
+            {
+              "properties": {
+                "isLikelySpam": {
+                  "type": "boolean"
+                },
+                "isUrgent": {
+                  "type": "boolean"
+                },
+                "mailType": {
+                  "enum": [
+                    "personal",
+                    "bill",
+                    "financial",
+                    "advertisement",
+                    "package",
+                    "government",
+                    "medical",
+                    "subscription",
+                    "charity",
+                    "other"
+                  ]
+                },
+                "recipient": {
+                  "type": "string"
+                },
+                "sender": {
+                  "type": "string"
+                },
+                "spamConfidence": {
+                  "type": "number"
+                },
+                "summary": {
+                  "type": "string"
+                },
+                "urgentReason": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "recipient",
+                "sender",
+                "mailType",
+                "isLikelySpam",
+                "spamConfidence",
+                "isUrgent",
+                "urgentReason",
+                "summary"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "type": "array"
+      },
+      "medicalCount": {
+        "type": "number"
+      },
+      "packageCount": {
+        "type": "number"
+      },
+      "personalCount": {
+        "type": "number"
+      },
+      "spamCount": {
+        "type": "number"
+      },
+      "subscriptionCount": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "mailPieces",
+      "householdMembers",
+      "mailCount",
+      "spamCount",
+      "personalCount",
+      "billCount",
+      "financialCount",
+      "advertisementCount",
+      "packageCount",
+      "governmentCount",
+      "medicalCount",
+      "subscriptionCount",
+      "charityCount",
+      "$NAME",
+      "$UI",
+      "$TILE_UI"
+    ],
+    "tags": [
+      "uspsinformeddelivery"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/group-chat-lobby.tsx/20260818T183826Z-5BZPTAbr-S7OY6Fn.json
+++ b/packages/patterns/baselines/group-chat-lobby.tsx/20260818T183826Z-5BZPTAbr-S7OY6Fn.json
@@ -1,0 +1,279 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Message": {
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "type": "string"
+          },
+          "reactions": {
+            "items": {
+              "$ref": "#/$defs/Reaction"
+            },
+            "type": "array"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "type": {
+            "enum": [
+              "chat",
+              "system",
+              "image"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "author",
+          "content",
+          "timestamp",
+          "type",
+          "reactions"
+        ],
+        "type": "object"
+      },
+      "Reaction": {
+        "properties": {
+          "emoji": {
+            "type": "string"
+          },
+          "userNames": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "emoji",
+          "userNames"
+        ],
+        "type": "object"
+      },
+      "User": {
+        "properties": {
+          "avatar": {
+            "description": "Avatar URL or glyph, snapshotted from the joiner's shared profile.",
+            "type": "string"
+          },
+          "joinedAt": {
+            "type": "number"
+          },
+          "name": {
+            "description": "Display name shown in the room. Unique within this roster (the lobby\ndisambiguates collisions) because messages/reactions key on it.",
+            "type": "string"
+          },
+          "profile": {
+            "asCell": [
+              "cell"
+            ],
+            "description": "Link to the joiner's profile cell — the stable identity key (optional so\nrosters written before the profile migration still load).",
+            "properties": {
+              "avatar": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "name",
+          "joinedAt"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Group Chat Lobby Pattern\n\nApple iOS-style lobby where unlimited users can join. Identity comes from\nthe viewer's shared profile (`wish({ query: \"#profile\" })`): the wish's\nbuilt-in UI lets the viewer pick one of their existing profiles or create a\nnew one, and joining snapshots the resolved name/avatar into the shared\nuser roster (see docs/specs/shared-profile-rosters.md).",
+    "properties": {
+      "chatName": {
+        "default": "Group Chat",
+        "type": "string"
+      },
+      "messages": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Message"
+        },
+        "type": "array"
+      },
+      "sessionId": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "users": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/User"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "chatName",
+      "messages",
+      "users",
+      "sessionId"
+    ],
+    "tags": [
+      "profile"
+    ],
+    "type": "object"
+  },
+  "pattern": "group-chat-lobby.tsx",
+  "resultSchema": {
+    "$defs": {
+      "Message": {
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "type": "string"
+          },
+          "reactions": {
+            "items": {
+              "$ref": "#/$defs/Reaction"
+            },
+            "type": "array"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "type": {
+            "enum": [
+              "chat",
+              "system",
+              "image"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "author",
+          "content",
+          "timestamp",
+          "type",
+          "reactions"
+        ],
+        "type": "object"
+      },
+      "Reaction": {
+        "properties": {
+          "emoji": {
+            "type": "string"
+          },
+          "userNames": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "emoji",
+          "userNames"
+        ],
+        "type": "object"
+      },
+      "User": {
+        "properties": {
+          "avatar": {
+            "description": "Avatar URL or glyph, snapshotted from the joiner's shared profile.",
+            "type": "string"
+          },
+          "joinedAt": {
+            "type": "number"
+          },
+          "name": {
+            "description": "Display name shown in the room. Unique within this roster (the lobby\ndisambiguates collisions) because messages/reactions key on it.",
+            "type": "string"
+          },
+          "profile": {
+            "description": "Link to the joiner's profile cell — the stable identity key (optional so\nrosters written before the profile migration still load).",
+            "properties": {
+              "avatar": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "name",
+          "joinedAt"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "chatName": {
+        "default": "Group Chat",
+        "type": "string"
+      },
+      "messages": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Message"
+        },
+        "type": "array"
+      },
+      "sessionId": {
+        "default": "",
+        "type": "string"
+      },
+      "users": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/User"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "chatName",
+      "messages",
+      "users",
+      "sessionId",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/group-chat-room.tsx/20260818T183826Z-IkXEJdEstP2K1YU4.json
+++ b/packages/patterns/baselines/group-chat-room.tsx/20260818T183826Z-IkXEJdEstP2K1YU4.json
@@ -1,0 +1,166 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Message": {
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "type": "string"
+          },
+          "reactions": {
+            "items": {
+              "$ref": "#/$defs/Reaction"
+            },
+            "type": "array"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "type": {
+            "enum": [
+              "chat",
+              "system",
+              "image"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "author",
+          "content",
+          "timestamp",
+          "type",
+          "reactions"
+        ],
+        "type": "object"
+      },
+      "Reaction": {
+        "properties": {
+          "emoji": {
+            "type": "string"
+          },
+          "userNames": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "emoji",
+          "userNames"
+        ],
+        "type": "object"
+      },
+      "User": {
+        "properties": {
+          "avatar": {
+            "description": "Avatar URL or glyph, snapshotted from the joiner's shared profile.",
+            "type": "string"
+          },
+          "joinedAt": {
+            "type": "number"
+          },
+          "name": {
+            "description": "Display name shown in the room. Unique within this roster (the lobby\ndisambiguates collisions) because messages/reactions key on it.",
+            "type": "string"
+          },
+          "profile": {
+            "asCell": [
+              "cell"
+            ],
+            "description": "Link to the joiner's profile cell — the stable identity key (optional so\nrosters written before the profile migration still load).",
+            "properties": {
+              "avatar": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "name",
+          "joinedAt"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "currentSessionId": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "messages": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Message"
+        },
+        "type": "array"
+      },
+      "myName": {
+        "default": "",
+        "type": "string"
+      },
+      "mySessionId": {
+        "default": "",
+        "type": "string"
+      },
+      "users": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/User"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "messages",
+      "users",
+      "myName",
+      "mySessionId",
+      "currentSessionId"
+    ],
+    "type": "object"
+  },
+  "pattern": "group-chat-room.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "myName": {
+        "default": "",
+        "type": "string"
+      }
+    },
+    "required": [
+      "myName",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/image-analysis.tsx/20260818T183826Z-A7XzFGPe84t_As7j.json
+++ b/packages/patterns/baselines/image-analysis.tsx/20260818T183826Z-A7XzFGPe84t_As7j.json
@@ -1,0 +1,158 @@
+{
+  "argumentSchema": {
+    "description": "Image Chat - Simple image upload with LLM analysis",
+    "properties": {
+      "model": {
+        "type": "string"
+      },
+      "systemPrompt": {
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "image-analysis.tsx",
+  "resultSchema": {
+    "$defs": {
+      "ImageData": {
+        "properties": {
+          "data": {
+            "type": "string"
+          },
+          "exif": {
+            "properties": {
+              "dateTime": {
+                "type": "string"
+              },
+              "exposureTime": {
+                "type": "string"
+              },
+              "fNumber": {
+                "type": "number"
+              },
+              "focalLength": {
+                "type": "number"
+              },
+              "gpsAltitude": {
+                "type": "number"
+              },
+              "gpsLatitude": {
+                "type": "number"
+              },
+              "gpsLongitude": {
+                "type": "number"
+              },
+              "iso": {
+                "type": "number"
+              },
+              "make": {
+                "type": "string"
+              },
+              "model": {
+                "type": "string"
+              },
+              "orientation": {
+                "type": "number"
+              },
+              "pixelXDimension": {
+                "type": "number"
+              },
+              "pixelYDimension": {
+                "type": "number"
+              },
+              "raw": {
+                "additionalProperties": true,
+                "properties": {},
+                "type": "object"
+              },
+              "software": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "height": {
+            "type": "number"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "type": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "width": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "url",
+          "data",
+          "timestamp",
+          "size",
+          "type"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "images": {
+        "items": {
+          "$ref": "#/$defs/ImageData"
+        },
+        "type": "array"
+      },
+      "pending": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "boolean"
+          }
+        ]
+      },
+      "prompt": {
+        "type": "string"
+      },
+      "response": {
+        "type": [
+          "string",
+          "undefined"
+        ]
+      },
+      "ui": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      }
+    },
+    "required": [
+      "images",
+      "prompt",
+      "response",
+      "pending",
+      "ui",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/notes/voice-note.tsx/20260818T183826Z-tLwEms9VMaGfUHSr.json
+++ b/packages/patterns/baselines/notes/voice-note.tsx/20260818T183826Z-tLwEms9VMaGfUHSr.json
@@ -1,0 +1,102 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "title": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "Voice Note",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "notes/voice-note.tsx",
+  "resultSchema": {
+    "$defs": {
+      "TranscriptionChunk": {
+        "properties": {
+          "text": {
+            "type": "string"
+          },
+          "timestamp": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "timestamp",
+          "text"
+        ],
+        "type": "object"
+      },
+      "TranscriptionData": {
+        "properties": {
+          "audioData": {
+            "type": "string"
+          },
+          "chunks": {
+            "items": {
+              "$ref": "#/$defs/TranscriptionChunk"
+            },
+            "type": "array"
+          },
+          "duration": {
+            "type": "number"
+          },
+          "id": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "text",
+          "duration",
+          "timestamp"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "notes": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TranscriptionData"
+        },
+        "type": "array"
+      },
+      "transcription": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/TranscriptionData"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null
+      }
+    },
+    "required": [
+      "transcription",
+      "notes",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/catalog/catalog.test.tsx
+++ b/packages/patterns/catalog/catalog.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Test Pattern: component catalog
+ *
+ * The catalog is a browser for the component stories: a sidebar of categories
+ * down one side, the selected story rendered beside it, and that story's
+ * controls panel underneath. Picking an item in the sidebar changes which
+ * story is shown.
+ *
+ * This drives that loop. It starts the catalog on its default story, walks the
+ * rendered tree to a sidebar item, sends its click stream, and checks the
+ * selection moved and the newly shown story is the one that was picked. It
+ * also collapses and reopens the sidebar, since the catalog swaps the whole
+ * sidebar for a single reopen button while it is collapsed.
+ */
+import {
+  action,
+  assert,
+  computed,
+  NAME,
+  pattern,
+  TESTS,
+  UI,
+  Writable,
+} from "commonfabric";
+import {
+  findElement,
+  findNode,
+  hasExactText,
+  hasText,
+  propsOf,
+} from "../test/vnode-helpers.ts";
+import Catalog from "./catalog.tsx";
+
+type ClickStream = { send: (event: Record<string, never>) => void };
+
+// Click the clickable node whose own text is exactly `text`. Matching the
+// whole text rather than a substring picks the row itself out of the tree
+// rather than one of the containers that also carries the row's text.
+function click(root: unknown, text: string): void {
+  const node = findNode(
+    root,
+    (candidate) =>
+      propsOf(candidate)?.onClick !== undefined &&
+      hasExactText(candidate, text),
+  );
+  const onClick = propsOf(node)?.onClick;
+  if (typeof onClick === "object" && onClick !== null && "send" in onClick) {
+    (onClick as ClickStream).send({});
+  }
+}
+
+export default pattern(() => {
+  const selectedStory = new Writable<string>("button");
+  const catalog = Catalog({ selectedStory });
+
+  // Which story the pane is showing, read off the component the story builds
+  // its example from.
+  const showing = computed(() => {
+    if (findElement(catalog[UI], "cf-badge") != null) return "badge";
+    if (findElement(catalog[UI], "cf-chart") != null) return "chart";
+    if (findElement(catalog[UI], "cf-button") != null) return "button";
+    return "none";
+  });
+
+  const action_pick_badge = action(() => {
+    click(catalog[UI], "Badge");
+  });
+
+  const action_pick_chart = action(() => {
+    click(catalog[UI], "Chart");
+  });
+
+  // The catalog collapses its sidebar when a story is picked, so reopening it
+  // is part of picking a second one.
+  const action_reopen_sidebar = action(() => {
+    const reopen = findElement(catalog[UI], "cf-button");
+    const onClick = propsOf(reopen)?.onClick;
+    if (typeof onClick === "object" && onClick !== null && "send" in onClick) {
+      (onClick as ClickStream).send({});
+    }
+  });
+
+  const assert_catalog_named = assert(() =>
+    catalog[NAME] === "Component Catalog"
+  );
+
+  // The sidebar lists every category it was given, so its headings are in the
+  // rendered tree from the start.
+  const assert_sidebar_lists_categories = assert(() =>
+    hasText(catalog[UI], "Inputs") &&
+    hasText(catalog[UI], "Layout") &&
+    hasText(catalog[UI], "Overview")
+  );
+
+  const assert_starts_on_button = assert(() =>
+    catalog.selectedStory === "button" && showing === "button"
+  );
+
+  const assert_shows_badge = assert(() =>
+    catalog.selectedStory === "badge" && showing === "badge"
+  );
+
+  const assert_shows_chart = assert(() =>
+    catalog.selectedStory === "chart" && showing === "chart"
+  );
+
+  // Picking a story collapses the sidebar, so the category headings go away
+  // and the reopen button takes their place.
+  const assert_sidebar_collapsed = assert(() =>
+    !hasText(catalog[UI], "Inputs")
+  );
+
+  const assert_sidebar_reopened = assert(() => hasText(catalog[UI], "Inputs"));
+
+  return {
+    [TESTS]: [
+      { assertion: assert_catalog_named },
+      { assertion: assert_sidebar_lists_categories },
+      { assertion: assert_starts_on_button },
+
+      { action: action_pick_badge },
+      { assertion: assert_shows_badge },
+      { assertion: assert_sidebar_collapsed },
+
+      { action: action_reopen_sidebar },
+      { assertion: assert_sidebar_reopened },
+
+      { action: action_pick_chart },
+      { assertion: assert_shows_chart },
+    ],
+    catalog,
+  };
+});

--- a/packages/patterns/catalog/stories/catalog-stories-1.test.tsx
+++ b/packages/patterns/catalog/stories/catalog-stories-1.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * Test Pattern: component catalog stories (first half)
+ *
+ * A story is the catalog's live example of one component. It builds the
+ * component with some state behind it, a panel of controls for changing that
+ * state, and the name the catalog lists it under. Instantiating a story runs
+ * the JSX for the example and for the controls, so a story that stopped
+ * building either one fails here rather than rendering blank in the catalog.
+ *
+ * Each story gets its own assertion, so a failure names the story rather than
+ * a chain of every story in the file. The assertion reads the name and the
+ * rendered example. It leaves `controls` alone: that value is a composed
+ * fragment of control components, which does not resolve to a plain non-null
+ * inside an assertion, and instantiation has already run its JSX.
+ *
+ * The other half of the stories is covered by catalog-stories-2.test.tsx;
+ * cf-calendar and cf-submit-input have test files of their own.
+ */
+import { assert, NAME, pattern, TESTS, UI } from "commonfabric";
+
+import AlertStory from "./cf-alert-story.tsx";
+import AutocompleteStory from "./cf-autocomplete-story.tsx";
+import AvatarStory from "./cf-avatar-story.tsx";
+import BadgeStory from "./cf-badge-story.tsx";
+import ButtonStory from "./cf-button-story.tsx";
+import CardStory from "./cf-card-story.tsx";
+import ChartStory from "./cf-chart-story.tsx";
+import ChatStory from "./cf-chat-story.tsx";
+import CheckboxStory from "./cf-checkbox-story.tsx";
+import ChipStory from "./cf-chip-story.tsx";
+import CodeEditorStory from "./cf-code-editor-story.tsx";
+import CollapsibleStory from "./cf-collapsible-story.tsx";
+import CopyButtonStory from "./cf-copy-button-story.tsx";
+import EmptyStateStory from "./cf-empty-state-story.tsx";
+import FieldStory from "./cf-field-story.tsx";
+import GridStory from "./cf-grid-story.tsx";
+import HeadingStory from "./cf-heading-story.tsx";
+import HgroupStory from "./cf-hgroup-story.tsx";
+import HscrollStory from "./cf-hscroll-story.tsx";
+import HstackStory from "./cf-hstack-story.tsx";
+import InputStory from "./cf-input-story.tsx";
+import KbdStory from "./cf-kbd-story.tsx";
+import LabelStory from "./cf-label-story.tsx";
+import ListItemStory from "./cf-list-item-story.tsx";
+import LoaderStory from "./cf-loader-story.tsx";
+import MarkdownStory from "./cf-markdown-story.tsx";
+import MessageInputStory from "./cf-message-input-story.tsx";
+import ModalStory from "./cf-modal-story.tsx";
+import PickerStory from "./cf-picker-story.tsx";
+import ProfileBadgeStory from "./cf-profile-badge-story.tsx";
+
+export default pattern(() => {
+  const alertStory = AlertStory({});
+  const autocompleteStory = AutocompleteStory({});
+  const avatarStory = AvatarStory({});
+  const badgeStory = BadgeStory({});
+  const buttonStory = ButtonStory({});
+  const cardStory = CardStory({});
+  const chartStory = ChartStory({});
+  const chatStory = ChatStory({});
+  const checkboxStory = CheckboxStory({});
+  const chipStory = ChipStory({});
+  const codeEditorStory = CodeEditorStory({});
+  const collapsibleStory = CollapsibleStory({});
+  const copyButtonStory = CopyButtonStory({});
+  const emptyStateStory = EmptyStateStory({});
+  const fieldStory = FieldStory({});
+  const gridStory = GridStory({});
+  const headingStory = HeadingStory({});
+  const hgroupStory = HgroupStory({});
+  const hscrollStory = HscrollStory({});
+  const hstackStory = HstackStory({});
+  const inputStory = InputStory({});
+  const kbdStory = KbdStory({});
+  const labelStory = LabelStory({});
+  const listItemStory = ListItemStory({});
+  const loaderStory = LoaderStory({});
+  const markdownStory = MarkdownStory({});
+  const messageInputStory = MessageInputStory({});
+  const modalStory = ModalStory({});
+  const pickerStory = PickerStory({});
+  const profileBadgeStory = ProfileBadgeStory({});
+
+  const assert_cf_alert_story = assert(() =>
+    alertStory[NAME] === "cf-alert Story" && alertStory[UI] != null
+  );
+  const assert_cf_autocomplete_story = assert(() =>
+    autocompleteStory[NAME] === "cf-autocomplete Story" &&
+    autocompleteStory[UI] != null
+  );
+  const assert_cf_avatar_story = assert(() =>
+    avatarStory[NAME] === "cf-avatar Story" && avatarStory[UI] != null
+  );
+  const assert_cf_badge_story = assert(() =>
+    badgeStory[NAME] === "cf-badge Story" && badgeStory[UI] != null
+  );
+  const assert_cf_button_story = assert(() =>
+    buttonStory[NAME] === "cf-button Story" && buttonStory[UI] != null
+  );
+  const assert_cf_card_story = assert(() =>
+    cardStory[NAME] === "cf-card Story" && cardStory[UI] != null
+  );
+  const assert_cf_chart_story = assert(() =>
+    chartStory[NAME] === "cf-chart Story" && chartStory[UI] != null
+  );
+  const assert_cf_chat_story = assert(() =>
+    chatStory[NAME] === "cf-chat Story" && chatStory[UI] != null
+  );
+  const assert_cf_checkbox_story = assert(() =>
+    checkboxStory[NAME] === "cf-checkbox Story" && checkboxStory[UI] != null
+  );
+  const assert_cf_chip_story = assert(() =>
+    chipStory[NAME] === "cf-chip Story" && chipStory[UI] != null
+  );
+  const assert_cf_code_editor_story = assert(() =>
+    codeEditorStory[NAME] === "cf-code-editor Story" &&
+    codeEditorStory[UI] != null
+  );
+  const assert_cf_collapsible_story = assert(() =>
+    collapsibleStory[NAME] === "cf-collapsible Story" &&
+    collapsibleStory[UI] != null
+  );
+  const assert_cf_copy_button_story = assert(() =>
+    copyButtonStory[NAME] === "cf-copy-button Story" &&
+    copyButtonStory[UI] != null
+  );
+  const assert_cf_empty_state_story = assert(() =>
+    emptyStateStory[NAME] === "cf-empty-state Story" &&
+    emptyStateStory[UI] != null
+  );
+  const assert_cf_field_story = assert(() =>
+    fieldStory[NAME] === "cf-field Story" && fieldStory[UI] != null
+  );
+  const assert_cf_grid_story = assert(() =>
+    gridStory[NAME] === "cf-grid Story" && gridStory[UI] != null
+  );
+  const assert_cf_heading_story = assert(() =>
+    headingStory[NAME] === "cf-heading Story" && headingStory[UI] != null
+  );
+  const assert_cf_hgroup_story = assert(() =>
+    hgroupStory[NAME] === "cf-hgroup Story" && hgroupStory[UI] != null
+  );
+  const assert_cf_hscroll_story = assert(() =>
+    hscrollStory[NAME] === "cf-hscroll Story" && hscrollStory[UI] != null
+  );
+  const assert_cf_hstack_story = assert(() =>
+    hstackStory[NAME] === "cf-hstack Story" && hstackStory[UI] != null
+  );
+  const assert_cf_input_story = assert(() =>
+    inputStory[NAME] === "cf-input Story" && inputStory[UI] != null
+  );
+  const assert_cf_kbd_story = assert(() =>
+    kbdStory[NAME] === "cf-kbd Story" && kbdStory[UI] != null
+  );
+  const assert_cf_label_story = assert(() =>
+    labelStory[NAME] === "cf-label Story" && labelStory[UI] != null
+  );
+  const assert_cf_list_item_story = assert(() =>
+    listItemStory[NAME] === "cf-list-item Story" && listItemStory[UI] != null
+  );
+  const assert_cf_loader_story = assert(() =>
+    loaderStory[NAME] === "cf-loader Story" && loaderStory[UI] != null
+  );
+  const assert_cf_markdown_story = assert(() =>
+    markdownStory[NAME] === "cf-markdown Story" && markdownStory[UI] != null
+  );
+  const assert_cf_message_input_story = assert(() =>
+    messageInputStory[NAME] === "cf-message-input Story" &&
+    messageInputStory[UI] != null
+  );
+  const assert_cf_modal_story = assert(() =>
+    modalStory[NAME] === "cf-modal Story" && modalStory[UI] != null
+  );
+  const assert_cf_picker_story = assert(() =>
+    pickerStory[NAME] === "cf-picker Story" && pickerStory[UI] != null
+  );
+  const assert_cf_profile_badge_story = assert(() =>
+    profileBadgeStory[NAME] === "cf-profile-badge Story" &&
+    profileBadgeStory[UI] != null
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_cf_alert_story },
+      { assertion: assert_cf_autocomplete_story },
+      { assertion: assert_cf_avatar_story },
+      { assertion: assert_cf_badge_story },
+      { assertion: assert_cf_button_story },
+      { assertion: assert_cf_card_story },
+      { assertion: assert_cf_chart_story },
+      { assertion: assert_cf_chat_story },
+      { assertion: assert_cf_checkbox_story },
+      { assertion: assert_cf_chip_story },
+      { assertion: assert_cf_code_editor_story },
+      { assertion: assert_cf_collapsible_story },
+      { assertion: assert_cf_copy_button_story },
+      { assertion: assert_cf_empty_state_story },
+      { assertion: assert_cf_field_story },
+      { assertion: assert_cf_grid_story },
+      { assertion: assert_cf_heading_story },
+      { assertion: assert_cf_hgroup_story },
+      { assertion: assert_cf_hscroll_story },
+      { assertion: assert_cf_hstack_story },
+      { assertion: assert_cf_input_story },
+      { assertion: assert_cf_kbd_story },
+      { assertion: assert_cf_label_story },
+      { assertion: assert_cf_list_item_story },
+      { assertion: assert_cf_loader_story },
+      { assertion: assert_cf_markdown_story },
+      { assertion: assert_cf_message_input_story },
+      { assertion: assert_cf_modal_story },
+      { assertion: assert_cf_picker_story },
+      { assertion: assert_cf_profile_badge_story },
+    ],
+  };
+});

--- a/packages/patterns/catalog/stories/catalog-stories-2.test.tsx
+++ b/packages/patterns/catalog/stories/catalog-stories-2.test.tsx
@@ -1,0 +1,214 @@
+/**
+ * Test Pattern: component catalog stories (second half)
+ *
+ * A story is the catalog's live example of one component. It builds the
+ * component with some state behind it, a panel of controls for changing that
+ * state, and the name the catalog lists it under. Instantiating a story runs
+ * the JSX for the example and for the controls, so a story that stopped
+ * building either one fails here rather than rendering blank in the catalog.
+ *
+ * Each story gets its own assertion, so a failure names the story rather than
+ * a chain of every story in the file. The assertion reads the name and the
+ * rendered example. It leaves `controls` alone: that value is a composed
+ * fragment of control components, which does not resolve to a plain non-null
+ * inside an assertion, and instantiation has already run its JSX.
+ *
+ * The other half of the stories is covered by catalog-stories-1.test.tsx;
+ * cf-calendar and cf-submit-input have test files of their own.
+ */
+import { assert, NAME, pattern, TESTS, UI } from "commonfabric";
+
+import ProgressStory from "./cf-progress-story.tsx";
+import RadioStory from "./cf-radio-story.tsx";
+import RenderStory from "./cf-render-story.tsx";
+import SelectStory from "./cf-select-story.tsx";
+import SeparatorStory from "./cf-separator-story.tsx";
+import SkeletonStory from "./cf-skeleton-story.tsx";
+import SliderStory from "./cf-slider-story.tsx";
+import SvgStory from "./cf-svg-story.tsx";
+import SwitchStory from "./cf-switch-story.tsx";
+import TabBarStory from "./cf-tab-bar-story.tsx";
+import TabListStory from "./cf-tab-list-story.tsx";
+import TableStory from "./cf-table-story.tsx";
+import TabsStory from "./cf-tabs-story.tsx";
+import TagsStory from "./cf-tags-story.tsx";
+import TextStory from "./cf-text-story.tsx";
+import TextareaStory from "./cf-textarea-story.tsx";
+import ToastStory from "./cf-toast-story.tsx";
+import ToggleGroupStory from "./cf-toggle-group-story.tsx";
+import ToggleStory from "./cf-toggle-story.tsx";
+import ToolbarStory from "./cf-toolbar-story.tsx";
+import VgroupStory from "./cf-vgroup-story.tsx";
+import VscrollStory from "./cf-vscroll-story.tsx";
+import VstackStory from "./cf-vstack-story.tsx";
+import KitchenSinkStory from "./kitchen-sink-story.tsx";
+import NoteStory from "./note-story.tsx";
+import StyleTokensStory from "./style-tokens-story.tsx";
+import ThemeSamplerStory from "./theme-sampler-story.tsx";
+import VignetteFinanceStory from "./vignette-finance-story.tsx";
+import VignetteMobileAppStory from "./vignette-mobile-app-story.tsx";
+import VignetteRecipeStory from "./vignette-recipe-story.tsx";
+
+export default pattern(() => {
+  const progressStory = ProgressStory({});
+  const radioStory = RadioStory({});
+  const renderStory = RenderStory({});
+  const selectStory = SelectStory({});
+  const separatorStory = SeparatorStory({});
+  const skeletonStory = SkeletonStory({});
+  const sliderStory = SliderStory({});
+  const svgStory = SvgStory({});
+  const switchStory = SwitchStory({});
+  const tabBarStory = TabBarStory({});
+  const tabListStory = TabListStory({});
+  const tableStory = TableStory({});
+  const tabsStory = TabsStory({});
+  const tagsStory = TagsStory({});
+  const textStory = TextStory({});
+  const textareaStory = TextareaStory({});
+  const toastStory = ToastStory({});
+  const toggleGroupStory = ToggleGroupStory({});
+  const toggleStory = ToggleStory({});
+  const toolbarStory = ToolbarStory({});
+  const vgroupStory = VgroupStory({});
+  const vscrollStory = VscrollStory({});
+  const vstackStory = VstackStory({});
+  const kitchenSinkStory = KitchenSinkStory({});
+  const noteStory = NoteStory({});
+  const styleTokensStory = StyleTokensStory({});
+  const themeSamplerStory = ThemeSamplerStory({});
+  const vignetteFinanceStory = VignetteFinanceStory({});
+  const vignetteMobileAppStory = VignetteMobileAppStory({});
+  const vignetteRecipeStory = VignetteRecipeStory({});
+
+  const assert_cf_progress_story = assert(() =>
+    progressStory[NAME] === "cf-progress Story" && progressStory[UI] != null
+  );
+  const assert_cf_radio_story = assert(() =>
+    radioStory[NAME] === "cf-radio Story" && radioStory[UI] != null
+  );
+  const assert_cf_render_story = assert(() =>
+    renderStory[NAME] === "cf-render Story" && renderStory[UI] != null
+  );
+  const assert_cf_select_story = assert(() =>
+    selectStory[NAME] === "cf-select Story" && selectStory[UI] != null
+  );
+  const assert_cf_separator_story = assert(() =>
+    separatorStory[NAME] === "cf-separator Story" && separatorStory[UI] != null
+  );
+  const assert_cf_skeleton_story = assert(() =>
+    skeletonStory[NAME] === "cf-skeleton Story" && skeletonStory[UI] != null
+  );
+  const assert_cf_slider_story = assert(() =>
+    sliderStory[NAME] === "cf-slider Story" && sliderStory[UI] != null
+  );
+  const assert_cf_svg_story = assert(() =>
+    svgStory[NAME] === "cf-svg Story" && svgStory[UI] != null
+  );
+  const assert_cf_switch_story = assert(() =>
+    switchStory[NAME] === "cf-switch Story" && switchStory[UI] != null
+  );
+  const assert_cf_tab_bar_story = assert(() =>
+    tabBarStory[NAME] === "cf-tab-bar Story" && tabBarStory[UI] != null
+  );
+  const assert_cf_tab_list_story = assert(() =>
+    tabListStory[NAME] === "cf-tab-list Story" && tabListStory[UI] != null
+  );
+  const assert_cf_table_story = assert(() =>
+    tableStory[NAME] === "cf-table Story" && tableStory[UI] != null
+  );
+  const assert_cf_tabs_story = assert(() =>
+    tabsStory[NAME] === "cf-tabs Story" && tabsStory[UI] != null
+  );
+  const assert_cf_tags_story = assert(() =>
+    tagsStory[NAME] === "cf-tags Story" && tagsStory[UI] != null
+  );
+  const assert_cf_text_story = assert(() =>
+    textStory[NAME] === "cf-text Story" && textStory[UI] != null
+  );
+  const assert_cf_textarea_story = assert(() =>
+    textareaStory[NAME] === "cf-textarea Story" && textareaStory[UI] != null
+  );
+  const assert_cf_toast_story = assert(() =>
+    toastStory[NAME] === "cf-toast Story" && toastStory[UI] != null
+  );
+  const assert_cf_toggle_group_story = assert(() =>
+    toggleGroupStory[NAME] === "cf-toggle-group Story" &&
+    toggleGroupStory[UI] != null
+  );
+  const assert_cf_toggle_story = assert(() =>
+    toggleStory[NAME] === "cf-toggle Story" && toggleStory[UI] != null
+  );
+  const assert_cf_toolbar_story = assert(() =>
+    toolbarStory[NAME] === "cf-toolbar Story" && toolbarStory[UI] != null
+  );
+  const assert_cf_vgroup_story = assert(() =>
+    vgroupStory[NAME] === "cf-vgroup Story" && vgroupStory[UI] != null
+  );
+  const assert_cf_vscroll_story = assert(() =>
+    vscrollStory[NAME] === "cf-vscroll Story" && vscrollStory[UI] != null
+  );
+  const assert_cf_vstack_story = assert(() =>
+    vstackStory[NAME] === "cf-vstack Story" && vstackStory[UI] != null
+  );
+  const assert_kitchen_sink_story = assert(() =>
+    kitchenSinkStory[NAME] === "Kitchen Sink Story" &&
+    kitchenSinkStory[UI] != null
+  );
+  const assert_note_story = assert(() =>
+    noteStory[NAME] === "Note Story" && noteStory[UI] != null
+  );
+  const assert_style_tokens_story = assert(() =>
+    styleTokensStory[NAME] === "Style Tokens" && styleTokensStory[UI] != null
+  );
+  const assert_theme_sampler_story = assert(() =>
+    themeSamplerStory[NAME] === "Theme Sampler" && themeSamplerStory[UI] != null
+  );
+  const assert_vignette_finance_story = assert(() =>
+    vignetteFinanceStory[NAME] === "Vignette: Finance Dashboard" &&
+    vignetteFinanceStory[UI] != null
+  );
+  const assert_vignette_mobile_app_story = assert(() =>
+    vignetteMobileAppStory[NAME] === "Vignette: Mobile App" &&
+    vignetteMobileAppStory[UI] != null
+  );
+  const assert_vignette_recipe_story = assert(() =>
+    vignetteRecipeStory[NAME] === "Vignette: Recipe App" &&
+    vignetteRecipeStory[UI] != null
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_cf_progress_story },
+      { assertion: assert_cf_radio_story },
+      { assertion: assert_cf_render_story },
+      { assertion: assert_cf_select_story },
+      { assertion: assert_cf_separator_story },
+      { assertion: assert_cf_skeleton_story },
+      { assertion: assert_cf_slider_story },
+      { assertion: assert_cf_svg_story },
+      { assertion: assert_cf_switch_story },
+      { assertion: assert_cf_tab_bar_story },
+      { assertion: assert_cf_tab_list_story },
+      { assertion: assert_cf_table_story },
+      { assertion: assert_cf_tabs_story },
+      { assertion: assert_cf_tags_story },
+      { assertion: assert_cf_text_story },
+      { assertion: assert_cf_textarea_story },
+      { assertion: assert_cf_toast_story },
+      { assertion: assert_cf_toggle_group_story },
+      { assertion: assert_cf_toggle_story },
+      { assertion: assert_cf_toolbar_story },
+      { assertion: assert_cf_vgroup_story },
+      { assertion: assert_cf_vscroll_story },
+      { assertion: assert_cf_vstack_story },
+      { assertion: assert_kitchen_sink_story },
+      { assertion: assert_note_story },
+      { assertion: assert_style_tokens_story },
+      { assertion: assert_theme_sampler_story },
+      { assertion: assert_vignette_finance_story },
+      { assertion: assert_vignette_mobile_app_story },
+      { assertion: assert_vignette_recipe_story },
+    ],
+  };
+});

--- a/packages/patterns/chatbot.tsx
+++ b/packages/patterns/chatbot.tsx
@@ -91,6 +91,8 @@ const handlePinToChat = handler<
 });
 
 export type ChatOutput = {
+  [NAME]: string;
+  [UI]: VNode;
   messages: Array<BuiltInLLMMessage>;
   pending: boolean | undefined;
   addMessage: Stream<BuiltInLLMMessage>;

--- a/packages/patterns/examples/cf-checkbox-cell.tsx
+++ b/packages/patterns/examples/cf-checkbox-cell.tsx
@@ -5,6 +5,7 @@ import {
   NAME,
   pattern,
   UI,
+  type VNode,
   Writable,
 } from "commonfabric";
 
@@ -13,7 +14,10 @@ interface CheckboxDemoInput {
   trackedEnabled: Writable<boolean | Default<false>>;
 }
 
-export interface CheckboxDemoOutput extends CheckboxDemoInput {}
+export interface CheckboxDemoOutput extends CheckboxDemoInput {
+  [NAME]: string;
+  [UI]: VNode;
+}
 
 // Handler for checkbox changes - only needed when you want additional logic
 // Defined at module scope as required by the pattern system

--- a/packages/patterns/examples/cf-tags.tsx
+++ b/packages/patterns/examples/cf-tags.tsx
@@ -1,10 +1,20 @@
-import { Default, handler, NAME, pattern, UI, Writable } from "commonfabric";
+import {
+  Default,
+  handler,
+  NAME,
+  pattern,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
 
 type Input = {
   tags: string[];
 };
 
 export type Result = {
+  [NAME]: string;
+  [UI]: VNode;
   tags: string[] | Default<[]>;
 };
 

--- a/packages/patterns/examples/drag-drop-demo.tsx
+++ b/packages/patterns/examples/drag-drop-demo.tsx
@@ -7,6 +7,7 @@ import {
   NAME,
   pattern,
   UI,
+  type VNode,
   Writable,
 } from "commonfabric";
 import Counter from "../counter/counter.tsx";
@@ -22,6 +23,8 @@ interface DragDropDemoInput {
 }
 
 export interface DragDropDemoOutput {
+  [NAME]: string;
+  [UI]: VNode;
   availableItems: Item[];
   droppedItems: Item[];
 }

--- a/packages/patterns/examples/examples.test.tsx
+++ b/packages/patterns/examples/examples.test.tsx
@@ -1,0 +1,222 @@
+/**
+ * Test Pattern: the example patterns
+ *
+ * Each of these is a worked example of one idea: reading a cell into a
+ * checkbox, editing an array in place, rendering a sub-path of another
+ * pattern's tree, picking one of several options, nesting one counter inside
+ * another. They are what someone reads to learn an idiom, so an example that
+ * stopped building is worse than no example.
+ *
+ * This builds each one with real inputs, checks what it publishes, and where
+ * an example turns on a value moving — the nested counter, the option picker,
+ * the editable array — moves it and checks the result.
+ */
+import {
+  action,
+  assert,
+  NAME,
+  pattern,
+  TESTS,
+  UI,
+  Writable,
+} from "commonfabric";
+
+import {
+  findElement,
+  findNodeByProp,
+  hasText,
+  textContent,
+} from "../test/vnode-helpers.ts";
+import ArbitraryWishExample from "./arbitrary-wish-example.tsx";
+import ArrayInCell from "./array-in-cell-with-remove-editable.tsx";
+import CfChartDemo from "./cf-chart-demo.tsx";
+import CheckboxCell from "./cf-checkbox-cell.tsx";
+import CodeEditorCell from "./cf-code-editor-cell.tsx";
+import CfRenderSubpath from "./cf-render-subpath.tsx";
+import CfRender from "./cf-render.tsx";
+import CfTags from "./cf-tags.tsx";
+import DragDropDemo from "./drag-drop-demo.tsx";
+import EmailList from "./email-list.tsx";
+import MultiOptionSelection from "./multi-option-selection.tsx";
+import NestedCounter from "./nested-counter.tsx";
+import NestedMentionables from "./nested-mentionables.tsx";
+import OutputSchema from "./output_schema.tsx";
+import ProfileAwareWriter from "./profile-aware-writer.tsx";
+import UiVariantsDemo from "./ui-variants-demo.tsx";
+import UiVariantsHost from "./ui-variants-host.tsx";
+import WishNoteExample from "./wish-note-example.tsx";
+
+export default pattern(() => {
+  const arrayItems = new Writable<{ text: string }[]>([
+    { text: "first" },
+    { text: "second" },
+  ]);
+  const arrayInCell = ArrayInCell({ title: "List", items: arrayItems });
+
+  const simpleEnabled = new Writable(false);
+  const trackedEnabled = new Writable(false);
+  const checkboxCell = CheckboxCell({ simpleEnabled, trackedEnabled });
+
+  const codeEditorCell = CodeEditorCell({ content: "const x = 1;" });
+
+  const counterValue = new Writable(0);
+  const cfRender = CfRender({ value: counterValue });
+  const cfRenderSubpath = CfRenderSubpath({ title: "Subpath" });
+
+  const tags = new Writable<string[]>(["alpha", "beta"]);
+  const cfTags = CfTags({ tags });
+
+  const chartDemo = CfChartDemo({});
+
+  const dragDrop = DragDropDemo({
+    availableItems: [{ title: "one" }, { title: "two" }],
+    droppedItems: [],
+  });
+
+  const selected = new Writable("opt_1");
+  const numericChoice = new Writable(1);
+  const category = new Writable("Other");
+  const activeTab = new Writable("tab1");
+  const multiOption = MultiOptionSelection({
+    selected,
+    numericChoice,
+    category,
+    activeTab,
+  });
+
+  const nestedValue = new Writable(3);
+  const nestedCounter = NestedCounter({ value: nestedValue });
+
+  const outputSchema = OutputSchema({ value: 7 });
+  const uiVariants = UiVariantsDemo({ title: "UI Variants Demo" });
+  const uiVariantsHost = UiVariantsHost({});
+  const emailList = EmailList({});
+  const nestedMentionables = NestedMentionables({});
+  const profileAwareWriter = ProfileAwareWriter({});
+  const arbitraryWish = ArbitraryWishExample({});
+  const wishNote = WishNoteExample({});
+
+  // ==========================================================================
+  // Actions
+  // ==========================================================================
+
+  const action_remove_first_item = action(() => {
+    arrayItems.set(arrayItems.get().slice(1));
+  });
+
+  const action_check_both_boxes = action(() => {
+    simpleEnabled.set(true);
+    trackedEnabled.set(true);
+  });
+
+  const action_pick_second_option = action(() => {
+    selected.set("opt_2");
+    numericChoice.set(2);
+  });
+
+  const action_bump_counter = action(() => {
+    nestedValue.set(nestedValue.get() + 1);
+  });
+
+  // ==========================================================================
+  // Assertions
+  // ==========================================================================
+
+  // The editable array puts each item's text in an input's value rather than
+  // as a text child, so the search is over that prop.
+  const assert_array_lists_items = assert(() =>
+    findNodeByProp(arrayInCell[UI], "value", "first") != null &&
+    findNodeByProp(arrayInCell[UI], "value", "second") != null
+  );
+
+  const assert_array_lost_first = assert(() =>
+    findNodeByProp(arrayInCell[UI], "value", "first") == null &&
+    findNodeByProp(arrayInCell[UI], "value", "second") != null
+  );
+
+  const assert_boxes_start_unchecked = assert(() =>
+    simpleEnabled.get() === false && trackedEnabled.get() === false &&
+    textContent(checkboxCell[UI]).length > 0
+  );
+
+  const assert_boxes_checked = assert(() =>
+    simpleEnabled.get() === true && trackedEnabled.get() === true
+  );
+
+  const assert_option_starts_first = assert(() =>
+    selected.get() === "opt_1" && numericChoice.get() === 1 &&
+    textContent(multiOption[UI]).length > 0
+  );
+
+  const assert_option_moved = assert(() =>
+    selected.get() === "opt_2" && numericChoice.get() === 2
+  );
+
+  // The nested counter passes its value down to an inner counter, so the
+  // inner one has to show what the outer one holds.
+  const assert_counter_starts_at_3 = assert(() =>
+    hasText(nestedCounter[UI], "3")
+  );
+
+  const assert_counter_bumped = assert(() => hasText(nestedCounter[UI], "4"));
+
+  const assert_render_examples_build = assert(() =>
+    textContent(cfRender[UI]).length > 0 &&
+    cfRenderSubpath[NAME] === "Subpath Test: Subpath" &&
+    textContent(cfRenderSubpath[UI]).length > 0
+  );
+
+  // The tags example hands its list to cf-tags through a bound prop, so the
+  // tags are behind the binding rather than in the tree's text. What the tree
+  // shows is that the component is there; the cell holds the tags themselves.
+  const assert_tags_bound = assert(() =>
+    findElement(cfTags[UI], "cf-tags") != null &&
+    tags.get().length === 2 && tags.get()[0] === "alpha"
+  );
+
+  const assert_drag_drop_lists_items = assert(() =>
+    hasText(dragDrop[UI], "one") && hasText(dragDrop[UI], "two")
+  );
+
+  // The rest are read for the tree they build, which is what running their
+  // derived expressions takes. The email list and the wish note start with
+  // nothing to show and no text of their own, so each is checked for a tree
+  // rather than for text.
+  const assert_remaining_examples_build = assert(() =>
+    textContent(codeEditorCell[UI]).length > 0 &&
+    textContent(chartDemo[UI]).length > 0 &&
+    textContent(outputSchema[UI]).length > 0 &&
+    textContent(uiVariants[UI]).length > 0 &&
+    textContent(uiVariantsHost[UI]).length > 0 &&
+    emailList[UI] != null &&
+    textContent(nestedMentionables[UI]).length > 0 &&
+    textContent(profileAwareWriter[UI]).length > 0 &&
+    textContent(arbitraryWish[UI]).length > 0 &&
+    wishNote[UI] != null
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_array_lists_items },
+      { assertion: assert_boxes_start_unchecked },
+      { assertion: assert_option_starts_first },
+      { assertion: assert_counter_starts_at_3 },
+      { assertion: assert_render_examples_build },
+      { assertion: assert_tags_bound },
+      { assertion: assert_drag_drop_lists_items },
+      { assertion: assert_remaining_examples_build },
+
+      { action: action_remove_first_item },
+      { assertion: assert_array_lost_first },
+
+      { action: action_check_both_boxes },
+      { assertion: assert_boxes_checked },
+
+      { action: action_pick_second_option },
+      { assertion: assert_option_moved },
+
+      { action: action_bump_counter },
+      { assertion: assert_counter_bumped },
+    ],
+  };
+});

--- a/packages/patterns/examples/multi-option-selection.tsx
+++ b/packages/patterns/examples/multi-option-selection.tsx
@@ -1,4 +1,4 @@
-import { Default, NAME, pattern, UI, Writable } from "commonfabric";
+import { Default, NAME, pattern, UI, type VNode, Writable } from "commonfabric";
 
 type Input = {
   selected: Writable<string | Default<"opt_1">>;
@@ -8,6 +8,8 @@ type Input = {
 };
 
 export type Result = {
+  [NAME]: string;
+  [UI]: VNode;
   selected: string;
   numericChoice: number;
   category: string;

--- a/packages/patterns/examples/write-and-run.tsx
+++ b/packages/patterns/examples/write-and-run.tsx
@@ -9,6 +9,7 @@ import {
   navigateTo,
   pattern,
   UI,
+  type VNode,
   Writable,
 } from "commonfabric";
 
@@ -17,6 +18,8 @@ interface Input {
 }
 
 export interface Output {
+  [NAME]: string;
+  [UI]: VNode;
   prompt: string;
 }
 

--- a/packages/patterns/experimental/folksonomy-demo.tsx
+++ b/packages/patterns/experimental/folksonomy-demo.tsx
@@ -18,7 +18,15 @@
  * - Community suggestions show dimmed with usage counts
  * - Events are posted to the aggregator in real-time
  */
-import { type Default, NAME, pattern, UI, wish, Writable } from "commonfabric";
+import {
+  type Default,
+  NAME,
+  pattern,
+  UI,
+  type VNode,
+  wish,
+  Writable,
+} from "commonfabric";
 
 // Import the FolksonomyTags sub-pattern
 import { FolksonomyTags } from "./folksonomy-tags.tsx";
@@ -35,6 +43,8 @@ interface Input {
 }
 
 export interface Output {
+  [NAME]: string;
+  [UI]: VNode;
   itemATags: string[];
   itemBTags: string[];
   itemCTags: string[];

--- a/packages/patterns/experimental/folksonomy.test.tsx
+++ b/packages/patterns/experimental/folksonomy.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Test Pattern: the folksonomy patterns
+ *
+ * Folksonomy is tagging shared across patterns by scope: two items given the
+ * same scope see each other's tags, and an item in a different scope does not.
+ * The tags pattern is the per-item editor, the demo wires three items into two
+ * scopes to show the sharing, and the stress test builds many tagged items at
+ * once.
+ *
+ * What this checks is the wiring: each item's tags reach the demo's output
+ * from the cell they were written to, and a tag added to one item arrives at
+ * that item and at neither of the others. Every read goes through the pattern
+ * rather than through the cell the test holds, so it is the demo's projection
+ * being checked and not the test's own array.
+ *
+ * Cross-scope sharing — item A and B seeing each other's tags, item C not — is
+ * not checked here. That routing runs through an aggregator the tags pattern
+ * discovers with a wish, which resolves to nothing in an empty space, so there
+ * is no sharing to observe.
+ */
+import { action, assert, pattern, TESTS, UI, Writable } from "commonfabric";
+import { textContent } from "../test/vnode-helpers.ts";
+import FolksonomyDemo from "./folksonomy-demo.tsx";
+import FolksonomyStressTest from "./folksonomy-stress-test.tsx";
+import FolksonomyTags from "./folksonomy-tags.tsx";
+
+export default pattern(() => {
+  const scope = new Writable("demo-shared");
+  const tags = new Writable<string[]>(["red", "blue"]);
+  const tagEditor = FolksonomyTags({ scope, tags });
+
+  const itemATags = new Writable<string[]>(["shared-a"]);
+  const itemBTags = new Writable<string[]>(["shared-b"]);
+  const itemCTags = new Writable<string[]>(["isolated-c"]);
+  const demo = FolksonomyDemo({
+    itemATags,
+    itemBTags,
+    itemCTags,
+    customScope: "demo-shared",
+  });
+
+  const stressTest = FolksonomyStressTest({});
+
+  const action_tag_item_a = action(() => {
+    itemATags.push("late-arrival");
+  });
+
+  const assert_editor_holds_its_tags = assert(() =>
+    tagEditor.tags.length === 2 && tagEditor.tags[0] === "red" &&
+    scope.get() === "demo-shared" &&
+    tagEditor[UI] != null
+  );
+
+  // Each item's tags reach the demo's output from its own cell.
+  const assert_demo_items_keep_their_tags = assert(() =>
+    demo.itemATags.length === 1 && demo.itemATags[0] === "shared-a" &&
+    demo.itemBTags.length === 1 && demo.itemBTags[0] === "shared-b" &&
+    demo.itemCTags.length === 1 && demo.itemCTags[0] === "isolated-c" &&
+    demo[UI] != null
+  );
+
+  // A tag added to one item lands on that item and nowhere else.
+  const assert_new_tag_lands_on_item_a = assert(() =>
+    demo.itemATags.length === 2 &&
+    demo.itemATags[1] === "late-arrival" &&
+    demo.itemBTags.length === 1 &&
+    demo.itemCTags.length === 1
+  );
+
+  const assert_stress_test_builds = assert(() =>
+    textContent(stressTest[UI]).length > 0
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_editor_holds_its_tags },
+      { assertion: assert_demo_items_keep_their_tags },
+      { assertion: assert_stress_test_builds },
+
+      { action: action_tag_item_a },
+      { assertion: assert_new_tag_lands_on_item_a },
+    ],
+  };
+});

--- a/packages/patterns/google/extractors/bam-school-dashboard.tsx
+++ b/packages/patterns/google/extractors/bam-school-dashboard.tsx
@@ -371,6 +371,8 @@ interface PatternInput {
 
 /** BAM School Dashboard - At-a-glance view of school events and announcements. #bamSchool */
 export interface PatternOutput {
+  [NAME]: string;
+  [UI]: VNode;
   emails: Email[];
   events: SchoolEvent[];
   urgentEvents: SchoolEvent[];

--- a/packages/patterns/google/extractors/berkeley-library.tsx
+++ b/packages/patterns/google/extractors/berkeley-library.tsx
@@ -701,6 +701,8 @@ interface PatternInput {
 
 /** Berkeley Public Library book tracker. #berkeleyLibrary */
 export interface PatternOutput {
+  [NAME]: string;
+  [UI]: VNode;
   trackedItems: TrackedItem[];
   holdsReady: TrackedItem[];
   overdueCount: number;

--- a/packages/patterns/google/extractors/calendar-change-detector.tsx
+++ b/packages/patterns/google/extractors/calendar-change-detector.tsx
@@ -266,6 +266,8 @@ interface PatternInput {
 
 /** Calendar change detector for tracking schedule changes. #calendarChanges */
 export interface PatternOutput {
+  [NAME]: string;
+  [UI]: VNode;
   changes: ScheduleChange[];
   criticalChanges: ScheduleChange[];
   urgentChanges: ScheduleChange[];

--- a/packages/patterns/google/extractors/email-ticket-finder.tsx
+++ b/packages/patterns/google/extractors/email-ticket-finder.tsx
@@ -551,6 +551,8 @@ interface PatternInput {
 
 /** Email ticket finder for tracking upcoming events. #emailTickets */
 export interface PatternOutput {
+  [NAME]: string;
+  [UI]: VNode;
   tickets: TrackedTicket[];
   todayTickets: TrackedTicket[];
   upcomingTickets: TrackedTicket[];

--- a/packages/patterns/google/extractors/favorite-foods-gmail-agent.tsx
+++ b/packages/patterns/google/extractors/favorite-foods-gmail-agent.tsx
@@ -7,7 +7,15 @@
  * UPDATED: Now uses the elegant agentic-tools API (defineItemSchema + listTool)
  * which eliminates the 3x redundancy of interface + input type + schema.
  */
-import { __cf_data, computed, Default, NAME, pattern, UI } from "commonfabric";
+import {
+  __cf_data,
+  computed,
+  Default,
+  NAME,
+  pattern,
+  UI,
+  type VNode,
+} from "commonfabric";
 import GmailAgenticSearch from "../core/experimental/gmail-agentic-search.tsx";
 import {
   defineItemSchema,
@@ -85,6 +93,8 @@ interface FavoriteFoodsInput {
 
 /** Favorite foods extractor from Gmail. #favoriteFoods */
 export interface FavoriteFoodsOutput {
+  [NAME]: string;
+  [UI]: VNode;
   foods: FoodPreference[];
   lastScanAt: number;
   count: number;

--- a/packages/patterns/google/extractors/flight-calendar-bridge.tsx
+++ b/packages/patterns/google/extractors/flight-calendar-bridge.tsx
@@ -26,6 +26,7 @@ import {
   pattern,
   toIndentedDebugString,
   UI,
+  type VNode,
   wish,
   Writable,
 } from "commonfabric";
@@ -453,6 +454,8 @@ interface PatternInput {
 
 /** Flight calendar bridge - generates travel events from flights. #flightCalendar */
 export interface PatternOutput {
+  [NAME]: string;
+  [UI]: VNode;
   flightCount: number;
   events: CalendarEvent[];
   flightEvents: CalendarEvent[];

--- a/packages/patterns/google/extractors/gmail-agents.test.tsx
+++ b/packages/patterns/google/extractors/gmail-agents.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * Test Pattern: Gmail extractor agents
+ *
+ * Each of these patterns wraps GmailExtractor (or, for the two "agent"
+ * patterns, a Gmail search loop) and derives a domain view from the emails it
+ * finds: flights, library loans, school events, mail pieces, calendar
+ * changes, event tickets, hotel loyalty numbers, favorite foods. With no
+ * Google account linked, none of them can fetch an email, so each one must
+ * come up empty rather than fail: no records, zero counts, and a rendered UI
+ * that says so.
+ *
+ * That empty state is what this test pins down. Every pattern is instantiated
+ * with an auth cell holding no token, then asked for the derived collections
+ * it publishes and for the text of its rendered tile. Reading the tile matters
+ * as much as reading the collections, because the derived expressions inside
+ * the rendered tree only run when something reads the nodes they build.
+ */
+import {
+  assert,
+  NAME,
+  pattern,
+  TESTS,
+  TILE_UI,
+  UI,
+  Writable,
+} from "commonfabric";
+import { textContent } from "../../test/vnode-helpers.ts";
+import type { Auth } from "../core/gmail-importer.tsx";
+import BamSchoolDashboard from "./bam-school-dashboard.tsx";
+import BerkeleyLibrary from "./berkeley-library.tsx";
+import CalendarChangeDetector from "./calendar-change-detector.tsx";
+import EmailTicketFinder from "./email-ticket-finder.tsx";
+import FavoriteFoodsExtractor from "./favorite-foods-gmail-agent.tsx";
+import FlightCalendarBridge from "./flight-calendar-bridge.tsx";
+import HotelMembershipExtractor from "./hotel-membership-gmail-agent.tsx";
+import UnitedFlightTracker from "./united-flight-tracker.tsx";
+import UspsInformedDelivery from "./usps-informed-delivery.tsx";
+
+function emptyAuth() {
+  return new Writable<Auth>({
+    token: "",
+    tokenType: "",
+    scope: [],
+    expiresIn: 0,
+    expiresAt: 0,
+    refreshToken: "",
+    user: { email: "", name: "", picture: "" },
+  });
+}
+
+export default pattern(() => {
+  const united = UnitedFlightTracker({ overrideAuth: emptyAuth() });
+  const library = BerkeleyLibrary({ overrideAuth: emptyAuth() });
+  const school = BamSchoolDashboard({ overrideAuth: emptyAuth() });
+  const usps = UspsInformedDelivery({ overrideAuth: emptyAuth() });
+  const calendarChanges = CalendarChangeDetector({ overrideAuth: emptyAuth() });
+  const tickets = EmailTicketFinder({ overrideAuth: emptyAuth() });
+  const hotels = HotelMembershipExtractor({});
+  const foods = FavoriteFoodsExtractor({});
+  const flightCalendar = FlightCalendarBridge({});
+
+  // ==========================================================================
+  // Assertions
+  // ==========================================================================
+
+  const assert_united_empty = assert(() =>
+    united[NAME] === "United Flight Tracker" &&
+    united.emailCount === 0 &&
+    united.flights.length === 0 &&
+    united.upcomingFlights.length === 0 &&
+    united.checkInAvailable.length === 0 &&
+    united.activeAlerts.length === 0 &&
+    united.pastFlights.length === 0 &&
+    united.trips.length === 0
+  );
+
+  const assert_library_empty = assert(() =>
+    library[NAME] === "Berkeley Library" &&
+    library.trackedItems.length === 0 &&
+    library.holdsReady.length === 0 &&
+    library.overdueCount === 0 &&
+    library.checkedOutCount === 0 &&
+    library.holdsReadyCount === 0
+  );
+
+  const assert_school_empty = assert(() =>
+    school.emails.length === 0 &&
+    school.events.length === 0 &&
+    school.urgentEvents.length === 0 &&
+    school.upcomingEvents.length === 0 &&
+    school.teacherMessages.length === 0
+  );
+
+  // The dashboard titles itself from its settings, so the default child name
+  // has to reach the pattern name.
+  const assert_school_named_for_child = assert(() =>
+    school[NAME] ===
+      "BAM Dashboard - Adeline Komoroske"
+  );
+
+  const assert_usps_named = assert(() =>
+    usps[NAME] === "USPS Informed Delivery"
+  );
+
+  const assert_calendar_changes_empty = assert(() =>
+    calendarChanges[NAME] ===
+      "Calendar Change Detector"
+  );
+
+  const assert_tickets_empty = assert(() => tickets[NAME] === "Email Tickets");
+
+  const assert_hotels_empty = assert(() =>
+    hotels.memberships.length === 0 &&
+    hotels.count === 0 &&
+    hotels.lastScanAt === 0
+  );
+
+  const assert_foods_empty = assert(() =>
+    foods.foods.length === 0 && foods.count === 0 && foods.lastScanAt === 0
+  );
+
+  // The bridge finds its flights through a wish, which resolves to nothing
+  // here, so every derived group is empty and it reports itself disconnected.
+  const assert_flight_calendar_disconnected = assert(() =>
+    flightCalendar.flightCount === 0 &&
+    flightCalendar.events.length === 0 &&
+    flightCalendar.flightEvents.length === 0 &&
+    flightCalendar.travelEvents.length === 0 &&
+    flightCalendar.eventGroups.length === 0 &&
+    flightCalendar.homeAddress === null &&
+    flightCalendar.isConnected === false
+  );
+
+  // Reading the rendered trees runs the derived expressions inside them.
+  // Each tile must produce text; a tile that threw or resolved to nothing
+  // would come back empty.
+  const assert_tiles_render = assert(() =>
+    textContent(united[TILE_UI]).length > 0 &&
+    textContent(library[TILE_UI]).length > 0 &&
+    textContent(school[TILE_UI]).length > 0 &&
+    textContent(usps[TILE_UI]).length > 0 &&
+    textContent(calendarChanges[TILE_UI]).length > 0 &&
+    textContent(tickets[TILE_UI]).length > 0
+  );
+
+  const assert_screens_render = assert(() =>
+    textContent(united[UI]).length > 0 &&
+    textContent(library[UI]).length > 0 &&
+    textContent(school[UI]).length > 0 &&
+    textContent(usps[UI]).length > 0 &&
+    textContent(calendarChanges[UI]).length > 0 &&
+    textContent(tickets[UI]).length > 0 &&
+    textContent(hotels[UI]).length > 0 &&
+    textContent(foods[UI]).length > 0 &&
+    textContent(flightCalendar[UI]).length > 0
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_united_empty },
+      { assertion: assert_library_empty },
+      { assertion: assert_school_empty },
+      { assertion: assert_school_named_for_child },
+      { assertion: assert_usps_named },
+      { assertion: assert_calendar_changes_empty },
+      { assertion: assert_tickets_empty },
+      { assertion: assert_hotels_empty },
+      { assertion: assert_foods_empty },
+      { assertion: assert_flight_calendar_disconnected },
+      { assertion: assert_tiles_render },
+      { assertion: assert_screens_render },
+    ],
+    united,
+    library,
+    school,
+    usps,
+    calendarChanges,
+    tickets,
+    hotels,
+    foods,
+    flightCalendar,
+  };
+});

--- a/packages/patterns/google/extractors/hotel-membership-gmail-agent.tsx
+++ b/packages/patterns/google/extractors/hotel-membership-gmail-agent.tsx
@@ -14,6 +14,7 @@ import {
   NAME,
   pattern,
   UI,
+  type VNode,
   wish,
   Writable,
 } from "commonfabric";
@@ -100,6 +101,13 @@ type MembershipRecord = InferItem<typeof MembershipSchema> & {
   _fromWish?: boolean;
 };
 
+/** One hotel brand the scan found more than one membership number for. */
+interface MultiAccountBrand {
+  brand: string;
+  /** One entry per distinct membership number, with the tier it was found at. */
+  accounts: { membershipNumber: string; tier?: string }[];
+}
+
 interface HotelMembershipInput {
   memberships?: MembershipRecord[] | Default<[]>;
   lastScanAt?: number | Default<0>;
@@ -122,6 +130,8 @@ interface HotelMembershipInput {
 
 /** Hotel loyalty membership extractor from Gmail. #hotelMemberships */
 export interface HotelMembershipOutput {
+  [NAME]: string;
+  [UI]: VNode;
   memberships: MembershipRecord[];
   lastScanAt: number;
   count: number;
@@ -247,40 +257,42 @@ const HotelMembershipExtractorV2 = pattern<
     // MULTI-ACCOUNT DETECTION
     // ========================================================================
 
-    // Find brands with multiple different membership numbers
+    // Find brands with multiple different membership numbers. The result is a
+    // list rather than a record so the UI walks it as an array: an array is
+    // what the rendered tree can map over.
     const brandsWithMultipleAccounts = computed(() => {
       const list = allMemberships as MembershipRecord[];
-      const brandNumbers: Record<string, Set<string>> = {};
-
-      for (const m of (list || [])) {
-        if (!m) continue; // Skip null/undefined entries during hydration
-        if (!brandNumbers[m.hotelBrand]) {
-          brandNumbers[m.hotelBrand] = new Set();
-        }
-        brandNumbers[m.hotelBrand].add(m.membershipNumber);
-      }
-
-      const multiAccountBrands: Record<
+      const byBrand: Record<
         string,
-        { numbers: string[]; memberships: MembershipRecord[] }
+        Record<string, { membershipNumber: string; tier?: string }>
       > = {};
 
-      for (const [brand, numbers] of Object.entries(brandNumbers)) {
-        if (numbers.size > 1) {
-          multiAccountBrands[brand] = {
-            numbers: Array.from(numbers),
-            memberships: (list || []).filter((m) =>
-              m && m.hotelBrand === brand
-            ),
+      // Keep the first record seen for each membership number, so a brand
+      // holding two records of one number contributes one account.
+      for (const m of (list || [])) {
+        if (!m) continue; // Skip null/undefined entries during hydration
+        if (!byBrand[m.hotelBrand]) byBrand[m.hotelBrand] = {};
+        if (!byBrand[m.hotelBrand][m.membershipNumber]) {
+          byBrand[m.hotelBrand][m.membershipNumber] = {
+            membershipNumber: m.membershipNumber,
+            tier: m.tier,
           };
+        }
+      }
+
+      const multiAccountBrands: MultiAccountBrand[] = [];
+
+      for (const [brand, accounts] of Object.entries(byBrand)) {
+        const distinct = Object.values(accounts);
+        if (distinct.length > 1) {
+          multiAccountBrands.push({ brand, accounts: distinct });
         }
       }
 
       return multiAccountBrands;
     });
 
-    const hasMultipleAccounts =
-      Object.keys(brandsWithMultipleAccounts).length > 0;
+    const hasMultipleAccounts = brandsWithMultipleAccounts.length > 0;
 
     // ========================================================================
     // AGENT GOAL
@@ -697,10 +709,7 @@ Report memberships as you find them. Don't wait until the end.`,
                       Multiple Accounts Detected
                     </div>
                     <div style={{ fontSize: "13px", color: "#78350f" }}>
-                      {Object.entries(brandsWithMultipleAccounts).map((
-                        [brand, data],
-                        brandIdx,
-                      ) => (
+                      {brandsWithMultipleAccounts.map((entry, brandIdx) => (
                         <div
                           key={brandIdx}
                           style={{
@@ -716,10 +725,10 @@ Report memberships as you find them. Don't wait until the end.`,
                               marginBottom: "4px",
                             }}
                           >
-                            {brand}
+                            {entry.brand}
                           </div>
                           <div style={{ fontSize: "12px", color: "#666" }}>
-                            Found {data.numbers.length}{" "}
+                            Found {entry.accounts.length}{" "}
                             different membership numbers:
                             <ul
                               style={{
@@ -727,34 +736,24 @@ Report memberships as you find them. Don't wait until the end.`,
                                 padding: "0",
                               }}
                             >
-                              {data.numbers.map(
-                                (num: string, i: number) => {
-                                  const membership = data.memberships.find((
-                                    m: MembershipRecord,
-                                  ) => m.membershipNumber === num);
-                                  return (
-                                    <li
-                                      key={i}
-                                      style={{ marginBottom: "2px" }}
-                                    >
-                                      <code
-                                        style={{
-                                          background: "#f3f4f6",
-                                          padding: "2px 6px",
-                                          borderRadius: "2px",
-                                        }}
-                                      >
-                                        {num}
-                                      </code>
-                                      {membership?.tier && (
-                                        <span style={{ marginLeft: "4px" }}>
-                                          ({membership.tier})
-                                        </span>
-                                      )}
-                                    </li>
-                                  );
-                                },
-                              )}
+                              {entry.accounts.map((m) => (
+                                <li style={{ marginBottom: "2px" }}>
+                                  <code
+                                    style={{
+                                      background: "#f3f4f6",
+                                      padding: "2px 6px",
+                                      borderRadius: "2px",
+                                    }}
+                                  >
+                                    {m.membershipNumber}
+                                  </code>
+                                  {m.tier && (
+                                    <span style={{ marginLeft: "4px" }}>
+                                      ({m.tier})
+                                    </span>
+                                  )}
+                                </li>
+                              ))}
                             </ul>
                           </div>
                           <div
@@ -798,100 +797,103 @@ Report memberships as you find them. Don't wait until the end.`,
                     );
                   }
 
-                  return brands.map((brand) => (
-                    <details
-                      open
-                      style={{
-                        border: "1px solid #e0e0e0",
-                        borderRadius: "8px",
-                        marginBottom: "12px",
-                        padding: "12px",
-                      }}
-                    >
-                      <summary
+                  return brands.map((brand) => {
+                    const brandMemberships = [...groups[brand]];
+                    return (
+                      <details
+                        open
                         style={{
-                          cursor: "pointer",
-                          fontWeight: "600",
-                          fontSize: "14px",
-                          marginBottom: "8px",
+                          border: "1px solid #e0e0e0",
+                          borderRadius: "8px",
+                          marginBottom: "12px",
+                          padding: "12px",
                         }}
                       >
-                        {brand || "Unknown Brand"} ({groups[brand].length})
-                      </summary>
-                      <cf-vstack gap={2} style="paddingLeft: 16px;">
-                        {groups[brand].map((m: MembershipRecord) => (
-                          <div
-                            style={{
-                              padding: "8px",
-                              background: m._fromWish ? "#e0f2fe" : "#f8f9fa",
-                              borderRadius: "4px",
-                              border: m._fromWish
-                                ? "1px dashed #0ea5e9"
-                                : "none",
-                            }}
-                          >
+                        <summary
+                          style={{
+                            cursor: "pointer",
+                            fontWeight: "600",
+                            fontSize: "14px",
+                            marginBottom: "8px",
+                          }}
+                        >
+                          {brand || "Unknown Brand"} ({brandMemberships.length})
+                        </summary>
+                        <cf-vstack gap={2} style="paddingLeft: 16px;">
+                          {brandMemberships.map((m: MembershipRecord) => (
                             <div
                               style={{
-                                fontWeight: "600",
-                                fontSize: "13px",
-                                marginBottom: "4px",
-                                display: "flex",
-                                alignItems: "center",
-                                gap: "6px",
+                                padding: "8px",
+                                background: m._fromWish ? "#e0f2fe" : "#f8f9fa",
+                                borderRadius: "4px",
+                                border: m._fromWish
+                                  ? "1px dashed #0ea5e9"
+                                  : "none",
                               }}
                             >
-                              {m.programName}
-                              {m._fromWish && (
-                                <span
-                                  style={{
-                                    fontSize: "10px",
-                                    background: "#0ea5e9",
-                                    color: "white",
-                                    padding: "2px 6px",
-                                    borderRadius: "10px",
-                                  }}
-                                >
-                                  imported
-                                </span>
-                              )}
-                            </div>
-                            <div style={{ marginBottom: "4px" }}>
-                              <code
-                                style={{
-                                  fontSize: "14px",
-                                  background: "white",
-                                  padding: "6px 12px",
-                                  borderRadius: "4px",
-                                  display: "inline-block",
-                                }}
-                              >
-                                {m.membershipNumber}
-                              </code>
-                            </div>
-                            {m.tier && (
                               <div
                                 style={{
-                                  fontSize: "12px",
-                                  color: "#666",
-                                  marginBottom: "2px",
+                                  fontWeight: "600",
+                                  fontSize: "13px",
+                                  marginBottom: "4px",
+                                  display: "flex",
+                                  alignItems: "center",
+                                  gap: "6px",
                                 }}
                               >
-                                ⭐ {m.tier}
+                                {m.programName}
+                                {m._fromWish && (
+                                  <span
+                                    style={{
+                                      fontSize: "10px",
+                                      background: "#0ea5e9",
+                                      color: "white",
+                                      padding: "2px 6px",
+                                      borderRadius: "10px",
+                                    }}
+                                  >
+                                    imported
+                                  </span>
+                                )}
                               </div>
-                            )}
-                            <div style={{ fontSize: "11px", color: "#999" }}>
-                              📧 {m.sourceEmailSubject || "Unknown email"} •
-                              {" "}
-                              {m.sourceEmailDate
-                                ? new Date(m.sourceEmailDate)
-                                  .toLocaleDateString()
-                                : "Unknown date"}
+                              <div style={{ marginBottom: "4px" }}>
+                                <code
+                                  style={{
+                                    fontSize: "14px",
+                                    background: "white",
+                                    padding: "6px 12px",
+                                    borderRadius: "4px",
+                                    display: "inline-block",
+                                  }}
+                                >
+                                  {m.membershipNumber}
+                                </code>
+                              </div>
+                              {m.tier && (
+                                <div
+                                  style={{
+                                    fontSize: "12px",
+                                    color: "#666",
+                                    marginBottom: "2px",
+                                  }}
+                                >
+                                  ⭐ {m.tier}
+                                </div>
+                              )}
+                              <div style={{ fontSize: "11px", color: "#999" }}>
+                                📧 {m.sourceEmailSubject || "Unknown email"} •
+                                {" "}
+                                {m.sourceEmailDate
+                                  ? new Date(m.sourceEmailDate)
+                                    .toLocaleDateString()
+                                  : "Unknown date"}
+                              </div>
                             </div>
-                          </div>
-                        ))}
-                      </cf-vstack>
-                    </details>
-                  ));
+                          ))}
+                        </cf-vstack>
+                      </details>
+                    );
+                  });
                 })}
               </div>
 

--- a/packages/patterns/google/extractors/united-flight-tracker.tsx
+++ b/packages/patterns/google/extractors/united-flight-tracker.tsx
@@ -512,6 +512,8 @@ interface Input {
 
 /** United Airlines flight tracker. #unitedFlights */
 export interface Output {
+  [NAME]: string;
+  [UI]: VNode;
   emailCount: number;
   flights: TrackedFlight[];
   upcomingFlights: TrackedFlight[];

--- a/packages/patterns/google/extractors/usps-informed-delivery.tsx
+++ b/packages/patterns/google/extractors/usps-informed-delivery.tsx
@@ -164,11 +164,11 @@ interface MailPieceAnalysisItem {
   imageUrl: string;
   analysis: {
     pending: boolean;
-    error?: unknown;
+    error?: string;
     result?: MailAnalysis;
   };
   pending: boolean;
-  error?: unknown;
+  error?: string;
   result?: MailAnalysis;
 }
 
@@ -383,6 +383,8 @@ interface PatternInput {
 
 /** USPS Informed Delivery mail analyzer. #uspsInformedDelivery */
 export interface PatternOutput {
+  [NAME]: string;
+  [UI]: VNode;
   mailPieces: (MailAnalysis | undefined)[];
   householdMembers: HouseholdMember[];
   mailCount: number;
@@ -400,7 +402,7 @@ export interface PatternOutput {
 }
 
 export default pattern<PatternInput, PatternOutput>(
-  (({ householdMembers, overrideAuth }: any) => {
+  ({ householdMembers, overrideAuth }) => {
     // Directly instantiate GmailExtractor with USPS-specific settings (raw mode)
     // This eliminates the need for separate gmail-importer piece + wish()
     const extractor = GmailExtractor({
@@ -1263,5 +1265,5 @@ export default pattern<PatternInput, PatternOutput>(
         </cf-screen>
       ),
     };
-  }) as any,
+  },
 );

--- a/packages/patterns/group-chat-lobby.tsx
+++ b/packages/patterns/group-chat-lobby.tsx
@@ -8,6 +8,7 @@ import {
   navigateTo,
   pattern,
   UI,
+  type VNode,
   wish,
   Writable,
 } from "commonfabric";
@@ -35,6 +36,8 @@ interface LobbyInput {
 }
 
 export interface LobbyOutput {
+  [NAME]: string;
+  [UI]: VNode;
   chatName: string | Default<"Group Chat">;
   messages: Writable<Message[] | Default<[]>>;
   users: Writable<User[] | Default<[]>>;

--- a/packages/patterns/group-chat-room.tsx
+++ b/packages/patterns/group-chat-room.tsx
@@ -8,6 +8,7 @@ import {
   NAME,
   pattern,
   UI,
+  type VNode,
   Writable,
 } from "commonfabric";
 
@@ -70,6 +71,8 @@ interface RoomInput {
 }
 
 export interface RoomOutput {
+  [NAME]: string;
+  [UI]: VNode;
   myName: string | Default<"">;
 }
 

--- a/packages/patterns/image-analysis.tsx
+++ b/packages/patterns/image-analysis.tsx
@@ -21,6 +21,8 @@ type ImageChatInput = {
 };
 
 export type ImageChatOutput = {
+  [NAME]: string;
+  [UI]: VNode;
   images: Writable<ImageData[]>;
   prompt: Writable<string>;
   response: string | undefined;

--- a/packages/patterns/notes/voice-note.tsx
+++ b/packages/patterns/notes/voice-note.tsx
@@ -6,6 +6,7 @@ import {
   NAME,
   pattern,
   UI,
+  type VNode,
   Writable,
 } from "commonfabric";
 
@@ -29,6 +30,8 @@ type Input = {
 };
 
 export type Output = {
+  [NAME]: string;
+  [UI]: VNode;
   transcription: TranscriptionData | null | Default<null>;
   notes: TranscriptionData[] | Default<[]>;
 };

--- a/packages/patterns/system/home-ben.tsx
+++ b/packages/patterns/system/home-ben.tsx
@@ -183,7 +183,7 @@ const removeSpaceHandler = handler<
   spaces.set(filtered);
 });
 
-export default pattern((_) => {
+export default pattern(() => {
   // OWN the data cells (.for for id stability)
   const favorites = new Writable<Favorite[]>([]).for("favorites");
   const journal = new Writable<JournalEntry[]>([]).for("journal");

--- a/packages/patterns/system/system-patterns.test.tsx
+++ b/packages/patterns/system/system-patterns.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * Test Pattern: the untested system patterns
+ *
+ * These are load-bearing product patterns: an alternative home screen, the
+ * space overview, the journal, and the mentionables inspector. Each finds its
+ * data through wishes rather than through inputs, so in an empty space each
+ * one has to come up with an empty view rather than fail.
+ *
+ * That empty view is what this pins down. Each pattern is built and its
+ * rendered tree read, which is what runs the derived expressions inside it.
+ */
+import { assert, NAME, pattern, TESTS, UI } from "commonfabric";
+import { hasText, textContent } from "../test/vnode-helpers.ts";
+import HomeBen from "./home-ben.tsx";
+import Journal from "./journal.tsx";
+import MentionablesInspector from "./mentionables-inspector.tsx";
+import SpaceOverview from "./space-overview.tsx";
+
+export default pattern(() => {
+  const home = HomeBen({});
+  const spaceOverview = SpaceOverview({});
+  const journal = Journal({});
+  const mentionables = MentionablesInspector({});
+
+  // The home screen composes the favorites manager, the journal, and the
+  // space list, so its tree carries all three sections.
+  const assert_home_shows_sections = assert(() =>
+    textContent(home[UI]).length > 0 &&
+    hasText(home[UI], "Journal")
+  );
+
+  const assert_space_overview_builds = assert(() =>
+    textContent(spaceOverview[UI]).length > 0
+  );
+
+  const assert_journal_builds = assert(() =>
+    journal[NAME] === "Journal" && textContent(journal[UI]).length > 0
+  );
+
+  // With nothing mentionable in the space the inspector lists nothing and
+  // carries no text of its own, so its tree is built but empty.
+  const assert_mentionables_inspector_is_empty = assert(() =>
+    textContent(mentionables[UI]).trim() === ""
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_home_shows_sections },
+      { assertion: assert_space_overview_builds },
+      { assertion: assert_journal_builds },
+      { assertion: assert_mentionables_inspector_is_empty },
+    ],
+  };
+});

--- a/packages/patterns/top-level-demos.test.tsx
+++ b/packages/patterns/top-level-demos.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * Test Pattern: the demo and fixture patterns at the top of the package
+ *
+ * These are the standalone demos and rendering fixtures that sit directly in
+ * `packages/patterns` rather than in a directory of their own. Each one is a
+ * whole small program, and none of them had a test, so nothing built them
+ * outside a browser.
+ *
+ * This builds each one with real inputs and checks what it publishes: the name
+ * it goes under, the collections it derives, and text its rendered tree
+ * carries. Where a demo has one headline action — the text swapper's swap, the
+ * chat lobby's join — the test drives it and checks the state it moved.
+ */
+import {
+  action,
+  assert,
+  NAME,
+  pattern,
+  TESTS,
+  UI,
+  Writable,
+} from "commonfabric";
+
+import AnnotationManager from "./annotation-manager.tsx";
+import Aside from "./aside.tsx";
+import Bookmarks from "./bookmarks.tsx";
+import Chatbot from "./chatbot.tsx";
+import Cheeseboard from "./cheeseboard.tsx";
+import FormDemo from "./form-demo.tsx";
+import GroupChatLobby from "./group-chat-lobby.tsx";
+import GroupChatRoom from "./group-chat-room.tsx";
+import ImageAnalysis from "./image-analysis.tsx";
+import LinkPreview from "./link-preview.tsx";
+import MobileAppDemo from "./mobile-app-demo.tsx";
+import NestedMapIfElseTest from "./nested-map-ifelse-test.tsx";
+import ProfileRosterLiveDemo from "./profile-roster-live-demo.tsx";
+import RenderTest from "./render-test.tsx";
+import { hasText, textContent } from "./test/vnode-helpers.ts";
+import TextSwapper from "./text-swapper.tsx";
+
+export default pattern(() => {
+  // ==========================================================================
+  // The demos, each with the inputs it needs
+  // ==========================================================================
+
+  const leftText = new Writable("Hello");
+  const rightText = new Writable("World");
+  const swapper = TextSwapper({ leftText, rightText });
+
+  const people = new Writable<
+    { name: string; email: string; role: "user" | "admin" }[]
+  >([
+    { name: "Ada", email: "ada@example.com", role: "admin" },
+    { name: "Bo", email: "bo@example.com", role: "user" },
+  ]);
+  const formDemo = FormDemo({ people });
+
+  const renderTest = RenderTest({
+    title: "Render Test",
+    globalCounter: 0,
+    items: [
+      { name: "first", value: 1, subItems: [] },
+      { name: "second", value: 2, subItems: [] },
+    ],
+  });
+
+  const nestedMap = NestedMapIfElseTest({
+    items: [
+      { title: "Milk", done: false, category: "Dairy" },
+      { title: "Bread", done: true, category: "Bakery" },
+    ],
+    log: [],
+  });
+
+  const linkPreview = LinkPreview({ url: "https://example.com" });
+
+  const messages = new Writable<[]>([]);
+  const users = new Writable<[]>([]);
+  const sessionId = new Writable("");
+  const lobby = GroupChatLobby({
+    chatName: "Test Chat",
+    messages,
+    users,
+    sessionId,
+  });
+
+  const roomMessages = new Writable<[]>([]);
+  const roomUsers = new Writable<[]>([]);
+  const currentSessionId = new Writable("session-1");
+  const room = GroupChatRoom({
+    messages: roomMessages,
+    users: roomUsers,
+    myName: "Ada",
+    mySessionId: "session-1",
+    currentSessionId,
+  });
+
+  const mobileApp = MobileAppDemo({});
+  const bookmarks = Bookmarks({});
+  const chatbot = Chatbot({});
+  const cheeseboard = Cheeseboard({});
+  const aside = Aside({});
+  const imageAnalysis = ImageAnalysis({});
+  const annotationManager = AnnotationManager({});
+  const profileRoster = ProfileRosterLiveDemo({});
+
+  // ==========================================================================
+  // Actions
+  // ==========================================================================
+
+  const action_swap_texts = action(() => {
+    const left = leftText.get();
+    leftText.set(rightText.get());
+    rightText.set(left);
+  });
+
+  const action_add_person = action(() => {
+    people.push({ name: "Cy", email: "cy@example.com", role: "user" });
+  });
+
+  // ==========================================================================
+  // Assertions
+  // ==========================================================================
+
+  const assert_swapper_starts = assert(() =>
+    swapper.leftText === "Hello" && swapper.rightText === "World"
+  );
+
+  const assert_swapper_swapped = assert(() =>
+    swapper.leftText === "World" && swapper.rightText === "Hello"
+  );
+
+  // The form demo titles itself with the number of people it holds and lists
+  // each of them.
+  const assert_form_demo_lists_people = assert(() =>
+    formDemo[NAME] === "People Directory (2)" &&
+    formDemo.people.length === 2 &&
+    hasText(formDemo[UI], "Ada") &&
+    hasText(formDemo[UI], "Bo")
+  );
+
+  const assert_form_demo_grew = assert(() =>
+    formDemo[NAME] === "People Directory (3)" &&
+    formDemo.people.length === 3 &&
+    hasText(formDemo[UI], "Cy")
+  );
+
+  // The two rendering fixtures pass their items straight back out, and each
+  // declares its output to be its input, so the items are what there is to
+  // check. Building them is what runs their nested maps and conditionals.
+  const assert_render_test_builds = assert(() =>
+    renderTest.title === "Render Test" && renderTest.items.length === 2
+  );
+
+  const assert_nested_map_builds = assert(() =>
+    nestedMap.items.length === 2 && nestedMap.items[0].title === "Milk"
+  );
+
+  const assert_link_preview_holds_url = assert(() =>
+    linkPreview.url === "https://example.com"
+  );
+
+  // The lobby names itself for the chat it fronts, and starts with nobody in.
+  const assert_lobby_empty = assert(() =>
+    lobby[NAME] === "Test Chat - Lobby" &&
+    lobby.users.get().length === 0 &&
+    lobby.messages.get().length === 0
+  );
+
+  const assert_room_named_for_me = assert(() => room.myName === "Ada");
+
+  // Every remaining demo builds a tree. Two are checked for a tree rather than
+  // for text: bookmarks starts with an empty list and has no text of its own,
+  // and the mobile app demo declares its screen `unknown`, which reads back as
+  // an opaque reference rather than as the tree it holds.
+  const assert_demos_render = assert(() =>
+    mobileApp[UI] != null &&
+    textContent(chatbot[UI]).length > 0 &&
+    textContent(cheeseboard[UI]).length > 0 &&
+    textContent(aside[UI]).length > 0 &&
+    textContent(imageAnalysis[UI]).length > 0 &&
+    textContent(annotationManager[UI]).length > 0 &&
+    textContent(profileRoster[UI]).length > 0 &&
+    bookmarks[UI] != null
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_swapper_starts },
+      { assertion: assert_form_demo_lists_people },
+      { assertion: assert_render_test_builds },
+      { assertion: assert_nested_map_builds },
+      { assertion: assert_link_preview_holds_url },
+      { assertion: assert_lobby_empty },
+      { assertion: assert_room_named_for_me },
+      { assertion: assert_demos_render },
+
+      { action: action_swap_texts },
+      { assertion: assert_swapper_swapped },
+
+      { action: action_add_person },
+      { assertion: assert_form_demo_grew },
+    ],
+    swapper,
+    formDemo,
+    lobby,
+    room,
+  };
+});

--- a/packages/patterns/untested-apps.test.tsx
+++ b/packages/patterns/untested-apps.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Test Pattern: the app patterns that had no test of their own
+ *
+ * Each of these lives in a directory of its own and is a whole small
+ * application: an activity log, an agent console, a router, three chat
+ * patterns built on scoped or shared profiles, a voice note, two policy demos,
+ * and a regression repro kept to pin down runtime behavior. None of them had a
+ * test, so nothing built any of them outside a browser.
+ *
+ * scope-bug-computed-vnode-blank is left out. It is a harness whose enabled
+ * section exists to produce a runtime error on purpose, so a passing test
+ * cannot contain it.
+ *
+ * Every one finds its data through wishes rather than through inputs, so in an
+ * empty space each has to come up with an empty view rather than fail. This
+ * builds each one, checks the name it goes under, and reads its rendered tree,
+ * which is what runs the derived expressions inside it.
+ */
+import { assert, NAME, pattern, TESTS, UI } from "commonfabric";
+import ActivityLog from "./activity-log/activity-log.tsx";
+import Agent from "./agent/agent.tsx";
+import CfcPromptInjectionDemo from "./cfc-agent-prompt-injection-demo/main.tsx";
+import CfcRowLabelRecords from "./cfc-row-label-records/main.tsx";
+import VoiceNote from "./notes/voice-note.tsx";
+import ProfileGroupChat from "./profile-group-chat/main.tsx";
+import Router from "./router/main.tsx";
+import ScopeReduceRepro from "./scope-bug-ct1597-reduce/main.tsx";
+import ScopedGroupChatPlainInputs from "./scoped-group-chat/main-plain-inputs.tsx";
+import SharedProfileRoster from "./shared-profile-roster/main.tsx";
+import { textContent } from "./test/vnode-helpers.ts";
+
+export default pattern(() => {
+  const activityLog = ActivityLog({});
+  const agent = Agent({});
+  const router = Router({});
+  const profileGroupChat = ProfileGroupChat({});
+  const scopedGroupChat = ScopedGroupChatPlainInputs({});
+  const sharedProfileRoster = SharedProfileRoster({});
+  const promptInjectionDemo = CfcPromptInjectionDemo({});
+  const rowLabelRecords = CfcRowLabelRecords({});
+  const scopeReduceRepro = ScopeReduceRepro({});
+  const voiceNote = VoiceNote({});
+
+  // ==========================================================================
+  // Assertions
+  // ==========================================================================
+
+  const assert_apps_named = assert(() =>
+    router[NAME] === "Main" &&
+    profileGroupChat[NAME] === "Profile group chat" &&
+    scopedGroupChat[NAME] === "Scoped group chat" &&
+    sharedProfileRoster[NAME] === "Shared-profile roster"
+  );
+
+  const assert_cfc_demos_named = assert(() =>
+    promptInjectionDemo[NAME] === "CFC agent prompt injection demo" &&
+    rowLabelRecords[NAME] === "Per-Row × Per-Column Labels (CFC Phase 3)"
+  );
+
+  const assert_repro_named = assert(() =>
+    scopeReduceRepro[NAME] === "Cozy lunch poll"
+  );
+
+  const assert_chat_apps_render = assert(() =>
+    textContent(profileGroupChat[UI]).length > 0 &&
+    textContent(scopedGroupChat[UI]).length > 0 &&
+    textContent(sharedProfileRoster[UI]).length > 0
+  );
+
+  const assert_tools_render = assert(() =>
+    textContent(activityLog[UI]).length > 0 &&
+    textContent(agent[UI]).length > 0 &&
+    textContent(router[UI]).length > 0 &&
+    voiceNote[NAME] === "Voice Note" &&
+    textContent(voiceNote[UI]).length > 0
+  );
+
+  const assert_cfc_demos_render = assert(() =>
+    textContent(promptInjectionDemo[UI]).length > 0 &&
+    textContent(rowLabelRecords[UI]).length > 0
+  );
+
+  // The repro exists because a tree came back blank, so a tree with text in
+  // it is the whole of what it claims.
+  const assert_repro_renders = assert(() =>
+    textContent(scopeReduceRepro[UI]).length > 0
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_apps_named },
+      { assertion: assert_cfc_demos_named },
+      { assertion: assert_repro_named },
+      { assertion: assert_chat_apps_render },
+      { assertion: assert_tools_render },
+      { assertion: assert_cfc_demos_render },
+      { assertion: assert_repro_renders },
+    ],
+  };
+});

--- a/tasks/pattern-compat-unevaluable.ts
+++ b/tasks/pattern-compat-unevaluable.ts
@@ -27,10 +27,4 @@ export const UNEVALUABLE_PATTERNS: ReadonlySet<string> = new Set([
   "google/core/util/google-docs-markdown.ts",
   // "Cell.of() only accepts static data, but found a reactive value"
   "google/core/imported-calendar.tsx",
-  // "Reactive.map(fn) is no longer supported: an inline pattern has no stable
-  // identity" — the authored `.map(...)` lowering.
-  "google/extractors/email-pattern-dreamer.tsx",
-  "google/extractors/email-pattern-launcher.tsx",
-  "google/extractors/hotel-membership-gmail-agent.tsx",
-  "google/extractors/usps-informed-delivery.tsx",
 ]);


### PR DESCRIPTION
packages/patterns carried 232,303 uncovered lines. Measuring where they were, rather than estimating, turned out to be the whole of the problem: one unimported file holds 77% of that total, and of what remains, three quarters sat in patterns that nothing had ever built. Those two facts decide what closes the debt, and they are written down in docs/history/packages/patterns/2026-08-14-uncovered-code-inventory.md along with the measurement that produced them.

Add ten pattern tests, 1,568 lines between them, which close 24,225 lines — a 45% cut in everything but that one file. The ratio comes from how pattern coverage works rather than from anything clever: it counts statements, and most of a pattern's lines are one statement each, so building a pattern with plausible inputs and reading what it publishes covers the bulk of it. Reading the rendered tree covers the derived expressions inside it, which run only when something reads the node they build.

The tests check what each pattern claims. The Gmail extractors come up empty rather than failing when no account is linked. The catalog is driven through picking a story, collapsing its sidebar, reopening it, and picking another. The contacts list is driven through both add buttons. The folksonomy demo is checked for a tag landing on the item it was written to and nowhere else. Sixty component stories report the name the catalog lists them under and build an example.

Nothing had instantiated most of these patterns, so writing the tests found patterns that do not build at all, and fixing them is most of the non-test half of this change.

usps-informed-delivery annotated its pattern-body parameter `: any` and cast the body back with `as any`. That hides from the transformer which values are reactive, so `.map(...)` over a reactive array in the rendered tree was left un-lowered and threw on instantiation. The `any` was also masking an `error` field typed `unknown`, which the runner reads back as undefined rather than materializing.

hotel-membership-gmail-agent built its multi-account summary as a record keyed by brand and walked it with `Object.entries(...)` inside the rendered tree. Entries taken off a reactive record yield reactive values, and `.map` on one throws the same way. It now builds a list of brands, each carrying its own memberships, so the tree walks arrays.

person and family-member wrote every collapsible section header as a helper call inside a JSX expression slot with the toggle handler bound inline. The whole expression compiles as one unit and the binding is not available inside it, so all nine headers across the two forms failed at render with "toggle is not a function". Each toggle is now bound in the pattern body, and the helper states its parameter types rather than taking `any`, which left the stream with no inferred type.

Seventeen patterns declared the screen they render as `[UI]: unknown`, which reads as shorthand for "some tree, I have not named the type" and until recently behaved like one. `unknown` is now the declaration for a field holding a reference the pattern tests but never reads through, and such a field projects to an empty object carrying only a back-to-cell annotation. For a field holding a rendered tree that is the whole value gone. Two of the seventeen are the product's own home screens: reading system/home.tsx's screen returned nothing at all, and returns its 689 characters once declared as the VNode it is.

Thirty-one output types named the data a pattern publishes and left out the pattern name and the rendered screen, both of which it returns. Declaring them follows what the rest of the package does and lets a caller read them without a cast, which the compiler rejects anyway.

Four patterns are left for their own change, because each needs more than a test around it: imported-calendar throws on `Cell.of()`, WIP's google-docs-importer is rejected over a string that reads as an HTML comment, cf-picker throws on a bidirectionally bound `$items`, and budget-planner opens a language-model request as it builds. record-icon is left out of its test for a different reason: it builds in under a second alone, takes about thirty seconds when any second pattern shares the runtime, and over two minutes for two copies of itself.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

