### PR TITLE
feat(dashboard): report the whole GitHub bill, not just Actions

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -313,7 +313,7 @@ surveillance tool.
 | common.tools | synthetic HTTP check of the public site | `COMMON_TOOLS_URL` (optional; defaults to `https://common.tools`) |
 | prod errors | SigNoz trace error rate for one service (errored spans / all spans): last-12h headline, with a per-hour sparkline over the retained trace history (~2 weeks) and the last-12h slice that feeds the headline highlighted. Scoped to `PROD_SERVICE` — the same SigNoz holds staging and one-off perf runs, whose rates are not production's. Gray (not red) when SigNoz is unreachable. Pops out to the SigNoz logs explorer | `SIGNOZ_URL`, `SIGNOZ_API_KEY`; optional `PROD_SERVICE`, `SIGNOZ_UI_URL` for the pop-out |
 | cloud spend | BigQuery billing export, after credits, projected to month-end from the available part of a 14-day daily-cost window early in the month. The header shows actual MTD spend. The highlighted part of the 45-day chart shows the days used for the estimate | `GCP_BILLING_TABLE` (+ Workload Identity, or `GCP_SA_KEY` locally), optional `GCP_DAILY_BUDGET` |
-| ci spend | GitHub Actions billing, projected to month-end in USD. The 45-day chart labels the line with MTD spend, and the header shows the same total. A report that stopped being written more than four days ago is unavailable rather than a run of $0 days. A month whose report cannot be read breaks the line across those days rather than charting them as $0 | `GH_TOKEN` (with org billing read); optional `GH_BILLING_ORG` |
+| github spend | the organization's whole metered GitHub bill, projected to month-end in USD: every product its billing report carries, added into one figure. The 45-day chart labels the line with MTD spend, and the header shows the same total. A report that stopped being written more than four days ago is unavailable rather than a run of $0 days. A month whose report cannot be read breaks the line across those days rather than charting them as $0. "What the GitHub figure covers" below says which spend reaches the API | `GH_TOKEN` (with org billing read); optional `GH_BILLING_ORG` |
 | benchmarks | a scale-invariant index of benchmark performance on `benchmarks.yml` main runs, trended over ~45 days (each run vs the last, geometric mean of per-benchmark changes, so every benchmark weighs the same, divided by the same run's machine calibration so a busy host does not read as a code change): red when the most recent run failed or produced no valid data (the main signal), orange only on a broad across-the-board rise from a CPU measured in the preceding twelve hours. Adding or removing a benchmark is a non-event. Drills through to the per-benchmark history | `GH_TOKEN` |
 | performance history → `/bench?view=runtime` | runtime benchmark trends, labs or loom CI duration history, and a detailed CI run Gantt. Historical views support windows from 1 through 45 days, date axes, and duration sorting. CI includes end-to-end workflow time, every job, and slowest-shard group lines | `GH_TOKEN` |
 | model spend | OpenAI + Anthropic + OpenRouter usage APIs. Headline is the projected full-month spend (extrapolated from the recent daily rate, spilling into last month when this month is under two weeks old), summed across providers. OpenAI and Anthropic (which expose per-day cost) are charted as one line each over ~45 days, with a recent daily-rate slice highlighted and each line's MTD in the right gutter; OpenRouter (monthly total only, abbreviated "OR") is folded into the totals. The subtitle is the bullet-separated key (`OpenAI • Anthropic • OR $0`); the combined MTD sits in the header (the `aside` slot); the span the chart covers is in its bottom-left corner (the `duration` slot). A provider we can't read shows `$???` and drops the tile to gray, but the rest still chart and total; a provider whose cost report stopped being written more than four days ago is one of those | any of `OPENAI_ADMIN_KEY`, `ANTHROPIC_ADMIN_KEY`, `OPENROUTER_KEY`; optional `MODEL_MONTHLY_BUDGET` |
@@ -331,6 +331,59 @@ runs. Each duration starts when GitHub creates the workflow run for the landed
 commit and ends when that run finishes, so it includes runner queueing and
 reruns.
 
+### What the GitHub figure covers
+
+The **github spend** tile reads the organization's billing usage report, which
+carries one row per product, SKU, repository and day. The tile adds up every
+row, so the figure is the organization's whole metered GitHub bill rather than
+any one product's share of it. GitHub meters these products, and a product the
+organization does not use simply has no row:
+
+| product | what it bills for |
+|---|---|
+| `actions` | workflow minutes on every runner size, plus Actions and cache storage |
+| `packages` | Packages storage and bandwidth |
+| `codespaces` | Codespaces compute, storage, and prebuild storage |
+| `git_lfs` | Git LFS storage and bandwidth |
+| `copilot` | Copilot seats (`copilot_for_business`, `copilot_enterprise`, `copilot_standalone`) and the AI credits Copilot consumes |
+| `ghec` | GitHub Enterprise Cloud seat licenses (`ghec_licenses`) |
+| `ghas` | Advanced Security seat licenses, whole and by tier |
+| `models` | model inference |
+| `sandbox` | Copilot sandbox compute, memory, and snapshots |
+| `spark` | Spark AI credits |
+
+Seat licenses arrive as billed dollars in that same report, so Copilot seats
+and Enterprise Cloud licenses are inside the figure without any per-seat price
+having to be configured here.
+
+One caveat applies to the projection rather than to the figure. GitHub dates
+every row by the day the usage occurred, and the month-end projection carries
+the recent daily rate across the remaining days, which suits spend that accrues
+daily. A charge posted as a single lump instead of as a daily series would be
+carried across the month as though it recurred, overstating the projection
+while leaving month-to-date correct. No such charge has been observed here, and
+seat licenses are the products to watch for one: compare the headline with the
+month-to-date total beside it the first month a seat-licensed product appears.
+
+What the API does not expose, and the figure therefore excludes:
+
+- **A subscription billed outside the usage report.** An organization's plan
+  reaches the API only when its licensing is metered, as `ghec_licenses` rows.
+  An organization billed for its plan as a flat subscription — a **Team** plan,
+  which has no product or SKU of its own at all, or an **Enterprise** plan whose
+  licensing has not moved to metered billing — has no row for it, and its
+  seat cost is absent from the figure. `orgs/{org}` reports the seat counts
+  (`plan.name`, `plan.seats`, `plan.filled_seats`) but never a price, so there
+  is nothing to add up from.
+- **Anything billed at the enterprise account rather than the organization.**
+  The usage report is scoped to one organization. An enterprise account's own
+  report is a separate endpoint under `enterprises/{enterprise}`, needs
+  enterprise-level administration, and is not read here.
+
+Both gaps are silent: the figure is a true total of what GitHub reports, not a
+total of what GitHub charges. Check it against the billing page the tile links
+to before treating it as the whole bill.
+
 ## Credentials
 
 Every tile that reads a private source is gated on its own env var(s) and grays
@@ -346,9 +399,9 @@ if you lose it you have to regenerate.
 ### `GH_TOKEN` (or `GITHUB_TOKEN`)
 
 Powers **labs ci**, **labs ci trust**, **labs ci duration**, the **loom**
-counterparts, **recent main runs**, **ci spend**, and **github users**. Needs repo
-**Actions: read** on both `commontoolsinc/labs` and `commontoolsinc/loom`; the
-github-ci-spend tile additionally needs org **Administration: read** on
+counterparts, **recent main runs**, **github spend**, and **github users**. Needs
+repo **Actions: read** on both `commontoolsinc/labs` and `commontoolsinc/loom`;
+the github-ci-spend tile additionally needs org **Administration: read** on
 `commontoolsinc`. The **github users** tile needs org **Members: read**. One
 fine-grained token can carry all of these permissions:
 
@@ -364,7 +417,7 @@ organization member; other callers see only public memberships.
    and `commontoolsinc/loom`.
 4. **Repository permissions**: set **Actions** and **Contents** to **Read-only**.
 5. **Organization permissions**: set **Members** to **Read-only** for GitHub
-   users. Set **Administration** to **Read-only** for ci spend. Only an org
+   users. Set **Administration** to **Read-only** for github spend. Only an org
    owner or billing manager can grant the latter permission. Skip either
    permission when its tile is not needed.
 6. **Generate token** and copy it (`github_pat_…`, shown once).
@@ -372,7 +425,7 @@ organization member; other callers see only public memberships.
 If you only need the labs CI tiles, keep `commontoolsinc` as the resource owner,
 select only `commontoolsinc/labs`, and grant Actions/Contents read without any
 organization permissions. Classic PATs also work (use `read:org` for GitHub
-users and `admin:org` for ci spend). If the org requires approval for
+users and `admin:org` for github spend). If the org requires approval for
 fine-grained tokens, yours stays pending until an owner approves it.
 
 ### `SIGNOZ_URL` + `SIGNOZ_API_KEY`
@@ -545,7 +598,7 @@ it.
 
 | env var | tile | purpose |
 |---|---|---|
-| `GH_BILLING_ORG` | ci spend | org login for billing (default: the org from `DASHBOARD_REPO` — `commontoolsinc`). |
+| `GH_BILLING_ORG` | github spend | org login for billing (default: the org from `DASHBOARD_REPO` — `commontoolsinc`). |
 | `MODEL_MONTHLY_BUDGET` | model spend | combined monthly USD budget across providers. |
 | `GCP_SA_KEY` | cloud spend | a service-account key JSON (the whole file, as the value) for local development; in GKE, Workload Identity supplies the token and this is unset. |
 | `GCP_DAILY_BUDGET` | cloud spend | daily USD budget. The projected month is compared with this daily rate multiplied by the number of days in the month. |
@@ -594,15 +647,27 @@ Notes:
   read. A second token would not reduce exposure because the process would hold
   both, so there is just one. With Actions read alone, those two tiles gray out
   and the other GitHub tiles still work.
-- **`ci spend`** shows the **projected** full-month GitHub Actions total. Its
-  recent daily rate uses at least two weeks and reaches into last month early in
-  a month. Spend is net of discounts and included usage. The projection is
-  compared with the Actions budget configured in GitHub. A missing budget
-  leaves the projection uncompared. A source that has stopped reporting turns
-  the tile gray. The billing report is one pipeline across every product the
-  organization uses, so any product's row dates it. Four days without a row is
-  a stopped feed rather than a slow one. A classic-plan organization falls back
-  to minutes against its included allowance.
+- **`github spend`** shows the **projected** full-month GitHub total. Its recent
+  daily rate uses at least two weeks and reaches into last month early in a
+  month. Spend is net of discounts and included usage. The projection is
+  compared with the organization's product budgets added together, which is
+  what it has authorized itself to spend. Only the budgeted products' share of
+  the projection goes into that comparison: a product with no budget of its own
+  is taken to be spending within one, so it counts toward the headline without
+  moving the color. The light therefore turns on the products someone actually
+  set a limit for, and taking up a product nobody has budgeted cannot redden
+  the tile on its own. The budget printed beside the headline covers the same
+  products the headline does — the budgets that exist, plus each unbudgeted
+  product's own projection standing in for the budget it lacks — so the
+  headline sits at or under it exactly when the tile is green. Printing the
+  configured total alone would show a headline above its budget on a green
+  tile. An organization with no product budget at all leaves the projection
+  uncompared. A
+  source that has stopped reporting turns the tile gray. The billing report is
+  one pipeline across every product the organization uses, so any product's row
+  dates it. Four days without a row is a stopped feed rather than a slow one. A
+  classic-plan organization falls back to minutes against its included
+  allowance.
 - **`benchmarks`** trends one **scale-invariant index per CPU** on the
   `benchmarks.yml` runs on main over ~45 days. The job runs `deno bench --json`
   over the bench files that workflow lists — micro-benchmarks across the runner,
@@ -895,9 +960,9 @@ Local-first: no build step, no deployment, a single process on `localhost`.
 
 Env knobs for the dev loop:
 
-- `GH_TOKEN` (or `GITHUB_TOKEN`) — required for the GitHub tiles. CI spend also
-  needs Administration read. GitHub users also needs Members read. Without the
-  token, those tiles stay gray.
+- `GH_TOKEN` (or `GITHUB_TOKEN`) — required for the GitHub tiles. GitHub spend
+  also needs Administration read. GitHub users also needs Members read. Without
+  the token, those tiles stay gray.
 - `DASHBOARD_PORT` — run several instances at once (e.g. one per branch) without clashing.
 - `DASHBOARD_REPO` — point the CI tiles at any repo. Its owner selects the
   organization for GitHub users.
@@ -975,7 +1040,7 @@ its embedded tsnet).
    ```
    The GitHub token is fine-grained and read-only. It has Actions read for the
    dashboard repositories. The GitHub users tile also needs org Members read;
-   CI spend also needs org Administration read.
+   GitHub spend also needs org Administration read.
 3. The infra manifests create separate 1 Gi `standard-rwo` PVCs for the Discord
    history file and Tailscale node state. The dashboard remains a one-replica
    `Recreate` Deployment; pod replacement reuses the same non-ephemeral

--- a/packages/dashboard/registry.ts
+++ b/packages/dashboard/registry.ts
@@ -29,7 +29,7 @@ export const TILES: Tile[] = [
   labsCiTrust,
   labsCiDuration,
   benchmark,
-  // Row 2: loom CI family + ci spend
+  // Row 2: loom CI family + github spend
   loomCi,
   loomCiTrust,
   loomCiDuration,

--- a/packages/dashboard/tiles/github-ci-spend.test.ts
+++ b/packages/dashboard/tiles/github-ci-spend.test.ts
@@ -406,6 +406,29 @@ Deno.test("github spend: a product with no budget of its own never trips the lig
   assertStringIncludes(budgeted.extra ?? "", "Budget $500");
 });
 
+Deno.test("github spend: an undated row weighs on the comparison as it does on the headline", async () => {
+  // A row the report dates unreadably still names an amount, and the headline
+  // counts it. A budgeted product's undated row has to reach the comparison
+  // too, or spend would go into the figure while staying out of the ceiling it
+  // is measured against, and the tile would read greener than the spend is.
+  const v = await view("2026-01-20T09:00:00Z", {
+    [usagePath(2026, 1)]: {
+      usageItems: [
+        ...days(2026, 1, 1, 10, 18), // $180, dated
+        item("", 100), // Actions again, with no readable date
+        stillReporting("2026-01-18"),
+      ],
+    },
+    [budgetsPath()]: { budgets: [productBudget("actions", 400)] },
+  });
+  // $280 over the 18 settled days across 31, in the headline and against the
+  // budget alike. Counting only the dated $180 would project $310 and pass.
+  assertEquals(v.value, "~$482/mo");
+  assertEquals(v.aside, '<span class="hmtd">$280 MTD</span>');
+  assertEquals(v.status, "warn"); // $482 of a $400 Actions budget
+  assertStringIncludes(v.extra ?? "", "Budget $400");
+});
+
 Deno.test("github spend: the headline sits under the shown budget exactly when the tile is green", async () => {
   // The color comes from the budgeted products while the headline carries
   // every product, so the two are only readable together if the ceiling shown

--- a/packages/dashboard/tiles/github-ci-spend.test.ts
+++ b/packages/dashboard/tiles/github-ci-spend.test.ts
@@ -1,5 +1,5 @@
 /**
- * ci spend tests. The tile is a pure collect(ctx) -> TileView over GitHub
+ * github spend tests. The tile is a pure collect(ctx) -> TileView over GitHub
  * billing data. The tests pin the clock and provide fixed responses.
  */
 
@@ -23,6 +23,7 @@ const pad = (n: number) => String(n).padStart(2, "0");
 // One row of the enhanced billing platform's usage report. The report splits a
 // product across SKUs and repos and carries a row only for a day with usage;
 // netAmount is the billable dollars, already net of the included allowance.
+// Every row counts toward the tile's figure, whatever product it names.
 const item = (date: string, netAmount: number, product = "actions") => ({
   date,
   product,
@@ -55,6 +56,16 @@ const days = (
 // whose rows stop days before today has stopped being written for all the tile
 // can tell, and the tile reads no further than the rows reach.
 const stillReporting = (date: string) => item(date, 0);
+
+// A budget over one product's whole spend, organization-wide: the only kind
+// the tile totals. A single-SKU budget sits inside one of these, and a budget
+// scoped below the organization caps part of its spend, so neither is added.
+const productBudget = (sku: string, amount: number) => ({
+  budget_type: "ProductPricing",
+  budget_product_sku: sku,
+  budget_scope: "organization",
+  budget_amount: amount,
+});
 
 const usagePath = (year: number, month: number, org = ORG) =>
   `organizations/${org}/settings/billing/usage?year=${year}&month=${month}`;
@@ -117,24 +128,25 @@ async function view(
   }
 }
 
-Deno.test("ci spend: without a token the tile is gray and names what it needs", async () => {
+Deno.test("github spend: without a token the tile is gray and names what it needs", async () => {
   const v = await githubCiSpend.collect(ctx({}));
+  assertEquals(v.label, "github spend");
   assertEquals(v.status, "unknown");
   assertEquals(v.value, "—");
   assertStringIncludes(v.sub ?? "", "GH_TOKEN");
   assertStringIncludes(v.sub ?? "", "org billing read"); // the extra right this tile needs
 });
 
-Deno.test("ci spend: a projection with no observed rate window preserves the measured total", () => {
+Deno.test("github spend: a projection with no observed rate window preserves the measured total", () => {
   assertEquals(projectMonthly(37, 0, 31, []), 37);
 });
 
-Deno.test("ci spend: projects the month from the settled daily rate, against the GitHub budget", async () => {
+Deno.test("github spend: projects the month from the settled daily rate, against the GitHub budget", async () => {
   // The 20th of a 31-day month. Actions spend of $17/day on the 1st-10th, plus a
-  // $10 row the report spells "Actions", is $180 month-to-date; the $500 of Copilot
-  // is a different product and none of the tile's business. The report is still
-  // being written through the 18th, so the days after the 10th are days that
-  // cost nothing.
+  // $10 row the report spells "Actions", plus $500 of Copilot, is $680
+  // month-to-date: every product the report bills for lands in the one figure.
+  // The report is still being written through the 18th, so the days after the
+  // 10th are days that cost nothing.
   const v = await view("2026-01-20T09:00:00Z", {
     [usagePath(2026, 1)]: {
       usageItems: [
@@ -147,20 +159,20 @@ Deno.test("ci spend: projects the month from the settled daily rate, against the
     [usagePath(2025, 12)]: { usageItems: days(2025, 12, 1, 31, 1) },
     [budgetsPath()]: {
       budgets: [
-        { budget_product_sku: "copilot", budget_amount: 5 },
-        { budget_product_sku: "actions", budget_amount: 2700 },
+        productBudget("copilot", 300),
+        productBudget("actions", 2700),
       ],
     },
   });
-  // $180 over the 18 settled days of the month (the 20th, less the 2-day billing
-  // lag), carried across all 31 -> $310. The quiet 11th-18th count; the unsettled
-  // 19th-20th do not.
-  assertEquals(v.value, "~$310/mo");
-  assertEquals(v.aside, '<span class="hmtd">$180 MTD</span>');
-  // The Actions budget, not the Copilot one that shares the response.
+  // $680 over the 18 settled days of the month (the 20th, less the 2-day billing
+  // lag), carried across all 31 -> $1171. The quiet 11th-18th count; the
+  // unsettled 19th-20th do not.
+  assertEquals(v.value, "~$1171/mo");
+  assertEquals(v.aside, '<span class="hmtd">$680 MTD</span>');
+  // Both products' budgets, since the figure they are held against covers both.
   assertEquals(v.sub, undefined);
-  assertStringIncludes(v.extra ?? "", "Budget $2700");
-  assertEquals(v.status, "good"); // $310 of a $2700 budget
+  assertStringIncludes(v.extra ?? "", "Budget $3000");
+  assertEquals(v.status, "good"); // $1171 of a $3000 budget
   assertEquals(
     v.href,
     "https://github.com/organizations/acme/settings/billing",
@@ -174,7 +186,7 @@ Deno.test("ci spend: projects the month from the settled daily rate, against the
   assertEquals(v.duration, 45 * D);
 });
 
-Deno.test("ci spend: a 200 without a usageItems array grays out rather than reading as $0", async () => {
+Deno.test("github spend: a 200 without a usageItems array grays out rather than reading as $0", async () => {
   // A permission-filtered view answers 200 with no usable report. Nothing was
   // measured, so nothing may be claimed — least of all a green "$0/mo".
   for (
@@ -195,7 +207,7 @@ Deno.test("ci spend: a 200 without a usageItems array grays out rather than read
   }
 });
 
-Deno.test("ci spend: a report that stopped days ago is unreadable, not a run of $0 days", async () => {
+Deno.test("github spend: a report that stopped days ago is unreadable, not a run of $0 days", async () => {
   // The report's newest row anywhere is the 10th, ten days before the tile
   // reads it. Reading the 11th onwards as days that cost nothing would take a
   // report that has stopped for a fortnight of thrift.
@@ -213,15 +225,37 @@ Deno.test("ci spend: a report that stopped days ago is unreadable, not a run of 
   );
 });
 
-Deno.test("ci spend: a quiet Actions week reads as $0 days while the report is written", async () => {
-  // Actions stops on the 10th, but the org's Copilot seats bill through the
-  // 18th. One pipeline writes both, so the report is current and the quiet
-  // Actions days are days Actions cost nothing.
+Deno.test("github spend: every metered product lands in the one GitHub figure", async () => {
+  // The seat licenses GitHub meters bill through this report alongside the
+  // usage-priced products, so Copilot seats and Enterprise Cloud licenses count
+  // toward the tile's figure exactly as Actions minutes and Codespaces do.
+  const v = await view("2026-01-20T09:00:00Z", {
+    [usagePath(2026, 1)]: {
+      usageItems: [
+        ...days(2026, 1, 1, 10, 18), // $180 of Actions
+        item("2026-01-15", 300, "copilot"), // Copilot seats
+        item("2026-01-15", 210, "ghec"), // Enterprise Cloud licenses
+        item("2026-01-16", 10, "codespaces"),
+        stillReporting("2026-01-18"),
+      ],
+    },
+  });
+  assertEquals(v.status, "good");
+  // $700 over the 18 settled days, carried across all 31.
+  assertEquals(v.value, "~$1206/mo");
+  assertEquals(v.aside, '<span class="hmtd">$700 MTD</span>');
+  assertStringIncludes(v.extra ?? "", "<polyline");
+});
+
+Deno.test("github spend: a quiet week reads as $0 days while the report is written", async () => {
+  // Spend stops on the 10th, but the report keeps being written through the
+  // 18th, so the days in between are days the org cost nothing rather than days
+  // with no figure.
   const v = await view("2026-01-20T09:00:00Z", {
     [usagePath(2026, 1)]: {
       usageItems: [
         ...days(2026, 1, 1, 10, 18),
-        item("2026-01-18", 500, "Copilot"),
+        stillReporting("2026-01-18"),
       ],
     },
   });
@@ -231,7 +265,7 @@ Deno.test("ci spend: a quiet Actions week reads as $0 days while the report is w
   assertStringIncludes(v.extra ?? "", "<polyline");
 });
 
-Deno.test("ci spend: a report with no row at all is an org that bills nothing here", async () => {
+Deno.test("github spend: a report with no row at all is an org that bills nothing here", async () => {
   // An empty report dates nothing, so there is no day to chart and no gap to
   // read as silence. It says the org has no billable usage, and the tile says
   // the same.
@@ -243,7 +277,7 @@ Deno.test("ci spend: a report with no row at all is an org that bills nothing he
   assertStringIncludes(v.extra ?? "", `${themedSwatch("#58a6ff")} GitHub $0`);
 });
 
-Deno.test("ci spend: no Actions budget in GitHub -> the projection stands, uncompared", async () => {
+Deno.test("github spend: no product budget in GitHub -> the projection stands, uncompared", async () => {
   const usage = {
     usageItems: [...days(2026, 1, 1, 10, 18), stillReporting("2026-01-18")],
   };
@@ -255,19 +289,154 @@ Deno.test("ci spend: no Actions budget in GitHub -> the projection stands, uncom
   assertEquals(none.sub, undefined);
   assertEquals((none.extra ?? "").includes("Budget"), false);
   assertEquals(none.status, "good"); // an absent budget never alarms
-  // The org budgets Actions' neighbors but not Actions.
-  const other = await view("2026-01-20T09:00:00Z", {
+  // The org's only budgets cap part of a product's spend rather than a whole
+  // product: one a single SKU, one a single repository, one a bundle spanning
+  // products. Totalling any of them against every product would compare the
+  // figure with a ceiling that was never set for it.
+  const partial = await view("2026-01-20T09:00:00Z", {
     [usagePath(2026, 1)]: usage,
     [budgetsPath()]: {
-      budgets: [{ budget_product_sku: "copilot", budget_amount: 5 }],
+      budgets: [
+        {
+          budget_type: "SkuPricing",
+          budget_product_sku: "actions_linux",
+          budget_scope: "organization",
+          budget_amount: 900,
+        },
+        {
+          budget_type: "ProductPricing",
+          budget_product_sku: "actions",
+          budget_scope: "repository",
+          budget_amount: 50,
+        },
+        {
+          budget_type: "BundlePricing",
+          budget_product_sku: "ai_credits",
+          budget_scope: "organization",
+          budget_amount: 20,
+        },
+      ],
     },
   });
-  assertEquals(other.sub, undefined);
-  assertEquals((other.extra ?? "").includes("Budget"), false);
-  assertEquals(other.status, "good");
+  assertEquals(partial.sub, undefined);
+  assertEquals((partial.extra ?? "").includes("Budget"), false);
+  assertEquals(partial.status, "good");
 });
 
-Deno.test("ci spend: a projection over budget goes amber, and well over goes red", async () => {
+Deno.test("github spend: a budget carrying no amount is no ceiling, not a $0 one", async () => {
+  // The endpoint answers with the budget's amount absent, null, or spelled as
+  // a string. Reading any of those as a number yields 0, and a $0 ceiling is
+  // one that every dollar of spend overruns — a red tile over a budget nobody
+  // set. The projection stands uncompared instead.
+  for (const budget_amount of [undefined, null, "", "2700", {}]) {
+    const v = await view("2026-01-20T09:00:00Z", {
+      [usagePath(2026, 1)]: {
+        usageItems: [...days(2026, 1, 1, 10, 18), stillReporting("2026-01-18")],
+      },
+      [budgetsPath()]: {
+        budgets: [{ ...productBudget("actions", 0), budget_amount }],
+      },
+    });
+    assertEquals(v.value, "~$310/mo");
+    assertEquals((v.extra ?? "").includes("Budget"), false);
+    assertEquals(v.status, "good");
+  }
+});
+
+Deno.test("github spend: one product budgeted twice sets one ceiling, not two", async () => {
+  // Two organization-wide budgets naming the same product cap that product
+  // once. Adding both would compare the projection with twice the ceiling that
+  // exists, and hide an overrun.
+  const v = await view("2026-01-20T09:00:00Z", {
+    [usagePath(2026, 1)]: {
+      usageItems: [...days(2026, 1, 1, 10, 18), stillReporting("2026-01-18")],
+    },
+    [budgetsPath()]: {
+      budgets: [
+        productBudget("actions", 200),
+        productBudget("Actions", 200),
+        productBudget("copilot", 100),
+      ],
+    },
+  });
+  // Actions' $200 counted once, plus Copilot's $100 — not $500.
+  assertStringIncludes(v.extra ?? "", "Budget $300");
+  assertEquals(v.status, "warn"); // $310 against a $300 ceiling
+});
+
+Deno.test("github spend: a product with no budget of its own never trips the light", async () => {
+  // Actions runs at $18/day against a $400 Actions budget, well inside it.
+  // Copilot spends $2000 and nobody has budgeted Copilot at all. Holding the
+  // combined figure against the Actions ceiling would turn the tile red over
+  // spend that ceiling was never set for, so an unbudgeted product is taken to
+  // be spending within a budget of its own and leaves the light alone.
+  const routes = {
+    [usagePath(2026, 1)]: {
+      usageItems: [
+        ...days(2026, 1, 1, 10, 18),
+        item("2026-01-05", 2000, "copilot"),
+        stillReporting("2026-01-18"),
+      ],
+    },
+    [budgetsPath()]: { budgets: [productBudget("actions", 400)] },
+  };
+  const v = await view("2026-01-20T09:00:00Z", routes);
+  assertEquals(v.status, "good"); // Actions projects $310 of its $400
+  // The headline and the month-to-date total still carry every dollar: the
+  // Copilot spend is out of the comparison, not out of the figure.
+  assertEquals(v.value, "~$3754/mo");
+  assertEquals(v.aside, '<span class="hmtd">$2180 MTD</span>');
+  // The ceiling shown covers what the headline covers: Actions' $400, plus
+  // Copilot's own $3444 projection standing in for the budget it lacks. A bare
+  // $400 next to a $3754 headline would read as an overrun on a green tile.
+  assertStringIncludes(v.extra ?? "", "Budget $3844");
+  assert(3754 <= 3844); // green, and the pair on the tile says so
+
+  // Budget Copilot too, and the same spend is now inside the comparison.
+  const budgeted = await view("2026-01-20T09:00:00Z", {
+    ...routes,
+    [budgetsPath()]: {
+      budgets: [productBudget("actions", 400), productBudget("copilot", 100)],
+    },
+  });
+  assertEquals(budgeted.status, "bad"); // $3754 against $500
+  assertEquals(budgeted.value, "~$3754/mo");
+  // Every product is budgeted now, so nothing stands in and the ceiling is the
+  // configured $500 — which the headline sits well above, as the red says.
+  assertStringIncludes(budgeted.extra ?? "", "Budget $500");
+});
+
+Deno.test("github spend: the headline sits under the shown budget exactly when the tile is green", async () => {
+  // The color comes from the budgeted products while the headline carries
+  // every product, so the two are only readable together if the ceiling shown
+  // moves with them. Walk Actions' spend across its budget and check the pair
+  // never disagrees, with an unbudgeted product inflating the headline
+  // throughout.
+  const usd = (text: string) => Number(text.replace(/[^0-9.-]/g, ""));
+  for (const perDay of [5, 18, 20, 24, 30, 60]) {
+    const v = await view("2026-01-20T09:00:00Z", {
+      [usagePath(2026, 1)]: {
+        usageItems: [
+          ...days(2026, 1, 1, 10, perDay),
+          item("2026-01-05", 900, "copilot"), // never budgeted
+          stillReporting("2026-01-18"),
+        ],
+      },
+      [budgetsPath()]: { budgets: [productBudget("actions", 400)] },
+    });
+    const headline = usd(v.value ?? "");
+    const ceiling = usd(
+      (v.extra ?? "").match(/Budget (\$[\d.-]+)/)?.[1] ?? "",
+    );
+    assertEquals(
+      headline <= ceiling,
+      v.status === "good",
+      `at $${perDay}/day the tile is ${v.status} with ${headline} of ${ceiling}`,
+    );
+  }
+});
+
+Deno.test("github spend: a projection over budget goes amber, and well over goes red", async () => {
   const spend = (perDay: number) => ({
     usageItems: [
       ...days(2026, 1, 1, 10, perDay),
@@ -277,9 +446,7 @@ Deno.test("ci spend: a projection over budget goes amber, and well over goes red
   const at = (perDay: number, budget: number) =>
     view("2026-01-20T09:00:00Z", {
       [usagePath(2026, 1)]: spend(perDay),
-      [budgetsPath()]: {
-        budgets: [{ budget_product_sku: "actions", budget_amount: budget }],
-      },
+      [budgetsPath()]: { budgets: [productBudget("actions", budget)] },
     });
   // $18/day over the 10 days that spent -> $180 rated over 18 settled days -> $310.
   assertEquals((await at(18, 400)).status, "good"); // under budget
@@ -287,7 +454,7 @@ Deno.test("ci spend: a projection over budget goes amber, and well over goes red
   assertEquals((await at(18, 100)).status, "bad"); // more than 25% over
 });
 
-Deno.test("ci spend: early in the month the rate comes from last month's tail", async () => {
+Deno.test("github spend: early in the month the rate comes from last month's tail", async () => {
   // The 3rd. Two days of this month is not a rate: $20/day here against $10/day
   // through December means the fortnight-long window has to reach back.
   const v = await view("2026-01-03T09:00:00Z", {
@@ -304,7 +471,7 @@ Deno.test("ci spend: early in the month the rate comes from last month's tail", 
   assertEquals(v.duration, 45 * D);
 });
 
-Deno.test("ci spend: a prior month we can't read shortens the chart, it doesn't break the tile", async () => {
+Deno.test("github spend: a prior month we can't read shortens the chart, it doesn't break the tile", async () => {
   // December 404s. This month has more than a fortnight of settled days, so the
   // projection never needed it; the chart just covers less.
   const v = await view("2026-01-20T09:00:00Z", {
@@ -317,12 +484,10 @@ Deno.test("ci spend: a prior month we can't read shortens the chart, it doesn't 
   assertEquals(v.duration, 18 * D); // January 1st to the settled 18th only
 });
 
-Deno.test("ci spend: an unavailable prior month is not zero-spend history", async () => {
+Deno.test("github spend: an unavailable prior month is not zero-spend history", async () => {
   const v = await view("2026-01-03T09:00:00Z", {
     [usagePath(2026, 1)]: { usageItems: days(2026, 1, 1, 2, 20) },
-    [budgetsPath()]: {
-      budgets: [{ budget_product_sku: "actions", budget_amount: 400 }],
-    },
+    [budgetsPath()]: { budgets: [productBudget("actions", 400)] },
   });
   assertEquals(v.value, "~$620/mo");
   assertEquals(v.aside, '<span class="hmtd">$40 MTD</span>');
@@ -330,7 +495,7 @@ Deno.test("ci spend: an unavailable prior month is not zero-spend history", asyn
   assertEquals(v.duration, 2 * D);
 });
 
-Deno.test("ci spend: a prior month that 404s leaves a hole in the chart, not zeros", async () => {
+Deno.test("github spend: a prior month that 404s leaves a hole in the chart, not zeros", async () => {
   // December's report is missing between two months that answered. The 45-day
   // window still reaches back to 20 November, and December is left undrawn.
   const v = await view("2026-01-05T09:00:00Z", {
@@ -344,7 +509,7 @@ Deno.test("ci spend: a prior month that 404s leaves a hole in the chart, not zer
   assertEquals((v.extra ?? "").match(/<polyline/g)?.length, 3);
 });
 
-Deno.test("ci spend: one day of data is not a chart, but it is still a projection", async () => {
+Deno.test("github spend: one day of data is not a chart, but it is still a projection", async () => {
   const v = await view("2026-01-20T09:00:00Z", {
     [usagePath(2026, 1)]: {
       usageItems: [item("2026-01-01", 180), stillReporting("2026-01-18")],
@@ -356,7 +521,7 @@ Deno.test("ci spend: one day of data is not a chart, but it is still a projectio
   assertEquals(v.duration, 0);
 });
 
-Deno.test("ci spend: a row whose date is unreadable leaves the chart out", async () => {
+Deno.test("github spend: a row whose date is unreadable leaves the chart out", async () => {
   const v = await view("2026-01-20T09:00:00Z", {
     [usagePath(2026, 1)]: {
       usageItems: [
@@ -373,7 +538,7 @@ Deno.test("ci spend: a row whose date is unreadable leaves the chart out", async
   assertEquals(v.duration, 0);
 });
 
-Deno.test("ci spend: the classic plan falls back to minutes against the included allowance", async () => {
+Deno.test("github spend: the classic plan falls back to minutes against the included allowance", async () => {
   // No enhanced billing platform: the usage report 404s and the old actions
   // endpoint answers in minutes.
   const classic = (used: number, included: number, paid: number) =>
@@ -397,7 +562,7 @@ Deno.test("ci spend: the classic plan falls back to minutes against the included
   assertEquals((await classic(0, 0, 0)).status, "good");
 });
 
-Deno.test("ci spend: both billing endpoints unreachable -> gray with a calm reason", async () => {
+Deno.test("github spend: both billing endpoints unreachable -> gray with a calm reason", async () => {
   const v = await view("2026-01-20T09:00:00Z", {
     [classicPath()]: new TypeError(
       "error sending request for url (https://api.github.com/orgs/acme/…)",
@@ -416,7 +581,7 @@ Deno.test("ci spend: both billing endpoints unreachable -> gray with a calm reas
   );
 });
 
-Deno.test("ci spend: a source that rejects without an Error remains unavailable", async () => {
+Deno.test("github spend: a source that rejects without an Error remains unavailable", async () => {
   const rejected = new RejectedRoute("billing stopped");
   const result = await view("2026-01-20T09:00:00Z", {
     [usagePath(2026, 1)]: rejected,
@@ -425,10 +590,10 @@ Deno.test("ci spend: a source that rejects without an Error remains unavailable"
 
   assertEquals(result.status, "unknown");
   assertEquals(result.value, "—");
-  assertEquals(result.sub, "CI spend unavailable");
+  assertEquals(result.sub, "GitHub spend unavailable");
 });
 
-Deno.test("ci spend: GITHUB_TOKEN works, and the org defaults to the CI tiles' repo owner", async () => {
+Deno.test("github spend: GITHUB_TOKEN works, and the org defaults to the CI tiles' repo owner", async () => {
   const org = REPO.split("/")[0];
   const v = await view(
     "2026-01-20T09:00:00Z",

--- a/packages/dashboard/tiles/github-ci-spend.ts
+++ b/packages/dashboard/tiles/github-ci-spend.ts
@@ -269,6 +269,17 @@ async function githubDollarSpend(
     (sum, item) => sum + (Number(item.netAmount) || 0),
     0,
   );
+  // The budgeted products' share of that total, counted from the rows rather
+  // than from the days, so a row whose date is unreadable weighs on the
+  // comparison as it already weighs on the headline. It has no day to chart,
+  // so it stays out of the series below.
+  const budgetedMtd = current.reduce(
+    (sum, item) =>
+      budgets.products.has(String(item.product).toLowerCase())
+        ? sum + (Number(item.netAmount) || 0)
+        : sum,
+    0,
+  );
   const byDay = new Map<string, number>();
   // The same days over the budgeted products alone. A product with no budget
   // of its own is taken to be spending within one, so it is left out of the
@@ -343,6 +354,7 @@ async function githubDollarSpend(
       now,
       {
         lagDays: GITHUB_LAG_DAYS,
+        measuredMtd: budgetedMtd,
         priorMonthDaily: priorMonthBudgetedDaily,
       },
     ).projected,

--- a/packages/dashboard/tiles/github-ci-spend.ts
+++ b/packages/dashboard/tiles/github-ci-spend.ts
@@ -1,12 +1,31 @@
 /**
- * Reports month-to-date GitHub Actions cost and projects it to a full-month
- * total. The 45-day daily-spend chart labels the line with month-to-date spend.
+ * Reports month-to-date GitHub cost and projects it to a full-month total. The
+ * 45-day daily-spend chart labels the line with month-to-date spend.
  *
- * GitHub's enhanced billing report supplies daily net Actions spend. It
- * reports a day or two after it ends, and a settled day with no row is a day
- * Actions spent nothing. That reading holds only while the report is still
- * writing rows, so a report whose newest row is too far back is unavailable
- * rather than a run of $0 days.
+ * GitHub's enhanced billing report supplies daily net spend, one row per
+ * product, SKU, repository and day. Every one of those rows counts here, so
+ * the tile carries the organization's whole GitHub bill as a single figure:
+ * Actions and its storage, Packages, Codespaces, Git LFS, models, sandboxes,
+ * and the seat licenses GitHub meters — Copilot, Advanced Security, and
+ * Enterprise Cloud. A product the organization does not use has no row and
+ * adds nothing.
+ *
+ * A subscription GitHub bills outside that report does not reach the API at
+ * all, and is absent from this figure. The package README records which spend
+ * that is, under "What the GitHub figure covers".
+ *
+ * A day reaches the report a day or two after it ends, and a settled day with
+ * no row is a day that spent nothing. That reading holds only while the report
+ * is still writing rows, so a report whose newest row is too far back is
+ * unavailable rather than a run of $0 days.
+ *
+ * The headline covers every product, while the budget the tile's color comes
+ * from covers only the products someone has budgeted. Those two are held apart
+ * rather than compared across: a product with no budget of its own is taken to
+ * be spending within one, so it adds to the figure without coloring it. The
+ * budget printed beside the headline stands in for those products at their own
+ * projection, so the two figures on the tile cover the same products and the
+ * headline sits at or under the budget exactly when the tile is green.
  */
 
 import type { Status, Tile, TileView } from "../types.ts";
@@ -29,6 +48,8 @@ interface UsageItem {
 }
 
 interface Budget {
+  budget_type?: string;
+  budget_scope?: string;
   budget_product_sku?: string;
   budget_amount?: number;
 }
@@ -50,6 +71,12 @@ interface GitHubDollarSpend extends DailySpend {
   kind: "dollars";
   budget: number;
   /**
+   * The projected month-end spend of the products the organization has
+   * budgeted, which is the figure the budget is a ceiling for. The headline
+   * covers every product; this covers the ones the budget speaks to.
+   */
+  projectedBudgeted: number;
+  /**
    * The calendar months whose usage report was read, as "YYYY-MM". A month
    * that could not be read is absent, and its days are unknown rather than $0.
    */
@@ -65,16 +92,13 @@ interface GitHubMinuteSpend {
 
 type GitHubSpend = GitHubDollarSpend | GitHubMinuteSpend;
 
-const actionsOf = (report: { usageItems?: UsageItem[] }): UsageItem[] =>
-  (report.usageItems ?? []).filter((item) =>
-    String(item.product).toLowerCase() === "actions"
-  );
-
 const usagePath = (org: string, year: number, month: number) =>
   `organizations/${org}/settings/billing/usage?year=${year}&month=${month}`;
 
 const monthKey = (year: number, month0: number) =>
   `${year}-${String(month0 + 1).padStart(2, "0")}`;
+
+const LABEL = "github spend";
 
 export const GITHUB_LAG_DAYS = 2;
 // How far back a source's newest row may sit before the tile stops reading the
@@ -106,14 +130,24 @@ function addDaily(
   target.set(day, (target.get(day) ?? 0) + amount);
 }
 
+/**
+ * Adds the report's rows to the whole-organization series, and the rows whose
+ * product carries a budget to the budgeted series beside it.
+ */
 function addGitHubDays(
   target: Map<string, number>,
+  budgetedTarget: Map<string, number>,
+  budgetedProducts: ReadonlySet<string>,
   items: UsageItem[],
 ): void {
   for (const item of items) {
     const day = dayKey(item.date);
     if (!day) continue;
-    addDaily(target, day, Number(item.netAmount) || 0);
+    const amount = Number(item.netAmount) || 0;
+    addDaily(target, day, amount);
+    if (budgetedProducts.has(String(item.product).toLowerCase())) {
+      addDaily(budgetedTarget, day, amount);
+    }
   }
 }
 
@@ -143,6 +177,51 @@ function requireCurrentReport(
   }
 }
 
+interface OrgBudget {
+  /** The product budgets added up, or NaN when none is set. */
+  total: number;
+  /** The products those budgets cover, lowercased. */
+  products: Set<string>;
+}
+
+const NO_BUDGET: OrgBudget = { total: NaN, products: new Set() };
+
+/**
+ * What the organization has budgeted across GitHub: its product budgets added
+ * up, and which products they speak for. A product budget caps one product's
+ * whole spend, so the products' budgets add up without overlapping. A
+ * single-SKU budget sits inside its own product's budget, and a bundle budget
+ * covers the AI credit SKUs of the products beside it, so adding either would
+ * count the same spend twice. A budget scoped to a repository or a user caps
+ * part of the organization's spend rather than adding to it. An organization
+ * with no product budget is uncompared, as NaN.
+ *
+ * Which products the budgets cover matters as much as the total, because the
+ * ceiling is held against those products' spend alone.
+ */
+function readBudgets(budgets: Budget[]): OrgBudget {
+  // Keyed by product, so a product the endpoint names more than once sets one
+  // ceiling rather than a multiple of it.
+  const byProduct = new Map<string, number>();
+  for (const entry of budgets) {
+    if (String(entry.budget_type).toLowerCase() !== "productpricing") continue;
+    if (String(entry.budget_scope).toLowerCase() !== "organization") continue;
+    const product = entry.budget_product_sku;
+    if (typeof product !== "string" || product === "") continue;
+    // An amount that is absent, null, or a string is not a ceiling. Reading it
+    // through Number() would turn each of those into a $0 budget, which every
+    // amount of spend overruns.
+    const amount = entry.budget_amount;
+    if (typeof amount !== "number" || !Number.isFinite(amount)) continue;
+    const key = product.toLowerCase();
+    byProduct.set(key, Math.max(byProduct.get(key) ?? amount, amount));
+  }
+  if (byProduct.size === 0) return NO_BUDGET;
+  let total = 0;
+  for (const amount of byProduct.values()) total += amount;
+  return { total, products: new Set(byProduct.keys()) };
+}
+
 async function githubDollarSpend(
   token: string,
   org: string,
@@ -151,6 +230,18 @@ async function githubDollarSpend(
   const year = now.getUTCFullYear();
   const month0 = now.getUTCMonth();
   const dayOfMonth = now.getUTCDate();
+  // Read first, because which products carry a budget decides how the report's
+  // rows are split as they are read.
+  let budgets = NO_BUDGET;
+  try {
+    const response = await github<{ budgets?: Budget[] }>(
+      `organizations/${org}/settings/billing/budgets`,
+      token,
+    );
+    budgets = readBudgets(response.budgets ?? []);
+  } catch {
+    // An unset GitHub budget leaves the spend projection uncompared.
+  }
   const report = await github<{ usageItems?: UsageItem[] }>(
     usagePath(org, year, month0 + 1),
     token,
@@ -161,29 +252,33 @@ async function githubDollarSpend(
 
   // One billing pipeline writes the report, a row at a time, for every product
   // the org used on a day. Its newest row, whatever product that row belongs
-  // to, is how far the pipeline has been written. Actions alone would say less:
-  // it can be quiet for days while the rest of the org keeps billing, and a
-  // quiet week and a stopped report look the same in its rows.
+  // to, is how far the pipeline has been written.
   let reportedThrough: string | undefined;
-  const noteReport = (items: UsageItem[] | undefined): void => {
-    for (const entry of items ?? []) {
+  const noteReport = (items: UsageItem[]): void => {
+    for (const entry of items) {
       const day = dayKey(entry.date);
       if (day && (reportedThrough === undefined || day > reportedThrough)) {
         reportedThrough = day;
       }
     }
   };
-  noteReport(report.usageItems);
 
-  const current = actionsOf(report);
+  const current = report.usageItems;
+  noteReport(current);
   const mtd = current.reduce(
     (sum, item) => sum + (Number(item.netAmount) || 0),
     0,
   );
   const byDay = new Map<string, number>();
-  addGitHubDays(byDay, current);
+  // The same days over the budgeted products alone. A product with no budget
+  // of its own is taken to be spending within one, so it is left out of the
+  // figure the ceiling is compared with, and the light turns on what the
+  // organization actually set a limit for.
+  const budgetedByDay = new Map<string, number>();
+  addGitHubDays(byDay, budgetedByDay, budgets.products, current);
   const months = new Set<string>([monthKey(year, month0)]);
   let priorMonthDaily: number[] = [];
+  let priorMonthBudgetedDaily: number[] = [];
   let immediatePrior = true;
   let remaining = SPEND_HISTORY_DAYS - dayOfMonth;
   let previousYear = year;
@@ -201,20 +296,24 @@ async function githubDollarSpend(
       );
       if (Array.isArray(previous.usageItems)) {
         noteReport(previous.usageItems);
-        const previousItems = actionsOf(previous);
-        addGitHubDays(byDay, previousItems);
+        addGitHubDays(
+          byDay,
+          budgetedByDay,
+          budgets.products,
+          previous.usageItems,
+        );
         months.add(monthKey(previousYear, previousMonth));
         if (immediatePrior) {
-          const previousSeries = calendarMonth(
-            byDay,
-            previousYear,
-            previousMonth,
-          );
-          priorMonthDaily = settled(
-            previousSeries,
-            previousSeries.length + dayOfMonth,
-            GITHUB_LAG_DAYS,
-          );
+          const settleMonth = (days: Map<string, number>) => {
+            const series = calendarMonth(days, previousYear, previousMonth);
+            return settled(
+              series,
+              series.length + dayOfMonth,
+              GITHUB_LAG_DAYS,
+            );
+          };
+          priorMonthDaily = settleMonth(byDay);
+          priorMonthBudgetedDaily = settleMonth(budgetedByDay);
         }
       }
     } catch {
@@ -226,22 +325,6 @@ async function githubDollarSpend(
     immediatePrior = false;
   }
   requireCurrentReport("GitHub billing report", reportedThrough, now);
-
-  let budget = NaN;
-  try {
-    const response = await github<{ budgets?: Budget[] }>(
-      `organizations/${org}/settings/billing/budgets`,
-      token,
-    );
-    const actions = (response.budgets ?? []).find((entry) =>
-      String(entry.budget_product_sku).toLowerCase() === "actions"
-    );
-    if (actions && Number.isFinite(Number(actions.budget_amount))) {
-      budget = Number(actions.budget_amount);
-    }
-  } catch {
-    // An unset GitHub budget leaves the spend projection uncompared.
-  }
 
   return {
     kind: "dollars",
@@ -255,7 +338,15 @@ async function githubDollarSpend(
         priorMonthDaily,
       },
     ),
-    budget,
+    projectedBudgeted: summarizeDailySpend(
+      budgetedByDay,
+      now,
+      {
+        lagDays: GITHUB_LAG_DAYS,
+        priorMonthDaily: priorMonthBudgetedDaily,
+      },
+    ).projected,
+    budget: budgets.total,
     months,
   };
 }
@@ -301,7 +392,7 @@ function minutesView(
     ? "warn"
     : "good";
   return {
-    label: "ci spend",
+    label: LABEL,
     status,
     value: `${spend.paid} paid min`,
     sub: `${spend.used} / ${spend.included} min · MTD`,
@@ -313,7 +404,7 @@ function minutesView(
 function unavailableMessage(error: unknown): string {
   if (error instanceof GitHubUsageShapeError) return error.message;
   if (error instanceof StalledReportError) return error.message;
-  if (!(error instanceof Error)) return "CI spend unavailable";
+  if (!(error instanceof Error)) return "GitHub spend unavailable";
   return friendlyError(error.message);
 }
 
@@ -321,7 +412,7 @@ export const githubCiSpend: Tile = {
   id: "github-ci-spend",
   intervalMs: 3_600_000,
   async collect(ctx): Promise<TileView> {
-    const label = "ci spend";
+    const label = LABEL;
     const token = ctx.env("GH_TOKEN") ?? ctx.env("GITHUB_TOKEN");
     if (!token) {
       return {
@@ -343,7 +434,10 @@ export const githubCiSpend: Tile = {
       if (spend.kind === "minutes") return minutesView(org, spend);
 
       const budget = spend.budget;
-      const status = budgetStatus(spend.projected, budget);
+      // Against the budgeted products' projection, not the headline's. The
+      // headline covers products the budget never spoke for, and holding those
+      // against it would turn the light on spend nobody set a limit for.
+      const status = budgetStatus(spend.projectedBudgeted, budget);
       const chart = spendChart(
         [{
           spend,
@@ -356,8 +450,16 @@ export const githubCiSpend: Tile = {
         status,
       );
       const amount = chart.chart ? "" : ` ${usd(spend.mtd)}`;
-      const budgetLabel = Number.isFinite(budget)
-        ? ` • Budget ${usd(budget)}`
+      // The ceiling shown beside the headline covers the products the headline
+      // covers: the budgets that exist, plus each unbudgeted product's own
+      // projection standing in for the budget nobody set for it. Showing the
+      // configured total alone would put a headline carrying unbudgeted spend
+      // above its own budget while the tile stayed green. Adding the difference
+      // between the two projections keeps the pair reading the same way the
+      // color does — at or under the ceiling exactly when the tile is green.
+      const shownBudget = budget + (spend.projected - spend.projectedBudgeted);
+      const budgetLabel = Number.isFinite(shownBudget)
+        ? ` • Budget ${usd(shownBudget)}`
         : "";
       const legend =
         `<p class="sub">${GITHUB_SWATCH} GitHub${amount}${budgetLabel}</p>`;


### PR DESCRIPTION
The spend tile read GitHub's billing usage report but kept only the rows whose product was "actions", so everything else the organization is billed for was invisible: Packages, Codespaces, Git LFS, model inference, sandboxes, and the seat licenses GitHub meters through the same report — Copilot, Advanced Security, and Enterprise Cloud. The dashboard claimed a GitHub figure that was one product's share of the bill.

The report carries one row per product, SKU, repository and day, and netAmount on each row is billable dollars already net of the included allowance. Summing every row rather than the Actions subset is all it takes to widen the figure, because the machinery around it — dating the report from its newest row, paging back through prior months, the daily chart, and the month-end projection — was never product-specific. A product the organization does not use contributes no row and so adds nothing, and a product it takes up later is counted from the day it starts billing, with no further change here.

Summing the whole report also closes a gap between the figure and the check that decides whether the figure can be trusted. The freshness guard was already dated from every product's rows while the total counted only Actions, so the row certifying the feed as current could contribute nothing to the number. Actions could stop billing for a fortnight while another product kept the guard passing, and the quiet days would be read as real zeros: a green tile understating spend several-fold. The rows that date the report are now the rows that are summed.

Widening the figure invalidates the budget it was held against. The tile compared the projection with the budget whose product SKU was "actions", which is the wrong ceiling for a number spanning products. Total the organization's product budgets instead, keyed by product so one product cannot set the ceiling twice. A product budget caps one product's whole spend, so the products' budgets add without overlapping. A single-SKU budget sits inside its own product's budget and a bundle budget covers the AI credit SKUs of the products beside it, so counting either would hold the projection against a ceiling covering the same spend twice; a budget scoped to a repository or a user caps part of the organization's spend rather than adding to it. Require a budget's amount to be a number before it counts: an amount that is absent, null, or spelled as a string reads as 0 through Number(), and a $0 ceiling is one that every dollar of spend overruns, so a single malformed entry painted the tile red over a budget nobody had set.

Totalling those budgets still leaves a ceiling that covers only the products someone has budgeted, while the figure covers every product. Comparing the two compares incommensurable things: an organization budgeting Actions at $400 and never budgeting Copilot would go red the moment Copilot spend carried the combined figure past $400, even though Actions sat well inside the only limit anyone set, and even though the sum of budgets belonging to other products has no bearing on whether the Copilot spend is acceptable. Take a product with no budget of its own to be spending within one. The report's rows accumulate into two daily series: every product, feeding the headline, the month-to-date total and the chart; and the budgeted products alone, feeding the projection the budget is compared with. Both are projected the same way, through the same settled-day window and the same reach into the previous month's tail, so they differ only in which products they count. Reading the budgets moves ahead of reading the usage report, since which products carry a budget decides how each row is filed as it arrives.

That leaves the two numbers printed on the tile describing different things, which the budget line now fixes. Each unbudgeted product stands in at its own projection, so the printed ceiling is the configured budgets plus the difference between the two projections — exactly the unbudgeted products' share. The headline therefore sits at or under the printed budget precisely when the tile is green. A tile that would have read "~$3754/mo • Budget $400" while green now reads "Budget $3844", and budgeting Copilot brings both figures back to the configured $500 the headline plainly overruns. The color still comes from the budgeted products against the budgets actually configured, which keeps the amber band at a quarter over a real limit rather than a quarter over a limit partly made of spend. Deriving the printed figure from the two projections rather than measuring a third series is what makes the agreement exact, even when the two series settle over different numbers of days.

One consequence is worth naming: a product nobody has budgeted can grow without ever changing the tile's color. That is the price of not alarming at an arbitrary threshold. The headline carries the spend where it is visible, and budgeting the product is what puts a limit on it.

Rename the tile from "ci spend" to "github spend". A tile reporting Copilot seats and Enterprise Cloud licenses is not reporting CI spend. The tile id and file name are unchanged, being internal keys rather than anything a reader sees.

Two kinds of GitHub spend still do not reach the figure, because the API does not expose them. A plan billed as a flat subscription rather than as metered licensing has no row in the usage report: a Team plan has no product or SKU of its own, and an Enterprise plan appears only once its licensing is metered, as ghec_licenses rows. The organization endpoint reports seat counts but never a price. Separately, anything billed against an enterprise account rather than an organization lives behind a different endpoint needing enterprise-level administration. Record both gaps in the package README, under a new section the tile's doc comment points at, along with a caveat about the projection: GitHub dates every row by the day the usage occurred and the projection carries the recent daily rate across the remaining days, so a charge posted as one lump rather than a daily series would be extrapolated as though it recurred, overstating the projection while leaving month-to-date correct. GitHub does not document the reporting cadence of license SKUs specifically and none have been observed, so the estimator is left alone and the case to watch is written down.

Verified against the live commontoolsinc billing API, which confirmed the report's shape and that its budgets carry the budget_type, budget_scope and budget_product_sku fields this relies on; against GitHub's product and SKU reference for the product list; with the dashboard package suite including its browser tests, and repository-wide formatting and linting. Every behavioral change was confirmed to reproduce its defect first: with the Actions-only filter restored the combined figure reads ~$310/mo rather than ~$1206/mo; with the previous budget totalling, a malformed amount renders a Budget line where none belongs and a product named twice reads Budget $500 where the ceiling set is $300; comparing the combined projection reports red where the budgeted products alone are green; and printing the configured budget alone shows a green tile reading $1636 against a budget of $400. Forward and reverse adversarial reviews were run over the first of these.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

