### PR TITLE
test(ts-transformers): pin both outcomes of the inline lift-applied map receiver

### DIFF
--- a/packages/ts-transformers/test/closures/array-method-policy-coverage.test.ts
+++ b/packages/ts-transformers/test/closures/array-method-policy-coverage.test.ts
@@ -125,4 +125,52 @@ describe("array-method-policy", () => {
 
     expect(shouldTransformArrayMethod(mapCall, context)).toBe(false);
   });
+
+  // The inline lift-applied receiver: `computed(() => …)` lowers to
+  // `__cfHelpers.lift(cb)(inputs)`, so a map chained straight onto the call —
+  // no local in between — takes this branch. Its transform-or-not turns on
+  // the surrounding context alone. `__cfHelpers` stays undeclared on
+  // purpose: emitted code's helper identifier resolves to no symbol, which
+  // is what routes recognition through the synthetic-helper path — declaring
+  // it here would instead match the shadowed-local refusal.
+  const INLINE_LIFT_APPLIED_MAP = `
+    const mapped = __cfHelpers.lift(() => [])({}).map((v) => v);
+  `;
+
+  function findInlineLiftAppliedMapCall(
+    sourceFile: ts.SourceFile,
+  ): ts.CallExpression {
+    let found: ts.CallExpression | undefined;
+    const visit = (node: ts.Node): void => {
+      if (
+        !found &&
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        node.expression.name.text === "map"
+      ) {
+        found = node;
+        return;
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+    if (!found) throw new Error("Expected a .map(...) call in the source");
+    return found;
+  }
+
+  it("transforms a map chained onto an inline lift-applied call in pattern context", () => {
+    const { sourceFile, checker } = createProgram(INLINE_LIFT_APPLIED_MAP);
+    const mapCall = findInlineLiftAppliedMapCall(sourceFile);
+    const context = testContext(checker, () => "pattern");
+
+    expect(shouldTransformArrayMethod(mapCall, context)).toBe(true);
+  });
+
+  it("leaves a map chained onto an inline lift-applied call alone in compute context", () => {
+    const { sourceFile, checker } = createProgram(INLINE_LIFT_APPLIED_MAP);
+    const mapCall = findInlineLiftAppliedMapCall(sourceFile);
+    const context = testContext(checker, () => "compute");
+
+    expect(shouldTransformArrayMethod(mapCall, context)).toBe(false);
+  });
 });


### PR DESCRIPTION
Follow-up to #5930's coverage work. A map chained straight onto an inline lift-applied call — `computed(() => …)` after lowering, no local in between — transforms in pattern context and stays untouched in compute context (`array-method-policy.ts`'s lift-applied branch). Neither outcome had a test executing it; they were also the package's last uncovered lines in that file, pre-dating #5930 (the ratchet never demanded them — this pins live behavior in the same crash class the gap-3 arc closed, and drops the group baseline).

One harness subtlety worth the comment it carries: `__cfHelpers` stays **undeclared** in the test program. Emitted code's helper identifier resolves to no symbol, which is what routes recognition through the synthetic-helper path — declaring it in the harness makes it a shadowed local with a CF-like name, which §5 correctly refuses to classify. (Found by the first draft doing exactly that.)

Verification: package suite green with the two new steps; local V8 coverage for `array-method-policy.ts` now reports zero uncovered lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

