### PR TITLE
perf(memory): an identical content-addressed re-set applies as a no-op

### DIFF
--- a/docs/specs/content-addressed-schemas.md
+++ b/docs/specs/content-addressed-schemas.md
@@ -311,7 +311,11 @@ which compares special objects by content hash) — conflicting sets of one id
 within a single commit included — because a deleted or altered
 dependency would invalidate every document referencing it. An
 idempotent re-`set` of the same content is how writers install closures
-and stays legal, and a sync frame's removes are watch-result removals,
+and stays legal — and it applies as a semantic no-op: the immutability
+comparison proves the content unchanged, so the engine writes no
+revision, advances no head, and marks nothing dirty, while the commit
+row and space sequence still advance (a blind closure re-install costs
+watchers nothing). A sync frame's removes are watch-result removals,
 not deletions.
 
 The commit boundary also validates the closure a commit's content

--- a/docs/specs/memory-v2/03-commit-model.md
+++ b/docs/specs/memory-v2/03-commit-model.md
@@ -433,8 +433,12 @@ in the commit log.
 2. Resolve all pending reads within the logical session.
 3. Assign the next global `seq`.
 4. Append a `commit` row containing the original payload and resolution data.
-5. Append one `revision` row per operation in the transaction.
-6. Update `head` pointers for touched entities.
+5. Append one `revision` row per operation in the transaction — except an
+   operation proven to change nothing (an identical re-`set` of a
+   content-addressed document), which appends no revision and is reported
+   in the verdict's elided operation indexes.
+6. Update `head` pointers for touched entities (an elided operation touches
+   nothing).
 7. Materialize or refresh snapshots as needed.
 8. Mark the session-local pending commit as confirmed and enqueue session sync
    for interested sessions.
@@ -582,11 +586,16 @@ Commits are ordered by canonical `seq`.
 
 The server applies a transaction atomically:
 
-- either every operation produces its corresponding revision rows and head
-  updates
+- either every material state change lands — one revision row and head
+  update per operation that changes state
 - or none of them do
 
-There is no partial visibility of a committed transaction.
+An identical re-`set` of a content-addressed document is a semantic no-op
+the engine proves before applying: it produces no revision, no head update,
+and no dirty mark, while the commit row and the space sequence still
+advance and the verdict names the elided operation indexes. There is no
+partial visibility of a committed transaction — a no-op is exact by proof,
+not a torn apply.
 
 ## 3.11 Branch-Aware Commits
 

--- a/docs/specs/memory-v2/09-invariants.md
+++ b/docs/specs/memory-v2/09-invariants.md
@@ -309,9 +309,18 @@ contended writes land).
 
 ### INV-8 — Transaction atomicity
 
-> All operations of an accepted transaction produce revision rows and head
-> updates at one seq, or none do. No partial visibility, on the server or in
-> any client's integrated view.
+> All material state changes of an accepted transaction land at one seq, or
+> none do. No partial visibility, on the server or in any client's
+> integrated view.
+
+An operation the engine PROVES changes nothing — a `set` of a
+content-addressed (`cid:`) document whose stored content is value-equal to
+the operation's — applies as a no-op: no revision row, no head update, no
+dirty mark. The commit row and the space sequence still advance, and the
+verdict reports the elided operation indexes. Atomicity is therefore
+phrased over material changes, not over one revision per submitted
+operation: every operation that changes state lands at the commit's seq,
+and a no-op operation is exact by proof, not a torn apply.
 
 Layer: engine (`applyCommitTransaction` runs in one database transaction);
 client integrate path.

--- a/packages/memory/test/v2-engine-validation.test.ts
+++ b/packages/memory/test/v2-engine-validation.test.ts
@@ -551,3 +551,59 @@ Deno.test("rejects a reference backed by a stored cid: document holding other co
     );
   });
 });
+
+Deno.test("applies an identical content-addressed re-set as a no-op", async () => {
+  await withEngine((engine) => {
+    const schema = { type: "string", title: "elided-re-set" } as const;
+    const install = applyCommit(engine, {
+      sessionId: "s:a",
+      commit: commit(1, {
+        operations: [setOp("cid:fid1:elided", schema)],
+      }),
+    });
+    assertEquals(install.revisions.length, 1);
+    assertEquals(install.elidedOpIndexes, undefined);
+    const headSeq = engine.database.prepare(
+      `SELECT seq FROM head WHERE id = 'cid:fid1:elided'`,
+    ).get<{ seq: number }>()!.seq;
+
+    // The identical re-set is proven unchanged by the immutability
+    // comparison, so it applies as a no-op: no revision, no head advance —
+    // and therefore nothing for fan-out to deliver — while the commit
+    // itself still records and advances the space log.
+    const reSet = applyCommit(engine, {
+      sessionId: "s:a",
+      commit: commit(2, {
+        operations: [
+          setOp("cid:fid1:elided", schema),
+          setOp("cid:fid1:elided", schema),
+          setOp("of:elide-bystander", { n: 1 }),
+        ],
+      }),
+    });
+    assertEquals(reSet.seq > install.seq, true);
+    assertEquals(reSet.elidedOpIndexes, [0, 1]);
+    assertEquals(reSet.revisions.map((revision) => revision.id), [
+      "of:elide-bystander",
+    ]);
+    const after = engine.database.prepare(
+      `SELECT seq FROM head WHERE id = 'cid:fid1:elided'`,
+    ).get<{ seq: number }>()!.seq;
+    assertEquals(after, headSeq);
+
+    // A differing re-set still cannot slip through as an elision.
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "s:a",
+          commit: commit(3, {
+            operations: [
+              setOp("cid:fid1:elided", { type: "number", title: "changed" }),
+            ],
+          }),
+        }),
+      ProtocolError,
+      "cannot change content-addressed document",
+    );
+  });
+});

--- a/packages/memory/test/v2-engine-validation.test.ts
+++ b/packages/memory/test/v2-engine-validation.test.ts
@@ -607,3 +607,33 @@ Deno.test("applies an identical content-addressed re-set as a no-op", async () =
     );
   });
 });
+
+Deno.test("a replayed eliding commit reports its elision again", async () => {
+  await withEngine((engine) => {
+    const schema = { type: "string", title: "replayed-elision" } as const;
+    applyCommit(engine, {
+      sessionId: "s:a",
+      commit: commit(1, {
+        operations: [setOp("cid:fid1:replayed", schema)],
+      }),
+    });
+    const elidingCommit = commit(2, {
+      operations: [setOp("cid:fid1:replayed", schema)],
+    });
+    const first = applyCommit(engine, {
+      sessionId: "s:a",
+      commit: elidingCommit,
+    });
+    assertEquals(first.elidedOpIndexes, [0]);
+    // The replay returns the stored result — including the elision report,
+    // which persisted no revision and must be re-derived, or the accept
+    // path would classify the unchanged document as dirty.
+    const replayed = applyCommit(engine, {
+      sessionId: "s:a",
+      commit: elidingCommit,
+    });
+    assertEquals(replayed.seq, first.seq);
+    assertEquals(replayed.elidedOpIndexes, [0]);
+    assertEquals(replayed.revisions, []);
+  });
+});

--- a/packages/memory/test/v2-verdict-catchup.test.ts
+++ b/packages/memory/test/v2-verdict-catchup.test.ts
@@ -1080,3 +1080,56 @@ Deno.test("memory v2 server: an all-elided accept still delivers its marker on a
   assertEquals(frame.upserts, []);
   assertEquals(frame.caughtUpLocalSeq, 2);
 });
+
+Deno.test("memory v2 server: an identical direct re-write fans out nothing", async () => {
+  const context = await setup({
+    subscriptionRefreshDelayMs: 60_000,
+    store: "memory://verdict-catchup-direct-elide",
+  });
+  const { server, space, committer, committerMessages, committerSessionId } =
+    context;
+  await server.flushSessions([space]);
+  assertEffect(shiftMessage(committerMessages));
+
+  // Watch the content-addressed document itself, so a spurious dirty mark
+  // from the direct-write path would be OBSERVED as a re-delivery.
+  await committer.receive(encodeMemoryBoundary({
+    type: "session.watch.add",
+    requestId: "watch-direct-cid",
+    space,
+    sessionId: committerSessionId,
+    watches: [{
+      id: "direct-cid",
+      kind: "graph",
+      query: {
+        roots: [{
+          id: "cid:fid1:direct",
+          selector: { path: [], schema: false },
+        }],
+      },
+    }],
+  }));
+  assertResponse(shiftMessage(committerMessages));
+
+  // The install — the blob-upload path — delivers its novelty...
+  const installed = await server.writeDocument(space, "cid:fid1:direct", {
+    type: "string",
+    title: "direct-elide",
+  });
+  assertEquals(installed.revisions.length, 1);
+  await server.flushSessions([space]);
+  const first = assertEffect(shiftMessage(committerMessages))
+    .effect as SessionSync;
+  assertEquals(first.upserts.map((upsert) => upsert.id), ["cid:fid1:direct"]);
+
+  // ...and the identical re-write is a proven no-op: it marks nothing
+  // dirty and schedules nothing, so the watcher hears nothing.
+  const reWritten = await server.writeDocument(space, "cid:fid1:direct", {
+    type: "string",
+    title: "direct-elide",
+  });
+  assertEquals(reWritten.elidedOpIndexes, [0]);
+  assertEquals(reWritten.revisions, []);
+  await server.flushSessions([space]);
+  assertEquals(committerMessages.length, 0);
+});

--- a/packages/memory/test/v2-verdict-catchup.test.ts
+++ b/packages/memory/test/v2-verdict-catchup.test.ts
@@ -913,3 +913,112 @@ Deno.test("memory v2 server: requeue after failure does not resurrect echo suppr
     ["of:doc:b"],
   );
 });
+
+Deno.test("memory v2 server: an identical cid re-set fans out no novelty to watchers", async () => {
+  const context = await setup({
+    subscriptionRefreshDelayMs: 60_000,
+    store: "memory://verdict-catchup-cid-elide",
+  });
+  const { server, space, committer, committerMessages, committerSessionId } =
+    context;
+  await server.flushSessions([space]);
+  assertEffect(shiftMessage(committerMessages));
+
+  // A second session observes the schema document and a control doc.
+  const observerMessages: ServerMessage[] = [];
+  const observer = server.connect((message) => observerMessages.push(message));
+  await observer.receive(encodeMemoryBoundary(HELLO));
+  const observerSessionOpen = expectHelloOk(observerMessages);
+  await observer.receive(encodeMemoryBoundary({
+    type: "session.open",
+    requestId: "observer-open",
+    space,
+    session: {},
+    invocation: authInvocation(observerSessionOpen),
+  }));
+  const observerSessionId =
+    assertResponse<{ sessionId: string }>(shiftMessage(observerMessages))
+      .ok!.sessionId;
+  await observer.receive(encodeMemoryBoundary({
+    type: "session.watch.set",
+    requestId: "observer-watch",
+    space,
+    sessionId: observerSessionId,
+    watches: [{
+      id: "elide-watch",
+      kind: "graph",
+      query: {
+        roots: [
+          {
+            id: "cid:fid1:elide-fanout",
+            selector: { path: [], schema: false },
+          },
+          { id: "of:elide-control", selector: { path: [], schema: false } },
+        ],
+      },
+    }],
+  }));
+  assertResponse(shiftMessage(observerMessages));
+
+  // Install both; the observer's frame carries both.
+  await committer.receive(encodeMemoryBoundary({
+    type: "transact",
+    requestId: "committer-install",
+    space,
+    sessionId: committerSessionId,
+    commit: {
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [
+        {
+          op: "set",
+          id: "cid:fid1:elide-fanout",
+          value: { value: { type: "string", title: "fanout" } },
+        },
+        { op: "set", id: "of:elide-control", value: { value: { round: 1 } } },
+      ],
+    },
+  }));
+  assertResponse(shiftMessage(committerMessages));
+  await server.flushSessions([space]);
+  // The committer's own accept rides home as an (echo-suppressed) marker
+  // frame; drain it so the next shift sees the second verdict.
+  assertEffect(shiftMessage(committerMessages));
+  const first = assertEffect(shiftMessage(observerMessages))
+    .effect as SessionSync;
+  assertEquals(
+    first.upserts.map((upsert) => upsert.id).toSorted(),
+    ["cid:fid1:elide-fanout", "of:elide-control"],
+  );
+
+  // The identical re-set applies as a no-op, so the observer's next frame
+  // carries ONLY the control change — before elision, the re-set advanced
+  // the schema document's head and re-delivered the unchanged content here.
+  await committer.receive(encodeMemoryBoundary({
+    type: "transact",
+    requestId: "committer-reset",
+    space,
+    sessionId: committerSessionId,
+    commit: {
+      localSeq: 2,
+      reads: { confirmed: [], pending: [] },
+      operations: [
+        {
+          op: "set",
+          id: "cid:fid1:elide-fanout",
+          value: { value: { type: "string", title: "fanout" } },
+        },
+        { op: "set", id: "of:elide-control", value: { value: { round: 2 } } },
+      ],
+    },
+  }));
+  assertResponse(shiftMessage(committerMessages));
+  await server.flushSessions([space]);
+  const second = assertEffect(shiftMessage(observerMessages))
+    .effect as SessionSync;
+  assertEquals(
+    second.upserts.map((upsert) => ({ id: upsert.id, doc: upsert.doc })),
+    [{ id: "of:elide-control", doc: { value: { round: 2 } } }],
+  );
+  observer.close();
+});

--- a/packages/memory/test/v2-verdict-catchup.test.ts
+++ b/packages/memory/test/v2-verdict-catchup.test.ts
@@ -1022,3 +1022,61 @@ Deno.test("memory v2 server: an identical cid re-set fans out no novelty to watc
   );
   observer.close();
 });
+
+Deno.test("memory v2 server: an all-elided accept still delivers its marker on an empty frame", async () => {
+  const context = await setup({
+    subscriptionRefreshDelayMs: 60_000,
+    store: "memory://verdict-catchup-all-elided",
+  });
+  const { server, space, committer, committerMessages, committerSessionId } =
+    context;
+  await server.flushSessions([space]);
+  assertEffect(shiftMessage(committerMessages));
+
+  await committer.receive(encodeMemoryBoundary({
+    type: "transact",
+    requestId: "committer-install",
+    space,
+    sessionId: committerSessionId,
+    commit: {
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: "cid:fid1:all-elided",
+        value: { value: { type: "string", title: "all-elided" } },
+      }],
+    },
+  }));
+  assertResponse(shiftMessage(committerMessages));
+  await server.flushSessions([space]);
+  assertEffect(shiftMessage(committerMessages));
+
+  // The whole commit elides: nothing is written and no document turns
+  // dirty, yet the writer parks its promotion on the catch-up marker — the
+  // flush must still run and carry it on an otherwise-empty frame.
+  await committer.receive(encodeMemoryBoundary({
+    type: "transact",
+    requestId: "committer-elided",
+    space,
+    sessionId: committerSessionId,
+    commit: {
+      localSeq: 2,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: "cid:fid1:all-elided",
+        value: { value: { type: "string", title: "all-elided" } },
+      }],
+    },
+  }));
+  const verdict = assertResponse<{ elidedOpIndexes?: number[] }>(
+    shiftMessage(committerMessages),
+  );
+  assertEquals(verdict.ok?.elidedOpIndexes, [0]);
+  await server.flushSessions([space]);
+  const frame = assertEffect(shiftMessage(committerMessages))
+    .effect as SessionSync;
+  assertEquals(frame.upserts, []);
+  assertEquals(frame.caughtUpLocalSeq, 2);
+});

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -969,6 +969,12 @@ export type AppliedCommit = {
   seq: number;
   branch: BranchName;
   revisions: AppliedRevision[];
+  /**
+   * Operation indexes whose `cid:` set matched the stored content exactly
+   * and applied as a no-op: no revision, no head advance, no dirty mark.
+   * The commit itself still records and advances the space log.
+   */
+  elidedOpIndexes?: number[];
   schedulerObservationId?: number;
   schedulerObservationResults?: AppliedSchedulerObservationResult[];
   schedulerDirtiedReaders?: SchedulerReaderIndexEntry[];
@@ -5194,6 +5200,14 @@ const applyCommitTransaction = (
   // survive to the final document (a remove-by-value operand, an
   // add-then-remove within one commit) is still validated.
   let cidSetsInCommit: Map<string, unknown> | null = null;
+  // Content-identical re-sets apply as no-ops: the comparison below already
+  // proves nothing changes, and writing a fresh revision anyway would
+  // advance the head and fan the unchanged document out to every watcher —
+  // the cost that makes blind closure re-installs expensive. The commit
+  // still records (the space log advances; a client basis at its seq is
+  // legal and truthful), only the per-document machinery goes quiet.
+  const elidedCidSetOpIndexes = new Set<number>();
+  const elidableCidIds = new Set<string>();
   const requiredSchemaRefs = new Set<string>();
   const collectLinkSchemaRefs = (content: unknown): void => {
     if (content === null || typeof content !== "object") return;
@@ -5206,7 +5220,7 @@ const applyCommitTransaction = (
       return schema;
     });
   };
-  for (const operation of commit.operations) {
+  for (const [opIndex, operation] of commit.operations.entries()) {
     if (operation.op === "sqlite") continue;
     if (operation.op === "patch") {
       for (const patch of operation.patches ?? []) {
@@ -5266,6 +5280,11 @@ const applyCommitTransaction = (
           `memory v2 commit carries conflicting sets of content-addressed document ${operation.id}`,
         );
       }
+      // A duplicate of a stored-identical set elides with it; a duplicate
+      // within a first install keeps today's write-both behavior.
+      if (elidableCidIds.has(operation.id)) {
+        elidedCidSetOpIndexes.add(opIndex);
+      }
       continue;
     }
     const stored = read(engine, {
@@ -5275,13 +5294,14 @@ const applyCommitTransaction = (
       principal,
       sessionId,
     });
-    if (
-      stored !== null &&
-      !valueEqual(stored as FabricValue, operation.value as FabricValue)
-    ) {
-      throw new ProtocolError(
-        `memory v2 commit cannot change content-addressed document ${operation.id}`,
-      );
+    if (stored !== null) {
+      if (!valueEqual(stored as FabricValue, operation.value as FabricValue)) {
+        throw new ProtocolError(
+          `memory v2 commit cannot change content-addressed document ${operation.id}`,
+        );
+      }
+      elidedCidSetOpIndexes.add(opIndex);
+      elidableCidIds.add(operation.id);
     }
     (cidSetsInCommit ??= new Map()).set(operation.id, operation.value);
   }
@@ -5435,6 +5455,7 @@ const applyCommitTransaction = (
       });
       continue;
     }
+    if (elidedCidSetOpIndexes.has(opIndex)) continue;
     const revision = writeOperation(engine, {
       branch,
       seq,
@@ -5481,6 +5502,11 @@ const applyCommitTransaction = (
     seq,
     branch,
     revisions,
+    ...(elidedCidSetOpIndexes.size > 0
+      ? {
+        elidedOpIndexes: [...elidedCidSetOpIndexes].toSorted((a, b) => a - b),
+      }
+      : {}),
     ...(schedulerObservationResult
       ? {
         schedulerObservationId: schedulerObservationResult.observationId,

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -5152,10 +5152,23 @@ const applyCommitTransaction = (
         observationReplay,
       )
       : undefined;
+    const replayedRevisions = selectCommitRevisions(engine, existing.seq);
+    // Re-derive the elision report: an elided operation persisted no
+    // revision, so a replayed verdict must name it again or the accept
+    // path would classify the unchanged document as dirty.
+    const revisionOpIndexes = new Set(
+      replayedRevisions.map((revision) => revision.opIndex),
+    );
+    const replayedElided = commit.operations.flatMap((operation, opIndex) =>
+      operation.op !== "sqlite" && !revisionOpIndexes.has(opIndex)
+        ? [opIndex]
+        : []
+    );
     return {
       seq: existing.seq,
       branch: existing.branch,
-      revisions: selectCommitRevisions(engine, existing.seq),
+      revisions: replayedRevisions,
+      ...(replayedElided.length > 0 ? { elidedOpIndexes: replayedElided } : {}),
       ...(observationResult?.schedulerObservationId !== undefined
         ? { schedulerObservationId: observationResult.schedulerObservationId }
         : {}),

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -2367,11 +2367,19 @@ export class Server {
               operation.op,
             );
           }
-          this.markSpaceDirty(message.space, dirtyOps.keys(), {
-            sessionId: message.sessionId,
-            seq: commit.seq,
-            ops: dirtyOps,
-          });
+          if (dirtyOps.size > 0) {
+            this.markSpaceDirty(message.space, dirtyOps.keys(), {
+              sessionId: message.sessionId,
+              seq: commit.seq,
+              ops: dirtyOps,
+            });
+          } else {
+            // Every operation elided: nothing was written, so no document
+            // turns dirty — but the accept still owes this session its
+            // catch-up marker, and the marker rides the batched flush.
+            // Schedule the pass without dirtying anything.
+            this.markSpaceDirty(message.space);
+          }
           // Stage the accept's catch-up obligation with the dirty mark. The
           // verdict response leaves this request before the independently
           // scheduled batch can send its covering frame. The batched fan-out

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -2354,8 +2354,14 @@ export class Server {
           // op produced the head this commit leaves behind, so it alone
           // decides the flush-time echo shape.
           const dirtyOps = new Map<string, DirtyOp>();
-          for (const operation of message.commit.operations) {
+          const elided = new Set(commit.elidedOpIndexes ?? []);
+          for (
+            const [opIndex, operation] of message.commit.operations.entries()
+          ) {
             if (operation.op === "sqlite") continue;
+            // An elided content-addressed re-set changed nothing — no head
+            // moved, so there is no novelty to fan out or classify.
+            if (elided.has(opIndex)) continue;
             dirtyOps.set(
               toDirtyKey(operation.id, declaredScope(operation.scope)),
               operation.op,

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -1513,7 +1513,11 @@ export class Server {
           }],
         },
       });
-      this.markSpaceDirty(space, [toDirtyKey(id)]);
+      // An elided direct write changed nothing, and unlike a session
+      // transact it owes no catch-up marker — skip the flush entirely.
+      if (commit.revisions.length > 0) {
+        this.markSpaceDirty(space, [toDirtyKey(id)]);
+      }
       await this.runPostCommitSchedulerSideEffects(
         space,
         commit,


### PR DESCRIPTION
Content-addressed schema documents are installed by blind idempotent re-sets — the materializer writes a link's closure on every carrying transaction, and CFC's `persistSchemaDocument` does the same — and every one of those re-sets previously inserted a fresh revision and advanced the document's head. An advanced head means a dirty mark, which means every session watching the document got a refresh evaluation, a re-scan of the seq-keyed verification caches, and a re-delivery of byte-identical content. In a busy space, the same handful of schema documents churned on essentially every commit, fanned out to every watcher.

The commit boundary's immutability guard already reads the stored document and proves an identical re-set unchanged (`valueEqual`); this change uses that proof instead of discarding it. An identical `cid:` re-set now applies as a no-op: no revision row, no head advance, no dirty mark. The engine reports the elided operation indexes on `AppliedCommit`, and the server's accept path skips them when classifying dirty keys.

**Protocol safety** (each verified against the code):
- The commit itself still records and advances the space log — verdict seqs and pending-read `localSeq` resolutions are per-commit, not per-revision.
- Staleness validation asks "any revisions after the cited basis?" (`findConflictSeq`), never exact-match; a client basis at the eliding commit's seq is ≤ serverSeq (explicitly legal) and truthful for the unchanged document.
- The catch-up marker cannot hang: the obligation is staged unconditionally with the accept, and `markSpaceDirty` schedules the flush unconditionally — the otherwise-empty marker frame already exists for accepts with no watched novelty.
- The client is deliberately unchanged: `confirmPending`'s uniform promotion at the commit seq is load-bearing for pending overlays without matching revisions (the redirect-transport resume tests pin it), and for an elided document it promotes identical content.

Tests: an engine pin that a duplicate-bearing identical re-set advances no head while a bystander write in the same commit still applies and the differing re-set still rejects; and a server-level fan-out pin — an observer watching a schema document and a control document receives only the control change when the schema document is identically re-set (red on the old engine, green on this one).

Verified: memory 519 + package check, runner 1,239 (6,837 steps) + package check, lint, fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

