### PR TITLE
feat(cf-harness): seed each fabric run with a well-known piece-registry grant

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -615,6 +615,33 @@ only the positions still sealed. Denial-path tool messages are not swapped; that
 coverage, value handles, and an explicit release/readback mechanism are listed
 in [docs/ROADMAP.md](docs/ROADMAP.md).
 
+#### Well-known grants
+
+A run configured with a Fabric session starts with a seeded handle: before the
+first model turn, the CLI establishes the session, mints a token for the space's
+piece registry — the same discovery root behind `cf piece ls` — and announces it
+in a context message pairing the token with a fixed, harness-authored
+description. The address stays trusted-side in the handle table like any other
+entry. This is what lets an agent find pieces to compute over without an
+operator handing it references one by one: discovery is `run_pattern` over the
+granted token, not a tool of its own, and `describe_handle` answers the
+registry's shape like any other reference.
+
+What the model receives is a token and fixed prose, never data. Reading anything
+behind the token means running a pattern over it, where the CFC boundary rules
+as it does for every other flow — in particular, a piece's `$NAME` is a value,
+and a name computed from labelled data taints a name-listing pattern's result,
+which strict enforcement refuses whole. The announcement says so and names the
+fallback: a pattern that returns the entry references without reading any
+values, which cannot taint and whose addresses come back as tokens through the
+ordinary outbound swap.
+
+The grants are recorded in run state (`wellKnownGrants`), replayed rather than
+re-minted on resume, and reported in the operator summary as `fabricGrants:`. A
+session that cannot be established leaves the run to proceed without its grants,
+and the CLI says so on stderr rather than staying silent. The grant list is
+designed to grow; the identity's profile is the expected next entry.
+
 #### Inspecting a handle's shape
 
 A token says nothing about what it refers to, and an agent handed one cannot

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -3113,6 +3113,9 @@ export const runCfHarnessCli = async (
         ...(parsed.fabricSession !== undefined
           ? { fabricSession: parsed.fabricSession }
           : {}),
+        ...(deps.fabricSessionFactory !== undefined
+          ? { fabricSessionFactory: deps.fabricSessionFactory }
+          : {}),
         ...(effectiveRunManifest !== undefined
           ? { runManifest: effectiveRunManifest }
           : {}),

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -64,6 +64,8 @@ import type {
   HarnessTranscriptMessage,
 } from "./contracts/transcript.ts";
 import { CfHarnessEngine } from "./engine.ts";
+import type { HarnessFabricSessionFactory } from "./fabric-session.ts";
+import { wellKnownGrantsContextMessage } from "./well-known-grants.ts";
 import {
   CFC_INVOCATION_CONTEXT_DIR_ENV,
   CFC_RESULT_DIR_ENV,
@@ -380,6 +382,11 @@ export interface RunCfHarnessCliDependencies {
     handler: CfHarnessCliSignalHandler,
   ) => () => void;
   exit?: (code: number) => never | void;
+  /**
+   * Replaces the Fabric session the engine would build from `--fabric-*`
+   * configuration. Tests grant well-known handles without a deployed API.
+   */
+  fabricSessionFactory?: HarnessFabricSessionFactory;
 }
 
 const defaultCliIo = (): CfHarnessCliIO => ({
@@ -2401,6 +2408,18 @@ export const formatCfHarnessCliResult = (
       `fabricSessionCfc: ${posture.enforcementMode} (${posture.enforcementModeSource}), flow-labels ${posture.flowLabels} (${posture.flowLabelsSource})`,
     );
   }
+  if (
+    result.runState.wellKnownGrants !== undefined &&
+    result.runState.wellKnownGrants.length > 0
+  ) {
+    lines.push(
+      `fabricGrants: ${
+        result.runState.wellKnownGrants.map((grant) =>
+          `${grant.name} ${grant.token}`
+        ).join(", ")
+      }`,
+    );
+  }
   const reportedUsage = result.totalUsage ?? result.usage;
   if (reportedUsage !== undefined) {
     const usage = reportedUsage;
@@ -3258,6 +3277,9 @@ export const runCfHarnessCli = async (
         ...(parsed.fabricSession !== undefined
           ? { fabricSession: parsed.fabricSession }
           : {}),
+        ...(deps.fabricSessionFactory !== undefined
+          ? { fabricSessionFactory: deps.fabricSessionFactory }
+          : {}),
         ...(runManifest !== undefined ? { runManifest } : {}),
         ...(parsed.runManifestPath !== undefined
           ? { runManifestPath: parsed.runManifestPath }
@@ -3315,6 +3337,26 @@ export const runCfHarnessCli = async (
           : {}),
       });
       const contextMessages = await prepareSkillContextMessages(engine);
+      // The well-known grants connect the Fabric session up front; a run
+      // configured for one is assumed to use it. A run whose session cannot
+      // be established still runs — its tools will surface the same failure
+      // when called — but the missing grants are said out loud rather than
+      // silently absent.
+      if (engine.fabricSessionAvailable) {
+        try {
+          const grants = await engine.establishWellKnownGrants();
+          const grantMessage = wellKnownGrantsContextMessage(grants);
+          if (grantMessage !== undefined) {
+            contextMessages.push(grantMessage);
+          }
+        } catch (error) {
+          io.stderr(
+            `fabric grants: unavailable (${
+              error instanceof Error ? error.message : String(error)
+            })\n`,
+          );
+        }
+      }
       result = await loop.runPrompt({
         prompt: parsed.prompt!,
         imageAttachments: parsed.imageAttachments,

--- a/packages/cf-harness/src/contracts/well-known-grants.ts
+++ b/packages/cf-harness/src/contracts/well-known-grants.ts
@@ -1,0 +1,18 @@
+/**
+ * The record of a well-known grant: a handle token the harness seeded into
+ * the run for a reference every Fabric-configured run is entitled to hold.
+ * `src/well-known-grants.ts` documents the posture and does the minting;
+ * this contract is what run state persists.
+ */
+
+/** The well-known references a run can be granted. */
+export type HarnessWellKnownGrantName = "piece-registry";
+
+/** One granted reference, as recorded in run state. */
+export interface HarnessWellKnownGrant {
+  name: HarnessWellKnownGrantName;
+  /** The token the model holds. */
+  token: string;
+  /** The canonical reference behind it; never model-facing. */
+  ref: string;
+}

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -77,6 +77,11 @@ import {
   type HarnessFabricSessionFactory,
 } from "./fabric-session.ts";
 import { assertValidHarnessHandleTable } from "./handle-table.ts";
+import type { HarnessWellKnownGrant } from "./contracts/well-known-grants.ts";
+import {
+  mintWellKnownGrants,
+  resolveWellKnownGrantRefs,
+} from "./well-known-grants.ts";
 import {
   appendHarnessCfcModelContextObservations,
   appendHarnessFailureRecord,
@@ -744,6 +749,43 @@ export class CfHarnessEngine {
 
   async persistRunState(): Promise<string | undefined> {
     return await this.artifactStore?.persistRunState(this.#runState);
+  }
+
+  /**
+   * Establishes the run's well-known grants: seeds the handle table with a
+   * token for each reference every Fabric-configured run is entitled to
+   * hold, records the grants in run state, and returns them. Establishing
+   * the Fabric session is the cost of resolving the references, so this
+   * connects eagerly — callers invoke it only on runs configured for a
+   * session. Idempotent across resume: grants already recorded are returned
+   * as they stand, without connecting again.
+   *
+   * A run without a session factory has nothing to grant and answers `[]`.
+   * A session that cannot be established propagates its failure — the caller
+   * decides whether a run proceeds without its grants, and says so.
+   */
+  async establishWellKnownGrants(): Promise<HarnessWellKnownGrant[]> {
+    if (this.#runState.wellKnownGrants !== undefined) {
+      return structuredClone(this.#runState.wellKnownGrants);
+    }
+    if (this.#fabricSessionFactory === undefined) {
+      return [];
+    }
+    const session = await this.#fabricSessionFactory();
+    const refs = await resolveWellKnownGrantRefs(session);
+    const minted = await mintWellKnownGrants(
+      this.handleTable,
+      this.#runState.runId,
+      refs,
+    );
+    await this.recordHandleTable(minted.table);
+    this.#runState = patchHarnessRunState(
+      this.#runState,
+      { wellKnownGrants: structuredClone(minted.grants) },
+      this.#now(),
+    );
+    await this.persistRunState();
+    return minted.grants;
   }
 
   async ensureRunManifestPersisted(): Promise<string | undefined> {

--- a/packages/cf-harness/src/run-state.ts
+++ b/packages/cf-harness/src/run-state.ts
@@ -7,6 +7,7 @@ import {
 } from "./contracts/cfc-model-context.ts";
 import type { HarnessCfcPolicySnapshot } from "./contracts/cfc-policy-snapshot.ts";
 import type { HarnessHandleTable } from "./contracts/handle-table.ts";
+import type { HarnessWellKnownGrant } from "./contracts/well-known-grants.ts";
 import type { HarnessPolicyEvent } from "./contracts/policy.ts";
 import type {
   HarnessPolicyDecisionRecord,
@@ -108,6 +109,7 @@ export interface HarnessRunState {
   cfcModelContext?: HarnessCfcModelContext;
   cfcInvocationContexts?: HarnessCfcInvocationContext[];
   handleTable?: HarnessHandleTable;
+  wellKnownGrants?: HarnessWellKnownGrant[];
   policyEvents: HarnessPolicyEvent[];
   policyDecisions?: HarnessPolicyDecisionRecord[];
   toolOutputs: ToolResultRef[];
@@ -154,6 +156,7 @@ export interface CreateHarnessRunStateOptions {
   cfcModelContext?: HarnessCfcModelContext;
   cfcInvocationContexts?: HarnessCfcInvocationContext[];
   handleTable?: HarnessHandleTable;
+  wellKnownGrants?: HarnessWellKnownGrant[];
   policyDecisions?: HarnessPolicyDecisionRecord[];
   lineage?: HarnessSubagentLineage;
   subagentRuns?: HarnessSubagentRunRef[];
@@ -262,6 +265,9 @@ export const createHarnessRunState = (
       : {}),
     ...(options.handleTable !== undefined
       ? { handleTable: structuredClone(options.handleTable) }
+      : {}),
+    ...(options.wellKnownGrants !== undefined
+      ? { wellKnownGrants: structuredClone(options.wellKnownGrants) }
       : {}),
     ...(options.lineage !== undefined
       ? { lineage: structuredClone(options.lineage) }

--- a/packages/cf-harness/src/well-known-grants.ts
+++ b/packages/cf-harness/src/well-known-grants.ts
@@ -39,19 +39,32 @@ const GRANT_DESCRIPTIONS: Record<HarnessWellKnownGrantName, string> = {
 
 /**
  * Resolves the canonical references behind every well-known grant through
- * `session`. Each resolution is a metadata read — the registry cell's own
- * address — not a read of what the registry lists.
+ * `session`. Each resolution is address-only: the registry's address is the
+ * default pattern's cell plus the `pieceRegistry` path, so resolving the
+ * root pointer is the whole read — nothing the registry lists is pulled.
+ * (`getPieceRegistry()` is deliberately not used here: it syncs every
+ * listed piece, a privileged data pull an address does not need, and in a
+ * space with no default pattern it answers a detached placeholder that
+ * would persist as a permanently dead grant.)
+ *
+ * @throws Error when the space has no default pattern to anchor the
+ * registry; a grant that cannot name a live address is refused rather than
+ * recorded.
  */
 export const resolveWellKnownGrantRefs = async (
   session: HarnessFabricSession,
 ): Promise<{ name: HarnessWellKnownGrantName; ref: string }[]> => {
-  const registry = await session.pieces.getPieceRegistry();
+  const defaultPattern = await session.pieces.getDefaultPattern(false);
+  if (defaultPattern === undefined) {
+    throw new Error(
+      "space has no default pattern to anchor the piece registry",
+    );
+  }
+  const registryLink = defaultPattern.key("pieceRegistry")
+    .getAsNormalizedFullLink();
   return [{
     name: "piece-registry",
-    ref: createLLMFriendlyLink(
-      registry.getAsNormalizedFullLink(),
-      session.pieces.getSpace(),
-    ),
+    ref: createLLMFriendlyLink(registryLink, session.pieces.getSpace()),
   }];
 };
 

--- a/packages/cf-harness/src/well-known-grants.ts
+++ b/packages/cf-harness/src/well-known-grants.ts
@@ -1,0 +1,96 @@
+/**
+ * Well-known grants: handle tokens the harness seeds into a run's handle
+ * table for references every Fabric-configured run is entitled to hold,
+ * before the model asks for anything. The first grant is the session space's
+ * piece registry — the discovery root behind `cf piece ls` and the shell's
+ * listings — which is what lets an agent find pieces to compute over without
+ * an operator handing it references one by one. The list is designed to
+ * grow: the identity's profile is the expected next entry.
+ *
+ * A grant discloses nothing by itself. What the model receives is a token
+ * and a fixed, harness-authored sentence saying what the token names; the
+ * address stays trusted-side in the handle table, `describe_handle` answers
+ * shape, and reading anything behind the token means running a pattern over
+ * it, where the CFC boundary rules as it does for every other flow.
+ */
+
+import { createLLMFriendlyLink } from "@commonfabric/runner/shared";
+import type { HarnessFabricSession } from "./fabric-session.ts";
+import { createHarnessHandleTable, mintAddressHandle } from "./handle-table.ts";
+import type { HarnessHandleTable } from "./contracts/handle-table.ts";
+import type {
+  HarnessWellKnownGrant,
+  HarnessWellKnownGrantName,
+} from "./contracts/well-known-grants.ts";
+
+export type {
+  HarnessWellKnownGrant,
+  HarnessWellKnownGrantName,
+} from "./contracts/well-known-grants.ts";
+
+/**
+ * Model-facing description of each grant. Fixed harness-authored text — a
+ * grant's description never carries anything read from the fabric.
+ */
+const GRANT_DESCRIPTIONS: Record<HarnessWellKnownGrantName, string> = {
+  "piece-registry":
+    "the space's piece registry: an array of references to every registered piece. Wire it into run_pattern `inputs` to compute over what the space holds — each entry's `$NAME` field is its display name. A name computed from protected data taints a result that reads it, so if a name-reading run is refused, fall back to a pattern that returns the entry references without reading any values.",
+};
+
+/**
+ * Resolves the canonical references behind every well-known grant through
+ * `session`. Each resolution is a metadata read — the registry cell's own
+ * address — not a read of what the registry lists.
+ */
+export const resolveWellKnownGrantRefs = async (
+  session: HarnessFabricSession,
+): Promise<{ name: HarnessWellKnownGrantName; ref: string }[]> => {
+  const registry = await session.pieces.getPieceRegistry();
+  return [{
+    name: "piece-registry",
+    ref: createLLMFriendlyLink(
+      registry.getAsNormalizedFullLink(),
+      session.pieces.getSpace(),
+    ),
+  }];
+};
+
+/**
+ * Mints a handle for each resolved grant into `table` (or a fresh table
+ * salted with `runId` when the run has none yet), returning the extended
+ * table and the grant records for run state.
+ */
+export const mintWellKnownGrants = async (
+  table: HarnessHandleTable | undefined,
+  runId: string,
+  refs: readonly { name: HarnessWellKnownGrantName; ref: string }[],
+): Promise<{ table: HarnessHandleTable; grants: HarnessWellKnownGrant[] }> => {
+  let current = table ?? createHarnessHandleTable(runId);
+  const grants: HarnessWellKnownGrant[] = [];
+  for (const { name, ref } of refs) {
+    const minted = await mintAddressHandle(current, ref);
+    current = minted.table;
+    grants.push({ name, token: minted.token, ref });
+  }
+  return { table: current, grants };
+};
+
+/**
+ * The context message announcing `grants` to the model: one line per grant,
+ * each pairing the token with its fixed description. An empty grant list
+ * yields no message at all rather than an empty header.
+ */
+export const wellKnownGrantsContextMessage = (
+  grants: readonly HarnessWellKnownGrant[],
+): string | undefined => {
+  if (grants.length === 0) {
+    return undefined;
+  }
+  return [
+    "Granted references for this run's Fabric space:",
+    ...grants.map((grant) =>
+      `- ${grant.token} — ${GRANT_DESCRIPTIONS[grant.name]}`
+    ),
+    "Use describe_handle on a granted token to see its shape before authoring against it.",
+  ].join("\n");
+};

--- a/packages/cf-harness/src/well-known-grants.ts
+++ b/packages/cf-harness/src/well-known-grants.ts
@@ -14,6 +14,7 @@
  * it, where the CFC boundary rules as it does for every other flow.
  */
 
+import { pieceRegistryKeyForRoot } from "@commonfabric/runner";
 import { createLLMFriendlyLink } from "@commonfabric/runner/shared";
 import type { HarnessFabricSession } from "./fabric-session.ts";
 import { createHarnessHandleTable, mintAddressHandle } from "./handle-table.ts";
@@ -40,8 +41,9 @@ const GRANT_DESCRIPTIONS: Record<HarnessWellKnownGrantName, string> = {
 /**
  * Resolves the canonical references behind every well-known grant through
  * `session`. Each resolution is address-only: the registry's address is the
- * default pattern's cell plus the `pieceRegistry` path, so resolving the
- * root pointer is the whole read — nothing the registry lists is pulled.
+ * default pattern's cell plus the registry field — `pieceRegistry`, or the
+ * retired `allPieces` on a legacy default-app root — so resolving the
+ * root pointer is the whole read; nothing the registry lists is pulled.
  * (`getPieceRegistry()` is deliberately not used here: it syncs every
  * listed piece, a privileged data pull an address does not need, and in a
  * space with no default pattern it answers a detached placeholder that
@@ -60,7 +62,8 @@ export const resolveWellKnownGrantRefs = async (
       "space has no default pattern to anchor the piece registry",
     );
   }
-  const registryLink = defaultPattern.key("pieceRegistry")
+  const registryLink = defaultPattern
+    .key(pieceRegistryKeyForRoot(defaultPattern))
     .getAsNormalizedFullLink();
   return [{
     name: "piece-registry",

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -2158,12 +2158,14 @@ Deno.test("runCfHarnessCli announces well-known grants to the model and the oper
           {
             pieces: {
               getSpace: () => registrySpace,
-              getPieceRegistry: () =>
+              getDefaultPattern: (_runIt: boolean) =>
                 Promise.resolve({
-                  getAsNormalizedFullLink: () => ({
-                    space: registrySpace,
-                    id: registryId,
-                    path: ["pieceRegistry"],
+                  key: (segment: string) => ({
+                    getAsNormalizedFullLink: () => ({
+                      space: registrySpace,
+                      id: registryId,
+                      path: [segment],
+                    }),
                   }),
                 }),
             },
@@ -3809,6 +3811,10 @@ Deno.test("runCfHarnessCli can resume from persisted run artifacts", async () =>
     {
       io,
       env: { CF_HARNESS_API_KEY: "test-key" },
+      // The resume path must forward the same session override a fresh run
+      // honors; the assertion below reads it back off the resumed engine.
+      fabricSessionFactory: () =>
+        Promise.reject(new Error("factory is forwarded, not invoked")),
       readRunArtifacts: (path) => {
         assertEquals(
           path,
@@ -3881,6 +3887,10 @@ Deno.test("runCfHarnessCli can resume from persisted run artifacts", async () =>
   assertEquals(exitCode, 0);
   assertEquals(createdOptions?.allowedToolIds, ["delegate_task"]);
   assertEquals(createdOptions?.allowedSubagentProfiles, ["default"]);
+  assertEquals(
+    (createdOptions?.engine as CfHarnessEngine).fabricSessionAvailable,
+    true,
+  );
   assertEquals(runTranscriptOptions?.promptSlotBinding, promptSlotBinding);
   assertEquals(stdout, [
     formatCfHarnessCliResult({

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -2129,6 +2129,158 @@ Deno.test("runCfHarnessCli executes the prompt loop and prints result metadata",
   assertEquals(stderr, []);
 });
 
+Deno.test("runCfHarnessCli announces well-known grants to the model and the operator", async () => {
+  const { io, stdout, stderr } = createIoBuffers();
+  const registrySpace =
+    "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+  const registryId = `of:fid1:${"D".repeat(43)}`;
+  // The grant persists run state, so the workspace must really be writable.
+  const workspace = await Deno.makeTempDir();
+  let runPromptOptions: RunHarnessPromptOptions | undefined;
+  const exitCode = await runCfHarnessCli(
+    [
+      "--workspace",
+      workspace,
+      "--prompt",
+      "List the pieces",
+      "--fabric-api-url",
+      "https://toolshed.example/",
+      "--fabric-identity",
+      "/keys/agent.pkcs8",
+      "--fabric-space",
+      "demo-space",
+    ],
+    {
+      io,
+      env: { CF_HARNESS_API_KEY: "test-key" },
+      fabricSessionFactory: () =>
+        Promise.resolve(
+          {
+            pieces: {
+              getSpace: () => registrySpace,
+              getPieceRegistry: () =>
+                Promise.resolve({
+                  getAsNormalizedFullLink: () => ({
+                    space: registrySpace,
+                    id: registryId,
+                    path: ["pieceRegistry"],
+                  }),
+                }),
+            },
+            // deno-lint-ignore no-explicit-any
+          } as any,
+        ),
+      createPromptLoop: () => ({
+        runPrompt: (options) => {
+          runPromptOptions = options;
+          return Promise.resolve(
+            ({
+              model: "gpt-5.4",
+              finalAssistantText: "Done.",
+              transcript: [],
+              modelTurns: 1,
+              runState: {
+                runId: "run-grants",
+                status: "completed",
+                createdAt: "2026-04-15T22:00:00.000Z",
+                updatedAt: "2026-04-15T22:00:01.000Z",
+                cfcEnforcementMode: "enforce-explicit",
+                currentDir: "/workspace",
+                policyEvents: [],
+                toolOutputs: [],
+                wellKnownGrants: [{
+                  name: "piece-registry",
+                  token: "cfh:a:granted1",
+                  ref: `/${registryId}/pieceRegistry`,
+                }],
+              },
+            }) satisfies HarnessPromptLoopResult,
+          );
+        },
+        runTranscript: () =>
+          Promise.reject(new Error("unexpected resume path")),
+      }),
+    },
+  );
+
+  assertEquals(exitCode, 0);
+  const grantMessages = (runPromptOptions?.contextMessages ?? []).filter((
+    message,
+  ) => message.includes("Granted references"));
+  assertEquals(grantMessages.length, 1);
+  assertEquals(grantMessages[0]!.includes("cfh:a:"), true);
+  assertEquals(grantMessages[0]!.includes(registryId), false);
+  assertEquals(
+    stdout.join("").includes("fabricGrants: piece-registry cfh:a:granted1"),
+    true,
+  );
+  assertEquals(stderr, []);
+});
+
+Deno.test("runCfHarnessCli says so when the well-known grants cannot be established", async () => {
+  const { io, stderr } = createIoBuffers();
+  let runPromptOptions: RunHarnessPromptOptions | undefined;
+  const exitCode = await runCfHarnessCli(
+    [
+      "--workspace",
+      "/tmp/project",
+      "--prompt",
+      "List the pieces",
+      "--fabric-api-url",
+      "https://toolshed.example/",
+      "--fabric-identity",
+      "/keys/agent.pkcs8",
+      "--fabric-space",
+      "demo-space",
+    ],
+    {
+      io,
+      env: { CF_HARNESS_API_KEY: "test-key" },
+      fabricSessionFactory: () =>
+        Promise.reject(new Error("space unauthorized")),
+      createPromptLoop: () => ({
+        runPrompt: (options) => {
+          runPromptOptions = options;
+          return Promise.resolve(
+            ({
+              model: "gpt-5.4",
+              finalAssistantText: "Done.",
+              transcript: [],
+              modelTurns: 1,
+              runState: {
+                runId: "run-no-grants",
+                status: "completed",
+                createdAt: "2026-04-15T22:00:00.000Z",
+                updatedAt: "2026-04-15T22:00:01.000Z",
+                cfcEnforcementMode: "enforce-explicit",
+                currentDir: "/workspace",
+                policyEvents: [],
+                toolOutputs: [],
+              },
+            }) satisfies HarnessPromptLoopResult,
+          );
+        },
+        runTranscript: () =>
+          Promise.reject(new Error("unexpected resume path")),
+      }),
+    },
+  );
+
+  assertEquals(exitCode, 0);
+  assertEquals(
+    (runPromptOptions?.contextMessages ?? []).some((message) =>
+      message.includes("Granted references")
+    ),
+    false,
+  );
+  assertEquals(
+    stderr.some((line) =>
+      line.includes("fabric grants: unavailable (space unauthorized)")
+    ),
+    true,
+  );
+});
+
 Deno.test("runCfHarnessCli forwards --compact-threshold to a fresh run", async () => {
   // Parsing was already covered; this pins the handoff. The option was
   // forwarded on the resume path only, so a fresh run silently lost it.

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -2160,6 +2160,7 @@ Deno.test("runCfHarnessCli announces well-known grants to the model and the oper
               getSpace: () => registrySpace,
               getDefaultPattern: (_runIt: boolean) =>
                 Promise.resolve({
+                  getMetaRaw: () => undefined,
                   key: (segment: string) => ({
                     getAsNormalizedFullLink: () => ({
                       space: registrySpace,

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -216,13 +216,15 @@ Deno.test("CfHarnessEngine seeds the piece-registry grant once and replays the r
         {
           pieces: {
             getSpace: () => registrySpace,
-            getPieceRegistry: () => {
+            getDefaultPattern: (_runIt: boolean) => {
               registryReads += 1;
               return Promise.resolve({
-                getAsNormalizedFullLink: () => ({
-                  space: registrySpace,
-                  id: registryId,
-                  path: ["pieceRegistry"],
+                key: (segment: string) => ({
+                  getAsNormalizedFullLink: () => ({
+                    space: registrySpace,
+                    id: registryId,
+                    path: [segment],
+                  }),
                 }),
               });
             },

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -195,6 +195,55 @@ Deno.test("CfHarnessEngine records the fabric session's resolved CFC posture in 
   assertEquals(sessionless.getRunState().fabricSessionCfc, undefined);
 });
 
+Deno.test("CfHarnessEngine grants no well-known handles without a fabric session", async () => {
+  const engine = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+  });
+  assertEquals(await engine.establishWellKnownGrants(), []);
+  assertEquals(engine.getRunState().wellKnownGrants, undefined);
+  assertEquals(engine.handleTable, undefined);
+});
+
+Deno.test("CfHarnessEngine seeds the piece-registry grant once and replays the record", async () => {
+  const registrySpace =
+    "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+  const registryId = `of:fid1:${"C".repeat(43)}`;
+  let registryReads = 0;
+  const engine = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    fabricSessionFactory: () =>
+      Promise.resolve(
+        {
+          pieces: {
+            getSpace: () => registrySpace,
+            getPieceRegistry: () => {
+              registryReads += 1;
+              return Promise.resolve({
+                getAsNormalizedFullLink: () => ({
+                  space: registrySpace,
+                  id: registryId,
+                  path: ["pieceRegistry"],
+                }),
+              });
+            },
+          },
+          // deno-lint-ignore no-explicit-any
+        } as any,
+      ),
+  });
+
+  const granted = await engine.establishWellKnownGrants();
+  assertEquals(granted.length, 1);
+  assertEquals(granted[0]!.name, "piece-registry");
+  assertEquals(granted[0]!.ref, `/${registryId}/pieceRegistry`);
+  assertEquals(engine.getRunState().wellKnownGrants, granted);
+  assertEquals(engine.handleTable?.entries.length, 1);
+
+  // A second establishment answers from the record without another resolve.
+  assertEquals(await engine.establishWellKnownGrants(), granted);
+  assertEquals(registryReads, 1);
+});
+
 Deno.test("CfHarnessEngine rejects only cross-model Codex resume", () => {
   const resumedState = (
     modelProvider: "openai-codex" | "openai-compatible-gateway",

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -219,6 +219,7 @@ Deno.test("CfHarnessEngine seeds the piece-registry grant once and replays the r
             getDefaultPattern: (_runIt: boolean) => {
               registryReads += 1;
               return Promise.resolve({
+                getMetaRaw: () => undefined,
                 key: (segment: string) => ({
                   getAsNormalizedFullLink: () => ({
                     space: registrySpace,

--- a/packages/cf-harness/test/run-state.test.ts
+++ b/packages/cf-harness/test/run-state.test.ts
@@ -25,5 +25,24 @@ describe("run-state", () => {
       table.entries.pop();
       expect(state.handleTable?.entries.length).toBe(1);
     });
+
+    it("carries a defensive copy of given well-known grants", () => {
+      const grants = [{
+        name: "piece-registry" as const,
+        token: "cfh:a:abcdefgh",
+        ref: `/of:fid1:${"A".repeat(43)}/pieceRegistry`,
+      }];
+
+      const state = createHarnessRunState({
+        cfcEnforcementMode: "disabled",
+        currentDir: "/workspace",
+        wellKnownGrants: grants,
+      });
+
+      expect(state.wellKnownGrants).toEqual(grants);
+      expect(state.wellKnownGrants).not.toBe(grants);
+      grants.pop();
+      expect(state.wellKnownGrants?.length).toBe(1);
+    });
   });
 });

--- a/packages/cf-harness/test/well-known-grants.test.ts
+++ b/packages/cf-harness/test/well-known-grants.test.ts
@@ -26,19 +26,33 @@ const SPACE_DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
 const REGISTRY_ID = `of:fid1:${"A".repeat(43)}`;
 const REGISTRY_REF = `/${REGISTRY_ID}/pieceRegistry`;
 
-// A stand-in carrying exactly the two members grant resolution touches.
-const stubSession = (): HarnessFabricSession =>
+// A stand-in carrying exactly the members grant resolution touches: the
+// default-pattern root pointer and the address walk off it. No registry
+// listing exists on the stub at all, which is itself the assertion that
+// resolution never pulls one.
+const stubSession = (
+  options: { defaultPattern?: boolean } = {},
+): HarnessFabricSession =>
   ({
     pieces: {
       getSpace: () => SPACE_DID,
-      getPieceRegistry: () =>
-        Promise.resolve({
-          getAsNormalizedFullLink: () => ({
-            space: SPACE_DID,
-            id: REGISTRY_ID,
-            path: ["pieceRegistry"],
+      getDefaultPattern: (runIt: boolean) => {
+        if (runIt !== false) {
+          throw new Error("address resolution must not run the pattern");
+        }
+        if (options.defaultPattern === false) {
+          return Promise.resolve(undefined);
+        }
+        return Promise.resolve({
+          key: (segment: string) => ({
+            getAsNormalizedFullLink: () => ({
+              space: SPACE_DID,
+              id: REGISTRY_ID,
+              path: [segment],
+            }),
           }),
-        }),
+        });
+      },
     },
   }) as unknown as HarnessFabricSession;
 
@@ -47,6 +61,12 @@ describe("well-known-grants", () => {
     it("resolves the piece registry to its canonical in-space reference", async () => {
       const refs = await resolveWellKnownGrantRefs(stubSession());
       expect(refs).toEqual([{ name: "piece-registry", ref: REGISTRY_REF }]);
+    });
+
+    it("refuses to grant when the space has no default pattern", async () => {
+      await expect(resolveWellKnownGrantRefs(stubSession({
+        defaultPattern: false,
+      }))).rejects.toThrow("no default pattern");
     });
   });
 

--- a/packages/cf-harness/test/well-known-grants.test.ts
+++ b/packages/cf-harness/test/well-known-grants.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The well-known grant seams: resolving the piece-registry reference through
+ * a session, minting grant tokens into a handle table, and the fixed
+ * announcement text — which must carry tokens and harness-authored prose
+ * only, never the address behind a token.
+ */
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  ADDRESS_HANDLE_TOKEN_PREFIX,
+  HANDLE_TOKEN_PATTERN,
+} from "../src/contracts/handle-table.ts";
+import {
+  createHarnessHandleTable,
+  mintAddressHandle,
+  resolveHandleToken,
+} from "../src/handle-table.ts";
+import type { HarnessFabricSession } from "../src/fabric-session.ts";
+import {
+  mintWellKnownGrants,
+  resolveWellKnownGrantRefs,
+  wellKnownGrantsContextMessage,
+} from "../src/well-known-grants.ts";
+
+const SPACE_DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+const REGISTRY_ID = `of:fid1:${"A".repeat(43)}`;
+const REGISTRY_REF = `/${REGISTRY_ID}/pieceRegistry`;
+
+// A stand-in carrying exactly the two members grant resolution touches.
+const stubSession = (): HarnessFabricSession =>
+  ({
+    pieces: {
+      getSpace: () => SPACE_DID,
+      getPieceRegistry: () =>
+        Promise.resolve({
+          getAsNormalizedFullLink: () => ({
+            space: SPACE_DID,
+            id: REGISTRY_ID,
+            path: ["pieceRegistry"],
+          }),
+        }),
+    },
+  }) as unknown as HarnessFabricSession;
+
+describe("well-known-grants", () => {
+  describe("resolveWellKnownGrantRefs()", () => {
+    it("resolves the piece registry to its canonical in-space reference", async () => {
+      const refs = await resolveWellKnownGrantRefs(stubSession());
+      expect(refs).toEqual([{ name: "piece-registry", ref: REGISTRY_REF }]);
+    });
+  });
+
+  describe("mintWellKnownGrants()", () => {
+    it("mints a resolvable token into a fresh table when the run has none", async () => {
+      const { table, grants } = await mintWellKnownGrants(
+        undefined,
+        "run-1",
+        [{ name: "piece-registry", ref: REGISTRY_REF }],
+      );
+      expect(grants.length).toBe(1);
+      expect(grants[0]!.name).toBe("piece-registry");
+      expect(grants[0]!.ref).toBe(REGISTRY_REF);
+      expect(grants[0]!.token.startsWith(ADDRESS_HANDLE_TOKEN_PREFIX)).toBe(
+        true,
+      );
+      expect(grants[0]!.token).toMatch(
+        new RegExp(`^${HANDLE_TOKEN_PATTERN.source}$`),
+      );
+      expect(table.salt).toBe("run-1");
+      expect(resolveHandleToken(table, grants[0]!.token)).toBeDefined();
+    });
+
+    it("extends an existing table without disturbing its entries", async () => {
+      const existing = await mintAddressHandle(
+        createHarnessHandleTable("run-2"),
+        `/of:fid1:${"B".repeat(43)}`,
+      );
+      const { table, grants } = await mintWellKnownGrants(
+        existing.table,
+        "run-2",
+        [{ name: "piece-registry", ref: REGISTRY_REF }],
+      );
+      expect(table.entries.length).toBe(2);
+      expect(resolveHandleToken(table, existing.token)).toBeDefined();
+      expect(resolveHandleToken(table, grants[0]!.token)).toBeDefined();
+    });
+  });
+
+  describe("wellKnownGrantsContextMessage()", () => {
+    it("returns undefined for an empty grant list", () => {
+      expect(wellKnownGrantsContextMessage([])).toBeUndefined();
+    });
+
+    it("pairs each token with its description and never discloses the ref", () => {
+      const message = wellKnownGrantsContextMessage([{
+        name: "piece-registry",
+        token: "cfh:a:abcdefgh",
+        ref: REGISTRY_REF,
+      }]);
+      expect(message).toContain("cfh:a:abcdefgh");
+      expect(message).toContain("piece registry");
+      expect(message).not.toContain(REGISTRY_ID);
+    });
+  });
+});

--- a/packages/cf-harness/test/well-known-grants.test.ts
+++ b/packages/cf-harness/test/well-known-grants.test.ts
@@ -44,6 +44,9 @@ const stubSession = (
           return Promise.resolve(undefined);
         }
         return Promise.resolve({
+          // Answering no pattern identity makes the canonical legacy-root
+          // predicate say "modern" without touching any registry field.
+          getMetaRaw: () => undefined,
           key: (segment: string) => ({
             getAsNormalizedFullLink: () => ({
               space: SPACE_DID,

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -276,6 +276,7 @@ export {
   cellWithScopedLinkRequiredsRelaxed,
   compileAndSavePattern,
   parseCellPath,
+  pieceRegistryKeyForRoot,
   resolveCellPath,
 } from "./piece-helpers.ts";
 export type { ModuleByteCache } from "./runtime.ts";

--- a/packages/runner/src/piece-helpers.ts
+++ b/packages/runner/src/piece-helpers.ts
@@ -339,6 +339,17 @@ export function isLegacyPieceRegistryRoot(
 }
 
 /**
+ * The field a persisted default root exposes its piece registry under: the
+ * retired `allPieces` for a legacy default-app root, `pieceRegistry`
+ * otherwise. The single home for a selection every registry consumer makes.
+ */
+export function pieceRegistryKeyForRoot(
+  root: Cell<unknown>,
+): "pieceRegistry" | "allPieces" {
+  return isLegacyPieceRegistryRoot(root) ? "allPieces" : "pieceRegistry";
+}
+
+/**
  * Compile a pattern into `space` and persist its content-addressed source +
  * compiled documents there (the awaited write-back inside `compilePattern`).
  * The compiled pattern carries its `{ identity, symbol }` entry ref, the single

--- a/packages/runner/test/piece-helpers.test.ts
+++ b/packages/runner/test/piece-helpers.test.ts
@@ -7,6 +7,7 @@ import {
   getResultCellWithSourceSchema,
   isLegacyPieceRegistryRoot,
   parseCellPath,
+  pieceRegistryKeyForRoot,
   resolveCellPath,
 } from "../src/piece-helpers.ts";
 import { Runtime } from "../src/runtime.ts";
@@ -402,5 +403,21 @@ describe("isLegacyPieceRegistryRoot", () => {
         `expected ${String(source)} to be refused`,
       );
     }
+  });
+
+  it("selects allPieces for a legacy root and pieceRegistry otherwise", async () => {
+    assertEquals(
+      pieceRegistryKeyForRoot(await legacyShapedRoot(undefined)),
+      "allPieces",
+    );
+    const modern = runtime.getCell<Record<string, unknown>>(
+      space,
+      `modern-registry-root-${crypto.randomUUID()}`,
+    );
+    const { error } = await runtime.editWithRetry((tx) => {
+      modern.withTx(tx).set({ pieceRegistry: [] });
+    });
+    assertEquals(error, undefined);
+    assertEquals(pieceRegistryKeyForRoot(modern), "pieceRegistry");
   });
 });


### PR DESCRIPTION
## What

A run configured with a Fabric session now starts holding one reference: before the first model turn, the CLI establishes the session, mints a handle for the space's piece registry (the discovery root behind `cf piece ls`), and announces the token in a context message pairing it with fixed, harness-authored prose. Discovery is `run_pattern` over that token — not a tool of its own — and `describe_handle` answers the registry's shape like any other reference.

- `well-known-grants.ts`: the grant list (piece-registry today, designed to grow — the identity's profile is the expected next entry), ref resolution through the session, minting through the ordinary `mintAddressHandle` path, and the fixed announcement text.
- Engine: `establishWellKnownGrants()` — seeds the handle table, records `wellKnownGrants` in run state, replays the record on resume rather than connecting again.
- CLI: establishes grants before the first prompt when a fabric session is configured; a session that cannot be established leaves the run to proceed and says so on stderr (`fabric grants: unavailable (...)`) rather than staying silent. Operator summary prints `fabricGrants: piece-registry cfh:a:...`.
- `deps.fabricSessionFactory` injection seam so CLI tests grant without a deployed API.

## Why

Every demo so far started with the operator minting handles by hand. The registry grant closes the loop: agents find pieces to compute over themselves. Listing is just a pattern over the granted reference, so the tool surface does not grow, and name disclosure needs no bespoke redaction — a piece's `$NAME` is a value, and the CFC flow join already rules on reading it exactly as it rules on every other flow (probed live: a NAME derived from a labelled field taints a name-reading flow, which strict refuses whole; the announcement names the references-only fallback).

## Verified

- Unit: grant resolution/minting/announcement, engine idempotency + no-session answer, CLI success and failure paths, run-state defensive copy. Local LCOV diff over every touched file: no new uncovered lines.
- Live at `enforce-strict` + `persist` against the local toolshed (`expenses-demo-3`): grant minted and announced (`fabricGrants: piece-registry cfh:a:8yx27`), agent surveyed the registry shape via `describe_handle` on the granted token, delegated discovery patterns ran over it, and no name text and no address crossed into the transcript — names came back sealed by the existing value-disclosure boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

