### PR TITLE
fix(dashboard): drop the unknown budget from the CI spend line

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -617,11 +617,13 @@ Notes:
   `CI_MONTHLY_BUDGET` overrides provider budgets. A single provider otherwise
   uses its own configured budget. With both providers, their budgets are added
   only when both exist. Blacksmith's budget is its monthly spending-alert
-  threshold. A failed configured source turns the tile gray and shows `$???`
-  for that source. The values from responding sources remain as a lower bound.
-  A source that has stopped reporting fails the same way. Both feeds report a
-  day or two after a day ends, and a settled day neither has a row for is a day
-  that cost nothing — which holds only while the feed is still being written.
+  threshold. A budget that resolves to no number is left out of the status line
+  rather than shown as an unknown amount. A failed configured source turns the
+  tile gray and shows `$???` for that source. The values from responding sources
+  remain as a lower bound. A source that has stopped reporting fails the same
+  way. Both feeds report a day or two after a day ends, and a settled day
+  neither has a row for is a day that cost nothing — which holds only while the
+  feed is still being written.
   Each is read no further than its own newest row reaches: GitHub's report is
   one pipeline across every product the org uses, so any product's row dates it,
   and Blacksmith's daily endpoint dates itself. Four days without a row is a

--- a/packages/dashboard/tiles/github-ci-spend.test.ts
+++ b/packages/dashboard/tiles/github-ci-spend.test.ts
@@ -312,7 +312,7 @@ Deno.test("ci spend: no Actions budget in GitHub -> the projection stands, uncom
   });
   assertEquals(none.value, "~$310/mo");
   assertEquals(none.sub, undefined);
-  assertStringIncludes(none.extra ?? "", "Budget $???");
+  assertEquals((none.extra ?? "").includes("Budget"), false);
   assertEquals(none.status, "good"); // an absent budget never alarms
   // The org budgets Actions' neighbors but not Actions.
   const other = await view("2026-01-20T09:00:00Z", {
@@ -322,7 +322,7 @@ Deno.test("ci spend: no Actions budget in GitHub -> the projection stands, uncom
     },
   });
   assertEquals(other.sub, undefined);
-  assertStringIncludes(other.extra ?? "", "Budget $???");
+  assertEquals((other.extra ?? "").includes("Budget"), false);
   assertEquals(other.status, "good");
 });
 
@@ -469,9 +469,9 @@ Deno.test("ci spend: both billing endpoints unreachable -> gray with a calm reas
     v.href,
     "https://github.com/organizations/acme/settings/billing",
   );
-  assertStringIncludes(
-    v.extra ?? "",
-    `${themedSwatch("#58a6ff")} GitHub $??? • Budget $???`,
+  assertEquals(
+    v.extra,
+    `<p class="sub">${themedSwatch("#58a6ff")} GitHub $???</p>`,
   );
 });
 
@@ -727,7 +727,7 @@ Deno.test("ci spend: a null threshold field is an unknown provider budget", asyn
   const result = await view(now, routes, BLACKSMITH_ENV);
   assertEquals(result.status, "good");
   assertEquals(result.value, "~$16/mo");
-  assertStringIncludes(result.extra ?? "", "Budget $???");
+  assertEquals((result.extra ?? "").includes("Budget"), false);
 });
 
 Deno.test("ci spend: Blacksmith token errors say how to restore the source", async () => {
@@ -931,7 +931,7 @@ Deno.test("ci spend: a partial provider budget is not treated as the combined bu
   );
 
   assertEquals(v.sub, undefined);
-  assertStringIncludes(v.extra ?? "", "Budget $???");
+  assertEquals((v.extra ?? "").includes("Budget"), false);
   assertEquals(v.status, "good");
 });
 

--- a/packages/dashboard/tiles/github-ci-spend.ts
+++ b/packages/dashboard/tiles/github-ci-spend.ts
@@ -574,7 +574,7 @@ export const githubCiSpend: Tile = {
             BLACKSMITH_COLOR,
             charted,
           ),
-          `Budget ${Number.isFinite(budget) ? usd(budget) : "$???"}`,
+          ...(Number.isFinite(budget) ? [`Budget ${usd(budget)}`] : []),
         ].join(" • ")
       }</p>`;
     if (present.length === 0) {


### PR DESCRIPTION
The `ci spend` tile's status line always ended with a budget entry. When no budget could be resolved, that entry read "Budget $???", which is the same notation the tile uses for a source it could not read.

The two mean different things. A source showing "$???" is a failure: the tile asked a billing API for a number, did not get one, and so the projection above it is a lower bound rather than a measurement. An unknown budget is not a failure. It means nobody set `CI_MONTHLY_BUDGET` and the provider account has no spending limit of its own, which is an ordinary configuration. Showing a routine absence in the notation reserved for broken sources reads as a second broken thing, on a tile that may already be reporting a real one.

There is nothing to compare the projection against when the budget is unknown, so the entry is now dropped instead of announced. This matches what the tile already did with the value: an unknown budget never moves the tile's color, and the projection simply stands uncompared. With a budget the line still reads "GitHub $180 • Budget $400"; without one it now stops after the sources.

The line cannot come out empty as a result. The tile returns early with a "set GH_TOKEN / BLACKSMITH_API_TOKEN" message when neither source is configured, so at least one source entry is always there to carry the line.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

