### PR TITLE
refactor(data-model): the JSON format has one boundary, not two

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -2497,8 +2497,8 @@ is not part of the public boundary interface.
  *
  * Deep-frozen invariant on the decode side: every such tree that
  * enters decoding is deep-frozen, enforced at the two construction
- * sites that feed it (`decode()` and `#fromBytes()`, unified in
- * `#parseWireText()`). This is what lets the tag-unwrap and `/quote` arms
+ * site that feeds it, `parseWireText()`. This is what lets the tag-unwrap and
+ * `/quote` arms
  * hand back extracted sub-trees directly without further copying. The
  * encode-side trees are transient (`JSON.stringify`-ed and discarded)
  * and are not covered by this invariant. The `readonly` on the array and
@@ -2517,8 +2517,10 @@ export type JsonCodecValue =
 ### 4.3 Public Boundary
 
 Every engine exposes `encode()` and `decode()`, parameterized by the boundary
-type — `string` for JSON, `Uint8Array` for a binary format — and an engine may
-add a pair for a second boundary type, as `JsonCodecEngine` does for bytes.
+type — `string` for JSON, `Uint8Array` for a binary format. An engine may add a
+pair for a second boundary type, though none does: a second pair over the same
+walk is API a caller can write for itself, and it invites the two forms to
+drift.
 Both are supplied by the base class and are not overridden: they mint the act
 and hand the work to it. An engine is otherwise its configuration — the codec
 registry and the leniency setting — and the two factories that say which act
@@ -2578,7 +2580,7 @@ running — the inner act gets its own bookkeeping instead of corrupting the
 outer one's. A format needing more than the base class knows about, such as a
 wire marker minted per call, subclasses the act and carries it there.
 
-`JsonCodecEngine` supplies both directions at both of its boundary types:
+`JsonCodecEngine` supplies both directions at its one boundary type:
 
 - `encode(value, env?)` encodes a `FabricValue` into the `/<Type>@<Version>`
   tagged wire format, then stringifies the result.
@@ -2591,8 +2593,7 @@ string, and a second entry point for the same walk was API without a purpose.
 > **Why the boundary is this narrow.** Tag wrapping and unwrapping belong to
 > the acts rather than to an engine's public surface, leaving only
 > `encode(value, env?) -> SerializedForm` and
-> `decode(data, env) -> FabricValue` — one such pair per boundary type the
-> engine offers — as public API. The engine owns the full pipeline rather than
+> `decode(data, env) -> FabricValue` — as public API. The engine owns the full pipeline rather than
 > the tag step alone, and its public surface says so by exposing no step of
 > it.
 
@@ -4007,8 +4008,8 @@ values cross from internal codec machinery to callers:
   each call site, so a caller reaching it outside the walker gets the same
   guarantee.
 
-- **`JsonCodecValue` parse boundary.** The `#parseWireText()` helper
-  (invoked by `decode()` and `#fromBytes()`) deep-freezes the parsed tree
+- **`JsonCodecValue` parse boundary.** The `parseWireText()` helper
+  (invoked by `decode()`) deep-freezes the parsed tree
   before handing it to the decode walker. This is what makes the
   decode-side `JsonCodecValue` invariant load-bearing: tag-unwrap and
   the `/quote` arm can hand back extracted sub-trees directly without

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -2496,10 +2496,9 @@ is not part of the public boundary interface.
  * serialized form (which is `string`). Internal to the JSON implementation.
  *
  * Deep-frozen invariant on the decode side: every such tree that
- * enters decoding is deep-frozen, enforced at the two construction
- * site that feeds it, `parseWireText()`. This is what lets the tag-unwrap and
- * `/quote` arms
- * hand back extracted sub-trees directly without further copying. The
+ * enters decoding is deep-frozen, enforced at the one construction site that
+ * feeds it, `parseWireText()`. This is what lets the tag-unwrap and `/quote`
+ * arms hand back extracted sub-trees directly without further copying. The
  * encode-side trees are transient (`JSON.stringify`-ed and discarded)
  * and are not covered by this invariant. The `readonly` on the array and
  * object arms of the union expresses the decode-side contract at the

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -2584,8 +2584,9 @@ wire marker minted per call, subclasses the act and carries it there.
   tagged wire format, then stringifies the result.
 - `decode(data, env)` parses a JSON string, then decodes tagged
   forms back into runtime types.
-- `encodeToBytes(value, env?)` and `decodeFromBytes(bytes, env)` are the same
-  two walks against UTF-8 bytes rather than a string.
+
+A caller wanting bytes encodes the string itself. The format's boundary is the
+string, and a second entry point for the same walk was API without a purpose.
 
 > **Why the boundary is this narrow.** Tag wrapping and unwrapping belong to
 > the acts rather than to an engine's public surface, leaving only

--- a/packages/connectors/agents/src/chunking.ts
+++ b/packages/connectors/agents/src/chunking.ts
@@ -10,9 +10,16 @@ export interface EventChunk<T> {
 }
 
 const fabricJsonCodec = newDefaultJsonCodecEngine();
+const textEncoder = new TextEncoder();
 
+/**
+ * The size a value takes on the wire, which is what a chunk budget is spent
+ * on: the UTF-8 length of this format's serialized form.
+ */
 export function encodedJsonBytes(value: unknown): number {
-  return fabricJsonCodec.encodeToBytes(stableFabricValue(value)).byteLength;
+  return textEncoder.encode(
+    fabricJsonCodec.encode(stableFabricValue(value)),
+  ).byteLength;
 }
 
 const EMPTY_ARRAY_BYTES = encodedJsonBytes([]);

--- a/packages/data-model/src/codec-common/BaseDecodeAct.ts
+++ b/packages/data-model/src/codec-common/BaseDecodeAct.ts
@@ -42,6 +42,12 @@ export abstract class BaseDecodeAct<Encoded, SerializedForm = Encoded>
    * `ProblematicStateError`, which the engine's `decode()` settles through
    * {@link #settleThrown} -- so a lenient decode returns a `ProblematicValue`
    * for a syntactic fault, exactly as it does for a fault found further in.
+   *
+   * **Called exactly once per act, and before any of the walk.** An act may
+   * therefore take what it needs of the serialized form here -- a marker read
+   * off an envelope, say -- and {@link #decodeValue} will see it. An engine
+   * adding an entry point of its own owes the same order rather than reaching
+   * a conversion around this one.
    */
   abstract encodedFromSerializedForm(data: SerializedForm): Encoded;
 

--- a/packages/data-model/src/codec-json/JsonCodecEngine.ts
+++ b/packages/data-model/src/codec-json/JsonCodecEngine.ts
@@ -1,11 +1,9 @@
 import { backtickQuote } from "@commonfabric/utils/markdown";
 
-import type { FabricValue } from "@/interface.ts";
 import { BaseCodecEngine } from "@/codec-common/BaseCodecEngine.ts";
 import { JsonDecodeAct } from "./JsonDecodeAct.ts";
 import { JsonEncodeAct } from "./JsonEncodeAct.ts";
-import { parseWireText, seemsLikeEncoded } from "./wire-text.ts";
-import { NULL_LIVE_ENVIRONMENT } from "@/codec-interface/NullLiveEnvironment.ts";
+import { seemsLikeEncoded } from "./wire-text.ts";
 import { CODEC, type LiveEnvironment } from "@/codec-interface/interface.ts";
 import { NullLiveEnvironment } from "@/codec-interface/NullLiveEnvironment.ts";
 import { UnknownValue } from "@/codec-common/UnknownValue.ts";
@@ -18,11 +16,9 @@ import type { CodecRegistry } from "@/codec-common/CodecRegistry.ts";
  * Whole-value JSON codec implementing the `/<Type>@<Version>` wire format from
  * the formal spec (Section 5).
  *
- * Public instance surface, two directions and two boundary types:
+ * Public instance surface, one boundary type and two directions:
  * - `encode(value, env?)` -- full pipeline: tree-encode + stringify
  * - `decode(data, env)` -- full pipeline: parse + tree-decode
- * - `encodeToBytes(value, env?)` -- as `encode()`, to UTF-8 bytes
- * - `decodeFromBytes(bytes, env)` -- as `decode()`, from UTF-8 bytes
  *
  * The machinery beneath belongs elsewhere. The walks and this format's account
  * of how a container is written down are `JsonEncodeAct`'s and
@@ -69,45 +65,9 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
     return new JsonDecodeAct(this, env);
   }
 
-  /** Encodes a fabric value to UTF-8 JSON bytes. */
-  encodeToBytes(
-    value: FabricValue,
-    env: LiveEnvironment = NULL_LIVE_ENVIRONMENT,
-  ): Uint8Array {
-    return JsonCodecEngine.#toBytes(this.newEncodeAct(env).encodeValue(value));
-  }
-
-  /**
-   * Decodes UTF-8 JSON bytes back into a fabric value. Carries no cycle
-   * guard, for the reason {@link #decode} gives: this walk too gets its tree
-   * from a parse.
-   */
-  decodeFromBytes(
-    bytes: Uint8Array,
-    env: LiveEnvironment = NULL_LIVE_ENVIRONMENT,
-  ): FabricValue {
-    const text = JsonCodecEngine.#textDecoder.decode(bytes);
-    const act = this.newDecodeAct(env, text);
-    let tree: JsonCodecValue;
-
-    try {
-      tree = parseWireText(text);
-    } catch (e) {
-      return act.settleThrown(e);
-    }
-
-    return act.decodeValue(tree);
-  }
-
   //
   // Static members
   //
-
-  /** Shared text encoder, created once. */
-  static readonly #textEncoder = new TextEncoder();
-
-  /** Shared text decoder, created once. */
-  static readonly #textDecoder = new TextDecoder();
 
   /**
    * Registry for the throwaway checks in the testing helpers below: this
@@ -263,10 +223,5 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
     }
 
     return encoded;
-  }
-
-  /** Converts a codec-value tree to UTF-8-encoded JSON bytes. */
-  static #toBytes(data: JsonCodecValue): Uint8Array {
-    return JsonCodecEngine.#textEncoder.encode(JSON.stringify(data));
   }
 }

--- a/packages/data-model/src/codec-json/JsonCodecEngine.ts
+++ b/packages/data-model/src/codec-json/JsonCodecEngine.ts
@@ -25,9 +25,8 @@ import type { CodecRegistry } from "@/codec-common/CodecRegistry.ts";
  * `JsonDecodeAct`'s, which this class mints through the two `protected`
  * factories -- that pair being the surface a second engine extends. What both
  * an engine and an act need of the wire text is in `wire-text.ts`, so that
- * neither imports the other. Byte conversion is this class's own and stays
- * `#`-private. Per-type encoding and decoding is delegated to the
- * `FabricCodec`s in the `CodecRegistry`.
+ * neither imports the other. Per-type encoding and decoding is delegated to
+ * the `FabricCodec`s in the `CodecRegistry`.
  *
  * Three statics are public besides: `seemsLikeEncoded()`, and the
  * `wrapEncodedValueForTesting()` / `unwrapEncodedValueForTesting()` pair

--- a/packages/data-model/src/codec-json/interface.ts
+++ b/packages/data-model/src/codec-json/interface.ts
@@ -26,8 +26,8 @@ export const ENCODING_PREFIX_TAG = "fvj1:" as const;
  * (which is `string`). Internal to the JSON implementation.
  *
  * Deep-frozen invariant: every such tree that *enters decoding* is
- * deep-frozen. This is enforced at the two construction sites that feed
- * the decode walk, in `parseWireText()`, and is what lets `unwrapTag()` /
+ * deep-frozen. This is enforced at the one construction site that feeds the
+ * decode walk, `parseWireText()`, and is what lets `unwrapTag()` /
  * the `/quote` arm hand back extracted sub-trees directly (see their
  * contracts). The transient trees built on the *encode* side are not covered
  * by this invariant: they are `JSON.stringify`-ed and discarded by `encode()`

--- a/packages/data-model/src/codec-json/interface.ts
+++ b/packages/data-model/src/codec-json/interface.ts
@@ -27,12 +27,11 @@ export const ENCODING_PREFIX_TAG = "fvj1:" as const;
  *
  * Deep-frozen invariant: every such tree that *enters decoding* is
  * deep-frozen. This is enforced at the two construction sites that feed
- * the decode walk -- `decode()` and `#fromBytes()`, unified in
- * `#parseWireText()` -- and is what lets `#unwrapTag()` / the `/quote` arm
- * hand back extracted sub-trees directly (see their contracts). The transient
- * trees built on the *encode* side are not covered by this invariant: they
- * are `JSON.stringify`-ed and discarded by `encode()` / `encodeToBytes()` and
- * never reach a caller. (The encode-side `/quote` form happens to be
+ * the decode walk, in `parseWireText()`, and is what lets `unwrapTag()` /
+ * the `/quote` arm hand back extracted sub-trees directly (see their
+ * contracts). The transient trees built on the *encode* side are not covered
+ * by this invariant: they are `JSON.stringify`-ed and discarded by `encode()`
+ * and never reach a caller. (The encode-side `/quote` form happens to be
  * deep-frozen as a side effect of `#unquote()`'s recursive rebuild, but no
  * other encode output is, and none needs to be.)
  */

--- a/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
@@ -455,112 +455,6 @@ describe("JsonCodecEngine", () => {
     });
   });
 
-  describe("`encodeToBytes()` / `decodeFromBytes()` (bytes entry points)", () => {
-    it("throws for unparseable bytes when strict", () => {
-      const bytes = new TextEncoder().encode("{not json");
-
-      expect(() =>
-        newDefaultJsonCodecEngine().decodeFromBytes(
-          bytes,
-          new TestLiveEnvironment(),
-        )
-      ).toThrow(/Malformed JSON in an encoded `FabricValue` string/);
-    });
-
-    it("returns a `ProblematicValue` for unparseable bytes when lenient", () => {
-      // This entry point reaches a conversion without passing through
-      // `decode()`, so it settles the refusal itself. Were it not to, the
-      // byte boundary would treat a malformed payload differently from the
-      // string boundary for no reason a caller could name.
-      const bytes = new TextEncoder().encode("{not json");
-      const decoded = newDefaultJsonCodecEngine({ lenient: true })
-        .decodeFromBytes(bytes, new TestLiveEnvironment());
-
-      expect(decoded).toBeInstanceOf(ProblematicValue);
-      expect((decoded as ProblematicValue).error)
-        .toMatch(/Malformed JSON in an encoded `FabricValue` string/);
-    });
-
-    it("returns `Uint8Array` from `encodeToBytes()`", () => {
-      const { jsonCodecEngine } = makeTestCodec();
-      const result = jsonCodecEngine.encodeToBytes(42);
-      expect(result).toBeInstanceOf(Uint8Array);
-    });
-
-    it("produces valid JSON bytes from `encodeToBytes()`", () => {
-      const { jsonCodecEngine } = makeTestCodec();
-      const bytes = jsonCodecEngine.encodeToBytes(
-        { a: 1 },
-      );
-      const json = new TextDecoder().decode(bytes);
-      expect(JSON.parse(json)).toEqual({ a: 1 });
-    });
-
-    it("decodes a `Uint8Array` through `decodeFromBytes()`", () => {
-      const { jsonCodecEngine, runtime } = makeTestCodec();
-      const bytes = new TextEncoder().encode(JSON.stringify({ a: 1 }));
-      const result = jsonCodecEngine.decodeFromBytes(
-        bytes,
-        runtime,
-      ) as Record<string, FabricValue>;
-      expect(result.a).toBe(1);
-    });
-
-    it("round-trips through `Uint8Array`", () => {
-      const { jsonCodecEngine, runtime } = makeTestCodec();
-      const value = {
-        name: "test",
-        count: 42,
-      };
-      const bytes = jsonCodecEngine.encodeToBytes(value);
-      const result = jsonCodecEngine.decodeFromBytes(
-        bytes,
-        runtime,
-      ) as Record<string, FabricValue>;
-      expect(result.name).toBe("test");
-      expect(result.count).toBe(42);
-    });
-
-    it("round-trips `FabricError` through `Uint8Array`", () => {
-      const { jsonCodecEngine, runtime } = makeTestCodec();
-      const err = FabricError.fromNativeError(new TypeError("oops"));
-      const bytes = jsonCodecEngine.encodeToBytes(err);
-      const result = jsonCodecEngine.decodeFromBytes(
-        bytes,
-        runtime,
-      );
-      expect(result).toBeInstanceOf(FabricError);
-      const se = result as unknown as FabricError;
-      expect(se.toNativeValue(true)).toBeInstanceOf(TypeError);
-      expect(se.message).toBe("oops");
-    });
-
-    it("round-trips `undefined` through `Uint8Array`", () => {
-      const { jsonCodecEngine, runtime } = makeTestCodec();
-      const bytes = jsonCodecEngine.encodeToBytes(undefined);
-      const result = jsonCodecEngine.decodeFromBytes(bytes, runtime);
-      expect(result).toBe(undefined);
-    });
-
-    it("round-trips complex structure through `Uint8Array`", () => {
-      const { jsonCodecEngine, runtime } = makeTestCodec();
-      const value = {
-        users: [{ name: "Alice" }, { name: "Bob" }],
-        error: FabricError.fromNativeError(new Error("fail")),
-        nothing: undefined,
-      };
-      const bytes = jsonCodecEngine.encodeToBytes(value);
-      const result = jsonCodecEngine.decodeFromBytes(
-        bytes,
-        runtime,
-      ) as Record<string, FabricValue>;
-      const users = result.users as FabricValue[];
-      expect((users[0] as Record<string, FabricValue>).name).toBe("Alice");
-      expect(result.error).toBeInstanceOf(FabricError);
-      expect(result.nothing).toBe(undefined);
-    });
-  });
-
   describe("primitives round-trip", () => {
     it("passes through `null`", () => {
       expect(roundTrip(null)).toBe(null);
@@ -1860,37 +1754,23 @@ describe("JsonCodecEngine", () => {
     });
   });
 
-  describe("deep-frozen encoded invariant (`decode()`/`decodeFromBytes()` symmetry)", () => {
-    // Every `JsonCodecValue` handed to the decode walk must be deep-frozen, so
-    // both decode entry points must produce equally deep-frozen
-    // results: `decode()` (string path) and `decodeFromBytes()` (bytes path
-    // via `#fromBytes()`).
+  describe("deep-frozen encoded invariant", () => {
+    // Every `JsonCodecValue` handed to the decode walk must be deep-frozen.
     //
     // The `/quote` arm does `return state`, handing back a node lifted straight
     // out of the parsed codec-value tree (see `#unwrapTag()`'s contract). That
     // shortcut is sound only because the parsed tree is deep-frozen at
     // construction, which both construction sites must therefore do. These
-    // cases pin the symmetry, so that dropping the guarantee at either one
-    // cannot pass unnoticed.
+    // cases pin it, so that dropping the guarantee cannot pass unnoticed.
 
-    /**
-     * Decodes the same codec-value tree both ways. The string path needs the
-     * encoding prefix; the bytes path does not (it does not strip one).
-     */
-    function decodeBothPaths(
-      data: JsonCodecValue,
-    ): { viaString: FabricValue; viaBytes: FabricValue } {
+    /** Decodes one codec-value tree through this format's boundary. */
+    function decodeTree(data: JsonCodecValue): FabricValue {
       const { jsonCodecEngine, runtime } = makeTestCodec();
-      const json = JSON.stringify(data);
-      const viaString = jsonCodecEngine.decode(
-        JsonCodecEngine.wrapEncodedValueForTesting(json),
+
+      return jsonCodecEngine.decode(
+        JsonCodecEngine.wrapEncodedValueForTesting(JSON.stringify(data)),
         runtime,
       );
-      const viaBytes = jsonCodecEngine.decodeFromBytes(
-        new TextEncoder().encode(json),
-        runtime,
-      );
-      return { viaString, viaBytes };
     }
 
     const cases: Array<[string, JsonCodecValue]> = [
@@ -1914,15 +1794,12 @@ describe("JsonCodecEngine", () => {
     ];
 
     for (const [name, encoded] of cases) {
-      it(`both paths yield a deep-frozen, equal result: ${name}`, () => {
-        const { viaString, viaBytes } = decodeBothPaths(encoded);
-        expect(isDeepFrozen(viaString)).toBe(true);
-        expect(isDeepFrozen(viaBytes)).toBe(true);
-        expect(viaString).toEqual(viaBytes);
+      it(`yields a deep-frozen result: ${name}`, () => {
+        expect(isDeepFrozen(decodeTree(encoded))).toBe(true);
       });
     }
 
-    it("string path deep-freezes `/quote` content at every depth (regression for `decode()` vs `#fromBytes()`)", () => {
+    it("deep-freezes `/quote` content at every depth", () => {
       const encoded = {
         "/quote": { outer: { inner: [1, 2] } },
       } as JsonCodecValue;
@@ -1940,23 +1817,6 @@ describe("JsonCodecEngine", () => {
       }).toThrow();
       expect(() => {
         (result.outer as Record<string, unknown>).added = true;
-      }).toThrow();
-    });
-
-    it("bytes path deep-freezes `/quote` content at every depth", () => {
-      const encoded = {
-        "/quote": { outer: { inner: [{ deep: 1 }] } },
-      } as JsonCodecValue;
-      const { jsonCodecEngine, runtime } = makeTestCodec();
-      const result = jsonCodecEngine.decodeFromBytes(
-        new TextEncoder().encode(JSON.stringify(encoded)),
-        runtime,
-      ) as Record<string, Record<string, Array<Record<string, FabricValue>>>>;
-
-      expect(isDeepFrozen(result)).toBe(true);
-      expect(Object.isFrozen(result.outer!.inner![0])).toBe(true);
-      expect(() => {
-        (result.outer!.inner![0] as Record<string, unknown>).deep = 2;
       }).toThrow();
     });
 
@@ -2003,23 +1863,6 @@ describe("JsonCodecEngine", () => {
       const decoded = jsonCodecEngine.decode(encoded, runtime);
       expect(decoded).toBeInstanceOf(FabricError);
       expect((decoded as unknown as FabricError).message).toBe("test");
-    });
-
-    it("`encodeToBytes()`/`decodeFromBytes()` round-trip", () => {
-      const jsonCodecEngine = newDefaultJsonCodecEngine();
-      const runtime = new TestLiveEnvironment();
-      const data = {
-        name: "test",
-        error: FabricError.fromNativeError(new Error("fail")),
-      };
-      const bytes = jsonCodecEngine.encodeToBytes(data);
-      expect(bytes).toBeInstanceOf(Uint8Array);
-      const decoded = jsonCodecEngine.decodeFromBytes(bytes, runtime) as Record<
-        string,
-        FabricValue
-      >;
-      expect(decoded.name).toBe("test");
-      expect(decoded.error).toBeInstanceOf(FabricError);
     });
 
     it("`.lenient` defaults to `false`", () => {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

`encodeToBytes()` and `decodeFromBytes()` leave `JsonCodecEngine`. The one
caller that wanted a byte count computes it where it is used.

## They had no clients

Checked across the whole repository, excluding only `data-model`'s own tests:

* **`decodeFromBytes()` -- zero callers.** Nothing decoded bytes anywhere. Its
  only mentions were its own definition, a doc-comment bullet, and one spec
  line.
* **`encodeToBytes()` -- one caller**, `connectors/agents/src/chunking.ts`,
  which took `.byteLength` off the result and discarded the array.

So the pair was a public boundary nothing crossed, kept alive by a caller that
wanted a number.

## They carried a second wire form

The bytes were bare JSON with no `fvj1:` prefix, where the string boundary has
carried one since **#3429**. That PR added the prefix to the string path and
**did not touch the byte pair at all** -- its diff contains no reference to
either method. The byte pair predates it, having been folded into its current
shape by #2970 from an older "serialization context that can produce and
consume `Uint8Array` bytes".

So the asymmetry was an omission at the moment the prefix landed, not a
decision about byte channels -- which is why no document describes a byte form.
There was never a choice to write down. A test helper had noticed, and said so
in a comment: *"the string path needs the encoding prefix; the bytes path does
not (it does not strip one)"*.

## What the one caller does now

`encodedJsonBytes()` measures the UTF-8 length of `encode()`'s output. That
includes the prefix where the old measure did not, shifting a chunk boundary by
five bytes, and it cannot be wrong: every use of the helper is relative --
`encodedJsonArrayElementBytes()` takes a difference, in which a constant
cancels -- and the helper's own test computes its expectations by calling it.

## A contract that is now unconditionally true

`BaseDecodeAct.encodedFromSerializedForm()` now states that it is **called
exactly once per act, and before any of the walk**, so an act may take what it
needs of the serialized form there and the walk will see it.

That could not be said before: `decodeFromBytes()` was the one caller that
reached a conversion around it, parsing directly and calling `decodeValue()`
itself. The statement is what `codec-realm` wants, its decode act taking the
sender's marker off the envelope in exactly that method.

## Verification

- `data-model`: `ok | 53 passed (2453 steps) | 0 failed`.
- `it()` diffed against the base: 176 -> 165. Every removed description names
  the removed API; one is a rename, the `/quote` deep-freeze case having lost
  its "string path" framing since there is no other path to distinguish it
  from.
- Cross-package: `connectors/agents` -- the caller that changed --
  green, with `memory`, `runner`, `cli` and `state-inspector`.
- Gates green: `lint`, `check`, `fmt --check`, `check-docs`,
  `check-skill-facts`, `check-package-cycles`, `check-no-waitfor`.
- The root `deno task test` was not run: it can launch a browser, which needs
  unsandboxed execution.

225 lines deleted against 30 added.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

