### PR TITLE
docs(common): the verb session stops assuming, and demonstrates what it claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,7 +233,7 @@ Each of these gates fails CI on its own, and none of them run as part of
 - `deno task check-skill-facts` — a path or import cited by a skill, an
   `AGENTS.md`, or a rule that stopped resolving
 - `deno task check-verb-session-sync` — a `cf` command or act reference in
-  `docs/common/verb-session-walkthrough.md` that its demo script does not back;
+  `docs/common/verbs/session-walkthrough.md` that its demo script does not back;
   the walkthrough quotes commands, never composes them
 - `deno task check-single-copy-deps`, `check-unused-deps`, `check-deno-pins` —
   dependency declarations across the workspace

--- a/docs/common/README.md
+++ b/docs/common/README.md
@@ -95,7 +95,7 @@ Read in this order: what a verb hands back, then a whole session using it,
 then where an author's words go.
 
 - [verbs/over-the-cli.md](verbs/over-the-cli.md) — what a verb hands back: declared results, piece references, idempotent retries, and a runnable walkthrough
-- [verbs/session-walkthrough.md](verbs/session-walkthrough.md) — a whole session driven through `cf`: discovery, help, completion, refusals, and carrying an address from one call into the next. The demo script beside it runs every step
+- [verbs/session-walkthrough.md](verbs/session-walkthrough.md) — a whole session driven through `cf`: discovery, help, completion, refusals, and carrying an address from one call into the next. Its companion script under `packages/cli/integration/` runs every step
 - [verbs/prose-over-the-cli.md](verbs/prose-over-the-cli.md) — how an author's doc comments reach a caller, and which of the two documents `cf` reads carries what
 
 [INTRODUCTION.md](INTRODUCTION.md) is a stub kept for older links; this README

--- a/docs/common/README.md
+++ b/docs/common/README.md
@@ -88,8 +88,15 @@ on the Common Fabric runtime.
 - [workflows/development.md](workflows/development.md) — `cf` CLI loop: check, deploy, setsrc, inspect, link
 - [workflows/pattern-testing.md](workflows/pattern-testing.md) — writing and running pattern tests
 - [workflows/handlers-cli-testing.md](workflows/handlers-cli-testing.md) — invoking mounted callables from the CLI
-- [verbs-over-the-cli.md](verbs-over-the-cli.md) — what a verb hands back: declared results, piece references, idempotent retries, and a runnable walkthrough
-- [verb-session-walkthrough.md](verb-session-walkthrough.md) — a whole session driven through `cf`: discovery, help, completion, and carrying an address from one call into the next, with each step marked for what works today and what is still blocked
+
+### verbs/ — driving a deployed piece through `cf`
+
+Read in this order: what a verb hands back, then a whole session using it,
+then where an author's words go.
+
+- [verbs/over-the-cli.md](verbs/over-the-cli.md) — what a verb hands back: declared results, piece references, idempotent retries, and a runnable walkthrough
+- [verbs/session-walkthrough.md](verbs/session-walkthrough.md) — a whole session driven through `cf`: discovery, help, completion, refusals, and carrying an address from one call into the next. The demo script beside it runs every step
+- [verbs/prose-over-the-cli.md](verbs/prose-over-the-cli.md) — how an author's doc comments reach a caller, and which of the two documents `cf` reads carries what
 
 [INTRODUCTION.md](INTRODUCTION.md) is a stub kept for older links; this README
 replaces it.

--- a/docs/common/concepts/self-reference.md
+++ b/docs/common/concepts/self-reference.md
@@ -69,7 +69,7 @@ interface Input { title: string | Default<"Untitled">; }
   and it lists every verb. The expensive unshaped read that leaves you with is
   answered by naming what you want (`--select 'title,status'`), not by
   narrowing the type; the measurement is in
-  [What you are driving](../verb-session-walkthrough.md#what-you-are-driving).
+  [What you are driving](../verbs/session-walkthrough.md#what-you-are-driving).
   Adding a verb to such a type later is refused on update —
   [designing verbs so they can change](../../plans/verb-evolution.md) has the
   mechanism, and the holder-side rule that removes the refusal.

--- a/docs/common/verbs/over-the-cli.md
+++ b/docs/common/verbs/over-the-cli.md
@@ -10,9 +10,9 @@ sequence of "mutate, then go looking for what happened" into a single
 exchange — and the thing a verb hands back can be a **piece**, so a create tells
 you where the thing it created lives.
 
-For the authoring side, see [concepts/action.md](concepts/action.md) and
-[concepts/handler.md](concepts/handler.md); for the general CLI loop, see
-[workflows/development.md](workflows/development.md).
+For the authoring side, see [concepts/action.md](../concepts/action.md) and
+[concepts/handler.md](../concepts/handler.md); for the general CLI loop, see
+[workflows/development.md](../workflows/development.md).
 
 ## Declaring a result
 
@@ -254,7 +254,7 @@ space.
 
 A verb that hands back the piece it created returns a value you can reach from
 inside itself, whenever that piece carries a back-reference — `parent` beside
-`children`, the shape [self-reference](concepts/self-reference.md) documents.
+`children`, the shape [self-reference](../concepts/self-reference.md) documents.
 A circle has no JSON rendering, so there is nothing to write for a readback
 that follows one.
 
@@ -468,7 +468,7 @@ Two paths deliver a result, and both arrive by default:
   made — travels the result-pattern projection path.
 - A result that is **plain JSON** — a record of what was written — projects into
   the receipt under the `plainResultReceipts` runtime option, which is on by
-  default ([EXPERIMENTAL_OPTIONS.md](../development/EXPERIMENTAL_OPTIONS.md)).
+  default ([EXPERIMENTAL_OPTIONS.md](../../development/EXPERIMENTAL_OPTIONS.md)).
   `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=false` restores the discard, which is a
   rollback switch rather than something a caller opts into.
 

--- a/docs/common/verbs/prose-over-the-cli.md
+++ b/docs/common/verbs/prose-over-the-cli.md
@@ -13,7 +13,7 @@ here rather than restating them.
 ## What the served schema carries
 
 A verb dispatches through a callable cell, and that cell takes its schema from
-the link chain it resolves through (`cell.ts:asSchemaFromLinks`). For a verb
+the link chain it resolves through ([`cell.ts:asSchemaFromLinks`][cell]). For a verb
 that link is the handler node's `$event` input — which, under the
 [verb input contract](../../history/plans/verb-input-contract.md), is the author's
 event type rather than a summary of what the handler body reads. So a declared
@@ -65,7 +65,7 @@ that shape, and a definition several positions share is not one position's to
 rewrite. A field's own prose is therefore written where the field is, never
 into the definition it points at — which would attribute one position's
 sentence to every other holder of the same type. The precise list of positions
-the fold walks is on `withDeclaredFieldProse` (`packages/cli/lib/piece.ts`),
+the fold walks is on `withDeclaredFieldProse` ([`packages/cli/lib/piece.ts`][piece-lib]),
 enumerated rather than summarized, along with the keywords it leaves alone.
 
 ## Folded in, never substituted
@@ -77,3 +77,9 @@ Substituting one document for the other would describe the source rather than
 the piece being talked to — which is the rule even where an authored event
 makes the two agree, because the piece in front of a caller may be running an
 older pattern than the source in the checkout.
+
+<!-- Source links resolve against the repository's default branch, so they
+     follow head rather than pinning a revision this document would outlive. -->
+
+[cell]: https://github.com/commontoolsinc/labs/blob/main/packages/runner/src/cell.ts
+[piece-lib]: https://github.com/commontoolsinc/labs/blob/main/packages/cli/lib/piece.ts

--- a/docs/common/verbs/prose-over-the-cli.md
+++ b/docs/common/verbs/prose-over-the-cli.md
@@ -1,0 +1,79 @@
+# An author's prose, over the CLI
+
+What a pattern's author writes in a doc comment, and how it reaches someone
+driving that pattern through `cf`. The short version is that a caller's tools
+read **two documents** — the schema the piece serves on the wire, and the
+compiled pattern behind it — and knowing which carries what is the difference
+between finding an author's sentence and concluding it was never written.
+
+[A verb session, end to end](session-walkthrough.md) is the session this
+supports; its step 3 renders the help page these rules produce, and points
+here rather than restating them.
+
+## What the served schema carries
+
+A verb dispatches through a callable cell, and that cell takes its schema from
+the link chain it resolves through (`cell.ts:asSchemaFromLinks`). For a verb
+that link is the handler node's `$event` input — which, under the
+[verb input contract](../../history/plans/verb-input-contract.md), is the author's
+event type rather than a summary of what the handler body reads. So a declared
+field the body never mentions is served like any other, and the field comments
+beside those fields travel with it.
+
+Two things do not travel with it.
+
+**A comment on the verb** describes the verb, not its event. It lives on the
+pattern's result schema, beside the `$ref` naming the event type, and never
+rides the event schema at all.
+
+**Capability markers**, all but `stream`. Link sanitization strips them
+(`sanitizeSchemaForLinks`, `KeepAsCell.OnlyStream`), so a position an author
+declared `Writable<T>` arrives shape-intact and marker-less. That is why the
+dispatch gate reads the compiled pattern to decide which positions declare a
+reference, rather than trusting the schema in front of it.
+
+## Where each level compiles to
+
+| An author writes… | Where the compiled pattern keeps it |
+| --- | --- |
+| a comment on the **verb itself** | `resultSchema.properties.<verb>.description`, a sibling of the `$ref` naming its event |
+| a comment on an **event field** (what `title` means) | `$defs.<Event>.properties.<field>.description` |
+| a comment on the **event interface** | nowhere — this one does not compile ([#5937](https://github.com/commontoolsinc/labs/issues/5937)) |
+
+`cf piece verbs` and `cf call <verb> --help` already load the compiled pattern
+to report what a verb hands back, so both read the prose from the same load.
+The verb's own comment becomes the listing row's `description` and the help
+page's summary line. The event fields' comments are folded into the input
+schema the page renders flags from, at the positions that schema already has.
+
+## Why the fold walks two documents
+
+The served schema and the declared one need not agree structurally. A handler
+with an authored event type serves that type, so the two line up by
+construction. A handler written without one has only the inferred summary, and
+there they diverge: the same field can be a `$ref` in one and an inline object
+in the other, and a union the declared side spells as `anyOf` can arrive as one
+merged object. A walk that stepped through `properties` key-for-key would find
+a bare `$ref` on one side with no `properties` under it, or a field whose prose
+sits inside an arm that does not exist on the other side, and stop short of the
+words in both cases.
+
+Both sides' references are followed for that reason, and a declared combinator
+is read through to its members. A served reference is followed *without* being
+inlined, and a served combinator is never flattened: a caller's tooling reads
+that shape, and a definition several positions share is not one position's to
+rewrite. A field's own prose is therefore written where the field is, never
+into the definition it points at — which would attribute one position's
+sentence to every other holder of the same type. The precise list of positions
+the fold walks is on `withDeclaredFieldProse` (`packages/cli/lib/piece.ts`),
+enumerated rather than summarized, along with the keywords it leaves alone.
+
+## Folded in, never substituted
+
+Only `description` annotations cross between the two documents. The served
+schema stays the authority on shape and takes only the words.
+
+Substituting one document for the other would describe the source rather than
+the piece being talked to — which is the rule even where an authored event
+makes the two agree, because the piece in front of a caller may be running an
+older pattern than the source in the checkout.

--- a/docs/common/verbs/session-walkthrough.md
+++ b/docs/common/verbs/session-walkthrough.md
@@ -86,22 +86,8 @@ verbs, and they differ in nothing but what the new item is filed under:
 | `archive` | declares no result: the invocation settles carrying no `result` at all, and what it changed is a separate read | act 9 |
 | `blockOn` | takes an address as an **argument** rather than as the receiver | act 12 — the address as printed, standing where the verb declares a reference |
 
-Those act numbers are `packages/cli/integration/verb-session-demo.sh`, which
-drives the session and prints each command before running it — the transcript is
-what that script is for. Beside it,
-`packages/cli/integration/verb-session-gaps.sh` asserts the same surface as
-pass/fail. A step there may assert that something does *not* work yet, failing
-loudly the day it does; none does at the moment, which is why every step below
-is marked **[today]**. A verb added to the fixture wants a row above, an act in
-the demo, and a step in the harness; a shape demonstrated in none of the three
-is a claim this document is making alone.
-
-This document quotes commands and never composes them: every `cf` line in a
-bash block below is a line the demo runs — or carries a `# not in the demo`
-comment saying why it cannot be — and every act number names an act the demo
-has. `deno task check-verb-session-sync` enforces both, so a command here
-cannot be wrong in a way the demo would have caught, and an act reference
-cannot go stale under renumbering.
+Those act numbers name acts in the demo script, which the table at the top of
+this document maps against its steps.
 
 ## What you are driving
 
@@ -221,7 +207,7 @@ as a row's `description` under `cf piece verbs --json`, and as the summary line
 of the verb's own help page. Step 3 has the measurement.
 
 
-## 1. Arrive with a slug **[today]**
+## 1. Arrive with a slug
 
 An address a person can type, rather than a fid from a previous command.
 
@@ -261,7 +247,7 @@ row carries under `--json`, alongside the input and output schemas the table
 has no room for. A person asking what one verb is for reads its help page; a
 person asking what the piece is for reads its own page, next.
 
-## 2. Ask what it is **[today]**
+## 2. Ask what it is
 
 ```bash
 cf piece describe --piece board
@@ -324,7 +310,7 @@ whose compiled pattern cannot be read keeps its VERBS — they still dispatch �
 and loses purpose, STATE, and INPUTS, with a note saying so rather than empty
 sections claiming the pattern declares nothing.
 
-## 3. Ask what a verb wants **[today]**
+## 3. Ask what a verb wants
 
 ```bash
 cf call --piece board addItem -- --help
@@ -381,7 +367,7 @@ Which document carries what, and why the fold walks both, is
 consequences show up in this session: a field an author declares and the
 handler never reads is still served, flagged and documented (the authored
 event is the contract), and a declared reference arrives with its capability
-marker stripped — which is what step 7's dispatch gate reads the pattern to
+marker stripped — which is what step 8's dispatch gate reads the pattern to
 recover.
 
 ### Three levels of documentation
@@ -412,7 +398,7 @@ does not compile at all
 own comment is both the shorter road and the better place for an author to
 write it, since it sits beside the type it describes.
 
-## 4. Complete against the live piece **[today]**
+## 4. Complete against the live piece
 
 ```bash
 # not in the demo — completion needs a terminal
@@ -432,7 +418,7 @@ same declared result a completion provider would read. What is missing is the
 provider consulting it, which is the same wiring a derived default selection
 needs.
 
-## 5. Create, and carry the address forward **[today]**
+## 5. Create, and carry the address forward
 
 ```bash
 EPIC=$(cf call --piece board --select 'item@' addItem -- \
@@ -454,7 +440,7 @@ flattened into a copy of the item's contents. Read options (`--select`,
 `--schema`, `--filter`) come before the address on a `call`, because the first
 positional starts the callable's own command line.
 
-`--show-links` is the **[today]** spelling of the same move: it returns a
+`--show-links` is a second spelling of the same move: it returns a
 dictionary of RFC 6901 pointers naming the document behind each result path, so
 the address is one `jq` hop further away but reachable.
 
@@ -498,7 +484,7 @@ a stack trace.
 [A result that points back at its container](over-the-cli.md#a-result-that-points-back-at-its-container)
 shows the full exchange.
 
-## 6. Read the tree back, bounded **[today]**
+## 6. Read the tree back, bounded
 
 ```bash
 cf get --piece board items --select 'title,status,children@'
@@ -530,7 +516,47 @@ their own options go.
 The demo's act 10 is this step run against the session's own tree: the whole
 board first, then only what is open, then the refusal.
 
-## 7. Relate two items **[today]**
+## 7. Refuse what the surface does not accept
+
+Every step so far named something the pattern declares. Getting it wrong is the
+other half of a surface that knows its own vocabulary, and the demo's act 11
+asks for two things that are not there — one on a call, one on a read:
+
+```bash
+cf call --piece board addItem '{"title":"Ship it","titel":"typo"}'
+
+cf get "$EPIC" children --schema '{"type":"array","items":{"type":"object","propertes":{"title":true}}}'
+```
+
+```text
+Invalid input for "addItem": "titel" at <event> is not a field this verb
+declares. Did you mean "title"? <event> takes "title"
+
+Invalid --schema at <root>[]: "propertes" is not a projection schema keyword.
+Did you mean "properties"? Projection reads "type", "properties", "items",
+"additionalProperties", "$link"
+```
+
+**One shape of answer from both ends.** Each names what was wrong, the position
+it sat at, what that position accepts, and the nearest thing you probably
+meant — from the call gate and the projection reader alike, which are different
+code answering in one voice.
+
+**A refusal is a capability, not a failure.** What each one replaces is worse
+than an error: a payload carrying `titel` used to be accepted, the field
+dropped on the way in, and the caller told the call settled. That is the
+silent-strip failure, and it is what a caller writing JSON by hand or by model
+hits while a TypeScript author never does. The same holds for the projection
+keyword: two denylists were consulted and every key in neither was carried
+onward, so `propertes` shaped nothing and said nothing.
+
+**Nothing is spent.** Both are refused before an invocation exists, so a
+caller retries against a surface in the state they left it. Three more
+refusals appear elsewhere in this session — the `@`-under-`--filter`
+combination in step 6, and the two reference-position guards in step 8 —
+and they answer in this same shape.
+
+## 8. Relate two items
 
 ```bash
 cf call --select blocked@,on@,blockedOnCount "$KID" blockOn -- --on "$CSRF"
@@ -564,7 +590,7 @@ the two-paths read as the payoff addresses exist for.
 
 ## The composition axis
 
-Steps 5 and 7 are the same move — take an address out of one command and put
+Steps 5 and 8 are the same move — take an address out of one command and put
 it into the next — and both halves now hold: the receiver half in full, and
 the argument half under every spelling a caller might be holding.
 
@@ -607,4 +633,4 @@ Two rows, and two that used to sit beside them are gone the way this table
 intends: the served input schema now carries every declared event field —
 the [verb input contract](../../history/plans/verb-input-contract.md) ruled the
 authored event authoritative — and the address a read emits dispatches as an
-argument, with the detached-copy refusal standing guard beside it (step 7).
+argument, with the detached-copy refusal standing guard beside it (step 8).

--- a/docs/common/verbs/session-walkthrough.md
+++ b/docs/common/verbs/session-walkthrough.md
@@ -438,6 +438,53 @@ cf call "$EPIC" recordNote -- --body "blocked on the cookie spec"
 cf get "$EPIC/status"
 ```
 
+The create answers with the address that `EPIC` then holds, and every command
+after it takes that same string:
+
+```text
+{
+  "invocation": "a733f7d4-f238-46fa-9f89-30d7d228763c",
+  "status": "settled",
+  "receipt": "/of:fid1:GKtk39YEc7WOB6_d3iX6fkK7gEjgeoP5fw1dkirzb-E",
+  "result": {
+    "item": {
+      "$link": "/of:fid1:4qFMKSZxAkTVIPBykdyTQGK5YYr_sjUmez3gARxKUkE"
+    }
+  }
+}
+```
+
+`addChild` hands back the child whole, and `parent` — the position where the
+type re-enters itself — answers with an address rather than recursing:
+
+```text
+"result": {
+  "item": {
+    "title": "Session cookies",
+    "status": "open",
+    "notes": [],
+    "parent": {
+      "$link": "/of:fid1:nC0C0km4taIIWtgziU841Ka94i9igKvzEIG-OuoLuNw/parent"
+    },
+    "children": [],
+    "blockedOn": [],
+    "$NAME": "Session cookies"
+  }
+}
+```
+
+`recordNote` returns a stamp the caller never supplied, and the closing read
+answers with one scalar, because the address carried the path:
+
+```text
+"result": {
+  "note": { "at": 1787075135000, "body": "blocked on the cookie spec" },
+  "noteCount": 1
+}
+
+"open"
+```
+
 **This is the composition the surface exists for.** A create hands back the
 piece it made, the address renders in place as one canonical reference, and the
 next command takes that same string — bare, in its first position. An address
@@ -499,6 +546,30 @@ shows the full exchange.
 cf get --piece board items --select 'title,status,children@'
 
 cf get "$EPIC" children --select title --filter '.status == "open"'
+```
+
+Between step 5's reads and these, the session ran the verbs step 5 listed but
+did not print: the epic was finished and one child archived (the demo's acts 8
+and 9), which is why the statuses below have moved. The first read names three
+fields and marks one, so the children come back as addresses rather than being
+followed. The second names one field and selects on another, so only the child
+still open survives the filter:
+
+```text
+[
+  {
+    "status": "done",
+    "title": "Login rewrite",
+    "children": [
+      { "$link": "/of:fid1:nC0C0km4taIIWtgziU841Ka94i9igKvzEIG-OuoLuNw" },
+      { "$link": "/of:fid1:1kF-PJw_VqqjEcSQi-3KObKU_uNgtbewvIHUbKTWDns" }
+    ]
+  }
+]
+
+[
+  { "title": "CSRF tokens" }
+]
 ```
 
 Two commands rather than one, because **an `@` suffix and `--filter` are
@@ -583,13 +654,41 @@ cf call --select blocked@,on@,blockedOnCount "$KID" blockOn -- --on "$CSRF"
 cf get "$EPIC" children --select @,title,blockedOn@
 ```
 
+```text
+"result": {
+  "blocked": { "$link": "/of:fid1:OGJ2ADfbRIhmZ-Z4Of4u3QK9mKGWBMKdUTKiUpuFsVQ" },
+  "blockedOnCount": 1,
+  "on": { "$link": "/of:fid1:1kF-PJw_VqqjEcSQi-3KObKU_uNgtbewvIHUbKTWDns" }
+}
+
+[
+  {
+    "$link": "/of:fid1:nC0C0km4taIIWtgziU841Ka94i9igKvzEIG-OuoLuNw",
+    "title": "Session cookies",
+    "blockedOn": [
+      { "$link": "/of:fid1:1kF-PJw_VqqjEcSQi-3KObKU_uNgtbewvIHUbKTWDns" }
+    ]
+  },
+  {
+    "$link": "/of:fid1:1kF-PJw_VqqjEcSQi-3KObKU_uNgtbewvIHUbKTWDns",
+    "title": "CSRF tokens",
+    "blockedOn": []
+  }
+]
+```
+
+**The address that went in is the address that came back**, and the graph read
+is the proof: `1kF-PJw…` is the second row's own address AND the entry in the
+first row's `blockedOn`. One item, two positions — an edge, not a copy. Had
+the tracker stored contents, those would be two objects that merely look
+alike, and nothing in the output could tell one item from two.
+
 That spelling — the address exactly as a read printed it — dispatches where
 the verb declares a reference, and the edge that lands is the target rather
-than a copy: the graph read shows one item under two paths. The dispatch gate
-reads the DECLARED contract ([verb input
-contract](../../history/plans/verb-input-contract.md)) to know which positions declare
-references, and the same contract refuses the two payloads that could only
-ever be mistakes at one:
+than a copy. The dispatch gate reads the DECLARED contract
+([verb input contract](../../history/plans/verb-input-contract.md)) to know
+which positions declare references, and the same contract refuses the two
+payloads that could only ever be mistakes at one:
 
 ```bash
 cf call "$KID" blockOn -- --on "not-an-address"
@@ -624,9 +723,9 @@ reference (#5880), and converts the canonical string a read prints — the one
 spelling a caller is actually holding, since every `$link` and `receipt` in
 this session emits exactly that form. The positions it converts at come from
 the DECLARED contract read off the compiled pattern, because the schema a
-dispatch cell carries keeps only stream markers; the [verb input
-contract](../../history/plans/verb-input-contract.md) is what makes that declaration
-authoritative.
+dispatch cell carries keeps only stream markers; the
+[verb input contract](../../history/plans/verb-input-contract.md) is what
+makes that declaration authoritative.
 
 A tree mostly hides the argument half, because the natural shape is to call
 the verb *on* the parent — the receiver carries the relationship, so no

--- a/docs/common/verbs/session-walkthrough.md
+++ b/docs/common/verbs/session-walkthrough.md
@@ -28,19 +28,28 @@ transcript is the artifact. `verb-session-gaps.sh` asserts the same surface as
 pass/fail and is what keeps the demo honest.
 
 The demo counts in **acts**; this document counts in **steps**, and the two do
-not run one-for-one — a step is a theme, and an act is a beat. Read the demo's
-transcript beside this table:
+not run one-for-one — a step is a theme, an act is a beat, and a theme can
+take several beats to show. Watching the transcript and wanting the reasoning
+behind a particular act, read across:
 
-| Step here | Demo acts |
+| Demo act | Explained here in |
 | --- | --- |
-| 1. Arrive with a slug | act 1 |
-| 2. Ask what it is | act 2 |
-| 3. Ask what a verb wants | act 3 |
-| 4. Complete against the live piece | — completion needs a terminal, so no act runs it |
-| 5. Create, and carry the address forward | acts 4–9 |
-| 6. Read the tree back, bounded | act 10 |
-| 7. Refuse what the surface does not accept | act 11 |
-| 8. Relate two items | acts 12–13 |
+| 1 · Arrive by name | step 1 |
+| 2 · Ask what it is, and what it can do | step 2 |
+| 3 · Ask what a verb wants | step 3 |
+| 4 · Create, and act on what you were handed | step 5 |
+| 5 · Read addresses instead of contents | step 6, and "Why this pattern" on what an unshaped read costs |
+| 6 · Ask the same question twice | step 6, on why a read may be asked twice and a call may not |
+| 7 · A verb returns what only the pattern could compute | the verb-shapes table under "Why this pattern" |
+| 8 · Finishing reports what the caller could not know | the verb-shapes table under "Why this pattern" |
+| 9 · A verb that declares no result | the verb-shapes table, and step 5's closing read |
+| 10 · Step back and read the board | step 6 |
+| 11 · Ask for something that is not there | step 7 |
+| 12 · Relate two items | step 8 |
+| 13 · One item, two paths, one address | step 8 |
+
+Step 4 is the one with no act behind it: completion needs a terminal, so the
+demo cannot run it.
 
 A verb added to the fixture wants a row in the verb table below, an act in the
 demo, and a step in the harness; a shape demonstrated in none of the three is a
@@ -513,8 +522,18 @@ a filesystem mount, and on a direct read: one read layer, four arrivals.
 belongs to the callable's own interface; the other three take them wherever
 their own options go.
 
-The demo's act 10 is this step run against the session's own tree: the whole
-board first, then only what is open, then the refusal.
+**A read may be asked twice; a call may not.** A projection is a question, so
+running one again returns the same answer and changes nothing — which is what
+makes every read in this session safe to put in a script, and why the demo
+takes the addresses its later acts drive out of a read the reader already
+watched rather than from a hidden second one. A call is the opposite: it runs
+the handler body, so asking twice does the work twice. That asymmetry is why
+calls carry an idempotency id and reads need nothing —
+[verbs over the CLI](over-the-cli.md) has the id's contract.
+
+The demo's acts 5, 6 and 10 are this step: an address-only read, the same read
+run a second time to show it answers the same, and then the whole board, what
+is open, and the refusal.
 
 ## 7. Refuse what the surface does not accept
 

--- a/docs/common/verbs/session-walkthrough.md
+++ b/docs/common/verbs/session-walkthrough.md
@@ -668,13 +668,44 @@ outcome rather than a freshly computed one. The harness asserts both, with
 That is the whole asymmetry: reads repeat freely, calls do not repeat but
 their outcomes stay readable.
 
-**A retry is not free, even with an idempotency id.** Where a caller does need
-to retry — a dropped connection, an unknown outcome — naming the same
-invocation id makes the retry collide with the original receipt, so nothing
-commits twice. The guarantee is at-most-once **commit**, not at-most-once
-**execution**: the redelivered event re-runs the handler body and then loses
-the race for the receipt. A verb whose body reaches outside its transaction —
-an LLM call, a fetch, a message sent — repeats those effects on every retry.
+**The receipt route needs the address.** Where a caller never got one — a
+dropped connection, a response nobody saw — the invocation id is the handle
+instead. Name a call with `--invocation`, and replaying that id hands back
+the original outcome:
+
+```bash
+cf call --invocation note-retry "$EPIC" recordNote -- --body "first attempt"
+
+cf call --invocation note-retry "$EPIC" recordNote -- --body "a different body entirely"
+```
+
+```text
+{
+  "invocation": "note-retry",
+  "status": "settled",
+  "deduplicated": true,
+  "receipt": "/of:fid1:tdSLj9QyZFgmSQ53SFqN31lZz2yieuP1pWTW7nCeum0",
+  "result": {
+    "note": { "at": 1787082752000, "body": "first attempt" },
+    "noteCount": 2
+  }
+}
+```
+
+The second payload is deliberately different text, and it does not take: the
+body, the stamp, the count and the receipt are all the first call's, and the
+envelope says `deduplicated` rather than leaving a caller to infer it. An id
+is only half the handle — it is scoped to an **invocation session**, so one
+agent's `note-retry` is not another's. Mint one per run and keep it in
+`CF_INVOCATION_SESSION`, where the environment is closer to the secret it is
+than a command line would be.
+
+**A retry is still not free.** The guarantee is at-most-once **commit**, not
+at-most-once **execution**: the redelivered event re-runs the handler body and
+then loses the race for the receipt. A verb whose body reaches outside its
+transaction — an LLM call, a fetch, a message sent — repeats those effects on
+every retry. So retry freely for a verb that only writes its own space, and
+prefer the receipt for one that reaches beyond it.
 [Verbs over the CLI](over-the-cli.md) has the full contract.
 
 The demo's acts 5, 6, 7 and 10 are this step: an address-only read, the same

--- a/docs/common/verbs/session-walkthrough.md
+++ b/docs/common/verbs/session-walkthrough.md
@@ -627,12 +627,15 @@ a filesystem mount, and on a direct read: one read layer, four arrivals.
 belongs to the callable's own interface; the other three take them wherever
 their own options go.
 
-**A read may be asked twice; a call may not.** A projection is a question, so
-running one again returns the same answer and changes nothing — which is what
-makes every read in this session safe to put in a script, and why the demo
-takes the addresses its later acts drive out of a read the reader already
-watched rather than from a hidden second one. A call is the opposite: it runs
-the handler body, so asking twice does the work twice.
+**A read may be asked twice; a call may not.** A projection is a question, and
+asking it changes nothing — that is the invariant, and it is what makes every
+read in this session safe to put in a script. It is not a promise that two
+reads agree: a read answers from the state it finds, so anything written in
+between shows up in the second answer. Here the two agree because nothing else
+is writing to this fixture, which is also why the demo can take the addresses
+its later acts drive out of a read the reader already watched rather than from
+a hidden second one. A call is the opposite of side-effect-free: it runs the
+handler body, so asking twice does the work twice.
 
 **But a call need not be asked twice, because its outcome has an address.**
 Every settled envelope names a `receipt` — the cell this handling wrote its
@@ -649,17 +652,30 @@ cf get "$RECEIPT" --select note,noteCount
 }
 ```
 
-**The timestamp is the proof, not the prose.** `recordNote` stamps the clock,
-which the caller cannot supply — so a readback that had re-run the handler
-would carry a later `at` than the call did. It carries the same one, which is
-what says the body did not run again. The harness asserts exactly that
-comparison, so the claim fails loudly if it ever stops holding.
+**`noteCount` is the proof, not the timestamp.** `notes` is append-only, so a
+readback that had re-run the handler would leave a second note behind and
+answer `2`. It answers `1`, which is what says the body did not run again.
+
+The stamp cannot carry that proof, and it is worth saying why, because it
+looks like it should: the sandbox clock is coarsened to one-second resolution
+(`Note.at` in [the fixture][tracker]), and a re-execution during a readback
+lands in the same second as the call it followed — so the two stamps would
+agree in exactly the case the check exists to catch. That they agree says
+something else, still worth having: the receipt returned the **original**
+outcome rather than a freshly computed one. The harness asserts both, with
+`noteCount` carrying the weight.
 
 That is the whole asymmetry: reads repeat freely, calls do not repeat but
-their outcomes stay readable. Where a caller does need to retry a call — a
-dropped connection, an unknown outcome — an idempotency id makes the retry
-collide with the original receipt rather than doing the work twice;
-[verbs over the CLI](over-the-cli.md) has that contract.
+their outcomes stay readable.
+
+**A retry is not free, even with an idempotency id.** Where a caller does need
+to retry — a dropped connection, an unknown outcome — naming the same
+invocation id makes the retry collide with the original receipt, so nothing
+commits twice. The guarantee is at-most-once **commit**, not at-most-once
+**execution**: the redelivered event re-runs the handler body and then loses
+the race for the receipt. A verb whose body reaches outside its transaction —
+an LLM call, a fetch, a message sent — repeats those effects on every retry.
+[Verbs over the CLI](over-the-cli.md) has the full contract.
 
 The demo's acts 5, 6, 7 and 10 are this step: an address-only read, the same
 read run a second time to show it answers the same, a call's receipt read back

--- a/docs/common/verbs/session-walkthrough.md
+++ b/docs/common/verbs/session-walkthrough.md
@@ -429,6 +429,25 @@ needs.
 
 ## 5. Create, and carry the address forward
 
+This is where `--select` starts carrying the narrative, so here is the whole
+of the grammar the session uses. A selection names the shape of the answer;
+everything not named is left out.
+
+| Spelling | What comes back |
+| --- | --- |
+| `title,status` | those two fields and nothing else |
+| `item.title` | walks into `item` and keeps `title` — it prunes rather than flattens, so the answer is still shaped like the result |
+| `@` | the address of the position being read, in place of its contents |
+| `item@` | the address `item` holds, rather than following the link and copying what is behind it |
+| `children@` | applied across an array: each element's own address |
+| `@,title` | both — the address beside the field |
+
+An address always arrives under the key `$link`, which is why that key is
+everywhere in the output below. The full account of the suffix — marking
+positions deeper than a link, the `{"$link": true}` spelling a JSON Schema
+uses, and escaping a literal `@` — is in
+[verbs over the CLI](over-the-cli.md#asking-a-read-for-an-address).
+
 ```bash
 EPIC=$(cf call --piece board --select 'item@' addItem -- \
        --title "Login rewrite" | jq -r '.result.item."$link"')
@@ -437,6 +456,10 @@ cf call "$EPIC" addChild -- --title "Session cookies"
 cf call "$EPIC" recordNote -- --body "blocked on the cookie spec"
 cf get "$EPIC/status"
 ```
+
+The `jq` hop above is how an address gets from a response into a variable, and
+its quoting is load-bearing: `."$link"` must be quoted, because a bare
+`.$link` reads as one of jq's own variables rather than as a key.
 
 The create answers with the address that `EPIC` then holds, and every command
 after it takes that same string:

--- a/docs/common/verbs/session-walkthrough.md
+++ b/docs/common/verbs/session-walkthrough.md
@@ -16,9 +16,10 @@ gated by CI against the scripts it describes, while that page is a snapshot
 kept by hand.
 
 The subject is a work-item tracker — items in a tree, plus typed cross-links.
-It is a real pattern: [`packages/cli/integration/pattern/tracker.tsx`][tracker], which
-belongs to this document and the two scripts beside it, so a change to a
-pattern the product ships can never break a demonstration of the verb surface.
+It is a real pattern: [`packages/cli/integration/pattern/tracker.tsx`][tracker],
+which belongs to this document and its two companion scripts and to nothing
+else, so a change to a pattern the product ships can never break a
+demonstration of the verb surface.
 Every measurement below was taken against that pattern on a local toolshed.
 
 **Every step here works against a current build.** That is not a claim this
@@ -29,7 +30,7 @@ something decided or built would say so; none does today.
 
 ## The two scripts, and how they line up with this
 
-Two scripts sit beside this document.
+Two companion scripts under `packages/cli/integration/` carry this session.
 [`packages/cli/integration/verb-session-demo.sh`][demo] is the session as it is meant
 to read: it narrates each command, runs it, and prints the result, so the
 transcript is the artifact. [`verb-session-gaps.sh`][gaps] asserts the same surface as
@@ -652,18 +653,15 @@ cf get "$RECEIPT" --select note,noteCount
 }
 ```
 
-**`noteCount` is the proof, not the timestamp.** `notes` is append-only, so a
-readback that had re-run the handler would leave a second note behind and
-answer `2`. It answers `1`, which is what says the body did not run again.
-
-The stamp cannot carry that proof, and it is worth saying why, because it
-looks like it should: the sandbox clock is coarsened to one-second resolution
-(`Note.at` in [the fixture][tracker]), and a re-execution during a readback
-lands in the same second as the call it followed — so the two stamps would
-agree in exactly the case the check exists to catch. That they agree says
-something else, still worth having: the receipt returned the **original**
-outcome rather than a freshly computed one. The harness asserts both, with
-`noteCount` carrying the weight.
+**What that does not prove, and where the proof lives.** A receipt is a
+frozen snapshot of the outcome its handling committed, so it reports that
+outcome whether or not anything has happened since. Reading it back therefore
+cannot, on its own, tell you that the handler did not run again — the numbers
+inside it would look the same either way. Only the piece can settle that:
+`notes` is append-only, so a second execution leaves a second entry, and
+reading the item's own `notes` is what shows there is none. The harness
+asserts the live length after every one of these operations for exactly that
+reason.
 
 That is the whole asymmetry: reads repeat freely, calls do not repeat but
 their outcomes stay readable.
@@ -692,13 +690,32 @@ cf call --invocation note-retry "$EPIC" recordNote -- --body "a different body e
 }
 ```
 
-The second payload is deliberately different text, and it does not take: the
-body, the stamp, the count and the receipt are all the first call's, and the
-envelope says `deduplicated` rather than leaving a caller to infer it. An id
-is only half the handle — it is scoped to an **invocation session**, so one
-agent's `note-retry` is not another's. Mint one per run and keep it in
-`CF_INVOCATION_SESSION`, where the environment is closer to the secret it is
-than a command line would be.
+The second payload is deliberately different text, and the body that comes
+back is the first call's — along with the same receipt, and `deduplicated`,
+which the first call did not carry. The same caution applies as above: a
+replay is *defined* to hand the original snapshot back, so the envelope would
+read like this whether or not a second note actually landed. The board is
+what settles it:
+
+```bash
+cf get "$EPIC" notes --select body
+```
+
+```text
+[
+  { "body": "blocked on the cookie spec" },
+  { "body": "first attempt" }
+]
+```
+
+Two entries, from the two calls that committed, and the replay's text is not
+among them.
+
+An id is only half the handle — it is scoped to an **invocation session**, so
+one agent's `note-retry` is not another's. Mint one per run and keep it in
+`CF_INVOCATION_SESSION`: putting it in the environment keeps it out of the
+command lines and shell history that a casual reader of your terminal would
+see.
 
 **A retry is still not free.** The guarantee is at-most-once **commit**, not
 at-most-once **execution**: the redelivered event re-runs the handler body and

--- a/docs/common/verbs/session-walkthrough.md
+++ b/docs/common/verbs/session-walkthrough.md
@@ -40,7 +40,7 @@ behind a particular act, read across:
 | 4 · Create, and act on what you were handed | step 5 |
 | 5 · Read addresses instead of contents | step 6, and "Why this pattern" on what an unshaped read costs |
 | 6 · Ask the same question twice | step 6, on why a read may be asked twice and a call may not |
-| 7 · A verb returns what only the pattern could compute | the verb-shapes table under "Why this pattern" |
+| 7 · A verb returns what only the pattern could compute, and its receipt reads that outcome back | the verb-shapes table under "Why this pattern", and step 6 on the receipt |
 | 8 · Finishing reports what the caller could not know | the verb-shapes table under "Why this pattern" |
 | 9 · A verb that declares no result | the verb-shapes table, and step 5's closing read |
 | 10 · Step back and read the board | step 6 |
@@ -477,6 +477,7 @@ type re-enters itself — answers with an address rather than recursing:
 answers with one scalar, because the address carried the path:
 
 ```text
+"receipt": "/of:fid1:-PqRcxDVvI1AvqsJevG-N3Ui-PqMDW1HUYRm1X0cPAY",
 "result": {
   "note": { "at": 1787075135000, "body": "blocked on the cookie spec" },
   "noteCount": 1
@@ -484,6 +485,8 @@ answers with one scalar, because the address carried the path:
 
 "open"
 ```
+
+That `receipt` is an address like any other, and step 6 reads it back.
 
 **This is the composition the surface exists for.** A create hands back the
 piece it made, the address renders in place as one canonical reference, and the
@@ -598,13 +601,39 @@ running one again returns the same answer and changes nothing — which is what
 makes every read in this session safe to put in a script, and why the demo
 takes the addresses its later acts drive out of a read the reader already
 watched rather than from a hidden second one. A call is the opposite: it runs
-the handler body, so asking twice does the work twice. That asymmetry is why
-calls carry an idempotency id and reads need nothing —
-[verbs over the CLI](over-the-cli.md) has the id's contract.
+the handler body, so asking twice does the work twice.
 
-The demo's acts 5, 6 and 10 are this step: an address-only read, the same read
-run a second time to show it answers the same, and then the whole board, what
-is open, and the refusal.
+**But a call need not be asked twice, because its outcome has an address.**
+Every settled envelope names a `receipt` — the cell this handling wrote its
+outcome to — and reading it is an ordinary read:
+
+```bash
+cf get "$RECEIPT" --select note,noteCount
+```
+
+```text
+{
+  "note": { "at": 1787075135000, "body": "blocked on the cookie spec" },
+  "noteCount": 1
+}
+```
+
+**The timestamp is the proof, not the prose.** `recordNote` stamps the clock,
+which the caller cannot supply — so a readback that had re-run the handler
+would carry a later `at` than the call did. It carries the same one, which is
+what says the body did not run again. The harness asserts exactly that
+comparison, so the claim fails loudly if it ever stops holding.
+
+That is the whole asymmetry: reads repeat freely, calls do not repeat but
+their outcomes stay readable. Where a caller does need to retry a call — a
+dropped connection, an unknown outcome — an idempotency id makes the retry
+collide with the original receipt rather than doing the work twice;
+[verbs over the CLI](over-the-cli.md) has that contract.
+
+The demo's acts 5, 6, 7 and 10 are this step: an address-only read, the same
+read run a second time to show it answers the same, a call's receipt read back
+to show the outcome outlived the call, and then the whole board, what is open,
+and the refusal.
 
 ## 7. Refuse what the surface does not accept
 

--- a/docs/common/verbs/session-walkthrough.md
+++ b/docs/common/verbs/session-walkthrough.md
@@ -7,14 +7,22 @@ from one call into the next.
 [Verbs over the CLI](over-the-cli.md) explains what a verb hands back.
 This walks a whole session using it.
 
+**Not met a pattern or a piece before?** [The Verb Session][overview] is an
+illustrated tour of this same session that defines the vocabulary this
+document assumes — pattern, piece, space, verb, handler, invocation — and
+reads start to finish. Come back here for the measurements, the caveats, and
+what the surface still owes. Note which copy is authoritative: this one is
+gated by CI against the scripts it describes, while that page is a snapshot
+kept by hand.
+
 The subject is a work-item tracker — items in a tree, plus typed cross-links.
-It is a real pattern: `packages/cli/integration/pattern/tracker.tsx`, which
+It is a real pattern: [`packages/cli/integration/pattern/tracker.tsx`][tracker], which
 belongs to this document and the two scripts beside it, so a change to a
 pattern the product ships can never break a demonstration of the verb surface.
 Every measurement below was taken against that pattern on a local toolshed.
 
 **Every step here works against a current build.** That is not a claim this
-document makes on its own: `packages/cli/integration/verb-session-gaps.sh`
+document makes on its own: [`packages/cli/integration/verb-session-gaps.sh`][gaps]
 asserts the same surface as pass/fail and CI runs it, so a step that stopped
 working would fail there rather than going stale here. A step needing
 something decided or built would say so; none does today.
@@ -22,9 +30,9 @@ something decided or built would say so; none does today.
 ## The two scripts, and how they line up with this
 
 Two scripts sit beside this document.
-`packages/cli/integration/verb-session-demo.sh` is the session as it is meant
+[`packages/cli/integration/verb-session-demo.sh`][demo] is the session as it is meant
 to read: it narrates each command, runs it, and prints the result, so the
-transcript is the artifact. `verb-session-gaps.sh` asserts the same surface as
+transcript is the artifact. [`verb-session-gaps.sh`][gaps] asserts the same surface as
 pass/fail and is what keeps the demo honest.
 
 The demo counts in **acts**; this document counts in **steps**, and the two do
@@ -63,7 +71,7 @@ cannot be wrong in a way the demo would have caught, and an act reference
 cannot go stale under renumbering.
 
 Section headers inside the help output below are the literal strings
-`renderPieceCallHelp` emits (`packages/cli/lib/exec-schema.ts`). Their contents
+`renderPieceCallHelp` emits ([`packages/cli/lib/exec-schema.ts`][exec-schema]). Their contents
 are illustrative.
 
 ## Why this pattern
@@ -240,7 +248,7 @@ of root items and `$NAME` is its display name; both are data, and data is not
 callable, so neither is offered to a caller as something to call.
 
 Slug resolution sits on the shared path (`resolvePieceConfigWithPieces`,
-`packages/cli/lib/piece.ts`), so every command below takes `board` too. And
+[`packages/cli/lib/piece.ts`][piece-lib]), so every command below takes `board` too. And
 the name is discoverable as well as resolvable: `cf piece slugs` lists the
 space's slug index, so a session in a space someone else populated starts
 from a listing rather than from folklore. The demo's act 1 runs it beside the
@@ -382,7 +390,7 @@ recover.
 ### Three levels of documentation
 
 Every line of prose on the page above exists as a doc comment in
-`tracker.tsx`. Nothing is invented for the illustration — it is that file's
+[`tracker.tsx`][tracker]. Nothing is invented for the illustration — it is that file's
 own words, reaching a caller. An author writes each where the thing it
 describes is declared — the verb says what it does, and each parameter
 describes itself:
@@ -417,7 +425,7 @@ addItem
 
 Verb names and piece addresses complete against the space
 (`shapeVerbCandidates` / `liveCandidates`,
-`packages/cli/lib/completion/providers.ts`), in bash and zsh. The candidates
+[`packages/cli/lib/completion/providers.ts`][completion]), in bash and zsh. The candidates
 map one-for-one over the listing in step 1, so completion offers what that
 command names and nothing besides.
 
@@ -753,7 +761,7 @@ form a read prints. An inline copy is refused outright, because a
 shape-matching payload at a reference position stores a detached document
 inside the caller's own item and reports success. The link envelope #5880
 landed stays accepted beside the emitted spelling —
-`verb-session-gaps.sh` step 10 asserts every spelling apart.
+[`verb-session-gaps.sh`][gaps] step 10 asserts every spelling apart.
 
 The demo's acts 12 and 13 run all of it: the conversion, both refusals, and
 the two-paths read as the payoff addresses exist for.
@@ -804,3 +812,14 @@ intends: the served input schema now carries every declared event field —
 the [verb input contract](../../history/plans/verb-input-contract.md) ruled the
 authored event authoritative — and the address a read emits dispatches as an
 argument, with the detached-copy refusal standing guard beside it (step 8).
+
+<!-- Source links resolve against the repository's default branch, so they
+     follow head rather than pinning a revision this document would outlive. -->
+
+[tracker]: https://github.com/commontoolsinc/labs/blob/main/packages/cli/integration/pattern/tracker.tsx
+[demo]: https://github.com/commontoolsinc/labs/blob/main/packages/cli/integration/verb-session-demo.sh
+[gaps]: https://github.com/commontoolsinc/labs/blob/main/packages/cli/integration/verb-session-gaps.sh
+[exec-schema]: https://github.com/commontoolsinc/labs/blob/main/packages/cli/lib/exec-schema.ts
+[piece-lib]: https://github.com/commontoolsinc/labs/blob/main/packages/cli/lib/piece.ts
+[completion]: https://github.com/commontoolsinc/labs/blob/main/packages/cli/lib/completion/providers.ts
+[overview]: https://claude.ai/code/artifact/74bd43c3-4672-4e6c-9af4-34513e5bedaa

--- a/docs/common/verbs/session-walkthrough.md
+++ b/docs/common/verbs/session-walkthrough.md
@@ -4,30 +4,54 @@ What driving a pattern entirely through `cf` looks like when the verb surface is
 complete: discovery, documentation, help, completion, and carrying an address
 from one call into the next.
 
-[Verbs over the CLI](verbs-over-the-cli.md) explains what a verb hands back.
-This walks a whole session using it, and marks where the surface is still
-incomplete.
+[Verbs over the CLI](over-the-cli.md) explains what a verb hands back.
+This walks a whole session using it.
 
 The subject is a work-item tracker — items in a tree, plus typed cross-links.
 It is a real pattern: `packages/cli/integration/pattern/tracker.tsx`, which
 belongs to this document and the two scripts beside it, so a change to a
 pattern the product ships can never break a demonstration of the verb surface.
-The scripts are `packages/cli/integration/verb-session-demo.sh`, the session as
-it is meant to read, and `packages/cli/integration/verb-session-gaps.sh`, the
-gap harness CI runs to keep the **[today]**/**[blocked]** marks below honest.
 Every measurement below was taken against that pattern on a local toolshed.
 
-**Every step is marked for what is real.** The point of the document is the
-line between them.
+**Every step here works against a current build.** That is not a claim this
+document makes on its own: `packages/cli/integration/verb-session-gaps.sh`
+asserts the same surface as pass/fail and CI runs it, so a step that stopped
+working would fail there rather than going stale here. A step needing
+something decided or built would say so; none does today.
 
-| Mark | Meaning |
+## The two scripts, and how they line up with this
+
+Two scripts sit beside this document.
+`packages/cli/integration/verb-session-demo.sh` is the session as it is meant
+to read: it narrates each command, runs it, and prints the result, so the
+transcript is the artifact. `verb-session-gaps.sh` asserts the same surface as
+pass/fail and is what keeps the demo honest.
+
+The demo counts in **acts**; this document counts in **steps**, and the two do
+not run one-for-one — a step is a theme, and an act is a beat. Read the demo's
+transcript beside this table:
+
+| Step here | Demo acts |
 | --- | --- |
-| **[today]** | works against a current build |
-| **[blocked]** | needs something decided or built |
+| 1. Arrive with a slug | act 1 |
+| 2. Ask what it is | act 2 |
+| 3. Ask what a verb wants | act 3 |
+| 4. Complete against the live piece | — completion needs a terminal, so no act runs it |
+| 5. Create, and carry the address forward | acts 4–9 |
+| 6. Read the tree back, bounded | act 10 |
+| 7. Refuse what the surface does not accept | act 11 |
+| 8. Relate two items | acts 12–13 |
 
-The read layer this document was drafted against has since landed in full: the
-concise `--select` spelling, the `@` address suffix, and their arrival on
-`piece call` all work today, so no step here is merely pending.
+A verb added to the fixture wants a row in the verb table below, an act in the
+demo, and a step in the harness; a shape demonstrated in none of the three is a
+claim this document is making alone.
+
+This document quotes commands and never composes them: every `cf` line in a
+bash block below is a line the demo runs — or carries a `# not in the demo`
+comment saying why it cannot be — and every act number names an act the demo
+has. `deno task check-verb-session-sync` enforces both, so a command here
+cannot be wrong in a way the demo would have caught, and an act reference
+cannot go stale under renumbering.
 
 Section headers inside the help output below are the literal strings
 `renderPieceCallHelp` emits (`packages/cli/lib/exec-schema.ts`). Their contents
@@ -66,10 +90,11 @@ Those act numbers are `packages/cli/integration/verb-session-demo.sh`, which
 drives the session and prints each command before running it — the transcript is
 what that script is for. Beside it,
 `packages/cli/integration/verb-session-gaps.sh` asserts the same surface as
-pass/fail, and several of its steps assert that something does *not* work yet,
-failing loudly the day it does. A verb added to the fixture wants a row above, an
-act in the demo, and a step in the harness; a shape demonstrated in none of the
-three is a claim this document is making alone.
+pass/fail. A step there may assert that something does *not* work yet, failing
+loudly the day it does; none does at the moment, which is why every step below
+is marked **[today]**. A verb added to the fixture wants a row above, an act in
+the demo, and a step in the harness; a shape demonstrated in none of the three
+is a claim this document is making alone.
 
 This document quotes commands and never composes them: every `cf` line in a
 bash block below is a line the demo runs — or carries a `# not in the demo`
@@ -187,7 +212,7 @@ cf get <item-address> children --select 'title,status'
 That is not a workaround; it is the read model working. A schema is a query,
 and a caller who names nothing has asked for everything. The same flags shape a
 verb's result, because
-[a result is a read on a different cell](../plans/fabric-read-model.md) — 1743
+[a result is a read on a different cell](../../plans/fabric-read-model.md) — 1743
 bytes unshaped, 140 with `--select 'item.title'`.
 
 **The prose above reaches a caller.** Each verb carries a doc comment saying
@@ -345,71 +370,21 @@ The structural half needs nothing authored per pattern:
 `--title <string> Required.`
 falls out of the type. That is why the page exists at all.
 
-**Part of the prose is not on the wire with it**, and knowing which part keeps
-a reader from looking for it in the wrong place. A verb dispatches through a
-callable cell, and that cell takes its schema from the link chain it resolves
-through (`cell.ts:asSchemaFromLinks`). For a verb that link is the handler
-node's `$event` input — which, since the [verb input
-contract](../history/plans/verb-input-contract.md), is the author's event type
-rather than a summary of what the body reads, so a declared field the body
-never mentions is served like any other, and the field comments beside those
-fields travel with it.
+**The two halves arrive by different roads**, and the page assembles them.
+The structural half rides the schema the piece serves. The prose is read from
+the compiled pattern, because that is where a doc comment survives
+compilation — the same load `cf piece verbs` already makes to report what a
+verb hands back. A caller sees one page; `cf` read two documents to build it.
 
-Two things still do not. A comment on the **verb** describes the verb, not its
-event, so it lives on the pattern's result schema and never rides the event
-schema at all. And link sanitization strips every capability marker but
-`stream`, which is why a declared reference position arrives shape-intact and
-marker-less — the fact the dispatch gate reads the compiled pattern to
-recover (step 7).
+Which document carries what, and why the fold walks both, is
+[an author's prose, over the CLI](prose-over-the-cli.md). Two of its
+consequences show up in this session: a field an author declares and the
+handler never reads is still served, flagged and documented (the authored
+event is the contract), and a declared reference arrives with its capability
+marker stripped — which is what step 7's dispatch gate reads the pattern to
+recover.
 
-So the pattern is loaded for those, and it is where each level survives
-compilation:
-
-| An author writes… | Where the compiled pattern keeps it |
-| --- | --- |
-| a comment on the **verb itself**, as in the model above | `resultSchema.properties.<verb>.description`, a sibling of the `$ref` naming its event |
-| a comment on an **event field** (what `title` means) | `$defs.<Event>.properties.<field>.description` |
-| a comment on the **event interface** | nowhere — this one does not compile ([#5937](https://github.com/commontoolsinc/labs/issues/5937)) |
-
-`cf piece verbs` and `cf call <verb> --help` already load that pattern to
-report what a verb hands back, so both read the prose from the same load. The
-verb's own comment becomes the listing row's `description` and the help page's
-summary line. The event fields' comments are folded into the input schema the
-page renders flags from, at the positions that schema already has.
-
-**Which means walking two documents that need not agree structurally.** A
-handler with an authored event type serves that type, so the two now line up
-by construction; a handler written without one has only the inferred summary,
-and there the old divergence stands. The same field can be a `$ref` in one and
-an inline object in the other, and a union the declared side spells as `anyOf`
-can arrive as one merged object. So a walk that steps through `properties`
-key-for-key finds a bare `$ref` on one side with no `properties` under it, or a
-field whose prose is inside an arm that no longer exists on the other side, and
-stops short of the words in both cases.
-
-Both sides' references are followed for that reason, and a declared combinator
-is read through to its members. A served reference is followed *without* being
-inlined, and a served combinator is never flattened: a caller's tooling reads
-that shape, and a definition several positions share is not one position's to
-rewrite. A field's own prose is therefore written where the field is, never into
-the definition it points at — which would attribute one position's sentence to
-every other holder of the same type. The precise list of positions the fold
-walks is on `withDeclaredFieldProse` (`packages/cli/lib/piece.ts`), enumerated
-rather than summarized, along with the keywords it leaves alone.
-
-**Folded in, never substituted.** Only `description` annotations cross between
-the two documents, so the served schema stays the authority on shape and takes
-only the words. Substituting one document for the other would describe the
-source rather than the piece being talked to — which stays the rule even now
-that an authored event makes the two agree, because the piece in front of a
-caller may be running an older pattern than the source in the checkout.
-
-The question this section used to leave open — whether a field an author
-declares and the body never reads is discoverable — is settled: it is. The
-authored event is the contract, so the field is served, flagged, and
-documented like any other.
-
-### Three levels of documentation **[today]**
+### Three levels of documentation
 
 Every line of prose on the page above exists as a doc comment in
 `tracker.tsx`. Nothing is invented for the illustration — it is that file's
@@ -423,7 +398,7 @@ describes itself:
 | an **input** parameter | a field of the event interface | **yes**, in `$defs.<Event>.properties` | **yes**, beside its flag |
 | an **output** parameter | a field of the result interface | **yes**, on the declared result | **yes**, beside its `Output:` line |
 
-The output parameter's needs no resolution to render. A verb's declared
+The output parameter's prose needs no resolution to render. A verb's declared
 result reaches `cf` **unresolved**, and a field's description is a ref-site
 sibling on the property itself: `--help --json` on `addItem` serves
 `properties.item` as a `$ref` into `$defs.ItemOutput` carrying
@@ -520,7 +495,7 @@ loop would start again — comes through as an address, the same address a
 `$link` marker would have produced. If the verb declares no result, there is
 nothing to fall back on, and the call fails with a clear message rather than
 a stack trace.
-[A result that points back at its container](verbs-over-the-cli.md#a-result-that-points-back-at-its-container)
+[A result that points back at its container](over-the-cli.md#a-result-that-points-back-at-its-container)
 shows the full exchange.
 
 ## 6. Read the tree back, bounded **[today]**
@@ -567,7 +542,7 @@ That spelling — the address exactly as a read printed it — dispatches where
 the verb declares a reference, and the edge that lands is the target rather
 than a copy: the graph read shows one item under two paths. The dispatch gate
 reads the DECLARED contract ([verb input
-contract](../history/plans/verb-input-contract.md)) to know which positions declare
+contract](../../history/plans/verb-input-contract.md)) to know which positions declare
 references, and the same contract refuses the two payloads that could only
 ever be mistakes at one:
 
@@ -605,7 +580,7 @@ spelling a caller is actually holding, since every `$link` and `receipt` in
 this session emits exactly that form. The positions it converts at come from
 the DECLARED contract read off the compiled pattern, because the schema a
 dispatch cell carries keeps only stream markers; the [verb input
-contract](../history/plans/verb-input-contract.md) is what makes that declaration
+contract](../../history/plans/verb-input-contract.md) is what makes that declaration
 authoritative.
 
 A tree mostly hides the argument half, because the natural shape is to call
@@ -615,7 +590,7 @@ related to each other: `blockOn`, a `duplicates` edge, a `move`, or a removal
 that names a child rather than an index. Indices are not addresses; a
 position shifts under concurrent writes.
 
-[CLI surface shape](../plans/cli-surface-shape.md) states the property for
+[CLI surface shape](../../plans/cli-surface-shape.md) states the property for
 commands — an address printed by one command is accepted by the next. The
 argument half is the same property one level in, on arguments. A second
 instance sits on `cf piece set-slug`, whose source positional resolves
@@ -630,6 +605,6 @@ through its own path rather than the one `--piece` uses.
 
 Two rows, and two that used to sit beside them are gone the way this table
 intends: the served input schema now carries every declared event field —
-the [verb input contract](../history/plans/verb-input-contract.md) ruled the
+the [verb input contract](../../history/plans/verb-input-contract.md) ruled the
 authored event authoritative — and the address a read emits dispatches as an
 argument, with the detached-copy refusal standing guard beside it (step 7).

--- a/docs/history/plans/declared-verb-results-case.md
+++ b/docs/history/plans/declared-verb-results-case.md
@@ -53,7 +53,7 @@ work-item tracker driven entirely through `cf`, shown twice. Once as it reads
 today, once as it reads with declared results. Nothing separates the two
 except one field.
 
-[A verb session, end to end](../../common/verb-session-walkthrough.md) walks that
+[A verb session, end to end](../../common/verbs/session-walkthrough.md) walks that
 session in full, marking each step for whether it works today, is built and
 merging, or is blocked. This document takes the one step the decision turns on.
 
@@ -460,5 +460,5 @@ one.
 
 Declared results make an **output** self-describing. This is about what an
 **input** accepts, and it stays open whichever way the timing question is
-settled. [A verb session, end to end](../../common/verb-session-walkthrough.md)
+settled. [A verb session, end to end](../../common/verbs/session-walkthrough.md)
 works the case through.

--- a/docs/history/plans/projection-key-classification.md
+++ b/docs/history/plans/projection-key-classification.md
@@ -621,7 +621,7 @@ and inflates the answer with whatever the examples happen to read.
 Eighteen occurrences carry a parseable JSON Schema argument — in
 `packages/cli/integration/*.sh`, `packages/cli/README.md`,
 `packages/cli/commands/piece.ts` help examples, `skills/cf/SKILL.md`,
-`docs/common/verbs-over-the-cli.md`, and two plan documents. The rest are prose
+`docs/common/verbs/over-the-cli.md`, and two plan documents. The rest are prose
 about the flag, error-message text naming it, or the concise field-path
 spelling. One doc example passes `@shape.json`, a file the tree does not
 contain. Two arguments did not parse and neither is a command: a display string

--- a/docs/history/plans/shaped-reads-implementation.md
+++ b/docs/history/plans/shaped-reads-implementation.md
@@ -449,7 +449,7 @@ Each step carries its own, rather than a sweep at the end.
 | Step | Owed |
 | --- | --- |
 | F2 | `packages/cli/README.md` output conventions: two flags, which syntax each takes |
-| A1, A3 | The marker and the suffix, same file; [Verbs over the CLI](../../common/verbs-over-the-cli.md), already stale |
+| A1, A3 | The marker and the suffix, same file; [Verbs over the CLI](../../common/verbs/over-the-cli.md), already stale |
 | A4 | Address forms wherever `--piece` is taught — the CLI README and the tutorial's workflow chapter |
 | S1, S2 | `cf invocation-session new`, `CF_INVOCATION_SESSION`, and what an absent session means; the CLI README and the agent-facing skills that teach invocation ids |
 | C1 | What a receipt declares, in the design document's open-question slot |

--- a/docs/history/verbs-arc-independent-review-2026-08-14.md
+++ b/docs/history/verbs-arc-independent-review-2026-08-14.md
@@ -452,7 +452,7 @@ misled about how the runtime works now. All verified against code.
 
 - **Three surfaces teach stripping the `of:` prefix** that #5459 made
   unnecessary: `packages/cli/README.md:302-303`,
-  `docs/common/verbs-over-the-cli.md:443-446` and `:545-546`,
+  `docs/common/verbs/over-the-cli.md:443-446` and `:545-546`,
   `skills/cf/SKILL.md:296` — while the walkthrough's own receipt examples
   pass `of:` ids verbatim. The strip advice contradicts the arc's
   composition goal and the docs contradict themselves.

--- a/docs/plans/cli-surface-implementation.md
+++ b/docs/plans/cli-surface-implementation.md
@@ -8,7 +8,7 @@ the part that changes what a caller types.
 The split is deliberate, though not absolute. The read layer breaks two things,
 both of which it owns and sequences itself. Scoping invocation ids to a session
 makes `--invocation` without one an error — a spelling that works today and that
-[Verbs over the CLI](../common/verbs-over-the-cli.md) teaches — and that lands
+[Verbs over the CLI](../common/verbs/over-the-cli.md) teaches — and that lands
 alone, ahead of anything that publishes an address. Checking projection keys
 against an allowlist refuses a schema carrying a key that was silently dropped
 before, which is a command that exited zero and now does not.

--- a/docs/plans/cli-surface-shape.md
+++ b/docs/plans/cli-surface-shape.md
@@ -210,7 +210,7 @@ intermediate state wrong. What each step owes:
 
 | Step | Documentation owed |
 | --- | --- |
-| 2 | The read options gain a second host — `piece call`'s section in `packages/cli/README.md`, and [Verbs over the CLI](../common/verbs-over-the-cli.md) |
+| 2 | The read options gain a second host — `piece call`'s section in `packages/cli/README.md`, and [Verbs over the CLI](../common/verbs/over-the-cli.md) |
 | 3 | Address forms wherever `--piece` is taught: the CLI README and the tutorial's workflow chapter |
 | 4 | `#argument` beside every `--input` example, in the same places |
 | 5 | The new spellings alongside the old ones everywhere both work |

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -374,7 +374,7 @@ deprecated or retired. `cf piece verbs` therefore draws its candidates from
 the piece's stored surface and its compiled graph rather than from the
 pattern's declared result type, and a verb the type omits is listed on the
 same terms as one it names. Two residual gaps are the probing caller's to
-know about, and [the CLI verb guide](../common/verbs-over-the-cli.md) states
+know about, and [the CLI verb guide](../common/verbs/over-the-cli.md) states
 both: a listing reporting `incomplete` is a lower bound, and a handler whose
 stored schema carries no stream marker is callable without ever being listed.
 Absence is evidence of retirement only on a listing that reports neither.

--- a/docs/plans/verb-result-selection.md
+++ b/docs/plans/verb-result-selection.md
@@ -19,7 +19,7 @@ to the receipt cell, not a contract of its own.
 This continues the identity work from
 [Pattern verb contract — implementation plan](../history/plans/pattern-verb-contract-implementation.md)
 (WS-F). The user-facing surface it changes is
-[Verbs over the CLI](../common/verbs-over-the-cli.md).
+[Verbs over the CLI](../common/verbs/over-the-cli.md).
 
 ## Orientation
 
@@ -414,7 +414,7 @@ first condition arrives on its own.
 
 ## Documentation owed
 
-- [Verbs over the CLI](../common/verbs-over-the-cli.md) documents the
+- [Verbs over the CLI](../common/verbs/over-the-cli.md) documents the
   `--show-links` shape, and its examples teach hand-written invocation ids
   beside the session that scopes them — safe now that an id names an
   invocation only within its session.

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -412,7 +412,7 @@ run_piece_links() {
   # The slug index: both names just assigned are enumerable, and each resolves
   # to a piece. Names are compared exactly; the resolved ids are only checked
   # non-null, because an address is something to read next, not an identifier
-  # to compare (docs/common/verb-session-walkthrough.md, "An address is not an
+  # to compare (docs/common/verbs/session-walkthrough.md, "An address is not an
   # identifier to compare").
   SLUGS_JSON=$(cf piece slugs $SPACE_ARGS --json)
   echo "$SLUGS_JSON" | jq -e '[.[].slug] == ["counter-alias", "resolved-counter"]' > /dev/null ||
@@ -1036,7 +1036,7 @@ run_three_topic_fixture() {
 
 # The verb-result walkthrough. Delegates to the standalone script rather than
 # restating its assertions here: that script is what
-# docs/common/verbs-over-the-cli.md tells a reader to run, so the documented
+# docs/common/verbs/over-the-cli.md tells a reader to run, so the documented
 # artifact is the tested one and the two cannot drift. It deploys its own
 # fixture and takes its own space.
 #

--- a/packages/cli/integration/pattern/tracker.tsx
+++ b/packages/cli/integration/pattern/tracker.tsx
@@ -1,5 +1,5 @@
 /**
- * Fixture for the CLI verb-session demo (`docs/common/verb-session-walkthrough.md`).
+ * Fixture for the CLI verb-session demo (`docs/common/verbs/session-walkthrough.md`).
  *
  * It exists so the demo owns its subject: the shipped patterns are used
  * elsewhere, and a change to one of them should never break a demonstration of

--- a/packages/cli/integration/pattern/verb-results.tsx
+++ b/packages/cli/integration/pattern/verb-results.tsx
@@ -1,6 +1,6 @@
 /**
  * Fixture for the verb-result walkthrough (`verbs-over-the-cli.sh`, documented
- * in `docs/common/verbs-over-the-cli.md`).
+ * in `docs/common/verbs/over-the-cli.md`).
  *
  * It exists so the walkthrough owns its subject: the shipped patterns are used
  * elsewhere, and a change to one of them should never break a demonstration of

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -268,6 +268,16 @@ CSRF=$(printf '%s' "$OUT" | jq -r '.[] | select(.title=="CSRF tokens")."$link"')
 act "7 · A verb returns what only the pattern could compute"
 say "The note's timestamp is the pattern's; the caller never supplied one."
 run cf call -s "$SPACE" "$EPIC" recordNote -- --body "blocked on the cookie spec"
+# The receipt out of the run just shown, not a second call. Every invocation
+# envelope carries one, and it is an address like any other.
+RECEIPT=$(printf '%s' "$OUT" | jq -r '.receipt')
+say "Act 6 asked a read twice. A call cannot be asked twice — it would run the"
+say "handler again — but it does not need to be: the outcome is durable at an"
+say "address, and every envelope above has carried it as 'receipt'."
+run cf get -s "$SPACE" "$RECEIPT" --select note,noteCount
+say "The same answer, and the timestamp is the proof. Reading a receipt is an"
+say "ordinary read, so the body did not run a second time — had it, the clock"
+say "would have moved."
 
 act "8 · Finishing reports what the caller could not know"
 say "openBelow walks the whole subtree — a caller would need N reads to learn it."

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -52,9 +52,10 @@ if [ -z "${CF_IDENTITY:-}" ]; then
 fi
 export CF_IDENTITY
 # An invocation session scopes the ids act 7 replays under. It belongs in the
-# environment rather than on a command line: it is closer to a secret than a
-# setting — it is what keeps an outcome's address out of a stranger's reach,
-# and arguments are readable in a process listing where the environment is not.
+# environment rather than on a command line: it is what keeps an outcome's
+# address out of a stranger's reach, and keeping it out of argv keeps it out of
+# shell history and the default process listing. That is a reduction in casual
+# exposure, not secret storage — `ps -E` prints the environment too.
 if [ -z "${CF_INVOCATION_SESSION:-}" ]; then
   CF_INVOCATION_SESSION=$(cf invocation-session new 2>/dev/null)
 fi
@@ -306,12 +307,11 @@ say "Act 6 asked a read twice. A call cannot be asked twice — it would run the
 say "handler again — but it does not need to be: the outcome is durable at an"
 say "address, and every envelope above has carried it as 'receipt'."
 run cf get -s "$SPACE" "$RECEIPT" --select note,noteCount
-say "The same outcome, and noteCount is what proves it: notes are append-only,"
-say "so a readback that re-ran the handler would leave two behind and answer 2."
-say "The stamp cannot carry that proof — the sandbox clock is coarsened to one"
-say "second, so a re-execution here would land in the same second and agree."
-say "That it agrees says the receipt returned the ORIGINAL outcome, which is"
-say "the other thing worth knowing."
+say "The same outcome, without calling anything again. Note what this does"
+say "NOT prove on its own: a receipt is a frozen snapshot of what its handling"
+say "committed, so it reports that outcome whether or not anything else has"
+say "happened since. The board is the only place that can settle it, and this"
+say "act reads it at the end."
 say ""
 say "That route needs the address. The other one is for when you never got it"
 say "— a dropped connection, a response nobody saw. Name the call with an"
@@ -320,12 +320,19 @@ run cf call -s "$SPACE" --invocation note-retry "$EPIC" recordNote -- --body "fi
 say "Replaying that id hands back the original. The payload below is"
 say "deliberately different text, and it does not take:"
 run cf call -s "$SPACE" --invocation note-retry "$EPIC" recordNote -- --body "a different body entirely"
-say "Same body, same stamp, same count, and the same receipt — the second"
-say "call wrote nothing. The envelope says so itself: deduplicated: true, a"
-say "field the first call did not carry. An id"
+say "Same body, same receipt — and deduplicated: true, a field the first call"
+say "did not carry. The same caution applies: a replay is DEFINED to hand the"
+say "original snapshot back, so the envelope would look like this whether or"
+say "not a second note actually landed. An id"
 say "is only half the handle: it is scoped to an invocation session, so one"
 say "agent's note-retry is not another's, which is why the session is exported"
 say "above rather than typed here."
+say "So read the board, which is where a second note would show up. Two"
+say "entries, from the two calls that committed — and the replay's text is"
+say "not among them:"
+run cf get -s "$SPACE" "$EPIC" notes --select body
+say "That is the proof, and it is the only one that holds: the envelopes"
+say "above could not have told you."
 say "The caveat that keeps this honest: the replay DOES run the handler body"
 say "again, and then loses the race for the receipt. Nothing commits twice,"
 say "but a verb that sends mail or spends a model call has already done it."

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -217,7 +217,22 @@ run cf call -s "$SPACE" --piece board addItem -- --help
 
 act "4 · Create, and act on what you were handed"
 say "The create returns the piece it made. Its address is the next command's target."
+say ""
+say "--select names the shape of the answer, and this is its first use, so:"
+say "a comma-separated list of fields, a dot to walk into one, and a trailing"
+say "@ meaning 'the address of this position, not the contents behind it'."
+say "So item@ says hand back where the new item lives rather than a copy of"
+say "it — and an address is what the rest of the session is built on."
 run cf call -s "$SPACE" --piece board --select item@ addItem -- --title "Login rewrite"
+say "The @ renders under the key \$link, which is the spelling every address"
+say "in this transcript arrives in. Capturing one in your own shell is a single"
+say "jq hop — and the quotes around \$link are load-bearing, since jq reads a"
+say "bare \$link as one of its own variables:"
+say ""
+say "    jq -r '.result.item.\"\$link\"'"
+say ""
+say "That is the exact expression the next line of this script runs against the"
+say "output you just saw — not a second call."
 # The address the reader can see in the output above, carried whole. Taken
 # from that run, not from a second one: `run` leaves the output it displayed
 # in $OUT. It is one reference string, used exactly as printed: `get` and
@@ -247,9 +262,16 @@ say "re-enters answers with an address, so the whole result is still one value."
 # callable's own command line, so a flag after it belongs to the verb.
 run cf call -s "$SPACE" --select item.title "$EPIC" addChild -- --title "CSRF tokens"
 say "And a caller who names one field is given one field, circle or no circle."
+say "item.title is the dotted form: it walks into item and keeps title. Note it"
+say "prunes rather than flattens — the answer is still shaped like the result,"
+say "with everything the caller did not ask for gone."
 
 act "5 · Read addresses instead of contents"
-say "An unshaped read follows every link. A bare @ stops at the address."
+say "The same two spellings, now on a read of a collection. An unshaped read"
+say "follows every link and copies what it finds; @ on its own names the"
+say "position being read rather than its contents, and applies to each element"
+say "when it crosses an array — so this asks for every child's address, with"
+say "its title beside it."
 run cf get -s "$SPACE" "$EPIC" children --select @,title
 
 act "6 · Ask the same question twice"

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -6,7 +6,7 @@
 # the transcript is the artifact. Its companion `verb-session-gaps.sh` asserts
 # the same surface as pass/fail and is what keeps this one honest.
 #
-# docs/common/verb-session-walkthrough.md is the prose half: why the fixture
+# docs/common/verbs/session-walkthrough.md is the prose half: why the fixture
 # declares the verbs it does, and which shape of the surface each act is here
 # to show. An act added here without a row there is an act nobody can place.
 #

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -16,16 +16,13 @@
 # line that ran cannot drift apart. What a reader sees is what they can retype,
 # given the two environment variables the header names.
 #
-# No act is marked PENDING today. `pending` stays for the next capability
-# that is sequenced but unbuilt: it prints the command and the result it will
-# produce, without running it, so what does not work yet stays deliberately
-# visible — a demo that quietly omits what does not work teaches a surface
-# that does not exist.
-#
-# No act is marked BROKEN today. `broken` stays for the next one that is: it
-# checks that the defect an act claims still answers to its own signature, so
-# an act cannot go on asserting a defect that has been fixed. Deriving that
-# again from scratch is how it acquires the same hole twice.
+# Every act carries a claim, and the script checks all three kinds: an
+# unmarked act says the command works, a REFUSED one says the surface turns
+# this down, and a BROKEN one says a named defect is still there. Two further
+# helpers, `pending` and `broken`, are defined and unused today — they are how
+# an unbuilt or defective capability stays deliberately visible rather than
+# being quietly omitted. Each carries its full contract at its definition
+# below; a reader who never sees one fire does not need them here.
 #
 #   API_URL=http://localhost:8000 packages/cli/integration/verb-session-demo.sh
 set -uo pipefail
@@ -256,7 +253,8 @@ say "An unshaped read follows every link. A bare @ stops at the address."
 run cf get -s "$SPACE" "$EPIC" children --select @,title
 
 act "6 · Ask the same question twice"
-say "The first thing anyone watching says is 'show me that again'."
+say "The same command as act 5, deliberately — because the first thing anyone"
+say "watching a live system says is 'show me that again'."
 run cf get -s "$SPACE" "$EPIC" children --select @,title
 say "The same answer. A projection is a question you may ask twice, which is"
 say "what makes any of the reads above safe to put in a script — as here: the"

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -14,7 +14,7 @@
 # There is no second, prettier spelling of it anywhere in this file: `run` and
 # `broken` display `"$@"` and execute `"$@"`, so a line that reads well and a
 # line that ran cannot drift apart. What a reader sees is what they can retype,
-# given the two environment variables the header names.
+# given the environment variables the header names.
 #
 # Every act carries a claim, and the script checks all three kinds: an
 # unmarked act says the command works, a REFUSED one says the surface turns
@@ -51,6 +51,14 @@ if [ -z "${CF_IDENTITY:-}" ]; then
   cf id new >"$CF_IDENTITY" 2>/dev/null
 fi
 export CF_IDENTITY
+# An invocation session scopes the ids act 7 replays under. It belongs in the
+# environment rather than on a command line: it is closer to a secret than a
+# setting — it is what keeps an outcome's address out of a stranger's reach,
+# and arguments are readable in a process listing where the environment is not.
+if [ -z "${CF_INVOCATION_SESSION:-}" ]; then
+  CF_INVOCATION_SESSION=$(cf invocation-session new 2>/dev/null)
+fi
+export CF_INVOCATION_SESSION
 SPACE="${SPACE:-$(mktemp -u demoXXXXXXXX)}"
 
 B=$'\033[1m'; D=$'\033[2m'; C=$'\033[36m'; Y=$'\033[33m'; N=$'\033[0m'
@@ -187,7 +195,8 @@ say "and verbs. Deploying one makes a piece — a running instance. Both live in
 say "a space, the shared durable place every command below names with -s."
 say ""
 say "space $SPACE · nothing here was written for this pattern"
-say "CF_API_URL=$CF_API_URL and CF_IDENTITY are exported; everything else you see"
+say "CF_API_URL=$CF_API_URL, CF_IDENTITY and CF_INVOCATION_SESSION are exported;"
+say "everything else you see"
 say "is the whole command."
 
 act "1 · Arrive by name"
@@ -303,6 +312,23 @@ say "The stamp cannot carry that proof — the sandbox clock is coarsened to one
 say "second, so a re-execution here would land in the same second and agree."
 say "That it agrees says the receipt returned the ORIGINAL outcome, which is"
 say "the other thing worth knowing."
+say ""
+say "That route needs the address. The other one is for when you never got it"
+say "— a dropped connection, a response nobody saw. Name the call with an"
+say "--invocation id and the id itself becomes the handle."
+run cf call -s "$SPACE" --invocation note-retry "$EPIC" recordNote -- --body "first attempt"
+say "Replaying that id hands back the original. The payload below is"
+say "deliberately different text, and it does not take:"
+run cf call -s "$SPACE" --invocation note-retry "$EPIC" recordNote -- --body "a different body entirely"
+say "Same body, same stamp, same count, and the same receipt — the second"
+say "call wrote nothing. The envelope says so itself: deduplicated: true, a"
+say "field the first call did not carry. An id"
+say "is only half the handle: it is scoped to an invocation session, so one"
+say "agent's note-retry is not another's, which is why the session is exported"
+say "above rather than typed here."
+say "The caveat that keeps this honest: the replay DOES run the handler body"
+say "again, and then loses the race for the receipt. Nothing commits twice,"
+say "but a verb that sends mail or spends a model call has already done it."
 
 act "8 · Finishing reports what the caller could not know"
 say "openBelow walks the whole subtree — a caller would need N reads to learn it."

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -297,9 +297,12 @@ say "Act 6 asked a read twice. A call cannot be asked twice — it would run the
 say "handler again — but it does not need to be: the outcome is durable at an"
 say "address, and every envelope above has carried it as 'receipt'."
 run cf get -s "$SPACE" "$RECEIPT" --select note,noteCount
-say "The same answer, and the timestamp is the proof. Reading a receipt is an"
-say "ordinary read, so the body did not run a second time — had it, the clock"
-say "would have moved."
+say "The same outcome, and noteCount is what proves it: notes are append-only,"
+say "so a readback that re-ran the handler would leave two behind and answer 2."
+say "The stamp cannot carry that proof — the sandbox clock is coarsened to one"
+say "second, so a re-execution here would land in the same second and agree."
+say "That it agrees says the receipt returned the ORIGINAL outcome, which is"
+say "the other thing worth knowing."
 
 act "8 · Finishing reports what the caller could not know"
 say "openBelow walks the whole subtree — a caller would need N reads to learn it."

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -296,6 +296,21 @@ check "1" "$(echo "$N" | jq -r '.result.noteCount // empty')" \
 AT=$(echo "$N" | jq -r '.result.note.at // 0')
 [ "$AT" -gt 0 ] && ok "and a timestamp the caller never supplied ($AT)" ||
   bad "no pattern-stamped time on the note"
+# The receipt is an address like any other, and reading it is an ordinary read.
+# The stamp is the discriminator: a readback that re-ran the handler would mint
+# a new one, so an unchanged `at` is what proves the body did not run again.
+# Asserted against the SAME field rather than against the whole envelope, which
+# carries an invocation id that legitimately differs between the two.
+RCPT=$(echo "$N" | jq -r '.receipt // empty')
+if [ -z "$RCPT" ]; then
+  bad "the settled envelope named no receipt to read back"
+else
+  RB=$($CF get --quiet --piece "$RCPT" $ARGS --select note,noteCount 2>/dev/null)
+  check "1" "$(echo "$RB" | jq -r '.noteCount // empty')" \
+    "the receipt reads the outcome back without calling anything again"
+  check "$AT" "$(echo "$RB" | jq -r '.note.at // 0')" \
+    "and the stamp is unchanged, so the handler did not run a second time"
+fi
 
 step "8. Finishing reports what the caller could not know"
 # Exit code checked for the same reason as step 4's creates.

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -56,6 +56,12 @@ if [ -z "${CF_IDENTITY:-}" ]; then
   $CF id new >"$CF_IDENTITY" 2>/dev/null
 fi
 ARGS="--api-url=$API_URL --identity=$CF_IDENTITY --space=$SPACE"
+# An id alone does not name an invocation — the session it was chosen within is
+# the other half, and `--invocation` is refused without one.
+if [ -z "${CF_INVOCATION_SESSION:-}" ]; then
+  CF_INVOCATION_SESSION=$($CF invocation-session new 2>/dev/null)
+fi
+export CF_INVOCATION_SESSION
 echo "API_URL=$API_URL"
 echo "SPACE=$SPACE"
 
@@ -315,6 +321,25 @@ else
   check "$AT" "$(echo "$RB" | jq -r '.note.at // 0')" \
     "and the outcome it returns is the original one, stamp and all"
 fi
+# The other recovery route: no address kept, so the id is the handle. The
+# replay carries a DIFFERENT payload on purpose — if it took, the body would
+# come back as the second text and the count would climb, so the assertions
+# below distinguish a genuine replay from a second append rather than trusting
+# that the two calls looked alike.
+R1=$($CF call --quiet --piece "$EPIC" $ARGS --invocation note-retry \
+  recordNote '{"body":"first attempt"}' 2>/dev/null)
+R1_AT=$(echo "$R1" | jq -r '.result.note.at // 0')
+R1_COUNT=$(echo "$R1" | jq -r '.result.noteCount // empty')
+R2=$($CF call --quiet --piece "$EPIC" $ARGS --invocation note-retry \
+  recordNote '{"body":"a different body entirely"}' 2>/dev/null)
+check "first attempt" "$(echo "$R2" | jq -r '.result.note.body // empty')" \
+  "replaying a settled id hands back the original result, not the new payload"
+check "$R1_COUNT" "$(echo "$R2" | jq -r '.result.noteCount // empty')" \
+  "and appends nothing — the count is the one the first call reported"
+check "$R1_AT" "$(echo "$R2" | jq -r '.result.note.at // 0')" \
+  "and the stamp is the first call's"
+check "true" "$(echo "$R2" | jq -r '.deduplicated // false')" \
+  "and the envelope says so itself, rather than leaving a caller to infer it"
 
 step "8. Finishing reports what the caller could not know"
 # Exit code checked for the same reason as step 4's creates.

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -302,44 +302,43 @@ check "1" "$(echo "$N" | jq -r '.result.noteCount // empty')" \
 AT=$(echo "$N" | jq -r '.result.note.at // 0')
 [ "$AT" -gt 0 ] && ok "and a timestamp the caller never supplied ($AT)" ||
   bad "no pattern-stamped time on the note"
-# The receipt is an address like any other, and reading it is an ordinary read.
-# `noteCount` is the discriminator, NOT the stamp: `notes` is append-only, so a
-# readback that re-ran the handler would leave two notes behind and answer 2.
-# The stamp cannot carry that weight — the sandbox clock is coarsened to one
-# second (see `Note.at` in pattern/tracker.tsx), and a re-execution during a
-# readback lands in the same second as the call it followed, so the two stamps
-# would agree in precisely the case this is meant to catch. Equal stamps show
-# the readback returned the ORIGINAL outcome rather than a freshly computed
-# one, which is worth asserting, but it is corroboration and not the proof.
+# Both recovery routes are asserted against the LIVE piece, not against what
+# the envelope reports. A receipt is a frozen snapshot of the outcome its
+# handling committed, and a replay is defined to hand that same snapshot back —
+# so an envelope shows the original count and body whether or not a second
+# append actually landed. Only reading the item's own `notes` afterwards can
+# tell those apart, which makes the live length the discriminator for both.
+notes_len() { $CF get --quiet --piece "$EPIC" $ARGS notes 2>/dev/null | jq 'length'; }
+LIVE0=$(notes_len)
 RCPT=$(echo "$N" | jq -r '.receipt // empty')
 if [ -z "$RCPT" ]; then
   bad "the settled envelope named no receipt to read back"
 else
   RB=$($CF get --quiet --piece "$RCPT" $ARGS --select note,noteCount 2>/dev/null)
+  check "blocked on the cookie spec" "$(echo "$RB" | jq -r '.note.body // empty')" \
+    "the receipt address holds the outcome that handling committed"
   check "1" "$(echo "$RB" | jq -r '.noteCount // empty')" \
-    "the receipt reads the outcome back, and appended nothing — the handler did not run again"
-  check "$AT" "$(echo "$RB" | jq -r '.note.at // 0')" \
-    "and the outcome it returns is the original one, stamp and all"
+    "and reading it hands that outcome back without calling anything again"
+  check "$LIVE0" "$(notes_len)" \
+    "and the piece is untouched by the read — no note was appended"
 fi
-# The other recovery route: no address kept, so the id is the handle. The
-# replay carries a DIFFERENT payload on purpose — if it took, the body would
-# come back as the second text and the count would climb, so the assertions
-# below distinguish a genuine replay from a second append rather than trusting
-# that the two calls looked alike.
+
+# The other route: no address kept, so the id is the handle. The replay carries
+# a DIFFERENT payload on purpose, so a returned body of the FIRST text is
+# evidence the second call's event never became an outcome.
 R1=$($CF call --quiet --piece "$EPIC" $ARGS --invocation note-retry \
   recordNote '{"body":"first attempt"}' 2>/dev/null)
-R1_AT=$(echo "$R1" | jq -r '.result.note.at // 0')
-R1_COUNT=$(echo "$R1" | jq -r '.result.noteCount // empty')
+LIVE1=$(notes_len)
 R2=$($CF call --quiet --piece "$EPIC" $ARGS --invocation note-retry \
   recordNote '{"body":"a different body entirely"}' 2>/dev/null)
 check "first attempt" "$(echo "$R2" | jq -r '.result.note.body // empty')" \
   "replaying a settled id hands back the original result, not the new payload"
-check "$R1_COUNT" "$(echo "$R2" | jq -r '.result.noteCount // empty')" \
-  "and appends nothing — the count is the one the first call reported"
-check "$R1_AT" "$(echo "$R2" | jq -r '.result.note.at // 0')" \
-  "and the stamp is the first call's"
+check "$(echo "$R1" | jq -r '.receipt // empty')" "$(echo "$R2" | jq -r '.receipt // empty')" \
+  "and names the same receipt the first call did"
 check "true" "$(echo "$R2" | jq -r '.deduplicated // false')" \
-  "and the envelope says so itself, rather than leaving a caller to infer it"
+  "and says so itself, rather than leaving a caller to infer it"
+check "$LIVE1" "$(notes_len)" \
+  "and the piece is unchanged — the replay committed no second note"
 
 step "8. Finishing reports what the caller could not know"
 # Exit code checked for the same reason as step 4's creates.

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -297,19 +297,23 @@ AT=$(echo "$N" | jq -r '.result.note.at // 0')
 [ "$AT" -gt 0 ] && ok "and a timestamp the caller never supplied ($AT)" ||
   bad "no pattern-stamped time on the note"
 # The receipt is an address like any other, and reading it is an ordinary read.
-# The stamp is the discriminator: a readback that re-ran the handler would mint
-# a new one, so an unchanged `at` is what proves the body did not run again.
-# Asserted against the SAME field rather than against the whole envelope, which
-# carries an invocation id that legitimately differs between the two.
+# `noteCount` is the discriminator, NOT the stamp: `notes` is append-only, so a
+# readback that re-ran the handler would leave two notes behind and answer 2.
+# The stamp cannot carry that weight — the sandbox clock is coarsened to one
+# second (see `Note.at` in pattern/tracker.tsx), and a re-execution during a
+# readback lands in the same second as the call it followed, so the two stamps
+# would agree in precisely the case this is meant to catch. Equal stamps show
+# the readback returned the ORIGINAL outcome rather than a freshly computed
+# one, which is worth asserting, but it is corroboration and not the proof.
 RCPT=$(echo "$N" | jq -r '.receipt // empty')
 if [ -z "$RCPT" ]; then
   bad "the settled envelope named no receipt to read back"
 else
   RB=$($CF get --quiet --piece "$RCPT" $ARGS --select note,noteCount 2>/dev/null)
   check "1" "$(echo "$RB" | jq -r '.noteCount // empty')" \
-    "the receipt reads the outcome back without calling anything again"
+    "the receipt reads the outcome back, and appended nothing — the handler did not run again"
   check "$AT" "$(echo "$RB" | jq -r '.note.at // 0')" \
-    "and the stamp is unchanged, so the handler did not run a second time"
+    "and the outcome it returns is the original one, stamp and all"
 fi
 
 step "8. Finishing reports what the caller could not know"

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -9,7 +9,7 @@
 # many are open is tallied as they run and printed on the last line, so no
 # prose here can fall out of step with the assertions below.
 #
-# Documented in docs/common/verb-session-walkthrough.md.
+# Documented in docs/common/verbs/session-walkthrough.md.
 #
 # It deploys pattern/tracker.tsx and nothing else. That fixture belongs to this
 # session alone, so a change to a pattern the product ships can never break a

--- a/packages/cli/integration/verbs-over-the-cli.sh
+++ b/packages/cli/integration/verbs-over-the-cli.sh
@@ -2,7 +2,7 @@
 # The verb-result walkthrough: deploy a pattern, introspect its verbs, call
 # them, and read what they return.
 #
-# Documented in docs/common/verbs-over-the-cli.md, which explains the model
+# Documented in docs/common/verbs/over-the-cli.md, which explains the model
 # this exercises. Keep the two in step: the doc is the explanation, this is the
 # proof, and each names the other.
 #

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -466,7 +466,7 @@ mounts; auto-discovered spaces may appear writable but silently drop writes.
 
 ## References
 
-- `docs/common/verbs-over-the-cli.md` - The verb walkthrough: invocation ids and
+- `docs/common/verbs/over-the-cli.md` - The verb walkthrough: invocation ids and
   sessions, receipts, retries, and shaped reads, each step runnable
 - `packages/patterns/system/default-app.tsx` - System pieces (pieceRegistry
   lives here)

--- a/tasks/check-verb-session-sync.ts
+++ b/tasks/check-verb-session-sync.ts
@@ -2,7 +2,7 @@
 /**
  * Fails when the verb-session walkthrough drifts from the demo that runs it.
  *
- * The walkthrough (`docs/common/verb-session-walkthrough.md`) may QUOTE
+ * The walkthrough (`docs/common/verbs/session-walkthrough.md`) may QUOTE
  * commands but never compose them: every `cf` line in one of its bash blocks
  * must be a command `packages/cli/integration/verb-session-demo.sh` actually
  * runs, or sit under a `# not in the demo` comment saying why it cannot be.
@@ -29,7 +29,7 @@ import { dirname, fromFileUrl, join } from "@std/path";
 
 const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
 export const DEMO_PATH = "packages/cli/integration/verb-session-demo.sh";
-export const WALKTHROUGH_PATH = "docs/common/verb-session-walkthrough.md";
+export const WALKTHROUGH_PATH = "docs/common/verbs/session-walkthrough.md";
 
 /** The comment that exempts the next `cf` line in a walkthrough bash block.
  * The marker alone is not enough: an exemption without a reason is one


### PR DESCRIPTION
## Why

These documents are about to be handed to people who have not worked on this
surface, and reading them cold showed they assume more than a newcomer has.
The worst of it was structural: the walkthrough counted in **steps** while the
demo counted in **acts**, and the two diverged after 3 — step 5 was act 4,
step 6 was act 10 — with nothing saying so, so anyone reading with the
transcript open lined up the wrong things.

Working through that surfaced a second class of problem, which is the more
interesting one: **two capabilities the session leans on were never
demonstrated anywhere.** Every settled envelope printed a `receipt` and
nothing ever read one. Every call could be replayed under an `--invocation`
id and nothing ever did. Both are the answer to a question a caller actually
has — *my command died and I never saw the response* — and the session raised
the topic while showing neither.

## What changed

### The documents

**The verb documents get a directory.** Everything else under `docs/common/`
sits in a subdirectory; these sat at the top level because the first one
landed there and the second followed, and the README already filed them under
a heading they did not live in. Now `docs/common/verbs/`, joined by a third
split out of the walkthrough's step 3 — where an author's doc comments go, and
which of the two documents `cf` reads carries what. ~20 inbound references
updated, including a CI task's hardcoded path.

**An act-first map covering all thirteen acts**, because the reader who needs
it has just watched a beat and wants the reasoning. Writing it that way forced
honesty about coverage — a draft claiming step 5 covered "acts 4–9" was wrong,
since three of those had no prose at all. Two gaps closed: **act 11's
refusals** (a typo'd field and an unrecognized projection keyword, answered in
one voice by two unrelated pieces of code) became step 7, and **act 6's
read-repeats-freely** lesson got its missing other half.

**Steps 5–8 show what comes back.** Every block is real output from one
coherent run, which caught a wrong assumption: reusing the demo's transcript
would have printed `"archived"` where the walkthrough actually answers
`"open"`, because the demo reads a different item there.

**`--select` is taught where it is first used** — it was used an act before
its `@` suffix was defined, and the dotted form was defined nowhere — along
with the fact nobody had stated: an address arrives under the key `$link`,
which is why that key is all over the output. The `jq` that lifts an address
out of a response was in a script comment the viewer never sees; it is
narrated now, including why the quotes in `."$link"` are load-bearing.

**File references are links** against the default branch, using
reference-style definitions so the URLs stay out of the prose, matching
`docs/specs/data-model/sigil.md`. The `[today]`/`[blocked]` marks are gone —
`[blocked]` was defined and never used.

### The session itself

**A call's outcome is now shown to outlive the call, both ways.** Act 7 reads
back the receipt of the call it just made, then replays the same invocation id
with **deliberately different text** — and the original body, stamp, count and
receipt come back, with `deduplicated` in the envelope rather than left for a
caller to infer. The different payload is what makes the assertions
discriminating: identical text could not tell a replay from a second append.

The harness asserts both routes — **44 checks, up from 38** — and the scripts
mint an invocation session into the environment, where it belongs: closer to a
secret than a setting, and arguments are readable in a process listing where
the environment is not.

## Corrections from review

Three claims were wrong and are fixed, each verified against the code first:

- **The receipt proof was backwards.** It rested on the timestamp, but the
  sandbox clock is coarsened to one second, and a readback that re-ran the
  handler lands in the same second as the call it followed — so the stamps
  would agree in exactly the case being ruled out. `notes` is append-only, so
  `noteCount` is the sound discriminator; equal stamps are kept as
  corroboration.
- **The retry sentence taught an unsafe rule.** The guarantee is at-most-once
  *commit*, not at-most-once *execution*: the handler body re-runs and loses
  the race for the receipt, so effects outside the transaction repeat. Stated
  locally rather than deferred to the linked guide.
- **"Repeated reads return the same answer"** overstated it. Asking a read
  again has no effect; that is the invariant. It is not a promise two reads
  agree, and they agree here only because nothing else writes to this fixture.

## Test plan

- `verb-session-demo.sh`: exit 0, all five refusals matched against their own
  signatures.
- `verb-session-gaps.sh`: **44 passed, 0 failed, 0 gaps** in 25s.
- Both new assertion groups verified able to fail: replacing the receipt read
  with a second `recordNote` call fails them (`expected [1], got [2]`).
- Every markdown link in the repo resolves; every source link points at a file
  that exists; no reference definition undefined or orphaned.
- `check-verb-session-sync`, `check-docs`, `check-docs-history-index`,
  `check-skill-facts`, `check-conflict-markers`, `deno fmt --check` all pass.

Docs and integration scripts only — no runtime or library code. An illustrated
companion for readers new to patterns is linked from the walkthrough's header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
