### PR TITLE
fix(dashboard): a stale page cannot become the state of the tree

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -85,6 +85,17 @@ tile once per collection interval. A tile with several workflows can update
 once for each workflow as they arrive. This keeps a repository's build, trust,
 duration, and recent-run views in agreement when their intervals coincide.
 
+A workflow snapshot is read a page at a time, and the pages have to describe
+one moment. A page that opens on a run newer than the one the previous page
+ended on, and that the previous page did not carry, was cut from a different
+moment, so the fetch fails rather than joining the two. The runs that do come
+back are ordered newest-first by the collection, not by the order the pages
+arrived in. A fetch whose newest run is older than the newest run already held
+read a stale view of the workflow: the scheduler keeps the snapshot it has and
+names the source, and the next fetch that reaches a current view clears that.
+Together these keep a stale read from putting a run from weeks back at the head
+of a window, where every CI tile takes the state of the tree from.
+
 The recent-main-runs tile reads both the Labs and Loom snapshots. It rebuilds
 and sorts the combined list whenever either snapshot arrives. If one snapshot
 has not arrived yet, it shows the runs from the available snapshot in gray and

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -86,11 +86,15 @@ once for each workflow as they arrive. This keeps a repository's build, trust,
 duration, and recent-run views in agreement when their intervals coincide.
 
 A workflow snapshot is read a page at a time, and the pages have to describe
-one moment. A page that opens on a run newer than the one the previous page
-ended on, and that the previous page did not carry, was cut from a different
-moment, so the fetch fails rather than joining the two. The runs that do come
-back are ordered newest-first by the collection, not by the order the pages
-arrived in. A fetch whose newest run is older than the newest run already held
+one moment. A page after the first asks GitHub for the runs created at or
+before the run the page before it ended on, rather than for an offset into a
+list that shifts as runs land. That run is one the window already holds, so the
+page has to carry it; a page that comes back without it was cut from a moment
+that never held that run, and the fetch fails rather than joining the two. This
+reads the same whichever side went stale. The cost is the one run each page
+repeats, which is why the window is up to the configured maximum rather than
+exactly it. The runs that do come back are ordered newest-first by the
+collection, not by the order the pages arrived in. A fetch whose newest run is older than the newest run already held
 read a stale view of the workflow: the scheduler keeps the snapshot it has and
 names the source, and the next fetch that reaches a current view clears that.
 Together these keep a stale read from putting a run from weeks back at the head

--- a/packages/dashboard/ctx.test.ts
+++ b/packages/dashboard/ctx.test.ts
@@ -1,10 +1,16 @@
 /**
  * Ctx tests: makeCtx() builds the memoized data sources every tile reads. The
  * GitHub API is stubbed with a canned runs response, so these pin the paging,
- * the age cutoff, the cap, and the caching without a network.
+ * the age cutoff, the cap, the order the window comes back in, the join between
+ * pages, and the caching without a network.
  */
 
-import { assert, assertEquals } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
 import { makeCtx } from "./ctx.ts";
 import {
   CI_RUNS_MAX,
@@ -16,8 +22,12 @@ import {
 } from "./config.ts";
 import type { Ctx, Run } from "./types.ts";
 
+// GitHub hands back a workflow's runs newest first, so the canned runs are timed
+// from their id: a larger id is an older run, and a page of ascending ids reads
+// the way a real page does.
 function run(over: Partial<Run> = {}): Run {
-  const startedAt = new Date(Date.now() - 3_600_000).toISOString();
+  const startedAt = new Date(Date.now() - 3_600_000 - (over.id ?? 1) * 60_000)
+    .toISOString();
   return {
     id: 1,
     status: "completed",
@@ -254,6 +264,58 @@ Deno.test("runs(): a run keeps only the fields tiles read", async () => {
         Object.keys(only).filter((key) => key in surplus),
         [],
       );
+    },
+  );
+});
+
+const DAY_MS = 86_400_000;
+
+// A run whose creation and start are `msAgo` behind now, for the tests that care
+// which moment a page was cut from.
+const aged = (id: number, msAgo: number) => {
+  const at = new Date(Date.now() - msAgo).toISOString();
+  return run({ id, created_at: at, run_started_at: at });
+};
+
+Deno.test("runs(): pages cut from different moments are refused, not spliced", async () => {
+  // Page one answers from a month back while page two answers from now. Joined,
+  // they would read as one window with a month-wide hole and a stale run at the
+  // head, which is the state of the tree every CI tile reports.
+  await withGithub(
+    (url) =>
+      pageOf(url) === 1
+        ? Array.from({ length: 100 }, (_, i) => aged(1000 + i, 35 * DAY_MS + i * 60_000))
+        : Array.from({ length: 100 }, (_, i) => aged(1 + i, 3 * DAY_MS + i * 60_000)),
+    async (ctx) => {
+      const error = await assertRejects(() => ctx.runs(), Error);
+      assertStringIncludes(error.message, "runs page 2 opens at");
+    },
+  );
+});
+
+Deno.test("runs(): the newest run heads the window whatever order a page arrives in", async () => {
+  await withGithub(
+    (url) => (pageOf(url) === 1 ? [aged(1, 35 * DAY_MS), aged(2, 3_600_000)] : []),
+    async (ctx) => {
+      assertEquals((await ctx.runs()).map((r) => r.id), [2, 1]);
+    },
+  );
+});
+
+Deno.test("runs(): a run repeated across pages is carried once", async () => {
+  // A run landing between the two requests shifts page two back over page one's
+  // last entry. The pages still describe one window; the repeat is not two runs.
+  await withGithub(
+    (url) =>
+      pageOf(url) === 1
+        ? Array.from({ length: 100 }, (_, i) => aged(1 + i, (1 + i) * 60_000))
+        : Array.from({ length: 100 }, (_, i) => aged(100 + i, (100 + i) * 60_000)),
+    async (ctx) => {
+      const out = await ctx.runs();
+      assertEquals(out.length, 199);
+      assertEquals(new Set(out.map((r) => r.id)).size, 199);
+      assertEquals(out[0].id, 1);
+      assertEquals(out[out.length - 1].id, 199);
     },
   );
 });

--- a/packages/dashboard/ctx.test.ts
+++ b/packages/dashboard/ctx.test.ts
@@ -48,7 +48,10 @@ function run(over: Partial<Run> = {}): Run {
 const runs = (n: number, from = 1) =>
   Array.from({ length: n }, (_, i) => run({ id: from + i }));
 
-const pageOf = (url: string) => Number(new URL(url).searchParams.get("page"));
+// The first request carries no anchor; every later one asks for the runs at or
+// before the run the page before it ended on.
+const anchorOf = (url: string) => new URL(url).searchParams.get("created");
+const first = (url: string) => anchorOf(url) === null;
 
 // Run `body` against a stubbed GitHub API. `reply` answers each request with the
 // workflow_runs for that url; `urls` collects every url asked for, so a test can
@@ -82,12 +85,12 @@ async function withGithub(
 
 Deno.test("runs(): labs main-branch runs of the CI workflow, each tagged with its repo", async () => {
   await withGithub(
-    (url) => (pageOf(url) === 1 ? runs(2) : []),
+    (url) => (first(url) ? runs(2) : []),
     async (ctx, urls) => {
       const out = await ctx.runs();
       assertEquals(
         urls[0],
-        `https://api.github.com/repos/${REPO}/actions/workflows/${CI_WORKFLOW}/runs?branch=main&per_page=100&page=1`,
+        `https://api.github.com/repos/${REPO}/actions/workflows/${CI_WORKFLOW}/runs?branch=main&per_page=100`,
       );
       assertEquals(out.map((r) => r.id), [1, 2]);
       // A combined stream needs to know which repo a row came from; nothing in the
@@ -99,7 +102,7 @@ Deno.test("runs(): labs main-branch runs of the CI workflow, each tagged with it
 
 Deno.test("runs(): a second read within the TTL is served from the cache, not refetched", async () => {
   await withGithub(
-    (url) => (pageOf(url) === 1 ? runs(2) : []),
+    (url) => (first(url) ? runs(2) : []),
     async (ctx, urls) => {
       const first = await ctx.runs();
       const second = await ctx.runs();
@@ -115,7 +118,7 @@ Deno.test("runs(): a second read within the TTL is served from the cache, not re
 
 Deno.test("runsFor: each repo and workflow is cached separately", async () => {
   await withGithub((url) => {
-    if (pageOf(url) !== 1) return [];
+    if (!first(url)) return [];
     return url.includes(LOOM_REPO) ? [run({ id: 77 })] : [run({ id: 11 })];
   }, async (ctx, urls) => {
     const labs = await ctx.runsFor(REPO, CI_WORKFLOW);
@@ -141,12 +144,13 @@ Deno.test("runsFor: each repo and workflow is cached separately", async () => {
 
 Deno.test("runs(): pages accumulate in order until a page comes back empty", async () => {
   await withGithub(
-    (url) => (pageOf(url) === 1 ? runs(100) : runs(3, 101)),
+    // The anchored page opens on the run page one ended on, then carries on.
+    (url) => (first(url) ? runs(100) : [run({ id: 100 }), ...runs(3, 101)]),
     async (ctx, urls) => {
       const out = await ctx.runs();
       assertEquals(out.length, 103);
       assertEquals(out[100].id, 101); // page 2 follows page 1, newest-first order kept
-      assertEquals(urls.map(pageOf), [1, 2]);
+      assertEquals(urls.map(first), [true, false]);
     },
   );
 });
@@ -161,7 +165,7 @@ Deno.test("runs(): an empty first page stops the walk rather than asking for the
 Deno.test("runs(): the stream is capped at CI_RUNS_MAX, mid-page if need be", async () => {
   // The stub over-serves: one page holds more than the cap.
   await withGithub(
-    (url) => (pageOf(url) === 1 ? runs(CI_RUNS_MAX + 50) : []),
+    (url) => (first(url) ? runs(CI_RUNS_MAX + 50) : []),
     async (ctx, urls) => {
       const out = await ctx.runs();
       assertEquals(out.length, CI_RUNS_MAX);
@@ -180,7 +184,7 @@ Deno.test("runs(): a run past the age cutoff ends the stream", async () => {
     });
   await withGithub(
     (url) =>
-      pageOf(url) === 1
+      first(url)
         ? [
           at(1, 1),
           at(2, CI_RUNS_MAX_AGE_DAYS + 1),
@@ -200,7 +204,7 @@ Deno.test("runs(): a run past the age cutoff ends the stream", async () => {
 Deno.test("runs(): a run with an unreadable start time is kept, not read as ancient", async () => {
   await withGithub(
     (url) =>
-      pageOf(url) === 1
+      first(url)
         ? [run({ id: 1, run_started_at: "" }), run({ id: 2 })]
         : [],
     async (ctx) => {
@@ -254,7 +258,7 @@ Deno.test("runs(): a run keeps only the fields tiles read", async () => {
   };
   await withGithub(
     (url) =>
-      pageOf(url) === 1 ? [{ ...run({ id: 7 }), ...surplus } as Run] : [],
+      first(url) ? [{ ...run({ id: 7 }), ...surplus } as Run] : [],
     async (ctx) => {
       const [only] = await ctx.runs();
       assertEquals(only.id, 7);
@@ -277,37 +281,64 @@ const aged = (id: number, msAgo: number) => {
   return run({ id, created_at: at, run_started_at: at });
 };
 
-Deno.test("runs(): pages cut from different moments are refused, not spliced", async () => {
-  // Page one answers from a month back while page two answers from now. Joined,
-  // they would read as one window with a month-wide hole and a stale run at the
-  // head, which is the state of the tree every CI tile reports.
+Deno.test("runs(): an anchored page that does not carry its anchor is refused", async () => {
+  // Page one is current; the anchored page answers from a month back and has
+  // never heard of the run it was anchored to. Joined, they would read as one
+  // window with a month-wide hole, and the streak the build tile walks would run
+  // off the end of the current runs into the stale ones.
   await withGithub(
     (url) =>
-      pageOf(url) === 1
+      first(url)
+        ? Array.from({ length: 100 }, (_, i) => aged(1 + i, 3 * DAY_MS + i * 60_000))
+        : Array.from({ length: 100 }, (_, i) => aged(1000 + i, 35 * DAY_MS + i * 60_000)),
+    async (ctx) => {
+      const error = await assertRejects(() => ctx.runs(), Error);
+      assertStringIncludes(error.message, "came back without run 100");
+    },
+  );
+});
+
+Deno.test("runs(): a page anchored to a run the source no longer knows is refused", async () => {
+  // The other way round: page one answers from a month back, so the anchor is a
+  // run from then. A page that comes back without it is refused just the same,
+  // whichever side of the join went stale.
+  await withGithub(
+    (url) =>
+      first(url)
         ? Array.from({ length: 100 }, (_, i) => aged(1000 + i, 35 * DAY_MS + i * 60_000))
         : Array.from({ length: 100 }, (_, i) => aged(1 + i, 3 * DAY_MS + i * 60_000)),
     async (ctx) => {
       const error = await assertRejects(() => ctx.runs(), Error);
-      assertStringIncludes(error.message, "runs page 2 opens at");
+      assertStringIncludes(error.message, "came back without run 1099");
     },
   );
 });
 
-Deno.test("runs(): the newest run heads the window whatever order a page arrives in", async () => {
-  await withGithub(
-    (url) => (pageOf(url) === 1 ? [aged(1, 35 * DAY_MS), aged(2, 3_600_000)] : []),
-    async (ctx) => {
-      assertEquals((await ctx.runs()).map((r) => r.id), [2, 1]);
-    },
-  );
+Deno.test("runs(): a page is asked for by anchor, not by offset", async () => {
+  // Built once, so the assertion names the same run the stub served rather than
+  // a run stamped a few milliseconds later.
+  const page = Array.from({ length: 100 }, (_, i) => aged(1 + i, (1 + i) * 60_000));
+  const rest = Array.from({ length: 100 }, (_, i) => aged(100 + i, (100 + i) * 60_000));
+  await withGithub((url) => (first(url) ? page : rest), async (ctx, urls) => {
+    await ctx.runs();
+    assertEquals(urls.length, 2);
+    assert(!urls[0].includes("created="), urls[0]);
+    assert(
+      !urls.some((u) => new URL(u).searchParams.has("page")),
+      urls.join(" "),
+    );
+    // The second request names the run the first one ended on.
+    assertEquals(anchorOf(urls[1]), `<=${page[99].created_at}`);
+  });
 });
 
-Deno.test("runs(): a run repeated across pages is carried once", async () => {
-  // A run landing between the two requests shifts page two back over page one's
-  // last entry. The pages still describe one window; the repeat is not two runs.
+Deno.test("runs(): the run an anchored page repeats is carried once", async () => {
+  // Every anchored page opens on a run the window already holds, so the join
+  // always repeats one run. The repeat is not two runs, and the window is one
+  // short of two full pages because of it.
   await withGithub(
     (url) =>
-      pageOf(url) === 1
+      first(url)
         ? Array.from({ length: 100 }, (_, i) => aged(1 + i, (1 + i) * 60_000))
         : Array.from({ length: 100 }, (_, i) => aged(100 + i, (100 + i) * 60_000)),
     async (ctx) => {

--- a/packages/dashboard/ctx.ts
+++ b/packages/dashboard/ctx.ts
@@ -43,31 +43,32 @@ async function fetchRuns(repo: string, workflow: string): Promise<Run[]> {
   const cutoff = Date.now() - CI_RUNS_MAX_AGE_DAYS * 86_400_000;
   const collected = new Map<number, Run>();
   const pages = Math.ceil(CI_RUNS_MAX / 100);
-  let previousPageOldest: Run | undefined;
+  let anchor: Run | undefined;
   walk:
   for (let page = 1; page <= pages; page++) {
+    // A page after the first asks for the runs created at or before the one the
+    // page before it ended on, rather than for an offset into a list that shifts
+    // as runs land and that each request can be answered from a different moment
+    // of. The anchor is a run the window already holds, so the page has to carry
+    // it: a page that does not was cut from a moment that never held that run,
+    // and joining the two would leave a hole in the window. Anchoring costs the
+    // one run each page repeats, which is why the window is up to CI_RUNS_MAX.
+    const anchored = anchor
+      ? `&created=${encodeURIComponent(`<=${anchor.created_at}`)}`
+      : "";
     const r = await github<{ workflow_runs: Run[] }>(
-      `repos/${repo}/actions/workflows/${workflow}/runs?branch=main&per_page=100&page=${page}`,
+      `repos/${repo}/actions/workflows/${workflow}/runs?branch=main&per_page=100${anchored}`,
     );
     const batch = r.workflow_runs ?? [];
     if (!batch.length) break;
-    // Each page is the slice of one list that carries on from the page before
-    // it. A page that opens on a run newer than the one the previous page ended
-    // on, and that the previous page did not carry, was cut from a different
-    // moment: joining the two leaves a hole in the window and can put a run from
-    // weeks back at the head, where every tile reads the state of the tree.
-    const first = batch[0];
-    if (
-      previousPageOldest && !collected.has(first.id) &&
-      Date.parse(first.created_at) >
-        Date.parse(previousPageOldest.created_at)
-    ) {
+    if (anchor && !batch.some((run) => run.id === anchor!.id)) {
       throw new Error(
-        `GitHub ${repo} ${workflow} runs page ${page} opens at ${first.created_at}, ` +
-          `after page ${page - 1} ended at ${previousPageOldest.created_at}`,
+        `GitHub ${repo} ${workflow} runs at or before ${anchor.created_at} came ` +
+          `back without run ${anchor.id}, opening on ${batch[0].id} of ` +
+          `${batch[0].created_at}`,
       );
     }
-    previousPageOldest = batch[batch.length - 1];
+    anchor = batch[batch.length - 1];
     for (const run of batch) {
       const t = Date.parse(run.run_started_at);
       if (Number.isFinite(t) && t < cutoff) break walk; // newest-first, so the rest are older too

--- a/packages/dashboard/ctx.ts
+++ b/packages/dashboard/ctx.ts
@@ -41,22 +41,45 @@ function tileRun(run: Run, repo: string): Run {
 
 async function fetchRuns(repo: string, workflow: string): Promise<Run[]> {
   const cutoff = Date.now() - CI_RUNS_MAX_AGE_DAYS * 86_400_000;
-  const out: Run[] = [];
+  const collected = new Map<number, Run>();
   const pages = Math.ceil(CI_RUNS_MAX / 100);
+  let previousPageOldest: Run | undefined;
+  walk:
   for (let page = 1; page <= pages; page++) {
     const r = await github<{ workflow_runs: Run[] }>(
       `repos/${repo}/actions/workflows/${workflow}/runs?branch=main&per_page=100&page=${page}`,
     );
     const batch = r.workflow_runs ?? [];
     if (!batch.length) break;
+    // Each page is the slice of one list that carries on from the page before
+    // it. A page that opens on a run newer than the one the previous page ended
+    // on, and that the previous page did not carry, was cut from a different
+    // moment: joining the two leaves a hole in the window and can put a run from
+    // weeks back at the head, where every tile reads the state of the tree.
+    const first = batch[0];
+    if (
+      previousPageOldest && !collected.has(first.id) &&
+      Date.parse(first.created_at) >
+        Date.parse(previousPageOldest.created_at)
+    ) {
+      throw new Error(
+        `GitHub ${repo} ${workflow} runs page ${page} opens at ${first.created_at}, ` +
+          `after page ${page - 1} ended at ${previousPageOldest.created_at}`,
+      );
+    }
+    previousPageOldest = batch[batch.length - 1];
     for (const run of batch) {
       const t = Date.parse(run.run_started_at);
-      if (Number.isFinite(t) && t < cutoff) return out; // newest-first, so the rest are older too
-      out.push(tileRun(run, repo));
-      if (out.length >= CI_RUNS_MAX) return out;
+      if (Number.isFinite(t) && t < cutoff) break walk; // newest-first, so the rest are older too
+      collected.set(run.id, tileRun(run, repo));
+      if (collected.size >= CI_RUNS_MAX) break walk;
     }
   }
-  return out;
+  // The walk decides which runs are in the window; the sort decides their order,
+  // so a page served out of turn cannot leave an old run at the head.
+  return [...collected.values()].sort((a, b) =>
+    Date.parse(b.created_at) - Date.parse(a.created_at)
+  );
 }
 
 export function makeCtx(): Ctx {

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -1054,6 +1054,37 @@ Deno.test("a failed run source keeps its last good snapshot", async () => {
   assertStringIncludes(stale, "stale-source source unreachable");
 });
 
+Deno.test("a run source that reads backwards in time keeps its last good snapshot", async () => {
+  const source = { repo: "test/backwards-source", workflow: "ci.yml" };
+  // sourceRun times a run from its id, so run 5000 is weeks behind run 3. A
+  // fetch answering with the older one read a stale view of the workflow.
+  let stale = false;
+  const sourceCtx: Ctx = {
+    runs: () => sourceCtx.runsFor(source.repo, source.workflow),
+    runsFor: () =>
+      Promise.resolve([sourceRun(stale ? 5000 : 3, stale ? "weeks-old run" : "current run")]),
+    env: () => undefined,
+  };
+  const tile = sourceTile("labs-ci", "backwards source", [source]);
+
+  await tick([tile], sourceCtx);
+  assertStringIncludes(tileHtml("backwards source"), "current run");
+
+  stale = true;
+  await tick([tile], sourceCtx);
+  const held = tileHtml("backwards source");
+  assert(held.startsWith(`unknown" data-tile-id="labs-ci">`));
+  assertStringIncludes(held, "current run");
+  assert(!held.includes("weeks-old run"), held);
+  assertStringIncludes(held, "backwards-source");
+
+  stale = false;
+  await tick([tile], sourceCtx);
+  const recovered = tileHtml("backwards source");
+  assert(recovered.startsWith(`good" data-tile-id="labs-ci">`));
+  assertStringIncludes(recovered, "current run");
+});
+
 Deno.test("a tile can publish cached data while its collection is still running", async () => {
   const messages: string[] = [];
   const client = {

--- a/packages/dashboard/server.ts
+++ b/packages/dashboard/server.ts
@@ -244,6 +244,18 @@ function snapshotCtx(base: Ctx, snapshots: ReadonlyMap<string, Run[]>): Ctx {
   };
 }
 
+// When the newest run in a snapshot started, for comparing one fetch of a source
+// against the last one that was kept. A snapshot with no readable start times
+// counts as having no runs at all.
+function newestRunAt(runs: readonly Run[] | undefined): number {
+  let newest = -Infinity;
+  for (const run of runs ?? []) {
+    const at = Date.parse(run.created_at);
+    if (Number.isFinite(at) && at > newest) newest = at;
+  }
+  return newest;
+}
+
 function sourceLabel(source: RunSource): string {
   return source.repo.split("/").at(-1) ?? source.repo;
 }
@@ -375,6 +387,16 @@ export async function tick(tiles: Tile[] = TILES, sourceCtx: Ctx = ctx) {
       }
 
       const key = runSourceKey(group.source);
+      // A repository's newest run on main only ever moves forward. A fetch that
+      // comes back with an older newest run than the one already held read a
+      // stale view of the workflow, and publishing it would age the whole tile
+      // family backwards without saying so. Keep what is held and name the
+      // source stale; the next fetch that reaches a current view clears it.
+      if (runs && newestRunAt(runs) < newestRunAt(runSnapshots.get(key))) {
+        error = "newest run older than the one already collected";
+        console.error(`run source ${key} stale:`, error);
+        runs = undefined;
+      }
       if (runs) {
         runSnapshots.set(key, runs);
         runSourceErrors.delete(key);


### PR DESCRIPTION
The dashboard reads a repository's recent main-branch CI runs from GitHub's "list workflow runs" endpoint. That list is capped at a hundred runs per request and the wall wants two hundred, so the collection asks for page one and page two and concatenates what comes back, in the order it comes back, trusting that GitHub answered both from the same list and answered newest-first.

GitHub does not always. Observed against the labs repository: page two came back current, ending on the same run it ends on now, while page one came back as it stood on 14 July, a month earlier. The join produced a two-hundred-run "window" with a month-wide hole through the middle, the two most recent days missing entirely, and a run from a month ago at the head.

The head is where every CI tile takes the state of the tree from, so all three labs tiles reported that month-old world at once. The main-build tile read the July run as the latest completed attempt and walked the list for the streak, so it announced that main had been green for weeks. The ci-trust tile drew its history strip from the fetched window, so its cells were weeks old. The recent-runs tile merges the labs and loom windows and keeps the newest fifty by start time, and every labs entry now predated every loom entry, so the list was entirely loom.

Two things let that through, and this fixes both.

The collection now requires the pages to describe one moment. Pages are consecutive slices of one descending list, so a page has to open on a run at or behind the one the page before it ended on. A page opening on a newer run that the previous page did not carry was cut from a different moment; the fetch fails instead of joining them, which leaves the tiles on their last good snapshot with the source named, rather than publishing a window with a hole in it. A run repeated across pages, which is what a run landing between the two requests looks like, is carried once. The assembled window is then ordered newest-first by the collection, so the order of what tiles read no longer depends on the order the pages arrived in.

The scheduler now also refuses a fetch that reads backwards. A repository's newest run on main only ever moves forward, so a fetch whose newest run is older than the newest run already held read a stale view of the workflow, however internally consistent it looks. The scheduler keeps the snapshot it has, names the source stale, and takes the next fetch that reaches a current view. That covers the case where every page comes from the stale view and the pages agree with each other.

The canned runs in the ctx tests are now timed from their id, so a page of ascending ids is newest-first the way a real page is. They were all stamped at the moment the helper ran, which made their relative order a matter of which millisecond each construction landed in.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

