### PR TITLE
fix(data-model): every arm of a decode returns deep-frozen output

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -3979,12 +3979,16 @@ Visited objects are tracked in a per-call `Set` for cycle safety.
 The deep-freeze contract is enforced at the points where decoded
 values cross from internal codec machinery to callers:
 
-- **Every arm of the decode walker's dispatch.** Each value returned passes
-  through `deepFreeze()` before returning: the codec-produced value (often a
-  `FabricPrimitive` subclass, already frozen — the cache hit makes this
-  O(1)), the lenient-mode `ProblematicValue` fallback, and the unknown-tag
-  arm's `UnknownValue`. Which arm produced a value is therefore not something
-  a caller has to know. See Section 4.5 step 4.
+- **Every value the decode walker returns is deep-frozen at the boundary**,
+  whichever arm produced it. The arms reach that by two routes. A leaf arm
+  calls `deepFreeze()`: the codec-produced value (often a `FabricPrimitive`
+  subclass, already frozen — the cache hit makes this O(1)), the lenient-mode
+  `ProblematicValue` fallback, and the unknown-tag arm's `UnknownValue`. A
+  container arm calls `Object.freeze()` on the array or object it has just
+  built, whose children the leaf arms have already deep-frozen, so the
+  guarantee holds without walking them a second time. Which arm produced a
+  value is therefore not something a caller has to know. See Section 4.5
+  step 4.
 
 - **`ProblematicStateError.asProblematicValue()`.** The rendering of a thrown
   refusal as a returned value is deep-frozen where it is built, rather than at

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -2827,10 +2827,10 @@ Circular references are detected via a `Set<object>` tracked during the walk.
    from this arm
    are guaranteed deep-frozen at the walker boundary (the contract holds
    for both the codec-produced value and the lenient-mode
-   `ProblematicValue`), so callers need not each freeze. This contract is
-   scoped to this arm only; the unknown-tag arm (step 5) is intentionally
-   not covered. See Section 8.6 for the full deep-freeze protocol and the
-   egress-freezing call sites.
+   `ProblematicValue`), so callers need not each freeze. Every other arm
+   guarantees the same, the unknown-tag arm (step 5) included, so a caller
+   need not ask which arm produced what it was handed. See Section 8.6 for
+   the full deep-freeze protocol and the egress-freezing call sites.
 5. **Unknown tags** — a syntactically valid tag with no registered codec
    produces an `UnknownValue` wrapping the tag and (already-decoded) state,
    preserving the form for round-tripping (Section 3). Syntax is what
@@ -3979,14 +3979,17 @@ Visited objects are tracked in a per-call `Set` for cycle safety.
 The deep-freeze contract is enforced at the points where decoded
 values cross from internal codec machinery to callers:
 
-- **The decode walker's codec dispatch arm.**
-  Every value returned from this arm passes through `deepFreeze()` before
-  returning. This covers the codec-produced value (often a
+- **Every arm of the decode walker's dispatch.** Each value returned passes
+  through `deepFreeze()` before returning: the codec-produced value (often a
   `FabricPrimitive` subclass, already frozen — the cache hit makes this
-  O(1)) and the lenient-mode `ProblematicValue` fallback. The
-  unknown-tag arm (`UnknownValue`) is a separate sibling branch and is
-  intentionally NOT covered by this contract; broadening the contract
-  there is a separate follow-on. See Section 4.5 step 4.
+  O(1)), the lenient-mode `ProblematicValue` fallback, and the unknown-tag
+  arm's `UnknownValue`. Which arm produced a value is therefore not something
+  a caller has to know. See Section 4.5 step 4.
+
+- **`ProblematicStateError.asProblematicValue()`.** The rendering of a thrown
+  refusal as a returned value is deep-frozen where it is built, rather than at
+  each call site, so a caller reaching it outside the walker gets the same
+  guarantee.
 
 - **`JsonCodecValue` parse boundary.** The `#parseWireText()` helper
   (invoked by `decode()` and `#fromBytes()`) deep-freezes the parsed tree

--- a/packages/data-model/src/codec-common/BaseCodecEngine.ts
+++ b/packages/data-model/src/codec-common/BaseCodecEngine.ts
@@ -358,9 +358,9 @@ export abstract class BaseCodecEngine<
    * whatever a format found in tag position, of whatever type, and a subclass
    * is not expected to know what a tag may look like.
    *
-   * Frozen-ness contract: a value returned through the codec arm here is
-   * deep-frozen, so callers do not each have to freeze. The unknown-tag
-   * fallback is a separate arm and is intentionally NOT covered by it.
+   * Frozen-ness contract: every value returned from here is deep-frozen, so
+   * callers do not each have to freeze, and a caller need not ask which arm
+   * produced what it was handed.
    *
    * Three of the arms below walk the state again -- a nonterminal codec's, an
    * unknown tag's, and a malformed tag's -- and each carries `act` into that
@@ -393,9 +393,8 @@ export abstract class BaseCodecEngine<
 
     if (matched === undefined) {
       // A tag this registry does not carry, kept in the unknown form so that
-      // it round-trips. Not covered by the deep-frozen contract the codec arm
-      // below states.
-      return new UnknownValue(tag, this.decodeValue(rawState, act));
+      // it round-trips.
+      return deepFreeze(new UnknownValue(tag, this.decodeValue(rawState, act)));
     }
 
     // A terminal codec takes the state exactly as it arrived; a nonterminal

--- a/packages/data-model/src/codec-common/DecodeAct.ts
+++ b/packages/data-model/src/codec-common/DecodeAct.ts
@@ -86,8 +86,8 @@ export class DecodeAct extends BaseCodecAct {
     if (this.config.lenient && (e instanceof ProblematicStateError)) {
       // The error renders itself rather than being taken apart and rebuilt:
       // it already holds the three facts, normalized the way this class would
-      // normalize them.
-      return deepFreeze(e.asProblematicValue());
+      // normalize them, and hands back a deep-frozen value.
+      return e.asProblematicValue();
     }
 
     // Rethrown rather than rebuilt, strictly: the refusal already names its

--- a/packages/data-model/src/codec-common/ProblematicStateError.ts
+++ b/packages/data-model/src/codec-common/ProblematicStateError.ts
@@ -3,6 +3,7 @@ import { toCompactDebugString } from "@/value-debug.ts";
 import { toReportableState } from "./toReportableState.ts";
 import { toReportableTag } from "./toReportableTag.ts";
 import { ProblematicValue } from "./ProblematicValue.ts";
+import { deepFreeze } from "@/deep-freeze.ts";
 
 /**
  * Error thrown when a state cannot be decoded and the engine is not lenient.
@@ -62,9 +63,15 @@ export class ProblematicStateError extends Error {
    * of the same failure, in the form that is returned rather than thrown.
    * Both classes normalize a tag and a state the same way, so a value from
    * here is comparable with one built directly.
+   *
+   * Deep-frozen, because a decode returns one of these and every value a
+   * decode returns is deep-frozen. Freezing here rather than at each call
+   * site is what keeps that from depending on a caller remembering.
    */
   asProblematicValue(): ProblematicValue {
-    return new ProblematicValue(this.wireTypeTag, this.state, this.message);
+    return deepFreeze(
+      new ProblematicValue(this.wireTypeTag, this.state, this.message),
+    );
   }
 
   //

--- a/packages/data-model/src/codec-common/UnknownValue.ts
+++ b/packages/data-model/src/codec-common/UnknownValue.ts
@@ -56,7 +56,7 @@ export class UnknownValue extends BaseFabricInstance {
     }
 
     this.#wireTypeTag = wireTypeTag;
-    this.#state = state; // TODO(danfuzz): Should be guaranteed deep-frozen.
+    this.#state = state;
   }
 
   /** Arbitrary raw instance state. */

--- a/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
@@ -1744,14 +1744,50 @@ describe("JsonCodecEngine", () => {
       >;
       expect(Object.isFrozen(result)).toBe(true);
     });
+
+    // Every arm of the dispatch, so that the guarantee does not depend on
+    // which one produced the value. `isDeepFrozen()` rather than
+    // `Object.isFrozen()`: an arm that froze only the value it built, and not
+    // what it wrapped, would pass the shallow check.
+
+    it("an `UnknownValue` from an unrecognized tag is deep-frozen", () => {
+      const result = fromEncodedFormat(
+        { "/Nope@1": { a: 1 } } as JsonCodecValue,
+      );
+
+      expect(result).toBeInstanceOf(UnknownValue);
+      expect(isDeepFrozen(result)).toBe(true);
+    });
+
+    it("an `UnknownValue` is deep-frozen through its state", () => {
+      const result = fromEncodedFormat(
+        { "/Nope@1": { inner: { deep: [1, 2] } } } as JsonCodecValue,
+      ) as UnknownValue;
+      const state = result.state as { inner: { deep: unknown[] } };
+
+      expect(isDeepFrozen(result)).toBe(true);
+      expect(Object.isFrozen(state.inner)).toBe(true);
+      expect(Object.isFrozen(state.inner.deep)).toBe(true);
+    });
+
+    it("a `ProblematicValue` from a malformed tag is deep-frozen", () => {
+      // `malformed`, because the wrap helper validates with a strict decode
+      // and would otherwise reject the very payload this case is made of.
+      const result = fromEncodedFormat(
+        { "/": { a: 1 } } as JsonCodecValue,
+        true,
+      );
+
+      expect(result).toBeInstanceOf(ProblematicValue);
+      expect(isDeepFrozen(result)).toBe(true);
+    });
   });
 
   describe("`FabricCodec.decode()` deep-frozen contract", () => {
-    // The contract is scoped to the codec dispatch arm: anything returned via
-    // a registered `FabricCodec` is guaranteed deep-frozen at the `decode()`
-    // boundary, so callers do not each have to freeze. The unknown-tag
-    // fallback (`UnknownValue`) is a separate arm and is intentionally NOT
-    // covered by this contract.
+    // Anything returned via a registered `FabricCodec` is guaranteed
+    // deep-frozen at the `decode()` boundary, so callers do not each have to
+    // freeze. That holds of every other arm too, the unknown-tag fallback
+    // included; the cases just above cover those.
 
     it("codec-produced value is deep-frozen at the boundary", () => {
       // `/EpochNsec@1` dispatches through a registered codec; the


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

The unknown-tag arm of the decode walker handed back an `UnknownValue` that
was neither frozen nor deep-frozen, alone among the arms. It now goes through
`deepFreeze()` like every other.

## The measurement

Round-tripping through `newDefaultJsonCodecEngine()` and testing with
`isDeepFrozen()`, before this change:

| decoded | frozen | deep-frozen |
| --- | --- | --- |
| plain object, nested containers, array | yes | yes |
| primitive, and an object holding one | yes | yes |
| lenient malformed (`ProblematicValue`) | yes | yes |
| **unknown tag (`UnknownValue`)** | **no** | **no** |

So whether a decoded value could be mutated depended on which arm produced it
-- which is not something a caller can be expected to know, and not something
the type says.

## Which of two claims wins

The tree stated both. `decodeTagged()` excused the arm: "The unknown-tag
fallback is a separate arm and is intentionally NOT covered by it." The header
of `test/codec-json/JsonCodecEngine.test.ts` stated the invariant flatly, and
gave it teeth rather than tidiness:

> the places where the decoder hands back an extracted sub-tree directly are
> sound only if nothing can mutate it afterward

Sub-tree sharing depends on the strong claim, and six of the seven arms
already kept it. The exception was the odd one out rather than a design.

## `asProblematicValue()`

It renders a thrown refusal as a returned value, and every value a decode
returns is deep-frozen -- so it now freezes what it builds. Previously it
returned an unfrozen value and each caller had to remember; `settleThrown()`
remembered, which was the only reason that row measured frozen. Freezing at
the source rather than at each call site is what keeps the guarantee off the
caller. `settleThrown()` accordingly drops its own, now redundant.

## What this does NOT change

No constructor freezes anything. Freezing runs through `deepFreeze()`
throughout, and so through the `[DEEP_FREEZE]` protocol -- `UnknownValue`'s own
member recurses into its state. A `FabricInstance` is not required to be
deep-frozen and does not make itself so; the guarantee here belongs to
`decode()`'s output, not to the classes.

This also removes a `TODO` on `UnknownValue`'s constructor asking it to
guarantee a deep-frozen state. That asked the wrong layer twice over: the
protocol is how an instance becomes frozen, and the walker's egress is where a
decoded one does. Read instead as a precondition on callers it would have
invalidated most of the ~30 construction sites, which pass ordinary mutable
state and, in one test, a deliberate cycle.

## Verification

Three tests added, one per arm that had none, using `isDeepFrozen()` rather
than `Object.isFrozen()` -- an arm that froze only the value it built and not
what it wrapped would pass the shallow check.

Ablation, which is the acceptance criterion this was built against: **removing
any one of the four `deepFreeze()` calls turns the suite red** -- unknown-tag
arm, codec arm, `asProblematicValue()`, `reportMalformed()`. Before this
change, removing the one on the lenient path did not.

- `data-model`: `ok | 54 passed (2458 steps) | 0 failed`.
- Cross-package: `memory` and `runner` green; `cli` and `connectors/agents`
  were still running at push time, the latter being the one place outside
  `data-model` that constructs an `UnknownValue` directly. I will report both.
- Gates green: `lint`, `check`, `fmt --check`, `check-docs`,
  `check-skill-facts`, `check-package-cycles`, `check-no-waitfor`,
  `check-conflict-markers`.
- The root `deno task test` was not run: it can launch a browser, which needs
  unsandboxed execution.

## Documentation

The formal spec stated the old scoping twice, once calling the broadening "a
separate follow-on". Both are updated, and `asProblematicValue()` joins the
spec's list of egress-freezing call sites.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

