### PR TITLE
docs(ts-transformers): §17.6 names the test that pins the helper encodings

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -3046,9 +3046,12 @@ Consequence for maintenance: the transformer's AST helper builders
 sandbox-contract string builders are maintained **by hand in two encodings**.
 Any drift between them is loud — every transformed module carries at least
 `__cfHardenFn(h);` (§17.2), so a non-matching helper fails verification for
-every pattern load — but there is no unit test asserting the equivalence
-directly (`packages/utils/test/sandbox-contract.test.ts` covers only the
-trusted-name lists).
+every pattern load — and the equivalence is asserted directly by
+`packages/runner/test/sandbox-contract-helper-equivalence.test.ts`, which
+transforms a module and compares each emitted helper declaration's
+trivia-stripped text against the corresponding string builder's output
+(`packages/utils/test/sandbox-contract.test.ts` covers only the trusted-name
+lists).
 
 ### 17.7 Edge cases (observed)
 


### PR DESCRIPTION
## What

The current-behavior spec's §17.6 closing sentence claimed there is **no unit test asserting the equivalence directly** between the transformer's AST-built hardening helpers (`module-scope-function-hardening.ts`) and the sandbox-contract string builders (`packages/utils/src/sandbox-contract.ts`) — but `packages/runner/test/sandbox-contract-helper-equivalence.test.ts` does exactly that: it transforms a module and compares each emitted helper declaration's trivia-stripped text against the corresponding string builder's output.

Per the spec's authority rule (the current-behavior spec loses to code/tests), this updates the sentence to name the test. The still-true parenthetical that `packages/utils/test/sandbox-contract.test.ts` covers only the trusted-name lists is kept.

## Verification

- `packages/ts-transformers/test/spec-sync.test.ts` — passes (3/3 steps)
- `packages/runner/test/sandbox-contract-helper-equivalence.test.ts` — passes (so the newly cited claim is backed by a live green test)
- repo-wide `deno fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

