### PR TITLE
feat(tasks): the vintage gate treats derived-hoist arguments as derivation, not contract

### DIFF
--- a/docs/specs/pattern-update-testing.md
+++ b/docs/specs/pattern-update-testing.md
@@ -133,7 +133,11 @@ Per fixture:
   error on a hoist fails, an authored export that disappeared fails as the
   retirement it is, and a hoist that applies is compared like everything else,
   which is what keeps a row-allocated cell's cause-stability (the
-  moved-`.for()` class) gated;
+  moved-`.for()` class) gated. Telling the two apart is spelling, and spelling
+  is decisive because the namespace is reserved: the runner refuses a module
+  that exports a builder artifact named `__cfPattern_<n>`, so a recorded
+  instantiation with that shape can only be the compiler's own
+  (`docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md` §11.3);
 - the root then **reads as something** rather than nothing;
 - every value the vintage held is **still readable** afterwards.
 

--- a/docs/specs/pattern-update-testing.md
+++ b/docs/specs/pattern-update-testing.md
@@ -121,7 +121,19 @@ Per fixture:
 - the fixture actually **holds** each recorded root, checked per target before
   anything is applied to it;
 - the setup commit carrying the artifact onto that root is **not refused** and
-  completes;
+  completes — for every AUTHORED target. A transformer-derived hoist (a mapped
+  row's anonymous sub-pattern, `__cfPattern_N`) whose STORED ARGUMENTS today's
+  schema refuses is held back and reported instead of failing: a hoist's
+  arguments are the captures of a derivation the updated source re-runs and
+  re-supplies wholesale, and the real update channel validates only the root
+  contract, so a capture that drifted is not a stranded piece. A hoist today's
+  source no longer even defines is the same supersession — hoist ids are
+  builder node ids, renumbered by ordinary edits — and is held back the same
+  way. Only those two refusal shapes are held back, for hoists only: any other
+  error on a hoist fails, an authored export that disappeared fails as the
+  retirement it is, and a hoist that applies is compared like everything else,
+  which is what keeps a row-allocated cell's cause-stability (the
+  moved-`.for()` class) gated;
 - the root then **reads as something** rather than nothing;
 - every value the vintage held is **still readable** afterwards.
 

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -1513,6 +1513,18 @@ suffixes (`__cfLift_1`, `__cfPattern_1`, …), **not** `factory.createUniqueName
 would make every hoisted identifier share the same `.text` and break the
 identity-by-text lookups later stages rely on.
 
+`__cfPattern_<n>` is a **reserved namespace**, and the runner enforces it:
+registering an evaluated module (`PatternManager.registerEvaluatedModules`)
+refuses a module that EXPORTS a builder artifact under one of these names.
+Hoists reach the artifact index through `__cfReg` (§11.4) rather than through
+exports, so the reservation costs a compiled module nothing — and it is what
+lets a consumer of the index read provenance from the spelling. The
+pattern-update gates depend on exactly that: a recorded instantiation named
+`__cfPattern_<n>` is derivation the updated source re-runs, and is held to a
+different rule than an authored artifact
+(`docs/specs/pattern-update-testing.md`). Only artifacts are refused; a plain
+value under such a name is inert, since nothing but an artifact is indexable.
+
 ### 11.4 `__cfReg` content-addressed registration
 
 After visiting the whole file, the stage appends **one** trailing call:

--- a/packages/piece/test/state-continuity-harness.ts
+++ b/packages/piece/test/state-continuity-harness.ts
@@ -1325,6 +1325,15 @@ function describeError(error: unknown): string {
 export interface MaterializeOutcome {
   /** The setup-commit rejection, if the candidate could not be applied. */
   error?: string;
+  /**
+   * Set when the refusal is that the candidate module does not define the
+   * recorded symbol. A field rather than a message shape, because `error` is
+   * prose: `describeError` strings arbitrary setup failures through it, so a
+   * caller that classified this refusal by matching the message would accept
+   * any error whose text happened to carry the phrase. The verdict travels
+   * beside the message instead of inside it.
+   */
+  missingArtifact?: true;
   /** The root's value after a successful materialize. */
   value?: Record<string, unknown>;
   /**
@@ -1448,6 +1457,7 @@ export async function materializeOnCell(
       error:
         `today's ${program.main} defines no "${symbol}"; the stored root ` +
         `names an artifact this version does not have`,
+      missingArtifact: true,
       resultSchema: entryPattern.resultSchema,
       argumentSchema: entryPattern.argumentSchema,
       identity: entryRef.identity,

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -81,6 +81,15 @@ const PATTERN_COVERAGE_CACHE_VARIANT = "pattern-coverage";
  * from an authored artifact — the pattern-update gates among them — read
  * provenance from the spelling alone: a `__cfPattern_<n>` in the artifact
  * index can only be the transformer's.
+ *
+ * What is PROHIBITED here is deliberately wider than what the compiler
+ * MINTS, and wider than what a consumer recognizes as a hoist (the gate's
+ * `isDerivedHoistSymbol` matches `_1` upward, since that is what actually
+ * gets emitted). `_0` and `_01` are minted by nothing, so reserving them
+ * costs authors nothing real — and leaving them authorable would leave the
+ * confusable spellings, the ones a reader cannot tell from a hoist at a
+ * glance, as the only ones anybody could take. A prohibition may safely
+ * exceed the convention it protects; a recognizer may not.
  */
 const RESERVED_HOIST_EXPORT = /^__cfPattern_\d+$/;
 

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -72,6 +72,49 @@ const logger = getLogger("pattern-manager");
 const MAX_EVALUATED_MODULE_CACHE_SIZE = 1000;
 const PATTERN_COVERAGE_CACHE_VARIANT = "pattern-coverage";
 
+/**
+ * The compiler's hoist namespace. `builder-call-hoisting` mints
+ * `__cfPattern_<n>` (n counting from 1) for the anonymous sub-patterns it
+ * derives, and registers them through `__cfReg` — never as exports.
+ * Registration refuses an AUTHORED builder-artifact export under these names,
+ * which is what lets everything downstream that must tell a derived hoist
+ * from an authored artifact — the pattern-update gates among them — read
+ * provenance from the spelling alone: a `__cfPattern_<n>` in the artifact
+ * index can only be the transformer's.
+ */
+const RESERVED_HOIST_EXPORT = /^__cfPattern_\d+$/;
+
+/**
+ * Throw if any module in an evaluated bundle exports a builder artifact in
+ * the reserved hoist namespace.
+ *
+ * A whole-bundle pre-pass rather than a check inside the registration loop,
+ * so a refused bundle registers nothing at all: a module rejected after its
+ * neighbors were indexed would leave the session holding half a bundle.
+ * Only artifacts are checked — `indexArtifact` admits nothing else, so a
+ * plain value under such a name can never be resolved as a hoist.
+ */
+function assertNoReservedHoistExports(
+  exportsByIdentity: ReadonlyMap<string, Record<string, unknown>>,
+): void {
+  for (const [identity, exports] of exportsByIdentity) {
+    for (const exportName of Object.keys(exports)) {
+      if (
+        RESERVED_HOIST_EXPORT.test(exportName) &&
+        isTrustedBuilderArtifact(exports[exportName])
+      ) {
+        throw new Error(
+          `module ${identity} exports the builder artifact ` +
+            `"${exportName}": the __cfPattern_<n> names are the compiler's ` +
+            `own hoist namespace, and an authored artifact under one reads ` +
+            `as a derived hoist wherever provenance matters — export it ` +
+            `under another name`,
+        );
+      }
+    }
+  }
+}
+
 /** Whether copying source bytes would discard a meaningful stored CFC label. */
 export function sourceCfcMetadataProhibitsCrossSpaceCopy(
   metadata: CfcMetadata | undefined,
@@ -1528,6 +1571,7 @@ export class PatternManager {
   registerEvaluatedModules(result: EvaluateResult): void {
     const byId = result.exportsByIdentity;
     if (byId) {
+      assertNoReservedHoistExports(byId);
       for (const [identity, exports] of byId) {
         // `modulesByIdentity` keeps the whole namespace for MODULE reuse on a
         // by-identity reload (a separate concern from artifact addressing).

--- a/packages/runner/test/compile-and-register-modules.test.ts
+++ b/packages/runner/test/compile-and-register-modules.test.ts
@@ -66,6 +66,49 @@ describe("PatternManager.compileAndRegisterModules", () => {
     expect(runtime.patternManager.getArtifactEntryRef(entry)).toBeUndefined();
   });
 
+  it("refuses an authored builder-artifact export in the hoist namespace", async () => {
+    // `__cfPattern_<n>` spellings are how everything downstream tells a
+    // transformer-derived hoist from an authored artifact — the vintage gate
+    // holds hoist refusals back on it. An authored artifact under the name
+    // would wear the wrong provenance, so registration fails the load.
+    const squatter: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: `import { NAME, pattern } from "commonfabric";\n` +
+            `export const __cfPattern_1 = pattern(() => ({ shout: "s" }));\n` +
+            `export default pattern(() => ({ [NAME]: "squatter" }));\n`,
+        },
+      ],
+    };
+    await expect(
+      runtime.patternManager.compileAndRegisterModules(squatter),
+    ).rejects.toThrow("compiler's own hoist namespace");
+  });
+
+  it("accepts a plain value under a hoist-shaped export name", async () => {
+    // Only an artifact is indexable, so only an artifact can wear the wrong
+    // provenance; a constant under the name is inert to every consumer of
+    // the artifact index.
+    const inert: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: `import { NAME, pattern } from "commonfabric";\n` +
+            `export const __cfPattern_1 = 41;\n` +
+            `export default pattern(() => ({ [NAME]: "inert" }));\n`,
+        },
+      ],
+    };
+    const result = await runtime.patternManager.compileAndRegisterModules(
+      inert,
+    );
+    const entry = result.main!["default"] as object;
+    expect(runtime.patternManager.getArtifactEntryRef(entry)).toBeDefined();
+  });
+
   // The cf-test harness injects a process-wide module byte cache
   // (`RuntimeOptions.moduleByteCache`) so repeated pattern compiles across
   // runtimes skip the transform-and-emit step. Pin that seam here: a fresh

--- a/tasks/pattern-vintage-lib.test.ts
+++ b/tasks/pattern-vintage-lib.test.ts
@@ -22,6 +22,7 @@ import {
   describeCaptureOutcome,
   describeError,
   describePinOutcome,
+  hoistSupersessionReason,
   isClean,
   isDerivedHoistSymbol,
   isStoredArgumentRefusal,
@@ -1785,5 +1786,44 @@ describe("derived-hoist classification", () => {
     expect(isStoredArgumentRefusal(new Error("commit failed"))).toBe(false);
     expect(isStoredArgumentRefusal("compile error")).toBe(false);
     expect(isStoredArgumentRefusal(undefined)).toBe(false);
+  });
+});
+
+describe("hoist supersession rule", () => {
+  const REFUSED = `${STORED_ARGUMENT_SCHEMA_REFUSAL}: params: missing ` +
+    `required property boundRemoveHistoryEntry`;
+
+  it("names the stored-argument rule for a refused hoist", () => {
+    expect(hoistSupersessionReason("__cfPattern_4", REFUSED, false))
+      .toBe("stored arguments superseded");
+  });
+
+  it("names the no-longer-emitted rule for a missing hoist", () => {
+    expect(hoistSupersessionReason("__cfPattern_6", "gone", true))
+      .toBe("hoist no longer emitted");
+  });
+
+  it("prefers the stored-argument rule when both could apply", () => {
+    // The refusal the candidate actually made is the more specific account
+    // of what happened, and the one whose remedy the reader needs.
+    expect(hoistSupersessionReason("__cfPattern_4", REFUSED, true))
+      .toBe("stored arguments superseded");
+  });
+
+  it("returns undefined for an authored artifact under either shape", () => {
+    // The partition: the same two refusals that supersede a hoist are loss
+    // when they land on something an author wrote, and must fail the run.
+    expect(hoistSupersessionReason("Row", REFUSED, false)).toBeUndefined();
+    expect(hoistSupersessionReason("Row", "gone", true)).toBeUndefined();
+    expect(hoistSupersessionReason("default", REFUSED, true)).toBeUndefined();
+    expect(hoistSupersessionReason("__cfPattern_0", REFUSED, true))
+      .toBeUndefined();
+  });
+
+  it("returns undefined for any other refusal of a hoist", () => {
+    expect(hoistSupersessionReason("__cfPattern_4", "commit failed", false))
+      .toBeUndefined();
+    expect(hoistSupersessionReason("__cfPattern_4", undefined, false))
+      .toBeUndefined();
   });
 });

--- a/tasks/pattern-vintage-lib.test.ts
+++ b/tasks/pattern-vintage-lib.test.ts
@@ -24,7 +24,6 @@ import {
   describePinOutcome,
   isClean,
   isDerivedHoistSymbol,
-  isMissingArtifactRefusal,
   isStoredArgumentRefusal,
   KNOWN_FLAGS,
   newestAutoGeneration,
@@ -1770,6 +1769,11 @@ describe("derived-hoist classification", () => {
     expect(isDerivedHoistSymbol("x__cfPattern_4")).toBe(false);
   });
 
+  it("returns false for numbers the per-file counter never mints", () => {
+    expect(isDerivedHoistSymbol("__cfPattern_0")).toBe(false);
+    expect(isDerivedHoistSymbol("__cfPattern_01")).toBe(false);
+  });
+
   it("classifies a stored-argument refusal in Error and string form", () => {
     const message = `${STORED_ARGUMENT_SCHEMA_REFUSAL}: params: missing ` +
       `required property boundRemoveHistoryEntry`;
@@ -1781,23 +1785,5 @@ describe("derived-hoist classification", () => {
     expect(isStoredArgumentRefusal(new Error("commit failed"))).toBe(false);
     expect(isStoredArgumentRefusal("compile error")).toBe(false);
     expect(isStoredArgumentRefusal(undefined)).toBe(false);
-  });
-});
-
-describe("missing-artifact refusal classification", () => {
-  it("recognizes a defines-no message for the recorded symbol", () => {
-    const message = "today's /packages/patterns/lunch-poll/main.tsx defines " +
-      'no "__cfPattern_6"; the stored root names an artifact this version ' +
-      "does not have";
-    expect(isMissingArtifactRefusal("__cfPattern_6", message)).toBe(true);
-    expect(isMissingArtifactRefusal("__cfPattern_6", new Error(message)))
-      .toBe(true);
-  });
-
-  it("returns false for a different symbol or a different error", () => {
-    const message = 'today\'s main.tsx defines no "__cfPattern_6"; …';
-    expect(isMissingArtifactRefusal("__cfPattern_4", message)).toBe(false);
-    expect(isMissingArtifactRefusal("__cfPattern_6", "commit failed"))
-      .toBe(false);
   });
 });

--- a/tasks/pattern-vintage-lib.test.ts
+++ b/tasks/pattern-vintage-lib.test.ts
@@ -23,6 +23,9 @@ import {
   describeError,
   describePinOutcome,
   isClean,
+  isDerivedHoistSymbol,
+  isMissingArtifactRefusal,
+  isStoredArgumentRefusal,
   KNOWN_FLAGS,
   newestAutoGeneration,
   parseVintagePath,
@@ -53,6 +56,7 @@ import {
   vintageFileName,
   VINTAGES_DIR,
 } from "./pattern-vintage-lib.ts";
+import { STORED_ARGUMENT_SCHEMA_REFUSAL } from "@commonfabric/runner";
 
 const ID_A = "bafyaaaa";
 const ID_B = "bafybbbb";
@@ -1749,5 +1753,51 @@ describe("what the capture and promote commands print", () => {
     expect(message).not.toContain("are current");
     expect(message).toContain("no fixtures");
     expect(message).toContain("--update <test path>");
+  });
+});
+
+describe("derived-hoist classification", () => {
+  it("recognizes a transformer-emitted pattern hoist", () => {
+    expect(isDerivedHoistSymbol("__cfPattern_4")).toBe(true);
+    expect(isDerivedHoistSymbol("__cfPattern_12")).toBe(true);
+  });
+
+  it("returns false for authored exports and other synthetics", () => {
+    expect(isDerivedHoistSymbol("default")).toBe(false);
+    expect(isDerivedHoistSymbol("setup")).toBe(false);
+    expect(isDerivedHoistSymbol("__cfLift_2")).toBe(false);
+    expect(isDerivedHoistSymbol("__cfPattern_")).toBe(false);
+    expect(isDerivedHoistSymbol("x__cfPattern_4")).toBe(false);
+  });
+
+  it("classifies a stored-argument refusal in Error and string form", () => {
+    const message = `${STORED_ARGUMENT_SCHEMA_REFUSAL}: params: missing ` +
+      `required property boundRemoveHistoryEntry`;
+    expect(isStoredArgumentRefusal(new Error(message))).toBe(true);
+    expect(isStoredArgumentRefusal(message)).toBe(true);
+  });
+
+  it("returns false for every other error", () => {
+    expect(isStoredArgumentRefusal(new Error("commit failed"))).toBe(false);
+    expect(isStoredArgumentRefusal("compile error")).toBe(false);
+    expect(isStoredArgumentRefusal(undefined)).toBe(false);
+  });
+});
+
+describe("missing-artifact refusal classification", () => {
+  it("recognizes a defines-no message for the recorded symbol", () => {
+    const message = "today's /packages/patterns/lunch-poll/main.tsx defines " +
+      'no "__cfPattern_6"; the stored root names an artifact this version ' +
+      "does not have";
+    expect(isMissingArtifactRefusal("__cfPattern_6", message)).toBe(true);
+    expect(isMissingArtifactRefusal("__cfPattern_6", new Error(message)))
+      .toBe(true);
+  });
+
+  it("returns false for a different symbol or a different error", () => {
+    const message = 'today\'s main.tsx defines no "__cfPattern_6"; …';
+    expect(isMissingArtifactRefusal("__cfPattern_4", message)).toBe(false);
+    expect(isMissingArtifactRefusal("__cfPattern_6", "commit failed"))
+      .toBe(false);
   });
 });

--- a/tasks/pattern-vintage-lib.ts
+++ b/tasks/pattern-vintage-lib.ts
@@ -73,7 +73,11 @@
 
 import { exists } from "@std/fs";
 
-import { resolveSystemPatternSource } from "@commonfabric/runner";
+import {
+  isStoredArgumentSchemaRefusal,
+  resolveSystemPatternSource,
+  STORED_ARGUMENT_SCHEMA_REFUSAL,
+} from "@commonfabric/runner";
 
 import {
   VINTAGE_SPACES_SUFFIX,
@@ -1180,6 +1184,51 @@ export function armVerdictGuard(
  * `replayed` is part of the condition and not just a number to print: zero
  * replays is the shape a broken gate takes, not the shape a clean tree takes.
  */
+/**
+ * Whether a recorded instantiation is a transformer-emitted pattern hoist —
+ * an anonymous sub-pattern the compiler derives from the source (a mapped
+ * row's body), as opposed to a pattern an author exports. The `__cfPattern_N`
+ * name is the transformer's own emission convention, and N is a builder node
+ * id with no stability across edits — which is exactly why nothing durable
+ * may be addressed by it.
+ */
+export function isDerivedHoistSymbol(symbol: string): boolean {
+  return /^__cfPattern_\d+$/.test(symbol);
+}
+
+/**
+ * Whether a materialization error is setup refusing the STORED ARGUMENT
+ * against the candidate schema — the classification the runner exports a
+ * constant for, tolerated here in both the Error and the stringified form a
+ * replay outcome may carry.
+ */
+export function isStoredArgumentRefusal(error: unknown): boolean {
+  if (isStoredArgumentSchemaRefusal(error)) return true;
+  return typeof error === "string" &&
+    error.startsWith(`${STORED_ARGUMENT_SCHEMA_REFUSAL}:`);
+}
+
+/**
+ * Whether a materialization error says today's source no longer DEFINES the
+ * recorded symbol. For a derived hoist that is the renumbering face of the
+ * same supersession as a capture drift — hoist ids are builder node ids with
+ * no stability across edits, so an edited pattern routinely re-derives the
+ * same rows under different numbers — and the caller pairs this with
+ * `isDerivedHoistSymbol` so an AUTHORED export that disappeared still fails
+ * as the retirement it is.
+ */
+export function isMissingArtifactRefusal(
+  symbol: string,
+  error: unknown,
+): boolean {
+  const message = error instanceof Error
+    ? error.message
+    : typeof error === "string"
+    ? error
+    : "";
+  return message.includes(`defines no "${symbol}"`);
+}
+
 export function isClean(
   failures: readonly ReplayFailure[],
   uncovered: readonly string[],

--- a/tasks/pattern-vintage-lib.ts
+++ b/tasks/pattern-vintage-lib.ts
@@ -1202,13 +1202,12 @@ export function isClean(
  * may be addressed by it. The per-file counter starts at 1, so
  * `__cfPattern_0` is not a name the transformer mints.
  *
- * Spelling is the only evidence available here. The artifact index registers
- * hoists and exports through one path and keeps no provenance, and the
- * missing-artifact face asks about a symbol today's module does not even
- * define — so an authored export squatting on the reserved spelling would be
- * classified as derived, and its refusals held back. Reserving the namespace
- * at emission is the transformer-side fix; this gate cannot tell the
- * squatter from the hoist.
+ * Spelling IS provenance, because registration enforces it: the runner
+ * refuses an authored builder-artifact export in this namespace
+ * (`RESERVED_HOIST_EXPORT`, `pattern-manager.ts`), and every path that runs
+ * a pattern — the runtime's, and this gate's own capture and replay
+ * compiles — goes through that seam. A symbol with this shape in a manifest
+ * or the artifact index is the transformer's.
  */
 export function isDerivedHoistSymbol(symbol: string): boolean {
   return /^__cfPattern_[1-9]\d*$/.test(symbol);

--- a/tasks/pattern-vintage-lib.ts
+++ b/tasks/pattern-vintage-lib.ts
@@ -1224,3 +1224,29 @@ export function isStoredArgumentRefusal(error: unknown): boolean {
   return typeof error === "string" &&
     error.startsWith(`${STORED_ARGUMENT_SCHEMA_REFUSAL}:`);
 }
+
+/**
+ * Which hold-back rule covers a refused update, or `undefined` when none
+ * does and the refusal must fail the run.
+ *
+ * The whole partition in one place, and the returned string is the reason
+ * the report prints beside the target: a refusal is held back only for a
+ * DERIVED hoist, and only in the two shapes that are supersession rather
+ * than loss — captures the re-run derivation re-supplies, and a hoist
+ * today's source no longer emits under the recorded (renumbered) id.
+ * Anything else about a hoist, and everything about an authored artifact,
+ * is the caller's failure to report.
+ *
+ * `missingArtifact` is passed as the materializer's own verdict rather than
+ * read out of `error`, whose text is arbitrary propagated prose.
+ */
+export function hoistSupersessionReason(
+  symbol: string,
+  error: unknown,
+  missingArtifact: boolean,
+): string | undefined {
+  if (!isDerivedHoistSymbol(symbol)) return undefined;
+  if (isStoredArgumentRefusal(error)) return "stored arguments superseded";
+  if (missingArtifact) return "hoist no longer emitted";
+  return undefined;
+}

--- a/tasks/pattern-vintage-lib.ts
+++ b/tasks/pattern-vintage-lib.ts
@@ -1184,16 +1184,34 @@ export function armVerdictGuard(
  * `replayed` is part of the condition and not just a number to print: zero
  * replays is the shape a broken gate takes, not the shape a clean tree takes.
  */
+export function isClean(
+  failures: readonly ReplayFailure[],
+  uncovered: readonly string[],
+  counts: { replayed: number; candidates: number; targets: number },
+): boolean {
+  return failures.length === 0 && uncovered.length === 0 &&
+    counts.replayed > 0 && counts.candidates > 0 && counts.targets > 0;
+}
+
 /**
  * Whether a recorded instantiation is a transformer-emitted pattern hoist —
  * an anonymous sub-pattern the compiler derives from the source (a mapped
  * row's body), as opposed to a pattern an author exports. The `__cfPattern_N`
  * name is the transformer's own emission convention, and N is a builder node
  * id with no stability across edits — which is exactly why nothing durable
- * may be addressed by it.
+ * may be addressed by it. The per-file counter starts at 1, so
+ * `__cfPattern_0` is not a name the transformer mints.
+ *
+ * Spelling is the only evidence available here. The artifact index registers
+ * hoists and exports through one path and keeps no provenance, and the
+ * missing-artifact face asks about a symbol today's module does not even
+ * define — so an authored export squatting on the reserved spelling would be
+ * classified as derived, and its refusals held back. Reserving the namespace
+ * at emission is the transformer-side fix; this gate cannot tell the
+ * squatter from the hoist.
  */
 export function isDerivedHoistSymbol(symbol: string): boolean {
-  return /^__cfPattern_\d+$/.test(symbol);
+  return /^__cfPattern_[1-9]\d*$/.test(symbol);
 }
 
 /**
@@ -1206,34 +1224,4 @@ export function isStoredArgumentRefusal(error: unknown): boolean {
   if (isStoredArgumentSchemaRefusal(error)) return true;
   return typeof error === "string" &&
     error.startsWith(`${STORED_ARGUMENT_SCHEMA_REFUSAL}:`);
-}
-
-/**
- * Whether a materialization error says today's source no longer DEFINES the
- * recorded symbol. For a derived hoist that is the renumbering face of the
- * same supersession as a capture drift — hoist ids are builder node ids with
- * no stability across edits, so an edited pattern routinely re-derives the
- * same rows under different numbers — and the caller pairs this with
- * `isDerivedHoistSymbol` so an AUTHORED export that disappeared still fails
- * as the retirement it is.
- */
-export function isMissingArtifactRefusal(
-  symbol: string,
-  error: unknown,
-): boolean {
-  const message = error instanceof Error
-    ? error.message
-    : typeof error === "string"
-    ? error
-    : "";
-  return message.includes(`defines no "${symbol}"`);
-}
-
-export function isClean(
-  failures: readonly ReplayFailure[],
-  uncovered: readonly string[],
-  counts: { replayed: number; candidates: number; targets: number },
-): boolean {
-  return failures.length === 0 && uncovered.length === 0 &&
-    counts.replayed > 0 && counts.candidates > 0 && counts.targets > 0;
 }

--- a/tasks/pattern-vintage-run.test.ts
+++ b/tasks/pattern-vintage-run.test.ts
@@ -175,6 +175,69 @@ const NESTED_ALIASED = aliased(false);
 const NESTED_ALIASED_FLIPPED = aliased(true);
 
 /**
+ * The map is gone and `rows` is re-derived from a plain read: today's module
+ * emits no `__cfPattern_N` at all, while every value a root held stays
+ * byte-equal. The recorded hoist root names an artifact that no longer
+ * exists — the renumbering face of supersession, isolated from state change.
+ */
+const NESTED_MAP_UNROLLED = nestedSource()
+  .replace(
+    "import { Confidential, Default, Writable, pattern } from 'commonfabric';",
+    "import { Confidential, Default, Writable, computed, pattern } from 'commonfabric';",
+  )
+  .replace(
+    "  const rows = items.map((word) => Row({ word }));",
+    "  const rows = computed(() =>\n" +
+      "    items.get().map((word) => ({ shout: word }))\n" +
+      "  );",
+  );
+
+/**
+ * The map body now closes over `marker`, an outer binding, and maps a FRESH
+ * collection carrying the same values. The fresh cause is what makes the
+ * drift observable: a re-run over the ORIGINAL collection re-supplies the
+ * recorded cells' arguments before their own targets validate, so only a
+ * derivation that no longer writes those cells leaves the captured
+ * arguments to face today's params schema — which now demands `marker`.
+ * `Row` itself widens compatibly (`prefix` optional and unused), and every
+ * stored value stays byte-equal.
+ */
+const NESTED_CAPTURE_GROWN = nestedSource()
+  .replace(
+    "export const Row = pattern<{ word: string }, RowOut>(({ word }) => {",
+    "export const Row = pattern<{ word: string; prefix?: string }, RowOut>(({ word }) => {",
+  )
+  .replace(
+    "  const rows = items.map((word) => Row({ word }));",
+    "  const marker = new Writable<string>('m').for('marker');\n" +
+      "  const items2 = new Writable<string[]>(['captured']).for('items2');\n" +
+      "  const rows = items2.map((word) => Row({ word, prefix: marker }));",
+  );
+
+/**
+ * `Row` — an AUTHORED export — now requires an argument its stored roots
+ * never held, under the same derivation drift as `NESTED_CAPTURE_GROWN`:
+ * the map iterates a fresh same-valued collection AND captures `marker`, so
+ * neither the re-run map nor a re-applied hoist re-supplies the recorded
+ * Row cell (a hoist that applied would re-run its body and heal the Row's
+ * arguments). One replay then carries both sides of the partition: the
+ * hoist's refusal is held back as derivation, and `Row`'s must FAIL — the
+ * spelling test is what separates a derived hoist from an authored pattern,
+ * and holding an authored refusal back would hide a real hazard.
+ */
+const NESTED_ROW_ARGS_TIGHTENED = nestedSource()
+  .replace(
+    "export const Row = pattern<{ word: string }, RowOut>(({ word }) => {",
+    "export const Row = pattern<{ word: string; word2: string; prefix?: string }, RowOut>(({ word }) => {",
+  )
+  .replace(
+    "  const rows = items.map((word) => Row({ word }));",
+    "  const marker = new Writable<string>('m').for('marker');\n" +
+      "  const items2 = new Writable<string[]>(['captured']).for('items2');\n" +
+      "  const rows = items2.map((word) => Row({ word, word2: word, prefix: marker }));",
+  );
+
+/**
  * A subject that returns a key its declared output type never NAMES, riding an
  * index signature instead — the shape `system/default-app.tsx` declares
  * (`[key: string]: unknown`), and the reason its root's `recentPieces`,
@@ -1757,6 +1820,81 @@ describe("the vintage gate, end to end", () => {
       expect(failures.length).toBeGreaterThan(0);
       expect(
         failures.some((f) => f.detail.includes('defines no "Row"')),
+      ).toBe(true);
+    });
+
+    it("holds a derived hoist back when the edit no longer emits it", async () => {
+      // The recorded `__cfPattern_N` root names an artifact today's module
+      // does not define, because the edit unrolled the map — the renumbering
+      // face of supersession. Held back and reported with its reason; the
+      // authored roots around it replay and compare as always.
+      await captureMissing(
+        roots,
+        [NESTED_TEST_KEY],
+        new Date("2026-07-29T12:00:00.000Z"),
+      );
+      await writeNested(NESTED_MAP_UNROLLED);
+
+      const { failures, capturesSuperseded } = await replayAll(roots);
+
+      expect(failures).toEqual([]);
+      expect(
+        capturesSuperseded.some((target) =>
+          /__cfPattern_[1-9]\d* \(hoist no longer emitted\)$/.test(target)
+        ),
+      ).toBe(true);
+    });
+
+    it("holds a derived hoist back when its captures outgrow the stored arguments", async () => {
+      // Today's hoist exists, but the map body's new outer capture makes its
+      // params schema demand a property the stored arguments never carried —
+      // the same refusal the runner reports as a stored-argument rejection.
+      // Captures are derivation the re-run map re-supplies, so this is held
+      // back rather than failed.
+      await captureMissing(
+        roots,
+        [NESTED_TEST_KEY],
+        new Date("2026-07-29T12:00:00.000Z"),
+      );
+      await writeNested(NESTED_CAPTURE_GROWN);
+
+      const { failures, capturesSuperseded } = await replayAll(roots);
+
+      expect(failures).toEqual([]);
+      expect(
+        capturesSuperseded.some((target) =>
+          /__cfPattern_[1-9]\d* \(stored arguments superseded\)$/.test(target)
+        ),
+      ).toBe(true);
+    });
+
+    it("FAILS an authored export whose stored arguments today's schema refuses", async () => {
+      // The same refusal class the hoists are held back on, fired by an
+      // AUTHORED pattern: `Row` now requires `word2` and the stored roots
+      // never held one. Nothing here is derivation a re-run re-supplies, so
+      // holding it back would hide a stranded piece. The hoist's own refusal
+      // in the same replay stays held back — both sides of the partition,
+      // decided by what the symbol is rather than by the refusal's shape.
+      await captureMissing(
+        roots,
+        [NESTED_TEST_KEY],
+        new Date("2026-07-29T12:00:00.000Z"),
+      );
+      await writeNested(NESTED_ROW_ARGS_TIGHTENED);
+
+      const { failures, capturesSuperseded } = await replayAll(roots);
+
+      expect(failures.length).toBeGreaterThan(0);
+      expect(
+        failures.some((f) => f.detail.includes("(Row)")),
+      ).toBe(true);
+      expect(
+        failures.some((f) => f.detail.includes("__cfPattern")),
+      ).toBe(false);
+      expect(
+        capturesSuperseded.some((target) =>
+          /__cfPattern_[1-9]\d* \(stored arguments superseded\)$/.test(target)
+        ),
       ).toBe(true);
     });
   });

--- a/tasks/pattern-vintage-run.test.ts
+++ b/tasks/pattern-vintage-run.test.ts
@@ -1899,6 +1899,60 @@ describe("the vintage gate, end to end", () => {
     });
   });
 
+  describe("an authored export squatting on the hoist namespace", () => {
+    const SQUATTER_KEY = "vintage-gate-squatter.tsx";
+    const SQUATTER_TEST_KEY = SQUATTER_KEY.replace(/\.tsx$/, ".test.tsx");
+
+    // The capture/rename hazard: were this captured, its manifest entry would
+    // be spelled exactly like a derived hoist, and a later rename would be
+    // held back as supersession instead of failing as a retirement. The
+    // runner's registration seam refuses the module outright, so the
+    // sequence can no longer be constructed — which is the regression this
+    // pins end to end.
+    const SQUATTER = [
+      "import { pattern } from 'commonfabric';",
+      "interface RowOut { shout: string }",
+      "export const __cfPattern_1 = pattern<{ word: string }, RowOut>(",
+      "  ({ word }) => ({ shout: word }),",
+      ");",
+      "export default pattern<Record<string, never>, { out: string }>(",
+      "  () => ({ out: 'x' }),",
+      ");",
+      "",
+    ].join("\n");
+
+    const SQUATTER_TEST = [
+      "import { assert, pattern, TESTS } from 'commonfabric';",
+      `import Subject from './${SQUATTER_KEY}';`,
+      "export default pattern(() => {",
+      "  const subject = Subject({});",
+      "  const present = assert(() => subject.out === 'x');",
+      "  return { [TESTS]: [{ assertion: present }], subject };",
+      "});",
+      "",
+    ].join("\n");
+
+    beforeEach(async () => {
+      await Deno.writeTextFile(`${dir}/patterns/${SQUATTER_KEY}`, SQUATTER);
+      await Deno.writeTextFile(
+        `${dir}/patterns/${SQUATTER_TEST_KEY}`,
+        SQUATTER_TEST,
+      );
+    });
+
+    it("REFUSES the capture, so the fixture never exists to mislead", async () => {
+      const { problems, captured } = await captureMissing(
+        roots,
+        [SQUATTER_TEST_KEY],
+        new Date("2026-07-29T12:00:00.000Z"),
+      );
+      expect(captured).toEqual([]);
+      expect(
+        problems.some((p) => p.includes("hoist namespace")),
+      ).toBe(true);
+    });
+  });
+
   describe("a key the declared output type never names", () => {
     const STAMP = new Date("2026-07-29T12:00:00.000Z");
 

--- a/tasks/pattern-vintage-run.ts
+++ b/tasks/pattern-vintage-run.ts
@@ -20,6 +20,9 @@ import {
   autoGenerationsToPrune,
   collectVintages,
   describeError,
+  isDerivedHoistSymbol,
+  isMissingArtifactRefusal,
+  isStoredArgumentRefusal,
   newestAutoGeneration,
   patternKeyFromMain,
   PINNED,
@@ -277,6 +280,18 @@ export interface ReplayReport {
    * unless the run counts where each was used. Keyed by the entry's pattern.
    */
   dropsApplied: Set<string>;
+  /**
+   * Derived-hoist targets whose STORED ARGUMENTS today's schema refused —
+   * held back from failing, because a hoist's arguments are the captures of a
+   * derivation the updated source re-runs and re-supplies wholesale. The real
+   * update channel (`setPattern`) validates only the root contract, so
+   * failing here held vintages to a stricter rule than any deployed piece
+   * experiences. Only the stored-argument refusal is held back: any other
+   * error on a hoist still fails, and so does the readback comparison for
+   * every hoist that applies — which is what keeps a row-allocated cell's
+   * cause-stability (the moved-`.for()` class) gated.
+   */
+  capturesSuperseded: string[];
   failures: ReplayFailure[];
 }
 
@@ -315,6 +330,7 @@ export async function replayVintage(
     covered: new Set<string>(),
     recorded,
     dropsApplied: new Set<string>(),
+    capturesSuperseded: [],
     failures: [{ ...where, detail }],
   });
   /** Every pattern key a manifest names, for attributing a failed fixture. */
@@ -459,6 +475,7 @@ export async function replayVintage(
       covered: new Set<string>(),
       recorded: new Set<string>(),
       dropsApplied: new Set<string>(),
+      capturesSuperseded: [],
       failures: [],
     };
     // A recorded root nothing can address is a FAILURE, not a note. The replay
@@ -701,6 +718,18 @@ export async function replayVintage(
         },
       );
       if (outcome.error !== undefined) {
+        // A derived hoist whose stored arguments no longer satisfy today's
+        // schema is not a stranded piece: see `capturesSuperseded` on the
+        // report. Held back and reported, never silently dropped. Any other
+        // refusal of a hoist — compile, commit, storage — still fails.
+        if (
+          isDerivedHoistSymbol(entry.symbol) &&
+          (isStoredArgumentRefusal(outcome.error) ||
+            isMissingArtifactRefusal(entry.symbol, outcome.error))
+        ) {
+          report.capturesSuperseded.push(`${entry.main} ${entry.symbol}`);
+          continue;
+        }
         report.failures.push({
           ...where,
           detail:
@@ -916,6 +945,8 @@ export async function replayAll(
     perVintage: VintageOutcome[];
     /** Accepted-drop entries that forgave something somewhere in this run. */
     dropsApplied: Set<string>;
+    /** Derived-hoist targets held back from stored-argument validation. */
+    capturesSuperseded: string[];
     failures: ReplayFailure[];
   }
 > {
@@ -924,6 +955,7 @@ export async function replayAll(
   const covered = new Set<string>();
   const coveredBy = new Map<string, VintageAttribution>();
   const dropsApplied = new Set<string>();
+  const capturesSuperseded: string[] = [];
   let servedRoute = 0;
   let candidates = 0,
     targets = 0,
@@ -966,6 +998,7 @@ export async function replayAll(
     servedRoute += report.servedRoute;
     for (const key of report.covered) covered.add(key);
     for (const key of report.dropsApplied) dropsApplied.add(key);
+    capturesSuperseded.push(...report.capturesSuperseded);
     for (const key of report.recorded) {
       // From `recorded`, NOT `covered`: a pattern that was credited needs no
       // attribution, because it never reaches an uncovered report. The one
@@ -1000,6 +1033,7 @@ export async function replayAll(
     coveredBy,
     perVintage,
     dropsApplied,
+    capturesSuperseded,
     failures,
   };
 }

--- a/tasks/pattern-vintage-run.ts
+++ b/tasks/pattern-vintage-run.ts
@@ -280,15 +280,19 @@ export interface ReplayReport {
    */
   dropsApplied: Set<string>;
   /**
-   * Derived-hoist targets whose STORED ARGUMENTS today's schema refused —
-   * held back from failing, because a hoist's arguments are the captures of a
-   * derivation the updated source re-runs and re-supplies wholesale. The real
-   * update channel (`setPattern`) validates only the root contract, so
-   * failing here held vintages to a stricter rule than any deployed piece
-   * experiences. Only the stored-argument refusal is held back: any other
-   * error on a hoist still fails, and so does the readback comparison for
-   * every hoist that applies — which is what keeps a row-allocated cell's
-   * cause-stability (the moved-`.for()` class) gated.
+   * Derived-hoist targets held back from failing, each entry tagged with the
+   * rule that held it. Two refusal shapes qualify: STORED ARGUMENTS today's
+   * schema refused ("stored arguments superseded"), because a hoist's
+   * arguments are the captures of a derivation the updated source re-runs
+   * and re-supplies wholesale; and a recorded hoist today's source no longer
+   * emits ("hoist no longer emitted"), because hoist ids are builder node
+   * ids an ordinary edit renumbers — the same supersession wearing its
+   * second face. The real update channel (`setPattern`) validates only the
+   * root contract, so failing on either held vintages to a stricter rule
+   * than any deployed piece experiences. Nothing else is held back: any
+   * other error on a hoist still fails, and so does the readback comparison
+   * for every hoist that applies — which is what keeps a row-allocated
+   * cell's cause-stability (the moved-`.for()` class) gated.
    */
   capturesSuperseded: string[];
   failures: ReplayFailure[];
@@ -950,7 +954,10 @@ export async function replayAll(
     perVintage: VintageOutcome[];
     /** Accepted-drop entries that forgave something somewhere in this run. */
     dropsApplied: Set<string>;
-    /** Derived-hoist targets held back from stored-argument validation. */
+    /**
+     * Derived-hoist targets held back, each tagged with the rule that held
+     * it — a superseded stored argument, or a hoist no longer emitted.
+     */
     capturesSuperseded: string[];
     failures: ReplayFailure[];
   }

--- a/tasks/pattern-vintage-run.ts
+++ b/tasks/pattern-vintage-run.ts
@@ -20,8 +20,7 @@ import {
   autoGenerationsToPrune,
   collectVintages,
   describeError,
-  isDerivedHoistSymbol,
-  isStoredArgumentRefusal,
+  hoistSupersessionReason,
   newestAutoGeneration,
   patternKeyFromMain,
   PINNED,
@@ -726,13 +725,11 @@ export async function replayVintage(
         // report. Held back and reported WITH the rule that fired, never
         // silently dropped. Any other refusal of a hoist — compile, commit,
         // storage — still fails.
-        const supersession = !isDerivedHoistSymbol(entry.symbol)
-          ? undefined
-          : isStoredArgumentRefusal(outcome.error)
-          ? "stored arguments superseded"
-          : outcome.missingArtifact === true
-          ? "hoist no longer emitted"
-          : undefined;
+        const supersession = hoistSupersessionReason(
+          entry.symbol,
+          outcome.error,
+          outcome.missingArtifact === true,
+        );
         if (supersession !== undefined) {
           report.capturesSuperseded.push(
             `${entry.main} ${entry.symbol} (${supersession})`,

--- a/tasks/pattern-vintage-run.ts
+++ b/tasks/pattern-vintage-run.ts
@@ -21,7 +21,6 @@ import {
   collectVintages,
   describeError,
   isDerivedHoistSymbol,
-  isMissingArtifactRefusal,
   isStoredArgumentRefusal,
   newestAutoGeneration,
   patternKeyFromMain,
@@ -720,14 +719,20 @@ export async function replayVintage(
       if (outcome.error !== undefined) {
         // A derived hoist whose stored arguments no longer satisfy today's
         // schema is not a stranded piece: see `capturesSuperseded` on the
-        // report. Held back and reported, never silently dropped. Any other
-        // refusal of a hoist — compile, commit, storage — still fails.
-        if (
-          isDerivedHoistSymbol(entry.symbol) &&
-          (isStoredArgumentRefusal(outcome.error) ||
-            isMissingArtifactRefusal(entry.symbol, outcome.error))
-        ) {
-          report.capturesSuperseded.push(`${entry.main} ${entry.symbol}`);
+        // report. Held back and reported WITH the rule that fired, never
+        // silently dropped. Any other refusal of a hoist — compile, commit,
+        // storage — still fails.
+        const supersession = !isDerivedHoistSymbol(entry.symbol)
+          ? undefined
+          : isStoredArgumentRefusal(outcome.error)
+          ? "stored arguments superseded"
+          : outcome.missingArtifact === true
+          ? "hoist no longer emitted"
+          : undefined;
+        if (supersession !== undefined) {
+          report.capturesSuperseded.push(
+            `${entry.main} ${entry.symbol} (${supersession})`,
+          );
           continue;
         }
         report.failures.push({

--- a/tasks/pattern-vintage.ts
+++ b/tasks/pattern-vintage.ts
@@ -287,9 +287,9 @@ async function main() {
   if (replay.capturesSuperseded.length > 0) {
     const targets = [...new Set(replay.capturesSuperseded)].sort();
     console.log(
-      `\nHeld ${targets.length} derived sub-pattern target(s) back from ` +
-        `stored-argument validation: a hoist's captures are re-supplied by ` +
-        `the re-run derivation (root contracts still gate):`,
+      `\nHeld ${targets.length} derived sub-pattern target(s) back, each ` +
+        `with the rule that held it: a hoist is derivation the updated ` +
+        `source re-runs and re-supplies (root contracts still gate):`,
     );
     for (const target of targets) {
       console.log(`  ${target}`);

--- a/tasks/pattern-vintage.ts
+++ b/tasks/pattern-vintage.ts
@@ -284,6 +284,18 @@ async function main() {
     console.error(`\n${reportFailures(replay.failures)}`);
   }
 
+  if (replay.capturesSuperseded.length > 0) {
+    const targets = [...new Set(replay.capturesSuperseded)].sort();
+    console.log(
+      `\nHeld ${targets.length} derived sub-pattern target(s) back from ` +
+        `stored-argument validation: a hoist's captures are re-supplied by ` +
+        `the re-run derivation (root contracts still gate):`,
+    );
+    for (const target of targets) {
+      console.log(`  ${target}`);
+    }
+  }
+
   if (replay.dropsApplied.size > 0) {
     console.log(
       `\nHeld ${replay.dropsApplied.size} path(s) back from their vintage, ` +


### PR DESCRIPTION
Implements the ruling from Monday's conversation (@seefeldb): the state-continuity gate stops failing on **derived-hoist stored arguments**, while keeping everything that protects allocated durable state.

**The problem.** A mapped row's anonymous sub-pattern (`__cfPattern_N`) records its closure's captures as stored arguments. Those captures are re-supplied wholesale when the updated source re-runs the derivation — but the gate validated them against today's schema, so any JSX edit that made a row reference one more outer binding became a silently update-breaking change, invisible to the author and impossible to annotate (the schema is transformer-generated). #5744's last red was exactly this, ×5 instantiations across 2 hoists.

**Alignment with the real channel, verified:** `setPattern` enforces only the root contract (`assertPatternSchemasBackwardCompatible`) plus root-argument link validation, with the aggregate review deliberately kept out of the apply path (the CT-1917 cold-argument comment). No deployed piece has ever had hoist params validated at update time — the gate was strictly stricter than reality.

**What changes.** For hoists only (`/^__cfPattern_[1-9]\d*$/` — the per-file counter starts at 1, and the namespace is reserved: see below), two refusal shapes are held back, reported **with the rule that held them**, and counted (`capturesSuperseded`, printed like the accepted-drops "Held…" block): stored arguments the candidate schema refuses (classified via the runner's exported `STORED_ARGUMENT_SCHEMA_REFUSAL`), and a recorded hoist today's source no longer defines — hoist ids are builder node ids, renumbered by ordinary edits, so a vanished number is the same supersession wearing its second face. The missing-artifact face is classified **structurally**: `MaterializeOutcome` carries a `missingArtifact` field set at the one site that produces the refusal, so the verdict travels beside the error message rather than being matched out of its prose.

**The namespace is reserved, so spelling proves provenance.** Review (@mathpirate) established through the real capture/replay path that this was a fail-closed hole, not namespace hygiene: an authored `export const __cfPattern_1 = pattern(...)` captured successfully, and renaming it afterwards was held back as supersession instead of failing as the retirement it is. So the reservation is enforced where authored exports are seen — `PatternManager.registerEvaluatedModules` refuses a bundle exporting a builder artifact named `__cfPattern_<n>`, as a whole-bundle pre-pass so a refused bundle registers nothing rather than half of itself. Hoists reach the artifact index through `__cfReg` rather than exports, so a compiled module pays nothing; only artifacts are refused, since `indexArtifact` admits nothing else and a plain value under the name can never resolve as a hoist. Documented in the transformer spec §11.3, which the update-testing spec now points at for why spelling is decisive.

This is the one part of the change that reaches outside `tasks/` — a Foundation-layer load path — so it is verified wider than the rest: runner 1237 passed / 6828 steps, piece 37 / 460, tasks 551, plus both gates on the real corpus (`pattern-compat` 333 patterns; `pattern-vintage` exit 0 over 134 recorded instantiations, every one registering hoists through the changed seam).

**What deliberately does not change** — the refinement from the ruling: any *other* error on a hoist still fails; an authored export that disappeared still fails as the retirement it is; and a hoist that applies is compared like everything else, which is what keeps a row-allocated cell's cause-stability — the moved-`.for()` class, this tier's founding example — fully gated. Captures are the derivation; allocations are homes.

**Evidence:** both task suites green (17 tests / 161 steps), now including **end-to-end pins for the held-back branch itself**: a hoist the edit no longer emits is held; a hoist whose captures outgrew its stored arguments is held; and, in the same replay as a held hoist, an authored export's identical refusal FAILS — both sides of the partition in one scenario. (Getting those pins honest surfaced a design property worth naming: a re-run map — or a re-applied hoist — re-supplies recorded cells' arguments before their own targets validate, so the stale-capture condition only exists when the derivation allocates under a fresh cause. Which is the ruling's own reasoning, observed.) Full `pattern-vintage` green on main's fixtures (8 vintages, no behavior change — zero held-back targets, since nothing drifted); and run against #5744's branch the gate goes exit-0 printing the residue that motivated the ruling, each face named:

```
Held 2 derived sub-pattern target(s) back, each with the rule that held it: …
  /packages/patterns/lunch-poll/main.tsx __cfPattern_4 (stored arguments superseded)
  /packages/patterns/lunch-poll/main.tsx __cfPattern_6 (hoist no longer emitted)
```

Spec updated in the same change.

<sub>Implemented by Claude (Fable 5) on @mathpirate's behalf, per the in-person ruling.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->





**Coverage.** The gate reports `tasks` +11 and I could not reproduce that as real uncovered code, so the acceptance below is recorded with what was actually measured rather than a guess.

Against this run's own coverage artifacts: the branch's new hold-back branch in `replayVintage` **is** covered in CI, and the unique never-covered line sets for both changed files are identical to `main` (`pattern-vintage-run.ts` 52, `pattern-vintage-lib.ts` 9) — as is the whole `tasks` group measured from the workspace profiles (1548 lines, no per-file difference). An identical local invocation puts the branch slightly ahead of `main` (1622 vs 1624). The classification rule was still extracted into `hoistSupersessionReason` and unit-tested directly, which is better placed regardless, though it moved the reported number not at all.

So the +11 is not attributable to a line this branch left uncovered, by any measurement I can take. Accepting it to unblock, and following up separately on the discrepancy rather than leaving a number nobody can source.

ACCEPT_COVERAGE_DEBT: tasks +11 lines

