### PR TITLE
feat(tasks): guard the accepted-break registries — required-pattern floor + decision records

### DIFF
--- a/docs/history/INDEX.md
+++ b/docs/history/INDEX.md
@@ -68,6 +68,7 @@ One line per archived document; [`README.md`](README.md) has the rules for this 
 
 ## Shipped or superseded designs and decision records
 
+- [topics-crossref-identity-break.md](topics-crossref-identity-break.md) — decision record for the topics reference-graph contract break shipped in #5921, the first accepted break in the pattern-update registries; backfilled when the registries gained their `record` linkage.
 - [action-id-per-instance-decision.md](specs/action-id-per-instance-decision.md) — per-instance action identity.
 - [projection-key-classification.md](plans/projection-key-classification.md) — the four-tier classification of `--schema` projection keywords, the rule that the projection reader never hands the read boundary a schema it did not construct, and the survival rule for a source-derived `required`, August 2026.
 - [declared-verb-results-case.md](plans/declared-verb-results-case.md) — the case for carrying a verb's declared result on `module.resultSchema` in the interim rather than waiting for the Fabric-types stream; decided yes, conditionally, August 2026.

--- a/docs/history/topics-crossref-identity-break.md
+++ b/docs/history/topics-crossref-identity-break.md
@@ -1,7 +1,7 @@
 ---
 status: historical
-created: 2026-08-19
-archived: 2026-08-19
+created: 2026-08-18
+archived: 2026-08-18
 reason: "Decision record for the topics reference-graph contract break shipped in #5921 — the first accepted break in the pattern-update registries. Backfilled from the shipping change's own prose when the registries gained their record linkage."
 ---
 

--- a/docs/history/topics-crossref-identity-break.md
+++ b/docs/history/topics-crossref-identity-break.md
@@ -1,0 +1,49 @@
+---
+status: historical
+created: 2026-08-19
+archived: 2026-08-19
+reason: "Decision record for the topics reference-graph contract break shipped in #5921 — the first accepted break in the pattern-update registries. Backfilled from the shipping change's own prose when the registries gained their record linkage."
+---
+
+# Topics reference-graph contract break (#5921)
+
+The first contract break the repository decided to ship, and the change that
+introduced the accepted-break registries it is recorded in
+(`tasks/pattern-compat-accepted-breaks.ts`,
+`tasks/pattern-vintage-accepted-drops.ts`). This record is a backfill: the
+deliberation below is taken from the shipping change's own prose
+([#5921](https://github.com/commontoolsinc/labs/pull/5921), merged
+2026-08-18), recorded when the registries gained their required `record`
+linkage.
+
+## The decision
+
+A topic's references became cell references rather than ids. The board derives
+the whole reference graph once, in one pivot, and every topic reads its own row
+out of the result by identity; rows are addressed by `Writable.for(topic)`, so
+a row keeps its address wherever the board reorders it. An index row IS the
+topic it describes, so the row's own address is the topic's address, and the
+copied `fid` field goes with the copy.
+
+## What broke, on purpose
+
+- The old prose reference-graph row (`crossrefs` and its per-topic and
+  per-mentionable copies) is gone wholesale; the pivot row that replaced it
+  carries a topic and who mentions it. Nothing of the old row survives to be
+  compared field by field.
+- `mention`'s payload stopped being `unknown` and now names `title` — a real
+  tightening of what the verb accepts, so it can tell a reference from a
+  non-reference in one read and reject an entry that resolves to no piece.
+- Stored topics' defaults moved (`title`, `body`, `createdByName` gained one)
+  so the board's card list can be declared over the topic itself rather than
+  over a card-shaped copy.
+
+## Disposition of deployed pieces
+
+Pieces holding the old shape are accepted casualties of the removed surface:
+the runtime updater refuses contract-changing swaps on ordinary pieces and
+`cf piece setsrc` refuses unprovable updates, so old pieces keep running their
+old source rather than breaking in place. Vintages captured before the rebuild
+(`capturedThrough: 2026-08-06T23-04-13.189Z`) are forgiven exactly the removed
+paths and nothing else; vintages captured after hold pivot rows and are
+compared with no exemption.

--- a/docs/specs/pattern-update-testing.md
+++ b/docs/specs/pattern-update-testing.md
@@ -73,6 +73,12 @@ decides to ship is declared instead, in `tasks/pattern-compat-accepted-breaks.ts
   per role, so a second problem in a role whose issue is an accepted path can
   still hide behind it; name as few paths as the removal needs.
 
+  An entry also names its decision record under `docs/history/` (`record`),
+  and may not name a required pattern — the home and default-app roots update
+  aggressively and unconditionally, so a break there is never accepted. Both
+  are enforced whenever either gate runs
+  (`tasks/pattern-break-registry-guards.ts`).
+
   The run prints every pair it forgave, and fails on one that no longer needs
   forgiving, so the list can only shrink. That audit is asked per pattern rather
   than of the whole list, because the CI job always sets `PATTERN_COMPAT_SHARD`
@@ -206,6 +212,9 @@ still fails. Nothing off the path to a drop is rebuilt either — a subtree that
 lost nothing is returned as itself, and a reduction (`{"[cell]": …}` and its
 kin) is never opened, because it stands for something the comparison must weigh
 whole.
+
+An entry names its decision record the same way Tier 1's does (`record`), and
+the required-pattern refusal applies here identically.
 
 The run prints every path it held back, and fails on one that no vintage needed,
 so this list can only shrink too. A pattern no fixture records is reported

--- a/docs/specs/pattern-update-testing.md
+++ b/docs/specs/pattern-update-testing.md
@@ -98,7 +98,12 @@ decides to ship is declared instead, in `tasks/pattern-compat-accepted-breaks.ts
   contract, so no baseline, so no check, forever. Fix it, or add it to
   `tasks/pattern-compat-unevaluable.ts` with a reason. That allowlist can only
   shrink: a listed pattern that evaluates again must leave the list, or its
-  exemption outlives the breakage it was granted for.
+  exemption outlives the breakage it was granted for. It may never name a
+  required pattern, and the gate refuses one that does: listing a root is a
+  wider exemption than any accepted break — not one finding forgiven but the
+  pattern not gated at all — and the roots that update aggressively and
+  unconditionally are the ones that can least afford it. For those, fixing
+  the pattern is the only move.
 
 An already-recorded contract is not re-validated. It was proved when recorded
 and has not changed since, and both the definition validator and the subset

--- a/tasks/pattern-break-registry-guards.test.ts
+++ b/tasks/pattern-break-registry-guards.test.ts
@@ -1,0 +1,92 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  type BreakRegistryEntry,
+  collectBreakRegistryEntries,
+  guardBreakRegistryEntries,
+} from "./pattern-break-registry-guards.ts";
+import {
+  DEFAULT_APP_PATTERN_SOURCE,
+  HOME_PATTERN_SOURCE,
+} from "../packages/piece/src/system-pattern-url.ts";
+import { requiredPatternKeys } from "./pattern-vintage-lib.ts";
+import { fromFileUrl } from "@std/path/from-file-url";
+
+const REPO_ROOT = fromFileUrl(new URL("..", import.meta.url));
+
+const entry = (overrides: Partial<BreakRegistryEntry>): BreakRegistryEntry => ({
+  registry: "pattern-compat-accepted-breaks",
+  pattern: "lunch-poll/main.tsx",
+  record: "docs/history/topics-crossref-identity-break.md",
+  ...overrides,
+});
+
+describe("pattern-break-registry-guards", () => {
+  it("returns no findings for an ordinary entry with an existing record", () => {
+    expect(guardBreakRegistryEntries({
+      entries: [entry({})],
+      requiredPatternKeys: new Set(["system/home.tsx"]),
+      recordExists: () => true,
+    })).toEqual([]);
+  });
+
+  it("returns a finding for an entry naming a required pattern", () => {
+    const findings = guardBreakRegistryEntries({
+      entries: [entry({ pattern: "system/home.tsx" })],
+      requiredPatternKeys: new Set(["system/home.tsx"]),
+      recordExists: () => true,
+    });
+    expect(findings.length).toBe(1);
+    expect(findings[0].detail).toContain("required pattern");
+  });
+
+  it("returns a finding for a record outside docs/history/", () => {
+    const findings = guardBreakRegistryEntries({
+      entries: [entry({ record: "docs/plans/some-plan.md" })],
+      requiredPatternKeys: new Set(),
+      recordExists: () => true,
+    });
+    expect(findings.length).toBe(1);
+    expect(findings[0].detail).toContain("docs/history/");
+  });
+
+  it("returns a finding for a record that does not exist", () => {
+    const findings = guardBreakRegistryEntries({
+      entries: [entry({ record: "docs/history/never-written.md" })],
+      requiredPatternKeys: new Set(),
+      recordExists: () => false,
+    });
+    expect(findings.length).toBe(1);
+    expect(findings[0].detail).toContain("does not exist");
+  });
+
+  it("reports every offending entry rather than the first", () => {
+    const findings = guardBreakRegistryEntries({
+      entries: [
+        entry({ pattern: "system/home.tsx" }),
+        entry({ record: "docs/history/never-written.md" }),
+      ],
+      requiredPatternKeys: new Set(["system/home.tsx"]),
+      recordExists: () => false,
+    });
+    // The first entry also fails the existence probe, so three findings.
+    expect(findings.length).toBe(3);
+  });
+
+  it("accepts the shipped registries against the real tree", () => {
+    const findings = guardBreakRegistryEntries({
+      entries: collectBreakRegistryEntries(),
+      requiredPatternKeys: new Set(
+        requiredPatternKeys([HOME_PATTERN_SOURCE, DEFAULT_APP_PATTERN_SOURCE]),
+      ),
+      recordExists: (path) => {
+        try {
+          return Deno.statSync(`${REPO_ROOT}/${path}`).isFile;
+        } catch {
+          return false;
+        }
+      },
+    });
+    expect(findings).toEqual([]);
+  });
+});

--- a/tasks/pattern-break-registry-guards.test.ts
+++ b/tasks/pattern-break-registry-guards.test.ts
@@ -60,6 +60,43 @@ describe("pattern-break-registry-guards", () => {
     expect(findings[0].detail).toContain("does not exist");
   });
 
+  it("returns a finding for a record that steps back out of the tree", () => {
+    // The prefix alone would accept this, and the probe would then stat a
+    // file OUTSIDE the history tree — so the shape check refuses it before
+    // the probe ever sees it.
+    const findings = guardBreakRegistryEntries({
+      entries: [entry({ record: "docs/history/../../README.md" })],
+      requiredPatternKeys: new Set(),
+      recordExists: () => true,
+    });
+    expect(findings.length).toBe(1);
+    expect(findings[0].detail).toContain("steps back out");
+  });
+
+  it("returns a finding for a record that is not a Markdown document", () => {
+    const findings = guardBreakRegistryEntries({
+      entries: [entry({ record: "docs/history/evidence.sqlite" })],
+      requiredPatternKeys: new Set(),
+      recordExists: () => true,
+    });
+    expect(findings.length).toBe(1);
+    expect(findings[0].detail).toContain("Markdown");
+  });
+
+  it("returns a finding for the history tree's own scaffolding", () => {
+    // Both live files under the tree exist and end in .md, and neither is a
+    // decision record.
+    for (const record of ["docs/history/README.md", "docs/history/INDEX.md"]) {
+      const findings = guardBreakRegistryEntries({
+        entries: [entry({ record })],
+        requiredPatternKeys: new Set(),
+        recordExists: () => true,
+      });
+      expect(findings.length).toBe(1);
+      expect(findings[0].detail).toContain("scaffolding");
+    }
+  });
+
   it("reports every offending entry rather than the first", () => {
     const findings = guardBreakRegistryEntries({
       entries: [

--- a/tasks/pattern-break-registry-guards.test.ts
+++ b/tasks/pattern-break-registry-guards.test.ts
@@ -3,16 +3,14 @@ import { expect } from "@std/expect";
 import {
   type BreakRegistryEntry,
   collectBreakRegistryEntries,
+  deriveRequiredPatternKeys,
   guardBreakRegistryEntries,
+  recordExistsUnder,
 } from "./pattern-break-registry-guards.ts";
 import {
   DEFAULT_APP_PATTERN_SOURCE,
   HOME_PATTERN_SOURCE,
 } from "../packages/piece/src/system-pattern-url.ts";
-import { requiredPatternKeys } from "./pattern-vintage-lib.ts";
-import { fromFileUrl } from "@std/path/from-file-url";
-
-const REPO_ROOT = fromFileUrl(new URL("..", import.meta.url));
 
 const entry = (overrides: Partial<BreakRegistryEntry>): BreakRegistryEntry => ({
   registry: "pattern-compat-accepted-breaks",
@@ -124,24 +122,56 @@ describe("pattern-break-registry-guards", () => {
       requiredPatternKeys: new Set(["system/home.tsx"]),
       recordExists: () => false,
     });
-    // The first entry also fails the existence probe, so three findings.
-    expect(findings.length).toBe(3);
+    // Asserted by CONTENT, not by count: the first entry also fails the
+    // existence probe, so a bare `length === 3` passes on the wrong three.
+    expect(findings.map((finding) => `${finding.pattern} ${finding.detail}`))
+      .toEqual([
+        "system/home.tsx names a required pattern — the auto-updating roots " +
+        "are never eligible for an accepted break",
+        'system/home.tsx record "docs/history/topics-crossref-identity-break' +
+        '.md" does not exist — an accepted break carries its deliberation, ' +
+        "not just its declaration",
+        'lunch-poll/main.tsx record "docs/history/never-written.md" does not ' +
+        "exist — an accepted break carries its deliberation, not just its " +
+        "declaration",
+      ]);
+  });
+
+  it("refuses a required pattern written as a bare suffix key", () => {
+    // `acceptedDropsFor` claims an entry by path SUFFIX, so `home.tsx` really
+    // does forgive drops on `system/home.tsx`. An exact-match floor would let
+    // the shorter spelling walk straight around it.
+    const findings = guardBreakRegistryEntries({
+      entries: [entry({ pattern: "home.tsx" })],
+      requiredPatternKeys: new Set(["system/home.tsx"]),
+      recordExists: () => true,
+    });
+    expect(findings.length).toBe(1);
+    expect(findings[0].detail).toContain("required pattern");
+  });
+
+  it("allows a pattern the required key merely ends with textually", () => {
+    // The boundary the suffix rule needs: `home.tsx` is claimed because the
+    // separator lines up, but `whome.tsx` is a different pattern that no
+    // required key addresses.
+    expect(guardBreakRegistryEntries({
+      entries: [entry({ pattern: "whome.tsx" })],
+      requiredPatternKeys: new Set(["system/home.tsx"]),
+      recordExists: () => true,
+    })).toEqual([]);
   });
 
   it("accepts the shipped registries against the real tree", () => {
-    const findings = guardBreakRegistryEntries({
+    // Through the same derivation and the same probe the gates use, so this
+    // case also proves those resolve correctly from wherever tests run.
+    const required = deriveRequiredPatternKeys(
+      [HOME_PATTERN_SOURCE, DEFAULT_APP_PATTERN_SOURCE],
+    );
+    expect("error" in required).toBe(false);
+    expect(guardBreakRegistryEntries({
       entries: collectBreakRegistryEntries(),
-      requiredPatternKeys: new Set(
-        requiredPatternKeys([HOME_PATTERN_SOURCE, DEFAULT_APP_PATTERN_SOURCE]),
-      ),
-      recordExists: (path) => {
-        try {
-          return Deno.statSync(`${REPO_ROOT}/${path}`).isFile;
-        } catch {
-          return false;
-        }
-      },
-    });
-    expect(findings).toEqual([]);
+      requiredPatternKeys: (required as { keys: ReadonlySet<string> }).keys,
+      recordExists: recordExistsUnder(),
+    })).toEqual([]);
   });
 });

--- a/tasks/pattern-break-registry-guards.test.ts
+++ b/tasks/pattern-break-registry-guards.test.ts
@@ -94,7 +94,14 @@ describe("pattern-break-registry-guards", () => {
   it("returns a finding for the history tree's own scaffolding", () => {
     // Both live files under the tree exist and end in .md, and neither is a
     // decision record.
-    for (const record of ["docs/history/README.md", "docs/history/INDEX.md"]) {
+    for (
+      const record of [
+        "docs/history/README.md",
+        "docs/history/INDEX.md",
+        "docs/history/readme.md",
+        "docs/history/index.md",
+      ]
+    ) {
       const findings = guardBreakRegistryEntries({
         entries: [entry({ record })],
         requiredPatternKeys: new Set(),
@@ -108,11 +115,18 @@ describe("pattern-break-registry-guards", () => {
   it("accepts a nested record named like the scaffolding", () => {
     // Only the tree root's own two files are scaffolding. A nested README.md
     // is an ordinary document the index covers.
-    expect(guardBreakRegistryEntries({
-      entries: [entry({ record: "docs/history/some-break/README.md" })],
-      requiredPatternKeys: new Set(),
-      recordExists: () => true,
-    })).toEqual([]);
+    for (
+      const record of [
+        "docs/history/some-break/README.md",
+        "docs/history/some-break/readme.md",
+      ]
+    ) {
+      expect(guardBreakRegistryEntries({
+        entries: [entry({ record })],
+        requiredPatternKeys: new Set(),
+        recordExists: () => true,
+      })).toEqual([]);
+    }
   });
 
   it("reports every offending entry rather than the first", () => {

--- a/tasks/pattern-break-registry-guards.test.ts
+++ b/tasks/pattern-break-registry-guards.test.ts
@@ -61,16 +61,24 @@ describe("pattern-break-registry-guards", () => {
   });
 
   it("returns a finding for a record that steps back out of the tree", () => {
-    // The prefix alone would accept this, and the probe would then stat a
-    // file OUTSIDE the history tree — so the shape check refuses it before
-    // the probe ever sees it.
-    const findings = guardBreakRegistryEntries({
-      entries: [entry({ record: "docs/history/../../README.md" })],
-      requiredPatternKeys: new Set(),
-      recordExists: () => true,
-    });
-    expect(findings.length).toBe(1);
-    expect(findings[0].detail).toContain("steps back out");
+    // The prefix alone would accept these, and the probe would then stat a
+    // file OUTSIDE the history tree — so the shape check refuses them before
+    // the probe ever sees them. The second spelling is the Windows face:
+    // stat resolves a backslash as a separator there.
+    for (
+      const record of [
+        "docs/history/../../README.md",
+        "docs/history/..\\..\\README.md",
+      ]
+    ) {
+      const findings = guardBreakRegistryEntries({
+        entries: [entry({ record })],
+        requiredPatternKeys: new Set(),
+        recordExists: () => true,
+      });
+      expect(findings.length).toBe(1);
+      expect(findings[0].detail).toContain("steps back out");
+    }
   });
 
   it("returns a finding for a record that is not a Markdown document", () => {
@@ -95,6 +103,16 @@ describe("pattern-break-registry-guards", () => {
       expect(findings.length).toBe(1);
       expect(findings[0].detail).toContain("scaffolding");
     }
+  });
+
+  it("accepts a nested record named like the scaffolding", () => {
+    // Only the tree root's own two files are scaffolding. A nested README.md
+    // is an ordinary document the index covers.
+    expect(guardBreakRegistryEntries({
+      entries: [entry({ record: "docs/history/some-break/README.md" })],
+      requiredPatternKeys: new Set(),
+      recordExists: () => true,
+    })).toEqual([]);
   });
 
   it("reports every offending entry rather than the first", () => {

--- a/tasks/pattern-break-registry-guards.test.ts
+++ b/tasks/pattern-break-registry-guards.test.ts
@@ -5,8 +5,10 @@ import {
   collectBreakRegistryEntries,
   deriveRequiredPatternKeys,
   guardBreakRegistryEntries,
+  guardUnevaluableExemptions,
   recordExistsUnder,
 } from "./pattern-break-registry-guards.ts";
+import { UNEVALUABLE_PATTERNS } from "./pattern-compat-unevaluable.ts";
 import {
   DEFAULT_APP_PATTERN_SOURCE,
   HOME_PATTERN_SOURCE,
@@ -158,6 +160,44 @@ describe("pattern-break-registry-guards", () => {
       entries: [entry({ pattern: "whome.tsx" })],
       requiredPatternKeys: new Set(["system/home.tsx"]),
       recordExists: () => true,
+    })).toEqual([]);
+  });
+
+  it("refuses an unevaluable pattern that is a required root", () => {
+    // A wider exemption than any accepted break: not "this finding is
+    // forgiven" but "this pattern is not gated at all".
+    const findings = guardUnevaluableExemptions({
+      unevaluable: new Set(["system/home.tsx", "examples/cf-picker.tsx"]),
+      requiredPatternKeys: new Set(["system/home.tsx"]),
+    });
+    expect(findings.length).toBe(1);
+    expect(findings[0].pattern).toBe("system/home.tsx");
+    expect(findings[0].registry).toBe("pattern-compat-unevaluable");
+  });
+
+  it("allows unevaluable patterns that no required key addresses", () => {
+    expect(guardUnevaluableExemptions({
+      unevaluable: new Set(["examples/cf-picker.tsx", "whome.tsx"]),
+      requiredPatternKeys: new Set(["system/home.tsx"]),
+    })).toEqual([]);
+  });
+
+  it("refuses a required root written as a bare suffix key there too", () => {
+    expect(
+      guardUnevaluableExemptions({
+        unevaluable: new Set(["home.tsx"]),
+        requiredPatternKeys: new Set(["system/home.tsx"]),
+      }).length,
+    ).toBe(1);
+  });
+
+  it("accepts the shipped unevaluable list against the real required set", () => {
+    const required = deriveRequiredPatternKeys(
+      [HOME_PATTERN_SOURCE, DEFAULT_APP_PATTERN_SOURCE],
+    ) as { keys: ReadonlySet<string> };
+    expect(guardUnevaluableExemptions({
+      unevaluable: UNEVALUABLE_PATTERNS,
+      requiredPatternKeys: required.keys,
     })).toEqual([]);
   });
 

--- a/tasks/pattern-break-registry-guards.test.ts
+++ b/tasks/pattern-break-registry-guards.test.ts
@@ -152,6 +152,47 @@ describe("pattern-break-registry-guards", () => {
     expect(findings[0].detail).toContain("required pattern");
   });
 
+  it("refuses a required pattern written with a longer path prefix", () => {
+    // The other side of the relation. `acceptedDropsFor` anchors its suffix
+    // on the MANIFEST path, so a key carrying a prefix the manifest also
+    // carries claims the same root — including the `api/patterns/` route a
+    // manifest's `main` may name.
+    for (
+      const pattern of [
+        "patterns/system/home.tsx",
+        "packages/patterns/system/home.tsx",
+        "api/patterns/system/home.tsx",
+      ]
+    ) {
+      const findings = guardBreakRegistryEntries({
+        entries: [entry({ pattern })],
+        requiredPatternKeys: new Set(["system/home.tsx"]),
+        recordExists: () => true,
+      });
+      expect(findings.length).toBe(1);
+      expect(findings[0].detail).toContain("required pattern");
+    }
+  });
+
+  it("allows a pattern no required key addresses in either direction", () => {
+    // The near misses the segment boundary has to keep apart, on both sides:
+    // a longer path through a different directory, and shorter spellings
+    // that only share trailing text.
+    for (
+      const pattern of [
+        "packages/patterns/subsystem/home.tsx",
+        "system/whome.tsx",
+        "whome.tsx",
+      ]
+    ) {
+      expect(guardBreakRegistryEntries({
+        entries: [entry({ pattern })],
+        requiredPatternKeys: new Set(["system/home.tsx"]),
+        recordExists: () => true,
+      })).toEqual([]);
+    }
+  });
+
   it("allows a pattern the required key merely ends with textually", () => {
     // The boundary the suffix rule needs: `home.tsx` is claimed because the
     // separator lines up, but `whome.tsx` is a different pattern that no

--- a/tasks/pattern-break-registry-guards.ts
+++ b/tasks/pattern-break-registry-guards.ts
@@ -69,7 +69,7 @@ export interface BreakRegistryFinding {
 const RECORD_PREFIX = "docs/history/";
 
 /** The history tree's own live scaffolding — never a decision record. */
-const RECORD_SCAFFOLDING = new Set(["README.md", "INDEX.md"]);
+const RECORD_SCAFFOLDING = new Set(["readme.md", "index.md"]);
 
 /**
  * Why `record` cannot name a decision record, or `undefined` when its shape
@@ -94,7 +94,14 @@ function recordPathProblem(record: string): string | undefined {
   }
   // The tree root's own two files; a NESTED file by either name is an
   // ordinary indexed document.
-  if (segments.length === 1 && RECORD_SCAFFOLDING.has(segments[0])) {
+  // Compared case-insensitively because the existence probe resolves the live
+  // README.md/INDEX.md for alternate casing on common macOS and Windows file
+  // systems — the same platforms the separator split above exists for. The
+  // shape check must reject those spellings before the probe ever runs.
+  if (
+    segments.length === 1 &&
+    RECORD_SCAFFOLDING.has(segments[0].toLowerCase())
+  ) {
     return `is the history tree's own scaffolding, not a decision record`;
   }
   return undefined;

--- a/tasks/pattern-break-registry-guards.ts
+++ b/tasks/pattern-break-registry-guards.ts
@@ -16,8 +16,11 @@
  * - **Every entry names its decision record, and the record exists.** The
  *   registry line is the declaration; the record under `docs/history/` is the
  *   deliberation — what broke, why it was accepted, and what happens to the
- *   pieces holding the old shape. `check-docs-history-index` keeps the record
- *   itself indexed; this guard keeps the entry pointing at one.
+ *   pieces holding the old shape. A record is a Markdown document of that
+ *   tree's own: the path may not step back out of it, and the tree's live
+ *   scaffolding (`README.md`, `INDEX.md`) does not qualify.
+ *   `check-docs-history-index` forces every other document under the tree to
+ *   be indexed, so this guard's shape-plus-existence check is membership.
  *
  * Pure and parameterized (entries, required set, existence probe) so the
  * rules are provable against synthetic registries in
@@ -45,6 +48,34 @@ export interface BreakRegistryFinding {
 }
 
 const RECORD_PREFIX = "docs/history/";
+
+/** The history tree's own live scaffolding — never a decision record. */
+const RECORD_SCAFFOLDING = new Set(["README.md", "INDEX.md"]);
+
+/**
+ * Why `record` cannot name a decision record, or `undefined` when its shape
+ * qualifies. Shape only — existence is the caller's probe, and it runs only
+ * on paths this has already passed, so the probe never resolves a traversal
+ * out of the tree.
+ */
+function recordPathProblem(record: string): string | undefined {
+  if (!record.startsWith(RECORD_PREFIX)) {
+    return `is not under ${RECORD_PREFIX} — the decision record lives in ` +
+      `the history tree`;
+  }
+  const segments = record.slice(RECORD_PREFIX.length).split("/");
+  if (segments.some((s) => s === ".." || s === "." || s === "")) {
+    return `steps back out of ${RECORD_PREFIX} — a dot or empty segment ` +
+      `defeats the prefix`;
+  }
+  if (!record.endsWith(".md")) {
+    return `is not a Markdown document — a decision record is one`;
+  }
+  if (RECORD_SCAFFOLDING.has(segments[segments.length - 1])) {
+    return `is the history tree's own scaffolding, not a decision record`;
+  }
+  return undefined;
+}
 
 /** Both shipped registries, flattened to the shape the guards judge. */
 export function collectBreakRegistryEntries(): BreakRegistryEntry[] {
@@ -77,12 +108,12 @@ export function guardBreakRegistryEntries(options: {
           `never eligible for an accepted break`,
       });
     }
-    if (!entry.record.startsWith(RECORD_PREFIX)) {
+    const pathProblem = recordPathProblem(entry.record);
+    if (pathProblem !== undefined) {
       findings.push({
         registry: entry.registry,
         pattern: entry.pattern,
-        detail: `record "${entry.record}" is not under ${RECORD_PREFIX} — ` +
-          `the decision record lives in the history tree`,
+        detail: `record "${entry.record}" ${pathProblem}`,
       });
     } else if (!options.recordExists(entry.record)) {
       findings.push({

--- a/tasks/pattern-break-registry-guards.ts
+++ b/tasks/pattern-break-registry-guards.ts
@@ -1,0 +1,119 @@
+/**
+ * Static guards over the two accepted-break registries
+ * (`pattern-compat-accepted-breaks.ts`, `pattern-vintage-accepted-drops.ts`).
+ *
+ * The registries' own audits are per-run and per-finding: an entry that stops
+ * forgiving anything fails the run that would have used it. These guards are
+ * about what an entry IS, before any finding exists:
+ *
+ * - **No entry may name a required pattern.** The home and default-app roots
+ *   are the patterns that update aggressively and unconditionally — a break
+ *   accepted there is a decision to strand every space's root the moment it
+ *   merges, which is never the intent of a per-pattern exemption. The
+ *   required set comes in from the caller, derived from the runtime's own
+ *   constants (the same seam `pattern-vintage` already uses), so this guard
+ *   cannot drift from what actually auto-updates.
+ * - **Every entry names its decision record, and the record exists.** The
+ *   registry line is the declaration; the record under `docs/history/` is the
+ *   deliberation — what broke, why it was accepted, and what happens to the
+ *   pieces holding the old shape. `check-docs-history-index` keeps the record
+ *   itself indexed; this guard keeps the entry pointing at one.
+ *
+ * Pure and parameterized (entries, required set, existence probe) so the
+ * rules are provable against synthetic registries in
+ * `pattern-break-registry-guards.test.ts`, with the shipped registries
+ * checked against the real tree in the same suite.
+ */
+
+import { ACCEPTED_CONTRACT_BREAKS } from "./pattern-compat-accepted-breaks.ts";
+import { ACCEPTED_STATE_DROPS } from "./pattern-vintage-accepted-drops.ts";
+
+/** The registry-independent shape both kinds of entry share. */
+export interface BreakRegistryEntry {
+  /** Which registry the entry sits in, for reporting. */
+  registry: string;
+  /** Pattern key: the path relative to `packages/patterns`. */
+  pattern: string;
+  /** Repo-relative path of the entry's decision record. */
+  record: string;
+}
+
+export interface BreakRegistryFinding {
+  registry: string;
+  pattern: string;
+  detail: string;
+}
+
+const RECORD_PREFIX = "docs/history/";
+
+/** Both shipped registries, flattened to the shape the guards judge. */
+export function collectBreakRegistryEntries(): BreakRegistryEntry[] {
+  return [
+    ...ACCEPTED_CONTRACT_BREAKS.map((entry) => ({
+      registry: "pattern-compat-accepted-breaks",
+      pattern: entry.pattern,
+      record: entry.record,
+    })),
+    ...ACCEPTED_STATE_DROPS.map((entry) => ({
+      registry: "pattern-vintage-accepted-drops",
+      pattern: entry.pattern,
+      record: entry.record,
+    })),
+  ];
+}
+
+export function guardBreakRegistryEntries(options: {
+  entries: readonly BreakRegistryEntry[];
+  requiredPatternKeys: ReadonlySet<string>;
+  recordExists: (repoRelativePath: string) => boolean;
+}): BreakRegistryFinding[] {
+  const findings: BreakRegistryFinding[] = [];
+  for (const entry of options.entries) {
+    if (options.requiredPatternKeys.has(entry.pattern)) {
+      findings.push({
+        registry: entry.registry,
+        pattern: entry.pattern,
+        detail: `names a required pattern — the auto-updating roots are ` +
+          `never eligible for an accepted break`,
+      });
+    }
+    if (!entry.record.startsWith(RECORD_PREFIX)) {
+      findings.push({
+        registry: entry.registry,
+        pattern: entry.pattern,
+        detail: `record "${entry.record}" is not under ${RECORD_PREFIX} — ` +
+          `the decision record lives in the history tree`,
+      });
+    } else if (!options.recordExists(entry.record)) {
+      findings.push({
+        registry: entry.registry,
+        pattern: entry.pattern,
+        detail: `record "${entry.record}" does not exist — an accepted ` +
+          `break carries its deliberation, not just its declaration`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Guard the shipped registries against the real tree, formatted for a task's
+ * failure output. Returns `undefined` when every entry is permitted.
+ */
+export function reportBreakRegistryFindings(options: {
+  requiredPatternKeys: ReadonlySet<string>;
+  recordExists: (repoRelativePath: string) => boolean;
+}): string | undefined {
+  const findings = guardBreakRegistryEntries({
+    entries: collectBreakRegistryEntries(),
+    requiredPatternKeys: options.requiredPatternKeys,
+    recordExists: options.recordExists,
+  });
+  if (findings.length === 0) return undefined;
+  const lines = findings.map((finding) =>
+    `  ${finding.registry}: ${finding.pattern}\n    ${finding.detail}`
+  );
+  return `${findings.length} accepted-break registry entr` +
+    `${findings.length === 1 ? "y is" : "ies are"} not permitted:\n\n` +
+    lines.join("\n");
+}

--- a/tasks/pattern-break-registry-guards.ts
+++ b/tasks/pattern-break-registry-guards.ts
@@ -30,6 +30,22 @@
 
 import { ACCEPTED_CONTRACT_BREAKS } from "./pattern-compat-accepted-breaks.ts";
 import { ACCEPTED_STATE_DROPS } from "./pattern-vintage-accepted-drops.ts";
+import { fromFileUrl } from "@std/path/from-file-url";
+import {
+  reportUnmappedUrls,
+  requiredPatternKeys,
+  unmappedPatternUrls,
+} from "./pattern-vintage-lib.ts";
+
+/**
+ * The repository root, absolute. Derived from this module's own location so
+ * every gate resolves a record to the same file whatever directory the task
+ * was invoked from — the workspace runner does not run them from the root.
+ */
+const REPO_ROOT = fromFileUrl(new URL("..", import.meta.url)).replace(
+  /\/$/,
+  "",
+);
 
 /** The registry-independent shape both kinds of entry share. */
 export interface BreakRegistryEntry {
@@ -104,7 +120,18 @@ export function guardBreakRegistryEntries(options: {
 }): BreakRegistryFinding[] {
   const findings: BreakRegistryFinding[] = [];
   for (const entry of options.entries) {
-    if (options.requiredPatternKeys.has(entry.pattern)) {
+    // Membership is judged the way the REGISTRIES' own consumers resolve a
+    // key, not by string equality. `acceptedDropsFor` claims an entry whose
+    // key is a path SUFFIX of the manifest's pattern path, so a Tier 2 entry
+    // written `home.tsx` forgives drops on `system/home.tsx` — and an exact
+    // `has()` would let the shorter spelling walk around this floor. Tier 1
+    // keys exactly, so a suffix-written entry there forgives nothing today
+    // and refusing it costs nothing; judging both registries by the looser
+    // rule keeps the floor ahead of either consumer.
+    const namesRequired = [...options.requiredPatternKeys].some((key) =>
+      key === entry.pattern || key.endsWith(`/${entry.pattern}`)
+    );
+    if (namesRequired) {
       findings.push({
         registry: entry.registry,
         pattern: entry.pattern,
@@ -151,4 +178,43 @@ export function reportBreakRegistryFindings(options: {
   return `${findings.length} accepted-break registry entr` +
     `${findings.length === 1 ? "y is" : "ies are"} not permitted:\n\n` +
     lines.join("\n");
+}
+
+/**
+ * The required-pattern set both gates hold their registries to, or the report
+ * to fail with.
+ *
+ * Derived here rather than in each gate so the two cannot come to different
+ * answers about what auto-updates. The unmapped check is part of the
+ * derivation and not a separate courtesy: a runtime constant that stops
+ * naming a patterns route would leave `requiredPatternKeys` returning a
+ * SHORTER list, and a floor that silently requires nothing is worse than no
+ * floor.
+ */
+export function deriveRequiredPatternKeys(
+  systemPatternUrls: readonly string[],
+): { keys: ReadonlySet<string> } | { error: string } {
+  const unmapped = unmappedPatternUrls(systemPatternUrls);
+  if (unmapped.length > 0) return { error: reportUnmappedUrls(unmapped) };
+  return { keys: new Set(requiredPatternKeys(systemPatternUrls)) };
+}
+
+/**
+ * An existence probe for records, resolved against an ABSOLUTE repo root.
+ *
+ * Shared so the gates cannot disagree about what a repo-relative record path
+ * resolves to. A probe built from a bare relative path answers differently
+ * depending on the directory the task was invoked from, and the workspace
+ * runner does not invoke these from the repo root.
+ */
+export function recordExistsUnder(
+  repoRoot: string = REPO_ROOT,
+): (repoRelativePath: string) => boolean {
+  return (repoRelativePath) => {
+    try {
+      return Deno.statSync(`${repoRoot}/${repoRelativePath}`).isFile;
+    } catch {
+      return false;
+    }
+  };
 }

--- a/tasks/pattern-break-registry-guards.ts
+++ b/tasks/pattern-break-registry-guards.ts
@@ -29,7 +29,10 @@
  */
 
 import { ACCEPTED_CONTRACT_BREAKS } from "./pattern-compat-accepted-breaks.ts";
-import { ACCEPTED_STATE_DROPS } from "./pattern-vintage-accepted-drops.ts";
+import {
+  ACCEPTED_STATE_DROPS,
+  patternKeyClaims,
+} from "./pattern-vintage-accepted-drops.ts";
 import { fromFileUrl } from "@std/path/from-file-url";
 import {
   reportUnmappedUrls,
@@ -100,27 +103,32 @@ function recordPathProblem(record: string): string | undefined {
 /**
  * Whether a key written in an exemption list addresses a required pattern.
  *
- * Membership is judged the way the lists' own consumers resolve a key, not by
- * string equality. `acceptedDropsFor` claims an entry whose key is a path
- * SUFFIX of the manifest's pattern path, so an entry written `home.tsx`
- * exempts `system/home.tsx` — and an exact `has()` would let the shorter
- * spelling walk straight around every floor here.
+ * Asked through `patternKeyClaims` — the registries' own matcher — rather
+ * than by string equality or by a rule this module derives for itself. A
+ * floor that judged membership its own way would accept a spelling the
+ * consumer honors, which is the whole of how an exemption walks around it.
  *
- * The other two lists match exactly, so this refuses a suffix-written entry
- * that exempts nothing today. That asymmetry is deliberate and cheap: a
- * prohibition may exceed the convention it protects, and the spelling nobody
- * needs is the one a reader cannot tell from the spelling that bites.
+ * Asked in BOTH directions, because the consumer anchors its suffix on the
+ * manifest path while a required pattern arrives here as a key. A key
+ * SHORTER than the required one claims it by being a suffix of it
+ * (`home.tsx` for `system/home.tsx`), and a key LONGER than it claims it by
+ * carrying a path prefix the manifest also carries
+ * (`packages/patterns/system/home.tsx`, or the `api/patterns/` route a
+ * manifest's `main` may name). Either spelling reaches the same pattern, so
+ * the floor has to refuse both.
  *
- * The `/` is part of the test rather than a bare `endsWith`: without it
- * `whome.tsx` would answer for `system/home.tsx`, which is a different
- * pattern that no required key addresses.
+ * The relation is prefix-agnostic on purpose: reconstructing a manifest path
+ * to compare against would hardcode one of the prefixes a manifest can
+ * actually carry, and the floor would be blind to the others.
  */
 function namesRequiredPattern(
   requiredPatternKeys: ReadonlySet<string>,
   pattern: string,
 ): boolean {
   for (const key of requiredPatternKeys) {
-    if (key === pattern || key.endsWith(`/${pattern}`)) return true;
+    if (patternKeyClaims(key, pattern) || patternKeyClaims(pattern, key)) {
+      return true;
+    }
   }
   return false;
 }

--- a/tasks/pattern-break-registry-guards.ts
+++ b/tasks/pattern-break-registry-guards.ts
@@ -63,7 +63,9 @@ function recordPathProblem(record: string): string | undefined {
     return `is not under ${RECORD_PREFIX} — the decision record lives in ` +
       `the history tree`;
   }
-  const segments = record.slice(RECORD_PREFIX.length).split("/");
+  // Both separators: on Windows the probe's stat resolves a backslash as a
+  // path separator, so a slash-only split would let `..\` step out.
+  const segments = record.slice(RECORD_PREFIX.length).split(/[/\\]/);
   if (segments.some((s) => s === ".." || s === "." || s === "")) {
     return `steps back out of ${RECORD_PREFIX} — a dot or empty segment ` +
       `defeats the prefix`;
@@ -71,7 +73,9 @@ function recordPathProblem(record: string): string | undefined {
   if (!record.endsWith(".md")) {
     return `is not a Markdown document — a decision record is one`;
   }
-  if (RECORD_SCAFFOLDING.has(segments[segments.length - 1])) {
+  // The tree root's own two files; a NESTED file by either name is an
+  // ordinary indexed document.
+  if (segments.length === 1 && RECORD_SCAFFOLDING.has(segments[0])) {
     return `is the history tree's own scaffolding, not a decision record`;
   }
   return undefined;

--- a/tasks/pattern-break-registry-guards.ts
+++ b/tasks/pattern-break-registry-guards.ts
@@ -97,6 +97,34 @@ function recordPathProblem(record: string): string | undefined {
   return undefined;
 }
 
+/**
+ * Whether a key written in an exemption list addresses a required pattern.
+ *
+ * Membership is judged the way the lists' own consumers resolve a key, not by
+ * string equality. `acceptedDropsFor` claims an entry whose key is a path
+ * SUFFIX of the manifest's pattern path, so an entry written `home.tsx`
+ * exempts `system/home.tsx` — and an exact `has()` would let the shorter
+ * spelling walk straight around every floor here.
+ *
+ * The other two lists match exactly, so this refuses a suffix-written entry
+ * that exempts nothing today. That asymmetry is deliberate and cheap: a
+ * prohibition may exceed the convention it protects, and the spelling nobody
+ * needs is the one a reader cannot tell from the spelling that bites.
+ *
+ * The `/` is part of the test rather than a bare `endsWith`: without it
+ * `whome.tsx` would answer for `system/home.tsx`, which is a different
+ * pattern that no required key addresses.
+ */
+function namesRequiredPattern(
+  requiredPatternKeys: ReadonlySet<string>,
+  pattern: string,
+): boolean {
+  for (const key of requiredPatternKeys) {
+    if (key === pattern || key.endsWith(`/${pattern}`)) return true;
+  }
+  return false;
+}
+
 /** Both shipped registries, flattened to the shape the guards judge. */
 export function collectBreakRegistryEntries(): BreakRegistryEntry[] {
   return [
@@ -120,18 +148,7 @@ export function guardBreakRegistryEntries(options: {
 }): BreakRegistryFinding[] {
   const findings: BreakRegistryFinding[] = [];
   for (const entry of options.entries) {
-    // Membership is judged the way the REGISTRIES' own consumers resolve a
-    // key, not by string equality. `acceptedDropsFor` claims an entry whose
-    // key is a path SUFFIX of the manifest's pattern path, so a Tier 2 entry
-    // written `home.tsx` forgives drops on `system/home.tsx` — and an exact
-    // `has()` would let the shorter spelling walk around this floor. Tier 1
-    // keys exactly, so a suffix-written entry there forgives nothing today
-    // and refusing it costs nothing; judging both registries by the looser
-    // rule keeps the floor ahead of either consumer.
-    const namesRequired = [...options.requiredPatternKeys].some((key) =>
-      key === entry.pattern || key.endsWith(`/${entry.pattern}`)
-    );
-    if (namesRequired) {
+    if (namesRequiredPattern(options.requiredPatternKeys, entry.pattern)) {
       findings.push({
         registry: entry.registry,
         pattern: entry.pattern,
@@ -159,23 +176,66 @@ export function guardBreakRegistryEntries(options: {
 }
 
 /**
+ * Findings for patterns exempted from Tier 1 by being unevaluable.
+ *
+ * `UNEVALUABLE_PATTERNS` is debt made visible: a file that throws while being
+ * evaluated yields no contract, so it can never be recorded and never
+ * checked. That is a WIDER exemption than any accepted break — not "this
+ * finding is forgiven" but "this pattern is not gated at all" — so the floor
+ * that keeps the auto-updating roots out of the break registries has to reach
+ * it too, or the strictest rule is the one with the easiest way around it.
+ *
+ * Tier 1 only, because Tier 1 is the gate this list exempts anything from.
+ * The list is empty of required patterns today, so this costs nothing now and
+ * refuses the one addition that would matter.
+ */
+export function guardUnevaluableExemptions(options: {
+  unevaluable: ReadonlySet<string>;
+  requiredPatternKeys: ReadonlySet<string>;
+}): BreakRegistryFinding[] {
+  const findings: BreakRegistryFinding[] = [];
+  for (const pattern of options.unevaluable) {
+    if (!namesRequiredPattern(options.requiredPatternKeys, pattern)) continue;
+    findings.push({
+      registry: "pattern-compat-unevaluable",
+      pattern,
+      detail: `names a required pattern — an unevaluable pattern is exempt ` +
+        `from the update gate entirely, which an auto-updating root may ` +
+        `never be. Fix the pattern rather than listing it.`,
+    });
+  }
+  return findings;
+}
+
+/**
  * Guard the shipped registries against the real tree, formatted for a task's
  * failure output. Returns `undefined` when every entry is permitted.
  */
 export function reportBreakRegistryFindings(options: {
   requiredPatternKeys: ReadonlySet<string>;
   recordExists: (repoRelativePath: string) => boolean;
+  /**
+   * Tier 1's unevaluable list, when the caller is the gate it exempts from.
+   * Omitted by Tier 2, which does not consult it.
+   */
+  unevaluable?: ReadonlySet<string>;
 }): string | undefined {
-  const findings = guardBreakRegistryEntries({
-    entries: collectBreakRegistryEntries(),
-    requiredPatternKeys: options.requiredPatternKeys,
-    recordExists: options.recordExists,
-  });
+  const findings = [
+    ...guardBreakRegistryEntries({
+      entries: collectBreakRegistryEntries(),
+      requiredPatternKeys: options.requiredPatternKeys,
+      recordExists: options.recordExists,
+    }),
+    ...(options.unevaluable === undefined ? [] : guardUnevaluableExemptions({
+      unevaluable: options.unevaluable,
+      requiredPatternKeys: options.requiredPatternKeys,
+    })),
+  ];
   if (findings.length === 0) return undefined;
   const lines = findings.map((finding) =>
     `  ${finding.registry}: ${finding.pattern}\n    ${finding.detail}`
   );
-  return `${findings.length} accepted-break registry entr` +
+  return `${findings.length} pattern-exemption entr` +
     `${findings.length === 1 ? "y is" : "ies are"} not permitted:\n\n` +
     lines.join("\n");
 }

--- a/tasks/pattern-compat-accepted-breaks.ts
+++ b/tasks/pattern-compat-accepted-breaks.ts
@@ -49,6 +49,12 @@ export interface AcceptedContractBreak {
   paths: readonly string[];
   /** Why the break was accepted. */
   reason: string;
+  /**
+   * Repo-relative path of the decision record under `docs/history/` — the
+   * deliberation behind this entry's declaration. Its existence is enforced
+   * when either gate runs (`pattern-break-registry-guards.ts`).
+   */
+  record: string;
 }
 
 export const ACCEPTED_CONTRACT_BREAKS: readonly AcceptedContractBreak[] = [
@@ -106,6 +112,7 @@ export const ACCEPTED_CONTRACT_BREAKS: readonly AcceptedContractBreak[] = [
       "fields go. `index` is the full-board survey surface, and its rows ARE " +
       "the topics: a row's own address is the topic's, so the copied `fid` " +
       "field goes with the copy.",
+    record: "docs/history/topics-crossref-identity-break.md",
   },
   {
     // The same removal seen from a topic: its own `crossrefs` row, and the
@@ -141,5 +148,6 @@ export const ACCEPTED_CONTRACT_BREAKS: readonly AcceptedContractBreak[] = [
       "`unknown` — the one field that lets the verb read a payload and tell a " +
       "reference from a bare string, which it now rejects rather than storing " +
       "inert.",
+    record: "docs/history/topics-crossref-identity-break.md",
   },
 ];

--- a/tasks/pattern-compat-unevaluable.ts
+++ b/tasks/pattern-compat-unevaluable.ts
@@ -11,7 +11,10 @@
  *
  * So the list is debt, made visible. The gate fails on an evaluation error
  * that is NOT listed here, and fails when a listed entry starts evaluating
- * again — so the list can only shrink, never quietly grow.
+ * again — so the list can only shrink, never quietly grow. It also fails on
+ * an entry naming a required pattern: an unevaluable pattern is exempt from
+ * the gate entirely, which the aggressively auto-updating roots may never be
+ * (`pattern-break-registry-guards.ts`).
  *
  * An entry is the pattern key (path relative to `packages/patterns`). An
  * entry may name a real `export default pattern(...)` rather than a helper

--- a/tasks/pattern-compat.ts
+++ b/tasks/pattern-compat.ts
@@ -39,7 +39,11 @@ import {
   DEFAULT_APP_PATTERN_SOURCE,
   HOME_PATTERN_SOURCE,
 } from "../packages/piece/src/system-pattern-url.ts";
-import { requiredPatternKeys } from "./pattern-vintage-lib.ts";
+import {
+  reportUnmappedUrls,
+  requiredPatternKeys,
+  unmappedPatternUrls,
+} from "./pattern-vintage-lib.ts";
 import {
   acceptedBreakKey,
   checkPattern,
@@ -71,13 +75,21 @@ async function main() {
     Deno.exit(2);
   }
 
+  // The required set comes from the runtime's own constants, the same seam
+  // `pattern-vintage` uses — and a constant that stops mapping to a patterns
+  // route would silently make this guard require nothing, so that is checked
+  // rather than absorbed.
+  const systemUrls = [HOME_PATTERN_SOURCE, DEFAULT_APP_PATTERN_SOURCE];
+  const unmappedUrls = unmappedPatternUrls(systemUrls);
+  if (unmappedUrls.length > 0) {
+    console.error(reportUnmappedUrls(unmappedUrls));
+    Deno.exit(1);
+  }
   // The registries are judged before any pattern is: an entry that names a
   // required pattern or points at no decision record is wrong regardless of
   // what this shard's findings turn out to be.
   const registryReport = reportBreakRegistryFindings({
-    requiredPatternKeys: new Set(
-      requiredPatternKeys([HOME_PATTERN_SOURCE, DEFAULT_APP_PATTERN_SOURCE]),
-    ),
+    requiredPatternKeys: new Set(requiredPatternKeys(systemUrls)),
     recordExists: (path) => {
       try {
         return Deno.statSync(path).isFile;

--- a/tasks/pattern-compat.ts
+++ b/tasks/pattern-compat.ts
@@ -90,6 +90,9 @@ async function main() {
   const registryReport = reportBreakRegistryFindings({
     requiredPatternKeys: required.keys,
     recordExists: recordExistsUnder(),
+    // Tier 1 owns the unevaluable list, so Tier 1 is where it is judged: a
+    // required pattern listed there escapes this gate altogether.
+    unevaluable: UNEVALUABLE_PATTERNS,
   });
   if (registryReport !== undefined) {
     console.error(registryReport);

--- a/tasks/pattern-compat.ts
+++ b/tasks/pattern-compat.ts
@@ -34,16 +34,15 @@ import {
 } from "./pattern-files.ts";
 import { UNEVALUABLE_PATTERNS } from "./pattern-compat-unevaluable.ts";
 import { ACCEPTED_CONTRACT_BREAKS } from "./pattern-compat-accepted-breaks.ts";
-import { reportBreakRegistryFindings } from "./pattern-break-registry-guards.ts";
+import {
+  deriveRequiredPatternKeys,
+  recordExistsUnder,
+  reportBreakRegistryFindings,
+} from "./pattern-break-registry-guards.ts";
 import {
   DEFAULT_APP_PATTERN_SOURCE,
   HOME_PATTERN_SOURCE,
 } from "../packages/piece/src/system-pattern-url.ts";
-import {
-  reportUnmappedUrls,
-  requiredPatternKeys,
-  unmappedPatternUrls,
-} from "./pattern-vintage-lib.ts";
 import {
   acceptedBreakKey,
   checkPattern,
@@ -75,28 +74,22 @@ async function main() {
     Deno.exit(2);
   }
 
-  // The required set comes from the runtime's own constants, the same seam
-  // `pattern-vintage` uses — and a constant that stops mapping to a patterns
-  // route would silently make this guard require nothing, so that is checked
-  // rather than absorbed.
-  const systemUrls = [HOME_PATTERN_SOURCE, DEFAULT_APP_PATTERN_SOURCE];
-  const unmappedUrls = unmappedPatternUrls(systemUrls);
-  if (unmappedUrls.length > 0) {
-    console.error(reportUnmappedUrls(unmappedUrls));
+  // The required set comes from the runtime's own constants, through the same
+  // derivation `pattern-vintage` uses, so the two gates cannot come to
+  // different answers about what auto-updates.
+  const required = deriveRequiredPatternKeys(
+    [HOME_PATTERN_SOURCE, DEFAULT_APP_PATTERN_SOURCE],
+  );
+  if ("error" in required) {
+    console.error(required.error);
     Deno.exit(1);
   }
   // The registries are judged before any pattern is: an entry that names a
   // required pattern or points at no decision record is wrong regardless of
   // what this shard's findings turn out to be.
   const registryReport = reportBreakRegistryFindings({
-    requiredPatternKeys: new Set(requiredPatternKeys(systemUrls)),
-    recordExists: (path) => {
-      try {
-        return Deno.statSync(path).isFile;
-      } catch {
-        return false;
-      }
-    },
+    requiredPatternKeys: required.keys,
+    recordExists: recordExistsUnder(),
   });
   if (registryReport !== undefined) {
     console.error(registryReport);

--- a/tasks/pattern-compat.ts
+++ b/tasks/pattern-compat.ts
@@ -34,6 +34,12 @@ import {
 } from "./pattern-files.ts";
 import { UNEVALUABLE_PATTERNS } from "./pattern-compat-unevaluable.ts";
 import { ACCEPTED_CONTRACT_BREAKS } from "./pattern-compat-accepted-breaks.ts";
+import { reportBreakRegistryFindings } from "./pattern-break-registry-guards.ts";
+import {
+  DEFAULT_APP_PATTERN_SOURCE,
+  HOME_PATTERN_SOURCE,
+} from "../packages/piece/src/system-pattern-url.ts";
+import { requiredPatternKeys } from "./pattern-vintage-lib.ts";
 import {
   acceptedBreakKey,
   checkPattern,
@@ -63,6 +69,26 @@ async function main() {
   } catch (error) {
     console.error(formatError(error));
     Deno.exit(2);
+  }
+
+  // The registries are judged before any pattern is: an entry that names a
+  // required pattern or points at no decision record is wrong regardless of
+  // what this shard's findings turn out to be.
+  const registryReport = reportBreakRegistryFindings({
+    requiredPatternKeys: new Set(
+      requiredPatternKeys([HOME_PATTERN_SOURCE, DEFAULT_APP_PATTERN_SOURCE]),
+    ),
+    recordExists: (path) => {
+      try {
+        return Deno.statSync(path).isFile;
+      } catch {
+        return false;
+      }
+    },
+  });
+  if (registryReport !== undefined) {
+    console.error(registryReport);
+    Deno.exit(1);
   }
 
   const allFiles = await collectPatternFiles();

--- a/tasks/pattern-vintage-accepted-drops.test.ts
+++ b/tasks/pattern-vintage-accepted-drops.test.ts
@@ -14,6 +14,7 @@ describe("pattern-vintage-accepted-drops", () => {
       paths: ["crossrefs", "topics[].crossrefs"],
       capturedThrough: "2026-08-06T23-04-13.189Z",
       reason: "removed",
+      record: "docs/history/topics-crossref-identity-break.md",
     },
   ];
   /** A capture from inside the window the entry was granted over. */

--- a/tasks/pattern-vintage-accepted-drops.ts
+++ b/tasks/pattern-vintage-accepted-drops.ts
@@ -62,6 +62,12 @@ export interface AcceptedStateDrop {
   capturedThrough: string;
   /** Why the removal was accepted. */
   reason: string;
+  /**
+   * Repo-relative path of the decision record under `docs/history/` — shared
+   * with the matching Tier 1 entry where there is one. Existence is enforced
+   * when either gate runs (`pattern-break-registry-guards.ts`).
+   */
+  record: string;
 }
 
 export const ACCEPTED_STATE_DROPS: readonly AcceptedStateDrop[] = [
@@ -98,6 +104,7 @@ export const ACCEPTED_STATE_DROPS: readonly AcceptedStateDrop[] = [
       "`referencedBy` instead of deriving its own edge row, so the old row is " +
       "gone from every child the board lists. The index rows became the topics " +
       "themselves, which is what retires their copied address and reference.",
+    record: "docs/history/topics-crossref-identity-break.md",
   },
   {
     pattern: "topics/topic.tsx",
@@ -111,6 +118,7 @@ export const ACCEPTED_STATE_DROPS: readonly AcceptedStateDrop[] = [
       "entry in tasks/pattern-compat-accepted-breaks.ts. The board's own " +
       "`crossrefs` came back as a pivot and strands nothing, so only a topic's " +
       "retired per-topic row is listed here.",
+    record: "docs/history/topics-crossref-identity-break.md",
   },
 ];
 

--- a/tasks/pattern-vintage-accepted-drops.ts
+++ b/tasks/pattern-vintage-accepted-drops.ts
@@ -127,6 +127,24 @@ export const acceptedDropKey = (pattern: string, path: string): string =>
   `${pattern} ${path}`;
 
 /**
+ * Whether a registry key addresses the pattern a manifest names.
+ *
+ * A manifest entry names its pattern by repo-relative path
+ * (`/packages/patterns/topics/topic.tsx`) or by the route the toolshed serves
+ * it at, while a registry key is written relative to `packages/patterns`. So
+ * a key is matched as a path SUFFIX rather than a bare one: `endsWith` alone
+ * would also claim a `subtopics/main.tsx` that no entry mentions, and the
+ * leading `/` is what makes the segment boundary part of the test.
+ *
+ * Exported because the guards that hold these registries to a floor have to
+ * ask the same question this asks, and a floor that judged membership by its
+ * own rule would let a spelling this accepts walk straight around it.
+ */
+export function patternKeyClaims(patternPath: string, key: string): boolean {
+  return patternPath === key || patternPath.endsWith(`/${key}`);
+}
+
+/**
  * The paths accepted as dropped for one pattern, in one vintage.
  *
  * A manifest entry names its pattern by repo-relative path
@@ -145,8 +163,7 @@ export function acceptedDropsFor(
   drops: readonly AcceptedStateDrop[] = ACCEPTED_STATE_DROPS,
 ): { paths: ReadonlySet<string>; pattern: string } | undefined {
   const entry = drops.find((drop) =>
-    (patternPath === drop.pattern ||
-      patternPath.endsWith(`/${drop.pattern}`)) &&
+    patternKeyClaims(patternPath, drop.pattern) &&
     stamp <= drop.capturedThrough
   );
   return entry === undefined

--- a/tasks/pattern-vintage.ts
+++ b/tasks/pattern-vintage.ts
@@ -117,7 +117,11 @@ import {
   DEFAULT_APP_PATTERN_SOURCE,
   HOME_PATTERN_SOURCE,
 } from "../packages/piece/src/system-pattern-url.ts";
-import { reportBreakRegistryFindings } from "./pattern-break-registry-guards.ts";
+import {
+  deriveRequiredPatternKeys,
+  recordExistsUnder,
+  reportBreakRegistryFindings,
+} from "./pattern-break-registry-guards.ts";
 import {
   armVerdictGuard,
   type CommandOutput,
@@ -130,12 +134,9 @@ import {
   reportReplaySummary,
   reportUncovered,
   reportUnknownFlags,
-  reportUnmappedUrls,
   reportUpdateNeedsATestKey,
-  requiredPatternKeys,
   uncoveredRequiredPatterns,
   unknownFlags,
-  unmappedPatternUrls,
   VINTAGES_DIR,
 } from "./pattern-vintage-lib.ts";
 import {
@@ -194,41 +195,30 @@ async function main() {
     vintagesRoot: `${REPO_ROOT}/${VINTAGES_DIR}`,
     signer: FIXTURE_SIGNER,
   };
-  // The required set comes from the runtime's OWN constants, so the gate
-  // cannot drift from what actually auto-updates. A constant that stops
-  // deriving a key would leave the gate requiring nothing, so that is checked
-  // rather than absorbed.
-  const systemUrls = [HOME_PATTERN_SOURCE, DEFAULT_APP_PATTERN_SOURCE];
-  const unmapped = unmappedPatternUrls(systemUrls);
-  if (unmapped.length > 0) {
-    console.error(reportUnmappedUrls(unmapped));
-    Deno.exit(1);
-  }
-  const required = requiredPatternKeys(systemUrls);
-  // Judge the accepted-break registries before replaying anything: an entry
-  // naming a required pattern or pointing at no decision record is wrong
-  // regardless of what this run's fixtures show.
-  {
-    const registryReport = reportBreakRegistryFindings({
-      requiredPatternKeys: new Set(required),
-      recordExists: (path) => {
-        try {
-          return Deno.statSync(`${REPO_ROOT}/${path}`).isFile;
-        } catch {
-          return false;
-        }
-      },
-    });
-    if (registryReport !== undefined) {
-      emit({ err: registryReport, code: 1 });
-    }
-  }
 
   // Before anything else: a flag this task does not know is a MISTAKE, not a
   // no-op. Unhandled, it falls through to the plain gate and exits 0 having
   // answered a question nobody asked.
   const unknown = unknownFlags(Deno.args);
   if (unknown.length > 0) emit({ err: reportUnknownFlags(unknown), code: 1 });
+
+  // The required set comes from the runtime's OWN constants, so the gate
+  // cannot drift from what actually auto-updates, and a constant that stopped
+  // deriving a key would leave it requiring nothing.
+  //
+  // Below the unknown-flag check on purpose. A record typo and a mistyped flag
+  // are both ordinary authoring slips, and whichever runs first is the one
+  // reported — so the flag, which decides what this invocation even does, is
+  // answered before the registries are judged. Still ahead of every replay.
+  const required = deriveRequiredPatternKeys(
+    [HOME_PATTERN_SOURCE, DEFAULT_APP_PATTERN_SOURCE],
+  );
+  if ("error" in required) emit({ err: required.error, code: 1 });
+  const registryReport = reportBreakRegistryFindings({
+    requiredPatternKeys: required.keys,
+    recordExists: recordExistsUnder(REPO_ROOT),
+  });
+  if (registryReport !== undefined) emit({ err: registryReport, code: 1 });
 
   if (Deno.args.includes("--update")) {
     // A capture NAMES the test to run. There is no default set, and deriving
@@ -289,7 +279,10 @@ async function main() {
   // Coverage is judged against the SAME list that was replayed. A second walk
   // would be a second answer to one question, and "replayed nothing" paired with
   // "everything is covered" is the disagreement that reads as a pass.
-  const uncovered = uncoveredRequiredPatterns(required, replay.covered);
+  const uncovered = uncoveredRequiredPatterns(
+    [...required.keys],
+    replay.covered,
+  );
 
   if (uncovered.length > 0) {
     console.error(reportUncovered(

--- a/tasks/pattern-vintage.ts
+++ b/tasks/pattern-vintage.ts
@@ -117,6 +117,7 @@ import {
   DEFAULT_APP_PATTERN_SOURCE,
   HOME_PATTERN_SOURCE,
 } from "../packages/piece/src/system-pattern-url.ts";
+import { reportBreakRegistryFindings } from "./pattern-break-registry-guards.ts";
 import {
   armVerdictGuard,
   type CommandOutput,
@@ -204,6 +205,24 @@ async function main() {
     Deno.exit(1);
   }
   const required = requiredPatternKeys(systemUrls);
+  // Judge the accepted-break registries before replaying anything: an entry
+  // naming a required pattern or pointing at no decision record is wrong
+  // regardless of what this run's fixtures show.
+  {
+    const registryReport = reportBreakRegistryFindings({
+      requiredPatternKeys: new Set(required),
+      recordExists: (path) => {
+        try {
+          return Deno.statSync(`${REPO_ROOT}/${path}`).isFile;
+        } catch {
+          return false;
+        }
+      },
+    });
+    if (registryReport !== undefined) {
+      emit({ err: registryReport, code: 1 });
+    }
+  }
 
   // Before anything else: a flag this task does not know is a MISTAKE, not a
   // no-op. Unhandled, it falls through to the plain gate and exits 0 having


### PR DESCRIPTION
Hardens the accepted-break registries that #5921 introduced, with two rules about what an entry IS — judged whenever either gate runs, before any finding exists:

**No entry may name a required pattern.** The home and default-app roots update aggressively and unconditionally, so a break accepted there strands every space's root the moment it merges — never the intent of a per-pattern exemption. The required set derives from the runtime's own constants (`HOME_PATTERN_SOURCE` / `DEFAULT_APP_PATTERN_SOURCE`), the same seam `pattern-vintage` already uses, so the floor cannot drift from what actually auto-updates.

**Every entry names its decision record, and the record exists.** Both registry interfaces gain a required `record:` field pointing under `docs/history/`. The registry line is the declaration; the record is the deliberation — what broke, why it was accepted, what happens to pieces holding the old shape. The path is judged by **shape before the existence probe runs**: a dot or empty segment cannot step the probe back out of the tree, a record is a Markdown document, and the tree's own scaffolding (`README.md`, `INDEX.md`) does not qualify — `check-docs-history-index` forces every other document under the tree to be indexed, so shape plus existence is membership. The topics entries (the registries' first break, #5921) gain a backfilled record assembled from that change's own prose. **@seefeldb — corrections wanted before this merges, not after:** `docs/history/README.md` freezes a record's content on arrival ("The only permitted edits are mechanical"), so a fix landing post-merge would be a rules violation by construction. If the backfill misreads anything about #5921, say so on this PR and it gets fixed here.

**The required set's own seam is checked in both gates.** The floor derives from the runtime's system-pattern constants; a constant that stopped mapping to a patterns route would silently shrink the floor to nothing. `pattern-vintage` already refused that; `pattern-compat` now makes the same refusal before deriving the set.

Mechanics: one pure, parameterized module (`tasks/pattern-break-registry-guards.ts`) with its own unit suite (synthetic-registry rules plus the shipped registries validated against the real tree), wired into both gate entrypoints. Both gates run green with the guards live; the vintage run's forgiveness reporting is unchanged.

**Not included, flagged for a separate decision:** review-ownership of the registries. The repo has no CODEOWNERS at all today, so making gate-owner review mechanical means introducing that convention repo-wide — a team-workflow call, not something to smuggle into a hardening PR.

<sub>Implemented by Claude (Fable 5) on @mathpirate's behalf.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



