### PR TITLE
feat(cli): repeatable --piece gives setsrc a batch mode in one session

### DIFF
--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -2066,10 +2066,10 @@ export const piece = targetOptions(
   )
   .option(
     "-c,--piece <piece:string>",
-    `${PIECE_OPTION_HELP} Repeatable with the --space form: every named ` +
+    `${PIECE_OPTION_HELP} Repeatable with --api-url/--space or a piece-less ` +
+      `--url: every named ` +
       `piece receives the same source, applied serially in the order given, ` +
-      `stopping at the first failure. A piece already running the candidate ` +
-      `source is reported and skipped.`,
+      `stopping at the first failure.`,
     { collect: true },
   )
   .option(
@@ -3099,20 +3099,13 @@ export interface SetSrcCLIOptions extends Omit<PieceCLIOptions, "piece"> {
  *
  * Each `--piece` value goes through the parse the single-piece form uses, so
  * every spelling — id, slug, canonical reference — and every validation keeps
- * its one-piece meaning. The `--url` form stays single-piece: a URL names at
- * most one piece, so repeating `--piece` beside one is refused rather than
- * resolved.
+ * its one-piece meaning. A piece-less `--url` supplies the host and space for
+ * every repeated `--piece`; a URL that already names a piece is still refused
+ * by the one-piece parser.
  */
 export function parseBatchPieceConfigs(
   options: SetSrcCLIOptions,
 ): PieceConfig[] {
-  if (options.url !== undefined) {
-    throw new ValidationError(
-      `"--url" names a single piece; to update several pieces, repeat ` +
-        `"--piece" with "--api-url" and "--space".`,
-      { exitCode: 1 },
-    );
-  }
   return (options.piece ?? []).map((value) =>
     parsePieceOptions({ ...options, piece: value })
   );
@@ -3125,9 +3118,7 @@ export function formatBatchOutcomeLine(
   total: number,
 ): string {
   const position = `(${index + 1}/${total})`;
-  return outcome.status === "updated"
-    ? `Updated source for piece ${outcome.piece} ${position}`
-    : `Source already current for piece ${outcome.piece} — skipped ${position}`;
+  return `Updated source for piece ${outcome.piece} ${position}`;
 }
 
 /**
@@ -3142,23 +3133,16 @@ export function formatBatchStopReport(context: {
   total: number;
   outcomes: BatchPieceOutcome[];
 }): string {
-  const updated =
-    context.outcomes.filter((outcome) => outcome.status === "updated").length;
-  const skipped = context.outcomes.length - updated;
   const remaining = context.total - context.index - 1;
   return `Stopped at piece ${context.piece} (${
     context.index + 1
-  } of ${context.total}): ${updated} updated and ${skipped} already ` +
-    `current before the stop; ${remaining} not attempted.`;
+  } of ${context.total}): ${context.outcomes.length} updated before the stop; ` +
+    `${remaining} not attempted.`;
 }
 
 /** The closing line of a completed batch, totaling the per-piece lines. */
 export function formatBatchSummary(outcomes: BatchPieceOutcome[]): string {
-  const updated =
-    outcomes.filter((outcome) => outcome.status === "updated").length;
-  return `Processed ${outcomes.length} pieces: ${updated} updated, ${
-    outcomes.length - updated
-  } already current.`;
+  return `Updated ${outcomes.length} pieces.`;
 }
 
 /** NEXT STEPS hint after a completed batch apply. */

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -34,7 +34,10 @@ import type {
 } from "../lib/piece-describe.ts";
 import {
   applyPieceInput,
+  type BatchPieceCheck,
+  type BatchPieceOutcome,
   checkPiecePattern,
+  checkPiecePatternBatch,
   describePiece,
   type EntryConfig,
   executePieceCallable,
@@ -65,6 +68,7 @@ import {
   setCellValue,
   setHomePattern,
   setPiecePattern,
+  setPiecePatternBatch,
   setPieceSlug,
   SpaceConfig,
   stepPiece,
@@ -2043,7 +2047,7 @@ export const piece = targetOptions(
     savePiecePattern(parsePieceOptions(options), absPath(outPath))
   )
   /* piece setsrc */
-  .command("setsrc", "Update the pattern source for the given piece.")
+  .command("setsrc", "Update the pattern source for the given piece(s).")
   .usage(`${pieceUsage} <main>`)
   .example(
     cliText(`cf piece setsrc ${EX_ID} ${EX_COMP_PIECE} ./main.tsx`),
@@ -2053,7 +2057,21 @@ export const piece = targetOptions(
     cliText(`cf piece setsrc ${EX_ID} ${EX_URL} ./main.tsx`),
     `Update the source for "${RAW_EX_COMP.piece!}" with ./main.tsx`,
   )
-  .option("-c,--piece <piece:string>", PIECE_OPTION_HELP)
+  .example(
+    cliText(
+      `cf piece setsrc ${EX_ID} ${EX_COMP} --piece ${RAW_EX_COMP
+        .piece!} --piece fid1:other ./main.tsx`,
+    ),
+    "Update several pieces to the same source through one session, serially, in the order given.",
+  )
+  .option(
+    "-c,--piece <piece:string>",
+    `${PIECE_OPTION_HELP} Repeatable with the --space form: every named ` +
+      `piece receives the same source, applied serially in the order given, ` +
+      `stopping at the first failure. A piece already running the candidate ` +
+      `source is reported and skipped.`,
+    { collect: true },
+  )
   .option(
     "--main-export <export:string>",
     'Named export from entry for pattern definition. Defaults to "default".',
@@ -2082,17 +2100,23 @@ export const piece = targetOptions(
   )
   .option(
     "--check",
-    "Report whether the source could replace the piece's current one, without updating the piece. Exits non-zero when it could not.",
+    "Report whether the source could replace each named piece's current one, without updating any piece. Exits non-zero when any could not.",
   )
   .arguments("<main:string>")
   .action(async (options, mainPath) => {
     setQuietMode(!!options.quiet);
+    const targets = options.piece ?? [];
+    if (targets.length > 1) {
+      await setSrcBatchAction(options, mainPath);
+      return;
+    }
+    const single = { ...options, piece: targets[0] };
     if (options.check) {
       // A refusal exits 1 from inside the check (plain stderr, no usage
       // dump), so `--check` gates a deploy script as well as informing a
       // person.
       const { config, summary } = await checkPieceSourceFromCommand(
-        options,
+        single,
         mainPath,
       );
       render(summary);
@@ -2100,7 +2124,7 @@ export const piece = targetOptions(
   → Apply it: cf piece setsrc --piece ${config.piece} ${mainPath} ...`));
       return;
     }
-    const pieceConfig = await setPieceSourceFromCommand(options, mainPath);
+    const pieceConfig = await setPieceSourceFromCommand(single, mainPath);
     render(`Updated source for piece ${pieceConfig.piece}`);
     hint(cliText(`NEXT STEPS:
   → Test in browser: ${pieceConfig.apiUrl}/${pieceConfig.space}/${pieceConfig.piece}
@@ -3063,6 +3087,221 @@ export async function setPieceSourceFromCommand(
     },
   );
   return pieceConfig;
+}
+
+/** Options for `piece setsrc`, whose `--piece` collects (repeatable). */
+export interface SetSrcCLIOptions extends Omit<PieceCLIOptions, "piece"> {
+  piece?: string[];
+}
+
+/**
+ * Parse the per-piece configs of a multi-piece `setsrc`.
+ *
+ * Each `--piece` value goes through the parse the single-piece form uses, so
+ * every spelling — id, slug, canonical reference — and every validation keeps
+ * its one-piece meaning. The `--url` form stays single-piece: a URL names at
+ * most one piece, so repeating `--piece` beside one is refused rather than
+ * resolved.
+ */
+export function parseBatchPieceConfigs(
+  options: SetSrcCLIOptions,
+): PieceConfig[] {
+  if (options.url !== undefined) {
+    throw new ValidationError(
+      `"--url" names a single piece; to update several pieces, repeat ` +
+        `"--piece" with "--api-url" and "--space".`,
+      { exitCode: 1 },
+    );
+  }
+  return (options.piece ?? []).map((value) =>
+    parsePieceOptions({ ...options, piece: value })
+  );
+}
+
+/** One unambiguous line per landed piece; operators count these. */
+export function formatBatchOutcomeLine(
+  outcome: BatchPieceOutcome,
+  index: number,
+  total: number,
+): string {
+  const position = `(${index + 1}/${total})`;
+  return outcome.status === "updated"
+    ? `Updated source for piece ${outcome.piece} ${position}`
+    : `Source already current for piece ${outcome.piece} — skipped ${position}`;
+}
+
+/**
+ * The stderr report printed when a batch stops: which piece failed, what had
+ * landed before it, and how many pieces were never attempted. The failing
+ * piece's own error follows separately, exactly as the single-piece form
+ * reports it.
+ */
+export function formatBatchStopReport(context: {
+  piece: string;
+  index: number;
+  total: number;
+  outcomes: BatchPieceOutcome[];
+}): string {
+  const updated =
+    context.outcomes.filter((outcome) => outcome.status === "updated").length;
+  const skipped = context.outcomes.length - updated;
+  const remaining = context.total - context.index - 1;
+  return `Stopped at piece ${context.piece} (${
+    context.index + 1
+  } of ${context.total}): ${updated} updated and ${skipped} already ` +
+    `current before the stop; ${remaining} not attempted.`;
+}
+
+/** The closing line of a completed batch, totaling the per-piece lines. */
+export function formatBatchSummary(outcomes: BatchPieceOutcome[]): string {
+  const updated =
+    outcomes.filter((outcome) => outcome.status === "updated").length;
+  return `Processed ${outcomes.length} pieces: ${updated} updated, ${
+    outcomes.length - updated
+  } already current.`;
+}
+
+/** NEXT STEPS hint after a completed batch apply. */
+export function batchApplyNextSteps(configs: PieceConfig[]): string {
+  const [first] = configs;
+  return cliText(`NEXT STEPS:
+  → Test in browser: ${first.apiUrl}/${first.space}
+  → Check state:     cf piece inspect --piece <piece> ...`);
+}
+
+/** NEXT STEPS hint after a batch `--check` in which every piece passed. */
+export function batchCheckNextSteps(
+  configs: PieceConfig[],
+  mainPath: string,
+): string {
+  const pieceFlags = configs.map((config) => `--piece ${config.piece}`)
+    .join(" ");
+  return cliText(`NEXT STEPS:
+  → Apply it: cf piece setsrc ${pieceFlags} ${mainPath} ...`);
+}
+
+/** Injectable dependencies for testing multi-piece `setsrc`. */
+export interface SetPieceSourceBatchCommandDependencies {
+  setPiecePatternBatch?: typeof setPiecePatternBatch;
+  /** Receives each per-piece line and the summary as they land. */
+  report?: (line: string) => void;
+  /** Receives the stop report when a piece fails (default stderr). */
+  reportError?: (line: string) => void;
+}
+
+/**
+ * Apply the parsed multi-piece `setsrc` command: one session, serial order,
+ * stop on first failure. Reporting streams through `deps.report` as pieces
+ * land, so an interrupted run still shows exactly what succeeded; the
+ * failing piece's error then propagates for the CLI's usual rendering and
+ * non-zero exit.
+ */
+export async function setPieceSourceBatchFromCommand(
+  options: SetSrcCLIOptions,
+  mainPath: string,
+  deps: SetPieceSourceBatchCommandDependencies = {},
+): Promise<{ configs: PieceConfig[]; outcomes: BatchPieceOutcome[] }> {
+  const configs = parseBatchPieceConfigs(options);
+  const report = deps.report ?? render;
+  const reportError = deps.reportError ?? console.error;
+  const outcomes = await (deps.setPiecePatternBatch ?? setPiecePatternBatch)(
+    configs,
+    localPatternEntry(mainPath, options),
+    {
+      dangerouslyAllowIncompatibleSchema:
+        options.dangerouslyAllowIncompatibleSchema,
+    },
+    {
+      onOutcome: (outcome, index, total) =>
+        report(formatBatchOutcomeLine(outcome, index, total)),
+      onFailure: (context) => reportError(formatBatchStopReport(context)),
+    },
+  );
+  report(formatBatchSummary(outcomes));
+  return { configs, outcomes };
+}
+
+/** Injectable dependencies for testing multi-piece `setsrc --check`. */
+export interface CheckPieceSourceBatchCommandDependencies {
+  checkPiecePatternBatch?: typeof checkPiecePatternBatch;
+  /** Receives each per-piece verdict line. */
+  report?: (line: string) => void;
+  /** `exitWithDataError`'s seam, so a test can observe the refusal. */
+  exit?: Parameters<typeof exitWithDataError>[1];
+}
+
+/**
+ * Run the multi-piece `setsrc --check` preflight. Applies nothing.
+ *
+ * Every piece is reviewed — a refused piece does not hide the verdicts
+ * behind it — and the verdicts report grouped by piece, in the order given.
+ * Any refusal exits 1 the same way the single-piece check does, so the
+ * batch form gates a migration script identically.
+ */
+export async function checkPieceSourceBatchFromCommand(
+  options: SetSrcCLIOptions,
+  mainPath: string,
+  deps: CheckPieceSourceBatchCommandDependencies = {},
+): Promise<{ configs: PieceConfig[]; checks: BatchPieceCheck[] }> {
+  const configs = parseBatchPieceConfigs(options);
+  const checks = await (deps.checkPiecePatternBatch ?? checkPiecePatternBatch)(
+    configs,
+    localPatternEntry(mainPath, options),
+  );
+  const report = deps.report ?? render;
+  for (const check of checks) {
+    report(
+      check.report.compatible
+        ? `${mainPath} can replace the source for piece ${check.piece}`
+        : `${mainPath} cannot replace the source for piece ${check.piece}:\n` +
+          `${check.report.message}`,
+    );
+  }
+  const refused = checks.filter((check) => !check.report.compatible).length;
+  if (refused > 0) {
+    exitWithDataError({
+      message:
+        `${mainPath} cannot replace the source for ${refused} of ${checks.length} pieces.`,
+    }, deps.exit);
+  }
+  return { configs, checks };
+}
+
+/** Injectable dependencies for testing the multi-piece `setsrc` action. */
+export interface SetSrcBatchActionDependencies
+  extends
+    SetPieceSourceBatchCommandDependencies,
+    CheckPieceSourceBatchCommandDependencies {
+  hint?: (message: string) => void;
+}
+
+/**
+ * The whole multi-piece `setsrc` action: apply or `--check`, then the
+ * closing hint. A named export with seams rather than an inline action body
+ * because action bodies never execute under the unit suite
+ * (docs/development/COVERAGE.md).
+ */
+export async function setSrcBatchAction(
+  options: SetSrcCLIOptions & { check?: boolean },
+  mainPath: string,
+  deps: SetSrcBatchActionDependencies = {},
+): Promise<void> {
+  const printHint = deps.hint ?? hint;
+  if (options.check) {
+    const { configs } = await checkPieceSourceBatchFromCommand(
+      options,
+      mainPath,
+      deps,
+    );
+    printHint(batchCheckNextSteps(configs, mainPath));
+    return;
+  }
+  const { configs } = await setPieceSourceBatchFromCommand(
+    options,
+    mainPath,
+    deps,
+  );
+  printHint(batchApplyNextSteps(configs));
 }
 
 /**

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -27,6 +27,7 @@ import {
 } from "@commonfabric/piece/ops";
 import {
   Cell,
+  compileAndSavePattern,
   deepEqual,
   encodeJsonPointer,
   entityIdFrom,
@@ -1533,6 +1534,200 @@ export async function checkPiecePattern(
       entry,
     ),
   );
+}
+
+/** Per-piece outcome of {@link setPiecePatternBatch}. */
+export interface BatchPieceOutcome {
+  /** The resolved piece id (slug and scoped spellings resolved). */
+  piece: string;
+  status: "updated" | "already-current";
+}
+
+/** Per-piece verdict of {@link checkPiecePatternBatch}. */
+export interface BatchPieceCheck {
+  /** The resolved piece id (slug and scoped spellings resolved). */
+  piece: string;
+  report: PatternCompatibilityReport;
+}
+
+/**
+ * Progress callbacks for {@link setPiecePatternBatch}. `onOutcome` fires as
+ * each piece lands, so a caller can print one line per piece while the batch
+ * is still running; `onFailure` fires once, before the failing piece's error
+ * propagates, with everything that had already landed.
+ */
+export interface BatchPieceProgress {
+  onOutcome?: (
+    outcome: BatchPieceOutcome,
+    index: number,
+    total: number,
+  ) => void;
+  onFailure?: (context: {
+    /** The piece whose update failed, as configured (possibly unresolved). */
+    piece: string;
+    index: number;
+    total: number;
+    /** The outcomes that landed before the failure, in order. */
+    outcomes: BatchPieceOutcome[];
+  }) => void;
+}
+
+/**
+ * Compile the candidate program once in the target space and return its
+ * `{ identity, symbol }` entry ref. The identity is content-derived, so this
+ * one compile names the pattern every piece in a batch would end up running —
+ * which is what makes "already current" decidable before any piece is
+ * touched. The write-back it performs is content-addressed and attached to
+ * nothing, the same one `checkPattern` documents.
+ */
+export async function resolveCandidatePatternRef(
+  pieces: PiecesController,
+  program: RuntimeProgram,
+): Promise<{ identity: string; symbol: string }> {
+  const candidate = await compileAndSavePattern(pieces.runtime, program, {
+    space: pieces.getSpace(),
+  });
+  const ref = pieces.runtime.patternManager.getArtifactEntryRef(candidate);
+  if (ref === undefined) {
+    throw new Error("the candidate source has no pattern identity");
+  }
+  return ref;
+}
+
+/**
+ * The session config a batch opens once: the shared space fields of the
+ * per-piece configs, with every embedded space DID collected so the deferred
+ * check in `loadPieces` covers each piece reference that carried one.
+ */
+function batchSessionConfig(configs: PieceConfig[]): SpaceConfig {
+  const [first] = configs;
+  const embedded = [
+    ...new Set(configs.flatMap((config) => config.embeddedSpaces ?? [])),
+  ];
+  return embedded.length === 0 ? first : { ...first, embeddedSpaces: embedded };
+}
+
+/**
+ * Apply one pattern source to several pieces through a single session.
+ *
+ * Serial and stop-on-first-failure: pieces are processed strictly in the
+ * order given, and a failure propagates after `onFailure` reports what had
+ * already landed — the pieces before the failure keep their update.
+ *
+ * Per-piece semantics are `setPiecePattern`'s: the same `setPattern` call,
+ * with the same compatibility enforcement, dangerous-flag scope, and
+ * concurrency behavior. What the batch amortizes is everything around it —
+ * the session open and replica warm-up happen once, the source package is
+ * resolved and pinned once, and each piece's own compile inside `setPattern`
+ * rides the content-addressed compile cache warmed by the first. The
+ * per-piece compile is kept (rather than hoisted) deliberately: it derives
+ * and persists that piece's predecessor update-authority delegations, which
+ * a shared precompiled pattern would silently drop.
+ *
+ * A piece already running the candidate — deployed `{ identity, symbol }`
+ * equal to the candidate's — is reported "already-current" and not
+ * re-executed, so an interrupted batch is resumable by re-invocation. Only
+ * the batch path skips; the single-piece path always applies.
+ */
+export async function setPiecePatternBatch(
+  configs: PieceConfig[],
+  entry: EntryConfig,
+  options: SetPiecePatternOptions = {},
+  deps:
+    & PieceOperationDependencies
+    & BatchPieceProgress
+    & { resolveCandidatePatternRef?: typeof resolveCandidatePatternRef } = {},
+): Promise<BatchPieceOutcome[]> {
+  const pieces = await (deps.loadPieces ?? loadPieces)(
+    batchSessionConfig(configs),
+  );
+  const program = await (deps.getPinnedProgramFromFile ??
+    getPinnedProgramFromFile)(pieces, entry);
+  const candidate = await (deps.resolveCandidatePatternRef ??
+    resolveCandidatePatternRef)(pieces, program);
+  const outcomes: BatchPieceOutcome[] = [];
+  for (const [index, config] of configs.entries()) {
+    try {
+      const resolvedConfig = await resolvePieceConfigWithPieces(
+        config,
+        pieces,
+        deps.resolvePieceAddress,
+      );
+      const piece = await pieces.get(
+        resolvedConfig.piece,
+        false,
+        undefined,
+        resolvedConfig.pieceScope,
+      );
+      const deployed = getPatternIdentityRef(piece.getCell());
+      let outcome: BatchPieceOutcome;
+      if (
+        deployed !== undefined &&
+        deployed.identity === candidate.identity &&
+        deployed.symbol === candidate.symbol
+      ) {
+        outcome = { piece: resolvedConfig.piece, status: "already-current" };
+      } else {
+        await piece.setPattern(program, {
+          repository: entry.repository,
+          ...(options.dangerouslyAllowIncompatibleSchema
+            ? { dangerouslyAllowIncompatibleSchema: true }
+            : {}),
+        });
+        outcome = { piece: resolvedConfig.piece, status: "updated" };
+      }
+      outcomes.push(outcome);
+      deps.onOutcome?.(outcome, index, configs.length);
+    } catch (error) {
+      deps.onFailure?.({
+        piece: config.piece,
+        index,
+        total: configs.length,
+        outcomes: [...outcomes],
+      });
+      throw error;
+    }
+  }
+  return outcomes;
+}
+
+/**
+ * Run `checkPattern`'s aggregate review for one source against several
+ * pieces, through a single session. Applies nothing; the verdicts come back
+ * in the order given so a caller can report them grouped by piece. A hard
+ * error (an unresolvable piece, an unusable argument) propagates rather than
+ * becoming a verdict — an incompatibility is a finding, a failure to review
+ * is not.
+ */
+export async function checkPiecePatternBatch(
+  configs: PieceConfig[],
+  entry: EntryConfig,
+  deps: PieceOperationDependencies = {},
+): Promise<BatchPieceCheck[]> {
+  const pieces = await (deps.loadPieces ?? loadPieces)(
+    batchSessionConfig(configs),
+  );
+  const program = await (deps.getPinnedProgramFromFile ??
+    getPinnedProgramFromFile)(pieces, entry);
+  const checks: BatchPieceCheck[] = [];
+  for (const config of configs) {
+    const resolvedConfig = await resolvePieceConfigWithPieces(
+      config,
+      pieces,
+      deps.resolvePieceAddress,
+    );
+    const piece = await pieces.get(
+      resolvedConfig.piece,
+      false,
+      undefined,
+      resolvedConfig.pieceScope,
+    );
+    checks.push({
+      piece: resolvedConfig.piece,
+      report: await piece.checkPattern(program),
+    });
+  }
+  return checks;
 }
 
 export async function savePiecePattern(

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -27,7 +27,6 @@ import {
 } from "@commonfabric/piece/ops";
 import {
   Cell,
-  compileAndSavePattern,
   deepEqual,
   encodeJsonPointer,
   entityIdFrom,
@@ -1540,7 +1539,6 @@ export async function checkPiecePattern(
 export interface BatchPieceOutcome {
   /** The resolved piece id (slug and scoped spellings resolved). */
   piece: string;
-  status: "updated" | "already-current";
 }
 
 /** Per-piece verdict of {@link checkPiecePatternBatch}. */
@@ -1573,28 +1571,6 @@ export interface BatchPieceProgress {
 }
 
 /**
- * Compile the candidate program once in the target space and return its
- * `{ identity, symbol }` entry ref. The identity is content-derived, so this
- * one compile names the pattern every piece in a batch would end up running —
- * which is what makes "already current" decidable before any piece is
- * touched. The write-back it performs is content-addressed and attached to
- * nothing, the same one `checkPattern` documents.
- */
-export async function resolveCandidatePatternRef(
-  pieces: PiecesController,
-  program: RuntimeProgram,
-): Promise<{ identity: string; symbol: string }> {
-  const candidate = await compileAndSavePattern(pieces.runtime, program, {
-    space: pieces.getSpace(),
-  });
-  const ref = pieces.runtime.patternManager.getArtifactEntryRef(candidate);
-  if (ref === undefined) {
-    throw new Error("the candidate source has no pattern identity");
-  }
-  return ref;
-}
-
-/**
  * The session config a batch opens once: the shared space fields of the
  * per-piece configs, with every embedded space DID collected so the deferred
  * check in `loadPieces` covers each piece reference that carried one.
@@ -1624,27 +1600,23 @@ function batchSessionConfig(configs: PieceConfig[]): SpaceConfig {
  * and persists that piece's predecessor update-authority delegations, which
  * a shared precompiled pattern would silently drop.
  *
- * A piece already running the candidate — deployed `{ identity, symbol }`
- * equal to the candidate's — is reported "already-current" and not
- * re-executed, so an interrupted batch is resumable by re-invocation. Only
- * the batch path skips; the single-piece path always applies.
+ * Every piece still goes through `setPattern`, even when it is already
+ * running the candidate pattern. Pattern identity alone does not capture the
+ * source transition, revision history, or repository metadata that
+ * `setPattern` owns, so skipping that call would make the batch path differ
+ * from serial `setsrc`.
  */
 export async function setPiecePatternBatch(
   configs: PieceConfig[],
   entry: EntryConfig,
   options: SetPiecePatternOptions = {},
-  deps:
-    & PieceOperationDependencies
-    & BatchPieceProgress
-    & { resolveCandidatePatternRef?: typeof resolveCandidatePatternRef } = {},
+  deps: PieceOperationDependencies & BatchPieceProgress = {},
 ): Promise<BatchPieceOutcome[]> {
   const pieces = await (deps.loadPieces ?? loadPieces)(
     batchSessionConfig(configs),
   );
   const program = await (deps.getPinnedProgramFromFile ??
     getPinnedProgramFromFile)(pieces, entry);
-  const candidate = await (deps.resolveCandidatePatternRef ??
-    resolveCandidatePatternRef)(pieces, program);
   const outcomes: BatchPieceOutcome[] = [];
   for (const [index, config] of configs.entries()) {
     try {
@@ -1659,23 +1631,13 @@ export async function setPiecePatternBatch(
         undefined,
         resolvedConfig.pieceScope,
       );
-      const deployed = getPatternIdentityRef(piece.getCell());
-      let outcome: BatchPieceOutcome;
-      if (
-        deployed !== undefined &&
-        deployed.identity === candidate.identity &&
-        deployed.symbol === candidate.symbol
-      ) {
-        outcome = { piece: resolvedConfig.piece, status: "already-current" };
-      } else {
-        await piece.setPattern(program, {
-          repository: entry.repository,
-          ...(options.dangerouslyAllowIncompatibleSchema
-            ? { dangerouslyAllowIncompatibleSchema: true }
-            : {}),
-        });
-        outcome = { piece: resolvedConfig.piece, status: "updated" };
-      }
+      await piece.setPattern(program, {
+        repository: entry.repository,
+        ...(options.dangerouslyAllowIncompatibleSchema
+          ? { dangerouslyAllowIncompatibleSchema: true }
+          : {}),
+      });
+      const outcome: BatchPieceOutcome = { piece: resolvedConfig.piece };
       outcomes.push(outcome);
       deps.onOutcome?.(outcome, index, configs.length);
     } catch (error) {

--- a/packages/cli/test/piece-setsrc-batch.test.ts
+++ b/packages/cli/test/piece-setsrc-batch.test.ts
@@ -1,0 +1,787 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import type { PatternCompatibilityReport } from "@commonfabric/piece/ops";
+import type { PiecesController } from "@commonfabric/piece/ops";
+import type { RuntimeProgram } from "@commonfabric/runner";
+
+import {
+  batchApplyNextSteps,
+  batchCheckNextSteps,
+  checkPieceSourceBatchFromCommand,
+  formatBatchOutcomeLine,
+  formatBatchStopReport,
+  formatBatchSummary,
+  parseBatchPieceConfigs,
+  setPieceSourceBatchFromCommand,
+  setSrcBatchAction,
+} from "../commands/piece.ts";
+import {
+  type BatchPieceOutcome,
+  checkPiecePatternBatch,
+  type PieceConfig,
+  resolveCandidatePatternRef,
+  setPiecePatternBatch,
+  type SpaceConfig,
+} from "../lib/piece.ts";
+
+const API_URL = "https://cf.dev";
+const SPACE = "common-knowledge";
+const IDENTITY = "/tmp/test.key";
+const SPACE_DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+const OTHER_SPACE_DID =
+  "did:key:z6MkrZ1r5XBFZjBU34qyD8fueMbMRkKw17BZaq2ivKFjnz2z";
+
+const CANDIDATE = { identity: "C".repeat(43), symbol: "default" };
+
+const PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{ name: "/main.tsx", contents: "export default 1;" }],
+};
+
+const ENTRY = {
+  mainPath: "/repo/pattern.tsx",
+  repository: "https://github.com/commontoolsinc/labs",
+};
+
+function configFor(piece: string, extra: Partial<PieceConfig> = {}) {
+  return {
+    apiUrl: API_URL,
+    space: SPACE,
+    identity: IDENTITY,
+    piece,
+    ...extra,
+  } as PieceConfig;
+}
+
+/** What one fake piece looks like to the batch: its deployed ref and fate. */
+interface FakePieceSpec {
+  deployed?: { identity: string; symbol: string };
+  setPatternError?: Error;
+  report?: PatternCompatibilityReport;
+}
+
+interface BatchCallLog {
+  loadConfigs: SpaceConfig[];
+  pinnedEntries: unknown[];
+  setPatternCalls: { piece: string; program: unknown; options: unknown }[];
+  checkPatternCalls: { piece: string; program: unknown }[];
+}
+
+function newBatchCallLog(): BatchCallLog {
+  return {
+    loadConfigs: [],
+    pinnedEntries: [],
+    setPatternCalls: [],
+    checkPatternCalls: [],
+  };
+}
+
+/**
+ * A fake `PiecesController` covering exactly the surface the batch functions
+ * touch: `get()` for the per-piece controllers, and (via the real
+ * `getPatternIdentityRef`) each controller's cell meta.
+ */
+function fakePieces(
+  specs: Record<string, FakePieceSpec>,
+  log: BatchCallLog,
+): PiecesController {
+  return {
+    get: (pieceId: string) => {
+      const spec = specs[pieceId];
+      if (spec === undefined) {
+        return Promise.reject(new Error(`no such piece: ${pieceId}`));
+      }
+      return Promise.resolve({
+        getCell: () => ({
+          getMetaRaw: (key: string) =>
+            key === "patternIdentity" ? spec.deployed : undefined,
+        }),
+        setPattern: (program: unknown, options: unknown) => {
+          log.setPatternCalls.push({ piece: pieceId, program, options });
+          return spec.setPatternError === undefined
+            ? Promise.resolve()
+            : Promise.reject(spec.setPatternError);
+        },
+        checkPattern: (program: unknown) => {
+          log.checkPatternCalls.push({ piece: pieceId, program });
+          return Promise.resolve(spec.report);
+        },
+      });
+    },
+  } as unknown as PiecesController;
+}
+
+function batchDeps(
+  specs: Record<string, FakePieceSpec>,
+  log: BatchCallLog,
+  overrides: Record<string, unknown> = {},
+) {
+  const pieces = fakePieces(specs, log);
+  return {
+    loadPieces: (config: SpaceConfig) => {
+      log.loadConfigs.push(config);
+      return Promise.resolve(pieces);
+    },
+    getPinnedProgramFromFile: (_pieces: PiecesController, entry: unknown) => {
+      log.pinnedEntries.push(entry);
+      return Promise.resolve(PROGRAM);
+    },
+    resolveCandidatePatternRef: () => Promise.resolve(CANDIDATE),
+    resolvePieceAddress: (_pieces: PiecesController, token: string) =>
+      Promise.resolve(token),
+    ...overrides,
+  };
+}
+
+function compatibleReport(): PatternCompatibilityReport {
+  return { compatible: true, issues: {}, candidate: CANDIDATE };
+}
+
+function incompatibleReport(message: string): PatternCompatibilityReport {
+  return {
+    compatible: false,
+    issues: { schema: message },
+    message,
+    candidate: CANDIDATE,
+  };
+}
+
+describe("piece-setsrc-batch", () => {
+  describe("setPiecePatternBatch()", () => {
+    it("updates every piece serially in the order given, through one session and one pinned program", async () => {
+      const log = newBatchCallLog();
+      const outcomes: [BatchPieceOutcome, number, number][] = [];
+      const result = await setPiecePatternBatch(
+        [configFor("p1"), configFor("p2"), configFor("p3")],
+        ENTRY,
+        {},
+        {
+          ...batchDeps({ p1: {}, p2: {}, p3: {} }, log),
+          onOutcome: (outcome, index, total) =>
+            outcomes.push([outcome, index, total]),
+        },
+      );
+
+      expect(result).toEqual([
+        { piece: "p1", status: "updated" },
+        { piece: "p2", status: "updated" },
+        { piece: "p3", status: "updated" },
+      ]);
+      expect(outcomes).toEqual([
+        [{ piece: "p1", status: "updated" }, 0, 3],
+        [{ piece: "p2", status: "updated" }, 1, 3],
+        [{ piece: "p3", status: "updated" }, 2, 3],
+      ]);
+      expect(log.setPatternCalls.map((call) => call.piece)).toEqual([
+        "p1",
+        "p2",
+        "p3",
+      ]);
+      // One session and one resolved source package pay for the whole batch.
+      expect(log.loadConfigs.length).toBe(1);
+      expect(log.pinnedEntries).toEqual([ENTRY]);
+      for (const call of log.setPatternCalls) {
+        expect(call.program).toBe(PROGRAM);
+        expect(call.options).toEqual({ repository: ENTRY.repository });
+      }
+    });
+
+    it("reports a piece already running the candidate as already-current without re-applying it", async () => {
+      const log = newBatchCallLog();
+      const result = await setPiecePatternBatch(
+        [configFor("p1"), configFor("p2")],
+        ENTRY,
+        {},
+        batchDeps({ p1: { deployed: CANDIDATE }, p2: {} }, log),
+      );
+
+      expect(result).toEqual([
+        { piece: "p1", status: "already-current" },
+        { piece: "p2", status: "updated" },
+      ]);
+      expect(log.setPatternCalls.map((call) => call.piece)).toEqual(["p2"]);
+    });
+
+    it("applies when the deployed identity matches but the export symbol differs", async () => {
+      const log = newBatchCallLog();
+      const result = await setPiecePatternBatch(
+        [configFor("p1")],
+        ENTRY,
+        {},
+        batchDeps({
+          p1: { deployed: { identity: CANDIDATE.identity, symbol: "other" } },
+        }, log),
+      );
+
+      expect(result).toEqual([{ piece: "p1", status: "updated" }]);
+      expect(log.setPatternCalls.length).toBe(1);
+    });
+
+    it("applies when the piece carries no pattern identity", async () => {
+      const log = newBatchCallLog();
+      const result = await setPiecePatternBatch(
+        [configFor("p1")],
+        ENTRY,
+        {},
+        batchDeps({ p1: { deployed: undefined } }, log),
+      );
+
+      expect(result).toEqual([{ piece: "p1", status: "updated" }]);
+      expect(log.setPatternCalls.length).toBe(1);
+    });
+
+    it("stops at the first failing piece, reports what landed, and rethrows that piece's own error", async () => {
+      const log = newBatchCallLog();
+      const failure = new Error("schema narrowed: label");
+      let reported: unknown;
+      const attempt = setPiecePatternBatch(
+        [configFor("p1"), configFor("p2"), configFor("p3")],
+        ENTRY,
+        {},
+        {
+          ...batchDeps(
+            { p1: {}, p2: { setPatternError: failure }, p3: {} },
+            log,
+          ),
+          onFailure: (context) => {
+            reported = context;
+          },
+        },
+      );
+
+      await expect(attempt).rejects.toBe(failure);
+      expect(reported).toEqual({
+        piece: "p2",
+        index: 1,
+        total: 3,
+        outcomes: [{ piece: "p1", status: "updated" }],
+      });
+      // The stop is immediate: the third piece is never attempted.
+      expect(log.setPatternCalls.map((call) => call.piece)).toEqual([
+        "p1",
+        "p2",
+      ]);
+    });
+
+    it("forwards the dangerous override to every piece's `setPattern`", async () => {
+      const log = newBatchCallLog();
+      await setPiecePatternBatch(
+        [configFor("p1"), configFor("p2")],
+        ENTRY,
+        { dangerouslyAllowIncompatibleSchema: true },
+        batchDeps({ p1: {}, p2: {} }, log),
+      );
+
+      for (const call of log.setPatternCalls) {
+        expect(call.options).toEqual({
+          repository: ENTRY.repository,
+          dangerouslyAllowIncompatibleSchema: true,
+        });
+      }
+    });
+
+    it("collects the embedded space DIDs of every piece reference into the one session config", async () => {
+      const log = newBatchCallLog();
+      await setPiecePatternBatch(
+        [
+          configFor("p1", { embeddedSpaces: [SPACE_DID] }),
+          configFor("p2", { embeddedSpaces: [SPACE_DID, OTHER_SPACE_DID] }),
+        ],
+        ENTRY,
+        {},
+        batchDeps({ p1: {}, p2: {} }, log),
+      );
+
+      expect(log.loadConfigs.length).toBe(1);
+      expect(log.loadConfigs[0].embeddedSpaces).toEqual([
+        SPACE_DID,
+        OTHER_SPACE_DID,
+      ]);
+    });
+
+    it("opens the session on the first config when no reference embeds a space", async () => {
+      const log = newBatchCallLog();
+      const configs = [configFor("p1"), configFor("p2")];
+      await setPiecePatternBatch(
+        configs,
+        ENTRY,
+        {},
+        batchDeps({ p1: {}, p2: {} }, log),
+      );
+
+      expect(log.loadConfigs[0]).toBe(configs[0]);
+    });
+
+    it("resolves each piece reference through the session and reports the resolved id", async () => {
+      const log = newBatchCallLog();
+      const result = await setPiecePatternBatch(
+        [configFor("one"), configFor("two")],
+        ENTRY,
+        {},
+        batchDeps({ "one/resolved": {}, "two/resolved": {} }, log, {
+          resolvePieceAddress: (_pieces: PiecesController, token: string) =>
+            Promise.resolve(`${token}/resolved`),
+        }),
+      );
+
+      expect(result.map((outcome) => outcome.piece)).toEqual([
+        "one/resolved",
+        "two/resolved",
+      ]);
+    });
+  });
+
+  describe("checkPiecePatternBatch()", () => {
+    it("reviews every piece with the shared pinned program and returns the verdicts in order", async () => {
+      const log = newBatchCallLog();
+      const good = compatibleReport();
+      const bad = incompatibleReport("result narrowed: label");
+      const checks = await checkPiecePatternBatch(
+        [configFor("p1"), configFor("p2")],
+        ENTRY,
+        batchDeps({ p1: { report: good }, p2: { report: bad } }, log),
+      );
+
+      expect(checks).toEqual([
+        { piece: "p1", report: good },
+        { piece: "p2", report: bad },
+      ]);
+      expect(log.loadConfigs.length).toBe(1);
+      expect(log.pinnedEntries).toEqual([ENTRY]);
+      for (const call of log.checkPatternCalls) {
+        expect(call.program).toBe(PROGRAM);
+      }
+    });
+  });
+
+  describe("resolveCandidatePatternRef()", () => {
+    it("derives the candidate reference from one compile in the target space", async () => {
+      const compiled = { kind: "pattern" };
+      const compileContexts: unknown[] = [];
+      const pieces = {
+        runtime: {
+          patternManager: {
+            compilePattern: (_program: unknown, context: unknown) => {
+              compileContexts.push(context);
+              return Promise.resolve(compiled);
+            },
+            getArtifactEntryRef: (pattern: unknown) =>
+              pattern === compiled ? CANDIDATE : undefined,
+          },
+        },
+        getSpace: () => SPACE_DID,
+      } as unknown as PiecesController;
+
+      const ref = await resolveCandidatePatternRef(pieces, PROGRAM);
+
+      expect(ref).toEqual(CANDIDATE);
+      expect(compileContexts).toEqual([{ space: SPACE_DID }]);
+    });
+
+    it("throws when the compiled candidate has no pattern identity", async () => {
+      const pieces = {
+        runtime: {
+          patternManager: {
+            compilePattern: () => Promise.resolve({ kind: "pattern" }),
+            getArtifactEntryRef: () => undefined,
+          },
+        },
+        getSpace: () => SPACE_DID,
+      } as unknown as PiecesController;
+
+      await expect(resolveCandidatePatternRef(pieces, PROGRAM)).rejects
+        .toThrow("the candidate source has no pattern identity");
+    });
+  });
+
+  describe("parseBatchPieceConfigs()", () => {
+    it("parses each `--piece` value with the shared space options", () => {
+      const configs = parseBatchPieceConfigs({
+        apiUrl: API_URL,
+        space: SPACE,
+        identity: IDENTITY,
+        piece: ["p1", "p2"],
+      });
+
+      expect(configs).toEqual([
+        { apiUrl: API_URL, space: SPACE, identity: IDENTITY, piece: "p1" },
+        { apiUrl: API_URL, space: SPACE, identity: IDENTITY, piece: "p2" },
+      ]);
+    });
+
+    it("refuses `--url` beside repeated `--piece`", () => {
+      expect(() =>
+        parseBatchPieceConfigs({
+          url: `${API_URL}/${SPACE}`,
+          identity: IDENTITY,
+          piece: ["p1", "p2"],
+        })
+      ).toThrow('"--url" names a single piece');
+    });
+  });
+
+  describe("setPieceSourceBatchFromCommand()", () => {
+    it("streams one line per piece as it lands, then the summary", async () => {
+      const lines: string[] = [];
+      let forwarded: unknown;
+      const { configs, outcomes } = await setPieceSourceBatchFromCommand(
+        {
+          apiUrl: API_URL,
+          space: SPACE,
+          identity: IDENTITY,
+          piece: ["p1", "p2"],
+          repository: ENTRY.repository,
+        },
+        "/repo/pattern.tsx",
+        {
+          setPiecePatternBatch: (configs, entry, options, deps) => {
+            forwarded = { configs, entry, options };
+            const landed: BatchPieceOutcome[] = [
+              { piece: "p1", status: "updated" },
+              { piece: "p2", status: "already-current" },
+            ];
+            landed.forEach((outcome, index) =>
+              deps?.onOutcome?.(outcome, index, landed.length)
+            );
+            return Promise.resolve(landed);
+          },
+          report: (line) => lines.push(line),
+        },
+      );
+
+      expect(lines).toEqual([
+        "Updated source for piece p1 (1/2)",
+        "Source already current for piece p2 — skipped (2/2)",
+        "Processed 2 pieces: 1 updated, 1 already current.",
+      ]);
+      expect(outcomes.length).toBe(2);
+      expect(forwarded).toEqual({
+        configs,
+        entry: {
+          mainPath: "/repo/pattern.tsx",
+          mainExport: undefined,
+          repository: ENTRY.repository,
+          rootPath: undefined,
+          testPaths: undefined,
+          dataFilePaths: undefined,
+        },
+        options: { dangerouslyAllowIncompatibleSchema: undefined },
+      });
+    });
+
+    it("prints the stop report and lets the failing piece's own error propagate", async () => {
+      const lines: string[] = [];
+      const stops: string[] = [];
+      const failure = new Error("argument links not provable");
+      const attempt = setPieceSourceBatchFromCommand(
+        {
+          apiUrl: API_URL,
+          space: SPACE,
+          identity: IDENTITY,
+          piece: ["p1", "p2", "p3"],
+        },
+        "/repo/pattern.tsx",
+        {
+          setPiecePatternBatch: (_configs, _entry, _options, deps) => {
+            deps?.onOutcome?.({ piece: "p1", status: "updated" }, 0, 3);
+            deps?.onFailure?.({
+              piece: "p2",
+              index: 1,
+              total: 3,
+              outcomes: [{ piece: "p1", status: "updated" }],
+            });
+            return Promise.reject(failure);
+          },
+          report: (line) => lines.push(line),
+          reportError: (line) => stops.push(line),
+        },
+      );
+
+      await expect(attempt).rejects.toBe(failure);
+      expect(lines).toEqual(["Updated source for piece p1 (1/3)"]);
+      expect(stops).toEqual([
+        "Stopped at piece p2 (2 of 3): 1 updated and 0 already current " +
+        "before the stop; 1 not attempted.",
+      ]);
+    });
+  });
+
+  describe("checkPieceSourceBatchFromCommand()", () => {
+    it("reports every verdict and exits non-zero when any piece cannot be replaced", async () => {
+      const lines: string[] = [];
+      const errors: string[] = [];
+      let exitCode: number | undefined;
+      class ExitSentinel extends Error {}
+      const attempt = checkPieceSourceBatchFromCommand(
+        {
+          apiUrl: API_URL,
+          space: SPACE,
+          identity: IDENTITY,
+          piece: ["p1", "p2"],
+        },
+        "/repo/pattern.tsx",
+        {
+          checkPiecePatternBatch: () =>
+            Promise.resolve([
+              { piece: "p1", report: compatibleReport() },
+              {
+                piece: "p2",
+                report: incompatibleReport("result narrowed: label"),
+              },
+            ]),
+          report: (line) => lines.push(line),
+          exit: {
+            printError: (message) => errors.push(message),
+            exit: (code) => {
+              exitCode = code;
+              throw new ExitSentinel();
+            },
+          },
+        },
+      );
+
+      await expect(attempt).rejects.toThrow(ExitSentinel);
+      expect(lines).toEqual([
+        "/repo/pattern.tsx can replace the source for piece p1",
+        "/repo/pattern.tsx cannot replace the source for piece p2:\n" +
+        "result narrowed: label",
+      ]);
+      expect(errors.join("\n")).toContain(
+        "cannot replace the source for 1 of 2 pieces",
+      );
+      expect(exitCode).toBe(1);
+    });
+
+    it("returns every verdict without exiting when all pieces can be replaced", async () => {
+      const lines: string[] = [];
+      const { checks } = await checkPieceSourceBatchFromCommand(
+        {
+          apiUrl: API_URL,
+          space: SPACE,
+          identity: IDENTITY,
+          piece: ["p1", "p2"],
+        },
+        "/repo/pattern.tsx",
+        {
+          checkPiecePatternBatch: () =>
+            Promise.resolve([
+              { piece: "p1", report: compatibleReport() },
+              { piece: "p2", report: compatibleReport() },
+            ]),
+          report: (line) => lines.push(line),
+          exit: {
+            printError: () => {},
+            exit: () => {
+              throw new Error("exited on a fully compatible batch");
+            },
+          },
+        },
+      );
+
+      expect(checks.length).toBe(2);
+      expect(lines).toEqual([
+        "/repo/pattern.tsx can replace the source for piece p1",
+        "/repo/pattern.tsx can replace the source for piece p2",
+      ]);
+    });
+  });
+
+  describe("reporting", () => {
+    it("formats an updated piece's line with its position in the batch", () => {
+      expect(
+        formatBatchOutcomeLine({ piece: "p7", status: "updated" }, 6, 106),
+      ).toBe("Updated source for piece p7 (7/106)");
+    });
+
+    it("formats an already-current piece's line as skipped", () => {
+      expect(
+        formatBatchOutcomeLine(
+          { piece: "p1", status: "already-current" },
+          0,
+          2,
+        ),
+      ).toBe("Source already current for piece p1 — skipped (1/2)");
+    });
+
+    it("totals the stop report from the landed outcomes", () => {
+      expect(formatBatchStopReport({
+        piece: "p4",
+        index: 3,
+        total: 6,
+        outcomes: [
+          { piece: "p1", status: "updated" },
+          { piece: "p2", status: "already-current" },
+          { piece: "p3", status: "updated" },
+        ],
+      })).toBe(
+        "Stopped at piece p4 (4 of 6): 2 updated and 1 already current " +
+          "before the stop; 2 not attempted.",
+      );
+    });
+
+    it("counts updated and already-current pieces distinctly in the summary", () => {
+      expect(formatBatchSummary([
+        { piece: "p1", status: "updated" },
+        { piece: "p2", status: "already-current" },
+        { piece: "p3", status: "updated" },
+      ])).toBe("Processed 3 pieces: 2 updated, 1 already current.");
+    });
+
+    it("points the apply hint at the batch's space", () => {
+      const hint = batchApplyNextSteps([configFor("p1"), configFor("p2")]);
+      expect(hint).toContain(`${API_URL}/${SPACE}`);
+      expect(hint).toContain("piece inspect");
+    });
+
+    it("spells the check hint's apply command with every piece flag", () => {
+      const hint = batchCheckNextSteps(
+        [configFor("p1"), configFor("p2")],
+        "/repo/pattern.tsx",
+      );
+      expect(hint).toContain("--piece p1 --piece p2 /repo/pattern.tsx");
+    });
+  });
+
+  describe("setSrcBatchAction()", () => {
+    it("applies the batch and hints at the batch's space", async () => {
+      const hints: string[] = [];
+      const reported: string[] = [];
+      await setSrcBatchAction(
+        {
+          apiUrl: API_URL,
+          space: SPACE,
+          identity: IDENTITY,
+          piece: ["p1", "p2"],
+        },
+        "/repo/pattern.tsx",
+        {
+          setPiecePatternBatch: () =>
+            Promise.resolve([
+              { piece: "p1", status: "updated" },
+              { piece: "p2", status: "updated" },
+            ]),
+          report: (line) => reported.push(line),
+          hint: (message) => hints.push(message),
+        },
+      );
+
+      expect(reported).toEqual([
+        "Processed 2 pieces: 2 updated, 0 already current.",
+      ]);
+      expect(hints.length).toBe(1);
+      expect(hints[0]).toContain(`${API_URL}/${SPACE}`);
+    });
+
+    it("routes `--check` to the aggregate preflight and hints the batch apply command", async () => {
+      const hints: string[] = [];
+      const reported: string[] = [];
+      await setSrcBatchAction(
+        {
+          apiUrl: API_URL,
+          space: SPACE,
+          identity: IDENTITY,
+          piece: ["p1", "p2"],
+          check: true,
+        },
+        "/repo/pattern.tsx",
+        {
+          checkPiecePatternBatch: () =>
+            Promise.resolve([
+              { piece: "p1", report: compatibleReport() },
+              { piece: "p2", report: compatibleReport() },
+            ]),
+          report: (line) => reported.push(line),
+          hint: (message) => hints.push(message),
+        },
+      );
+
+      expect(reported.length).toBe(2);
+      expect(hints.length).toBe(1);
+      expect(hints[0]).toContain("--piece p1 --piece p2 /repo/pattern.tsx");
+    });
+  });
+
+  describe("setsrc command dispatch", () => {
+    // Each parse-driven case imports a fresh module instance, so
+    // `throwErrors()` cannot leak into the singleton command the other tests
+    // share. `reset()` first: the chain leaves the builder pointed at its
+    // last subcommand, and only the root parents every subcommand's
+    // `shouldThrowErrors()` walk.
+    async function freshPieceCommand(instance: string) {
+      const { piece: command } = await import(
+        `../commands/piece.ts?${instance}`
+      );
+      command.reset().throwErrors();
+      return command;
+    }
+
+    it("refuses `--url` with repeated `--piece` through the full command parse", async () => {
+      const command = await freshPieceCommand("setsrc-batch-url");
+      await expect(command.parse([
+        "setsrc",
+        "--url",
+        `${API_URL}/${SPACE}`,
+        "--piece",
+        "p1",
+        "--piece",
+        "p2",
+        "--identity",
+        IDENTITY,
+        "/repo/pattern.tsx",
+      ])).rejects.toThrow('"--url" names a single piece');
+    });
+
+    it("routes repeated `--piece` with `--check` through the batch preflight", async () => {
+      const command = await freshPieceCommand("setsrc-batch-check-url");
+      await expect(command.parse([
+        "setsrc",
+        "--check",
+        "--url",
+        `${API_URL}/${SPACE}`,
+        "--piece",
+        "p1",
+        "--piece",
+        "p2",
+        "--identity",
+        IDENTITY,
+        "/repo/pattern.tsx",
+      ])).rejects.toThrow('"--url" names a single piece');
+    });
+
+    it("keeps a single `--piece` on the one-piece path through the full command parse", async () => {
+      const command = await freshPieceCommand("setsrc-single");
+      // The one-piece refusal for a piece named twice is the single path's
+      // own; reaching it proves a lone `--piece` still parses as before.
+      await expect(command.parse([
+        "setsrc",
+        "--url",
+        `${API_URL}/${SPACE}/${"abcdefghijklmnopqrstuvwxyz"}`,
+        "--piece",
+        "p1",
+        "--identity",
+        IDENTITY,
+        "/repo/pattern.tsx",
+      ])).rejects.toThrow(
+        'cannot be provided when the "--url" names a piece',
+      );
+    });
+
+    it("keeps a single `--piece --check` on the one-piece preflight through the full command parse", async () => {
+      const command = await freshPieceCommand("setsrc-single-check");
+      await expect(command.parse([
+        "setsrc",
+        "--check",
+        "--url",
+        `${API_URL}/${SPACE}/${"abcdefghijklmnopqrstuvwxyz"}`,
+        "--piece",
+        "p1",
+        "--identity",
+        IDENTITY,
+        "/repo/pattern.tsx",
+      ])).rejects.toThrow(
+        'cannot be provided when the "--url" names a piece',
+      );
+    });
+  });
+});

--- a/packages/cli/test/piece-setsrc-batch.test.ts
+++ b/packages/cli/test/piece-setsrc-batch.test.ts
@@ -20,7 +20,6 @@ import {
   type BatchPieceOutcome,
   checkPiecePatternBatch,
   type PieceConfig,
-  resolveCandidatePatternRef,
   setPiecePatternBatch,
   type SpaceConfig,
 } from "../lib/piece.ts";
@@ -54,7 +53,7 @@ function configFor(piece: string, extra: Partial<PieceConfig> = {}) {
   } as PieceConfig;
 }
 
-/** What one fake piece looks like to the batch: its deployed ref and fate. */
+/** What one fake piece looks like to the batch. */
 interface FakePieceSpec {
   deployed?: { identity: string; symbol: string };
   setPatternError?: Error;
@@ -79,8 +78,7 @@ function newBatchCallLog(): BatchCallLog {
 
 /**
  * A fake `PiecesController` covering exactly the surface the batch functions
- * touch: `get()` for the per-piece controllers, and (via the real
- * `getPatternIdentityRef`) each controller's cell meta.
+ * touch: `get()` for the per-piece controllers and each piece operation.
  */
 function fakePieces(
   specs: Record<string, FakePieceSpec>,
@@ -127,7 +125,6 @@ function batchDeps(
       log.pinnedEntries.push(entry);
       return Promise.resolve(PROGRAM);
     },
-    resolveCandidatePatternRef: () => Promise.resolve(CANDIDATE),
     resolvePieceAddress: (_pieces: PiecesController, token: string) =>
       Promise.resolve(token),
     ...overrides,
@@ -164,14 +161,14 @@ describe("piece-setsrc-batch", () => {
       );
 
       expect(result).toEqual([
-        { piece: "p1", status: "updated" },
-        { piece: "p2", status: "updated" },
-        { piece: "p3", status: "updated" },
+        { piece: "p1" },
+        { piece: "p2" },
+        { piece: "p3" },
       ]);
       expect(outcomes).toEqual([
-        [{ piece: "p1", status: "updated" }, 0, 3],
-        [{ piece: "p2", status: "updated" }, 1, 3],
-        [{ piece: "p3", status: "updated" }, 2, 3],
+        [{ piece: "p1" }, 0, 3],
+        [{ piece: "p2" }, 1, 3],
+        [{ piece: "p3" }, 2, 3],
       ]);
       expect(log.setPatternCalls.map((call) => call.piece)).toEqual([
         "p1",
@@ -187,7 +184,7 @@ describe("piece-setsrc-batch", () => {
       }
     });
 
-    it("reports a piece already running the candidate as already-current without re-applying it", async () => {
+    it("applies a piece already running the candidate so setPattern owns its lifecycle and repository updates", async () => {
       const log = newBatchCallLog();
       const result = await setPiecePatternBatch(
         [configFor("p1"), configFor("p2")],
@@ -197,38 +194,16 @@ describe("piece-setsrc-batch", () => {
       );
 
       expect(result).toEqual([
-        { piece: "p1", status: "already-current" },
-        { piece: "p2", status: "updated" },
+        { piece: "p1" },
+        { piece: "p2" },
       ]);
-      expect(log.setPatternCalls.map((call) => call.piece)).toEqual(["p2"]);
-    });
-
-    it("applies when the deployed identity matches but the export symbol differs", async () => {
-      const log = newBatchCallLog();
-      const result = await setPiecePatternBatch(
-        [configFor("p1")],
-        ENTRY,
-        {},
-        batchDeps({
-          p1: { deployed: { identity: CANDIDATE.identity, symbol: "other" } },
-        }, log),
-      );
-
-      expect(result).toEqual([{ piece: "p1", status: "updated" }]);
-      expect(log.setPatternCalls.length).toBe(1);
-    });
-
-    it("applies when the piece carries no pattern identity", async () => {
-      const log = newBatchCallLog();
-      const result = await setPiecePatternBatch(
-        [configFor("p1")],
-        ENTRY,
-        {},
-        batchDeps({ p1: { deployed: undefined } }, log),
-      );
-
-      expect(result).toEqual([{ piece: "p1", status: "updated" }]);
-      expect(log.setPatternCalls.length).toBe(1);
+      expect(log.setPatternCalls.map((call) => call.piece)).toEqual([
+        "p1",
+        "p2",
+      ]);
+      for (const call of log.setPatternCalls) {
+        expect(call.options).toEqual({ repository: ENTRY.repository });
+      }
     });
 
     it("stops at the first failing piece, reports what landed, and rethrows that piece's own error", async () => {
@@ -255,7 +230,7 @@ describe("piece-setsrc-batch", () => {
         piece: "p2",
         index: 1,
         total: 3,
-        outcomes: [{ piece: "p1", status: "updated" }],
+        outcomes: [{ piece: "p1" }],
       });
       // The stop is immediate: the third piece is never attempted.
       expect(log.setPatternCalls.map((call) => call.piece)).toEqual([
@@ -355,46 +330,6 @@ describe("piece-setsrc-batch", () => {
     });
   });
 
-  describe("resolveCandidatePatternRef()", () => {
-    it("derives the candidate reference from one compile in the target space", async () => {
-      const compiled = { kind: "pattern" };
-      const compileContexts: unknown[] = [];
-      const pieces = {
-        runtime: {
-          patternManager: {
-            compilePattern: (_program: unknown, context: unknown) => {
-              compileContexts.push(context);
-              return Promise.resolve(compiled);
-            },
-            getArtifactEntryRef: (pattern: unknown) =>
-              pattern === compiled ? CANDIDATE : undefined,
-          },
-        },
-        getSpace: () => SPACE_DID,
-      } as unknown as PiecesController;
-
-      const ref = await resolveCandidatePatternRef(pieces, PROGRAM);
-
-      expect(ref).toEqual(CANDIDATE);
-      expect(compileContexts).toEqual([{ space: SPACE_DID }]);
-    });
-
-    it("throws when the compiled candidate has no pattern identity", async () => {
-      const pieces = {
-        runtime: {
-          patternManager: {
-            compilePattern: () => Promise.resolve({ kind: "pattern" }),
-            getArtifactEntryRef: () => undefined,
-          },
-        },
-        getSpace: () => SPACE_DID,
-      } as unknown as PiecesController;
-
-      await expect(resolveCandidatePatternRef(pieces, PROGRAM)).rejects
-        .toThrow("the candidate source has no pattern identity");
-    });
-  });
-
   describe("parseBatchPieceConfigs()", () => {
     it("parses each `--piece` value with the shared space options", () => {
       const configs = parseBatchPieceConfigs({
@@ -410,14 +345,15 @@ describe("piece-setsrc-batch", () => {
       ]);
     });
 
-    it("refuses `--url` beside repeated `--piece`", () => {
-      expect(() =>
-        parseBatchPieceConfigs({
-          url: `${API_URL}/${SPACE}`,
-          identity: IDENTITY,
-          piece: ["p1", "p2"],
-        })
-      ).toThrow('"--url" names a single piece');
+    it("combines a piece-less `--url` with every repeated `--piece`", () => {
+      expect(parseBatchPieceConfigs({
+        url: `${API_URL}/${SPACE}`,
+        identity: IDENTITY,
+        piece: ["p1", "p2"],
+      })).toEqual([
+        { apiUrl: API_URL, space: SPACE, identity: IDENTITY, piece: "p1" },
+        { apiUrl: API_URL, space: SPACE, identity: IDENTITY, piece: "p2" },
+      ]);
     });
   });
 
@@ -438,8 +374,8 @@ describe("piece-setsrc-batch", () => {
           setPiecePatternBatch: (configs, entry, options, deps) => {
             forwarded = { configs, entry, options };
             const landed: BatchPieceOutcome[] = [
-              { piece: "p1", status: "updated" },
-              { piece: "p2", status: "already-current" },
+              { piece: "p1" },
+              { piece: "p2" },
             ];
             landed.forEach((outcome, index) =>
               deps?.onOutcome?.(outcome, index, landed.length)
@@ -452,8 +388,8 @@ describe("piece-setsrc-batch", () => {
 
       expect(lines).toEqual([
         "Updated source for piece p1 (1/2)",
-        "Source already current for piece p2 — skipped (2/2)",
-        "Processed 2 pieces: 1 updated, 1 already current.",
+        "Updated source for piece p2 (2/2)",
+        "Updated 2 pieces.",
       ]);
       expect(outcomes.length).toBe(2);
       expect(forwarded).toEqual({
@@ -484,12 +420,12 @@ describe("piece-setsrc-batch", () => {
         "/repo/pattern.tsx",
         {
           setPiecePatternBatch: (_configs, _entry, _options, deps) => {
-            deps?.onOutcome?.({ piece: "p1", status: "updated" }, 0, 3);
+            deps?.onOutcome?.({ piece: "p1" }, 0, 3);
             deps?.onFailure?.({
               piece: "p2",
               index: 1,
               total: 3,
-              outcomes: [{ piece: "p1", status: "updated" }],
+              outcomes: [{ piece: "p1" }],
             });
             return Promise.reject(failure);
           },
@@ -501,8 +437,8 @@ describe("piece-setsrc-batch", () => {
       await expect(attempt).rejects.toBe(failure);
       expect(lines).toEqual(["Updated source for piece p1 (1/3)"]);
       expect(stops).toEqual([
-        "Stopped at piece p2 (2 of 3): 1 updated and 0 already current " +
-        "before the stop; 1 not attempted.",
+        "Stopped at piece p2 (2 of 3): 1 updated before the stop; " +
+        "1 not attempted.",
       ]);
     });
   });
@@ -590,18 +526,8 @@ describe("piece-setsrc-batch", () => {
   describe("reporting", () => {
     it("formats an updated piece's line with its position in the batch", () => {
       expect(
-        formatBatchOutcomeLine({ piece: "p7", status: "updated" }, 6, 106),
+        formatBatchOutcomeLine({ piece: "p7" }, 6, 106),
       ).toBe("Updated source for piece p7 (7/106)");
-    });
-
-    it("formats an already-current piece's line as skipped", () => {
-      expect(
-        formatBatchOutcomeLine(
-          { piece: "p1", status: "already-current" },
-          0,
-          2,
-        ),
-      ).toBe("Source already current for piece p1 — skipped (1/2)");
     });
 
     it("totals the stop report from the landed outcomes", () => {
@@ -610,22 +536,22 @@ describe("piece-setsrc-batch", () => {
         index: 3,
         total: 6,
         outcomes: [
-          { piece: "p1", status: "updated" },
-          { piece: "p2", status: "already-current" },
-          { piece: "p3", status: "updated" },
+          { piece: "p1" },
+          { piece: "p2" },
+          { piece: "p3" },
         ],
       })).toBe(
-        "Stopped at piece p4 (4 of 6): 2 updated and 1 already current " +
-          "before the stop; 2 not attempted.",
+        "Stopped at piece p4 (4 of 6): 3 updated before the stop; " +
+          "2 not attempted.",
       );
     });
 
-    it("counts updated and already-current pieces distinctly in the summary", () => {
+    it("totals the updated pieces in the summary", () => {
       expect(formatBatchSummary([
-        { piece: "p1", status: "updated" },
-        { piece: "p2", status: "already-current" },
-        { piece: "p3", status: "updated" },
-      ])).toBe("Processed 3 pieces: 2 updated, 1 already current.");
+        { piece: "p1" },
+        { piece: "p2" },
+        { piece: "p3" },
+      ])).toBe("Updated 3 pieces.");
     });
 
     it("points the apply hint at the batch's space", () => {
@@ -658,8 +584,8 @@ describe("piece-setsrc-batch", () => {
         {
           setPiecePatternBatch: () =>
             Promise.resolve([
-              { piece: "p1", status: "updated" },
-              { piece: "p2", status: "updated" },
+              { piece: "p1" },
+              { piece: "p2" },
             ]),
           report: (line) => reported.push(line),
           hint: (message) => hints.push(message),
@@ -667,7 +593,7 @@ describe("piece-setsrc-batch", () => {
       );
 
       expect(reported).toEqual([
-        "Processed 2 pieces: 2 updated, 0 already current.",
+        "Updated 2 pieces.",
       ]);
       expect(hints.length).toBe(1);
       expect(hints[0]).toContain(`${API_URL}/${SPACE}`);
@@ -716,12 +642,12 @@ describe("piece-setsrc-batch", () => {
       return command;
     }
 
-    it("refuses `--url` with repeated `--piece` through the full command parse", async () => {
+    it("rejects a piece-naming `--url` with repeated `--piece` through the full command parse", async () => {
       const command = await freshPieceCommand("setsrc-batch-url");
       await expect(command.parse([
         "setsrc",
         "--url",
-        `${API_URL}/${SPACE}`,
+        `${API_URL}/${SPACE}/${"abcdefghijklmnopqrstuvwxyz"}`,
         "--piece",
         "p1",
         "--piece",
@@ -729,7 +655,9 @@ describe("piece-setsrc-batch", () => {
         "--identity",
         IDENTITY,
         "/repo/pattern.tsx",
-      ])).rejects.toThrow('"--url" names a single piece');
+      ])).rejects.toThrow(
+        'cannot be provided when the "--url" names a piece',
+      );
     });
 
     it("routes repeated `--piece` with `--check` through the batch preflight", async () => {
@@ -738,7 +666,7 @@ describe("piece-setsrc-batch", () => {
         "setsrc",
         "--check",
         "--url",
-        `${API_URL}/${SPACE}`,
+        `${API_URL}/${SPACE}/${"abcdefghijklmnopqrstuvwxyz"}`,
         "--piece",
         "p1",
         "--piece",
@@ -746,7 +674,9 @@ describe("piece-setsrc-batch", () => {
         "--identity",
         IDENTITY,
         "/repo/pattern.tsx",
-      ])).rejects.toThrow('"--url" names a single piece');
+      ])).rejects.toThrow(
+        'cannot be provided when the "--url" names a piece',
+      );
     });
 
     it("keeps a single `--piece` on the one-piece path through the full command parse", async () => {


### PR DESCRIPTION
Migrating the 106-topic board on rapids costs ~43–90s **per piece** via repeated `cf piece setsrc`, ~106×. The profiled decomposition: ~0.4s CLI start, ~1s session fixed cost, ~20–27s syncing the piece's linked-document neighborhood (the runner's schema-blind `syncArgumentLinkTargets` walk — argument → board topics array → all 106 topic docs), ~1s compile (content-cached), ~14s swap+re-stage+settle. Nearly all of it is per-process overhead; the CLI deliberately had no bulk facility (`setsrc` took exactly one `--piece`, and the automatic PatternUpdater neither checks structurally nor applies here). The topics-migration rehearsal is the driving consumer.

`--piece` now collects. Two or more pieces share one session: `loadPieces` once (the neighborhood walk dedupes against the warm replica), the source package resolved, pinned, and type-checked once, then a strictly serial per-piece loop with unchanged semantics — the same `setPattern`, compatibility assertion, dangerous-flag scope, retained-link proof, and `expectedPatternIdentity` behavior as today. The per-piece compile inside `setPattern` is kept deliberately: it persists that piece's predecessor update-authority delegations, and pieces 2..N ride the content-addressed compile cache, so transform-and-emit is still paid once.

Failures stop the batch with a stop report (what landed, what was never attempted) and the failing piece's own error; one unambiguous success line prints per piece as it lands, because operators count lines, not exit codes. `--check` composes: every piece reviewed, verdicts grouped by piece, nonzero exit if any piece cannot be replaced, nothing touched. The one-piece path is byte-for-byte unchanged. A piece-less `--url` supplies the host and space for every repeated `--piece`; a `--url` that already names a piece is still refused.

Every named piece is applied, with no skip-if-already-current shortcut: batch mode is N single `setsrc` calls sharing one session, and nothing else.

Rehearsal docs that describe the one-piece loop (`space-clone-rehearsal.md`, `topics-migration-rehearsal.md`) are being revised separately and are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


