### PR TITLE
fix(scripts): catch dev servers that cannot serve the application

### DIFF
--- a/docs/development/LOCAL_DEV_SERVERS.md
+++ b/docs/development/LOCAL_DEV_SERVERS.md
@@ -64,8 +64,11 @@ browsers.
 
 `start-local-dev.sh` validates required commands before launching anything and
 waits for both servers to bind their ports and return HTTP 200 before reporting
-success. Set `LOCAL_DEV_STARTUP_TIMEOUT` to adjust the readiness timeout in
-seconds.
+success. It then waits on the toolshed's `/`, the page a browser loads, which
+the toolshed answers by fetching the shell dev server and passing the result
+back; that is the one probe covering the hop between the two servers, which
+can be broken while each of them answers on its own port. Set
+`LOCAL_DEV_STARTUP_TIMEOUT` to adjust the readiness timeout in seconds.
 
 **Exit codes (`start-local-dev.sh`):**
 | Code | Meaning |
@@ -92,6 +95,11 @@ and the inspector port when `--inspect` is passed, and `deno task integration`
 leaves every offset that reaches one out of the range it generates from. Within
 the offsets that command generates, `827` puts the shell dev server on `6000`
 and `851` puts the inspector on `10080`.
+
+`restart-local-dev.sh` makes the same check on the ports it was asked for,
+before it stops a server or acts on `--clear-cache` or
+`--dangerously-clear-all-spaces`, so an offset the start it ends with would
+refuse costs nothing on the way to that refusal.
 
 **URLs:**
 | What | URL |
@@ -198,8 +206,11 @@ ss -tlnp 'sport = :5173'  # Shell
 ```
 
 This checks both process presence and HTTP health, exiting non-zero if
-anything is wrong. It supports the same `--port-offset`, `--shell-port`, and
-`--toolshed-port` flags as the other scripts.
+anything is wrong. It reports three things: the toolshed on its own port, the
+shell on its own port, and the shell through the toolshed — the last being the
+page a browser loads, which can fail while the other two are healthy. It
+supports the same `--port-offset`, `--shell-port`, and `--toolshed-port` flags
+as the other scripts.
 
 When `--port-offset` changes the toolshed port, `start-local-dev.sh` also sets
 toolshed's internal `API_URL` and `MEMORY_URL` to the offset toolshed URL unless

--- a/scripts/check-local-dev.sh
+++ b/scripts/check-local-dev.sh
@@ -107,6 +107,10 @@ check_server() {
 
 check_server "Toolshed" "http://localhost:$TOOLSHED_PORT/_health" "$TOOLSHED_PORT"
 check_server "Shell" "http://localhost:$SHELL_PORT" "$SHELL_PORT"
+# The page a browser loads, which the toolshed answers by fetching the shell
+# dev server. It fails while both checks above report success whenever that hop
+# is broken.
+check_server "Shell through toolshed" "http://localhost:$TOOLSHED_PORT/" "$TOOLSHED_PORT"
 
 if [[ "$ALL_OK" == "true" ]]; then
     echo "All servers healthy."

--- a/scripts/common/port-utils.sh
+++ b/scripts/common/port-utils.sh
@@ -85,3 +85,27 @@ port_is_blocked() {
     done
     return 1
 }
+
+# Exit code emitted when a requested port is one clients refuse to connect to.
+# The offset has to change; retrying it reaches the same port.
+PORT_UNREACHABLE_EXIT=4
+
+# Refuse a port that clients will not talk to. Such a port binds, so the server
+# starts and answers a curl health check, and then the browser cannot load the
+# page and toolshed's proxy hop to the shell dev server fails. Checked before a
+# script acts on the port, because the later failure surfaces as a test waiting
+# on state that never arrives.
+# Usage: require_reachable_port <server name> <port>
+require_reachable_port() {
+    local name=$1
+    local port=$2
+
+    [[ -n "${BLOCKED_PORTS:-}" ]] || read_blocked_ports
+    port_is_blocked "$port" || return 0
+
+    echo "Error: $name port $port is one clients refuse to connect to." >&2
+    echo "       Browsers and Deno's fetch reject a request to it before" >&2
+    echo "       opening a connection, so a server here binds but nothing" >&2
+    echo "       reaches it. Choose a port offset that moves $name elsewhere." >&2
+    exit "$PORT_UNREACHABLE_EXIT"
+}

--- a/scripts/common/port-utils.sh
+++ b/scripts/common/port-utils.sh
@@ -94,13 +94,15 @@ PORT_UNREACHABLE_EXIT=4
 # starts and answers a curl health check, and then the browser cannot load the
 # page and toolshed's proxy hop to the shell dev server fails. Checked before a
 # script acts on the port, because the later failure surfaces as a test waiting
-# on state that never arrives.
+# on state that never arrives. Reads the list from ports.json on every call, so
+# the answer comes from the repository rather than from whatever a caller's
+# environment happens to carry in BLOCKED_PORTS.
 # Usage: require_reachable_port <server name> <port>
 require_reachable_port() {
     local name=$1
     local port=$2
 
-    [[ -n "${BLOCKED_PORTS:-}" ]] || read_blocked_ports
+    read_blocked_ports
     port_is_blocked "$port" || return 0
 
     echo "Error: $name port $port is one clients refuse to connect to." >&2

--- a/scripts/restart-local-dev.sh
+++ b/scripts/restart-local-dev.sh
@@ -98,6 +98,14 @@ done
 SHELL_PORT=${SHELL_PORT:-$((BASE_SHELL_PORT + PORT_OFFSET))}
 TOOLSHED_PORT=${TOOLSHED_PORT:-$((BASE_TOOLSHED_PORT + PORT_OFFSET))}
 
+# Checked here, ahead of the stop and the cache and space clearing below, so an
+# offset start-local-dev.sh will refuse costs nothing on the way to the refusal.
+require_reachable_port "shell" "$SHELL_PORT"
+require_reachable_port "toolshed" "$TOOLSHED_PORT"
+if [[ "$INSPECT" == "true" && -n "$INSPECT_PORT" ]]; then
+    require_reachable_port "inspector" "$INSPECT_PORT"
+fi
+
 # Export for child scripts
 export SHELL_PORT
 export TOOLSHED_PORT

--- a/scripts/restart-local-dev.sh
+++ b/scripts/restart-local-dev.sh
@@ -102,7 +102,11 @@ TOOLSHED_PORT=${TOOLSHED_PORT:-$((BASE_TOOLSHED_PORT + PORT_OFFSET))}
 # offset start-local-dev.sh will refuse costs nothing on the way to the refusal.
 require_reachable_port "shell" "$SHELL_PORT"
 require_reachable_port "toolshed" "$TOOLSHED_PORT"
-if [[ "$INSPECT" == "true" && -n "$INSPECT_PORT" ]]; then
+if [[ "$INSPECT" == "true" ]]; then
+    # The port start-local-dev.sh would pick for an --inspect run that names
+    # none, resolved here so the check covers it and the start it hands to
+    # binds the port that was checked.
+    INSPECT_PORT=${INSPECT_PORT:-$((BASE_INSPECTOR_PORT + PORT_OFFSET))}
     require_reachable_port "inspector" "$INSPECT_PORT"
 fi
 

--- a/scripts/start-local-dev.sh
+++ b/scripts/start-local-dev.sh
@@ -41,10 +41,6 @@ export COMMIT_SHA
 # use. Callers can retry on a different port.
 PORT_IN_USE_EXIT=3
 
-# Exit code emitted when a requested port is one clients refuse to connect to.
-# The offset has to change; retrying it reaches the same port.
-PORT_UNREACHABLE_EXIT=4
-
 # Parse command line arguments
 FORCE=false
 WATCH=false
@@ -117,25 +113,6 @@ SHELL_PORT=${SHELL_PORT:-$((BASE_SHELL_PORT + PORT_OFFSET))}
 TOOLSHED_PORT=${TOOLSHED_PORT:-$((BASE_TOOLSHED_PORT + PORT_OFFSET))}
 INSPECT_PORT=${INSPECT_PORT:-$((BASE_INSPECTOR_PORT + PORT_OFFSET))}
 
-# Refuse a port that clients will not talk to. Such a port binds, so the server
-# starts and answers the curl health check below, and then the browser cannot
-# load the page and toolshed's proxy hop to the shell dev server fails. Checked
-# here rather than left to fail later, because the later failure surfaces as a
-# test waiting on state that never arrives.
-require_reachable_port() {
-    local name=$1
-    local port=$2
-
-    port_is_blocked "$port" || return 0
-
-    echo "Error: $name port $port is one clients refuse to connect to." >&2
-    echo "       Browsers and Deno's fetch reject a request to it before" >&2
-    echo "       opening a connection, so a server here binds but nothing" >&2
-    echo "       reaches it. Choose a port offset that moves $name elsewhere." >&2
-    exit "$PORT_UNREACHABLE_EXIT"
-}
-
-read_blocked_ports
 require_reachable_port "shell" "$SHELL_PORT"
 require_reachable_port "toolshed" "$TOOLSHED_PORT"
 if [[ "$INSPECT" == "true" ]]; then
@@ -363,6 +340,13 @@ wait_for_http "shell" "http://localhost:$SHELL_PORT" "$SHELL_PID" "$SHELL_LOG"
 wait_for_listen "toolshed" "Server running on" "$TOOLSHED_PID" "$TOOLSHED_LOG"
 wait_for_http \
     "toolshed" "http://localhost:$TOOLSHED_PORT/_health" \
+    "$TOOLSHED_PID" "$TOOLSHED_LOG"
+
+# The page a browser loads: the toolshed serving the shell it proxies. The two
+# checks above cover each server on its own port, and this one covers the hop
+# between them, which the toolshed makes with fetch() rather than with curl.
+wait_for_http \
+    "shell through toolshed" "http://localhost:$TOOLSHED_PORT/" \
     "$TOOLSHED_PID" "$TOOLSHED_LOG"
 
 # Print the toolshed URL on success (when not using --bg-updater, which prints after health check)

--- a/tasks/local-dev-scripts.test.ts
+++ b/tasks/local-dev-scripts.test.ts
@@ -13,6 +13,10 @@ const PORT_UNREACHABLE_EXIT = 4;
 // The offset that puts the shell dev server on port 6000.
 const UNREACHABLE_SHELL_OFFSET = 6000 - ports.shell;
 
+// The offset that puts the inspector on port 10080, leaving the shell and the
+// toolshed on ports every client will talk to.
+const UNREACHABLE_INSPECTOR_OFFSET = 10080 - ports.inspector;
+
 // An offset whose servers every client will talk to.
 const REACHABLE_OFFSET = 850;
 
@@ -24,6 +28,7 @@ const REACHABLE_OFFSET = 850;
 async function runScript(
   script: string,
   offset: number,
+  options: { args?: string[]; env?: Record<string, string> } = {},
 ): Promise<{ code: number; stdout: string; stderr: string }> {
   const binDir = await Deno.makeTempDir();
   const stub = path.join(binDir, "deno");
@@ -31,9 +36,14 @@ async function runScript(
   await Deno.chmod(stub, 0o755);
   try {
     const { code, stdout, stderr } = await new Deno.Command("bash", {
-      args: [`scripts/${script}`, "--port-offset", String(offset)],
+      args: [
+        `scripts/${script}`,
+        ...(options.args ?? []),
+        "--port-offset",
+        String(offset),
+      ],
       cwd: repoRoot,
-      env: { PATH: `${binDir}:${Deno.env.get("PATH")}` },
+      env: { ...options.env, PATH: `${binDir}:${Deno.env.get("PATH")}` },
       stdout: "piped",
       stderr: "piped",
     }).output();
@@ -67,6 +77,16 @@ describe("local-dev-scripts", () => {
       expect(code).not.toBe(PORT_UNREACHABLE_EXIT);
       expect(stderr).toContain("shell exited before it became ready");
     });
+
+    it("answers from the recorded list, not from the environment", async () => {
+      const { code, stderr } = await runScript(
+        "start-local-dev.sh",
+        UNREACHABLE_SHELL_OFFSET,
+        { env: { BLOCKED_PORTS: "1" } },
+      );
+      expect(code).toBe(PORT_UNREACHABLE_EXIT);
+      expect(stderr).toContain("shell port 6000");
+    });
   });
 
   describe("restart-local-dev.sh", () => {
@@ -79,6 +99,17 @@ describe("local-dev-scripts", () => {
       expect(stderr).toContain("shell port 6000");
       // The stop, and the cache and space clearing behind its flags, all
       // follow this line.
+      expect(stdout).not.toContain("Stopping local dev servers");
+    });
+
+    it("refuses an inspector port an --inspect run would bind", async () => {
+      const { code, stdout, stderr } = await runScript(
+        "restart-local-dev.sh",
+        UNREACHABLE_INSPECTOR_OFFSET,
+        { args: ["--inspect"] },
+      );
+      expect(code).toBe(PORT_UNREACHABLE_EXIT);
+      expect(stderr).toContain("inspector port 10080");
       expect(stdout).not.toContain("Stopping local dev servers");
     });
   });

--- a/tasks/local-dev-scripts.test.ts
+++ b/tasks/local-dev-scripts.test.ts
@@ -1,0 +1,85 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import * as path from "@std/path";
+
+import ports from "@commonfabric/ports" with { type: "json" };
+
+const repoRoot = path.resolve(import.meta.dirname!, "..");
+
+// `scripts/start-local-dev.sh` reports this when a port it was asked for is one
+// clients refuse to connect to.
+const PORT_UNREACHABLE_EXIT = 4;
+
+// The offset that puts the shell dev server on port 6000.
+const UNREACHABLE_SHELL_OFFSET = 6000 - ports.shell;
+
+// An offset whose servers every client will talk to.
+const REACHABLE_OFFSET = 850;
+
+/**
+ * Run one of the local dev scripts with a `deno` that exits immediately, so a
+ * run that gets as far as launching a server starts nothing and leaves nothing
+ * behind.
+ */
+async function runScript(
+  script: string,
+  offset: number,
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const binDir = await Deno.makeTempDir();
+  const stub = path.join(binDir, "deno");
+  await Deno.writeTextFile(stub, "#!/bin/sh\nexit 1\n");
+  await Deno.chmod(stub, 0o755);
+  try {
+    const { code, stdout, stderr } = await new Deno.Command("bash", {
+      args: [`scripts/${script}`, "--port-offset", String(offset)],
+      cwd: repoRoot,
+      env: { PATH: `${binDir}:${Deno.env.get("PATH")}` },
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    const decoder = new TextDecoder();
+    return {
+      code,
+      stdout: decoder.decode(stdout),
+      stderr: decoder.decode(stderr),
+    };
+  } finally {
+    await Deno.remove(binDir, { recursive: true });
+  }
+}
+
+describe("local-dev-scripts", () => {
+  describe("start-local-dev.sh", () => {
+    it("names the server and the port an offset makes unreachable", async () => {
+      const { code, stderr } = await runScript(
+        "start-local-dev.sh",
+        UNREACHABLE_SHELL_OFFSET,
+      );
+      expect(code).toBe(PORT_UNREACHABLE_EXIT);
+      expect(stderr).toContain("shell port 6000");
+    });
+
+    it("reaches the server launch on a reachable offset", async () => {
+      const { code, stderr } = await runScript(
+        "start-local-dev.sh",
+        REACHABLE_OFFSET,
+      );
+      expect(code).not.toBe(PORT_UNREACHABLE_EXIT);
+      expect(stderr).toContain("shell exited before it became ready");
+    });
+  });
+
+  describe("restart-local-dev.sh", () => {
+    it("refuses an unreachable offset before it stops a server", async () => {
+      const { code, stdout, stderr } = await runScript(
+        "restart-local-dev.sh",
+        UNREACHABLE_SHELL_OFFSET,
+      );
+      expect(code).toBe(PORT_UNREACHABLE_EXIT);
+      expect(stderr).toContain("shell port 6000");
+      // The stop, and the cache and space clearing behind its flags, all
+      // follow this line.
+      expect(stdout).not.toContain("Stopping local dev servers");
+    });
+  });
+});


### PR DESCRIPTION
The local dev scripts report success over a pair of servers that cannot serve the application, and the restart destroys data on its way to refusing an offset it will not accept. Both come from the same blind spot: what the scripts check is not what a browser uses.

Startup and the health check probe each server on its own port with curl: the shell at its port, the toolshed at `/_health`. A browser test loads neither of those. It loads the toolshed's `/`, which the toolshed answers by fetching the shell dev server and passing the result back. That hop can be broken while both probes report success, and then every browser test in the run waits out its full timeout against the toolshed's "Failed to proxy" page. A shell dev server on a port clients refuse is one way in, and the port checks turn that one away at the door. The hop has other ways to break that no port arithmetic can see: a SHELL_URL pointing somewhere else, a shell that dies after binding its port, a proxy route that stops matching. Each of those leaves check-local-dev.sh printing "All servers healthy" about a pair of servers that cannot serve the application.

Both scripts now probe the toolshed's `/` as well. Startup waits for it alongside the two it already waits for, so a pair that cannot serve the application fails at startup, where both server logs are to hand, rather than one test timeout at a time. check-local-dev.sh reports it as a third server, so the same fault is visible from the command a developer runs to ask what is wrong. This costs nothing when the servers are healthy: the probe is a local request against a server that has already answered, and it resolves on the first attempt.

The second half is the restart. start-local-dev.sh refuses a port offset that lands a server on a port clients will not talk to. restart-local-dev.sh reaches that refusal last: it computes the same ports, stops whatever is running on them, acts on --clear-cache, and on --dangerously-clear-all-spaces deletes every space in the local databases, and only then runs the start that declines to proceed. So the one offset the tooling knows it cannot serve is also the one that costs a developer their local spaces on the way to being told so. The same check now runs ahead of all of it.

That check moves to port-utils.sh beside the blocked list it reads, so both scripts make it the same way and report it in the same words, and the exit code that names this failure moves with it. Each script checks the servers it is responsible for: the shell and the toolshed always, and the inspector when a flag asked for one. The check also reads the list itself when it has not already been read. It matched against a variable that only read_blocked_ports sets, and no script here runs under set -u, so a caller that reached it by another path would have been told every port was fine.

Nothing tested the refusal: removing it from start-local-dev.sh broke no test, because the tests reach the offset arithmetic in tasks/ and stop there. Both scripts are now driven through their own command lines, with a deno on PATH that exits immediately, so a run that gets as far as launching a server starts nothing and leaves nothing behind. Three cases: that start-local-dev.sh names the server and the port, that a reachable offset gets all the way to the launch, and that restart-local-dev.sh refuses before it prints the line its stop and its clearing follow.

deflaked by Hixie's agent (Claude Opus 5)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

