### PR TITLE
fix(cli): clarify new and deleted file summaries

### DIFF
--- a/packages/cli/lib/view/fold.ts
+++ b/packages/cli/lib/view/fold.ts
@@ -82,8 +82,9 @@ interface SummaryInput {
   readonly binary: boolean;
 }
 
-/** Build the collapsed summary line: `▸ path  +A −D`, with a `(new)` /
- * `(deleted)` / `(binary)` tag and `old → new` for a rename. */
+/** Build the collapsed summary line: `▸ path  +A −D`, with new and deleted
+ * files showing only their applicable count and status. Binary files carry a
+ * `(binary)` tag, and renames show `old → new`. */
 function summaryLine(f: SummaryInput): Line {
   const spans: Span[] = [];
   let text = "";
@@ -101,16 +102,15 @@ function summaryLine(f: SummaryInput): Line {
     add(f.newPath ?? f.oldPath ?? "(unknown file)", "sectionHeader");
   }
 
-  const tag = f.binary
-    ? "binary"
-    : f.newPath === undefined
-    ? "deleted"
-    : f.oldPath === undefined
-    ? "new"
-    : "";
-  if (tag) add(`  (${tag})`, "diffMeta");
-
-  if (!f.binary) {
+  if (f.binary) {
+    add("  (binary)", "diffMeta");
+  } else if (f.newPath === undefined) {
+    add("  ", "whitespace");
+    add(`−${f.dels} (deleted)`, "diffDel");
+  } else if (f.oldPath === undefined) {
+    add("  ", "whitespace");
+    add(`+${f.adds} (new)`, "diffAdd");
+  } else {
     add("  ", "whitespace");
     add(`+${f.adds}`, "diffAdd");
     add(" ", "whitespace");

--- a/packages/cli/test/view-fold.test.ts
+++ b/packages/cli/test/view-fold.test.ts
@@ -65,7 +65,12 @@ Deno.test("diffFiles: new / deleted / renamed / binary summaries", () => {
       "",
     ].join("\n"),
   );
-  assertEquals(created[0].summary.text, "▸ new.ts  (new)  +2 −0");
+  assertEquals(created[0].summary.text, "▸ new.ts  +2 (new)");
+  assertEquals(created[0].summary.spans.at(-1), {
+    col: 10,
+    text: "+2 (new)",
+    cls: "diffAdd",
+  });
 
   const deleted = diffFiles(
     [
@@ -79,7 +84,12 @@ Deno.test("diffFiles: new / deleted / renamed / binary summaries", () => {
       "",
     ].join("\n"),
   );
-  assertEquals(deleted[0].summary.text, "▸ gone.ts  (deleted)  +0 −2");
+  assertEquals(deleted[0].summary.text, "▸ gone.ts  −2 (deleted)");
+  assertEquals(deleted[0].summary.spans.at(-1), {
+    col: 11,
+    text: "−2 (deleted)",
+    cls: "diffDel",
+  });
 
   const renamed = diffFiles(
     [

--- a/packages/cli/test/view-jumplist.test.ts
+++ b/packages/cli/test/view-jumplist.test.ts
@@ -101,6 +101,45 @@ Deno.test("jumplist: i lists the diff's files, dirs summarized", () => {
   assertEquals(s.view().overlay?.selectedLine, 0);
 });
 
+Deno.test("jumplist: new and deleted files color their applicable counts", () => {
+  const s = diffSession(
+    [
+      "diff --git a/new.ts b/new.ts",
+      "new file mode 100644",
+      "--- /dev/null",
+      "+++ b/new.ts",
+      "@@ -0,0 +1,2 @@",
+      "+a",
+      "+b",
+      "diff --git a/gone.ts b/gone.ts",
+      "deleted file mode 100644",
+      "--- a/gone.ts",
+      "+++ /dev/null",
+      "@@ -1,2 +0,0 @@",
+      "-a",
+      "-b",
+      "",
+    ].join("\n"),
+  );
+  press(s, "i");
+
+  const lines = s.view().overlay!.lines;
+  assertEquals(lines.map((line) => line.text), [
+    "   ▸ new.ts  +2 (new)",
+    "   ▸ gone.ts  −2 (deleted)",
+  ]);
+  assertEquals(lines[0].spans.at(-1), {
+    col: 13,
+    text: "+2 (new)",
+    cls: "diffAdd",
+  });
+  assertEquals(lines[1].spans.at(-1), {
+    col: 14,
+    text: "−2 (deleted)",
+    cls: "diffDel",
+  });
+});
+
 Deno.test("jumplist: a git show lists the commit message before its files", () => {
   const s = diffSession(SHOW);
   press(s, "i");


### PR DESCRIPTION
New and deleted files in the cf view index card showed an inapplicable zero count and styled their status as diff metadata. This made a newly added file read `(new) +104 −0` instead of grouping its only meaningful count with its status.

Render new-file statuses in the addition span and deleted-file statuses in the deletion span. Omit the opposite zero count while leaving ordinary, renamed, and binary summaries unchanged.

Tests cover the collapsed summary text and spans and the actual jump-list rows. The focused behavior tests, repository type check, formatting check, and lint pass. The full CLI suite reaches 1,695 passing tests; its two remaining failures are existing color-mode assertions which also fail in isolation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

