### PR TITLE
refactor(runner): meta-linked docs are delivered whole, never schema-traversed

### DIFF
--- a/packages/memory/test/v2-query.test.ts
+++ b/packages/memory/test/v2-query.test.ts
@@ -1643,3 +1643,69 @@ Deno.test("memory v2 schema scan and verification caches stay bounded at scale",
     await Deno.remove(path);
   }
 });
+
+Deno.test("memory v2 delivers a meta-linked document that arrives after its referrer", async () => {
+  const { engine, path } = await createEngine();
+  const space = "did:key:z6Mk-memory-v2-meta-arrival";
+  try {
+    // The referrer's `pattern` meta link points at a document nothing has
+    // written yet. The absent target must still enter the tracker — the
+    // tracker is what makes the graph reactive — or its arrival would
+    // never reach this watch.
+    applyCommit(engine, {
+      sessionId: "session:meta-arrival-writer",
+      invocation: invocationFor(1),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "of:meta-arrival-referrer",
+          value: {
+            value: { n: 1 },
+            pattern: {
+              "/": {
+                "link@1": { id: "of:meta-arrival-target", path: [] },
+              },
+            },
+          },
+        }],
+      },
+    });
+    const tracked = trackGraph(space, engine, {
+      roots: [{
+        id: "of:meta-arrival-referrer",
+        selector: { path: [], schema: false },
+      }],
+    });
+    const targetKey = `${space}/space/of:meta-arrival-target` as const;
+    assert(tracked.state.tracker.has(targetKey));
+
+    applyCommit(engine, {
+      sessionId: "session:meta-arrival-writer",
+      invocation: invocationFor(2),
+      authorization,
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "of:meta-arrival-target",
+          value: { value: { arrived: true } },
+        }],
+      },
+    });
+    const refreshed = refreshTrackedGraph(
+      space,
+      engine,
+      tracked.state,
+      new Set([toDirtyKey("of:meta-arrival-target")]),
+    );
+    assertExists(refreshed);
+    assert(refreshed.updates.has(targetKey));
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -2537,14 +2537,18 @@ function loadMetaLinkedDocFromLink(
   if (address === undefined) {
     return undefined;
   }
-  // This read only loads the linked metadata doc so traversal can inspect it.
-  // The schema-guided traversal below records the real scheduling reads.
+  // Track the target before reading it: the tracker entry is what makes
+  // the graph reactive to this document — a change or a later arrival
+  // dirties a tracked key — so an absent-at-evaluation target must be
+  // tracked too, or nothing would re-run this load when it arrives. The
+  // read itself is deliberately not a scheduling read: delivery
+  // reactivity rides the tracker, not the runner scheduler.
+  const docKey = getTrackerKey(address);
+  schemaTracker.add(docKey, REJECTING_SELECTOR);
   const result = tx.read(address, { meta: ignoreReadForScheduling });
   if (result.error) {
     return undefined;
   }
-  const docKey = getTrackerKey(address);
-  schemaTracker.add(docKey, REJECTING_SELECTOR);
   return { address, value: result.ok.value };
 }
 

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -2461,7 +2461,7 @@ function loadMetaLinkedDoc(
   valueEntry: IMemorySpaceAttestation,
   meta: "cfc" | "result" | "pattern" | "argument" | "internal",
   schemaTracker: MapSet<string, SchemaPathSelector>,
-): MetaLinkedDoc[] {
+): IMemorySpaceAttestation[] {
   const targetObj = valueEntry.value as Immutable<JSONObject>;
   if (!isObjectOrArray(targetObj) || !(meta in targetObj)) return [];
   const loaded = [];
@@ -2545,7 +2545,7 @@ function loadMetaLinkedDocFromLink(
   }
   const docKey = getTrackerKey(address);
   schemaTracker.add(docKey, REJECTING_SELECTOR);
-  return { address, value: result.ok.value, selector: REJECTING_SELECTOR };
+  return { address, value: result.ok.value };
 }
 
 /**
@@ -2676,53 +2676,10 @@ function cfcMetaToSigilLink(obj: unknown): SigilLink | undefined {
   return undefined;
 }
 
-type MetaLinkedDoc = IMemorySpaceAttestation & {
-  selector: SchemaPathSelector;
-};
-
-function traverseMetaLinkedDoc(
-  tx: IExtendedStorageTransaction,
-  doc: MetaLinkedDoc,
-  context: TraversalContext,
-) {
-  if (
-    doc.selector.schema === undefined ||
-    ContextualFlowControl.isFalseSchema(doc.selector.schema)
-  ) {
-    return;
-  }
-  if (!isObjectOrArray(doc.value) || !("value" in doc.value)) {
-    return;
-  }
-
-  const docContext = createTraversalContext(
-    new CompoundCycleTracker<
-      FabricValue,
-      JSONSchema | undefined
-    >(),
-    context.schemaTracker,
-    context.includeMeta,
-    context.metaDocsVisited,
-    context.onMissingLinkTarget,
-    context.schemaDocsLoaded,
-    context.schemaDocsAvailable,
-  );
-  const traverser = new SchemaObjectTraverser(
-    tx,
-    doc.selector,
-    docContext,
-  );
-  const fullDoc = doc.value as Immutable<JSONObject>;
-  traverser.traverse({
-    address: {
-      ...doc.address,
-      path: ["value"],
-    },
-    value: fullDoc.value,
-  });
-}
-
-// Recursively load the meta linked docs from the doc
+// Recursively load the meta linked docs from the doc. Every loaded doc is
+// delivered whole — tracked under the rejecting selector — and never
+// schema-traversed; narrowing a meta document by schema is not a policy
+// this traversal has.
 export function loadMetaLinkedDocs(
   tx: IExtendedStorageTransaction,
   valueEntry: IMemorySpaceAttestation,
@@ -2760,7 +2717,6 @@ export function loadMetaLinkedDocs(
         const linkedDocKey = getTrackerKey(linkedDoc.address);
         if (context.metaDocsVisited.has(linkedDocKey)) continue;
         context.metaDocsVisited.add(linkedDocKey);
-        traverseMetaLinkedDoc(tx, linkedDoc, context);
         pendingDocs.push(linkedDoc);
       }
     }


### PR DESCRIPTION
`traverseMetaLinkedDoc` was structurally dead: `loadMetaLinkedDocFromLink` is the only constructor of `MetaLinkedDoc` and hardcodes `REJECTING_SELECTOR`, so the function's selector guard fired on every call and the schema-guided traversal behind it could never execute. It descends from the original client-side schema-query work, from an era when meta links plausibly carried real selectors; the policy has since settled on delivering meta documents whole.

This removes the function, the call, the `selector` field, and the `MetaLinkedDoc` type (~50 lines). The live machinery is untouched: `loadMetaLinkedDocs`' worklist still chases meta chains, `metaDocsVisited` still guards cycles, `cid:` documents are still skipped, and every loaded meta doc is still tracked under the rejecting selector — the delivery that carries it into query results and watch sets. The loader's comment now states the policy outright: narrowing a meta document by schema is not a policy this traversal has.

Also erases two of the five accepted defense-in-depth coverage-debt lines on `packages/runner` (the dead function's sub-context construction).

A second commit hardens the loader the removal exposed: its comment deferred the unscheduled read to "the schema-guided traversal below" — the traversal that never ran. Delivery reactivity in fact rides the tracker entry, so the comment now says that, and the entry moves ahead of the read, making the invariant unconditional: whatever the evaluation consulted is tracked, whatever the read outcome. Absence was already covered (the engine manager answers an absent document with an empty read, not an error — absent targets were tracked and their arrival delivered, now pinned by a memory test); the reorder extends coverage to error-class reads (a row that fails to decode, a permission failure), whose repair previously would not re-trigger the watch.

Verified: runner 1,236 tests (6,817 steps) + package type check, memory 517 tests, fmt, lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


