### PR TITLE
fix(patterns): suggestable patterns wait for a topic before asking

### DIFF
--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -1378,6 +1378,10 @@ inputs and produces a focused output.
 
 Generates a concise summary of provided context using an LLM.
 
+An instance with no `topic` has nothing to summarize. Its prompt stays empty, so
+no model request opens: `pending` stays `false` and `summary` stays `""`. The
+first `topic` a caller supplies is what starts the request.
+
 **Keywords:** summary, generateText, suggestion-fuel
 
 ### Input Schema
@@ -1402,6 +1406,10 @@ type SummaryOutput = {
 ## `suggestable/checklist.tsx`
 
 Generates a checklist of actionable steps from a topic and context.
+
+An instance with no `topic` has no steps to draw up. Its prompt stays empty, so
+no model request opens: `pending` stays `false` and `items` stays empty. The
+first `topic` a caller supplies is what starts the request.
 
 **Keywords:** checklist, generateObject, suggestion-fuel
 
@@ -1433,6 +1441,11 @@ type ChecklistOutput = {
 
 Generates a clarifying question with optional multiple-choice options.
 
+An instance with no `topic` has nothing to ask about. Its prompt stays empty, so
+no model request opens: `pending` stays `false`, `question` stays `""` and
+`options` stays empty. The first `topic` a caller supplies is what starts the
+request.
+
 **Keywords:** question, generateObject, suggestion-fuel
 
 ### Input Schema
@@ -1461,6 +1474,10 @@ type QuestionOutput = {
 Generates an ASCII diagram illustrating relationships, flows, or structures.
 Rendered in a `<pre>` tag with monospace styling.
 
+An instance with no `topic` has nothing to draw. Its prompt stays empty, so no
+model request opens: `pending` stays `false` and `diagram` stays `""`. The first
+`topic` a caller supplies is what starts the request.
+
 **Keywords:** diagram, ASCII, generateText, suggestion-fuel
 
 ### Input Schema
@@ -1486,6 +1503,10 @@ type DiagramOutput = {
 
 Generates an SVG diagram illustrating relationships, flows, or structures.
 Rendered via `<cf-svg>` web component for scalable vector output.
+
+An instance with no `topic` has nothing to draw. Its prompt stays empty, so no
+model request opens: `pending` stays `false` and `diagram` stays `""`. The first
+`topic` a caller supplies is what starts the request.
 
 **Keywords:** diagram, SVG, generateText, suggestion-fuel, cf-svg
 

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -1376,11 +1376,10 @@ inputs and produces a focused output.
 
 ## `suggestable/summary.tsx`
 
-Generates a concise summary of provided context using an LLM.
-
-An instance with no `topic` has nothing to summarize. Its prompt stays empty, so
-no model request opens: `pending` stays `false` and `summary` stays `""`. The
-first `topic` a caller supplies is what starts the request.
+Generates a concise summary of provided context using an LLM. The topic is what
+asks for the summary: with none given the pattern holds the request back, so
+`pending` stays `false` and `summary` stays empty until a caller names a
+subject.
 
 **Keywords:** summary, generateText, suggestion-fuel
 
@@ -1405,11 +1404,9 @@ type SummaryOutput = {
 
 ## `suggestable/checklist.tsx`
 
-Generates a checklist of actionable steps from a topic and context.
-
-An instance with no `topic` has no steps to draw up. Its prompt stays empty, so
-no model request opens: `pending` stays `false` and `items` stays empty. The
-first `topic` a caller supplies is what starts the request.
+Generates a checklist of actionable steps from a topic and context. The topic is
+what asks for the steps: with none given the pattern holds the request back, so
+`pending` stays `false` and `items` stays empty until a caller names a subject.
 
 **Keywords:** checklist, generateObject, suggestion-fuel
 
@@ -1439,12 +1436,10 @@ type ChecklistOutput = {
 
 ## `suggestable/question.tsx`
 
-Generates a clarifying question with optional multiple-choice options.
-
-An instance with no `topic` has nothing to ask about. Its prompt stays empty, so
-no model request opens: `pending` stays `false`, `question` stays `""` and
-`options` stays empty. The first `topic` a caller supplies is what starts the
-request.
+Generates a clarifying question with optional multiple-choice options. The topic
+is what asks for the question: with none given the pattern holds the request
+back, so `pending` stays `false` and both `question` and `options` stay empty
+until a caller names a subject.
 
 **Keywords:** question, generateObject, suggestion-fuel
 
@@ -1472,11 +1467,9 @@ type QuestionOutput = {
 ## `suggestable/diagram.tsx`
 
 Generates an ASCII diagram illustrating relationships, flows, or structures.
-Rendered in a `<pre>` tag with monospace styling.
-
-An instance with no `topic` has nothing to draw. Its prompt stays empty, so no
-model request opens: `pending` stays `false` and `diagram` stays `""`. The first
-`topic` a caller supplies is what starts the request.
+Rendered in a `<pre>` tag with monospace styling. The topic is what asks for the
+diagram: with none given the pattern holds the request back, so `pending` stays
+`false` and `diagram` stays empty until a caller names a subject.
 
 **Keywords:** diagram, ASCII, generateText, suggestion-fuel
 
@@ -1502,11 +1495,10 @@ type DiagramOutput = {
 ## `suggestable/svg-diagram.tsx`
 
 Generates an SVG diagram illustrating relationships, flows, or structures.
-Rendered via `<cf-svg>` web component for scalable vector output.
-
-An instance with no `topic` has nothing to draw. Its prompt stays empty, so no
-model request opens: `pending` stays `false` and `diagram` stays `""`. The first
-`topic` a caller supplies is what starts the request.
+Rendered via `<cf-svg>` web component for scalable vector output. The topic is
+what asks for the diagram: with none given the pattern holds the request back,
+so `pending` stays `false` and `diagram` stays empty until a caller names a
+subject.
 
 **Keywords:** diagram, SVG, generateText, suggestion-fuel, cf-svg
 

--- a/packages/patterns/suggestable/checklist.test.tsx
+++ b/packages/patterns/suggestable/checklist.test.tsx
@@ -1,0 +1,32 @@
+import { assert, pattern, TESTS, UI } from "commonfabric";
+import { hasText } from "../test/vnode-helpers.ts";
+import Checklist from "./checklist.tsx";
+
+export default pattern(() => {
+  // Nothing names what the steps would be for, so no model request opens and
+  // the checklist is built and read entirely from what it holds on its own.
+  const subject = Checklist({});
+
+  const assert_built = assert(() => subject != null);
+  const assert_no_topic = assert(() => subject.topic === "");
+  const assert_not_pending = assert(() => subject.pending === false);
+  const assert_no_items = assert(() => subject.items.length === 0);
+  const assert_generic_heading = assert(() =>
+    hasText(subject[UI], "Checklist")
+  );
+  const assert_no_loader = assert(() =>
+    !hasText(subject[UI], "Generating checklist")
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_built },
+      { assertion: assert_no_topic },
+      { assertion: assert_not_pending },
+      { assertion: assert_no_items },
+      { assertion: assert_generic_heading },
+      { assertion: assert_no_loader },
+    ],
+    subject,
+  };
+});

--- a/packages/patterns/suggestable/checklist.tsx
+++ b/packages/patterns/suggestable/checklist.tsx
@@ -37,9 +37,13 @@ export type ChecklistOutput = {
  */
 const Checklist = pattern<ChecklistInput, ChecklistOutput>(
   ({ topic, context }) => {
+    // An empty prompt holds the request back: `generateObject` clears its
+    // state and makes no call until one arrives. A checklist with no topic
+    // has no steps to draw up, so the model is asked only once a caller names
+    // what the steps are for.
     const prompt = computed(() => {
-      const t = topic || "the following";
-      return `Generate a checklist of actionable steps for: ${t}`;
+      if (!topic) return "";
+      return `Generate a checklist of actionable steps for: ${topic}`;
     });
 
     const response = generateObject<{ items: ChecklistItem[] }>({

--- a/packages/patterns/suggestable/diagram.test.tsx
+++ b/packages/patterns/suggestable/diagram.test.tsx
@@ -1,0 +1,30 @@
+import { assert, pattern, TESTS, UI } from "commonfabric";
+import { hasText } from "../test/vnode-helpers.ts";
+import Diagram from "./diagram.tsx";
+
+export default pattern(() => {
+  // Nothing names the subject to draw, so no model request opens and the
+  // diagram is built and read entirely from what it holds on its own.
+  const subject = Diagram({});
+
+  const assert_built = assert(() => subject != null);
+  const assert_no_topic = assert(() => subject.topic === "");
+  const assert_not_pending = assert(() => subject.pending === false);
+  const assert_no_diagram = assert(() => subject.diagram === "");
+  const assert_generic_heading = assert(() => hasText(subject[UI], "Diagram"));
+  const assert_no_loader = assert(() =>
+    !hasText(subject[UI], "Generating diagram")
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_built },
+      { assertion: assert_no_topic },
+      { assertion: assert_not_pending },
+      { assertion: assert_no_diagram },
+      { assertion: assert_generic_heading },
+      { assertion: assert_no_loader },
+    ],
+    subject,
+  };
+});

--- a/packages/patterns/suggestable/diagram.tsx
+++ b/packages/patterns/suggestable/diagram.tsx
@@ -32,9 +32,12 @@ export type DiagramOutput = {
  * representation of concepts using plain text art.
  */
 const Diagram = pattern<DiagramInput, DiagramOutput>(({ topic, context }) => {
+  // An empty prompt holds the request back: `generateText` clears its state
+  // and makes no call until one arrives. A diagram with no topic has nothing
+  // to draw, so the model is asked only once a caller names the subject.
   const prompt = computed(() => {
-    const t = topic || "the following";
-    return `Create a clear ASCII diagram illustrating: ${t}`;
+    if (!topic) return "";
+    return `Create a clear ASCII diagram illustrating: ${topic}`;
   });
 
   const response = generateText({

--- a/packages/patterns/suggestable/question.test.tsx
+++ b/packages/patterns/suggestable/question.test.tsx
@@ -1,0 +1,32 @@
+import { assert, pattern, TESTS, UI } from "commonfabric";
+import { hasText } from "../test/vnode-helpers.ts";
+import Question from "./question.tsx";
+
+export default pattern(() => {
+  // Nothing names the subject to ask about, so no model request opens and the
+  // question is built and read entirely from what it holds on its own.
+  const subject = Question({});
+
+  const assert_built = assert(() => subject != null);
+  const assert_no_topic = assert(() => subject.topic === "");
+  const assert_not_pending = assert(() => subject.pending === false);
+  const assert_no_question = assert(() => subject.question === "");
+  const assert_no_options = assert(() => subject.options.length === 0);
+  const assert_generic_heading = assert(() => hasText(subject[UI], "Question"));
+  const assert_no_loader = assert(() =>
+    !hasText(subject[UI], "Generating question")
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_built },
+      { assertion: assert_no_topic },
+      { assertion: assert_not_pending },
+      { assertion: assert_no_question },
+      { assertion: assert_no_options },
+      { assertion: assert_generic_heading },
+      { assertion: assert_no_loader },
+    ],
+    subject,
+  };
+});

--- a/packages/patterns/suggestable/question.tsx
+++ b/packages/patterns/suggestable/question.tsx
@@ -46,9 +46,13 @@ const onAnswer = handler<
  */
 const Question = pattern<QuestionInput, QuestionOutput>(
   ({ topic, context }) => {
+    // An empty prompt holds the request back: `generateObject` clears its
+    // state and makes no call until one arrives. A question with no topic has
+    // nothing to ask about, so the model is asked only once a caller names the
+    // subject.
     const prompt = computed(() => {
-      const t = topic || "the current situation";
-      return `Generate a single, thoughtful clarifying question about: ${t}. Include 2-4 multiple choice options if appropriate, or leave options empty for a free-text answer.`;
+      if (!topic) return "";
+      return `Generate a single, thoughtful clarifying question about: ${topic}. Include 2-4 multiple choice options if appropriate, or leave options empty for a free-text answer.`;
     });
 
     const response = generateObject<{

--- a/packages/patterns/suggestable/summary.test.tsx
+++ b/packages/patterns/suggestable/summary.test.tsx
@@ -1,0 +1,30 @@
+import { assert, pattern, TESTS, UI } from "commonfabric";
+import { hasText } from "../test/vnode-helpers.ts";
+import Summary from "./summary.tsx";
+
+export default pattern(() => {
+  // Nothing names the subject to summarize, so no model request opens and the
+  // summary is built and read entirely from what it holds on its own.
+  const subject = Summary({});
+
+  const assert_built = assert(() => subject != null);
+  const assert_no_topic = assert(() => subject.topic === "");
+  const assert_not_pending = assert(() => subject.pending === false);
+  const assert_no_summary = assert(() => subject.summary === "");
+  const assert_generic_heading = assert(() => hasText(subject[UI], "Summary"));
+  const assert_no_loader = assert(() =>
+    !hasText(subject[UI], "Generating summary")
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_built },
+      { assertion: assert_no_topic },
+      { assertion: assert_not_pending },
+      { assertion: assert_no_summary },
+      { assertion: assert_generic_heading },
+      { assertion: assert_no_loader },
+    ],
+    subject,
+  };
+});

--- a/packages/patterns/suggestable/summary.tsx
+++ b/packages/patterns/suggestable/summary.tsx
@@ -32,10 +32,12 @@ export type SummaryOutput = {
  * instantiated across many different contexts.
  */
 const Summary = pattern<SummaryInput, SummaryOutput>(({ topic, context }) => {
-  // Build the prompt dynamically based on topic and context
+  // An empty prompt holds the request back: `generateText` clears its state
+  // and makes no call until one arrives. A summary with no topic has nothing
+  // to condense, so the model is asked only once a caller names the subject.
   const prompt = computed(() => {
-    const t = topic || "the following";
-    return `Please provide a concise, well-structured summary of ${t}`;
+    if (!topic) return "";
+    return `Please provide a concise, well-structured summary of ${topic}`;
   });
 
   // Generate the summary

--- a/packages/patterns/suggestable/svg-diagram.test.tsx
+++ b/packages/patterns/suggestable/svg-diagram.test.tsx
@@ -1,0 +1,32 @@
+import { assert, pattern, TESTS, UI } from "commonfabric";
+import { hasText } from "../test/vnode-helpers.ts";
+import SvgDiagram from "./svg-diagram.tsx";
+
+export default pattern(() => {
+  // Nothing names the subject to draw, so no model request opens and the
+  // diagram is built and read entirely from what it holds on its own.
+  const subject = SvgDiagram({});
+
+  const assert_built = assert(() => subject != null);
+  const assert_no_topic = assert(() => subject.topic === "");
+  const assert_not_pending = assert(() => subject.pending === false);
+  const assert_no_diagram = assert(() => subject.diagram === "");
+  const assert_generic_heading = assert(() =>
+    hasText(subject[UI], "SVG Diagram")
+  );
+  const assert_no_loader = assert(() =>
+    !hasText(subject[UI], "Generating diagram")
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_built },
+      { assertion: assert_no_topic },
+      { assertion: assert_not_pending },
+      { assertion: assert_no_diagram },
+      { assertion: assert_generic_heading },
+      { assertion: assert_no_loader },
+    ],
+    subject,
+  };
+});

--- a/packages/patterns/suggestable/svg-diagram.tsx
+++ b/packages/patterns/suggestable/svg-diagram.tsx
@@ -33,9 +33,13 @@ export type SvgDiagramOutput = {
  */
 const SvgDiagram = pattern<SvgDiagramInput, SvgDiagramOutput>(
   ({ topic, context }) => {
+    // An empty prompt holds the request back: `generateText` clears its
+    // state and makes no call until one arrives. A diagram with no topic has
+    // nothing to draw, so the model is asked only once a caller names the
+    // subject.
     const prompt = computed(() => {
-      const t = topic || "the following";
-      return `Create a clear SVG diagram illustrating: ${t}`;
+      if (!topic) return "";
+      return `Create a clear SVG diagram illustrating: ${topic}`;
     });
 
     const response = generateText({

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -1009,17 +1009,22 @@ export function generateText(
     // If neither prompt nor messages is provided, don't make a request
     const hasPrompt = Array.isArray(prompt) ? prompt.length > 0 : !!prompt;
     if (!hasPrompt && !messages) {
-      // Advancing the run abandons a request already in flight, so the response
-      // it eventually produces fails its guard and writes nothing. Dropping the
-      // remembered hash lets the same prompt, if it comes back, go out again
-      // rather than match the in-flight check and never be sent.
-      currentRun++;
-      previousCallHash = undefined;
+      // Abandon a request already in flight, where abandoning one is possible.
+      // Advancing the run makes its response fail the guard on the way back, so
+      // nothing of it reaches the cell, and dropping the remembered hash lets
+      // the same prompt go out again rather than match the in-flight check and
+      // never be sent. A queued request is neither of those: the queue owns its
+      // lifecycle and runs it to completion, so forgetting its hash would
+      // enqueue a second copy of a call that is still going to arrive.
+      const queued = inputs.key("queue").withTx(tx).get() !== undefined;
+      if (!queued) {
+        currentRun++;
+        previousCallHash = undefined;
+      }
       resultWithLog.set(undefined);
       errorWithLog.set(undefined);
       partialWithLog.set(undefined);
       pendingWithLog.set(false);
-      requestHashWithLog.set(undefined);
       return;
     }
 
@@ -1317,18 +1322,23 @@ export function generateObject<T extends Record<string, unknown>>(
       (!hasPrompt && (!messages || messages.length === 0)) ||
       schema === undefined
     ) {
-      // Advancing the run abandons a request already in flight, so the response
-      // it eventually produces fails its guard and writes nothing. Dropping the
-      // remembered hash lets the same prompt, if it comes back, go out again
-      // rather than match the in-flight check and never be sent.
-      currentRun++;
-      previousCallHash = undefined;
+      // Abandon a request already in flight, where abandoning one is possible.
+      // Advancing the run makes its response fail the guard on the way back, so
+      // nothing of it reaches the cell, and dropping the remembered hash lets
+      // the same prompt go out again rather than match the in-flight check and
+      // never be sent. A queued request is neither of those: the queue owns its
+      // lifecycle and runs it to completion, so forgetting its hash would
+      // enqueue a second copy of a call that is still going to arrive.
+      const queued = inputs.key("queue").withTx(tx).get() !== undefined;
+      if (!queued) {
+        currentRun++;
+        previousCallHash = undefined;
+      }
       resultWithLog.set(undefined);
       messagesWithLog.set(undefined);
       errorWithLog.set(undefined);
       partialWithLog.set(undefined);
       pendingWithLog.set(false);
-      requestHashWithLog.set(undefined);
       return;
     }
 

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -954,6 +954,10 @@ export function generateText(
 
   let currentRun = 0;
   let previousCallHash: string | undefined = undefined;
+  // Whether the most recently issued request went through a queue. Read when a
+  // later run finds no prompt, so the decision follows the request that may
+  // still be in flight rather than whatever the `queue` input says by then.
+  let lastRequestQueued = false;
   let cellsInitialized = false;
   let resultCell: Cell<Schema<typeof GenerateTextResultSchema>>;
   let cellScope: CellScope | undefined;
@@ -1015,9 +1019,9 @@ export function generateText(
       // the same prompt go out again rather than match the in-flight check and
       // never be sent. A queued request is neither of those: the queue owns its
       // lifecycle and runs it to completion, so forgetting its hash would
-      // enqueue a second copy of a call that is still going to arrive.
-      const queued = inputs.key("queue").withTx(tx).get() !== undefined;
-      if (!queued) {
+      // enqueue a second copy of a call that is still going to arrive. The
+      // mode is the one the request in flight was issued under.
+      if (!lastRequestQueued) {
         currentRun++;
         previousCallHash = undefined;
       }
@@ -1098,6 +1102,7 @@ export function generateText(
       currentRun++;
     }
     const thisRun = currentRun;
+    lastRequestQueued = !!queueName;
 
     resultWithLog.set(undefined);
     errorWithLog.set(undefined);
@@ -1253,6 +1258,10 @@ export function generateObject<T extends Record<string, unknown>>(
 
   let currentRun = 0;
   let previousCallHash: string | undefined = undefined;
+  // Whether the most recently issued request went through a queue. Read when a
+  // later run finds no prompt, so the decision follows the request that may
+  // still be in flight rather than whatever the `queue` input says by then.
+  let lastRequestQueued = false;
   let cellsInitialized = false;
   let resultCell: Cell<Schema<typeof GenerateObjectResultSchema>>;
   let cellScope: CellScope | undefined;
@@ -1328,9 +1337,9 @@ export function generateObject<T extends Record<string, unknown>>(
       // the same prompt go out again rather than match the in-flight check and
       // never be sent. A queued request is neither of those: the queue owns its
       // lifecycle and runs it to completion, so forgetting its hash would
-      // enqueue a second copy of a call that is still going to arrive.
-      const queued = inputs.key("queue").withTx(tx).get() !== undefined;
-      if (!queued) {
+      // enqueue a second copy of a call that is still going to arrive. The
+      // mode is the one the request in flight was issued under.
+      if (!lastRequestQueued) {
         currentRun++;
         previousCallHash = undefined;
       }
@@ -1509,6 +1518,7 @@ export function generateObject<T extends Record<string, unknown>>(
         currentRun++;
       }
       const thisRun = currentRun;
+      lastRequestQueued = !!queueName;
 
       resultWithLog.set(undefined);
       messagesWithLog.set(undefined);
@@ -1870,6 +1880,7 @@ export function generateObject<T extends Record<string, unknown>>(
         currentRun++;
       }
       const thisRun = currentRun;
+      lastRequestQueued = !!queueName;
 
       resultWithLog.set(undefined);
       messagesWithLog.set(undefined);

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -569,12 +569,14 @@ function markRequestHashPendingCommit(
   hash: string,
   getPreviousCallHash: () => string | undefined,
   setPreviousCallHash: (hash: string | undefined) => void,
+  onRollback?: () => void,
 ): void {
   const previousCallHash = getPreviousCallHash();
   setPreviousCallHash(hash);
   tx.addCommitCallback((_committedTx, commitResult) => {
     if (commitResult.error && getPreviousCallHash() === hash) {
       setPreviousCallHash(previousCallHash);
+      onRollback?.();
     }
   });
 }
@@ -1087,12 +1089,17 @@ export function generateText(
       return;
     }
 
+    const previousRequestQueued = lastRequestQueued;
+    lastRequestQueued = !!queueName;
     markRequestHashPendingCommit(
       tx,
       hash,
       () => previousCallHash,
       (next) => {
         previousCallHash = next;
+      },
+      () => {
+        lastRequestQueued = previousRequestQueued;
       },
     );
 
@@ -1102,7 +1109,6 @@ export function generateText(
       currentRun++;
     }
     const thisRun = currentRun;
-    lastRequestQueued = !!queueName;
 
     resultWithLog.set(undefined);
     errorWithLog.set(undefined);
@@ -1505,6 +1511,8 @@ export function generateObject<T extends Record<string, unknown>>(
         return;
       }
 
+      const previousRequestQueued = lastRequestQueued;
+      lastRequestQueued = !!queueName;
       markRequestHashPendingCommit(
         tx,
         hash,
@@ -1512,13 +1520,15 @@ export function generateObject<T extends Record<string, unknown>>(
         (next) => {
           previousCallHash = next;
         },
+        () => {
+          lastRequestQueued = previousRequestQueued;
+        },
       );
 
       if (hash !== currentRequestHash) {
         currentRun++;
       }
       const thisRun = currentRun;
-      lastRequestQueued = !!queueName;
 
       resultWithLog.set(undefined);
       messagesWithLog.set(undefined);
@@ -1865,12 +1875,17 @@ export function generateObject<T extends Record<string, unknown>>(
         return;
       }
 
+      const previousRequestQueued = lastRequestQueued;
+      lastRequestQueued = !!queueName;
       markRequestHashPendingCommit(
         tx,
         hash,
         () => previousCallHash,
         (next) => {
           previousCallHash = next;
+        },
+        () => {
+          lastRequestQueued = previousRequestQueued;
         },
       );
 
@@ -1880,7 +1895,6 @@ export function generateObject<T extends Record<string, unknown>>(
         currentRun++;
       }
       const thisRun = currentRun;
-      lastRequestQueued = !!queueName;
 
       resultWithLog.set(undefined);
       messagesWithLog.set(undefined);

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -1009,10 +1009,17 @@ export function generateText(
     // If neither prompt nor messages is provided, don't make a request
     const hasPrompt = Array.isArray(prompt) ? prompt.length > 0 : !!prompt;
     if (!hasPrompt && !messages) {
+      // Advancing the run abandons a request already in flight, so the response
+      // it eventually produces fails its guard and writes nothing. Dropping the
+      // remembered hash lets the same prompt, if it comes back, go out again
+      // rather than match the in-flight check and never be sent.
+      currentRun++;
+      previousCallHash = undefined;
       resultWithLog.set(undefined);
       errorWithLog.set(undefined);
       partialWithLog.set(undefined);
       pendingWithLog.set(false);
+      requestHashWithLog.set(undefined);
       return;
     }
 
@@ -1310,11 +1317,18 @@ export function generateObject<T extends Record<string, unknown>>(
       (!hasPrompt && (!messages || messages.length === 0)) ||
       schema === undefined
     ) {
+      // Advancing the run abandons a request already in flight, so the response
+      // it eventually produces fails its guard and writes nothing. Dropping the
+      // remembered hash lets the same prompt, if it comes back, go out again
+      // rather than match the in-flight check and never be sent.
+      currentRun++;
+      previousCallHash = undefined;
       resultWithLog.set(undefined);
       messagesWithLog.set(undefined);
       errorWithLog.set(undefined);
       partialWithLog.set(undefined);
       pendingWithLog.set(false);
+      requestHashWithLog.set(undefined);
       return;
     }
 

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -564,6 +564,12 @@ function enqueuePostCommitLLMWork(
   );
 }
 
+/**
+ * Record the hash of the request this transaction stages, which a later run
+ * reads to recognize a request already in flight. If the transaction reports an
+ * error, the hash goes back to what it was and `onRollback` runs, so a caller
+ * can undo state it recorded for the same request.
+ */
 function markRequestHashPendingCommit(
   tx: IExtendedStorageTransaction,
   hash: string,

--- a/packages/runner/test/llm-no-request.test.ts
+++ b/packages/runner/test/llm-no-request.test.ts
@@ -17,6 +17,11 @@
  * abandon a request already in flight, so a response that lands afterwards
  * writes nothing; and it has to forget the request it remembered, so the same
  * prompt coming back is sent again rather than suppressed as a duplicate.
+ *
+ * Both of those apply to a request the builtin can abandon. A queued request
+ * runs to completion under the queue's own lifecycle, so it is remembered
+ * across the empty prompt and the same prompt returning does not enqueue a
+ * second copy. A fourth test holds that line.
  */
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
@@ -334,6 +339,61 @@ describe("LLM builtin no-request paths", () => {
       expect(result.key("result").get()).toEqual({ answer: "cats" });
     } finally {
       LLMClient.prototype.generateObject = original;
+    }
+  });
+
+  it("`generateText` keeps a queued request remembered across an empty prompt", async () => {
+    const original = LLMClient.prototype.sendRequest;
+    let calls = 0;
+    LLMClient.prototype.sendRequest = () => {
+      calls++;
+      return Promise.resolve({ content: "a summary of cats" } as never);
+    };
+    try {
+      const testPattern = builder.pattern<{ prompt: string }>(({ prompt }) =>
+        builder.generateText({ prompt, queue: "no-request-queue" })
+      );
+      const promptCell = runtime.getCell<string>(
+        space,
+        "queued-prompt-input",
+        undefined,
+        tx,
+      );
+      promptCell.set("summarize cats");
+      const resultCell = runtime.getCell(
+        space,
+        "queued-prompt",
+        testPattern.resultSchema,
+        tx,
+      );
+      const result = runtime.run(
+        tx,
+        testPattern,
+        { prompt: promptCell },
+        resultCell,
+      );
+      tx.commit();
+      tx = runtime.edit();
+
+      await waitForLlmSettled(runtime, result);
+      expect(calls).toBe(1);
+
+      const clear = runtime.edit();
+      promptCell.withTx(clear).set("");
+      clear.commit();
+      await runtime.settled();
+
+      const restore = runtime.edit();
+      promptCell.withTx(restore).set("summarize cats");
+      restore.commit();
+      await runtime.settled();
+
+      // The queue owns a queued request's lifecycle, so the builtin goes on
+      // remembering it and the returning prompt matches rather than enqueuing a
+      // second copy of the same call.
+      expect(calls).toBe(1);
+    } finally {
+      LLMClient.prototype.sendRequest = original;
     }
   });
 });

--- a/packages/runner/test/llm-no-request.test.ts
+++ b/packages/runner/test/llm-no-request.test.ts
@@ -10,6 +10,13 @@
  * Each test spies the client method the builtin would call and asserts it never
  * fires, then confirms the cell settled with no result. The wait resolves on the
  * `pending` the early return writes, the same signal a real response would clear.
+ *
+ * A prompt can also become empty after having been set, which a pattern that
+ * gates its prompt on an input does every time that input is cleared. Two
+ * further tests cover that transition. Entering the no-request state has to
+ * abandon a request already in flight, so a response that lands afterwards
+ * writes nothing; and it has to forget the request it remembered, so the same
+ * prompt coming back is sent again rather than suppressed as a duplicate.
  */
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
@@ -145,6 +152,186 @@ describe("LLM builtin no-request paths", () => {
       expect(calls).toBe(0);
       expect(settled.pending).toBe(false);
       expect(result.key("result").get()).toBeUndefined();
+    } finally {
+      LLMClient.prototype.generateObject = original;
+    }
+  });
+  it("`generateText` leaves no trace of a request a cleared prompt abandoned", async () => {
+    const original = LLMClient.prototype.sendRequest;
+    let release: (() => void) | undefined;
+    const arrived = Promise.withResolvers<void>();
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    LLMClient.prototype.sendRequest = async () => {
+      arrived.resolve();
+      await held;
+      return { content: "a summary of cats" } as never;
+    };
+    try {
+      const testPattern = builder.pattern<{ prompt: string }>(({ prompt }) =>
+        builder.generateText({ prompt })
+      );
+      const promptCell = runtime.getCell<string>(
+        space,
+        "cleared-prompt-input",
+        undefined,
+        tx,
+      );
+      promptCell.set("summarize cats");
+      const resultCell = runtime.getCell(
+        space,
+        "cleared-prompt",
+        testPattern.resultSchema,
+        tx,
+      );
+      const result = runtime.run(
+        tx,
+        testPattern,
+        { prompt: promptCell },
+        resultCell,
+      );
+      tx.commit();
+      tx = runtime.edit();
+
+      // The request is out and parked inside the client; the response has not
+      // been produced yet.
+      await arrived.promise;
+
+      const clear = runtime.edit();
+      promptCell.withTx(clear).set("");
+      clear.commit();
+      await runtime.idle();
+
+      release!();
+      await runtime.settled();
+
+      // `requestHash` is what tells an applied response from an abandoned one.
+      // Reading `result` alone cannot: the builtin's action reads the cell it
+      // writes, so a response applied after the prompt went empty re-triggers
+      // the action, which clears `result` again and hides that anything
+      // landed. Only the stamp is left behind, and a hash here means the
+      // answer to a prompt that no longer exists was written to the cell.
+      expect(result.key("requestHash").get()).toBeUndefined();
+      expect(result.key("result").get()).toBeUndefined();
+      expect(result.key("partial").get()).toBeUndefined();
+      expect(result.key("pending").get()).toBe(false);
+    } finally {
+      LLMClient.prototype.sendRequest = original;
+    }
+  });
+
+  it("`generateText` sends again when a cleared prompt comes back", async () => {
+    const original = LLMClient.prototype.sendRequest;
+    let calls = 0;
+    LLMClient.prototype.sendRequest = () => {
+      calls++;
+      return Promise.resolve({ content: "a summary of cats" } as never);
+    };
+    try {
+      const testPattern = builder.pattern<{ prompt: string }>(({ prompt }) =>
+        builder.generateText({ prompt })
+      );
+      const promptCell = runtime.getCell<string>(
+        space,
+        "restored-prompt-input",
+        undefined,
+        tx,
+      );
+      promptCell.set("summarize cats");
+      const resultCell = runtime.getCell(
+        space,
+        "restored-prompt",
+        testPattern.resultSchema,
+        tx,
+      );
+      const result = runtime.run(
+        tx,
+        testPattern,
+        { prompt: promptCell },
+        resultCell,
+      );
+      tx.commit();
+      tx = runtime.edit();
+
+      await waitForLlmSettled(runtime, result);
+      expect(calls).toBe(1);
+      expect(result.key("result").get()).toBe("a summary of cats");
+
+      const clear = runtime.edit();
+      promptCell.withTx(clear).set("");
+      clear.commit();
+      await runtime.settled();
+      expect(result.key("result").get()).toBeUndefined();
+
+      const restore = runtime.edit();
+      promptCell.withTx(restore).set("summarize cats");
+      restore.commit();
+      await runtime.settled();
+
+      // The same prompt is a new request, not a duplicate of one whose result
+      // was thrown away.
+      expect(calls).toBe(2);
+      expect(result.key("result").get()).toBe("a summary of cats");
+    } finally {
+      LLMClient.prototype.sendRequest = original;
+    }
+  });
+
+  it("`generateObject` sends again when a cleared prompt comes back", async () => {
+    const schema: JSONSchema = {
+      type: "object",
+      properties: { answer: { type: "string" } },
+    };
+    const original = LLMClient.prototype.generateObject;
+    let calls = 0;
+    LLMClient.prototype.generateObject = () => {
+      calls++;
+      return Promise.resolve({ object: { answer: "cats" } } as never);
+    };
+    try {
+      const testPattern = builder.pattern<{ prompt: string }>(({ prompt }) =>
+        builder.generateObject({ prompt, schema })
+      );
+      const promptCell = runtime.getCell<string>(
+        space,
+        "restored-object-prompt-input",
+        undefined,
+        tx,
+      );
+      promptCell.set("name an animal");
+      const resultCell = runtime.getCell(
+        space,
+        "restored-object-prompt",
+        testPattern.resultSchema,
+        tx,
+      );
+      const result = runtime.run(
+        tx,
+        testPattern,
+        { prompt: promptCell },
+        resultCell,
+      );
+      tx.commit();
+      tx = runtime.edit();
+
+      await waitForLlmSettled(runtime, result);
+      expect(calls).toBe(1);
+      expect(result.key("result").get()).toEqual({ answer: "cats" });
+
+      const clear = runtime.edit();
+      promptCell.withTx(clear).set("");
+      clear.commit();
+      await runtime.settled();
+      expect(result.key("result").get()).toBeUndefined();
+
+      const restore = runtime.edit();
+      promptCell.withTx(restore).set("name an animal");
+      restore.commit();
+      await runtime.settled();
+
+      expect(calls).toBe(2);
+      expect(result.key("result").get()).toEqual({ answer: "cats" });
     } finally {
       LLMClient.prototype.generateObject = original;
     }

--- a/packages/runner/test/llm-no-request.test.ts
+++ b/packages/runner/test/llm-no-request.test.ts
@@ -396,4 +396,70 @@ describe("LLM builtin no-request paths", () => {
       LLMClient.prototype.sendRequest = original;
     }
   });
+  it("`generateText` abandons an unqueued request even if `queue` is set later", async () => {
+    const original = LLMClient.prototype.sendRequest;
+    let release: (() => void) | undefined;
+    const arrived = Promise.withResolvers<void>();
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    LLMClient.prototype.sendRequest = async () => {
+      arrived.resolve();
+      await held;
+      return { content: "a summary of cats" } as never;
+    };
+    try {
+      const testPattern = builder.pattern<{ prompt: string; queue: string }>((
+        { prompt, queue },
+      ) => builder.generateText({ prompt, queue }));
+      const promptCell = runtime.getCell<string>(
+        space,
+        "late-queue-prompt-input",
+        undefined,
+        tx,
+      );
+      promptCell.set("summarize cats");
+      const queueCell = runtime.getCell<string>(
+        space,
+        "late-queue-name-input",
+        undefined,
+        tx,
+      );
+      queueCell.set("");
+      const resultCell = runtime.getCell(
+        space,
+        "late-queue-prompt",
+        testPattern.resultSchema,
+        tx,
+      );
+      const result = runtime.run(
+        tx,
+        testPattern,
+        { prompt: promptCell, queue: queueCell },
+        resultCell,
+      );
+      tx.commit();
+      tx = runtime.edit();
+
+      // The request went out unqueued, and is parked inside the client.
+      await arrived.promise;
+
+      // `queue` gains a name only now. The request already in flight is still
+      // the unqueued one, and clearing the prompt has to abandon it.
+      const change = runtime.edit();
+      queueCell.withTx(change).set("late-queue");
+      promptCell.withTx(change).set("");
+      change.commit();
+      await runtime.idle();
+
+      release!();
+      await runtime.settled();
+
+      expect(result.key("requestHash").get()).toBeUndefined();
+      expect(result.key("result").get()).toBeUndefined();
+      expect(result.key("pending").get()).toBe(false);
+    } finally {
+      LLMClient.prototype.sendRequest = original;
+    }
+  });
 });


### PR DESCRIPTION
Five of the suggestable patterns opened a language-model request the moment they were built, whether or not anyone had said what the request was for. Each one composed its prompt with a placeholder standing in for the missing topic: `const t = topic || "the following"` in checklist, summary, diagram and svg-diagram, and `topic || "the current situation"` in question. An instance created with no topic still had a complete prompt, so it asked the model to summarize "the following" or to draw a diagram of "the following", and paid for the answer.

That has two costs. The first is money: the call is billed for building the pattern rather than for using it, and the suggestion system builds these patterns speculatively. The second is that it makes the patterns untestable outside a configured runtime. A test that instantiates one of them reaches for a language-model endpoint that a test runtime does not have, and the request fails with `Invalid URL: '//api/ai/llm'`.

Both `generateText` and `generateObject` already have a way to say there is nothing to do: given neither a prompt nor a messages list, they clear `result`, `error` and `partial`, set `pending` to false, and make no call. This change reaches for it. Each prompt now returns the empty string when it has no topic, and composes the real prompt only once a caller supplies one:

    const prompt = computed(() => {
      if (!topic) return "";
      return `Create a clear ASCII diagram illustrating: ${topic}`;
    });

So a topic-less instance is inert: it reports itself not pending, holds no result, and renders its idle branch rather than its loader. It comes to life the first time a caller names a topic.

Each pattern gains a pattern test beside it that builds it with no topic and reads that state back. The check that matters most is not any single assertion but the runner's console-warning gate: an ungated pattern still emits the `[LLM Error] Invalid URL` warning, and the test fails on that even when every assertion passes. The patterns' entries in `packages/patterns/index.md` now say what a topic-less instance does.

The same shape in `suggestable/budget-planner.tsx` is fixed separately.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

