### PR TITLE
refactor(topics): drop every computed() wrapper the language now spells bare

### DIFF
--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -1,6 +1,5 @@
 import {
   action,
-  computed,
   Default,
   equals,
   handler,
@@ -315,9 +314,9 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
   // the fields once here would pin the composer to the empty profile the board
   // started with: the Start button never enables, and a topic filed through it
   // carries blank attribution.
-  const profileName = computed(() => profileWish.result?.name ?? "");
-  const profileAvatar = computed(() => profileWish.result?.avatar ?? "");
-  const hasProfile = computed(() => profileName.trim().length > 0);
+  const profileName = profileWish.result?.name ?? "";
+  const profileAvatar = profileWish.result?.avatar ?? "";
+  const hasProfile = profileName.trim().length > 0;
 
   const addTopic = action<AddTopicEvent, AddTopicResult>((
     { title, body, agentName },

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -2,7 +2,6 @@ import {
   action,
   cellFromUrl,
   type ComparableCell,
-  computed,
   Default,
   equals,
   handler,
@@ -780,9 +779,9 @@ export default pattern<TopicInput, TopicOutput>(
     // the fields once here would pin the page to the empty profile the topic
     // opened with: the composer's controls never enable, and a comment or edit
     // made through them carries blank attribution.
-    const profileName = computed(() => profileWish.result?.name ?? "");
-    const profileAvatar = computed(() => profileWish.result?.avatar ?? "");
-    const hasProfile = computed(() => profileName.trim().length > 0);
+    const profileName = profileWish.result?.name ?? "";
+    const profileAvatar = profileWish.result?.avatar ?? "";
+    const hasProfile = profileName.trim().length > 0;
     const createdByView = createdByOf({ createdBy, createdByName });
 
     // --- Streams (external API; also usable headlessly via CLI) ---
@@ -958,15 +957,9 @@ export default pattern<TopicInput, TopicOutput>(
       bodyUpdatedAt,
     });
 
-    // `computed()` here and for `linksView` below is not ceremony: a `.get()`
-    // whose result is the array itself — bare, or fed to a callback-taking
-    // method — is the shape the transformer rejects at pattern scope. Scalar
-    // reductions like `comments.get().length` need no wrapper.
-    const commentsView = computed(() =>
-      comments.get().toSorted((a, b) => a.sentAt - b.sentAt)
-    );
+    const commentsView = comments.get().toSorted((a, b) => a.sentAt - b.sentAt);
 
-    const linksView = computed(() => links.get());
+    const linksView = links.get();
     const hasLinks = linksView.length > 0;
     const hasComments = commentCount > 0;
     const hasBody = body.get().trim().length > 0;
@@ -982,7 +975,7 @@ export default pattern<TopicInput, TopicOutput>(
     // also carries the editor's map and the link resolutions, and a control
     // here could not honestly retract either: a mention in the prose is removed
     // by editing the prose, and a link's reference belongs to the link.
-    const mentionedView = computed(() => mentioned.get());
+    const mentionedView = mentioned.get();
     const hasMentioned = mentionedView.length > 0;
 
     const topicName = title.get().trim() || "(untitled topic)";
@@ -1281,7 +1274,7 @@ export default pattern<TopicInput, TopicOutput>(
 
     // A link's URL, asked of `cellFromUrl` once per link. Most answer with no
     // cell — they are web pages — and those simply are not mentions.
-    const linkUrls = computed(() => links.get().map((link) => link.url ?? ""));
+    const linkUrls = links.get().map((link) => link.url ?? "");
     const linkTargets = linkUrls.map((url) => cellFromUrl({ url }));
     // Outbound: what this topic points at. Only this half depends on the
     // topic's own content, which is what keeps the board's join reading one


### PR DESCRIPTION
## What

Removes all ten `computed()` wrappers across the topics patterns — the cleanup that motivated the has-a-lowerable-site arc (#5454) in the first place, now that its follow-ups (#5797, #5919, #5930, #5939) lower every one of these shapes directly:

- `topic.tsx`: `commentsView`'s sorted read, the bare `linksView` and `mentionedView` reads, `linkUrls`' value-position map, and the profile wish-field trio (`profileName`/`profileAvatar`/`hasProfile`)
- `main.tsx`: the same wish-field trio
- The comment explaining the old rejection constraint goes with them; the note about wish fields staying derivations stands, since the lift is the derivation

Every binding still lowers into a lift with its result key unchanged (`.for("commentsView", …)` et al.), so this is spelling, not semantics.

## Verification

- `cf check` clean on both files; emitted output inspected — each removed wrapper became a site-lift (`profileName = __cfLift_1({ profileWish: … })`, `commentsView = __cfLift_5(…).for("commentsView", true)`, …)
- Topics pattern tests pass (lane-2 harness, all three files)
- Pattern coverage holds baseline exactly: `topic.tsx` 817 instrumented / 1 uncovered (the pre-existing crossref spread line; six fewer instrumented lines are the deleted wrapper lines themselves), `main.tsx` fully covered — the suite's render tripwire confirms the JSX paths, including the `hasProfile`-gated composer controls, still execute through the real reconciler
- `deno fmt --check` clean on touched files

The deployed board picks this up at its next redeploy; a glance at the composer enabling after profile-wish resolution is the one live-fire check worth making then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

