### PR TITLE
fix(data-model): codec type tag syntax, a decode hole, and prose the refactor arc left behind

### DIFF
--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -54,8 +54,29 @@ All special types in JSON use a single convention: single-key objects where the
 key follows the pattern `/<Type>@<Version>`.
 
 - `/` — sigil prefix (nodding to IPLD heritage)
-- `<Type>` — `UpperCamelCase` type name
-- `@<Version>` — version number (natural number, starting at 1)
+- `<Type>` — type name
+- `@<Version>` — version number
+
+The tag is the key without its sigil, and its syntax is exact, because that
+syntax is what separates an unrecognized type from a malformation. A name is an
+uppercase ASCII letter followed by any number of ASCII letters and digits —
+`UpperCamelCase`. A version is a decimal integer with no leading zero, so the
+lowest version is 1. A tag is a name, `@`, and a version, with nothing before
+or after. `Bytes@1` and `Abc123@1234` are tags; `bytes@1`, `By-tes@1`,
+`Bytes@0`, `Bytes@01` and `Bytes@1.0` are not, and neither is any of those
+padded with whitespace or a newline.
+
+A string outside that syntax is not an unrecognized tag; it is not a tag at
+all. A key naming one is a structural violation under Section 9 rather than an
+`UnknownValue` under Section 8, and that is what lets an `UnknownValue` always
+hold a real tag. The escapes `/quote`, `/hole` and `/object` (Section 6) fall
+outside the syntax deliberately, each being a structural marker the format
+handles itself rather than a type anything encodes.
+
+The syntax is not particular to JSON. It is the type-tag syntax the whole codec
+system shares: a registry refuses a codec that declares a fixed tag outside it,
+so no codec can claim a tag the decoder would reject, and a format that lays
+its tags out differently on the wire still writes tags of this syntax.
 
 This convention does **not** prohibit storing plain objects that happen to have
 `/`-prefixed keys. The escaping mechanism in Section 6 (`/object` and

--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -267,7 +267,7 @@ round-trip correctly.
 > malformed input — wrong type, invalid format, or missing fields — the codec
 > must reject it rather than silently produce garbage. A codec may reject by
 > throwing, or by returning a `ProblematicValue` (see `1-fabric-values.md`
-> Section 3.5); the two are equivalent, because the encoding context settles
+> Section 3.5); the two are equivalent, because the engine settles
 > them into one answer according to its own `lenient` setting (see
 > `1-fabric-values.md` Section 4.5). Which one a codec uses is therefore a
 > matter of what reads well where it is written, and carries no meaning for a
@@ -320,7 +320,7 @@ ambiguity about what is an encoding signal and what is user data.
 Types that require no decoding state use `null` as the value:
 
 ```json
-{ "/Stream@1": null }
+{ "/Undefined@1": null }
 ```
 
 Both `null` and `{}` are acceptable for "no state needed." `null` is the
@@ -431,7 +431,13 @@ for:
   `ProblematicValue` is not re-wrapped this way; see Section 8.
 - Settling a codec's rejection according to `lenient`: in lenient mode a
   codec's throw becomes a `ProblematicValue`, and in strict mode a
-  `ProblematicValue` a codec returns becomes a throw.
+  `ProblematicValue` a codec returns becomes a throw. `ProblematicValue`'s
+  own codec is exempt from the second half, because for that one a
+  `ProblematicValue` is the successful product rather than a rejection: a
+  payload under `Problematic@1` is a well-formed record of a past failure,
+  and reading one back is not a failure of this decode. Without the
+  exemption a strict reader could never read such a record, which is most
+  of what preserving one is for.
 
 Note: `/object` escaping (Section 6) is applied directly by the engine's
 internal encode walker in its plain-objects path, since it is structural
@@ -439,7 +445,7 @@ escaping rather than type encoding.
 
 ## 8. Unknown Type Handling
 
-When a JSON context encounters a `/<Type>@<Version>` key it doesn't recognize,
+When a JSON decode encounters a `/<Type>@<Version>` key it doesn't recognize,
 it wraps the data in `UnknownValue` (see `1-fabric-values.md` Section 3) to
 preserve it for round-tripping. Re-encoding reproduces the original key,
 the codec's `tagForValue()` reading back the preserved tag and `encode()`
@@ -480,10 +486,10 @@ Specifically:
 - **Multi-key objects** containing one or more `/`-prefixed keys are structural
   encoding errors, and are rejected. They are not valid plain objects.
 
-A structural violation is malformed wire data the encoding context detects
-itself, rather than a state a codec refuses, and the two are settled the same
-way: against `lenient` (see `1-fabric-values.md` Section 4.5). A lenient
-context yields a `ProblematicValue`, and a strict one raises. Which of the two
+A structural violation is malformed wire data the engine detects itself,
+rather than a state a codec refuses, and the two are settled the same way:
+against `lenient` (see `1-fabric-values.md` Section 4.5). A lenient decode
+yields a `ProblematicValue`, and a strict one raises. Which of the two
 noticed the fault is an implementation detail of where a check lives, and does
 not reach a caller.
 

--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -69,9 +69,10 @@ padded with whitespace or a newline.
 A string outside that syntax is not an unrecognized tag; it is not a tag at
 all. A key naming one is a structural violation under Section 9 rather than an
 `UnknownValue` under Section 8, and that is what lets an `UnknownValue` always
-hold a real tag. The escapes `/quote`, `/hole` and `/object` (Section 6) fall
-outside the syntax deliberately, each being a structural marker the format
-handles itself rather than a type anything encodes.
+hold a real tag. The escapes `/quote` and `/object` (Section 6), and the
+sparse-array marker `/hole` (Section 3), fall outside the syntax deliberately,
+each being a structural marker the format handles itself rather than a type
+anything encodes.
 
 The syntax is not particular to JSON. It is the type-tag syntax the whole codec
 system shares: a registry refuses a codec that declares a fixed tag outside it,

--- a/packages/data-model/src/codec-common/BaseDecodeAct.ts
+++ b/packages/data-model/src/codec-common/BaseDecodeAct.ts
@@ -127,13 +127,10 @@ export abstract class BaseDecodeAct<Encoded, SerializedForm = Encoded>
    * fault in the code doing the decoding does not come back to a caller
    * disguised as malformed input.
    *
-   * The commonest thing to hand this is a refusal of the serialized form
-   * itself, from a format's own entry points, which reach a conversion without
-   * passing through `decode()` -- `JsonCodecEngine`'s byte pair, for one. Such
-   * a form is data off a channel like any other, so being the wrong shape for
-   * this format is a malformation of the same kind as a bad state inside a
-   * well-formed one, and settles the same way. Nothing here is specific to
-   * that case.
+   * A refusal of the serialized form itself arrives here too. Such a form is
+   * data off a channel like any other, so being the wrong shape for this
+   * format is a malformation of the same kind as a bad state inside a
+   * well-formed one, and settles the same way.
    *
    * @throws Whatever it was given, if this act is not lenient or the throw was
    *   not a `ProblematicStateError`.

--- a/packages/data-model/src/codec-common/CodecRegistry.ts
+++ b/packages/data-model/src/codec-common/CodecRegistry.ts
@@ -6,9 +6,9 @@
  * sentinel in place of a codec.
  *
  * A registry is mutable while it is being assembled and immutable once frozen,
- * and that is a safety property rather than a convenience. A codec holds the
+ * and that is a safety property rather than a convenience. An engine holds the
  * registry it was constructed with, so one handed out unfrozen could gain a
- * registration underneath a codec already relying on it. Building further on a
+ * registration underneath an engine already relying on it. Building further on a
  * frozen registry means extending it into a new one.
  */
 
@@ -80,8 +80,8 @@ function constructorOf(
  *
  * An instance is mutable while it is being built and immutable once
  * `Object.freeze()`d: every mutator refuses on a frozen instance. Freezing is
- * how a registry becomes safe to hand out, since a codec holds the registry it
- * was constructed with and would otherwise see a later registration. Use
+ * how a registry becomes safe to hand out, since an engine holds the registry
+ * it was constructed with and would otherwise see a later registration. Use
  * {@link #extend} to build on one that is already frozen.
  */
 export class CodecRegistry<Encoded> {

--- a/packages/data-model/src/codec-common/index.ts
+++ b/packages/data-model/src/codec-common/index.ts
@@ -1,15 +1,15 @@
 /**
  * This directory holds the codec system's active machinery: the registry that
  * indexes codecs, the lookup that finds a class's codec, the engine base, the
- * per-act contexts, and the two classes a fault produces. It is also the
+ * per-act encode and decode classes, and the two classes a fault produces. It is also the
  * package's public face for the codec system as a whole, re-exporting the
  * declarations in `codec-interface/` so that an outside caller has one entry
  * point rather than two.
  *
- * That convenience is for this barrel alone. A module inside the package
- * imports the file it wants directly -- nothing here imports this barrel --
- * which is what keeps a module that only needs to name a codec from pulling
- * the machinery in behind it, and is the point of the two directories.
+ * That convenience is for callers. A module inside this directory imports
+ * the file it wants directly, which is what keeps a module that only needs
+ * to name a codec from pulling the machinery in behind it, and is the point
+ * of the two directories.
  *
  * Everything here is format-agnostic. Nothing in this directory knows which
  * wire format is in play, and a codec that exists because one particular

--- a/packages/data-model/src/codec-common/isCodecTypeTag.ts
+++ b/packages/data-model/src/codec-common/isCodecTypeTag.ts
@@ -1,9 +1,9 @@
 /**
  * Syntax of a codec type tag: a type name, `@`, and a version number. The name
- * is `UpperCamelCase` -- an uppercase letter followed by letters and digits --
- * and the version is a positive integer with no leading zero. Section 2 of
- * `3-json-encoding.md` is where that convention is written down; this is the
- * check that holds every format to it.
+ * is `UpperCamelCase` -- an uppercase ASCII letter followed by ASCII letters
+ * and digits -- and the version is a decimal integer with no leading zero.
+ * Section 2 of `3-json-encoding.md` is where that syntax is written down; this
+ * is the check that holds every format to it.
  */
 const CODEC_TYPE_TAG_SYNTAX = /^[A-Z][A-Za-z0-9]*@[1-9][0-9]*$/;
 

--- a/packages/data-model/src/codec-interface/BaseFabricCodec.ts
+++ b/packages/data-model/src/codec-interface/BaseFabricCodec.ts
@@ -64,7 +64,7 @@ export abstract class BaseFabricCodec<Encoded> implements FabricCodec<Encoded> {
     return this.#recognizedTypeTag;
   }
 
-  /** @innheritDoc */
+  /** @inheritDoc */
   canEncode(value: FabricValue): boolean {
     const cls = this.#uniqueHandledClass;
 

--- a/packages/data-model/src/codec-interface/NullLiveEnvironment.ts
+++ b/packages/data-model/src/codec-interface/NullLiveEnvironment.ts
@@ -11,8 +11,8 @@ import type { LiveEnvironment } from "./interface.ts";
 import { BaseLiveEnvironment } from "./BaseLiveEnvironment.ts";
 
 /**
- * `LiveEnvironment` whose `getCell()` always throws. `shouldDeepFreeze`
- * is inherited from `BaseLiveEnvironment` (defaults to `true`).
+ * `LiveEnvironment` whose `getCell()` always throws. `shouldDeepFreeze` is
+ * inherited from `BaseLiveEnvironment`, and is required at construction.
  */
 export class NullLiveEnvironment extends BaseLiveEnvironment {
   readonly #getCellMessage: string;

--- a/packages/data-model/src/codec-interface/interface.ts
+++ b/packages/data-model/src/codec-interface/interface.ts
@@ -49,7 +49,7 @@ export const CODEC: unique symbol = Symbol("data-model.codec");
  * `FabricValue`s and leaves every terminal decision to whatever walks the
  * result, so one binding serves every format.
  */
-export const JSON_CODEC: unique symbol = Symbol("data-model.jsonCodecEngine");
+export const JSON_CODEC: unique symbol = Symbol("data-model.jsonCodec");
 
 /**
  * Interface for codecs (encoder-decoder objects). These are objects which can
@@ -250,7 +250,8 @@ export interface LiveEnvironment {
    * for free by extending `BaseLiveEnvironment`, which centralizes the
    * getter; the `cloneIfNecessary`-style `true` default lives there.
    *
-   * Enforcement: each codec's `decode()` queries this and abides by it,
+   * Enforcement: a decode deep-freezes its result, and a codec that builds
+   * a value cheaper when it may stay thawed reads this to decide,
    * producing a deep-frozen result when it is `true`.
    */
   get shouldDeepFreeze(): boolean;

--- a/packages/data-model/src/codec-json/BigIntCodec.ts
+++ b/packages/data-model/src/codec-json/BigIntCodec.ts
@@ -16,8 +16,8 @@ import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
  * string encoding the bigint's two's-complement big-endian byte representation.
  * Wire format: `{ "/BigInt@1": "<base64>" }`.
  *
- * The byte encoding is the same one used by the hash (Section 3.7 of the
- * byte-level spec): minimal two's-complement big-endian, with sign extension
+ * The byte encoding is the same one used by the hash
+ * (`2-hash-byte-format.md` Section 4.5): minimal two's-complement big-endian, with sign extension
  * as needed.
  *
  * `BigInt` is a non-`new`-able pseudo-constructor, so it is cast to

--- a/packages/data-model/src/codec-json/JsonDecodeAct.ts
+++ b/packages/data-model/src/codec-json/JsonDecodeAct.ts
@@ -64,6 +64,16 @@ export class JsonDecodeAct extends BaseDecodeAct<JsonCodecValue, string> {
 
       // `CODEC_META_TAGS.quote` literal handling (`3-json-encoding.md` Section 6).
       if (tag === CODEC_META_TAGS.quote) {
+        // TODO(danfuzz): Quote content is returned whole, so a key this
+        // runtime reserves is admitted here where the `/object` and
+        // plain-object arms below refuse one. `JSON.parse` makes such a key an
+        // own property, so it does arrive. The result cannot be re-encoded --
+        // `BaseEncodeAct.assertEncodableKey()` refuses it -- so a decode
+        // through this arm can produce a value that does not round-trip.
+        // Settling it means deciding whether the reservation covers every arm
+        // or only the arms that rebuild an object by assignment, and writing
+        // that answer into Section 9, which does not currently mention these
+        // keys at all.
         return rawState;
       }
 

--- a/packages/data-model/src/codec-json/JsonDecodeAct.ts
+++ b/packages/data-model/src/codec-json/JsonDecodeAct.ts
@@ -62,12 +62,12 @@ export class JsonDecodeAct extends BaseDecodeAct<JsonCodecValue, string> {
     if (decoded !== null) {
       const { tag, state: rawState } = decoded;
 
-      // `CODEC_META_TAGS.quote` literal handling (Section 5.6).
+      // `CODEC_META_TAGS.quote` literal handling (`3-json-encoding.md` Section 6).
       if (tag === CODEC_META_TAGS.quote) {
         return rawState;
       }
 
-      // `CODEC_META_TAGS.object` unwrapping (Section 5.6).
+      // `CODEC_META_TAGS.object` unwrapping (`3-json-encoding.md` Section 6).
       if (tag === CODEC_META_TAGS.object) {
         if (!isPlainObject(rawState)) {
           return this.reportMalformed(
@@ -216,7 +216,7 @@ export class JsonDecodeAct extends BaseDecodeAct<JsonCodecValue, string> {
    * returned `state` is extracted directly from `data`, so if `data` is
    * deep-frozen (as it should be) then `state` will be too.
    *
-   * See Section 5.4 of the formal spec.
+   * See `3-json-encoding.md` Section 4.
    */
   static #unwrapTag(
     data: JsonCodecValue,

--- a/packages/data-model/src/codec-json/JsonEncodeAct.ts
+++ b/packages/data-model/src/codec-json/JsonEncodeAct.ts
@@ -30,8 +30,8 @@ export class JsonEncodeAct extends BaseEncodeAct<JsonCodecValue, string> {
   /**
    * @inheritDoc
    *
-   * Prepends `/` to the tag to produce the JSON key. See Section 5.2 of the
-   * formal spec.
+   * Prepends `/` to the tag to produce the JSON key. See `3-json-encoding.md`
+   * Section 2.
    *
    * The result is not frozen. An encode-side tree is stringified and
    * discarded without ever reaching a caller, so the deep-frozen invariant
@@ -92,7 +92,7 @@ export class JsonEncodeAct extends BaseEncodeAct<JsonCodecValue, string> {
    * order. See `3-json-encoding.md` Section 10.
    *
    * A `/`-prefixed key collides with the tag form, so an object bearing one is
-   * escaped per Section 5.6: all values are encoded first, and if every one is
+   * escaped per `3-json-encoding.md` Section 6: all values are encoded first, and if every one is
    * quote-safe the whole object is wrapped in `/quote` with any `/quote`
    * children collapsed into it, and otherwise in `/object` so that the decoder
    * walks the entries.

--- a/packages/data-model/src/codec-json/UndefinedCodec.ts
+++ b/packages/data-model/src/codec-json/UndefinedCodec.ts
@@ -7,7 +7,7 @@ import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 /**
  * Codec for `undefined`. Encodes to the `Undefined@1` tag with `null` state.
  * `undefined` has no corresponding class, so there is no `uniqueHandledClass`;
- * matching is by `canEncode()`. See Section 1.4.1 of the formal spec.
+ * matching is by `canEncode()`. See `1-fabric-values.md` Section 1.3.
  */
 export class UndefinedCodec extends BaseTerminalCodec<JsonCodecValue> {
   /** Constructs an instance. */

--- a/packages/data-model/src/codecs.ts
+++ b/packages/data-model/src/codecs.ts
@@ -84,8 +84,8 @@ export function jsonFromFabricValue(
  * Decodes a string in the `FabricValue` JSON-embedded encoding format, which is
  * expected to be a plain object. Throws if it turns out to be something else.
  * If no live environment is given, {@link NULL_LIVE_ENVIRONMENT} is
- * substituted (via `fabricFromJsonValue()`), which throws if any decoding
- * is needed.
+ * substituted (via `fabricFromJsonValue()`), which throws if anything asks
+ * it for a cell.
  */
 export function plainObjectFromJson<T extends object = object>(
   json: string,
@@ -113,7 +113,7 @@ export function plainObjectFromJson<T extends object = object>(
 /**
  * Decodes a string in the `FabricValue` JSON-embedded encoding format. If no
  * live environment is given, {@link NULL_LIVE_ENVIRONMENT} is substituted,
- * which throws if any decoding is needed.
+ * which throws if anything asks it for a cell.
  */
 export function fabricFromJsonValue(
   json: string,

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -17,7 +17,7 @@ import type {
   FabricError as ApiFabricError,
   FabricErrorConstructor as ApiFabricErrorConstructor,
 } from "@commonfabric/api";
-import { isUnsafeObjectKey } from "@commonfabric/utils/types";
+import { isPlainObject, isUnsafeObjectKey } from "@commonfabric/utils/types";
 
 import { FabricNativeWrapper } from "./FabricNativeWrapper.ts";
 import {
@@ -458,6 +458,10 @@ export class FabricError extends FabricNativeWrapper<Error>
         state: FabricValue,
         env: LiveEnvironment,
       ): FabricValue {
+        if (!isPlainObject(state)) {
+          throw new Error("`Error@1` state is not an object.");
+        }
+
         const s = state as Record<string, FabricValue>;
         const type = (s.type as string) ?? (s.name as string) ?? "Error";
         // `null` `name` means "same as `type`" (the wire-level optimization).

--- a/packages/data-model/src/fabric-primitives/index.ts
+++ b/packages/data-model/src/fabric-primitives/index.ts
@@ -30,9 +30,9 @@ export { FabricEpochDays } from "./FabricEpochDays.ts";
 
 /**
  * The concrete primitive classes whose instances are available over the wire,
- * each via its static `[JSON_CODEC]`. This is the curated source of truth for
- * which primitive types participate in encoding: add a class here once it
- * gains a `[JSON_CODEC]`.
+ * each via the codec it binds under a wire format's own symbol. This is the
+ * curated source of truth for which primitive types participate in encoding:
+ * add a class here once it binds a codec for every format that is built.
  *
  * Typed only as classes, which is weaker than it looks: a `FabricPrimitive`
  * binds its codec under a wire format's own symbol, so a type saying which

--- a/packages/data-model/test/codec-common/isCodecTypeTag.test.ts
+++ b/packages/data-model/test/codec-common/isCodecTypeTag.test.ts
@@ -62,6 +62,16 @@ describe("isCodecTypeTag", () => {
     expect(isCodecTypeTag("link@1")).toBe(false);
   });
 
+  it("returns `false` for a name holding a non-ASCII letter", () => {
+    // The alphabet is ASCII, which Section 2 of `3-json-encoding.md` states
+    // and a Unicode-property spelling of the same syntax would not honor. A
+    // tag crosses between systems, so the set of names it can carry cannot
+    // depend on which alphabet a decoder reads it with.
+    expect(isCodecTypeTag("\u00c9clair@1")).toBe(false);
+    expect(isCodecTypeTag("Caf\u00e9@1")).toBe(false);
+    expect(isCodecTypeTag("\u0411ytes@1")).toBe(false);
+  });
+
   it("returns `false` for a tag padded with whitespace or a newline", () => {
     // The syntax is anchored at both ends and is not multiline, so padding a
     // tag does not make the string one. The newline pair is the only case in

--- a/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
@@ -1834,7 +1834,7 @@ describe("JsonCodecEngine", () => {
     });
   });
 
-  describe("JsonCodecEngine", () => {
+  describe("entry points", () => {
     it("`encode()` returns a prefixed JSON string", () => {
       const jsonCodecEngine = newDefaultJsonCodecEngine();
       const result = jsonCodecEngine.encode(42);

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -595,6 +595,17 @@ describe("FabricError", () => {
       // Decoding hand-built state (not via `encode()`): exercises name/type
       // handling and back-compat that the round-trip tests don't.
       describe("decode()", () => {
+        it("throws for state that is not a plain object", () => {
+          // Wire state is untrusted input. Without the shape check these
+          // decode into a `FabricError` bearing default type and an empty
+          // message, which is a malformation admitted silently rather than
+          // reported. The engine settles the throw against `lenient`.
+          for (const state of ["hello", 42, true, null, [1, 2]]) {
+            expect(() => codec.decode(expectedTag, state as never, env))
+              .toThrow("`Error@1` state is not an object.");
+          }
+        });
+
         // `JSON.parse` creates an own `__proto__` property where an object
         // literal instead invokes the setter, so parsed wire state is the one
         // place a prototype-sensitive key genuinely arrives as decodable input.


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

An independent review of the codec subsystem as a whole, plus the tag-syntax gap
that prompted it. Everything here is general — nothing is specific to a wire
format still in flight.

## The tag syntax, written down

`3-json-encoding.md` leaned on the codec type tag syntax in two places without
ever stating it. Section 8 routes a syntactically valid but unclaimed tag to
`UnknownValue`, so it round-trips. Section 9 routes a key that is not a tag to a
structural violation, which is refused. `BaseDecodeAct.decodeTagged()` cites
Section 9 by name when it takes that second branch. So the syntax decides which
of two quite different fates a wire value meets — and Section 2 offered only
"`UpperCamelCase` type name" and a version that is a "natural number, starting
at 1", which does not decide `Foo@01`.

Section 2 now states the syntax exactly, and then what follows from it: a string
outside the syntax is not an unrecognized tag but not a tag at all, so it lands
under Section 9 rather than Section 8, which is what lets an `UnknownValue`
always hold a real tag. Two further facts that were nowhere written down: the
syntax spans every wire format rather than JSON alone, and `CodecRegistry`
refuses a codec declaring a fixed tag outside it.

`isCodecTypeTag`'s doc described a name as "an uppercase letter followed by
letters and digits". The check is ASCII-only, so a type named `Éclair` is
refused and a reader had no way to know. Both the comment and the spec now say
ASCII, and a test holds it.

## `Error@1` accepted any state shape

`FabricError`'s codec read its properties straight off the state with no shape
check. Decoding `{"/Error@1": <state>}` before and after:

```
before                                    after
"hello" -> FabricError  (silent)          ProblematicStateError: `Error@1` state is not an object.
42      -> FabricError  (silent)          ProblematicStateError: ...
[1,2]   -> FabricError  (silent)          ProblematicStateError: ...
null    -> ProblematicStateError           ProblematicStateError: ...
           (raw property-access message)
```

Three of those decoded silently into a `FabricError` carrying a default type
and an empty message. Wire state is untrusted input; every sibling codec
validates and reports, and the spec's decoding-validation rule requires
rejection over garbage, so this was the one codec in the roster exempting itself
from the rule the spec states for all of them. It now throws, which the engine
settles against `lenient`. `FabricError` binds its codec format-neutrally, so
this closes the same hole for every wire format.

## A decode hole, marked rather than fixed

The `/quote` arm returns quote content whole, so a key this runtime reserves
passes through it where the `/object` and plain-object arms beside it refuse
one. `JSON.parse` makes such a key an own property, so it does arrive, and the
result cannot be re-encoded — the encode side refuses the key. A decode through
that arm can produce a value that does not round-trip.

A `TODO(danfuzz)` marks it, because the fix is a decision about the format
rather than a bug to patch: the reservation either covers every arm or only the
arms that rebuild an object by assignment, and Section 9 does not currently
mention these keys at all, so whichever answer is chosen has to be written there
too. (The realm format has no `/quote` arm, so the gap is JSON's alone.)

## Prose the refactor arc moved out from under

No gate reads prose, so each of these stood unchallenged. Corrected by claim
rather than by line.

Five comments still cite pre-extraction section numbers — worse than dangling,
because `5.2` does resolve, to an unrelated section of a neighboring document.
Two more cited the wrong place outright: `BigIntCodec` a section the byte-level
spec does not have, and `UndefinedCodec` the wrapper-class table, which does not
cover `undefined`. Each now names its document as well as its section.

`settleThrown` named a caller that no longer exists — a format's byte entry
points, which reached a conversion without passing through `decode()`. Those are
gone; it now has exactly one caller, inside `decode()`.

The `codec-common` barrel said nothing inside the package imports it;
`value-hash.ts` and `data-uri-codec.ts` both do. `CodecRegistry` credited the
freeze guarantee to a codec twice, where an engine is what holds a registry. The
`fabric-primitives` roster called itself a `[JSON_CODEC]` list while its own next
paragraph says it serves every format. The spec stated the strict-mode rule
without the exemption the engine implements, so its Section 7 and its
`Problematic@1` block contradicted each other. Section 5 illustrated stateless
types with a tag no registry reserves, and three sentences called the engine a
"context" against this document's own Section 7 heading.

Smaller: an `@innheritDoc` typo; a `shouldDeepFreeze` documented as defaulting
when its constructor requires it; a symbol description naming an engine where it
binds a codec; an enforcement note claiming every codec queries
`shouldDeepFreeze` when a decode freezes unconditionally; two entry-point docs
saying the null environment throws "if any decoding is needed" when it throws
only when asked for a cell; and a nested `describe()` repeating its enclosing
one's name.

## Notes for the reviewer

**Deliberately not done.** `Stream@1` appears in the Section 3 tag map and in no
source file, but `Map@1` and `Set@1` are reserved in `CODEC_TYPE_TAGS` with
stubbed codecs while `Stream@1` is reserved nowhere, and `1-fabric-values.md`
carries a migration note pointing at it. Removing it might drop a reservation
rather than a phantom, which is a call about a planned feature. Section 5's use
of it as the sole illustration of stateless types is fixed, since `Undefined@1`
actually exists and is stateless.

**The two behavior claims were probed, not reasoned.** The before/after table
above is observed output. The `/quote` hole was confirmed the same way, with the
`/object` and plain-object arms as controls — they refuse, which is what shows
the probe would have caught a sweep in the quote arm had there been one.

**The ASCII test has grip.** Ablating the pattern to
`/^\p{Lu}[\p{L}\p{N}]*@[1-9][0-9]*$/u` type-checks clean and fails that one test
and no other. The ablation compiling matters: a red suite from a compile error
would prove nothing about behavior.

## Verification

* `deno task check`, `deno lint`, repo-wide `deno fmt --check`,
  `deno task check-docs` (559 blocks): all clean.
* `data-model`: `ok | 53 passed (2455 steps) | 0 failed`.
* Workspace `deno task test`: all packages `(ok)`, "All tests passing!".
