### PR TITLE
feat(cli): dim __cfBindVerifiedBinding as a synthetic in cf view (CT-1870)

### DIFF
--- a/packages/cli/lib/view/languages/typescript/vocab.ts
+++ b/packages/cli/lib/view/languages/typescript/vocab.ts
@@ -48,6 +48,7 @@ const SYNTHETIC_PREFIXES = [
   SYNTHETIC_MODULE_CALLBACK_PREFIX,
   "__cfHandler",
   "__cfAction",
+  "__cfBindVerifiedBinding",
   "__cf_pattern_input",
   "__cfAmdHooks",
 ];


### PR DESCRIPTION
With binding-identity annotation coverage widened to all function-bearing builder artifacts (CT-1870, #6003), `__cfBindVerifiedBinding` now appears in nearly every builder-bearing module's transformed output — undimmed, because it was missing from the pager's synthetic vocabulary.

One line: add the name to `SYNTHETIC_PREFIXES` in `packages/cli/lib/view/languages/typescript/vocab.ts`, grouped with the other inline-literal helper names (`__cfHandler`, `__cfAction`). The list is `startsWith`-matched and the transformer emits the helper as a bare unsuffixed identifier (`BINDING_IDENTITY_HELPER_NAME` in `packages/utils/src/sandbox-contract.ts`), so the exact name as a prefix entry is the right shape. Dimming rides on `isSyntheticName` alone; `describeSynthetic` falling through to `null` is the accepted path for names without a tooltip descriptor.

- `packages/cli` suite: 175 passed (211 steps), 0 failed
- repo-wide `deno fmt --check` + `deno lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

