### PR TITLE
docs(data-model,utils): any plain-object key is data; say where this implementation falls short

### DIFF
--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -303,6 +303,21 @@ built-in escape, or an encoding error.
 > `/`-prefixed keys in the wire format are always encoding signals, never
 > literal user-data keys.
 
+> **JS implementation note.** "Any keys" is the format's rule and this
+> implementation does not yet meet it: a plain object carrying `__proto__` or
+> `constructor` is refused rather than encoded, on both sides of the wire and
+> in the inert check that decides what a fabric value is at all. Neither name
+> is reserved by the format, and neither is a limit of JavaScript. They are
+> refused because of how *this* implementation rebuilds a record — by
+> assignment, which for `__proto__` reaches a prototype accessor instead of
+> creating a property — and because other boundaries here already drop
+> `constructor`, so accepting it would admit a key that something later
+> discards silently. `unsafeObjectKeyIn()` in `@commonfabric/utils/types`
+> carries the reasoning and the conditions for lifting each one. An
+> implementation on a host that does not route property assignment through a
+> prototype chain reserves no names at all, which is the behavior the format
+> describes.
+
 The common case — a **tagged value** — is a single-key object whose sole key
 starts with `/`:
 

--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -315,8 +315,8 @@ built-in escape, or an encoding error.
 > JavaScript takes its presence as the mark of a thenable, its own runtime
 > internals included, so a record carrying one is consumed by promise
 > resolution that nothing asked for and no boundary reports.
-> `unsafeObjectKeyIn()` in `@commonfabric/utils/types` carries the reasoning
-> per name and the conditions for lifting each. An implementation on a host
+> `unsafeObjectKeyIn()` in `@commonfabric/utils/types` carries what makes each
+> name awkward and what carrying it would take. An implementation on a host
 > that neither routes property assignment through a prototype chain nor
 > duck-types promises reserves no names at all, which is the behavior the
 > format describes.

--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -266,10 +266,11 @@ built-in escape, or an encoding error.
 > `__proto__` and `constructor` are about copying: this implementation rebuilds
 > a record by assignment, which for `__proto__` reaches a prototype accessor
 > instead of creating a property, and other boundaries here already drop
-> `constructor`. `then` is about what the host does with a record afterward —
-> JavaScript takes its presence as the mark of a thenable, its own runtime
-> internals included, so a record carrying one is consumed by promise
-> resolution that nothing asked for and no boundary reports. An implementation
+> `constructor`. `then` is about what the host does with a record afterward:
+> JavaScript's promise resolution probes for that name and adopts whatever
+> answers it, if what answers is callable. A record read through a layer that
+> can answer a property with a function is therefore consumed by resolution
+> nothing asked for, with no fault reported. An implementation
 > on a host that neither routes property assignment through a prototype chain
 > nor duck-types promises reserves no names at all, which is the behavior the
 > format describes.

--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -95,169 +95,124 @@ round-trip correctly.
 > applies to `Bytes@1`, `BigInt@1`, `EpochNsec@1`, and `EpochDays@1` state
 > values, and to the `hash` field of `Hash@1` state.
 
-```typescript
-// Illustrative tag-to-format map. The canonical tag-string constants live
-// in `packages/data-model/src/codec-interface/codec-type-tags.ts`
-// (`CODEC_TYPE_TAGS`) and `codec-meta-tags.ts` (`CODEC_META_TAGS`).
+The JSON key for a tagged value is the tag with `/` prepended, per Section 2:
+a value under `Link@1` is written `{ "/Link@1": <state> }`. What follows
+specifies each built-in type's state. Which classes and codecs are registered
+under these tags is a separate question, specified in `1-fabric-values.md`
+Section 4.5.
 
-/**
- * Standard JSON encodings for all built-in special types.
- *
- * In each case, the tag string (e.g. `"Link@1"`) is passed to the engine's
- * internal `wrapTag()` method, which prepends `/` to produce the JSON key
- * (e.g. `"/Link@1"`).
- */
+These types need no rule beyond the shape of their state:
 
-// Cell references (links to other documents)
-// Tag: "Link@1"
-// { "/Link@1": { id: string, path: string[], space: string } }
+- `Link@1` — `{ id: string, path: string[], space: string }`.
+- `Error@1` — `{ type: string, name: string | null, message: string, stack?:
+  string, cause?: <any>, ... }`, where the trailing properties are the error's
+  own custom ones.
+- `Undefined@1` — `null`. The type is stateless (Section 5).
+- `Map@1` — `[[key, value], ...]`, entry pairs in insertion order.
+- `Set@1` — `[value, ...]`, values in insertion order.
+- `Bytes@1` — a base64url string, per the convention above.
+- `hole` — a positive integer giving the length of a run of array holes. This
+  is a structural meta-key rather than a type tag, and is valid only directly
+  inside an array; see the sparse-array note below.
 
-// Errors
-// Tag: "Error@1"
-// { "/Error@1": { type: string, name: string | null, message: string, stack?: string, cause?: ..., ... } }
+### `Hash@1` — content hashes
 
-// Undefined (stateless -- value is null)
-// Tag: "Undefined@1"
-// { "/Undefined@1": null }
+State is `{ tag: string, hash: string }`. `tag` is the algorithm tag (for
+example `fid1`), and `hash` is the hash bytes as an unpadded base64url string,
+per the convention above. On decoding, a state that is not an object, or whose
+fields are not strings, produces a `ProblematicValue`. See `1-fabric-values.md`
+Section 1.4.9.
 
-// Array holes (run-length encoded; value is a positive integer; only valid
-// inside arrays)
-// Tag: "hole"
-// { "/hole": <count> }   e.g. { "/hole": 1 }, { "/hole": 5 }
+### `RegExp@1` — regular expressions
 
-// Stream markers (stateless -- value is null)
-// Tag: "Stream@1"
-// { "/Stream@1": null }
+State is `{ source: string, flags: string, flavor: string }`. `source` is the
+pattern string and `flags` the flag string (for example `gi`). `flavor`
+identifies the regular-expression dialect, `es2025` being the default.
 
-// Maps (entry pairs preserve insertion order)
-// Tag: "Map@1"
-// { "/Map@1": [[key, value], ...] }
+On decoding, a state that is not an object produces a `ProblematicValue`, as
+does an `es2025` pattern that fails to construct. A pattern under any other
+flavor is stored faithfully and **not** validated, its dialect not being one
+this format can construct. See `1-fabric-values.md` Section 1.4.5.
 
-// Sets (values preserve insertion order)
-// Tag: "Set@1"
-// { "/Set@1": [value, ...] }
+### `BigInt@1` — arbitrary-precision integers
 
-// Binary data (base64url-encoded per the base64url convention above)
-// Tag: "Bytes@1"
-// { "/Bytes@1": string }
+State is the base64url encoding of the value's minimal two's-complement
+representation in big-endian byte order. The minimum length is one byte, so
+even `0n` encodes as a single `0x00`:
 
-// Content hashes (see `1-fabric-values.md` Section 1.4.9)
-// Tag: "Hash@1"
-// { "/Hash@1": { tag: string, hash: string } }
-//
-// `tag` is the algorithm tag (e.g. "fid1"); `hash` is the hash bytes as an
-// unpadded base64url string (per the convention above). On
-// decoding, a non-object state or non-string fields produce a
-// `ProblematicValue` (see `1-fabric-values.md` Section 3.5) per the
-// general codec-validation rule below.
+| Value | Bytes | State |
+|-------|-------|-------|
+| `0n` | `0x00` | `"AA"` |
+| `1n` | `0x01` | `"AQ"` |
+| `-1n` | `0xFF` | `"_w"` |
+| `128n` | `0x00 0x80` | `"AIA"` |
+| `-128n` | `0x80` | `"gA"` |
 
-// Regular expressions (see `1-fabric-values.md` Section 1.4.5)
-// Tag: "RegExp@1"
-// { "/RegExp@1": { source: string, flags: string, flavor: string } }
-//
-// `source` is the pattern string; `flags` is the flag string (e.g. "gi");
-// `flavor` identifies the regex dialect (e.g. "es2025", the default). On
-// decoding, a non-object state produces a `ProblematicValue`, as
-// does an `es2025` pattern that fails native `RegExp` construction;
-// non-`es2025` flavors are stored faithfully without syntax validation
-// (their dialects cannot be validated here).
+`128n` is the case that shows why the representation is two's complement rather
+than magnitude: `0x80` alone decodes as `-128`, so a leading zero byte is
+required to keep the value positive. This is the same encoding the hash byte
+format uses for bigint payloads (`2-hash-byte-format.md` Section 4.5).
 
-// Epoch nanoseconds (bigint, encoded per BigInt@1 conventions)
-// Tag: "EpochNsec@1"
-// { "/EpochNsec@1": string }
-//
-// The state is the base64url encoding of the bigint value's minimal two's
-// complement representation in big-endian byte order — the same encoding
-// as BigInt@1.
+### `EpochNsec@1` and `EpochDays@1` — epoch quantities
 
-// Epoch days (bigint, encoded per BigInt@1 conventions)
-// Tag: "EpochDays@1"
-// { "/EpochDays@1": string }
-//
-// Same encoding convention as EpochNsec@1 (base64url of two's complement
-// big-endian bytes).
+Both carry a bigint, and both encode it exactly as `BigInt@1` does: base64url
+of the minimal two's-complement big-endian bytes.
 
-// BigInts (base64url of two's complement big-endian bytes; see convention above)
-// Tag: "BigInt@1"
-// { "/BigInt@1": string }
-//
-// The state is the base64url encoding of the value's minimal two's complement
-// representation in big-endian byte order. The minimum byte length is 1 —
-// even `0n` produces a single `0x00` byte. Examples:
-//   - `0n`  → single byte 0x00 → "AA"
-//   - `1n`  → 0x01             → "AQ"
-//   - `-1n` → 0xFF             → "_w"
-//   - `128n` → 0x00 0x80       → "AIA"  (leading 0x00 needed: 0x80 alone would decode as -128)
-//   - `-128n` → 0x80           → "gA"
-// This matches the hash byte format (2-hash-byte-format.md), which already
-// uses two's complement big-endian for BigInt payloads.
+### `SpecialNumber@1` — numbers JSON cannot represent
 
-// Special numeric values that JSON cannot represent natively.
-// Tag: "SpecialNumber@1"
-// { "/SpecialNumber@1": string }
-//
-// The state is one of exactly four literal strings:
-//   - "-0"          → the negative-zero value
-//   - "NaN"         → Number.NaN (any input NaN bit pattern encodes as
-//                     this single literal and round-trips back to NaN)
-//   - "+Infinity"   → positive infinity
-//   - "-Infinity"   → negative infinity
-//
-// String state (rather than a JSON number) is used because JSON.stringify
-// emits `null` for NaN/±Infinity and drops the sign on -0; a numeric-state
-// form would be lossy through the JSON layer. On decoding, any state
-// other than these four literals — including a non-string state — produces
-// a `ProblematicValue` (see `1-fabric-values.md` Section 3.5) per the
-// general codec-validation rule below.
-//
-// Whether such values reach this encoder depends on the fabric-value
-// conversion gate; see `1-fabric-values.md` Section 4.9. The wire format
-// above is the encoder's contract regardless of how the values arrived.
+State is one of exactly four literal strings, and nothing else:
 
-// Registry-interned symbols (`Symbol.for(key)`).
-// Tag: "Symbol@1"
-// { "/Symbol@1": string }
-//
-// The state is the registry key — the JavaScript string returned by
-// `Symbol.keyFor(s)`. On decoding, `Symbol.for(state)` retrieves
-// (or creates) the registry symbol with the matching key, so the result
-// is `===` to any other `Symbol.for(state)` in the same realm.
-//
-// Unique symbols (`Symbol(desc)`, where `Symbol.keyFor(s)` returns
-// `undefined`) have no portable representation. The codec's
-// `canEncode()` returns `false` for them, which routes them to the
-// registry's "unhandled value" path rather than coercing them silently
-// to a registry key. On decoding, any state other than a string
-// yields a `ProblematicValue` (see `1-fabric-values.md` Section 3.5)
-// per the general codec-validation rule below.
-//
-// Whether a symbol value reaches this encoder depends on the fabric-value
-// conversion gate; see `1-fabric-values.md` Section 4.9. The wire format
-// above is the encoder's contract regardless of how the value arrived.
+- `"-0"` — negative zero.
+- `"NaN"` — any input NaN bit pattern encodes to this one literal, and decodes
+  back to `NaN`.
+- `"+Infinity"` — positive infinity.
+- `"-Infinity"` — negative infinity.
 
-// Preserved failures (see `1-fabric-values.md` Section 3.5)
-// Tag: "Problematic@1"
-// { "/Problematic@1": { tag: string, state: <any>, error: string } }
-//
-// `tag` is the tag the faulty data arrived under, `state` is what was at
-// fault, and `error` describes what is wrong with it. All three are
-// preserved, so a recorded failure survives a round trip as the account of
-// a failure rather than as an unremarkable value.
-//
-// Unlike every other entry above, the tag here is fixed rather than being
-// the tag of the value it stands in for. The preserved tag rides inside the
-// state because it need not be a well-formed tag at all -- reporting one
-// that is not is among the things this type is for, and such a value cannot
-// go back out under it. `UnknownValue` is the type that re-emits under its
-// preserved tag (Section 8), which it can because that tag is checked to be
-// a real one.
-//
-// On decoding, a non-object state, a non-string `tag` or `error`, or
-// an absent `state` property produces a `ProblematicValue` describing this
-// decode. `state` is checked for presence rather than type because every
-// `FabricValue` is a valid state, `undefined` among them, so filling in an
-// absent one would put a reshaped record back on the wire.
-```
+The state is a string rather than a JSON number because a numeric state would
+be lossy through the JSON layer: `JSON.stringify` emits `null` for `NaN` and
+the infinities, and drops the sign of `-0`. On decoding, any other state —
+including one that is not a string — produces a `ProblematicValue`.
+
+Whether such a value reaches the encoder at all depends on the fabric-value
+conversion gate (`1-fabric-values.md` Section 4.9). The encoding above is the
+encoder's contract however the value arrived.
+
+### `Symbol@1` — registry-interned symbols
+
+State is the registry key: the string `Symbol.keyFor()` returns for the symbol.
+On decoding, `Symbol.for(state)` retrieves or creates the registry symbol with
+that key, so the result is identical to any other symbol interned under it in
+the same realm.
+
+A symbol with no registry key has no portable representation, and the codec
+declines to encode one rather than coercing it to a key. On decoding, a state
+that is not a string produces a `ProblematicValue`.
+
+Whether such a value reaches the encoder at all depends on the fabric-value
+conversion gate (`1-fabric-values.md` Section 4.9). The encoding above is the
+encoder's contract however the value arrived.
+
+### `Problematic@1` — preserved failures
+
+State is `{ tag: string, state: <any>, error: string }`. `tag` is the tag the
+faulty data arrived under, `state` is what was at fault, and `error` describes
+what is wrong with it. All three are preserved, so a recorded failure survives
+a round trip as an account of a failure rather than as an unremarkable value.
+
+Alone among these types, the key here is a fixed tag rather than the tag of the
+value it stands in for. The preserved tag rides inside the state because it
+need not be a well-formed tag at all — reporting one that is not is among the
+things this type is for, and such a value could not go back out under it.
+`UnknownValue` is the type that re-emits under its preserved tag (Section 8),
+which it can because that tag is known to be a real one.
+
+On decoding, a state that is not an object, a `tag` or `error` that is not a
+string, or an absent `state` property produces a `ProblematicValue` describing
+that decode. `state` is checked for presence rather than for type, because
+every fabric value is a valid state, `undefined` among them; filling in an
+absent one would put a reshaped record back on the wire.
+
+See `1-fabric-values.md` Section 3.5.
 
 > **Decoding validation.** Decoding cannot assume type safety from
 > the wire. Each codec must validate the format of its state in `decode()`
@@ -434,9 +389,8 @@ properties a decoder preserves regardless of which form it sees.
 
 ## 7. Codec Engine Responsibilities
 
-The JSON engine's internal `wrapTag()` / `#unwrapTag()` methods
-generate and parse `/<Type>@<Version>` keys. The engine is also responsible
-for:
+The JSON engine generates and parses `/<Type>@<Version>` keys. It is also
+responsible for:
 
 - Owning recursion and tag-wrapping around the shallow per-type codecs
   (see `1-fabric-values.md` Sections 2.4 and 4.5): tags come from

--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -304,19 +304,22 @@ built-in escape, or an encoding error.
 > literal user-data keys.
 
 > **JS implementation note.** "Any keys" is the format's rule and this
-> implementation does not yet meet it: a plain object carrying `__proto__` or
-> `constructor` is refused rather than encoded, on both sides of the wire and
-> in the inert check that decides what a fabric value is at all. Neither name
-> is reserved by the format, and neither is a limit of JavaScript. They are
-> refused because of how *this* implementation rebuilds a record — by
-> assignment, which for `__proto__` reaches a prototype accessor instead of
-> creating a property — and because other boundaries here already drop
-> `constructor`, so accepting it would admit a key that something later
-> discards silently. `unsafeObjectKeyIn()` in `@commonfabric/utils/types`
-> carries the reasoning and the conditions for lifting each one. An
-> implementation on a host that does not route property assignment through a
-> prototype chain reserves no names at all, which is the behavior the format
-> describes.
+> implementation does not yet meet it: a plain object carrying `__proto__`,
+> `constructor` or `then` is refused rather than encoded, on both sides of the
+> wire and in the inert check that decides what a fabric value is at all. No
+> such name is reserved by the format, and none is a limit of JavaScript.
+> `__proto__` and `constructor` are about copying: this implementation rebuilds
+> a record by assignment, which for `__proto__` reaches a prototype accessor
+> instead of creating a property, and other boundaries here already drop
+> `constructor`. `then` is about what the host does with a record afterward —
+> JavaScript takes its presence as the mark of a thenable, its own runtime
+> internals included, so a record carrying one is consumed by promise
+> resolution that nothing asked for and no boundary reports.
+> `unsafeObjectKeyIn()` in `@commonfabric/utils/types` carries the reasoning
+> per name and the conditions for lifting each. An implementation on a host
+> that neither routes property assignment through a prototype chain nor
+> duck-types promises reserves no names at all, which is the behavior the
+> format describes.
 
 The common case — a **tagged value** — is a single-key object whose sole key
 starts with `/`:

--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -314,11 +314,9 @@ built-in escape, or an encoding error.
 > `constructor`. `then` is about what the host does with a record afterward —
 > JavaScript takes its presence as the mark of a thenable, its own runtime
 > internals included, so a record carrying one is consumed by promise
-> resolution that nothing asked for and no boundary reports.
-> `unsafeObjectKeyIn()` in `@commonfabric/utils/types` carries what makes each
-> name awkward and what carrying it would take. An implementation on a host
-> that neither routes property assignment through a prototype chain nor
-> duck-types promises reserves no names at all, which is the behavior the
+> resolution that nothing asked for and no boundary reports. An implementation
+> on a host that neither routes property assignment through a prototype chain
+> nor duck-types promises reserves no names at all, which is the behavior the
 > format describes.
 
 The common case — a **tagged value** — is a single-key object whose sole key

--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -259,21 +259,15 @@ built-in escape, or an encoding error.
 > literal user-data keys.
 
 > **JS implementation note.** "Any keys" is the format's rule and this
-> implementation does not yet meet it: a plain object carrying `__proto__`,
-> `constructor` or `then` is refused rather than encoded, on both sides of the
-> wire and in the inert check that decides what a fabric value is at all. No
-> such name is reserved by the format, and none is a limit of JavaScript.
-> `__proto__` and `constructor` are about copying: this implementation rebuilds
-> a record by assignment, which for `__proto__` reaches a prototype accessor
-> instead of creating a property, and other boundaries here already drop
-> `constructor`. `then` is about what the host does with a record afterward:
-> JavaScript's promise resolution probes for that name and adopts whatever
-> answers it, if what answers is callable. A record read through a layer that
-> can answer a property with a function is therefore consumed by resolution
-> nothing asked for, with no fault reported. An implementation
-> on a host that neither routes property assignment through a prototype chain
-> nor duck-types promises reserves no names at all, which is the behavior the
-> format describes.
+> implementation does not yet meet it: a plain object carrying `__proto__` or
+> `constructor` is refused rather than encoded, on both sides of the wire and
+> in the inert check that decides what a fabric value is at all. Neither name
+> is reserved by the format, and neither is a limit of JavaScript. Both are
+> about copying: this implementation rebuilds a record by assignment, which for
+> `__proto__` reaches a prototype accessor instead of creating a property, and
+> other boundaries here already drop `constructor`. An implementation on a host
+> that does not route property assignment through a prototype chain reserves no
+> names at all, which is the behavior the format describes.
 
 The common case — a **tagged value** — is a single-key object whose sole key
 starts with `/`:

--- a/packages/data-model/src/codec-json/JsonDecodeAct.ts
+++ b/packages/data-model/src/codec-json/JsonDecodeAct.ts
@@ -65,15 +65,18 @@ export class JsonDecodeAct extends BaseDecodeAct<JsonCodecValue, string> {
       // `CODEC_META_TAGS.quote` literal handling (`3-json-encoding.md` Section 6).
       if (tag === CODEC_META_TAGS.quote) {
         // TODO(danfuzz): Quote content is returned whole, so a key this
-        // runtime reserves is admitted here where the `/object` and
+        // implementation reserves is admitted here where the `/object` and
         // plain-object arms below refuse one. `JSON.parse` makes such a key an
-        // own property, so it does arrive. The result cannot be re-encoded --
-        // `BaseEncodeAct.assertEncodableKey()` refuses it -- so a decode
-        // through this arm can produce a value that does not round-trip.
-        // Settling it means deciding whether the reservation covers every arm
-        // or only the arms that rebuild an object by assignment, and writing
-        // that answer into Section 9, which does not currently mention these
-        // keys at all.
+        // own property, so it does arrive, and the result cannot be re-encoded:
+        // `BaseEncodeAct.assertEncodableKey()` refuses it. A decode through
+        // this arm therefore yields a value that does not round-trip.
+        //
+        // The format accepts any key, so this arm is the one behaving
+        // correctly and the refusals elsewhere are the shortfall
+        // (`UNSAFE_OBJECT_KEYS` in `@commonfabric/utils/types`). What is wrong
+        // here is only the disagreement: until that set empties, one arm
+        // admitting what the others refuse is a round trip that breaks in the
+        // middle rather than a refusal a caller can see.
         return rawState;
       }
 

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -258,6 +258,22 @@ describe("type-check", () => {
   });
 
   describe("isFabricValue()", () => {
+    it("returns `true` for a schema using the `if` / `then` / `else` keywords", () => {
+      // This system's schemas are themselves fabric values, and JSON Schema
+      // spells conditional subschemas with those three keywords. So `then` is
+      // a data key a schema routinely carries, and reserving it -- as a
+      // defense against promise resolution adopting a callable `then` -- would
+      // stop an ordinary schema being a fabric value at all. That hazard is
+      // handled where a property can become callable, in the value proxies,
+      // rather than by refusing the name here.
+      expect(isFabricValue({
+        type: "object",
+        if: { properties: { kind: { const: "a" } } },
+        then: { required: ["aField"] },
+        else: { required: ["bField"] },
+      })).toBe(true);
+    });
+
     describe("given a scalar `FabricValue`", () => {
       it("returns `true` for a boolean", () => {
         expect(isFabricValue(true)).toBe(true);

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -284,12 +284,10 @@ export type Constructor<T = unknown> = abstract new (...args: any[]) => T;
 
 // TODO(danfuzz): The wire formats accept a plain object with any keys, that
 // being the rule a cross-language format has to hold to. This implementation
-// refuses these names instead, and closing that gap means learning to carry
-// them: reconstructing records through mechanisms that preserve the name, and
-// keeping a record that carries `then` clear of promise resolution. That code
-// reads this same list -- as the names needing care rather than the names
-// refused -- so the list stays and what reading it means is what changes.
-// `unsafeObjectKeyIn()` below states what makes each name awkward.
+// refuses these names instead. Closing that gap means carrying such records
+// rather than refusing them, and code that does will read this list too, to
+// know which names need the care. `unsafeObjectKeyIn()` below states what
+// makes each name awkward.
 const UNSAFE_OBJECT_KEYS = new Set(["__proto__", "constructor", "then"]);
 
 /**
@@ -335,18 +333,11 @@ export function isUnsafeObjectKey(key: string): boolean {
  *   rather than the record, or nothing at all, and no boundary reports a fault
  *   because none occurred.
  *
- * Refusing them is what this implementation does today, and it is not the end
- * state: the format asks that these records be carried, and carrying them is
- * work this implementation has to grow. `__proto__` needs records rebuilt
- * through a mechanism that preserves the name. `constructor` needs the later
- * boundaries that drop it to keep it instead. `then` needs a record carrying
- * it kept clear of promise resolution, the host being what makes that name
- * awkward and the host not being ours to change.
- *
- * None of that empties this list. Handling a name with care needs the same
- * knowledge of which names need it, so what such work changes is what reading
- * this list means, not whether it is read. Until then, refusal is what keeps a
- * record from being corrupted in transit or quietly consumed after it.
+ * Refusing them is what this implementation does today. The format asks that
+ * such records be carried instead, which is work this implementation has to
+ * grow, and which will read this list too, to know which names need the care.
+ * Until then, refusal is what keeps a record from being corrupted in transit
+ * or quietly consumed after it.
  *
  * The check is one `Object.hasOwn()` call per reserved name rather than a walk
  * over the object's own keys, so it costs nothing per property and can sit on

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -325,13 +325,16 @@ export function isUnsafeObjectKey(key: string): boolean {
  *   in this implementation already refuse it: the projection to native values
  *   drops it, and `FabricError` throws on it. Accepting it here would mean
  *   admitting a key that a later boundary discards without saying so.
- * * `then` copies faithfully and survives every boundary here. It is reserved
- *   because its mere presence is what JavaScript takes for a `Thenable`, the
- *   runtime's own internals included, so a record carrying one is adopted by
- *   promise machinery it never asked to meet. Nothing awaits it deliberately;
- *   resolution finds it. What comes out the far side is then the key's value
- *   rather than the record, or nothing at all, and no boundary reports a fault
- *   because none occurred.
+ * * `then` copies faithfully, and the name alone is not the hazard: promise
+ *   adoption probes for `then` and takes over only when what it finds is
+ *   callable, so a record holding a string under that name resolves intact.
+ *   What makes the name unsafe is that a record's properties are not always
+ *   answered by the record. A layer surfacing a value through a proxy decides
+ *   what a property read returns, and one that can answer with a function
+ *   turns the data key into a thenable, which promise resolution then adopts
+ *   -- taking the record out of the caller's hands with no fault reported,
+ *   because none occurred. The value proxies here already guard the name for
+ *   that reason.
  *
  * Refusing them is what this implementation does today. The format asks that
  * such records be carried instead, which is work this implementation has to

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -288,7 +288,15 @@ export type Constructor<T = unknown> = abstract new (...args: any[]) => T;
 // rather than refusing them, and code that does will read this list too, to
 // know which names need the care. `unsafeObjectKeyIn()` below states what
 // makes each name awkward.
-const UNSAFE_OBJECT_KEYS = new Set(["__proto__", "constructor", "then"]);
+//
+// `then` is deliberately absent, and belongs here less than it looks. A
+// callable `then` is adopted by promise resolution, and a layer that answers a
+// property with a function can make a data key callable -- which is why the
+// value proxies in `runner` guard the name. But JSON Schema uses `if` / `then`
+// / `else`, and this system's schemas are themselves fabric values, so
+// reserving the name would stop an ordinary schema being one. The hazard is
+// real and is handled where a property becomes callable, not here.
+const UNSAFE_OBJECT_KEYS = new Set(["__proto__", "constructor"]);
 
 /**
  * Indicates whether `key` is one this implementation refuses to copy onto an
@@ -307,11 +315,10 @@ export function isUnsafeObjectKey(key: string): boolean {
  * Returns the reserved own property name the given object carries, if any.
  *
  * This asks about this implementation, not about the data model. A property
- * name is data like any other, and an implementation on a host that neither
- * routes property assignment through a prototype chain nor duck-types
- * promises -- which is most of them -- would reserve no names at all. Each
- * name here is refused for its own local reason, and none is a limit of the
- * language:
+ * name is data like any other, and an implementation on a host that does not
+ * route property assignment through a prototype chain -- which is most of them
+ * -- would reserve no names at all. Each name here is refused for its own
+ * local reason, and neither is a limit of the language:
  *
  * * `__proto__` cannot be rebuilt by the copying this system actually does.
  *   Records are reconstructed by assignment (`target[key] = value`) and
@@ -325,16 +332,6 @@ export function isUnsafeObjectKey(key: string): boolean {
  *   in this implementation already refuse it: the projection to native values
  *   drops it, and `FabricError` throws on it. Accepting it here would mean
  *   admitting a key that a later boundary discards without saying so.
- * * `then` copies faithfully, and the name alone is not the hazard: promise
- *   adoption probes for `then` and takes over only when what it finds is
- *   callable, so a record holding a string under that name resolves intact.
- *   What makes the name unsafe is that a record's properties are not always
- *   answered by the record. A layer surfacing a value through a proxy decides
- *   what a property read returns, and one that can answer with a function
- *   turns the data key into a thenable, which promise resolution then adopts
- *   -- taking the record out of the caller's hands with no fault reported,
- *   because none occurred. The value proxies here already guard the name for
- *   that reason.
  *
  * Refusing them is what this implementation does today. The format asks that
  * such records be carried instead, which is work this implementation has to

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -283,10 +283,13 @@ export type Immutable<T> = T extends ReadonlyArray<infer U>
 export type Constructor<T = unknown> = abstract new (...args: any[]) => T;
 
 // TODO(danfuzz): The wire formats accept a plain object with any keys, that
-// being the rule a cross-language format has to hold to; this implementation
-// refuses these three, and the set is what stands between the two positions.
-// `unsafeObjectKeyIn()` below states the local reason for each and what would
-// let it go. Emptying this set is what closes the gap.
+// being the rule a cross-language format has to hold to. This implementation
+// refuses these names instead, and closing that gap means learning to carry
+// them: reconstructing records through mechanisms that preserve the name, and
+// keeping a record that carries `then` clear of promise resolution. That code
+// reads this same list -- as the names needing care rather than the names
+// refused -- so the list stays and what reading it means is what changes.
+// `unsafeObjectKeyIn()` below states what makes each name awkward.
 const UNSAFE_OBJECT_KEYS = new Set(["__proto__", "constructor", "then"]);
 
 /**
@@ -332,14 +335,18 @@ export function isUnsafeObjectKey(key: string): boolean {
  *   rather than the record, or nothing at all, and no boundary reports a fault
  *   because none occurred.
  *
- * A name leaves this set when what makes it awkward is dealt with, and what
- * that takes differs. `__proto__` needs the copy loops rebuilt on a mechanism
- * that carries the name. `constructor` needs the later boundaries that drop it
- * changed to keep it. `then` needs nothing here, and can be dealt with
- * nowhere: what makes it awkward is how the host resolves promises, so it
- * stays reserved for as long as this system runs on such a host. While a name
- * is in the set, the reservation is what keeps a record from being corrupted
- * in transit or quietly consumed after it.
+ * Refusing them is what this implementation does today, and it is not the end
+ * state: the format asks that these records be carried, and carrying them is
+ * work this implementation has to grow. `__proto__` needs records rebuilt
+ * through a mechanism that preserves the name. `constructor` needs the later
+ * boundaries that drop it to keep it instead. `then` needs a record carrying
+ * it kept clear of promise resolution, the host being what makes that name
+ * awkward and the host not being ours to change.
+ *
+ * None of that empties this list. Handling a name with care needs the same
+ * knowledge of which names need it, so what such work changes is what reading
+ * this list means, not whether it is read. Until then, refusal is what keeps a
+ * record from being corrupted in transit or quietly consumed after it.
  *
  * The check is one `Object.hasOwn()` call per reserved name rather than a walk
  * over the object's own keys, so it costs nothing per property and can sit on

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -284,10 +284,10 @@ export type Constructor<T = unknown> = abstract new (...args: any[]) => T;
 
 // TODO(danfuzz): The wire formats accept a plain object with any keys, that
 // being the rule a cross-language format has to hold to; this implementation
-// refuses these two, and the set is what stands between the two positions.
+// refuses these three, and the set is what stands between the two positions.
 // `unsafeObjectKeyIn()` below states the local reason for each and what would
 // let it go. Emptying this set is what closes the gap.
-const UNSAFE_OBJECT_KEYS = new Set(["__proto__", "constructor"]);
+const UNSAFE_OBJECT_KEYS = new Set(["__proto__", "constructor", "then"]);
 
 /**
  * Indicates whether `key` is one this implementation refuses to copy onto an
@@ -306,10 +306,11 @@ export function isUnsafeObjectKey(key: string): boolean {
  * Returns the reserved own property name the given object carries, if any.
  *
  * This asks about this implementation, not about the data model. A property
- * name is data like any other, and an implementation on a host that does not
- * route property assignment through a prototype chain -- which is most of them
- * -- would reserve no names at all. The two here are refused for two different
- * local reasons, and neither is a limit of the language:
+ * name is data like any other, and an implementation on a host that neither
+ * routes property assignment through a prototype chain nor duck-types
+ * promises -- which is most of them -- would reserve no names at all. Each
+ * name here is refused for its own local reason, and none is a limit of the
+ * language:
  *
  * * `__proto__` cannot be rebuilt by the copying this system actually does.
  *   Records are reconstructed by assignment (`target[key] = value`) and
@@ -323,13 +324,26 @@ export function isUnsafeObjectKey(key: string): boolean {
  *   in this implementation already refuse it: the projection to native values
  *   drops it, and `FabricError` throws on it. Accepting it here would mean
  *   admitting a key that a later boundary discards without saying so.
+ * * `then` copies faithfully and survives every boundary here. It is reserved
+ *   because its mere presence is what JavaScript takes for a `Thenable`, the
+ *   runtime's own internals included, so a record carrying one is adopted by
+ *   promise machinery it never asked to meet. Nothing awaits it deliberately;
+ *   resolution finds it. What comes out the far side is then the key's value
+ *   rather than the record, or nothing at all, and no boundary reports a fault
+ *   because none occurred.
  *
- * Both are therefore removable, by rebuilding the copy loops on a faithful
- * mechanism and revisiting the boundaries that filter these names. Until then
- * the reservation is what keeps a record from being corrupted in transit.
+ * A name leaves this set when what makes it awkward is dealt with, and what
+ * that takes differs. `__proto__` needs the copy loops rebuilt on a mechanism
+ * that carries the name. `constructor` needs the later boundaries that drop it
+ * changed to keep it. `then` needs nothing here, and can be dealt with
+ * nowhere: what makes it awkward is how the host resolves promises, so it
+ * stays reserved for as long as this system runs on such a host. While a name
+ * is in the set, the reservation is what keeps a record from being corrupted
+ * in transit or quietly consumed after it.
  *
- * The check is two `Object.hasOwn()` calls rather than a key walk, so it costs
- * nothing per property and can sit on a hot validation path.
+ * The check is one `Object.hasOwn()` call per reserved name rather than a walk
+ * over the object's own keys, so it costs nothing per property and can sit on
+ * a hot validation path.
  *
  * @param value The object to check.
  * @returns The offending property name, or `undefined` if there is none.

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -282,13 +282,21 @@ export type Immutable<T> = T extends ReadonlyArray<infer U>
 /** Standard type meaning constructor function, a/k/a "class object." */
 export type Constructor<T = unknown> = abstract new (...args: any[]) => T;
 
+// TODO(danfuzz): The wire formats accept a plain object with any keys, that
+// being the rule a cross-language format has to hold to; this implementation
+// refuses these two, and the set is what stands between the two positions.
+// `unsafeObjectKeyIn()` below states the local reason for each and what would
+// let it go. Emptying this set is what closes the gap.
 const UNSAFE_OBJECT_KEYS = new Set(["__proto__", "constructor"]);
 
 /**
- * Indicates whether `key` must never be copied onto an object from untrusted
- * input, because assigning it can pollute the prototype chain. Use at
- * boundaries where external data enters the system (deserialization,
- * structural copying).
+ * Indicates whether `key` is one this implementation refuses to copy onto an
+ * object from untrusted input. Use at boundaries where external data enters
+ * the system (deserialization, structural copying).
+ *
+ * The reservation belongs to this implementation and not to the data model:
+ * see {@link unsafeObjectKeyIn} for which names are refused, why each one is,
+ * and what would let it be accepted.
  */
 export function isUnsafeObjectKey(key: string): boolean {
   return UNSAFE_OBJECT_KEYS.has(key);

--- a/packages/utils/test/types.test.ts
+++ b/packages/utils/test/types.test.ts
@@ -392,14 +392,6 @@ describe("types", () => {
       expect(isUnsafeObjectKey("constructor")).toBe(true);
     });
 
-    it("returns `true` for `then`", () => {
-      // Reserved for a different reason than the two above, which is why it
-      // gets its own case. `then` copies faithfully; what it does not survive
-      // is a layer that answers the property with a function, which promise
-      // resolution then adopts.
-      expect(isUnsafeObjectKey("then")).toBe(true);
-    });
-
     it("returns `false` for ordinary keys", () => {
       expect(isUnsafeObjectKey("id")).toBe(false);
       expect(isUnsafeObjectKey("space")).toBe(false);
@@ -408,16 +400,14 @@ describe("types", () => {
     });
 
     it("returns `false` for near-miss keys that are not in the set", () => {
-      // The set is exactly three names, not every prototype-adjacent or
-      // promise-adjacent one. `catch` and `finally` sit beside `then` on a
-      // promise and are ordinary keys here, because it is `then` alone that
-      // resolution duck-types.
+      // Only `__proto__` and `constructor` are unsafe -- not every
+      // prototype-adjacent name, and not `then`, which a schema may carry as
+      // a JSON Schema keyword.
       expect(isUnsafeObjectKey("prototype")).toBe(false);
       expect(isUnsafeObjectKey("proto")).toBe(false);
       expect(isUnsafeObjectKey("toString")).toBe(false);
       expect(isUnsafeObjectKey("hasOwnProperty")).toBe(false);
-      expect(isUnsafeObjectKey("catch")).toBe(false);
-      expect(isUnsafeObjectKey("finally")).toBe(false);
+      expect(isUnsafeObjectKey("then")).toBe(false);
     });
 
     it("is backstopped by the runtime keeping `__proto__` inert", () => {
@@ -454,7 +444,6 @@ describe("types", () => {
       });
       expect(unsafeObjectKeyIn(withProto)).toBe("__proto__");
       expect(unsafeObjectKeyIn({ ["constructor"]: 1 })).toBe("constructor");
-      expect(unsafeObjectKeyIn({ ["then"]: 1 })).toBe("then");
     });
 
     it("returns `undefined` for ordinary objects", () => {

--- a/packages/utils/test/types.test.ts
+++ b/packages/utils/test/types.test.ts
@@ -392,6 +392,14 @@ describe("types", () => {
       expect(isUnsafeObjectKey("constructor")).toBe(true);
     });
 
+    it("returns `true` for `then`", () => {
+      // Reserved for a different reason than the two above, which is why it
+      // gets its own case: `then` copies faithfully and passes every boundary
+      // here. What it does not survive is promise resolution, which duck-types
+      // any object carrying the name.
+      expect(isUnsafeObjectKey("then")).toBe(true);
+    });
+
     it("returns `false` for ordinary keys", () => {
       expect(isUnsafeObjectKey("id")).toBe(false);
       expect(isUnsafeObjectKey("space")).toBe(false);
@@ -400,12 +408,16 @@ describe("types", () => {
     });
 
     it("returns `false` for near-miss keys that are not in the set", () => {
-      // Only `__proto__` and `constructor` are unsafe — not every
-      // prototype-adjacent name.
+      // The set is exactly three names, not every prototype-adjacent or
+      // promise-adjacent one. `catch` and `finally` sit beside `then` on a
+      // promise and are ordinary keys here, because it is `then` alone that
+      // resolution duck-types.
       expect(isUnsafeObjectKey("prototype")).toBe(false);
       expect(isUnsafeObjectKey("proto")).toBe(false);
       expect(isUnsafeObjectKey("toString")).toBe(false);
       expect(isUnsafeObjectKey("hasOwnProperty")).toBe(false);
+      expect(isUnsafeObjectKey("catch")).toBe(false);
+      expect(isUnsafeObjectKey("finally")).toBe(false);
     });
 
     it("is backstopped by the runtime keeping `__proto__` inert", () => {
@@ -442,6 +454,7 @@ describe("types", () => {
       });
       expect(unsafeObjectKeyIn(withProto)).toBe("__proto__");
       expect(unsafeObjectKeyIn({ ["constructor"]: 1 })).toBe("constructor");
+      expect(unsafeObjectKeyIn({ ["then"]: 1 })).toBe("then");
     });
 
     it("returns `undefined` for ordinary objects", () => {

--- a/packages/utils/test/types.test.ts
+++ b/packages/utils/test/types.test.ts
@@ -394,9 +394,9 @@ describe("types", () => {
 
     it("returns `true` for `then`", () => {
       // Reserved for a different reason than the two above, which is why it
-      // gets its own case: `then` copies faithfully and passes every boundary
-      // here. What it does not survive is promise resolution, which duck-types
-      // any object carrying the name.
+      // gets its own case. `then` copies faithfully; what it does not survive
+      // is a layer that answers the property with a function, which promise
+      // resolution then adopts.
       expect(isUnsafeObjectKey("then")).toBe(true);
     });
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

The wire formats are meant to carry a plain object with any keys. That is what
a format with implementations in several languages has to hold to: a name that
is awkward in one host is data like any other, and baking one host's
awkwardness into the format exports it to every other implementation.

This says so where it was unsaid, and marks where this implementation does not
manage it.

**No behavior changes.** Every changed line outside the documentation and the
tests is a comment: `git diff origin/main...HEAD` over
`packages/utils/src/types.ts` and `packages/data-model/src/`, with comment and
blank lines filtered out, is empty.

## The format's rule, and this implementation's shortfall

Section 4 of `3-json-encoding.md` already said user-data plain objects may
carry any keys. Nothing said that this implementation refuses some of them --
on both sides of the wire, and in the inert check that decides what a fabric
value is at all. A **JS implementation note** now records that beside the rule,
in the form the document already uses for a JavaScript quirk a reader would
otherwise mistake for the format's own. The general text names no key: which
names a host finds awkward is that host's business.

`isUnsafeObjectKey`'s doc said such a key "must never be copied", an absolute
that its own sibling `unsafeObjectKeyIn` already contradicted four lines down,
where the reservation is explained as local and per-name. It now points there.

A `TODO(danfuzz)` marks the reserved set as the distance between the format's
rule and this implementation. Closing it means carrying such records rather
than refusing them -- and code that does will read the same list, to know which
names need the care, so the list stays and what reading it means changes.

## `then` is deliberately not reserved

A callable `then` is adopted by promise resolution, and a layer that answers a
property with a function can make a data key callable -- which is why the value
proxies in `runner` already guard the name. That argues for reserving it, and
this branch did for a while.

It cannot be reserved. JSON Schema spells a conditional subschema with `if` /
`then` / `else`, and this system's schemas are themselves fabric values, so
reserving the name stops an ordinary schema being one:

```
isFabricValue({ type: "object", if: {...}, then: {...}, else: {...} })
  with `then` reserved -> false, and encoding throws
  as it stands         -> true,  and encoding succeeds
```

The hazard is real and is handled where a property can become callable, not by
refusing the name to data entitled to carry it. A comment at the set records
why the name is absent, and a test in `type-check` holds the schema case, so
re-adding it fails loudly. That test is the one addition here with teeth:
adding `then` back to the set fails it and nothing else, on a tree that still
type-checks.

## Standard type encodings become specification

Section 3 held every built-in type's encoding inside a fenced `typescript`
block of 121 comment lines and no code. The container did the content several
disservices:

* It was labelled illustrative, though for much of what it held it was the only
  statement anywhere -- the worked bigint examples, the four literals
  `SpecialNumber@1` admits, the rule that a regular expression under an
  unrecognized flavor is stored unvalidated, and why `Problematic@1` checks its
  `state` for presence rather than for type.
* Being a code block, it passed `check-docs` while holding nothing to check.
  The gate's count is one lower now, which is that block leaving.
* It was where implementation detail collected out of reach of review: a
  pointer into this repository's source, an engine's internal `wrapTag()`, and
  `Stream@1` -- a tag in no source file, no registry, and no other document.

The encodings are now ordinary specification: a list for types whose state is
only a shape, and a subsection each for those carrying rules, in the form
Section 6 already uses. Section 7 opened with the same two method names, one of
them private, and now says what the engine does without naming how this
implementation spells it.

## Notes for the reviewer

**Deleting the Section 3 block was the first plan and was wrong.** Several of
its claims exist nowhere else, each confirmed absent from both sibling specs
with a control showing the pattern could match. `128n` encoding as `"AIA"` is
the case that makes it plain: `0x80` alone decodes as `-128`, so the leading
zero byte is what keeps the value positive, and nothing else in the tree says
so.

**Left alone deliberately.** The shape lines for `Link@1`, `Error@1`, `Map@1`
and the rest do restate what `1-fabric-values.md` Section 4.5 tabulates. A
reader of the JSON encoding should not have to open another document to learn
what a tagged value looks like, so the duplication stays, named rather than
resolved.

## Verification

* `deno task check`, `deno lint`, repo-wide `deno fmt --check`,
  `check-docs`, `check-docs-history-index`, `check-conflict-markers`: clean.
* `utils`: `ok | 99 passed (664 steps) | 0 failed`.
* `data-model`: `ok | 53 passed (2456 steps) | 0 failed`.
