### PR TITLE
fix(test-support,ci): test records stop failing in a worktree and unprovisioned

### DIFF
--- a/.github/workflows/test-records-janitor.yml
+++ b/.github/workflows/test-records-janitor.yml
@@ -20,6 +20,10 @@ permissions:
 jobs:
   janitor:
     name: "Lease Key Holders"
+    # Where test records are not provisioned there is no broker identity to
+    # assume and no key holders to lease, so the job skips. An outage here
+    # already fails in the right direction: nothing gets disabled.
+    if: vars.TEST_RECORDS_BROKER_WIF_PROVIDER != ''
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository

--- a/.github/workflows/test-records-relay.yml
+++ b/.github/workflows/test-records-relay.yml
@@ -33,12 +33,18 @@ jobs:
     name: "Relay Test Records"
     # Cancelled and timed-out runs are included deliberately: a job killed
     # at its bound is the wedge case whose surviving artifacts matter most.
+    #
+    # The provider variable gates the whole job. Where test records are not
+    # provisioned there is no identity to assume and nothing to ship, and the
+    # relay is best-effort by design -- nothing gates on the store -- so the
+    # honest outcome is a skipped job rather than a failed one.
     if: >-
+      vars.TEST_RECORDS_RELAY_WIF_PROVIDER != '' && (
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success' ||
       github.event.workflow_run.conclusion == 'failure' ||
       github.event.workflow_run.conclusion == 'cancelled' ||
-      github.event.workflow_run.conclusion == 'timed_out'
+      github.event.workflow_run.conclusion == 'timed_out' )
     runs-on: ubuntu-latest
     steps:
       # Every third-party action in this credentialed workflow is pinned to

--- a/packages/test-support/src/records/paths.test.ts
+++ b/packages/test-support/src/records/paths.test.ts
@@ -25,7 +25,15 @@ describe("paths", () => {
     it("returns the directory holding .git when run inside a repository", () => {
       const root = repositoryRoot();
       expect(root).toBeDefined();
-      expect(Deno.statSync(join(root!, ".git")).isDirectory).toBe(true);
+      expect(Deno.cwd().startsWith(root!)).toBe(true);
+
+      // `.git` is a directory in an ordinary clone and a file holding a
+      // `gitdir:` pointer in a worktree. The climb keys on the entry
+      // existing, which `statSync()` answers for either shape, so asserting
+      // which shape it is would fail wherever the checkout is a worktree --
+      // and continuous integration, which uses a clone, would never see that.
+      const stat = Deno.statSync(join(root!, ".git"));
+      expect(stat.isDirectory || stat.isFile).toBe(true);
     });
 
     it("returns undefined outside any repository", () => {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

The roll-forward alternative to reverting #5986. Three files, 20 lines added:
it fixes both defects and keeps the feature. Whichever of the two lands, the
other should be closed.

## The test asserted more than the function promises

`repositoryRoot()` climbs to the entry named `.git` and returns the directory
holding it. That is right for both checkout shapes: in an ordinary clone the
entry is a directory, and in a git worktree it is a *file* holding a `gitdir:`
pointer. `statSync()` answers for either, so the climb itself already worked.

Its test asserted the entry is a directory:

```ts
expect(Deno.statSync(join(root!, ".git")).isDirectory).toBe(true);
```

which holds only in a clone. Continuous integration checks out a clone, so it
never saw the failure. Locally it was worse than one red test, because the
workspace suite stops at a failing package: a run from a worktree reached 22
packages instead of 41, leaving `runner`, `memory`, `toolshed` and `utils`
untested.

The test now asserts what the climb actually keys on -- that the entry exists,
in either shape -- and, so that it does not go slack, that the returned root
contains the working directory.

**It keeps its grip.** Ablating `repositoryRoot()` to return the parent of the
root fails it, along with the nested-climb test, on a tree that still
type-checks. The assertion was weakened only where it was wrong about
worktrees, not where it was doing work.

## The workflows want provisioning that does not exist

`Test Records Relay` and `Test Records Janitor` have failed on every run since
they landed:

```
google-github-actions/auth failed with: the GitHub Action workflow must
specify exactly one of "workload_identity_provider" or "credentials_json"!
```

Both assume a Google Cloud identity from repository variables naming a Workload
Identity Federation provider and service account. No `TEST_RECORDS_*` variables
are set here, so both expand to empty and the action refuses.

Each job now runs only when its provider variable is set. Skipping is the
honest outcome for a repository where test records are not provisioned: there
is no identity to assume and nothing to ship. It also suits what each workflow
says of itself -- the relay is best-effort and nothing gates on the store, and
the janitor already means to fail in the direction that disables nobody. Once
the variables are set, both jobs resume with no further change.

`Test Records Mint` reads the same broker variables but runs only on manual
dispatch, so it has never run and is left alone. A dispatch against an
unprovisioned repository should say what is wrong rather than skip silently.

## Verification

* `packages/test-support`: `ok | 16 passed (163 steps) | 0 failed`, run from a
  worktree -- where it was previously `15 passed, 1 failed`.
* `deno task check`, `deno lint`, repo-wide `deno fmt --check`, and
  `tasks/ci-workflow.test.ts`: all clean.
* Both edited workflows parse, with the relay's added condition binding across
  the whole existing disjunction rather than only its first arm:
  `vars.TEST_RECORDS_RELAY_WIF_PROVIDER != '' && ( … || … )`.

A full workspace run was still in progress when this was opened; the number to
watch is whether it reaches 41 packages from a worktree again.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

