### PR TITLE
Run the topics restore drill in CI, and teach the restore a wiring link it did not know

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -836,9 +836,7 @@ jobs:
       - name: 📦 Install CLI integration dependencies
         uses: ./.github/actions/apt-install
         with:
-          # sqlite3 is the topics restore drill's snapshot step: a snapshot is
-          # `VACUUM INTO` on the store file, not an API call.
-          packages: ${{ matrix.install_fuse_deps && 'jq sqlite3 fuse3 libfuse3-dev' || 'jq sqlite3' }}
+          packages: ${{ matrix.install_fuse_deps && 'jq fuse3 libfuse3-dev' || 'jq' }}
           cache-key: cli-integration
 
       - name: 🧪 Run CLI integration suite

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -836,7 +836,9 @@ jobs:
       - name: 📦 Install CLI integration dependencies
         uses: ./.github/actions/apt-install
         with:
-          packages: ${{ matrix.install_fuse_deps && 'jq fuse3 libfuse3-dev' || 'jq' }}
+          # sqlite3 is the topics restore drill's snapshot step: a snapshot is
+          # `VACUUM INTO` on the store file, not an API call.
+          packages: ${{ matrix.install_fuse_deps && 'jq sqlite3 fuse3 libfuse3-dev' || 'jq sqlite3' }}
           cache-key: cli-integration
 
       - name: 🧪 Run CLI integration suite

--- a/docs/plans/topics-migration-rehearsal.md
+++ b/docs/plans/topics-migration-rehearsal.md
@@ -278,6 +278,11 @@ API_URL=http://localhost:8010 CF_DRILL_STORE_DIR=<the server's MEMORY_DIR> \
   packages/cli/integration/topics-restore-drill.sh
 ```
 
+CI runs that same loop in the `piece-call` CLI-integration shard, so the
+restore path is exercised on every pull request rather than only when someone
+rehearses. What CI cannot do is rehearse against real data, which is what the
+clone pass above is for.
+
 ```bash
 # Damage one topic the worst way a bad migration would.
 echo '{"title":"CLOBBERED","body":"","comments":[]}' | \

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -1090,25 +1090,32 @@ run_topics_restore_drill() {
   echo "Running the topics restore drill..."
   local repo_root store_dir=""
   repo_root="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+  local root_store="$repo_root/cache/memory"
+  local toolshed_store="$repo_root/packages/toolshed/cache/memory"
   if [ -n "${CF_DRILL_STORE_DIR:-}" ]; then
     store_dir="$CF_DRILL_STORE_DIR"
   else
-    local candidate
-    for candidate in "$repo_root/cache/memory" \
-      "$repo_root/packages/toolshed/cache/memory"; do
+    local candidate found=()
+    for candidate in "$root_store" "$toolshed_store"; do
       # The OUTER engine directory, which the server creates at startup. The
       # inner one holds the per-space files and does not exist until a space
       # is written, which on a fresh server has not happened yet.
-      if [ -d "$candidate/engine-v3" ]; then
-        store_dir="$candidate"
-        break
-      fi
+      [ -d "$candidate/engine-v3" ] && found+=("$candidate")
     done
+    # Both existing means a previous run left one behind, and picking either
+    # is a guess: snapshot the store the server is NOT serving and the drill
+    # fails hunting for a space that was written elsewhere. Refuse instead —
+    # the operator knows which one is live and CF_DRILL_STORE_DIR says so.
+    if [ "${#found[@]}" -gt 1 ]; then
+      error "The topics restore drill found more than one candidate store \
+(${found[*]}) and cannot tell which the server is using. Set \
+CF_DRILL_STORE_DIR to the serving toolshed's MEMORY_DIR."
+    fi
+    [ "${#found[@]}" -eq 1 ] && store_dir="${found[0]}"
   fi
   if [ -z "$store_dir" ]; then
     error "The topics restore drill needs the serving toolshed's store; \
-looked in $repo_root/cache/memory and \
-$repo_root/packages/toolshed/cache/memory. Set CF_DRILL_STORE_DIR."
+looked in $root_store and $toolshed_store. Set CF_DRILL_STORE_DIR."
   fi
   echo "  store: $store_dir"
   API_URL="$API_URL" CF_DRILL_STORE_DIR="$store_dir" \

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -1068,6 +1068,55 @@ run_verb_session_gaps() {
   echo "Successfully ran the verb-session gap harness for ${API_URL}."
 }
 
+# The Topics content-safety drill: export a space's authored content, clobber a
+# topic the way a bad migration would, restore it, and prove the restore
+# byte-exact. docs/plans/topics-migration-rehearsal.md makes it part of every
+# clean rehearsal pass, and a restore mechanism nobody exercises is not a
+# mechanism — so it runs here rather than only by hand.
+#
+# Same delegation rationale as the two above: it deploys its own board into its
+# own fresh space. Unlike them it exercises the REAL topics pattern on purpose,
+# because its subject is content safety for that pattern; a topics change that
+# breaks export or restore SHOULD break this.
+#
+# It needs the serving toolshed's store, since a snapshot is `sqlite3 VACUUM
+# INTO` on the store file rather than an API call. MEMORY_DIR defaults to
+# `<the toolshed's cwd>/cache/memory`, and that cwd is NOT the same in both
+# places the suite runs: CI starts the binary from the workspace root, while
+# `start-local-dev.sh` starts it from `packages/toolshed`. So the store is
+# discovered rather than assumed, and an explicit CF_DRILL_STORE_DIR still
+# wins — pass it when serving from anywhere else.
+run_topics_restore_drill() {
+  echo "Running the topics restore drill..."
+  local repo_root store_dir=""
+  repo_root="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+  if [ -n "${CF_DRILL_STORE_DIR:-}" ]; then
+    store_dir="$CF_DRILL_STORE_DIR"
+  else
+    local candidate
+    for candidate in "$repo_root/cache/memory" \
+      "$repo_root/packages/toolshed/cache/memory"; do
+      # The OUTER engine directory, which the server creates at startup. The
+      # inner one holds the per-space files and does not exist until a space
+      # is written, which on a fresh server has not happened yet.
+      if [ -d "$candidate/engine-v3" ]; then
+        store_dir="$candidate"
+        break
+      fi
+    done
+  fi
+  if [ -z "$store_dir" ]; then
+    error "The topics restore drill needs the serving toolshed's store; \
+looked in $repo_root/cache/memory and \
+$repo_root/packages/toolshed/cache/memory. Set CF_DRILL_STORE_DIR."
+  fi
+  echo "  store: $store_dir"
+  API_URL="$API_URL" CF_DRILL_STORE_DIR="$store_dir" \
+    bash "$SCRIPT_DIR/topics-restore-drill.sh" ||
+    error "The topics restore drill failed."
+  echo "Successfully ran the topics restore drill for ${API_URL}."
+}
+
 # The top-level spellings are the same commands as their `cf piece`
 # counterparts (docs/plans/cli-surface-shape.md, step 5). The unit guard
 # (test/piece-data-spellings.test.ts) proves the two mounts share one
@@ -1269,6 +1318,8 @@ case "$SECTION" in
     run_verbs_walkthrough
     cf_test_step_begin verb-session-gaps
     run_verb_session_gaps
+    cf_test_step_begin topics-restore-drill
+    run_topics_restore_drill
     ;;
   piece-call-retry)
     cf_test_step_begin piece-call-retry
@@ -1289,6 +1340,10 @@ case "$SECTION" in
   verb-gaps)
     cf_test_step_begin verb-session-gaps
     run_verb_session_gaps
+    ;;
+  topics-drill)
+    cf_test_step_begin topics-restore-drill
+    run_topics_restore_drill
     ;;
   *)
     error "Unknown CLI integration section: $SECTION"

--- a/packages/cli/integration/topics-restore-drill.sh
+++ b/packages/cli/integration/topics-restore-drill.sh
@@ -11,9 +11,13 @@
 # break this script.
 #
 # Requirements beyond the usual: sqlite3 on PATH (for the VACUUM INTO
-# snapshot), and CF_DRILL_STORE_DIR pointing at the serving toolshed's
-# MEMORY_DIR (default <server cwd>/cache/memory), because a snapshot is taken
-# from the store file, not over the API.
+# snapshot — preinstalled on the CI runners and on macOS, so it is checked
+# rather than installed), and CF_DRILL_STORE_DIR pointing at the serving
+# toolshed's MEMORY_DIR (default <server cwd>/cache/memory), because a
+# snapshot is taken from the store file, not over the API.
+#
+# An identity is minted when CF_IDENTITY names none, the way
+# verbs-over-the-cli.sh does: CI sets no key, and every cf call here needs one.
 #
 #   API_URL=http://localhost:8000 CF_DRILL_STORE_DIR=cache/memory \
 #     packages/cli/integration/topics-restore-drill.sh
@@ -66,8 +70,23 @@ ENGINE_DIR="$STORE_DIR/engine-v3/engine-v3"
 WORK="$(mktemp -d)"
 SPACE="topics-drill-$(python3 -c 'import uuid; print(uuid.uuid4().hex[:12])')"
 
+# Every cf call below reads CF_IDENTITY from the environment, and CI sets
+# none. Mint one for this run rather than failing on the first deploy with
+# nothing to say about why.
+if [ -z "${CF_IDENTITY:-}" ]; then
+  CF_IDENTITY="$WORK/identity.key"
+  $CF id new > "$CF_IDENTITY" 2> /dev/null || {
+    echo "could not mint an identity for the drill" >&2
+    exit 1
+  }
+fi
+export CF_IDENTITY
+
 step "deploy the topics board into a fresh space ($SPACE)"
-ls "$ENGINE_DIR" 2> /dev/null > "$WORK/dbs-before" || true
+# `.sqlite` only: each store also carries -wal and -shm companions, and a
+# snapshot is taken from the database file itself.
+ls "$ENGINE_DIR" 2> /dev/null | grep '\.sqlite$' | sort > "$WORK/dbs-before" ||
+  true
 BOARD="$(
   $CF piece new "$REPO_ROOT/packages/patterns/topics/main.tsx" \
     --space "$SPACE" --api-url "$API_URL" 2> /dev/null |
@@ -109,25 +128,33 @@ $CF piece call -q --piece "$TOPIC_ALIAS" --space "$SPACE" \
   > /dev/null 2>&1
 ok "seeded"
 
-step "snapshot the space store (VACUUM INTO)"
-ls "$ENGINE_DIR" > "$WORK/dbs-after"
-NEW_DB="$(comm -13 "$WORK/dbs-before" "$WORK/dbs-after" | head -1)"
-[ -n "$NEW_DB" ] || {
+step "snapshot the space store (VACUUM INTO) and export from it"
+ls "$ENGINE_DIR" 2> /dev/null | grep '\.sqlite$' | sort > "$WORK/dbs-after"
+NEW_DBS="$(comm -13 "$WORK/dbs-before" "$WORK/dbs-after")"
+[ -n "$NEW_DBS" ] || {
   bad "no new space DB under $ENGINE_DIR — is API_URL served from this store?"
   exit 1
 }
-sqlite3 "$ENGINE_DIR/$NEW_DB" "VACUUM INTO '$WORK/$NEW_DB'" &&
-  ok "snapshot: $NEW_DB" || {
-  bad "VACUUM INTO failed"
-  exit 1
-}
-
-step "export from the snapshot"
-deno run --allow-run --allow-read --allow-write \
-  "$REPO_ROOT/scripts/topics-export.ts" "$WORK/$NEW_DB" \
-  --out "$WORK/export.json" > "$WORK/export.log" 2>&1 &&
-  ok "export ran" || {
-  bad "export failed: $(cat "$WORK/export.log")"
+# More than one store can be new: a run that minted its own identity also
+# created that identity's home space. Rather than guess between them —
+# whichever sorts first is a coin flip, and picking wrong fails later in the
+# export where the cause is invisible — snapshot each and let the export say
+# which holds the topics. "The store the export can read" IS the criterion.
+NEW_DB=""
+while read -r candidate; do
+  [ -n "$candidate" ] || continue
+  sqlite3 "$ENGINE_DIR/$candidate" "VACUUM INTO '$WORK/$candidate'" \
+    2> /dev/null || continue
+  if deno run --allow-run --allow-read --allow-write \
+    "$REPO_ROOT/scripts/topics-export.ts" "$WORK/$candidate" \
+    --out "$WORK/export.json" > "$WORK/export.log" 2>&1; then
+    NEW_DB="$candidate"
+    break
+  fi
+done <<< "$NEW_DBS"
+[ -n "$NEW_DB" ] && ok "snapshot and export: $NEW_DB" || {
+  bad "no new store exported as a topics space; last attempt said:
+$(cat "$WORK/export.log" 2> /dev/null)"
   exit 1
 }
 TOPIC="$(jq -r '.topics[0].fid' "$WORK/export.json")"

--- a/packages/cli/integration/topics-restore-drill.sh
+++ b/packages/cli/integration/topics-restore-drill.sh
@@ -17,6 +17,9 @@
 #
 #   API_URL=http://localhost:8000 CF_DRILL_STORE_DIR=cache/memory \
 #     packages/cli/integration/topics-restore-drill.sh
+#
+# CI runs it through integration.sh's `piece-call` section, which supplies the
+# store directory; `topics-drill` runs it alone.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -50,10 +53,13 @@ command -v jq > /dev/null || {
   echo "jq is required" >&2
   exit 1
 }
+# The inner directory holds the per-space files and is created with the first
+# space, so a fresh server has only the outer one — which is what to check,
+# since this script is about to create that first space itself.
 ENGINE_DIR="$STORE_DIR/engine-v3/engine-v3"
-[ -d "$ENGINE_DIR" ] || {
-  echo "no store at $ENGINE_DIR — point CF_DRILL_STORE_DIR at the serving" \
-    "toolshed's MEMORY_DIR (its default is <server cwd>/cache/memory)" >&2
+[ -d "$STORE_DIR/engine-v3" ] || {
+  echo "no store at $STORE_DIR/engine-v3 — point CF_DRILL_STORE_DIR at the" \
+    "serving toolshed's MEMORY_DIR (its default is <server cwd>/cache/memory)" >&2
   exit 1
 }
 
@@ -61,7 +67,7 @@ WORK="$(mktemp -d)"
 SPACE="topics-drill-$(python3 -c 'import uuid; print(uuid.uuid4().hex[:12])')"
 
 step "deploy the topics board into a fresh space ($SPACE)"
-ls "$ENGINE_DIR" > "$WORK/dbs-before"
+ls "$ENGINE_DIR" 2> /dev/null > "$WORK/dbs-before" || true
 BOARD="$(
   $CF piece new "$REPO_ROOT/packages/patterns/topics/main.tsx" \
     --space "$SPACE" --api-url "$API_URL" 2> /dev/null |

--- a/scripts/topics-rehearsal-lib.ts
+++ b/scripts/topics-rehearsal-lib.ts
@@ -122,7 +122,24 @@ export interface TopicsExport {
 /** The known link-valued argument fields a restore handles specially:
  * `mentionable` is re-established with `cf piece link` after the write, and
  * the deprecated `myName` stays retired. */
-export const STRUCTURAL_LINK_FIELDS = ["mentionable"] as const;
+/**
+ * The link-valued argument fields a restore re-establishes with
+ * `cf piece link` rather than writing as data, mapped to the board path each
+ * one points at. A document write cannot carry a `$link`, so these are routed
+ * aside and re-linked after the apply.
+ *
+ * Adding a wiring input to the topic pattern means adding it here. Leaving it
+ * out is not silent: `buildRestoreDocument` throws on any link-valued field it
+ * does not recognize, because writing one as data would corrupt it and
+ * dropping it would destroy it. The restore drill
+ * (`packages/cli/integration/topics-restore-drill.sh`) is what turns that
+ * throw into a failing check rather than a surprise mid-incident.
+ */
+export const STRUCTURAL_LINK_SOURCES: Record<string, string> = {
+  mentionable: "topics",
+  boardCrossrefs: "crossrefs",
+};
+export const STRUCTURAL_LINK_FIELDS = Object.keys(STRUCTURAL_LINK_SOURCES);
 export const LEGACY_LINK_FIELDS = ["myName"] as const;
 
 export interface RestoreDocument {

--- a/scripts/topics-restore.ts
+++ b/scripts/topics-restore.ts
@@ -50,6 +50,7 @@ import {
   cfJson,
   deepEqual,
   normalizeFid,
+  STRUCTURAL_LINK_SOURCES,
   type TopicsExport,
 } from "./topics-rehearsal-lib.ts";
 
@@ -146,51 +147,55 @@ for (const [field, wanted] of Object.entries(restoreDoc)) {
 }
 
 const boardFid = export_.board?.fid;
-const wantsMentionable = structural.includes("mentionable");
-const liveMentionable = await cfJson<unknown>([
-  "get",
-  "-q",
-  ...addr,
-  "--input",
-  "--select",
-  "mentionable@",
-]).catch(() => undefined);
-const mentionableMissing = wantsMentionable && liveMentionable === undefined;
+// A structural link the export recorded but the live piece has lost is a
+// reason to restore even when every content field already matches.
+const missingLinks: string[] = [];
+for (const field of structural) {
+  const live = await cfJson<unknown>([
+    "get",
+    "-q",
+    ...addr,
+    "--input",
+    "--select",
+    `${field}@`,
+  ]).catch(() => undefined);
+  if (live === undefined) missingLinks.push(field);
+}
 
-if (differing.length === 0 && !mentionableMissing) {
+if (differing.length === 0 && missingLinks.length === 0) {
   console.log("nothing to restore: every content field matches the export");
   Deno.exit(0);
 }
 for (const field of differing) console.log(`${field}: differs from export`);
-if (mentionableMissing) console.log("mentionable: board link absent");
+for (const field of missingLinks) console.log(`${field}: board link absent`);
 if (dryRun) {
   console.log(`dry run: ${differing.length} field(s) would be restored`);
   Deno.exit(0);
 }
 
 await cfApply(addr, restoreDoc);
-// The apply replaced the whole document, so a board link that was present a
-// moment ago is gone now — relink whenever the export says one belongs,
+// The apply replaced the whole document, so any board link that was present a
+// moment ago is gone now — relink every structural field the export recorded,
 // never on the pre-apply reading.
-if (wantsMentionable) {
+for (const field of structural) {
+  const source = STRUCTURAL_LINK_SOURCES[field];
   if (!boardFid) {
     console.error(
-      "mentionable was linked but the export records no board; " +
-        "re-link it by hand with `cf piece link <board>/topics " +
-        `${targetFid}/mentionable\``,
+      `${field} was linked but the export records no board; re-link it by ` +
+        `hand with \`cf piece link <board>/${source} ${targetFid}/${field}\``,
     );
-  } else {
-    await cf([
-      "piece",
-      "link",
-      "--space",
-      space,
-      "--api-url",
-      apiUrl,
-      `${normalizeFid(boardFid)}/topics`,
-      `${targetFid}/mentionable`,
-    ]);
+    continue;
   }
+  await cf([
+    "piece",
+    "link",
+    "--space",
+    space,
+    "--api-url",
+    apiUrl,
+    `${normalizeFid(boardFid)}/${source}`,
+    `${targetFid}/${field}`,
+  ]);
 }
 
 let failed = 0;
@@ -203,20 +208,20 @@ for (const field of Object.keys(restoreDoc)) {
     failed++;
   }
 }
-if (wantsMentionable) {
+for (const field of structural) {
   const after = await cfJson<unknown>([
     "get",
     "-q",
     ...addr,
     "--input",
     "--select",
-    "mentionable@",
+    `${field}@`,
   ]).catch(() => undefined);
   if (after === undefined) {
-    console.error("mentionable: board link NOT re-established");
+    console.error(`${field}: board link NOT re-established`);
     failed++;
   } else {
-    console.log("mentionable: board link present");
+    console.log(`${field}: board link present`);
   }
 }
 for (const field of legacy) {

--- a/scripts/topics-restore.ts
+++ b/scripts/topics-restore.ts
@@ -24,19 +24,25 @@
  * session-scoped fields no other session can see. So the script applies the
  * complete document in one call — built from the export's RAW argument, so
  * a plain authored field no field list here names still rides the restore —
- * then re-establishes the board link that a document write cannot carry
+ * then re-establishes every wiring link a document write cannot carry
  * (`$link` values are refused by the same validation), using
- * `cf piece link` on the board recorded in the export.
+ * `cf piece link` against the board recorded in the export.
+ *
+ * Those wiring links are `STRUCTURAL_LINK_SOURCES`, which maps each one to
+ * the board path it points at: `mentionable` to the board's `topics`, and
+ * `boardCrossrefs` to its `crossrefs`. A link-valued field absent from that
+ * map stops the restore rather than being guessed at, so a wiring input
+ * added to the topic pattern announces itself here.
  *
  * Three honest costs. Comment and link elements are re-written as plain
  * values, so their element entities are minted fresh: content, order,
  * timestamps, and attribution are exact, but a stored reference to an
- * individual old element is not preserved. The re-established `mentionable`
- * targets the board's result `topics` where the original targeted its
- * argument document — aliases of one another (#5632), so a before/after
- * diff of the stored link differs while resolution does not. And the
- * deprecated `myName` legacy link is not restored — it exists only as the
- * pre-agentName attribution fallback.
+ * individual old element is not preserved. A re-established link targets the
+ * board's RESULT path where the original targeted its argument document —
+ * aliases of one another (#5632), so a before/after diff of the stored link
+ * differs while resolution does not. And the deprecated `myName` legacy link
+ * is not restored — it exists only as the pre-agentName attribution
+ * fallback.
  *
  * The target's deployed pattern identity must match the export row's;
  * --allow-identity-mismatch overrides, which a restore after a deliberate


### PR DESCRIPTION
## Why

Closes #5962. The Topics restore drill (added in #5957) exercises the whole content-safety loop — export a space's authored content, clobber a topic the way a bad migration would, restore it, verify byte-exact — and it gated nothing. That is the #5685 shape exactly: a safety check nobody runs goes stale invisibly, and it is worse than a known gap because `docs/plans/topics-migration-rehearsal.md` cites the drill as part of what makes a rehearsal pass clean. A restore mechanism that has never run is not a mechanism.

**Wiring it up immediately proved the point** — the drill failed on first run against a current board, for two real reasons that are now fixed. Both would otherwise have been discovered mid-incident, which is the one moment you cannot afford to debug your recovery tooling.

## What changed

- **The drill runs in CI**, in the `piece-call` CLI-integration shard beside the verb walkthrough and three-topic fixture it belongs with, and standalone under a new `topics-drill` section. `sqlite3` joins that shard's apt packages: a snapshot is `VACUUM INTO` on the store file, not an API call.
- **The restore now understands `boardCrossrefs`.** #5921 wires it into every child the board creates; the restore knew only `mentionable` and `myName`, so it threw on any topic the current board made — refusing rather than corrupting, but refusing all the same. Structural links became a field → board-path map that both the relink and the verification read, so adding a wiring input to the topic pattern means adding one entry, and forgetting it stays loud.
- **The drill no longer requires the store's inner engine directory up front.** That directory appears with the first space written — the space the drill is itself about to create — so a fresh server refused it.
- **The store is discovered, not assumed.** CI starts the toolshed from the workspace root; `start-local-dev.sh` starts it from `packages/toolshed`. Its `MEMORY_DIR` default therefore differs between the two places this runs, and hardcoding either one breaks the other.

## Test plan

- Ran through the new section against a local toolshed: `CF_CLI_INTEGRATION_SECTION=topics-drill ./integration/integration.sh` → **12 passed, 0 failed**, including the restore that previously threw and the `mentionable` link resolving live afterward.
- Exercised the fresh-server path (no spaces yet), which is what caught the inner-directory bug.
- `scripts/` unit tests, `deno fmt`, `deno lint`, `deno check`, `check-skill-facts` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

