### PR TITLE
docs(common): an agent's entry to the verb surface

### DIFF
--- a/docs/common/README.md
+++ b/docs/common/README.md
@@ -92,8 +92,10 @@ on the Common Fabric runtime.
 ### verbs/ — driving a deployed piece through `cf`
 
 Read in this order: what a verb hands back, then a whole session using it,
-then where an author's words go.
+then where an author's words go. Arriving without a piece id, start with the
+agent's entry instead.
 
+- [verbs/agents-over-the-cli.md](verbs/agents-over-the-cli.md) — reaching a piece with no id in hand: the discovery surfaces and what bounds each, orienting on an unfamiliar piece, and the conclusions an empty answer does not support
 - [verbs/over-the-cli.md](verbs/over-the-cli.md) — what a verb hands back: declared results, piece references, idempotent retries, and a runnable walkthrough
 - [verbs/session-walkthrough.md](verbs/session-walkthrough.md) — a whole session driven through `cf`: discovery, help, completion, refusals, and carrying an address from one call into the next. Its companion script under `packages/cli/integration/` runs every step
 - [verbs/prose-over-the-cli.md](verbs/prose-over-the-cli.md) — how an author's doc comments reach a caller, and which of the two documents `cf` reads carries what

--- a/docs/common/verbs/agents-over-the-cli.md
+++ b/docs/common/verbs/agents-over-the-cli.md
@@ -1,0 +1,198 @@
+# An agent over the CLI
+
+Its three siblings all begin with a piece id already in hand. This one is about
+getting one, and about what an answer is worth once you have it.
+
+That is the shape of an agent's problem rather than a person's. A person opens a
+space in the shell and sees what is in it; an agent gets a space name and a key,
+and every command it can run takes a `--piece` it does not yet have. The
+commands that close that gap exist and are current — this collects them, names
+what bounds each one, and states the conclusions a caller is not entitled to
+draw from them.
+
+Read [Verbs over the CLI](over-the-cli.md) for what a verb hands back, and
+[the session walkthrough](session-walkthrough.md) for the surface measured
+end to end. [`skills/cf/SKILL.md`](../../../skills/cf/SKILL.md) is the command
+map, including the `--select` / `--schema` / `--filter` grammar this document
+uses without restating.
+
+## Arriving cold
+
+Five ways to reach a piece, each bounded by something different:
+
+| Starting from | Command | Bounded by |
+| --- | --- | --- |
+| the space itself | `cf piece ls` | the piece registry |
+| a name someone assigned | `cf piece slugs` | the slug index |
+| text you expect to be in the data | `cf piece search <query>` | registered pieces, matched client-side |
+| a convention a pattern publishes | `cf wish <target>` | the collection that target names |
+| an address you were handed | `--piece <reference>` | nothing — this is not discovery |
+
+All but the last are partial views, and they are partial in different
+directions, so an empty result from one says nothing about the others.
+[Finding pieces](../concepts/piece-discovery.md) is the full account of the
+boundaries. One consequence is worth carrying into every session:
+
+> **A piece created inside a handler is not registered.** Top-level creation
+> normally registers a piece through the default pattern's `addPiece` handler;
+> instantiating a child pattern does not register the child. So `cf piece ls`
+> and `cf piece search` do not see the items a board created, however many
+> there are.
+
+The collection that holds those pieces is the discovery path for them — read
+the board and follow its links, or read the index the pattern publishes for
+exactly this purpose. Substituting `cf piece ls` for a pattern's own listing is
+the single most common way to conclude a space is empty when it is not.
+
+`cf wish` reaches collections a pattern publishes by convention rather than the
+registry: `#pieceRegistry` resolves the registry itself, `#mentionable`,
+`#favorites`, and `#recent` resolve the collections of those names, and the
+`#profile` family resolves against the identity's home space. It takes the same
+projection flags as `cf get`, so a survey can be narrowed on the way out.
+
+## Orienting on one piece
+
+`cf piece describe` is the first call to make against an unfamiliar piece. It
+prints the piece's man page — what it is, what it holds, what a caller supplies,
+and what it can do — with every sentence compiled from the pattern's own doc
+comments:
+
+```bash
+cf piece describe --piece <piece>
+```
+
+```text
+NAME    Donut counter
+PATTERN cf:module/ZPxyGdkkv-YmizdHdNx5DIlqlpc9JRSm5iXTl4Tb2T0#default (/counter.tsx)
+
+  Counts donuts by glaze. State changes only through verbs.
+
+STATE
+  glazes  GlazeOutput[]
+
+INPUTS
+  glazes  GlazeOutput[]
+
+VERBS
+  addGlaze
+      Record a glaze nobody has counted yet.
+```
+
+`--json` returns the same content as data. `--all` adds the wrapper-tier and
+deprecated verbs the default view hides; hidden verbs stay callable either way.
+
+Three reads form a narrowing ladder, and each answers a question the one above
+it does not:
+
+| Read | Returns |
+| --- | --- |
+| `cf piece describe` | the whole piece in prose — purpose, state, inputs, one summary line per verb |
+| `cf piece verbs --json` | every verb's input schema, and its result schema where it declares one |
+| `cf call <verb> --help --json` | one verb, in full |
+
+`describe` is where to start and rarely where to stop: it summarizes each verb
+in a line and does not carry the schema a payload has to satisfy. Build a
+payload from the `verbs` listing or from a verb's own help page, both of which
+report the schema the dispatcher will judge the payload against.
+
+## Which pattern you are actually talking to
+
+The `PATTERN` line on a `describe` page, and the source identity on a
+`cf piece verbs` listing, name the pattern the deployed piece is running.
+
+That line is what makes every other claim checkable. A piece runs whatever
+source was last deployed to it, which may be older than the checkout in front of
+you and older than any guide describing it. An older pattern silently discards
+fields its schema does not declare, returns nothing from a verb that now returns
+a record, and may not carry a computed field a caller intends to read.
+
+**Establish which pattern a piece is running before the first mutation, not
+after.** A create against an unexpected version can leave a piece you then
+cannot address, and no later read recovers what was discarded on the way in.
+
+## Acting
+
+Once a piece is in hand, [Verbs over the CLI](over-the-cli.md) is the whole
+story. Three of its properties are the ones that shape how an agent structures a
+run:
+
+**Mint one invocation session per run, and name your mutations.**
+
+```bash
+export CF_INVOCATION_SESSION=$(cf invocation-session new)
+cf call --piece <piece> --invocation add-glaze-1 addGlaze '{"name":"maple"}'
+```
+
+Replaying that id within that session returns the original result and writes
+nothing a second time, which is what makes a retry safe when a response was
+never seen. A refused call never spends its id, so a corrected payload reuses
+it.
+
+**Carry addresses forward instead of searching again.** A verb that creates
+something can hand back the piece it created; `--show-links` adds the address of
+each document behind the result, and `--piece` takes such an address exactly as
+emitted. Filing a thing and then searching a collection for it is a guess the
+moment two callers write concurrently.
+
+**Collect outcomes by address.** Every settled call carries a `receipt` — the
+address of the cell the handling wrote its outcome to. Reading it back is an
+ordinary read, so it does not run the verb body again. Prefer it to a replay for
+any verb that reaches outside its own space.
+
+## What a negative answer is worth
+
+Every command here can return an empty or absent answer for a reason other than
+the one a caller expects. These are the conclusions the surface does not support:
+
+**An empty verb listing is not proof that no such verb exists.** A handler whose
+stored schema carries no stream marker is callable but not listed, and a listing
+whose compiled pattern could not be read reports `incomplete` rather than
+passing a short list off as the surface. Absence from a listing that reports no
+`incomplete` means no *listable* verb of that name — enough to enumerate
+against, not enough to prove a named verb does not exist.
+
+**An absent `result` is not a failed write.** A verb that declares a result
+hands one back where the channel carrying it is enabled; where a plain record is
+absent, the option was turned off and the verb still performed its write. Treat
+an absent result as "not enabled here", never as "the mutation did not land". A
+verb returning an empty record is indistinguishable from one returning nothing,
+so a pattern that needs the distinction declares at least one field.
+
+**Two different addresses are not two pieces.** Addresses are many-to-one over
+cells, and two positions holding one piece can render different addresses. Feed
+an address into the next command rather than comparing it to another. Whether
+two addresses name the same piece is not a question the CLI answers today.
+
+**A receipt witnesses the commit, not the execution.** A replay runs the handler
+body again and then loses the race for the receipt, so nothing commits twice —
+but anything the body did outside that transaction happened twice. A verb that
+sends mail or spends a model call is not made idempotent by an invocation id.
+
+**A read that exits nonzero is not an empty value.** A result read whose
+required values have not materialized reports that stored data is present and
+points at `--step`; a projection that cannot render says so and states that it
+is not JSON `null`. A printed `null` is a projected null or an absent optional
+source — never proof of no matches.
+
+**An unregistered piece is not a missing piece.** Covered above, and repeated
+here because it is the failure that reads most like a definitive answer: `ls`
+and `search` returning nothing is consistent with a space full of pieces created
+inside handlers.
+
+## Building a domain guide on this
+
+A guide to one pattern — how to run workstreams on a tracker, how to file
+against a board — refers here for mechanism and states its own consequences.
+The test for a line in such a guide:
+
+> Could this sentence be true of a different pattern?
+
+Where it could, the sentence belongs in this tree and the domain guide links it.
+Where it names a verb, a field, a deployed instance, or a team convention, the
+domain guide owns it and nothing here can know it.
+
+That puts the general rules above in the domain guide as *named consequences*
+rather than as summaries: not "computed reads need `--step`" but which fields on
+this pattern are computed; not "retries are safe" but what a double call would
+do to this board. A pattern's own README carries its verbs and contract; a
+domain guide carries the deployed instance and the conventions around it.

--- a/docs/common/verbs/agents-over-the-cli.md
+++ b/docs/common/verbs/agents-over-the-cli.md
@@ -33,11 +33,13 @@ directions, so an empty result from one says nothing about the others.
 [Finding pieces](../concepts/piece-discovery.md) is the full account of the
 boundaries. One consequence is worth carrying into every session:
 
-> **A piece created inside a handler is not registered.** Top-level creation
-> normally registers a piece through the default pattern's `addPiece` handler;
-> instantiating a child pattern does not register the child. So `cf piece ls`
-> and `cf piece search` do not see the items a board created, however many
-> there are.
+> **A piece created inside a handler is not registered automatically.**
+> Registration happens by sending the piece to the default pattern's `addPiece`
+> handler, which a handler can do deliberately
+> ([adding pieces](../conventions/adding-pieces.md)) and which instantiating a
+> child pattern does not do on its own. So `cf piece ls` and `cf piece search`
+> may not see the items a board created, however many there are — whether they
+> do is the pattern author's decision, not something the listing reports.
 
 The collection that holds those pieces is the discovery path for them — read
 the board and follow its links, or read the index the pattern publishes for
@@ -87,13 +89,19 @@ it does not:
 | Read | Returns |
 | --- | --- |
 | `cf piece describe` | the whole piece in prose — purpose, state, inputs, one summary line per verb |
-| `cf piece verbs --json` | every verb's input schema, and its result schema where it declares one |
+| `cf piece verbs --json` | each shown verb's input schema, and its result schema where it declares one |
+| `cf piece verbs --json --all` | the same, plus the wrapper-tier and deprecated verbs the default view withholds |
 | `cf call <verb> --help --json` | one verb, in full |
 
 `describe` is where to start and rarely where to stop: it summarizes each verb
 in a line and does not carry the schema a payload has to satisfy. Build a
 payload from the `verbs` listing or from a verb's own help page, both of which
 report the schema the dispatcher will judge the payload against.
+
+**Both listings hide wrapper-tier and deprecated verbs by default**, and both
+say so rather than hiding them silently: `--json` carries a `hidden` object
+counting what it withheld, and the human view prints the same counts as a note.
+Hidden verbs stay callable. `--all` is what makes either listing exhaustive.
 
 ## Which pattern you are actually talking to
 
@@ -144,12 +152,18 @@ any verb that reaches outside its own space.
 Every command here can return an empty or absent answer for a reason other than
 the one a caller expects. These are the conclusions the surface does not support:
 
-**An empty verb listing is not proof that no such verb exists.** A handler whose
-stored schema carries no stream marker is callable but not listed, and a listing
-whose compiled pattern could not be read reports `incomplete` rather than
-passing a short list off as the surface. Absence from a listing that reports no
-`incomplete` means no *listable* verb of that name — enough to enumerate
-against, not enough to prove a named verb does not exist.
+**An empty verb listing is not proof that no such verb exists.** A listing can
+be short in three ways. A handler whose stored schema carries no stream marker
+is callable but not listed at all. A listing whose compiled pattern could not be
+read reports `incomplete` rather than passing a short list off as the surface.
+And the default view withholds wrapper-tier and deprecated verbs, reporting the
+count under `hidden`. Only the third is recoverable — `--all` lists those rows;
+nothing recovers a verb the pattern could not be read to name.
+
+So enumerate against a listing that reports **neither `incomplete` nor
+`hidden`**, or against `--all`. Even then it means no *listable* verb of that
+name, which is enough to work from and not enough to prove a named verb does not
+exist.
 
 **An absent `result` is not a failed write.** A verb that declares a result
 hands one back where the channel carrying it is enabled; where a plain record is
@@ -171,13 +185,15 @@ sends mail or spends a model call is not made idempotent by an invocation id.
 **A read that exits nonzero is not an empty value.** A result read whose
 required values have not materialized reports that stored data is present and
 points at `--step`; a projection that cannot render says so and states that it
-is not JSON `null`. A printed `null` is a projected null or an absent optional
-source — never proof of no matches.
+is not JSON `null`. A printed `null` has several origins — a projected null, an
+absent optional source, or a wish run under `--allow-empty`, which prints `null`
+and exits 0 where it would otherwise error — and no caller can tell them apart
+from the output. Read it as "no value here", never as proof of no matches.
 
 **An unregistered piece is not a missing piece.** Covered above, and repeated
 here because it is the failure that reads most like a definitive answer: `ls`
-and `search` returning nothing is consistent with a space full of pieces created
-inside handlers.
+and `search` returning nothing is consistent with a space full of pieces whose
+creating handler never sent them to `addPiece`.
 
 ## Building a domain guide on this
 

--- a/docs/common/verbs/over-the-cli.md
+++ b/docs/common/verbs/over-the-cli.md
@@ -10,6 +10,9 @@ sequence of "mutate, then go looking for what happened" into a single
 exchange — and the thing a verb hands back can be a **piece**, so a create tells
 you where the thing it created lives.
 
+Every command here takes a `--piece` the caller already holds. Reaching one
+without an id in hand is [an agent over the CLI](agents-over-the-cli.md).
+
 For the authoring side, see [concepts/action.md](../concepts/action.md) and
 [concepts/handler.md](../concepts/handler.md); for the general CLI loop, see
 [workflows/development.md](../workflows/development.md).

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -147,13 +147,13 @@ See `docs/development/EXPERIMENTAL_OPTIONS.md` for available flags.
 | Set field          | `echo '{"data":...}' \| deno task cf set --piece ID path ...`                                                                |
 | Call handler       | `deno task cf call --piece ID handlerName ...`                                                                               |
 | Shape a result     | `deno task cf call --piece ID --select topic.title addTopic ...`                                                             |
-| List verbs         | `deno task cf piece verbs --piece ID --json ...`                                                                             |
+| List verbs         | `deno task cf piece verbs --piece ID --json ...` (`--all` adds wrapper/deprecated; `hidden` counts them)                     |
 | Trigger recompute  | `deno task cf piece step --piece ID ...`                                                                                     |
 | Mint a session     | `export CF_INVOCATION_SESSION="$(deno task cf invocation-session new)"` (once per run; ids deduplicate only within it)       |
 | Replayable call    | `deno task cf call --piece ID --invocation my-id-1 handlerName ...` (same pair retries settle on the original outcome)       |
 | Detached call      | `deno task cf call --piece ID --no-wait --invocation my-id-1 handlerName ...` (exits at commit with `receipt` address)       |
 | Collect a receipt  | `deno task cf get --piece <receipt> ...` (the envelope's `receipt` string, later, from any process)                          |
-| List pieces        | `deno task cf piece ls -i key -a url -s space` (registry only — a piece created inside a handler is absent)                  |
+| List pieces        | `deno task cf piece ls -i key -a url -s space` (registry only — a handler-created piece appears only if sent to `addPiece`)  |
 | Describe a piece   | `deno task cf piece describe --piece ID ...` (name, purpose, state, inputs, verbs; `--json`, `--all`)                        |
 | List slugs         | `deno task cf piece slugs ...`                                                                                               |
 | Search piece data  | `deno task cf piece search <query> ...` (registered pieces only)                                                             |

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -153,7 +153,10 @@ See `docs/development/EXPERIMENTAL_OPTIONS.md` for available flags.
 | Replayable call    | `deno task cf call --piece ID --invocation my-id-1 handlerName ...` (same pair retries settle on the original outcome)       |
 | Detached call      | `deno task cf call --piece ID --no-wait --invocation my-id-1 handlerName ...` (exits at commit with `receipt` address)       |
 | Collect a receipt  | `deno task cf get --piece <receipt> ...` (the envelope's `receipt` string, later, from any process)                          |
-| List pieces        | `deno task cf piece ls -i key -a url -s space`                                                                               |
+| List pieces        | `deno task cf piece ls -i key -a url -s space` (registry only — a piece created inside a handler is absent)                  |
+| Describe a piece   | `deno task cf piece describe --piece ID ...` (name, purpose, state, inputs, verbs; `--json`, `--all`)                        |
+| List slugs         | `deno task cf piece slugs ...`                                                                                               |
+| Search piece data  | `deno task cf piece search <query> ...` (registered pieces only)                                                             |
 | Visualize          | `deno task cf piece map ...`                                                                                                 |
 | Rehearse an update | `deno task cf space clone <did> --from <snapshot> --to <dir>` (then `verify` / `reset`)                                      |
 
@@ -466,6 +469,9 @@ mounts; auto-discovered spaces may appear writable but silently drop writes.
 
 ## References
 
+- `docs/common/verbs/agents-over-the-cli.md` - Reaching a piece with no id in
+  hand: what bounds each discovery surface, and what an empty answer does not
+  prove
 - `docs/common/verbs/over-the-cli.md` - The verb walkthrough: invocation ids and
   sessions, receipts, retries, and shaped reads, each step runnable
 - `packages/patterns/system/default-app.tsx` - System pieces (pieceRegistry


### PR DESCRIPTION
## Why

The three documents under `docs/common/verbs/` all open with a `--piece` the
caller already holds. An agent does not have one. It gets a space name and a
key, and every command it can run takes an id it has yet to find — so the
existing docs start one step past where an agent actually stands.

The commands that close that gap exist and are current, but they are scattered
and, in two cases, effectively undiscoverable:

- `cf piece describe` — the most agent-shaped command in the CLI (name,
  purpose, state, inputs, verbs; `--json`, `--all`) — had **zero** mentions in
  `skills/cf/SKILL.md` and one quoted line in the walkthrough.
- `cf piece slugs` and `cf piece search` had zero mentions in the skill.
- `docs/common/concepts/piece-discovery.md` documents the *boundaries* (what
  cannot be enumerated) but is a limits doc, not a how-to-look doc, and nothing
  in `verbs/` linked to it.

The second gap is epistemic rather than mechanical. Each sibling doc carries one
rule about what an answer is *not* worth — an empty verb listing is not proof of
absence, an absent `result` is not a failed write, two differing addresses are
not two pieces — one per file, none collected. Those are the claims a confident
agent gets wrong, and they are the ones most worth having in one place.

## What Changed

New `docs/common/verbs/agents-over-the-cli.md`, in five sections with stable
anchors so a per-pattern guide can link them rather than paraphrase:

1. **Arriving cold** — the five entry points and what bounds each, with the
   consequence pulled out: a piece created inside a handler is not registered,
   so `cf piece ls` is not a pattern's own listing.
2. **Orienting on one piece** — `describe` first, then the narrowing ladder
   `describe` → `verbs --json` → `call --help --json`, and why `describe` alone
   is not enough to build a payload.
3. **Which pattern you are actually talking to** — the `PATTERN` line, and why
   it is checked before the first mutation rather than after.
4. **Acting** — invocation sessions, carrying addresses forward, collecting by
   receipt; pointers into `over-the-cli.md` rather than a second copy of it.
5. **What a negative answer is worth** — six rules the surface does not support
   concluding past.

A closing section states the rule for guides built on top of this — refer for
the mechanism, restate for the consequence — so the next per-pattern document
has the test written down instead of rediscovering it.

Wiring: an index entry and read-order line in `docs/common/README.md`, a
pointer from `over-the-cli.md`, and in `skills/cf/SKILL.md` rows for
`describe` / `slugs` / `search`, the registry caveat on the `piece ls` row, and
a References entry.

## Test plan

Facts were taken from the CLI and its source rather than from the neighboring
docs: discovery flags from each `--help`; the `describe` output shape from
`pieceDescribeLines` (`packages/cli/commands/piece.ts`); the search boundary
from `searchPieces` (`packages/cli/lib/piece.ts`); the two `--step` diagnostics
from `PieceResultProjectionError` and the `CellSelectionError` beside it.

Gates, and what each one actually covers here:

| Gate | Result | Covers this change? |
| --- | --- | --- |
| `check-skill-facts` | pass | **Yes** — mutation-tested: breaking the newly cited path turns it red |
| `check-docs` | pass | No — the new blocks are `bash`/`text`, so it contributes none |
| `check-verb-session-sync` | pass | No — the gate hardcodes `session-walkthrough.md` |
| `deno fmt --check` | pass on the skill | Partial — `docs/` is in the `fmt` exclude list |
| all relative links in the new doc | resolve | — |

**Known gap, deliberate:** the `cf` commands in this document are ungated — the
only file in `verbs/` where that is true. Backing them with steps in
`packages/cli/integration/verb-session-gaps.sh` is the follow-up; leaving it out
of this PR is a scoping decision, not an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

