### PR TITLE
perf: server-execution v2 stage C — the tuning trio: single CFC probe, arrival retirement, honest deadline + mid-wave renew

### DIFF
--- a/docs/specs/server-side-execution/events.md
+++ b/docs/specs/server-side-execution/events.md
@@ -235,6 +235,23 @@ ambient-state one.
   default) is SUBSUMED by `eventWatermark` under the flag; the two
   mechanisms MUST NOT be active for the same event
   (runtime-mapping.md N26).
+- **The drain's own re-scan (stage C tuning, 2026-08-18):** the drain
+  queues a pending entry into the serving scheduler AT MOST ONCE while
+  that copy is still queued, held, or running — an entry whose earlier
+  drain copy has not yet reached its final commit callback is skipped
+  on a re-drain (`events.drainInFlightSkips`), and re-drains as before
+  once the copy completes, defers, or fails (a withdrawn wave, a
+  deferral, a requeue leave the entry pending and it re-queues). This
+  is the mark path's own exactly-once, made robust to the honest flush
+  deadline (serving-loop.md §3): a cycle that ends before its drained
+  event ran re-arms the scan, and the next cycle's drain used to queue
+  a second copy — a per-cut-cycle multiplier on a NON-IDEMPOTENT
+  handler. Stated narrowly: it dedupes the drain against ITSELF only.
+  The LT1 same-space in-process cascade copy (a `streamEntry`-less
+  emit queued in-process alongside the durable append — #5969's (α))
+  and the general "one durable entry = one COMPLETED delivery"
+  invariant across BOTH producers remain owed to the owner's ruling
+  (verification-coverage.md OW32's Stage-C dossier), not decided here.
 
 FORBIDDEN: a processed-events table; per-event acks from clients;
 handler-run provenance records.

--- a/docs/specs/server-side-execution/events.md
+++ b/docs/specs/server-side-execution/events.md
@@ -236,17 +236,24 @@ ambient-state one.
   mechanisms MUST NOT be active for the same event
   (runtime-mapping.md N26).
 - **The drain's own re-scan (stage C tuning, 2026-08-18):** the drain
-  queues a pending entry into the serving scheduler AT MOST ONCE while
-  that copy is still queued, held, or running — an entry whose earlier
-  drain copy has not yet reached its final commit callback is skipped
-  on a re-drain (`events.drainInFlightSkips`), and re-drains as before
-  once the copy completes, defers, or fails (a withdrawn wave, a
-  deferral, a requeue leave the entry pending and it re-queues). This
-  is the mark path's own exactly-once, made robust to the honest flush
-  deadline (serving-loop.md §3): a cycle that ends before its drained
-  event ran re-arms the scan, and the next cycle's drain used to queue
-  a second copy — a per-cut-cycle multiplier on a NON-IDEMPOTENT
-  handler. Stated narrowly: it dedupes the drain against ITSELF only.
+  queues a pending entry into the serving scheduler AT MOST ONCE until
+  the store has spoken for it — a re-drain skips an entry whose earlier
+  drain copy is still queued, held, or running, OR whose consequence
+  mark is sealed into a wave the store has not yet committed
+  (`events.drainInFlightSkips`); the copy is released by the wave
+  outcome (committed or requeued — every abort arm reports its
+  event-handler contributions as requeued), by a deferral (no mark; the
+  rescan retries), by its final callback when nothing of it reached a
+  wave (an aborted run, a name-resolution drop), or by a notice that
+  failed to stage — a still-pending entry then re-drains exactly as
+  before. Releasing at the copy's SEAL would not do: the mark rides an
+  uncommitted wave while the entry is still pending, and a re-drain in
+  that window would queue the second copy. This is the mark path's
+  at-most-one-copy discipline, made robust to the honest flush deadline
+  (serving-loop.md §3): a cycle that ends before its drained event ran
+  re-arms the scan, and the next cycle's drain used to queue a second
+  copy — a per-cut-cycle multiplier on a NON-IDEMPOTENT handler. Stated
+  narrowly: it dedupes the drain against ITSELF only.
   The LT1 same-space in-process cascade copy (a `streamEntry`-less
   emit queued in-process alongside the durable append — #5969's (α))
   and the general "one durable entry = one COMPLETED delivery"

--- a/docs/specs/server-side-execution/serving-loop.md
+++ b/docs/specs/server-side-execution/serving-loop.md
@@ -163,7 +163,17 @@ processes* (deploy overlap, partition) it holds via the lease:
   the in-process residue is a local obligation, not wire machinery.
 - Acquire with a conditional write; TTL 15 s; renew every 5 s **by direct
   table update — a lease renewal is NEVER a commit** (v1's renewal-adjacent
-  traffic was part of the storm).
+  traffic was part of the storm). The renew has TWO drivers (stage C
+  tuning T3, 2026-08-18): the interval timer, and a MID-WAVE renew issued
+  from the serving scheduler's cooperative macrotask yield (§3) once the
+  tenure has gone TTL/3 without a renewal — the timer rides the macrotask
+  queue a long settle used to starve (the stage-C attribution's t2:
+  renew gaps to 10 s against the 15-s TTL, then `lease-lost` on every
+  active space at once), so the belt renews at the same cadence without
+  depending on the timer queue being serviced. Neither driver is a
+  commit. Impl: `space-server.ts` `#renewIfDue` on
+  `Runtime.servingYieldObserver`; pinned in
+  `executor-cooperative-yield.test.ts` (ii).
 - On renewal failure or expiry: the SpaceServer MUST stop committing
   immediately (in-flight transaction aborts), then re-acquire or park.
 - The memory server rejects a derived-class commit whose `holder` does not
@@ -257,6 +267,26 @@ visibility in the same batch — head-of-line blocking ACROSS users,
 because the whole input batch commits once at the batch's derived
 closure. With it, a consequence is visible within roughly
 2·T_flush + push even while the wave behind it keeps deriving.
+**The deadline is HONEST only if the settle yields (stage C tuning T3,
+2026-08-18):** the scheduler's settle loop and per-demander fan-out
+loop ran a whole wave's runs on one microtask chain, so the deadline
+timer could fire only after the last run — the stage-C attribution
+measured chat event waves late by 2.5–8.3 s with `wavesBudgetExhausted`
+a symptom, not a bound. A SERVING runtime's scheduler now yields one
+macrotask between runs whenever its slice of continuous work (16 ms)
+is spent (`scheduler/cooperative-yield.ts`; the OFF arm and clients
+construct no yielder and keep their exact microtask shape), so the
+deadline fires within one run + a slice of its time (measured live:
+lateness p50 25 ms, p90 152 ms, max 399 ms — a single long walk
+instance or a resubscribe still runs to its end; the WORK is the
+design half's). Its companion, the DRAIN'S IN-FLIGHT GUARD: with cycles
+routinely cut before a just-drained event has run, the post-commit
+re-arm re-drains the still-pending entry every cycle and used to queue
+a SECOND copy each time (4× dispatch of the lockdown toggle on the
+two-browsers gate); the drain now skips an entry whose earlier drain
+copy has not yet reached its commit callback (`events.drainInFlightSkips`;
+events.md §4). Pinned: `executor-cooperative-yield.test.ts` (i) and
+`executor-events-down.test.ts` (exactly-once under an honest deadline).
 Light waves never reach the deadline and stay single-commit — the
 zero-delta case, which is why this is a trigger on the EXISTING
 exhaustion machinery rather than a new commit topology. T_flush is

--- a/docs/specs/server-side-execution/serving-loop.md
+++ b/docs/specs/server-side-execution/serving-loop.md
@@ -268,18 +268,23 @@ because the whole input batch commits once at the batch's derived
 closure. With it, a consequence is visible within roughly
 2·T_flush + push even while the wave behind it keeps deriving.
 **The deadline is HONEST only if the settle yields (stage C tuning T3,
-2026-08-18):** the scheduler's settle loop and per-demander fan-out
-loop ran a whole wave's runs on one microtask chain, so the deadline
-timer could fire only after the last run — the stage-C attribution
-measured chat event waves late by 2.5–8.3 s with `wavesBudgetExhausted`
-a symptom, not a bound. A SERVING runtime's scheduler now yields one
-macrotask between runs whenever its slice of continuous work (16 ms)
-is spent (`scheduler/cooperative-yield.ts`; the OFF arm and clients
-construct no yielder and keep their exact microtask shape), so the
-deadline fires within one run + a slice of its time (measured live:
-lateness p50 25 ms, p90 152 ms, max 399 ms — a single long walk
-instance or a resubscribe still runs to its end; the WORK is the
-design half's). Its companion, the DRAIN'S IN-FLIGHT GUARD: with cycles
+2026-08-18):** the scheduler's settle loop ran a whole wave's actions
+on one microtask chain, so the deadline timer could fire only after the
+last one — the stage-C attribution measured chat event waves late by
+2.5–8.3 s with `wavesBudgetExhausted` a symptom, not a bound. A SERVING
+runtime's scheduler now yields one macrotask between ACTIONS in the
+settle loop whenever its slice of continuous work (16 ms) is spent
+(`scheduler/cooperative-yield.ts`; the OFF arm and clients construct no
+yielder and keep their exact microtask shape), so the deadline fires
+within one action + a slice of its time (measured live: lateness p50
+25 ms, p90 152 ms, max 399 ms — one action's instance runs and its
+resubscribe still run to their end; the WORK is the design half's).
+NOT inside the per-demander fan-out loop (considered and rejected): a
+macrotask there let a run's own asynchronous seal refusal land mid-pass,
+and the loop re-ran the dirtied instance in the same pass while the
+refusal's queued retry ran it again — two durable emissions of one
+served event; the retry machinery's contract is that a failed run's
+retry lands on the QUEUED pass, never the current one. Its companion, the DRAIN'S IN-FLIGHT GUARD: with cycles
 routinely cut before a just-drained event has run, the post-commit
 re-arm re-drains the still-pending entry every cycle and used to queue
 a SECOND copy each time (4× dispatch of the lockdown toggle on the

--- a/docs/specs/server-side-execution/speculation.md
+++ b/docs/specs/server-side-execution/speculation.md
@@ -83,7 +83,22 @@ On each pushed `derived` commit with `derivedThrough = W` and
 1. Apply the commit to the local store replica (existing path).
 2. Retire overlay entries whose `origin` is `intent(e)` for `e ∈ E` —
    the authoritative consequences (or, for a dropped event, its
-   notice — events.md §5) now exist; the echo's job is done.
+   notice — events.md §5) now exist; the echo's job is done. This is a
+   condition on STATE, not on arrival order (stage C tuning T2,
+   2026-08-18): an echo of `e` sealed AFTER `e`'s terminal consequence
+   (consequenced, errored, dropped, or refused) has already arrived at
+   this client — the local dispatch ran late (a load-parked head event,
+   a busy worker) — is jobless on the same grounds and is NOT
+   registered: its writes are dropped before any layer is sealed. A
+   non-idempotent handler's late echo is divergent by construction (it
+   re-toggles the already-served state), and its floor sits at the
+   served commit's seq, above every W reachable until the next authored
+   input, so it would otherwise stand indefinitely and hide the served
+   value (the two-browsers lockdown chip's 48-s / 300-s stalls; #5969's
+   late castVote echo). Impl: `overlay-destination.ts`
+   `#terminalIntents` at `#sealSpeculative`; pinned in
+   `speculation-arrival-gate.test.ts` (the late-echo rule, scripted,
+   with its mutation).
 3. Retire overlay entries whose `origin` is `input` once their authored
    commit is acked AND `W ≥` that commit's seq AND — the ARRIVAL GATE
    (RULED 2026-08-16, landed with fan-out stage A) — every doc INSTANCE
@@ -155,7 +170,25 @@ covering watermark, or one the client never watched, keeps its echo
 until the next watermark event (value-identical when the values agree;
 otherwise the echo hides the authoritative value that long). An arrival
 re-sweep is the owed follow-up if that coupling ever loosens (recorded
-in verification-coverage.md's stage-A delta). Two riders ride with the
+in verification-coverage.md's stage-A delta). **LANDED (stage C tuning
+T2, 2026-08-18): the coupling DID loosen — an EXHAUSTED wave carries no
+watermark movement (serving-loop.md §3: its `derivedThrough` is frozen),
+so its derived values arrive DECOUPLED from W, and with the honest flush
+deadline (T3) exhaustion is the routine shape of a busy wave. The
+replica now fires an ARRIVAL wake
+(`ISpaceReplica.speculationArrivalObserver`) at the end of integrating
+any frame that moves a doc's confirmed seq forward, and the overlay
+re-sweeps the space when an arrived doc is one some live entry WROTE.
+The gate's predicates are UNCHANGED — arrival is a second, EARLIER
+trigger, never a relaxation of coverage (`W ≥ floor`) or of the arrival
+gate itself; the sweep re-evaluates both on replica state at every
+trigger, so the wake can only retire an entry the next watermark event
+would have retired anyway (the store has spoken for the instance at seq
+≥ the entry's floor: the derivation the gate waits for HAS landed).
+Pinned in `speculation-arrival-gate.test.ts` (the E2 shape end to end,
+mutation: wake removed → the entry stands until an unrelated commit;
+scripted: an arrival for an unwritten doc sweeps nothing, an arrival
+while `W < floor` retires nothing).** Two riders ride with the
 gate: SUPERSEDE-BY-NEWER — a
 newer entry of the same writer whose WHOLE-DOC ops cover every doc an
 older entry wrote retires the older one at seal (the drop of a lower

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -1169,7 +1169,9 @@ nod, 2026-08-07; recorded in the plan's stage list):**
   scope — is illegal and its reads are empty either way. (vi) The
   arrival gate's sweep has no arrival trigger of its own (speculation.md
   §4 now states the frame-coupling assumption); an arrival re-sweep is
-  owed if that coupling loosens. (vii) Two PRE-EXISTING SpaceServer
+  owed if that coupling loosens — LANDED, stage C tuning T2 (2026-08-18;
+  the coupling loosened by construction under the honest flush deadline
+  — see the stage-C tuning delta below). (vii) Two PRE-EXISTING SpaceServer
   blip-window shapes surfaced by the fix round's E2E, not stage A's and
   not filled: (a) with the lease row expired but the in-process tenure
   live, the loop re-attempts its watermark advance every cycle and each
@@ -3219,6 +3221,136 @@ supply; OW29/OW32/OW34 closed):
   draft) — a recurrence in CI is evidence about B7 (a keyed cascade
   not dirtying a walk instance) and should be read as such, not
   retried.
+
+- **Stage C tuning delta (2026-08-18) — the tuning trio, owner-approved
+  as the tuning half of the tuning-vs-design split (the design half —
+  the per-demander demand walk × roots, and the client's whole-sidecar
+  intent tracking with a CFC probe per fire — is a SEPARATE stage;
+  untouched here). Every item re-measured on the harness protocol
+  (fresh store per run, ON binary posture-verified via `/api/meta` +
+  `servingLoop` present, load recorded, NO configured LLM model — the
+  attribution found the 08-17 daytime greens masked by exactly that
+  churn):**
+  - **T1 — one CFC flow-label probe per commit** (`cfc/prepare.ts`
+    `flowLabelWorkExists`, evaluated by both `Runtime.prepareTxForCommit`
+    and the commit chokepoint on the same unprepared, not-yet-relevant
+    tx — 65 % of a saturated client worker on the ON note series). The
+    NEGATIVE verdict is memoized on the transaction
+    (`IExtendedStorageTransaction.probeFlowLabelWork`), invalidated by
+    any journaled read/write/dereference trace/trigger read (an activity
+    epoch); a positive verdict marks the tx relevant, after which nobody
+    probes. Shared client code, both arms: verdicts unchanged (a memo of
+    a deterministic function; the flow-label suites pin them), probe
+    count 2 → 1 per commit in both. Pinned:
+    `cfc-flow-probe-memo.test.ts` (one evaluation + one memo hit; a
+    read or a write between the asks re-evaluates; a positive verdict is
+    never memoized; both arms) with mutations (memo disabled → red;
+    read-bump removed → the invalidation pin red). Re-measured, note
+    create n=20 (`default-app.test.ts`, `CF_NOTE_CREATE_TIMING_SERIES=20`):
+    ON createToView p50 **4 224 / 4 361 ms** (two reps, loads 3.3 / 3.0)
+    vs the attribution's baseline **8 927 / 5 841 ms**; p95 **8 165 /
+    7 358 ms** vs **23 335 / 26 451**; the series completed n=20 in
+    253 / 227 s (baseline 502 s, and a 780-s cap hit at note 18); the
+    adjacent OFF control (OFF binary from the same tip, load 3.6)
+    createToView p50 **1 129 ms** / p95 1 236 — inside the baseline OFF
+    band (1 085–1 171 / 1 328–1 496): the OFF arm's timing is unchanged.
+    ON/OFF ratio 3.7× (was 5.4–8.2×). The per-note growth is still
+    monotone (1.2 → 14.9 s at note 20): the O(events²) intent-tracking
+    term is the design half's, as predicted; the console-gate red on the
+    ON reps is the pre-existing `splitDefinitions` error the
+    attribution's §6 records, unrelated to timing.
+  - **T2 — retirement on ARRIVAL, and the late-echo rule** (the
+    attribution's §4: a correctly served + pushed derived value held 48 s
+    by the client's overlay). (a) The owed arrival re-sweep LANDED: the
+    replica fires `speculationArrivalObserver` at the end of integrating
+    a frame that moves a doc's confirmed seq forward; the overlay
+    re-sweeps when an arrived doc is one some live entry wrote. The
+    gate's predicates are UNCHANGED — arrival is a second, EARLIER
+    trigger (speculation.md §4's amended paragraph states the soundness
+    argument: the sweep re-evaluates coverage and arrival on replica
+    state at every trigger). Reconciled with #5969's arrival-gate KEEP
+    verdict: the gate STAYS as the fallback; the wake fires ahead of the
+    watermark. (b) The late-echo edge #5969 flagged is the SAME gate and
+    IS covered here, by a different sentence than the arrival wake: an
+    event-handler echo sealed after its intent's terminal consequence
+    already arrived is not registered (speculation.md §4 step 2 read as
+    the state it names — the consequences exist, the echo is jobless).
+    Evidence that E2 WAS that edge: the chip never flipped even
+    speculatively (`flippedAt=-1`) — no prompt echo — while Alice's
+    worker was busy for 8.7–12 s (`ipc/runtime:idle` max in every red
+    run: A1 8 658, D4 12 015, E2 8 699 ms; the green runs 3.2–7.3 s);
+    the toggle handler is bound to `onClick` with no `detail.checked`,
+    so a dispatch that runs after the served consequences reads
+    `everyoneIsAdmin=false` and toggles it BACK — the DOM's "Everyone is
+    admin"; that echo's floor is the served commit's seq (above every W
+    until the next authored input) and its mark was consumed before it
+    existed, so nothing retires it — until Bob's draft lifts W (the
+    48-s release the report timed). Pinned: `speculation-arrival-gate.test.ts`
+    (the E2 shape end to end — a served value arriving decoupled from a
+    watermark advance retires and renders at once, mutation: wake
+    removed → the entry stands; the trigger-not-relaxation scripted pin;
+    the late-echo rule scripted with its mutation). Re-measured, the
+    two-browsers lockdown gate at night-like conditions (no LLM model,
+    loads 2.2–6.5): **GREEN 10/10** — 7/7 on the final binary
+    (`a9534d18…`, G3–G9: 30–58 s walls) + I1 (instrumented, byte-equal
+    code) + G1/G2 on interim builds — vs the attribution's 5 stalls in 12
+    night attempts; per browser, `overlayArrivalSweeps` 15–25 per run
+    (the wake fires routinely — served values now arrive decoupled from W
+    as the ordinary shape), `overlayLateEchoDrops` 0 (the late dispatch
+    did not recur: Alice's `ipc/runtime:idle` max fell to 0.66–2.3 s per
+    run, total 3.4–6.7 s vs 11.8–31.4 s — T1's client relief; the
+    late-echo rule stands as the backstop). Also found and FIXED while
+    landing (a): the browser worker bundle drops UNINITIALIZED class
+    fields, so `"speculationAckObserver" in replica` read false in
+    browsers — leg-C's origin-ack wake had never installed in a browser
+    client (Deno-only green); the replica's observer fields are now
+    initialized explicitly and the overlay probes capability by method
+    (`speculationRetirementView`). The overlay counters ride the browser
+    load summary (`cfc-browser-helpers.ts` churn:
+    `overlayLateEchoDrops`, `overlayArrivalSweeps`).
+  - **T3 — the honest deadline and the mid-wave renew** (attribution
+    §2b/§3: deadline late by 2.5–8.3 s; renew gaps to 10 s vs a 15-s TTL;
+    t2's `lease-lost` on all spaces at once). A SERVING runtime's
+    scheduler yields one macrotask between settle-loop runs and between a
+    fanned-out node's instance runs once its 16-ms slice of continuous
+    work is spent (`scheduler/cooperative-yield.ts` — `setTimeout(0)`,
+    the one primitive that lets due timers fire in deadline order;
+    MessageChannel and setImmediate measured to starve them); the OFF arm
+    and clients construct no yielder (posture-gated at construction).
+    The SpaceServer installs `Runtime.servingYieldObserver` at
+    activation and renews the lease from it once the tenure has gone
+    TTL/3 without a renewal (`leaseTtlMs` policy knob for tests). Pinned:
+    `executor-cooperative-yield.test.ts` — (i) a 1.2-s synthetic walk
+    under a 100-ms deadline commits its first exhausted wave in < 600 ms
+    (mutation: yield removed → 1 239 ms, red); (ii) a wave outliving a
+    600-ms TTL twice over commits under a live lease with the timer inert
+    (mutation: renew-on-yield removed → the commit is refused, red);
+    (iii) posture gate; unit. Live (I1, instrumented scratch build):
+    deadline lateness on exhausted cycles p50 **25 ms**, p90 152, max
+    399 ms (was p50 125 / p90 443 / max 1 155 on the note run, and
+    seconds on chat event waves); renew gaps p50 **5 020 ms**, max 5 120
+    (was p50 5.0–7.9 s, max 10.0 s); `lease.lost` **0** in all 13
+    re-measured runs; `wavesBudgetExhausted` now an honest count
+    (140–210 per chat run vs 29 — it counts every cut cycle). Its
+    COMPANION, forced by honesty: with cycles cut before a drained event
+    ran, the post-commit re-arm re-drained the still-pending entry every
+    cycle and queued a second copy each time — G1 (pre-guard) showed
+    `events: appended 8 / processed 34` (4.25× dispatch of the lockdown
+    toggle; #5969's (β) re-scan variant); the drain now skips an entry
+    whose earlier drain copy has not reached its commit callback
+    (`events.drainInFlightSkips`; events.md §4's new sentence, stated
+    narrowly as the drain deduping against ITSELF — the LT1 (α)
+    in-process copy and the cross-producer invariant stay owed to the
+    owner's ruling). Pinned: `executor-events-down.test.ts` (exactly-once
+    under an honest deadline: one fire mid-settle → processed 1, ONE
+    consequence commit, the counter reads 1; mutation: guard removed →
+    processed 11, red). Every guarded run: `processed == appended`.
+  - OFF witness: T1 is arm-independent by design (verdicts pinned);
+    T2 lives in the flag-ON client overlay (constructed only under the
+    flag on non-serving runtimes) and the replica seam fires only with an
+    observer installed; T3 is gated on `runtime.servingPosture` at
+    construction (the yielder does not exist elsewhere) and the drain
+    guard sits inside the serving loop. Whole-suite witness in the PR.
 
 ## 4. Standing rule
 

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -2150,7 +2150,13 @@ Delta 2026-08-11 — Phase 4 (the client-effect channel; the phase PR):
   (MINOR-3) the receipt-race divert is PINNED structurally: zero
   authored-class commits touch the served navigation's target doc
   (the divert-neutralization probe that left the full runner suite
-  green now goes red);
+  green now goes red) — NOTE (2026-08-18, the stage-C tuning
+  independent review): this pin FLAKES under load, PRE-EXISTING and
+  not the tuning trio's — its 20-s `waitUntil` for the served intent
+  to land times out at 1-min load ≈ 5 (the fan-out-B base tip 2/20,
+  the trio's tip 2/16, ≈10 %); a sweep should read a red here as the
+  wait budget, not the divert, until the budget or the wake is
+  addressed;
   (MINOR-4) the `locallyPresent` suppression gate deleted — see
   (vii) above;
   (MINOR-5) same-principal two-session isolation pinned BOTH
@@ -3230,7 +3236,13 @@ supply; OW29/OW32/OW34 closed):
   (fresh store per run, ON binary posture-verified via `/api/meta` +
   `servingLoop` present, load recorded, NO configured LLM model — the
   attribution found the 08-17 daytime greens masked by exactly that
-  churn):**
+  churn). Provenance: the figures below are the FINAL binaries' — ON
+  `a2d9a2b7…` / OFF `e8d8ae60…`, both built from the PR tip
+  `2e9d86478` — with the interim reps (`a9534d18…` ON, `6ac8a606…` OFF,
+  and earlier scratch builds) kept where they add evidence and labeled
+  as such; this register's first cut (`5c296cefe`) carried the interim
+  figures alone and was reconciled 2026-08-18 by the independent
+  review's fix batch:**
   - **T1 — one CFC flow-label probe per commit** (`cfc/prepare.ts`
     `flowLabelWorkExists`, evaluated by both `Runtime.prepareTxForCommit`
     and the commit chokepoint on the same unprepared, not-yet-relevant
@@ -3247,18 +3259,23 @@ supply; OW29/OW32/OW34 closed):
     never memoized; both arms) with mutations (memo disabled → red;
     read-bump removed → the invalidation pin red). Re-measured, note
     create n=20 (`default-app.test.ts`, `CF_NOTE_CREATE_TIMING_SERIES=20`):
-    ON createToView p50 **4 224 / 4 361 ms** (two reps, loads 3.3 / 3.0)
-    vs the attribution's baseline **8 927 / 5 841 ms**; p95 **8 165 /
-    7 358 ms** vs **23 335 / 26 451**; the series completed n=20 in
-    253 / 227 s (baseline 502 s, and a 780-s cap hit at note 18); the
-    adjacent OFF control (OFF binary from the same tip, load 3.6)
-    createToView p50 **1 129 ms** / p95 1 236 — inside the baseline OFF
-    band (1 085–1 171 / 1 328–1 496): the OFF arm's timing is unchanged.
-    ON/OFF ratio 3.7× (was 5.4–8.2×). The per-note growth is still
-    monotone (1.2 → 14.9 s at note 20): the O(events²) intent-tracking
-    term is the design half's, as predicted; the console-gate red on the
-    ON reps is the pre-existing `splitDefinitions` error the
-    attribution's §6 records, unrelated to timing.
+    ON createToView p50 **5 758 / 3 838 ms** on the FINAL binary
+    (`a2d9a2b7…`, FN1/FN2, loads 6.0 / 5.1) and **4 224 / 4 361 ms** on
+    the interim `a9534d18…` (N1/N2, loads 3.3 / 3.0) vs the
+    attribution's baseline **8 927 / 5 841 ms**; p95 **10 003 / 9 908 ms**
+    (final) and **8 165 / 7 358 ms** (interim) vs **23 335 / 26 451**;
+    the series completed n=20 in 292 / 229 s (final) and 253 / 227 s
+    (interim) — every rep — vs 502 s and a 780-s cap hit at note 18; the
+    adjacent OFF controls (OFF binaries from the same tips: final
+    `e8d8ae60…` at load 5.8, interim `6ac8a606…` at load 3.6)
+    createToView p50 **1 205 / 1 129 ms**, p95 1 447 / 1 236 — inside the
+    baseline OFF band (1 085–1 171 / 1 328–1 496): the OFF arm's timing
+    is unchanged. ON/OFF ratio 3.2–4.8× (was 5.4–8.2×). The per-note
+    growth is still monotone (1.2 → 14.9 s at note 20 on the interim
+    reps): the O(events²) intent-tracking term is the design half's, as
+    predicted; the console-gate red on some ON reps is the pre-existing
+    `splitDefinitions` error the attribution's §6 records, unrelated to
+    timing.
   - **T2 — retirement on ARRIVAL, and the late-echo rule** (the
     attribution's §4: a correctly served + pushed derived value held 48 s
     by the client's overlay). (a) The owed arrival re-sweep LANDED: the
@@ -3289,7 +3306,11 @@ supply; OW29/OW32/OW34 closed):
     evidence, not witnessed by a client trace (the report's "last
     inch"): the re-measured runs never reproduced the late dispatch
     (`overlayLateEchoDrops` 0), so the rule's live firing is unobserved;
-    its unit pin covers the mechanism. The rule reaches the late echo's
+    its unit pin covers the mechanism. The rule's sentence in
+    speculation.md §4 step 2 is DATED (2026-08-18), not RULED —
+    **pending owner ratification** (#5969 had called it a candidate
+    rule, owner call; it landed here as the retirement condition the
+    step already states). The rule reaches the late echo's
     client CASCADE too (a child echo whose `parentEventId` is the jobless
     intent, and its children), and a dropped late echo's enactable
     effects are owned and not enacted (the closed-overlay arm's shape).
@@ -3299,10 +3320,12 @@ supply; OW29/OW32/OW34 closed):
     removed → the entry stands; the trigger-not-relaxation scripted pin;
     the late-echo rule scripted with its mutation). Re-measured, the
     two-browsers lockdown gate at night-like conditions (no LLM model,
-    loads 2.2–6.5): **GREEN 10/10** — 7/7 on the final binary
-    (`a9534d18…`, G3–G9: 30–58 s walls) + I1 (instrumented, byte-equal
-    code) + G1/G2 on interim builds — vs the attribution's 5 stalls in 12
-    night attempts; per browser, `overlayArrivalSweeps` 15–25 per run
+    loads 2.2–6.5): **GREEN 16/16** — 6/6 on the FINAL binary
+    (`a2d9a2b7…`, F10–F15: 36–43 s walls), 7/7 on the interim
+    `a9534d18…` (G3–G9: 31–58 s walls), I1 (instrumented, byte-equal
+    code) and G1/G2 on earlier interim builds — vs the attribution's 5
+    stalls in 12 night attempts; per browser, `overlayArrivalSweeps`
+    14–25 per run
     (the wake fires routinely — served values now arrive decoupled from W
     as the ordinary shape), `overlayLateEchoDrops` 0 (the late dispatch
     did not recur: Alice's `ipc/runtime:idle` max fell to 0.66–2.3 s per
@@ -3333,16 +3356,18 @@ supply; OW29/OW32/OW34 closed):
     TTL/3 without a renewal (`leaseTtlMs` policy knob for tests). Pinned:
     `executor-cooperative-yield.test.ts` — (i) a 1.2-s synthetic walk
     under a 100-ms deadline commits its first exhausted wave in < 600 ms
-    (mutation: yield removed → 1 239 ms, red); (ii) a wave outliving a
-    600-ms TTL twice over commits under a live lease with the timer inert
-    (mutation: renew-on-yield removed → the commit is refused, red);
-    (iii) posture gate; unit. Live (I1, instrumented scratch build):
-    deadline lateness on exhausted cycles p50 **25 ms**, p90 152, max
-    399 ms (was p50 125 / p90 443 / max 1 155 on the note run, and
-    seconds on chat event waves); renew gaps p50 **5 020 ms**, max 5 120
-    (was p50 5.0–7.9 s, max 10.0 s); `lease.lost` **0** in all 13
-    re-measured runs; `wavesBudgetExhausted` now an honest count
-    (140–210 per chat run vs 29 — it counts every cut cycle). Its
+    (mutation: yield removed → 1 239 ms, red); (ii) a 45-step, 1.8-s
+    walk outliving a 900-ms TTL twice over commits under a live lease
+    with the timer inert (mutation: renew-on-yield removed → the commit
+    is refused, red); (iii) posture gate; unit. Live (I1, instrumented
+    scratch build): deadline lateness on exhausted cycles p50 **25 ms**,
+    p90 152, max 399 ms (was p50 125 / p90 443 / max 1 155 on the note
+    run, and seconds on chat event waves); renew gaps p50 **5 020 ms**,
+    max 5 120 (was p50 5.0–7.9 s, max 10.0 s); `lease.lost` **0** in
+    all 22 re-measured runs (the 16 gate runs and the 4 ON note runs hold
+    leases; the 2 OFF note controls hold none); `wavesBudgetExhausted`
+    now an honest count (117–210 per chat run vs 29 — it counts every
+    cut cycle). Its
     COMPANION, forced by honesty: with cycles cut before a drained event
     ran, the post-commit re-arm re-drained the still-pending entry every
     cycle and queued a second copy each time — G1 (pre-guard) showed
@@ -3362,6 +3387,16 @@ supply; OW29/OW32/OW34 closed):
     `executor-events-down.test.ts` (exactly-once under an honest
     deadline: one fire mid-settle → processed 1, ONE consequence commit,
     the counter reads 1; mutation: guard removed → processed 11, red).
+    The RELEASE POINT itself is pinned too (the independent review's
+    MINOR-2, 2026-08-18 — the exactly-once pin above passes with either
+    release point): the same file's SEAL→OUTCOME-window pin parks a
+    re-drain at the sidecar sync (the serving manager's `syncCell` seam,
+    engaged on re-drains only) until the copy's consequence has SEALED
+    into a wave the store has not committed — the store still holds the
+    pre-fire value, the entry is unconsequenced — then lets the drain
+    reach the entry's guard check: it skips (`marked`), the wave commits,
+    processed 1, value 1; mutation: release at the seal → that re-drain
+    queues a second copy (processed 2, value 2), red.
     Every guarded run: `processed == appended`.
   - OFF witness: T1 is arm-independent by design (verdicts pinned);
     T2 lives in the flag-ON client overlay (constructed only under the

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -3319,9 +3319,12 @@ supply; OW29/OW32/OW34 closed):
   - **T3 — the honest deadline and the mid-wave renew** (attribution
     §2b/§3: deadline late by 2.5–8.3 s; renew gaps to 10 s vs a 15-s TTL;
     t2's `lease-lost` on all spaces at once). A SERVING runtime's
-    scheduler yields one macrotask between settle-loop runs and between a
-    fanned-out node's instance runs once its 16-ms slice of continuous
-    work is spent (`scheduler/cooperative-yield.ts` — `setTimeout(0)`,
+    scheduler yields one macrotask between settle-loop ACTIONS once its
+    16-ms slice of continuous work is spent — not inside the per-demander
+    fan-out loop, where a yield let a run's own async seal refusal land
+    mid-pass and double a served emission (the LT6 early-emit arm caught
+    it; the retry lands on the queued pass by contract)
+    (`scheduler/cooperative-yield.ts` — `setTimeout(0)`,
     the one primitive that lets due timers fire in deadline order;
     MessageChannel and setImmediate measured to starve them); the OFF arm
     and clients construct no yielder (posture-gated at construction).

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -3285,7 +3285,15 @@ supply; OW29/OW32/OW34 closed):
     admin"; that echo's floor is the served commit's seq (above every W
     until the next authored input) and its mark was consumed before it
     existed, so nothing retires it — until Bob's draft lifts W (the
-    48-s release the report timed). Pinned: `speculation-arrival-gate.test.ts`
+    48-s release the report timed). Stated as INFERRED from that
+    evidence, not witnessed by a client trace (the report's "last
+    inch"): the re-measured runs never reproduced the late dispatch
+    (`overlayLateEchoDrops` 0), so the rule's live firing is unobserved;
+    its unit pin covers the mechanism. The rule reaches the late echo's
+    client CASCADE too (a child echo whose `parentEventId` is the jobless
+    intent, and its children), and a dropped late echo's enactable
+    effects are owned and not enacted (the closed-overlay arm's shape).
+    Pinned: `speculation-arrival-gate.test.ts`
     (the E2 shape end to end — a served value arriving decoupled from a
     watermark advance retires and renders at once, mutation: wake
     removed → the entry stands; the trigger-not-relaxation scripted pin;
@@ -3337,14 +3345,21 @@ supply; OW29/OW32/OW34 closed):
     cycle and queued a second copy each time — G1 (pre-guard) showed
     `events: appended 8 / processed 34` (4.25× dispatch of the lockdown
     toggle; #5969's (β) re-scan variant); the drain now skips an entry
-    whose earlier drain copy has not reached its commit callback
-    (`events.drainInFlightSkips`; events.md §4's new sentence, stated
-    narrowly as the drain deduping against ITSELF — the LT1 (α)
-    in-process copy and the cross-producer invariant stay owed to the
-    owner's ruling). Pinned: `executor-events-down.test.ts` (exactly-once
-    under an honest deadline: one fire mid-settle → processed 1, ONE
-    consequence commit, the counter reads 1; mutation: guard removed →
-    processed 11, red). Every guarded run: `processed == appended`.
+    whose earlier drain copy is still in flight — queued/held/running,
+    or with its mark sealed into a wave the store has not yet committed
+    — and releases it only on a store-visible outcome (the wave's
+    committed/requeued ids) or a provably markless end (deferral, an
+    aborted run's final callback, a notice that failed to stage); the
+    self-review's finding 1 moved the release off the SEAL, where a
+    re-drain hitting a real await between wave-detach and the guard
+    check could still queue a second copy (`events.drainInFlightSkips`;
+    events.md §4's new sentence, stated narrowly as the drain deduping
+    against ITSELF — the LT1 (α) in-process copy and the cross-producer
+    invariant stay owed to the owner's ruling). Pinned:
+    `executor-events-down.test.ts` (exactly-once under an honest
+    deadline: one fire mid-settle → processed 1, ONE consequence commit,
+    the counter reads 1; mutation: guard removed → processed 11, red).
+    Every guarded run: `processed == appended`.
   - OFF witness: T1 is arm-independent by design (verdicts pinned);
     T2 lives in the flag-ON client overlay (constructed only under the
     flag on non-serving runtimes) and the replica seam fires only with an

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -1950,6 +1950,15 @@ export interface ChurnCounters {
   scheduleRunErrors: number;
   /** Event handlers that lost the receipt race permanently (`scheduler/event-lost-race`). */
   eventLostRaces: number;
+  /** Server-execution v2 stage C tuning T2 (flag-ON clients only, else 0):
+   * event-handler echoes dropped at seal because their intent was already
+   * terminal (`speculation-overlay/late-echo-dropped`) — the late-echo
+   * class the two-browsers lockdown stall belonged to. */
+  overlayLateEchoDrops: number;
+  /** Stage C tuning T2: overlay sweeps the replica's arrival wake ran
+   * (`speculation-overlay/arrival-sweep`) — served values arriving
+   * decoupled from a watermark advance. */
+  overlayArrivalSweeps: number;
 }
 
 export interface BrowserLoadSummary {
@@ -2087,6 +2096,8 @@ export async function collectBrowserLoadSummary(
       commitRejected: 0,
       scheduleRunErrors: 0,
       eventLostRaces: 0,
+      overlayLateEchoDrops: 0,
+      overlayArrivalSweeps: 0,
     };
     try {
       const workerCounts = await cf?.rt?.getLoggerCounts?.();
@@ -2139,6 +2150,14 @@ export async function collectBrowserLoadSummary(
       churn.commitRejected = countOf("storage.v2", "commit-rejected");
       churn.scheduleRunErrors = countOf("scheduler", "schedule-run-error");
       churn.eventLostRaces = countOf("scheduler", "event-lost-race");
+      churn.overlayLateEchoDrops = countOf(
+        "speculation-overlay",
+        "late-echo-dropped",
+      );
+      churn.overlayArrivalSweeps = countOf(
+        "speculation-overlay",
+        "arrival-sweep",
+      );
     } catch {
       // Worker may be disposed during teardown — main-thread IPC still tells
       // the contention story.
@@ -2210,7 +2229,9 @@ export function logBrowserLoadSummary(summary: BrowserLoadSummary): void {
     ` commitConflicts=${c.commitConflicts} commitReverts=${c.commitReverts}` +
     ` commitRejected=${c.commitRejected}` +
     ` scheduleRunErrors=${c.scheduleRunErrors}` +
-    ` eventLostRaces=${c.eventLostRaces}`;
+    ` eventLostRaces=${c.eventLostRaces}` +
+    ` overlayLateEchoDrops=${c.overlayLateEchoDrops}` +
+    ` overlayArrivalSweeps=${c.overlayArrivalSweeps}`;
   const pendingLine = summary.pendingIpc.length === 0
     ? "    (none)"
     : summary.pendingIpc.map((row) =>

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -297,17 +297,30 @@ export class SpaceServer implements TransactionSealDestination {
    * `now − lastRenewAt ≥ TTL/3`, i.e. exactly when the interval timer
    * would have fired had the wave's settle let it. */
   #lastRenewAt = 0;
-  /** EventIds the drain has queued into the serving scheduler whose
-   * dispatch has not yet reached its final commit callback (stage C
-   * tuning, T3's companion guard — see `events.drainInFlightSkips`): a
-   * re-drain must not queue a SECOND copy of an entry whose first copy
-   * is still queued, shaper-held, or running. Every id here was queued
-   * WITH its `streamEntry` (the mark path), which is #5969's stated
-   * safety condition for skipping a re-drain on the strength of another
-   * copy; the LT1 in-process cascade copy (no streamEntry) is a
-   * different producer and is deliberately NOT tracked here. Cleared at
-   * park (the scheduler queue dies with the runtime). */
-  readonly #drainInFlight = new Set<string>();
+  /** The drain's IN-FLIGHT copies (stage C tuning, T3's companion guard
+   * — see `events.drainInFlightSkips`): eventId → phase. A re-drain must
+   * not queue a SECOND copy of an entry whose first copy is still queued,
+   * shaper-held, running, OR whose consequence mark is sealed into a wave
+   * the store has not yet committed. Phases: `queued` — the copy sits in
+   * the scheduler (queued/held/running) and nothing of it has reached a
+   * wave; `marked` — a consequence (the handler tx's mark, or the
+   * drain's error/drop notice) is sealed into, or being staged for, an
+   * OPEN wave. Release points, each a store-visible or provably-markless
+   * end of the copy: the WAVE OUTCOME (`committedEventIds` ∪
+   * `requeuedEventIds` after `commitWave` — every abort arm reports its
+   * event-handler contributions as requeued), a DEFERRED dispatch (no
+   * mark, `#armDeferredRescan` retries), the queued copy's final callback
+   * while still `queued` (a name-resolution drop, an aborted run — no
+   * mark), a notice that failed to stage/seal, and park (the queue dies
+   * with the runtime). Releasing at the copy's SEAL was not enough (self-
+   * review finding 1): the mark rides an uncommitted wave while the entry
+   * is still pending in the store, and a re-drain that hit a real await
+   * in that window queued the second copy. Every id here was queued WITH
+   * its `streamEntry` (the mark path), which is #5969's stated safety
+   * condition for skipping a re-drain on the strength of another copy;
+   * the LT1 in-process cascade copy (no streamEntry) is a different
+   * producer and is deliberately NOT tracked here. */
+  readonly #drainInFlight = new Map<string, "queued" | "marked">();
   #currentWave: WaveAccumulator | undefined;
   #sealChain: Promise<unknown> = Promise.resolve();
   #feed: AdmittedCommitNotice[] = [];
@@ -922,6 +935,20 @@ export class SpaceServer implements TransactionSealDestination {
           // the mark precedes commitWave. Non-event contexts note
           // nothing (noteSealFailure filters).
           wave.noteSealFailure(waveRunContextOf(tx));
+        } else {
+          // The drain's in-flight guard: an ACCEPTED event-handler seal
+          // for a drained copy means its consequence mark now rides an
+          // open wave — the copy stays in flight until the wave outcome
+          // says the store committed or requeued it (never released at
+          // seal; see #drainInFlight).
+          const context = waveRunContextOf(tx);
+          if (
+            context?.kind === "event-handler" &&
+            context.eventId !== undefined &&
+            this.#drainInFlight.has(context.eventId)
+          ) {
+            this.#drainInFlight.set(context.eventId, "marked");
+          }
         }
         return result;
       },
@@ -1984,8 +2011,9 @@ export class SpaceServer implements TransactionSealDestination {
           if (entry.rendererTrusted === true) {
             markRendererTrustedEvent(entry.payload);
           }
-          this.#drainInFlight.add(entry.eventId);
+          this.#drainInFlight.set(entry.eventId, "queued");
           const eventId = entry.eventId;
+          const tenure = runtime;
           runtime.scheduler.queueEvent(
             link,
             entry.payload,
@@ -1995,9 +2023,17 @@ export class SpaceServer implements TransactionSealDestination {
             false,
             // The queued copy's FINAL callback (every terminal path of the
             // dispatch — commit result, drop, deferral, name-resolution
-            // drop, error): the in-flight guard releases the id here.
+            // drop, error): releases the guard ONLY while the copy is
+            // still `queued`, i.e. nothing of it reached a wave (an
+            // aborted run, a name-resolution drop). A `marked` copy is
+            // released by the wave outcome. Tenure-checked: a callback
+            // from a parked runtime's last pass must not release the next
+            // tenure's copy.
             () => {
-              this.#drainInFlight.delete(eventId);
+              if (this.#runtime !== tenure) return;
+              if (this.#drainInFlight.get(eventId) === "queued") {
+                this.#drainInFlight.delete(eventId);
+              }
             },
             false,
             {
@@ -2047,9 +2083,7 @@ export class SpaceServer implements TransactionSealDestination {
                   : {}),
                 streamEntry,
                 onFailure: (outcome) => {
-                  // Belt: a failed/deferred/dropped copy is no longer in
-                  // flight (its commit callback releases too).
-                  this.#drainInFlight.delete(eventId);
+                  if (this.#runtime !== tenure) return;
                   if (outcome.kind === "deferred") {
                     const deferrals =
                       (this.#eventDeferrals.get(entry.eventId) ?? 0) + 1;
@@ -2059,14 +2093,21 @@ export class SpaceServer implements TransactionSealDestination {
                       // re-drain waits for input or the backstop tick
                       // (the cold-view creation race — OW19's
                       // conflation caution), NEVER a synchronous spin.
+                      // The copy left no mark: release the guard so the
+                      // rescan can queue it again.
+                      this.#drainInFlight.delete(eventId);
                       this.#armDeferredRescan();
                       return;
                     }
                     // The race window is long past: no runnable handler
                     // exists — events.md §5's drop predicate. The
                     // notice un-renders the echo and un-wedges the
-                    // stream (and the park criterion).
+                    // stream (and the park criterion). Its mark is
+                    // being STAGED for a wave: the copy is `marked`
+                    // until the wave outcome (or the notice's own
+                    // failure) releases it.
                     this.#eventDeferrals.delete(entry.eventId);
+                    this.#drainInFlight.set(eventId, "marked");
                     this.#sealEventConsequenceNotice(
                       runtime,
                       entry,
@@ -2080,7 +2121,9 @@ export class SpaceServer implements TransactionSealDestination {
                     );
                     return;
                   }
+                  // The error/drop notice is a mark on its way to a wave.
                   this.#eventDeferrals.delete(entry.eventId);
+                  this.#drainInFlight.set(eventId, "marked");
                   this.#sealEventConsequenceNotice(
                     runtime,
                     entry,
@@ -2093,6 +2136,9 @@ export class SpaceServer implements TransactionSealDestination {
           );
           queued += 1;
         } catch (drainError) {
+          // Nothing was queued: release the guard (a throw between the
+          // add and the queue must not strand the entry until park).
+          this.#drainInFlight.delete(entry.eventId);
           logger.warn("drain-debug", () => ["per-entry threw", drainError]);
           this.#armDeferredRescan();
         }
@@ -2151,6 +2197,9 @@ export class SpaceServer implements TransactionSealDestination {
         }
       }
       const sealed = tx.commit().catch((error) => {
+        // The mark never reached a wave: the drain's guard releases so
+        // the re-drain can queue the entry again.
+        this.#drainInFlight.delete(entry.eventId);
         logger.warn("event-notice-seal-failed", () => [
           `consequence notice for ${entry.eventId} failed to seal; the ` +
           "entry stays pending and the next wave re-drains it",
@@ -2162,6 +2211,7 @@ export class SpaceServer implements TransactionSealDestination {
         this.#eventNoticeWork.delete(sealed as Promise<unknown>);
       });
     } catch (error) {
+      this.#drainInFlight.delete(entry.eventId);
       logger.warn("event-notice-failed", () => [
         `consequence notice for ${entry.eventId} could not be staged; ` +
         "the entry stays pending and the next wave re-drains it",
@@ -3001,6 +3051,18 @@ export class SpaceServer implements TransactionSealDestination {
       : this.#watermark;
     const outcome = await closing.commitWave(this.#sink!, { derivedThrough });
     await closing.settled();
+    // The drain's in-flight guard: the store has now spoken for every
+    // event this wave carried — committed (its mark landed) or requeued
+    // (its contributions withdrawn: lease-lost, rejected, foreign-failed,
+    // raced — every abort arm reports its event-handler contributions as
+    // requeued). Either way a later drain may queue the entry again if it
+    // is still pending.
+    for (const eventId of outcome.committedEventIds) {
+      this.#drainInFlight.delete(eventId);
+    }
+    for (const eventId of outcome.requeuedEventIds) {
+      this.#drainInFlight.delete(eventId);
+    }
     // The effect handoff (stage G, serving-loop.md §3): external effects
     // go to the outbox POST-commit. Taken off the map here either way;
     // the lease-lost branch below parks, so its batches are simply

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -297,6 +297,17 @@ export class SpaceServer implements TransactionSealDestination {
    * `now − lastRenewAt ≥ TTL/3`, i.e. exactly when the interval timer
    * would have fired had the wave's settle let it. */
   #lastRenewAt = 0;
+  /** EventIds the drain has queued into the serving scheduler whose
+   * dispatch has not yet reached its final commit callback (stage C
+   * tuning, T3's companion guard — see `events.drainInFlightSkips`): a
+   * re-drain must not queue a SECOND copy of an entry whose first copy
+   * is still queued, shaper-held, or running. Every id here was queued
+   * WITH its `streamEntry` (the mark path), which is #5969's stated
+   * safety condition for skipping a re-drain on the strength of another
+   * copy; the LT1 in-process cascade copy (no streamEntry) is a
+   * different producer and is deliberately NOT tracked here. Cleared at
+   * park (the scheduler queue dies with the runtime). */
+  readonly #drainInFlight = new Set<string>();
   #currentWave: WaveAccumulator | undefined;
   #sealChain: Promise<unknown> = Promise.resolve();
   #feed: AdmittedCommitNotice[] = [];
@@ -1928,6 +1939,19 @@ export class SpaceServer implements TransactionSealDestination {
           this.#sealEventConsequenceNotice(runtime, entry, streamEntry);
           continue;
         }
+        // The in-flight guard (stage C tuning; #5969's (β), drain-own
+        // copies only): an entry whose earlier drain copy is still
+        // queued/held/running in the scheduler is not queued AGAIN — the
+        // honest flush deadline (T3) ends cycles before a just-drained
+        // event has run, and the post-commit re-arm re-drains the
+        // still-pending entry every cut cycle. The copy completes (its
+        // commit callback removes the id) or fails/defers (onFailure
+        // removes it too), and a still-pending entry then re-drains as
+        // before — the requeue and deferral retries are untouched.
+        if (this.#drainInFlight.has(entry.eventId)) {
+          this.#options.stats.events.drainInFlightSkips += 1;
+          continue;
+        }
         const link: NormalizedFullLink = {
           space,
           id: entry.stream.id as NormalizedFullLink["id"],
@@ -1960,6 +1984,8 @@ export class SpaceServer implements TransactionSealDestination {
           if (entry.rendererTrusted === true) {
             markRendererTrustedEvent(entry.payload);
           }
+          this.#drainInFlight.add(entry.eventId);
+          const eventId = entry.eventId;
           runtime.scheduler.queueEvent(
             link,
             entry.payload,
@@ -1967,7 +1993,12 @@ export class SpaceServer implements TransactionSealDestination {
             // the entry unconsequenced and durable, and the post-wave
             // re-arm rescans it — the wave IS the retry cadence.
             false,
-            undefined,
+            // The queued copy's FINAL callback (every terminal path of the
+            // dispatch — commit result, drop, deferral, name-resolution
+            // drop, error): the in-flight guard releases the id here.
+            () => {
+              this.#drainInFlight.delete(eventId);
+            },
             false,
             {
               eventId: entry.eventId,
@@ -2016,6 +2047,9 @@ export class SpaceServer implements TransactionSealDestination {
                   : {}),
                 streamEntry,
                 onFailure: (outcome) => {
+                  // Belt: a failed/deferred/dropped copy is no longer in
+                  // flight (its commit callback releases too).
+                  this.#drainInFlight.delete(eventId);
                   if (outcome.kind === "deferred") {
                     const deferrals =
                       (this.#eventDeferrals.get(entry.eventId) ?? 0) + 1;
@@ -3193,6 +3227,8 @@ export class SpaceServer implements TransactionSealDestination {
       this.#deferredRescanTimer = undefined;
     }
     this.#feedArrived?.resolve();
+    // The drain's in-flight copies die with the scheduler queue below.
+    this.#drainInFlight.clear();
     for (const cancel of this.#demandSinks.values()) {
       try {
         cancel();

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -68,6 +68,7 @@ import {
 import type { NormalizedFullLink } from "../link-types.ts";
 import {
   EXECUTION_LEASE_RENEW_INTERVAL_MS,
+  EXECUTION_LEASE_TTL_MS,
   ExecutionLeaseCycle,
   executionLeaseHolder,
 } from "@commonfabric/memory/v2/execution-lease";
@@ -144,6 +145,12 @@ export type SpaceServerPolicy = {
   /** serving-loop.md §1's IDLE_PARK_MS. */
   idleParkMs?: number;
   renewIntervalMs?: number;
+  /** The execution lease's TTL (serving-loop.md §2; production takes the
+   * wire default EXECUTION_LEASE_TTL_MS). A knob so tests can pin the
+   * mid-wave renew (stage C tuning T3) with a short tenure instead of
+   * waiting out the 15-s default; the mid-wave renew fires once a wave
+   * has run longer than TTL/3 without a renewal. */
+  leaseTtlMs?: number;
   /** Deadline on the park's runtime dispose (park LIVENESS): a serving
    * runtime killed mid-wave can hang `runtime.dispose()` forever, and a
    * park gated on it never resolves `whenParked` — wedging every
@@ -285,6 +292,11 @@ export class SpaceServer implements TransactionSealDestination {
   #disposeRuntime: (() => Promise<void>) | undefined;
   #sink: EngineWaveCommitSink | undefined;
   #renewTimer: ReturnType<typeof setInterval> | undefined;
+  /** Wall-clock of the last successful acquire/renew (stage C tuning T3):
+   * the mid-wave renew fires from the scheduler's cooperative yield once
+   * `now − lastRenewAt ≥ TTL/3`, i.e. exactly when the interval timer
+   * would have fired had the wave's settle let it. */
+  #lastRenewAt = 0;
   #currentWave: WaveAccumulator | undefined;
   #sealChain: Promise<unknown> = Promise.resolve();
   #feed: AdmittedCommitNotice[] = [];
@@ -505,12 +517,16 @@ export class SpaceServer implements TransactionSealDestination {
       engine,
       space,
       holder: this.#holder,
+      ...(this.#options.policy?.leaseTtlMs !== undefined
+        ? { ttlMs: this.#options.policy.leaseTtlMs }
+        : {}),
     });
     if (!lease.acquire()) {
       this.#options.onParked?.("lease-unavailable");
       return false;
     }
     this.#lease = lease;
+    this.#lastRenewAt = Date.now();
     this.#options.stats.lease.held += 1;
 
     let runtime: Runtime;
@@ -756,6 +772,16 @@ export class SpaceServer implements TransactionSealDestination {
     const renewMs = this.#options.policy?.renewIntervalMs ??
       EXECUTION_LEASE_RENEW_INTERVAL_MS;
     this.#renewTimer = setInterval(() => this.#renew(), renewMs);
+    // The MID-WAVE renew (stage C tuning T3, serving-loop.md §2): the
+    // renew timer above rides the macrotask queue a long settle used to
+    // starve (the attribution's t2: renew gaps to 10 s against the 15-s
+    // TTL, then `lease-lost` on every active space at once). The serving
+    // scheduler now yields a macrotask between runs (cooperative-yield.ts)
+    // — which already lets the timer fire — and reports every such yield
+    // here, where a renew is issued directly once the wave has run TTL/3
+    // without one: a belt that does not depend on the timer queue being
+    // serviced, only on the scheduler reaching a run boundary.
+    runtime.servingYieldObserver = () => this.#renewIfDue();
 
     this.#active = true;
     this.#options.stats.activeSpaces += 1;
@@ -1484,9 +1510,26 @@ export class SpaceServer implements TransactionSealDestination {
     return { ok: {} };
   }
 
+  /** The mid-wave renew (stage C tuning T3): called from the serving
+   * scheduler's cooperative yield; renews once the tenure has gone TTL/3
+   * without a renewal (the interval timer's own cadence), otherwise a
+   * no-op — so a wave shorter than TTL/3 costs nothing here and a wave
+   * longer than TTL/3 renews at the same cadence the timer would have. */
+  #renewIfDue(): void {
+    const lease = this.#lease;
+    if (lease === undefined || !this.#active) return;
+    const ttlMs = this.#options.policy?.leaseTtlMs ?? EXECUTION_LEASE_TTL_MS;
+    if (Date.now() - this.#lastRenewAt < ttlMs / 3) return;
+    this.#renew();
+  }
+
   #renew(): void {
     const lease = this.#lease;
     if (lease === undefined || !this.#active) return;
+    // Stamped before the outcome is known: a FAILED renew ends the tenure
+    // (park or reacquire below), and a reacquire is itself a fresh
+    // tenure start.
+    this.#lastRenewAt = Date.now();
     if (!lease.renew()) {
       // Stop committing immediately (serving-loop.md §2's MUST): the
       // tenure ended inside renew(), so an in-flight wave aborts at its
@@ -3197,6 +3240,7 @@ export class SpaceServer implements TransactionSealDestination {
         this.#runtime.connectedSessionProbe = undefined;
         this.#runtime.notifyServedIntentSealFailure = undefined;
         this.#runtime.pieceStartCommitFailureObserver = undefined;
+        this.#runtime.servingYieldObserver = undefined;
         // The shadow-flip wake dies with the tenure (a late flip on a
         // disposing replica must not poke a parked loop's stale wait).
         this.#runtime.storageManager.open(this.#options.space).replica

--- a/packages/runner/src/executor/stats.ts
+++ b/packages/runner/src/executor/stats.ts
@@ -151,6 +151,18 @@ export type ServingLoopStats = {
     processed: number;
     coalescedPerWaveMax: number;
     skippedIdempotent: number;
+    /** Stage C tuning (T3's companion guard): drain passes that found a
+     * pending entry whose EARLIER drain copy is still queued or in flight
+     * in the serving scheduler (its dispatch has not reached its commit
+     * callback yet) and did NOT queue it again. With an honest flush
+     * deadline (T3) a cycle routinely ends before a just-drained event
+     * has run, and the post-commit re-arm re-drains the still-pending
+     * entry next cycle — pre-guard that queued a second copy per cut
+     * cycle (4× dispatch of the lockdown toggle on the two-browsers gate;
+     * #5969's re-scan variant, (β)). Counted per skipped re-queue; a count
+     * that grows without `processed` settling names a drain copy that
+     * never completes. */
+    drainInFlightSkips: number;
   };
   memo: { hits: number; misses: number; inflight: number };
   outbox: {
@@ -194,6 +206,7 @@ export const emptyServingLoopStats = (): ServingLoopStats => ({
     processed: 0,
     coalescedPerWaveMax: 0,
     skippedIdempotent: 0,
+    drainInFlightSkips: 0,
   },
   memo: { hits: 0, misses: 0, inflight: 0 },
   outbox: { queued: 0, completed: 0, failed: 0, budgetDeferrals: 0 },

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -604,6 +604,11 @@ export interface RuntimeOptions {
 
 export interface CfcRuntimeStats {
   cfcRelevantTx: number;
+  /** Stage C tuning T1: flow-label relevance probes actually EVALUATED
+   * (`flowLabelWorkExists`) vs answered from the transaction's memoized
+   * negative verdict. Measurement only. */
+  flowLabelProbesComputed: number;
+  flowLabelProbeMemoHits: number;
   cfcPreparedTx: number;
   cfcPrepareRejects: number;
   cfcDigestInvalidations: number;
@@ -636,6 +641,8 @@ export interface CfcRuntimeStats {
 
 const initialCfcRuntimeStats = (): CfcRuntimeStats => ({
   cfcRelevantTx: 0,
+  flowLabelProbesComputed: 0,
+  flowLabelProbeMemoHits: 0,
   cfcPreparedTx: 0,
   cfcPrepareRejects: 0,
   cfcDigestInvalidations: 0,
@@ -1480,6 +1487,20 @@ export class Runtime {
     | undefined;
 
   /**
+   * Server-execution v2 stage C tuning (T3; serving-loop.md §2/§3): the
+   * serving scheduler's mid-wave hook. A SERVING runtime's scheduler
+   * yields one macrotask between runs whenever its slice of continuous
+   * work is spent (scheduler/cooperative-yield.ts — that is what makes the
+   * wave's flush deadline honest and lets the lease-renew and push-flush
+   * timers fire mid-settle), and calls this observer synchronously at
+   * every such yield. The SpaceServer installs it at activation to renew
+   * the lease mid-wave once the wave has run longer than TTL/3 — a renew
+   * that never depends on the timer queue being serviced. Undefined
+   * everywhere else (the OFF arm and clients construct no yielder at all).
+   */
+  servingYieldObserver: (() => void) | undefined;
+
+  /**
    * Register an in-flight async builtin operation so `settled()` waits for it
    * instead of racing the post-commit flush. The scheduler registers an
    * effect-bearing commit's promise here (a race-free barrier — the flush runs
@@ -1827,6 +1848,10 @@ export class Runtime {
         this.installCfcPolicyManifest(space, reference, tx),
       onRelevantTx: () => {
         this.cfcStats.cfcRelevantTx += 1;
+      },
+      onFlowLabelProbe: (outcome) => {
+        if (outcome === "memo") this.cfcStats.flowLabelProbeMemoHits += 1;
+        else this.cfcStats.flowLabelProbesComputed += 1;
       },
       onPreparedTx: () => {
         this.cfcStats.cfcPreparedTx += 1;
@@ -2299,10 +2324,13 @@ export class Runtime {
     }
     // Flow-label relevance is computed, not caller-marked (S16): the
     // laundering txs are exactly the ones nothing marked relevant.
+    // Stage C tuning T1: probed ONCE per transaction activity epoch — the
+    // commit chokepoint re-uses this call's negative verdict (see
+    // IExtendedStorageTransaction.probeFlowLabelWork).
     if (
       !state.relevant &&
       state.flowLabelsMode !== "off" &&
-      flowLabelWorkExists(tx)
+      (tx.probeFlowLabelWork?.() ?? flowLabelWorkExists(tx))
     ) {
       tx.markCfcRelevant("flow-labels");
     }

--- a/packages/runner/src/scheduler/cooperative-yield.ts
+++ b/packages/runner/src/scheduler/cooperative-yield.ts
@@ -1,0 +1,107 @@
+// The serving scheduler's cooperative macrotask yield (server-execution v2
+// stage C tuning, T3; serving-loop.md §2/§3).
+//
+// Why: the settle loop (`settle.ts`) and the per-demander fan-out loop
+// (`run.ts`) run every action of a pass on one microtask chain — no
+// macrotask boundary from the first run to the last. On a serving
+// runtime that is the wave's whole settle: the stage-C attribution
+// measured chat event waves of 2.6–3.6 s in which the 100-ms flush
+// deadline fired 2.5–8.3 s LATE (`wavesBudgetExhausted` was a symptom,
+// not a bound), the lease-renew `setInterval` starved for up to 10 s
+// against a 15-s TTL (t2: `wave-commit-rejected` then `lease-lost` on
+// every active space within 10 ms — the process's renew timers missing
+// together), and the memory server's 5-ms push flush waited too. The
+// timers all ride the macrotask queue the loop never yields to.
+//
+// What: a time-sliced yield. `maybeYield()` is called between runs;
+// when the current slice of continuous scheduler work has run longer
+// than `sliceMs` it awaits one macrotask turn (`setTimeout(0)` — the one
+// primitive that lets DUE timers fire in deadline order before it
+// resumes; measured on Deno: a MessageChannel turn or `setImmediate`
+// let 0–2 of 8 due timers fire across a 360-ms loop, `setTimeout(0)`
+// all 8 within a few ms of their deadlines) and reports the slice to the
+// installed observer FIRST, synchronously — the mid-wave lease renew
+// rides that hook, so it never depends on the timer queue being
+// serviced. Between yields nothing changes: the OFF arm and client
+// runtimes never construct one of these (the scheduler creates it only
+// under `runtime.servingPosture`), so their settle loops keep the exact
+// microtask shape they had.
+//
+// Bound, stated honestly: the deadline becomes honest to within ONE run
+// plus a slice — a single 250-ms demand walk or a 1.6-s union-log
+// resubscribe still runs to its end; nothing here shortens the WORK
+// (that is the design half of stage C, the per-demander walk).
+
+import { getLogger } from "@commonfabric/utils/logger";
+
+const logger = getLogger("cooperative-yield", {
+  enabled: true,
+  level: "warn",
+});
+
+/** One frame's worth of continuous scheduler work per macrotask turn on a
+ * serving runtime. Sized against the yield's own cost (~2 ms per
+ * `setTimeout(0)` on Deno) and the deadline's granularity (T_flush 100
+ * ms): ≤ ~12 % overhead on pure-CPU runs, far less on the 20–250-ms
+ * demand walks the attribution measured, and a deadline honest to
+ * within one run + this slice. */
+export const DEFAULT_SERVING_YIELD_SLICE_MS = 16;
+
+export class CooperativeYield {
+  readonly #sliceMs: number;
+  #sliceStart = performance.now();
+  #yields = 0;
+  /** The mid-wave hook (the SpaceServer's lease renew): called
+   * synchronously at every yield, BEFORE the macrotask turn. */
+  onYield: (() => void) | undefined;
+
+  constructor(sliceMs: number = DEFAULT_SERVING_YIELD_SLICE_MS) {
+    this.#sliceMs = sliceMs;
+  }
+
+  /** DIAGNOSTIC (tests): macrotask turns taken so far. */
+  get yieldCount(): number {
+    return this.#yields;
+  }
+
+  /** The caller just crossed a macrotask boundary of its own (a new
+   * execute pass): restart the slice clock so an idle gap does not read
+   * as spent work. */
+  noteMacrotaskBoundary(): void {
+    this.#sliceStart = performance.now();
+  }
+
+  /**
+   * Yield one macrotask turn iff the current slice is spent. Returns
+   * `undefined` when there is nothing to await, so a caller can skip the
+   * `await` (and its microtask hop) entirely on the hot path.
+   */
+  maybeYield(): Promise<void> | undefined {
+    if (performance.now() - this.#sliceStart < this.#sliceMs) {
+      return undefined;
+    }
+    return this.yieldNow();
+  }
+
+  /** Yield one macrotask turn unconditionally: report the slice to the
+   * observer (synchronously — see the header), then let due timers run. */
+  yieldNow(): Promise<void> {
+    this.#yields += 1;
+    try {
+      this.onYield?.();
+    } catch (error) {
+      // The observer is the serving loop's; a throw there must not take
+      // the scheduler down with it (same containment posture as the
+      // replica's observer seams).
+      logger.warn("yield-observer-failed", () => [
+        "cooperative-yield observer threw",
+        error,
+      ]);
+    }
+    return new Promise<void>((resolve) => setTimeout(resolve, 0)).then(
+      () => {
+        this.#sliceStart = performance.now();
+      },
+    );
+  }
+}

--- a/packages/runner/src/scheduler/cooperative-yield.ts
+++ b/packages/runner/src/scheduler/cooperative-yield.ts
@@ -1,10 +1,10 @@
 // The serving scheduler's cooperative macrotask yield (server-execution v2
 // stage C tuning, T3; serving-loop.md §2/§3).
 //
-// Why: the settle loop (`settle.ts`) and the per-demander fan-out loop
-// (`run.ts`) run every action of a pass on one microtask chain — no
-// macrotask boundary from the first run to the last. On a serving
-// runtime that is the wave's whole settle: the stage-C attribution
+// Why: the settle loop (`settle.ts`) runs every action of a pass on one
+// microtask chain — no macrotask boundary from the first run to the
+// last. On a serving runtime that is the wave's whole settle: the
+// stage-C attribution
 // measured chat event waves of 2.6–3.6 s in which the 100-ms flush
 // deadline fired 2.5–8.3 s LATE (`wavesBudgetExhausted` was a symptom,
 // not a bound), the lease-renew `setInterval` starved for up to 10 s
@@ -27,10 +27,13 @@
 // under `runtime.servingPosture`), so their settle loops keep the exact
 // microtask shape they had.
 //
-// Bound, stated honestly: the deadline becomes honest to within ONE run
-// plus a slice — a single 250-ms demand walk or a 1.6-s union-log
-// resubscribe still runs to its end; nothing here shortens the WORK
-// (that is the design half of stage C, the per-demander walk).
+// Bound, stated honestly: the deadline becomes honest to within ONE
+// action plus a slice — an action's per-demander instance runs (a
+// 250-ms demand walk × its demanders) and its union-log resubscribe
+// still run to their end; nothing here shortens the WORK (that is the
+// design half of stage C, the per-demander walk). The yield is NOT
+// placed inside the fan-out loop (see run.ts's note): a macrotask there
+// let a run's own async seal refusal re-enter the pass.
 
 import { getLogger } from "@commonfabric/utils/logger";
 

--- a/packages/runner/src/scheduler/execution.ts
+++ b/packages/runner/src/scheduler/execution.ts
@@ -172,6 +172,12 @@ export interface SchedulerSettleLoopState {
   readonly clearComputationDebounceState: (action: Action) => void;
   readonly isLiveAction: (action: Action) => boolean;
   readonly runAction: (action: Action) => Promise<unknown>;
+  /** The serving posture's cooperative macrotask yield between runs
+   * (server-execution v2 stage C tuning T3, cooperative-yield.ts):
+   * returns a promise to await when the current slice is spent, else
+   * undefined. Installed only on a serving runtime — absent (inert) on
+   * the OFF arm and on flag-ON clients. */
+  readonly yieldBetweenRuns?: () => Promise<void> | undefined;
 }
 
 export function recordSettleActionRun(

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -1002,9 +1002,9 @@ export class Scheduler {
     };
   }
 
-  /** The bound yield hook handed to the settle loop and the fan-out loop
-   * (stage C tuning T3): a promise to await when the slice is spent, else
-   * undefined. Defined only when `cooperativeYield` exists. */
+  /** The bound yield hook handed to the settle loop (stage C tuning T3):
+   * a promise to await when the slice is spent, else undefined. Defined
+   * only when `cooperativeYield` exists. */
   private readonly cooperativeYieldBetweenRuns = ():
     | Promise<void>
     | undefined => this.cooperativeYield?.maybeYield();
@@ -2328,11 +2328,6 @@ export class Scheduler {
         this.executingAction = null;
         this.currentActionId = undefined;
       },
-      // Stage C tuning T3: only a serving runtime yields between a fanned-out
-      // node's instance runs.
-      ...(this.cooperativeYield !== undefined
-        ? { yieldBetweenRuns: this.cooperativeYieldBetweenRuns }
-        : {}),
     };
   }
 

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -104,6 +104,7 @@ import {
   type SettlingTracker,
 } from "./execution.ts";
 import { runPullSchedulerSettleLoop } from "./settle.ts";
+import { CooperativeYield } from "./cooperative-yield.ts";
 import { collectPullIterationSeeds as collectPullIterationSeedsState } from "./settle.ts";
 import {
   type DirtyPullRunnableState,
@@ -424,6 +425,12 @@ export class Scheduler {
   private graphSnapshotState!: SchedulerGraphSnapshotState;
   private settleLoopState!: SchedulerSettleLoopState;
   private executeContinuationState!: ExecuteContinuationState;
+  // The serving posture's cooperative macrotask yield (server-execution
+  // v2 stage C tuning T3, cooperative-yield.ts): constructed ONLY for a
+  // serving runtime, so the OFF arm and flag-ON clients keep their
+  // settle loops' exact microtask shape. Its observer is the runtime's
+  // `servingYieldObserver` seam — the SpaceServer's mid-wave lease renew.
+  private readonly cooperativeYield: CooperativeYield | undefined;
 
   // ============================================================
   // Public API
@@ -434,6 +441,11 @@ export class Scheduler {
     consoleHandler?: ConsoleHandler,
     errorHandlers?: ErrorHandler[],
   ) {
+    if (runtime.servingPosture) {
+      const yielder = new CooperativeYield();
+      yielder.onYield = () => runtime.servingYieldObserver?.();
+      this.cooperativeYield = yielder;
+    }
     this.initializeSchedulerState();
 
     this.consoleHandler = consoleHandler ||
@@ -988,6 +1000,18 @@ export class Scheduler {
       instanceKeys: [...state.instances.keys()],
       cleanKeys: [...state.clean],
     };
+  }
+
+  /** The bound yield hook handed to the settle loop and the fan-out loop
+   * (stage C tuning T3): a promise to await when the slice is spent, else
+   * undefined. Defined only when `cooperativeYield` exists. */
+  private readonly cooperativeYieldBetweenRuns = (): Promise<void> | undefined =>
+    this.cooperativeYield?.maybeYield();
+
+  /** DIAGNOSTIC (tests): the serving posture's cooperative yielder, if
+   * this scheduler has one. */
+  get servingYield(): CooperativeYield | undefined {
+    return this.cooperativeYield;
   }
 
   queueExecution(): void {
@@ -1597,6 +1621,10 @@ export class Scheduler {
   private async execute(): Promise<void> {
     if (this.disposed) return;
     logger.timeStart("scheduler", "execute");
+    // Each execute pass starts in a fresh macrotask (queueTask): restart
+    // the serving posture's yield slice so idle time between passes never
+    // reads as spent work (stage C tuning T3).
+    this.cooperativeYield?.noteMacrotaskBoundary();
 
     // In case a directly invoked `run` is still running, wait for it to finish.
     if (this.runningPromise) await this.runningPromise;
@@ -2127,6 +2155,10 @@ export class Scheduler {
         this.gates.clearComputationDebounceState(action),
       isLiveAction: (action) => this.isLiveAction(action),
       runAction: (action) => this.run(action),
+      // Stage C tuning T3: only a serving runtime yields between runs.
+      ...(this.cooperativeYield !== undefined
+        ? { yieldBetweenRuns: this.cooperativeYieldBetweenRuns }
+        : {}),
     };
   }
 
@@ -2295,6 +2327,11 @@ export class Scheduler {
         this.executingAction = null;
         this.currentActionId = undefined;
       },
+      // Stage C tuning T3: only a serving runtime yields between a fanned-out
+      // node's instance runs.
+      ...(this.cooperativeYield !== undefined
+        ? { yieldBetweenRuns: this.cooperativeYieldBetweenRuns }
+        : {}),
     };
   }
 

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -1005,8 +1005,9 @@ export class Scheduler {
   /** The bound yield hook handed to the settle loop and the fan-out loop
    * (stage C tuning T3): a promise to await when the slice is spent, else
    * undefined. Defined only when `cooperativeYield` exists. */
-  private readonly cooperativeYieldBetweenRuns = (): Promise<void> | undefined =>
-    this.cooperativeYield?.maybeYield();
+  private readonly cooperativeYieldBetweenRuns = ():
+    | Promise<void>
+    | undefined => this.cooperativeYield?.maybeYield();
 
   /** DIAGNOSTIC (tests): the serving posture's cooperative yielder, if
    * this scheduler has one. */

--- a/packages/runner/src/scheduler/run.ts
+++ b/packages/runner/src/scheduler/run.ts
@@ -590,6 +590,19 @@ export async function runSchedulerAction(
     let ran = false;
     const deferred = new Set<ScopeKey>();
     for (;;) {
+      // Stage C tuning T3: the per-demander walk is where a serving wave
+      // spends its settle (20–250 ms per instance run × demanders ×
+      // roots — the attribution's dominant server term), and this loop
+      // had no macrotask boundary between instances. Yield once the
+      // slice is spent, so the flush deadline, the lease renew and the
+      // push flush can fire between one demander's run and the next.
+      // BEFORE the instance-set snapshot below: a demander can depart (or
+      // the ratchet move) during the turn, and the run must act on the
+      // set as it stands after it.
+      if (ran && state.yieldBetweenRuns !== undefined) {
+        const turn = state.yieldBetweenRuns();
+        if (turn !== undefined) await turn;
+      }
       const currentDemanders = state.runtime.serverRunDemandersFor(
         demandRootIds!,
       ) ?? [];
@@ -599,16 +612,6 @@ export async function runSchedulerAction(
         (instance) => !deferred.has(instance.key),
       );
       if (toRun.length === 0) break;
-      // Stage C tuning T3: the per-demander walk is where a serving wave
-      // spends its settle (20–250 ms per instance run × demanders ×
-      // roots — the attribution's dominant server term), and this loop
-      // had no macrotask boundary between instances. Yield once the
-      // slice is spent, so the flush deadline, the lease renew and the
-      // push flush can fire between one demander's run and the next.
-      if (ran && state.yieldBetweenRuns !== undefined) {
-        const turn = state.yieldBetweenRuns();
-        if (turn !== undefined) await turn;
-      }
       const instance = toRun[0];
       const startGen = fanOutRunStarted(fanOut, instance);
       const causes = invalidCauses === undefined

--- a/packages/runner/src/scheduler/run.ts
+++ b/packages/runner/src/scheduler/run.ts
@@ -368,13 +368,6 @@ export interface SchedulerActionRunState {
   readonly queueExecution: () => void;
   readonly setExecutingAction: (action: Action, actionId: string) => void;
   readonly clearExecutingAction: () => void;
-  /** The serving posture's cooperative macrotask yield between a
-   * fanned-out node's INSTANCE runs (server-execution v2 stage C tuning
-   * T3, cooperative-yield.ts; same seam the settle loop uses between
-   * actions). Installed only on a serving runtime; the fan-out loop
-   * itself is reachable only there (demanders exist only under the
-   * SpaceServer's resolver), so this is inert everywhere else. */
-  readonly yieldBetweenRuns?: () => Promise<void> | undefined;
 }
 
 export async function runSchedulerAction(
@@ -589,20 +582,19 @@ export async function runSchedulerAction(
     let lastResult: unknown;
     let ran = false;
     const deferred = new Set<ScopeKey>();
+    // Deliberately NO cooperative macrotask yield between instance runs
+    // (stage C tuning T3 considered and REJECTED it here): the settle
+    // loop yields between ACTIONS (settle.ts); a yield inside this loop
+    // let a run's own asynchronous seal refusal land mid-pass and dirty
+    // its instance, which the next iteration's snapshot then re-ran in
+    // THIS pass while the refusal's queued retry re-ran it again — two
+    // durable emissions of one served event (executor-space-server's
+    // LT6 early-emit arm caught it). The retry machinery's contract is
+    // that a failed run's retry lands on the QUEUED pass, never this one;
+    // the loop keeps its microtask shape so that holds. Cost: the flush
+    // deadline is honest to within one action (all of its instance runs),
+    // not one instance.
     for (;;) {
-      // Stage C tuning T3: the per-demander walk is where a serving wave
-      // spends its settle (20–250 ms per instance run × demanders ×
-      // roots — the attribution's dominant server term), and this loop
-      // had no macrotask boundary between instances. Yield once the
-      // slice is spent, so the flush deadline, the lease renew and the
-      // push flush can fire between one demander's run and the next.
-      // BEFORE the instance-set snapshot below: a demander can depart (or
-      // the ratchet move) during the turn, and the run must act on the
-      // set as it stands after it.
-      if (ran && state.yieldBetweenRuns !== undefined) {
-        const turn = state.yieldBetweenRuns();
-        if (turn !== undefined) await turn;
-      }
       const currentDemanders = state.runtime.serverRunDemandersFor(
         demandRootIds!,
       ) ?? [];

--- a/packages/runner/src/scheduler/run.ts
+++ b/packages/runner/src/scheduler/run.ts
@@ -368,6 +368,13 @@ export interface SchedulerActionRunState {
   readonly queueExecution: () => void;
   readonly setExecutingAction: (action: Action, actionId: string) => void;
   readonly clearExecutingAction: () => void;
+  /** The serving posture's cooperative macrotask yield between a
+   * fanned-out node's INSTANCE runs (server-execution v2 stage C tuning
+   * T3, cooperative-yield.ts; same seam the settle loop uses between
+   * actions). Installed only on a serving runtime; the fan-out loop
+   * itself is reachable only there (demanders exist only under the
+   * SpaceServer's resolver), so this is inert everywhere else. */
+  readonly yieldBetweenRuns?: () => Promise<void> | undefined;
 }
 
 export async function runSchedulerAction(
@@ -592,6 +599,16 @@ export async function runSchedulerAction(
         (instance) => !deferred.has(instance.key),
       );
       if (toRun.length === 0) break;
+      // Stage C tuning T3: the per-demander walk is where a serving wave
+      // spends its settle (20–250 ms per instance run × demanders ×
+      // roots — the attribution's dominant server term), and this loop
+      // had no macrotask boundary between instances. Yield once the
+      // slice is spent, so the flush deadline, the lease renew and the
+      // push flush can fire between one demander's run and the next.
+      if (ran && state.yieldBetweenRuns !== undefined) {
+        const turn = state.yieldBetweenRuns();
+        if (turn !== undefined) await turn;
+      }
       const instance = toRun[0];
       const startGen = fanOutRunStarted(fanOut, instance);
       const causes = invalidCauses === undefined

--- a/packages/runner/src/scheduler/settle.ts
+++ b/packages/runner/src/scheduler/settle.ts
@@ -519,6 +519,16 @@ async function runPullSettleOrder(
 ): Promise<number> {
   let actionsRun = 0;
   for (const fn of order) {
+    // The serving posture's cooperative macrotask yield (server-execution
+    // v2 stage C tuning T3, cooperative-yield.ts): between runs, once the
+    // slice is spent, let the wave's flush-deadline timer, the lease
+    // renew, and the push flush fire. `yieldBetweenRuns` is installed
+    // only on a serving runtime; everywhere else this is one undefined
+    // check and the loop keeps its exact microtask shape (no `await`).
+    if (state.yieldBetweenRuns !== undefined) {
+      const turn = state.yieldBetweenRuns();
+      if (turn !== undefined) await turn;
+    }
     actionsRun += await runPullSettleAction(
       state,
       fn,

--- a/packages/runner/src/speculation/overlay-destination.ts
+++ b/packages/runner/src/speculation/overlay-destination.ts
@@ -50,14 +50,20 @@
 // derived doc and the covering watermark advance rode ONE frame; an
 // EXHAUSTED wave carries no watermark movement (its derivedThrough is
 // frozen — serving-loop.md §3), so its derived values arrive DECOUPLED
-// from W and the echo stood until the next unrelated commit lifted W (the
-// attribution's 48-s lockdown-chip stall). The gate itself is unchanged —
-// the arrival is a second, earlier TRIGGER, never a relaxation of the
-// coverage or arrival predicates. Its soundness argument: the sweep's
-// predicates are evaluated afresh on replica state at every trigger, so
-// an extra trigger can only retire an entry the gate would have retired
-// at the next watermark event anyway; the arrival of the authoritative
-// value IS the landing the gate waits for.
+// from W and an entry whose floor W already covered stood until the next
+// watermark event. With the honest flush deadline (T3) that is the
+// ROUTINE shape of a busy wave, which is what the wake closes. The gate
+// itself is unchanged — the arrival is a second, earlier TRIGGER, never a
+// relaxation of the coverage or arrival predicates. Its soundness
+// argument: the sweep's predicates are evaluated afresh on replica state
+// at every trigger, so an extra trigger can only retire an entry the gate
+// would have retired at the next watermark event anyway; the arrival of
+// the authoritative value IS the landing the gate waits for. (The
+// attribution's 48-s lockdown-chip stall itself is a DIFFERENT entry —
+// a late event echo whose floor sits ABOVE every reachable W; see the
+// late-echo rule at `#sealSpeculative`. Its mechanism is inferred from
+// the red runs' evidence — no prompt echo, a worker busy for 8.7–12 s —
+// not witnessed by a client trace.)
 //
 // Post-commit effects of a speculative run follow the egress rule
 // (README §1): "speculate on anything you can throw away; never on
@@ -241,6 +247,11 @@ export class SpeculationOverlayDestination
    * (speculation.md §4 step 2) — and is not registered. */
   readonly #terminalIntents = new Set<string>();
   static readonly #MAX_TERMINAL_INTENTS = 4096;
+  /** Transactions dropped as late echoes: `deferSealedEffects` owns and
+   * DROPS their enactable effects too (the closed-overlay arm's shape) —
+   * an optimistic navigation for a run whose writes were discarded must
+   * not enact. */
+  readonly #droppedLateEchoTxs = new WeakSet<object>();
   /** DIAGNOSTIC counters (tests). */
   #arrivalSweeps = 0;
   #lateEchoDrops = 0;
@@ -379,14 +390,28 @@ export class SpeculationOverlayDestination
     // run completes normally. Same-tick soundness: an intent is terminal
     // only through a store signal or an admission refusal, both of which
     // this overlay recorded before this seal ran.
+    // The rule reaches the late echo's CASCADE too (self-review finding
+    // 2): a send from inside the late run queues a client cascade child
+    // under a MINTED id (never an intent, never terminal) whose echo
+    // would seal over served state, register, and stand with the same
+    // floor-above-W shape — the parent's `parentEventId` names the
+    // jobless intent, and the dropped run's own id joins the set so
+    // grandchildren fold in. The server's authoritative run of the intent
+    // produced (or produces, in later waves) the durable cascade; the
+    // client's late copies have no job at any depth.
     if (
       context?.kind === "event-handler" && context.eventId !== undefined &&
-      this.#terminalIntents.has(context.eventId)
+      (this.#terminalIntents.has(context.eventId) ||
+        (context.parentEventId !== undefined &&
+          this.#terminalIntents.has(context.parentEventId)))
     ) {
+      this.#noteJoblessIntent(context.eventId);
+      this.#droppedLateEchoTxs.add(tx);
       this.#lateEchoDrops += 1;
       logger.debug("late-echo-dropped", () => [
         `late event echo ${context.eventId} dropped at seal: its intent ` +
-        "already reached a terminal consequence (speculation.md §4 step 2)",
+        "(or its cascade parent's) already reached a terminal " +
+        "consequence (speculation.md §4 step 2)",
       ]);
       return { ok: {} };
     }
@@ -557,6 +582,32 @@ export class SpeculationOverlayDestination
       }
       return { ok: {} };
     }
+    if (
+      context?.kind === "event-handler" && context.eventId !== undefined &&
+      (this.#terminalIntents.has(context.eventId) ||
+        (context.parentEventId !== undefined &&
+          this.#terminalIntents.has(context.parentEventId)))
+    ) {
+      // The late-echo rule's post-await re-check (self-review finding 5,
+      // the closed arm's shape): the terminal signal landed while
+      // `sealInto` was in flight — `retireIntent` ran before this entry
+      // existed, so registering now would strand exactly the echo the
+      // rule closes. Withdraw the collected entries; the seal reports ok.
+      this.#noteJoblessIntent(context.eventId);
+      this.#droppedLateEchoTxs.add(tx);
+      this.#lateEchoDrops += 1;
+      for (const { entry } of sealedSpaces) {
+        entry.resolveVerdict({
+          withdrawn: {
+            message: "late event echo withdrawn at seal: its intent " +
+              "reached a terminal consequence while sealing " +
+              "(speculation.md §4 step 2)",
+            superseded: true,
+          },
+        });
+      }
+      return { ok: {} };
+    }
     for (const { space, entry } of sealedSpaces) {
       let entries = this.#entries.get(space);
       if (entries === undefined) {
@@ -604,6 +655,13 @@ export class SpeculationOverlayDestination
       // optimistic navigation for a commit that was never accepted.
       // Still OWNED (true): a derivation's effects never take the
       // ordinary inline flush.
+      return true;
+    }
+    if (this.#droppedLateEchoTxs.has(tx)) {
+      // A late echo's effects (stage C tuning T2): its writes were
+      // dropped at seal, so its reversible kinds must not enact either
+      // — the authoritative intent already rode (or rides) the effects
+      // channel. Owned, not enacted: the closed arm's shape.
       return true;
     }
     const enactable = effects.filter((effect) =>
@@ -783,15 +841,8 @@ export class SpeculationOverlayDestination
     const key = `${space}\0${eventId}`;
     // The late-echo rule's memory (stage C tuning T2): every terminal
     // signal — consequenced, errored, dropped, refused — makes a later
-    // echo of this intent jobless. Bounded like the replica's ack record.
-    this.#terminalIntents.add(eventId);
-    if (
-      this.#terminalIntents.size >
-        SpeculationOverlayDestination.#MAX_TERMINAL_INTENTS
-    ) {
-      const oldest = this.#terminalIntents.values().next();
-      if (!oldest.done) this.#terminalIntents.delete(oldest.value);
-    }
+    // echo of this intent jobless.
+    this.#noteJoblessIntent(eventId);
     const waiters = this.#intentConsequenceWaiters.get(key);
     if (waiters !== undefined && waiters.length > 0) {
       this.#intentConsequenceWaiters.delete(key);
@@ -802,6 +853,20 @@ export class SpeculationOverlayDestination
     // in-flight fires; consumed by the next waiter).
     if (!this.#intentConsequenceMemo.has(key)) {
       this.#intentConsequenceMemo.set(key, outcome);
+    }
+  }
+
+  /** Record an intent whose echo has no job (a terminal consequence
+   * arrived, or its late echo was dropped — its cascade is jobless too).
+   * Bounded like the replica's ack record (oldest pruned). */
+  #noteJoblessIntent(eventId: string): void {
+    this.#terminalIntents.add(eventId);
+    if (
+      this.#terminalIntents.size >
+        SpeculationOverlayDestination.#MAX_TERMINAL_INTENTS
+    ) {
+      const oldest = this.#terminalIntents.values().next();
+      if (!oldest.done) this.#terminalIntents.delete(oldest.value);
     }
   }
 
@@ -1017,10 +1082,11 @@ export class SpeculationOverlayDestination
    * frame that moves the confirmed seq of a doc some live entry WROTE
    * re-sweeps the space off the freshest observed W. Filtered to written
    * docs — the ack observer and the watermark sink already cover the
-   * read-side triggers — so a busy space's unrelated frames cost one set
-   * lookup per upsert. Sweeps synchronously: the replica fires it AFTER
-   * the frame's own notifications, on a consistent replica (the ack
-   * observer's precedent). */
+   * read-side triggers — so an unrelated frame costs one Set of the
+   * arrived keys plus O(live entries × their written docs) lookups, no
+   * sweep. Sweeps synchronously: the replica fires it AFTER the frame's
+   * own notifications, on a consistent replica (the ack observer's
+   * precedent). */
   #ensureArrivalObserver(space: MemorySpace): void {
     if (this.#arrivalObserverReleases.has(space)) return;
     try {
@@ -1063,8 +1129,14 @@ export class SpeculationOverlayDestination
         ]);
         this.#sweep(space, this.#watermarks.get(space) ?? 0);
       };
+      const installed = observable.speculationArrivalObserver;
       this.#arrivalObserverReleases.set(space, () => {
-        observable.speculationArrivalObserver = undefined;
+        // Release only our own wake: two overlays on one replica (two
+        // runtimes over one manager — a test shape) must not clobber
+        // each other's install.
+        if (observable.speculationArrivalObserver === installed) {
+          observable.speculationArrivalObserver = undefined;
+        }
       });
     } catch (error) {
       logger.warn("arrival-observer-failed", () => [
@@ -1099,8 +1171,11 @@ export class SpeculationOverlayDestination
         if (this.#closed) return;
         this.#sweep(space, this.#watermarks.get(space) ?? 0);
       };
+      const installed = observable.speculationAckObserver;
       this.#ackObserverReleases.set(space, () => {
-        observable.speculationAckObserver = undefined;
+        if (observable.speculationAckObserver === installed) {
+          observable.speculationAckObserver = undefined;
+        }
       });
     } catch (error) {
       logger.warn("ack-observer-failed", () => [

--- a/packages/runner/src/speculation/overlay-destination.ts
+++ b/packages/runner/src/speculation/overlay-destination.ts
@@ -1025,7 +1025,13 @@ export class SpeculationOverlayDestination
     if (this.#arrivalObserverReleases.has(space)) return;
     try {
       const replica = this.#runtime.storageManager.open(space).replica;
-      if (!("speculationArrivalObserver" in replica)) return;
+      // Capability probe by METHOD, not by `in` on the observer field: the
+      // browser worker bundle drops uninitialized class fields, so an `in`
+      // probe on the field read false there and the install silently
+      // returned (the ack observer below had exactly that latent gap).
+      // A replica that implements the retirement view is the one that
+      // fires these wakes.
+      if (typeof replica.speculationRetirementView !== "function") return;
       const observable = replica as {
         speculationArrivalObserver:
           | ((arrived: readonly { id: URI; scope?: CellScope }[]) => void)
@@ -1081,7 +1087,11 @@ export class SpeculationOverlayDestination
     if (this.#ackObserverReleases.has(space)) return;
     try {
       const replica = this.#runtime.storageManager.open(space).replica;
-      if (!("speculationAckObserver" in replica)) return;
+      // Capability probe by method (see #ensureArrivalObserver): the `in`
+      // probe on the observer FIELD read false in the browser worker
+      // bundle (uninitialized class fields are dropped there), so this
+      // wake had never installed in a browser client.
+      if (typeof replica.speculationRetirementView !== "function") return;
       const observable = replica as {
         speculationAckObserver: (() => void) | undefined;
       };

--- a/packages/runner/src/speculation/overlay-destination.ts
+++ b/packages/runner/src/speculation/overlay-destination.ts
@@ -41,6 +41,24 @@
 // SUCCESS-shaped withdrawal (`superseded`), the authoritative value
 // replaces the echo in the same render path, and nothing cascades.
 //
+// Retirement TRIGGERS (speculation.md §4; stage C tuning T2): the sweep
+// runs from the watermark-doc sink, the origin-ack observer, chained
+// settlements, the post-seal microtask — and, since stage C, from the
+// replica's ARRIVAL observer: a frame that moves the confirmed seq of a
+// doc some entry WROTE re-sweeps at once. Before that wake, "a served node
+// retires the moment its derived value arrives" held only because the
+// derived doc and the covering watermark advance rode ONE frame; an
+// EXHAUSTED wave carries no watermark movement (its derivedThrough is
+// frozen — serving-loop.md §3), so its derived values arrive DECOUPLED
+// from W and the echo stood until the next unrelated commit lifted W (the
+// attribution's 48-s lockdown-chip stall). The gate itself is unchanged —
+// the arrival is a second, earlier TRIGGER, never a relaxation of the
+// coverage or arrival predicates. Its soundness argument: the sweep's
+// predicates are evaluated afresh on replica state at every trigger, so
+// an extra trigger can only retire an entry the gate would have retired
+// at the next watermark event anyway; the arrival of the authoritative
+// value IS the landing the gate waits for.
+//
 // Post-commit effects of a speculative run follow the egress rule
 // (README §1): "speculate on anything you can throw away; never on
 // anything you can't take back." Reversible, client-enacted effects —
@@ -209,6 +227,23 @@ export class SpeculationOverlayDestination
    * blocked, and the covering watermark event has already passed — the
    * ack wake re-sweeps so a then-quiet space cannot strand them. */
   readonly #ackObserverReleases = new Map<MemorySpace, () => void>();
+  /** space -> release fn for the ARRIVAL wake installed on the replica
+   * (ISpaceReplica.speculationArrivalObserver; stage C tuning T2): a
+   * frame that moves the confirmed seq of a doc some entry wrote
+   * re-sweeps the space. */
+  readonly #arrivalObserverReleases = new Map<MemorySpace, () => void>();
+  /** Intents whose TERMINAL consequence this overlay has observed
+   * (consequenced / errored / dropped / refused), keyed by eventId (a
+   * per-fire mint — event-identity.ts — unique across spaces), bounded and
+   * insertion-ordered (oldest pruned). Stage C tuning T2's
+   * LATE-ECHO rule reads it at seal: an event-handler echo whose intent is
+   * already terminal has no job — the authoritative consequences exist
+   * (speculation.md §4 step 2) — and is not registered. */
+  readonly #terminalIntents = new Set<string>();
+  static readonly #MAX_TERMINAL_INTENTS = 4096;
+  /** DIAGNOSTIC counters (tests). */
+  #arrivalSweeps = 0;
+  #lateEchoDrops = 0;
   /** space -> last observed watermark (for registration-time sweeps). */
   readonly #watermarks = new Map<MemorySpace, number>();
   /** Fired-intent notice watch (events.md §5, speculation.md §5):
@@ -264,6 +299,18 @@ export class SpeculationOverlayDestination
     return this.#eventEchoSeals;
   }
 
+  /** DIAGNOSTIC (tests): sweeps the ARRIVAL wake ran (stage C tuning T2). */
+  get arrivalSweepCount(): number {
+    return this.#arrivalSweeps;
+  }
+
+  /** DIAGNOSTIC (tests): event-handler echoes dropped at seal because
+   * their intent was already terminal (stage C tuning T2's late-echo
+   * rule). */
+  get lateEchoDropCount(): number {
+    return this.#lateEchoDrops;
+  }
+
   seal(tx: IExtendedStorageTransaction): Promise<Result<Unit, CommitError>> {
     const kind = speculationRunContextOf(tx)?.kind;
     if (kind !== "derivation" && kind !== "event-handler") {
@@ -309,6 +356,39 @@ export class SpeculationOverlayDestination
           reason: new Error("speculation-event-handler-without-event"),
         },
       };
+    }
+    // The LATE-ECHO rule (stage C tuning T2; speculation.md §4 step 2
+    // read as the state it names): an event-handler echo whose intent's
+    // TERMINAL consequence has ALREADY arrived — the client's local
+    // dispatch ran after the served round trip (a load-parked head event,
+    // a busy worker) — has no job: the authoritative consequences (or the
+    // dropped/refused notice) exist, which is exactly the condition under
+    // which `retireIntent` withdraws such an echo the moment the mark
+    // arrives. Ordering alone made the difference: the mark was consumed
+    // before this echo existed, so nothing would ever retire it, and a
+    // NON-IDEMPOTENT handler run over the already-served state is
+    // divergent by construction (the lockdown toggle read the served
+    // `everyoneIsAdmin=false` and toggled it BACK; #5969's castVote echo,
+    // the same). Such an entry's floor also sits at the served commit's
+    // seq — above every W reachable until the next authored input — so it
+    // stood indefinitely, hiding the served value (the attribution's E2:
+    // 48 s until an unrelated draft lifted W). Disposition: the run's
+    // writes are DROPPED before any layer is sealed (the closed-overlay
+    // arm's shape — the results are re-derivable, and here already
+    // derived authoritatively); the seal reports ok so the scheduler's
+    // run completes normally. Same-tick soundness: an intent is terminal
+    // only through a store signal or an admission refusal, both of which
+    // this overlay recorded before this seal ran.
+    if (
+      context?.kind === "event-handler" && context.eventId !== undefined &&
+      this.#terminalIntents.has(context.eventId)
+    ) {
+      this.#lateEchoDrops += 1;
+      logger.debug("late-echo-dropped", () => [
+        `late event echo ${context.eventId} dropped at seal: its intent ` +
+        "already reached a terminal consequence (speculation.md §4 step 2)",
+      ]);
+      return { ok: {} };
     }
     const inner = tx.tx;
     if (inner.sealInto === undefined) {
@@ -701,6 +781,17 @@ export class SpeculationOverlayDestination
     outcome: IntentConsequence,
   ): void {
     const key = `${space}\0${eventId}`;
+    // The late-echo rule's memory (stage C tuning T2): every terminal
+    // signal — consequenced, errored, dropped, refused — makes a later
+    // echo of this intent jobless. Bounded like the replica's ack record.
+    this.#terminalIntents.add(eventId);
+    if (
+      this.#terminalIntents.size >
+        SpeculationOverlayDestination.#MAX_TERMINAL_INTENTS
+    ) {
+      const oldest = this.#terminalIntents.values().next();
+      if (!oldest.done) this.#terminalIntents.delete(oldest.value);
+    }
     const waiters = this.#intentConsequenceWaiters.get(key);
     if (waiters !== undefined && waiters.length > 0) {
       this.#intentConsequenceWaiters.delete(key);
@@ -887,6 +978,7 @@ export class SpeculationOverlayDestination
 
   #ensureWatermarkSink(space: MemorySpace): void {
     this.#ensureAckObserver(space);
+    this.#ensureArrivalObserver(space);
     if (this.#watermarkSinks.has(space)) return;
     try {
       // Constructed INLINE from the wire-module constant rather than
@@ -915,6 +1007,64 @@ export class SpeculationOverlayDestination
       logger.warn("watermark-sink-failed", () => [
         `watermark sink for ${space} failed; overlay retirement for the ` +
         "space will rely on entry re-runs",
+        error,
+      ]);
+    }
+  }
+
+  /** Install the ARRIVAL wake (ISpaceReplica.speculationArrivalObserver;
+   * stage C tuning T2, speculation.md §4's owed arrival re-sweep): a
+   * frame that moves the confirmed seq of a doc some live entry WROTE
+   * re-sweeps the space off the freshest observed W. Filtered to written
+   * docs — the ack observer and the watermark sink already cover the
+   * read-side triggers — so a busy space's unrelated frames cost one set
+   * lookup per upsert. Sweeps synchronously: the replica fires it AFTER
+   * the frame's own notifications, on a consistent replica (the ack
+   * observer's precedent). */
+  #ensureArrivalObserver(space: MemorySpace): void {
+    if (this.#arrivalObserverReleases.has(space)) return;
+    try {
+      const replica = this.#runtime.storageManager.open(space).replica;
+      if (!("speculationArrivalObserver" in replica)) return;
+      const observable = replica as {
+        speculationArrivalObserver:
+          | ((arrived: readonly { id: URI; scope?: CellScope }[]) => void)
+          | undefined;
+      };
+      observable.speculationArrivalObserver = (arrived) => {
+        if (this.#closed) return;
+        const entries = this.#entries.get(space);
+        if (entries === undefined || entries.size === 0) return;
+        const arrivedKeys = new Set(
+          arrived.map((doc) => `${doc.scope ?? ""}\0${doc.id}`),
+        );
+        let relevant = false;
+        for (const entry of entries.values()) {
+          if (
+            entry.writtenDocs.some((doc) =>
+              arrivedKeys.has(`${doc.scope ?? ""}\0${doc.id}`)
+            )
+          ) {
+            relevant = true;
+            break;
+          }
+        }
+        if (!relevant) return;
+        this.#arrivalSweeps += 1;
+        logger.debug("arrival-sweep", () => [
+          `authoritative value arrived for a speculated doc in ${space}; ` +
+          "re-sweeping the overlay (stage C tuning T2)",
+        ]);
+        this.#sweep(space, this.#watermarks.get(space) ?? 0);
+      };
+      this.#arrivalObserverReleases.set(space, () => {
+        observable.speculationArrivalObserver = undefined;
+      });
+    } catch (error) {
+      logger.warn("arrival-observer-failed", () => [
+        `arrival observer for ${space} failed; retirement of entries whose ` +
+        "served value arrives decoupled from W will rely on later " +
+        "watermark events",
         error,
       ]);
     }
@@ -1105,5 +1255,14 @@ export class SpeculationOverlayDestination
       }
     }
     this.#ackObserverReleases.clear();
+    for (const release of this.#arrivalObserverReleases.values()) {
+      try {
+        release();
+      } catch {
+        // observer release is best-effort during teardown
+      }
+    }
+    this.#arrivalObserverReleases.clear();
+    this.#terminalIntents.clear();
   }
 }

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -128,6 +128,10 @@ const createOnlyMarkKey = (
 
 type CfcInstrumentationHooks = {
   onRelevantTx?(): void;
+  /** Stage C tuning T1: one flow-label probe was evaluated (`computed`) or
+   * answered from the memoized negative verdict (`memo`). Measurement
+   * only. */
+  onFlowLabelProbe?(outcome: "computed" | "memo"): void;
   onPreparedTx?(): void;
   onPrepareReject?(reasons: readonly string[]): void;
   onDigestInvalidation?(reason: string): void;
@@ -393,10 +397,42 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   #sealDestination: TransactionSealDestination | undefined;
   #sealDestinationPinned = false;
 
+  // Stage C tuning T1 (see IExtendedStorageTransaction.probeFlowLabelWork):
+  // the activity epoch counts every journaled read, write, dereference
+  // trace and trigger read; the memo holds the last NEGATIVE probe verdict
+  // with the epoch it was taken at (stamped AFTER the probe, whose own
+  // metadata reads are internal-verifier reads that never change the
+  // verdict but do move the epoch).
+  #cfcActivityEpoch = 0;
+  #flowLabelProbeMemo: { epoch: number } | undefined;
+
   constructor(
     public tx: IStorageTransaction,
     private cfcInstrumentation: CfcInstrumentationHooks = {},
   ) {}
+
+  /** Stage C tuning T1: any transaction activity that could change the
+   * flow-label probe's answer moves the epoch. */
+  #noteCfcActivity(): void {
+    this.#cfcActivityEpoch += 1;
+  }
+
+  probeFlowLabelWork(): boolean {
+    if (this.#flowLabelProbeMemo?.epoch === this.#cfcActivityEpoch) {
+      this.cfcInstrumentation.onFlowLabelProbe?.("memo");
+      return false;
+    }
+    this.cfcInstrumentation.onFlowLabelProbe?.("computed");
+    const verdict = flowLabelWorkExists(this);
+    // Only the negative verdict is worth remembering: a positive one makes
+    // the caller mark the tx relevant, and a relevant tx is never probed
+    // again. Stamped with the epoch as it stands AFTER the probe (its own
+    // metadata reads moved it).
+    this.#flowLabelProbeMemo = verdict
+      ? undefined
+      : { epoch: this.#cfcActivityEpoch };
+    return verdict;
+  }
 
   /**
    * One-shot configuration of the seal destination, called by the Runtime
@@ -694,6 +730,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   }
 
   addCfcTriggerReads(reads: readonly IMemorySpaceAddress[]): void {
+    this.#noteCfcActivity();
     if (this.#cfcState.prepare.status === "prepared") {
       this.invalidateCfc("trigger-reads-after-prepare");
     }
@@ -979,6 +1016,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   }
 
   private prepareRead(address: Pick<IMemorySpaceAddress, "scope">): void {
+    this.#noteCfcActivity();
     if (this.#cfcState.prepare.status === "prepared") {
       this.invalidateCfc("read-after-prepare");
     }
@@ -1047,6 +1085,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
    */
   private noteWrite(): void {
     this.#hasWrites = true;
+    this.#noteCfcActivity();
   }
 
   private invalidateReadResultCache(): void {
@@ -1058,6 +1097,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   }
 
   recordCfcDereferenceTrace(trace: CfcDereferenceTrace): void {
+    this.#noteCfcActivity();
     // Freeze on entry: from this point on the record is owned by the tx and
     // identity-stable. Mirrors the chokepoint pattern on
     // `recordCfcWritePolicyInput()`; together they ensure every CfcAddress
@@ -2025,12 +2065,16 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
       // exactly the txs nobody marked). Probe only while unprepared: the
       // probe reads metadata, and a read after prepare would invalidate the
       // digest of a transaction that already did its flow work.
+      // Stage C tuning T1: `Runtime.prepareTxForCommit` usually asked the
+      // same question a moment ago on this very transaction; the memoized
+      // negative verdict answers here unless the tx journaled anything
+      // since (see probeFlowLabelWork).
       if (
         !this.#cfcState.relevant &&
         this.#cfcState.prepare.status === "unprepared" &&
         this.#cfcState.flowLabelsMode !== "off" &&
         this.#cfcState.enforcementMode !== "disabled" &&
-        flowLabelWorkExists(this)
+        this.probeFlowLabelWork()
       ) {
         this.markCfcRelevant("flow-labels");
       }
@@ -2378,6 +2422,11 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
 
   addCfcTriggerReads(reads: readonly IMemorySpaceAddress[]): void {
     this.wrapped.addCfcTriggerReads(reads);
+  }
+
+  probeFlowLabelWork(): boolean {
+    return this.wrapped.probeFlowLabelWork?.() ??
+      flowLabelWorkExists(this.wrapped);
   }
 
   runWithAmbientReadMeta<T>(meta: Metadata, fn: () => T): T {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -1369,6 +1369,22 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
    */
   addCfcTriggerReads(reads: readonly IMemorySpaceAddress[]): void;
   /**
+   * The flow-label relevance probe (`cfc/prepare.ts`'s
+   * `flowLabelWorkExists`) evaluated ONCE per transaction activity epoch
+   * (server-execution v2 stage C tuning, T1). The commit chokepoint and
+   * `Runtime.prepareTxForCommit` both ask "did this tx observe or write a
+   * labeled doc?" on the same unprepared, not-yet-relevant transaction, and
+   * the probe is O(reads × dereference traces) — evaluated twice back to
+   * back it was 65 % of a saturated client worker in the stage-C
+   * attribution. A NEGATIVE verdict is memoized on the transaction and
+   * stays valid until the transaction journals any further read, write,
+   * dereference trace or trigger read (each bumps an activity epoch); a
+   * positive verdict marks the tx relevant, after which neither caller
+   * probes again. Optional so hand-built transactions keep working — a
+   * caller falls back to the free function.
+   */
+  probeFlowLabelWork?(): boolean;
+  /**
    * Run `fn` with `meta` merged into every read issued within (explicit
    * per-read meta wins). Lets scheduling machinery tag its reads without
    * threading metadata through intermediate APIs.
@@ -2200,6 +2216,28 @@ export interface ISpaceReplica extends ISpace {
    * one had no client-side wake, so the entry stayed pending forever.
    */
   speculationAckObserver?: (() => void) | undefined;
+
+  /**
+   * The overlay's retirement WAKE for AUTHORITATIVE ARRIVALS
+   * (server-execution v2 stage C tuning T2 — speculation.md §4's owed
+   * "arrival re-sweep"): when set, invoked at the end of integrating a
+   * session sync frame whose upserts moved at least one doc's CONFIRMED
+   * seq forward, with exactly those docs. The speculation overlay
+   * destination installs it beside its watermark sink: the arrival gate
+   * retires an entry only once every doc it wrote holds a confirmed value
+   * at seq ≥ its floor, and until this wake existed the sweep ran only
+   * from the watermark sink, the origin-ack observer and chained
+   * settlements — so a derived value that arrived DECOUPLED from a
+   * watermark advance (an exhausted wave carries no watermark movement;
+   * a doc arriving in a later frame than the covering W) kept its echo
+   * standing until the next unrelated commit lifted W. Fired regardless of
+   * whether the value is VISIBLE through materialization (an arrival under
+   * the entry's own pending layer is invisible to the change
+   * notification, which is why the notification cannot carry this).
+   */
+  speculationArrivalObserver?:
+    | ((arrived: readonly { id: URI; scope?: CellScope }[]) => void)
+    | undefined;
 }
 
 /**

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -2432,6 +2432,15 @@ class SpaceReplica implements ISpaceReplica {
   // ACCEPTED origins had no client-side wake. Guarded at the call
   // site — an observer throw must not corrupt accept settlement.
   speculationAckObserver: (() => void) | undefined;
+  // The overlay destination's retirement WAKE for authoritative ARRIVALS
+  // (ISpaceReplica.speculationArrivalObserver, stage C tuning T2 —
+  // speculation.md §4's owed arrival re-sweep): fired at the end of
+  // applySessionSync with the docs whose confirmed seq a frame moved
+  // forward. Guarded at the call site — an observer throw must not
+  // corrupt frame integration.
+  speculationArrivalObserver:
+    | ((arrived: readonly { id: URI; scope?: CellScope }[]) => void)
+    | undefined;
   #caughtUpLocalSeqWaiters: {
     localSeq: number;
     pending: PromiseWithResolvers<void>;
@@ -4926,6 +4935,12 @@ class SpaceReplica implements ISpaceReplica {
       )
       : undefined;
 
+    // Docs whose CONFIRMED seq this frame moved FORWARD — the arrival
+    // wake's payload (stage C tuning T2). Collected only while an
+    // observer is installed (a client overlay's), so every other replica
+    // pays one undefined check.
+    const arrived: LocalDocAddress[] | undefined =
+      this.speculationArrivalObserver !== undefined ? [] : undefined;
     for (const upsert of sync.upserts) {
       const record = this.record(
         upsert.id as URI,
@@ -4944,6 +4959,15 @@ class SpaceReplica implements ISpaceReplica {
         upsert.deleted === true ? undefined : upsert.doc,
       );
       record.materialized = undefined;
+      if (arrived !== undefined && upsert.seq > previousConfirmedSeq) {
+        arrived.push({
+          id: upsert.id as URI,
+          scope: upsert.scope,
+          ...(upsert.scopeKey !== undefined
+            ? { scopeKey: upsert.scopeKey }
+            : {}),
+        });
+      }
       const key = docKey(
         upsert.id as URI,
         this.instanceKey(upsert.scope, undefined, upsert.scopeKey),
@@ -5036,6 +5060,24 @@ class SpaceReplica implements ISpaceReplica {
       }
     } else if (shouldNotifySinks) {
       this.notifySinksForIds(touched);
+    }
+    // The arrival wake (stage C tuning T2, speculation.md §4): AFTER the
+    // frame's own notifications, on a consistent replica — the overlay's
+    // sweep resolves verdicts (dropping its retired layers through the
+    // ordinary rollback path), which must not interleave with the
+    // integration above. Same containment posture as the ack observer.
+    if (
+      arrived !== undefined && arrived.length > 0 &&
+      this.speculationArrivalObserver !== undefined
+    ) {
+      try {
+        this.speculationArrivalObserver(arrived);
+      } catch (error) {
+        logger.error("speculation-arrival-observer-error", () => [
+          "speculationArrivalObserver threw during frame integration",
+          error,
+        ]);
+      }
     }
   }
 

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -2405,7 +2405,15 @@ class SpaceReplica implements ISpaceReplica {
   // one input whose dirtiness arrives WITHOUT a new admitted commit on
   // the host feed (the commit was drained waves ago; only its
   // VISIBILITY changed).
-  shadowFlipObserver: (() => void) | undefined;
+  // Initialized EXPLICITLY (`= undefined`), as are the two overlay wakes
+  // below: the browser worker bundle compiles class fields without define
+  // semantics, so an UNINITIALIZED field is dropped from the class body and
+  // an `"observer" in replica` probe reads false — the overlay's install
+  // silently returned and the wake never fired in browsers (found while
+  // landing stage C tuning T2's arrival wake; the ack wake had the same
+  // shape). The overlay now probes by capability method instead, and the
+  // initializers keep the fields visible either way.
+  shadowFlipObserver: (() => void) | undefined = undefined;
   // localSeq -> the store seq its accept committed at (server-execution
   // v2 Phase 2, speculation.md §4): the overlay destination's retirement
   // floor is "the origin ACKED and W ≥ that commit's seq", and the ack
@@ -2431,7 +2439,7 @@ class SpaceReplica implements ISpaceReplica {
   // then-quiet space: rejected origins cascade into the entry, but
   // ACCEPTED origins had no client-side wake. Guarded at the call
   // site — an observer throw must not corrupt accept settlement.
-  speculationAckObserver: (() => void) | undefined;
+  speculationAckObserver: (() => void) | undefined = undefined;
   // The overlay destination's retirement WAKE for authoritative ARRIVALS
   // (ISpaceReplica.speculationArrivalObserver, stage C tuning T2 —
   // speculation.md §4's owed arrival re-sweep): fired at the end of
@@ -2440,7 +2448,7 @@ class SpaceReplica implements ISpaceReplica {
   // corrupt frame integration.
   speculationArrivalObserver:
     | ((arrived: readonly { id: URI; scope?: CellScope }[]) => void)
-    | undefined;
+    | undefined = undefined;
   #caughtUpLocalSeqWaiters: {
     localSeq: number;
     pending: PromiseWithResolvers<void>;

--- a/packages/runner/test/cfc-flow-probe-memo.test.ts
+++ b/packages/runner/test/cfc-flow-probe-memo.test.ts
@@ -86,9 +86,24 @@ describe("CFC flow-label probe memo (stage C tuning T1)", () => {
     const { runtime, storageManager } = newRuntime();
     try {
       const tx = runtime.edit();
-      const a = runtime.getCell(signer.did(), "probe-memo-inv-a", undefined, tx);
-      const b = runtime.getCell(signer.did(), "probe-memo-inv-b", undefined, tx);
-      const c = runtime.getCell(signer.did(), "probe-memo-inv-c", undefined, tx);
+      const a = runtime.getCell(
+        signer.did(),
+        "probe-memo-inv-a",
+        undefined,
+        tx,
+      );
+      const b = runtime.getCell(
+        signer.did(),
+        "probe-memo-inv-b",
+        undefined,
+        tx,
+      );
+      const c = runtime.getCell(
+        signer.did(),
+        "probe-memo-inv-c",
+        undefined,
+        tx,
+      );
       a.getRaw();
       b.set({ v: 1 });
       const before = probeCounts(runtime);
@@ -193,8 +208,18 @@ describe("CFC flow-label probe memo (stage C tuning T1)", () => {
       const { runtime, storageManager } = newRuntime({ serverExecution });
       try {
         const tx = runtime.edit();
-        const a = runtime.getCell(signer.did(), "probe-memo-arm-a", undefined, tx);
-        const b = runtime.getCell(signer.did(), "probe-memo-arm-b", undefined, tx);
+        const a = runtime.getCell(
+          signer.did(),
+          "probe-memo-arm-a",
+          undefined,
+          tx,
+        );
+        const b = runtime.getCell(
+          signer.did(),
+          "probe-memo-arm-b",
+          undefined,
+          tx,
+        );
         a.getRaw();
         b.set({ v: 1 });
         const before = probeCounts(runtime);

--- a/packages/runner/test/cfc-flow-probe-memo.test.ts
+++ b/packages/runner/test/cfc-flow-probe-memo.test.ts
@@ -1,0 +1,219 @@
+// Server-execution v2 stage C tuning, T1: the flow-label relevance probe
+// (`flowLabelWorkExists`) is evaluated ONCE per commit, not twice.
+//
+// The commit chokepoint (`ExtendedStorageTransaction.commit`) and
+// `Runtime.prepareTxForCommit` both ask "did this tx observe or write a
+// labeled doc?" on the same unprepared, not-yet-relevant transaction, back
+// to back (`startReactiveActionCommit` calls the one then the other). The
+// probe walks every read activity against every dereference trace
+// (`forEachFlowObservation` → `isPrefix`) — evaluated twice per commit it
+// was 65 % of a saturated client worker on the ON note-create series
+// (stage-c-attribution-report §2c). The negative verdict is now memoized
+// on the transaction (`probeFlowLabelWork`) and stays valid until the tx
+// journals any further read, write, dereference trace or trigger read.
+//
+// Pins:
+// - the common shape (prepareTxForCommit then commit, nothing between)
+//   evaluates the probe ONCE and answers the second ask from the memo;
+// - a read or a write between the two asks INVALIDATES the memo (the
+//   second ask re-evaluates) — a memo must never outlive the activity it
+//   was taken over;
+// - the memo never hides a positive verdict: a labeled read makes the tx
+//   relevant on the first ask, and the second ask does not probe at all;
+// - the OFF arm and a flag-ON client are the same code: verdicts are
+//   unchanged (the memo is a cache of a deterministic function), and the
+//   probe count halves in both — the existing flow-label suites pin the
+//   verdicts.
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-flow-probe-memo");
+
+const newRuntime = (options: { serverExecution?: boolean } = {}) => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL("https://example.com"),
+    storageManager,
+    cfcEnforcementMode: "enforce-explicit",
+    cfcFlowLabels: "persist",
+    ...(options.serverExecution
+      ? { experimental: { serverExecution: true } }
+      : {}),
+  });
+  return { runtime, storageManager };
+};
+
+const probeCounts = (runtime: Runtime) => {
+  const stats = runtime.getCfcStats();
+  return {
+    computed: stats.flowLabelProbesComputed,
+    memo: stats.flowLabelProbeMemoHits,
+  };
+};
+
+describe("CFC flow-label probe memo (stage C tuning T1)", () => {
+  it("prepareTxForCommit then commit evaluate the probe ONCE: the second ask is a memo hit", async () => {
+    const { runtime, storageManager } = newRuntime();
+    try {
+      const tx = runtime.edit();
+      const a = runtime.getCell(signer.did(), "probe-memo-a", undefined, tx);
+      const b = runtime.getCell(signer.did(), "probe-memo-b", undefined, tx);
+      // Plain, unlabeled reads and a write: the probe's negative shape.
+      a.getRaw();
+      b.set({ v: 1 });
+      const before = probeCounts(runtime);
+      runtime.prepareTxForCommit(tx);
+      const afterPrepare = probeCounts(runtime);
+      expect(afterPrepare.computed - before.computed).toBe(1);
+      expect(afterPrepare.memo - before.memo).toBe(0);
+      expect((await tx.commit()).ok).toBeDefined();
+      const afterCommit = probeCounts(runtime);
+      // ONE evaluation for the whole commit; the chokepoint hit the memo.
+      expect(afterCommit.computed - before.computed).toBe(1);
+      expect(afterCommit.memo - before.memo).toBe(1);
+      expect(tx.getCfcState().relevant).toBe(false);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("a read between the two asks INVALIDATES the memo: the commit chokepoint re-evaluates (the memo never outlives the activity it was taken over)", async () => {
+    const { runtime, storageManager } = newRuntime();
+    try {
+      const tx = runtime.edit();
+      const a = runtime.getCell(signer.did(), "probe-memo-inv-a", undefined, tx);
+      const b = runtime.getCell(signer.did(), "probe-memo-inv-b", undefined, tx);
+      const c = runtime.getCell(signer.did(), "probe-memo-inv-c", undefined, tx);
+      a.getRaw();
+      b.set({ v: 1 });
+      const before = probeCounts(runtime);
+      runtime.prepareTxForCommit(tx);
+      // Activity after the first ask: a further read.
+      c.getRaw();
+      expect((await tx.commit()).ok).toBeDefined();
+      const after = probeCounts(runtime);
+      expect(after.computed - before.computed).toBe(2);
+      expect(after.memo - before.memo).toBe(0);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("a write between the two asks INVALIDATES the memo too", async () => {
+    const { runtime, storageManager } = newRuntime();
+    try {
+      const tx = runtime.edit();
+      const a = runtime.getCell(signer.did(), "probe-memo-w-a", undefined, tx);
+      const b = runtime.getCell(signer.did(), "probe-memo-w-b", undefined, tx);
+      a.getRaw();
+      b.set({ v: 1 });
+      const before = probeCounts(runtime);
+      runtime.prepareTxForCommit(tx);
+      b.set({ v: 2 });
+      expect((await tx.commit()).ok).toBeDefined();
+      const after = probeCounts(runtime);
+      expect(after.computed - before.computed).toBe(2);
+      expect(after.memo - before.memo).toBe(0);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("the memo never hides a positive verdict: a labeled read marks the tx relevant on the first ask and the second ask does not probe", async () => {
+    const { runtime, storageManager } = newRuntime();
+    try {
+      // Doc A: labeled secret (the S16 laundering seed).
+      const seed = runtime.edit();
+      const sourceId = runtime.getCell(
+        signer.did(),
+        "probe-memo-labeled-source",
+        undefined,
+      ).getAsNormalizedFullLink().id;
+      seed.writeOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: sourceId,
+        path: [],
+      }, {
+        value: { secret: "s3cr3t" },
+        cfc: {
+          version: 1,
+          schemaHash: "seed-schema",
+          labelMap: {
+            version: 1,
+            entries: [{
+              path: ["secret"],
+              label: { confidentiality: ["secret"] },
+            }],
+          },
+        },
+      });
+      expect((await seed.commit()).ok).toBeDefined();
+
+      const tx = runtime.edit();
+      const source = runtime.getCell(
+        signer.did(),
+        "probe-memo-labeled-source",
+        undefined,
+        tx,
+      );
+      const raw = source.getRaw() as { secret?: string };
+      expect(raw.secret).toBe("s3cr3t");
+      const derived = runtime.getCell(
+        signer.did(),
+        "probe-memo-labeled-derived",
+        undefined,
+        tx,
+      );
+      derived.set({ copied: `${raw.secret}!` });
+      const before = probeCounts(runtime);
+      runtime.prepareTxForCommit(tx);
+      expect(tx.getCfcState().relevant).toBe(true);
+      expect((await tx.commit()).ok).toBeDefined();
+      const after = probeCounts(runtime);
+      // One evaluation (positive), zero memo hits: a relevant tx is not
+      // probed again by anyone.
+      expect(after.computed - before.computed).toBe(1);
+      expect(after.memo - before.memo).toBe(0);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("the OFF arm and a flag-ON client share the shape: every evaluation is paired with exactly one memo hit — no transaction probes twice in either arm (verdicts pinned by the flow-label suites)", async () => {
+    for (const serverExecution of [false, true]) {
+      const { runtime, storageManager } = newRuntime({ serverExecution });
+      try {
+        const tx = runtime.edit();
+        const a = runtime.getCell(signer.did(), "probe-memo-arm-a", undefined, tx);
+        const b = runtime.getCell(signer.did(), "probe-memo-arm-b", undefined, tx);
+        a.getRaw();
+        b.set({ v: 1 });
+        const before = probeCounts(runtime);
+        runtime.prepareTxForCommit(tx);
+        expect((await tx.commit()).ok).toBeDefined();
+        const after = probeCounts(runtime);
+        // The OFF arm commits exactly this one transaction; a flag-ON
+        // client's commit also rides a couple of runtime-internal
+        // transactions (each prepared then committed the same way), so
+        // the arm-independent pin is the PAIRING: computed === memo hits.
+        expect(after.computed - before.computed).toBeGreaterThanOrEqual(1);
+        expect(after.memo - before.memo).toBe(after.computed - before.computed);
+        if (!serverExecution) {
+          expect(after.computed - before.computed).toBe(1);
+        }
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    }
+  });
+});

--- a/packages/runner/test/cfc-runtime-stats.test.ts
+++ b/packages/runner/test/cfc-runtime-stats.test.ts
@@ -32,6 +32,8 @@ describe("CFC runtime stats", () => {
 
     expect(runtime.getCfcStats()).toEqual({
       cfcRelevantTx: 0,
+      flowLabelProbesComputed: 0,
+      flowLabelProbeMemoHits: 0,
       cfcPreparedTx: 0,
       cfcPrepareRejects: 0,
       cfcDigestInvalidations: 0,
@@ -166,6 +168,12 @@ describe("CFC runtime stats", () => {
 
     expect(runtime.getCfcStats()).toEqual({
       cfcRelevantTx: 4,
+      // Stage C tuning T1: this runtime leaves the flow-labels dial at its
+      // "off" default, so the flow-label probe never runs here and its
+      // memo is never consulted. The probe's own pins live in
+      // cfc-flow-probe-memo.test.ts.
+      flowLabelProbesComputed: 0,
+      flowLabelProbeMemoHits: 0,
       cfcPreparedTx: 3,
       cfcPrepareRejects: 1,
       cfcDigestInvalidations: 1,

--- a/packages/runner/test/clock-preload.ts
+++ b/packages/runner/test/clock-preload.ts
@@ -40,6 +40,12 @@ installFakeClock({
     // interval and flush deadline), one level down: the stage-G
     // recovery-seam tests drive a real SpaceServer directly.
     "executor-space-server",
+    // Stage C tuning T3: the cooperative-yield suite drives a live
+    // ExecutorHost with a real flush deadline and a (short) real lease
+    // TTL — the yield's `setTimeout(0)` turns and the deadline/renew
+    // timers are the wall-clock behavior under test; auto-advance would
+    // fire them as fast as they arm.
+    "executor-cooperative-yield",
     // The Phase-2 speculation-overlay journeys run a live ExecutorHost
     // (the serving side of the client-loses-derivation-commit journey)
     // under the same wall-clock policies.

--- a/packages/runner/test/executor-cooperative-yield.test.ts
+++ b/packages/runner/test/executor-cooperative-yield.test.ts
@@ -181,7 +181,7 @@ describe("stage C tuning T3: cooperative yield + mid-wave renew", () => {
    * effects, each burning STEP_MS synchronously and sealing one write.
    * They run in the next execute pass — one settle of ~1.2 s inside the
    * wave that their first seal opens. Returns the out-doc ids. */
-  const registerWalk = (): string[] => {
+  const registerWalk = (steps: number = WALK_STEPS): string[] => {
     const runtime = servingRuntime!;
     const trigger = runtime.getCell<{ value: number }>(
       space,
@@ -189,7 +189,7 @@ describe("stage C tuning T3: cooperative yield + mid-wave renew", () => {
       undefined,
     );
     const outIds: string[] = [];
-    for (let step = 0; step < WALK_STEPS; step++) {
+    for (let step = 0; step < steps; step++) {
       const out = runtime.getCell<{ step: number; n: number }>(
         space,
         `yield-walk-out-${step}`,
@@ -257,14 +257,19 @@ describe("stage C tuning T3: cooperative yield + mid-wave renew", () => {
     expect(host.stats().lease.lost).toBe(0);
   });
 
-  it("(ii) a wave longer than TTL/3 renews the lease MID-WAVE from the yield observer, with the renew timer inert: the 1.2-s walk outlives a 600-ms TTL twice over and still commits under a live lease; lease.lost stays 0 (mutation: renew-on-yield removed → the lease lapses and the wave's commit is refused)", async () => {
+  it("(ii) a wave longer than TTL/3 renews the lease MID-WAVE from the yield observer, with the renew timer inert: a 1.8-s walk outlives a 900-ms TTL twice over and still commits under a live lease; lease.lost stays 0 (mutation: renew-on-yield removed → the lease lapses and the wave's commit is refused)", async () => {
+    // The TTL clock starts at acquire (activation), so the headroom for
+    // activation + boot settle + walk registration is the TTL itself:
+    // 900 ms against a measured 30–100 ms; a slower box has ~9× slack.
+    const ttlMs = 900;
+    const walkSteps = 45;
     host = newHost({
       flushDeadlineMs: 5_000,
       idleParkMs: 600_000,
       // The interval timer never fires within the test: every renewal
       // that lands is the mid-wave belt.
       renewIntervalMs: 600_000,
-      leaseTtlMs: 600,
+      leaseTtlMs: ttlMs,
     });
     const engine = await activate();
     const spaceServer = host.spaceServer(space)!;
@@ -273,12 +278,12 @@ describe("stage C tuning T3: cooperative yield + mid-wave renew", () => {
     const seqBefore = Engine.serverSeq(engine);
     const derivedBefore = host.stats().derivedCommits;
 
-    const outIds = registerWalk();
-    // The wave commits — under a lease that would have EXPIRED 600 ms in
-    // without the mid-wave renew (the walk is 1 200 ms; the deadline 5 s,
+    const outIds = registerWalk(walkSteps);
+    // The wave commits — under a lease that would have EXPIRED 900 ms in
+    // without the mid-wave renew (the walk is 1 800 ms; the deadline 5 s,
     // so it is ONE wave).
     await waitUntil(
-      () => storedOutCount(engine, outIds) === WALK_STEPS,
+      () => storedOutCount(engine, outIds) === walkSteps,
       "the walk's single wave to commit every step",
       20_000,
     );
@@ -343,8 +348,10 @@ describe("stage C tuning T3: cooperative yield + mid-wave renew", () => {
       if (t !== undefined) await t;
     }
     expect(firedAt).toBeGreaterThanOrEqual(0);
-    // Fired within about one slice + one step of its due time.
-    expect(firedAt).toBeLessThan(10 + 20 + 5 + 30);
+    // Fired before the loop's own work ended: without the yields the
+    // 20 × 5-ms burns run to completion (~100 ms) before any timer can
+    // fire; with them the due timer lands within a slice or two.
+    expect(firedAt).toBeLessThan(90);
     // An observer throw is contained.
     yielder.onYield = () => {
       throw new Error("boom");

--- a/packages/runner/test/executor-cooperative-yield.test.ts
+++ b/packages/runner/test/executor-cooperative-yield.test.ts
@@ -197,7 +197,9 @@ describe("stage C tuning T3: cooperative yield + mid-wave renew", () => {
       );
       outIds.push(out.getAsNormalizedFullLink().id);
       const walk = (tx: IExtendedStorageTransaction): void => {
-        const value = trigger.withTx(tx).get() as { value?: number } | undefined;
+        const value = trigger.withTx(tx).get() as
+          | { value?: number }
+          | undefined;
         burn(STEP_MS);
         out.withTx(tx).set({ step, n: value?.value ?? 0 });
       };

--- a/packages/runner/test/executor-cooperative-yield.test.ts
+++ b/packages/runner/test/executor-cooperative-yield.test.ts
@@ -1,0 +1,353 @@
+// Server-execution v2 stage C tuning, T3 (serving-loop.md §2/§3): the
+// serving scheduler's cooperative macrotask yield and the mid-wave lease
+// renew, pinned end to end on the ExecutorHost harness (a real memory
+// server, a client session, the SpaceServer's serving runtime).
+//
+// The attribution that motivated it (stage-c-attribution-report §2b/§3):
+// the settle loop ran a whole wave's runs on one microtask chain, so the
+// 100-ms flush deadline fired seconds LATE (`wavesBudgetExhausted` was a
+// symptom, not a bound) and the lease-renew `setInterval` starved for up
+// to 10 s against a 15-s TTL (t2: `wave-commit-rejected` then
+// `lease-lost` on every space within 10 ms).
+//
+// - (i) HONEST DEADLINE: a synthetic 30-step walk (40 ms of synchronous
+//   work per step, 1.2 s total) under a 100-ms deadline commits its first
+//   (exhausted) wave within ~one step of the deadline, not after the whole
+//   walk. Mutation (the yield removed from settle.ts) → the first commit
+//   lands only after the full 1.2 s → RED.
+// - (ii) MID-WAVE RENEW: the same walk with a 600-ms lease TTL, the renew
+//   TIMER inert (600 s) and a 5-s deadline — the wave outlives the TTL
+//   twice over and still COMMITS under a live lease, because the yield
+//   observer renewed it mid-wave; `lease.lost` stays 0 and the lease row's
+//   expiry moved during the wave. Mutation (the observer's renew removed,
+//   or the yield removed) → the lease lapses at 600 ms and the wave's
+//   commit is refused at admission → RED.
+// - (iii) POSTURE GATE: a runtime without `servingPosture` constructs no
+//   yielder — the OFF arm and flag-ON clients keep their settle loops'
+//   exact microtask shape.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import * as Engine from "@commonfabric/memory/v2/engine";
+import { liveExecutionLeaseHolder } from "@commonfabric/memory/v2/execution-lease";
+import { SessionRegistry } from "@commonfabric/memory/v2/server";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { Runtime } from "../src/runtime.ts";
+import type {
+  IExtendedStorageTransaction,
+  MemorySpace,
+} from "../src/storage/interface.ts";
+import { ExecutorHost } from "../src/executor/host.ts";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { CooperativeYield } from "../src/scheduler/cooperative-yield.ts";
+
+const newSharedServer = () =>
+  new MemoryV2Server.Server({
+    sessions: new SessionRegistry({ ttlMs: 600_000 }),
+    subscriptionRefreshDelayMs: 0,
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
+  });
+
+const spaceSigner = await Identity.fromPassphrase("cooperative yield space");
+const space = spaceSigner.did() as MemorySpace;
+const serviceSigner = await Identity.fromPassphrase(
+  "cooperative yield service",
+);
+const aliceSigner = await Identity.fromPassphrase("cooperative yield alice");
+
+const waitUntil = async (
+  predicate: () => boolean,
+  label: string,
+  timeoutMs = 15_000,
+  pollMs = 5,
+): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${label}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+};
+
+/** Synchronous CPU work — a stand-in for one demand-walk instance run. */
+const burn = (ms: number): void => {
+  const until = performance.now() + ms;
+  while (performance.now() < until) {
+    // spin
+  }
+};
+
+const WALK_STEPS = 30;
+const STEP_MS = 40;
+
+const leaseExpiry = (engine: Engine.Engine): number =>
+  (engine.database.prepare(
+    `SELECT expires_at FROM execution_lease WHERE space = :space`,
+  ).get({ space }) as { expires_at: number } | undefined)?.expires_at ?? 0;
+
+describe("stage C tuning T3: cooperative yield + mid-wave renew", () => {
+  let server: MemoryV2Server.Server;
+  let host: ExecutorHost | undefined;
+  let clientManager: EmulatedStorageManager;
+  let clientRuntime: Runtime;
+  let servingRuntime: Runtime | undefined;
+
+  const newHost = (
+    policy?: ConstructorParameters<typeof ExecutorHost>[0]["policy"],
+  ): ExecutorHost =>
+    new ExecutorHost({
+      server,
+      serviceIdentity: serviceSigner.did(),
+      createRuntime: () => {
+        const manager = EmulatedStorageManager.connectTo(server, {
+          as: serviceSigner,
+        });
+        const runtime = new Runtime({
+          apiUrl: new URL(import.meta.url),
+          storageManager: manager,
+          servingPosture: true,
+          experimental: { serverExecution: true },
+        });
+        servingRuntime = runtime;
+        return Promise.resolve({
+          runtime,
+          dispose: async () => {
+            await runtime.dispose();
+            await manager.close();
+          },
+        });
+      },
+      policy,
+    });
+
+  beforeEach(() => {
+    server = newSharedServer();
+    servingRuntime = undefined;
+  });
+
+  afterEach(async () => {
+    await host?.close();
+    host = undefined;
+    await clientRuntime?.dispose();
+    await clientManager?.close();
+    await server.close();
+  });
+
+  const openClient = () => {
+    clientManager = EmulatedStorageManager.connectTo(server, {
+      as: aliceSigner,
+    });
+    clientRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: clientManager,
+    });
+  };
+
+  /** Activate the space through an authored client commit and wait for
+   * the loop to sit idle in wait-for-input (its watermark covering the
+   * input). */
+  const activate = async (): Promise<Engine.Engine> => {
+    openClient();
+    const input = clientRuntime.getCell<{ value: number }>(
+      space,
+      "yield-input",
+      undefined,
+    );
+    const tx = clientRuntime.edit();
+    input.withTx(tx).set({ value: 1 });
+    expect((await tx.commit()).error).toBeUndefined();
+    await waitUntil(
+      () => host!.spaceServer(space)?.active === true,
+      "space to activate",
+    );
+    const engine = await server.engineForSpace(space);
+    const authoredSeq = Engine.serverSeq(engine);
+    await waitUntil(
+      () => host!.spaceServer(space)!.watermark >= authoredSeq,
+      "the activation cycle to settle",
+    );
+    return engine;
+  };
+
+  /** Register the synthetic walk on the SERVING runtime: WALK_STEPS
+   * effects, each burning STEP_MS synchronously and sealing one write.
+   * They run in the next execute pass — one settle of ~1.2 s inside the
+   * wave that their first seal opens. Returns the out-doc ids. */
+  const registerWalk = (): string[] => {
+    const runtime = servingRuntime!;
+    const trigger = runtime.getCell<{ value: number }>(
+      space,
+      "yield-input",
+      undefined,
+    );
+    const outIds: string[] = [];
+    for (let step = 0; step < WALK_STEPS; step++) {
+      const out = runtime.getCell<{ step: number; n: number }>(
+        space,
+        `yield-walk-out-${step}`,
+        undefined,
+      );
+      outIds.push(out.getAsNormalizedFullLink().id);
+      const walk = (tx: IExtendedStorageTransaction): void => {
+        const value = trigger.withTx(tx).get() as { value?: number } | undefined;
+        burn(STEP_MS);
+        out.withTx(tx).set({ step, n: value?.value ?? 0 });
+      };
+      Object.defineProperty(walk, "name", {
+        value: `synthetic-walk-${step}`,
+        configurable: true,
+      });
+      runtime.scheduler.register(walk, undefined, { isEffect: true });
+    }
+    return outIds;
+  };
+
+  const storedOutCount = (
+    engine: Engine.Engine,
+    outIds: readonly string[],
+  ): number =>
+    outIds.filter((id) => Engine.read(engine, { id }) !== null).length;
+
+  it("(i) the flush deadline is honest: a 1.2-s synthetic walk under a 100-ms deadline commits its first, exhausted wave within about one step of the deadline — not after the whole walk (mutation: yield removed → the first commit waits out the walk)", async () => {
+    host = newHost({ flushDeadlineMs: 100, idleParkMs: 600_000 });
+    const engine = await activate();
+    const before = host.stats();
+    const seqBefore = Engine.serverSeq(engine);
+
+    const t0 = performance.now();
+    const outIds = registerWalk();
+    await waitUntil(
+      () => Engine.serverSeq(engine) > seqBefore,
+      "the first wave commit of the walk",
+      15_000,
+      2,
+    );
+    const firstCommitAfterMs = performance.now() - t0;
+    // The whole walk is WALK_STEPS × STEP_MS = 1 200 ms of synchronous
+    // runs; pre-fix the deadline could only fire after the last one. With
+    // the yield the first (exhausted) commit lands at ~deadline + one
+    // step + a slice. Generous bound for a loaded box, still far below the
+    // walk's length.
+    expect(firstCommitAfterMs).toBeLessThan(WALK_STEPS * STEP_MS / 2);
+    // The walk still completes in full: every step's write lands, and W
+    // eventually covers everything (the last cycle settles un-exhausted).
+    await waitUntil(
+      () => storedOutCount(engine, outIds) === WALK_STEPS,
+      "every walk step's write to land",
+      20_000,
+    );
+    await waitUntil(
+      () => host!.stats().wavesBudgetExhausted > before.wavesBudgetExhausted,
+      "an exhausted wave to be counted",
+    );
+    // The scheduler yielded (the mechanism, not just the effect).
+    expect(servingRuntime!.scheduler.servingYield).toBeDefined();
+    expect(servingRuntime!.scheduler.servingYield!.yieldCount)
+      .toBeGreaterThan(0);
+    expect(host.stats().lease.lost).toBe(0);
+  });
+
+  it("(ii) a wave longer than TTL/3 renews the lease MID-WAVE from the yield observer, with the renew timer inert: the 1.2-s walk outlives a 600-ms TTL twice over and still commits under a live lease; lease.lost stays 0 (mutation: renew-on-yield removed → the lease lapses and the wave's commit is refused)", async () => {
+    host = newHost({
+      flushDeadlineMs: 5_000,
+      idleParkMs: 600_000,
+      // The interval timer never fires within the test: every renewal
+      // that lands is the mid-wave belt.
+      renewIntervalMs: 600_000,
+      leaseTtlMs: 600,
+    });
+    const engine = await activate();
+    const spaceServer = host.spaceServer(space)!;
+    const expiryAtStart = leaseExpiry(engine);
+    expect(expiryAtStart).toBeGreaterThan(0);
+    const seqBefore = Engine.serverSeq(engine);
+    const derivedBefore = host.stats().derivedCommits;
+
+    const outIds = registerWalk();
+    // The wave commits — under a lease that would have EXPIRED 600 ms in
+    // without the mid-wave renew (the walk is 1 200 ms; the deadline 5 s,
+    // so it is ONE wave).
+    await waitUntil(
+      () => storedOutCount(engine, outIds) === WALK_STEPS,
+      "the walk's single wave to commit every step",
+      20_000,
+    );
+    expect(Engine.serverSeq(engine)).toBeGreaterThan(seqBefore);
+    expect(host.stats().derivedCommits).toBeGreaterThan(derivedBefore);
+    expect(host.stats().lease.lost).toBe(0);
+    expect(spaceServer.active).toBe(true);
+    // The row was renewed while the wave ran (no timer could have).
+    expect(leaseExpiry(engine)).toBeGreaterThan(expiryAtStart);
+    expect(liveExecutionLeaseHolder(engine, space)).toBe(spaceServer.holder);
+    expect(servingRuntime!.scheduler.servingYield!.yieldCount)
+      .toBeGreaterThan(0);
+  });
+
+  it("(iii) posture gate: a runtime without servingPosture constructs no yielder — the OFF arm and flag-ON clients keep their settle loop's exact microtask shape", async () => {
+    openClient();
+    expect(clientRuntime.scheduler.servingYield).toBeUndefined();
+    const flagOnClientManager = EmulatedStorageManager.connectTo(server, {
+      as: aliceSigner,
+    });
+    const flagOnClient = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: flagOnClientManager,
+      experimental: { serverExecution: true },
+    });
+    try {
+      expect(flagOnClient.scheduler.servingYield).toBeUndefined();
+    } finally {
+      await flagOnClient.dispose();
+      await flagOnClientManager.close();
+    }
+  });
+
+  it("CooperativeYield unit: yields only once the slice is spent, reports every yield to the observer FIRST, and lets a due timer fire between slices", async () => {
+    const yielder = new CooperativeYield(20);
+    let observed = 0;
+    let observedBeforeTurn = 0;
+    yielder.onYield = () => {
+      observed += 1;
+    };
+    // Fresh slice: no yield.
+    expect(yielder.maybeYield()).toBeUndefined();
+    burn(25);
+    // Spent slice: a yield, observer called synchronously before the turn.
+    const turn = yielder.maybeYield();
+    expect(turn).toBeDefined();
+    observedBeforeTurn = observed;
+    expect(observedBeforeTurn).toBe(1);
+    await turn;
+    expect(yielder.yieldCount).toBe(1);
+    // Right after a turn the slice is fresh again.
+    expect(yielder.maybeYield()).toBeUndefined();
+    // A due timer fires between slices of continuous work.
+    let firedAt = -1;
+    const start = performance.now();
+    setTimeout(() => {
+      firedAt = performance.now() - start;
+    }, 10);
+    for (let i = 0; i < 20 && firedAt < 0; i++) {
+      burn(5);
+      const t = yielder.maybeYield();
+      if (t !== undefined) await t;
+    }
+    expect(firedAt).toBeGreaterThanOrEqual(0);
+    // Fired within about one slice + one step of its due time.
+    expect(firedAt).toBeLessThan(10 + 20 + 5 + 30);
+    // An observer throw is contained.
+    yielder.onYield = () => {
+      throw new Error("boom");
+    };
+    await yielder.yieldNow();
+    expect(yielder.yieldCount).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/packages/runner/test/executor-cooperative-yield.test.ts
+++ b/packages/runner/test/executor-cooperative-yield.test.ts
@@ -15,13 +15,13 @@
 //   (exhausted) wave within ~one step of the deadline, not after the whole
 //   walk. Mutation (the yield removed from settle.ts) → the first commit
 //   lands only after the full 1.2 s → RED.
-// - (ii) MID-WAVE RENEW: the same walk with a 600-ms lease TTL, the renew
-//   TIMER inert (600 s) and a 5-s deadline — the wave outlives the TTL
-//   twice over and still COMMITS under a live lease, because the yield
-//   observer renewed it mid-wave; `lease.lost` stays 0 and the lease row's
-//   expiry moved during the wave. Mutation (the observer's renew removed,
-//   or the yield removed) → the lease lapses at 600 ms and the wave's
-//   commit is refused at admission → RED.
+// - (ii) MID-WAVE RENEW: a 45-step (1.8-s) walk with a 900-ms lease TTL,
+//   the renew TIMER inert (600 s) and a 5-s deadline — the wave outlives
+//   the TTL twice over and still COMMITS under a live lease, because the
+//   yield observer renewed it mid-wave; `lease.lost` stays 0 and the
+//   lease row's expiry moved during the wave. Mutation (the observer's
+//   renew removed, or the yield removed) → the lease lapses at 900 ms and
+//   the wave's commit is refused at admission → RED.
 // - (iii) POSTURE GATE: a runtime without `servingPosture` constructs no
 //   yielder — the OFF arm and flag-ON clients keep their settle loops'
 //   exact microtask shape.

--- a/packages/runner/test/executor-events-down.test.ts
+++ b/packages/runner/test/executor-events-down.test.ts
@@ -40,6 +40,7 @@ import {
 } from "@commonfabric/memory/v2";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import { Runtime } from "../src/runtime.ts";
+import type { Cell } from "../src/cell.ts";
 import type {
   IExtendedStorageTransaction,
   MemorySpace,
@@ -61,7 +62,14 @@ import { newSharedServer } from "./memory-v2-test-utils.ts";
  * settle in EVERY cycle (empty ones included), so an unconditional gate
  * would catch some idle cycle already in flight and starve the drain
  * the test needs — the predicate lets exactly the cycle that SEALED the
- * watched state hang. Undefined everywhere else. */
+ * watched state hang. Undefined everywhere else.
+ *
+ * The second seam, the drain's SYNC gate (`syncGate` / `syncGateWhen`,
+ * the seal→outcome-window pin): the serving drain awaits the sidecar
+ * doc's `syncCell` BEFORE any entry's in-flight guard check, so a drain
+ * parked here (after the real sync — the doc IS synced; only the drain's
+ * continuation is held) reaches the guard check exactly when the test
+ * lets it. `syncGateWhen` receives the synced doc's id. */
 class GatedStorageManager extends EmulatedStorageManager {
   static override connectTo(
     server: MemoryV2Server.Server,
@@ -72,12 +80,32 @@ class GatedStorageManager extends EmulatedStorageManager {
 
   settleGate: Promise<void> | undefined;
   settleGateWhen: (() => boolean) | undefined;
+  syncGate: Promise<void> | undefined;
+  syncGateWhen: ((id: string) => boolean) | undefined;
+  /** How many syncs the sync gate has parked (a pin's evidence that a
+   * drain WAS held in the window it constructs). */
+  syncGateHits = 0;
 
   override async inputSynced(): Promise<void> {
     await super.inputSynced();
     if (this.settleGate !== undefined && (this.settleGateWhen?.() ?? true)) {
       await this.settleGate;
     }
+  }
+
+  override async syncCell<T>(
+    cell: Cell<T>,
+    options?: Parameters<EmulatedStorageManager["syncCell"]>[1],
+  ): Promise<Cell<T>> {
+    const synced = await super.syncCell(cell, options);
+    if (
+      this.syncGate !== undefined &&
+      (this.syncGateWhen?.(cell.getAsNormalizedFullLink().id) ?? true)
+    ) {
+      this.syncGateHits += 1;
+      await this.syncGate;
+    }
+    return synced;
   }
 }
 
@@ -478,6 +506,177 @@ describe("Phase 3 events-down (serving side)", () => {
       id: argument.getAsNormalizedFullLink().id,
     });
     expect((doc?.value as { value?: number })?.value).toBe(1);
+    cancelDemand();
+  });
+
+  it("the guard holds through the SEAL→OUTCOME window (stage C tuning; self-review finding 1): a re-drain that reaches the entry AFTER its copy's consequence has SEALED into a wave the store has not yet committed skips it — the copy is released by the wave OUTCOME, never at seal (mutation: release at the seal → that re-drain queues a second copy: processed 2, value 2)", async () => {
+    // The window the exactly-once pin above cannot see (it passes with
+    // EITHER release point): the copy's mark rides an uncommitted wave
+    // while the entry is still pending in the store, and a re-drain
+    // whose guard check lands in that window must still skip. Held
+    // deterministically here: the re-drain is parked at the sidecar
+    // sync (which the drain awaits BEFORE any entry's guard check) until
+    // the copy's consequence is visible SEALED on the serving overlay
+    // and — witnessed — NOT in the store; then the drain proceeds to the
+    // check.
+    ({ manager: clientManager, runtime: clientRuntime } = openClient());
+    const engine = await server.engineForSpace(space);
+    const { argument, result } = await standUp(clientRuntime, BUMP_PATTERN, {
+      arg: "sealwindow-arg",
+      result: "sealwindow-result",
+    });
+    const cancelDemand = result.sink(() => {});
+    await clientRuntime.idle();
+    await clientRuntime.storageManager.synced();
+
+    host = newHost({ flushDeadlineMs: 100, idleParkMs: 600_000 });
+    {
+      const poke = clientRuntime.getCell<{ n: number }>(
+        space,
+        "sealwindow-activate",
+        undefined,
+      );
+      const tx = clientRuntime.edit();
+      poke.withTx(tx).set({ n: 1 });
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    await waitUntil(
+      () => host!.spaceServer(space)?.active === true,
+      "space to activate",
+    );
+    const bootSeq = Engine.serverSeq(engine);
+    await waitUntil(
+      () => readWatermarkSeq(engine) >= bootSeq,
+      "the boot serve to settle",
+      15_000,
+    );
+    // The serving-side view of the consequence doc: a SEALED write is
+    // visible through it (the open wave's overlay) before the store
+    // holds it. Synced before the fire.
+    const serving = servingRuntime!;
+    const servingArg = serving.getCell<{ value: number }>(
+      space,
+      "sealwindow-arg",
+      undefined,
+    );
+    await servingArg.sync();
+    const argId = argument.getAsNormalizedFullLink().id;
+    const storedValue = (): number | undefined =>
+      (Engine.read(engine, { id: argId })?.value as
+        | { value?: number }
+        | undefined)?.value;
+    expect(storedValue()).toBe(0);
+
+    // The same 1.2-s synthetic walk as above, ahead of the fire: the
+    // copy's dispatch queues BEHIND it (events run at the next execute
+    // pass), the honest deadline cuts cycles meanwhile, and every cut
+    // cycle re-drains the still-pending entry.
+    const trigger = serving.getCell<{ value: number }>(
+      space,
+      "sealwindow-walk-trigger",
+      undefined,
+    );
+    const outs: Cell<{ step: number }>[] = [];
+    for (let step = 0; step < 30; step++) {
+      const out = serving.getCell<{ step: number }>(
+        space,
+        `sealwindow-walk-out-${step}`,
+        undefined,
+      );
+      outs.push(out);
+      const walk = (tx: IExtendedStorageTransaction): void => {
+        trigger.withTx(tx).get();
+        const until = performance.now() + 40;
+        while (performance.now() < until) {
+          // spin
+        }
+        out.withTx(tx).set({ step });
+      };
+      serving.scheduler.register(walk, undefined, { isEffect: true });
+    }
+    // The walk is under way (its first step sealed) before the fire, so
+    // the copy is queued mid-walk, never ahead of it.
+    await waitUntil(() => outs[0].get() !== undefined, "the walk to start");
+
+    // The sync gate: engaged for RE-drains only — the drain that queues
+    // the copy counts it at its end (`processed`), so the first drain
+    // passes and every later one parks after its sidecar sync.
+    const gate = Promise.withResolvers<void>();
+    servingManager!.syncGate = gate.promise;
+    servingManager!.syncGateWhen = (id) =>
+      id.startsWith("of:stream-events:") &&
+      host!.stats().events.processed >= 1;
+    let sidecarId: string;
+    try {
+      result.key("bump").send({});
+      await clientRuntime.storageManager.synced();
+      await waitUntil(
+        () => sidecarIdsIn(engine).length === 1,
+        "the event append to land",
+      );
+      sidecarId = sidecarIdsIn(engine)[0];
+      await waitUntil(
+        () => host!.stats().events.processed === 1,
+        "the copy to be queued once",
+      );
+      // The copy runs after the walk and its consequence SEALS — visible
+      // on the serving overlay while the store still holds the pre-fire
+      // value and the entry is unconsequenced: the seal→outcome window
+      // is open, and a re-drain is parked in it (the gate was hit).
+      await waitUntil(
+        () => (servingArg.key("value").get() as number | undefined) === 1,
+        "the copy's consequence to SEAL into the open wave",
+        20_000,
+      );
+      expect(storedValue()).toBe(0);
+      const sealedEntry = (Engine.read(engine, { id: sidecarId })
+        ?.value as StreamEventsDocValue).entries![0];
+      expect(sealedEntry.consequenced).not.toBe(true);
+      expect(servingManager!.syncGateHits).toBeGreaterThanOrEqual(1);
+      expect(host!.stats().events.processed).toBe(1);
+      // Let the parked re-drain reach the entry's guard check now — copy
+      // sealed, wave uncommitted.
+      gate.resolve();
+    } finally {
+      gate.resolve();
+      servingManager!.syncGate = undefined;
+      servingManager!.syncGateWhen = undefined;
+    }
+
+    await waitUntil(
+      () => {
+        const value = Engine.read(engine, { id: sidecarId })?.value as
+          | StreamEventsDocValue
+          | undefined;
+        return value?.entries?.[0]?.consequenced === true;
+      },
+      "the entry to consequence",
+      20_000,
+    );
+    // Let any duplicate copy that was queued run its course before the
+    // negative assertions.
+    await serving.idle();
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    await serving.idle();
+    const entry = (Engine.read(engine, { id: sidecarId })
+      ?.value as StreamEventsDocValue).entries![0];
+    const stats = host.stats();
+    // THE PIN: the re-drain that reached the check inside the window
+    // SKIPPED the sealed copy (the guard held it `marked` until the wave
+    // outcome) — one delivery, ONE consequence commit, value 1. Released
+    // at the seal instead, that re-drain queues the second copy:
+    // processed 2, value 2.
+    expect(stats.events.appended).toBe(1);
+    expect(stats.events.processed).toBe(1);
+    expect(stats.events.drainInFlightSkips).toBeGreaterThanOrEqual(1);
+    const carrying = (engine.database.prepare(
+      `SELECT seq, consequence_of FROM "commit"
+       WHERE class = 'derived' AND consequence_of IS NOT NULL`,
+    ).all() as Array<{ seq: number; consequence_of: string }>).filter((
+      row,
+    ) => row.consequence_of.includes(entry.eventId));
+    expect(carrying.length).toBe(1);
+    expect(storedValue()).toBe(1);
     cancelDemand();
   });
 

--- a/packages/runner/test/executor-events-down.test.ts
+++ b/packages/runner/test/executor-events-down.test.ts
@@ -40,7 +40,10 @@ import {
 } from "@commonfabric/memory/v2";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import { Runtime } from "../src/runtime.ts";
-import type { MemorySpace } from "../src/storage/interface.ts";
+import type {
+  IExtendedStorageTransaction,
+  MemorySpace,
+} from "../src/storage/interface.ts";
 import { ExecutorHost } from "../src/executor/host.ts";
 import { readWatermarkSeq } from "../src/executor/watermark.ts";
 import {
@@ -365,6 +368,116 @@ describe("Phase 3 events-down (serving side)", () => {
       "the durable-ack settle callback",
     );
     expect(ackStatus).not.toBe("error");
+    cancelDemand();
+  });
+
+  it("exactly-once under an HONEST flush deadline (stage C tuning): a fire that lands while the serving scheduler is mid-settle is drained ONCE — the re-drains that follow every cut cycle skip the still-in-flight copy; the counter reads exactly 1 and ONE commit consequences the event (mutation: the drain's in-flight guard removed → a copy per cut cycle, processed ≫ appended, value ≫ 1)", async () => {
+    ({ manager: clientManager, runtime: clientRuntime } = openClient());
+    const engine = await server.engineForSpace(space);
+    const { argument, result } = await standUp(clientRuntime, BUMP_PATTERN, {
+      arg: "inflight-arg",
+      result: "inflight-result",
+    });
+    const cancelDemand = result.sink(() => {});
+    await clientRuntime.idle();
+    await clientRuntime.storageManager.synced();
+
+    // T3's honest deadline: cycles are cut every 100 ms of settle. The
+    // host activates on the next ADMISSION (the client's session was
+    // already open): a plain authored write triggers it, so the serving
+    // runtime exists before the walk is registered.
+    host = newHost({ flushDeadlineMs: 100, idleParkMs: 600_000 });
+    {
+      const poke = clientRuntime.getCell<{ n: number }>(
+        space,
+        "inflight-activate",
+        undefined,
+      );
+      const tx = clientRuntime.edit();
+      poke.withTx(tx).set({ n: 1 });
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    await waitUntil(
+      () => host!.spaceServer(space)?.active === true,
+      "space to activate",
+    );
+    // Let the boot serve settle so the walk below is the only work.
+    const bootSeq = Engine.serverSeq(engine);
+    await waitUntil(
+      () => readWatermarkSeq(engine) >= bootSeq,
+      "the boot serve to settle",
+      15_000,
+    );
+    // A synthetic 1.2-s settle on the SERVING runtime (30 × 40 ms of
+    // synchronous work, one sealed write each): the fire's dispatch waits
+    // behind it, and ~10 cut cycles re-drain the still-pending entry
+    // meanwhile.
+    const serving = servingRuntime!;
+    const trigger = serving.getCell<{ value: number }>(
+      space,
+      "inflight-walk-trigger",
+      undefined,
+    );
+    for (let step = 0; step < 30; step++) {
+      const out = serving.getCell<{ step: number }>(
+        space,
+        `inflight-walk-out-${step}`,
+        undefined,
+      );
+      const walk = (tx: IExtendedStorageTransaction): void => {
+        trigger.withTx(tx).get();
+        const until = performance.now() + 40;
+        while (performance.now() < until) {
+          // spin
+        }
+        out.withTx(tx).set({ step });
+      };
+      serving.scheduler.register(walk, undefined, { isEffect: true });
+    }
+    // Fire NOW: the append lands mid-walk.
+    result.key("bump").send({});
+    await clientRuntime.storageManager.synced();
+
+    await waitUntil(
+      () => sidecarIdsIn(engine).length === 1,
+      "the event append to land",
+    );
+    const sidecarId = sidecarIdsIn(engine)[0];
+    await waitUntil(
+      () => {
+        const value = Engine.read(engine, { id: sidecarId })?.value as
+          | StreamEventsDocValue
+          | undefined;
+        return value?.entries?.[0]?.consequenced === true;
+      },
+      "the entry to consequence",
+      20_000,
+    );
+    // Let any duplicate copy that was queued run its course before the
+    // negative assertions.
+    await serving.idle();
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    await serving.idle();
+    const entry = (Engine.read(engine, { id: sidecarId })
+      ?.value as StreamEventsDocValue).entries![0];
+    const stats = host.stats();
+    // THE PIN: one durable entry, ONE delivery, ONE consequence commit,
+    // the counter incremented exactly once — with the guard having
+    // skipped at least one re-drain (the cut cycles did re-scan).
+    expect(stats.events.appended).toBe(1);
+    expect(stats.events.processed).toBe(1);
+    expect(stats.events.drainInFlightSkips).toBeGreaterThanOrEqual(1);
+    const carrying = (engine.database.prepare(
+      `SELECT seq, consequence_of FROM "commit"
+       WHERE class = 'derived' AND consequence_of IS NOT NULL`,
+    ).all() as Array<{ seq: number; consequence_of: string }>).filter((
+      row,
+    ) => row.consequence_of.includes(entry.eventId));
+    expect(carrying.length).toBe(1);
+    const doc = Engine.read(engine, {
+      id: argument.getAsNormalizedFullLink().id,
+    });
+    expect((doc?.value as { value?: number })?.value).toBe(1);
     cancelDemand();
   });
 

--- a/packages/runner/test/speculation-arrival-gate.test.ts
+++ b/packages/runner/test/speculation-arrival-gate.test.ts
@@ -30,6 +30,22 @@
 //   entry of the same writer whose whole-doc ops cover an older entry's
 //   docs retires the older one at seal; a PATCH does not; another writer
 //   does not.
+//
+// Stage C tuning T2 (speculation.md §4's owed ARRIVAL RE-SWEEP + the
+// LATE-ECHO rule; stage-c-attribution-report §4):
+// - the E2 shape: a served derived value that arrives DECOUPLED from a
+//   watermark advance (an exhausted wave carries none; W already covers
+//   the entry's floor) retires the echo and renders — without waiting for
+//   an unrelated commit to lift W (mutation: the arrival observer removed
+//   → the entry stands until the next watermark event);
+// - the arrival wake is FILTERED to docs some entry wrote and never
+//   relaxes the gate (scripted: an arrival for an unrelated doc sweeps
+//   nothing; an arrival while W < floor retires nothing);
+// - a LATE echo — an event-handler echo sealed after its intent's
+//   TERMINAL consequence already arrived — is dropped at seal, never
+//   registered (its writes render nothing); a fresh intent's echo still
+//   registers (mutation: the check removed → the late echo registers and
+//   its divergent write renders).
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
@@ -51,6 +67,7 @@ import {
   SpeculationOverlayDestination,
   stampSpeculationRunContext,
 } from "../src/speculation/overlay-destination.ts";
+import { readWatermarkSeq as readWatermark } from "../src/executor/watermark.ts";
 
 const spaceSigner = await Identity.fromPassphrase("arrival gate space");
 const space = spaceSigner.did() as MemorySpace;
@@ -501,6 +518,354 @@ describe("speculation arrival gate (speculation.md §4, RULED 2026-08-16)", () =
     // superseded (dropping a patch layer under a whole-doc set is
     // invisible); B's entry stays.
     expect((await seal(writerA, [set])).ok).toBeDefined();
+    expect(destination.entryCount(space)).toBe(2);
+    destination.close();
+  });
+
+  it("stage C T2, the E2 shape: a served value arriving DECOUPLED from a watermark advance (W already covers the floor; the arrival's own seq is above W) retires the echo and renders at once — no unrelated commit needed (mutation: arrival observer removed → the entry stands)", async () => {
+    // Same substrate as the OW32 pin above: alice's per-user echo, a
+    // watermark covering its basis, the instance not yet served.
+    const alice = openClient(aliceSigner);
+    const engine = await server.engineForSpace(space);
+    const compiled = await alice.patternManager.compilePattern({
+      main: "/main.tsx",
+      files: [{ name: "/main.tsx", contents: PER_USER_PATTERN }],
+    }, { space });
+    const arg = alice.getCell<Record<string, unknown>>(
+      space,
+      "ag-arrival-arg",
+      undefined,
+    );
+    const result = alice.getCell<{ echo: string }>(
+      space,
+      "ag-arrival-result",
+      compiled.resultSchema,
+    );
+    await arg.sync();
+    await result.sync();
+    {
+      const tx = alice.edit();
+      arg.withTx(tx).set({});
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    {
+      const tx = alice.edit();
+      alice.run(tx, compiled, arg, result);
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    await alice.idle();
+    await alice.storageManager.synced();
+    const cancelDemand = result.sink(() => {});
+    const typedArg = alice.getCell<{ draft: string }>(
+      space,
+      "ag-arrival-arg",
+      compiled.argumentSchema,
+    );
+    {
+      const tx = alice.edit();
+      typedArg.key("draft").withTx(tx).set("A");
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    await alice.idle();
+    await alice.storageManager.synced();
+    await waitUntil(
+      () => result.key("echo").get() === "echo:A",
+      "the speculative echo to render",
+    );
+    const overlay = alice.speculationOverlay!;
+    expect(overlay.entryCount(space)).toBeGreaterThanOrEqual(1);
+
+    // W covers the basis; the instance is unserved → the entry stands.
+    const writer = openClient(spaceSigner);
+    await pushWatermark(writer, Engine.serverSeq(engine));
+    await alice.idle();
+    await alice.storageManager.synced();
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(overlay.entryCount(space)).toBeGreaterThanOrEqual(1);
+    expect(result.key("echo").get()).toBe("echo:A");
+    const arrivalSweepsBefore = overlay.arrivalSweepCount;
+
+    // The ARRIVAL, decoupled: the authoritative value for BOTH written
+    // docs lands at a seq ABOVE the covering W — an exhausted wave's
+    // derived commit carries no watermark movement — and NO further
+    // watermark write follows. Pre-fix nothing re-swept: the entry stood
+    // (hiding the served value) until the next unrelated commit lifted W
+    // (the attribution's E2: 48 s, released by another user's draft).
+    const echoLink = result.key("echo").getAsNormalizedFullLink();
+    const echoTarget = alice.getCellFromLink<unknown>({
+      ...echoLink,
+      schema: undefined,
+    }).getRaw({ lastNode: "writeRedirect" }) as
+      | { "/": { "link@1": { id?: string } } }
+      | undefined;
+    const echoDocId = echoTarget?.["/"]?.["link@1"]?.id ??
+      (() => {
+        const raw = alice.getCellFromLink<unknown>({
+          ...result.getAsNormalizedFullLink(),
+          schema: undefined,
+        }).getRaw() as { echo?: { "/": { "link@1": { id?: string } } } };
+        return raw?.echo?.["/"]?.["link@1"]?.id;
+      })();
+    expect(echoDocId).toBeDefined();
+    const aliceAgain = openClient(aliceSigner);
+    const authoritative = aliceAgain.getCellFromLink<unknown>({
+      space,
+      id: echoDocId as never,
+      scope: "user",
+      path: [],
+    });
+    const authoritativeSlot = aliceAgain.getCellFromLink<unknown>({
+      space,
+      id: echoDocId as never,
+      scope: "space",
+      path: [],
+    });
+    await authoritative.sync();
+    await authoritativeSlot.sync();
+    const watermarkAtArrival = readWatermark(engine);
+    {
+      const tx = aliceAgain.edit();
+      authoritative.withTx(tx).set("echo:server" as never);
+      authoritativeSlot.withTx(tx).set(
+        {
+          "/": {
+            "link@1": {
+              id: echoDocId,
+              overwrite: "redirect",
+              path: [],
+              scope: "user",
+            },
+          },
+        } as never,
+      );
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    await aliceAgain.storageManager.synced();
+    // The arrival's seq is above W and W does not move.
+    expect(Engine.serverSeq(engine)).toBeGreaterThan(watermarkAtArrival);
+    // THE PIN: retired and rendered off the arrival alone.
+    await waitUntil(
+      () => overlay.entryCount(space) === 0,
+      "the entry to retire on the decoupled arrival",
+      10_000,
+    );
+    await waitUntil(
+      () => result.key("echo").get() === "echo:server",
+      "the authoritative value to render",
+      10_000,
+    );
+    expect(overlay.arrivalSweepCount).toBeGreaterThan(arrivalSweepsBefore);
+    expect(readWatermark(engine)).toBe(watermarkAtArrival);
+    await alice.idle();
+    expect(alice.scheduler.isNonSettling()).toBe(false);
+    cancelDemand();
+  });
+
+  it("stage C T2, the arrival wake is a TRIGGER, not a relaxation (scripted): an arrival for a doc no entry wrote sweeps nothing; an arrival while W < floor retires nothing; an arrival with W ≥ floor retires the entry", async () => {
+    const doc = "of:arrival-scripted" as never;
+    const other = "of:arrival-unrelated" as never;
+    let nextLocalSeq = 10;
+    let confirmedSeq = 0;
+    const replica = {
+      sealNative: (
+        native: { operations: Array<Record<string, unknown>> },
+        _source: unknown,
+        verdict: Promise<unknown>,
+      ) => {
+        const localSeq = nextLocalSeq++;
+        return {
+          localSeq,
+          commit: {
+            localSeq,
+            // A confirmed read at seq 40: the entry's floor.
+            reads: {
+              confirmed: [{ id: "of:input", seq: 40 }],
+              pending: [],
+            },
+            operations: native.operations,
+          },
+          settled: verdict.then(() => undefined, () => undefined),
+        };
+      },
+      speculationRetirementView: () => ({
+        confirmedSeq,
+        pendingLocalSeqs: [] as number[],
+      }),
+      ackedSeqOf: () => undefined,
+      speculationAckObserver: undefined as (() => void) | undefined,
+      speculationArrivalObserver: undefined as
+        | ((arrived: readonly { id: string; scope?: string }[]) => void)
+        | undefined,
+    };
+    const watermarkSinks: Array<(value: unknown) => void> = [];
+    const runtime = {
+      storageManager: { open: () => ({ replica }) },
+      getCellFromLink: (link: { id: string }) => ({
+        sink: (cb: (value: unknown) => void) => {
+          if (link.id === SERVER_EXECUTION_WATERMARK_DOC_ID) {
+            watermarkSinks.push(cb);
+          }
+          return () => {};
+        },
+      }),
+    } as unknown as Runtime;
+    const destination = new SpeculationOverlayDestination(runtime);
+    const tx = {
+      tx: {
+        sourceAction: { name: "writer" },
+        sealInto: (collector: {
+          sealSpaceCommit: (
+            space: MemorySpace,
+            native: unknown,
+            source: unknown,
+          ) => Promise<unknown>;
+        }) =>
+          collector.sealSpaceCommit(
+            space,
+            {
+              operations: [{
+                op: "set",
+                id: doc,
+                scope: "user",
+                value: { value: 1 },
+              }],
+              preconditions: [],
+            },
+            { sourceAction: { name: "writer" } },
+          ).then(() => ({ ok: {} })),
+      },
+    } as unknown as IExtendedStorageTransaction;
+    stampSpeculationRunContext(tx, { actionId: "arrival", kind: "derivation" });
+    expect((await destination.seal(tx)).ok).toBeDefined();
+    expect(destination.entryCount(space)).toBe(1);
+    // The overlay installed its arrival wake beside the watermark sink.
+    expect(replica.speculationArrivalObserver).toBeDefined();
+    const arrive = (id: string) =>
+      replica.speculationArrivalObserver!([{ id, scope: "user" }]);
+    // W < floor (30 < 40): an arrival of the written doc retires NOTHING
+    // — the coverage rule stands; the wake is not a relaxation.
+    for (const sink of watermarkSinks) sink({ seq: 30 });
+    confirmedSeq = 45;
+    arrive(doc);
+    expect(destination.entryCount(space)).toBe(1);
+    expect(destination.arrivalSweepCount).toBe(1);
+    // W ≥ floor, but the arrival names a doc no entry wrote: no sweep.
+    for (const sink of watermarkSinks) sink({ seq: 40 });
+    // (the watermark sink itself swept — and retired nothing? It would
+    // retire now: W 40 ≥ floor 40 and confirmedSeq 45 ≥ 40. Re-seal a
+    // fresh entry to test the filter on a live one.)
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(destination.entryCount(space)).toBe(0);
+    confirmedSeq = 0;
+    expect((await destination.seal(tx)).ok).toBeDefined();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(destination.entryCount(space)).toBe(1);
+    const sweepsBefore = destination.arrivalSweepCount;
+    arrive(other);
+    expect(destination.arrivalSweepCount).toBe(sweepsBefore);
+    expect(destination.entryCount(space)).toBe(1);
+    // The arrival of the WRITTEN doc with W ≥ floor: retired.
+    confirmedSeq = 46;
+    arrive(doc);
+    expect(destination.arrivalSweepCount).toBe(sweepsBefore + 1);
+    expect(destination.entryCount(space)).toBe(0);
+    destination.close();
+    expect(replica.speculationArrivalObserver).toBeUndefined();
+  });
+
+  it("stage C T2, the LATE-ECHO rule (scripted): an event-handler echo sealed AFTER its intent reached a terminal consequence is dropped at seal — never registered, its writes render nothing; a fresh intent's echo still registers (mutation: check removed → the late echo registers)", async () => {
+    let nextLocalSeq = 10;
+    const sealed: Array<Record<string, unknown>[]> = [];
+    const replica = {
+      sealNative: (
+        native: { operations: Array<Record<string, unknown>> },
+        _source: unknown,
+        verdict: Promise<unknown>,
+      ) => {
+        sealed.push(native.operations);
+        const localSeq = nextLocalSeq++;
+        return {
+          localSeq,
+          commit: {
+            localSeq,
+            reads: { confirmed: [], pending: [] },
+            operations: native.operations,
+          },
+          settled: verdict.then(() => undefined, () => undefined),
+        };
+      },
+      speculationRetirementView: () => ({
+        confirmedSeq: 0,
+        pendingLocalSeqs: [] as number[],
+      }),
+      ackedSeqOf: () => undefined,
+      speculationAckObserver: undefined as (() => void) | undefined,
+      speculationArrivalObserver: undefined,
+    };
+    const runtime = {
+      storageManager: { open: () => ({ replica }) },
+      getCellFromLink: () => ({ sink: () => () => {} }),
+    } as unknown as Runtime;
+    const destination = new SpeculationOverlayDestination(runtime);
+    const sidecarId = "of:late-echo-sidecar";
+    const echoOf = (eventId: string) => {
+      const tx = {
+        tx: {
+          sourceAction: { name: "handler" },
+          sealInto: (collector: {
+            sealSpaceCommit: (
+              space: MemorySpace,
+              native: unknown,
+              source: unknown,
+            ) => Promise<unknown>;
+          }) =>
+            collector.sealSpaceCommit(
+              space,
+              {
+                operations: [{
+                  op: "set",
+                  id: "of:toggle",
+                  scope: "space",
+                  value: { everyoneIsAdmin: true },
+                }],
+                preconditions: [],
+              },
+              { sourceAction: { name: "handler" } },
+            ).then(() => ({ ok: {} })),
+        },
+      } as unknown as IExtendedStorageTransaction;
+      stampSpeculationRunContext(tx, {
+        actionId: "handler",
+        kind: "event-handler",
+        eventId,
+      });
+      return tx;
+    };
+    // Intent 1: fired, then its TERMINAL consequence arrives (a refused
+    // delivery — the same `#settleIntentConsequence` seam the consequenced
+    // mark, the dropped notice and the served error all reach) BEFORE the
+    // client's local dispatch seals its echo.
+    destination.trackIntent(space, sidecarId, "evt-late");
+    destination.resolveIntent(space, sidecarId, "evt-late", {
+      kind: "refused",
+      reason: "test: terminal before the echo",
+    });
+    expect((await destination.seal(echoOf("evt-late"))).ok).toBeDefined();
+    // Dropped: nothing sealed into the replica, no entry, counted.
+    expect(sealed.length).toBe(0);
+    expect(destination.entryCount(space)).toBe(0);
+    expect(destination.lateEchoDropCount).toBe(1);
+    // Intent 2: fired and still pending — its echo registers as before.
+    destination.trackIntent(space, sidecarId, "evt-fresh");
+    expect((await destination.seal(echoOf("evt-fresh"))).ok).toBeDefined();
+    expect(sealed.length).toBe(1);
+    expect(destination.entryCount(space)).toBe(1);
+    expect(destination.lateEchoDropCount).toBe(1);
+    // An untracked eventId (a client cascade's minted id) is never
+    // terminal: it registers too.
+    expect((await destination.seal(echoOf("evt-cascade-minted"))).ok)
+      .toBeDefined();
+    expect(sealed.length).toBe(2);
     expect(destination.entryCount(space)).toBe(2);
     destination.close();
   });

--- a/packages/runner/test/speculation-arrival-gate.test.ts
+++ b/packages/runner/test/speculation-arrival-gate.test.ts
@@ -861,12 +861,61 @@ describe("speculation arrival gate (speculation.md §4, RULED 2026-08-16)", () =
     expect(sealed.length).toBe(1);
     expect(destination.entryCount(space)).toBe(1);
     expect(destination.lateEchoDropCount).toBe(1);
-    // An untracked eventId (a client cascade's minted id) is never
-    // terminal: it registers too.
+    // An untracked eventId (a client cascade's minted id) with no
+    // terminal parent is never jobless: it registers too.
     expect((await destination.seal(echoOf("evt-cascade-minted"))).ok)
       .toBeDefined();
     expect(sealed.length).toBe(2);
     expect(destination.entryCount(space)).toBe(2);
+    // The late echo's CASCADE (self-review finding 2): a child echo whose
+    // `parentEventId` is the terminal intent is dropped too, and so is
+    // ITS child (the dropped run's minted id joins the jobless set) —
+    // while a child of a live intent still registers.
+    const cascadeOf = (eventId: string, parentEventId: string) => {
+      const tx = echoOf(eventId);
+      stampSpeculationRunContext(tx, {
+        actionId: "handler",
+        kind: "event-handler",
+        eventId,
+        parentEventId,
+      });
+      return tx;
+    };
+    expect(
+      (await destination.seal(cascadeOf("evt-late-child", "evt-late")))
+        .ok,
+    ).toBeDefined();
+    expect(
+      (await destination.seal(
+        cascadeOf("evt-late-grandchild", "evt-late-child"),
+      )).ok,
+    ).toBeDefined();
+    expect(sealed.length).toBe(2);
+    expect(destination.entryCount(space)).toBe(2);
+    expect(destination.lateEchoDropCount).toBe(3);
+    expect(
+      (await destination.seal(cascadeOf("evt-fresh-child", "evt-fresh")))
+        .ok,
+    ).toBeDefined();
+    expect(sealed.length).toBe(3);
+    expect(destination.entryCount(space)).toBe(3);
+    // A dropped late echo's enactable effects are OWNED and not enacted
+    // (the closed arm's shape): deferSealedEffects returns true without
+    // flushing.
+    let flushed = 0;
+    const dropped = echoOf("evt-late");
+    expect((await destination.seal(dropped)).ok).toBeDefined();
+    expect(
+      destination.deferSealedEffects(dropped, [{
+        id: "nav:late",
+        kind: "navigateTo",
+        flush: () => {
+          flushed += 1;
+        },
+      }]),
+    ).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(flushed).toBe(0);
     destination.close();
   });
 });


### PR DESCRIPTION
## Why

Stacked on fan-out B (#5924's branch tip `fb2292a24`). The stage-C attribution report (`stage-c-attribution-report.md`, 2026-08-18) measured the ON-vs-OFF verdict at this tip and split the fix arc into a **design half** (the per-demander demand walk × roots; the client's whole-sidecar intent tracking with a CFC probe per fire — a SEPARATE stage, untouched here) and a **tuning half** the owner approved 2026-08-18: three contained, measured mechanisms. This PR is that tuning half, each item re-measured on the harness protocol (fresh store per run, ON binary posture-verified via `/api/meta` + `servingLoop`, load recorded, **no configured LLM model** — the report found the 08-17 daytime greens masked by exactly that churn):

- **T1 — one CFC flow-label probe per commit** (report §2c): `flowLabelWorkExists` — O(reads × dereference traces) — was evaluated TWICE per commit (`Runtime.prepareTxForCommit`, then the commit chokepoint) on the same unprepared, not-yet-relevant tx; 65 % of a saturated client worker on the ON note-create series.
- **T2 — retirement on ARRIVAL, not only on watermark** (report §4): a correctly served + pushed derived value was held 48 s by the client overlay's coverage/arrival gate — the sweep had no arrival trigger (speculation.md §4's stated frame-coupling ASSUMPTION; "an arrival re-sweep is the owed follow-up if that coupling ever loosens"). It loosened: an exhausted wave carries no watermark movement, and with an honest deadline that is the routine shape.
- **T3 — honest deadline + mid-wave renew** (report §2b/§3): the settle loop ran a whole wave's actions on one microtask chain, so the 100-ms flush deadline fired 2.5–8.3 s LATE (`wavesBudgetExhausted` a symptom, not a bound) and the lease-renew timer starved (renew gaps to 10 s vs a 15-s TTL; t2's `lease-lost` on every space at once).

Plus one **companion the honest deadline forced**: with cycles cut before a just-drained event has run, the post-commit re-arm re-drained the still-pending entry every cycle and queued a second copy each time — the first ON gate run showed `events: appended 8 / processed 34` (4.25× dispatch of the lockdown toggle; #5969's (β) re-scan variant). The drain now dedupes against ITSELF (narrowly; see Flags).

## What

- **T1** `storage/extended-storage-transaction.ts`, `storage/interface.ts`, `runtime.ts`: `IExtendedStorageTransaction.probeFlowLabelWork()` memoizes the NEGATIVE verdict on the tx, invalidated by an activity epoch bumped on every journaled read (`prepareRead`), write (`noteWrite`), dereference trace and trigger read; a positive verdict marks the tx relevant (nobody probes again). Both call sites use it. `cfcStats.flowLabelProbesComputed / flowLabelProbeMemoHits` (measurement). Shared client code, both arms — verdicts unchanged (a memo of a deterministic function; the flow-label suites pin them), probe count 2 → 1 in both.
- **T2** `storage/v2.ts` + `storage/interface.ts`: `ISpaceReplica.speculationArrivalObserver` fired at the end of `applySessionSync` with the docs whose confirmed seq moved forward. `speculation/overlay-destination.ts`: (a) the ARRIVAL wake — re-sweep when an arrived doc is one some live entry WROTE; the gate's predicates UNCHANGED (arrival is a second, earlier TRIGGER, never a relaxation; the soundness argument is in speculation.md §4 and the code comment); (b) the **late-echo rule** (speculation.md §4 step 2 read as the state it names): an event-handler echo sealed AFTER its intent's terminal consequence already arrived — or a cascade child of one — is not registered (writes dropped before any layer is sealed; enactable effects owned and not enacted; post-`sealInto` re-check mirrors the closed arm); (c) found and fixed while landing (a): the browser worker bundle drops UNINITIALIZED class fields, so `"speculationAckObserver" in replica` read false in browsers — **leg-C's origin-ack wake had never installed in a browser client**; the replica's observer fields are now initialized explicitly and the overlay probes capability by method. Diagnostics: `overlay.arrivalSweepCount / lateEchoDropCount`, logger keys `arrival-sweep` / `late-echo-dropped`, surfaced in the browser load summary's churn line (`cfc-browser-helpers.ts`: `overlayLateEchoDrops`, `overlayArrivalSweeps`).
- **T3** `scheduler/cooperative-yield.ts` (new), `scheduler/settle.ts`, `scheduler/execution.ts`, `scheduler/facade.ts`, `runtime.ts`, `executor/space-server.ts`: a SERVING runtime's scheduler yields one macrotask (`setTimeout(0)` — measured the only primitive that lets due timers fire in deadline order; MessageChannel/setImmediate starve them) between settle-loop ACTIONS once a 16-ms slice of continuous work is spent; the yielder is constructed only under `runtime.servingPosture` (the OFF arm and clients keep their exact microtask shape — no `await` added there). `Runtime.servingYieldObserver` seam: the SpaceServer renews the lease from every yield once the tenure has gone TTL/3 (`#renewIfDue`; `leaseTtlMs` policy knob for tests). Deliberately NO yield inside the per-demander fan-out loop (considered, tried, rejected — see Verification).
- **Companion** `executor/space-server.ts`, `executor/stats.ts`: the drain's in-flight guard — `#drainInFlight: Map<eventId, queued | marked>`; a re-drain skips an entry whose earlier drain copy is queued/held/running or whose consequence mark is sealed into a wave the store has not yet committed; released only on a store-visible outcome (the wave's `committedEventIds` ∪ `requeuedEventIds` — every abort arm reports event-handler contributions as requeued) or a provably markless end (deferral, the copy's final callback while still `queued`, a notice that failed to stage), and at park. `events.drainInFlightSkips`. Narrow by construction: drain-own copies only (all carry the mark path — #5969's stated safety condition); the LT1 in-process cascade copy (α) is untouched.
- **Docs**: speculation.md §4 (arrival re-sweep LANDED + the late-echo sentence), serving-loop.md §2 (mid-wave renew) / §3 (honest deadline; the fan-out-loop rejection; the drain guard), events.md §4 (the drain's own re-scan, stated narrowly), verification-coverage.md (the owed (vi) closed; a stage-C tuning delta with every measurement).
- **Tests**: `cfc-flow-probe-memo.test.ts` (new, 5 pins), `executor-cooperative-yield.test.ts` (new, 4 pins; on the preload's real-clock list), `speculation-arrival-gate.test.ts` (+3: the E2 shape E2E, the trigger-not-relaxation scripted, the late-echo rule incl. cascade + effects), `executor-events-down.test.ts` (+1: exactly-once under an honest deadline), `cfc-runtime-stats.test.ts` (shape).

## Verification

**Re-measurements vs the attribution's baselines** (fresh store, ON binary `a2d9a2b7…` = this tip built with `EXPERIMENTAL_SERVER_EXECUTION=true`, `/api/meta.shellServerExecutionDefine="true"`, `servingLoop` present, load 1-min recorded, toolshed log `No default model available` every run; OFF binary `e8d8ae60…` from the same tip; interim builds noted; full ledger `…/scratchpad/tune/ledger.md`):

- **T1 — note create n=20** (`default-app.test.ts`, `CF_NOTE_CREATE_TIMING_SERIES=20`): ON createToView **p50 4 224 / 4 361 ms** (interim tip `a9534d18…`, loads 3.3 / 3.0) and **5 758 / 3 838 ms** (final tip, loads 6.0 / 5.1) vs baseline **8 927 / 5 841 ms**; **p95 7.4–10.0 s** vs **23.3 / 26.5 s**; the series completed n=20 in **227–292 s** every rep vs 502 s and a 780-s cap hit at note 18. Adjacent OFF control (same tip, loads 3.6 / 5.8): createToView **p50 1 129 / 1 205 ms**, p95 1 236 / 1 447 — inside the baseline OFF band (1 085–1 171 / 1 328–1 496): OFF timing unchanged. ON/OFF ratio 3.2–4.8× (was 5.4–8.2×). Per-note growth is still monotone (the O(events²) intent-tracking term is the design half's, as the report predicted); the console-gate red on some ON reps is the pre-existing `splitDefinitions` error the report's §6 records.
- **T2 — the two-browsers lockdown gate at night-like conditions** (no LLM model, loads 2.2–6.5): **GREEN 16/16** — 6/6 on the final binary (F10–F15, walls 36–43 s), 7/7 on the interim `a9534d18…` (G3–G9), 1 instrumented (I1), 2 on earlier interim builds — vs the attribution's 5 stalls in 12 night attempts. Per browser per run: `overlayArrivalSweeps` 14–25 (the wake fires routinely — served values now arrive decoupled from W as the ordinary shape), `overlayLateEchoDrops` 0 (the late dispatch did not recur; Alice's `ipc/runtime:idle` max fell to 0.66–2.3 s per run vs 8.7–12 s in every red attribution run — T1's client relief; the late-echo rule stands as the backstop). E2's late-echo mechanism is INFERRED from the red runs' evidence (no prompt echo, a busy worker, the click-bound toggle re-toggling), not witnessed by a client trace — stated so in the register.
- **T3 — instrumented scratch build I1** (byte-equal code + two log lines, reverted): deadline lateness on exhausted cycles **p50 25 ms, p90 152, max 399 ms** (was p50 125 / p90 443 / max 1 155 on the note run, and 2.5–8.3 s on chat event waves); renew gaps **p50 5 020 ms, max 5 120** (was p50 5.0–7.9 s, max 10.0 s); `lease.lost` **0** in all 22 re-measured runs; `wavesBudgetExhausted` an honest count (117–210 per chat run vs 29 — it counts every cut cycle). Companion: every guarded run `events.processed == appended` (8/8 chat, 93–94/93–94 note; pre-guard G1: 8/34).
- **Pins + mutations**: T1 memo disabled → the single-probe pins red; read-bump removed → the invalidation pin red. T2 arrival observer removed → the E2 E2E + scripted arrival pins red (timeout); late-echo check neutralized → the late-echo pin red. T3 settle-loop yield removed → (i) first commit at 1 239 ms vs bound 600 (red) and (ii) red; renew-on-yield removed → (ii) commit refused (red). Guard removed → the events-down exactly-once pin: processed 11 vs 1 (red).
- **Suites** (foreground): runner 4 chunks **1 209 passed / 6 692 steps / 0 failed**; memory 521/0 · toolshed 142/0 · runtime-client 61/0 · piece 37/0 · spec-model 23/0; ON-lane danger sets (fan-out, scheduler-fan-out, run-supply, instance-keyed-replica, space-server, events-down, effect-channel, effects-channel-dispose, serving-loop, speculation-overlay, cross-space, watermark, wave, outbox, outbox-budget, instance-keying, navigate) green; skip-list validator 17/17; tripwires intact; `./tasks/check.sh` green; `deno task check-docs` 548 blocks; fmt/lint clean on the changed files.
- **Soaks**: serving-loop **10/10** (24 steps, 12 s each, 120-s caps), effect-channel **5/5**, cooperative-yield ×5, events-down ×3, arrival-gate ×3 — all green.
- **The fan-out-loop yield, tried and rejected**: relocating a yield inside the per-demander loop reproduced a real double emission (executor-space-server's LT6 early-emit arm: two durable entries) — a macrotask there lets a run's own async seal refusal land mid-pass and dirty its instance, which the same pass re-runs while the refusal's queued retry runs it again. The loop keeps its microtask shape; deadline honesty is "within one action" (its instance runs + resubscribe), stated in serving-loop.md §3.
- **OFF arm**: T1 arm-independent by design (verdicts pinned; OFF probe count halves too, timing unchanged per the control); T2 lives in the flag-ON client overlay + a replica seam that fires only with an observer installed; T3 gated on `servingPosture` at construction; the guard is inside the serving loop.

## Flags

1. **The drain guard touches #5969's flagged (β) — narrowly, and stated as such.** #5969 flagged the drain/LT1 double-dispatch as an owner call ("one durable entry = one COMPLETED delivery" invariant + resolution (i)/(ii)). The honest deadline turned (β) from rare into 4× on the very gate T2 targets, so this PR closes the drain's OWN re-scan (a drain copy is never queued twice until the store has spoken — all drain copies carry the mark path, #5969's own safety condition) and NOTHING else: the LT1 in-process copy (α) and the cross-producer invariant sentence stay owed to the owner's ruling (events.md §4 says so). If the owner prefers (ii)'s full sentence first, this guard is the drain half of its enforcement.
2. **The late-echo rule is speculation.md §4 step 2 applied as a state predicate; #5969 had called it a "candidate rule (owner call)".** Landed here because it is the retirement condition the sentence already states (the consequences exist ⇒ the echo's job is done), it is E2's inferred mechanism, and the task named the late-echo edge as the same gate; the sentence is dated but carries no RULED marker — ratify or mark pending. Sub-question (self-review): a dropped late echo's client cascade is treated as jobless too (via `parentEventId`) and its enactable effects are not enacted — the alternative (fail the seal / leave children) is stated in the review report.
3. **E2's mechanism is inferred, not witnessed.** 16/16 green with `overlayLateEchoDrops = 0` means the rule never fired live; the arrival wake fires 14–25×/run. If the owner wants the "last inch" closed with a client trace, the probe recipe is the report's (D4/E2) plus the new churn counters.
4. **Pre-existing, found here: leg-C's origin-ack wake was browser-inert** (uninitialized class field + `in` probe). Fixed by construction; a bundle-level pin (assert the worker bundle emits the replica's observer fields) would keep the class from recurring — not added.
5. **T3 makes lease-loss-during-settle the designed park path more reachable** (self-review Q5): `park()` clears the seal destination while the scheduler's pass keeps running — a pre-existing window; not changed.
6. Self-review Q6: the belt renews at TTL/3 while the timer's cadence is a separate constant (both 5 s today) — left decoupled; flag if they should read one knob.

Self-review: adversarial subagent over the full diff — report at `/Users/berni/labs-worktrees/stage-c-tuning-review-report.md` (no blocker; 1 MAJOR-latent + 8 minors, every one addressed or dispositioned in its trailer; the guard's release point moved off the seal, the fan-out yield removed after its double-emission repro, the late-echo cascade/effects arms added, tests hardened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

