### PR TITLE
fix(dashboard): log GitHub request failures

### DIFF
--- a/packages/dashboard/github-rate-limit.test.ts
+++ b/packages/dashboard/github-rate-limit.test.ts
@@ -1176,18 +1176,31 @@ Deno.test("performance GitHub requests report unusable rate-limit responses", as
   try {
     for (
       const response of [
-        new Response("unavailable", { status: 503 }),
+        new Response("unavailable", {
+          status: 503,
+          headers: {
+            "x-github-request-id": "rate-probe-request",
+            "x-ratelimit-remaining": "0",
+            "retry-after": "60",
+          },
+        }),
         Response.json({ resources: {} }),
       ]
     ) {
       const token = `rate-probe-${crypto.randomUUID()}`;
       globalThis.fetch = (() =>
         Promise.resolve(response.clone())) as typeof fetch;
-      await assertRejects(
+      const error = await assertRejects(
         () => performanceGithub("repos/o/r", token),
         GitHubRateLimitBudgetError,
         "rate limit status could not be read",
       );
+      if (response.status === 503) {
+        assertStringIncludes(error.message, "request rate-probe-request");
+        assertStringIncludes(error.message, "rate limit 0 remaining");
+        assertStringIncludes(error.message, "retry after 60");
+        assertStringIncludes(error.message, "unavailable");
+      }
     }
   } finally {
     globalThis.fetch = originalFetch;
@@ -1215,11 +1228,15 @@ Deno.test("GitHub download helpers return response bodies without JSON decoding"
 
   try {
     assertEquals(
-      await (await githubDownload("repos/o/archive", token)).text(),
+      new TextDecoder().decode(
+        (await githubDownload("repos/o/archive", token)).body,
+      ),
       "archive",
     );
     assertEquals(
-      await (await performanceGithubDownload("repos/o/archive", token)).text(),
+      new TextDecoder().decode(
+        (await performanceGithubDownload("repos/o/archive", token)).body,
+      ),
       "archive",
     );
     assertEquals(calls.map((call) => call.path), [

--- a/packages/dashboard/github-rate-limit.test.ts
+++ b/packages/dashboard/github-rate-limit.test.ts
@@ -1,4 +1,5 @@
 import {
+  assert,
   assertEquals,
   assertRejects,
   assertStringIncludes,
@@ -1199,9 +1200,37 @@ Deno.test("performance GitHub requests report unusable rate-limit responses", as
         assertStringIncludes(error.message, "request rate-probe-request");
         assertStringIncludes(error.message, "rate limit 0 remaining");
         assertStringIncludes(error.message, "retry after 60");
-        assertStringIncludes(error.message, "unavailable");
       }
     }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("an unusable rate-limit response does not wait for body cleanup", async () => {
+  const originalFetch = globalThis.fetch;
+  let cancelled = false;
+  const response = new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("short detail"));
+      },
+      cancel() {
+        cancelled = true;
+        return new Promise<void>(() => {});
+      },
+    }),
+    { status: 503 },
+  );
+  try {
+    globalThis.fetch = (() => Promise.resolve(response)) as typeof fetch;
+    const token = `rate-probe-cleanup-${crypto.randomUUID()}`;
+    await assertRejects(
+      () => performanceGithub("repos/o/r", token),
+      GitHubRateLimitBudgetError,
+      "rate limit status could not be read",
+    );
+    assert(cancelled);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/packages/dashboard/lib-extra.test.ts
+++ b/packages/dashboard/lib-extra.test.ts
@@ -140,6 +140,30 @@ Deno.test("github: an HTTP failure logs the endpoint and GitHub response context
   });
 });
 
+Deno.test("github: response header details are bounded and single-line", async () => {
+  await withTokens({ GH_TOKEN: "t" }, async () => {
+    await captureConsole("error", async (messages) => {
+      const unsafe = `request-\x1b[31m${"x".repeat(500)}`;
+      await withFetch(
+        () =>
+          new Response("unavailable", {
+            status: 503,
+            headers: { "x-github-request-id": unsafe },
+          }),
+        async () => {
+          await assertRejects(() => github("repos/o/runs"), Error);
+        },
+      );
+      assertEquals(messages.length, 1);
+      assert([...messages[0]].every((character) => {
+        const code = character.charCodeAt(0);
+        return code > 31 && (code < 127 || code > 159);
+      }));
+      assert(messages[0].length < 500);
+    });
+  });
+});
+
 Deno.test("github: a request failure logs its endpoint, stage, and elapsed time", async () => {
   await withTokens({ GH_TOKEN: "t" }, async () => {
     await captureConsole("error", async (messages) => {
@@ -227,6 +251,40 @@ Deno.test("github: a failed error body preserves the known HTTP failure", async 
       assert(messages[0].includes("could not read the error response"));
       assert(messages[0].includes("body connection closed"));
       assert(messages[1].includes("returned HTTP 403"));
+    });
+  });
+});
+
+Deno.test("github: a large error keeps a bounded prefix and cancels the body", async () => {
+  await withTokens({ GH_TOKEN: "t" }, async () => {
+    await captureConsole("error", async (messages) => {
+      let sent = false;
+      let cancelled = false;
+      const response = new Response(
+        new ReadableStream({
+          pull(controller) {
+            if (sent) return;
+            sent = true;
+            controller.enqueue(
+              new TextEncoder().encode(`useful detail ${"x".repeat(10_000)}`),
+            );
+          },
+          cancel() {
+            cancelled = true;
+          },
+        }),
+        { status: 500 },
+      );
+      await withFetch(
+        () => response,
+        async () => {
+          await assertRejects(() => github("repos/o/error"), Error);
+        },
+      );
+      assert(cancelled);
+      assertEquals(messages.length, 1);
+      assert(messages[0].includes("useful detail"));
+      assert(messages[0].length < 500);
     });
   });
 });
@@ -396,7 +454,7 @@ Deno.test("github: an abandoned download has already completed its body", async 
   });
 });
 
-Deno.test("github: a failed download consumes and logs its error body", async () => {
+Deno.test("github: a failed download cancels its body and logs response context", async () => {
   await withTokens({ GH_TOKEN: "t" }, async () => {
     await captureConsole("error", async (messages) => {
       const response = Response.json(
@@ -425,27 +483,25 @@ Deno.test("github: a failed download consumes and logs its error body", async ()
         messages[0].includes("for download repos/o/actions/artifacts/1/zip"),
       );
       assert(messages[0].includes("HTTP 410, request download-123"));
-      assert(messages[0].includes("artifact expired"));
+      assert(!messages[0].includes("artifact expired"));
     });
   });
 });
 
-Deno.test("github: a large download error keeps a bounded prefix and cancels the body", async () => {
+Deno.test("github: a failed download does not wait for body cleanup", async () => {
   await withTokens({ GH_TOKEN: "t" }, async () => {
     await captureConsole("error", async (messages) => {
-      let sent = false;
       let cancelled = false;
       const response = new Response(
         new ReadableStream({
-          pull(controller) {
-            if (sent) return;
-            sent = true;
+          start(controller) {
             controller.enqueue(
-              new TextEncoder().encode(`useful detail ${"x".repeat(10_000)}`),
+              new TextEncoder().encode("short detail"),
             );
           },
           cancel() {
             cancelled = true;
+            return new Promise<void>(() => {});
           },
         }),
         { status: 500 },
@@ -459,13 +515,12 @@ Deno.test("github: a large download error keeps a bounded prefix and cancels the
       );
       assert(cancelled);
       assertEquals(messages.length, 1);
-      assert(messages[0].includes("useful detail"));
-      assert(messages[0].length < 500);
+      assert(!messages[0].includes("short detail"));
     });
   });
 });
 
-Deno.test("github: an ignored download status does not hide transport failures", async () => {
+Deno.test("github: an ignored download status does not hide cleanup or transport failures", async () => {
   await withTokens({ GH_TOKEN: "t" }, async () => {
     await captureConsole("error", async (messages) => {
       const response = new Response("missing", { status: 404 });
@@ -487,8 +542,8 @@ Deno.test("github: an ignored download status does not hide transport failures",
         () =>
           new Response(
             new ReadableStream({
-              pull(controller) {
-                controller.error(new Error("body connection closed"));
+              cancel() {
+                return Promise.reject(new Error("body cancellation failed"));
               },
             }),
             { status: 404 },
@@ -502,8 +557,9 @@ Deno.test("github: an ignored download status does not hide transport failures",
           assertEquals(download.status, 404);
         },
       );
+      await Promise.resolve();
       assertEquals(messages.length, 1);
-      assert(messages[0].includes("body connection closed"));
+      assert(messages[0].includes("body cancellation failed"));
       await withFetch(
         () => Promise.reject(new TypeError("connection closed")),
         async () => {

--- a/packages/dashboard/lib-extra.test.ts
+++ b/packages/dashboard/lib-extra.test.ts
@@ -50,14 +50,10 @@ async function captureConsole(
 
 // Run `fn` with the token vars set as given; a key left out is unset for the
 // duration. Whatever the process had is put back.
-async function withTokens(
-  env: Record<string, string>,
-  fn: () => Promise<void>,
-) {
+async function withTokens(env: Record<string, string>, fn: () => Promise<void>) {
   const keys = ["GH_TOKEN", "GITHUB_TOKEN"];
   const saved = keys.map((k) => [k, Deno.env.get(k)] as const);
-  const apply = (k: string, v: string | undefined) =>
-    v === undefined ? Deno.env.delete(k) : Deno.env.set(k, v);
+  const apply = (k: string, v: string | undefined) => v === undefined ? Deno.env.delete(k) : Deno.env.set(k, v);
   try {
     for (const k of keys) apply(k, env[k]);
     await fn();
@@ -66,17 +62,13 @@ async function withTokens(
   }
 }
 
-const auth = (c: { init: RequestInit }) =>
-  (c.init.headers as Record<string, string>).authorization;
+const auth = (c: { init: RequestInit }) => (c.init.headers as Record<string, string>).authorization;
 
 Deno.test("github: no token -> a 'set GH_TOKEN' error, and no request is attempted", async () => {
   await withTokens({}, async () => {
     await withFetch(() => Response.json({}), async (calls) => {
       const e = await assertRejects(() => github("repos/o/r"), Error);
-      assertEquals(
-        e.message,
-        "GitHub API repos/o/r: set GH_TOKEN or GITHUB_TOKEN",
-      );
+      assertEquals(e.message, "GitHub API repos/o/r: set GH_TOKEN or GITHUB_TOKEN");
       assertEquals(calls.length, 0);
       // The message is one friendlyError recognizes, so a token-gated tile grays
       // out with "set GH_TOKEN" rather than "temporarily unavailable".
@@ -87,14 +79,11 @@ Deno.test("github: no token -> a 'set GH_TOKEN' error, and no request is attempt
 
 Deno.test("github: non-OK -> throws with the status; the error body is not returned as data", async () => {
   await withTokens({ GH_TOKEN: "t" }, async () => {
-    await withFetch(
-      () => Response.json({ message: "Not Found" }, { status: 404 }),
-      async () => {
-        const e = await assertRejects(() => github("repos/o/missing"), Error);
-        assertEquals(e.message, "GitHub API repos/o/missing failed: HTTP 404");
-        assertEquals(friendlyError(e.message), "not found");
-      },
-    );
+    await withFetch(() => Response.json({ message: "Not Found" }, { status: 404 }), async () => {
+      const e = await assertRejects(() => github("repos/o/missing"), Error);
+      assertEquals(e.message, "GitHub API repos/o/missing failed: HTTP 404");
+      assertEquals(friendlyError(e.message), "not found");
+    });
     await withFetch(() => Response.json({}, { status: 429 }), async () => {
       const e = await assertRejects(() => github("rate/limited"), Error);
       assertEquals(e.message, "GitHub API rate/limited failed: HTTP 429");
@@ -228,9 +217,7 @@ Deno.test("github: unreadable JSON logs the endpoint and response context", asyn
         },
       );
       assertEquals(messages.length, 1);
-      assert(
-        messages[0].includes("for repos/o/invalid could not read valid JSON"),
-      );
+      assert(messages[0].includes("for repos/o/invalid could not read valid JSON"));
       assert(messages[0].includes("HTTP 200, request invalid-123"));
       assert(messages[0].includes("SyntaxError"));
     });
@@ -415,9 +402,7 @@ Deno.test("github: an in-progress request reports what it is waiting on", async 
     let requestStarted = () => {};
     const started = new Promise<void>((resolve) => requestStarted = resolve);
     let finishRequest = (_response: Response) => {};
-    const response = new Promise<Response>((resolve) =>
-      finishRequest = resolve
-    );
+    const response = new Promise<Response>((resolve) => finishRequest = resolve);
     await withFetch(
       () => {
         requestStarted();
@@ -445,17 +430,15 @@ Deno.test("github: JSON stays active while its response body is read", async () 
     let bodyRead = () => {};
     const reading = new Promise<void>((resolve) => bodyRead = resolve);
     let finishPull = () => {};
-    const response = new Response(
-      new ReadableStream<Uint8Array>({
-        start(controller) {
-          bodyController = controller;
-        },
-        pull() {
-          bodyRead();
-          return new Promise<void>((resolve) => finishPull = resolve);
-        },
-      }),
-    );
+    const response = new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        bodyController = controller;
+      },
+      pull() {
+        bodyRead();
+        return new Promise<void>((resolve) => finishPull = resolve);
+      },
+    }));
     await withFetch(
       () => response,
       async () => {
@@ -464,9 +447,7 @@ Deno.test("github: JSON stays active while its response body is read", async () 
         const operations = githubOperationsInProgress();
         assertEquals(operations.length, 1);
         assertEquals(operations[0].stage, "reading GitHub response");
-        bodyController!.enqueue(
-          new TextEncoder().encode('{"workflow_runs":[]}'),
-        );
+        bodyController!.enqueue(new TextEncoder().encode('{"workflow_runs":[]}'));
         bodyController!.close();
         finishPull();
         assertEquals(await pending, { workflow_runs: [] });
@@ -482,17 +463,15 @@ Deno.test("github: a download stays active while its response body is read", asy
     let bodyRead = () => {};
     const reading = new Promise<void>((resolve) => bodyRead = resolve);
     let finishPull = () => {};
-    const response = new Response(
-      new ReadableStream<Uint8Array>({
-        start(controller) {
-          bodyController = controller;
-        },
-        pull() {
-          bodyRead();
-          return new Promise<void>((resolve) => finishPull = resolve);
-        },
-      }),
-    );
+    const response = new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        bodyController = controller;
+      },
+      pull() {
+        bodyRead();
+        return new Promise<void>((resolve) => finishPull = resolve);
+      },
+    }));
     await withFetch(
       () => response,
       async () => {
@@ -582,9 +561,7 @@ Deno.test("github: a failed download does not wait for body cleanup", async () =
       await withFetch(
         () => response,
         async () => {
-          const download = await githubDownload(
-            "repos/o/actions/artifacts/1/zip",
-          );
+          const download = await githubDownload("repos/o/actions/artifacts/1/zip");
           assertEquals(download.status, 500);
         },
       );
@@ -778,11 +755,7 @@ Deno.test("github: a slow successful operation logs response context", async () 
           },
         );
         assertEquals(messages.length, 1);
-        assert(
-          messages[0].includes(
-            "for repos/o/slow completed slowly after 10000 ms",
-          ),
-        );
+        assert(messages[0].includes("for repos/o/slow completed slowly after 10000 ms"));
         assert(messages[0].includes("HTTP 200, request slow-123"));
       });
     });
@@ -793,24 +766,18 @@ Deno.test("github: a slow successful operation logs response context", async () 
 
 Deno.test("github: parsed JSON from api.github.com, with the auth and version headers", async () => {
   await withTokens({ GH_TOKEN: "env-token" }, async () => {
-    await withFetch(
-      () => Response.json({ login: "octocat", id: 1 }),
-      async (calls) => {
-        const body = await github<{ login: string; id: number }>("/user");
-        assertEquals(body, { login: "octocat", id: 1 });
-        assertEquals(calls.length, 1);
-        // A leading slash on the path does not double up against the base url.
-        assertEquals(calls[0].url, "https://api.github.com/user");
-        const h = calls[0].init.headers as Record<string, string>;
-        assertEquals(h.authorization, "Bearer env-token");
-        assertEquals(h.accept, "application/vnd.github+json");
-        assertEquals(h["x-github-api-version"], "2022-11-28");
-        assert(
-          calls[0].init.signal,
-          "the request is bounded by a timeout signal",
-        );
-      },
-    );
+    await withFetch(() => Response.json({ login: "octocat", id: 1 }), async (calls) => {
+      const body = await github<{ login: string; id: number }>("/user");
+      assertEquals(body, { login: "octocat", id: 1 });
+      assertEquals(calls.length, 1);
+      // A leading slash on the path does not double up against the base url.
+      assertEquals(calls[0].url, "https://api.github.com/user");
+      const h = calls[0].init.headers as Record<string, string>;
+      assertEquals(h.authorization, "Bearer env-token");
+      assertEquals(h.accept, "application/vnd.github+json");
+      assertEquals(h["x-github-api-version"], "2022-11-28");
+      assert(calls[0].init.signal, "the request is bounded by a timeout signal");
+    });
   });
 });
 
@@ -823,11 +790,7 @@ Deno.test("github: an explicit token wins over the env; GITHUB_TOKEN backs up GH
     await withTokens({ GITHUB_TOKEN: "github" }, async () => {
       await github("x");
     });
-    assertEquals(calls.map(auth), [
-      "Bearer explicit",
-      "Bearer gh",
-      "Bearer github",
-    ]);
+    assertEquals(calls.map(auth), ["Bearer explicit", "Bearer gh", "Bearer github"]);
   });
 });
 
@@ -848,9 +811,7 @@ Deno.test("memo: a rejection is not cached -> the next call retries", async () =
   let n = 0;
   const get = memo(60_000, () => {
     n++;
-    return n === 1
-      ? Promise.reject(new Error("error sending request"))
-      : Promise.resolve("ok");
+    return n === 1 ? Promise.reject(new Error("error sending request")) : Promise.resolve("ok");
   });
   const e = await assertRejects(() => get(), Error);
   assertEquals(e.message, "error sending request");

--- a/packages/dashboard/lib-extra.test.ts
+++ b/packages/dashboard/lib-extra.test.ts
@@ -4,11 +4,17 @@
  */
 
 import { assert, assertEquals, assertRejects } from "@std/assert";
-import { friendlyError, github, memo } from "./lib.ts";
+import {
+  friendlyError,
+  github,
+  githubDownload,
+  githubOperationsInProgress,
+  memo,
+} from "./lib.ts";
 
 // Run `fn` with fetch replaced by `stub`, handing `fn` the calls made so far.
 async function withFetch(
-  stub: (url: string) => Response,
+  stub: (url: string) => Response | Promise<Response>,
   fn: (calls: { url: string; init: RequestInit }[]) => Promise<void>,
 ) {
   const calls: { url: string; init: RequestInit }[] = [];
@@ -22,6 +28,21 @@ async function withFetch(
     await fn(calls);
   } finally {
     globalThis.fetch = original;
+  }
+}
+
+async function captureConsole(
+  level: "error" | "warn",
+  fn: (messages: string[]) => Promise<void>,
+) {
+  const original = console[level];
+  const messages: string[] = [];
+  console[level] = (...parts: unknown[]) =>
+    messages.push(parts.map(String).join(" "));
+  try {
+    await fn(messages);
+  } finally {
+    console[level] = original;
   }
 }
 
@@ -82,6 +103,304 @@ Deno.test("github: non-OK -> throws with the status; the error body is not retur
       },
     );
   });
+});
+
+Deno.test("github: an HTTP failure logs the endpoint and GitHub response context", async () => {
+  await withTokens({ GH_TOKEN: "secret-token" }, async () => {
+    await captureConsole("error", async (messages) => {
+      await withFetch(
+        () =>
+          Response.json(
+            { message: "API rate limit exceeded" },
+            {
+              status: 403,
+              headers: {
+                "x-github-request-id": "request-123",
+                "x-ratelimit-limit": "5000",
+                "x-ratelimit-remaining": "0",
+                "x-ratelimit-reset": "1787100000",
+                "retry-after": "60",
+              },
+            },
+          ),
+        async () => {
+          await assertRejects(() => github("repos/o/runs?per_page=100"), Error);
+        },
+      );
+      assertEquals(messages.length, 1);
+      assert(messages[0].includes("GitHub API operation"));
+      assert(messages[0].includes("repos/o/runs?per_page=100"));
+      assert(messages[0].includes("HTTP 403"));
+      assert(messages[0].includes("request request-123"));
+      assert(messages[0].includes("rate limit 0 remaining of 5000"));
+      assert(messages[0].includes("retry after 60"));
+      assert(messages[0].includes("API rate limit exceeded"));
+      assert(!messages[0].includes("secret-token"));
+    });
+  });
+});
+
+Deno.test("github: a request failure logs its endpoint, stage, and elapsed time", async () => {
+  await withTokens({ GH_TOKEN: "t" }, async () => {
+    await captureConsole("error", async (messages) => {
+      await withFetch(
+        () => Promise.reject(new TypeError("connection closed")),
+        async () => {
+          await assertRejects(() => github("repos/o/runs"), TypeError);
+        },
+      );
+      assertEquals(messages.length, 1);
+      assert(messages[0].includes("for repos/o/runs failed after"));
+      assert(messages[0].includes("while requesting GitHub"));
+      assert(messages[0].includes("TypeError: connection closed"));
+      assertEquals(githubOperationsInProgress(), []);
+    });
+  });
+});
+
+Deno.test("github: unreadable JSON logs the endpoint and response context", async () => {
+  await withTokens({ GH_TOKEN: "t" }, async () => {
+    await captureConsole("error", async (messages) => {
+      await withFetch(
+        () =>
+          new Response("not json", {
+            headers: { "x-github-request-id": "invalid-123" },
+          }),
+        async () => {
+          await assertRejects(() => github("repos/o/invalid"), SyntaxError);
+        },
+      );
+      assertEquals(messages.length, 1);
+      assert(messages[0].includes("for repos/o/invalid could not read valid JSON"));
+      assert(messages[0].includes("HTTP 200, request invalid-123"));
+      assert(messages[0].includes("SyntaxError"));
+    });
+  });
+});
+
+Deno.test("github: a failed error body preserves the known HTTP failure", async () => {
+  await withTokens({ GH_TOKEN: "t" }, async () => {
+    await captureConsole("error", async (messages) => {
+      await withFetch(
+        () =>
+          new Response(
+            new ReadableStream({
+              pull(controller) {
+                controller.error(new Error("body connection closed"));
+              },
+            }),
+            { status: 403 },
+          ),
+        async () => {
+          const error = await assertRejects(
+            () => github("repos/o/broken-error"),
+            Error,
+          );
+          assertEquals(
+            error.message,
+            "GitHub API repos/o/broken-error failed: HTTP 403",
+          );
+          assertEquals(friendlyError(error.message), "auth failed");
+        },
+      );
+      assertEquals(messages.length, 2);
+      assert(messages[0].includes("could not read the error response"));
+      assert(messages[0].includes("body connection closed"));
+      assert(messages[1].includes("returned HTTP 403"));
+    });
+  });
+});
+
+Deno.test("github: an expected HTTP failure can omit its request log", async () => {
+  await withTokens({ GH_TOKEN: "t" }, async () => {
+    await captureConsole("error", async (messages) => {
+      await withFetch(
+        () => new Response("missing", { status: 404 }),
+        async () => {
+          await assertRejects(
+            () =>
+              github("repos/o/optional", undefined, {
+                reportErrors: false,
+              }),
+            Error,
+          );
+        },
+      );
+      assertEquals(messages, []);
+    });
+  });
+});
+
+Deno.test("github: an ignored status does not hide transport failures", async () => {
+  await withTokens({ GH_TOKEN: "t" }, async () => {
+    await captureConsole("error", async (messages) => {
+      await withFetch(
+        () => new Response("missing", { status: 404 }),
+        async () => {
+          await assertRejects(
+            () =>
+              github("repos/o/optional", undefined, {
+                ignoreStatuses: [404],
+              }),
+            Error,
+          );
+        },
+      );
+      assertEquals(messages, []);
+      await withFetch(
+        () => Promise.reject(new TypeError("connection closed")),
+        async () => {
+          await assertRejects(
+            () =>
+              github("repos/o/optional", undefined, {
+                ignoreStatuses: [404],
+              }),
+            TypeError,
+          );
+        },
+      );
+      assertEquals(messages.length, 1);
+      assert(messages[0].includes("TypeError: connection closed"));
+    });
+  });
+});
+
+Deno.test("github: an in-progress request reports what it is waiting on", async () => {
+  await withTokens({ GH_TOKEN: "t" }, async () => {
+    let requestStarted = () => {};
+    const started = new Promise<void>((resolve) => requestStarted = resolve);
+    let finishRequest = (_response: Response) => {};
+    const response = new Promise<Response>((resolve) => finishRequest = resolve);
+    await withFetch(
+      () => {
+        requestStarted();
+        return response;
+      },
+      async () => {
+        const pending = github("repos/o/actions/runs?branch=main");
+        await started;
+        const operations = githubOperationsInProgress();
+        assertEquals(operations.length, 1);
+        assertEquals(operations[0].path, "repos/o/actions/runs?branch=main");
+        assertEquals(operations[0].stage, "requesting GitHub");
+        assert(operations[0].elapsedMs >= 0);
+        finishRequest(Response.json({ workflow_runs: [] }));
+        await pending;
+        assertEquals(githubOperationsInProgress(), []);
+      },
+    );
+  });
+});
+
+Deno.test("github: JSON stays active while its response body is read", async () => {
+  await withTokens({ GH_TOKEN: "t" }, async () => {
+    let bodyController: ReadableStreamDefaultController<Uint8Array> | undefined;
+    let bodyRead = () => {};
+    const reading = new Promise<void>((resolve) => bodyRead = resolve);
+    let finishPull = () => {};
+    const response = new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        bodyController = controller;
+      },
+      pull() {
+        bodyRead();
+        return new Promise<void>((resolve) => finishPull = resolve);
+      },
+    }));
+    await withFetch(
+      () => response,
+      async () => {
+        const pending = github("repos/o/actions/runs?branch=main");
+        await reading;
+        const operations = githubOperationsInProgress();
+        assertEquals(operations.length, 1);
+        assertEquals(operations[0].stage, "reading GitHub response");
+        bodyController!.enqueue(new TextEncoder().encode('{"workflow_runs":[]}'));
+        bodyController!.close();
+        finishPull();
+        assertEquals(await pending, { workflow_runs: [] });
+        assertEquals(githubOperationsInProgress(), []);
+      },
+    );
+  });
+});
+
+Deno.test("github: a download stays active while its response body is read", async () => {
+  await withTokens({ GH_TOKEN: "t" }, async () => {
+    let bodyController: ReadableStreamDefaultController<Uint8Array> | undefined;
+    let bodyRead = () => {};
+    const reading = new Promise<void>((resolve) => bodyRead = resolve);
+    let finishPull = () => {};
+    const response = new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        bodyController = controller;
+      },
+      pull() {
+        bodyRead();
+        return new Promise<void>((resolve) => finishPull = resolve);
+      },
+    }));
+    await withFetch(
+      () => response,
+      async () => {
+        const pending = githubDownload("repos/o/archive");
+        await reading;
+        const operations = githubOperationsInProgress();
+        assertEquals(operations.length, 1);
+        assertEquals(operations[0].path, "repos/o/archive");
+        assertEquals(operations[0].stage, "reading GitHub response");
+        bodyController!.enqueue(new TextEncoder().encode("archive"));
+        bodyController!.close();
+        finishPull();
+        const download = await pending;
+        assertEquals(new TextDecoder().decode(download.body), "archive");
+        assertEquals(githubOperationsInProgress(), []);
+      },
+    );
+  });
+});
+
+Deno.test("github: an abandoned download has already completed its body", async () => {
+  await withTokens({ GH_TOKEN: "t" }, async () => {
+    const response = new Response("archive");
+    await withFetch(
+      () => response,
+      async () => {
+        const download = await githubDownload("repos/o/archive");
+        assertEquals(githubOperationsInProgress(), []);
+        assertEquals(new TextDecoder().decode(download.body), "archive");
+      },
+    );
+  });
+});
+
+Deno.test("github: a slow successful operation logs response context", async () => {
+  const realNow = Date.now;
+  let now = realNow();
+  Date.now = () => now;
+  try {
+    await withTokens({ GH_TOKEN: "t" }, async () => {
+      await captureConsole("warn", async (messages) => {
+        await withFetch(
+          () => {
+            now += 10_000;
+            return Response.json(
+              { ok: true },
+              { headers: { "x-github-request-id": "slow-123" } },
+            );
+          },
+          async () => {
+            await github("repos/o/slow");
+          },
+        );
+        assertEquals(messages.length, 1);
+        assert(messages[0].includes("for repos/o/slow completed slowly after 10000 ms"));
+        assert(messages[0].includes("HTTP 200, request slow-123"));
+      });
+    });
+  } finally {
+    Date.now = realNow;
+  }
 });
 
 Deno.test("github: parsed JSON from api.github.com, with the auth and version headers", async () => {

--- a/packages/dashboard/lib-extra.test.ts
+++ b/packages/dashboard/lib-extra.test.ts
@@ -10,7 +10,9 @@ import {
   githubDownload,
   githubOperationsInProgress,
   memo,
+  performanceGithub,
 } from "./lib.ts";
+import { performanceGitHubRateLimit } from "./github-rate-limit.ts";
 
 // Run `fn` with fetch replaced by `stub`, handing `fn` the calls made so far.
 async function withFetch(
@@ -48,10 +50,14 @@ async function captureConsole(
 
 // Run `fn` with the token vars set as given; a key left out is unset for the
 // duration. Whatever the process had is put back.
-async function withTokens(env: Record<string, string>, fn: () => Promise<void>) {
+async function withTokens(
+  env: Record<string, string>,
+  fn: () => Promise<void>,
+) {
   const keys = ["GH_TOKEN", "GITHUB_TOKEN"];
   const saved = keys.map((k) => [k, Deno.env.get(k)] as const);
-  const apply = (k: string, v: string | undefined) => v === undefined ? Deno.env.delete(k) : Deno.env.set(k, v);
+  const apply = (k: string, v: string | undefined) =>
+    v === undefined ? Deno.env.delete(k) : Deno.env.set(k, v);
   try {
     for (const k of keys) apply(k, env[k]);
     await fn();
@@ -60,13 +66,17 @@ async function withTokens(env: Record<string, string>, fn: () => Promise<void>) 
   }
 }
 
-const auth = (c: { init: RequestInit }) => (c.init.headers as Record<string, string>).authorization;
+const auth = (c: { init: RequestInit }) =>
+  (c.init.headers as Record<string, string>).authorization;
 
 Deno.test("github: no token -> a 'set GH_TOKEN' error, and no request is attempted", async () => {
   await withTokens({}, async () => {
     await withFetch(() => Response.json({}), async (calls) => {
       const e = await assertRejects(() => github("repos/o/r"), Error);
-      assertEquals(e.message, "GitHub API repos/o/r: set GH_TOKEN or GITHUB_TOKEN");
+      assertEquals(
+        e.message,
+        "GitHub API repos/o/r: set GH_TOKEN or GITHUB_TOKEN",
+      );
       assertEquals(calls.length, 0);
       // The message is one friendlyError recognizes, so a token-gated tile grays
       // out with "set GH_TOKEN" rather than "temporarily unavailable".
@@ -77,11 +87,14 @@ Deno.test("github: no token -> a 'set GH_TOKEN' error, and no request is attempt
 
 Deno.test("github: non-OK -> throws with the status; the error body is not returned as data", async () => {
   await withTokens({ GH_TOKEN: "t" }, async () => {
-    await withFetch(() => Response.json({ message: "Not Found" }, { status: 404 }), async () => {
-      const e = await assertRejects(() => github("repos/o/missing"), Error);
-      assertEquals(e.message, "GitHub API repos/o/missing failed: HTTP 404");
-      assertEquals(friendlyError(e.message), "not found");
-    });
+    await withFetch(
+      () => Response.json({ message: "Not Found" }, { status: 404 }),
+      async () => {
+        const e = await assertRejects(() => github("repos/o/missing"), Error);
+        assertEquals(e.message, "GitHub API repos/o/missing failed: HTTP 404");
+        assertEquals(friendlyError(e.message), "not found");
+      },
+    );
     await withFetch(() => Response.json({}, { status: 429 }), async () => {
       const e = await assertRejects(() => github("rate/limited"), Error);
       assertEquals(e.message, "GitHub API rate/limited failed: HTTP 429");
@@ -215,7 +228,9 @@ Deno.test("github: unreadable JSON logs the endpoint and response context", asyn
         },
       );
       assertEquals(messages.length, 1);
-      assert(messages[0].includes("for repos/o/invalid could not read valid JSON"));
+      assert(
+        messages[0].includes("for repos/o/invalid could not read valid JSON"),
+      );
       assert(messages[0].includes("HTTP 200, request invalid-123"));
       assert(messages[0].includes("SyntaxError"));
     });
@@ -289,6 +304,56 @@ Deno.test("github: a large error keeps a bounded prefix and cancels the body", a
   });
 });
 
+Deno.test("github: error response reader setup and cancellation failures are logged", async () => {
+  await withTokens({ GH_TOKEN: "t" }, async () => {
+    await captureConsole("error", async (messages) => {
+      const unreadable = {
+        ok: false,
+        status: 500,
+        headers: new Headers(),
+        body: {
+          getReader() {
+            throw new Error("reader setup failed");
+          },
+        },
+      } as unknown as Response;
+      await withFetch(
+        () => unreadable,
+        async () => {
+          await assertRejects(() => github("repos/o/unreadable-error"), Error);
+        },
+      );
+      assertEquals(messages.length, 2);
+      assert(messages[0].includes("could not read the error response"));
+      assert(messages[0].includes("reader setup failed"));
+
+      const uncancellable = new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array(5_000));
+          },
+          cancel() {
+            throw new Error("reader cancellation failed");
+          },
+        }),
+        { status: 500 },
+      );
+      await withFetch(
+        () => uncancellable,
+        async () => {
+          await assertRejects(
+            () => github("repos/o/uncancellable-error"),
+            Error,
+          );
+        },
+      );
+      assertEquals(messages.length, 4);
+      assert(messages[2].includes("could not stop reading the error response"));
+      assert(messages[2].includes("reader cancellation failed"));
+    });
+  });
+});
+
 Deno.test("github: an ignored status does not hide transport failures", async () => {
   await withTokens({ GH_TOKEN: "t" }, async () => {
     await captureConsole("error", async (messages) => {
@@ -350,7 +415,9 @@ Deno.test("github: an in-progress request reports what it is waiting on", async 
     let requestStarted = () => {};
     const started = new Promise<void>((resolve) => requestStarted = resolve);
     let finishRequest = (_response: Response) => {};
-    const response = new Promise<Response>((resolve) => finishRequest = resolve);
+    const response = new Promise<Response>((resolve) =>
+      finishRequest = resolve
+    );
     await withFetch(
       () => {
         requestStarted();
@@ -378,15 +445,17 @@ Deno.test("github: JSON stays active while its response body is read", async () 
     let bodyRead = () => {};
     const reading = new Promise<void>((resolve) => bodyRead = resolve);
     let finishPull = () => {};
-    const response = new Response(new ReadableStream<Uint8Array>({
-      start(controller) {
-        bodyController = controller;
-      },
-      pull() {
-        bodyRead();
-        return new Promise<void>((resolve) => finishPull = resolve);
-      },
-    }));
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          bodyController = controller;
+        },
+        pull() {
+          bodyRead();
+          return new Promise<void>((resolve) => finishPull = resolve);
+        },
+      }),
+    );
     await withFetch(
       () => response,
       async () => {
@@ -395,7 +464,9 @@ Deno.test("github: JSON stays active while its response body is read", async () 
         const operations = githubOperationsInProgress();
         assertEquals(operations.length, 1);
         assertEquals(operations[0].stage, "reading GitHub response");
-        bodyController!.enqueue(new TextEncoder().encode('{"workflow_runs":[]}'));
+        bodyController!.enqueue(
+          new TextEncoder().encode('{"workflow_runs":[]}'),
+        );
         bodyController!.close();
         finishPull();
         assertEquals(await pending, { workflow_runs: [] });
@@ -411,15 +482,17 @@ Deno.test("github: a download stays active while its response body is read", asy
     let bodyRead = () => {};
     const reading = new Promise<void>((resolve) => bodyRead = resolve);
     let finishPull = () => {};
-    const response = new Response(new ReadableStream<Uint8Array>({
-      start(controller) {
-        bodyController = controller;
-      },
-      pull() {
-        bodyRead();
-        return new Promise<void>((resolve) => finishPull = resolve);
-      },
-    }));
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          bodyController = controller;
+        },
+        pull() {
+          bodyRead();
+          return new Promise<void>((resolve) => finishPull = resolve);
+        },
+      }),
+    );
     await withFetch(
       () => response,
       async () => {
@@ -509,7 +582,9 @@ Deno.test("github: a failed download does not wait for body cleanup", async () =
       await withFetch(
         () => response,
         async () => {
-          const download = await githubDownload("repos/o/actions/artifacts/1/zip");
+          const download = await githubDownload(
+            "repos/o/actions/artifacts/1/zip",
+          );
           assertEquals(download.status, 500);
         },
       );
@@ -518,6 +593,109 @@ Deno.test("github: a failed download does not wait for body cleanup", async () =
       assert(!messages[0].includes("short detail"));
     });
   });
+});
+
+Deno.test("github: download response edge cases finish or log their operation", async () => {
+  await withTokens({ GH_TOKEN: "t" }, async () => {
+    await captureConsole("error", async (messages) => {
+      await withFetch(
+        () => new Response(null, { status: 500 }),
+        async () => {
+          const download = await githubDownload("repos/o/no-error-body");
+          assertEquals(download.status, 500);
+        },
+      );
+
+      const cancellationThrows = {
+        ok: false,
+        status: 500,
+        headers: new Headers(),
+        body: {
+          cancel() {
+            throw new Error("synchronous cancellation failure");
+          },
+        },
+      } as unknown as Response;
+      await withFetch(
+        () => cancellationThrows,
+        async () => {
+          const download = await githubDownload("repos/o/cancellation-throws");
+          assertEquals(download.status, 500);
+        },
+      );
+      assert(
+        messages.some((message) =>
+          message.includes("synchronous cancellation failure")
+        ),
+      );
+
+      await withFetch(
+        () => new Response(null, { status: 204 }),
+        async () => {
+          assertEquals(await githubDownload("repos/o/empty-download"), {
+            ok: true,
+            status: 204,
+            body: new Uint8Array(),
+          });
+        },
+      );
+
+      const unreadable = {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        body: {},
+        arrayBuffer() {
+          return Promise.reject(new Error("download body failed"));
+        },
+      } as unknown as Response;
+      await withFetch(
+        () => unreadable,
+        async () => {
+          await assertRejects(
+            () => githubDownload("repos/o/unreadable-download"),
+            Error,
+            "download body failed",
+          );
+        },
+      );
+      assert(
+        messages.some((message) => message.includes("download body failed")),
+      );
+      assertEquals(githubOperationsInProgress(), []);
+    });
+  });
+});
+
+Deno.test("github: performance reservation completion failures are logged", async () => {
+  const originalReserve = performanceGitHubRateLimit.reserve;
+  performanceGitHubRateLimit.reserve = () =>
+    Promise.resolve({
+      complete: () =>
+        Promise.reject(new Error("reservation completion failed")),
+    });
+  try {
+    await withTokens({ GH_TOKEN: "t" }, async () => {
+      await captureConsole("error", async (messages) => {
+        await withFetch(
+          () => Response.json({ ok: true }),
+          async () => {
+            await assertRejects(
+              () => performanceGithub("repos/o/performance"),
+              Error,
+              "reservation completion failed",
+            );
+          },
+        );
+        assertEquals(messages.length, 1);
+        assert(messages[0].includes("while recording performance-request use"));
+        assert(messages[0].includes("reservation completion failed"));
+        assertEquals(githubOperationsInProgress(), []);
+      });
+    });
+  } finally {
+    performanceGitHubRateLimit.reserve = originalReserve;
+  }
 });
 
 Deno.test("github: an ignored download status does not hide cleanup or transport failures", async () => {
@@ -600,7 +778,11 @@ Deno.test("github: a slow successful operation logs response context", async () 
           },
         );
         assertEquals(messages.length, 1);
-        assert(messages[0].includes("for repos/o/slow completed slowly after 10000 ms"));
+        assert(
+          messages[0].includes(
+            "for repos/o/slow completed slowly after 10000 ms",
+          ),
+        );
         assert(messages[0].includes("HTTP 200, request slow-123"));
       });
     });
@@ -611,18 +793,24 @@ Deno.test("github: a slow successful operation logs response context", async () 
 
 Deno.test("github: parsed JSON from api.github.com, with the auth and version headers", async () => {
   await withTokens({ GH_TOKEN: "env-token" }, async () => {
-    await withFetch(() => Response.json({ login: "octocat", id: 1 }), async (calls) => {
-      const body = await github<{ login: string; id: number }>("/user");
-      assertEquals(body, { login: "octocat", id: 1 });
-      assertEquals(calls.length, 1);
-      // A leading slash on the path does not double up against the base url.
-      assertEquals(calls[0].url, "https://api.github.com/user");
-      const h = calls[0].init.headers as Record<string, string>;
-      assertEquals(h.authorization, "Bearer env-token");
-      assertEquals(h.accept, "application/vnd.github+json");
-      assertEquals(h["x-github-api-version"], "2022-11-28");
-      assert(calls[0].init.signal, "the request is bounded by a timeout signal");
-    });
+    await withFetch(
+      () => Response.json({ login: "octocat", id: 1 }),
+      async (calls) => {
+        const body = await github<{ login: string; id: number }>("/user");
+        assertEquals(body, { login: "octocat", id: 1 });
+        assertEquals(calls.length, 1);
+        // A leading slash on the path does not double up against the base url.
+        assertEquals(calls[0].url, "https://api.github.com/user");
+        const h = calls[0].init.headers as Record<string, string>;
+        assertEquals(h.authorization, "Bearer env-token");
+        assertEquals(h.accept, "application/vnd.github+json");
+        assertEquals(h["x-github-api-version"], "2022-11-28");
+        assert(
+          calls[0].init.signal,
+          "the request is bounded by a timeout signal",
+        );
+      },
+    );
   });
 });
 
@@ -635,7 +823,11 @@ Deno.test("github: an explicit token wins over the env; GITHUB_TOKEN backs up GH
     await withTokens({ GITHUB_TOKEN: "github" }, async () => {
       await github("x");
     });
-    assertEquals(calls.map(auth), ["Bearer explicit", "Bearer gh", "Bearer github"]);
+    assertEquals(calls.map(auth), [
+      "Bearer explicit",
+      "Bearer gh",
+      "Bearer github",
+    ]);
   });
 });
 
@@ -656,7 +848,9 @@ Deno.test("memo: a rejection is not cached -> the next call retries", async () =
   let n = 0;
   const get = memo(60_000, () => {
     n++;
-    return n === 1 ? Promise.reject(new Error("error sending request")) : Promise.resolve("ok");
+    return n === 1
+      ? Promise.reject(new Error("error sending request"))
+      : Promise.resolve("ok");
   });
   const e = await assertRejects(() => get(), Error);
   assertEquals(e.message, "error sending request");

--- a/packages/dashboard/lib-extra.test.ts
+++ b/packages/dashboard/lib-extra.test.ts
@@ -211,26 +211,6 @@ Deno.test("github: a failed error body preserves the known HTTP failure", async 
   });
 });
 
-Deno.test("github: an expected HTTP failure can omit its request log", async () => {
-  await withTokens({ GH_TOKEN: "t" }, async () => {
-    await captureConsole("error", async (messages) => {
-      await withFetch(
-        () => new Response("missing", { status: 404 }),
-        async () => {
-          await assertRejects(
-            () =>
-              github("repos/o/optional", undefined, {
-                reportErrors: false,
-              }),
-            Error,
-          );
-        },
-      );
-      assertEquals(messages, []);
-    });
-  });
-});
-
 Deno.test("github: an ignored status does not hide transport failures", async () => {
   await withTokens({ GH_TOKEN: "t" }, async () => {
     await captureConsole("error", async (messages) => {
@@ -371,6 +351,78 @@ Deno.test("github: an abandoned download has already completed its body", async 
         assertEquals(new TextDecoder().decode(download.body), "archive");
       },
     );
+  });
+});
+
+Deno.test("github: a failed download consumes and logs its error body", async () => {
+  await withTokens({ GH_TOKEN: "t" }, async () => {
+    await captureConsole("error", async (messages) => {
+      const response = Response.json(
+        { message: "artifact expired" },
+        {
+          status: 410,
+          headers: { "x-github-request-id": "download-123" },
+        },
+      );
+      await withFetch(
+        () => response,
+        async () => {
+          const download = await githubDownload(
+            "repos/o/actions/artifacts/1/zip",
+          );
+          assertEquals(download, {
+            ok: false,
+            status: 410,
+            body: new Uint8Array(),
+          });
+        },
+      );
+      assert(response.bodyUsed);
+      assertEquals(messages.length, 1);
+      assert(
+        messages[0].includes("for download repos/o/actions/artifacts/1/zip"),
+      );
+      assert(messages[0].includes("HTTP 410, request download-123"));
+      assert(messages[0].includes("artifact expired"));
+    });
+  });
+});
+
+Deno.test("github: an ignored download status does not hide transport failures", async () => {
+  await withTokens({ GH_TOKEN: "t" }, async () => {
+    await captureConsole("error", async (messages) => {
+      const response = new Response("missing", { status: 404 });
+      await withFetch(
+        () => response,
+        async () => {
+          const download = await githubDownload(
+            "repos/o/actions/artifacts/1/zip",
+            undefined,
+            { ignoreStatuses: [404] },
+          );
+          assertEquals(download.status, 404);
+          assertEquals(download.ok, false);
+        },
+      );
+      assert(response.bodyUsed);
+      assertEquals(messages, []);
+      await withFetch(
+        () => Promise.reject(new TypeError("connection closed")),
+        async () => {
+          await assertRejects(
+            () =>
+              githubDownload(
+                "repos/o/actions/artifacts/1/zip",
+                undefined,
+                { ignoreStatuses: [404] },
+              ),
+            TypeError,
+          );
+        },
+      );
+      assertEquals(messages.length, 1);
+      assert(messages[0].includes("TypeError: connection closed"));
+    });
   });
 });
 

--- a/packages/dashboard/lib-extra.test.ts
+++ b/packages/dashboard/lib-extra.test.ts
@@ -158,6 +158,26 @@ Deno.test("github: a request failure logs its endpoint, stage, and elapsed time"
   });
 });
 
+Deno.test("github: request failure details are bounded and single-line", async () => {
+  await withTokens({ GH_TOKEN: "t" }, async () => {
+    await captureConsole("error", async (messages) => {
+      const unsafe = `connection\nclosed\x1b[31m${"x".repeat(500)}`;
+      await withFetch(
+        () => Promise.reject(new TypeError(unsafe)),
+        async () => {
+          await assertRejects(() => github("repos/o/runs"), TypeError);
+        },
+      );
+      assertEquals(messages.length, 1);
+      assert([...messages[0]].every((character) => {
+        const code = character.charCodeAt(0);
+        return code > 31 && (code < 127 || code > 159);
+      }));
+      assert(messages[0].length < 500);
+    });
+  });
+});
+
 Deno.test("github: unreadable JSON logs the endpoint and response context", async () => {
   await withTokens({ GH_TOKEN: "t" }, async () => {
     await captureConsole("error", async (messages) => {
@@ -228,6 +248,28 @@ Deno.test("github: an ignored status does not hide transport failures", async ()
       );
       assertEquals(messages, []);
       await withFetch(
+        () =>
+          new Response(
+            new ReadableStream({
+              pull(controller) {
+                controller.error(new Error("body connection closed"));
+              },
+            }),
+            { status: 404 },
+          ),
+        async () => {
+          await assertRejects(
+            () =>
+              github("repos/o/optional", undefined, {
+                ignoreStatuses: [404],
+              }),
+            Error,
+          );
+        },
+      );
+      assertEquals(messages.length, 1);
+      assert(messages[0].includes("body connection closed"));
+      await withFetch(
         () => Promise.reject(new TypeError("connection closed")),
         async () => {
           await assertRejects(
@@ -239,8 +281,8 @@ Deno.test("github: an ignored status does not hide transport failures", async ()
           );
         },
       );
-      assertEquals(messages.length, 1);
-      assert(messages[0].includes("TypeError: connection closed"));
+      assertEquals(messages.length, 2);
+      assert(messages[1].includes("TypeError: connection closed"));
     });
   });
 });
@@ -388,6 +430,41 @@ Deno.test("github: a failed download consumes and logs its error body", async ()
   });
 });
 
+Deno.test("github: a large download error keeps a bounded prefix and cancels the body", async () => {
+  await withTokens({ GH_TOKEN: "t" }, async () => {
+    await captureConsole("error", async (messages) => {
+      let sent = false;
+      let cancelled = false;
+      const response = new Response(
+        new ReadableStream({
+          pull(controller) {
+            if (sent) return;
+            sent = true;
+            controller.enqueue(
+              new TextEncoder().encode(`useful detail ${"x".repeat(10_000)}`),
+            );
+          },
+          cancel() {
+            cancelled = true;
+          },
+        }),
+        { status: 500 },
+      );
+      await withFetch(
+        () => response,
+        async () => {
+          const download = await githubDownload("repos/o/actions/artifacts/1/zip");
+          assertEquals(download.status, 500);
+        },
+      );
+      assert(cancelled);
+      assertEquals(messages.length, 1);
+      assert(messages[0].includes("useful detail"));
+      assert(messages[0].length < 500);
+    });
+  });
+});
+
 Deno.test("github: an ignored download status does not hide transport failures", async () => {
   await withTokens({ GH_TOKEN: "t" }, async () => {
     await captureConsole("error", async (messages) => {
@@ -407,6 +484,27 @@ Deno.test("github: an ignored download status does not hide transport failures",
       assert(response.bodyUsed);
       assertEquals(messages, []);
       await withFetch(
+        () =>
+          new Response(
+            new ReadableStream({
+              pull(controller) {
+                controller.error(new Error("body connection closed"));
+              },
+            }),
+            { status: 404 },
+          ),
+        async () => {
+          const download = await githubDownload(
+            "repos/o/actions/artifacts/1/zip",
+            undefined,
+            { ignoreStatuses: [404] },
+          );
+          assertEquals(download.status, 404);
+        },
+      );
+      assertEquals(messages.length, 1);
+      assert(messages[0].includes("body connection closed"));
+      await withFetch(
         () => Promise.reject(new TypeError("connection closed")),
         async () => {
           await assertRejects(
@@ -420,8 +518,8 @@ Deno.test("github: an ignored download status does not hide transport failures",
           );
         },
       );
-      assertEquals(messages.length, 1);
-      assert(messages[0].includes("TypeError: connection closed"));
+      assertEquals(messages.length, 2);
+      assert(messages[1].includes("TypeError: connection closed"));
     });
   });
 });

--- a/packages/dashboard/lib.ts
+++ b/packages/dashboard/lib.ts
@@ -31,6 +31,128 @@ function githubToken(path: string, token?: string): string {
   return t;
 }
 
+type GitHubOperationStage =
+  | "waiting for performance-request capacity"
+  | "requesting GitHub"
+  | "recording performance-request use"
+  | "reading GitHub response";
+
+interface ActiveGitHubOperation {
+  id: number;
+  path: string;
+  startedAt: number;
+  stage: GitHubOperationStage;
+}
+
+export interface GitHubOperationInProgress {
+  id: number;
+  path: string;
+  elapsedMs: number;
+  stage: GitHubOperationStage;
+}
+
+const activeGitHubOperations = new Map<number, ActiveGitHubOperation>();
+let nextGitHubOperationId = 1;
+const SLOW_GITHUB_OPERATION_MS = 10_000;
+
+export interface GitHubRequestOptions {
+  // False keeps an expected failure from an optional probe out of the logs.
+  reportErrors?: boolean;
+  // These expected HTTP responses stay quiet while transport failures still log.
+  ignoreStatuses?: readonly number[];
+}
+
+export interface GitHubDownload {
+  readonly ok: boolean;
+  readonly status: number;
+  readonly body: Uint8Array<ArrayBuffer>;
+}
+
+export function githubOperationsInProgress(
+  now = Date.now(),
+): GitHubOperationInProgress[] {
+  return [...activeGitHubOperations.values()].map((operation) => ({
+    id: operation.id,
+    path: operation.path,
+    elapsedMs: Math.max(0, now - operation.startedAt),
+    stage: operation.stage,
+  }));
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error
+    ? `${error.name}: ${error.message}`
+    : String(error);
+}
+
+function githubResponseContext(response: Response): string {
+  const parts = [`HTTP ${response.status}`];
+  const requestId = response.headers.get("x-github-request-id");
+  if (requestId) parts.push(`request ${requestId}`);
+  const remaining = response.headers.get("x-ratelimit-remaining");
+  const limit = response.headers.get("x-ratelimit-limit");
+  if (remaining || limit) {
+    parts.push(`rate limit ${remaining ?? "?"} remaining of ${limit ?? "?"}`);
+  }
+  const reset = response.headers.get("x-ratelimit-reset");
+  if (reset) parts.push(`rate limit resets at ${reset}`);
+  const retryAfter = response.headers.get("retry-after");
+  if (retryAfter) parts.push(`retry after ${retryAfter}`);
+  return parts.join(", ");
+}
+
+function githubErrorBody(body: string): string | undefined {
+  let detail = body;
+  try {
+    const value: unknown = JSON.parse(body);
+    if (
+      value !== null && typeof value === "object" && "message" in value &&
+      typeof value.message === "string"
+    ) {
+      detail = value.message;
+    }
+  } catch {
+    // A plain-text GitHub error body is already the useful detail.
+  }
+  const withoutControls = [...detail].map((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || (code >= 127 && code <= 159) ? " " : character;
+  }).join("");
+  const compact = withoutControls.replace(/\s+/g, " ").trim();
+  return compact ? compact.slice(0, 300) : undefined;
+}
+
+function finishGitHubOperation(
+  operation: ActiveGitHubOperation,
+  response: Response | undefined,
+  failed: boolean,
+): void {
+  const elapsedMs = Math.max(0, Date.now() - operation.startedAt);
+  activeGitHubOperations.delete(operation.id);
+  if (!failed && response?.ok && elapsedMs >= SLOW_GITHUB_OPERATION_MS) {
+    console.warn(
+      `GitHub API operation ${operation.id} for ${operation.path} completed slowly after ` +
+        `${elapsedMs} ms: ${githubResponseContext(response)}`,
+    );
+  }
+}
+
+function logGitHubOperationFailure(
+  operation: ActiveGitHubOperation,
+  error: unknown,
+): void {
+  console.error(
+    `GitHub API operation ${operation.id} for ${operation.path} failed after ` +
+      `${Math.max(0, Date.now() - operation.startedAt)} ms ` +
+      `while ${operation.stage}: ${errorMessage(error)}`,
+  );
+}
+
+interface GitHubResponseResult {
+  response: Response;
+  operation: ActiveGitHubOperation;
+}
+
 function githubRequest(path: string, token: string, withTimeout: boolean): Promise<Response> {
   const init: RequestInit = {
     headers: {
@@ -51,7 +173,17 @@ async function githubPrimaryRateLimit(
 ): Promise<GitHubPrimaryRateLimit> {
   const response = await githubRequest("rate_limit", token, false);
   if (!response.ok) {
-    throw new Error(`GitHub API rate_limit failed: HTTP ${response.status}`);
+    let body = "";
+    try {
+      body = await response.text();
+    } catch (error) {
+      body = `could not read error response: ${errorMessage(error)}`;
+    }
+    const detail = githubErrorBody(body);
+    throw new Error(
+      `GitHub API rate_limit failed: ${githubResponseContext(response)}` +
+        `${detail ? `: ${detail}` : ""}`,
+    );
   }
   const value = await response.json() as {
     resources?: { core?: GitHubPrimaryRateLimit };
@@ -67,73 +199,202 @@ async function githubResponse(
   token: string,
   performance: boolean,
   withTimeout: boolean,
-): Promise<Response> {
-  const reservation = performance
-    ? await performanceGitHubRateLimit.reserve(
-      token,
-      () => githubPrimaryRateLimit(token),
-    )
-    : null;
+  reportErrors: boolean,
+): Promise<GitHubResponseResult> {
+  const normalizedPath = path.replace(/^\//, "");
+  const operation: ActiveGitHubOperation = {
+    id: nextGitHubOperationId++,
+    path: normalizedPath,
+    startedAt: Date.now(),
+    stage: performance
+      ? "waiting for performance-request capacity"
+      : "requesting GitHub",
+  };
+  activeGitHubOperations.set(operation.id, operation);
+  let reservation: Awaited<ReturnType<typeof performanceGitHubRateLimit.reserve>> | null = null;
   let response: Response | undefined;
+  let failed = false;
+  let operationError: unknown;
   try {
+    if (performance) {
+      reservation = await performanceGitHubRateLimit.reserve(
+        token,
+        () => githubPrimaryRateLimit(token),
+      );
+      operation.stage = "requesting GitHub";
+    }
     response = await githubRequest(path, token, withTimeout);
-    return response;
-  } finally {
-    if (reservation) await reservation.complete(response);
+  } catch (error) {
+    failed = true;
+    operationError = error;
+    if (reportErrors) logGitHubOperationFailure(operation, error);
   }
+  try {
+    if (reservation) {
+      operation.stage = "recording performance-request use";
+      await reservation.complete(response);
+    }
+  } catch (error) {
+    failed = true;
+    operationError = error;
+    if (reportErrors) logGitHubOperationFailure(operation, error);
+  }
+  if (failed) {
+    finishGitHubOperation(operation, response, true);
+    throw operationError;
+  }
+  operation.stage = "reading GitHub response";
+  return { response: response!, operation };
 }
 
 async function githubJson<T>(
   path: string,
   token: string,
   performance: boolean,
+  options: GitHubRequestOptions,
 ): Promise<T> {
-  const res = await githubResponse(path, token, performance, true);
+  const reportErrors = options.reportErrors !== false;
+  const { response: res, operation } = await githubResponse(
+    path,
+    token,
+    performance,
+    true,
+    reportErrors,
+  );
   if (!res.ok) {
+    const reportHttpError = reportErrors &&
+      !options.ignoreStatuses?.includes(res.status);
+    let body = "";
+    try {
+      body = await res.text();
+    } catch (error) {
+      if (reportHttpError) {
+        console.error(
+          `GitHub API operation ${operation.id} for ${operation.path} could not read ` +
+            `the error response from ${githubResponseContext(res)}: ${errorMessage(error)}`,
+        );
+      }
+    }
     let rateLimited = false;
     if (res.status === 403) {
-      const message = await res.text();
       rateLimited = res.headers.get("x-ratelimit-remaining") === "0" ||
-        res.headers.has("retry-after") || /rate.?limit/i.test(message);
+        res.headers.has("retry-after") || /rate.?limit/i.test(body);
     }
     const detail = rateLimited ? " (rate-limited)" : "";
+    const responseDetail = githubErrorBody(body);
+    if (reportHttpError) {
+      console.error(
+        `GitHub API operation ${operation.id} for ${operation.path} returned ` +
+          `${githubResponseContext(res)} after ` +
+          `${Math.max(0, Date.now() - operation.startedAt)} ms` +
+          `${responseDetail ? `: ${responseDetail}` : ""}`,
+      );
+    }
+    finishGitHubOperation(operation, res, true);
     throw new Error(
       `GitHub API ${path} failed: HTTP ${res.status}${detail}`,
     );
   }
-  return await res.json() as T;
+  try {
+    const value = await res.json() as T;
+    finishGitHubOperation(operation, res, false);
+    return value;
+  } catch (error) {
+    if (reportErrors) {
+      console.error(
+        `GitHub API operation ${operation.id} for ${operation.path} could not read valid JSON ` +
+          `from ${githubResponseContext(res)} after ` +
+          `${Math.max(0, Date.now() - operation.startedAt)} ms: ${errorMessage(error)}`,
+      );
+    }
+    finishGitHubOperation(operation, res, true);
+    throw error;
+  }
 }
 
 export async function github<T = unknown>(
   path: string,
   token?: string,
+  options: GitHubRequestOptions = {},
 ): Promise<T> {
   const t = githubToken(path, token);
-  return await githubJson<T>(path, t, false);
+  return await githubJson<T>(path, t, false, options);
 }
 
 export async function githubDownload(
   path: string,
   token?: string,
-): Promise<Response> {
+  options: GitHubRequestOptions = {},
+): Promise<GitHubDownload> {
   const t = githubToken(path, token);
-  return await githubResponse(path, t, false, false);
+  return await githubDownloadResponse(
+    path,
+    t,
+    false,
+    options.reportErrors !== false,
+  );
 }
 
 export async function performanceGithub<T = unknown>(
   path: string,
   token?: string,
+  options: GitHubRequestOptions = {},
 ): Promise<T> {
   const t = githubToken(path, token);
-  return await githubJson<T>(path, t, true);
+  return await githubJson<T>(path, t, true, options);
 }
 
 export async function performanceGithubDownload(
   path: string,
   token?: string,
-): Promise<Response> {
+  options: GitHubRequestOptions = {},
+): Promise<GitHubDownload> {
   const t = githubToken(path, token);
-  return await githubResponse(path, t, true, false);
+  return await githubDownloadResponse(
+    path,
+    t,
+    true,
+    options.reportErrors !== false,
+  );
+}
+
+async function githubDownloadResponse(
+  path: string,
+  token: string,
+  performance: boolean,
+  reportErrors: boolean,
+): Promise<GitHubDownload> {
+  const { response, operation } = await githubResponse(
+    path,
+    token,
+    performance,
+    false,
+    reportErrors,
+  );
+  if (!response.ok) {
+    if (reportErrors) {
+      console.error(
+        `GitHub API operation ${operation.id} for download ${operation.path} returned ` +
+          `${githubResponseContext(response)} after ` +
+          `${Math.max(0, Date.now() - operation.startedAt)} ms`,
+      );
+    }
+    finishGitHubOperation(operation, response, true);
+    return { ok: false, status: response.status, body: new Uint8Array() };
+  }
+  if (!response.body) {
+    finishGitHubOperation(operation, response, false);
+    return { ok: true, status: response.status, body: new Uint8Array() };
+  }
+  try {
+    const body = new Uint8Array(await response.arrayBuffer());
+    finishGitHubOperation(operation, response, false);
+    return { ok: true, status: response.status, body };
+  } catch (error) {
+    if (reportErrors) logGitHubOperationFailure(operation, error);
+    finishGitHubOperation(operation, response, true);
+    throw error;
+  }
 }
 
 // Cache an async result for ttlMs; a rejection is not cached (so it retries).

--- a/packages/dashboard/lib.ts
+++ b/packages/dashboard/lib.ts
@@ -54,6 +54,8 @@ export interface GitHubOperationInProgress {
 const activeGitHubOperations = new Map<number, ActiveGitHubOperation>();
 let nextGitHubOperationId = 1;
 const SLOW_GITHUB_OPERATION_MS = 10_000;
+const GITHUB_ERROR_BODY_BYTES = 4_096;
+const GITHUB_LOG_DETAIL_CHARS = 300;
 
 export interface GitHubRequestOptions {
   // These expected HTTP responses stay quiet while transport failures still log.
@@ -77,10 +79,21 @@ export function githubOperationsInProgress(
   }));
 }
 
+function boundedLogDetail(detail: string): string | undefined {
+  const prefix = detail.slice(0, GITHUB_LOG_DETAIL_CHARS * 4);
+  const withoutControls = [...prefix].map((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || (code >= 127 && code <= 159) ? " " : character;
+  }).join("");
+  const compact = withoutControls.replace(/\s+/g, " ").trim();
+  return compact ? compact.slice(0, GITHUB_LOG_DETAIL_CHARS) : undefined;
+}
+
 function errorMessage(error: unknown): string {
-  return error instanceof Error
+  const detail = error instanceof Error
     ? `${error.name}: ${error.message}`
     : String(error);
+  return boundedLogDetail(detail) ?? "unknown error";
 }
 
 function githubResponseContext(response: Response): string {
@@ -112,12 +125,7 @@ function githubErrorBody(body: string): string | undefined {
   } catch {
     // A plain-text GitHub error body is already the useful detail.
   }
-  const withoutControls = [...detail].map((character) => {
-    const code = character.charCodeAt(0);
-    return code <= 31 || (code >= 127 && code <= 159) ? " " : character;
-  }).join("");
-  const compact = withoutControls.replace(/\s+/g, " ").trim();
-  return compact ? compact.slice(0, 300) : undefined;
+  return boundedLogDetail(detail);
 }
 
 function finishGitHubOperation(
@@ -149,18 +157,56 @@ function logGitHubOperationFailure(
 async function githubErrorResponseBody(
   response: Response,
   operation: ActiveGitHubOperation,
-  reportError: boolean,
 ): Promise<string> {
-  try {
-    return await response.text();
-  } catch (error) {
-    if (reportError) {
-      console.error(
-        `GitHub API operation ${operation.id} for ${operation.path} could not read ` +
-          `the error response from ${githubResponseContext(response)}: ${errorMessage(error)}`,
-      );
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+  const detail = (): string => {
+    const bytes = new Uint8Array(length);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.length;
     }
+    return new TextDecoder().decode(bytes);
+  };
+  const logReadFailure = (action: string, error: unknown): void => {
+    console.error(
+      "GitHub API operation " + operation.id + " for " + operation.path +
+        " could not " + action + " the error response from " +
+        githubResponseContext(response) + ": " + errorMessage(error),
+    );
+  };
+  if (!response.body) return "";
+  let reader: ReadableStreamDefaultReader<Uint8Array>;
+  try {
+    reader = response.body.getReader();
+  } catch (error) {
+    logReadFailure("read", error);
     return "";
+  }
+  const cancel = async (): Promise<void> => {
+    try {
+      await reader.cancel();
+    } catch (error) {
+      logReadFailure("stop reading", error);
+    }
+  };
+  try {
+    while (length < GITHUB_ERROR_BODY_BYTES) {
+      const { done, value } = await reader.read();
+      if (done) return detail();
+      const remaining = GITHUB_ERROR_BODY_BYTES - length;
+      const kept = value.slice(0, remaining);
+      chunks.push(kept);
+      length += kept.length;
+    }
+    await cancel();
+    return detail();
+  } catch (error) {
+    logReadFailure("read", error);
+    return detail();
+  } finally {
+    reader.releaseLock();
   }
 }
 
@@ -279,7 +325,6 @@ async function githubJson<T>(
     const body = await githubErrorResponseBody(
       res,
       operation,
-      reportHttpError,
     );
     let rateLimited = false;
     if (res.status === 403) {
@@ -379,7 +424,6 @@ async function githubDownloadResponse(
     const responseBody = await githubErrorResponseBody(
       response,
       operation,
-      reportHttpError,
     );
     if (reportHttpError) {
       const responseDetail = githubErrorBody(responseBody);

--- a/packages/dashboard/lib.ts
+++ b/packages/dashboard/lib.ts
@@ -98,16 +98,20 @@ function errorMessage(error: unknown): string {
 
 function githubResponseContext(response: Response): string {
   const parts = [`HTTP ${response.status}`];
-  const requestId = response.headers.get("x-github-request-id");
+  const header = (name: string): string | undefined => {
+    const value = response.headers.get(name);
+    return value === null ? undefined : boundedLogDetail(value);
+  };
+  const requestId = header("x-github-request-id");
   if (requestId) parts.push(`request ${requestId}`);
-  const remaining = response.headers.get("x-ratelimit-remaining");
-  const limit = response.headers.get("x-ratelimit-limit");
+  const remaining = header("x-ratelimit-remaining");
+  const limit = header("x-ratelimit-limit");
   if (remaining || limit) {
     parts.push(`rate limit ${remaining ?? "?"} remaining of ${limit ?? "?"}`);
   }
-  const reset = response.headers.get("x-ratelimit-reset");
+  const reset = header("x-ratelimit-reset");
   if (reset) parts.push(`rate limit resets at ${reset}`);
-  const retryAfter = response.headers.get("retry-after");
+  const retryAfter = header("retry-after");
   if (retryAfter) parts.push(`retry after ${retryAfter}`);
   return parts.join(", ");
 }
@@ -154,6 +158,33 @@ function logGitHubOperationFailure(
   );
 }
 
+function logGitHubErrorResponseFailure(
+  response: Response,
+  operation: ActiveGitHubOperation,
+  action: string,
+  error: unknown,
+): void {
+  console.error(
+    "GitHub API operation " + operation.id + " for " + operation.path +
+      " could not " + action + " the error response from " +
+      githubResponseContext(response) + ": " + errorMessage(error),
+  );
+}
+
+function discardGitHubErrorResponseBody(
+  response: Response,
+  operation: ActiveGitHubOperation,
+): void {
+  if (!response.body) return;
+  try {
+    void response.body.cancel().catch((error) => {
+      logGitHubErrorResponseFailure(response, operation, "discard", error);
+    });
+  } catch (error) {
+    logGitHubErrorResponseFailure(response, operation, "discard", error);
+  }
+}
+
 async function githubErrorResponseBody(
   response: Response,
   operation: ActiveGitHubOperation,
@@ -169,26 +200,19 @@ async function githubErrorResponseBody(
     }
     return new TextDecoder().decode(bytes);
   };
-  const logReadFailure = (action: string, error: unknown): void => {
-    console.error(
-      "GitHub API operation " + operation.id + " for " + operation.path +
-        " could not " + action + " the error response from " +
-        githubResponseContext(response) + ": " + errorMessage(error),
-    );
-  };
   if (!response.body) return "";
   let reader: ReadableStreamDefaultReader<Uint8Array>;
   try {
     reader = response.body.getReader();
   } catch (error) {
-    logReadFailure("read", error);
+    logGitHubErrorResponseFailure(response, operation, "read", error);
     return "";
   }
   const cancel = async (): Promise<void> => {
     try {
       await reader.cancel();
     } catch (error) {
-      logReadFailure("stop reading", error);
+      logGitHubErrorResponseFailure(response, operation, "stop reading", error);
     }
   };
   try {
@@ -203,7 +227,7 @@ async function githubErrorResponseBody(
     await cancel();
     return detail();
   } catch (error) {
-    logReadFailure("read", error);
+    logGitHubErrorResponseFailure(response, operation, "read", error);
     return detail();
   } finally {
     reader.releaseLock();
@@ -232,19 +256,13 @@ function githubRequest(path: string, token: string, withTimeout: boolean): Promi
 
 async function githubPrimaryRateLimit(
   token: string,
+  operation: ActiveGitHubOperation,
 ): Promise<GitHubPrimaryRateLimit> {
   const response = await githubRequest("rate_limit", token, false);
   if (!response.ok) {
-    let body = "";
-    try {
-      body = await response.text();
-    } catch (error) {
-      body = `could not read error response: ${errorMessage(error)}`;
-    }
-    const detail = githubErrorBody(body);
+    discardGitHubErrorResponseBody(response, operation);
     throw new Error(
-      `GitHub API rate_limit failed: ${githubResponseContext(response)}` +
-        `${detail ? `: ${detail}` : ""}`,
+      `GitHub API rate_limit failed: ${githubResponseContext(response)}`,
     );
   }
   const value = await response.json() as {
@@ -280,7 +298,7 @@ async function githubResponse(
     if (performance) {
       reservation = await performanceGitHubRateLimit.reserve(
         token,
-        () => githubPrimaryRateLimit(token),
+        () => githubPrimaryRateLimit(token, operation),
       );
       operation.stage = "requesting GitHub";
     }
@@ -421,17 +439,12 @@ async function githubDownloadResponse(
   );
   if (!response.ok) {
     const reportHttpError = !options.ignoreStatuses?.includes(response.status);
-    const responseBody = await githubErrorResponseBody(
-      response,
-      operation,
-    );
+    discardGitHubErrorResponseBody(response, operation);
     if (reportHttpError) {
-      const responseDetail = githubErrorBody(responseBody);
       console.error(
         `GitHub API operation ${operation.id} for download ${operation.path} returned ` +
           `${githubResponseContext(response)} after ` +
-          `${Math.max(0, Date.now() - operation.startedAt)} ms` +
-          `${responseDetail ? `: ${responseDetail}` : ""}`,
+          `${Math.max(0, Date.now() - operation.startedAt)} ms`,
       );
     }
     finishGitHubOperation(operation, response, true);

--- a/packages/dashboard/lib.ts
+++ b/packages/dashboard/lib.ts
@@ -56,8 +56,6 @@ let nextGitHubOperationId = 1;
 const SLOW_GITHUB_OPERATION_MS = 10_000;
 
 export interface GitHubRequestOptions {
-  // False keeps an expected failure from an optional probe out of the logs.
-  reportErrors?: boolean;
   // These expected HTTP responses stay quiet while transport failures still log.
   ignoreStatuses?: readonly number[];
 }
@@ -148,6 +146,24 @@ function logGitHubOperationFailure(
   );
 }
 
+async function githubErrorResponseBody(
+  response: Response,
+  operation: ActiveGitHubOperation,
+  reportError: boolean,
+): Promise<string> {
+  try {
+    return await response.text();
+  } catch (error) {
+    if (reportError) {
+      console.error(
+        `GitHub API operation ${operation.id} for ${operation.path} could not read ` +
+          `the error response from ${githubResponseContext(response)}: ${errorMessage(error)}`,
+      );
+    }
+    return "";
+  }
+}
+
 interface GitHubResponseResult {
   response: Response;
   operation: ActiveGitHubOperation;
@@ -199,7 +215,6 @@ async function githubResponse(
   token: string,
   performance: boolean,
   withTimeout: boolean,
-  reportErrors: boolean,
 ): Promise<GitHubResponseResult> {
   const normalizedPath = path.replace(/^\//, "");
   const operation: ActiveGitHubOperation = {
@@ -227,7 +242,7 @@ async function githubResponse(
   } catch (error) {
     failed = true;
     operationError = error;
-    if (reportErrors) logGitHubOperationFailure(operation, error);
+    logGitHubOperationFailure(operation, error);
   }
   try {
     if (reservation) {
@@ -237,7 +252,7 @@ async function githubResponse(
   } catch (error) {
     failed = true;
     operationError = error;
-    if (reportErrors) logGitHubOperationFailure(operation, error);
+    logGitHubOperationFailure(operation, error);
   }
   if (failed) {
     finishGitHubOperation(operation, response, true);
@@ -253,28 +268,19 @@ async function githubJson<T>(
   performance: boolean,
   options: GitHubRequestOptions,
 ): Promise<T> {
-  const reportErrors = options.reportErrors !== false;
   const { response: res, operation } = await githubResponse(
     path,
     token,
     performance,
     true,
-    reportErrors,
   );
   if (!res.ok) {
-    const reportHttpError = reportErrors &&
-      !options.ignoreStatuses?.includes(res.status);
-    let body = "";
-    try {
-      body = await res.text();
-    } catch (error) {
-      if (reportHttpError) {
-        console.error(
-          `GitHub API operation ${operation.id} for ${operation.path} could not read ` +
-            `the error response from ${githubResponseContext(res)}: ${errorMessage(error)}`,
-        );
-      }
-    }
+    const reportHttpError = !options.ignoreStatuses?.includes(res.status);
+    const body = await githubErrorResponseBody(
+      res,
+      operation,
+      reportHttpError,
+    );
     let rateLimited = false;
     if (res.status === 403) {
       rateLimited = res.headers.get("x-ratelimit-remaining") === "0" ||
@@ -300,13 +306,11 @@ async function githubJson<T>(
     finishGitHubOperation(operation, res, false);
     return value;
   } catch (error) {
-    if (reportErrors) {
-      console.error(
-        `GitHub API operation ${operation.id} for ${operation.path} could not read valid JSON ` +
-          `from ${githubResponseContext(res)} after ` +
-          `${Math.max(0, Date.now() - operation.startedAt)} ms: ${errorMessage(error)}`,
-      );
-    }
+    console.error(
+      `GitHub API operation ${operation.id} for ${operation.path} could not read valid JSON ` +
+        `from ${githubResponseContext(res)} after ` +
+        `${Math.max(0, Date.now() - operation.startedAt)} ms: ${errorMessage(error)}`,
+    );
     finishGitHubOperation(operation, res, true);
     throw error;
   }
@@ -331,7 +335,7 @@ export async function githubDownload(
     path,
     t,
     false,
-    options.reportErrors !== false,
+    options,
   );
 }
 
@@ -354,7 +358,7 @@ export async function performanceGithubDownload(
     path,
     t,
     true,
-    options.reportErrors !== false,
+    options,
   );
 }
 
@@ -362,21 +366,28 @@ async function githubDownloadResponse(
   path: string,
   token: string,
   performance: boolean,
-  reportErrors: boolean,
+  options: GitHubRequestOptions,
 ): Promise<GitHubDownload> {
   const { response, operation } = await githubResponse(
     path,
     token,
     performance,
     false,
-    reportErrors,
   );
   if (!response.ok) {
-    if (reportErrors) {
+    const reportHttpError = !options.ignoreStatuses?.includes(response.status);
+    const responseBody = await githubErrorResponseBody(
+      response,
+      operation,
+      reportHttpError,
+    );
+    if (reportHttpError) {
+      const responseDetail = githubErrorBody(responseBody);
       console.error(
         `GitHub API operation ${operation.id} for download ${operation.path} returned ` +
           `${githubResponseContext(response)} after ` +
-          `${Math.max(0, Date.now() - operation.startedAt)} ms`,
+          `${Math.max(0, Date.now() - operation.startedAt)} ms` +
+          `${responseDetail ? `: ${responseDetail}` : ""}`,
       );
     }
     finishGitHubOperation(operation, response, true);
@@ -391,7 +402,7 @@ async function githubDownloadResponse(
     finishGitHubOperation(operation, response, false);
     return { ok: true, status: response.status, body };
   } catch (error) {
-    if (reportErrors) logGitHubOperationFailure(operation, error);
+    logGitHubOperationFailure(operation, error);
     finishGitHubOperation(operation, response, true);
     throw error;
   }

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -34,6 +34,7 @@ import {
 } from "./config.ts";
 import { TILES } from "./registry.ts";
 import { labsCi } from "./tiles/main-build.ts";
+import { github } from "./lib.ts";
 import type { Ctx, Run, RunSource, Tile, TileView } from "./types.ts";
 import { DASHBOARD_MESSAGE_LIFETIME_MS } from "./dashboard-message.ts";
 import { dashboardCacheFile } from "./history-files.ts";
@@ -358,6 +359,9 @@ Deno.test("the ticker leaves a tile alone until its interval has elapsed", async
 
 Deno.test("an update still running after one minute stays gray until it completes", async () => {
   const realNow = Date.now;
+  const realError = console.error;
+  const errors: string[] = [];
+  console.error = (...parts: unknown[]) => errors.push(parts.map(String).join(" "));
   const startedAt = realNow() + 10_000;
   let now = startedAt;
   Date.now = () => now;
@@ -411,6 +415,10 @@ Deno.test("an update still running after one minute stays gray until it complete
     assertStringIncludes(stale, "refresh still pending");
     assertStringIncludes(stale, "last chart");
     assertEquals(messages.length, 1, "the stale transition is published");
+    assertEquals(errors, [
+      "dashboard refresh still pending: tiles model-spend (60000 ms); " +
+      "active run sources none; active GitHub operations none",
+    ]);
 
     now += 15_000;
     await tick([tile]);
@@ -442,6 +450,71 @@ Deno.test("an update still running after one minute stays gray until it complete
       await collection;
     } finally {
       Date.now = realNow;
+      console.error = realError;
+    }
+  }
+});
+
+Deno.test("a stale source log names its active GitHub operation", async () => {
+  const realNow = Date.now;
+  const realFetch = globalThis.fetch;
+  const realError = console.error;
+  const realWarn = console.warn;
+  const realToken = Deno.env.get("GH_TOKEN");
+  let now = realNow();
+  Date.now = () => now;
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  console.error = (...parts: unknown[]) => errors.push(parts.map(String).join(" "));
+  console.warn = (...parts: unknown[]) => warnings.push(parts.map(String).join(" "));
+  const response = deferred<Response>();
+  const requested = deferred<void>();
+  globalThis.fetch = () => {
+    requested.resolve();
+    return response.promise;
+  };
+  Deno.env.set("GH_TOKEN", "test-token");
+  const source = { repo: "test/github-diagnostic", workflow: "ci.yml" };
+  const sourceCtx: Ctx = {
+    runs: () => sourceCtx.runsFor(source.repo, source.workflow),
+    async runsFor() {
+      const body = await github<{ workflow_runs: Run[] }>(
+        "repos/test/github-diagnostic/actions/runs?branch=main",
+      );
+      return body.workflow_runs;
+    },
+    env: () => undefined,
+  };
+  const tile = sourceTile("github-diagnostic", "GitHub diagnostic", [source]);
+  let refresh: Promise<void> | undefined;
+  try {
+    refresh = tick([tile], sourceCtx);
+    await requested.promise;
+    now += 60_000;
+    await tick([tile], sourceCtx);
+    assertEquals(errors.length, 1);
+    assertStringIncludes(errors[0], "tiles github-diagnostic (60000 ms)");
+    assertStringIncludes(errors[0], "active run sources test/github-diagnostic ci.yml");
+    assertStringIncludes(
+      errors[0],
+      "repos/test/github-diagnostic/actions/runs?branch=main (requesting GitHub, 60000 ms)",
+    );
+  } finally {
+    response.resolve(Response.json({ workflow_runs: [] }));
+    try {
+      await refresh;
+      assertEquals(warnings.length, 1);
+      assertStringIncludes(
+        warnings[0],
+        "for repos/test/github-diagnostic/actions/runs?branch=main completed slowly after 60000 ms",
+      );
+    } finally {
+      Date.now = realNow;
+      globalThis.fetch = realFetch;
+      console.error = realError;
+      console.warn = realWarn;
+      if (realToken === undefined) Deno.env.delete("GH_TOKEN");
+      else Deno.env.set("GH_TOKEN", realToken);
     }
   }
 });

--- a/packages/dashboard/server.ts
+++ b/packages/dashboard/server.ts
@@ -27,7 +27,7 @@
 import { CI_WORKFLOW, PORT, REPO } from "./config.ts";
 import { TILES } from "./registry.ts";
 import { makeCtx } from "./ctx.ts";
-import { friendlyError } from "./lib.ts";
+import { friendlyError, githubOperationsInProgress } from "./lib.ts";
 import { faviconPng, faviconStatus } from "./favicon.ts";
 import type { FaviconStatus } from "./favicon.ts";
 import { renderTile, shell } from "./render.ts";
@@ -199,13 +199,22 @@ function activeTileView(tile: Tile, view: TileView): TileView {
 }
 
 function grayStaleTileUpdates(now: number): void {
-  let changed = false;
-  for (const active of activeTileUpdates.values()) {
+  const newlyStale: string[] = [];
+  for (const [tileId, active] of activeTileUpdates) {
     if (active.stale || now - active.startedAt < STALE_UPDATE_MS) continue;
     active.stale = true;
-    changed = true;
+    newlyStale.push(`${tileId} (${Math.max(0, now - active.startedAt)} ms)`);
   }
-  if (changed) {
+  if (newlyStale.length) {
+    const sources = [...activeRunSourceUpdates];
+    const github = githubOperationsInProgress(now).map((operation) =>
+      `${operation.id} ${operation.path} (${operation.stage}, ${operation.elapsedMs} ms)`
+    );
+    console.error(
+      `dashboard refresh still pending: tiles ${newlyStale.join(", ")}; ` +
+        `active run sources ${sources.length ? sources.join(", ") : "none"}; ` +
+        `active GitHub operations ${github.length ? github.join(", ") : "none"}`,
+    );
     lastChange = now;
     updateFaviconRedSince(now, false);
     broadcast(dashboardUpdate());

--- a/packages/dashboard/tiles/benchmark.ts
+++ b/packages/dashboard/tiles/benchmark.ts
@@ -84,6 +84,7 @@ import {
   durationTag,
   escapeHtml,
   friendlyError,
+  type GitHubDownload,
   github,
   githubDownload,
   humanSpan,
@@ -143,7 +144,7 @@ const BENCHMARK_FETCH_CONCURRENCY = 8;
 
 interface BenchmarkGitHub {
   json<T>(path: string, token: string): Promise<T>;
-  download(path: string, token: string): Promise<Response>;
+  download(path: string, token: string): Promise<GitHubDownload>;
 }
 
 const ordinaryBenchmarkGitHub: BenchmarkGitHub = {
@@ -497,7 +498,7 @@ async function fetchZip(
     token,
   );
   if (!res.ok) throw new Error(`artifact ${artifactId}: HTTP ${res.status}`);
-  return new Uint8Array(await res.arrayBuffer());
+  return res.body;
 }
 
 // The benchmarks.yml runs on main, newest first, paging back until past the

--- a/packages/dashboard/tiles/github-ci-spend.test.ts
+++ b/packages/dashboard/tiles/github-ci-spend.test.ts
@@ -585,6 +585,29 @@ Deno.test("github spend: the classic plan falls back to minutes against the incl
   assertEquals((await classic(0, 0, 0)).status, "good");
 });
 
+Deno.test("github spend: enhanced billing outages log before classic fallback", async () => {
+  const realError = console.error;
+  const errors: string[] = [];
+  console.error = (...parts: unknown[]) =>
+    errors.push(parts.map(String).join(" "));
+  try {
+    const result = await view("2026-01-20T09:00:00Z", {
+      [usagePath(2026, 1)]: new TypeError("enhanced billing disconnected"),
+      [classicPath()]: {
+        total_minutes_used: 1000,
+        included_minutes: 3000,
+        total_paid_minutes_used: 0,
+      },
+    });
+    assertEquals(result.status, "good");
+    assertEquals(errors.length, 1);
+    assertStringIncludes(errors[0], usagePath(2026, 1));
+    assertStringIncludes(errors[0], "enhanced billing disconnected");
+  } finally {
+    console.error = realError;
+  }
+});
+
 Deno.test("github spend: both billing endpoints unreachable -> gray with a calm reason", async () => {
   const v = await view("2026-01-20T09:00:00Z", {
     [classicPath()]: new TypeError(

--- a/packages/dashboard/tiles/github-ci-spend.test.ts
+++ b/packages/dashboard/tiles/github-ci-spend.test.ts
@@ -507,6 +507,34 @@ Deno.test("github spend: a prior month we can't read shortens the chart, it does
   assertEquals(v.duration, 18 * D); // January 1st to the settled 18th only
 });
 
+Deno.test("github spend: optional billing failures log while current data remains usable", async () => {
+  const realError = console.error;
+  const errors: string[] = [];
+  console.error = (...parts: unknown[]) =>
+    errors.push(parts.map(String).join(" "));
+  try {
+    const result = await view("2026-01-20T09:00:00Z", {
+      [usagePath(2026, 1)]: {
+        usageItems: [
+          ...days(2026, 1, 1, 10, 18),
+          stillReporting("2026-01-18"),
+        ],
+      },
+      [usagePath(2025, 12)]: new TypeError("prior billing disconnected"),
+      [budgetsPath()]: new TypeError("budget disconnected"),
+    });
+    assertEquals(result.status, "good");
+    assertEquals(result.value, "~$310/mo");
+    assertEquals(errors.length, 2);
+    assertStringIncludes(errors[0], budgetsPath());
+    assertStringIncludes(errors[0], "budget disconnected");
+    assertStringIncludes(errors[1], usagePath(2025, 12));
+    assertStringIncludes(errors[1], "prior billing disconnected");
+  } finally {
+    console.error = realError;
+  }
+});
+
 Deno.test("github spend: an unavailable prior month is not zero-spend history", async () => {
   const v = await view("2026-01-03T09:00:00Z", {
     [usagePath(2026, 1)]: { usageItems: days(2026, 1, 1, 2, 20) },

--- a/packages/dashboard/tiles/github-ci-spend.ts
+++ b/packages/dashboard/tiles/github-ci-spend.ts
@@ -245,6 +245,7 @@ async function githubDollarSpend(
   const report = await github<{ usageItems?: UsageItem[] }>(
     usagePath(org, year, month0 + 1),
     token,
+    { ignoreStatuses: [404] },
   );
   if (!Array.isArray(report.usageItems)) {
     throw new GitHubUsageShapeError("billing usage unavailable");
@@ -304,6 +305,7 @@ async function githubDollarSpend(
       const previous = await github<{ usageItems?: UsageItem[] }>(
         usagePath(org, previousYear, previousMonth + 1),
         token,
+        { reportErrors: false },
       );
       if (Array.isArray(previous.usageItems)) {
         noteReport(previous.usageItems);

--- a/packages/dashboard/tiles/github-ci-spend.ts
+++ b/packages/dashboard/tiles/github-ci-spend.ts
@@ -237,6 +237,7 @@ async function githubDollarSpend(
     const response = await github<{ budgets?: Budget[] }>(
       `organizations/${org}/settings/billing/budgets`,
       token,
+      { ignoreStatuses: [404] },
     );
     budgets = readBudgets(response.budgets ?? []);
   } catch {
@@ -305,7 +306,7 @@ async function githubDollarSpend(
       const previous = await github<{ usageItems?: UsageItem[] }>(
         usagePath(org, previousYear, previousMonth + 1),
         token,
-        { reportErrors: false },
+        { ignoreStatuses: [404] },
       );
       if (Array.isArray(previous.usageItems)) {
         noteReport(previous.usageItems);

--- a/packages/dashboard/tiles/github-members.test.ts
+++ b/packages/dashboard/tiles/github-members.test.ts
@@ -327,6 +327,7 @@ Deno.test("github users: unavailable or malformed organization data stays gray",
     reply(url: URL): unknown | Response;
     sub: string;
     log: string;
+    requestLog?: string[];
   }[] = [
     {
       reply: (url) =>
@@ -334,6 +335,10 @@ Deno.test("github users: unavailable or malformed organization data stays gray",
           ? new Response("forbidden", { status: 403 })
           : [],
       sub: "auth failed",
+      requestLog: [
+        `for orgs/${ORG}/members?per_page=100&page=1 returned HTTP 403`,
+        "forbidden",
+      ],
       log:
         `github users: could not read organization users: GitHub API orgs/${ORG}/members?per_page=100&page=1 failed: HTTP 403`,
     },
@@ -346,6 +351,11 @@ Deno.test("github users: unavailable or malformed organization data stays gray",
           })
           : [],
       sub: "rate limit hit",
+      requestLog: [
+        `for orgs/${ORG}/outside_collaborators?per_page=100&page=1 returned HTTP 403`,
+        "rate limit 0 remaining of ?",
+        "rate limit exceeded",
+      ],
       log:
         `github users: could not read organization users: GitHub API orgs/${ORG}/outside_collaborators?per_page=100&page=1 failed: HTTP 403 (rate-limited)`,
     },
@@ -367,7 +377,15 @@ Deno.test("github users: unavailable or malformed organization data stays gray",
       assertEquals(view.value, "—");
       assertEquals(view.sub, testCase.sub);
       assertEquals(wire.writes, []);
-      assertEquals(wire.logged, [testCase.log]);
+      if (testCase.requestLog) {
+        assertEquals(wire.logged.length, 2);
+        for (const part of testCase.requestLog) {
+          assertStringIncludes(wire.logged[0], part);
+        }
+        assertEquals(wire.logged[1], testCase.log);
+      } else {
+        assertEquals(wire.logged, [testCase.log]);
+      }
     });
   }
 });


### PR DESCRIPTION
Track each dashboard GitHub operation from rate-limit reservation through response-body consumption. When a request fails, log the endpoint, operation stage, elapsed time, GitHub request identifier, available rate-limit headers, retry guidance, and a bounded response detail. Slow successful operations are also reported.

When a dashboard refresh remains pending long enough to turn its tiles gray, log the affected tiles, active run sources, and any GitHub operations still in progress. This makes a hung request distinguishable from an HTTP failure, an interrupted response, invalid JSON, and exhausted rate-limit capacity.

Return completed artifact bytes from the download helpers so body transfers remain visible without wrapping Response objects or retaining abandoned operations. Suppress only expected optional-probe responses while continuing to log transport, authentication, rate-limit, and server failures.

Verified with the complete dashboard unit, favicon, and headless browser suites, repository-wide formatting and linting, and the repository type check.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

