### PR TITLE
fix(patterns): a pattern's own screen is a tree, not a reference

### DIFF
--- a/docs/common/concepts/types-and-schemas/unknown.md
+++ b/docs/common/concepts/types-and-schemas/unknown.md
@@ -69,6 +69,35 @@ Prefer whichever names the smaller surface. A reference that is only compared
 wants `unknown`; one whose title is rendered wants a two-field projection, not
 the piece.
 
+### A pattern's own screen is not a reference
+
+`[UI]` on a pattern's result holds the tree that pattern built, not a pointer at
+a tree somewhere else. Declare it `VNode`.
+
+```typescript
+// Shown as interface or class members.
+[NAME]: string;
+[UI]: VNode;
+```
+
+Declared `unknown`, that screen still renders: the renderer reads a piece's
+`$UI` under a schema of its own rather than under the pattern's declared result
+schema. The loss shows up wherever the tree is read as a value instead — a
+pattern that reads another pattern's screen, a pattern test that inspects one —
+and what those get is an empty object.
+
+The consuming side of the same field goes the other way, and the two
+declarations are independent of each other. A pattern that takes another
+pattern's result as an argument and only renders it declares that position
+`unknown`, which is what keeps it a reference to the sub-piece's own screen
+rather than a copy, so the controls in it stay bound to the piece that owns
+them. `packages/patterns/record.tsx` reads the settings screen its sub-pieces
+export this way. An argument declaration also has to keep accepting every value
+it accepted before, which a narrower one does not, so a consumer view of a
+result type holds `unknown` even where the producing type names `VNode`;
+`BackwardsCompatibleProfile` in `packages/patterns/system/profile-home.tsx` is
+the worked example.
+
 ### `unknown` is not `any`
 
 They admit the same values and mean opposite things here. `any` says "fetch it

--- a/packages/patterns/baselines/cfc-authorship-chat/main.tsx/20260818T214948Z-lv-0mr9i7UhhN00H.json
+++ b/packages/patterns/baselines/cfc-authorship-chat/main.tsx/20260818T214948Z-lv-0mr9i7UhhN00H.json
@@ -1,0 +1,33 @@
+{
+  "argumentSchema": {
+    "type": "unknown"
+  },
+  "pattern": "cfc-authorship-chat/main.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "forgedClaim": {
+        "type": "string"
+      },
+      "unsignedState": {
+        "type": "string"
+      },
+      "verifiedAuthor": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "verifiedAuthor",
+      "forgedClaim",
+      "unsignedState",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/cfc-spec-gallery/main.tsx/20260818T214948Z-IXWgEM630HPMBvoK.json
+++ b/packages/patterns/baselines/cfc-spec-gallery/main.tsx/20260818T214948Z-IXWgEM630HPMBvoK.json
@@ -1,0 +1,563 @@
+{
+  "argumentSchema": {
+    "additionalProperties": false,
+    "properties": {},
+    "type": "object"
+  },
+  "pattern": "cfc-spec-gallery/main.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "acceptInvite": {
+        "ifc": {
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc-spec-gallery/main.tsx",
+              "moduleIdentity": "eQtSODwtQI__HWy6KkWwBLJdCREn0BUyf7la8hN0NzY",
+              "path": [
+                "acceptInvite"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "acknowledgeAlert": {
+        "ifc": {
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc-spec-gallery/main.tsx",
+              "moduleIdentity": "eQtSODwtQI__HWy6KkWwBLJdCREn0BUyf7la8hN0NzY",
+              "path": [
+                "acknowledgeAlert"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "acknowledgeDisclosure": {
+        "ifc": {
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc-spec-gallery/main.tsx",
+              "moduleIdentity": "eQtSODwtQI__HWy6KkWwBLJdCREn0BUyf7la8hN0NzY",
+              "path": [
+                "acknowledgeDisclosure"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "authorizeResearchSend": {
+        "ifc": {
+          "uiContract": {
+            "action": "TrustedAuthorizeResearchSend",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedDirectCommandSurface"
+            ],
+            "trustedPattern": "TrustedDirectCommandSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc/trusted-surfaces/direct-command.tsx",
+              "moduleIdentity": "Gsqzx67QKgUcOimnMA2ya8Ip4mZ_Dj2CzHiafoExQog",
+              "path": [
+                "commitTrustedResearchSend"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "authorizeResearchSendCell": {
+        "type": "string"
+      },
+      "capturedCommand": {
+        "ifc": {
+          "uiContract": {
+            "action": "TrustedCaptureDirectCommand",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedDirectCommandSurface"
+            ],
+            "trustedPattern": "TrustedDirectCommandSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc/trusted-surfaces/direct-command.tsx",
+              "moduleIdentity": "Gsqzx67QKgUcOimnMA2ya8Ip4mZ_Dj2CzHiafoExQog",
+              "path": [
+                "captureTrustedDirectCommand"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "capturedCommandCell": {
+        "type": "string"
+      },
+      "completedCount": {
+        "type": "number"
+      },
+      "confirmReceipt": {
+        "ifc": {
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc-spec-gallery/main.tsx",
+              "moduleIdentity": "eQtSODwtQI__HWy6KkWwBLJdCREn0BUyf7la8hN0NzY",
+              "path": [
+                "confirmReceipt"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "escalateSupportCase": {
+        "ifc": {
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc-spec-gallery/main.tsx",
+              "moduleIdentity": "eQtSODwtQI__HWy6KkWwBLJdCREn0BUyf7la8hN0NzY",
+              "path": [
+                "escalateSupportCase"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "finalizeChecklist": {
+        "ifc": {
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc-spec-gallery/main.tsx",
+              "moduleIdentity": "eQtSODwtQI__HWy6KkWwBLJdCREn0BUyf7la8hN0NzY",
+              "path": [
+                "finalizeChecklist"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "forwardHotelNote": {
+        "ifc": {
+          "uiContract": {
+            "action": "TrustedForwardNote",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedForwardSurface"
+            ],
+            "trustedPattern": "TrustedForwardSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc/trusted-surfaces/forward.tsx",
+              "moduleIdentity": "25M8GzBg2y7WsCDRX7gJ1YOQKRjLWnEMa2oZmwTUE5Q",
+              "path": [
+                "commitTrustedForward"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "forwardHotelNoteCell": {
+        "type": "string"
+      },
+      "forwardPreparedPreview": {
+        "ifc": {
+          "uiContract": {
+            "action": "TrustedPrepareForward",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedForwardSurface"
+            ],
+            "trustedPattern": "TrustedForwardSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc/trusted-surfaces/forward.tsx",
+              "moduleIdentity": "25M8GzBg2y7WsCDRX7gJ1YOQKRjLWnEMa2oZmwTUE5Q",
+              "path": [
+                "prepareTrustedForward"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "forwardPreparedPreviewCell": {
+        "type": "string"
+      },
+      "forwardRecipientInput": {
+        "type": "string"
+      },
+      "forwardRecipientInputCell": {
+        "type": "string"
+      },
+      "forwardSourceNote": {
+        "type": "string"
+      },
+      "forwardStage": {
+        "type": "string"
+      },
+      "hotelMembershipReturn": {
+        "ifc": {
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc-spec-gallery/main.tsx",
+              "moduleIdentity": "eQtSODwtQI__HWy6KkWwBLJdCREn0BUyf7la8hN0NzY",
+              "path": [
+                "returnHotelMembership"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "hotelMembershipReturnCell": {
+        "type": "string"
+      },
+      "lastCompleted": {
+        "type": "string"
+      },
+      "prepareForwardHotelNote": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "prepareSafeLinkRelease": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "previewResearchBrief": {
+        "ifc": {
+          "uiContract": {
+            "action": "TrustedPrepareResearchBrief",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedDirectCommandSurface"
+            ],
+            "trustedPattern": "TrustedDirectCommandSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc/trusted-surfaces/direct-command.tsx",
+              "moduleIdentity": "Gsqzx67QKgUcOimnMA2ya8Ip4mZ_Dj2CzHiafoExQog",
+              "path": [
+                "prepareTrustedResearchBrief"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "releaseRedactedSummary": {
+        "ifc": {
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc-spec-gallery/main.tsx",
+              "moduleIdentity": "eQtSODwtQI__HWy6KkWwBLJdCREn0BUyf7la8hN0NzY",
+              "path": [
+                "releaseRedactedSummary"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "releaseSafeLink": {
+        "ifc": {
+          "uiContract": {
+            "action": "TrustedReleaseSafeLink",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedSafeLinkSurface"
+            ],
+            "trustedPattern": "TrustedSafeLinkSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc/trusted-surfaces/safe-link.tsx",
+              "moduleIdentity": "RQExot6AFkGN773cFYaFMGrES2r7ongsz-nm1VcQnXc",
+              "path": [
+                "commitTrustedSafeLink"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "releaseSafeLinkCell": {
+        "type": "string"
+      },
+      "researchCommandInput": {
+        "type": "string"
+      },
+      "researchCommandInputCell": {
+        "type": "string"
+      },
+      "researchPreparedBrief": {
+        "ifc": {
+          "uiContract": {
+            "action": "TrustedPrepareResearchBrief",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedDirectCommandSurface"
+            ],
+            "trustedPattern": "TrustedDirectCommandSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc/trusted-surfaces/direct-command.tsx",
+              "moduleIdentity": "Gsqzx67QKgUcOimnMA2ya8Ip4mZ_Dj2CzHiafoExQog",
+              "path": [
+                "prepareTrustedResearchBrief"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "researchPreparedBriefCell": {
+        "type": "string"
+      },
+      "researchStage": {
+        "type": "string"
+      },
+      "runAcceptInvite": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "runAcknowledgeAlert": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "runAcknowledgeDisclosure": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "runAuthorizeResearchSend": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "runCaptureDirectCommand": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "runConfirmReceipt": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "runEscalateSupportCase": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "runFinalizeChecklist": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "runForwardHotelNote": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "runHotelMembershipReturn": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "runPreviewResearchBrief": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "runReleaseRedactedSummary": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "runReleaseSafeLink": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "runSelectSearchResult": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "safeLinkPrepared": {
+        "ifc": {
+          "uiContract": {
+            "action": "TrustedPrepareSafeLink",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedSafeLinkSurface"
+            ],
+            "trustedPattern": "TrustedSafeLinkSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc/trusted-surfaces/safe-link.tsx",
+              "moduleIdentity": "RQExot6AFkGN773cFYaFMGrES2r7ongsz-nm1VcQnXc",
+              "path": [
+                "prepareTrustedSafeLink"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "safeLinkPreparedCell": {
+        "type": "string"
+      },
+      "safeLinkSource": {
+        "type": "string"
+      },
+      "safeLinkSourceCell": {
+        "type": "string"
+      },
+      "safeLinkStage": {
+        "type": "string"
+      },
+      "selectSearchResult": {
+        "ifc": {
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc-spec-gallery/main.tsx",
+              "moduleIdentity": "eQtSODwtQI__HWy6KkWwBLJdCREn0BUyf7la8hN0NzY",
+              "path": [
+                "selectSearchResult"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "selectSearchResultCell": {
+        "type": "string"
+      },
+      "setForwardRecipient": {
+        "asCell": [
+          "stream"
+        ],
+        "type": "string"
+      },
+      "setResearchCommand": {
+        "asCell": [
+          "stream"
+        ],
+        "type": "string"
+      },
+      "setSafeLinkSource": {
+        "asCell": [
+          "stream"
+        ],
+        "type": "string"
+      },
+      "totalExamples": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "totalExamples",
+      "completedCount",
+      "lastCompleted",
+      "hotelMembershipReturn",
+      "forwardHotelNote",
+      "forwardSourceNote",
+      "forwardRecipientInput",
+      "forwardPreparedPreview",
+      "forwardStage",
+      "forwardRecipientInputCell",
+      "forwardPreparedPreviewCell",
+      "forwardHotelNoteCell",
+      "selectSearchResult",
+      "acknowledgeDisclosure",
+      "acknowledgeAlert",
+      "acceptInvite",
+      "releaseRedactedSummary",
+      "escalateSupportCase",
+      "previewResearchBrief",
+      "researchCommandInput",
+      "capturedCommand",
+      "researchPreparedBrief",
+      "researchStage",
+      "researchCommandInputCell",
+      "capturedCommandCell",
+      "researchPreparedBriefCell",
+      "authorizeResearchSendCell",
+      "finalizeChecklist",
+      "confirmReceipt",
+      "authorizeResearchSend",
+      "releaseSafeLink",
+      "safeLinkSource",
+      "safeLinkPrepared",
+      "safeLinkStage",
+      "safeLinkSourceCell",
+      "safeLinkPreparedCell",
+      "releaseSafeLinkCell",
+      "hotelMembershipReturnCell",
+      "selectSearchResultCell",
+      "runHotelMembershipReturn",
+      "setForwardRecipient",
+      "prepareForwardHotelNote",
+      "runForwardHotelNote",
+      "runSelectSearchResult",
+      "runAcknowledgeDisclosure",
+      "runAcknowledgeAlert",
+      "runAcceptInvite",
+      "runReleaseRedactedSummary",
+      "runEscalateSupportCase",
+      "setResearchCommand",
+      "runCaptureDirectCommand",
+      "runPreviewResearchBrief",
+      "runFinalizeChecklist",
+      "runConfirmReceipt",
+      "runAuthorizeResearchSend",
+      "setSafeLinkSource",
+      "prepareSafeLinkRelease",
+      "runReleaseSafeLink",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/custom-field.tsx/20260818T214948Z-RmyUGVq5e7HtLqDK.json
+++ b/packages/patterns/baselines/custom-field.tsx/20260818T214948Z-RmyUGVq5e7HtLqDK.json
@@ -1,0 +1,77 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "CustomFieldValueType": {
+        "enum": [
+          "number",
+          "boolean",
+          "text",
+          "date",
+          "url"
+        ]
+      }
+    },
+    "properties": {
+      "name": {
+        "default": "",
+        "description": "Field name (e.g., \"Employee ID\", \"SKU\")",
+        "type": "string"
+      },
+      "value": {
+        "default": "",
+        "description": "Field value (stored as string, parsed by UI)",
+        "type": "string"
+      },
+      "valueType": {
+        "$ref": "#/$defs/CustomFieldValueType",
+        "default": "text",
+        "description": "Value type determines input UI"
+      }
+    },
+    "required": [
+      "name",
+      "value",
+      "valueType"
+    ],
+    "type": "object"
+  },
+  "pattern": "custom-field.tsx",
+  "resultSchema": {
+    "$defs": {
+      "CustomFieldValueType": {
+        "enum": [
+          "number",
+          "boolean",
+          "text",
+          "date",
+          "url"
+        ]
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "name": {
+        "type": "string"
+      },
+      "value": {
+        "type": "string"
+      },
+      "valueType": {
+        "$ref": "#/$defs/CustomFieldValueType"
+      }
+    },
+    "required": [
+      "name",
+      "value",
+      "valueType",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/image.tsx/20260818T214949Z-UzSOBnJN4VvuIpMR.json
+++ b/packages/patterns/baselines/image.tsx/20260818T214949Z-UzSOBnJN4VvuIpMR.json
@@ -1,0 +1,43 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "caption": {
+        "default": "",
+        "type": "string"
+      },
+      "url": {
+        "default": "",
+        "type": "string"
+      }
+    },
+    "required": [
+      "url",
+      "caption"
+    ],
+    "type": "object"
+  },
+  "pattern": "image.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "caption": {
+        "type": "string"
+      },
+      "url": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "url",
+      "caption",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/mobile-app-demo.tsx/20260818T214949Z-ezBRKehy71-qpIbq.json
+++ b/packages/patterns/baselines/mobile-app-demo.tsx/20260818T214949Z-ezBRKehy71-qpIbq.json
@@ -1,0 +1,22 @@
+{
+  "argumentSchema": {
+    "properties": {},
+    "type": "object"
+  },
+  "pattern": "mobile-app-demo.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      }
+    },
+    "required": [
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/photo.tsx/20260818T214949Z-cfnQzZNLsicV7nXq.json
+++ b/packages/patterns/baselines/photo.tsx/20260818T214949Z-cfnQzZNLsicV7nXq.json
@@ -1,0 +1,253 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "ImageData": {
+        "properties": {
+          "data": {
+            "type": "string"
+          },
+          "exif": {
+            "properties": {
+              "dateTime": {
+                "type": "string"
+              },
+              "exposureTime": {
+                "type": "string"
+              },
+              "fNumber": {
+                "type": "number"
+              },
+              "focalLength": {
+                "type": "number"
+              },
+              "gpsAltitude": {
+                "type": "number"
+              },
+              "gpsLatitude": {
+                "type": "number"
+              },
+              "gpsLongitude": {
+                "type": "number"
+              },
+              "iso": {
+                "type": "number"
+              },
+              "make": {
+                "type": "string"
+              },
+              "model": {
+                "type": "string"
+              },
+              "orientation": {
+                "type": "number"
+              },
+              "pixelXDimension": {
+                "type": "number"
+              },
+              "pixelYDimension": {
+                "type": "number"
+              },
+              "raw": {
+                "additionalProperties": true,
+                "properties": {},
+                "type": "object"
+              },
+              "software": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "height": {
+            "type": "number"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "type": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "width": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "url",
+          "data",
+          "timestamp",
+          "size",
+          "type"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "image": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/ImageData"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "description": "The uploaded image data (null if no image)"
+      },
+      "label": {
+        "default": "",
+        "description": "User-defined label for the photo",
+        "type": "string"
+      }
+    },
+    "required": [
+      "image",
+      "label"
+    ],
+    "type": "object"
+  },
+  "pattern": "photo.tsx",
+  "resultSchema": {
+    "$defs": {
+      "ImageData": {
+        "properties": {
+          "data": {
+            "type": "string"
+          },
+          "exif": {
+            "properties": {
+              "dateTime": {
+                "type": "string"
+              },
+              "exposureTime": {
+                "type": "string"
+              },
+              "fNumber": {
+                "type": "number"
+              },
+              "focalLength": {
+                "type": "number"
+              },
+              "gpsAltitude": {
+                "type": "number"
+              },
+              "gpsLatitude": {
+                "type": "number"
+              },
+              "gpsLongitude": {
+                "type": "number"
+              },
+              "iso": {
+                "type": "number"
+              },
+              "make": {
+                "type": "string"
+              },
+              "model": {
+                "type": "string"
+              },
+              "orientation": {
+                "type": "number"
+              },
+              "pixelXDimension": {
+                "type": "number"
+              },
+              "pixelYDimension": {
+                "type": "number"
+              },
+              "raw": {
+                "additionalProperties": true,
+                "properties": {},
+                "type": "object"
+              },
+              "software": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "height": {
+            "type": "number"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "type": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "width": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "url",
+          "data",
+          "timestamp",
+          "size",
+          "type"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "image": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/ImageData"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "label": {
+        "type": "string"
+      },
+      "settingsUI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      }
+    },
+    "required": [
+      "settingsUI",
+      "image",
+      "label",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/system/home.tsx/20260818T220011Z-KnU5UM1qdaNt22eV.json
+++ b/packages/patterns/baselines/system/home.tsx/20260818T220011Z-KnU5UM1qdaNt22eV.json
@@ -1,0 +1,855 @@
+{
+  "argumentSchema": {
+    "additionalProperties": false,
+    "properties": {},
+    "type": "object"
+  },
+  "pattern": "system/home.tsx",
+  "resultSchema": {
+    "$defs": {
+      "BackwardsCompatibleProfile": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "$UI": {
+            "type": "unknown"
+          },
+          "addElement": {
+            "$ref": "#/$defs/MutateProfileElementsEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addExternalLink": {
+            "$ref": "#/$defs/MutateExternalProfileLinksEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addPiece": {
+            "$ref": "#/$defs/MutateProfileElementsEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "avatar": {
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+                  "path": [
+                    "setAvatar"
+                  ]
+                }
+              }
+            },
+            "type": "string"
+          },
+          "bio": {
+            "default": "",
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+                  "path": [
+                    "setBio"
+                  ]
+                }
+              }
+            },
+            "type": "string"
+          },
+          "elements": {
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+                  "path": [
+                    "mutateElements"
+                  ]
+                }
+              }
+            },
+            "items": {
+              "$ref": "#/$defs/ProfileElement"
+            },
+            "type": "array"
+          },
+          "externalLinks": {
+            "default": [],
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+                  "path": [
+                    "mutateExternalProfileLinks"
+                  ]
+                }
+              }
+            },
+            "items": {
+              "$ref": "#/$defs/ExternalProfileLink"
+            },
+            "type": "array"
+          },
+          "initialNameApplied": {
+            "type": "string"
+          },
+          "isEditing": {
+            "default": false,
+            "type": "boolean"
+          },
+          "name": {
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+                  "path": [
+                    "setName"
+                  ]
+                }
+              }
+            },
+            "type": "string"
+          },
+          "publishVerifiedIdentities": {
+            "$ref": "#/$defs/MutateVerifiedIdentitiesEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "removeElement": {
+            "$ref": "#/$defs/MutateProfileElementsEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "removeExternalLink": {
+            "$ref": "#/$defs/MutateExternalProfileLinksEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "revokeVerifiedIdentities": {
+            "$ref": "#/$defs/MutateVerifiedIdentitiesEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "setAvatar": {
+            "$ref": "#/$defs/SetProfileAvatarEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "setBio": {
+            "$ref": "#/$defs/SetProfileBioEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "setName": {
+            "$ref": "#/$defs/SetProfileNameEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "toggleEditing": {
+            "asCell": [
+              "stream",
+              "opaque"
+            ]
+          },
+          "verifiedIdentities": {
+            "default": [],
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+                  "path": [
+                    "publishVerifiedIdentities"
+                  ]
+                }
+              }
+            },
+            "items": {
+              "$ref": "#/$defs/VerifiedExternalIdentity"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "$NAME",
+          "$UI",
+          "name",
+          "avatar",
+          "bio",
+          "externalLinks",
+          "verifiedIdentities",
+          "elements",
+          "setName",
+          "setAvatar",
+          "addElement",
+          "removeElement",
+          "isEditing",
+          "initialNameApplied"
+        ],
+        "type": "object"
+      },
+      "CreateProfileEvent": {
+        "properties": {
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "ExternalIdentityAssertion": {
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "verifiedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "value",
+          "verifiedAt"
+        ],
+        "type": "object"
+      },
+      "ExternalProfileLink": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "url"
+        ],
+        "type": "object"
+      },
+      "Favorite": {
+        "properties": {
+          "cell": {
+            "properties": {
+              "$NAME": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "id": {
+            "type": "string"
+          },
+          "spaceName": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "userTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "cell",
+          "tags",
+          "userTags"
+        ],
+        "type": "object"
+      },
+      "JournalEntry": {
+        "properties": {
+          "eventType": {
+            "type": "string"
+          },
+          "narrative": {
+            "type": "string"
+          },
+          "narrativePending": {
+            "type": "boolean"
+          },
+          "snapshot": {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "schemaTag": {
+                "type": "string"
+              },
+              "valueExcerpt": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "space": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "unknown"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "timestamp": {
+            "type": "number"
+          }
+        },
+        "type": "object"
+      },
+      "MutateExternalProfileLinksEvent": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "MutateProfileElementsEvent": {
+        "properties": {
+          "catalogId": {
+            "type": "string"
+          },
+          "cell": true,
+          "patternUrl": {
+            "type": "string"
+          },
+          "pieceId": {
+            "type": "string"
+          },
+          "pieceSpace": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "userTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "MutateVerifiedIdentitiesEvent": {
+        "properties": {
+          "identities": {
+            "items": {
+              "$ref": "#/$defs/VerifiedExternalIdentity"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ProfileElement": {
+        "properties": {
+          "cell": true,
+          "source": {
+            "enum": [
+              "piece",
+              "url",
+              "catalog"
+            ]
+          },
+          "tag": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "userTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "cell",
+          "tag",
+          "userTags"
+        ],
+        "type": "object"
+      },
+      "SetProfileAvatarEvent": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "SetProfileBioEvent": {
+        "properties": {
+          "bio": {
+            "type": "string"
+          },
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "SetProfileNameEvent": {
+        "properties": {
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "SpaceEntry": {
+        "properties": {
+          "did": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "TrustedDefaultProfile": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/BackwardsCompatibleProfile"
+          }
+        ]
+      },
+      "TrustedProfileLink": {
+        "$ref": "#/$defs/BackwardsCompatibleProfile",
+        "ifc": {
+          "addIntegrity": [
+            "profile-link"
+          ],
+          "uiContract": {
+            "action": "CreateProfile",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "ProfileCreateSurface"
+            ],
+            "trustedPattern": "ProfileCreateSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/system/profile-create.tsx",
+              "moduleIdentity": "uXrqB8Or9ITFDECGZOKn9bJzSZaTH-yv3rEurb041z0",
+              "path": [
+                "submitProfileCreation"
+              ]
+            }
+          }
+        }
+      },
+      "TrustedProfileList": {
+        "ifc": {
+          "addIntegrity": [
+            "profile-link"
+          ],
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/system/profile-create.tsx",
+              "moduleIdentity": "uXrqB8Or9ITFDECGZOKn9bJzSZaTH-yv3rEurb041z0",
+              "path": [
+                "submitProfileCreation"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/TrustedProfileLink"
+        },
+        "type": "array"
+      },
+      "TrustedProfileMru": {
+        "ifc": {
+          "addIntegrity": [
+            "profile-link"
+          ],
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/system/profile-create.tsx",
+              "moduleIdentity": "uXrqB8Or9ITFDECGZOKn9bJzSZaTH-yv3rEurb041z0",
+              "path": [
+                "setMruProfile"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/BackwardsCompatibleProfile",
+          "ifc": {
+            "addIntegrity": [
+              "profile-link"
+            ],
+            "uiContract": {
+              "action": "SetMruProfile",
+              "helper": "UiAction",
+              "requiredEventIntegrity": [
+                "ProfilePickerSurface"
+              ],
+              "trustedPattern": "ProfilePickerSurface"
+            },
+            "writeAuthorizedBy": {
+              "__ctWriterIdentityOf": {
+                "file": "/packages/patterns/system/profile-create.tsx",
+                "moduleIdentity": "uXrqB8Or9ITFDECGZOKn9bJzSZaTH-yv3rEurb041z0",
+                "path": [
+                  "setMruProfile"
+                ]
+              }
+            }
+          }
+        },
+        "type": "array"
+      },
+      "VerifiedExternalIdentity": {
+        "$ref": "#/$defs/ExternalIdentityAssertion",
+        "ifc": {
+          "requiredIntegrity": [
+            "loom-verified-external-identity"
+          ]
+        }
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addFavorite": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "piece": {
+            "properties": {
+              "$NAME": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "spaceName": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "piece"
+        ],
+        "type": "object"
+      },
+      "addJournalEntry": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "entry": {
+            "$ref": "#/$defs/JournalEntry"
+          }
+        },
+        "required": [
+          "entry"
+        ],
+        "type": "object"
+      },
+      "addSpace": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "type": "object"
+      },
+      "createProfile": {
+        "$ref": "#/$defs/CreateProfileEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "defaultAppUrl": {
+        "default": "",
+        "type": "string"
+      },
+      "defaultProfile": {
+        "$ref": "#/$defs/TrustedDefaultProfile"
+      },
+      "favorites": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Favorite"
+        },
+        "type": "array"
+      },
+      "journal": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/JournalEntry"
+        },
+        "type": "array"
+      },
+      "mru": {
+        "$ref": "#/$defs/TrustedProfileMru",
+        "default": []
+      },
+      "profiles": {
+        "$ref": "#/$defs/TrustedProfileList",
+        "default": []
+      },
+      "removeFavorite": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "piece": {
+            "type": "unknown"
+          }
+        },
+        "type": "object"
+      },
+      "removeSpace": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "spaces": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/SpaceEntry"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "favorites",
+      "journal",
+      "spaces",
+      "defaultAppUrl",
+      "profiles",
+      "mru",
+      "createProfile",
+      "addFavorite",
+      "removeFavorite",
+      "addJournalEntry",
+      "addSpace",
+      "removeSpace",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/system/profile-create.tsx/20260818T220011Z--UmvkwvwvKu5vR0X.json
+++ b/packages/patterns/baselines/system/profile-create.tsx/20260818T220011Z--UmvkwvwvKu5vR0X.json
@@ -1,0 +1,552 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "BackwardsCompatibleProfile": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "$UI": {
+            "type": "unknown"
+          },
+          "addElement": {
+            "$ref": "#/$defs/MutateProfileElementsEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addExternalLink": {
+            "$ref": "#/$defs/MutateExternalProfileLinksEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addPiece": {
+            "$ref": "#/$defs/MutateProfileElementsEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "avatar": {
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+                  "path": [
+                    "setAvatar"
+                  ]
+                }
+              }
+            },
+            "type": "string"
+          },
+          "bio": {
+            "default": "",
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+                  "path": [
+                    "setBio"
+                  ]
+                }
+              }
+            },
+            "type": "string"
+          },
+          "elements": {
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+                  "path": [
+                    "mutateElements"
+                  ]
+                }
+              }
+            },
+            "items": {
+              "$ref": "#/$defs/ProfileElement"
+            },
+            "type": "array"
+          },
+          "externalLinks": {
+            "default": [],
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+                  "path": [
+                    "mutateExternalProfileLinks"
+                  ]
+                }
+              }
+            },
+            "items": {
+              "$ref": "#/$defs/ExternalProfileLink"
+            },
+            "type": "array"
+          },
+          "initialNameApplied": {
+            "type": "string"
+          },
+          "isEditing": {
+            "default": false,
+            "type": "boolean"
+          },
+          "name": {
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+                  "path": [
+                    "setName"
+                  ]
+                }
+              }
+            },
+            "type": "string"
+          },
+          "publishVerifiedIdentities": {
+            "$ref": "#/$defs/MutateVerifiedIdentitiesEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "removeElement": {
+            "$ref": "#/$defs/MutateProfileElementsEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "removeExternalLink": {
+            "$ref": "#/$defs/MutateExternalProfileLinksEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "revokeVerifiedIdentities": {
+            "$ref": "#/$defs/MutateVerifiedIdentitiesEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "setAvatar": {
+            "$ref": "#/$defs/SetProfileAvatarEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "setBio": {
+            "$ref": "#/$defs/SetProfileBioEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "setName": {
+            "$ref": "#/$defs/SetProfileNameEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "toggleEditing": {
+            "asCell": [
+              "stream",
+              "opaque"
+            ]
+          },
+          "verifiedIdentities": {
+            "default": [],
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+                  "path": [
+                    "publishVerifiedIdentities"
+                  ]
+                }
+              }
+            },
+            "items": {
+              "$ref": "#/$defs/VerifiedExternalIdentity",
+              "asCell": [
+                "cell"
+              ]
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "$NAME",
+          "$UI",
+          "name",
+          "avatar",
+          "bio",
+          "externalLinks",
+          "verifiedIdentities",
+          "elements",
+          "setName",
+          "setAvatar",
+          "addElement",
+          "removeElement",
+          "isEditing",
+          "initialNameApplied"
+        ],
+        "type": "object"
+      },
+      "ExternalIdentityAssertion": {
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "verifiedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "value",
+          "verifiedAt"
+        ],
+        "type": "object"
+      },
+      "ExternalProfileLink": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "url"
+        ],
+        "type": "object"
+      },
+      "MutateExternalProfileLinksEvent": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "MutateProfileElementsEvent": {
+        "properties": {
+          "catalogId": {
+            "type": "string"
+          },
+          "cell": true,
+          "patternUrl": {
+            "type": "string"
+          },
+          "pieceId": {
+            "type": "string"
+          },
+          "pieceSpace": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "userTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "MutateVerifiedIdentitiesEvent": {
+        "properties": {
+          "identities": {
+            "items": {
+              "$ref": "#/$defs/VerifiedExternalIdentity",
+              "asCell": [
+                "cell"
+              ]
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ProfileElement": {
+        "properties": {
+          "cell": true,
+          "source": {
+            "enum": [
+              "url",
+              "catalog",
+              "piece"
+            ]
+          },
+          "tag": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "userTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "cell",
+          "tag",
+          "userTags"
+        ],
+        "type": "object"
+      },
+      "SetProfileAvatarEvent": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "SetProfileBioEvent": {
+        "properties": {
+          "bio": {
+            "type": "string"
+          },
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "SetProfileNameEvent": {
+        "properties": {
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "VerifiedExternalIdentity": {
+        "$ref": "#/$defs/ExternalIdentityAssertion",
+        "ifc": {
+          "requiredIntegrity": [
+            "loom-verified-external-identity"
+          ]
+        }
+      }
+    },
+    "properties": {
+      "defaultName": {
+        "type": "string"
+      },
+      "inputId": {
+        "type": "string"
+      },
+      "profiles": {
+        "asCell": [
+          "cell"
+        ],
+        "items": {
+          "$ref": "#/$defs/BackwardsCompatibleProfile"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "profiles"
+    ],
+    "type": "object"
+  },
+  "pattern": "system/profile-create.tsx",
+  "resultSchema": {
+    "$defs": {
+      "CreateProfileEvent": {
+        "properties": {
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "createProfile": {
+        "$ref": "#/$defs/CreateProfileEvent",
+        "asCell": [
+          "stream"
+        ]
+      }
+    },
+    "required": [
+      "createProfile",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/system/profile-embed.tsx/20260818T214949Z-Zga6lJ6RvqpC6q1g.json
+++ b/packages/patterns/baselines/system/profile-embed.tsx/20260818T214949Z-Zga6lJ6RvqpC6q1g.json
@@ -1,0 +1,31 @@
+{
+  "argumentSchema": {
+    "additionalProperties": false,
+    "properties": {},
+    "type": "object"
+  },
+  "pattern": "system/profile-embed.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "hasProfile": {
+        "type": "boolean"
+      },
+      "isEditing": {
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "hasProfile",
+      "isEditing",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/system/profile-home.tsx/20260818T220011Z-UcBTDVAWi7CCHKBC.json
+++ b/packages/patterns/baselines/system/profile-home.tsx/20260818T220011Z-UcBTDVAWi7CCHKBC.json
@@ -1,0 +1,487 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "initialName": {
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "system/profile-home.tsx",
+  "resultSchema": {
+    "$defs": {
+      "ExternalIdentityAssertion": {
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "verifiedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "value",
+          "verifiedAt"
+        ],
+        "type": "object"
+      },
+      "ExternalProfileLink": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "url"
+        ],
+        "type": "object"
+      },
+      "MutateExternalProfileLinksEvent": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "MutateProfileElementsEvent": {
+        "properties": {
+          "catalogId": {
+            "type": "string"
+          },
+          "cell": true,
+          "patternUrl": {
+            "type": "string"
+          },
+          "pieceId": {
+            "type": "string"
+          },
+          "pieceSpace": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "userTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "MutateVerifiedIdentitiesEvent": {
+        "properties": {
+          "identities": {
+            "items": {
+              "$ref": "#/$defs/VerifiedExternalIdentity"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ProfileElement": {
+        "properties": {
+          "cell": true,
+          "source": {
+            "enum": [
+              "catalog",
+              "url",
+              "piece"
+            ]
+          },
+          "tag": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "userTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "cell",
+          "tag",
+          "userTags"
+        ],
+        "type": "object"
+      },
+      "SetProfileAvatarEvent": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "SetProfileBioEvent": {
+        "properties": {
+          "bio": {
+            "type": "string"
+          },
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "SetProfileNameEvent": {
+        "properties": {
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "VerifiedExternalIdentity": {
+        "$ref": "#/$defs/ExternalIdentityAssertion",
+        "ifc": {
+          "requiredIntegrity": [
+            "loom-verified-external-identity"
+          ]
+        }
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addElement": {
+        "$ref": "#/$defs/MutateProfileElementsEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "addExternalLink": {
+        "$ref": "#/$defs/MutateExternalProfileLinksEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "addPiece": {
+        "$ref": "#/$defs/MutateProfileElementsEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "avatar": {
+        "ifc": {
+          "addIntegrity": [
+            {
+              "kind": "represents-principal",
+              "subject": {
+                "__ctCurrentPrincipal": true
+              }
+            }
+          ],
+          "ownerPrincipal": {
+            "__ctCurrentPrincipal": true
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/system/profile-home.tsx",
+              "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+              "path": [
+                "setAvatar"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "bio": {
+        "default": "",
+        "ifc": {
+          "addIntegrity": [
+            {
+              "kind": "represents-principal",
+              "subject": {
+                "__ctCurrentPrincipal": true
+              }
+            }
+          ],
+          "ownerPrincipal": {
+            "__ctCurrentPrincipal": true
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/system/profile-home.tsx",
+              "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+              "path": [
+                "setBio"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "elements": {
+        "ifc": {
+          "addIntegrity": [
+            {
+              "kind": "represents-principal",
+              "subject": {
+                "__ctCurrentPrincipal": true
+              }
+            }
+          ],
+          "ownerPrincipal": {
+            "__ctCurrentPrincipal": true
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/system/profile-home.tsx",
+              "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+              "path": [
+                "mutateElements"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/ProfileElement"
+        },
+        "type": "array"
+      },
+      "externalLinks": {
+        "default": [],
+        "ifc": {
+          "addIntegrity": [
+            {
+              "kind": "represents-principal",
+              "subject": {
+                "__ctCurrentPrincipal": true
+              }
+            }
+          ],
+          "ownerPrincipal": {
+            "__ctCurrentPrincipal": true
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/system/profile-home.tsx",
+              "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+              "path": [
+                "mutateExternalProfileLinks"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/ExternalProfileLink"
+        },
+        "type": "array"
+      },
+      "initialNameApplied": {
+        "type": "string"
+      },
+      "isEditing": {
+        "default": false,
+        "type": "boolean"
+      },
+      "name": {
+        "ifc": {
+          "addIntegrity": [
+            {
+              "kind": "represents-principal",
+              "subject": {
+                "__ctCurrentPrincipal": true
+              }
+            }
+          ],
+          "ownerPrincipal": {
+            "__ctCurrentPrincipal": true
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/system/profile-home.tsx",
+              "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+              "path": [
+                "setName"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "publishVerifiedIdentities": {
+        "$ref": "#/$defs/MutateVerifiedIdentitiesEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "removeElement": {
+        "$ref": "#/$defs/MutateProfileElementsEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "removeExternalLink": {
+        "$ref": "#/$defs/MutateExternalProfileLinksEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "revokeVerifiedIdentities": {
+        "$ref": "#/$defs/MutateVerifiedIdentitiesEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "setAvatar": {
+        "$ref": "#/$defs/SetProfileAvatarEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "setBio": {
+        "$ref": "#/$defs/SetProfileBioEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "setName": {
+        "$ref": "#/$defs/SetProfileNameEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "toggleEditing": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "verifiedIdentities": {
+        "default": [],
+        "ifc": {
+          "addIntegrity": [
+            {
+              "kind": "represents-principal",
+              "subject": {
+                "__ctCurrentPrincipal": true
+              }
+            }
+          ],
+          "ownerPrincipal": {
+            "__ctCurrentPrincipal": true
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/system/profile-home.tsx",
+              "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+              "path": [
+                "publishVerifiedIdentities"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/VerifiedExternalIdentity"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "name",
+      "avatar",
+      "bio",
+      "externalLinks",
+      "verifiedIdentities",
+      "elements",
+      "setName",
+      "setAvatar",
+      "setBio",
+      "addExternalLink",
+      "removeExternalLink",
+      "publishVerifiedIdentities",
+      "revokeVerifiedIdentities",
+      "addElement",
+      "removeElement",
+      "addPiece",
+      "toggleEditing",
+      "isEditing",
+      "initialNameApplied",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/system/profile-picker.tsx/20260818T220011Z-J-y30yE6xQ8axACi.json
+++ b/packages/patterns/baselines/system/profile-picker.tsx/20260818T220011Z-J-y30yE6xQ8axACi.json
@@ -1,0 +1,530 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "BackwardsCompatibleProfile": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "$UI": {
+            "type": "unknown"
+          },
+          "addElement": {
+            "$ref": "#/$defs/MutateProfileElementsEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addExternalLink": {
+            "$ref": "#/$defs/MutateExternalProfileLinksEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addPiece": {
+            "$ref": "#/$defs/MutateProfileElementsEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "avatar": {
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+                  "path": [
+                    "setAvatar"
+                  ]
+                }
+              }
+            },
+            "type": "string"
+          },
+          "bio": {
+            "default": "",
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+                  "path": [
+                    "setBio"
+                  ]
+                }
+              }
+            },
+            "type": "string"
+          },
+          "elements": {
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+                  "path": [
+                    "mutateElements"
+                  ]
+                }
+              }
+            },
+            "items": {
+              "$ref": "#/$defs/ProfileElement"
+            },
+            "type": "array"
+          },
+          "externalLinks": {
+            "default": [],
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+                  "path": [
+                    "mutateExternalProfileLinks"
+                  ]
+                }
+              }
+            },
+            "items": {
+              "$ref": "#/$defs/ExternalProfileLink"
+            },
+            "type": "array"
+          },
+          "initialNameApplied": {
+            "type": "string"
+          },
+          "isEditing": {
+            "default": false,
+            "type": "boolean"
+          },
+          "name": {
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+                  "path": [
+                    "setName"
+                  ]
+                }
+              }
+            },
+            "type": "string"
+          },
+          "publishVerifiedIdentities": {
+            "$ref": "#/$defs/MutateVerifiedIdentitiesEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "removeElement": {
+            "$ref": "#/$defs/MutateProfileElementsEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "removeExternalLink": {
+            "$ref": "#/$defs/MutateExternalProfileLinksEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "revokeVerifiedIdentities": {
+            "$ref": "#/$defs/MutateVerifiedIdentitiesEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "setAvatar": {
+            "$ref": "#/$defs/SetProfileAvatarEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "setBio": {
+            "$ref": "#/$defs/SetProfileBioEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "setName": {
+            "$ref": "#/$defs/SetProfileNameEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "toggleEditing": {
+            "asCell": [
+              "stream",
+              "opaque"
+            ]
+          },
+          "verifiedIdentities": {
+            "default": [],
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "XEaU1O_qDlj_cNPxMROO9JQD-xd9qQ6tI0mrvpJXpJI",
+                  "path": [
+                    "publishVerifiedIdentities"
+                  ]
+                }
+              }
+            },
+            "items": {
+              "$ref": "#/$defs/VerifiedExternalIdentity",
+              "asCell": [
+                "cell"
+              ]
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "$NAME",
+          "$UI",
+          "name",
+          "avatar",
+          "bio",
+          "externalLinks",
+          "verifiedIdentities",
+          "elements",
+          "setName",
+          "setAvatar",
+          "addElement",
+          "removeElement",
+          "isEditing",
+          "initialNameApplied"
+        ],
+        "type": "object"
+      },
+      "ExternalIdentityAssertion": {
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "verifiedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "value",
+          "verifiedAt"
+        ],
+        "type": "object"
+      },
+      "ExternalProfileLink": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "url"
+        ],
+        "type": "object"
+      },
+      "MutateExternalProfileLinksEvent": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "MutateProfileElementsEvent": {
+        "properties": {
+          "catalogId": {
+            "type": "string"
+          },
+          "cell": true,
+          "patternUrl": {
+            "type": "string"
+          },
+          "pieceId": {
+            "type": "string"
+          },
+          "pieceSpace": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "userTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "MutateVerifiedIdentitiesEvent": {
+        "properties": {
+          "identities": {
+            "items": {
+              "$ref": "#/$defs/VerifiedExternalIdentity",
+              "asCell": [
+                "cell"
+              ]
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ProfileElement": {
+        "properties": {
+          "cell": true,
+          "source": {
+            "enum": [
+              "url",
+              "catalog",
+              "piece"
+            ]
+          },
+          "tag": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "userTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "cell",
+          "tag",
+          "userTags"
+        ],
+        "type": "object"
+      },
+      "SetProfileAvatarEvent": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "SetProfileBioEvent": {
+        "properties": {
+          "bio": {
+            "type": "string"
+          },
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "SetProfileNameEvent": {
+        "properties": {
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "VerifiedExternalIdentity": {
+        "$ref": "#/$defs/ExternalIdentityAssertion",
+        "ifc": {
+          "requiredIntegrity": [
+            "loom-verified-external-identity"
+          ]
+        }
+      }
+    },
+    "properties": {
+      "defaultProfile": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/BackwardsCompatibleProfile"
+          }
+        ],
+        "asCell": [
+          "cell"
+        ]
+      },
+      "mru": {
+        "asCell": [
+          "cell"
+        ],
+        "items": {
+          "$ref": "#/$defs/BackwardsCompatibleProfile"
+        },
+        "type": "array"
+      },
+      "profiles": {
+        "asCell": [
+          "cell"
+        ],
+        "items": {
+          "$ref": "#/$defs/BackwardsCompatibleProfile"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "profiles",
+      "defaultProfile",
+      "mru"
+    ],
+    "type": "object"
+  },
+  "pattern": "system/profile-picker.tsx",
+  "resultSchema": {
+    "properties": {
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      }
+    },
+    "required": [
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/text-import.tsx/20260818T214949Z-SPzkuVc7h1vdb52j.json
+++ b/packages/patterns/baselines/text-import.tsx/20260818T214949Z-SPzkuVc7h1vdb52j.json
@@ -1,0 +1,45 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "content": {
+        "default": "",
+        "description": "The text content from the uploaded file",
+        "type": "string"
+      },
+      "filename": {
+        "default": "",
+        "description": "The original filename",
+        "type": "string"
+      }
+    },
+    "required": [
+      "content",
+      "filename"
+    ],
+    "type": "object"
+  },
+  "pattern": "text-import.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "content": {
+        "type": "string"
+      },
+      "filename": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "content",
+      "filename",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/cfc-authorship-chat/main.tsx
+++ b/packages/patterns/cfc-authorship-chat/main.tsx
@@ -1,4 +1,12 @@
-import { type Cfc, computed, NAME, pattern, UI, Writable } from "commonfabric";
+import {
+  type Cfc,
+  computed,
+  NAME,
+  pattern,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
 
 type AuthorshipIntegrity<Author extends string> = {
   readonly kind: "authored-by";
@@ -28,7 +36,7 @@ type AuthoredMessageWithIntegrity<
 
 export type AuthorshipChatOutput = {
   [NAME]: string;
-  [UI]: unknown;
+  [UI]: VNode;
   verifiedAuthor: string;
   forgedClaim: string;
   unsignedState: string;

--- a/packages/patterns/cfc-spec-gallery/main.tsx
+++ b/packages/patterns/cfc-spec-gallery/main.tsx
@@ -9,6 +9,7 @@ import {
   Stream,
   type TrustedActionWrite,
   UI,
+  type VNode,
   Writable,
   WriteAuthorizedBy,
 } from "commonfabric";
@@ -140,7 +141,7 @@ const makeFactCheckDisclosure = lift<
 
 export interface GalleryOutput {
   [NAME]: string;
-  [UI]: unknown;
+  [UI]: VNode;
   totalExamples: number;
   completedCount: number;
   lastCompleted: string;

--- a/packages/patterns/custom-field.tsx
+++ b/packages/patterns/custom-field.tsx
@@ -17,6 +17,7 @@ import {
   NAME,
   pattern,
   UI,
+  type VNode,
   Writable,
 } from "commonfabric";
 import type { ModuleMetadata } from "./container-protocol.ts";
@@ -91,10 +92,9 @@ export interface CustomFieldModuleInput {
   valueType: CustomFieldValueType | Default<"text">;
 }
 
-// Output interface with unknown for UI properties to prevent OOM (CT-1148)
 export interface CustomFieldModuleOutput {
-  [NAME]: unknown;
-  [UI]: unknown;
+  [NAME]: string;
+  [UI]: VNode;
   name: string;
   value: string;
   valueType: CustomFieldValueType;

--- a/packages/patterns/image.tsx
+++ b/packages/patterns/image.tsx
@@ -5,6 +5,7 @@ import {
   NAME,
   pattern,
   UI,
+  type VNode,
 } from "commonfabric";
 
 type ImageInput = {
@@ -13,8 +14,8 @@ type ImageInput = {
 };
 
 export type ImageOutput = {
-  [NAME]: unknown;
-  [UI]: unknown;
+  [NAME]: string;
+  [UI]: VNode;
   url: string;
   caption: string;
 };

--- a/packages/patterns/mobile-app-demo.tsx
+++ b/packages/patterns/mobile-app-demo.tsx
@@ -1,10 +1,18 @@
-import { action, computed, NAME, pattern, UI, Writable } from "commonfabric";
+import {
+  action,
+  computed,
+  NAME,
+  pattern,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
 
 // deno-lint-ignore no-empty-interface
 interface MobileAppDemoInput {}
 export interface MobileAppDemoOutput {
   [NAME]: string;
-  [UI]: unknown;
+  [UI]: VNode;
 }
 
 const IOS_HOME_THEME = {

--- a/packages/patterns/photo.tsx
+++ b/packages/patterns/photo.tsx
@@ -15,6 +15,7 @@ import {
   pattern,
   str,
   UI,
+  type VNode,
   Writable,
 } from "commonfabric";
 import type { ModuleMetadata } from "./container-protocol.ts";
@@ -41,12 +42,10 @@ export interface PhotoModuleInput {
   label: string | Default<"">;
 }
 
-// Output interface with unknown for UI properties to prevent OOM (CT-1148)
-// TypeScript infers deeply nested VNode types without this, causing memory explosion
 export interface PhotoModuleOutput {
-  [NAME]: unknown;
-  [UI]: unknown;
-  settingsUI: unknown;
+  [NAME]: string;
+  [UI]: VNode;
+  settingsUI: VNode;
   image: ImageData | null;
   label: string;
 }
@@ -82,8 +81,6 @@ export const PhotoModule = pattern<PhotoModuleInput, PhotoModuleOutput>(
   ({ image: inputImage, label }) => {
     // We use an array internally for cf-image-input compatibility
     // but the module only supports a single image
-    // NOTE: Writable must use empty array to avoid TypeScript OOM (CT-1148)
-    // Using input params in new Writable() causes deep type inference explosion
     const images = new Writable<ImageData[]>([]);
 
     // Sync image Cell with images array (first element)

--- a/packages/patterns/system/home.tsx
+++ b/packages/patterns/system/home.tsx
@@ -7,6 +7,7 @@ import {
   pattern,
   Stream,
   UI,
+  type VNode,
   Writable,
 } from "commonfabric";
 import FavoritesManager from "./favorites-manager.tsx";
@@ -50,7 +51,7 @@ type SpaceEntry = {
 
 export type HomeOutput = {
   [NAME]: string;
-  [UI]: unknown;
+  [UI]: VNode;
   // These defaults are part of Home's published result contract. Pattern setup
   // generates the output fields, so a newly added result does not need a
   // migration default; once a default has shipped, however, removing it changes

--- a/packages/patterns/system/profile-embed.tsx
+++ b/packages/patterns/system/profile-embed.tsx
@@ -6,6 +6,7 @@ import {
   pattern,
   Stream,
   UI,
+  type VNode,
   wish,
   Writable,
 } from "commonfabric";
@@ -123,7 +124,7 @@ export type ProfileEmbedInput = Record<string, never>;
 
 export type ProfileEmbedOutput = {
   [NAME]: string;
-  [UI]: unknown;
+  [UI]: VNode;
   // Whether the viewer's profile has resolved (a profile exists). When false the
   // wish fallback (the trusted create surface) is rendered.
   hasProfile: boolean;

--- a/packages/patterns/system/profile-home.owner-gated.test.ts
+++ b/packages/patterns/system/profile-home.owner-gated.test.ts
@@ -82,6 +82,20 @@ describe("host embedding contract: profile pinning is owner-gated", () => {
     expect(home).toContain("isEditing: Default<boolean, false>");
   });
 
+  it("weakens the rendered screen in the consumer view", () => {
+    // The other half of the consumer seam. `ProfileHomeOutput` names the screen
+    // `VNode`, which is what lets a reader of a profile's own result reach the
+    // tree it holds. An argument declaration is checked the other way round: it
+    // has to keep accepting every value it accepted before, and a profile
+    // stored under any earlier vintage of this type has to pass it. Narrowing
+    // this position to `VNode` too would fail pattern-compat at every consumer
+    // that takes a stored profile — `system/profile-picker.tsx` on
+    // `defaultProfile`, `system/profile-create.tsx` on `profiles[]`.
+    expect(home).toContain("[UI]: VNode;");
+    expect(home).toContain("& Omit<ProfileHomeOutput, typeof UI>");
+    expect(home).toContain("& { [UI]: unknown }");
+  });
+
   it("recognizes every one of the viewer's profiles as owner-editable", () => {
     // `#profile.result` is just the viewer's selected default profile. The
     // candidate list contains every profile linked from their home, so an

--- a/packages/patterns/system/profile-home.tsx
+++ b/packages/patterns/system/profile-home.tsx
@@ -15,6 +15,7 @@ import {
   SELF,
   Stream,
   UI,
+  type VNode,
   wish,
   Writable,
   WriteAuthorizedBy,
@@ -156,7 +157,7 @@ export type MutateVerifiedIdentitiesEvent = {
 
 export type ProfileHomeOutput = {
   [NAME]: string;
-  [UI]: unknown;
+  [UI]: VNode;
   name: OwnerProtectedProfileWrite<string, typeof setName>;
   avatar: OwnerProtectedProfileWrite<string, typeof setAvatar>;
   // A short, human-authored free-text description of the profile owner
@@ -244,8 +245,16 @@ type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 // missing here re-bricks old docs at every consumer seam.
 // Introduction dates: setBio/addPiece 2026-06-17, toggleEditing 2026-06-16,
 // external links #4731 and verified identities #4745 both 2026-07-15.
+//
+// The rendered screen is weakened here too, for the other reason a consumer
+// view exists. `ProfileHomeOutput` names it `VNode`, which is what a reader of
+// a profile's own result needs to reach the tree it holds. An argument
+// declaration is checked the other way round: it has to keep accepting every
+// value it accepted before, and a stored profile written under any earlier
+// vintage of this type has to pass it. `unknown` accepts them all.
 export type BackwardsCompatibleProfile = PartialBy<
-  ProfileHomeOutput,
+  & Omit<ProfileHomeOutput, typeof UI>
+  & { [UI]: unknown },
   | "setBio"
   | "addExternalLink"
   | "removeExternalLink"

--- a/packages/patterns/text-import.tsx
+++ b/packages/patterns/text-import.tsx
@@ -14,6 +14,7 @@ import {
   pattern,
   str,
   UI,
+  type VNode,
   Writable,
 } from "commonfabric";
 import type { ModuleMetadata } from "./container-protocol.ts";
@@ -40,10 +41,9 @@ export interface TextImportModuleInput {
   filename: string | Default<"">;
 }
 
-// Output interface with unknown for UI properties to prevent OOM (CT-1148)
 export interface TextImportModuleOutput {
-  [NAME]: unknown;
-  [UI]: unknown;
+  [NAME]: string;
+  [UI]: VNode;
   content: string;
   filename: string;
 }

--- a/packages/patterns/top-level-demos.test.tsx
+++ b/packages/patterns/top-level-demos.test.tsx
@@ -169,12 +169,10 @@ export default pattern(() => {
 
   const assert_room_named_for_me = assert(() => room.myName === "Ada");
 
-  // Every remaining demo builds a tree. Two are checked for a tree rather than
-  // for text: bookmarks starts with an empty list and has no text of its own,
-  // and the mobile app demo declares its screen `unknown`, which reads back as
-  // an opaque reference rather than as the tree it holds.
+  // Every remaining demo builds a tree. Bookmarks is checked for a tree rather
+  // than for text: it starts with an empty list and has no text of its own.
   const assert_demos_render = assert(() =>
-    mobileApp[UI] != null &&
+    textContent(mobileApp[UI]).length > 0 &&
     textContent(chatbot[UI]).length > 0 &&
     textContent(cheeseboard[UI]).length > 0 &&
     textContent(aside[UI]).length > 0 &&


### PR DESCRIPTION
Ten patterns declared the screen they render as `[UI]: unknown`, and four of those declared their piece's name `[NAME]: unknown` alongside it. `unknown` is the declaration for a field that holds a reference to another piece — one this pattern tests, compares and passes on, but never reads through. Since "an `unknown` field keeps the reference it holds" (#5848), such a field projects to an empty object carrying only a back-to-cell annotation: truthy, comparable by identity, and carrying no properties at all. For a field that holds the tree the pattern just built, that is the whole value gone.

The shell is unaffected, and that is worth stating plainly because it bounds the damage. A piece's screen is rendered by reading its `$UI` under `rendererVDOMSchema`, which the renderer supplies itself; the pattern's declared result schema never enters that path. Rendering each of these through the same in-process reconciler the browser and the CLI use produces the full tree in every case. What was lost is every read of the tree as a value: another pattern reading the screen, or a pattern test inspecting it, got `{}`. `textContent(mobileApp[UI])` was empty; it is now the demo's text. Likewise `[NAME]` — a plain string, opaque under `unknown` the same way an object is — read back as `{}` rather than as the piece's name.

The producing side of such a field now names its type. A result schema may narrow: the compatibility gate asks that everything the new pattern produces still be accepted by the contract each running piece was started under, and `VNode` is narrower than `unknown`, so every result here passes over every recorded baseline.

An argument schema is checked the other way round — it has to keep accepting every value it accepted before — so the same narrowing is not available at a consumer seam. `BackwardsCompatibleProfile` is exactly such a seam: it is `ProfileHomeOutput` weakened for consumers that take a stored profile of any vintage, and `system/profile-picker.tsx` and `system/profile-create.tsx` take it as an argument. It keeps `[UI]` declared `unknown`, which is also what those two want at that position: an argument that stays a reference to the sub-piece's own screen rather than a copy of it, so the controls in the tree stay bound to the piece that owns them. `packages/patterns/record.tsx` already reads a sub-piece's settings screen that way and says so.

With that one weakening in place the whole change is compatible: no contract fails to apply over any baseline, and nothing needs declaring in `tasks/pattern-compat-accepted-breaks.ts`.

Four comments in these files said an `unknown` was there to stop TypeScript exhausting memory (CT-1148). None of them still holds, and each was checked rather than assumed. The depth limits added to the recursive type helpers under the same issue removed the explosion. `photo.tsx` and `text-import.tsx` type-check under 800 MB with the screen declared `VNode`, and under 650 MB even with the output type inferred rather than declared, which is the condition three of the comments describe. The fourth, on `photo.tsx`'s internal image list, warned that an input parameter in `new Writable()` would explode type inference; writing that shape costs 932 MB and three seconds. Its real objection is not memory at all, and the compiler already states it at the line where it applies: "Property access used in computation is not allowed in reactive context. Wrap the computation in computed(() => ...) instead." All four comments are removed rather than rewritten. The code they sat above is unchanged: the exported output interfaces stand on their own as the published result contract, and the image list still starts empty because `syncedImage` falls back to the input image until something is stored.

Also included:

- `photo.tsx` exports a second screen, `settingsUI`, with the same defect and the same fix.
- `top-level-demos.test.tsx` checked the mobile app demo for a tree rather than for text, because the text was unreachable. It now checks the text, like every other demo in that assertion.
- `profile-home.owner-gated.test.ts` pins the new weakening, next to the stream weakenings it already pins.
- `docs/common/concepts/types-and-schemas/unknown.md` gains the rule these patterns were missing: which side of a screen-holding field gets `unknown` and which gets `VNode`.

The render-policy demo and the trusted-component galleries reached the same declaration from the other direction, through the standalone type-check fix (#5907), and are left as they landed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

