### PR TITLE
test(integration): make a failed shell navigation say what loaded

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -996,6 +996,30 @@ MutationObserver hub would have nothing to pulse on and the wait would fall back
 to the coarse 500-millisecond in-page backstop. That polls more slowly than the
 50-millisecond loop it would replace.
 
+So the poll stays, and what it reports when it gives up is what has to carry the
+diagnosis. On its own, a `waitFor` timeout says only that a predicate did not
+come true, with a stack that points at `waitFor` and nothing about the page.
+`waitForState` catches that and adds a block naming the view it was awaiting,
+the identity it was awaiting where one was given, the last state it managed to
+read, and what the page held at the moment it gave up: the document's URL,
+title, and HTTP status, whether the shell's `x-root-view` element is in it,
+whether `globalThis.app` is there and which view it holds, and the tail of
+console messages `Page.applyConsoleFormatter` retains in the page. The page half
+of that is `readShellPageProbe` in
+`packages/integration/shell-page-probe.ts`; `describeStateWaitFailure` in
+`shell-utils.ts` assembles the whole block, and a test may call it directly to
+report a wait of its own the same way.
+
+`ShellIntegration.goto()` checks one of those facts before it starts waiting at
+all. The shell's entry document carries an `x-root-view` element, so a document
+without one is not the shell, and every wait that follows reads state through
+`globalThis.app`, which such a document never defines. `assertShellDocument`
+fails the navigation there and then, naming the document that arrived. The case
+this catches is a server answering with something other than the shell — for
+instance the toolshed's `Failed to proxy to ...` page, served with a 502 when
+its own fetch to the shell dev server fails. Without the check, every test in
+the run waits out the full minute and reports nothing that names the cause.
+
 ### A human-in-the-loop flow that no CI lane runs
 
 `packages/patterns/google/core/integration/google-calendar-importer.test.ts`

--- a/packages/integration/shell-page-probe.ts
+++ b/packages/integration/shell-page-probe.ts
@@ -1,0 +1,165 @@
+import type { Page } from "./page.ts";
+
+// How much of the document's text a probe carries back. Enough to read a
+// server's error page, short enough to stay one line of a failure report.
+const TEXT_LIMIT = 500;
+
+// How many of the retained console messages a probe carries back.
+const CONSOLE_TAIL_LIMIT = 40;
+
+/**
+ * What a page held at the moment a shell navigation or state wait failed.
+ *
+ * Read with {@link readShellPageProbe} and rendered with
+ * {@link describeShellPage}. Every field answers a question an investigator
+ * asks of a failed shell test: is this the shell at all, did the server answer
+ * with the document that was asked for, had the shell booted far enough to
+ * publish itself, and what was it showing.
+ */
+export interface ShellPageProbe {
+  /** The document's own URL, which a redirect can make differ from the one requested. */
+  url: string;
+  /** The document's title. */
+  title: string;
+  /**
+   * HTTP status of the navigation response, taken from the page's navigation
+   * timing entry. Absent for a document that came from no network response.
+   */
+  status?: number;
+  /** Whether the shell's root element, `x-root-view`, is in the document. */
+  rootView: boolean;
+  /** Whether the shell has published itself on `globalThis.app`. */
+  app: boolean;
+  /** The view `globalThis.app` holds, read from its serialized state. */
+  view?: unknown;
+  /** Why that state could not be read, when `app` is set and reading it threw. */
+  viewError?: string;
+  /** Whether that state carries an identity. */
+  identity?: boolean;
+  /** The start of the document's rendered text. */
+  text: string;
+  /**
+   * The console messages `Page.applyConsoleFormatter` retained in the page,
+   * oldest first, each prefixed with how long before the probe it was logged.
+   * Empty for a document the formatter was never applied to.
+   */
+  consoleTail: string[];
+}
+
+/** Read {@link ShellPageProbe} from the document currently in `page`. */
+export async function readShellPageProbe(page: Page): Promise<ShellPageProbe> {
+  return await page.evaluate((textLimit: number, tailLimit: number) => {
+    const scope = globalThis as typeof globalThis & {
+      app?: { serialize?: () => { view?: unknown; identity?: unknown } };
+      __cfConsoleTail?: Array<{ t: number; method: string; text: string }>;
+    };
+
+    const navigation = performance.getEntriesByType("navigation")[0] as
+      | (PerformanceNavigationTiming & { responseStatus?: number })
+      | undefined;
+    const status = typeof navigation?.responseStatus === "number"
+      ? navigation.responseStatus
+      : undefined;
+
+    const app = typeof scope.app?.serialize === "function";
+    let view: unknown;
+    let viewError: string | undefined;
+    let identity: boolean | undefined;
+    if (app) {
+      try {
+        const state = scope.app!.serialize!();
+        view = state.view;
+        identity = !!state.identity;
+      } catch (error) {
+        viewError = String(error);
+      }
+    }
+
+    const body = document.body;
+    const text = (body?.innerText ?? body?.textContent ?? "").trim()
+      .slice(0, textLimit);
+
+    const now = Date.now();
+    const consoleTail = (scope.__cfConsoleTail ?? []).slice(-tailLimit).map(
+      (entry) => `${now - entry.t}ms ago [${entry.method}] ${entry.text}`,
+    );
+
+    return {
+      url: location.href,
+      title: document.title,
+      status,
+      rootView: !!document.querySelector("x-root-view"),
+      app,
+      view,
+      viewError,
+      identity,
+      text,
+      consoleTail,
+    };
+  }, { args: [TEXT_LIMIT, CONSOLE_TAIL_LIMIT] });
+}
+
+/**
+ * Render `probe` as the indented block of detail lines that follows the first
+ * line of a failure message.
+ *
+ * The document's text is included only when the document is not the shell.
+ * For the shell it is the whole rendered application, which says less about a
+ * stalled wait than the view and the console tail already do.
+ */
+export function describeShellPage(probe: ShellPageProbe): string {
+  const lines: string[] = [
+    `  document URL: ${probe.url}`,
+    `  document title: ${probe.title || "(none)"}`,
+  ];
+  if (probe.status !== undefined) {
+    lines.push(`  response status: ${probe.status}`);
+  }
+  lines.push(`  x-root-view: ${probe.rootView ? "present" : "absent"}`);
+  if (probe.viewError !== undefined) {
+    lines.push(
+      `  globalThis.app: present, but reading its state threw: ${probe.viewError}`,
+    );
+  } else if (probe.app) {
+    lines.push(
+      `  globalThis.app: present, holding view ${JSON.stringify(probe.view)}` +
+        ` and ${probe.identity ? "an identity" : "no identity"}`,
+    );
+  } else {
+    lines.push("  globalThis.app: absent");
+  }
+  if (!probe.rootView) {
+    const text = probe.text.replace(/\s+/g, " ");
+    lines.push(`  document text: ${text || "(empty)"}`);
+  }
+  if (probe.consoleTail.length === 0) {
+    lines.push("  console tail: empty");
+  } else {
+    lines.push(`  console tail (${probe.consoleTail.length} most recent):`);
+    for (const entry of probe.consoleTail) lines.push(`    ${entry}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Fail unless the document in `page` is the shell.
+ *
+ * The shell's entry document carries an `x-root-view` element, so a document
+ * without one came from somewhere else: the toolshed's proxy failure page when
+ * it cannot reach the shell dev server, a 404 from a server that serves no
+ * shell, a browser error page. Everything a shell test waits for afterwards is
+ * read through `globalThis.app`, which such a document never defines, so the
+ * wait runs to its bound and reports only that time ran out. Checking here
+ * reports the document that arrived instead, at the moment it arrived.
+ */
+export async function assertShellDocument(
+  page: Page,
+  requestedUrl: string,
+): Promise<void> {
+  const probe = await readShellPageProbe(page);
+  if (probe.rootView) return;
+  throw new Error(
+    `Navigated to ${requestedUrl}, but the document that loaded is not the ` +
+      `shell: it has no x-root-view element.\n${describeShellPage(probe)}`,
+  );
+}

--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -27,6 +27,11 @@ import {
   enablePatternCoverage,
 } from "./pattern-coverage.ts";
 import { getPresentationSession } from "./presentation/session.ts";
+import {
+  assertShellDocument,
+  describeShellPage,
+  readShellPageProbe,
+} from "./shell-page-probe.ts";
 import { waitFor, waitForCondition } from "./utils.ts";
 
 import "../shell/src/globals.ts";
@@ -103,6 +108,48 @@ export async function login(page: Page, identity: Identity): Promise<void> {
       args: [transferrableId, identity.did()],
     },
   );
+}
+
+// How an `AppState` reads in a failure message. The identity is named by its
+// DID, which the serialized state a page probe reads does not carry.
+function describeAppState(state: AppState | undefined): string {
+  if (!state) return "none (the page never yielded a state)";
+  const identity = state.identity ? state.identity.did() : "none";
+  return `view ${JSON.stringify(state.view)}, identity ${identity}`;
+}
+
+/**
+ * The indented detail block a failed {@link ShellIntegration.waitForState}
+ * reports: what the wait was for, the last state it managed to read, and what
+ * `page` holds now.
+ *
+ * The two states answer different questions. `lastState` is what the wait saw,
+ * decoded in the test process, so it names the identity by DID. The page probe
+ * is read at failure time and covers the case the wait itself cannot describe:
+ * a document that is not the shell, where no state was ever there to read.
+ */
+export async function describeStateWaitFailure(
+  page: Page,
+  params: { view: AppView; identity?: Identity },
+  lastState: AppState | undefined,
+): Promise<string> {
+  const lines = [`  awaited view: ${JSON.stringify(params.view)}`];
+  if (params.identity) {
+    lines.push(`  awaited identity: ${params.identity.did()}`);
+  }
+  lines.push(`  last state read: ${describeAppState(lastState)}`);
+  try {
+    lines.push(describeShellPage(await readShellPageProbe(page)));
+  } catch (error) {
+    lines.push(
+      `  the page could not be probed: ${
+        error instanceof Error
+          ? error.message
+          : Deno.inspect(error, { colors: false })
+      }`,
+    );
+  }
+  return lines.join("\n");
 }
 
 export interface ShellIntegrationConfig {
@@ -227,14 +274,41 @@ export class ShellIntegration {
 
     this.checkIsOk();
 
-    await waitFor(async () => {
-      return stateMatches(await this.state(), params);
-    });
+    // The last state the poll below managed to read. A failure reports it, so
+    // the message says what the wait actually saw rather than only that it
+    // never saw what it wanted.
+    let lastState: AppState | undefined;
+    try {
+      await waitFor(async () => {
+        lastState = await this.state();
+        return stateMatches(lastState, params);
+      });
+    } catch (error) {
+      // A page exception arrives as the protocol's own detail object rather
+      // than an `Error`. Deno prints the cause below the message, so such a
+      // value is reported there rather than stringified into the summary,
+      // where it would read as "[object Object]".
+      const summary = error instanceof Error
+        ? error.message
+        : "the wait threw the value reported as the cause below.";
+      const detail = await describeStateWaitFailure(
+        this.page(),
+        params,
+        lastState,
+      );
+      throw new Error(
+        `Waiting for the shell's app state failed: ${summary}\n${detail}`,
+        { cause: error },
+      );
+    }
     const state = await this.state();
     // Unlikely to occur, but recheck state once more to ensure
     // the state returned explicitly matches requirement.
     if (!state || !(stateMatches(state, params))) {
-      throw new Error("State changed after matching requirements.");
+      throw new Error(
+        "The shell's app state changed after it matched what was awaited.\n" +
+          await describeStateWaitFailure(this.page(), params, state),
+      );
     }
     return state;
   }
@@ -261,6 +335,11 @@ export class ShellIntegration {
     const page = this.page();
     await page.goto(url);
     await page.applyConsoleFormatter();
+    // Everything below reads the page through `globalThis.app`, which only the
+    // shell defines. Check the shell is what loaded before any of it, so a
+    // server that answered with something else is reported here rather than as
+    // a state wait that runs to its bound with nothing to say.
+    await assertShellDocument(page, url);
     // The worker runtime reads this when it is constructed, at login, so it has
     // to be set after the page has an origin to store it against and before the
     // login below.

--- a/packages/integration/test/shell-failure-reports.test.ts
+++ b/packages/integration/test/shell-failure-reports.test.ts
@@ -1,0 +1,239 @@
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+
+import { Browser } from "../browser.ts";
+import type { Page } from "../page.ts";
+import {
+  assertShellDocument,
+  describeShellPage,
+  readShellPageProbe,
+} from "../shell-page-probe.ts";
+import { describeStateWaitFailure } from "../shell-utils.ts";
+
+// What the toolshed answers with when its fetch to the shell dev server fails.
+const PROXY_FAILURE_TEXT =
+  "Failed to proxy to http://localhost:6000/. Is the shell dev server running?";
+
+// The part of the shell's entry document that matters here: a title, and the
+// root element every shell wait afterwards depends on.
+const SHELL_DOCUMENT = `<!DOCTYPE html>
+<html><head><title>Common Fabric</title></head>
+<body><x-root-view></x-root-view></body></html>`;
+
+// The same document with the shell already booted far enough to have published
+// itself, holding the home view and an identity.
+const BOOTED_SHELL_DOCUMENT = `<!DOCTYPE html>
+<html><head><title>Common Fabric</title></head>
+<body><x-root-view></x-root-view>
+<script>
+  globalThis.app = {
+    serialize: () => ({
+      view: { builtin: "home" },
+      identity: { privateKey: [1, 2, 3] },
+    }),
+  };
+</script>
+</body></html>`;
+
+function handle(request: Request): Response {
+  const { pathname } = new URL(request.url);
+  switch (pathname) {
+    case "/proxy-failure":
+      return new Response(PROXY_FAILURE_TEXT, {
+        status: 502,
+        headers: { "content-type": "text/plain; charset=utf-8" },
+      });
+    case "/shell":
+      return new Response(SHELL_DOCUMENT, {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    case "/booted-shell":
+      return new Response(BOOTED_SHELL_DOCUMENT, {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+  }
+  return new Response("not found", { status: 404 });
+}
+
+// The message of the error `work` rejects with. Fails the test when it
+// resolves, so a check on the message cannot pass vacuously.
+async function rejectionMessage(work: Promise<unknown>): Promise<string> {
+  try {
+    await work;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  throw new Error("Expected the call to throw, and it returned instead.");
+}
+
+describe("shell-failure-reports", () => {
+  let server: Deno.HttpServer;
+  let origin: string;
+  let browser: Browser;
+  let page: Page;
+
+  beforeAll(async () => {
+    server = Deno.serve({ port: 0, onListen: () => {} }, handle);
+    origin = `http://localhost:${(server.addr as Deno.NetAddr).port}`;
+    browser = await Browser.launch();
+    page = await browser.newPage();
+  });
+
+  afterAll(async () => {
+    await page.close();
+    await browser.close();
+    await server.shutdown();
+  });
+
+  // Loads `path` from the local server and installs the console formatter,
+  // which is the state `ShellIntegration.goto` leaves a page in before it
+  // starts waiting.
+  const load = async (path: string): Promise<string> => {
+    const url = `${origin}${path}`;
+    await page.goto(url);
+    await page.applyConsoleFormatter();
+    return url;
+  };
+
+  describe("readShellPageProbe()", () => {
+    it("returns the status and text of a document that is not the shell", async () => {
+      await load("/proxy-failure");
+
+      const probe = await readShellPageProbe(page);
+      expect(probe.rootView).toBe(false);
+      expect(probe.app).toBe(false);
+      expect(probe.status).toBe(502);
+      expect(probe.text).toBe(PROXY_FAILURE_TEXT);
+    });
+
+    it("returns the title and root element of the shell's own document", async () => {
+      await load("/shell");
+
+      const probe = await readShellPageProbe(page);
+      expect(probe.rootView).toBe(true);
+      expect(probe.title).toBe("Common Fabric");
+      expect(probe.status).toBe(200);
+      // Nothing has booted, so nothing has published `globalThis.app`.
+      expect(probe.app).toBe(false);
+    });
+
+    it("returns the view and identity a booted shell holds", async () => {
+      await load("/booted-shell");
+
+      const probe = await readShellPageProbe(page);
+      expect(probe.app).toBe(true);
+      expect(probe.view).toEqual({ builtin: "home" });
+      expect(probe.identity).toBe(true);
+    });
+
+    it("returns the console messages the page retained", async () => {
+      await load("/booted-shell");
+      await page.evaluate(() => {
+        console.warn("the page said something before the wait gave up");
+      });
+
+      const probe = await readShellPageProbe(page);
+      expect(probe.consoleTail.length).toBe(1);
+      expect(probe.consoleTail[0]).toContain(
+        "[warn] the page said something before the wait gave up",
+      );
+    });
+  });
+
+  describe("assertShellDocument()", () => {
+    it("throws naming the document that loaded instead of the shell", async () => {
+      const url = await load("/proxy-failure");
+
+      const message = await rejectionMessage(assertShellDocument(page, url));
+      expect(message).toContain(
+        "the document that loaded is not the shell: it has no x-root-view",
+      );
+      expect(message).toContain("response status: 502");
+      expect(message).toContain("globalThis.app: absent");
+      expect(message).toContain(
+        "document text: Failed to proxy to http://localhost:6000/",
+      );
+    });
+
+    it("returns for the shell's own document", async () => {
+      const url = await load("/shell");
+
+      await assertShellDocument(page, url);
+    });
+  });
+
+  describe("describeShellPage()", () => {
+    it("returns a block naming the view and identity the page holds", async () => {
+      await load("/booted-shell");
+
+      const described = describeShellPage(await readShellPageProbe(page));
+      expect(described).toContain(
+        'globalThis.app: present, holding view {"builtin":"home"} and an identity',
+      );
+      expect(described).toContain("x-root-view: present");
+    });
+
+    it("omits the document's text for a page that is the shell", async () => {
+      await load("/shell");
+
+      const described = describeShellPage(await readShellPageProbe(page));
+      expect(described).not.toContain("document text:");
+    });
+  });
+
+  describe("describeStateWaitFailure()", () => {
+    it("returns a block naming the awaited view beside the view held", async () => {
+      await load("/booted-shell");
+
+      const described = await describeStateWaitFailure(
+        page,
+        { view: { spaceName: "some-space" } },
+        undefined,
+      );
+      expect(described).toContain('awaited view: {"spaceName":"some-space"}');
+      expect(described).toContain(
+        "last state read: none (the page never yielded a state)",
+      );
+      expect(described).toContain(
+        'globalThis.app: present, holding view {"builtin":"home"}',
+      );
+    });
+
+    it("names both identity DIDs when an identity was awaited", async () => {
+      await load("/booted-shell");
+
+      const awaited = await Identity.generate();
+      const held = await Identity.generate();
+      const described = await describeStateWaitFailure(
+        page,
+        { view: { builtin: "home" }, identity: awaited },
+        {
+          view: { builtin: "home" },
+          identity: held,
+          apiUrl: new URL(origin),
+          config: {},
+        },
+      );
+      expect(described).toContain(`awaited identity: ${awaited.did()}`);
+      expect(described).toContain(
+        `last state read: view {"builtin":"home"}, identity ${held.did()}`,
+      );
+    });
+
+    it("names a document that is not the shell", async () => {
+      await load("/proxy-failure");
+
+      const described = await describeStateWaitFailure(
+        page,
+        { view: { builtin: "home" } },
+        undefined,
+      );
+      expect(described).toContain("x-root-view: absent");
+      expect(described).toContain("globalThis.app: absent");
+      expect(described).toContain("response status: 502");
+      expect(described).toContain("document text: Failed to proxy to ");
+    });
+  });
+});


### PR DESCRIPTION
`ShellIntegration.goto` navigates and then waits, through `waitForState`, for the shell to publish the requested view on `globalThis.app`. That wait is a bounded poll, kept deliberately (see docs/development/waiting-in-tests.md), and when the page the browser loaded is not the shell at all, every poll reads the same nothing. The run then fails after a full minute with "Timeout: waitFor predicate could not complete after 60000ms" and a stack that points only at `waitFor`. Nothing in the page threw, so no console error and no page exception is recorded either.

That happens for real. When the toolshed cannot reach the shell dev server it answers every navigation with its own `Failed to proxy to ...` text page, served with a 502. A CI run drew a port offset that put the shell dev server on port 6000, which the Fetch standard tells clients to refuse, so the toolshed's own fetch failed and every browser test in the job failed the same opaque way, one minute each. The run read as a mysterious hang rather than "the server served the wrong thing", and diagnosing it took hours of log archaeology.

The harness already knows enough to say what happened; it just was not saying it. This change makes it report what it knows.

A new module, packages/integration/shell-page-probe.ts, reads the page in one evaluate: the document's URL, its title, the HTTP status of the navigation response (from the page's own navigation timing entry), whether the shell's `x-root-view` element is in the document, whether `globalThis.app` is there and which view and identity it holds, the start of the document's text, and the bounded console tail that `Page.applyConsoleFormatter` already retains on
`globalThis.__cfConsoleTail` for exactly this purpose.

`goto` now checks one of those facts before it starts waiting. `assertShellDocument` fails the navigation immediately when the document has no `x-root-view` element, because every wait that follows reads state through `globalThis.app`, which such a document never defines. Against a stopped shell dev server the login suite now fails in under a second with:

    Navigated to http://localhost:8000/common-knowledge, but the
    document that loaded is not the shell: it has no x-root-view
    element.
      document URL: http://localhost:8000/common-knowledge
      document title: (none)
      response status: 502
      x-root-view: absent
      globalThis.app: absent
      document text: Failed to proxy to
      http://localhost:5173/common-knowledge. Is the shell dev server
      running?
      console tail: empty

`waitForState` keeps its poll, and now catches what the poll throws and adds the same block, together with the view and identity it was awaiting and the last state it managed to read. The last state is recorded as the poll goes, so the report names what the wait actually saw; it is also where the identity is named by DID, which the serialized state a page probe reads does not carry. The original error is preserved as the new error's cause. The "State changed after matching requirements." case gets the same treatment.

No retries, sleeps, or new timeouts are added, and the existing bound is unchanged. This is only about what a failure reports.

The tests in packages/integration/test/shell-failure-reports.test.ts drive a real browser against a local server that serves the toolshed's 502 text page, the shell's own document, and a booted shell, and check each rendered failure block. The file covers `shell-page-probe.ts` and `describeStateWaitFailure` in `shell-utils.ts` together, since they need the same browser and server, which is why it takes a kebab-case name rather than the name of one source file. Every assertion was checked against deliberately broken production code: with the root-element check removed from `assertShellDocument`, the navigation-response status never read, and the console tail never collected, the tests that pin those facts fail, and they fail for the reason expected rather than merely exiting non-zero.

The documentation of the `waitForState` poll in
docs/development/waiting-in-tests.md now records what its failure carries and what the navigation check does.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

