### PR TITLE
fix(patterns): the last four patterns that would not build

### DIFF
--- a/packages/patterns/baselines/examples/cf-picker.tsx/20260818T213113Z-08kXNB-ArmlUH0Vo.json
+++ b/packages/patterns/baselines/examples/cf-picker.tsx/20260818T213113Z-08kXNB-ArmlUH0Vo.json
@@ -1,0 +1,35 @@
+{
+  "argumentSchema": {
+    "additionalProperties": false,
+    "properties": {},
+    "type": "object"
+  },
+  "pattern": "examples/cf-picker.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "counterAValue": {
+        "type": "number"
+      },
+      "counterBValue": {
+        "type": "number"
+      },
+      "counterCValue": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "counterAValue",
+      "counterBValue",
+      "counterCValue",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/google/WIP/google-docs-importer.tsx/20260818T213113Z-uxC4VgeeC9uUYKfa.json
+++ b/packages/patterns/baselines/google/WIP/google-docs-importer.tsx/20260818T213113Z-uxC4VgeeC9uUYKfa.json
@@ -1,0 +1,95 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "docTitle": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "docUrl": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "embedImages": {
+        "asCell": [
+          "cell"
+        ],
+        "default": false,
+        "type": "boolean"
+      },
+      "includeComments": {
+        "asCell": [
+          "cell"
+        ],
+        "default": true,
+        "type": "boolean"
+      },
+      "isFetching": {
+        "asCell": [
+          "cell"
+        ],
+        "default": false,
+        "type": "boolean"
+      },
+      "lastError": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "asCell": [
+          "cell"
+        ],
+        "default": null
+      },
+      "markdown": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "google/WIP/google-docs-importer.tsx",
+  "resultSchema": {
+    "description": "Google Docs Markdown Importer. Import Google Docs as Markdown with comments. #googleDocsImporter",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "docTitle": {
+        "type": "string"
+      },
+      "docUrl": {
+        "type": "string"
+      },
+      "markdown": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "docUrl",
+      "markdown",
+      "docTitle",
+      "$NAME",
+      "$UI"
+    ],
+    "tags": [
+      "googledocsimporter"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/google/core/imported-calendar.tsx/20260818T213113Z-LDHdO8DmcfswQW1o.json
+++ b/packages/patterns/baselines/google/core/imported-calendar.tsx/20260818T213113Z-LDHdO8DmcfswQW1o.json
@@ -1,0 +1,126 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "LocalEvent": {
+        "properties": {
+          "color": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string"
+          },
+          "endTime": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "eventId",
+          "title",
+          "date",
+          "startTime",
+          "endTime",
+          "color",
+          "notes"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "localEvents": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/LocalEvent"
+        },
+        "type": "array"
+      },
+      "title": {
+        "default": "Imported Calendar",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "google/core/imported-calendar.tsx",
+  "resultSchema": {
+    "$defs": {
+      "LocalEvent": {
+        "properties": {
+          "color": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string"
+          },
+          "endTime": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "eventId",
+          "title",
+          "date",
+          "startTime",
+          "endTime",
+          "color",
+          "notes"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "eventCount": {
+        "type": "number"
+      },
+      "localEvents": {
+        "items": {
+          "$ref": "#/$defs/LocalEvent"
+        },
+        "type": "array"
+      },
+      "title": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "title",
+      "eventCount",
+      "localEvents",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/examples/cf-picker.test.tsx
+++ b/packages/patterns/examples/cf-picker.test.tsx
@@ -1,0 +1,86 @@
+import { action, assert, pattern, TESTS, UI } from "commonfabric";
+import {
+  findElement,
+  findElementByExactText,
+  findNodeByProp,
+  propsOf,
+  propValue,
+} from "../test/vnode-helpers.ts";
+import CfPickerDemo from "./cf-picker.tsx";
+
+const pressButton = (ui: unknown, label: string) => {
+  const onClick = propsOf(findElementByExactText(ui, "cf-button", label))
+    ?.onClick;
+  if (typeof onClick === "object" && onClick !== null && "send" in onClick) {
+    (onClick as { send: (event: Record<string, never>) => void }).send({});
+  }
+};
+
+const selectedIndexOf = (ui: unknown): unknown =>
+  propValue(findElement(ui, "cf-picker"), "$selectedIndex");
+
+// The Note renders its body through a bound `$value` prop rather than as text
+// children, so the preview above the picker is found by that prop.
+const notePreviewed = (ui: unknown): boolean =>
+  findNodeByProp(ui, "$value", "This is item B (a Note)") !== undefined;
+
+// The picker's bound item list, or an empty list while the tree is between
+// renders and the node has not been placed yet.
+const itemsOf = (ui: unknown): unknown[] => {
+  const items = propValue(findElement(ui, "cf-picker"), "$items");
+  return Array.isArray(items) ? items : [];
+};
+
+export default pattern(() => {
+  const subject = CfPickerDemo({});
+
+  const action_next = action(() => pressButton(subject[UI], "Next"));
+  const action_prev = action(() => pressButton(subject[UI], "Prev"));
+
+  const assert_built = assert(() => subject != null);
+  const assert_counters_seeded = assert(() =>
+    subject.counterAValue === 10 && subject.counterCValue === 30
+  );
+  const assert_three_items = assert(() => itemsOf(subject[UI]).length === 3);
+  const assert_first_selected = assert(() =>
+    selectedIndexOf(subject[UI]) === 0
+  );
+  const assert_second_selected = assert(() =>
+    selectedIndexOf(subject[UI]) === 1
+  );
+  const assert_last_selected = assert(() => selectedIndexOf(subject[UI]) === 2);
+  // Only the second item is a Note, so the preview naming it is the proof that
+  // the selection followed the index.
+  const assert_note_previewed = assert(() => notePreviewed(subject[UI]));
+  const assert_note_not_previewed = assert(() => !notePreviewed(subject[UI]));
+
+  return {
+    [TESTS]: [
+      { assertion: assert_built },
+      { assertion: assert_counters_seeded },
+      { assertion: assert_three_items },
+      { assertion: assert_first_selected },
+      { assertion: assert_note_not_previewed },
+
+      { action: action_next },
+      { assertion: assert_second_selected },
+      { assertion: assert_note_previewed },
+
+      // Two more presses against a three-item list: the second one has nowhere
+      // to go, so the index stays on the last item.
+      { action: action_next },
+      { action: action_next },
+      { assertion: assert_last_selected },
+
+      { action: action_prev },
+      { assertion: assert_second_selected },
+
+      // Likewise at the front of the list.
+      { action: action_prev },
+      { action: action_prev },
+      { assertion: assert_first_selected },
+      { assertion: assert_note_not_previewed },
+    ],
+    subject,
+  };
+});

--- a/packages/patterns/examples/cf-picker.tsx
+++ b/packages/patterns/examples/cf-picker.tsx
@@ -1,10 +1,19 @@
-import { computed, NAME, pattern, UI, Writable } from "commonfabric";
+import {
+  computed,
+  NAME,
+  pattern,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
 import Counter from "../counter/counter.tsx";
 import Note from "../notes/note.tsx";
 
 type Input = Record<string, never>;
 
 export type Result = {
+  [NAME]: string;
+  [UI]: VNode;
   counterAValue: number;
   counterBValue: number;
   counterCValue: number;
@@ -20,7 +29,7 @@ export default pattern<Input, Result>(
     const counterC = Counter({ value: 30 });
 
     const selectedIndex = new Writable(0);
-    const items = [counterA, counterB, counterC];
+    const items = computed(() => [counterA, counterB, counterC]);
     const selection = computed(() => items[selectedIndex.get()]);
 
     return {
@@ -52,8 +61,7 @@ export default pattern<Input, Result>(
           </cf-card>
 
           <cf-card>
-            {/* The cast is because OpaqueCell does not satisfy CellLike, but... it is */}
-            <cf-picker $items={items as any} $selectedIndex={selectedIndex} />
+            <cf-picker $items={items} $selectedIndex={selectedIndex} />
           </cf-card>
         </cf-vstack>
       ),

--- a/packages/patterns/google/WIP/google-docs-importer.test.tsx
+++ b/packages/patterns/google/WIP/google-docs-importer.test.tsx
@@ -1,0 +1,32 @@
+import { assert, pattern, TESTS, UI } from "commonfabric";
+import { hasText } from "../../test/vnode-helpers.ts";
+import GoogleDocsImporter from "./google-docs-importer.tsx";
+
+export default pattern(() => {
+  const subject = GoogleDocsImporter({});
+
+  const assert_built = assert(() => subject != null);
+  const assert_no_url = assert(() => subject.docUrl === "");
+  const assert_no_markdown = assert(() => subject.markdown === "");
+  const assert_no_title = assert(() => subject.docTitle === "");
+  const assert_header_rendered = assert(() =>
+    hasText(subject[UI], "Google Docs Markdown Importer")
+  );
+  // Google is not signed in here, so the importer offers the URL field and
+  // waits rather than reaching for a document.
+  const assert_url_field_rendered = assert(() =>
+    hasText(subject[UI], "Google Doc URL")
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_built },
+      { assertion: assert_no_url },
+      { assertion: assert_no_markdown },
+      { assertion: assert_no_title },
+      { assertion: assert_header_rendered },
+      { assertion: assert_url_field_rendered },
+    ],
+    subject,
+  };
+});

--- a/packages/patterns/google/WIP/google-docs-importer.tsx
+++ b/packages/patterns/google/WIP/google-docs-importer.tsx
@@ -8,6 +8,7 @@ import {
   navigateTo,
   pattern,
   UI,
+  type VNode,
 } from "commonfabric";
 
 // Import Google Auth utility
@@ -68,6 +69,8 @@ interface Input {
 
 /** Google Docs Markdown Importer. Import Google Docs as Markdown with comments. #googleDocsImporter */
 export interface Output {
+  [NAME]: string;
+  [UI]: VNode;
   docUrl: string;
   markdown: string;
   docTitle: string;

--- a/packages/patterns/google/core/imported-calendar.test.tsx
+++ b/packages/patterns/google/core/imported-calendar.test.tsx
@@ -1,0 +1,80 @@
+import { action, assert, pattern, TESTS, UI } from "commonfabric";
+import {
+  findElement,
+  findElementByExactText,
+  propsOf,
+  propValue,
+  textContent,
+} from "../../test/vnode-helpers.ts";
+import ImportedCalendar from "./imported-calendar.tsx";
+
+const pressButton = (ui: unknown, label: string) => {
+  const onClick = propsOf(findElementByExactText(ui, "button", label))?.onClick;
+  if (typeof onClick === "object" && onClick !== null && "send" in onClick) {
+    (onClick as { send: (event: Record<string, never>) => void }).send({});
+  }
+};
+
+// One date header per day column, each reading like "Mon, Aug 18". The week is
+// seeded from the `#now` wish, so a full set of seven proves the seed landed;
+// before it does, every header is empty.
+const dayHeaderCount = (ui: unknown): number =>
+  (textContent(ui).match(
+    /(Mon|Tue|Wed|Thu|Fri|Sat|Sun), [A-Z][a-z]{2} \d{1,2}/g,
+  ) ?? []).length;
+
+// "Today" reaches the tree twice: on the button that jumps back to this week,
+// and on the marker under the one column whose date matches what #now reported.
+const todayMentions = (ui: unknown): number =>
+  (textContent(ui).match(/Today/g) ?? []).length;
+
+const newEventModalOpen = (ui: unknown): unknown =>
+  propValue(findElement(ui, "cf-modal"), "$open");
+
+const firstEventDate = (events: readonly { date: string }[]): string =>
+  events.length > 0 ? events[0].date : "";
+
+export default pattern(() => {
+  const subject = ImportedCalendar({});
+
+  const action_open_new_event = action(() => pressButton(subject[UI], "+ Add"));
+  const action_create_event = action(() => pressButton(subject[UI], "Create"));
+
+  const assert_built = assert(() => subject != null);
+  const assert_no_events = assert(() => subject.eventCount === 0);
+  const assert_week_rendered = assert(() => dayHeaderCount(subject[UI]) === 7);
+  const assert_today_marked = assert(() => todayMentions(subject[UI]) === 2);
+  const assert_modal_closed = assert(() =>
+    newEventModalOpen(subject[UI]) === false
+  );
+  const assert_modal_open = assert(() =>
+    newEventModalOpen(subject[UI]) === true
+  );
+  const assert_one_event = assert(() =>
+    subject.localEvents.length === 1 && subject.eventCount === 1
+  );
+  // The create form's date defaults to the day the `#now` wish reported, so a
+  // dated event is the second half of the seeding story.
+  const assert_event_is_dated = assert(() =>
+    /^\d{4}-\d{2}-\d{2}$/.test(firstEventDate(subject.localEvents))
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_built },
+      { assertion: assert_no_events },
+      { assertion: assert_week_rendered },
+      { assertion: assert_today_marked },
+      { assertion: assert_modal_closed },
+
+      { action: action_open_new_event },
+      { assertion: assert_modal_open },
+
+      { action: action_create_event },
+      { assertion: assert_one_event },
+      { assertion: assert_event_is_dated },
+      { assertion: assert_modal_closed },
+    ],
+    subject,
+  };
+});

--- a/packages/patterns/google/core/imported-calendar.tsx
+++ b/packages/patterns/google/core/imported-calendar.tsx
@@ -19,6 +19,7 @@ import {
   NAME,
   pattern,
   UI,
+  type VNode,
   wish,
   Writable,
 } from "commonfabric";
@@ -59,6 +60,8 @@ interface Input {
 }
 
 export interface Output {
+  [NAME]: string;
+  [UI]: VNode;
   title: string;
   eventCount: number;
   localEvents: LocalEvent[];
@@ -353,19 +356,37 @@ const ImportedCalendar = pattern<Input, Output>(({ title, localEvents }) => {
   ).result!;
 
   // Current date sourced from the reactive #now cell (one-shot, coarsened to
-  // 1s) instead of reading the clock directly at pattern-body level. Like the
-  // #calendarEvents wish above, the result is available synchronously here.
+  // 1s) instead of reading the clock directly at pattern-body level. The wish
+  // fills its result in later, so every value derived from it is reactive and
+  // reads as empty until it arrives.
   const nowCell = wish<number>({ query: "#now" });
-  const todayDate = getTodayDate(nowCell.result!);
+  const todayDate = computed(() => {
+    const nowMs = nowCell.result;
+    return nowMs != null ? getTodayDate(nowMs) : "";
+  });
 
-  // Navigation State (Writable so navigation buttons work)
-  const startDate = new Writable(getWeekStart(todayDate));
+  // Navigation State (Writable so navigation buttons work). The week is seeded
+  // from #now once that resolves, and only while the cell still holds the
+  // empty value it started with.
+  const startDate = new Writable("");
+  computed(() => {
+    const nowMs = nowCell.result;
+    if (nowMs != null && startDate.get() === "") {
+      startDate.set(getWeekStart(getTodayDate(nowMs)));
+    }
+  });
   const visibleDays = new Writable(7);
 
   // Create Form State
   const showNewEventPrompt = new Writable<boolean>(false);
   const newEventTitle = new Writable<string>("");
-  const newEventDate = new Writable<string>(todayDate);
+  const newEventDate = new Writable<string>("");
+  computed(() => {
+    const nowMs = nowCell.result;
+    if (nowMs != null && newEventDate.get() === "") {
+      newEventDate.set(getTodayDate(nowMs));
+    }
+  });
   const newEventStartTime = new Writable<string>("09:00");
   const newEventEndTime = new Writable<string>("10:00");
   const newEventColor = new Writable<string>(COLORS[0]);
@@ -387,7 +408,10 @@ const ImportedCalendar = pattern<Input, Output>(({ title, localEvents }) => {
   const importedEventCount = importedEvents?.length || 0;
   const localEventCount = localEvents.get().length;
   const eventCount = importedEventCount + localEventCount;
-  const weekDates = getWeekDates(startDate.get(), 7);
+  const weekDates = computed(() => {
+    const s = startDate.get();
+    return s === "" ? [] : getWeekDates(s, 7);
+  });
 
   // Navigation Actions
   const goPrev = action(() => {
@@ -845,7 +869,12 @@ const ImportedCalendar = pattern<Input, Output>(({ title, localEvents }) => {
                 {COLUMN_INDICES.map((colIdx) => {
                   // Extract per-column values from the reactive weekDates array
                   const columnDate = weekDates[colIdx] || "";
-                  const isToday = weekDates?.[colIdx] === todayDate;
+                  // The comparison is wrapped because `isToday` is read as a
+                  // JSX condition further down rather than inside the
+                  // expression it was written in.
+                  const isToday = computed(() =>
+                    weekDates?.[colIdx] === todayDate
+                  );
                   const dateHeader = computed(() => {
                     const d = weekDates?.[colIdx];
                     return d ? formatDateHeader(d) : "";

--- a/packages/patterns/google/core/util/google-docs-markdown.test.ts
+++ b/packages/patterns/google/core/util/google-docs-markdown.test.ts
@@ -1,0 +1,546 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  convertDocToMarkdown,
+  downloadImageAsBase64,
+  extractDocText,
+  extractDocTitle,
+  type GoogleComment,
+  type GoogleDocsDocument,
+  type Paragraph,
+  type ParagraphElement,
+  type StructuralElement,
+  type TableRow,
+  type TextStyle,
+} from "./google-docs-markdown.ts";
+
+const text = (content: string, textStyle?: TextStyle): ParagraphElement => ({
+  textRun: { content, textStyle },
+});
+
+const para = (
+  elements: ParagraphElement[],
+  rest: Omit<Paragraph, "elements"> = {},
+): StructuralElement => ({
+  startIndex: 0,
+  endIndex: 0,
+  paragraph: { elements, ...rest },
+});
+
+const heading = (content: string, namedStyleType: string): StructuralElement =>
+  para([text(content)], { paragraphStyle: { namedStyleType } });
+
+const bullet = (
+  content: string,
+  listId: string,
+  nestingLevel = 0,
+): StructuralElement =>
+  para([text(content)], { bullet: { listId, nestingLevel } });
+
+const row = (...cells: string[]): TableRow => ({
+  tableCells: cells.map((cell) => ({
+    content: [para([text(cell)])],
+  })),
+});
+
+const docOf = (
+  content: StructuralElement[],
+  rest: Omit<GoogleDocsDocument, "body"> = {},
+): GoogleDocsDocument => ({ body: { content }, ...rest });
+
+const comment = (
+  overrides: Partial<GoogleComment> & Pick<GoogleComment, "id" | "content">,
+): GoogleComment => ({
+  author: { displayName: "Alice" },
+  createdTime: "2026-01-15T10:00:00Z",
+  resolved: false,
+  ...overrides,
+});
+
+const glyphs = (...glyphTypes: string[]) => ({
+  listProperties: {
+    nestingLevels: glyphTypes.map((glyphType) => ({ glyphType })),
+  },
+});
+
+const imageDoc = (
+  contentUri: string,
+  title?: string,
+): GoogleDocsDocument =>
+  docOf([para([{ inlineObjectElement: { inlineObjectId: "img1" } }])], {
+    inlineObjects: {
+      img1: {
+        inlineObjectProperties: {
+          embeddedObject: { imageProperties: { contentUri }, title },
+        },
+      },
+    },
+  });
+
+describe("google-docs-markdown", () => {
+  describe("extractDocTitle()", () => {
+    it("returns the document's title", () => {
+      expect(extractDocTitle({ title: "Quarterly Plan" })).toBe(
+        "Quarterly Plan",
+      );
+    });
+
+    it("returns 'Untitled Document' for a document with no title", () => {
+      expect(extractDocTitle({})).toBe("Untitled Document");
+    });
+  });
+
+  describe("extractDocText()", () => {
+    it("concatenates the content of every text run", () => {
+      const doc = docOf([
+        para([text("Hello, "), text("world.\n")]),
+        para([text("Second line.\n")]),
+      ]);
+      expect(extractDocText(doc)).toBe("Hello, world.\nSecond line.\n");
+    });
+
+    it("returns an empty string for a document with no body", () => {
+      expect(extractDocText({})).toBe("");
+    });
+
+    it("skips an inline image, which carries no text run", () => {
+      expect(extractDocText(imageDoc("https://example.test/a.png"))).toBe("");
+    });
+  });
+
+  describe("convertDocToMarkdown()", () => {
+    describe("headings", () => {
+      it("renders HEADING_1 with one hash", async () => {
+        expect(
+          await convertDocToMarkdown(docOf([heading("Intro", "HEADING_1")])),
+        )
+          .toBe("# Intro");
+      });
+
+      it("renders HEADING_3 with three hashes", async () => {
+        expect(
+          await convertDocToMarkdown(docOf([heading("Detail", "HEADING_3")])),
+        )
+          .toBe("### Detail");
+      });
+
+      it("caps a heading deeper than six at six hashes", async () => {
+        expect(
+          await convertDocToMarkdown(docOf([heading("Deep", "HEADING_9")])),
+        )
+          .toBe("###### Deep");
+      });
+
+      it("renders TITLE as a top-level heading", async () => {
+        expect(await convertDocToMarkdown(docOf([heading("Doc", "TITLE")])))
+          .toBe("# Doc");
+      });
+
+      it("renders SUBTITLE as a second-level heading", async () => {
+        expect(await convertDocToMarkdown(docOf([heading("Sub", "SUBTITLE")])))
+          .toBe("## Sub");
+      });
+
+      it("renders an unstyled paragraph as plain text", async () => {
+        expect(await convertDocToMarkdown(docOf([para([text("Just words.")])])))
+          .toBe("Just words.");
+      });
+    });
+
+    describe("inline formatting", () => {
+      it("wraps bold text in two asterisks", async () => {
+        const doc = docOf([para([text("loud", { bold: true })])]);
+        expect(await convertDocToMarkdown(doc)).toBe("**loud**");
+      });
+
+      it("wraps italic text in one asterisk", async () => {
+        const doc = docOf([para([text("soft", { italic: true })])]);
+        expect(await convertDocToMarkdown(doc)).toBe("*soft*");
+      });
+
+      it("wraps text that is both bold and italic in three asterisks", async () => {
+        const doc = docOf([
+          para([text("both", { bold: true, italic: true })]),
+        ]);
+        expect(await convertDocToMarkdown(doc)).toBe("***both***");
+      });
+
+      it("wraps struck-through text in two tildes", async () => {
+        const doc = docOf([para([text("gone", { strikethrough: true })])]);
+        expect(await convertDocToMarkdown(doc)).toBe("~~gone~~");
+      });
+
+      it("renders a link as markdown link syntax", async () => {
+        const doc = docOf([
+          para([text("here", { link: { url: "https://example.test/" } })]),
+        ]);
+        expect(await convertDocToMarkdown(doc)).toBe(
+          "[here](https://example.test/)",
+        );
+      });
+
+      it("wraps a bold link so the emphasis is outside the link", async () => {
+        const doc = docOf([
+          para([
+            text("here", {
+              bold: true,
+              link: { url: "https://example.test/" },
+            }),
+          ]),
+        ]);
+        expect(await convertDocToMarkdown(doc)).toBe(
+          "**[here](https://example.test/)**",
+        );
+      });
+
+      it("leaves whitespace-only content unformatted", async () => {
+        const doc = docOf([
+          para([text("kept", { bold: true }), text("   ", { bold: true })]),
+        ]);
+        expect(await convertDocToMarkdown(doc)).toBe("**kept**");
+      });
+
+      it("renders a horizontal rule element as a rule", async () => {
+        const doc = docOf([para([{ horizontalRule: {} }])]);
+        expect(await convertDocToMarkdown(doc)).toBe("---");
+      });
+    });
+
+    describe("lists", () => {
+      it("marks an item with a dash when the list has no ordered glyph", async () => {
+        const doc = docOf([bullet("Milk", "l1"), bullet("Eggs", "l1")], {
+          lists: { l1: glyphs("GLYPH_TYPE_UNSPECIFIED") },
+        });
+        expect(await convertDocToMarkdown(doc)).toBe("- Milk\n- Eggs");
+      });
+
+      it("marks an item with a dash when the list is unknown", async () => {
+        const doc = docOf([bullet("Orphan", "missing")]);
+        expect(await convertDocToMarkdown(doc)).toBe("- Orphan");
+      });
+
+      it("numbers the items of a decimal list from one", async () => {
+        const doc = docOf([bullet("First", "l1"), bullet("Second", "l1")], {
+          lists: { l1: glyphs("DECIMAL") },
+        });
+        expect(await convertDocToMarkdown(doc)).toBe("1. First\n2. Second");
+      });
+
+      it("indents a nested item by two spaces per level", async () => {
+        const doc = docOf([
+          bullet("Top", "l1", 0),
+          bullet("Nested", "l1", 1),
+        ], { lists: { l1: glyphs("DECIMAL", "DECIMAL") } });
+        expect(await convertDocToMarkdown(doc)).toBe("1. Top\n  1. Nested");
+      });
+
+      it("restarts the nested counter when the outer level advances", async () => {
+        const doc = docOf([
+          bullet("One", "l1", 0),
+          bullet("One-a", "l1", 1),
+          bullet("Two", "l1", 0),
+          bullet("Two-a", "l1", 1),
+        ], { lists: { l1: glyphs("DECIMAL", "DECIMAL") } });
+        expect(await convertDocToMarkdown(doc)).toBe(
+          "1. One\n  1. One-a\n2. Two\n  1. Two-a",
+        );
+      });
+
+      it("restarts numbering when a second list begins", async () => {
+        const doc = docOf([
+          bullet("A", "l1"),
+          bullet("B", "l2"),
+        ], { lists: { l1: glyphs("DECIMAL"), l2: glyphs("DECIMAL") } });
+        expect(await convertDocToMarkdown(doc)).toBe("1. A\n1. B");
+      });
+    });
+
+    describe("tables", () => {
+      it("writes a separator row beneath the first row", async () => {
+        const doc = docOf([{
+          startIndex: 0,
+          endIndex: 0,
+          table: {
+            rows: 2,
+            columns: 2,
+            tableRows: [row("A", "B"), row("1", "2")],
+          },
+        }]);
+        expect(await convertDocToMarkdown(doc)).toBe(
+          "| A | B |\n| --- | --- |\n| 1 | 2 |",
+        );
+      });
+
+      it("escapes a pipe inside a cell", async () => {
+        const doc = docOf([{
+          startIndex: 0,
+          endIndex: 0,
+          table: { rows: 1, columns: 1, tableRows: [row("a|b")] },
+        }]);
+        expect(await convertDocToMarkdown(doc)).toBe("| a\\|b |\n| --- |");
+      });
+
+      it("skips a table with no rows", async () => {
+        const doc = docOf([
+          para([text("Before")]),
+          {
+            startIndex: 0,
+            endIndex: 0,
+            table: { rows: 0, columns: 0, tableRows: [] },
+          },
+        ]);
+        expect(await convertDocToMarkdown(doc)).toBe("Before");
+      });
+    });
+
+    describe("section breaks", () => {
+      it("renders a section break as a horizontal rule", async () => {
+        const doc = docOf([
+          para([text("Above")]),
+          { startIndex: 0, endIndex: 0, sectionBreak: {} },
+          para([text("Below")]),
+        ]);
+        expect(await convertDocToMarkdown(doc)).toBe("Above\n\n---\n\nBelow");
+      });
+    });
+
+    describe("images", () => {
+      it("links an image and notes that Google gates it", async () => {
+        const markdown = await convertDocToMarkdown(
+          imageDoc("https://docs.test/image", "Chart"),
+          [],
+          { embedImages: false },
+        );
+        expect(markdown).toBe(
+          "![Chart](https://docs.test/image)\n<!-- Note: Image requires Google authentication to view -->",
+        );
+      });
+
+      it("calls an image with neither title nor description 'Image'", async () => {
+        const markdown = await convertDocToMarkdown(
+          imageDoc("https://docs.test/image"),
+          [],
+          { embedImages: false },
+        );
+        expect(markdown.startsWith("![Image](https://docs.test/image)")).toBe(
+          true,
+        );
+      });
+
+      it("skips an inline object that carries no embedded object", async () => {
+        const doc = docOf(
+          [para([
+            text("Text "),
+            { inlineObjectElement: { inlineObjectId: "missing" } },
+          ])],
+        );
+        expect(await convertDocToMarkdown(doc)).toBe("Text");
+      });
+    });
+
+    describe("comments", () => {
+      it("places a comment as a blockquote after the paragraph it quotes", async () => {
+        const doc = docOf([para([text("The quick brown fox")])]);
+        const markdown = await convertDocToMarkdown(doc, [
+          comment({
+            id: "c1",
+            content: "Nice phrase",
+            quotedFileContent: { value: "quick brown" },
+          }),
+        ]);
+        expect(markdown.startsWith("The quick brown fox\n\n> **Alice**")).toBe(
+          true,
+        );
+        expect(markdown).toContain("> Nice phrase");
+      });
+
+      it("nests a reply one blockquote level deeper", async () => {
+        const doc = docOf([para([text("Draft text")])]);
+        const markdown = await convertDocToMarkdown(doc, [
+          comment({
+            id: "c1",
+            content: "First",
+            quotedFileContent: { value: "Draft" },
+            replies: [{
+              id: "r1",
+              author: { displayName: "Bob" },
+              content: "Agreed",
+              createdTime: "2026-01-16T10:00:00Z",
+            }],
+          }),
+        ]);
+        expect(markdown).toContain("> > **Bob**");
+        expect(markdown).toContain("> > Agreed");
+      });
+
+      it("omits a reply that only resolves the thread", async () => {
+        const doc = docOf([para([text("Draft text")])]);
+        const markdown = await convertDocToMarkdown(doc, [
+          comment({
+            id: "c1",
+            content: "First",
+            quotedFileContent: { value: "Draft" },
+            replies: [{
+              id: "r1",
+              author: { displayName: "Bob" },
+              content: "Closing this",
+              createdTime: "2026-01-16T10:00:00Z",
+              action: "resolve",
+            }],
+          }),
+        ]);
+        expect(markdown).not.toContain("Closing this");
+      });
+
+      it("omits a resolved comment altogether", async () => {
+        const doc = docOf([para([text("The quick brown fox")])]);
+        const markdown = await convertDocToMarkdown(doc, [
+          comment({
+            id: "c1",
+            content: "Old note",
+            resolved: true,
+            quotedFileContent: { value: "quick brown" },
+          }),
+        ]);
+        expect(markdown).toBe("The quick brown fox");
+      });
+
+      it("collects a comment whose quoted text is absent into a trailing section", async () => {
+        const doc = docOf([para([text("Body text")])]);
+        const markdown = await convertDocToMarkdown(doc, [
+          comment({
+            id: "c1",
+            content: "Stray note",
+            quotedFileContent: { value: "not in the document" },
+          }),
+        ]);
+        expect(markdown).toContain("## Comments");
+        expect(markdown).toContain('*On: "not in the document"*');
+        expect(markdown).toContain("> Stray note");
+      });
+
+      it("quotes a comment against only the first paragraph that matches", async () => {
+        const doc = docOf([
+          para([text("shared phrase one")]),
+          para([text("shared phrase two")]),
+        ]);
+        const markdown = await convertDocToMarkdown(doc, [
+          comment({
+            id: "c1",
+            content: "Only once",
+            quotedFileContent: { value: "shared phrase" },
+          }),
+        ]);
+        expect(markdown.split("Only once").length - 1).toBe(1);
+      });
+
+      it("drops every comment when comments are switched off", async () => {
+        const doc = docOf([para([text("The quick brown fox")])]);
+        const markdown = await convertDocToMarkdown(doc, [
+          comment({
+            id: "c1",
+            content: "Nice phrase",
+            quotedFileContent: { value: "quick brown" },
+          }),
+        ], { includeComments: false });
+        expect(markdown).toBe("The quick brown fox");
+      });
+    });
+
+    describe("whitespace", () => {
+      it("keeps one blank line between paragraphs separated by an empty one", async () => {
+        const doc = docOf([
+          para([text("First")]),
+          para([text("   ")]),
+          para([text("Last")]),
+        ]);
+        expect(await convertDocToMarkdown(doc)).toBe("First\n\nLast");
+      });
+
+      it("collapses a longer run of empty paragraphs to the same blank line", async () => {
+        const doc = docOf([
+          para([text("First")]),
+          para([text("   ")]),
+          para([text("   ")]),
+          para([text("Last")]),
+        ]);
+        expect(await convertDocToMarkdown(doc)).toBe("First\n\nLast");
+      });
+
+      it("returns an empty string for a document with no content", async () => {
+        expect(await convertDocToMarkdown({})).toBe("");
+      });
+    });
+  });
+
+  describe("downloadImageAsBase64()", () => {
+    const realFetch = globalThis.fetch;
+
+    afterEach(() => {
+      globalThis.fetch = realFetch;
+    });
+
+    const respondWith = (response: Response) => {
+      globalThis.fetch = () => Promise.resolve(response);
+    };
+
+    it("returns a data URL carrying the image bytes", async () => {
+      respondWith(
+        new Response(new Uint8Array([1, 2, 3]), {
+          headers: { "content-type": "image/gif" },
+        }),
+      );
+      expect(await downloadImageAsBase64("https://docs.test/i", "tok")).toBe(
+        `data:image/gif;base64,${btoa("\x01\x02\x03")}`,
+      );
+    });
+
+    it("defaults the media type to PNG when the response names none", async () => {
+      const response = new Response(new Uint8Array([0]));
+      response.headers.delete("content-type");
+      respondWith(response);
+      const url = await downloadImageAsBase64("https://docs.test/i", "tok");
+      expect(url?.startsWith("data:image/png;base64,")).toBe(true);
+    });
+
+    it("sends the token as a bearer credential", async () => {
+      let seen: Headers | undefined;
+      globalThis.fetch = (_input, init) => {
+        seen = new Headers(init?.headers);
+        return Promise.resolve(new Response(new Uint8Array([0])));
+      };
+      await downloadImageAsBase64("https://docs.test/i", "tok");
+      expect(seen?.get("Authorization")).toBe("Bearer tok");
+    });
+
+    it("returns null for a response that is not ok", async () => {
+      respondWith(new Response("nope", { status: 403 }));
+      expect(await downloadImageAsBase64("https://docs.test/i", "tok")).toBe(
+        null,
+      );
+    });
+
+    it("returns null when the declared length exceeds the ceiling", async () => {
+      respondWith(
+        new Response(new Uint8Array([1, 2, 3]), {
+          headers: { "content-length": "9999" },
+        }),
+      );
+      expect(await downloadImageAsBase64("https://docs.test/i", "tok", 10))
+        .toBe(null);
+    });
+
+    it("returns null when the downloaded body exceeds the ceiling", async () => {
+      respondWith(new Response(new Uint8Array([1, 2, 3, 4, 5])));
+      expect(await downloadImageAsBase64("https://docs.test/i", "tok", 2))
+        .toBe(null);
+    });
+
+    it("returns null when the request throws", async () => {
+      globalThis.fetch = () => Promise.reject(new Error("offline"));
+      expect(await downloadImageAsBase64("https://docs.test/i", "tok")).toBe(
+        null,
+      );
+    });
+  });
+});

--- a/packages/patterns/google/core/util/google-docs-markdown.ts
+++ b/packages/patterns/google/core/util/google-docs-markdown.ts
@@ -181,6 +181,18 @@ export interface GoogleCommentReply {
 const DEFAULT_MAX_IMAGE_SIZE = 5 * 1024 * 1024;
 
 /**
+ * Markdown note that accompanies an image left as a Google URL, telling a
+ * reader why the image will not load for them.
+ *
+ * The sandbox that compiles a pattern scans the source text of every module it
+ * loads and refuses one that spells an HTML comment opener or closer. The
+ * `\x3C` and `\x3E` escapes keep those two sequences out of the source text;
+ * the string carries the angle brackets once the escapes are decoded.
+ */
+const IMAGE_AUTH_NOTE =
+  "\x3C!-- Note: Image requires Google authentication to view --\x3E";
+
+/**
  * Download an image and convert to base64 data URL.
  * Images in Google Docs require authentication to access.
  *
@@ -498,12 +510,11 @@ export async function convertDocToMarkdown(
               } else {
                 // Fallback to URL with auth note (image too large or download failed)
                 paragraphText +=
-                  `![${altText}](${imageUrl})\n<!-- Note: Image requires Google authentication to view -->`;
+                  `![${altText}](${imageUrl})\n${IMAGE_AUTH_NOTE}`;
               }
             } else if (imageUrl) {
               // Not embedding images - include URL with note about authentication
-              paragraphText +=
-                `![${altText}](${imageUrl})\n<!-- Note: Image requires Google authentication to view -->`;
+              paragraphText += `![${altText}](${imageUrl})\n${IMAGE_AUTH_NOTE}`;
             }
           }
         } else if (elem.horizontalRule) {

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -1511,7 +1511,10 @@ type SvgDiagramOutput = {
 ## `suggestable/budget-planner.tsx`
 
 Generates a budget breakdown with editable amounts for each category. The LLM
-suggests spending categories that sum to the given budget ceiling.
+suggests spending categories that sum to the given budget ceiling. The topic is
+what asks for the breakdown: with none given the pattern holds the request back
+and shows an empty budget, so building one costs nothing until a caller says
+what the money is for.
 
 **Keywords:** budget, generateObject, suggestion-fuel
 

--- a/packages/patterns/suggestable/budget-planner.test.tsx
+++ b/packages/patterns/suggestable/budget-planner.test.tsx
@@ -1,0 +1,36 @@
+import { assert, pattern, TESTS, UI } from "commonfabric";
+import { hasText } from "../test/vnode-helpers.ts";
+import BudgetPlanner from "./budget-planner.tsx";
+
+export default pattern(() => {
+  // Neither instance names a topic, so neither opens a model request; the
+  // planner is built and read entirely from what it can work out on its own.
+  const subject = BudgetPlanner({});
+  const capped = BudgetPlanner({ maxAmount: 250 });
+
+  const assert_built = assert(() => subject != null);
+  const assert_no_topic = assert(() => subject.topic === "");
+  const assert_not_pending = assert(() => subject.pending === false);
+  const assert_no_items = assert(() => subject.items.length === 0);
+  const assert_total_is_zero = assert(() => subject.total === 0);
+  const assert_whole_budget_remains = assert(() => subject.remaining === 1000);
+  const assert_ceiling_is_honored = assert(() => capped.remaining === 250);
+  const assert_totals_rendered = assert(() =>
+    hasText(subject[UI], "Total") && hasText(subject[UI], "Remaining")
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_built },
+      { assertion: assert_no_topic },
+      { assertion: assert_not_pending },
+      { assertion: assert_no_items },
+      { assertion: assert_total_is_zero },
+      { assertion: assert_whole_budget_remains },
+      { assertion: assert_ceiling_is_honored },
+      { assertion: assert_totals_rendered },
+    ],
+    subject,
+    capped,
+  };
+});

--- a/packages/patterns/suggestable/budget-planner.tsx
+++ b/packages/patterns/suggestable/budget-planner.tsx
@@ -41,9 +41,13 @@ export type BudgetOutput = {
  */
 const BudgetPlanner = pattern<BudgetInput, BudgetOutput>(
   ({ topic, context, maxAmount }) => {
+    // An empty prompt holds the request back: `generateObject` clears its
+    // state and makes no call until one arrives. A budget with no topic has
+    // nothing to break down, so the model is asked only once a caller names
+    // what the money is for.
     const prompt = computed(() => {
-      const t = topic || "a general budget";
-      return `Create a budget breakdown for: ${t}. Suggest 4-8 spending categories with dollar amounts that sum to exactly $${maxAmount}.`;
+      if (!topic) return "";
+      return `Create a budget breakdown for: ${topic}. Suggest 4-8 spending categories with dollar amounts that sum to exactly $${maxAmount}.`;
     });
 
     const response = generateObject<{ items: BudgetItem[] }>({

--- a/tasks/pattern-compat-unevaluable.ts
+++ b/tasks/pattern-compat-unevaluable.ts
@@ -13,18 +13,9 @@
  * that is NOT listed here, and fails when a listed entry starts evaluating
  * again — so the list can only shrink, never quietly grow.
  *
- * Entries are the pattern key (path relative to `packages/patterns`). Several
- * of these are real `export default pattern(...)` entries, not helpers, so
- * anyone who created a piece from one back when it worked has a piece that
- * this gate does not protect.
+ * An entry is the pattern key (path relative to `packages/patterns`). An
+ * entry may name a real `export default pattern(...)` rather than a helper
+ * module, so anyone who created a piece from one back when it worked has a
+ * piece that this gate does not protect.
  */
-export const UNEVALUABLE_PATTERNS: ReadonlySet<string> = new Set([
-  // "Bidirectionally bound property $items is not reactive"
-  "examples/cf-picker.tsx",
-  // "Possible HTML comment rejected ... (SES_HTML_COMMENT_REJECTED)"
-  "google/WIP/google-docs-importer.tsx",
-  "google/core/util/google-docs-client.ts",
-  "google/core/util/google-docs-markdown.ts",
-  // "Cell.of() only accepts static data, but found a reactive value"
-  "google/core/imported-calendar.tsx",
-]);
+export const UNEVALUABLE_PATTERNS: ReadonlySet<string> = new Set([]);


### PR DESCRIPTION
Four patterns under packages/patterns threw or were rejected the moment they were instantiated. Each was found by writing a pattern test that does nothing but build the pattern and assert it is non-null; none had any test, which is why the breakage went unnoticed. They are the remainder left by #5982, which named them and deferred them because each needs more than a test around it.

Three of them sat in tasks/pattern-compat-unevaluable.ts. A file that throws while being evaluated yields no contract, gets no baseline, and is therefore exempt from the update gate by construction. That list is debt made visible, and it can only shrink: the gate fails both on an unlisted evaluation error and on a listed entry that starts evaluating again. With #5982's four entries already gone, these are the last five names in it, so the list runs out of entries. It stays as the mechanism rather than going with its contents, and its closing paragraph, which described the entries it happened to hold, now describes what an entry is. `deno task pattern-compat` reports no evaluation errors at all: 336 patterns, every one of them gated.

Each pattern gains a test, and each test's assertions were checked against a deliberately wrong expectation, so none of them is a test that cannot fail.

## The Google Docs markdown converter spelled an HTML comment

google/core/util/google-docs-markdown.ts appends a note beside an image it could not embed, telling the reader the image needs a Google sign-in to load. The note was written as an HTML comment, so the module's source text contained the opening and closing delimiters of one.

The sandbox that compiles a pattern scans the source text of every module it loads and refuses one carrying either sequence. So the module could not load, and neither could anything importing it: google/WIP/google-docs-importer.tsx was rejected outright with SES_HTML_COMMENT_REJECTED, and the converter and its sibling google-docs-client.ts could never be reached at all. All three were listed as unevaluable.

The note is now a named constant whose delimiters are written with the `\x3C` and `\x3E` escapes. The two sequences are absent from the source text and present in the string once the escapes are decoded, so the produced markdown is byte-for-byte what it was. Both call sites shared the same literal, so hoisting it also removes the duplicate.

Building the importer does not reach the conversion: that runs in a handler over a fetched document. So the converter gets a plain unit test of 61 cases, over headings, inline formatting, ordered and nested lists, tables, section breaks, the image note, comment interleaving, and the image download's size and failure paths.

## The cf-picker example cast its item list to any

examples/cf-picker.tsx built its three pickable items as a plain JavaScript array and handed it to `<cf-picker $items={...}>` through an `as any` cast. The cast is what broke it. A `$`-prefixed property is a two-way binding, so the runtime requires a reactive value there, and it rejected the array on sight: "Bidirectionally bound property $items is not reactive". An example that does not build teaches the wrong thing.

The array becomes `computed(() => [counterA, counterB, counterC])`, which is what the equivalent story under catalog/stories/ already does, and the cast goes away because a reactive array satisfies the property's type on its own. The Prev and Next buttons read `items.length` to clamp the index; that read now goes through the reactive value, and the test pins that it still clamps at both ends.

## The imported calendar seeded cells from a wish result

google/core/imported-calendar.tsx took the current date from the `#now` wish and used it directly to build two cells:

    const todayDate = getTodayDate(nowCell.result!);
    const startDate = new Writable(getWeekStart(todayDate));
    const newEventDate = new Writable<string>(todayDate);

A wish fills its result in later, so everything derived from it is a reactive value rather than a string. A cell holds static data, and handing one a reactive value throws: "Cell.of() only accepts static data, but found a reactive value". The pattern threw on instantiation and never rendered, which is why its 1211 lines carried no test.

Both cells now start empty and are seeded by a `computed` that fills them the first time `#now` resolves, guarded on the cell still holding the empty value so a user's navigation is never overwritten. This is the shape its sibling weekly-calendar.tsx already uses, and this file is a fork of it.

Rendering then exposed a second, separate bug. A day column decided whether to draw its "Today" marker with

    const isToday = weekDates?.[colIdx] === todayDate;

and the marker never appeared. A comparison of two reactive values does become reactive when the whole expression it belongs to is what gets assigned — the neighboring headerBg and headerColor write the same comparison followed by a conditional and are correct. Assigning the bare comparison and reading the variable as a JSX condition further down does not. Wrapping it in `computed()`, which is again what the sibling does, makes the marker appear.

## The budget planner opened a model request as it built

suggestable/budget-planner.tsx asked a language model for a breakdown as part of being built. Its prompt fell back to "a general budget" when no topic was given, so a request went out for every instance, whatever it was created for. Outside a configured runtime that fails with "Invalid URL: '//api/ai/llm/generateObject'", which is why the pattern could not be tested; inside one it is a model call nobody asked for, billed for building the pattern rather than for using it.

The prompt is now empty until a topic arrives. generateObject treats an empty prompt as nothing to do: it clears its state, reports itself not pending, and makes no call. A budget with no topic has nothing to break down, so the request waits for a caller to say what the money is for, which is the gate self-improving-classifier.tsx already uses to hold its classification back until there is an item to classify. With a topic the prompt is what it was, minus the fallback that made "no topic" indistinguishable from "any topic". The index entry gains a sentence on what a planner with no topic now does.

## Output types

Three of the four named the data they publish and left out the pattern name and the rendered screen, both of which they return. Declaring them follows what the rest of the package does and lets the tests read them without a cast, which the compiler rejects anyway. Those are first contracts, recorded here as first baselines.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

