### PR TITLE
docs(verbs): correct two claims that testing disproved

### DIFF
--- a/docs/common/verbs/over-the-cli.md
+++ b/docs/common/verbs/over-the-cli.md
@@ -313,10 +313,11 @@ one per agent run and carry it on every call of that run:
 export CF_INVOCATION_SESSION=$(cf invocation-session new)
 ```
 
-The environment is where a session belongs, because it is closer to a secret
-than a setting: it is what keeps an outcome's address out of reach of a
-stranger, and a command's arguments are readable in a process listing where its
-environment is not. `--invocation-session <id>` overrides it for one call.
+The environment is where a session belongs: it is what keeps an outcome's
+address out of reach of a stranger, and keeping it out of argv keeps it out of
+shell history and of the process listing anyone gets by default. That is a
+reduction in casual exposure rather than secret storage — `ps -E` prints the
+environment too, so treat the session as a credential either way. `--invocation-session <id>` overrides it for one call.
 
 The pair is what names an invocation. Replaying a settled id **from the session
 that chose it** hands back the **original** result, and nothing is written a

--- a/docs/common/verbs/session-walkthrough.md
+++ b/docs/common/verbs/session-walkthrough.md
@@ -860,9 +860,10 @@ position shifts under concurrent writes.
 
 [CLI surface shape](../../plans/cli-surface-shape.md) states the property for
 commands — an address printed by one command is accepted by the next. The
-argument half is the same property one level in, on arguments. A second
-instance sits on `cf piece set-slug`, whose source positional resolves
-through its own path rather than the one `--piece` uses.
+argument half is the same property one level in, on arguments, and it holds
+now at both. `cf piece set-slug` resolves its source positional through its
+own path rather than the one `--piece` uses, and takes the emitted address
+there too.
 
 ## What the session is waiting on
 


### PR DESCRIPTION
## Why

Two sentences in the verb documents asserted things that are not true. Both
were found by testing the claim rather than re-reading it, and both would
mislead someone acting on them.

**`cf piece set-slug` was named as an outstanding gap.** The walkthrough
listed it as a second site where the address one command prints is not
accepted by the next. Run against a live toolshed, it takes the `/of:…` form
its source positional is handed — so the composition property the section is
about actually holds at both sites now. Leaving it in place would send
someone to fix something that works, and understates what has landed.

**A session was described as effectively private in the environment.**
`over-the-cli.md` said a command's arguments are readable in a process listing
"where its environment is not." `ps -E` prints the environment. Anyone
choosing where to put a credential on the strength of that sentence would be
choosing on a false premise.

## What changed

Two sentences, no behaviour. The set-slug note keeps the accurate half — its
source resolves through its own path — and drops the implication that this
is a gap. The session note says what keeping a value out of argv actually
buys (shell history, the default process listing) and names it as reduced
casual exposure rather than secret storage, with the session treated as a
credential either way.

## Test plan

- `cf piece set-slug <name> /of:fid1:…` against a local toolshed: accepted,
  which is what prompted the first correction.
- `check-verb-session-sync`, `check-docs`, `deno fmt --check` pass.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

